### PR TITLE
hello: Fix header alignment when page is around 375px.

### DIFF
--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -4050,6 +4050,10 @@ nav ul li.active::after {
         padding: 0 45px 0 45px;
     }
 
+    .portico-landing.hello .integrations .content header {
+        padding: 0;
+    }
+
     .portico-landing.hello .integrations .integration-icons .group {
         margin: 4px 2px;
     }


### PR DESCRIPTION
Fixes: #10771

<!-- What's this PR for?  (Just a link to an issue is fine.) -->



**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/30157875/49466695-76574a80-f7df-11e8-8dd2-25115aaf7305.png)
Tested on Chrome ***Version 70.0.3538.77 (Official Build) (64-bit)*** 


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
