### PR TITLE
dev provision: Remove unused `puppet` dependency.

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -128,7 +128,6 @@ UBUNTU_COMMON_APT_DEPENDENCIES = [
     "yui-compressor",
     "wget",
     "ca-certificates",      # Explicit dependency in case e.g. wget is already installed
-    "puppet",               # Used by lint
     "puppet-lint",
     "gettext",              # Used by makemessages i18n
     "curl",                 # Used for fetching PhantomJS as wget occasionally fails on redirects


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
I checked https://packages.ubuntu.com/trusty/ruby/puppet-lint that `puppet-lint` doesn't depend on `puppet`.

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
