### PR TITLE
Fix digest email links

### DIFF
--- a/zerver/lib/notifications.py
+++ b/zerver/lib/notifications.py
@@ -11,7 +11,8 @@ from zerver.decorator import statsd_increment
 from zerver.lib.message import bulk_access_messages
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.send_email import send_future_email, FromAddress
-from zerver.lib.url_encoding import pm_narrow_url, stream_narrow_url, topic_narrow_url
+from zerver.lib.url_encoding import personal_narrow_url, pm_narrow_url, \
+    stream_narrow_url, topic_narrow_url
 from zerver.models import (
     Recipient,
     ScheduledEmail,
@@ -168,7 +169,10 @@ def build_message_list(user_profile: UserProfile, messages: List[Message]) -> Li
     def message_header(user_profile: UserProfile, message: Message) -> Dict[str, Any]:
         if message.recipient.type == Recipient.PERSONAL:
             header = "You and %s" % (message.sender.full_name,)
-            html_link = pm_narrow_url(user_profile.realm, [message.sender.email])
+            html_link = personal_narrow_url(
+                realm=user_profile.realm,
+                sender=message.sender,
+            )
             header_html = "<a style='color: #ffffff;' href='%s'>%s</a>" % (html_link, header)
         elif message.recipient.type == Recipient.HUDDLE:
             disp_recipient = get_display_recipient(message.recipient)

--- a/zerver/lib/url_encoding.py
+++ b/zerver/lib/url_encoding.py
@@ -21,10 +21,10 @@ def personal_narrow_url(realm: Realm, sender: UserProfile) -> str:
     pm_slug = str(sender.id) + '-' + hash_util_encode(email_user)
     return base_url + pm_slug
 
-def pm_narrow_url(realm: Realm, participants: List[str]) -> str:
-    participants.sort()
+def huddle_narrow_url(realm: Realm, other_user_ids: List[int]) -> str:
+    pm_slug = ','.join(str(user_id) for user_id in sorted(other_user_ids)) + '-group'
     base_url = "%s/#narrow/pm-with/" % (realm.uri,)
-    return base_url + hash_util_encode(",".join(participants))
+    return base_url + pm_slug
 
 def stream_narrow_url(realm: Realm, stream: Stream) -> str:
     base_url = "%s/#narrow/stream/" % (realm.uri,)

--- a/zerver/lib/url_encoding.py
+++ b/zerver/lib/url_encoding.py
@@ -1,7 +1,7 @@
 import urllib
 from typing import Any, Dict, List
 
-from zerver.models import Realm, Stream
+from zerver.models import Realm, Stream, UserProfile
 
 def hash_util_encode(string: str) -> str:
     # Do the same encoding operation as hash_util.encodeHashComponent on the
@@ -14,6 +14,12 @@ def encode_stream(stream_id: int, stream_name: str) -> str:
     # We encode streams for urls as something like 99-Verona.
     stream_name = stream_name.replace(' ', '-')
     return str(stream_id) + '-' + hash_util_encode(stream_name)
+
+def personal_narrow_url(realm: Realm, sender: UserProfile) -> str:
+    base_url = "%s/#narrow/pm-with/" % (realm.uri,)
+    email_user = sender.email.split('@')[0].lower()
+    pm_slug = str(sender.id) + '-' + hash_util_encode(email_user)
+    return base_url + pm_slug
 
 def pm_narrow_url(realm: Realm, participants: List[str]) -> str:
     participants.sort()

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -23,8 +23,8 @@ class TestDigestEmailMessages(ZulipTestCase):
         # build dummy messages for missed messages email reply
         # have Hamlet send Othello a PM. Othello will reply via email
         # Hamlet will receive the message.
-        email = self.example_email('hamlet')
-        self.login(email)
+        hamlet = self.example_user('hamlet')
+        self.login(hamlet.email)
         result = self.client_post("/json/messages", {"type": "private",
                                                      "content": "test_receive_missed_message_email_messages",
                                                      "client": "test suite",
@@ -40,7 +40,8 @@ class TestDigestEmailMessages(ZulipTestCase):
         kwargs = mock_send_future_email.call_args[1]
         self.assertEqual(kwargs['to_user_id'], user_profile.id)
         html = kwargs['context']['unread_pms'][0]['header']['html']
-        self.assertIn("'http://zulip.testserver/#narrow/pm-with/hamlet.40zulip.2Ecom'", html)
+        expected_url = "'http://zulip.testserver/#narrow/pm-with/{id}-hamlet'".format(id=hamlet.id)
+        self.assertIn(expected_url, html)
 
     @mock.patch('zerver.lib.digest.enough_traffic')
     @mock.patch('zerver.lib.digest.send_future_email')

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -36,7 +36,11 @@ class TestDigestEmailMessages(ZulipTestCase):
 
         handle_digest_email(user_profile.id, cutoff)
         self.assertEqual(mock_send_future_email.call_count, 1)
-        self.assertEqual(mock_send_future_email.call_args[1]['to_user_id'], user_profile.id)
+
+        kwargs = mock_send_future_email.call_args[1]
+        self.assertEqual(kwargs['to_user_id'], user_profile.id)
+        html = kwargs['context']['unread_pms'][0]['header']['html']
+        self.assertIn("'http://zulip.testserver/#narrow/pm-with/hamlet.40zulip.2Ecom'", html)
 
     @mock.patch('zerver.lib.digest.queue_digest_recipient')
     @mock.patch('zerver.lib.digest.timezone_now')

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -74,7 +74,14 @@ class TestDigestEmailMessages(ZulipTestCase):
         kwargs = mock_send_future_email.call_args[1]
         self.assertEqual(kwargs['to_user_id'], user_profile.id)
         html = kwargs['context']['unread_pms'][0]['header']['html']
-        self.assertIn("'http://zulip.testserver/#narrow/pm-with/cordelia.40zulip.2Ecom.2Chamlet.40zulip.2Ecom'", html)
+
+        other_user_ids = sorted([
+            self.example_user('cordelia').id,
+            self.example_user('hamlet').id,
+        ])
+        slug = ','.join(str(user_id) for user_id in other_user_ids) + '-group'
+        expected_url = "'http://zulip.testserver/#narrow/pm-with/" + slug + "'"
+        self.assertIn(expected_url, html)
 
     @mock.patch('zerver.lib.digest.queue_digest_recipient')
     @mock.patch('zerver.lib.digest.timezone_now')


### PR DESCRIPTION
To test this:

Log on as Hamlet.
Have Hamlet send Cordelia two PMs--one direct, one huddled w/Othello.
Log out.
Watch server log for missed message emails (can be a minute or so).
Only now log on as Cordelia.
Go to "/emails" page.
Verify links in missed message emails addressed to Cordelia.