### PR TITLE
portico.scss: Add icon and warning label to the warn admonition.

### DIFF
--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -1690,6 +1690,13 @@ input.new-organization-button {
     font-weight: 600;
 }
 
+.markdown .warn p::before {
+    display: inline-block;
+    content: "\f071 ";
+    font-family: FontAwesome, "Yantramanav", Source Sans Pro;
+    font-weight: 600;
+}
+
 .markdown .keyboard_tip::before {
     display: inline;
     content: "\f11c   Keyboard Shortcut:  ";


### PR DESCRIPTION
@rishig This adds a warn icon and label to the docs warning. @synicalsyntax might be a good reviewer?

**Testing Plan:** 
I just looked at the output.

**GIFs or Screenshots:**
![screenshot from 2018-10-09 14-06-41](https://user-images.githubusercontent.com/549661/46688994-c1ccee00-cbcc-11e8-8965-12f37fb2b676.png)
