### PR TITLE
Fixed the issue #10654 by adding overlays for each modal

### DIFF
--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -141,6 +141,9 @@ exports.close_active = function () {
     }
 
     exports.close_overlay(open_overlay_name);
+    $('#full_name_overlay').removeClass ('show');
+    $('#email_overlay').removeClass ('show');
+    $('#password_overlay').removeClass ('show');
 };
 
 exports.close_modal = function (name) {
@@ -163,6 +166,9 @@ exports.close_modal = function (name) {
     blueslip.debug('close modal: ' + name);
 
     $("#" + name).modal("hide").attr("aria-hidden", true);
+    $('#full_name_overlay').removeClass ('show');
+    $('#email_overlay').removeClass ('show');
+    $('#password_overlay').removeClass ('show');
 };
 
 exports.close_active_modal = function () {
@@ -172,6 +178,9 @@ exports.close_active_modal = function () {
     }
 
     $(".modal.in").modal("hide").attr("aria-hidden", true);
+    $('#full_name_overlay').removeClass ('show');
+    $('#email_overlay').removeClass ('show');
+    $('#password_overlay').removeClass ('show');
 };
 
 exports.close_for_hash_change = function () {

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -243,6 +243,8 @@ exports.set_up = function () {
     clear_password_change();
 
     $("#change_full_name").on('click', function (e) {
+        $('#full_name_overlay').addClass ('show');
+
         e.preventDefault();
         e.stopPropagation();
         if (!page_params.realm_name_changes_disabled || page_params.is_admin) {
@@ -251,6 +253,7 @@ exports.set_up = function () {
     });
 
     $('#change_password').on('click', function (e) {
+        $('#password_overlay').addClass ('show');
         e.preventDefault();
         e.stopPropagation();
         overlays.open_modal('change_password_modal');
@@ -384,6 +387,8 @@ exports.set_up = function () {
     });
 
     $('#change_email').on('click', function (e) {
+        $('#email_overlay').addClass ('show');
+
         e.preventDefault();
         e.stopPropagation();
         if (!page_params.realm_email_changes_disabled || page_params.is_admin) {

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -17,6 +17,7 @@
                       title="{{t 'Changing email addresses has been disabled by your Zulip organization administrators. Contact an administrator for help.' }}"></i>
                 </div>
 
+                <div id="email_overlay" class="overlay">    
                 <div id="change_email_modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog"
                   aria-labelledby="change_email_modal_label" aria-hidden="true">
                     <div class="modal-header">
@@ -34,6 +35,7 @@
                         <button class="button white rounded" type="button" data-dismiss="modal">{{t "Cancel" }}</button>
                         <button id='change_email_button' class="button rounded sea-green" data-dismiss="modal">{{t "Change" }}</button>
                     </div>
+                </div>
                 </div>
             </form>
 
@@ -58,6 +60,8 @@
                           {{#if page_params.is_admin}}style="display:none"{{else}}{{#unless page_params.realm_name_changes_disabled}}style="display:none"{{/unless}}{{/if}}
                           title="{{t 'Changing your name has been disabled by your Zulip organization administrators. Contact an administrator for help.' }}"/>
                     </div>
+
+                    <div id="full_name_overlay" class="overlay">  
                     <div id="change_full_name_modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog"
                       aria-labelledby="change_full_name_modal_label" aria-hidden="true">
                         <div class="modal-header">
@@ -76,6 +80,7 @@
                             <button id='change_full_name_button' class="button rounded sea-green" data-dismiss="modal">{{t "Change" }}</button>
                         </div>
                     </div>
+                    </div>
                 </div>
             </form>
 
@@ -92,6 +97,7 @@
                 </div>
                 {{/if}}
 
+                <div id="password_overlay" class="overlay">  
                 <div id="change_password_modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog"
                   aria-labelledby="change_password_modal_label" aria-hidden="true">
                     <div class="modal-header">
@@ -121,6 +127,7 @@
                         <button class="button white rounded" type="button" data-dismiss="modal">{{t "Cancel" }}</button>
                         <button id='change_password_button' class="button rounded sea-green">{{t "Change" }}</button>
                     </div>
+                </div>
                 </div>
             </form>
 


### PR DESCRIPTION
https://github.com/zulip/zulip/issues/10654

**Testing**
After clicking on edit email or full name or password, the modal pops over and the background is disabled against clicks. Clicking anywhere except on the modal closes the modal. I have done this testing manually.

This is my first PR in zulip. Any feedback and suggestions are appreciated.