### PR TITLE
portico: Fix spacing for logged-in dropdown in nav bar.

### DIFF
--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -770,6 +770,7 @@ input.text-error {
 .portico-header .dropdown-pill {
     border: 1px solid rgba(0, 0, 0, 0.2);
     border-radius: 4px;
+    margin-left: 10px;
     font-weight: 400;
     cursor: pointer;
 }


### PR DESCRIPTION
Old:
![image](https://user-images.githubusercontent.com/890911/47838146-b607be00-dd6b-11e8-9d34-256f2b77c81d.png)

New:
![image](https://user-images.githubusercontent.com/890911/47838142-abe5bf80-dd6b-11e8-85f7-ff2a65822878.png)

10px matches the margin of the other elements in the nav bar.