### PR TITLE
Play 'default' sound for iOS notifications.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -555,6 +555,7 @@ def get_apns_payload(user_profile: UserProfile, message: Message) -> Dict[str, A
             'subtitle': get_apns_alert_subtitle(message),
             'body': content,
         },
+        'sound': 'default',
         'badge': 0,  # TODO: set badge count in a better way
         'custom': {'zulip': zulip_data},
     }

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -750,6 +750,7 @@ class TestGetAPNsPayload(PushNotificationTest):
                 'body': message.content,
             },
             'badge': 0,
+            'sound': 'default',
             'custom': {
                 'zulip': {
                     'message_ids': [message.id],
@@ -778,6 +779,7 @@ class TestGetAPNsPayload(PushNotificationTest):
                 'subtitle': 'King Hamlet:',
                 'body': message.content,
             },
+            'sound': 'default',
             'badge': 0,
             'custom': {
                 'zulip': {
@@ -811,6 +813,7 @@ class TestGetAPNsPayload(PushNotificationTest):
                 'subtitle': 'King Hamlet:',
                 'body': message.content,
             },
+            'sound': 'default',
             'badge': 0,
             'custom': {
                 'zulip': {
@@ -842,6 +845,7 @@ class TestGetAPNsPayload(PushNotificationTest):
                 'subtitle': 'King Hamlet mentioned you:',
                 'body': message.content,
             },
+            'sound': 'default',
             'badge': 0,
             'custom': {
                 'zulip': {
@@ -874,6 +878,7 @@ class TestGetAPNsPayload(PushNotificationTest):
                 'subtitle': "King Hamlet:",
                 'body': "***REDACTED***",
             },
+            'sound': 'default',
             'badge': 0,
             'custom': {
                 'zulip': {


### PR DESCRIPTION
Fixes zulip/zulip-mobile#2651.

This was tested on an iPhone 7 running iOS 12.

@zulipbot add "area: notifications (messages)"
@gnprice 