### PR TITLE
message-view : Zooming in expands viewing window on lightbox.

### DIFF
--- a/static/js/lightbox_canvas.js
+++ b/static/js/lightbox_canvas.js
@@ -221,6 +221,32 @@ var LightboxCanvas = (function () {
             canvas.width = canvas.width;
             context.imageSmoothingEnabled = false;
 
+            if (canvas.width < canvas.height) {
+                var maxWidth = window.innerWidth * 0.75;
+                var defaultWidth = canvas.width / 2;
+                var adjustedWidth;
+                var ratio;
+
+                // 4 is hardcoded as the zoom level where the maxWidth will be used,
+                // since most people will only be zooming in at the early levels.
+                var maxedOnZoom = 4;
+                var zoomRatio = (meta.zoom - 1) / (maxedOnZoom - 1);
+                // If meta.zoom hasn't reached 4, the variable width formula is used,
+                // until it reaches 4 and defaults to the max width.
+                if (meta.zoom < maxedOnZoom) {
+                    adjustedWidth = defaultWidth + (maxWidth - defaultWidth) * zoomRatio;
+                } else {
+                    adjustedWidth = maxWidth;
+                }
+                ratio = canvas.width * meta.zoom / adjustedWidth;
+                canvas.style.width = adjustedWidth + "px";
+                w  = canvas.width / 2 * ratio;
+                // Prevents the image from going off-screen.
+                if (x + w <= canvas.width) {
+                    x = canvas.width - w;
+                }
+            }
+
             context.drawImage(meta.image, x, y, w, h);
         },
 


### PR DESCRIPTION
#10587
@rishig 
![zulip](https://user-images.githubusercontent.com/15152698/47463471-4f573300-d7b4-11e8-8e2d-b112c93a2ebe.gif)
I set the "limit" of the maximum width for the zoom to be 75% of the screen, as well as making the maximum width to be reached when the zoom level is 4 (zoom level goes up to 10). I did this because I figure the earlier zoom levels will be more widely used by users, so the viewing window should grow larger early rather than scale linearly.
