### PR TITLE
Add a server-specific compatibility check to api_get_server_settings.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1514,6 +1514,10 @@ class FetchAuthBackends(ZulipTestCase):
         if error:
             raise AssertionError(error)
 
+    def test_get_server_settings_without_user_agent(self) -> None:
+        result = self.client_get("/api/v1/server_settings", subdomain="")
+        self.assert_json_error(result, 'User-Agent header missing from request')
+
     def test_get_server_settings(self) -> None:
         def check_result(result: HttpResponse, extra_fields: List[Tuple[str, Validator]]=[]) -> None:
             self.assert_json_success(result)

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -851,6 +851,9 @@ def check_server_incompatibility(request: HttpRequest) -> bool:
 @require_GET
 @csrf_exempt
 def api_get_server_settings(request: HttpRequest) -> HttpResponse:
+    if request.META.get('HTTP_USER_AGENT') is None:
+        return json_error(_('User-Agent header missing from request'))
+
     result = dict(
         authentication_methods=get_auth_backends_data(request),
         zulip_version=ZULIP_VERSION,


### PR DESCRIPTION
This is a continuation of the changes proposed in #10924 (which corresponds to zulip/zulip-mobile#3158; it adds the boolean value `is_compatible` (edit: renamed to `is_incompatible`) to the result returned from `/server_settings`.

@timabbott @gnprice 