### PR TITLE
Add styling for linking latest Zulip release

### DIFF
--- a/docs/subsystems/release-checklist.md
+++ b/docs/subsystems/release-checklist.md
@@ -33,7 +33,7 @@ preparing a new release.
 
 * Do final updates to `changelog.md`, for any final changes and with
   any revisions from the draft blog post.  (And the date!)
-* Update `ZULIP_VERSION` in `version.py`.
+* Update `ZULIP_VERSION`, `LATEST_RELEASE_VERSION`, etc. in `version.py`.
 * Update `version` and/or `release` in `docs/conf.py` (ReadTheDocs meta tags).
   Leave "+git" off.
 * Use `build-release-tarball` to generate a final release tarball.

--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -1283,6 +1283,22 @@ nav ul li.active::after {
     z-index: 1;
 
     background-color: hsl(217, 22%, 93%);
+
+    #install {
+        display: flex;
+        align-items: center;
+        flex-direction: column;
+        padding-top: 10px;
+
+        .button {
+            border-radius: 4px;
+        }
+
+        p {
+            font-size: 14px;
+            text-align: center;
+        }
+    }
 }
 
 .portico-landing.hello .open-source .flex {
@@ -1367,6 +1383,7 @@ nav ul li.active::after {
     position: relative;
 }
 
+.open-source #install .button,
 .tour .carousel-inner .start-button {
     padding: 11px 25px 11px 25px;
     font-size: 1.2rem;
@@ -1376,6 +1393,9 @@ nav ul li.active::after {
     background: linear-gradient(145deg, rgb(76, 181, 205), rgb(37, 177, 151));
     box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.3);
     border: 0;
+}
+
+.tour .carousel-inner .start-button {
     position: absolute;
     left: 50%;
     margin-left: -100px;
@@ -1386,6 +1406,7 @@ nav ul li.active::after {
     z-index: 10;
 }
 
+.open-source #install .button:hover,
 .tour .carousel-inner .start-button:hover {
     background-color: rgb(37, 177, 151);
     box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.3);

--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -365,6 +365,12 @@
                     <a href="https://github.com/RocketChat/Rocket.Chat/graphs/contributors">Rocket.Chat</a>,
                     and <a href="https://github.com/matrix-org/synapse/graphs/contributors">matrix.org</a>.
                 </p>
+                <div id="install">
+                    <a href="https://zulip.readthedocs.io/en/stable/production/install.html" class="button">Install Zulip {{ latest_release_version }}</a>
+                    <p>
+                        Read the Zulip {{ latest_major_version }} <a href="{{ latest_release_announcement }}">release announcement</a>
+                    </p>
+                </div>
             </div>
         </div>
     </div>

--- a/version.py
+++ b/version.py
@@ -1,4 +1,7 @@
 ZULIP_VERSION = "1.9.0+git"
+LATEST_MAJOR_VERSION = "1.9"
+LATEST_RELEASE_VERSION = "1.9.0"
+LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2018/11/07/zulip-1-9-released/"
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -20,7 +20,8 @@ from zerver.lib.send_email import FromAddress
 from zerver.lib.subdomains import get_subdomain
 from zerver.lib.realm_icon import get_realm_icon_url
 
-from version import ZULIP_VERSION
+from version import ZULIP_VERSION, LATEST_RELEASE_VERSION, \
+    LATEST_RELEASE_ANNOUNCEMENT, LATEST_MAJOR_VERSION
 
 def common_context(user: UserProfile) -> Dict[str, Any]:
     """Common context used for things like outgoing emails that don't
@@ -136,6 +137,9 @@ def zulip_default_context(request: HttpRequest) -> Dict[str, Any]:
         'jitsi_server_url': settings.JITSI_SERVER_URL,
         'two_factor_authentication_enabled': settings.TWO_FACTOR_AUTHENTICATION_ENABLED,
         'zulip_version': ZULIP_VERSION,
+        'latest_release_version': LATEST_RELEASE_VERSION,
+        'latest_major_version': LATEST_MAJOR_VERSION,
+        'latest_release_announcement': LATEST_RELEASE_ANNOUNCEMENT,
         'user_is_authenticated': user_is_authenticated,
         'settings_path': settings_path,
         'secrets_path': secrets_path,


### PR DESCRIPTION
Hello page update:
![screenshot at nov 17 20-17-11](https://user-images.githubusercontent.com/15116870/48668591-068a5580-eaa6-11e8-9edb-ef840f60ec3f.png)

README badge update:
![screenshot at nov 17 20-19-26](https://user-images.githubusercontent.com/15116870/48668596-186bf880-eaa6-11e8-8333-598cc01e2c07.png)

Fixes part of #10846.
