### PR TITLE
right sidebar: Fix night-mode presence styling.

### DIFF
--- a/static/templates/group_pms.handlebars
+++ b/static/templates/group_pms.handlebars
@@ -5,7 +5,7 @@
         {{#if fraction_present}}
         <span class="group-pm-status-indicator" style="background:rgba(68,194,29,{{fraction_present}});"></span>
         {{else}}
-        <span class="group-pm-status-indicator" style="background:rgb(255,255,255); border-color:rgb(127,127,127);"></span>
+        <span class="group-pm-status-indicator" style="background:none; border-color:rgb(127,127,127);"></span>
         {{/if}}
         <a href="{{href}}" data-name="{{name}}" title="{{name}}" class="group-pm-link">{{short_name}}</a>
         <span class="count"><span class="value"></span></span>


### PR DESCRIPTION
This PR fixes the background color of night-mode presence indicators by setting the background color to transparent instead of white when inactive.

Fixes #10932.

**Screenshot:** 

<img width="230" alt="screenshot" src="https://user-images.githubusercontent.com/17259768/49330111-ff038b80-f53e-11e8-8792-6f312f02f0bd.png">
