### PR TITLE
Fix issue #8631 right sidebar: Show last active time more prominently.

### DIFF
--- a/static/templates/user_info_popover_content.handlebars
+++ b/static/templates/user_info_popover_content.handlebars
@@ -25,7 +25,8 @@
         {{/if}}
 
         {{#if user_time}}
-        <li>{{ user_time }} {{#tr this}}Local time{{/tr}}</li>
+        <li>{{#tr this}}Local time: {{/tr}}{{ user_time }} </li>
+        <li>{{#tr this}}Last online: {{/tr}}{{ user_last_seen_time_status}} </li>
         {{/if}}
     </div>
     <hr />


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/8631

**Testing Plan:** <!-- How have you tested? -->
I have done many test in the dev server and it behave as excepted.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
![capture](https://user-images.githubusercontent.com/28706249/46918311-d0395200-cf9e-11e8-95ee-730e056fc2be.PNG)
