### PR TITLE
help: Fix left sidebar content in smaller window.

### DIFF
--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -1846,10 +1846,17 @@ input.new-organization-button {
         transition: all 0.3s ease;
     }
 
+    .help .sidebar .content:not(.show) {
+        visibility: hidden;
+    }
+
     .app.help .sidebar.show {
         pointer-events: initial;
         transform: translateX(calc(100% - 50px));
         overflow: auto;
+        .content {
+            visibility: visible;
+        }
     }
 
     .app.help .sidebar.show + .hamburger {


### PR DESCRIPTION
This fixes an issue where some of the content of left
sidebar gets visible even in smaller window which looks ugly.

Fixes: #10898.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<img src="https://cl.ly/cea1c4bc9884/download/Screen%20Recording%202018-12-07%20at%2002.50%20PM.gif"/>

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
