### PR TITLE
upgrade-zulip-from-git: Support specifying tag or commit ID for refname.

### DIFF
--- a/scripts/upgrade-zulip-from-git
+++ b/scripts/upgrade-zulip-from-git
@@ -55,6 +55,7 @@ get_deployment_lock(error_rerun_script)
 
 try:
     deploy_path = make_deploy_path()
+    deploy_branch = 'deploy-' + deploy_path.split('/')[-1]
     if not os.path.exists(LOCAL_GIT_CACHE_DIR):
         logging.info("Cloning the repository")
         subprocess.check_call(["git", "clone", "-q", remote_url, "--mirror", LOCAL_GIT_CACHE_DIR],
@@ -66,10 +67,11 @@ try:
     subprocess.check_call(["git", "remote", "set-url", "origin", remote_url], preexec_fn=su_to_zulip)
     subprocess.check_call(["git", "fetch", "-q"], preexec_fn=su_to_zulip)
 
-    subprocess.check_call(["git", "clone", "-q", "-b", refname, LOCAL_GIT_CACHE_DIR, deploy_path],
+    subprocess.check_call(["git", "clone", "-q", LOCAL_GIT_CACHE_DIR, deploy_path],
                           stdout=open('/dev/null', 'w'),
                           preexec_fn=su_to_zulip)
     os.chdir(deploy_path)
+    subprocess.check_call(["git", "checkout", "-b", deploy_branch, refname], preexec_fn=su_to_zulip)
 
     subprocess.check_call(["ln", "-nsf", "/etc/zulip/settings.py",
                            os.path.join(deploy_path, "zproject/prod_settings.py")])


### PR DESCRIPTION
Fixes #10706.
Issue: Before this commit, the `refname` positional argument to
`upgrade-zulip-from-git` script would run successfully for a branch
name on the given remote, but the script would fail if it was
provided with a tag or commit ID.
Solution: `git clone -q -b refname LOCAL_GIT_CACHE_DIR deploy_path`
would be split into two commands:
1.) `git clone -q LOCAL_GIT_CACHE_DIR deploy_path`
2.) `git checkout -b refname refname` which makes a new branch
having same name as the refname.

In case of an invalid refname, following will be the output:
```
root@shubham-padia:~# /home/zulip/deployments/current/scripts/upgrade-zulip-from-git 57w348953
2018-10-22 22:32:13,426 upgrade-zulip-from-git: Fetching the latest commits
fatal: Cannot update paths and switch to branch '57w348953' at the same time.
Did you intend to checkout '57w348953' which can not be resolved as commit?
Traceback (most recent call last):
  File "/home/zulip/deployments/current/scripts/upgrade-zulip-from-git", line 73, in <module>
    subprocess.check_call(["git", "checkout", "-b", refname, refname], preexec_fn=su_to_zulip)
  File "/usr/lib/python3.5/subprocess.py", line 581, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['git', 'checkout', '-b', '57w348953', '57w348953']' returned non-zero exit status 128
```