### PR TITLE
Certbot: allow issuing certificates for multiple domains.

### DIFF
--- a/docs/production/ssl-certificates.md
+++ b/docs/production/ssl-certificates.md
@@ -72,6 +72,9 @@ The `--hostname` and `--email` options are required when using
 Zulip server machine to be reachable by that name from the public
 Internet.
 
+If you need to configure a multiple domain certificate, you can generate
+one as described in the section below after installing Zulip.
+
 [doc-install-script]: ../production/install.html#step-2-install-zulip
 
 ### After Zulip is already installed
@@ -80,11 +83,12 @@ To enable the Certbot automation on an already-installed Zulip
 server, run the following commands:
 ```
 sudo -s  # If not already root
-/home/zulip/deployments/current/scripts/setup/setup-certbot --hostname=HOSTNAME --email=EMAIL
+/home/zulip/deployments/current/scripts/setup/setup-certbot --email=EMAIL HOSTNAME [HOSTNAME2...]
 ```
 where HOSTNAME is the domain name users see in their browser when
 using the server (e.g., `zulip.example.com`), and EMAIL is a contact
-address for the server admins.
+address for the server admins. Additional hostnames can also be
+specified to issue a certificate for multiple domains.
 
 ### How it works
 

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -161,7 +161,7 @@ fi
 if [ -n "$USE_CERTBOT" ]; then
     "$ZULIP_PATH"/scripts/setup/setup-certbot \
         --no-zulip-conf --method=standalone \
-        --hostname "$EXTERNAL_HOST" --email "$ZULIP_ADMINISTRATOR"
+        "$EXTERNAL_HOST" --email "$ZULIP_ADMINISTRATOR"
 elif [ -n "$SELF_SIGNED_CERT" ]; then
     "$ZULIP_PATH"/scripts/setup/generate-self-signed-cert \
         --exists-ok "${EXTERNAL_HOST:-$(hostname)}"

--- a/scripts/setup/setup-certbot
+++ b/scripts/setup/setup-certbot
@@ -4,7 +4,8 @@ set -e
 
 usage() {
     cat <<EOF >&2
-Usage: $0 --hostname=zulip.example.com --email=admin@example.com [--method={webroot|standalone}] [--no-zulip-conf]
+Usage: $0 --email=admin@example.com [--method={webroot|standalone}] \
+[--no-zulip-conf] hostname.com [another.hostname.com]
 EOF
     exit 1
 }
@@ -15,15 +16,10 @@ if [ "$EUID" -ne 0 ]; then
 fi
 
 method=webroot
-args="$(getopt -o '' --long help,hostname:,email:,method:,deploy-hook:,no-zulip-conf,agree-tos -n "$0" -- "$@")"
+args="$(getopt -o '' --long help,email:,method:,deploy-hook:,no-zulip-conf,agree-tos -n "$0" -- "$@")"
 eval "set -- $args"
 while true; do
     case "$1" in
-        --hostname)
-            DOMAIN="$2"
-            shift
-            shift
-            ;;
         --email)
             EMAIL="$2"
             shift
@@ -52,10 +48,18 @@ while true; do
             shift
             ;;
         --)
+            shift
             break
             ;;
     esac
 done
+
+# Parse the remaining arguments as Subject Alternative Names to pass to certbot
+HOSTNAMES=()
+for arg; do
+    HOSTNAMES+=(-d "$arg")
+done
+DOMAIN=$1
 
 if [ -n "$show_help" ]; then
     usage
@@ -94,7 +98,7 @@ chmod a+x "$CERTBOT_PATH"
 # Passing --force-interactive suppresses a warning, but also brings up
 # an annoying prompt we stifle with --no-eff-email.
 "$CERTBOT_PATH" certonly "${method_args[@]}" \
-                -d "$DOMAIN" -m "$EMAIL" \
+                "${HOSTNAMES[@]}" -m "$EMAIL" \
                 $agree_tos --force-renewal \
                 "${deploy_hook[@]}" \
                 --force-interactive --no-eff-email


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

Fixes #10674.

**Testing Plan:**

The first commit here is tested. See the certificate at:

1. https://nightly.zulipdev.org
2. https://nightly-test.zulipdev.org

Command used to issue: `sudo scripts/setup/setup-certbot --hostname=nightly.zulipdev.org --email=aero31aero@gmail.com --althostnames=nightly-test.zulipdev.org --agree-tos`

**NOTE**: The second commit hasn't been tested at all. I'm not sure what's the best strategy for testing that without doing a complete prod install.