### PR TITLE
docs: Fix path to REST endpoints index

### DIFF
--- a/docs/tutorials/documenting-api-endpoints.md
+++ b/docs/tutorials/documenting-api-endpoints.md
@@ -6,7 +6,7 @@ This document briefly explains how to document
 Our API documentation files live under `templates/zerver/api/*`. To
 begin, we recommend using an existing doc file (`render-message.md` is
 a good example) as a template. Make sure you link to your new Markdown
-file in `templates/zerver/help/rest-endpoints.md` , so that it appears
+file in `templates/zerver/help/include/rest-endpoints.md` , so that it appears
 in the index in the left sidebar on the `/api` page.
 
 The markdown framework is the same one used by the


### PR DESCRIPTION
The path in the tutorial was incorrect.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
