### PR TITLE
stream settings: Rephrase info to state guest user can't join public stream.

### DIFF
--- a/static/templates/subscription_type.handlebars
+++ b/static/templates/subscription_type.handlebars
@@ -4,7 +4,7 @@
     {{else}}{{t 'New members can only see messages sent after they join.' }}
     {{/if}}
 {{else}}
-    {{t 'This is a <span class="fa fa-globe" aria-hidden="true"></span> <b>public stream</b>. Anybody in your organization can join.' }}
+    {{t 'This is a <span class="fa fa-globe" aria-hidden="true"></span> <b>public stream</b>. Any member of the organization can join.' }}
 {{/if}}
 {{#if is_announcement_only}}
 {{t 'Only organization administrators can post.'}}


### PR DESCRIPTION
Change wording of public stream description to
"Any member of the organization" from "Anybody"
to indicate that guest users can't subscribe even
public stream of organization.

Followup of #10779 
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![screen shot 2018-11-12 at 12 26 31 pm](https://user-images.githubusercontent.com/25907420/48331480-3b497780-e676-11e8-83b1-f390fde5040b.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
