### PR TITLE
Fix full name input field reset after form invalidation.

### DIFF
--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -108,17 +108,11 @@ $(function () {
     function update_full_name_section() {
         var selected_realm = $("#source_realm_select").find(":selected").val();
         if (selected_realm && selected_realm !== "on") {
-            $("#full_name_input_section").hide();
             $("#profile_info_section").show();
             var avatar_url = $("#source_realm_select").find(":selected").attr('data-avatar');
-            var full_name = $("#source_realm_select").find(":selected").attr('data-full-name');
-            $("#profile_full_name").text(full_name);
-            $("#id_full_name").val(full_name);
             $("#profile_avatar").attr("src", avatar_url);
         } else {
-            $("#full_name_input_section").show();
             $("#profile_info_section").hide();
-            $("#id_full_name").val("");
         }
     }
 


### PR DESCRIPTION
https://github.com/zulip/zulip/issues/10867

    
This code prevents the Full name input field from being incorrectly clear after the sign up form is rendered again after invalid data is submitted.

Fixes #10867 
