### PR TITLE
portico: Increase the clickable area of logout button

### DIFF
--- a/static/js/portico/header.js
+++ b/static/js/portico/header.js
@@ -1,5 +1,5 @@
 $(function () {
-    $('.portico-header a .logout').on('click', function () {
+    $('.portico-header li.logout').on('click', function () {
         $('#logout_form').submit();
         return false;
     });

--- a/templates/zerver/portico-header-dropdown.html
+++ b/templates/zerver/portico-header-dropdown.html
@@ -10,13 +10,11 @@
                 Go home
             </a>
         </li>
-        <li>
+        <li class="logout">
             {% include 'zerver/app/logout.html' %}
             <a href="#logout">
-                <span class="logout">
-                    <i class="icon-vector-off"></i>
-                    Log out
-                </span>
+                <i class="icon-vector-off"></i>
+                Log out
             </a>
         </li>
     </ul>


### PR DESCRIPTION
The current logout button in portico pages is very hard to click as the clickable area is very small. 

(for example login to zullip realm and open http://localhost:9991/apps/)

![screenshot from 2018-10-04 23-37-56](https://user-images.githubusercontent.com/7190633/46493795-e755a280-c82e-11e8-9b5d-f7da32a499e2.png)

In most cases users would be having trouble logging out due to the small size. I and @akashnimare thought that the button was not working due to this issue.

A straightforward solution is to increase the clickable area which is what this PR does.

![screenshot from 2018-10-04 23-38-56](https://user-images.githubusercontent.com/7190633/46493903-1f5ce580-c82f-11e8-999f-8cd63bfed58e.png)

@akashnimare Can you see whether this PR fixes your issue?