### PR TITLE
settings: Fix width not maximum while uploading user avatar.

### DIFF
--- a/static/js/avatar.js
+++ b/static/js/avatar.js
@@ -61,13 +61,13 @@ exports.build_user_avatar_widget = function (upload_function) {
         e.stopPropagation();
         channel.del({
             url: '/json/users/me/avatar',
-            success: function (data) {
-                $("#user-settings-avatar").expectOne().attr("src", data.avatar_url);
+            success: function () {
                 $("#user_avatar_delete_button").hide();
                 $("#user-avatar-source").show();
                 // Need to clear input because of a small edge case
                 // where you try to upload the same image you just deleted.
                 get_file_input().val('');
+                // Rest of the work is done via the user_events -> avatar_url event we will get
             },
         });
     });

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -475,11 +475,11 @@ exports.set_up = function () {
             cache: false,
             processData: false,
             contentType: false,
-            success: function (data) {
+            success: function () {
                 loading.destroy_indicator($("#upload_avatar_spinner"));
-                $("#user-avatar-block").expectOne().attr("src", data.avatar_url);
                 $("#user_avatar_delete_button").show();
                 $("#user-avatar-source").hide();
+                // Rest of the work is done via the user_events -> avatar_url event we will get
             },
             error: function () {
                 if (page_params.avatar_source === 'G') {


### PR DESCRIPTION
New user avatar width is not maximum when user upload
new image. Because wrong html element is accessed for
setting value of image src attribute.
This commit removes these code from success of ajax call,
cause we already handle this in event `user_events - avatar_url`.

This issue was previously also encountered by @rishig. [Link to discussion](https://chat.zulip.org/#narrow/stream/9-issues/subject/upload.20avatar.20bug/near/643829)


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![upload_avatar](https://user-images.githubusercontent.com/25907420/47208524-b4bdb500-d3ab-11e8-8e02-96c48f8ceab5.gif)

