### PR TITLE
Fix 10237 empty looking message when a url

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -481,6 +481,14 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
 
         return url
 
+    def is_content_type_image(self, url: str) -> bool:
+        url = self.get_actual_image_url(url)
+        response = requests.head(url, allow_redirects=True)
+        # FIXME: content type missing, content length zero probably because cached
+        if response.headers.get('Content-Type','image').startswith("image"):
+            return True
+        return False
+
     def is_image(self, url: str) -> bool:
         if not image_preview_enabled_for_realm():
             return False
@@ -861,7 +869,7 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
                       class_attr=class_attr,
                       use_thumbnails=False)
                 continue
-            if self.is_image(url):
+            if self.is_image(url) and self.is_content_type_image(url):
                 self.handle_image_inlining(root, found_url)
                 continue
             if get_tweet_id(url) is not None:

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -503,10 +503,10 @@ class BugdownTest(ZulipTestCase):
 
         self.assertEqual(converted, '<p>Test: <a href="https://github.com/zulip/zulip/blob/master/static/images/logo/zulip-icon-128x128.png" target="_blank" title="https://github.com/zulip/zulip/blob/master/static/images/logo/zulip-icon-128x128.png">https://github.com/zulip/zulip/blob/master/static/images/logo/zulip-icon-128x128.png</a></p>\n<div class="message_inline_image"><a href="https://github.com/zulip/zulip/blob/master/static/images/logo/zulip-icon-128x128.png" target="_blank" title="https://github.com/zulip/zulip/blob/master/static/images/logo/zulip-icon-128x128.png"><img data-src-fullsize="/thumbnail?url=https%3A%2F%2Fraw.githubusercontent.com%2Fzulip%2Fzulip%2Fmaster%2Fstatic%2Fimages%2Flogo%2Fzulip-icon-128x128.png&amp;size=full" src="/thumbnail?url=https%3A%2F%2Fraw.githubusercontent.com%2Fzulip%2Fzulip%2Fmaster%2Fstatic%2Fimages%2Flogo%2Fzulip-icon-128x128.png&amp;size=thumbnail"></a></div>')
 
-        msg = 'Test: https://developer.github.com/assets/images/hero-circuit-bg.png'
+        msg = 'Test: https://developer.github.com/assets/images/icon-circle-ci.png'
         converted = bugdown_convert(msg)
 
-        self.assertEqual(converted, '<p>Test: <a href="https://developer.github.com/assets/images/hero-circuit-bg.png" target="_blank" title="https://developer.github.com/assets/images/hero-circuit-bg.png">https://developer.github.com/assets/images/hero-circuit-bg.png</a></p>\n<div class="message_inline_image"><a href="https://developer.github.com/assets/images/hero-circuit-bg.png" target="_blank" title="https://developer.github.com/assets/images/hero-circuit-bg.png"><img data-src-fullsize="/thumbnail?url=https%3A%2F%2Fdeveloper.github.com%2Fassets%2Fimages%2Fhero-circuit-bg.png&amp;size=full" src="/thumbnail?url=https%3A%2F%2Fdeveloper.github.com%2Fassets%2Fimages%2Fhero-circuit-bg.png&amp;size=thumbnail"></a></div>')
+        self.assertEqual(converted, '<p>Test: <a href="https://developer.github.com/assets/images/icon-circle-ci.png" target="_blank" title="https://developer.github.com/assets/images/icon-circle-ci.png">https://developer.github.com/assets/images/icon-circle-ci.png</a></p>\n<div class="message_inline_image"><a href="https://developer.github.com/assets/images/icon-circle-ci.png" target="_blank" title="https://developer.github.com/assets/images/icon-circle-ci.png"><img data-src-fullsize="/thumbnail?url=https%3A%2F%2Fdeveloper.github.com%2Fassets%2Fimages%2Ficon-circle-ci.png&amp;size=full" src="/thumbnail?url=https%3A%2F%2Fdeveloper.github.com%2Fassets%2Fimages%2Ficon-circle-ci.png&amp;size=thumbnail"></a></div>')
 
     def test_twitter_id_extraction(self) -> None:
         self.assertEqual(bugdown.get_tweet_id('http://twitter.com/#!/VizzQuotes/status/409030735191097344'), '409030735191097344')
@@ -1186,12 +1186,7 @@ class BugdownTest(ZulipTestCase):
             converted,
             '<p>'
             '<a href="https://example.com/testimage.png" target="_blank" title="https://example.com/testimage.png">My favorite image</a>'
-            '</p>\n'
-            '<div class="message_inline_image">'
-            '<a href="https://example.com/testimage.png" target="_blank" title="My favorite image">'
-            '<img data-src-fullsize="/thumbnail?url=https%3A%2F%2Fexample.com%2Ftestimage.png&amp;size=full" src="/thumbnail?url=https%3A%2F%2Fexample.com%2Ftestimage.png&amp;size=thumbnail">'
-            '</a>'
-            '</div>'
+            '</p>'
         )
 
     def test_mit_rendering(self) -> None:


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#10237

This method assumes that it is possible to check the headers of every link pasted in the message field which has an image-like extension. We want to make sure this way of doing this is okay before we continue.
One way of speeding up this by using a cache for link metadata? But we are not too sure what this will look like.

**Testing Plan:** <!-- How have you tested? -->
Ran all of tests/test-backend. 

BugdownTest.test_inline_image_preview_order fails due to a timeout error (when we set timeout to 12 the test passes)
We could fix this by using mock.patch for the link-metadata as opposed to the link contents itself. 

Will write tests for our new function and improve this PR if this implementation looks okay.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![before](https://user-images.githubusercontent.com/7081681/46654659-0fdef300-cbc7-11e8-9237-ba5172237111.PNG)

![after](https://user-images.githubusercontent.com/7081681/46654667-166d6a80-cbc7-11e8-9ce9-8f79215e7426.PNG)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->



Thanks to @tanvibhakta for pair programming with me on this one, and huge props to @punchagan for leading the Zulip PyConIndia 2018 devsprint and helping us out!