### PR TITLE
styles: Convert hex values to HSL equivalents.

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -59,5 +59,8 @@
 
         "comment-whitespace-inside": "always",
         "indentation": 4,
+        
+        # Limit language features
+        "color-no-hex": true,
     }
 }

--- a/static/styles/app_components.scss
+++ b/static/styles/app_components.scss
@@ -240,7 +240,7 @@
 
 .new-style .tab-switcher .ind-tab.selected {
     position: relative;
-    background: hsl(0, 0%, 53%);
+    background-color: hsl(0, 0%, 53%);
     color: hsl(0, 0%, 100%);
     border: 1px solid hsl(0, 0%, 46%);
     z-index: 2;

--- a/static/styles/app_components.scss
+++ b/static/styles/app_components.scss
@@ -87,7 +87,7 @@
 }
 
 .new-style .button.grey {
-    background-color: hsl(0, 0%, 66%);
+    background-color: hsl(0, 0%, 67%);
 }
 
 .new-style .button.standalone {
@@ -242,14 +242,14 @@
     position: relative;
     background-color: hsl(0, 0%, 53%);
     color: hsl(0, 0%, 100%);
-    border: 1px solid hsl(0, 0%, 46%);
+    border: 1px solid hsl(0, 0%, 47%);
     z-index: 2;
 }
 
 .new-style .tab-switcher .ind-tab.disabled {
     pointer-events: none;
     color: hsl(0, 0%, 80%);
-    border-color: hsl(0, 0%, 86%);
+    border-color: hsl(0, 0%, 87%);
 }
 
 /* -- unified overlay design component -- */
@@ -334,8 +334,8 @@
 .grey-box {
     margin: 0px;
     padding: 5px 10px;
-    background-color: hsl(0, 0%, 97%);
-    border: 1px solid hsl(0, 0%, 86%);
+    background-color: hsl(0, 0%, 98%);
+    border: 1px solid hsl(0, 0%, 87%);
     border-radius: 4px;
 
     list-style-type: none;
@@ -343,5 +343,5 @@
 
 .white-box {
     background-color: hsl(0, 0%, 100%);
-    border: 1px solid hsl(0, 0%, 86%);
+    border: 1px solid hsl(0, 0%, 87%);
 }

--- a/static/styles/billing.scss
+++ b/static/styles/billing.scss
@@ -39,7 +39,7 @@
     }
 
     .tab-content {
-        border: 1px solid #ddd;
+        border: 1px solid hsl(0, 0%, 87%);
         border-bottom-left-radius: 4px;
         border-bottom-right-radius: 4px;
         padding: 20px;
@@ -174,13 +174,13 @@
     }
 
     .updating-card-logo svg circle {
-        fill: #444;
-        stroke: #444;
+        fill: hsl(0, 0%, 27%);
+        stroke: hsl(0, 0%, 27%);
     }
 
     .updating-card-logo svg path {
-        fill: #fff;
-        stroke: #fff;
+        fill: hsl(0, 0%, 100%);
+        stroke: hsl(0, 0%, 100%);
     }
 
     #updating_card_indicator {

--- a/static/styles/billing.scss
+++ b/static/styles/billing.scss
@@ -66,7 +66,7 @@
             &:checked {
                 + .box {
                     background-color: hsl(153, 32%, 55%);
-                    color: white;
+                    color: hsl(0, 0%, 100%);
                     border-color: hsl(152, 33%, 39%);
                 }
             }
@@ -108,7 +108,7 @@
     .stripe-button-el {
         padding: 11px 25px 11px 25px;
         font-weight: 400;
-        color: white;
+        color: hsl(0, 0%, 100%);
         background-color: hsl(185, 38%, 55%);
         background: linear-gradient(145deg, rgb(76, 181, 205), rgb(37, 177, 151));
         box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.2);

--- a/static/styles/billing.scss
+++ b/static/styles/billing.scss
@@ -1,10 +1,10 @@
 .billing-upgrade-page {
     font-family: Source Sans Pro, Helvetica, Arial, sans-serif;
-    background: hsl(0, 0%, 98%);
+    background-color: hsl(0, 0%, 98%);
     height: 100vh;
 
     .hero {
-        background: hsl(153, 32%, 55%);
+        background-color: hsl(153, 32%, 55%);
         color: hsl(153, 32%, 55%);
         position: absolute;
         top: 0;
@@ -43,7 +43,7 @@
         border-bottom-left-radius: 4px;
         border-bottom-right-radius: 4px;
         padding: 20px;
-        background: hsl(0, 0%, 100%);
+        background-color: hsl(0, 0%, 100%);
         font-size: 1.1em;
     }
 
@@ -65,7 +65,7 @@
             display: none;
             &:checked {
                 + .box {
-                    background: hsl(153, 32%, 55%);
+                    background-color: hsl(153, 32%, 55%);
                     color: white;
                     border-color: hsl(152, 33%, 39%);
                 }
@@ -74,7 +74,7 @@
         .box {
             width: 120px;
             height: 70px;
-            background: hsl(0, 0%, 94%);
+            background-color: hsl(0, 0%, 94%);
             transition: all .2s ease;
             display: inline-block;
             text-align: center;
@@ -86,7 +86,7 @@
             padding: 30px 20px;
             vertical-align: top;
             &:hover {
-                background: hsl(0, 0%, 91%);
+                background-color: hsl(0, 0%, 91%);
                 border-color: hsl(0, 0%, 80%);
             }
             .schedule-time {
@@ -109,7 +109,7 @@
         padding: 11px 25px 11px 25px;
         font-weight: 400;
         color: white;
-        background: hsl(185, 38%, 55%);
+        background-color: hsl(185, 38%, 55%);
         background: linear-gradient(145deg, rgb(76, 181, 205), rgb(37, 177, 151));
         box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.2);
         border: 0;
@@ -126,13 +126,13 @@
     }
 
     .stripe-button-el:hover {
-        background: rgb(37, 177, 151);
+        background-color: rgb(37, 177, 151);
         box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.3);
     }
 
     .stripe-button-el:active,
     .stripe-button-el:not(:disabled):active {
-        background: rgb(25, 139, 118);
+        background-color: rgb(25, 139, 118);
         span {
             background: 0;
             box-shadow: none;

--- a/static/styles/billing.scss
+++ b/static/styles/billing.scss
@@ -1,11 +1,11 @@
 .billing-upgrade-page {
     font-family: Source Sans Pro, Helvetica, Arial, sans-serif;
-    background: #fafafa;
+    background: hsl(0, 0%, 98%);
     height: 100vh;
 
     .hero {
-        background: #69b190;
-        color: #69b190;
+        background: hsl(153, 32%, 55%);
+        color: hsl(153, 32%, 55%);
         position: absolute;
         top: 0;
         width: 100%;
@@ -43,7 +43,7 @@
         border-bottom-left-radius: 4px;
         border-bottom-right-radius: 4px;
         padding: 20px;
-        background: #fefefe;
+        background: hsl(0, 0%, 100%);
         font-size: 1.1em;
     }
 
@@ -65,29 +65,29 @@
             display: none;
             &:checked {
                 + .box {
-                    background: #69b190;
+                    background: hsl(153, 32%, 55%);
                     color: white;
-                    border-color: #438667;
+                    border-color: hsl(152, 33%, 39%);
                 }
             }
         }
         .box {
             width: 120px;
             height: 70px;
-            background: #efefef;
+            background: hsl(0, 0%, 94%);
             transition: all .2s ease;
             display: inline-block;
             text-align: center;
             cursor: pointer;
             position: relative;
-            border: 1px solid #e7e7e7;
+            border: 1px solid hsl(0, 0%, 91%);
             border-radius: 8px;
             margin: 0 10px 5px 0;
             padding: 30px 20px;
             vertical-align: top;
             &:hover {
-                background: #e7e7e7;
-                border-color: #cbcbcb;
+                background: hsl(0, 0%, 91%);
+                border-color: hsl(0, 0%, 80%);
             }
             .schedule-time {
                 font-weight: bold;
@@ -109,7 +109,7 @@
         padding: 11px 25px 11px 25px;
         font-weight: 400;
         color: white;
-        background: #61b1b8;
+        background: hsl(185, 38%, 55%);
         background: linear-gradient(145deg, rgb(76, 181, 205), rgb(37, 177, 151));
         box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.2);
         border: 0;

--- a/static/styles/components.scss
+++ b/static/styles/components.scss
@@ -67,11 +67,11 @@ a.no-underline:hover {
 }
 
 .ps--scrolling-x > .ps__rail-x > .ps__thumb-x:hover {
-    background-color: #606060;
+    background-color: hsl(0, 0%, 38%);
 }
 
 .ps--scrolling-y > .ps__rail-y > .ps__thumb-y:hover {
-    background-color: #606060;
+    background-color: hsl(0, 0%, 38%);
 }
 
 /* -- flex forms -- */

--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -69,7 +69,7 @@
 }
 
 .compose_table .message_header_colorblock.message_header_private_message {
-    background: hsl(0, 0%, 27%);
+    background-color: hsl(0, 0%, 27%);
 }
 
 .compose_table .right_part {
@@ -156,7 +156,7 @@ table.compose_table {
     z-index: 2;
     width: 100%;
 
-    background: hsl(0, 0%, 100%);
+    background-color: hsl(0, 0%, 100%);
 }
 
 #compose-container {
@@ -276,7 +276,7 @@ div[id^="message-edit-send-status"],
     position: relative;
     margin-bottom: 6px;
 
-    background: hsla(152, 51%, 63%, 0.25);
+    background-color: hsla(152, 51%, 63%, 0.25);
     border: 1px solid hsla(0, 0%, 0%, 0.1);
     border-radius: 4px;
 }

--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -156,7 +156,7 @@ table.compose_table {
     z-index: 2;
     width: 100%;
 
-    background: #fff;
+    background: hsl(0, 0%, 100%);
 }
 
 #compose-container {

--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -34,7 +34,7 @@
 
 .alert-draft {
     font-size: 14px;
-    color: hsl(170, 47%, 54%);
+    color: hsl(170, 48%, 54%);
     padding: 3px 12px;
     font-weight: 400;
     display: none;
@@ -323,7 +323,7 @@ textarea.new_message_textarea,
 
 textarea.new_message_textarea:focus,
 .compose_table .recipient_box:focus {
-    border: 1px solid hsl(0, 0%, 66%);
+    border: 1px solid hsl(0, 0%, 67%);
     box-shadow: none;
     -webkit-box-shadow: none;
 }
@@ -368,7 +368,7 @@ input.recipient_box {
 }
 
 #send_controls .compose_checkbox_label {
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
     margin-right: 2px;
 }
 
@@ -379,12 +379,12 @@ input.recipient_box {
     margin-right: 7px;
     font-weight: 600;
     border: 1px solid hsl(170, 68%, 41%);
-    background-color: hsl(170, 47%, 54%);
+    background-color: hsl(170, 48%, 54%);
     color: hsl(0, 0%, 100%);
 }
 
 #compose-send-button:focus {
-    box-shadow: 0px 0px 10px hsl(170, 47%, 54%), 0px 0px 5px hsl(170, 47%, 54%);
+    box-shadow: 0px 0px 10px hsl(170, 48%, 54%), 0px 0px 5px hsl(170, 48%, 54%);
 }
 
 #stream-message,
@@ -459,7 +459,7 @@ input.recipient_box {
 
     margin-top: 5px;
 
-    border: 1px solid hsl(0, 0%, 66%);
+    border: 1px solid hsl(0, 0%, 67%);
     border-radius: 4px;
     background-color: hsla(0, 0%, 0%, 0.02);
     cursor: not-allowed;
@@ -470,7 +470,7 @@ a#undo_markdown_preview {
     text-decoration: none;
     position: relative;
     font-size: 16px;
-    color: hsl(0, 0%, 46%);
+    color: hsl(0, 0%, 47%);
 }
 
 #markdown_preview_spinner {

--- a/static/styles/drafts.scss
+++ b/static/styles/drafts.scss
@@ -18,7 +18,7 @@
     padding-top: 4px;
     text-align: center;
     text-transform: uppercase;
-    border-bottom: 1px solid hsl(0, 0%, 86%);
+    border-bottom: 1px solid hsl(0, 0%, 87%);
 }
 
 .drafts-header h1 {
@@ -31,7 +31,7 @@
     position: absolute;
     top: 10px;
     right: 10px;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
     cursor: pointer;
 }
 
@@ -56,7 +56,7 @@
     margin-top: calc(45vh - 30px - 1.5em);
     text-align: center;
     font-size: 1.5em;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
     pointer-events: none;
     -webkit-font-smoothing: antialiased;
 }
@@ -65,7 +65,7 @@
     display: block;
     text-align: center;
     font-size: 1em;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
     pointer-events: none;
     -webkit-font-smoothing: antialiased;
 }
@@ -112,7 +112,7 @@
 .draft_controls .restore-draft {
     cursor: pointer;
     margin-right: 5px;
-    color: hsl(170, 47%, 54%);
+    color: hsl(170, 48%, 54%);
     opacity: 0.7;
 }
 

--- a/static/styles/hotspots.scss
+++ b/static/styles/hotspots.scss
@@ -11,7 +11,7 @@
     margin: -12.5px 0 0 -12.5px;
     border-radius: 50%;
     position: absolute;
-    background: hsla(196, 100%, 82%, 0.3);
+    background-color: hsla(196, 100%, 82%, 0.3);
     border: 2px solid hsl(215, 47%, 50%);
     top: 50%;
     left: 50%;
@@ -24,7 +24,7 @@
     position: absolute;
     top: 50%;
     left: 50%;
-    background: hsl(0, 0%, 100%);
+    background-color: hsl(0, 0%, 100%);
     border-radius: 50%;
     border: 1px solid hsl(205, 100%, 70%);
     animation: pulsate 1.5s ease-out;
@@ -249,13 +249,13 @@
     max-width: 95%;
     box-shadow: 0 5px 10px rgba(133, 136, 142, 0.1);
     border-radius: 4px;
-    background: hsl(0, 0%, 98%);
+    background-color: hsl(0, 0%, 98%);
     margin: 0 auto;
     position: relative;
 }
 
 .hotspot-inline-top .hotspot-title {
-    background: hsl(168, 100%, 35%);
+    background-color: hsl(168, 100%, 35%);
     margin: 0;
     color: hsl(0, 0%, 100%);
     font-weight: 600;
@@ -280,7 +280,7 @@
 
 #hotspot_intro_reply_icon {
     position: relative;
-    background: hsl(0, 0%, 100%);
+    background-color: hsl(0, 0%, 100%);
     top: 50%;
     transform: perspective(1px) translateY(-75%);
 }

--- a/static/styles/hotspots.scss
+++ b/static/styles/hotspots.scss
@@ -133,7 +133,7 @@
     border: none;
     font-size: 1.15em;
     font-weight: 600;
-    color: #fff;
+    color: hsl(0, 0%, 100%);
     background-color: hsl(164, 44%, 47%);
     border-radius: 4px;
     white-space: normal;

--- a/static/styles/hotspots.scss
+++ b/static/styles/hotspots.scss
@@ -134,7 +134,7 @@
     font-size: 1.15em;
     font-weight: 600;
     color: #fff;
-    background-color: #43ad90;
+    background-color: hsl(164, 44%, 47%);
     border-radius: 4px;
     white-space: normal;
     padding: 7px 20px;
