### PR TITLE
Root check

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -6,11 +6,10 @@ import types
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(BASE_DIR)
 import scripts.lib.setup_path_on_import
+from scripts.lib.zulip_tools import script_should_not_be_root
 
 if __name__ == "__main__":
-    if 'posix' in os.name and os.geteuid() == 0:
-        print("manage.py should not be run as root.  Use `su zulip` to drop root.")
-        sys.exit(1)
+    script_should_not_be_root()
     if (os.access('/etc/zulip/zulip.conf', os.R_OK) and not
             os.access('/etc/zulip/zulip-secrets.conf', os.R_OK)):
         # The best way to detect running manage.py as another user in

--- a/scripts/lib/upgrade-zulip
+++ b/scripts/lib/upgrade-zulip
@@ -11,15 +11,13 @@ os.environ["PYTHONUNBUFFERED"] = "y"
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 from scripts.lib.zulip_tools import DEPLOYMENTS_DIR, FAIL, WARNING, ENDC, \
-    su_to_zulip, get_deployment_lock, release_deployment_lock
+    su_to_zulip, get_deployment_lock, release_deployment_lock, script_should_be_root
+
+script_should_be_root('scripts/upgrade-zulip')  # autodetected path starts with /scripts/lib/
 
 logging.Formatter.converter = time.gmtime
 logging.basicConfig(format="%(asctime)s upgrade-zulip: %(message)s",
                     level=logging.INFO)
-
-if os.getuid() != 0:
-    logging.error("Must be run as root.")
-    sys.exit(1)
 
 if len(sys.argv) != 2:
     print(FAIL + "Usage: %s <tarball>" % (sys.argv[0],) + ENDC)

--- a/scripts/lib/upgrade-zulip-from-git
+++ b/scripts/lib/upgrade-zulip-from-git
@@ -24,15 +24,13 @@ os.environ["PYTHONUNBUFFERED"] = "y"
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 from scripts.lib.zulip_tools import DEPLOYMENTS_DIR, FAIL, WARNING, ENDC, make_deploy_path, \
-    get_deployment_lock, release_deployment_lock, su_to_zulip
+    get_deployment_lock, release_deployment_lock, su_to_zulip, script_should_be_root
+
+script_should_be_root('scripts/upgrade-zulip-from-git')  # autodetected path starts with /scripts/lib/
 
 logging.Formatter.converter = time.gmtime
 logging.basicConfig(format="%(asctime)s upgrade-zulip-from-git: %(message)s",
                     level=logging.INFO)
-
-if os.getuid() != 0:
-    logging.error("Must be run as root.")
-    sys.exit(1)
 
 parser = argparse.ArgumentParser()
 parser.add_argument("refname", help="Git reference, e.g. a branch, tag, or commit ID.")

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -20,15 +20,13 @@ os.environ["LANG"] = "en_US.UTF-8"
 os.environ["LANGUAGE"] = "en_US.UTF-8"
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
-from scripts.lib.zulip_tools import DEPLOYMENTS_DIR, FAIL, WARNING, ENDC, su_to_zulip
+from scripts.lib.zulip_tools import DEPLOYMENTS_DIR, FAIL, WARNING, ENDC, su_to_zulip, script_should_be_root
+
+script_should_be_root()
 
 logging.Formatter.converter = time.gmtime
 logging.basicConfig(format="%(asctime)s upgrade-zulip-stage-2: %(message)s",
                     level=logging.INFO)
-
-if os.getuid() != 0:
-    logging.error("Must be run as root.")
-    sys.exit(1)
 
 # make sure we have appropriate file permissions
 os.umask(0o22)

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -359,3 +359,21 @@ def file_or_package_hash_updated(paths, hash_name, is_force, package_versions=[]
             hash_file.write(new_hash)
             return True
     return False
+
+def is_root() -> bool:
+    if 'posix' in os.name and os.geteuid() == 0:
+        return True
+    return False
+
+def script_should_not_be_root(script_name: str = sys.argv[0]) -> None:
+    if is_root():
+        msg = ("{name} should not be run as root. Use `su zulip` to switch to the 'zulip'\n"
+               "user before rerunning this, or use `su zulip -c '{name} ...'` to switch\n"
+               "users and run this as a single command.").format(name=script_name)
+        print(msg)
+        sys.exit(1)
+
+def script_should_be_root(script_name: str = sys.argv[0]) -> None:
+    if not is_root():
+        print("{} must be run as root.".format(script_name))
+        sys.exit(1)

--- a/scripts/zulip-puppet-apply
+++ b/scripts/zulip-puppet-apply
@@ -5,7 +5,9 @@ import sys
 import subprocess
 import configparser
 import re
-from lib.zulip_tools import parse_lsb_release
+from lib.zulip_tools import parse_lsb_release, script_should_be_root
+
+script_should_be_root()
 
 force = False
 extra_args = sys.argv[1:]


### PR DESCRIPTION
Fixes #10833. Adds three small helper functions that can be used in the future in other places.

**Testing Plan:** <!-- How have you tested? -->
Manual testing on nightly:

```
zulip@nightly:~$ cd deployments/current
zulip@nightly:~/deployments/current$ sudo ./manage.py 
./manage.py should not be run as root.  Use `su zulip` to drop root.
zulip@nightly:~/deployments/current$ scripts/zulip-puppet-apply 
scripts/zulip-puppet-apply must be run as root.
zulip@nightly:~/deployments/current$ sudo !!
sudo scripts/zulip-puppet-apply 
(...runs...)
zulip@nightly:~/deployments/current$ scripts/upgrade-zulip-from-git 
tee: /var/log/zulip/upgrade.log: Permission denied
2018-11-15 10:17:36,068 upgrade-zulip-from-git: Must be run as root.
zulip@nightly:~/deployments/current$ 
```