### PR TITLE
Fix redundant check in str_utils.py

### DIFF
--- a/zerver/lib/str_utils.py
+++ b/zerver/lib/str_utils.py
@@ -47,8 +47,6 @@ def force_str(s: Union[str, bytes], encoding: str='utf-8') -> str:
     """converts a string to a native string"""
     if isinstance(s, str):
         return s
-    elif isinstance(s, str):
-        return s.encode(encoding)
     elif isinstance(s, bytes):
         return s.decode(encoding)
     else:


### PR DESCRIPTION
The `elif isinstance(s, str):` is never executed since the `if` tests the same condition. It used to be `elif isinstance(s, Text):`, but a refactor in https://github.com/zulip/zulip/commit/1f9244e060895dbc1a752a23e157f25ebcc92a7f changed `Text` to `str`, so it looks like this case can be removed.