### PR TITLE
Typing changes to remove descriptors/backends/actions from mypy.ini

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -163,8 +163,6 @@ strict_optional = False
 strict_optional = False
 [mypy-zerver.lib.actions]
 strict_optional = False
-[mypy-zproject.backends]
-strict_optional = False
 [mypy-zerver.worker.queue_processors]
 strict_optional = False
 [mypy-zerver.tornado.websocket_client]

--- a/mypy.ini
+++ b/mypy.ini
@@ -161,8 +161,6 @@ strict_optional = False
 strict_optional = False
 [mypy-zerver.lib.push_notifications]
 strict_optional = False
-[mypy-zerver.lib.actions]
-strict_optional = False
 [mypy-zerver.worker.queue_processors]
 strict_optional = False
 [mypy-zerver.tornado.websocket_client]

--- a/mypy.ini
+++ b/mypy.ini
@@ -115,9 +115,6 @@ strict_optional = False
 [mypy-zerver.tornado.handlers]  # Delayed setup of ASyncDjangoHandler._request_middleware (Optional), line 200 error
 strict_optional = False
 
-[mypy-zerver.tornado.descriptors]  # line 10: 'get' can return None; only used in zerver/tornado/handlers?
-strict_optional = False
-
 # Tests (may be many issues in file; comment is just one error noted)
 
 [mypy-zerver/tests/test_tornado]  #202: error: Item "None" of "Optional[Morsel[Any]]" has no attribute "coded_value"

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -521,7 +521,7 @@ def notify_created_bot(user_profile: UserProfile) -> None:
     event = created_bot_event(user_profile)
     send_event(event, bot_owner_user_ids(user_profile))
 
-def create_users(realm: Realm, name_list: Iterable[Tuple[str, str]], bot_type: int=None) -> None:
+def create_users(realm: Realm, name_list: Iterable[Tuple[str, str]], bot_type: Optional[int]=None) -> None:
     user_set = set()
     for full_name, email in name_list:
         short_name = email_to_username(email)
@@ -3343,7 +3343,7 @@ def do_set_user_display_setting(user_profile: UserProfile,
     event = {'type': 'update_display_settings',
              'user': user_profile.email,
              'setting_name': setting_name,
-             'setting': setting_value}
+             'setting': setting_value}  # type: Dict[str, Union[bool, str, None]]
     if setting_name == "default_language":
         assert isinstance(setting_value, str)
         event['language_name'] = get_language_name(setting_value)
@@ -4658,6 +4658,8 @@ def do_revoke_user_invite(prereg_user: PreregistrationUser) -> None:
     notify_invites_changed(prereg_user)
 
 def do_resend_user_invite_email(prereg_user: PreregistrationUser) -> int:
+    assert prereg_user.referred_by is not None
+    assert prereg_user.realm is not None
     check_invite_limit(prereg_user.referred_by.realm, 1)
 
     prereg_user.invited_at = timezone_now()
@@ -4928,7 +4930,7 @@ def notify_realm_custom_profile_fields(realm: Realm, operation: str) -> None:
 
 def try_add_realm_custom_profile_field(realm: Realm, name: str, field_type: int,
                                        hint: str='',
-                                       field_data: ProfileFieldData=None) -> CustomProfileField:
+                                       field_data: Optional[ProfileFieldData]=None) -> CustomProfileField:
     field = CustomProfileField(realm=realm, name=name, field_type=field_type)
     field.hint = hint
     if field.field_type == CustomProfileField.CHOICE:
@@ -4953,7 +4955,7 @@ def do_remove_realm_custom_profile_fields(realm: Realm) -> None:
 
 def try_update_realm_custom_profile_field(realm: Realm, field: CustomProfileField,
                                           name: str, hint: str='',
-                                          field_data: ProfileFieldData=None) -> None:
+                                          field_data: Optional[ProfileFieldData]=None) -> None:
     field.name = name
     field.hint = hint
     if field.field_type == CustomProfileField.CHOICE:

--- a/zerver/lib/addressee.py
+++ b/zerver/lib/addressee.py
@@ -84,7 +84,7 @@ class Addressee:
     def legacy_build(sender: UserProfile,
                      message_type_name: str,
                      message_to: Sequence[str],
-                     topic_name: str,
+                     topic_name: Optional[str],
                      realm: Optional[Realm]=None) -> 'Addressee':
 
         # For legacy reason message_to used to be either a list of
@@ -117,7 +117,7 @@ class Addressee:
             raise JsonableError(_("Invalid message type"))
 
     @staticmethod
