### PR TITLE
upload: Use a placeholder when quoting and replying.

### DIFF
--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -390,15 +390,13 @@ exports.quote_and_reply = function (opts) {
     var message_id = current_msg_list.selected_id();
 
     exports.respond_to_message(opts);
+    compose_ui.insert_syntax_and_focus("[Quoting…]\n", textarea);
+
     channel.get({
         url: '/json/messages/' + message_id,
         idempotent: true,
         success: function (data) {
-            if (textarea.val() === "") {
-                textarea.val("```quote\n" + data.raw_content + "\n```\n");
-            } else {
-                textarea.val(textarea.val() + "\n```quote\n" + data.raw_content + "\n```\n");
-            }
+            compose_ui.replace_syntax('[Quoting…]', '```quote\n' + data.raw_content + '\n```', textarea);
             $("#compose-textarea").trigger("autosize.resize");
         },
     });


### PR DESCRIPTION
This PR adds the placeholder `[Quoting…]` when quoting and replying before a quote has been added to the message. This improves the user experience if a user begins typing before the quote is added.

Fixes #10705.

**Testing Plan:** <!-- How have you tested? -->

This PR adds tests to the `compose_actions` Node tests for the new behavior.

**GIFs or Screenshots:**

This GIF shows the placeholder being added and then removed once the quote is added, along with "qwerty" being added as a reply. (The placeholder isn't shown for a very long time because the response is relatively fast.)

![GIF of placeholder](https://user-images.githubusercontent.com/17259768/47884357-a92bae80-dded-11e8-9737-5682b29fa85c.gif)
