### PR TITLE
hipchat import: Fix bug w/rogue UserMessage records.

### DIFF
--- a/zerver/data_import/hipchat.py
+++ b/zerver/data_import/hipchat.py
@@ -626,8 +626,8 @@ def make_user_messages(zerver_message: List[ZerverFieldsT],
         recipient_id = message['recipient']
         sender_id = message['sender']
         mention_user_ids = mention_map[message_id]
-        user_ids = subscriber_map.get(recipient_id, set())
-        user_ids.add(sender_id)
+        subscriber_ids = subscriber_map.get(recipient_id, set())
+        user_ids = subscriber_ids | {sender_id}
 
         for user_id in user_ids:
             is_mentioned = user_id in mention_user_ids


### PR DESCRIPTION
This bug was introduced very recently and is an
aliasing bug.  It caused extra UserMessage rows to
be created as we inadvertently updated the underlying
subscriber_map sets for multiple messages.

This probably mostly affected PMs.

It's doubtful the bug ever got out into the field.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
