### PR TITLE
user profiles: Remove empty space under profiles with no set fields.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -206,8 +206,8 @@ exports.show_user_profile = function (element, user) {
             } else {
                 profile_field.value = field_value;
             }
+            profile_data.push(profile_field);
         }
-        profile_data.push(profile_field);
     });
 
     var args = {

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -145,13 +145,6 @@ ul.remind_me_popover .remind_icon {
 #user-profile-modal {
     border-radius: 4px;
 
-    #body {
-        padding-bottom: 10px;
-        padding-top: 4px;
-        margin-bottom: 10px;
-        margin-top: 10px;
-    }
-
     #exit-sign {
         font-size: 1.5rem;
     }
@@ -221,6 +214,21 @@ ul.remind_me_popover .remind_icon {
                 white-space: pre-line;
                 overflow-wrap: break-word;
             }
+        }
+    }
+
+    &.no-fields {
+        hr,
+        #content {
+            display: none;
+        }
+    }
+
+    &:not(.no-fields) {
+        #body {
+            padding-bottom: 10px;
+            padding-top: 4px;
+            margin: 10px 0;
         }
     }
 }

--- a/static/templates/user_profile_modal.handlebars
+++ b/static/templates/user_profile_modal.handlebars
@@ -1,4 +1,4 @@
-<div id="user-profile-modal" class="modal modal-bg fade" tabindex="-1"
+<div id="user-profile-modal" class="modal modal-bg fade{{#unless profile_data.length}} no-fields{{/unless}}" tabindex="-1"
   role="dialog" aria-labelledby="user_profile_modal label" aria-hidden="true">
     <div class="modal-body" id="body">
         <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}">
@@ -37,20 +37,18 @@
         <hr>
         <div id="content">
             {{#each profile_data}}
-                {{#if this.value}}
-                <div data-type="{{this.type}}" class="field-section">
-                    <div class="name">{{this.name}}</div>
-                    {{#if this.is_user_field}}
-                    <div class="pill-container not-editable" data-field-id="{{this.id}}">
-                        <div class="input" contenteditable="false" style="display: none;"></div>
-                    </div>
-                    {{else if this.is_link}}
-                    <a href={{this.value}} target="_blank" class="value">{{this.value}}</a>
-                    {{else}}
-                    <div class="value">{{this.value}}</div>
-                    {{/if}}
+            <div data-type="{{this.type}}" class="field-section">
+                <div class="name">{{this.name}}</div>
+                {{#if this.is_user_field}}
+                <div class="pill-container not-editable" data-field-id="{{this.id}}">
+                    <div class="input" contenteditable="false" style="display: none;"></div>
                 </div>
+                {{else if this.is_link}}
+                <a href={{this.value}} target="_blank" class="value">{{this.value}}</a>
+                {{else}}
+                <div class="value">{{this.value}}</div>
                 {{/if}}
+            </div>
             {{/each}}
         </div>
     </div>


### PR DESCRIPTION
Add a `.no-fields` class to user profile modals with no custom fields set so we can render the modal without the extra whitespace on the bottom when a user hasn't set any custom fields.

No fields:
![screenshot at oct 12 19-11-12](https://user-images.githubusercontent.com/15116870/46907496-3c955200-cec8-11e8-9d38-9f15e1d96c5d.png)

With fields:
![screenshot at oct 12 19-34-08](https://user-images.githubusercontent.com/15116870/46907497-3c955200-cec8-11e8-90d1-719af96abfd9.png)

Fixes #10652.