### PR TITLE
message view: Fix order of Recipient bar

### DIFF
--- a/static/templates/recipient_row.handlebars
+++ b/static/templates/recipient_row.handlebars
@@ -37,6 +37,7 @@
                     <i class="fa fa-external-link-square" aria-hidden="true"></i>
                 </a>
                 {{/each}}
+                
                 {{! edit subject pencil icon }}
                 {{#if always_visible_topic_edit}}
                     <i class="fa fa-pencil always_visible_topic_edit" aria-hidden="true" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}}></i>

--- a/static/templates/recipient_row.handlebars
+++ b/static/templates/recipient_row.handlebars
@@ -31,6 +31,12 @@
                 </a>
                 <!-- The missing whitespace on the next line is a hack; ideally, would be user-select: none. -->
             </span><span class="recipient_bar_controls no-select">
+                {{! exterior links (e.g. to a trac ticket) }}
+                {{#each subject_links}}
+                <a href="{{this}}" target="_blank" class="no-underline">
+                    <i class="fa fa-external-link-square" aria-hidden="true"></i>
+                </a>
+                {{/each}}
                 {{! edit subject pencil icon }}
                 {{#if always_visible_topic_edit}}
                     <i class="fa fa-pencil always_visible_topic_edit" aria-hidden="true" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}}></i>
@@ -39,12 +45,6 @@
                     <i class="fa fa-pencil on_hover_topic_edit" aria-hidden="true" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}}></i>
                     {{/if}}
                 {{/if}}
-                {{! exterior links (e.g. to a trac ticket) }}
-                {{#each subject_links}}
-                <a href="{{this}}" target="_blank" class="no-underline">
-                    <i class="fa fa-external-link-square" aria-hidden="true"></i>
-                </a>
-                {{/each}}
 
                 <span class="topic_edit">
                     <span class="topic_edit_form" id="{{id}}"></span>

--- a/static/templates/recipient_row.handlebars
+++ b/static/templates/recipient_row.handlebars
@@ -37,7 +37,6 @@
                     <i class="fa fa-external-link-square" aria-hidden="true"></i>
                 </a>
                 {{/each}}
-                
                 {{! edit subject pencil icon }}
                 {{#if always_visible_topic_edit}}
                     <i class="fa fa-pencil always_visible_topic_edit" aria-hidden="true" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}}></i>


### PR DESCRIPTION
Swapped order of the "blue square" outgoing link and the edit pencil.

Fixes #10681 

I'm still reading up on how to set up the environment on my local system, but I've tested it manually by tinkering with the front-end expected outputs.


**Screenshot:** 
![image](https://user-images.githubusercontent.com/17107833/47204686-8b982700-d3a1-11e8-9383-0b8b34dd1d3b.png)