### PR TITLE
compose: Check if `raw_content` is present when quoting.

### DIFF
--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -283,6 +283,24 @@ run_test('quote_and_reply', () => {
     };
 
     quote_and_reply(opts);
+
+    current_msg_list.selected_message = function () {
+        return {
+            type: 'stream',
+            stream: 'devel',
+            subject: 'test',
+            reply_to: 'bob',
+            sender_full_name: 'Bob',
+            sender_id: 40,
+            raw_content: 'Testing.',
+        };
+    };
+
+    channel.get = function () {
+        assert.fail('channel.get should not be used if raw_content is present');
+    };
+
+    quote_and_reply(opts);
 });
 
 run_test('get_focus_area', () => {

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -388,9 +388,16 @@ exports.on_topic_narrow = function () {
 exports.quote_and_reply = function (opts) {
     var textarea = $("#compose-textarea");
     var message_id = current_msg_list.selected_id();
+    var message = current_msg_list.selected_message();
 
     exports.respond_to_message(opts);
     compose_ui.insert_syntax_and_focus("[Quoting…]\n", textarea);
+
+    if (message && message.raw_content) {
+        compose_ui.replace_syntax('[Quoting…]', '```quote\n' + message.raw_content + '\n```', textarea);
+        $("#compose-textarea").trigger("autosize.resize");
+        return;
+    }
 
     channel.get({
         url: '/json/messages/' + message_id,


### PR DESCRIPTION
This PR fixes https://github.com/zulip/zulip/issues/10705#issuecomment-436718248.

When quoting and replying, if `raw_content` is already present for the selected message, skip making a request to the server.

**Testing Plan:** <!-- How have you tested? -->
 
This PR adds to `frontend_tests/node_tests/compose_actions` to test that no request is made when `raw_content` is present.