### PR TITLE
css: Vertically center username.

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -760,8 +760,8 @@ input[type=checkbox].inline-block {
 
 .bots_list .name {
     font-weight: 600;
-    font-size: 1.3rem;
-    margin: 10px 0px 5px 0px;
+    font-size: 1.1rem;
+    margin: 7px 5px;
 
     overflow: hidden;
     line-height: 1.3em;
@@ -830,7 +830,8 @@ input[type=checkbox].inline-block {
     box-shadow: 0px 0px 4px hsla(0, 0%, 0%, 0.1);
 }
 
-.bots_list .email {
+.bots_list .email,
+.bots_list .type {
     margin-bottom: 5px;
 }
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
"issues > minor css issue" stream on chat.zulip.org opened by @rishig.
![pasted_image](https://user-images.githubusercontent.com/7443383/47252829-d2b50500-d3ff-11e8-985f-0f7a82899ffc.png)

**Testing Plan:** <!-- How have you tested? -->
Implemented fix and verified spacing was applied. Screenshot below.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<img width="365" alt="screen shot 2018-10-20 at 12 21 47 am" src="https://user-images.githubusercontent.com/7443383/47252825-bfa23500-d3ff-11e8-93c9-868cfec8f27b.png">

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
