### PR TITLE
Make stripe.error stubs more similar to stripe python lib

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -175,7 +175,7 @@ class StripeTest(ZulipTestCase):
         @catch_stripe_errors
         def raise_invalid_request_error() -> None:
             raise stripe.error.InvalidRequestError(
-                "Request req_oJU621i6H6X4Ez: No such token: x", None, json_body={})
+                "message", "param", "code", json_body={})
         with self.assertRaises(BillingError) as context:
             raise_invalid_request_error()
         self.assertEqual('other stripe error', context.exception.description)
@@ -819,7 +819,7 @@ class BillingProcessorTest(ZulipTestCase):
             log_row=entry1, state=BillingProcessor.DONE)
         Customer.objects.create(realm=get_realm('zulip'), stripe_customer_id='cust_1')
         with patch('corporate.lib.stripe.do_adjust_subscription_quantity',
-                   side_effect=stripe.error.StripeError('message', 'param', 'code', json_body={})):
+                   side_effect=stripe.error.StripeError('message', json_body={})):
             with self.assertRaises(BillingError):
                 run_billing_processor_one_step(processor)
         mock_billing_logger_error.assert_called()

--- a/stubs/stripe/error/__init__.pyi
+++ b/stubs/stripe/error/__init__.pyi
@@ -1,22 +1,38 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 # List of StripeError's from https://stripe.com/docs/api/python#error_handling
+# and https://github.com/stripe/stripe-python/blob/master/stripe/error.py
 
 class StripeError(Exception):
+    def __init__(self, message: Optional[str]=None, http_body: Optional[str]=None,
+                 http_status: Optional[int]=None, json_body: Optional[Dict[str, Any]]=None,
+                 headers: Optional[Dict[str, Any]]=None, code: Optional[str]=None) -> None:
+        ...
+
     http_status: str
     json_body: Dict[str, Any]
 
 class CardError(StripeError):
-    ...
+    def __init__(self, message: str, param: str, code: str, http_body: Optional[str]=None,
+                 http_status: Optional[int]=None, json_body: Optional[Dict[str, Any]]=None,
+                 headers: Optional[Dict[str, Any]]=None) -> None:
+        ...
 
 class RateLimitError(StripeError):
     ...
 
 class InvalidRequestError(StripeError):
-    ...
+    def __init__(self, message: str, param: str, code: str, http_body: Optional[str]=None,
+                 http_status: Optional[int]=None, json_body: Optional[Dict[str, Any]]=None,
+                 headers: Optional[Dict[str, Any]]=None) -> None:
+        ...
 
 class AuthenticationError(StripeError):
     ...
 
 class APIConnectionError(StripeError):
-    ...
+    def __init__(self, message: Optional[str]=None, http_body: Optional[str]=None,
+                 http_status: Optional[int]=None, json_body: Optional[Dict[str, Any]]=None,
+                 headers: Optional[Dict[str, Any]]=None, code: Optional[str]=None,
+                 should_retry: bool=False) -> None:
+        ...


### PR DESCRIPTION
This will also fix the error that is generated during the mypy 0.641 upgrade in PR #10691.

@timabbott @rishig 