### PR TITLE
org settings: Admin cannot update user

### DIFF
--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -173,6 +173,9 @@ class PermissionTest(ZulipTestCase):
         self.assert_json_success(result)
         hamlet = self.example_user('hamlet')
         self.assertEqual(hamlet.full_name, new_name)
+        req['is_admin'] = ujson.dumps(False)
+        result = self.client_patch('/json/users/{}'.format(hamlet.id), req)
+        self.assert_json_success(result)
 
     def test_non_admin_cannot_change_full_name(self) -> None:
         self.login(self.example_email("hamlet"))

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -82,9 +82,11 @@ def update_user_backend(request: HttpRequest, user_profile: UserProfile, user_id
     target = access_user_by_id(user_profile, user_id, allow_deactivated=True, allow_bots=True)
 
     if is_admin is not None:
-        if not is_admin and check_last_admin(user_profile):
-            return json_error(_('Cannot remove the only organization administrator'))
-        do_change_is_admin(target, is_admin)
+        # If target user's is_realm_admin property is changed
+        if target.is_realm_admin != is_admin:
+            if not is_admin and check_last_admin(user_profile):
+                return json_error(_('Cannot remove the only organization administrator'))
+            do_change_is_admin(target, is_admin)
 
     if (full_name is not None and target.full_name != full_name and
             full_name.strip() != ""):


### PR DESCRIPTION
Currently, if there is only one admin in realm and admin tries
to updates any non-adminuser's full name it throws error,
"Cannot remove only realm admin". Because in `/json/users/<user_id>`
api check_if_last_admin_is_changed is checked even if property
is_admin is not changed.

This commit fix this issue and add tests for it.

Issue:

![cannotrenameuser](https://user-images.githubusercontent.com/25907420/47221108-3411af80-d3d1-11e8-9770-9fe32090f77a.gif)
![renameuser](https://user-images.githubusercontent.com/25907420/47221001-f4e35e80-d3d0-11e8-8c76-81c3ae19fa0b.gif)

