### PR TITLE
Add placeholder endpoint for server-specific compatibility checks.

### DIFF
--- a/zerver/views/compatibility.py
+++ b/zerver/views/compatibility.py
@@ -10,3 +10,9 @@ def check_global_compatibility(request: HttpRequest) -> HttpResponse:
     if user_agent['name'] == "ZulipInvalid":
         return json_error("Client is too old")
     return json_success()
+
+def check_server_compatibility(request: HttpRequest) -> HttpResponse:
+    user_agent = parse_user_agent(request.META["HTTP_USER_AGENT"])
+    if user_agent['name'] == "ZulipInvalid":
+        return json_error("Client is too old")
+    return json_success()

--- a/zerver/views/compatibility.py
+++ b/zerver/views/compatibility.py
@@ -5,7 +5,7 @@ from typing import Any, List, Dict, Optional
 from zerver.lib.response import json_error, json_success
 from zerver.lib.user_agent import parse_user_agent
 
-def check_compatibility(request: HttpRequest) -> HttpResponse:
+def check_global_compatibility(request: HttpRequest) -> HttpResponse:
     user_agent = parse_user_agent(request.META["HTTP_USER_AGENT"])
     if user_agent['name'] == "ZulipInvalid":
         return json_error("Client is too old")

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -592,7 +592,9 @@ urls += [
     url(r'^api/v1/get_auth_backends', zerver.views.auth.api_get_auth_backends,
         name='zerver.views.auth.api_get_auth_backends'),
 
-    # used by mobile apps to check if they are compatible with the server
+    # Used as a global check by all mobile clients, which currently send
+    # requests to https://zulipchat.com/compatibility almost immediately after
+    # starting up.
     url(r'^compatibility$', zerver.views.compatibility.check_compatibility),
 
     # This json format view used by the mobile apps accepts a username

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -597,6 +597,9 @@ urls += [
     # starting up.
     url(r'^compatibility$', zerver.views.compatibility.check_global_compatibility),
 
+    # For server-specific compatibility checks
+    url(r'^api/v1/server_compatibility', zerver.views.compatibility.check_server_compatibility),
+
     # This json format view used by the mobile apps accepts a username
     # password/pair and returns an API key.
     url(r'^api/v1/fetch_api_key$', zerver.views.auth.api_fetch_api_key,

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -595,7 +595,7 @@ urls += [
     # Used as a global check by all mobile clients, which currently send
     # requests to https://zulipchat.com/compatibility almost immediately after
     # starting up.
-    url(r'^compatibility$', zerver.views.compatibility.check_compatibility),
+    url(r'^compatibility$', zerver.views.compatibility.check_global_compatibility),
 
     # This json format view used by the mobile apps accepts a username
     # password/pair and returns an API key.


### PR DESCRIPTION
This is the server-side part to zulip/zulip-mobile#3158.

@gnprice 
@zulipbot add "area: mobile"