### PR TITLE
mypy: REQ/None fixes revisited

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -83,9 +83,7 @@ follow_imports = skip
 
 strict_optional = True
 
-# REQ returning None issue
-[mypy-zerver.decorator]
-strict_optional = False
+# Various issues
 
 [mypy-zerver.webhooks.gitlab.view]
 strict_optional = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -86,42 +86,8 @@ strict_optional = True
 # REQ returning None issue
 [mypy-zerver.decorator]
 strict_optional = False
-[mypy-zerver.views.zephyr]
-strict_optional = False
-[mypy-zerver.views.user_settings]
-strict_optional = False
-[mypy-zerver.views.streams]
-strict_optional = False
-[mypy-zerver.views.storage]
-strict_optional = False
-[mypy-zerver.views.report]
-strict_optional = False
-[mypy-zerver.views.integrations]
-strict_optional = False
-[mypy-zerver.tornado.views]
-strict_optional = False
-[mypy-zerver.views.events_register]
-strict_optional = False
 
-[mypy-zerver.lib.webhooks.common]
-strict_optional = False
-[mypy-zerver.webhooks.yo.view]
-strict_optional = False
-[mypy-zerver.webhooks.transifex.view]
-strict_optional = False
-[mypy-zerver.webhooks.newrelic.view]
-strict_optional = False
-[mypy-zerver.webhooks.gogs.view]
-strict_optional = False
 [mypy-zerver.webhooks.gitlab.view]
-strict_optional = False
-[mypy-zerver.webhooks.github.view]
-strict_optional = False
-[mypy-zerver.webhooks.bitbucket.view]
-strict_optional = False
-[mypy-zerver.webhooks.bitbucket2.view]
-strict_optional = False
-[mypy-zerver.webhooks.beanstalk.view]
 strict_optional = False
 
 [mypy-zerver.views.auth]  # Other issues in this file too

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -146,7 +146,7 @@ def get_client_name(request: HttpRequest, is_browser_view: bool) -> str:
     if 'client' in request.POST:
         return request.POST['client']
     if "HTTP_USER_AGENT" in request.META:
-        user_agent = parse_user_agent(request.META["HTTP_USER_AGENT"])
+        user_agent = parse_user_agent(request.META["HTTP_USER_AGENT"])  # type: Optional[Dict[str, str]]
     else:
         user_agent = None
     if user_agent is not None:
@@ -282,14 +282,13 @@ def log_exception_to_webhook_logger(request: HttpRequest, user_profile: UserProf
 
     custom_header_template = "{header}: {value}\n"
 
-    header_message = ""
+    header_text = ""
     for header in request.META.keys():
         if header.lower().startswith('http_x'):
-            header_message += custom_header_template.format(
+            header_text += custom_header_template.format(
                 header=header, value=request.META[header])
 
-    if not header_message:
-        header_message = None
+    header_message = header_text if header_text else None
 
     message = """
 user: {email} ({realm})
@@ -556,7 +555,7 @@ def authenticated_uploads_api_view() -> Callable[[ViewFuncT], ViewFuncT]:
 #
 # If webhook_client_name is specific, the request is a webhook view
 # with that string as the basis for the client string.
-def authenticated_rest_api_view(*, webhook_client_name: str=None,
+def authenticated_rest_api_view(*, webhook_client_name: Optional[str]=None,
                                 is_webhook: bool=False) -> Callable[[ViewFuncT], ViewFuncT]:
     def _wrapped_view_func(view_func: ViewFuncT) -> ViewFuncT:
         @csrf_exempt


### PR DESCRIPTION
The latest mypy allows the `REQ` pattern to return `None` explicitly (python/mypy#4214), so this PR removes the constraint in mypy.ini to not check some files as deeply. Many pass with no changes; another commit allows `decorator.py` to pass. Others require more work, but not with regard to the `REQ` issue.

This passes mypy & travis passes fine.