### PR TITLE
sticky Compose: Use position sticky automatically resizes without JS.

### DIFF
--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -56,9 +56,9 @@ exports.set_focus = function (msg_type, opts) {
     }
 
     if (window.getSelection().toString() === "" ||
-         opts.trigger !== "message click") {
+        opts.trigger !== "message click") {
         var elt = $('#' + focus_area);
-        elt.focus().select();
+        elt.select();
     }
 };
 

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -52,10 +52,8 @@ function get_new_heights() {
     var top_navbar_height = $("#top_navbar").safeOuterHeight(true);
     var invite_user_link_height = $("#invite-user-link").safeOuterHeight(true) || 0;
 
-    res.bottom_whitespace_height = viewport_height * 0.4;
-
     res.main_div_min_height = viewport_height - top_navbar_height;
-
+    $('#main_div').css('min-height', res.main_div_min_height - 137 + "px");
     res.bottom_sidebar_height = viewport_height - top_navbar_height;
 
     res.right_sidebar_height = viewport_height - parseInt($("#right-sidebar").css("marginTop"), 10);
@@ -116,10 +114,8 @@ function left_userlist_get_new_heights() {
     var user_list_real_height = buddy_list_wrapper.prop("scrollHeight");
     var group_pms_real_height = group_pms.prop("scrollHeight");
 
-    res.bottom_whitespace_height = viewport_height * 0.4;
-
     res.main_div_min_height = viewport_height - top_navbar_height;
-
+    $('#main_div').css('min-height', res.main_div_min_height - 137 + "px");
     res.bottom_sidebar_height = viewport_height
                                 - parseInt($("#left-sidebar").css("marginTop"),10)
                                 - parseInt($(".bottom_sidebar").css("marginTop"),10);

--- a/static/js/scroll_bar.js
+++ b/static/js/scroll_bar.js
@@ -47,15 +47,7 @@ exports.initialize = function () {
         $(".app-main .right-sidebar").css({"margin-left": sbWidth + "px",
                                            width: 250 - sbWidth + "px"});
 
-        $("#compose").css("left", "-" + sbWidth + "px");
-        $(".compose-content").css({left: sbWidth + "px",
-                                   "margin-right": 250 + sbWidth + "px"});
-        $("#compose-container").css("max-width", 1400 + sbWidth + "px");
         $('#keyboard-icon').css({right: sbWidth + 13 + "px"});
-
-        $("head").append("<style> @media (max-width: 1165px) { .compose-content, .header-main .column-middle { margin-right: " + (7 + sbWidth) + "px !important; } } " +
-                         "@media (max-width: 775px) { .fixed-app .column-middle { margin-left: " + (7 + sbWidth) + "px !important; } } " +
-                         "</style>");
     }
 
     ui.set_up_scrollbar($("#stream-filters-container"));

--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -156,12 +156,11 @@ table.compose_table {
 }
 
 #compose {
-    position: fixed;
+    position: sticky;
     bottom: 0px;
     left: 0px;
     z-index: 2;
     width: 100%;
-
     background-color: hsl(0, 0%, 100%);
 }
 
@@ -175,8 +174,8 @@ table.compose_table {
 
 .compose-content {
     padding: 8px 10px 8px 10px;
-    margin-left: 250px;
-    margin-right: 250px;
+    margin-left: 0px;
+    margin-right: 0px;
     position: relative;
 
     border-left: 1px solid hsl(0, 0%, 93%);

--- a/static/styles/media.scss
+++ b/static/styles/media.scss
@@ -61,10 +61,6 @@
         display: block;
     }
 
-    .compose-content {
-        margin-right: 7px;
-    }
-
     #typing_notifications {
         margin-right: 7px;
     }
@@ -155,11 +151,6 @@
 
     #streamlist-toggle {
         display: block;
-    }
-
-    .compose-content {
-        margin-right: 7px;
-        margin-left: 7px;
     }
 
     #typing_notifications {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2097,7 +2097,7 @@ div.floating_recipient {
 
 #bottom_whitespace {
     display: block;
-    height: 300px;
+    height: 80px;
 }
 
 .loading_indicator_spinner {

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -123,7 +123,7 @@
                             </div>
                         </div>
                     </div>
-                    {% include "zerver/app/home.html" %}
+
                 </div>
 
                 {% if show_debug %}
@@ -132,6 +132,7 @@
                 </div>
                 {% endif %}
             </div><!--/tab-content-->
+            {% include "zerver/app/home.html" %}
         </div>
         <div class="column-right">
             {% include "zerver/app/right_sidebar.html" %}


### PR DESCRIPTION
Currently the `#compose` box is glued to the bottom/center using some js and css magic. This makes it harder to create some additional styling, like for example setting background colors, or setting margins or borders. The current use of margins cause it to overlap sometimes with content in the left column. 

This pr uses `position:sticky` to automatically adjust the size, independent of viewport.
When using `#compose{ position:sticky} ` the `width` is automatically adapted from its parent (middle-column). 

Because of this
- there is no need to resize, set margins, etc. using javascript.
- continually adjusting `bottom_whitespace` `height` isn't needed anymore.
The Height is set to 80px, so when Compose box opens it doesn't scroll to the last message .
- it allows to add some design/css changes later on, like setting a `background-color` (both for the compose box,  and the left column independently ). 
- cleaner code

There should be no visual differences because of this this PR (except smaller `bottom_whitespace`). 
