### PR TITLE
Make mock_stripe handle StripeErrors

### DIFF
--- a/corporate/tests/stripe_fixtures/upgrade_where_subscription_save_fails_at_first:Subscription.create.1.json
+++ b/corporate/tests/stripe_fixtures/upgrade_where_subscription_save_fails_at_first:Subscription.create.1.json
@@ -1,0 +1,34 @@
+{
+  "_message": "Your card was declined.",
+  "param": "",
+  "http_status": 402,
+  "json_body": {
+    "error": {
+      "param": "",
+      "type": "card_error",
+      "code": "card_declined",
+      "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+      "message": "Your card was declined.",
+      "decline_code": "generic_decline"
+    }
+  },
+  "http_body": "{\n  \"error\": {\n    \"code\": \"card_declined\",\n    \"decline_code\": \"generic_decline\",\n    \"doc_url\": \"https://stripe.com/docs/error-codes/card-declined\",\n    \"message\": \"Your card was declined.\",\n    \"param\": \"\",\n    \"type\": \"card_error\"\n  }\n}\n",
+  "code": "card_declined",
+  "headers": {
+    "Stripe-Version": "2018-08-23",
+    "Connection": "keep-alive",
+    "Content-Length": "241",
+    "Access-Control-Allow-Methods": "GET, POST, HEAD, OPTIONS, DELETE",
+    "Content-Type": "application/json",
+    "Access-Control-Max-Age": "300",
+    "Date": "Tue, 30 Oct 2018 10:46:04 GMT",
+    "Access-Control-Allow-Credentials": "true",
+    "Strict-Transport-Security": "max-age=31556926; includeSubDomains; preload",
+    "Cache-Control": "no-cache, no-store",
+    "Request-Id": "req_vACbrVvv7Dk1QN",
+    "Access-Control-Expose-Headers": "Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required",
+    "Server": "nginx",
+    "Access-Control-Allow-Origin": "*"
+  },
+  "request_id": "req_vACbrVvv7Dk1QN"
+}

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -121,10 +121,16 @@ def read_stripe_fixture(decorated_function_name: str,
     return _read_stripe_fixture
 
 def mock_stripe(mocked_function_name: str,
-                generate_this_fixture: bool=False) -> Callable[[CallableT], CallableT]:
+                generate_this_fixture: Optional[bool]=None) -> Callable[[CallableT], CallableT]:
     def _mock_stripe(decorated_function: CallableT) -> CallableT:
         mocked_function = operator.attrgetter(mocked_function_name)(sys.modules[__name__])
-        if GENERATE_STRIPE_FIXTURES or generate_this_fixture:
+
+        if generate_this_fixture is not None:
+            generate_fixture = generate_this_fixture
+        else:
+            generate_fixture = GENERATE_STRIPE_FIXTURES
+
+        if generate_fixture:
             side_effect = generate_and_save_stripe_fixture(
                 decorated_function.__name__, mocked_function_name, mocked_function)  # nocoverage
         else:
@@ -144,9 +150,9 @@ class Kandra(object):
         return True
 
 class StripeTest(ZulipTestCase):
-    @mock_stripe("stripe.Coupon.create")
-    @mock_stripe("stripe.Plan.create")
-    @mock_stripe("stripe.Product.create")
+    @mock_stripe("stripe.Coupon.create", False)
+    @mock_stripe("stripe.Plan.create", False)
+    @mock_stripe("stripe.Product.create", False)
     def setUp(self, mock3: Mock, mock2: Mock, mock1: Mock) -> None:
         call_command("setup_stripe")
 

--- a/stubs/stripe/__init__.pyi
+++ b/stubs/stripe/__init__.pyi
@@ -1,5 +1,6 @@
 import stripe.error as error
 import stripe.util as util
+import stripe.api_requestor as api_requestor
 from stripe.api_resources.list_object import SubscriptionListObject
 
 from typing import Optional, Any, Dict, List, Union

--- a/stubs/stripe/api_requestor/__init__.pyi
+++ b/stubs/stripe/api_requestor/__init__.pyi
@@ -1,0 +1,5 @@
+from typing import Any, Dict
+
+class APIRequestor:
+    def interpret_response(self, http_body: str, http_status: int, http_headers: Dict[str, Any]) -> None:
+        ...


### PR DESCRIPTION
Need a bit more work to make this work. Currently having trouble converting some fields of `stripe_error.__dict__` to JSON.