### PR TITLE
billing: Make URL hash work in billing page

### DIFF
--- a/static/js/billing/billing.js
+++ b/static/js/billing/billing.js
@@ -43,8 +43,15 @@ $(function () {
         e.preventDefault();
     });
 
-    $('#billing-tabs a').click(function (e) {
-        e.preventDefault();
+    var hash = window.location.hash;
+    if (hash) {
+        $('#billing-tabs.nav a[href="' + hash + '"]').tab('show');
+        $('html,body').scrollTop(0);
+    }
+
+    $('#billing-tabs.nav-tabs a').click(function () {
         $(this).tab('show');
+        window.location.hash = this.hash;
+        $('html,body').scrollTop(0);
     });
 });

--- a/templates/corporate/billing.html
+++ b/templates/corporate/billing.html
@@ -23,8 +23,8 @@
                 <h1>{{ _("Billing") }}</h1>
                 {% if admin_access %}
                 <ul class="nav nav-tabs" id="billing-tabs">
-                    <li class="active"><a href="#overview">Overview</a></li>
-                    <li><a href="#payment-method">Payment Method</a></li>
+                    <li class="active"><a data-toggle="tab" href="#overview">Overview</a></li>
+                    <li><a data-toggle="tab" href="#payment-method">Payment Method</a></li>
                 </ul>
 
                 <div class="tab-content">


### PR DESCRIPTION
This will change the hash of the URL when a new tab gets selected. Vice versa when the billing page is opened the appropriate tab is selected according to hash of the URL. This means when the card gets updated the page would be reloaded correctly to show #payment-method
tab.

![billing-page-tab-hash](https://user-images.githubusercontent.com/7190633/47780558-9c418900-dd21-11e8-83d6-c669eed7684a.gif)
