### PR TITLE
webhooks/stripe: Handle customer.discount events properly.

### DIFF
--- a/zerver/webhooks/stripe/fixtures/customer_discount_created.json
+++ b/zerver/webhooks/stripe/fixtures/customer_discount_created.json
@@ -1,0 +1,39 @@
+{
+    "created":1326853478,
+    "livemode":false,
+    "id":"customer.discount.created_00000000000000",
+    "type":"customer.discount.created",
+    "object":"event",
+    "request":null,
+    "pending_webhooks":1,
+    "api_version":"2018-02-28",
+    "data":{
+        "object":{
+            "object":"discount",
+            "coupon":{
+                "id":"25_00000000000000",
+                "object":"coupon",
+                "amount_off":null,
+                "created":1543438043,
+                "currency":null,
+                "duration":"repeating",
+                "duration_in_months":3,
+                "livemode":false,
+                "max_redemptions":null,
+                "metadata":{
+
+                },
+                "name":"25.5% off",
+                "percent_off":26,
+                "percent_off_precise":25.5,
+                "redeem_by":null,
+                "times_redeemed":0,
+                "valid":true
+            },
+            "customer":"cus_00000000000000",
+            "end":1551386843,
+            "start":1543438043,
+            "subscription":null
+        }
+    }
+}

--- a/zerver/webhooks/stripe/tests.py
+++ b/zerver/webhooks/stripe/tests.py
@@ -76,6 +76,12 @@ Quantity: 1"""
                                               expected_topic, expected_message,
                                               content_type="application/x-www-form-urlencoded")
 
+    def test_customer_discount_created(self) -> None:
+        expected_topic = u"cus_00000000000000"
+        expected_message = u"Discount created ([25.5% off](https://dashboard.stripe.com/coupons/25_00000000000000))."
+        self.send_and_test_stream_message('customer_discount_created', expected_topic, expected_message,
+                                          content_type="application/x-www-form-urlencoded")
+
     def test_invoice_payment_failed(self) -> None:
         expected_topic = u"cus_00000000000000"
         expected_message = u"[Invoice](https://dashboard.stripe.com/invoices/in_00000000000000) payment failed"

--- a/zerver/webhooks/stripe/view.py
+++ b/zerver/webhooks/stripe/view.py
@@ -89,9 +89,12 @@ def api_stripe_webhook(request: HttpRequest, user_profile: UserProfile,
                 if object_['metadata']:  # nocoverage
                     for key, value in object_['metadata'].items():
                         body += '\n{}: {}'.format(key, value)
-        if resource == 'discount':  # nocoverage
-            body = default_body() + '. ({coupon})'.format(
-                coupon=linkified_id(object_['coupon'], lower=True))
+        if resource == 'discount':
+            body = 'Discount {verbed} ([{coupon_name}]({coupon_url})).'.format(
+                verbed=event.replace('_', ' '),
+                coupon_name=object_['coupon']['name'],
+                coupon_url='https://dashboard.stripe.com/{}/{}'.format('coupons', object_['coupon']['id'])
+            )
         if resource == 'source':  # nocoverage
             body = default_body()
         if resource == 'subscription':


### PR DESCRIPTION
Recent changes merged in #10877 didn't handle these events
correctly. The linkified_id function breaks for the `discount`
object in the JSON payload. A cursory glance at Stripe's docs
tells me that since a discount is associated with a customer,
it makes sense for a `discount` object to not have an ID that
can necessarily be linked to. So, we can just link to the
customer instead.

@rishig, @timabbott: FYI :)