### PR TITLE
webhooks/common: Decode stream name on our end.

### DIFF
--- a/zerver/webhooks/jira/view.py
+++ b/zerver/webhooks/jira/view.py
@@ -241,5 +241,7 @@ def api_jira_webhook(request: HttpRequest, user_profile: UserProfile,
     else:
         raise UnexpectedWebhookEventType('Jira', event)
 
-    check_send_webhook_message(request, user_profile, subject, content)
+    check_send_webhook_message(request, user_profile,
+                               subject, content,
+                               unquote_stream=True)
     return json_success()


### PR DESCRIPTION
Recently, one of our users reported that a JIRA webhook was not
able to send messages to a stream with a space character in its
name. Turns out that JIRA does something weird with webhook URLs,
such that escaped space characters (%20) are escaped again, so
that when the request gets to Zulip, the double escaped %20 is
evaluated as the literal characters `%20`, and not as a space.

We fix this by unescaping the stream name on our end before
sending the message!

@rishig: FYI :)