### PR TITLE
Initial accessibility improvements

### DIFF
--- a/static/templates/recipient_row.handlebars
+++ b/static/templates/recipient_row.handlebars
@@ -9,7 +9,7 @@
                 title="{{#tr this}}Narrow to stream &quot;__display_recipient__&quot;{{/tr}}">
                 {{! invite only lock }}
                 {{#if invite_only}}
-                <i class="fa fa-lock invite-stream-icon" aria-hidden="true" title="{{t 'This is a private stream' }}"></i>
+                <i class="fa fa-lock invite-stream-icon" title="{{t 'This is a private stream' }}" aria-label="{{t 'This is a private stream' }}"></i>
                 {{/if}}
                 {{display_recipient}}
             </a>
@@ -34,16 +34,16 @@
                 {{! exterior links (e.g. to a trac ticket) }}
                 {{#each subject_links}}
                 <a href="{{this}}" target="_blank" class="no-underline">
-                    <i class="fa fa-external-link-square" aria-hidden="true"></i>
+                    <i class="fa fa-external-link-square" aria-label="{{t 'External link' }}"></i>
                 </a>
                 {{/each}}
 
                 {{! edit subject pencil icon }}
                 {{#if always_visible_topic_edit}}
-                    <i class="fa fa-pencil always_visible_topic_edit" aria-hidden="true" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}}></i>
+                    <i class="fa fa-pencil always_visible_topic_edit" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} role="button" tabindex="0" aria-label="{{t 'Edit' }}"></i>
                 {{else}}
                     {{#if on_hover_topic_edit}}
-                    <i class="fa fa-pencil on_hover_topic_edit" aria-hidden="true" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}}></i>
+                    <i class="fa fa-pencil on_hover_topic_edit" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} role="button" tabindex="0" aria-label="{{t 'Edit' }}"></i>
                     {{/if}}
                 {{/if}}
 
@@ -51,7 +51,7 @@
                     <span class="topic_edit_form" id="{{id}}"></span>
                 </span>
 
-                <i class="fa fa-eye-slash on_hover_topic_mute" aria-hidden="true" data-stream-id="{{stream_id}}" data-topic-name="{{subject}}" title="{{t 'Mute topic' }} (M)"></i>
+                <i class="fa fa-eye-slash on_hover_topic_mute" data-stream-id="{{stream_id}}" data-topic-name="{{subject}}" title="{{t 'Mute topic' }} (M)" role="button" tabindex="0" aria-label="{{t 'Mute topic' }} (M)"></i>
                 <span class="recipient_row_date {{#if show_date}}{{else}}hide-date{{/if}}">{{{date}}}</span>
             </span>
         </div>

--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -1,5 +1,6 @@
 <div zid="{{msg/id}}" id="{{table_name}}{{msg/id}}"
-  class="message_row{{^msg/is_stream}} private-message{{/msg/is_stream}}{{#include_sender}} include-sender{{/include_sender}}{{#contains_mention}} mention{{/contains_mention}}{{#include_footer}} last_message{{/include_footer}}{{#msg.unread}} unread{{/msg.unread}} {{#if msg.locally_echoed}}local{{/if}} selectable_row">
+  class="message_row{{^msg/is_stream}} private-message{{/msg/is_stream}}{{#include_sender}} include-sender{{/include_sender}}{{#contains_mention}} mention{{/contains_mention}}{{#include_footer}} last_message{{/include_footer}}{{#msg.unread}} unread{{/msg.unread}} {{#if msg.locally_echoed}}local{{/if}} selectable_row"
+  role="region" aria-label="{{t 'Message' }}">
     <div class="unread_marker"><div class="unread-marker-fill"></div></div>
     <div class="messagebox{{^include_sender}} prev_is_same_sender{{/include_sender}}{{^msg/is_stream}} private-message{{/msg/is_stream}} {{#if next_is_same_sender}}next_is_same_sender{{/if}}"
       style="box-shadow: inset 2px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}}, -1px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}};">
@@ -16,7 +17,7 @@
                                 <span class="sender-status">
                                     <span class="sender_name-in-status auto-select sender_info_hover">{{msg/sender_full_name}}</span>
                                     {{#if sender_is_bot}}
-                                    <i class="zulip-icon bot" aria-hidden="true"></i>
+                                    <i class="zulip-icon bot" aria-label="{{t 'Bot' }}"></i>
                                     {{/if}}
                                     <span class="status-message">
                                         {{{ status_message }}}
@@ -28,7 +29,7 @@
                             {{else}}
                                 <span class="sender_name auto-select">{{msg/sender_full_name}}</span>
                                 {{#if sender_is_bot}}
-                                <i class="zulip-icon bot" aria-hidden="true"></i>
+                                <i class="zulip-icon bot" aria-label="{{t 'Bot' }}"></i>
                                 {{/if}}
                             {{/if}}
                         {{/include_sender}}
@@ -45,18 +46,18 @@
                         <div class="edit_content"></div>
                         {{else}}
                         <div class="reaction_button">
-                            <i class="fa fa-smile-o" aria-hidden="true" title="{{#tr this}}Add emoji reaction{{/tr}} (:)"></i>
+                            <i class="fa fa-smile-o" title="{{#tr this}}Add emoji reaction{{/tr}} (:)" aria-label="{{#tr this}}Add emoji reaction{{/tr}} (:)" role="button" aria-haspopup="true" tabindex="0"></i>
                         </div>
                         {{/if}}
 
                         {{#unless msg/locally_echoed}}
                         <div class="info actions_hover">
-                            <i class="fa fa-chevron-down" aria-hidden="true" title="{{#tr this}}Message actions{{/tr}} (i)"></i>
+                            <i class="fa fa-chevron-down" title="{{#tr this}}Message actions{{/tr}} (i)" title="{{#tr this}}Message actions{{/tr}}" role="button" aria-haspopup="true" tabindex="0" aria-label="{{#tr this}}Message actions{{/tr}}"></i>
                         </div>
                         {{/unless}}
 
                         <div class="message_failed {{#unless msg.failed_request}}notvisible{{/unless}}">
-                            <i class="fa fa-refresh refresh-failed-message" aria-hidden="true" data-toggle="tooltip" title="{{t 'Retry' }}"></i>
+                            <i class="fa fa-refresh refresh-failed-message" data-toggle="tooltip" title="{{t 'Retry' }}" aria-label="{{t 'Retry' }}" role="button" tabindex="0"></i>
                             <i class="fa fa-times-circle remove-failed-message" aria-hidden="true" data-toggle="tooltip" title="{{t 'Cancel' }}"></i>
                         </div>
 

--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -15,7 +15,7 @@
                             </div>
                             {{#if status_message}}
                                 <span class="sender-status">
-                                    <span class="sender_name-in-status auto-select sender_info_hover">{{msg/sender_full_name}}</span>
+                                    <span class="sender_name-in-status auto-select sender_info_hover" role="button" tabindex="0">{{msg/sender_full_name}}</span>
                                     {{#if sender_is_bot}}
                                     <i class="zulip-icon bot" aria-label="{{t 'Bot' }}"></i>
                                     {{/if}}
@@ -27,7 +27,7 @@
                                     {{/if_and}}
                                 </span>
                             {{else}}
-                                <span class="sender_name auto-select">{{msg/sender_full_name}}</span>
+                                <span class="sender_name auto-select" role="button" tabindex="0">{{msg/sender_full_name}}</span>
                                 {{#if sender_is_bot}}
                                 <i class="zulip-icon bot" aria-label="{{t 'Bot' }}"></i>
                                 {{/if}}

--- a/templates/zerver/app/home.html
+++ b/templates/zerver/app/home.html
@@ -124,9 +124,9 @@
     <div id="empty_search_narrow_message" class="empty_feed_notice">
         <h4>{{ _('Nobody has talked about that yet!') }}</h4>
     </div>
-    <div class="message_table focused_table" id="zhome">
+    <div class="message_table focused_table" id="zhome" role="region" aria-live="polite" aria-label="{{ _('Messages') }}">
     </div>
-    <div class="message_table" id="zfilt">
+    <div class="message_table" id="zfilt" role="region" aria-live="polite" aria-label="{{ _('Messages') }}">
     </div>
     <div id="typing_notifications">
     </div>


### PR DESCRIPTION
A few things about this branch:

 * I'm a blind screen reader user. One challenge with being blind and working on accessibility is that inaccessible interfaces can be invisible to me, and the process is incrementally about making the interface visible, then fixing issues over time. This work is incomplete and doesn't make the messages area entirely accessible, but it adds a number of fixes that show me what needs to happen. So it'd be nice if it periodically got reviewed and merged.
 * This is a large codebase and I haven't gotten to grips with all of it yet. I can try fixing everything, but some things may be easier for folks more familiar with the code to fix. So I'll include pointers with my latest pushes with what I'd appreciate help on.

That said, this initial push does a few things that are nice:

 * Adds a few ARIA regions. This makes navigating large interfaces a bit easier, to jump straight to the messages area, for instance.
 * Makes incoming chat messages a live region. As a screen reader user, this means incoming messages are automatically read to me, which is helpful.
 * Exposes some hidden icons with essential functionality, and makes them reachable by screen readers. Note that this doesn't make said functionality usable yet since it has no keyboard controls, but it at least reveals it to me as a reminder that it needs fixing. :)

Things I'd appreciate help with, or would like to raise to the front-end team:

 * Please don't do things like `<i ... aria-hidden="true"></i>` for buttons containing essential functionality. See the changes made in this PR for examples of what to do about this. Note that these changes don't finish the job, but they're a good start.
 * Use `aria-label` in addition to `title` for labelling icons. `title` is inconsistently handled by screen readers, whereas `aria-label` has a very specific meaning. `title` is useful for visual users, but it should also be duplicated with an `aria-label` for accessibility.

Things I need help with:

 * You're using `<i/>` for icon buttons. This is doable, but has some definite disadvantages:
   * You'll need to add `role="button"` to all of these to indicate to screen readers that they're buttons.
   * We'll need custom keyboard handling on all of these. It may be possible to dynamically add it everywhere `role="button"` is set, but I don't know enough about the codebase to know where would be the best place to do this. The action should trigger when Space or Enter is pressed.
   * In the case of a popup button--actions or reactions for instance--focus should move automatically to the first control.
 * I'd appreciate it if my above feedback could be added to any code linters, etc. that check the frontend code. I don't want to fix bunches of these issues, only to have new ones introduced. :)

Thanks! Happy to answer any further questions. Also happy to continue this work, but I've already spent a few hours on it and want to test how receptive everyone is before doing any more. :)