### PR TITLE
Lazy-load inline profile pictures

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "jquery": "3.3.1",
     "jquery-validation": "1.17.0",
     "katex": "0.8.3",
+    "lazysizes": "4.1.6",
     "mini-css-extract-plugin": "0.4.0",
     "moment": "2.22.1",
     "moment-timezone": "0.5.17",

--- a/static/js/bundles/commons.js
+++ b/static/js/bundles/commons.js
@@ -10,6 +10,7 @@ import "js/common.js";
 import "node_modules/moment/min/moment.min.js";
 import "node_modules/moment-timezone/builds/moment-timezone-with-data.min.js";
 import "node_modules/sortablejs/Sortable.js";
+import "node_modules/lazysizes/lazysizes.js";
 import "third/bootstrap/css/bootstrap.css";
 import "third/bootstrap/css/bootstrap-btn.css";
 import "third/bootstrap/css/bootstrap-responsive.css";

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1535,6 +1535,7 @@ blockquote p {
     vertical-align: top;
     border-radius: 4px;
     overflow: hidden;
+    background-color: hsl(0, 0%, 90%);
 
     &.guest-avatar::after {
         outline: 2px solid hsl(0, 0%, 100%);

--- a/static/templates/message_avatar.handlebars
+++ b/static/templates/message_avatar.handlebars
@@ -1,3 +1,3 @@
 <div class="u-{{msg/sender_id}} inline_profile_picture {{#sender_is_guest}} guest-avatar{{/sender_is_guest}}" aria-hidden="true">
-    <img src="{{small_avatar_url}}" alt="" class="no-drag"/>
+    <img data-src="{{small_avatar_url}}" alt="" class="lazyload no-drag"/>
 </div>


### PR DESCRIPTION
Using lazysizes library, we just load images visible to user and then lazyload every other inline profile picture later as the user scrolls. This will decrease load time and make the site interactive little bit faster.

While the are loading or in case of network failure the profile picture block will be light greyish block.


**Testing Plan:** I tested this by adding some extra users and messages (`./manage.py populate_db -n100 --extra-users 100`), then once the message list loads disabled the network using devtools.



**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![screen shot 2018-10-21 at 1 27 35 pm](https://user-images.githubusercontent.com/23620441/47270136-15c4c480-d535-11e8-855d-5b6da7ba890e.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
