### PR TITLE
css: Make single-line codeblocks inline.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -428,6 +428,7 @@ code::after {
 }
 
 .message_content code {
+    display: inline-block;
     white-space: pre-wrap;
     padding: 0px 4px;
     background-color: hsl(0, 0%, 100%);


### PR DESCRIPTION
**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before:
![image](https://user-images.githubusercontent.com/8033238/46985961-879ea780-d10a-11e8-8e55-369c6c37442e.png)
After:
![image](https://user-images.githubusercontent.com/8033238/46985969-92f1d300-d10a-11e8-979a-1b24ed02a901.png)
