### PR TITLE
stripe: Fix the button glitch in /upgrade page

### DIFF
--- a/static/styles/billing.scss
+++ b/static/styles/billing.scss
@@ -146,6 +146,12 @@
         }
     }
 
+    .stripe-button-el:hover:disabled {
+        box-shadow: none;
+        background-color: rgb(200, 200, 200);
+        pointer-events: none;
+    }
+
     #error-message-box {
         margin-top: 10px;
         font-weight: 600;


### PR DESCRIPTION
Disabled gray button turns green after the card is added in /upgrade page. This PR should fix that.

## Before
![button-glitch](https://user-images.githubusercontent.com/7190633/47423782-8a9d3600-d7a3-11e8-9f32-e59a74517c9a.gif)


## After the fix
![button-glitch-fix](https://user-images.githubusercontent.com/7190633/47423787-8ec95380-d7a3-11e8-872b-3904afb32507.gif)

