### PR TITLE
onboarding: Fix help text overflow on new orgnisation registration page

### DIFF
--- a/static/styles/portico-signin.scss
+++ b/static/styles/portico-signin.scss
@@ -757,7 +757,6 @@ button.login-google-button {
 
 #registration #subdomain_section .inline-block {
     width: 100%;
-    overflow-x: auto;
 }
 
 #registration #subdomain_section .or {


### PR DESCRIPTION
Fixes #10866 
**GIFs or Screenshots:** 
![screenshot from 2018-12-05 09-17-04](https://user-images.githubusercontent.com/5001704/49488930-c29d9b80-f86e-11e8-82b7-855aeb03ded0.png)
![zulip-1](https://user-images.githubusercontent.com/5001704/49488926-be717e00-f86e-11e8-9234-0b232ff9ad25.gif)

Tested on Chrome Version 70.0.3538.110 (Official Build) (64-bit).