### PR TITLE
Require Android users on pre-16.2.96 releases to upgrade.

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -501,6 +501,7 @@ def build_custom_checkers(by_lang):
          'exclude': set(['zerver/tests']),
          'exclude_line': set([
              # We don't want this string tagged for translation.
+             ('zerver/views/compatibility.py', 'return json_error("Client is too old")  # take 0'),
              ('zerver/views/compatibility.py', 'return json_error("Client is too old")'),
          ]),
          'description': 'Argument to json_error should a literal string enclosed by _()'},

--- a/zerver/lib/user_agent.py
+++ b/zerver/lib/user_agent.py
@@ -5,6 +5,10 @@ from typing import Dict
 #   zerver/tests/test_decorators.py
 # And extend zerver/tests/fixtures/user_agents_unique with any new test cases
 def parse_user_agent(user_agent: str) -> Dict[str, str]:
-    match = re.match("^(?P<name>[^/ ]*[^0-9/(]*)(/(?P<version>[^/ ]*))?([ /].*)?$", user_agent)
+    match = re.match(
+        """^ (?P<name> [^/ ]* [^0-9/(]* )
+             (/ (?P<version> [^/ ]* ))?
+             ([ /] .*)?
+           $""", user_agent, re.X)
     assert match is not None
     return match.groupdict()

--- a/zerver/tests/test_compatibility.py
+++ b/zerver/tests/test_compatibility.py
@@ -8,6 +8,7 @@ class VersionTest(ZulipTestCase):
         1.2.3    =  1.2.3
         1.4.1    >  1.2.3
         1.002a   =  1.2a
+        1.2      <  1.2.3
         1.2.3    ?  1.2-dev
         1.2-dev  ?  1.2a
         1.2a     ?  1.2rc3

--- a/zerver/tests/test_compatibility.py
+++ b/zerver/tests/test_compatibility.py
@@ -1,5 +1,43 @@
 
 from zerver.lib.test_classes import ZulipTestCase
+from zerver.views.compatibility import version_lt
+
+class VersionTest(ZulipTestCase):
+    data = [case.split() for case in '''
+        1.2.3    <  1.2.4
+        1.2.3    =  1.2.3
+        1.4.1    >  1.2.3
+        1.002a   =  1.2a
+        1.2.3    ?  1.2-dev
+        1.2-dev  ?  1.2a
+        1.2a     ?  1.2rc3
+        1.2rc3   ?  1.2
+        1.2      ?  1.2-g0f1e2d3c4
+        10.1     >  1.2
+        0.17.18  <  16.2.96
+        9.10.11  <  16.2.96
+        15.1.95  <  16.2.96
+        16.2.96  =  16.2.96
+        20.0.103 >  16.2.96
+    '''.strip().split('\n')]
+
+    def test_version_lt(self) -> None:
+        for ver1, cmp, ver2 in self.data:
+            msg = 'expected {} {} {}'.format(ver1, cmp, ver2)
+            if cmp == '<':
+                self.assertTrue(version_lt(ver1, ver2), msg=msg)
+                self.assertFalse(version_lt(ver2, ver1), msg=msg)
+            elif cmp == '=':
+                self.assertFalse(version_lt(ver1, ver2), msg=msg)
+                self.assertFalse(version_lt(ver2, ver1), msg=msg)
+            elif cmp == '>':
+                self.assertFalse(version_lt(ver1, ver2), msg=msg)
+                self.assertTrue(version_lt(ver2, ver1), msg=msg)
+            elif cmp == '?':
+                self.assertIsNone(version_lt(ver1, ver2), msg=msg)
+                self.assertIsNone(version_lt(ver2, ver1), msg=msg)
+            else:
+                assert False  # nocoverage
 
 class CompatibilityTest(ZulipTestCase):
     def test_compatibility(self) -> None:

