### PR TITLE
integrations: Change the truncation marker for long messages.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3767,7 +3767,7 @@ def truncate_content(content: str, max_length: int, truncation_message: str) -> 
     return content
 
 def truncate_body(body: str) -> str:
-    return truncate_content(body, MAX_MESSAGE_LENGTH, "...")
+    return truncate_content(body, MAX_MESSAGE_LENGTH, "\n[message truncated]")
 
 def truncate_topic(topic: str) -> str:
     return truncate_content(topic, MAX_TOPIC_NAME_LENGTH, "...")

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -10,7 +10,8 @@ from django.conf import settings
 
 from zerver.lib.actions import decode_email_address, get_email_gateway_message_string_from_address, \
     internal_send_message, internal_send_private_message, \
-    internal_send_stream_message, internal_send_huddle_message
+    internal_send_stream_message, internal_send_huddle_message, \
+    truncate_body, truncate_topic
 from zerver.lib.notifications import convert_html_to_markdown
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.redis_utils import get_redis_client
@@ -192,8 +193,8 @@ def send_zulip(sender: str, stream: Stream, topic: str, content: str) -> None:
         sender,
         "stream",
         stream.name,
-        topic[:MAX_TOPIC_NAME_LENGTH],
-        content[:MAX_MESSAGE_LENGTH],
+        truncate_topic(topic),
+        truncate_body(content),
         email_gateway=True)
 
 def valid_stream(stream_name: str, token: str) -> bool:

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -1544,7 +1544,7 @@ class MessagePOSTTest(ZulipTestCase):
 
         sent_message = self.get_last_message()
         self.assertEqual(sent_message.content,
-                         "A" * (MAX_MESSAGE_LENGTH - 3) + "...")
+                         "A" * (MAX_MESSAGE_LENGTH - 20) + "\n[message truncated]")
 
     def test_long_topic(self) -> None:
         """


### PR DESCRIPTION
This PR change the truncation marker from `...` to `\n[message truncated]` when receiving messages from the API or through email.

Fix #10871.

**Testing Plan:** <!-- How have you tested? -->

This PR updates tests to account for the new change.

**GIFs or Screenshots:** 

Screenshot of truncation after CURL request: (I pasted an over-10000 character string into the terminal, and then it is truncated by the server)

![nov-24-2018 22-47-08](https://user-images.githubusercontent.com/17259768/48976366-f856af00-f03a-11e8-9007-e0a66c68578d.gif)
