### PR TITLE
presence: Allow bots to fetch realm presence data

### DIFF
--- a/zerver/views/presence.py
+++ b/zerver/views/presence.py
@@ -79,3 +79,6 @@ def update_active_status_backend(request: HttpRequest, user_profile: UserProfile
             ret['zephyr_mirror_active'] = False
 
     return json_success(ret)
+
+def get_statuses_for_realm(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
+    return json_success(get_status_list(user_profile))

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -116,6 +116,9 @@ v1_api_and_json_patterns = [
     url(r'^realm/deactivate$', rest_dispatch,
         {'POST': 'zerver.views.realm.deactivate_realm'}),
 
+    url(r'^realm/presence$', rest_dispatch,
+        {'GET': 'zerver.views.presence.get_statuses_for_realm'}),
+
     # users -> zerver.views.users
     #
     # Since some of these endpoints do something different if used on


### PR DESCRIPTION
Before, presence information for an entire realm could only be queried
via the `POST /api/v1/users/me/presence` endpoint. However, this endpoint also updates
the presence information for the user making the request. Therefore, bot
users are not allowed to access this endpoint because they don't have
any presence data.

This commit adds a new endpoint `GET /api/v1/realm/presence` that just returns
the presence information for the realm of the caller.

Closes #10651

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/10651

I wasn't sure what to name the new endpoint.

Also, the change is really minimal. Am I missing any logic from the POST version? I didn't think the Zephyr logic applied.

**Testing Plan:** <!-- How have you tested? -->
I accessed `http://localhost:9991/json/realm/presence` after logging in as Iago, and got
```
{"result":"success","presences":{"AARON@zulip.com":{"website":{"pushable":false,"timestamp":1539366646,"status":"active","client":"website"},"aggregated":{"timestamp":1539366646,"status":"active","client":"website"}},"cordelia@zulip.com":{"aggregated":{"timestamp":1539366646,"status":"active","client":"ZulipAndroid"},"ZulipAndroid":{"pushable":false,"timestamp":1539366646,"status":"active","client":"ZulipAndroid"}},"polonius@zulip.com":{"website":{"pushable":false,"timestamp":1539366646,"status":"active","client":"website"},"aggregated":{"timestamp":1539366646,"status":"active","client":"website"}},"othello@zulip.com":{"website":{"pushable":false,"timestamp":1539366646,"status":"active","client":"website"},"aggregated":{"timestamp":1539366646,"status":"active","client":"website"}},"prospero@zulip.com":{"website":{"pushable":false,"timestamp":1539366646,"status":"active","client":"website"},"aggregated":{"timestamp":1539366646,"status":"active","client":"website"}},"iago@zulip.com":{"website":{"pushable":false,"timestamp":1539627841,"status":"active","client":"website"},"aggregated":{"timestamp":1539627841,"status":"active","client":"website"}},"hamlet@zulip.com":{"website":{"pushable":false,"timestamp":1539366646,"status":"active","client":"website"},"aggregated":{"timestamp":1539366646,"status":"active","client":"website"}},"ZOE@zulip.com":{"website":{"pushable":false,"timestamp":1539366646,"status":"active","client":"website"},"aggregated":{"timestamp":1539366646,"status":"active","client":"website"}}},"server_timestamp":1539627848.9954984188,"msg":""}
```

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