--- a/zerver/tests/test_compatibility.py
+++ b/zerver/tests/test_compatibility.py
@@ -1,6 +1,6 @@
 
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.views.compatibility import version_lt
+from zerver.views.compatibility import find_mobile_os, version_lt
 
 class VersionTest(ZulipTestCase):
     data = [case.split() for case in '''
@@ -42,6 +42,20 @@ class VersionTest(ZulipTestCase):
                 self.assertIsNone(version_lt(ver2, ver1), msg=msg)
             else:
                 assert False  # nocoverage
+
+    mobile_os_data = [case.split(None, 1) for case in '''
+      android ZulipMobile/1.2.3 (Android 4.5)
+      ios     ZulipMobile/1.2.3 (iPhone OS 2.1)
+      ios     ZulipMobile/1.2.3 (iOS 6)
+      None    ZulipMobile/1.2.3 (Windows 8)
+    '''.strip().split('\n')]
+
+    def test_find_mobile_os(self) -> None:
+        for expected_, user_agent in self.mobile_os_data:
+            expected = None if expected_ == 'None' else expected_
+            self.assertEqual(find_mobile_os(user_agent), expected,
+                             msg=user_agent)
+
 
 class CompatibilityTest(ZulipTestCase):
     def test_compatibility(self) -> None:

--- a/zerver/tests/test_compatibility.py
+++ b/zerver/tests/test_compatibility.py
@@ -20,7 +20,10 @@ class VersionTest(ZulipTestCase):
         15.1.95  <  16.2.96
         16.2.96  =  16.2.96
         20.0.103 >  16.2.96
-    '''.strip().split('\n')]
+    '''.strip().split('\n')] + [
+        ['', '?', '1'],
+        ['', '?', 'a'],
+    ]
 
     def test_version_lt(self) -> None:
         for ver1, cmp, ver2 in self.data:

--- a/zerver/tests/test_compatibility.py
+++ b/zerver/tests/test_compatibility.py
@@ -64,5 +64,12 @@ class CompatibilityTest(ZulipTestCase):
         def get(user_agent: str) -> HttpResponse:
             return self.client_get("/compatibility", HTTP_USER_AGENT=user_agent)
 
-        self.assert_json_success(get('ZulipMobile/5.0'))
         self.assert_json_error(get('ZulipInvalid/5.0'), "Client is too old")
+        self.assert_json_success(get('ZulipMobile/5.0'))
+        self.assert_json_success(get('ZulipMobile/5.0 (iOS 11)'))
+        self.assert_json_success(get('ZulipMobile/5.0 (Androidish 9)'))
+        self.assert_json_error(get('ZulipMobile/5.0 (Android 9)'), "Client is too old")
+        self.assert_json_error(get('ZulipMobile/15.1.95 (Android 9)'), "Client is too old")
+        self.assert_json_error(get('ZulipMobile/16.1.94 (Android 9)'), "Client is too old")
+        self.assert_json_success(get('ZulipMobile/16.2.96 (Android 9)'))
+        self.assert_json_success(get('ZulipMobile/20.0.103 (Android 9)'))

--- a/zerver/tests/test_compatibility.py
+++ b/zerver/tests/test_compatibility.py
@@ -1,4 +1,6 @@
 
+from django.http import HttpResponse
+
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.views.compatibility import find_mobile_os, version_lt
 
@@ -59,7 +61,8 @@ class VersionTest(ZulipTestCase):
 
 class CompatibilityTest(ZulipTestCase):
     def test_compatibility(self) -> None:
-        result = self.client_get("/compatibility", HTTP_USER_AGENT='ZulipMobile/5.0')
-        self.assert_json_success(result)
-        result = self.client_get("/compatibility", HTTP_USER_AGENT='ZulipInvalid/5.0')
-        self.assert_json_error(result, "Client is too old")
+        def get(user_agent: str) -> HttpResponse:
+            return self.client_get("/compatibility", HTTP_USER_AGENT=user_agent)
+
+        self.assert_json_success(get('ZulipMobile/5.0'))
+        self.assert_json_error(get('ZulipInvalid/5.0'), "Client is too old")

--- a/zerver/views/compatibility.py
+++ b/zerver/views/compatibility.py
@@ -31,6 +31,8 @@ def version_lt(ver1: str, ver2: str) -> Optional[bool]:
     '''
     num1, rest1 = pop_numerals(ver1)
     num2, rest2 = pop_numerals(ver2)
+    if not num1 or not num2:
+        return None
     common_len = min(len(num1), len(num2))
     common_num1, rest_num1 = num1[:common_len], num1[common_len:]
     common_num2, rest_num2 = num2[:common_len], num2[common_len:]

--- a/zerver/views/compatibility.py
+++ b/zerver/views/compatibility.py
@@ -1,9 +1,52 @@
 
 from django.http import HttpResponse, HttpRequest
-from typing import Any, List, Dict, Optional
+import re
+from typing import Any, List, Dict, Optional, Tuple, Union
 
 from zerver.lib.response import json_error, json_success
 from zerver.lib.user_agent import parse_user_agent
+
+def pop_int(ver: str) -> Tuple[Optional[int], str]:
+    match = re.search(r'^(\d+)(.*)', ver)
+    if match is None:
+        return None, ver
+    return int(match.group(1)), match.group(2)
+
+def version_lt(ver1: str, ver2: str) -> Optional[bool]:
+    '''
+    Compare two Zulip-style version strings.
+
+    Versions are dot-separated sequences of decimal integers,
+    followed by arbitrary trailing decoration.  Comparison is
+    lexicographic on the integer sequences, and refuses to
+    guess how any trailing decoration compares to any other,
+    to further numerals, or to nothing.
+
+    Returns:
+      True if ver1 < ver2
+      False if ver1 >= ver2
+      None if can't tell.
+    '''
+    while True:
+        # Pull off the leading numeral from each version.
+        maj1, rest1 = pop_int(ver1)
+        maj2, rest2 = pop_int(ver2)
+        if maj1 is None or maj2 is None:
+            # One or both has no leading numeral; some unknown format.
+            return None
+        if maj1 < maj2:
+            return True
+        if maj1 > maj2:
+            return False
+        # Leading numerals are equal.
+
+        if rest1 == rest2:
+            return False
+        if not(rest1.startswith('.') and rest2.startswith('.')):
+            return None
+        ver1 = rest1[1:]
+        ver2 = rest2[1:]
+
 
 def check_global_compatibility(request: HttpRequest) -> HttpResponse:
     user_agent = parse_user_agent(request.META["HTTP_USER_AGENT"])

--- a/zerver/views/compatibility.py
+++ b/zerver/views/compatibility.py
@@ -55,6 +55,15 @@ def version_lt(ver1: str, ver2: str) -> Optional[bool]:
         return False
     return None
 
+
+def find_mobile_os(user_agent: str) -> Optional[str]:
+    if re.search(r'\b Android \b', user_agent, re.I | re.X):
+        return 'android'
+    if re.search(r'\b(?: iOS | iPhone\ OS )\b', user_agent, re.I | re.X):
+        return 'ios'
+    return None
+
+
 def check_global_compatibility(request: HttpRequest) -> HttpResponse:
     user_agent = parse_user_agent(request.META["HTTP_USER_AGENT"])
     if user_agent['name'] == "ZulipInvalid":


### PR DESCRIPTION
This will enable us to roll out "remove notification when read" (zulip/zulip-mobile#3119) to all Android users.
