### PR TITLE
[Fix  #10539] email integration: Include subject line as first line of message if longer than 60 characters.

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -192,7 +192,6 @@ class ZulipEmailForwardError(Exception):
 
 def send_zulip(sender: str, stream: Stream, topic: str, content: str) -> None:
     if len(topic) > MAX_SUBJECT_LENGTH:
-        #import pdb; pdb.set_trace()
         try:
             Message.objects.get(subject=topic[:MAX_SUBJECT_LENGTH])
         except:

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -191,12 +191,20 @@ class ZulipEmailForwardError(Exception):
     pass
 
 def send_zulip(sender: str, stream: Stream, topic: str, content: str) -> None:
+    if len(topic) > MAX_SUBJECT_LENGTH:
+        #import pdb; pdb.set_trace()
+        try:
+            Message.objects.get(subject=topic[:MAX_SUBJECT_LENGTH])
+        except:
+            content = '{}\n{}'.format(topic, content)
+        topic = topic[:MAX_SUBJECT_LENGTH]
+
     internal_send_message(
         stream.realm,
         sender,
         "stream",
         stream.name,
-        topic[:MAX_SUBJECT_LENGTH],
+        topic,
         content[:MAX_MESSAGE_LENGTH],
         email_gateway=True)
 

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -194,7 +194,7 @@ def send_zulip(sender: str, stream: Stream, topic: str, content: str) -> None:
     if len(topic) > MAX_SUBJECT_LENGTH:
         try:
             Message.objects.get(subject=topic[:MAX_SUBJECT_LENGTH])
-        except:
+        except Message.DoesNotExist:
             content = '{}\n{}'.format(topic, content)
         topic = topic[:MAX_SUBJECT_LENGTH]
 

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -136,6 +136,31 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
         self.assertEqual(get_display_recipient(message.recipient), stream.name)
         self.assertEqual(message.topic_name(), incoming_valid_message['Subject'])
 
+    def test_receive_stream_email_messages_over_60_char_subject(self) -> None:
+        user_profile = self.example_user('hamlet')
+        self.login(user_profile.email)
+        self.subscribe(user_profile, "Denmark")
+        stream = get_stream("Denmark", user_profile.realm)
+
+        stream_to_address = encode_email_address(stream)
+        
+        mail_subject = 'x'*70  # 70 character long string
+
+        incoming_valid_message = MIMEText('TestStreamEmailMessages Body')
+        incoming_valid_message['Subject'] = mail_subject
+        incoming_valid_message['From'] = self.example_email('hamlet')
+        incoming_valid_message['To'] = stream_to_address
+        incoming_valid_message['Reply-to'] = self.example_email('othello')
+
+        process_message(incoming_valid_message)
+        message = most_recent_message(user_profile)
+
+        self.assertEqual(message.content.split('\n')[0], mail_subject)
+
+        process_message(incoming_valid_message)
+        message = most_recent_message(user_profile)
+        self.assertNotEqual(message.content.split('\n')[0], mail_subject)
+
     def test_receive_stream_email_messages_blank_subject_success(self) -> None:
         user_profile = self.example_user('hamlet')
         self.login(user_profile.email)

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -143,7 +143,7 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
         stream = get_stream("Denmark", user_profile.realm)
 
         stream_to_address = encode_email_address(stream)
-        
+
         mail_subject = 'x'*70  # 70 character long string
 
         incoming_valid_message = MIMEText('TestStreamEmailMessages Body')


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/10539

**Testing Plan:** <!-- How have you tested? -->
Run test case in zerver/tests/test_email_mirror.py.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
