### PR TITLE
webhooks/jira: Decode topics on our end.

### DIFF
--- a/zerver/lib/webhooks/common.py
+++ b/zerver/lib/webhooks/common.py
@@ -67,7 +67,7 @@ def check_send_webhook_message(
         request: HttpRequest, user_profile: UserProfile,
         topic: str, body: str, stream: Optional[str]=REQ(default=None),
         user_specified_topic: Optional[str]=REQ("topic", default=None),
-        unquote_stream: Optional[bool]=False
+        unquote_url_parameters: Optional[bool]=False
 ) -> None:
 
     if stream is None:
@@ -78,12 +78,14 @@ def check_send_webhook_message(
         # Some third-party websites (such as Atlassian's JIRA), tend to
         # double escape their URLs in a manner that escaped space characters
         # (%20) are never properly decoded. We work around that by making sure
-        # that the stream name is decoded on our end.
-        if unquote_stream:
+        # that the URL parameters are decoded on our end.
+        if unquote_url_parameters:
             stream = unquote(stream)
 
         if user_specified_topic is not None:
             topic = user_specified_topic
+            if unquote_url_parameters:
+                topic = unquote(topic)
 
         try:
             check_send_stream_message(user_profile, request.client,

--- a/zerver/webhooks/jira/tests.py
+++ b/zerver/webhooks/jira/tests.py
@@ -66,6 +66,14 @@ class JiraHookTests(WebhookTestCase):
         self.assertEqual(msg.content, expected_message)
         self.assertEqual(msg.topic_name(), expected_topic)
 
+    def test_created_with_topic_with_spaces_double_escaped(self) -> None:
+        self.url = self.build_webhook_url(topic=quote(quote('alerts test')))
+        expected_topic = "alerts test"
+        expected_message = """Leo Franchi **created** [BUG-15](http://lfranchi.com:8080/browse/BUG-15) priority Major, assigned to **no one**:
+
+> New bug with hook"""
+        self.send_and_test_stream_message('created_v1', expected_topic, expected_message)
+
     def test_created_with_unicode(self) -> None:
             expected_topic = u"BUG-15: New bug with à hook"
             expected_message = u"""Leo Franchià **created** [BUG-15](http://lfranchi.com:8080/browse/BUG-15) priority Major, assigned to **no one**:

--- a/zerver/webhooks/jira/view.py
+++ b/zerver/webhooks/jira/view.py
@@ -243,5 +243,5 @@ def api_jira_webhook(request: HttpRequest, user_profile: UserProfile,
 
     check_send_webhook_message(request, user_profile,
                                subject, content,
-                               unquote_stream=True)
+                               unquote_url_parameters=True)
     return json_success()


### PR DESCRIPTION
The problem addressed in 006e47198c5db5e6dd40170100f1831b7114dc18
resurfaces with topics when a user provides a custom topic in the
webhook URL.

@timabbott: FYI, I made sure my test failed without the changes I introduced! :) Thanks!