@@ -142,7 +142,7 @@
 }
 
 .hotspot-confirm:hover {
-    background-color: #5cc0a5;
+    background-color: hsl(164, 44%, 56%);
 }
 
 .hotspot.overlay .hotspot-confirm {
@@ -249,13 +249,13 @@
     max-width: 95%;
     box-shadow: 0 5px 10px rgba(133, 136, 142, 0.1);
     border-radius: 4px;
-    background: #f9f9f9;
+    background: hsl(0, 0%, 98%);
     margin: 0 auto;
     position: relative;
 }
 
 .hotspot-inline-top .hotspot-title {
-    background: #00b08d;
+    background: hsl(168, 100%, 35%);
     margin: 0;
     color: hsl(0, 0%, 100%);
     font-weight: 600;

--- a/static/styles/informational-overlays.scss
+++ b/static/styles/informational-overlays.scss
@@ -23,7 +23,7 @@
 .informational-overlays .overlay-tabs .exit {
     float: right;
     font-size: 1.5rem;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
     font-weight: 600;
     margin: 1px 15px;
 }

--- a/static/styles/input_pill.scss
+++ b/static/styles/input_pill.scss
@@ -22,14 +22,14 @@
     border: 1px solid hsla(0, 0%, 0%, 0.15);
 
     border-radius: 4px;
-    background: hsla(0, 0%, 0%, 0.07);
+    background-color: hsla(0, 0%, 0%, 0.07);
     cursor: pointer;
 }
 
 .pill-container .pill:focus {
     color: hsl(0, 0%, 100%);
     border: 1px solid hsl(176, 78%, 28%);
-    background: hsl(176, 49%, 42%);
+    background-color: hsl(176, 49%, 42%);
     outline: none;
 }
 
