### PR TITLE
accessibility: Model messages as a list with items, each representing a single message.

### DIFF
--- a/static/templates/draft.handlebars
+++ b/static/templates/draft.handlebars
@@ -27,7 +27,7 @@
 
         </div>
         {{/if}}
-        <div class="message_row{{^is_stream}} private-message{{/is_stream}}">
+        <div class="message_row{{^is_stream}} private-message{{/is_stream}}" role="listitem">
             <div class="messagebox"
               style="box-shadow: inset 2px 0px 0px 0px {{#if is_stream}}{{stream_color}}{{else}}#444444{{/if}}, -1px 0px 0px 0px {{#if is_stream}}{{stream_color}}{{else}}#444444{{/if}};">
                 <div class="messagebox-content">

--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -1,6 +1,6 @@
 <div zid="{{msg/id}}" id="{{table_name}}{{msg/id}}"
   class="message_row{{^msg/is_stream}} private-message{{/msg/is_stream}}{{#include_sender}} include-sender{{/include_sender}}{{#contains_mention}} mention{{/contains_mention}}{{#include_footer}} last_message{{/include_footer}}{{#msg.unread}} unread{{/msg.unread}} {{#if msg.locally_echoed}}local{{/if}} selectable_row"
-  role="region" aria-label="{{t 'Message' }}">
+  role="listitem">
     <div class="unread_marker"><div class="unread-marker-fill"></div></div>
     <div class="messagebox{{^include_sender}} prev_is_same_sender{{/include_sender}}{{^msg/is_stream}} private-message{{/msg/is_stream}} {{#if next_is_same_sender}}next_is_same_sender{{/if}}"
       style="box-shadow: inset 2px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}}, -1px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}};">

--- a/templates/zerver/app/home.html
+++ b/templates/zerver/app/home.html
@@ -124,9 +124,9 @@
     <div id="empty_search_narrow_message" class="empty_feed_notice">
         <h4>{{ _('Nobody has talked about that yet!') }}</h4>
     </div>
-    <div class="message_table focused_table" id="zhome" role="region" aria-live="polite" aria-label="{{ _('Messages') }}">
+    <div class="message_table focused_table" id="zhome" role="list" aria-live="polite" aria-label="{{ _('Messages') }}">
     </div>
-    <div class="message_table" id="zfilt" role="region" aria-live="polite" aria-label="{{ _('Messages') }}">
+    <div class="message_table" id="zfilt" role="list" aria-live="polite" aria-label="{{ _('Messages') }}">
     </div>
     <div id="typing_notifications">
     </div>


### PR DESCRIPTION
Previously, messages were a string of disconnected regions. Modeling them as a list brings several benefits:
 * Quickly jump to the message list by using a screen reader's list navigation hotkey.
 * Quickly jump between messages by using a screen reader's list item navigation hotkey.
 * Quickly jump to the beginning or end of message lists in screen readers that support it.