### PR TITLE
guest user: Few minor followups.

### DIFF
--- a/analytics/tests/test_views.py
+++ b/analytics/tests/test_views.py
@@ -24,6 +24,12 @@ class TestStatsEndpoint(ZulipTestCase):
         # Check that we get something back
         self.assert_in_response("Zulip analytics for", result)
 
+    def test_guest_user_cant_access_stats(self) -> None:
+        self.user = self.example_user('polonius')
+        self.login(self.user.email)
+        result = self.client_get('/stats')
+        self.assert_json_error(result, "Not allowed for guest users", 400)
+
     def test_stats_for_realm(self) -> None:
         user_profile = self.example_user('hamlet')
         self.login(user_profile.email)

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -52,6 +52,8 @@ def render_stats(request: HttpRequest, data_url_suffix: str, target_name: str,
 @zulip_login_required
 def stats(request: HttpRequest) -> HttpResponse:
     realm = request.user.realm
+    if request.user.is_guest:
+        raise JsonableError(_("Not allowed for guest users"))
     return render_stats(request, '', realm.name or realm.string_id)
 
 @require_server_admin

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -569,9 +569,12 @@ run_test('compose_announce', () => {
 });
 
 run_test('compose_not_subscribed', () => {
-    var html = render('compose_not_subscribed');
+    var html = render('compose_not_subscribed', {should_display_sub_button: true});
     var button = $(html).find("button:first");
     assert.equal(button.text(), "translated: Subscribe");
+    html = render('compose_not_subscribed', {should_display_sub_button: false});
+    button = $(html).find("button:first");
+    assert.equal(button.length, 0);
 });
 
 run_test('compose_notification', () => {

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -471,7 +471,9 @@ exports.validation_error = function (error_type, stream_name) {
         compose_error(i18n.t("Error checking subscription"), $("#stream"));
         return false;
     case "not-subscribed":
-        var new_row = templates.render("compose_not_subscribed");
+        var sub = stream_data.get_sub(stream_name);
+        var new_row = templates.render("compose_not_subscribed", {
+            should_display_sub_button: sub.should_display_subscription_button});
         compose_not_subscribed_error(new_row, $('#stream'));
         return false;
     }

--- a/static/templates/compose_not_subscribed.handlebars
+++ b/static/templates/compose_not_subscribed.handlebars
@@ -5,6 +5,8 @@
         {{/tr}}
     </p>
     <div>
+        {{#if should_display_sub_button}}
         <button id="error-message-sub-button" class="btn btn-warning subscribe-button sub_unsub_button">{{t "Subscribe" }}</button><button type="button" id="compose_not_subscribed_close" class="close">&times;</button>
+        {{/if}}
     </div>
 </div>

--- a/templates/zerver/app/navbar.html
+++ b/templates/zerver/app/navbar.html
@@ -147,12 +147,14 @@
                                     <i class="fa fa-sitemap" aria-hidden="true"></i> {{ _('API documentation') }}
                                 </a>
                             </li>
+                            {% if not is_guest %}
                             <li role="presentation">
                                 <a href="/stats" target="_blank" role="menuitem">
                                     <i class="fa fa-bar-chart" aria-hidden="true"></i>
                                     <span>{{ _('Statistics') }}</span>
                                 </a>
                             </li>
+                            {% endif %}
                             {% if show_plans %}
                             <li role="presentation">
                                 <a href="/plans" role="menuitem">


### PR DESCRIPTION
Issue #10749 
Stream settings

- [X]   If you unsubscribe from a stream, it shows a Subscribe button. Guests can't subscribe to streams.
- [ ]  The Add subscribers feature (under Stream membership) should be hidden
(It will probably easy to handle once #10752 gets merged)

Message view

- [X]  If you unsubscribe from a stream, you get

Guests can't subcribe to streams, so we shouldn't show the button.

- [X] Hide subscription button in warning
![screen shot 2018-11-01 at 12 14 45 am](https://user-images.githubusercontent.com/25907420/47811216-3b3ea300-dd6b-11e8-90ad-533bff2cf801.png)
Its not bug only for guest user, but also for realm user.

Settings

- [X]   We should hide the "Your bots" tab, since guests can't own bots

![screen shot 2018-10-31 at 11 04 24 pm](https://user-images.githubusercontent.com/25907420/47808546-96b96280-dd64-11e8-870f-c73c0e66ef89.png)


Other

- [X]   Guests shouldn't be able to access /stats (including at the API level)