@@ -46,7 +46,7 @@
 .pill-container.not-editable .pill:focus {
     color: inherit;
     border: 1px solid hsla(0, 0%, 0%, 0.15);
-    background: hsla(0, 0%, 0%, 0.07);
+    background-color: hsla(0, 0%, 0%, 0.07);
 }
 
 .pill-container.not-editable .pill .exit {

--- a/static/styles/input_pill.scss
+++ b/static/styles/input_pill.scss
@@ -27,7 +27,7 @@
 }
 
 .pill-container .pill:focus {
-    color: #fff;
+    color: hsl(0, 0%, 100%);
     border: 1px solid hsl(176, 78%, 28%);
     background: hsl(176, 49%, 42%);
     outline: none;

--- a/static/styles/input_pill.scss
+++ b/static/styles/input_pill.scss
@@ -28,7 +28,7 @@
 
 .pill-container .pill:focus {
     color: #fff;
-    border: 1px solid #108179;
+    border: 1px solid hsl(176, 78%, 28%);
     background: hsl(176, 49%, 42%);
     outline: none;
 }

--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -7,7 +7,7 @@ body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     margin: 0;
-    background-color: #fff;
+    background-color: hsl(0, 0%, 100%);
     color: hsl(0, 0%, 27%);
     line-height: normal;
 
@@ -151,7 +151,7 @@ button {
 
     font-family: inherit;
     font-size: 0.7em;
-    background-color: #fff;
+    background-color: hsl(0, 0%, 100%);
     color: hsl(0, 0%, 27%);
 
     border-radius: 4px;
@@ -177,7 +177,7 @@ button:active {
 }
 
 button.green {
-    color: #fff;
+    color: hsl(0, 0%, 100%);
     background-color: hsl(170, 47%, 53%);
 
     border: 1px solid hsl(169, 45%, 43%);
@@ -185,9 +185,9 @@ button.green {
 
 button.black-disabled {
     cursor: default;
-    color: #333;
+    color: hsl(0, 0%, 20%);
     background-color: transparent;
-    border: 1px solid #888;
+    border: 1px solid hsl(0, 0%, 53%);
 }
 
 button.button.grey-transparent {
@@ -198,9 +198,9 @@ button.button.grey-transparent {
     font-size: 1.1rem;
     font-weight: 400;
 
-    color: #fff;
+    color: hsl(0, 0%, 100%);
     background-color: transparent;
-    border: 1px solid #fff;
+    border: 1px solid hsl(0, 0%, 100%);
 
     transition: all 0.2s ease;
 }
@@ -210,7 +210,7 @@ button.button.grey-transparent:hover {
 }
 
 button.button.grey-transparent:active {
-    background-color: #fff;
+    background-color: hsl(0, 0%, 100%);
     color: hsl(0, 0%, 40%);
 }
 
@@ -219,7 +219,7 @@ button.button.grey-transparent:active {
 nav {
     width: calc(100% - 80px);
     position: absolute;
-    color: #fff;
+    color: hsl(0, 0%, 100%);
 
     padding: 40px;
 
@@ -231,7 +231,7 @@ nav .brand.logo {
 }
 
 nav.white {
-    background-color: #fff;
+    background-color: hsl(0, 0%, 100%);
 }
 
 a.silver {
@@ -239,7 +239,7 @@ a.silver {
 }
 
 .silver {
-    color: #fff !important;
+    color: hsl(0, 0%, 100%) !important;
     opacity: 0.8;
 }
 
@@ -250,35 +250,35 @@ a.silver {
 nav.white li a,
 nav.white li a:hover,
 nav.white li a:visited {
-    color: #444;
+    color: hsl(0, 0%, 27%);
 }
 
 nav.white ul li.active::after {
-    color: #444;
+    color: hsl(0, 0%, 27%);
 }
 
 nav.white .brand.logo span {
-    color: #444;
+    color: hsl(0, 0%, 27%);
 }
 
 nav.white .brand-logo circle {
-    fill: #444 !important;
+    fill: hsl(0, 0%, 27%) !important;
 }
 
 nav.white .brand-logo path {
-    fill: #fff !important;
-    stroke: #fff !important;
+    fill: hsl(0, 0%, 100%) !important;
+    stroke: hsl(0, 0%, 100%) !important;
 }
 
 nav .hamburger {
     display: none;
-    fill: #fff;
+    fill: hsl(0, 0%, 100%);
     cursor: pointer;
     margin-top: 3px;
 }
 
 nav.white .hamburger {
-    fill: #444;
+    fill: hsl(0, 0%, 27%);
 }
 
 nav .content {
@@ -295,7 +295,7 @@ nav .logo span {
     position: relative;
     left: 5px;
     top: 1px;
-    color: #fff;
+    color: hsl(0, 0%, 100%);
     font-weight: 600;
     vertical-align: top;
     text-transform: uppercase;
@@ -304,7 +304,7 @@ nav .logo span {
 }
 
 nav.white .brand.logo span {
-    color: #444;
+    color: hsl(0, 0%, 27%);
 }
 
 nav .brand-logo {
@@ -338,7 +338,7 @@ nav ul li {
     display: inline-block;
     margin: 10px;
 
-    color: #fff;
+    color: hsl(0, 0%, 100%);
 
     opacity: 0.7;
     transition: all 0.2s ease;
@@ -348,7 +348,7 @@ nav li a,
 nav li a:hover,
 nav li a:visited {
     text-decoration: none;
-    color: #fff;
+    color: hsl(0, 0%, 100%);
 
     font-size: 1.05em;
 }
@@ -432,7 +432,7 @@ nav ul li.active::after {
 
     max-width: none;
 
-    color: #fff;
+    color: hsl(0, 0%, 100%);
 
     background-color: hsla(0, 0%, 0%, 0.1);
 }
@@ -549,7 +549,7 @@ nav ul li.active::after {
     padding: 50px 100px;
     max-width: calc(1000px);
 
-    background-color: #fff;
+    background-color: hsl(0, 0%, 100%);
     border-radius: 10px;
 
     box-shadow: 10px 20px 80px rgba(0, 0, 0, 0.15);
@@ -595,7 +595,7 @@ nav ul li.active::after {
     font-size: 1.2em;
     font-weight: 400;
 
-    color: #888;
+    color: hsl(0, 0%, 53%);
 }
 
 .portico-landing.features-app section.notifications .feature-list h3::before {
@@ -688,7 +688,7 @@ nav ul li.active::after {
     position: relative;
     padding: 60px 50px 30px 50px;
 
-    color: #fff;
+    color: hsl(0, 0%, 100%);
 
     overflow: hidden;
 }
@@ -717,7 +717,7 @@ nav ul li.active::after {
 }
 
 .portico-landing.hello .gradients .gradient.white-fade {
-    background: linear-gradient(0deg, #fff 0%, transparent 40%);
+    background: linear-gradient(0deg, hsl(0, 0%, 100%) 0%, transparent 40%);
 }
 
 .portico-landing.hello .hero .waves {
@@ -839,8 +839,8 @@ nav ul li.active::after {
     margin-top: 0px;
     padding: 12px 20px;
 
-    background: #fff;
-    border: 2px solid #fff;
+    background: hsl(0, 0%, 100%);
+    border: 2px solid hsl(0, 0%, 100%);
 
     font-size: 1.2em;
     font-weight: 500;
@@ -897,7 +897,7 @@ nav ul li.active::after {
 /* -- compare css -- */
 .compare {
     background-color: hsl(163, 22%, 31%);
-    color: #fff;
+    color: hsl(0, 0%, 100%);
 }
 
 .compare .text-header .text-content h1 {
@@ -940,7 +940,7 @@ nav ul li.active::after {
     font-weight: 600;
     padding: 15px 0px;
 
-    color: #fff;
+    color: hsl(0, 0%, 100%);
 }
 
 .compare thead th.normal {
@@ -1160,7 +1160,7 @@ nav ul li.active::after {
     padding: 3px 5px 0px 5px;
     margin: 0px 5px;
 
-    background-color: #fff;
+    background-color: hsl(0, 0%, 100%);
     border-radius: 4px;
 
     box-shadow: 0px 0px 15px hsla(0, 0%, 0%, 0.01);
@@ -1250,7 +1250,7 @@ nav ul li.active::after {
 .portico-landing.hello .features {
     padding: 50px 0px 100px 0px;
 
-    background-color: #fff;
+    background-color: hsl(0, 0%, 100%);
 }
 
 .portico-landing.hello .features .col-2 {
@@ -1349,7 +1349,7 @@ nav ul li.active::after {
 }
 
 .portico-landing .tour {
-    color: #000;
+    color: hsl(0, 0%, 0%);
     width: 1200px;
     max-width: 100%;
     margin: 0 auto;
@@ -1627,7 +1627,7 @@ nav ul li.active::after {
 }
 
 .portico-landing.hello .testimonials {
-    color: #fff;
+    color: hsl(0, 0%, 100%);
     background-color: hsl(168, 43%, 24%);
 }
 
@@ -1802,7 +1802,7 @@ nav ul li.active::after {
     background: -webkit-linear-gradient(145deg, hsl(169, 65%, 42%), hsl(191, 55%, 54%));
     background: linear-gradient(145deg, hsl(191, 56%, 55%), hsl(169, 65%, 42%));
 
-    color: #fff;
+    color: hsl(0, 0%, 100%);
 }
 
 .portico-landing.hello .apps .triangle {
@@ -1813,16 +1813,16 @@ nav ul li.active::after {
     height: 0;
     border-style: solid;
     border-width: 150px 100vw 0 0;
-    border-color: #fff transparent transparent transparent;
+    border-color: hsl(0, 0%, 100%) transparent transparent transparent;
 }
 
 .portico-landing.hello .apps .arrow {
-    color: #fff;
+    color: hsl(0, 0%, 100%);
     font-weight: 400;
 }
 
 .portico-landing.hello .apps .arrow::before {
-    background-color: #fff;
+    background-color: hsl(0, 0%, 100%);
 }
 
 .portico-landing.hello .apps .left-side,
@@ -1978,7 +1978,7 @@ nav ul li.active::after {
 }
 
 .footer.hello li a:hover {
-    color: #fff;
+    color: hsl(0, 0%, 100%);
 }
 
 /* -- apps page -- */
@@ -1988,7 +1988,7 @@ nav ul li.active::after {
 
 .portico-landing.apps .main,
 .portico-landing.features-app .main {
-    background-color: #fff;
+    background-color: hsl(0, 0%, 100%);
 }
 
 .portico-landing.apps .hero {
@@ -1998,7 +1998,7 @@ nav ul li.active::after {
     background: linear-gradient(35deg, hsl(197, 100%, 16%), hsl(166, 45%, 49%));
     height: 600px;
 
-    color: #fff;
+    color: hsl(0, 0%, 100%);
 
     overflow: hidden;
 }
@@ -2072,7 +2072,7 @@ nav ul li.active::after {
 }
 
 .portico-landing.apps .other-apps {
-    background-color: #fff;
+    background-color: hsl(0, 0%, 100%);
     padding: 50px 50px 120px 50px;
 
     text-align: center;
@@ -2097,7 +2097,7 @@ nav ul li.active::after {
     padding: 20px 30px;
     border-radius: 70px;
 
-    color: #ccc;
+    color: hsl(0, 0%, 80%);
 
     font-size: 3em;
     text-align: center;
@@ -2106,7 +2106,7 @@ nav ul li.active::after {
 }
 
 .portico-landing.apps .other-apps .apps .icon:hover {
-    color: #777;
+    color: hsl(0, 0%, 47%);
     background: linear-gradient(-45deg, hsl(0, 0%, 83%), hsl(0, 0%, 98%));
 }
 
@@ -2143,7 +2143,7 @@ nav ul li.active::after {
     padding: 200px 50px 100px 50px;
 
     background: hsl(153, 32%, 55%);
-    color: #fff;
+    color: hsl(0, 0%, 100%);
 }
 
 .portico-landing.why-page .hero.small-hero {
@@ -2194,7 +2194,7 @@ nav ul li.active::after {
 
 .portico-landing.why-page .main li strong {
     font-weight: 600;
-    color: #333;
+    color: hsl(0, 0%, 20%);
 }
 
 .portico-landing.why-page .main blockquote {
@@ -2239,7 +2239,7 @@ nav ul li.active::after {
 
     font-size: 0.8em;
     font-weight: normal;
-    color: #888;
+    color: hsl(0, 0%, 53%);
 }
 
 .portico-landing.why-page .team h2 {
@@ -2281,7 +2281,7 @@ nav ul li.active::after {
 
 .portico-landing.why-page .testimonials {
     background: hsl(168, 43%, 24%);
-    color: #fff;
+    color: hsl(0, 0%, 100%);
     margin-bottom: 40px;
 }
 
@@ -2346,7 +2346,7 @@ nav ul li.active::after {
 
     -webkit-transform: translateY(50px);
 
-    background-color: #fff;
+    background-color: hsl(0, 0%, 100%);
 }
 
 .portico-landing.hello .apps .screen.android {
@@ -2419,7 +2419,7 @@ nav ul li.active::after {
     max-width: 1170px;
     margin: 0 auto;
 
-    background-color: #fff;
+    background-color: hsl(0, 0%, 100%);
     box-shadow: 0px 0px 80px hsla(0, 0%, 0%, 0.12);
 
     visibility: hidden;
@@ -2480,7 +2480,7 @@ nav ul li.active::after {
 .portico-landing.integrations .portico-page-subheading {
     font-weight: 400;
     font-size: 1.1em;
-    color: #aaa;
+    color: hsl(0, 0%, 67%);
     line-height: 1.2;
     text-align: center;
 }
@@ -2729,7 +2729,7 @@ nav ul li.active::after {
 }
 
 .gradients .gradient.white-fade {
-    background: linear-gradient(0deg, #fff 0%, transparent 40%);
+    background: linear-gradient(0deg, hsl(0, 0%, 100%) 0%, transparent 40%);
 }
 
 /* -- pricing css -- */
@@ -2742,18 +2742,18 @@ nav ul li.active::after {
     font-size: 2.5em;
     margin: 0px;
 
-    color: #fff;
+    color: hsl(0, 0%, 100%);
 }
 
 .portico-landing.plans .main .padded-content > h2 {
-    color: #444;
+    color: hsl(0, 0%, 27%);
     text-align: center;
 
     font-size: 1.5em;
 
     margin-bottom: 50px;
 
-    color: #fff;
+    color: hsl(0, 0%, 100%);
 }
 
 .pricing-model .pricing-container {
@@ -2769,7 +2769,7 @@ nav ul li.active::after {
     padding: 10px;
     margin-bottom: 3px;
 
-    color: #fff;
+    color: hsl(0, 0%, 100%);
 
     font-size: 2em;
     font-weight: 300;
@@ -2787,7 +2787,7 @@ nav ul li.active::after {
 
 
     text-align: left;
-    background-color: #fff;
+    background-color: hsl(0, 0%, 100%);
 
     transition-property: all;
     transition-duration: 0.3s;
@@ -2819,7 +2819,7 @@ nav ul li.active::after {
 .pricing-model .pricing-container .text-content .description {
     font-size: 0.9em;
     font-weight: 400;
-    color: #888;
+    color: hsl(0, 0%, 53%);
 }
 
 .pricing-model .pricing-container ul.feature-list {
@@ -2858,7 +2858,7 @@ nav ul li.active::after {
     width: 100%;
     height: 150px;
 
-    background-color: #eee;
+    background-color: hsl(0, 0%, 93%);
 }
 
 .pricing-model .pricing-container .text-content .price::before {
@@ -2870,7 +2870,7 @@ nav ul li.active::after {
 
     font-size: 2rem;
     font-weight: 300;
-    color: #888;
+    color: hsl(0, 0%, 53%);
 }
 
 .pricing-model .pricing-container .text-content .price {
@@ -2890,7 +2890,7 @@ nav ul li.active::after {
 
     font-size: 0.9em;
     font-weight: 400;
-    color: #888;
+    color: hsl(0, 0%, 53%);
 
     text-align: left;
 }
@@ -2968,7 +2968,7 @@ nav ul li.active::after {
     margin-top: -2px;
     width: calc(100% - 300px - 50px);
 
-    background: #fff;
+    background: hsl(0, 0%, 100%);
     opacity: 0;
     transform: translateY(300px);
 
@@ -2992,7 +2992,7 @@ nav ul li.active::after {
 }
 
 .pricing-overlay.pricing-model .info-box .text-content p {
-    color: #888;
+    color: hsl(0, 0%, 53%);
 }
 
 .pricing-overlay.pricing-model .info-box .text-content .feature-detail-box {
@@ -3006,7 +3006,7 @@ nav ul li.active::after {
     display: inline-block;
     width: calc(33% - 21px);
     height: 200px;
-    background-color: #eee;
+    background-color: hsl(0, 0%, 93%);
     margin: 10px;
 }
 
@@ -3015,7 +3015,7 @@ nav ul li.active::after {
     height: 25px;
 
     font-weight: 400;
-    color: #888;
+    color: hsl(0, 0%, 53%);
     font-style: italic;
     text-align: center;
 }
@@ -3208,12 +3208,12 @@ nav ul li.active::after {
     }
 
     nav .logo span {
-        color: #fff;
+        color: hsl(0, 0%, 100%);
     }
 
     nav svg.brand-logo circle {
-        fill: #fff !important;
-        stroke: #fff !important;
+        fill: hsl(0, 0%, 100%) !important;
+        stroke: hsl(0, 0%, 100%) !important;
     }
 
     nav svg.brand-logo path {
@@ -3782,7 +3782,7 @@ nav ul li.active::after {
         width: 300px;
         padding-left: 30px;
 
-        background-color: #fff;
+        background-color: hsl(0, 0%, 100%);
         transform: translate(-350px, 0px);
 
 

--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -1132,7 +1132,7 @@ nav ul li.active::after {
 }
 
 .screen .navbar {
-    background-color: hsl(170, 47%, 54%);
+    background-color: hsl(170, 48%, 54%);
     padding: 10px;
 }
 
@@ -1741,7 +1741,7 @@ nav ul li.active::after {
     height: 60px;
     width: calc(25% - 44px);
 
-    background-color: hsl(0, 0%, 66%);
+    background-color: hsl(0, 0%, 67%);
     background-size: contain;
     background-position: center;
     background-repeat: no-repeat;
@@ -2401,7 +2401,7 @@ nav ul li.active::after {
 }
 
 .portico-landing.hello .apps .screen.ios .main-page {
-    border-color: hsl(0, 0%, 86%);
+    border-color: hsl(0, 0%, 87%);
 }
 
 .portico-landing.hello .apps .screen.android .main-page {

--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -739,7 +739,7 @@ nav ul li.active::after {
     width: 100%;
     height: 100%;
 
-    background-color: white;
+    background-color: hsl(0, 0%, 100%);
     border-radius: 35%;
 
     opacity: 0.3;
@@ -1371,7 +1371,7 @@ nav ul li.active::after {
     padding: 11px 25px 11px 25px;
     font-size: 1.2rem;
     font-weight: 400;
-    color: white;
+    color: hsl(0, 0%, 100%);
     background-color: hsl(185, 38%, 55%);
     background: linear-gradient(145deg, rgb(76, 181, 205), rgb(37, 177, 151));
     box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.3);
@@ -1544,7 +1544,7 @@ nav ul li.active::after {
 
     font-size: 1.2rem;
     font-weight: 400;
-    color: white;
+    color: hsl(0, 0%, 100%);
 
     background-color: hsl(185, 38%, 55%);
     background: linear-gradient(145deg, rgb(76, 181, 205), rgb(37, 177, 151));
@@ -2314,7 +2314,7 @@ nav ul li.active::after {
     margin-top: 5px;
     margin-bottom: 30px;
 
-    color: white;
+    color: hsl(0, 0%, 100%);
     opacity: 0.7;
     font-weight: 400;
     line-height: 140%;

--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -839,7 +839,7 @@ nav ul li.active::after {
     margin-top: 0px;
     padding: 12px 20px;
 
-    background: hsl(0, 0%, 100%);
+    background-color: hsl(0, 0%, 100%);
     border: 2px solid hsl(0, 0%, 100%);
 
     font-size: 1.2em;
@@ -1360,7 +1360,7 @@ nav ul li.active::after {
     height: 520px;
     margin: 20px auto;
     padding: 30px 20px;
-    background: rgba(246, 247, 249, 0.6);
+    background-color: rgba(246, 247, 249, 0.6);
     background: linear-gradient(rgba(246, 247, 249, 0.4), rgba(246, 247, 249, 0.9));
     border-radius: 12px;
     box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.02);
@@ -1372,7 +1372,7 @@ nav ul li.active::after {
     font-size: 1.2rem;
     font-weight: 400;
     color: white;
-    background: hsl(185, 38%, 55%);
+    background-color: hsl(185, 38%, 55%);
     background: linear-gradient(145deg, rgb(76, 181, 205), rgb(37, 177, 151));
     box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.3);
     border: 0;
@@ -1387,7 +1387,7 @@ nav ul li.active::after {
 }
 
 .tour .carousel-inner .start-button:hover {
-    background: rgb(37, 177, 151);
+    background-color: rgb(37, 177, 151);
     box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.3);
 }
 
@@ -1546,14 +1546,14 @@ nav ul li.active::after {
     font-weight: 400;
     color: white;
 
-    background: hsl(185, 38%, 55%);
+    background-color: hsl(185, 38%, 55%);
     background: linear-gradient(145deg, rgb(76, 181, 205), rgb(37, 177, 151));
     box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.2);
     border: 0;
 }
 
 .tour .carousel-inner button.call-to-action:hover {
-    background: rgb(37, 177, 151);
+    background-color: rgb(37, 177, 151);
     box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.3);
 }
 
@@ -1598,7 +1598,7 @@ nav ul li.active::after {
     margin-left: 10px;
     text-indent: -999px;
     cursor: pointer;
-    background: hsl(222, 12%, 66%);
+    background-color: hsl(222, 12%, 66%);
     transition: background .1s ease;
 }
 
@@ -1623,7 +1623,7 @@ nav ul li.active::after {
 }
 
 .carousel-indicators li.active {
-    background: hsl(220, 23%, 33%);
+    background-color: hsl(220, 23%, 33%);
 }
 
 .portico-landing.hello .testimonials {
@@ -1798,7 +1798,7 @@ nav ul li.active::after {
     padding: 200px 80px 100px 80px;
     margin-top: -50px;
 
-    background: hsl(177, 52%, 55%);
+    background-color: hsl(177, 52%, 55%);
     background: -webkit-linear-gradient(145deg, hsl(169, 65%, 42%), hsl(191, 55%, 54%));
     background: linear-gradient(145deg, hsl(191, 56%, 55%), hsl(169, 65%, 42%));
 
@@ -1942,7 +1942,7 @@ nav ul li.active::after {
     color: hsl(220, 15%, 66%);
 
     border: 1px solid hsl(220, 15%, 66%);
-    background: transparent;
+    background-color: transparent;
 
     transition: all 0.2s ease;
 }
@@ -2142,7 +2142,7 @@ nav ul li.active::after {
 .portico-landing.why-page .hero {
     padding: 200px 50px 100px 50px;
 
-    background: hsl(153, 32%, 55%);
+    background-color: hsl(153, 32%, 55%);
     color: hsl(0, 0%, 100%);
 }
 
@@ -2198,7 +2198,7 @@ nav ul li.active::after {
 }
 
 .portico-landing.why-page .main blockquote {
-    background: white;
+    background-color: hsl(0, 0%, 100%);
     border-color: hsl(168, 24%, 51%);
     padding: 20px 30px;
     margin-top: 20px;
@@ -2280,7 +2280,7 @@ nav ul li.active::after {
 }
 
 .portico-landing.why-page .testimonials {
-    background: hsl(168, 43%, 24%);
+    background-color: hsl(168, 43%, 24%);
     color: hsl(0, 0%, 100%);
     margin-bottom: 40px;
 }
@@ -2968,7 +2968,7 @@ nav ul li.active::after {
     margin-top: -2px;
     width: calc(100% - 300px - 50px);
 
-    background: hsl(0, 0%, 100%);
+    background-color: hsl(0, 0%, 100%);
     opacity: 0;
     transform: translateY(300px);
 

--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -417,7 +417,7 @@ nav ul li.active::after {
     justify-content: space-around;
     margin: 40px auto;
     padding: 0px 30px;
-    color: #2a3241;
+    color: hsl(219, 21%, 21%);
 }
 
 .portico-landing.features-app section.hero {
@@ -472,8 +472,8 @@ nav ul li.active::after {
     padding: 50px;
     /* this should only be a thing if the section above is not white */
     margin-top: 0px;
-    background-color: #2a3241;
-    color: #e1eafb;
+    background-color: hsl(219, 21%, 21%);
+    color: hsl(219, 76%, 93%);
 }
 
 .portico-landing.features-app section.keyboard-shortcuts::after {
@@ -507,7 +507,7 @@ nav ul li.active::after {
 
 .portico-landing.features-app section.keyboard-shortcuts a.cta {
     font-size: 1em;
-    color: #8cdbce;
+    color: hsl(170, 52%, 70%);
 }
 
 .portico-landing.features-app section.keyboard-shortcuts img {
@@ -705,15 +705,15 @@ nav ul li.active::after {
 }
 
 .portico-landing.hello .gradients .gradient.green {
-    background: linear-gradient(-25deg, transparent 40%, #3fb082);
+    background: linear-gradient(-25deg, transparent 40%, hsl(156, 47%, 47%));
 }
 
 .portico-landing.hello .gradients .gradient.blue {
-    background: linear-gradient(25deg, transparent 40%, #5298b1);
+    background: linear-gradient(25deg, transparent 40%, hsl(196, 38%, 51%));
 }
 
 .portico-landing.hello .gradients .gradient.sunburst {
-    background: linear-gradient(5deg, transparent 20%, #e8d275);
+    background: linear-gradient(5deg, transparent 20%, hsl(49, 71%, 68%));
 }
 
 .portico-landing.hello .gradients .gradient.white-fade {
@@ -844,7 +844,7 @@ nav ul li.active::after {
 
     font-size: 1.2em;
     font-weight: 500;
-    color: #679f81;
+    color: hsl(148, 23%, 51%);
 
     box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.2);
 
@@ -1012,7 +1012,7 @@ nav ul li.active::after {
 /* -- faq css -- */
 .faqs {
     position: relative;
-    background-color: #fafafa;
+    background-color: hsl(0, 0%, 98%);
 }
 
 .faqs .padded-content {
@@ -1033,7 +1033,7 @@ nav ul li.active::after {
     margin: 50px auto;
     max-width: 700px;
     font-size: 1.2em;
-    color: #3b3d42;
+    color: hsl(223, 6%, 25%);
 }
 
 /* the last faq in the box shouldn't have an extra 50px of margin. */
@@ -1043,7 +1043,7 @@ nav ul li.active::after {
 
 .faqs .faq .question {
     font-weight: 600;
-    color: #525e7a;
+    color: hsl(222, 20%, 40%);
     font-size: 1.1em;
 }
 
@@ -1282,7 +1282,7 @@ nav ul li.active::after {
     position: relative;
     z-index: 1;
 
-    background-color: #e9ecf1;
+    background-color: hsl(217, 22%, 93%);
 }
 
 .portico-landing.hello .open-source .flex {
@@ -1372,7 +1372,7 @@ nav ul li.active::after {
     font-size: 1.2rem;
     font-weight: 400;
     color: white;
-    background: #61b1b8;
+    background: hsl(185, 38%, 55%);
     background: linear-gradient(145deg, rgb(76, 181, 205), rgb(37, 177, 151));
     box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.3);
     border: 0;
@@ -1397,7 +1397,7 @@ nav ul li.active::after {
     display: block;
     width: 100%;
     max-width: 100%;
-    border: 1px solid #dfdfdf;
+    border: 1px solid hsl(0, 0%, 87%);
     opacity: 0.4;
 }
 
@@ -1440,7 +1440,7 @@ nav ul li.active::after {
 }
 
 .tour .carousel-inner img {
-    border: 1px solid #f2f3f4;
+    border: 1px solid hsl(210, 8%, 95%);
 }
 
 .tour .carousel-inner img.centered-image {
@@ -1546,7 +1546,7 @@ nav ul li.active::after {
     font-weight: 400;
     color: white;
 
-    background: #61b1b8;
+    background: hsl(185, 38%, 55%);
     background: linear-gradient(145deg, rgb(76, 181, 205), rgb(37, 177, 151));
     box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.2);
     border: 0;
@@ -1560,7 +1560,7 @@ nav ul li.active::after {
 .tour .carousel-control {
     background: 0;
     border: 0;
-    color: #747d94;
+    color: hsl(223, 13%, 52%);
     font-size: 2em;
     top: 50%;
     font-weight: 400;
@@ -1569,7 +1569,7 @@ nav ul li.active::after {
 }
 
 .tour .carousel-control:hover {
-    color: #414e68;
+    color: hsl(220, 23%, 33%);
 }
 
 .tour .carousel-control.right {
@@ -1598,7 +1598,7 @@ nav ul li.active::after {
     margin-left: 10px;
     text-indent: -999px;
     cursor: pointer;
-    background: #9fa5b3;
+    background: hsl(222, 12%, 66%);
     transition: background .1s ease;
 }
 
@@ -1623,12 +1623,12 @@ nav ul li.active::after {
 }
 
 .carousel-indicators li.active {
-    background: #414e68;
+    background: hsl(220, 23%, 33%);
 }
 
 .portico-landing.hello .testimonials {
     color: #fff;
-    background-color: #23584d;
+    background-color: hsl(168, 43%, 24%);
 }
 
 .portico-landing.hello .testimonials .text-header .text-content {
@@ -1660,7 +1660,7 @@ nav ul li.active::after {
 
 .portico-landing.hello .testimonials .fa-chevron-left,
 .portico-landing.hello .testimonials .fa-chevron-right {
-    color: #ffffff;
+    color: hsl(0, 0%, 100%);
     opacity: 0.5;
     position: absolute;
     font-size: 36px;
@@ -1691,7 +1691,7 @@ nav ul li.active::after {
     margin-top: 5px;
     margin-bottom: 30px;
 
-    color: #ffffff;
+    color: hsl(0, 0%, 100%);
     opacity: 0.7;
     font-weight: 400;
 }
@@ -1902,7 +1902,7 @@ nav ul li.active::after {
     margin: 10px 5px;
     color: hsl(219, 23%, 33%);
     border-radius: 5px;
-    border: 1px solid #e5eef5;
+    border: 1px solid hsl(206, 44%, 93%);
 }
 
 .portico-landing.hello .integrations .integration-icons .group:hover {
@@ -1995,7 +1995,7 @@ nav ul li.active::after {
     position: relative;
 
     padding: 100px 50px 50px 50px;
-    background: linear-gradient(35deg, #003b52, #45b59b);
+    background: linear-gradient(35deg, hsl(197, 100%, 16%), hsl(166, 45%, 49%));
     height: 600px;
 
     color: #fff;
@@ -2107,7 +2107,7 @@ nav ul li.active::after {
 
 .portico-landing.apps .other-apps .apps .icon:hover {
     color: #777;
-    background: linear-gradient(-45deg, #d4d4d4, #fafafa);
+    background: linear-gradient(-45deg, hsl(0, 0%, 83%), hsl(0, 0%, 98%));
 }
 
 .portico-landing.apps .other-apps .apps .icon.fa-mobile-phone {
@@ -2132,7 +2132,7 @@ nav ul li.active::after {
 /* -- /for/open-source/ -- */
 .portico-landing.why-page {
     padding-top: 0px;
-    color: #3b3d42;
+    color: hsl(223, 6%, 25%);
 }
 
 .portico-landing.why-page .main {
@@ -2142,7 +2142,7 @@ nav ul li.active::after {
 .portico-landing.why-page .hero {
     padding: 200px 50px 100px 50px;
 
-    background: #69b190;
+    background: hsl(153, 32%, 55%);
     color: #fff;
 }
 
@@ -2199,7 +2199,7 @@ nav ul li.active::after {
 
 .portico-landing.why-page .main blockquote {
     background: white;
-    border-color: #65a195;
+    border-color: hsl(168, 24%, 51%);
     padding: 20px 30px;
     margin-top: 20px;
     font-size: 1.05em;
@@ -2207,7 +2207,7 @@ nav ul li.active::after {
         line-height: 1.5;
         margin: 0;
         font-weight: 400;
-        color: #414e68;
+        color: hsl(220, 23%, 33%);
     }
     p:last-child {
         margin-top: 10px;
@@ -2280,7 +2280,7 @@ nav ul li.active::after {
 }
 
 .portico-landing.why-page .testimonials {
-    background: #23584d;
+    background: hsl(168, 43%, 24%);
     color: #fff;
     margin-bottom: 40px;
 }
@@ -2564,7 +2564,7 @@ nav ul li.active::after {
     margin: 3px 0;
     border-radius: 5px;
     transition: all 0.3s ease;
-    color: #414e67;
+    color: hsl(219, 23%, 33%);
 }
 
 .portico-landing.integrations .integration-categories-sidebar h4.selected,
@@ -2594,7 +2594,7 @@ nav ul li.active::after {
     margin: 7px 5px;
     border-radius: 5px;
     border: 1px solid hsl(208, 46%, 93%);
-    color: #414e67;
+    color: hsl(219, 23%, 33%);
     text-align: center;
     transition: all 0.3s ease;
 }
@@ -2689,7 +2689,7 @@ nav ul li.active::after {
     text-align: center;
     border-radius: 5px;
     transition: all 0.3s ease;
-    color: #414e67;
+    color: hsl(219, 23%, 33%);
 }
 
 .portico-landing.integrations .integration-instruction-block .categories .integration-category:hover {
@@ -2717,15 +2717,15 @@ nav ul li.active::after {
 }
 
 .gradients .gradient.green {
-    background: linear-gradient(-25deg, transparent 40%, #3fb082);
+    background: linear-gradient(-25deg, transparent 40%, hsl(156, 47%, 47%));
 }
 
 .gradients .gradient.blue {
-    background: linear-gradient(25deg, transparent 40%, #5298b1);
+    background: linear-gradient(25deg, transparent 40%, hsl(196, 38%, 51%));
 }
 
 .gradients .gradient.sunburst {
-    background: linear-gradient(5deg, transparent 20%, #e8d275);
+    background: linear-gradient(5deg, transparent 20%, hsl(49, 71%, 68%));
 }
 
 .gradients .gradient.white-fade {
@@ -2812,7 +2812,7 @@ nav ul li.active::after {
 
 .pricing-model .pricing-container hr {
     border: none;
-    border-bottom: 2px solid #4fc0ad;
+    border-bottom: 2px solid hsl(170, 47%, 53%);
     margin: 15px 0px 15px 0px;
 }
 
@@ -2909,7 +2909,7 @@ nav ul li.active::after {
 }
 
 .pricing-model .pricing-container .price-box:focus button {
-    box-shadow: 0px 0px 25px #6acab9;
+    box-shadow: 0px 0px 25px hsl(169, 48%, 60%);
     animation: box-shadow-pulse 2s infinite;
 }
 
@@ -3026,7 +3026,7 @@ nav ul li.active::after {
 
     float: right;
 
-    background-color: #3ca08d;
+    background-color: hsl(169, 45%, 43%);
 }
 
 @keyframes box-shadow-pulse {
@@ -3204,7 +3204,7 @@ nav ul li.active::after {
     }
 
     nav .logo span {
-        color: #52c2af;
+        color: hsl(170, 48%, 54%);
     }
 
     nav .logo span {
@@ -3217,8 +3217,8 @@ nav ul li.active::after {
     }
 
     nav svg.brand-logo path {
-        fill: #4e9da0 !important;
-        stroke: #4e9da0 !important;
+        fill: hsl(182, 34%, 47%) !important;
+        stroke: hsl(182, 34%, 47%) !important;
     }
 
     .portico-landing.features-app section .headliner .image {
@@ -3384,8 +3384,8 @@ nav ul li.active::after {
     }
 
     .portico-landing.integrations .integration-categories-dropdown h4 {
-        border-left: 1px solid #e4edf5;
-        border-right: 1px solid #e4edf5;
+        border-left: 1px solid hsl(208, 46%, 93%);
+        border-right: 1px solid hsl(208, 46%, 93%);
         transition: all 0.3s ease;
         font-size: .9em;
     }
@@ -4059,15 +4059,15 @@ nav ul li.active::after {
        want to have the gradients stay darker for longer.
     */
     .gradients .gradient.green {
-        background: linear-gradient(-25deg, transparent 10%, #3fb082 80%);
+        background: linear-gradient(-25deg, transparent 10%, hsl(156, 47%, 47%) 80%);
     }
 
     .gradients .gradient.blue {
-        background: linear-gradient(25deg, transparent 10%, #5298b1 80%);
+        background: linear-gradient(25deg, transparent 10%, hsl(196, 38%, 51%) 80%);
     }
 
     .gradients .gradient.sunburst {
-        background: linear-gradient(5deg, transparent 20%, #e8d275 80%);
+        background: linear-gradient(5deg, transparent 20%, hsl(49, 71%, 68%) 80%);
     }
 }
 

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -110,7 +110,7 @@ ul.filters hr {
 li.active-filter,
 li.active-sub-filter {
     font-weight: 600 !important;
-    background: hsl(202, 56%, 91%);
+    background-color: hsl(202, 56%, 91%);
     position: relative;
 }
 
@@ -171,7 +171,7 @@ li.active-sub-filter {
 .topic-unread-count,
 .private_message_count {
     float: right;
-    background: hsl(105, 2%, 50%);
+    background-color: hsl(105, 2%, 50%);
     padding: 0 4px;
     height: 16px;
     line-height: 16px;

--- a/static/styles/lightbox.scss
+++ b/static/styles/lightbox.scss
@@ -106,7 +106,7 @@
 
 #lightbox_overlay .image-actions .lightbox-canvas-trigger:hover {
     background-color: hsl(0, 0%, 100%);
-    border: 1px solid #fff;
+    border: 1px solid hsl(0, 0%, 100%);
     color: hsl(227, 40%, 16%);
     opacity: 1;
 }

--- a/static/styles/media.scss
+++ b/static/styles/media.scss
@@ -31,7 +31,7 @@
     }
 
     .column-right.expanded .right-sidebar {
-        background: hsla(0, 0%, 100%, 1.0);
+        background-color: hsla(0, 0%, 100%, 1.0);
         box-shadow: 0px -2px 3px 0px hsla(0, 0%, 0%, 0.1);
         border-left: 1px solid hsl(0, 0%, 86%);
         margin-top: 40px;
@@ -112,7 +112,7 @@
     }
 
     .column-left.expanded .left-sidebar {
-        background: hsla(0, 0%, 100%, 1.0);
+        background-color: hsla(0, 0%, 100%, 1.0);
         box-shadow: 0px 2px 3px 0px hsla(0, 0%, 0%, 0.1);
         border-right: 1px solid hsl(0, 0%, 86%);
         margin-top: 40px;

--- a/static/styles/media.scss
+++ b/static/styles/media.scss
@@ -33,7 +33,7 @@
     .column-right.expanded .right-sidebar {
         background-color: hsla(0, 0%, 100%, 1.0);
         box-shadow: 0px -2px 3px 0px hsla(0, 0%, 0%, 0.1);
-        border-left: 1px solid hsl(0, 0%, 86%);
+        border-left: 1px solid hsl(0, 0%, 87%);
         margin-top: 40px;
         padding: 10px 15px 0px 15px;
         height: 100%;
@@ -114,7 +114,7 @@
     .column-left.expanded .left-sidebar {
         background-color: hsla(0, 0%, 100%, 1.0);
         box-shadow: 0px 2px 3px 0px hsla(0, 0%, 0%, 0.1);
-        border-right: 1px solid hsl(0, 0%, 86%);
+        border-right: 1px solid hsl(0, 0%, 87%);
         margin-top: 40px;
         padding-top: 10px;
         height: 100%;

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -38,11 +38,11 @@ body.night-mode {
     }
 
     .modal-bg {
-        background: hsl(212, 28%, 18%);
+        background-color: hsl(212, 28%, 18%);
     }
 
     .streams_popover .sp-container {
-        background: transparent;
+        background-color: transparent;
     }
 
     /* this one is because in the app we have blue and in night-mode it should be white. */
@@ -110,7 +110,7 @@ on a dark background, and don't change the dark labels dark either. */
     .pm_recipient .pill-container .pill {
         color: inherit;
         border: 1px solid hsla(0, 0%, 0%, 0.50);
-        background: hsla(0, 0%, 0%, 0.25);
+        background-color: hsla(0, 0%, 0%, 0.25);
         font-weight: 600;
     }
 
@@ -118,7 +118,7 @@ on a dark background, and don't change the dark labels dark either. */
     .pm_recipient .pill-container .pill:focus {
         color: hsl(0, 0%, 100%);
         border: 1px solid hsla(176, 78%, 28%, 0.6);
-        background: hsla(176, 49%, 42%, 0.4);
+        background-color: hsla(176, 49%, 42%, 0.4);
     }
 
     .new-style .button.no-style {
@@ -153,7 +153,7 @@ on a dark background, and don't change the dark labels dark either. */
     .message-header-contents,
     .message_header_private_message .message-header-contents,
     #tab_list li.active {
-        background: hsla(0, 0%, 0%, 0.2);
+        background-color: hsla(0, 0%, 0%, 0.2);
     }
 
     .message-header-contents,
@@ -359,7 +359,7 @@ on a dark background, and don't change the dark labels dark either. */
     }
 
     .user-mention-me {
-        background: hsla(355, 37%, 31%, 1);
+        background-color: hsla(355, 37%, 31%, 1);
         box-shadow: 0px 0px 0px 1px hsla(330, 40%, 20%, 1);
     }
 
@@ -381,7 +381,7 @@ on a dark background, and don't change the dark labels dark either. */
 
     .alert.alert-error,
     .alert.alert-danger {
-        background: hsl(318, 12%, 21%);
+        background-color: hsl(318, 12%, 21%);
         color: inherit;
         border: 1px solid hsl(0, 75%, 65%);
     }
@@ -392,7 +392,7 @@ on a dark background, and don't change the dark labels dark either. */
 
     .alert-box .alert,
     .alert.alert-error {
-        background: hsl(318, 12%, 21%);
+        background-color: hsl(318, 12%, 21%);
         color: inherit;
         border: 1px solid hsl(0, 75%, 65%);
     }
@@ -509,7 +509,7 @@ on a dark background, and don't change the dark labels dark either. */
     }
 
     .ps__rail-y {
-        background: hsl(212, 28%, 18%);
+        background-color: hsl(212, 28%, 18%);
     }
 
     #bots_lists_navbar .active a {

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -116,7 +116,7 @@ on a dark background, and don't change the dark labels dark either. */
 
     #search_arrows .pill:focus,
     .pm_recipient .pill-container .pill:focus {
-        color: #fff;
+        color: hsl(0, 0%, 100%);
         border: 1px solid hsla(176, 78%, 28%, 0.6);
         background: hsla(176, 49%, 42%, 0.4);
     }
@@ -513,9 +513,9 @@ on a dark background, and don't change the dark labels dark either. */
     }
 
     #bots_lists_navbar .active a {
-        color: #ddd;
+        color: hsl(0, 0%, 87%);
         background-color: hsl(212, 28%, 18%);
-        border-color: #ddd;
+        border-color: hsl(0, 0%, 87%);
         border-bottom-color: transparent;
     }
 

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -376,7 +376,7 @@ on a dark background, and don't change the dark labels dark either. */
     .alert.alert-success {
         color: inherit;
         background-color: hsla(161, 60%, 46%, 0.20);
-        border-color: #1e9e7f;
+        border-color: hsl(165, 68%, 37%);
     }
 
     .alert.alert-error,
@@ -501,11 +501,11 @@ on a dark background, and don't change the dark labels dark either. */
     }
 
     .email_tooltip {
-        background-color: #404c59;
+        background-color: hsl(211, 16%, 30%);
     }
 
     .email_tooltip::after {
-        border-bottom-color: #404c59 !important;
+        border-bottom-color: hsl(211, 16%, 30%) !important;
     }
 
     .ps__rail-y {

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -34,7 +34,7 @@
 }
 
 .streams_popover .sp-container {
-    background: hsl(0, 0%, 100%);
+    background-color: hsl(0, 0%, 100%);
     cursor: pointer;
     border: none;
 }

--- a/static/styles/portico-signin.scss
+++ b/static/styles/portico-signin.scss
@@ -478,7 +478,7 @@ html {
     color: hsl(0, 0%, 66%);
     border: 1px solid hsl(0, 0%, 86%);
     border-radius: 4px;
-    background: transparent;
+    background-color: transparent;
 
     transition: color 0.3s ease, border 0.3s ease;
 }

--- a/static/styles/portico-signin.scss
+++ b/static/styles/portico-signin.scss
@@ -339,7 +339,7 @@ html {
 
     width: 280px;
 
-    border: 1px solid hsl(0, 0%, 86%);
+    border: 1px solid hsl(0, 0%, 87%);
     box-shadow: none;
     border-radius: 4px;
 
@@ -366,7 +366,7 @@ html {
     transform: translateY(35px) translateX(14px);
     font-size: 1.2rem;
     font-weight: 400;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
 
     pointer-events: none;
 }
@@ -466,7 +466,7 @@ html {
 
 .portico-page .pitch p {
     font-weight: 400;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
 }
 
 .register-account .pitch {
@@ -475,8 +475,8 @@ html {
 }
 
 .login-page-container input[type=submit] {
-    color: hsl(0, 0%, 66%);
-    border: 1px solid hsl(0, 0%, 86%);
+    color: hsl(0, 0%, 67%);
+    border: 1px solid hsl(0, 0%, 87%);
     border-radius: 4px;
     background-color: transparent;
 
@@ -541,7 +541,7 @@ html {
 
 .info-box .organization-path {
     font-weight: 400;
-    color: hsl(0, 0%, 46%);
+    color: hsl(0, 0%, 47%);
     margin-top: 5px;
 }
 
@@ -574,7 +574,7 @@ html {
     left: 0;
     z-index: -1;
 
-    border-bottom: 2px solid hsl(0, 0%, 86%);
+    border-bottom: 2px solid hsl(0, 0%, 87%);
 }
 
 .portico-page .or span {
@@ -778,7 +778,7 @@ button.login-google-button {
     font-weight: 400;
     font-size: 1.2rem;
 
-    background-color: hsl(0, 0%, 86%);
+    background-color: hsl(0, 0%, 87%);
 }
 
 #registration .center-block .pitch {

--- a/static/styles/portico-signin.scss
+++ b/static/styles/portico-signin.scss
@@ -20,14 +20,14 @@ html {
     padding: 30px;
     min-width: 0px;
 
-    background-color: #fff;
+    background-color: hsl(0, 0%, 100%);
     box-shadow: 0px 0px 4px hsla(0, 0%, 0%, 0.1);
-    border: 1px solid #ddd;
+    border: 1px solid hsl(0, 0%, 87%);
     border-radius: 4px;
 }
 
 .grey {
-    color: #aaa;
+    color: hsl(0, 0%, 67%);
 }
 
 .find-account-page-container #find_account i {
@@ -83,7 +83,7 @@ html {
 .register-page-container.closed-realm .invite-required {
     display: block;
 
-    color: #aaa;
+    color: hsl(0, 0%, 67%);
     font-weight: normal;
 }
 
@@ -184,7 +184,7 @@ html {
 }
 
 .header {
-    background-color: #fff;
+    background-color: hsl(0, 0%, 100%);
     position: fixed;
     width: 100%;
     top: 0;
@@ -200,8 +200,8 @@ html {
 }
 
 .header .header-main .logo .brand-logo path {
-    fill: #fff !important;
-    stroke: #fff !important;
+    fill: hsl(0, 0%, 100%) !important;
+    stroke: hsl(0, 0%, 100%) !important;
 }
 
 .new-style {
@@ -442,7 +442,7 @@ html {
     font-weight: 400;
     box-sizing: border-box;
     outline: none;
-    color: #fff;
+    color: hsl(0, 0%, 100%);
     background-color: hsl(213, 23%, 25%);
 
     border: none;
@@ -592,11 +592,11 @@ button.login-social-button {
     margin-left: 0px;
     margin-top: 0px;
 
-    color: #fff;
+    color: hsl(0, 0%, 100%);
 }
 
 button.login-social-button {
-    background-color: #fff;
+    background-color: hsl(0, 0%, 100%);
     box-shadow: 0px 1px 3px hsla(0, 0%, 0%, 0.3), 0px 0px 5px hsla(0, 0%, 0%, 0.1);
     color: hsl(0, 0%, 34%);
 }

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -309,7 +309,7 @@ body {
     vertical-align: top;
     padding: 3px 6.5px 3px 7.5px;
     margin-right: 5px;
-    background-color: hsl(170, 47%, 54%);
+    background-color: hsl(170, 48%, 54%);
     color: white;
     border-radius: 100%;
     font-size: 0.9em;
@@ -392,7 +392,7 @@ li div.codehilite {
 
     color: hsl(0, 0%, 27%);
 
-    border: 1px solid hsl(0, 0%, 86%);
+    border: 1px solid hsl(0, 0%, 87%);
     border-radius: 4px;
     background-color: hsl(0, 0%, 98%);
 }
@@ -1350,7 +1350,7 @@ input.new-organization-button {
 .footer-navigation li a {
     display: inline-block;
     vertical-align: middle;
-    color: hsl(0, 0%, 46%);
+    color: hsl(0, 0%, 47%);
     font-size: 0.9em;
     font-weight: 400;
     cursor: pointer;
@@ -1397,7 +1397,7 @@ input.new-organization-button {
 .button-muted {
     display: block;
     font-size: 12px;
-    color: hsl(0, 0%, 86%);
+    color: hsl(0, 0%, 87%);
 }
 
 /* -- password reset container -- */
@@ -2062,7 +2062,7 @@ input.new-organization-button {
 
 .input-group.grid {
     padding: 10px 0px;
-    border-bottom: 1px solid hsl(0, 0%, 86%);
+    border-bottom: 1px solid hsl(0, 0%, 87%);
 }
 
 label.label-title {

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -1,5 +1,5 @@
 body {
-    background-color: #fafafa;
+    background-color: hsl(0, 0%, 98%);
 }
 
 .noscroll {
@@ -104,7 +104,7 @@ body {
 .code-section .blocks {
     padding: 20px;
 
-    background-color: #fafafa;
+    background-color: hsl(0, 0%, 98%);
     border: 1px solid #ddd;
 
     border-radius: 0px 4px 4px 4px;
@@ -343,7 +343,7 @@ ol > li > div.codehilite,
 }
 
 li div.codehilite {
-    background-color: #ffffff;
+    background-color: hsl(0, 0%, 100%);
 }
 
 .portico-landing.integrations ol ul {
@@ -743,7 +743,7 @@ input.text-error {
 }
 
 .portico-header .dropdown ul li:hover {
-    background: linear-gradient(to bottom, #08c, #0077b3);
+    background: linear-gradient(to bottom, #08c, hsl(200, 100%, 35%));
     transition: none;
 }
 
@@ -1190,14 +1190,14 @@ input#terminal:checked ~ #tab-terminal {
 }
 
 .btn-user {
-    background-color: #ffffff;
+    background-color: hsl(0, 0%, 100%);
     border-color: hsl(169, 44%, 54%);
     border-style: solid;
     color: hsl(170, 40%, 41%);
 }
 
 .btn-admin {
-    background-color: #ffffff;
+    background-color: hsl(0, 0%, 100%);
     border-color: hsl(198, 100%, 48%);
     border-style: solid;
     color: hsl(207, 89%, 54%);
@@ -1746,7 +1746,7 @@ input.new-organization-button {
 .error_page {
     padding: 20px 0px;
     min-height: calc(100vh - 290px);
-    background-color: #c9e9e0;
+    background-color: hsl(163, 42%, 85%);
     font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif;
 }
 
@@ -1764,10 +1764,10 @@ input.new-organization-button {
 
 .error_page .errorbox {
     margin: auto;
-    border: 2px solid #44a98c;
+    border: 2px solid hsl(163, 43%, 46%);
     max-width: 500px;
     background-color: white;
-    box-shadow: 0 0 4px #44a98c;
+    box-shadow: 0 0 4px hsl(163, 43%, 46%);
     font-size: 18px;
 }
 
@@ -1776,7 +1776,7 @@ input.new-organization-button {
 }
 
 .error_page p {
-    color: #333333;
+    color: hsl(0, 0%, 20%);
 }
 
 .error_page .errorcontent {
@@ -1785,7 +1785,7 @@ input.new-organization-button {
 }
 
 .error_page .lead {
-    color: #39a688;
+    color: hsl(163, 49%, 44%);
     font-size: 35px;
     margin-bottom: 20px;
     line-height: normal;

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -44,7 +44,7 @@ body {
     padding: 6px 0px;
     height: 29px;
 
-    background-color: #fff;
+    background-color: hsl(0, 0%, 100%);
     box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.1);
 
     z-index: 100;
@@ -90,7 +90,7 @@ body {
     padding: 3px 10px;
     margin: 0;
 
-    border: 1px solid #ddd;
+    border: 1px solid hsl(0, 0%, 87%);
     border-bottom: none;
     border-radius: 4px 4px 0px 0px;
 
@@ -105,7 +105,7 @@ body {
     padding: 20px;
 
     background-color: hsl(0, 0%, 98%);
-    border: 1px solid #ddd;
+    border: 1px solid hsl(0, 0%, 87%);
 
     border-radius: 0px 4px 4px 4px;
 }
@@ -634,7 +634,7 @@ input.text-error {
 }
 
 .footer section ul {
-    color: #aaa;
+    color: hsl(0, 0%, 67%);
 
     list-style-type: none;
     margin-left: 0;
@@ -662,7 +662,7 @@ input.text-error {
 
     font-size: 1.2rem;
     font-weight: 400;
-    color: #333;
+    color: hsl(0, 0%, 20%);
     opacity: 0.5;
 }
 
@@ -677,7 +677,7 @@ input.text-error {
     margin-top: 8px;
     margin-left: 10px;
 
-    color: #fff;
+    color: hsl(0, 0%, 100%);
     font-size: 1.2rem;
     font-weight: 600;
     letter-spacing: 0.1em;
@@ -704,11 +704,11 @@ input.text-error {
     list-style-type: none;
     width: 200px;
 
-    background: #fff;
+    background: hsl(0, 0%, 100%);
     padding: 5px 0px;
 
     border-radius: 4px;
-    border: 1px solid #ddd;
+    border: 1px solid hsl(0, 0%, 87%);
     box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.1);
 }
 
@@ -724,7 +724,7 @@ input.text-error {
     right: 9px;
 
     font-size: 0.5em;
-    color: #ddd;
+    color: hsl(0, 0%, 87%);
 
     line-height: 0;
 
@@ -743,7 +743,7 @@ input.text-error {
 }
 
 .portico-header .dropdown ul li:hover {
-    background: linear-gradient(to bottom, #08c, hsl(200, 100%, 35%));
+    background: linear-gradient(to bottom, hsl(163, 92%, 39%), hsl(200, 100%, 35%));
     transition: none;
 }
 
@@ -755,12 +755,12 @@ input.text-error {
     font-size: 0.9em;
     font-weight: 400;
 
-    color: #444;
+    color: hsl(0, 0%, 27%);
 }
 
 .portico-header .dropdown ul li:hover a {
     background: transparent;
-    color: #fff;
+    color: hsl(0, 0%, 100%);
 }
 
 .portico-header .dropdown ul li a i {
@@ -826,7 +826,7 @@ input.text-error {
 }
 
 a.bottom-signup-button {
-    color: #fff !important;
+    color: hsl(0, 0%, 100%) !important;
     text-decoration: none !important;
     font-size: 20px;
     padding: 20px;
@@ -878,7 +878,7 @@ a.bottom-signup-button {
 }
 
 .table.table-striped {
-    background: #fff;
+    background: hsl(0, 0%, 100%);
     box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.1);
 }
 
@@ -975,9 +975,9 @@ a.bottom-signup-button {
 }
 
 .team input:checked + label {
-    border: 1px solid #eee;
+    border: 1px solid hsl(0, 0%, 93%);
     border-top: 2px solid yellowgreen;
-    border-bottom-color: #fff;
+    border-bottom-color: hsl(0, 0%, 100%);
 }
 
 .contributors-list {
@@ -998,7 +998,7 @@ input#python-zulip-api:checked ~ #tab-python-zulip-api,
 input#zulip-js:checked ~ #tab-zulip-js,
 input#zulipbot:checked ~ #tab-zulipbot,
 input#terminal:checked ~ #tab-terminal {
-    border-top: 1px solid #eee;
+    border-top: 1px solid hsl(0, 0%, 93%);
     padding-top: 20px;
     display: grid;
     grid-gap: 5px;
@@ -1012,13 +1012,13 @@ input#terminal:checked ~ #tab-terminal {
 .contributors .person {
     box-sizing: border-box;
     padding: 10px;
-    border: 1px solid #eee;
+    border: 1px solid hsl(0, 0%, 93%);
     border-radius: 4px;
     transition: all 0.3s ease;
 }
 
 .contributors .person:hover {
-    border: 1px solid #bbb;
+    border: 1px solid hsl(0, 0%, 73%);
 }
 
 .contributors .person .avatar {
@@ -1046,7 +1046,7 @@ input#terminal:checked ~ #tab-terminal {
 
 .tab-loading,
 .last-updated {
-    color: #aaa;
+    color: hsl(0, 0%, 67%);
     font-size: 0.9em !important;
     padding-top: 30px;
     text-align: center;
@@ -1373,7 +1373,7 @@ input.new-organization-button {
 
 .top-links a {
     display: inline-block;
-    color: #fff;
+    color: hsl(0, 0%, 100%);
     padding: 2px 7px 1px 8px;
     font-weight: 600;
     font-size: 16px;
@@ -1529,7 +1529,7 @@ input.new-organization-button {
 }
 
 .help .markdown {
-    background-color: #fff;
+    background-color: hsl(0, 0%, 100%);
     width: calc(100vw - 300px);
     height: calc(100vh - 59px);
 }
@@ -1537,7 +1537,7 @@ input.new-organization-button {
 .markdown .content {
     padding: 30px;
     max-width: 768px;
-    background: #fff;
+    background: hsl(0, 0%, 100%);
 }
 
 .markdown a {
@@ -1591,7 +1591,7 @@ input.new-organization-button {
 
 .markdown h1,
 .why-page .main h1 {
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid hsl(0, 0%, 93%);
     padding-bottom: 10px;
     margin-bottom: 15px;
 }
@@ -1620,7 +1620,7 @@ input.new-organization-button {
 .markdown img {
     vertical-align: top;
     box-shadow: 0px 0px 4px hsla(0, 0%, 0%, 0.05);
-    border: 1px solid #ddd;
+    border: 1px solid hsl(0, 0%, 87%);
     border-radius: 4px;
 }
 
@@ -2095,7 +2095,7 @@ input.new-organization-button {
     font-weight: 400;
 
     background-color: hsl(207, 55%, 53%);
-    color: #fff;
+    color: hsl(0, 0%, 100%);
     outline: none;
     border: none;
     border-radius: 2px;
@@ -2119,7 +2119,7 @@ input.new-organization-button {
 
 .button-new.sea-green {
     background-color: hsl(177, 70%, 46%);
-    color: #fff;
+    color: hsl(0, 0%, 100%);
 }
 
 .float-left {

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -310,7 +310,7 @@ body {
     padding: 3px 6.5px 3px 7.5px;
     margin-right: 5px;
     background-color: hsl(170, 48%, 54%);
-    color: white;
+    color: hsl(0, 0%, 100%);
     border-radius: 100%;
     font-size: 0.9em;
     line-height: 1.1;
@@ -415,11 +415,11 @@ li div.codehilite {
 }
 
 a.title {
-    color: black;
+    color: hsl(0, 0%, 0%);
 }
 
 a.title:hover {
-    color: gray;
+    color: hsl(0, 0%, 50%);
     text-decoration: none;
 }
 
@@ -560,7 +560,7 @@ img.screenshot {
 
 .darker-background {
     background-color: hsl(0, 0%, 28%);
-    color: white;
+    color: hsl(0, 0%, 100%);
 }
 
 .alert-hidden {
@@ -574,8 +574,8 @@ label.text-error {
 }
 
 input.text-error {
-    border-color: red;
-    outline-color: red;
+    border-color: hsl(0, 100%, 50%);
+    outline-color: hsl(0, 100%, 50%);
 }
 
 .portico-container {
@@ -1300,7 +1300,7 @@ input.new-organization-button {
 .main-headline-text {
     display: block;
     text-align: center;
-    color: black;
+    color: hsl(0, 0%, 0%);
     font-weight: 300;
 }
 
@@ -1312,7 +1312,7 @@ input.new-organization-button {
 .main-headline-text .footnote {
     display: block;
     font-size: 18px;
-    color: black;
+    color: hsl(0, 0%, 0%);
     margin-top: 15px;
 }
 
@@ -1766,7 +1766,7 @@ input.new-organization-button {
     margin: auto;
     border: 2px solid hsl(163, 43%, 46%);
     max-width: 500px;
-    background-color: white;
+    background-color: hsl(0, 0%, 100%);
     box-shadow: 0 0 4px hsl(163, 43%, 46%);
     font-size: 18px;
 }

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -704,7 +704,7 @@ input.text-error {
     list-style-type: none;
     width: 200px;
 
-    background: hsl(0, 0%, 100%);
+    background-color: hsl(0, 0%, 100%);
     padding: 5px 0px;
 
     border-radius: 4px;
@@ -759,7 +759,7 @@ input.text-error {
 }
 
 .portico-header .dropdown ul li:hover a {
-    background: transparent;
+    background-color: transparent;
     color: hsl(0, 0%, 100%);
 }
 
@@ -878,7 +878,7 @@ a.bottom-signup-button {
 }
 
 .table.table-striped {
-    background: hsl(0, 0%, 100%);
+    background-color: hsl(0, 0%, 100%);
     box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.1);
 }
 
@@ -1063,7 +1063,7 @@ input#terminal:checked ~ #tab-terminal {
 
 .integration-lozenge-static:hover {
     box-shadow: none;
-    background: hsl(0, 0%, 93%);
+    background-color: hsl(0, 0%, 93%);
 }
 
 .integration-lozenge .integration-link:hover {
@@ -1537,7 +1537,7 @@ input.new-organization-button {
 .markdown .content {
     padding: 30px;
     max-width: 768px;
-    background: hsl(0, 0%, 100%);
+    background-color: hsl(0, 0%, 100%);
 }
 
 .markdown a {

--- a/static/styles/pygments.scss
+++ b/static/styles/pygments.scss
@@ -6,7 +6,7 @@
     background-color: hsl(60, 100%, 90%);
 }
 .codehilite {
-    background-color: hsl(0, 0%, 97%);
+    background-color: hsl(0, 0%, 98%);
 }
 .codehilite .c {
     color: hsl(180, 33%, 37%);
@@ -29,7 +29,7 @@
     color: hsl(38, 100%, 36%);
 } /* Comment.Preproc */
 .codehilite .c1 {
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
     font-style: italic;
 } /* Comment.Single */
 .codehilite .cs {

--- a/static/styles/pygments.scss
+++ b/static/styles/pygments.scss
@@ -6,7 +6,7 @@
     background-color: hsl(60, 100%, 90%);
 }
 .codehilite {
-    background: hsl(0, 0%, 97%);
+    background-color: hsl(0, 0%, 97%);
 }
 .codehilite .c {
     color: hsl(180, 33%, 37%);

--- a/static/styles/pygments.scss
+++ b/static/styles/pygments.scss
@@ -13,7 +13,7 @@
     font-style: italic;
 } /* Comment */
 .codehilite .err {
-    border: 1px solid #ff0000;
+    border: 1px solid hsl(0, 100%, 50%);
 } /* Error */
 .codehilite .k {
     color: hsl(332, 70%, 38%);
@@ -214,8 +214,8 @@
 
 body.night-mode .codehilite code,
 body.night-mode .codehilite pre {
-    color: #a2cdff;
-    background-color: #1c252f;
+    color: hsl(212, 100%, 82%);
+    background-color: hsl(212, 25%, 15%);
 }
 
 body.night-mode .codehilite .hll {
@@ -223,25 +223,25 @@ body.night-mode .codehilite .hll {
 }
 
 body.night-mode .codehilite .err {
-    color: #e37170;
-    background-color: #3d3535;
+    color: hsl(1, 67%, 66%);
+    background-color: hsl(0, 7%, 22%);
 }
 
 body.night-mode .codehilite .k {
-    color: #ef9b3f;
+    color: hsl(31, 85%, 59%);
 }
 
 body.night-mode .codehilite .p {
-    color: #41706f;
+    color: hsl(179, 27%, 35%);
 }
 
 body.night-mode .codehilite .cs {
-    color: #cd0000;
+    color: hsl(0, 100%, 40%);
     font-weight: 700;
 }
 
 body.night-mode .codehilite .gd {
-    color: #cd0000;
+    color: hsl(0, 100%, 40%);
 }
 
 body.night-mode .codehilite .ge {
@@ -268,45 +268,45 @@ body.night-mode .codehilite .gu {
 }
 
 body.night-mode .codehilite .gt {
-    color: #0040d0;
+    color: hsl(222, 100%, 41%);
 }
 
 body.night-mode .codehilite .kc {
-    color: #dca3a3;
+    color: hsl(0, 45%, 75%);
 }
 
 body.night-mode .codehilite .kd {
-    color: #ffff86;
+    color: hsl(60, 100%, 76%);
 }
 
 body.night-mode .codehilite .kn {
-    color: #dfaf8f;
+    color: hsl(24, 56%, 72%);
     font-weight: 700;
 }
 
 body.night-mode .codehilite .kp {
-    color: #cdcf99;
+    color: hsl(62, 36%, 71%);
 }
 
 body.night-mode .codehilite .kr {
-    color: #d04e50;
+    color: hsl(359, 58%, 56%);
 }
 
 body.night-mode .codehilite .ni {
-    color: #c28182;
+    color: hsl(359, 35%, 63%);
 }
 
 body.night-mode .codehilite .ne {
-    color: #c3bf9f;
+    color: hsl(53, 23%, 69%);
     font-weight: 700;
 }
 
 body.night-mode .codehilite .nn {
-    color: #8fbede;
+    color: hsl(204, 54%, 72%);
 }
 
 body.night-mode .codehilite .vi {
-    color: #ffffc7;
+    color: hsl(60, 100%, 89%);
 }
 
 body.night-mode .codehilite .c,
@@ -314,7 +314,7 @@ body.night-mode .codehilite .g,
 body.night-mode .codehilite .cm,
 body.night-mode .codehilite .cp,
 body.night-mode .codehilite .c1 {
-    color: #7d8e9e;
+    color: hsl(209, 15%, 55%);
 }
 
 body.night-mode .codehilite .l,
@@ -331,23 +331,23 @@ body.night-mode .codehilite .w {
 body.night-mode .codehilite .n,
 body.night-mode .codehilite .nv,
 body.night-mode .codehilite .vg {
-    color: #dcdccc;
+    color: hsl(60, 19%, 83%);
 }
 
 body.night-mode .codehilite .o,
 body.night-mode .codehilite .ow {
-    color: #f0efd0;
+    color: hsl(58, 52%, 88%);
 }
 
 body.night-mode .codehilite .gh,
 body.night-mode .codehilite .gp {
-    color: #dcdccc;
+    color: hsl(60, 19%, 83%);
     font-weight: 700;
 }
 
 body.night-mode .codehilite .gi,
 body.night-mode .codehilite .kt {
-    color: #00cd00;
+    color: hsl(120, 100%, 40%);
 }
 
 body.night-mode .codehilite .ld,
@@ -363,7 +363,7 @@ body.night-mode .codehilite .sx,
 body.night-mode .codehilite .sr,
 body.night-mode .codehilite .s1,
 body.night-mode .codehilite .ss {
-    color: #cc9393;
+    color: hsl(0, 36%, 69%);
 }
 
 body.night-mode .codehilite .m,
@@ -372,12 +372,12 @@ body.night-mode .codehilite .mh,
 body.night-mode .codehilite .mi,
 body.night-mode .codehilite .mo,
 body.night-mode .codehilite .il {
-    color: #8cd0d3;
+    color: hsl(183, 45%, 69%);
 }
 
 body.night-mode .codehilite .na,
 body.night-mode .codehilite .nt {
-    color: #9ac39f;
+    color: hsl(127, 25%, 68%);
 }
 
 body.night-mode .codehilite .nb,
@@ -385,5 +385,5 @@ body.night-mode .codehilite .nc,
 body.night-mode .codehilite .nf,
 body.night-mode .codehilite .bp,
 body.night-mode .codehilite .vc {
-    color: #efef8f;
+    color: hsl(60, 75%, 75%);
 }

--- a/static/styles/pygments.scss
+++ b/static/styles/pygments.scss
@@ -219,7 +219,7 @@ body.night-mode .codehilite pre {
 }
 
 body.night-mode .codehilite .hll {
-    background-color: #222;
+    background-color: hsl(0, 0%, 13%);
 }
 
 body.night-mode .codehilite .err {
@@ -245,7 +245,7 @@ body.night-mode .codehilite .gd {
 }
 
 body.night-mode .codehilite .ge {
-    color: #ccc;
+    color: hsl(0, 0%, 80%);
     font-style: italic;
 }
 
@@ -258,7 +258,7 @@ body.night-mode .codehilite .go {
 }
 
 body.night-mode .codehilite .gs {
-    color: #ccc;
+    color: hsl(0, 0%, 80%);
     font-weight: 700;
 }
 
@@ -325,7 +325,7 @@ body.night-mode .codehilite .nl,
 body.night-mode .codehilite .nx,
 body.night-mode .codehilite .py,
 body.night-mode .codehilite .w {
-    color: #ccc;
+    color: hsl(0, 0%, 80%);
 }
 
 body.night-mode .codehilite .n,

--- a/static/styles/pygments.scss
+++ b/static/styles/pygments.scss
@@ -250,11 +250,11 @@ body.night-mode .codehilite .ge {
 }
 
 body.night-mode .codehilite .gr {
-    color: red;
+    color: hsl(0, 100%, 50%);
 }
 
 body.night-mode .codehilite .go {
-    color: gray;
+    color: hsl(0, 0%, 50%);
 }
 
 body.night-mode .codehilite .gs {
@@ -263,7 +263,7 @@ body.night-mode .codehilite .gs {
 }
 
 body.night-mode .codehilite .gu {
-    color: purple;
+    color: hsl(300, 100%, 25%);
     font-weight: 700;
 }
 

--- a/static/styles/reactions.scss
+++ b/static/styles/reactions.scss
@@ -20,7 +20,7 @@
 }
 
 .private-message .message_reactions .message_reaction {
-    background-color: hsl(192, 19%, 95%);
+    background-color: hsl(192, 20%, 95%);
 }
 
 .message_reactions .message_reaction.reacted {

--- a/static/styles/reactions.scss
+++ b/static/styles/reactions.scss
@@ -28,7 +28,7 @@
 }
 
 .emoji-popover-emoji.reacted.reaction:focus {
-    background: hsl(195, 55%, 88%);
+    background-color: hsl(195, 55%, 88%);
     outline: none;
 }
 
@@ -267,7 +267,7 @@
 }
 
 .emoji-popover-category-tabs .emoji-popover-tab-item.active {
-    background: hsla(0, 0%, 100%, 0.2);
+    background-color: hsla(0, 0%, 100%, 0.2);
 }
 
 .typeahead .emoji {

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -88,7 +88,7 @@
     background: -o-linear-gradient(top, hsla(0, 0%, 100%, 0.0) 50%, hsla(29, 84%, 51%, 1.0) 50%); /* Opera 11.10+ */
     background: -ms-linear-gradient(top, hsla(0, 0%, 100%, 0.0) 50%, hsla(29, 84%, 51%, 1.0) 50%); /* IE10+ */
     background: linear-gradient(to bottom, hsla(0, 0%, 100%, 0.0) 50%, hsla(29, 84%, 51%, 1.0) 50%); /* W3C */
-    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#ec7e18', GradientType=0 ); /* IE6-9 */
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#ec7e18', GradientType=0 ); /* IE6-9; filters only work with hex colors */
 }
 
 .user-status-indicator {

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -153,7 +153,7 @@
 .group-pms-sidebar-entry .count {
     float: right;
     padding: 0 4px;
-    background: hsl(105, 2%, 50%);
+    background-color: hsl(105, 2%, 50%);
     border-radius: 0px;
     color: hsl(0, 0%, 100%);
     font-size: 12px;

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -405,7 +405,7 @@ input[type=checkbox] + .inline-block {
 #settings_page .icon-button.primary .icon-button-icon {
     font-size: 15px;
     font-weight: lighter;
-    color: white;
+    color: hsl(0, 0%, 100%);
 }
 
 #settings_page .save-button-controls {
@@ -1041,7 +1041,7 @@ input[type=checkbox].inline-block {
 }
 
 .white-color {
-    color: white;
+    color: hsl(0, 0%, 100%);
 }
 
 #realm-settings-icon {
@@ -1775,7 +1775,7 @@ thead .actions {
 .custom_user_field .pill-container {
     padding: 2px 6px;
     height: 24px;
-    background-color: white;
+    background-color: hsl(0, 0%, 100%);
 }
 
 .custom_user_field .pill-container:focus-within {

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1146,7 +1146,7 @@ input[type=checkbox].inline-block {
 #user-groups .save-instructions {
     display: none;
     opacity: 0;
-    color: #333;
+    color: hsl(0, 0%, 20%);
     font-size: 0.9em;
 }
 

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1401,7 +1401,7 @@ input[type=checkbox].inline-block {
 }
 
 body:not(.night-mode) #account-settings .custom_user_field .datepicker {
-    background-color: #ffffff;
+    background-color: hsl(0, 0%, 100%);
 }
 
 #settings_page .custom_user_field textarea {
@@ -1590,7 +1590,7 @@ input[type=text]#settings_search {
 }
 
 .subsection-failed-status p {
-    background: #f2dede;
+    background: hsl(0, 43%, 91%);
     padding: 2px 6px;
     border-radius: 4px;
     margin: 0 0 0 5px;

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -375,7 +375,7 @@ input[type=checkbox] + .inline-block {
 }
 
 #settings_page .icon-button:hover {
-    background: hsl(0, 0%, 100%);
+    background-color: hsl(0, 0%, 100%);
     border: 1px solid hsl(0, 0%, 61%);
     color: hsl(0, 0%, 18%);
 }
@@ -422,7 +422,7 @@ input[type=checkbox] + .inline-block {
 }
 
 #settings_page .icon-button.save-button.saving {
-    background: hsl(156, 14%, 40%);
+    background-color: hsl(156, 14%, 40%);
     border-color: hsl(156, 14%, 40%);
 }
 
@@ -559,7 +559,7 @@ input[type=checkbox].inline-block {
     height: auto !important;
     width: auto !important;
 
-    background: transparent;
+    background-color: transparent;
     border-radius: 4px;
     margin-top: 14px;
     margin-left: 10px;
@@ -1590,7 +1590,7 @@ input[type=text]#settings_search {
 }
 
 .subsection-failed-status p {
-    background: hsl(0, 43%, 91%);
+    background-color: hsl(0, 43%, 91%);
     padding: 2px 6px;
     border-radius: 4px;
     margin: 0 0 0 5px;

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -150,7 +150,7 @@ label {
 }
 
 .table tbody {
-    border-bottom: 1px solid hsl(0, 0%, 86%);
+    border-bottom: 1px solid hsl(0, 0%, 87%);
 }
 
 .table-condensed td {
@@ -312,12 +312,12 @@ td .button {
 
 .dynamic-input div:empty::after {
     content: "username";
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
 }
 
 .dynamic-input.bot_user_name div:empty::after {
     content: "bot_user_name";
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
 }
 
 .button,
@@ -369,7 +369,7 @@ input[type=checkbox] + .inline-block {
     font-size: 14px;
     padding: 3px 14px 4px 11px;
     text-decoration: none;
-    color: hsl(0, 0%, 46%);
+    color: hsl(0, 0%, 47%);
     min-width: 80px;
     line-height: 16px;
 }
@@ -693,7 +693,7 @@ input[type=checkbox].inline-block {
 }
 
 .add-new-emoji-box #emoji-file-name {
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
 }
 
 .add-new-profile-field-box button,
@@ -772,7 +772,7 @@ input[type=checkbox].inline-block {
 .bots_list .regenerate_bot_api_key {
     position: relative;
     margin-left: 5px;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
     transition: all 0.3s ease;
 }
 
@@ -861,7 +861,7 @@ input[type=checkbox].inline-block {
     font-weight: 300;
     text-transform: uppercase;
     font-weight: 600;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
 }
 
 .bot_error {
@@ -891,7 +891,7 @@ input[type=checkbox].inline-block {
 .edit_bot_form label {
     text-transform: uppercase;
     font-weight: 600;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
     margin-top: 5px;
 }
 
@@ -1177,7 +1177,7 @@ input[type=checkbox].inline-block {
 
 #settings_page .sidebar .tab-container {
     padding: 6px;
-    border-bottom: 1px solid hsl(0, 0%, 86%);
+    border-bottom: 1px solid hsl(0, 0%, 87%);
 }
 
 #settings_page .sidebar .normal-settings-list,
@@ -1197,7 +1197,7 @@ input[type=checkbox].inline-block {
 #settings_page .content-wrapper .settings-header {
     width: 100%;
     height: 43px;
-    border-bottom: 1px solid hsl(0, 0%, 86%);
+    border-bottom: 1px solid hsl(0, 0%, 87%);
 }
 
 #settings_page .content-wrapper .settings-header h1 .section {
@@ -1214,7 +1214,7 @@ input[type=checkbox].inline-block {
 
 #settings_page .settings-header.mobile {
     display: none;
-    border-bottom: 1px solid hsl(0, 0%, 86%);
+    border-bottom: 1px solid hsl(0, 0%, 87%);
 }
 
 .settings-header.mobile .fa-chevron-left {
@@ -1288,7 +1288,7 @@ input[type=checkbox].inline-block {
     height: calc(100% - 45px);
 
     background-color: hsl(0, 0%, 100%);
-    border-left: 1px solid hsl(0, 0%, 86%);
+    border-left: 1px solid hsl(0, 0%, 87%);
 
     pointer-events: none;
     transition: all 0.3s ease;
@@ -1328,7 +1328,7 @@ input[type=checkbox].inline-block {
 #settings_page .form-sidebar .title {
     padding: 10px 20px;
     background-color: hsl(0, 0%, 98%);
-    border-bottom: 1px solid hsl(0, 0%, 86%);
+    border-bottom: 1px solid hsl(0, 0%, 87%);
 }
 
 #settings_page .form-sidebar .title h1 {
@@ -1354,7 +1354,7 @@ input[type=checkbox].inline-block {
     text-transform: uppercase;
 
     background-color: hsl(180, 6%, 93%);
-    border-bottom: 1px solid hsl(0, 0%, 86%);
+    border-bottom: 1px solid hsl(0, 0%, 87%);
 }
 
 #settings_page .settings-header {
@@ -1374,7 +1374,7 @@ input[type=checkbox].inline-block {
     position: absolute;
     top: 10px;
     right: 10px;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
     cursor: pointer;
 }
 
@@ -1393,7 +1393,7 @@ input[type=checkbox].inline-block {
 }
 
 #account-settings .custom_user_field .field_hint {
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
 }
 
 #settings_page .custom_user_field {
@@ -1505,7 +1505,7 @@ input[type=text]#settings_search {
     font-size: 0.9rem;
     padding: 3px 5px;
     outline: none;
-    border: 1px solid hsl(0, 0%, 86%);
+    border: 1px solid hsl(0, 0%, 87%);
     border-radius: 4px;
 }
 
@@ -1513,7 +1513,7 @@ input[type=text]:focus#settings_search {
     box-shadow: none;
     border: 1px solid hsl(0, 0%, 73%);
 
-    border-bottom: 1px solid hsl(0, 0%, 86%);
+    border-bottom: 1px solid hsl(0, 0%, 87%);
 }
 
 input[type=text]#settings_search {
@@ -1714,7 +1714,7 @@ thead .actions {
     display: block;
 
     font-style: italic;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
 }
 
 .required-text.thick:empty::after {

--- a/static/styles/stats.scss
+++ b/static/styles/stats.scss
@@ -158,7 +158,7 @@ hr {
 }
 
 .button:hover {
-    background: hsl(0, 0%, 84%) !important;
+    background-color: hsl(0, 0%, 84%) !important;
 }
 
 .button[data-user="everyone"] {

--- a/static/styles/stats.scss
+++ b/static/styles/stats.scss
@@ -6,7 +6,7 @@
 
 body {
     font-family: 'Source Sans Pro', 'Helvetica Neue', sans-serif !important;
-    background-color: #fafafa;
+    background-color: hsl(0, 0%, 98%);
 
     -webkit-font-smoothing: antialiased;
 }
@@ -66,11 +66,11 @@ hr {
 }
 
 .buttons button {
-    background-color: #f0f0f0;
+    background-color: hsl(0, 0%, 94%);
 }
 
 .buttons button.selected {
-    background-color: #d8d8d8;
+    background-color: hsl(0, 0%, 85%);
 }
 
 .pie-chart .buttons {

--- a/static/styles/stats.scss
+++ b/static/styles/stats.scss
@@ -31,8 +31,8 @@ p {
     margin: 10px 0px;
     padding: 20px;
 
-    border: 2px solid #eee;
-    background-color: #fff;
+    border: 2px solid hsl(0, 0%, 93%);
+    background-color: hsl(0, 0%, 100%);
 }
 
 .analytics-page-header {
@@ -187,7 +187,7 @@ hr {
     font-size: 0.8em;
     font-weight: 400;
     text-align: center;
-    color: #aaa;
+    color: hsl(0, 0%, 67%);
 }
 
 @keyframes spinner {
@@ -207,8 +207,8 @@ hr {
     margin-top: -15px;
     margin-left: -15px;
     border-radius: 50%;
-    border: 1px solid #ccc;
-    border-top-color: #07d;
+    border: 1px solid hsl(0, 0%, 80%);
+    border-top-color: hsl(155, 93%, 42%);
     animation: spinner 1s linear infinite;
 }
 

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -1059,7 +1059,7 @@ form#add_new_subscription {
 
         top: 45px;
         border-top: 1px solid hsl(0, 0%, 86%);
-        background-color: #fff;
+        background-color: hsl(0, 0%, 100%);
         border-top: none;
 
         transition: all 0.3s ease;

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -112,8 +112,8 @@
     font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
     padding: 5px;
     font-size: 0.9em;
-    background-color: hsl(0, 0%, 97%);
-    border: 1px solid hsl(0, 0%, 86%);
+    background-color: hsl(0, 0%, 98%);
+    border: 1px solid hsl(0, 0%, 87%);
     border-radius: 4px;
 }
 
@@ -200,7 +200,7 @@ form#add_new_subscription {
     font-size: 2.2em;
     font-weight: 300;
     line-height: 1;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
 
     display: inline-block;
     transition: all 0.2s ease;
@@ -239,7 +239,7 @@ form#add_new_subscription {
 
 .subscriber-list-box {
     text-align: center;
-    border: 1px solid hsl(0, 0%, 86%);
+    border: 1px solid hsl(0, 0%, 87%);
     border-radius: 4px;
 }
 
@@ -293,7 +293,7 @@ form#add_new_subscription {
     display: block;
     padding: 5px;
     text-align: center;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
 }
 
 .subscriber-list tbody:empty::after,
@@ -302,7 +302,7 @@ form#add_new_subscription {
     display: block;
 
     text-align: center;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
 }
 
 .subscriber-list:empty {
@@ -395,7 +395,7 @@ form#add_new_subscription {
     text-align: center;
     text-transform: uppercase;
     font-weight: 700;
-    border-bottom: 1px solid hsl(0, 0%, 86%);
+    border-bottom: 1px solid hsl(0, 0%, 87%);
 }
 
 .subscriptions-header .fa-chevron-left {
@@ -407,7 +407,7 @@ form#add_new_subscription {
     position: relative;
     transform: translate(-50px, 0px);
     opacity: 0;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
 
     float: left;
     padding: 2px 10px;
@@ -434,7 +434,7 @@ form#add_new_subscription {
     position: absolute;
     top: 10px;
     right: 10px;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
     cursor: pointer;
 }
 
@@ -470,7 +470,7 @@ form#add_new_subscription {
 }
 
 .subscriptions-container .right .nothing-selected span {
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
 }
 
 .subscriptions-container .right .nothing-selected button {
@@ -480,12 +480,12 @@ form#add_new_subscription {
 }
 
 .subscriptions-container .left {
-    border-right: 1px solid hsl(0, 0%, 86%);
+    border-right: 1px solid hsl(0, 0%, 87%);
 }
 
 .subscriptions-container .left .search-container {
     padding: 6px 8px;
-    border-bottom: 1px solid hsl(0, 0%, 86%);
+    border-bottom: 1px solid hsl(0, 0%, 87%);
     display: flex;
     justify-content: space-between;
 }
@@ -494,7 +494,7 @@ form#add_new_subscription {
     padding: 6px;
     text-align: center;
     font-weight: 600;
-    border-bottom: 1px solid hsl(0, 0%, 86%);
+    border-bottom: 1px solid hsl(0, 0%, 87%);
 }
 
 .subscriptions-container .display-type.preview::after {
@@ -633,7 +633,7 @@ form#add_new_subscription {
 
 .stream-row:hover .check:not(.checked) svg,
 .stream-row.active:hover .check:not(.checked) svg {
-    fill: hsl(0, 0%, 86%);
+    fill: hsl(0, 0%, 87%);
 }
 
 .stream-row .check:not(.checked):hover svg,
@@ -646,7 +646,7 @@ form#add_new_subscription {
 }
 
 .stream-row .checked svg {
-    fill: hsl(170, 47%, 54%);
+    fill: hsl(170, 48%, 54%);
 }
 
 .stream-row .icon {
@@ -703,7 +703,7 @@ form#add_new_subscription {
 .stream-row .sub-info-box .top-bar .subscriber-count,
 .stream-row .sub-info-box .bottom-bar .stream-message-count {
     white-space: nowrap;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
 }
 
 .stream-row .sub-info-box .top-bar .subscriber-count-text,
@@ -726,7 +726,7 @@ form#add_new_subscription {
 .stream-row .sub-info-box .description:empty::after {
     content: attr(data-no-description);
     font-style: italic;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
 }
 
 #subscription_overlay #stream-creation {
@@ -749,7 +749,7 @@ form#add_new_subscription {
 .stream-row .settings-dropdown-trigger {
     float: right;
     margin-left: 10px;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
 }
 
 .add-user-label {
@@ -847,7 +847,7 @@ form#add_new_subscription {
 
 .editable-section[contenteditable=true] {
     display: inline-block;
-    color: hsl(170, 47%, 54%);
+    color: hsl(170, 48%, 54%);
 }
 
 .editable-section[contenteditable=true]:focus {
@@ -858,7 +858,7 @@ form#add_new_subscription {
     position: relative;
     top: -1px;
     margin-left: 5px;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
     cursor: pointer;
     font-size: 1.4rem;
     font-weight: 300;
@@ -886,7 +886,7 @@ form#add_new_subscription {
     display: none;
     margin-left: 5px;
     font-size: 0.9rem;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
 
     cursor: pointer;
 }
@@ -942,7 +942,7 @@ form#add_new_subscription {
 
 #stream_privacy_modal ul.grey-box li,
 #subscription_overlay ul.grey-box li {
-    border-bottom: 1px solid hsl(0, 0%, 86%);
+    border-bottom: 1px solid hsl(0, 0%, 87%);
     padding: 5px 0px;
 }
 
@@ -1058,7 +1058,7 @@ form#add_new_subscription {
         left: 101%;
 
         top: 45px;
-        border-top: 1px solid hsl(0, 0%, 86%);
+        border-top: 1px solid hsl(0, 0%, 87%);
         background-color: hsl(0, 0%, 100%);
         border-top: none;
 

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -607,12 +607,12 @@ form#add_new_subscription {
 
 .stream-row::-moz-selection,
 .stream-row .icon .hashtag::-moz-selection {
-    background: transparent;
+    background-color: transparent;
 }
 
 .stream-row::selection,
 .stream-row .icon .hashtag::selection {
-    background: transparent;
+    background-color: transparent;
 }
 
 .stream-row .check {
@@ -771,7 +771,7 @@ form#add_new_subscription {
     display: flex !important;
     justify-content: center;
     align-items: center;
-    background: hsla(0, 0%, 100%, 0.9);
+    background-color: hsla(0, 0%, 100%, 0.9);
     z-index: 1;
 }
 

--- a/static/styles/widgets.scss
+++ b/static/styles/widgets.scss
@@ -44,8 +44,8 @@
 }
 
 .poll-vote {
-    color: #3c906e;
-    border-color: #9dc8b7;
+    color: hsl(156, 41%, 40%);
+    border-color: hsl(156, 28%, 70%);
     margin-right: 4px;
     background-color: white;
 }
@@ -54,17 +54,17 @@ button.task {
     height: 20px;
     width: 20px;
     background-color: transparent;
-    border-color: #9dc8b7;
+    border-color: hsl(156, 28%, 70%);
     margin-right: 4px;
     border-radius: 3px;
 }
 
 button.task:hover {
-    border: 1px solid #2988a4;
+    border: 1px solid hsl(194, 60%, 40%);
 }
 
 button.task-completed {
-    border-color: #b9cec6;
+    border-color: hsl(157, 18%, 77%);
     padding: 0px;
 }
 
@@ -73,7 +73,7 @@ img.task-completed {
 }
 
 .poll-vote:hover {
-    border-color: #59a687;
+    border-color: hsl(156, 30%, 50%);
 }
 
 input.add-task,
@@ -90,7 +90,7 @@ button.add-task,
 button.poll-comment,
 button.poll-question {
     border-radius: 3px;
-    border: 1px solid #cccccc;
+    border: 1px solid hsl(0, 0%, 80%);
     background-color: white;
     width: 100px;
 }
@@ -98,10 +98,10 @@ button.poll-question {
 button.add-task:hover,
 button.poll-comment:hover,
 button.poll-question:hover {
-    border-color: #999999;
+    border-color: hsl(0, 0%, 60%);
 }
 
 .widget-error {
-    color: #b94a48;
+    color: hsl(1, 45%, 50%);
     font-size: 12px;
 }

--- a/static/styles/widgets.scss
+++ b/static/styles/widgets.scss
@@ -9,7 +9,7 @@
 
 .widget-choices button {
     font-weight: 700;
-    color: blue;
+    color: hsl(240, 100%, 50%);
 }
 
 .widget-choices-heading {
@@ -36,7 +36,7 @@
 
 .poll-widget .poll-names .todo-widget {
     font-size: 14px;
-    color: green;
+    color: hsl(120, 100%, 25%);
 }
 
 .poll-widget .poll-option {
@@ -47,7 +47,7 @@
     color: hsl(156, 41%, 40%);
     border-color: hsl(156, 28%, 70%);
     margin-right: 4px;
-    background-color: white;
+    background-color: hsl(0, 0%, 100%);
 }
 
 button.task {
@@ -91,7 +91,7 @@ button.poll-comment,
 button.poll-question {
     border-radius: 3px;
     border: 1px solid hsl(0, 0%, 80%);
-    background-color: white;
+    background-color: hsl(0, 0%, 100%);
     width: 100px;
 }
 

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -94,13 +94,13 @@ p.n-margin {
 }
 
 .top-messages-logo svg circle {
-    fill: #444;
-    stroke: #444;
+    fill: hsl(0, 0%, 27%);
+    stroke: hsl(0, 0%, 27%);
 }
 
 .top-messages-logo svg path {
-    fill: #fff;
-    stroke: #fff;
+    fill: hsl(0, 0%, 100%);
+    stroke: hsl(0, 0%, 100%);
 }
 
 #unmute_muted_topic_notification {
@@ -234,7 +234,7 @@ p.n-margin {
     margin: 0px auto;
     padding: 0px;
     position: relative;
-    background-color: #fff;
+    background-color: hsl(0, 0%, 100%);
 }
 
 .app-main {
@@ -1245,7 +1245,7 @@ a.message_label_clickable:hover {
 .dark_background a:hover,
 a.dark_background:hover,
 .dark_background {
-    color: #fff !important;
+    color: hsl(0, 0%, 100%) !important;
 }
 
 .dark_background a.message_label_clickable:hover {
@@ -1738,7 +1738,7 @@ blockquote p {
 }
 
 .typeahead.dropdown-menu .active {
-    color: #fff;
+    color: hsl(0, 0%, 100%);
 }
 
 .typeahead.dropdown-menu .unsubscribed_icon {
@@ -2608,7 +2608,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
     vertical-align: middle;
     width: 33%;
     border-top: 1px solid hsl(0, 0%, 88%);
-    border-bottom: 1px solid #fff;
+    border-bottom: 1px solid hsl(0, 0%, 100%);
     margin: 0px 5px 0px 5px;
 }
 
@@ -2639,7 +2639,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
     width: 50%;
     height: 0px;
     border-top: 1px solid hsl(0, 0%, 88%);
-    border-bottom: 1px solid #fff;
+    border-bottom: 1px solid hsl(0, 0%, 100%);
 }
 
 .sub-unsub-message span::before,
@@ -2865,7 +2865,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
     height: 100%;
     top: 0;
 
-    background: linear-gradient(0deg, #fff, transparent 10%);
+    background: linear-gradient(0deg, hsl(0, 0%, 100%), transparent 10%);
 }
 
 @media (max-width: 600px) {
@@ -2933,7 +2933,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
     top: 10px;
     border-radius: 6px;
     background-color: hsl(0, 0%, 30%);
-    color: #fff;
+    color: hsl(0, 0%, 100%);
     transition: visibility 0.2s ease-out, opacity 0.2s linear;
 
     ::after {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -194,11 +194,11 @@ p.n-margin {
 }
 
 #panels .alert.alert-info {
-    background: hsl(170, 46%, 54%);
+    background-color: hsl(170, 46%, 54%);
 }
 
 #panels .alert.alert-info.red {
-    background: hsl(0, 46%, 54%);
+    background-color: hsl(0, 46%, 54%);
 }
 
 #panels .alert .close {
@@ -880,7 +880,7 @@ td.pointer {
 }
 
 .summary_row_private_message .summary_colorblock {
-    background: hsl(0, 0%, 0%);
+    background-color: hsl(0, 0%, 0%);
 }
 
 .messages-expand,
@@ -1074,7 +1074,7 @@ td.pointer {
 }
 
 .unread-marker-fill {
-    background: hsl(107, 74%, 29%);
+    background-color: hsl(107, 74%, 29%);
     width: 3px;
     height: 100%;
     box-shadow: inset 0px -1px 0px 0px hsl(0, 0%, 100%);
@@ -1709,7 +1709,7 @@ blockquote p {
     height: 12px;
     min-width: 12px;
     line-height: 12px;
-    background: hsl(0, 100%, 20%);
+    background-color: hsl(0, 100%, 20%);
     top: 4px;
     right: 4px;
     border: 1px solid hsl(0, 0%, 93%);
@@ -1849,7 +1849,7 @@ nav a .no-style {
 }
 
 .modal-bg {
-    background: hsl(0, 0%, 98%);
+    background-color: hsl(0, 0%, 98%);
 }
 
 #searchbox {
@@ -2070,7 +2070,7 @@ div.floating_recipient {
 }
 
 .message-header-contents {
-    background: hsl(0, 0%, 88%);
+    background-color: hsl(0, 0%, 88%);
 }
 
 .recipient_row.sticky {
@@ -2252,7 +2252,7 @@ li .message_inline_image img {
     padding: 5px 8px 5px 10px;
     font-size: 12px;
     border-radius: 4px;
-    background: hsl(0, 0%, 0%);
+    background-color: hsl(0, 0%, 0%);
     color: hsl(0, 0%, 100%);
     opacity: 0.7;
 }
@@ -2723,7 +2723,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
 
 .user-group-mention,
 .user-mention {
-    background: hsl(0, 0%, 93%);
+    background-color: hsl(0, 0%, 93%);
     border-radius: 3px;
     padding: 0 0.2em;
     box-shadow: 0px 0px 0px 1px hsl(0, 0%, 80%);
@@ -2741,7 +2741,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
 }
 
 .user-mention-me {
-    background: hsl(112, 88%, 87%);
+    background-color: hsl(112, 88%, 87%);
 }
 
 .alert-word {
@@ -2768,7 +2768,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
     position: absolute;
     left: 0;
     top: 0;
-    background: hsl(0, 0%, 0%);
+    background-color: hsl(0, 0%, 0%);
     z-index: 20000;
 }
 

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2980,7 +2980,7 @@ div.message_content button.tictactoe-square {
     border: none;
     border-radius: 3px;
     font-size: 25px;
-    color: white;
+    color: hsl(0, 0%, 100%);
 }
 
 div.message_content button.tictactoe-square:hover {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -665,7 +665,7 @@ td.pointer {
     position: absolute;
     right: -110px;
     font-size: 14px;
-    color: hsl(170, 47%, 54%);
+    color: hsl(170, 48%, 54%);
     background-color: hsl(0, 0%, 100%);
     z-index: 999;
     padding-left: 20px;
@@ -675,7 +675,7 @@ td.pointer {
 }
 
 .private-message .alert-msg {
-    background-color: hsl(192, 19%, 95%);
+    background-color: hsl(192, 20%, 95%);
 }
 
 .include-sender .alert-msg {
@@ -1492,7 +1492,7 @@ blockquote p {
 .messagebox blockquote {
     padding-left: 5px;
     margin-left: 10px;
-    border-left-color: hsl(0, 0%, 86%);
+    border-left-color: hsl(0, 0%, 87%);
 }
 
 .messagebox .rtl blockquote {
@@ -1501,7 +1501,7 @@ blockquote p {
     margin-left: unset;
     margin-right: 10px;
     border-left: unset;
-    border-right: 5px solid hsl(0, 0%, 86%);
+    border-right: 5px solid hsl(0, 0%, 87%);
 }
 
 .bookend {
@@ -1579,7 +1579,7 @@ blockquote p {
     display: inline-block;
     position: relative;
     font-weight: 300;
-    background-color: hsl(0, 0%, 97%);
+    background-color: hsl(0, 0%, 98%);
     margin: 0px;
     padding: 0px;
     text-overflow: ellipsis;
@@ -1778,7 +1778,7 @@ blockquote p {
     right: 10px;
     display: inline-block;
     border-right: 7px solid transparent;
-    border-bottom: 7px solid hsl(0, 0%, 66%);
+    border-bottom: 7px solid hsl(0, 0%, 67%);
     border-left: 7px solid transparent;
     content: '';
     z-index: 10;
@@ -1839,7 +1839,7 @@ nav .column-left .company-name {
     margin-left: 8px;
     font-size: 1.2rem;
     font-weight: 600;
-    color: hsl(170, 47%, 54%);
+    color: hsl(170, 48%, 54%);
     letter-spacing: 0.1em;
     cursor: pointer;
 }
@@ -2439,7 +2439,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
 
 #invite-user .modal-header {
     padding: 7px 15px;
-    border-color: hsl(0, 0%, 86%);
+    border-color: hsl(0, 0%, 87%);
 }
 
 #invite-user .modal-header .exit {
@@ -2450,7 +2450,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
     position: absolute;
     top: 6px;
     right: 5px;
-    color: hsl(0, 0%, 66%);
+    color: hsl(0, 0%, 67%);
 }
 
 #invitee_emails {
@@ -2537,7 +2537,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
 }
 
 .twitter-tweet {
-    border: 1px solid hsl(0, 0%, 86%);
+    border: 1px solid hsl(0, 0%, 87%);
     padding: .5em .75em;
     margin-bottom: 0.25em;
     word-break: break-word;
@@ -2689,7 +2689,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
 
 #message_edit_form a.message-control-button {
     display: inline;
-    color: hsl(0, 0%, 46%);
+    color: hsl(0, 0%, 47%);
     text-decoration: none;
     font-size: 12px;
     width: 12px;
@@ -2913,7 +2913,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
 
 .email_copied,
 .user_popover_email i:hover {
-    color: hsl(170, 47%, 54%);
+    color: hsl(170, 48%, 54%);
 }
 
 .email_copied i {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1849,7 +1849,7 @@ nav a .no-style {
 }
 
 .modal-bg {
-    background: #f9f9f9;
+    background: hsl(0, 0%, 98%);
 }
 
 #searchbox {
@@ -2913,7 +2913,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
 
 .email_copied,
 .user_popover_email i:hover {
-    color: #53c1ae;
+    color: hsl(170, 47%, 54%);
 }
 
 .email_copied i {
@@ -2932,7 +2932,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
     left: -50%;
     top: 10px;
     border-radius: 6px;
-    background-color: #4c4c4c;
+    background-color: hsl(0, 0%, 30%);
     color: #fff;
     transition: visibility 0.2s ease-out, opacity 0.2s linear;
 
@@ -2945,7 +2945,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
         border-width: 7px;
         border-style: solid;
         border-color: transparent;
-        border-bottom: #4c4c4c solid 7px;
+        border-bottom: hsl(0, 0%, 30%) solid 7px;
     }
 }
 
@@ -2974,7 +2974,7 @@ div.message_content td.tictactoe {
 }
 
 div.message_content button.tictactoe-square {
-    background-color: #81bba4;
+    background-color: hsl(156, 30%, 62%);
     width: 40px;
     height: 40px;
     border: none;
@@ -2984,11 +2984,11 @@ div.message_content button.tictactoe-square {
 }
 
 div.message_content button.tictactoe-square:hover {
-    background-color: #808c87;
+    background-color: hsl(155, 5%, 53%);
 }
 
 div.message_content button.tictactoe-square:disabled {
-    background-color: #beded1;
+    background-color: hsl(156, 33%, 81%);
 }
 
 // Hide the up and down arrows in the Flatpickr datepicker year

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -22,7 +22,7 @@
 <link id="emoji-spritesheet" href="/static/generated/emoji/{{ emojiset }}-sprite.css" rel="stylesheet" type="text/css">
 <style>
     #css-loading {
-    background-color: white;
+    background-color: hsl(0, 0%, 100%);
     position: fixed;
     height: 100%;
     width: 100%;

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -22,7 +22,7 @@
 <link id="emoji-spritesheet" href="/static/generated/emoji/{{ emojiset }}-sprite.css" rel="stylesheet" type="text/css">
 <style>
     #css-loading {
-    background: white;
+    background-color: white;
     position: fixed;
     height: 100%;
     width: 100%;

--- a/templates/zerver/emails/digest.html
+++ b/templates/zerver/emails/digest.html
@@ -10,9 +10,9 @@
     <p>You have some missed private messages. Here are some of them:</p>
     <div id='private-messages' style="width: 600px;font-size: 12px;font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;overflow-y: scroll;">
         {% for recipient_block in unread_pms %}
-        <div class='recipient_block' style="background-color: #f0f4f5;border: 1px solid black;margin-bottom: 4px;">
-            <div class='recipient_header' style="color: #ffffff;background-color: #444444;border-bottom: 1px solid black;font-weight: bold;padding: 2px;">{{ recipient_block.header.html|safe }}</div>
-            <div class='message_content' style="background-color: #f0f4f5;margin-left: 1px;margin-right: 2px;">
+        <div class='recipient_block' style="background-color: hsl(192, 20%, 95%);border: 1px solid black;margin-bottom: 4px;">
+            <div class='recipient_header' style="color: hsl(0, 0%, 100%);background-color: hsl(0, 0%, 27%);border-bottom: 1px solid black;font-weight: bold;padding: 2px;">{{ recipient_block.header.html|safe }}</div>
+            <div class='message_content' style="background-color: hsl(192, 20%, 95%);margin-left: 1px;margin-right: 2px;">
                 {% for sender_block in recipient_block.senders %}
                     {% if sender_block.sender %} <div class="message_sender" style="font-weight: bold;padding-top: 1px;">{{ sender_block.sender }}</div>{% endif %}
                     {% for message_block in sender_block.content %}
@@ -42,7 +42,7 @@
         <div id='messages' style="width: 600px;font-size: 12px;font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;overflow-y: scroll;">
             {% for recipient_block in convo.first_few_messages %}
                 <div class='recipient_block' style="border: 1px solid black;margin-bottom: 4px;">
-                    <div class='recipient_header' style="background-color: #9ecaff;border-bottom: 1px solid black;font-weight: bold;padding: 2px">{{ recipient_block.header.html|safe }}</div>
+                    <div class='recipient_header' style="background-color: hsl(213, 100%, 81%);border-bottom: 1px solid black;font-weight: bold;padding: 2px">{{ recipient_block.header.html|safe }}</div>
                     <div class='message_content' style="margin-left: 1px;margin-right: 2px;">
                         {% for sender_block in recipient_block.senders %}
                             {% if sender_block.sender %} <div class="message_sender" style="font-weight: bold;padding-top: 1px;">{{ sender_block.sender }}</div>{% endif %}

--- a/templates/zerver/emails/email.css
+++ b/templates/zerver/emails/email.css
@@ -6,7 +6,7 @@ img {
 }
 
 body {
-    background: #f5f9f8;
+    background-color: hsl(165, 25%, 97%);
     font-family: sans-serif;
     -webkit-font-smoothing: antialiased;
     font-size: 14px;
@@ -31,7 +31,7 @@ table td {
 }
 
 .body {
-    background: #f5f9f8;
+    background-color: hsl(165, 25%, 97%);
     width: 100%;
 }
 
@@ -51,7 +51,7 @@ table td {
 }
 
 .main {
-    background: #fff;
+    background-color: hsl(0, 0%, 100%);
     border-radius: 3px;
     width: 100%;
 }
@@ -73,7 +73,7 @@ table td {
 .footer p,
 .footer span,
 .footer a {
-    color: #999999;
+    color: hsl(0, 0%, 60%);
     font-size: 12px;
     text-align: center;
 }
@@ -86,7 +86,7 @@ h1,
 h2,
 h3,
 h4 {
-    color: #000000;
+    color: hsl(0, 0%, 0%);
     font-family: sans-serif;
     font-weight: 400;
     line-height: 1.4;
@@ -118,16 +118,16 @@ ol li {
 }
 
 a {
-    color: #45a98e;
+    color: hsl(164, 42%, 47%);
     text-decoration: underline;
 }
 
 a:hover {
-    color: #51c6a6;
+    color: hsl(164, 51%, 55%);
 }
 
 .important {
-    border-bottom: 3px solid #d5e4e9;
+    border-bottom: 3px solid hsl(195, 31%, 87%);
 }
 
 .button {
@@ -135,12 +135,12 @@ a:hover {
     padding: 10px 0px;
     margin: 20px auto;
     width: 200px;
-    border: 1px solid #7fd1ba;
-    background: #7fd1ba;
+    border: 1px solid hsl(163, 47%, 66%);
+    background-color: hsl(163, 47%, 66%);
     border-radius: 4px;
     font-size: 16px;
     outline: none;
-    color: #ffffff;
+    color: hsl(0, 0%, 100%);
     font-family: sans-serif;
     text-decoration: none;
     text-align: center;
@@ -148,7 +148,7 @@ a:hover {
 }
 
 a.button:hover {
-    color: #ccf7eb;
+    color: hsl(163, 73%, 88%);
     text-decoration: none;
 }
 

--- a/templates/zerver/emails/email_base_messages.html
+++ b/templates/zerver/emails/email_base_messages.html
@@ -10,7 +10,7 @@
           color:transparent;
           mso-hide:all;
           font-size:1px;
-          color:#ffffff;
+          color:hsl(0, 0%, 100%);
           line-height:1px;
           max-height:0px;
           height:0px;

--- a/templates/zerver/emails/missed_message.html
+++ b/templates/zerver/emails/missed_message.html
@@ -20,9 +20,9 @@
     {% if show_message_content %}
     <div id='messages' style="width: 600px;font-size: 12px;font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;overflow-y: auto;">
         {% for recipient_block in messages %}
-        <div class='recipient_block' style="{% if not recipient_block.header.stream_message %}background-color: #f0f4f5;{% endif %}border: 1px solid black;margin-bottom: 4px;">
-            <div class='recipient_header' style="{% if recipient_block.header.stream_message %}background-color: #9ecaff;{% else %}color: #ffffff;background-color: #444444;{% endif %}border-bottom: 1px solid black;font-weight: bold;padding: 2px;">{{ recipient_block.header.html|safe }}</div>
-            <div class='message_content' style="{% if not recipient_block.header.stream_message %}background-color: #f0f4f5;{% endif %}margin-left: 1px;margin-right: 2px;">
+        <div class='recipient_block' style="{% if not recipient_block.header.stream_message %}background-color: hsl(192, 20%, 95%);{% endif %}border: 1px solid black;margin-bottom: 4px;">
+            <div class='recipient_header' style="{% if recipient_block.header.stream_message %}background-color: hsl(213, 100%, 81%);{% else %}color: hsl(0, 0%, 100%);background-color: hsl(0, 0%, 27%);{% endif %}border-bottom: 1px solid black;font-weight: bold;padding: 2px;">{{ recipient_block.header.html|safe }}</div>
+            <div class='message_content' style="{% if not recipient_block.header.stream_message %}background-color: hsl(192, 20%, 95%);{% endif %}margin-left: 1px;margin-right: 2px;">
                 {% for sender_block in recipient_block.senders %}
                     {% if sender_block.sender %} <div class="message_sender" style="font-weight: bold;padding-top: 1px;">{{ sender_block.sender }}</div>{% endif %}
                     {% for message_block in sender_block.content %}


### PR DESCRIPTION
Converts all hex values in CSS/SASS files to their HSL equivalents. Here's the [script](https://gist.github.com/synicalsyntax/d036c663d1b2e0ef36a85617bf77b5ba) I wrote to replace them.

Not sure if we should also switch RGB values to HSL as well, but I guess that can be implemented in a future PR :)

Before merging, please review the changes to ensure that no hex values for filters were changed as well as if any selectors/colors were accidentally broken, since HSL isn't compatible with those.

Fixes #9689.

cc @timabbott 