### PR TITLE
[WIP] Subject to topic on frontend

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -259,7 +259,7 @@ run_test('validate', () => {
 
     compose_state.stream_name('Denmark');
     page_params.realm_mandatory_topics = true;
-    compose_state.subject('');
+    compose_state.topic('');
     $("#subject").select(noop);
     assert(!compose.validate());
     assert.equal($('#compose-error-msg').html(), i18n.t('Please specify a topic'));
@@ -331,7 +331,7 @@ run_test('test_validate_stream_message_announcement_only', () => {
     stream_data.get_announcement_only = function () {
         return true;
     };
-    compose_state.subject('subject102');
+    compose_state.topic('subject102');
     stream_data.add_sub('stream102', sub);
     assert(!compose.validate());
     assert.equal($('#compose-error-msg').html(), i18n.t("Only organization admins are allowed to post to this stream."));
@@ -588,7 +588,7 @@ run_test('send_message', () => {
     // Tests start here.
     (function test_message_send_success_codepath() {
         stub_state = initialize_state_stub_dict();
-        compose_state.subject('');
+        compose_state.topic('');
         compose_state.set_message_type('private');
         page_params.user_id = 101;
         page_params.topic_name = 'topic';

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -591,6 +591,7 @@ run_test('send_message', () => {
         compose_state.subject('');
         compose_state.set_message_type('private');
         page_params.user_id = 101;
+        page_params.topic_name = 'topic';
         compose_state.recipient = function () {
             return 'alice@example.com';
         };
@@ -606,7 +607,7 @@ run_test('send_message', () => {
                 sender_id: 101,
                 queue_id: undefined,
                 stream: '',
-                subject: '',
+                topic: '',
                 to: '["alice@example.com"]',
                 reply_to: 'alice@example.com',
                 private_message_recipient: 'alice@example.com',
@@ -1606,7 +1607,7 @@ run_test('create_message_object', () => {
 
     var message = compose.create_message_object();
     assert.equal(message.to, 'social');
-    assert.equal(message.subject, 'lunch');
+    assert.equal(message.topic, 'lunch');
     assert.equal(message.content, 'burrito');
 
     global.compose_state.get_message_type = function () {

--- a/frontend_tests/node_tests/compose_fade.js
+++ b/frontend_tests/node_tests/compose_fade.js
@@ -68,12 +68,12 @@ run_test('set_focused_recipient', () => {
     var good_msg = {
         type: 'stream',
         stream_id: 101,
-        subject: 'lunch',
+        topic: 'lunch',
     };
     var bad_msg = {
         type: 'stream',
         stream_id: 999,
-        subject: 'lunch',
+        topic: 'lunch',
     };
     assert(!compose_fade.should_fade_message(good_msg));
     assert(compose_fade.should_fade_message(bad_msg));

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -147,7 +147,7 @@ run_test('snapshot_message', () => {
         global.compose_state.stream_name = function () {
             return draft.stream;
         };
-        global.compose_state.subject = function () {
+        global.compose_state.topic = function () {
             return draft.subject;
         };
     }

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -160,7 +160,7 @@ run_test('public_operators', () => {
 run_test('canonicalizations', () => {
     assert.equal(Filter.canonicalize_operator('Is'), 'is');
     assert.equal(Filter.canonicalize_operator('Stream'), 'stream');
-    assert.equal(Filter.canonicalize_operator('Subject'), 'topic');
+    assert.equal(Filter.canonicalize_operator('Topic'), 'topic');
 
     var term;
     term = Filter.canonicalize_term({operator: 'Stream', operand: 'Denmark'});
@@ -233,16 +233,16 @@ run_test('predicate_basics', () => {
     make_sub('Foo', stream_id);
     var predicate = get_predicate([['stream', 'Foo'], ['topic', 'Bar']]);
 
-    assert(predicate({type: 'stream', stream_id: stream_id, subject: 'bar'}));
-    assert(!predicate({type: 'stream', stream_id: stream_id, subject: 'whatever'}));
+    assert(predicate({type: 'stream', stream_id: stream_id, topic: 'bar'}));
+    assert(!predicate({type: 'stream', stream_id: stream_id, topic: 'whatever'}));
     assert(!predicate({type: 'stream', stream_id: 9999999}));
     assert(!predicate({type: 'private'}));
 
     // For old streams that we are no longer subscribed to, we may not have
     // a sub, but these should still match by stream name.
     predicate = get_predicate([['stream', 'old-Stream'], ['topic', 'Bar']]);
-    assert(predicate({type: 'stream', stream: 'Old-stream', subject: 'bar'}));
-    assert(!predicate({type: 'stream', stream: 'no-match', subject: 'whatever'}));
+    assert(predicate({type: 'stream', stream: 'Old-stream', topic: 'bar'}));
+    assert(!predicate({type: 'stream', stream: 'no-match', topic: 'whatever'}));
 
     predicate = get_predicate([['search', 'emoji']]);
     assert(predicate({}));
@@ -289,8 +289,8 @@ run_test('predicate_basics', () => {
     assert(!predicate({id: 6}));
 
     predicate = get_predicate([['id', 5], ['topic', 'lunch']]);
-    assert(predicate({type: 'stream', id: 5, subject: 'lunch'}));
-    assert(!predicate({type: 'stream', id: 5, subject: 'dinner'}));
+    assert(predicate({type: 'stream', id: 5, topic: 'lunch'}));
+    assert(!predicate({type: 'stream', id: 5, topic: 'dinner'}));
 
     predicate = get_predicate([['sender', 'Joe@example.com']]);
     assert(predicate({sender_id: joe.user_id}));
@@ -371,15 +371,15 @@ run_test('mit_exceptions', () => {
     global.page_params.realm_is_zephyr_mirror_realm = true;
 
     var predicate = get_predicate([['stream', 'Foo'], ['topic', 'personal']]);
-    assert(predicate({type: 'stream', stream: 'foo', subject: 'personal'}));
-    assert(predicate({type: 'stream', stream: 'foo.d', subject: 'personal'}));
-    assert(predicate({type: 'stream', stream: 'foo.d', subject: ''}));
+    assert(predicate({type: 'stream', stream: 'foo', topic: 'personal'}));
+    assert(predicate({type: 'stream', stream: 'foo.d', topic: 'personal'}));
+    assert(predicate({type: 'stream', stream: 'foo.d', topic: ''}));
     assert(!predicate({type: 'stream', stream: 'wrong'}));
-    assert(!predicate({type: 'stream', stream: 'foo', subject: 'whatever'}));
+    assert(!predicate({type: 'stream', stream: 'foo', topic: 'whatever'}));
     assert(!predicate({type: 'private'}));
 
     predicate = get_predicate([['stream', 'Foo'], ['topic', 'bar']]);
-    assert(predicate({type: 'stream', stream: 'foo', subject: 'bar.d'}));
+    assert(predicate({type: 'stream', stream: 'foo', topic: 'bar.d'}));
 
     // Try to get the MIT regex to explode for an empty stream.
     var terms = [
@@ -387,7 +387,7 @@ run_test('mit_exceptions', () => {
         {operator: 'topic', operand: 'bar'},
     ];
     predicate = new Filter(terms).predicate();
-    assert(!predicate({type: 'stream', stream: 'foo', subject: 'bar'}));
+    assert(!predicate({type: 'stream', stream: 'foo', topic: 'bar'}));
 
     // Try to get the MIT regex to explode for an empty topic.
     terms = [
@@ -395,7 +395,7 @@ run_test('mit_exceptions', () => {
         {operator: 'topic', operand: ''},
     ];
     predicate = new Filter(terms).predicate();
-    assert(!predicate({type: 'stream', stream: 'foo', subject: 'bar'}));
+    assert(!predicate({type: 'stream', stream: 'foo', topic: 'bar'}));
 });
 
 run_test('predicate_edge_cases', () => {
@@ -425,7 +425,7 @@ run_test('predicate_edge_cases', () => {
     var filter = new Filter(terms);
     filter.predicate();
     predicate = filter.predicate(); // get cached version
-    assert(predicate({type: 'stream', stream: 'foo', subject: 'bar'}));
+    assert(predicate({type: 'stream', stream: 'foo', topic: 'bar'}));
 
 });
 

--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -76,7 +76,8 @@ const messages = {
         stream_id: denmark_stream.stream_id,
         type: 'stream',
         flags: ['has_alert_word'],
-        subject: 'copenhagen',
+        subject: 'copenhagen', // TODO: SUB->TOPIC
+        topic: 'copenhagen',
         // note we don't have every field that a "real" message
         // would have, and that can be fine
     },
@@ -171,13 +172,13 @@ run_test('filter', () => {
     assert.equal(predicate({
         type: 'stream',
         stream_id: denmark_stream.stream_id,
-        subject: 'does not match filter',
+        topic: 'does not match filter',
     }), false);
 
     assert.equal(predicate({
         type: 'stream',
         stream_id: denmark_stream.stream_id,
-        subject: 'copenhagen',
+        topic: 'copenhagen',
     }), true);
 });
 

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -391,38 +391,38 @@ run_test('marked', () => {
 
 run_test('subject_links', () => {
     var message = {type: 'stream', subject: "No links here"};
-    markdown.add_subject_links(message);
+    markdown.add_topic_links(message);
     assert.equal(message.subject_links.length, []);
 
     message = {type: 'stream', subject: "One #123 link here"};
-    markdown.add_subject_links(message);
+    markdown.add_topic_links(message);
     assert.equal(message.subject_links.length, 1);
     assert.equal(message.subject_links[0], "https://trac.zulip.net/ticket/123");
 
     message = {type: 'stream', subject: "Two #123 #456 link here"};
-    markdown.add_subject_links(message);
+    markdown.add_topic_links(message);
     assert.equal(message.subject_links.length, 2);
     assert.equal(message.subject_links[0], "https://trac.zulip.net/ticket/123");
     assert.equal(message.subject_links[1], "https://trac.zulip.net/ticket/456");
 
     message = {type: 'stream', subject: "New ZBUG_123 link here"};
-    markdown.add_subject_links(message);
+    markdown.add_topic_links(message);
     assert.equal(message.subject_links.length, 1);
     assert.equal(message.subject_links[0], "https://trac2.zulip.net/ticket/123");
 
     message = {type: 'stream', subject: "New ZBUG_123 with #456 link here"};
-    markdown.add_subject_links(message);
+    markdown.add_topic_links(message);
     assert.equal(message.subject_links.length, 2);
     assert(message.subject_links.indexOf("https://trac2.zulip.net/ticket/123") !== -1);
     assert(message.subject_links.indexOf("https://trac.zulip.net/ticket/456") !== -1);
 
     message = {type: 'stream', subject: "One ZGROUP_123:45 link here"};
-    markdown.add_subject_links(message);
+    markdown.add_topic_links(message);
     assert.equal(message.subject_links.length, 1);
     assert.equal(message.subject_links[0], "https://zone_45.zulip.net/ticket/123");
 
     message = {type: "not-stream"};
-    markdown.add_subject_links(message);
+    markdown.add_topic_links(message);
     assert.equal(message.subject_links.length, 0);
 });
 

--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -66,6 +66,7 @@ run_test('merge_message_groups', () => {
             type: 'stream',
             stream: 'Test Stream 1',
             subject: 'Test Subject 1',
+            topic: 'Test Subject 1',
             sender_email: 'test@example.com',
             timestamp: _.uniqueId(),
         });
@@ -124,7 +125,7 @@ run_test('merge_message_groups', () => {
         assert_message_list_equal(result.rerender_messages, []);
     }());
 
-    (function test_append_message_same_subject() {
+    (function test_append_message_same_topic() {
 
         var message1 = build_message_context();
         var message_group1 = build_message_group([
@@ -156,7 +157,7 @@ run_test('merge_message_groups', () => {
             message1,
         ]);
 
-        var message2 = build_message_context({subject: 'Test subject 2'});
+        var message2 = build_message_context({subject: 'Test subject 2', topic: 'Test subject 2'});
         var message_group2 = build_message_group([
             message2,
         ]);
@@ -287,7 +288,7 @@ run_test('merge_message_groups', () => {
             message1,
         ]);
 
-        var message2 = build_message_context({subject: 'Test Subject 2'});
+        var message2 = build_message_context({subject: 'Test Subject 2', topic: 'Test Subject 2'});
         var message_group2 = build_message_group([
             message2,
         ]);

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -101,7 +101,6 @@ run_test('add_message_metadata', () => {
         sender_id: me.user_id,
         type: 'stream',
         display_recipient: 'Zoolippy',
-        topic: 'cool thing',
         subject: 'the_subject',
         id: 2068,
     };
@@ -112,6 +111,8 @@ run_test('add_message_metadata', () => {
     assert.equal(message.reply_to, 'me@example.com');
     assert.deepEqual(message.flags, undefined);
     assert.equal(message.alerted, false);
+    assert.equal(message.subject, 'the_subject');
+    assert.equal(message.topic, 'the_subject');
 });
 
 run_test('errors', () => {

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -62,12 +62,12 @@ run_test('lower_bound', () => {
 
 run_test('same_recipient', () => {
     assert(util.same_recipient(
-        {type: 'stream', stream_id: 101, subject: 'Bar'},
-        {type: 'stream', stream_id: 101, subject: 'bar'}));
+        {type: 'stream', stream_id: 101, topic: 'Bar'},
+        {type: 'stream', stream_id: 101, topic: 'bar'}));
 
     assert(!util.same_recipient(
-        {type: 'stream', stream_id: 101, subject: 'Bar'},
-        {type: 'stream', stream_id: 102, subject: 'whatever'}));
+        {type: 'stream', stream_id: 101, topic: 'Bar'},
+        {type: 'stream', stream_id: 102, topic: 'whatever'}));
 
     assert(util.same_recipient(
         {type: 'private', to_user_ids: '101,102'},
@@ -78,7 +78,7 @@ run_test('same_recipient', () => {
         {type: 'private', to_user_ids: '103'}));
 
     assert(!util.same_recipient(
-        {type: 'stream', stream_id: 101, subject: 'Bar'},
+        {type: 'stream', stream_id: 101, topic: 'Bar'},
         {type: 'private'}));
 
     assert(!util.same_recipient(

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -137,10 +137,10 @@ exports.empty_topic_placeholder = function () {
 };
 
 function create_message_object() {
-    // Subjects are optional, and we provide a placeholder if one isn't given.
-    var subject = compose_state.subject();
-    if (subject === "") {
-        subject = compose.empty_topic_placeholder();
+    // Topics are optional, and we provide a placeholder if one isn't given.
+    var topic = compose_state.subject();
+    if (topic === '') {
+        topic = compose.empty_topic_placeholder();
     }
 
     var content = make_uploads_relative(compose_state.message_content());
@@ -152,8 +152,8 @@ function create_message_object() {
         sender_id: page_params.user_id,
         queue_id: page_params.queue_id,
         stream: '',
-        subject: '',
     };
+    message[page_params.topic_name] = '';
 
     if (message.type === "private") {
         // TODO: this should be collapsed with the code in composebox_typeahead.js
@@ -171,7 +171,7 @@ function create_message_object() {
         if (sub) {
             message.stream_id = sub.stream_id;
         }
-        message.subject = subject;
+        message[page_params.topic_name] = topic;
     }
     return message;
 }

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -138,7 +138,7 @@ exports.empty_topic_placeholder = function () {
 
 function create_message_object() {
     // Topics are optional, and we provide a placeholder if one isn't given.
-    var topic = compose_state.subject();
+    var topic = compose_state.topic();
     if (topic === '') {
         topic = compose.empty_topic_placeholder();
     }
@@ -497,7 +497,7 @@ function validate_stream_message() {
     }
 
     if (page_params.realm_mandatory_topics) {
-        var topic = compose_state.subject();
+        var topic = compose_state.topic();
         if (topic === "") {
             compose_error(i18n.t("Please specify a topic"), $("#subject"));
             return false;

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -188,7 +188,7 @@ function same_recipient_as_before(msg_type, opts) {
     return compose_state.get_message_type() === msg_type &&
             (msg_type === "stream" &&
               opts.stream === compose_state.stream_name() &&
-              opts.subject === compose_state.subject() ||
+              opts.subject === compose_state.topic() ||
              msg_type === "private" &&
               opts.private_message_recipient === compose_state.recipient());
 }
@@ -219,7 +219,7 @@ exports.start = function (msg_type, opts) {
     }
 
     compose_state.stream_name(opts.stream);
-    compose_state.subject(opts.subject);
+    compose_state.topic(opts.subject);
 
     // Set the recipients with a space after each comma, so it looks nice.
     compose_state.recipient(opts.private_message_recipient.replace(/,\s*/g, ", "));
@@ -246,9 +246,9 @@ exports.cancel = function () {
         // at least clear the subject and unfade.
         compose_fade.clear_compose();
         if (page_params.narrow_topic !== undefined) {
-            compose_state.subject(page_params.narrow_topic);
+            compose_state.topic(page_params.narrow_topic);
         } else {
-            compose_state.subject("");
+            compose_state.topic("");
         }
         return;
     }
@@ -362,7 +362,7 @@ exports.on_topic_narrow = function () {
         return;
     }
 
-    if (compose_state.subject() && compose_state.has_message_content()) {
+    if (compose_state.topic() && compose_state.has_message_content()) {
         // If the user has written something to a different topic,
         // they probably want that content, so leave compose open.
         //
@@ -379,7 +379,7 @@ exports.on_topic_narrow = function () {
     // we should update the compose topic to match the new narrow.
     // See #3300 for context--a couple users specifically asked for
     // this convenience.
-    compose_state.subject(narrow_state.topic());
+    compose_state.topic(narrow_state.topic());
     compose_fade.set_focused_recipient("stream");
     compose_fade.update_message_list();
     $('#compose-textarea').focus().select();

--- a/static/js/compose_fade.js
+++ b/static/js/compose_fade.js
@@ -22,7 +22,7 @@ exports.set_focused_recipient = function (msg_type) {
 
     if (focused_recipient.type === "stream") {
         var stream_name = $('#stream').val();
-        focused_recipient.subject = $('#subject').val();
+        focused_recipient.topic = $('#subject').val();
         focused_recipient.stream = stream_name;
         var sub = stream_data.get_sub(stream_name);
         if (sub) {
@@ -167,7 +167,7 @@ function want_normal_display() {
         // the user simply hasn't started typing it yet, but disabling fading here
         // means the feature doesn't help realms where topics aren't mandatory
         // (which is most realms as of this writing).
-        if (focused_recipient.subject === "") {
+        if (focused_recipient.topic === '') {
             return true;
         }
     }

--- a/static/js/compose_state.js
+++ b/static/js/compose_state.js
@@ -41,7 +41,7 @@ function get_or_set(fieldname, keep_leading_whitespace) {
 
 // TODO: Break out setters and getter into their own functions.
 exports.stream_name     = get_or_set('stream');
-exports.subject         = get_or_set('subject');
+exports.topic           = get_or_set('subject');
 // We can't trim leading whitespace in `compose_textarea` because
 // of the indented syntax for multi-line code blocks.
 exports.message_content = get_or_set('compose-textarea', true);

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -81,7 +81,7 @@ exports.snapshot_message = function () {
         message.private_message_recipient = recipient;
     } else {
         message.stream = compose_state.stream_name();
-        message.subject = compose_state.subject();
+        message.subject = compose_state.topic();
     }
     return message;
 };

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -127,14 +127,15 @@ exports.edit_locally = function edit_locally(message, raw_content, new_topic) {
     if (new_topic !== undefined) {
         topic_data.remove_message({
             stream_id: message.stream_id,
-            topic_name: message.subject,
+            topic_name: message.topic,
         });
 
-        message.subject = new_topic;
+        message.subject = new_topic; // TODO: SUB->TOPIC
+        message.topic = new_topic;
 
         topic_data.add_message({
             stream_id: message.stream_id,
-            topic_name: message.subject,
+            topic_name: message.topic,
             message_id: message.id,
         });
     }

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -62,7 +62,7 @@ function insert_local_message(message_request, local_id) {
     message.local_id = local_id;
     message.locally_echoed = true;
     message.id = message.local_id;
-    markdown.add_subject_links(message);
+    markdown.add_topic_links(message);
 
     waiting_for_id[message.local_id] = message;
     waiting_for_ack[message.local_id] = message;

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -31,7 +31,7 @@ function zephyr_topic_name_match(message, operand) {
         related_regexp = new RegExp(/^/.source + util.escape_regexp(base_topic) + /(\.d)*$/.source, 'i');
     }
 
-    return related_regexp.test(message.subject);
+    return related_regexp.test(message.topic);
 }
 
 function message_in_home(message) {
@@ -106,7 +106,7 @@ function message_matches_search_term(message, operator, operand) {
         if (page_params.realm_is_zephyr_mirror_realm) {
             return zephyr_topic_name_match(message, operand);
         }
-        return message.subject.toLowerCase() === operand;
+        return message.topic.toLowerCase() === operand;
 
 
     case 'sender':
@@ -154,7 +154,7 @@ function Filter(operators) {
     }
 }
 
-var canonical_operators = {from: "sender", subject: "topic"};
+var canonical_operators = {from: "sender", topic: "topic"};
 
 Filter.canonicalize_operator = function (operator) {
     operator = operator.toLowerCase();
@@ -298,7 +298,7 @@ Filter.parse = function (str) {
 /* Convert a list of operators to a string.
    Each operator is a key-value pair like
 
-       ['subject', 'my amazing subject']
+       ['topic', 'my amazing subject']
 
    These are not keys in a JavaScript object, because we
    might need to support multiple operators of the same type.
@@ -595,7 +595,7 @@ Filter.operator_to_prefix = function (operator, negated) {
     case 'id':
         return verb + 'message ID';
 
-    case 'subject':
+    case 'subject': // TODO: SUB->TOPIC
     case 'topic':
         return verb + 'topic';
 

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -105,18 +105,18 @@ exports.apply_markdown = function (message) {
     message.is_me_message = exports.is_status_message(message.raw_content, message.content);
 };
 
-exports.add_subject_links = function (message) {
+exports.add_topic_links = function (message) {
     if (message.type !== 'stream') {
         message.subject_links = [];
         return;
     }
-    var subject = message.subject;
+    var topic = message.subject; // TODO: SUB->TOPIC
     var links = [];
     _.each(realm_filter_list, function (realm_filter) {
         var pattern = realm_filter[0];
         var url = realm_filter[1];
         var match;
-        while ((match = pattern.exec(subject)) !== null) {
+        while ((match = pattern.exec(topic)) !== null) {
             var link_url = url;
             var matched_groups = match.slice(1);
             var i = 0;

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -163,9 +163,9 @@ exports.update_messages = function update_messages(events) {
 
             if (going_forward_change && stream_name && compose_stream_name) {
                 if (stream_name.toLowerCase() === compose_stream_name.toLowerCase()) {
-                    if (event.orig_subject === compose_state.subject()) {
+                    if (event.orig_subject === compose_state.topic()) {
                         changed_compose = true;
-                        compose_state.subject(event.subject);
+                        compose_state.topic(event.subject);
                         compose_fade.set_focused_recipient("stream");
                     }
                 }

--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -133,6 +133,9 @@ exports.add_message_metadata = function (message) {
         message.is_stream = true;
         message.stream = message.display_recipient;
         message.reply_to = message.sender_email;
+        if (!message.topic) {
+            message.topic = message.subject;
+        }
 
         topic_data.add_message({
             stream_id: message.stream_id,

--- a/static/js/reload.js
+++ b/static/js/reload.js
@@ -28,7 +28,7 @@ function preserve_state(send_after_reload, save_pointer, save_narrow, save_compo
         if (msg_type === 'stream') {
             url += "+msg_type=stream";
             url += "+stream=" + encodeURIComponent(compose_state.stream_name());
-            url += "+subject=" + encodeURIComponent(compose_state.subject());
+            url += "+subject=" + encodeURIComponent(compose_state.topic());
         } else if (msg_type === 'private') {
             url += "+msg_type=private";
             url += "+recipient=" + encodeURIComponent(compose_state.recipient());

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -403,7 +403,7 @@ exports.sort_people_and_user_groups = function (query, matches) {
         users,
         query,
         compose_state.stream_name(),
-        compose_state.subject(),
+        compose_state.topic(),
         groups);
     return recipients;
 };

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -59,7 +59,7 @@ exports.lower_bound = function (array, arg1, arg2, arg3, arg4) {
 exports.same_stream_and_topic = function util_same_stream_and_topic(a, b) {
     // Streams and topics are case-insensitive.
     return a.stream_id === b.stream_id &&
-            a.subject.toLowerCase() === b.subject.toLowerCase();
+            a.topic.toLowerCase() === b.topic.toLowerCase();
 };
 
 exports.is_pm_recipient = function (email, message) {

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -177,6 +177,7 @@ class HomeTest(ZulipTestCase):
             "subscriptions",
             "test_suite",
             "timezone",
+            "topic_name",
             "translate_emoticons",
             "translation_data",
             "twenty_four_hour_time",

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -29,6 +29,7 @@ from zerver.lib.push_notifications import num_push_devices_for_user
 from zerver.lib.streams import access_stream_by_name
 from zerver.lib.subdomains import get_subdomain
 from zerver.lib.utils import statsd, generate_random_token
+from zerver.lib.topic import TOPIC_NAME
 from two_factor.utils import default_device
 
 import calendar
@@ -211,6 +212,7 @@ def home_real(request: HttpRequest) -> HttpResponse:
         furthest_read_time    = sent_time_in_epoch_seconds(latest_read),
         has_mobile_devices    = num_push_devices_for_user(user_profile) > 0,
         bot_types             = get_bot_types(user_profile),
+        topic_name            = TOPIC_NAME,
         two_fa_enabled        = two_fa_enabled,
         # Adding two_fa_enabled as condition saves us 3 queries when
         # 2FA is not enabled.


### PR DESCRIPTION
This PR works on refactoring subject to topic on the frontend code. The path I'm taking is to add a lot of minor commits, first adding topics alongside subjects and then commits removing subjects as and when possible. At the end, I suppose a lot of these would be squashed into one.

**Testing Plan:** <!-- How have you tested? -->
Basic manual testing so far. I'm trusting the unit tests for the most part till now, will push it on nightly to play around and catch bugs.


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
