### PR TITLE
mypy version updated 0.641

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -6,7 +6,7 @@
 Django==1.11.14
 
 # needed for mypy TypedDict
-mypy_extensions==0.3.0
+mypy_extensions==0.4.1
 
 # Needed for rendering backend templates
 Jinja2==2.10

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -96,8 +96,8 @@ markupsafe==1.0
 matrix-client==0.3.2
 mock==2.0.0
 moto==1.3.3
-mypy==0.620
-mypy_extensions==0.3.0
+mypy-extensions==0.4.1
+mypy==0.641
 ndg-httpsclient==0.5.1
 oauth2client==4.1.2
 oauthlib==2.1.0
@@ -177,6 +177,7 @@ twilio==6.15.2
 twisted==18.4.0
 typed-ast==1.1.0          # via mypy
 typing==3.6.4
+typing_extensions==3.6.6
 uritemplate==3.0.0
 urllib3==1.22             # via requests, transifex-client
 virtualenv-clone==0.3.0

--- a/requirements/mypy.in
+++ b/requirements/mypy.in
@@ -2,6 +2,7 @@
 # /tools/update-locked-requirements to update requirements/dev.txt
 # and requirements/mypy.txt.
 # See requirements/README.md for more detail.
-mypy==0.620
+mypy==0.641
 # Include typing explicitly, since it's needed on Python 3.4
 typing==3.6.4
+typing_extensions==3.6.6

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -7,6 +7,8 @@
 #
 # For details, see requirements/README.md .
 #
-mypy==0.620
+mypy-extensions==0.4.1    # via mypy
+mypy==0.641
 typed-ast==1.1.0          # via mypy
 typing==3.6.4
+typing_extensions==3.6.6

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -69,7 +69,7 @@ markdown==2.6.11
 markupsafe==1.0
 matrix-client==0.3.2
 mock==2.0.0
-mypy_extensions==0.3.0
+mypy_extensions==0.4.1
 ndg-httpsclient==0.5.1
 oauth2client==4.1.2
 oauthlib==2.1.0

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.9.0-rc2+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '26.10'
+PROVISION_VERSION = '26.11'


### PR DESCRIPTION
Solved Issue : #10642 

I have tested it in my vagrant env. ,  it has passed all the tests except one which I found is not related with what I committed.

mypy version 0.641 
and 
mypy_extensions 0.4.1
typing_extensions 3.6.6 added 
typing_extension is required by  mypy version 0.641






![screenshot_20181020_030409](https://user-images.githubusercontent.com/36006520/47245003-2ed65400-d415-11e8-8897-74d153e26e0e.png)

-> test at which it failed