### PR TITLE
portico: Add autofocus to the first input field with errors.

### DIFF
--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -45,14 +45,13 @@ $(function () {
     }
 
     if ($("#registration").length > 0) {
-        if ($("#id_team_name").length === 1) {
-            common.autofocus('#id_team_name');
-        } else if ($('#id_email').length === 1 && !$('#id_email').attr('disabled')) {
-            common.autofocus('#id_email');
-        } else if ($("#source_realm_select").length === 1) {
-            common.autofocus('#source_realm_select');
-        } else {
-            common.autofocus('#id_full_name');
+        // Check if there is no input field with errors.
+        if ($('.help-inline:not(:empty)').length === 0) {
+            // Find the first input field present in the form that is
+            // not hidden and disabled and store it in a variable.
+            var firstInputElement = $("input:not(:hidden, :disabled):first");
+            // Focus on the first input field in the form.
+            common.autofocus(firstInputElement);
         }
 
         // reset error message displays

--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -52,6 +52,11 @@ $(function () {
             var firstInputElement = $("input:not(:hidden, :disabled):first");
             // Focus on the first input field in the form.
             common.autofocus(firstInputElement);
+        } else { // If input field with errors is present.
+            // Find the input field having errors and stores it in a variable.
+            var inputElementWithError = $('.help-inline:not(:empty):first').parent().find('input');
+            // Focus on the input field having errors.
+            common.autofocus(inputElementWithError);
         }
 
         // reset error message displays


### PR DESCRIPTION
This code brings the focus to the first input field with errors rather than just the first input field present in the form after the sign up form is rendered again when invalid data is submitted.

Fixes #10869