### PR TITLE
Python dependency upgrade 13 followup

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -23,7 +23,7 @@ ipython==6.5.0
 Pillow==5.3.0
 
 # Needed for building complex DB queries
-SQLAlchemy==1.2.10
+SQLAlchemy==1.2.14
 
 # Needed for password hashing
 argon2-cffi==18.3.0

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -14,7 +14,7 @@ Twisted==18.9.0
 Scrapy==1.5.1
 
 # Needed to compute test coverage
-coverage==4.5.1
+coverage==4.5.2
 
 # fake for LDAP testing
 fakeldap==0.6.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -40,7 +40,7 @@ click==6.6                # via gitlint, pip-tools
 commonmark==0.5.4
 constantly==15.1.0        # via twisted
 cookies==2.2.1            # via moto, responses
-coverage==4.5.1
+coverage==4.5.2
 cryptography==2.4.1
 cssselect==1.0.1          # via parsel, premailer, scrapy
 cssutils==1.0.2           # via premailer

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -167,7 +167,7 @@ sourcemap==0.2.1
 sphinx-rtd-theme==0.4.2
 sphinx==1.8.2
 sphinxcontrib-websupport==1.0.1  # via sphinx
-sqlalchemy==1.2.10
+sqlalchemy==1.2.14
 statsd==3.2.1             # via django-statsd-mozilla
 stripe==2.3.0
 tblib==1.3.2

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,4 +1,4 @@
 # Dependencies for setting up pip to install our requirements.txt file.
 pip==18.1
-setuptools==40.5.0
+setuptools==40.6.1
 wheel==0.32.2

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -116,7 +116,7 @@ social-auth-app-django==3.1.0
 social-auth-core==1.5.0   # via social-auth-app-django
 sockjs-tornado==1.0.6
 sourcemap==0.2.1
-sqlalchemy==1.2.10
+sqlalchemy==1.2.14
 statsd==3.2.1             # via django-statsd-mozilla
 stripe==2.3.0
 tornado==4.5.3

--- a/version.py
+++ b/version.py
@@ -8,4 +8,4 @@ ZULIP_VERSION = "1.9.0+git"
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '26.12'
+PROVISION_VERSION = '26.13'


### PR DESCRIPTION
I missed SQLAlchemy during the upgrade. Coverage and Setuptools got upgraded upstream since the last upgrade so I upgraded them as well. More details on #10804