-    def for_stream(stream_name: str, topic: str) -> 'Addressee':
+    def for_stream(stream_name: str, topic: Optional[str]) -> 'Addressee':
         if topic is None:
             raise JsonableError(_("Missing topic"))
         topic = topic.strip()

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1428,12 +1428,13 @@ class Message(AbstractMessage):
                 'bitcoin:' in content)
 
     @staticmethod
-    def is_status_message(content: str, rendered_content: str) -> bool:
+    def is_status_message(content: str, rendered_content: Optional[str]) -> bool:
         """
         Returns True if content and rendered_content are from 'me_message'
         """
         if content.startswith('/me ') and '\n' not in content:
-            if rendered_content.startswith('<p>') and rendered_content.endswith('</p>'):
+            if rendered_content is None or \
+                    (rendered_content.startswith('<p>') and rendered_content.endswith('</p>')):
                 return True
         return False
 

--- a/zerver/tornado/descriptors.py
+++ b/zerver/tornado/descriptors.py
@@ -6,7 +6,7 @@ if False:
 
 descriptors_by_handler_id = {}  # type: Dict[int, ClientDescriptor]
 
-def get_descriptor_by_handler_id(handler_id: int) -> 'ClientDescriptor':
+def get_descriptor_by_handler_id(handler_id: int) -> Optional['ClientDescriptor']:
     return descriptors_by_handler_id.get(handler_id)
 
 def set_descriptor_by_handler_id(handler_id: int,

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -81,7 +81,7 @@ def require_email_format_usernames(realm: Optional[Realm]=None) -> bool:
     return True
 
 def common_get_active_user(email: str, realm: Realm,
-                           return_data: Dict[str, Any]=None) -> Optional[UserProfile]:
+                           return_data: Optional[Dict[str, Any]]=None) -> Optional[UserProfile]:
     try:
         user_profile = get_user(email, realm)
     except UserProfile.DoesNotExist:
@@ -159,7 +159,7 @@ class ZulipDummyBackend(ZulipAuthMixin):
 
     def authenticate(self, username: Optional[str]=None, realm: Optional[Realm]=None,
                      use_dummy_backend: bool=False,
-                     return_data: Dict[str, Any]=None) -> Optional[UserProfile]:
+                     return_data: Optional[Dict[str, Any]]=None) -> Optional[UserProfile]:
         if use_dummy_backend:
             # These are kwargs only for readability; they should never be None
             assert username is not None
@@ -215,7 +215,7 @@ class GoogleMobileOauth2Backend(ZulipAuthMixin):
         https://developers.google.com/accounts/docs/CrossClientAuth#offlineAccess
     """
 
-    def authenticate(self, google_oauth2_token: str=None, realm: Optional[Realm]=None,
+    def authenticate(self, google_oauth2_token: Optional[str]=None, realm: Optional[Realm]=None,
                      return_data: Optional[Dict[str, Any]]=None) -> Optional[UserProfile]:
         # We lazily import apiclient as part of optimizing the base
         # import time for a Zulip management command, since it's only
@@ -346,7 +346,8 @@ class ZulipLDAPAuthBackend(ZulipLDAPAuthBackendBase):
         try:
             username = self.django_to_ldap_username(username)
         except ZulipLDAPExceptionOutsideDomain:
-            return_data['outside_ldap_domain'] = True
+            if return_data is not None:
+                return_data['outside_ldap_domain'] = True
             return None
 
         return ZulipLDAPAuthBackendBase.authenticate(self,


### PR DESCRIPTION
These are 3 further commits to remove 3 more exclusions from the strict-optional section of `mypy.ini`.

* descriptors is straightforward (it's used in the excluded tornado/handlers, but annotations match the code)
* backends is related to using `Optional` in some function default parameters; since `return_data` is `Optional` then I've wrapped the assignment in the `except` block in a conditional (ok?)
* the actions commit is the most complex:
  - some annotation changes in that file (should be ok)
  - `Addressee` has topics `Optional` in two extra places (should be ok)
  - the `Message.is_status_message()` parameter `rendered_content` is now `Optional`; the function body is adjusted accordingly

I've currently marked the last commit as DO_NOT_MERGE, since there are two asserts in actions.py in `do_resend_user_invite_email` concerning the `referred_by` and `realm` members of the `PreregistrationUser`; these forcibly 'fix' the issue there, but I'd appreciate input regarding what the `None` values of these represent - or just an alternative proper fix, of course ;)

I adjusted the commits slightly, but my backend tests don't pass on the droplet against master, so I'm relying on the online ci to check.