### PR TITLE
outgoing webhooks: Support widget content.

### DIFF
--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -58,6 +58,8 @@ class GenericOutgoingWebhookService(OutgoingWebhookServiceInterface):
         if "content" in response_json:
             content = str(response_json['content'])
             success_data = dict(content=content)
+            if 'widget_content' in response_json:
+                success_data['widget_content'] = response_json['widget_content']
             return success_data
 
         return None
@@ -144,6 +146,8 @@ def send_response_message(bot_id: str, message_info: Dict[str, Any], response_da
     if not content:
         raise JsonableError(_("Missing content"))
 
+    widget_content = response_data.get('widget_content')
+
     if message_type == 'stream':
         message_to = [display_recipient]
     elif message_type == 'private':
@@ -158,6 +162,7 @@ def send_response_message(bot_id: str, message_info: Dict[str, Any], response_da
         message_to=message_to,
         topic_name=topic_name,
         message_content=content,
+        widget_content=widget_content,
         realm=realm,
     )
 
@@ -253,9 +258,10 @@ def process_success_response(event: Dict[str, Any],
     if content is None:
         return
 
+    widget_content = success_data.get('widget_content')
     bot_id = event['user_profile_id']
     message_info = event['message']
-    response_data = dict(content=content)
+    response_data = dict(content=content, widget_content=widget_content)
     send_response_message(bot_id=bot_id, message_info=message_info, response_data=response_data)
 
 def do_rest_call(base_url: str,

--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -78,6 +78,18 @@ class TestGenericOutgoingWebhookService(ZulipTestCase):
         success_response = self.handler.process_success(response, self.event)
         self.assertEqual(success_response, dict(content='test_content'))
 
+        response = dict(
+            content='test_content',
+            widget_content='test_widget_content',
+            red_herring='whatever',
+        )
+        success_response = self.handler.process_success(response, self.event)
+        expected_response = dict(
+            content='test_content',
+            widget_content='test_widget_content',
+        )
+        self.assertEqual(success_response, expected_response)
+
         response = dict()
         success_response = self.handler.process_success(response, self.event)
         self.assertEqual(success_response, None)


### PR DESCRIPTION
If we use an outgoing webhook and the web server
responds with `widget_content` in the payload, we
include that in what we send through the send-message
codepath.

This makes outgoing webhook bots more consistent with
generic bots.
