### PR TITLE
Using id -g for finding a user's group works better than whoami

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -202,7 +202,7 @@ if [ ! -w /srv/zulip ]; then
     # sudo is required since our uid is not 1000
     echo '    vagrant halt -f'
     echo '    rm -rf /PATH/TO/ZULIP/CLONE/.vagrant'
-    echo '    sudo chown -R 1000:$(whoami) /PATH/TO/ZULIP/CLONE'
+    echo '    sudo chown -R 1000:$(id -g) /PATH/TO/ZULIP/CLONE'
     echo "Replace /PATH/TO/ZULIP/CLONE with the path to where zulip code is cloned."
     echo "You can resume setting up your vagrant environment by running:"
     echo "    vagrant up"

--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -889,7 +889,7 @@ It is okay to proceed and start the Zulip server.
 ##### Permissions errors
 
 When building the development environment using Vagrant and the LXC provider,
-if you encounter permissions errors, you may need to `chown -R 1000:$(whoami)
+if you encounter permissions errors, you may need to `chown -R 1000:$(id -g)
 /path/to/zulip` on the host before running `vagrant up` in order to ensure that
 the synced directory has the correct owner during provision. This issue will
 arise if you run `id username` on the host where `username` is the user running

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -126,7 +126,7 @@ something valuable to helping keep Zulip bug-free.
 
 - When building the development environment using Vagrant and the LXC
   provider, if you encounter permissions errors, you may need to
-  `chown -R 1000:$(whoami) /path/to/zulip` on the host before running
+  `chown -R 1000:$(id -g) /path/to/zulip` on the host before running
   `vagrant up` in order to ensure that the synced directory has the
   correct owner during provision. This issue will arise if you run `id
   username` on the host where `username` is the user running Vagrant


### PR DESCRIPTION
On OSX, user id and group id don't match. Using `whoami` for finding the group
id doesn't work.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
