### PR TITLE
Substring match

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -1247,8 +1247,9 @@ run_test('typeahead_results', () => {
 
     assert_emoji_matches('da',[{emoji_name: "tada", emoji_url: "TBD", codepoint: "1f389"},
                                {emoji_name: "panda_face", emoji_url: "TBD", codepoint: "1f43c"}]);
-    assert_emoji_matches('da_', []);
-    assert_emoji_matches('da ', []);
+    assert_emoji_matches('da_', [{emoji_name: "panda_face", emoji_url: "TBD", codepoint: "1f43c"}]);
+    assert_emoji_matches('da ', [{emoji_name: "panda_face", emoji_url: "TBD", codepoint: "1f43c"}]);
+    assert_emoji_matches('da nomatch', []);
     assert_emoji_matches('panda ', [{emoji_name: "panda_face", emoji_url: "TBD", codepoint: "1f43c"}]);
     assert_emoji_matches('panda_', [{emoji_name: "panda_face", emoji_url: "TBD", codepoint: "1f43c"}]);
     assert_emoji_matches('japanese__post_', [{emoji_name: "japanese_post_office", emoji_url: "TBD", codepoint: "1f3e3"}]);
@@ -1260,16 +1261,16 @@ run_test('typeahead_results', () => {
     assert_mentions_matches('cordelia   le    ', []);
     assert_mentions_matches('King ', [hamlet, lear]);
     assert_mentions_matches('King H', [hamlet]);
-    assert_mentions_matches('King L', [lear]);
-    assert_mentions_matches('delia lear', []);
-    assert_mentions_matches('Mark Tw', [twin1, twin2]);
+    assert_mentions_matches('King L', [lear, hamlet]);
+    assert_mentions_matches('King e', [hamlet, lear]);
+    assert_mentions_matches('delia lr', []);
     // Autocomplete user group mentions by group name.
     assert_mentions_matches('hamletchar', [hamletcharacters]);
     // Autocomplete user group mentions by group descriptions.
     assert_mentions_matches('characters   ', [hamletcharacters]);
     assert_mentions_matches('characters   of   ', [hamletcharacters]);
-    assert_mentions_matches('characters o ', []);
-    assert_mentions_matches('haracters of   hamlet', []);
+    assert_mentions_matches('characters o ', [hamletcharacters]);
+    assert_mentions_matches('haracters of   hamlet', [hamletcharacters]);
     assert_mentions_matches('of hamlet', []);
     // Autocomplete stream by stream name or stream description.
     assert_stream_matches('den', [denmark_stream, sweden_stream]);

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -1251,13 +1251,13 @@ run_test('typeahead_results', () => {
     assert_emoji_matches('da ', []);
     assert_emoji_matches('panda ', [{emoji_name: "panda_face", emoji_url: "TBD", codepoint: "1f43c"}]);
     assert_emoji_matches('panda_', [{emoji_name: "panda_face", emoji_url: "TBD", codepoint: "1f43c"}]);
-    assert_emoji_matches('japanese_post_', [{emoji_name: "japanese_post_office", emoji_url: "TBD", codepoint: "1f3e3"}]);
-    assert_emoji_matches('japanese post ', [{emoji_name: "japanese_post_office", emoji_url: "TBD", codepoint: "1f3e3"}]);
+    assert_emoji_matches('japanese__post_', [{emoji_name: "japanese_post_office", emoji_url: "TBD", codepoint: "1f3e3"}]);
+    assert_emoji_matches('japanese   post   ', [{emoji_name: "japanese_post_office", emoji_url: "TBD", codepoint: "1f3e3"}]);
     assert_emoji_matches('notaemoji', []);
     // Autocomplete user mentions by user name.
     assert_mentions_matches('cordelia', [cordelia]);
-    assert_mentions_matches('cordelia le', [cordelia]);
-    assert_mentions_matches('cordelia le ', []);
+    assert_mentions_matches('cordelia   le', [cordelia]);
+    assert_mentions_matches('cordelia   le    ', []);
     assert_mentions_matches('King ', [hamlet, lear]);
     assert_mentions_matches('King H', [hamlet]);
     assert_mentions_matches('King L', [lear]);
@@ -1266,17 +1266,17 @@ run_test('typeahead_results', () => {
     // Autocomplete user group mentions by group name.
     assert_mentions_matches('hamletchar', [hamletcharacters]);
     // Autocomplete user group mentions by group descriptions.
-    assert_mentions_matches('characters ', [hamletcharacters]);
-    assert_mentions_matches('characters of ', [hamletcharacters]);
+    assert_mentions_matches('characters   ', [hamletcharacters]);
+    assert_mentions_matches('characters   of   ', [hamletcharacters]);
     assert_mentions_matches('characters o ', []);
-    assert_mentions_matches('haracters of hamlet', []);
+    assert_mentions_matches('haracters of   hamlet', []);
     assert_mentions_matches('of hamlet', []);
     // Autocomplete stream by stream name or stream description.
     assert_stream_matches('den', [denmark_stream, sweden_stream]);
     assert_stream_matches('denmark', [denmark_stream]);
-    assert_stream_matches('denmark ', []);
+    assert_stream_matches('denmark   ', []);
     assert_stream_matches('den ', []);
     assert_stream_matches('cold', [sweden_stream, denmark_stream]);
-    assert_stream_matches('the ', [netherland_stream]);
+    assert_stream_matches('the   ', [netherland_stream]);
     assert_stream_matches('city', [netherland_stream]);
 });

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -37,9 +37,8 @@ function query_matches_string(query, source_str, split_char) {
     // match where query is a substring of one of the target characters.
     if (query.indexOf(split_char) > 0) {
         // If there's a whitespace character in the query, then we
-        // require a perfect prefix match (e.g. for 'ab cd ef',
-        // query needs to be e.g. 'ab c', not 'cd ef' or 'b cd
-        // ef', etc.).
+        // require a substring match (e.g. for 'ab cd ef',
+        // query needs to be e.g. 'ab c' or 'a c e', not 'cdx ef').
 
         var escaped_split_char = split_char.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
         // Split on multiple split characters (e,g. multiple whitespaces).
@@ -49,19 +48,15 @@ function query_matches_string(query, source_str, split_char) {
         var sources = source_str.split(multiple_split_char_regex);
         var i;
 
-        for (i = 0; i < queries.length - 1; i += 1) {
-            if (sources[i] !== queries[i]) {
+        for (i = 0; i < queries.length; i += 1) {
+            if (sources[i] === undefined) {
+                return false;
+            }
+            if (sources[i].indexOf(queries[i]) === -1) {
                 return false;
             }
         }
-
-        // This block is effectively a final iteration of the last
-        // loop.  What differs is that for the last word, a
-        // partial match at the beginning of the word is OK.
-        if (sources[i] === undefined) {
-            return false;
-        }
-        return sources[i].indexOf(queries[i]) === 0;
+        return true;
     }
 
     // For a single token, the match can be anywhere in the string.

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -40,8 +40,13 @@ function query_matches_string(query, source_str, split_char) {
         // require a perfect prefix match (e.g. for 'ab cd ef',
         // query needs to be e.g. 'ab c', not 'cd ef' or 'b cd
         // ef', etc.).
-        var queries = query.split(split_char);
-        var sources = source_str.split(split_char);
+
+        var escaped_split_char = split_char.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+        // Split on multiple split characters (e,g. multiple whitespaces).
+        // "a   b   " will be split into ["a", "b", ""]
+        var multiple_split_char_regex = new RegExp(escaped_split_char + '+', "g");
+        var queries = query.split(multiple_split_char_regex);
+        var sources = source_str.split(multiple_split_char_regex);
         var i;
 
         for (i = 0; i < queries.length - 1; i += 1) {


### PR DESCRIPTION
Commit 1:

Earlier, queries like `John  Do` would not match to `John Doe` due to an extra space between `John` and `do` in the query. The first commit takes care of this issue by performing `String.prototype.split` on a regex for multiple separators(space in our case) instead of a single separator. With this commit, `John Doe    ` would split into ["John", "Doe", ""]. If the separator is '_'(underscore) `John___Doe__` would split into ["John", "Doe", ""]. Note: If the separator is not a space, multiple spaces won't be equivalent as single space. btw I noticed that Slack also does this.
Note: As we are using this to match names, I'm not aware of a use case where an exact match of multiple spaces is required.

Commit 2:

compose: Use substring match instead of phrase match.  …
Fixes #10517.
- Substring match will be used in 3 places.
- PM addressee input block typeahead.
- mentions, stream, user group and emoji typeaheads in the compose content textarea.
- `n d` will match to John Doe.
- Note: No changes to `single word query can match any part of the source string` policy has been made. e.g. `Pa` can match `John Patrick Doe` while `Pat Do` will not match `John Patrick Doe`.

P.S. Commit 1 is ready to merge if it looks good. A review on commit 2 would be great, but you might want to hold on merging it until an additional commit is made to address the issue discussed afterwards [here](https://chat.zulip.org/#narrow/stream/9-issues/topic/compose.20typeahead.20search). [`from the` does not match `Prospero from the Tempest`]