### PR TITLE
[Fix #10654] You can click "Change email" while the "Change full name" modal is open and get exception

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -246,6 +246,10 @@ exports.set_up = function () {
         e.preventDefault();
         e.stopPropagation();
         if (!page_params.realm_name_changes_disabled || page_params.is_admin) {
+            if (overlays.is_modal_open()) {
+                overlays.close_active_modal();
+                return;
+            }
             overlays.open_modal('change_full_name_modal');
         }
     });
@@ -253,6 +257,10 @@ exports.set_up = function () {
     $('#change_password').on('click', function (e) {
         e.preventDefault();
         e.stopPropagation();
+        if (overlays.is_modal_open()) {
+            overlays.close_active_modal();
+            return;
+        }
         overlays.open_modal('change_password_modal');
         $('#pw_change_controls').show();
         if (page_params.realm_password_auth_enabled !== false) {
@@ -387,6 +395,10 @@ exports.set_up = function () {
         e.preventDefault();
         e.stopPropagation();
         if (!page_params.realm_email_changes_disabled || page_params.is_admin) {
+            if (overlays.is_modal_open()) {
+                overlays.close_active_modal();
+                return;
+            }
             overlays.open_modal('change_email_modal');
             var email = $('#email_value').text().trim();
             $('.email_change_container').find("input[name='email']").val(email);


### PR DESCRIPTION
… is open will close the currently opened modal

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

https://github.com/zulip/zulip/issues/10654


**Testing Plan:** <!-- How have you tested? -->
I've tested the change manually by trying to open the change email modal while change full name modal was open

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
![modal_change](https://user-images.githubusercontent.com/1143331/46902460-5db76c00-cee3-11e8-9801-7e14a4e0ba28.gif)

  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
