### PR TITLE
setup-advanced: Fix a subsubsection header formatting.

### DIFF
--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -121,8 +121,7 @@ git](https://github.com/zulip/tsearch_extras).
 
 Now continue with the [All Systems](#all-systems) instructions below.
 
-#### Using the [official Zulip PPA][zulip-ppa] (for 14.04
-     Trusty, 16.04 Xenial, or 18.04 Bionic):
+#### Using the [official Zulip PPA][zulip-ppa] (for 14.04 Trusty, 16.04 Xenial, or 18.04 Bionic):
 
 [zulip-ppa]: https://launchpad.net/~tabbott/+archive/ubuntu/zulip/+packages
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

A subsubsection header appears to be lopped off:
![2018-12-05-135512_1093x250_scrot](https://user-images.githubusercontent.com/395821/49518049-934e5500-f895-11e8-9036-57f36eb0bc60.png)

I'm not sure if using a backslash would fix the problem, but this one will surely work at least.

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
