### PR TITLE
auth: Always force Google to show account chooser

### DIFF
--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -348,6 +348,7 @@ def send_oauth_request_to_google(request: HttpRequest) -> HttpResponse:
         'redirect_uri': reverse_on_root('zerver.views.auth.finish_google_oauth2'),
         'scope': 'profile email',
         'state': csrf_state,
+        'prompt': 'select_account',
     }
     return redirect(google_uri + urllib.parse.urlencode(params))
 


### PR DESCRIPTION
Fixes #10515

![force-google-to-show-account-chooser2](https://user-images.githubusercontent.com/7190633/48565479-a7e69f80-e91e-11e8-8b8c-8735ca94c1eb.gif)

