### PR TITLE
navbar: CSS scroll fix #10562

### DIFF
--- a/static/js/scroll_bar.js
+++ b/static/js/scroll_bar.js
@@ -32,12 +32,9 @@ function getScrollbarWidth() {
 exports.initialize = function () {
 // Workaround for browsers with fixed scrollbars
     var sbWidth = getScrollbarWidth();
-
     if (sbWidth > 0) {
-        $(".header").css("left", "-" + sbWidth + "px");
-        $(".header-main").css("left", sbWidth + "px");
-        $(".header-main").css("max-width", 1400 + sbWidth + "px");
-        $(".header-main .column-middle").css("margin-right", 250 + sbWidth + "px");
+
+        $(".global-nav-inner .container").css("max-width", 1400 + sbWidth + "px");
 
         $(".fixed-app").css("left", "-" + sbWidth + "px");
         $(".fixed-app .app-main").css("max-width", 1400 + sbWidth + "px");

--- a/static/styles/media.scss
+++ b/static/styles/media.scss
@@ -99,7 +99,8 @@
         display: inline-block !important;
     }
 
-    .column-left {
+    .column-left,
+    .nav-column-left {
         display: none;
     }
 
@@ -148,6 +149,14 @@
         margin-right: 0px;
     }
 
+    .nav-column-middle {
+        width: calc(100% - 25px);
+        max-width: calc(100% - 25px);
+    }
+    .nav-column-right {
+        width: 15px;
+    }
+
     .skinny-user-gravatar {
         position: absolute;
         top: 0px;
@@ -191,6 +200,10 @@
 }
 
 @media (max-width: 500px) {
+
+    .header-main {
+        height: 30px;
+    }
     .column-right.expanded .right-sidebar,
     .column-left.expanded .left-sidebar {
         margin-top: 31px;

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -174,6 +174,19 @@ p.n-margin {
     height: 40px;
 }
 
+.global-nav-inner {
+    height: 40px;
+}
+
+.global-nav-inner .container {
+    margin: 0px auto;
+    height: 100%;
+    width: auto;
+    max-width: 1410px;
+}
+
+
+
 #panels {
     -webkit-font-smoothing: antialiased;
 
@@ -226,8 +239,7 @@ p.n-margin {
     -webkit-overflow-scrolling: touch;
 }
 
-.app-main,
-.header-main {
+.app-main {
     width: 100%;
     max-width: 1400px;
     min-width: 950px;
@@ -240,6 +252,43 @@ p.n-margin {
 .app-main {
     height: 100%;
     min-height: 100%;
+}
+
+.header {
+    position: fixed;
+    top: 0px;
+    right: 0px;
+    left: 0px;
+}
+
+.header-main {
+    width: 100%;
+    position: relative;
+    background-color: hsl(0, 0%, 100%);
+    height: 40px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.25);
+}
+
+.nav-column-left {
+    height: 40px;
+    width: 240px;
+    max-width: 240px;
+    float: left;
+    padding: 0 0 0 10px;
+}
+
+.nav-column-middle {
+    float: left;
+    max-width: calc(100% - 510px);
+    width: calc(100% - 510px);
+    overflow: hidden;
+}
+
+.nav-column-right {
+    width: 250px;
+    float: right;
+    height: 100%;
+    padding-right: 10px;
 }
 
 .fixed-app {
@@ -1823,7 +1872,10 @@ nav a.no-style:hover {
     cursor: pointer;
 }
 
-nav .column-left .nav-logo {
+
+
+
+nav .nav-column-left .nav-logo {
     display: inline-block;
     vertical-align: top;
     margin-top: 8px;
@@ -1831,7 +1883,7 @@ nav .column-left .nav-logo {
     height: 25px;
 }
 
-nav .column-left .company-name {
+nav .nav-column-left .company-name {
     display: inline-block;
     vertical-align: top;
     text-transform: uppercase;

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -185,22 +185,20 @@ p.n-margin {
     max-width: 1410px;
 }
 
-
-
 #panels {
     -webkit-font-smoothing: antialiased;
-
     font-size: 1rem;
+    position: fixed;
+    z-index: 103;
+    width: 100%;
 }
 
 #panels .alert {
     margin: 0;
     padding-top: 12px;
     padding-bottom: 12px;
-
     border: none;
     border-radius: 0;
-
     text-align: center;
     text-shadow: none;
     color: hsl(0, 0%, 100%);

--- a/templates/zerver/app/navbar.html
+++ b/templates/zerver/app/navbar.html
@@ -29,184 +29,188 @@
 </div>
 <div class="header">
     <nav class="header-main rightside-userlist" id="top_navbar">
-        <div class="column-left">
-            <a class="brand no-style" href="#">
-                <img src="/static/images/logo/zulip-icon-128x128.png" class="nav-logo no-drag" alt=""/>
-                <div class="company-name">
-                    zulip
-                </div>
-            </a>
-        </div>
-        <div class="column-middle" id="navbar-middle">
-            <div class="column-middle-inner">
-                <div id="streamlist-toggle" title="{{ _('Stream list') }} (q)" {%if embedded %} style="visibility: hidden"{% endif %}>
-                    <a href="#" id="streamlist-toggle-button" role="button"><i class="fa fa-reorder" aria-hidden="true"></i>
-                        <span id="streamlist-toggle-unreadcount">0</span>
+        <div class="global-nav-inner" >
+            <div class="container">
+                <div class="nav-column-left">
+                    <a class="brand no-style" href="#">
+                        <img src="/static/images/logo/zulip-icon-128x128.png" class="nav-logo no-drag" alt=""/>
+                        <div class="company-name">
+                            zulip
+                        </div>
                     </a>
                 </div>
-                {% if search_pills_enabled %}
-                <div id="searchbox" class="searchbox-rightmargin">
-                    <div id="tab_bar" class="notdisplayed">
-                    </div>
-                    <a class="search_icon" href="#search-operators" data-overlay-trigger="search-operators" title="{{ _('Search help') }}"><i class="fa fa-search" aria-hidden="true"></i></a>
-                    <form id="searchbox_form" class="form-search navbar-search">
-                        <div id="search_arrows" class="pill-container input-append">
-                            <div contenteditable="true" class="input search-query input-block-level" id="search_query" type="text" placeholder="{{ _('Search') }}"
-                              autocomplete="off" aria-label="{{ _('Search') }}" title="{{ _('Search') }} (/)"> </div>
+                <div class="nav-column-middle" id="navbar-middle">
+                    <div class="column-middle-inner">
+                        <div id="streamlist-toggle" title="{{ _('Stream list') }} (q)" {%if embedded %} style="visibility: hidden"{% endif %}>
+                            <a href="#" id="streamlist-toggle-button" role="button"><i class="fa fa-reorder" aria-hidden="true"></i>
+                                <span id="streamlist-toggle-unreadcount">0</span>
+                            </a>
                         </div>
-                    </form>
-                    {# Start the button off disabled since there is no active search #}
-                    <button class="btn search_button" type="button" id="search_exit" disabled="disabled" aria-label="{{ _('Exit search') }}"><i class="fa fa-remove" aria-hidden="true"></i></button>
-                </div>
-                {% else %}
-                <div id="searchbox_legacy" class="searchbox-rightmargin">
-                    <div id="tab_bar" class="notdisplayed">
-                    </div>
-                    <form id="searchbox_form" class="form-search navbar-search">
-                        <div id="search_arrows" class="input-append">
-                            <input class="search-query input-block-level" id="search_query" type="text" placeholder="{{ _('Search') }}"
-                              autocomplete="off" aria-label="{{ _('Search') }}" title="{{ _('Search') }} (/)"/>
+                        {% if search_pills_enabled %}
+                        <div id="searchbox" class="searchbox-rightmargin">
+                            <div id="tab_bar" class="notdisplayed">
+                            </div>
+                            <a class="search_icon" href="#search-operators" data-overlay-trigger="search-operators" title="{{ _('Search help') }}"><i class="fa fa-search" aria-hidden="true"></i></a>
+                            <form id="searchbox_form" class="form-search navbar-search">
+                                <div id="search_arrows" class="pill-container input-append">
+                                    <div contenteditable="true" class="input search-query input-block-level" id="search_query" type="text" placeholder="{{ _('Search') }}"
+                                      autocomplete="off" aria-label="{{ _('Search') }}" title="{{ _('Search') }} (/)"> </div>
+                                </div>
+                            </form>
                             {# Start the button off disabled since there is no active search #}
                             <button class="btn search_button" type="button" id="search_exit" disabled="disabled" aria-label="{{ _('Exit search') }}"><i class="fa fa-remove" aria-hidden="true"></i></button>
-                            <a class="search_icon" href="#search-operators" data-overlay-trigger="search-operators" title="{{ _('Search help') }}"><i class="fa fa-search" aria-hidden="true"></i></a>
                         </div>
-                    </form>
+                        {% else %}
+                        <div id="searchbox_legacy" class="searchbox-rightmargin">
+                            <div id="tab_bar" class="notdisplayed">
+                            </div>
+                            <form id="searchbox_form" class="form-search navbar-search">
+                                <div id="search_arrows" class="input-append">
+                                    <input class="search-query input-block-level" id="search_query" type="text" placeholder="{{ _('Search') }}"
+                                      autocomplete="off" aria-label="{{ _('Search') }}" title="{{ _('Search') }} (/)" />
+                                    {# Start the button off disabled since there is no active search #}
+                                    <button class="btn search_button" type="button" id="search_exit" disabled="disabled" aria-label="{{ _('Exit search') }}"><i class="fa fa-remove" aria-hidden="true"></i></button>
+                                    <a class="search_icon" href="#search-operators" data-overlay-trigger="search-operators" title="{{ _('Search help') }}"><i class="fa fa-search" aria-hidden="true"></i></a>
+                                </div>
+                            </form>
+                        </div>
+                        {% endif %}
+                    </div>
                 </div>
-                {% endif %}
-            </div>
-        </div>
-        <div class="column-right">
-            <div id="userlist-toggle" title="{{ _('User list') }} (w)">
-                <a href="#" id="userlist-toggle-button" role="button"><i class="fa fa-group" aria-hidden="true"></i>
-                    <span id="userlist-toggle-unreadcount">0</span>
-                </a>
-            </div>
-            <div id="navbar-buttons" {%if embedded %} style="visibility: hidden"{% endif %}>
-                <ul class="nav" role="navigation">
-                    <li class="dropdown actual-dropdown-menu" id="gear-menu">
-                        <a id="settings-dropdown" href="#" role="button" class="dropdown-toggle" data-target="nada" data-toggle="dropdown" title="{{ _('Menu') }} (g)">
-                            <i class="fa fa-cog" aria-hidden="true"></i><i class="fa fa-caret-down settings-dropdown-caret" aria-hidden="true"></i>
+                <div class="nav-column-right">
+                    <div id="userlist-toggle" title="{{ _('User list') }} (w)">
+                        <a href="#" id="userlist-toggle-button" role="button"><i class="fa fa-group" aria-hidden="true"></i>
+                            <span id="userlist-toggle-unreadcount">0</span>
                         </a>
-                        <ul class="dropdown-menu" role="menu" aria-labelledby="settings-dropdown">
-                            {#
-                            It is quite ingrained in our frontend code that your Home
-                            view is a Bootstrap Nav tab, even though we don't show the tab
-                            anymore
-                            #}
-                            <li class="invisible" style="display:none;" role="presentation"><a href="#home" data-toggle="tab"></a></li>
-                            <li role="presentation">
-                                <a href="#streams" role="menuitem">
-                                    <i class="fa fa-exchange" aria-hidden="true"></i> {{ _('Manage streams') }}
+                    </div>
+                    <div id="navbar-buttons" {%if embedded %} style="visibility: hidden"{% endif %}>
+                        <ul class="nav" role="navigation">
+                            <li class="dropdown actual-dropdown-menu" id="gear-menu">
+                                <a id="settings-dropdown" href="#" role="button" class="dropdown-toggle" data-target="nada" data-toggle="dropdown" title="{{ _('Menu') }} (g)">
+                                    <i class="fa fa-cog" aria-hidden="true"></i><i class="fa fa-caret-down settings-dropdown-caret" aria-hidden="true"></i>
                                 </a>
+                                <ul class="dropdown-menu" role="menu" aria-labelledby="settings-dropdown">
+                                    {#
+                                    It is quite ingrained in our frontend code that your Home
+                                    view is a Bootstrap Nav tab, even though we don't show the tab
+                                    anymore
+                                    #}
+                                    <li class="invisible" style="display:none;" role="presentation"><a href="#home" data-toggle="tab"></a></li>
+                                    <li role="presentation">
+                                        <a href="#streams" role="menuitem">
+                                            <i class="fa fa-exchange" aria-hidden="true"></i> {{ _('Manage streams') }}
+                                        </a>
+                                    </li>
+                                    <li role="presentation">
+                                        <a href="#settings" role="menuitem">
+                                            <i class="fa fa-wrench" aria-hidden="true"></i> {{ _('Settings') }}
+                                        </a>
+                                    </li>
+                                    <li class="admin-menu-item" role="presentation">
+                                        <a href="#organization" role="menuitem">
+                                            <i class="fa fa-bolt" aria-hidden="true"></i>
+                                            <span>{{ _('Manage organization') }}</span>
+                                        </a>
+                                    </li>
+                                    <li class="divider"></li>
+                                    <li role="presentation">
+                                        <a href="/help" target="_blank" role="menuitem">
+                                            <i class="fa fa-question-circle" aria-hidden="true"></i> {{ _('Help center') }}
+                                        </a>
+                                    </li>
+                                    <li role="presentation">
+                                        <a tabindex="0" role="menuitem" data-overlay-trigger="keyboard-shortcuts">
+                                            <i class="fa fa-keyboard-o" aria-hidden="true"></i> {{ _('Keyboard shortcuts') }} <span class="hotkey-hint">(?)</span>
+                                        </a>
+                                    </li>
+                                    <li role="presentation">
+                                        <a tabindex="0" role="menuitem" data-overlay-trigger="message-formatting">
+                                            <i class="fa fa-pencil" aria-hidden="true"></i> {{ _('Message formatting') }}
+                                        </a>
+                                    </li>
+                                    <li role="presentation">
+                                        <a tabindex="0" role="menuitem" data-overlay-trigger="search-operators">
+                                            <i class="fa fa-search" aria-hidden="true"></i> {{ _('Search operators') }}
+                                        </a>
+                                    </li>
+                                    <li class="divider" role="presentation"></li>
+                                    <li role="presentation">
+                                        <a href="{{ apps_page_url }}" target="_blank" role="menuitem">
+                                            <i class="fa fa-desktop" aria-hidden="true"></i> {{ _('Desktop & mobile apps') }}
+                                        </a>
+                                    </li>
+                                    <li role="presentation">
+                                        <a href="/integrations" target="_blank" role="menuitem">
+                                            <i class="fa fa-github" aria-hidden="true"></i> {{ _('Integrations') }}
+                                        </a>
+                                    </li>
+                                    <li role="presentation">
+                                        <a href="/api" target="_blank" role="menuitem">
+                                            <i class="fa fa-sitemap" aria-hidden="true"></i> {{ _('API documentation') }}
+                                        </a>
+                                    </li>
+                                    {% if not is_guest %}
+                                    <li role="presentation">
+                                        <a href="/stats" target="_blank" role="menuitem">
+                                            <i class="fa fa-bar-chart" aria-hidden="true"></i>
+                                            <span>{{ _('Statistics') }}</span>
+                                        </a>
+                                    </li>
+                                    {% endif %}
+                                    {% if show_plans %}
+                                    <li role="presentation">
+                                        <a href="/plans" target="_blank" role="menuitem">
+                                            <i class="fa fa-rocket" aria-hidden="true"></i> {{ _('Plans and pricing') }}
+                                        </a>
+                                    </li>
+                                    {% endif %}
+                                    {% if show_billing %}
+                                    <li role="presentation">
+                                        <a href="/billing" target="_blank" role="menuitem">
+                                            <i class="fa fa-credit-card" aria-hidden="true"></i> {{ _('Billing') }}
+                                        </a>
+                                    </li>
+                                    {% endif %}
+                                    <li class="divider" role="presentation"></li>
+                                    {% if enable_feedback %}
+                                    <li role="presentation">
+                                        <a href="#feedback" class="feedback" role="menuitem">
+                                            <i class="fa fa-comment" aria-hidden="true"></i> {{ _('Feedback') }}
+                                        </a>
+                                    </li>
+                                    {% endif %}
+                                    {% if show_invites %}
+                                    <li role="presentation">
+                                        <a href="#invite" role="menuitem">
+                                            <i class="fa fa-plus-circle" aria-hidden="true"></i> {{ _('Invite users') }}
+                                        </a>
+                                    </li>
+                                    <li class="divider" role="presentation"></li>
+                                    {% endif %}
+                                    {% if show_webathena %}
+                                    <li title="{% trans %}Grant Zulip the Kerberos tickets needed to run your Zephyr mirror via Webathena{% endtrans %}" id="webathena_login_menu" role="presentation">
+                                        <a href="#webathena" class="webathena_login" role="menuitem">
+                                            <i class="fa fa-bolt" aria-hidden="true"></i>{{ _('Link with Webathena') }}
+                                        </a>
+                                    </li>
+                                    {% endif %}
+                                    <li role="presentation">
+                                        <a href="#logout" class="logout_button" role="menuitem">
+                                            <i class="fa fa-power-off" aria-hidden="true"></i> {{ _('Log out') }}
+                                        </a>
+                                    </li>
+                                    {% if show_debug %}
+                                    <li role="presentation">
+                                        <a href="#debug" data-toggle="tab" role="menuitem">
+                                            <i class="fa fa-barcode" aria-hidden="true"></i> {{ _('Debug') }}
+                                        </a>
+                                    </li>
+                                    {% endif %}
+                                </ul>
                             </li>
-                            <li role="presentation">
-                                <a href="#settings" role="menuitem">
-                                    <i class="fa fa-wrench" aria-hidden="true"></i> {{ _('Settings') }}
-                                </a>
-                            </li>
-                            <li class="admin-menu-item" role="presentation">
-                                <a href="#organization" role="menuitem">
-                                    <i class="fa fa-bolt" aria-hidden="true"></i>
-                                    <span>{{ _('Manage organization') }}</span>
-                                </a>
-                            </li>
-                            <li class="divider"></li>
-                            <li role="presentation">
-                                <a href="/help" target="_blank" role="menuitem">
-                                    <i class="fa fa-question-circle" aria-hidden="true"></i> {{ _('Help center') }}
-                                </a>
-                            </li>
-                            <li role="presentation">
-                                <a tabindex="0" role="menuitem" data-overlay-trigger="keyboard-shortcuts">
-                                    <i class="fa fa-keyboard-o" aria-hidden="true"></i> {{ _('Keyboard shortcuts') }} <span class="hotkey-hint">(?)</span>
-                                </a>
-                            </li>
-                            <li role="presentation">
-                                <a tabindex="0" role="menuitem" data-overlay-trigger="message-formatting">
-                                    <i class="fa fa-pencil" aria-hidden="true"></i> {{ _('Message formatting') }}
-                                </a>
-                            </li>
-                            <li role="presentation">
-                                <a tabindex="0" role="menuitem" data-overlay-trigger="search-operators">
-                                    <i class="fa fa-search" aria-hidden="true"></i> {{ _('Search operators') }}
-                                </a>
-                            </li>
-                            <li class="divider" role="presentation"></li>
-                            <li role="presentation">
-                                <a href="{{ apps_page_url }}" target="_blank" role="menuitem">
-                                    <i class="fa fa-desktop" aria-hidden="true"></i> {{ _('Desktop & mobile apps') }}
-                                </a>
-                            </li>
-                            <li role="presentation">
-                                <a href="/integrations" target="_blank" role="menuitem">
-                                    <i class="fa fa-github" aria-hidden="true"></i> {{ _('Integrations') }}
-                                </a>
-                            </li>
-                            <li role="presentation">
-                                <a href="/api" target="_blank" role="menuitem">
-                                    <i class="fa fa-sitemap" aria-hidden="true"></i> {{ _('API documentation') }}
-                                </a>
-                            </li>
-                            {% if not is_guest %}
-                            <li role="presentation">
-                                <a href="/stats" target="_blank" role="menuitem">
-                                    <i class="fa fa-bar-chart" aria-hidden="true"></i>
-                                    <span>{{ _('Statistics') }}</span>
-                                </a>
-                            </li>
-                            {% endif %}
-                            {% if show_plans %}
-                            <li role="presentation">
-                                <a href="/plans" target="_blank" role="menuitem">
-                                    <i class="fa fa-rocket" aria-hidden="true"></i> {{ _('Plans and pricing') }}
-                                </a>
-                            </li>
-                            {% endif %}
-                            {% if show_billing %}
-                            <li role="presentation">
-                                <a href="/billing" target="_blank" role="menuitem">
-                                    <i class="fa fa-credit-card" aria-hidden="true"></i> {{ _('Billing') }}
-                                </a>
-                            </li>
-                            {% endif %}
-                            <li class="divider" role="presentation"></li>
-                            {% if enable_feedback %}
-                            <li role="presentation">
-                                <a href="#feedback" class="feedback" role="menuitem">
-                                    <i class="fa fa-comment" aria-hidden="true"></i> {{ _('Feedback') }}
-                                </a>
-                            </li>
-                            {% endif %}
-                            {% if show_invites %}
-                            <li role="presentation">
-                                <a href="#invite" role="menuitem">
-                                    <i class="fa fa-plus-circle" aria-hidden="true"></i> {{ _('Invite users') }}
-                                </a>
-                            </li>
-                            <li class="divider" role="presentation"></li>
-                            {% endif %}
-                            {% if show_webathena %}
-                            <li title="{% trans %}Grant Zulip the Kerberos tickets needed to run your Zephyr mirror via Webathena{% endtrans %}" id="webathena_login_menu" role="presentation">
-                                <a href="#webathena" class="webathena_login" role="menuitem">
-                                    <i class="fa fa-bolt" aria-hidden="true"></i>{{ _('Link with Webathena') }}
-                                </a>
-                            </li>
-                            {% endif %}
-                            <li role="presentation">
-                                <a href="#logout" class="logout_button" role="menuitem">
-                                    <i class="fa fa-power-off" aria-hidden="true"></i> {{ _('Log out') }}
-                                </a>
-                            </li>
-                            {% if show_debug %}
-                            <li role="presentation">
-                                <a href="#debug" data-toggle="tab" role="menuitem">
-                                    <i class="fa fa-barcode" aria-hidden="true"></i> {{ _('Debug') }}
-                                </a>
-                            </li>
-                            {% endif %}
                         </ul>
-                    </li>
-                </ul>
+                    </div>
+                </div>
             </div>
         </div>
     </nav>

--- a/zerver/tests/test_realm_filters.py
+++ b/zerver/tests/test_realm_filters.py
@@ -53,6 +53,14 @@ class RealmFilterTest(ZulipTestCase):
         result = self.client_post("/json/realm/filters", info=data)
         self.assert_json_success(result)
 
+        # This is something we'd like to support, but don't currently;
+        # this test is a reminder of something we should allow in the
+        # future.
+        data['pattern'] = r'(?P<org>[a-z]+)/(?P<repo>[a-z]+)#(?P<id>[0-9]+)'
+        data['url_format_string'] = 'https://github.com/%(org)/%(repo)/issue/%(id)'
+        result = self.client_post("/json/realm/filters", info=data)
+        self.assert_json_error(result, 'URL format string must be in the following format: `https://example.com/%(\\w+)s`')
+
     def test_not_realm_admin(self) -> None:
         email = self.example_email('hamlet')
         self.login(email)


### PR DESCRIPTION
This fixes  #10562 by removing the javascript resizing of the `nav-bar` `width`, and using CSS instead.
The navbar uses the full width, while the content stays centered like the rest of the page.

There are minor changes in the looks of the page:
- 1 navbar always uses full width
- 2 the brand logo is aligned with the content of the left column. (which looks better, imho.) 
- 3 the alert panels use `position:fixed` now. This prevents messing up the `top` or 'top-margin` of the main content. 

The html structure is now similar to what is mostly used for bootstrap sites.

![screenshot from 2018-11-24 17-02-07](https://user-images.githubusercontent.com/1678423/48970289-f37a0700-f00a-11e8-95a3-a9a26e7e1f7f.png)
