### PR TITLE
message_edit: Allow editing topics indefinitely.

### DIFF
--- a/frontend_tests/node_tests/message_edit.js
+++ b/frontend_tests/node_tests/message_edit.js
@@ -75,6 +75,7 @@ run_test('get_editability', () => {
         realm_allow_community_topic_editing: true,
         realm_allow_message_editing: true,
         realm_message_content_edit_limit_seconds: 0,
+        is_admin: false,
     };
     message.timestamp = current_timestamp - 60;
     assert.equal(get_editability(message), editability_types.TOPIC_ONLY);
@@ -88,6 +89,14 @@ run_test('get_editability', () => {
 
     message.sent_by_me = false;
     global.page_params.realm_allow_community_topic_editing = false;
+    assert.equal(message_edit.is_topic_editable(message), false);
+
+    message.sent_by_me = false;
+    global.page_params.realm_allow_community_topic_editing = false;
+    global.page_params.is_admin = true;
+    assert.equal(message_edit.is_topic_editable(message), true);
+
+    global.page_params.realm_allow_message_editing = false;
     assert.equal(message_edit.is_topic_editable(message), false);
 });
 

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -16,13 +16,9 @@ var editability_types = {
 };
 exports.editability_types = editability_types;
 
-function is_topic_editable(message, edit_limit_seconds_buffer) {
-    var now = new XDate();
-    edit_limit_seconds_buffer = edit_limit_seconds_buffer || 0;
-
-    // TODO: Change hardcoded value (24 hrs) to be realm setting
-    return message.sent_by_me || page_params.realm_allow_community_topic_editing
-        && 86400 + edit_limit_seconds_buffer + now.diffSeconds(message.timestamp * 1000) > 0;
+function is_topic_editable(message) {
+    return page_params.realm_allow_message_editing && (page_params.is_admin || message.sent_by_me
+        || page_params.realm_allow_community_topic_editing);
 }
 
 function get_editability(message, edit_limit_seconds_buffer) {
@@ -30,7 +26,7 @@ function get_editability(message, edit_limit_seconds_buffer) {
     if (!message) {
         return editability_types.NO;
     }
-    if (!is_topic_editable(message, edit_limit_seconds_buffer)) {
+    if (!is_topic_editable(message)) {
         return editability_types.NO;
     }
     if (message.failed_request) {

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -87,7 +87,7 @@ function set_topic_edit_properties(group, message) {
     // to encourage updating them. Admins can also edit any topic.
     if (message.subject === compose.empty_topic_placeholder()) {
         group.always_visible_topic_edit = true;
-    } else if (page_params.is_admin || message_edit.is_topic_editable(message)) {
+    } else if (message_edit.is_topic_editable(message)) {
         group.on_hover_topic_edit = true;
     }
 }

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -2467,14 +2467,14 @@ class EditMessageTest(ZulipTestCase):
         self.login(self.example_email("cordelia"))
         do_edit_message_assert_error(id_, 'D', "Your organization has turned off message editing")
 
-        # non-admin users cannot edit topics sent > 24 hrs ago
+        # non-admin users can edit message topic any time
         message.pub_date = message.pub_date - datetime.timedelta(seconds=90000)
         message.save()
         self.login(self.example_email("iago"))
         set_message_editing_params(True, 0, True)
         do_edit_message_assert_success(id_, 'E')
         self.login(self.example_email("cordelia"))
-        do_edit_message_assert_error(id_, 'F', "The time limit for editing this message has passed")
+        do_edit_message_assert_success(id_, 'F')
 
         # anyone should be able to edit "no topic" indefinitely
         message.subject = "(no topic)"

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -1327,16 +1327,6 @@ def update_message_backend(request: HttpRequest, user_profile: UserMessage,
         if (timezone_now() - message.pub_date) > datetime.timedelta(seconds=deadline_seconds):
             raise JsonableError(_("The time limit for editing this message has passed"))
 
-    # If there is a change to the topic, check that the user is allowed to
-    # edit it and that it has not been too long. If this is not the user who
-    # sent the message, they are not the admin, and the time limit for editing
-    # topics is passed, raise an error.
-    if content is None and message.sender != user_profile and not user_profile.is_realm_admin and \
-            not is_no_topic_msg:
-        deadline_seconds = Realm.DEFAULT_COMMUNITY_TOPIC_EDITING_LIMIT_SECONDS + edit_limit_buffer
-        if (timezone_now() - message.pub_date) > datetime.timedelta(seconds=deadline_seconds):
-            raise JsonableError(_("The time limit for editing this message has passed"))
-
     if subject is None and content is None:
         return json_error(_("Nothing to change"))
     if subject is not None:


### PR DESCRIPTION
Topic editing was allowed only if the message was no more than one day old.
Removed this condition. We want the topic editing to be allowed only based on
the policies set in realm settings.
Closes #10568.
