### PR TITLE
[Fix #10654] Background links work even when a modal is active in user settings

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -723,6 +723,12 @@ exports.initialize = function () {
             popovers.hide_all();
         }
 
+        // If user clicks outside an active modal
+        if ($('.modal.in').has(e.target).length === 0) {
+            // Enable mouse events for the background as the modal closes
+            $('.overlay.show').attr("style", null);
+        }
+
         if (compose_state.composing()) {
             if ($(e.target).closest("a").length > 0) {
                 // Refocus compose message text box if link is clicked

--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -102,6 +102,8 @@ exports.open_modal = function (name) {
     blueslip.debug('open modal: ' + name);
 
     $("#" + name).modal("show").attr("aria-hidden", false);
+    // Disable background mouse events when modal is active
+    $('.overlay.show').attr("style", "pointer-events : none");
     // Remove previous alert messsages from modal, if exists.
     $("#" + name).find(".alert").hide();
 };
@@ -163,6 +165,9 @@ exports.close_modal = function (name) {
     blueslip.debug('close modal: ' + name);
 
     $("#" + name).modal("hide").attr("aria-hidden", true);
+    // Enable mouse events for the background as the modal closes.
+    $('.overlay.show').attr("style", null);
+
 };
 
 exports.close_active_modal = function () {

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -309,6 +309,12 @@ exports.set_up = function () {
         clear_password_change();
     });
 
+    // If the modal is closed using the 'close' button or the 'Cancel' button
+    $('.modal').find('[data-dismiss=modal]').on('click', function () {
+        // Enable mouse events for the background on closing modal
+        $('.overlay.show').attr("style", null);
+    });
+
     $('#change_password_button').on('click', function (e) {
         e.preventDefault();
         e.stopPropagation();

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1462,6 +1462,7 @@ body:not(.night-mode) #account-settings .custom_user_field .datepicker {
 
 .modal.fade.in {
     top: 50%;
+    pointer-events: all;
 }
 
 #id_realm_create_stream_permission,


### PR DESCRIPTION
Fix #10654

**Testing Plan:**
Manually tested by opening and closing the "change full name", "change email", and the "change password" modal. The background links are inactive when the modal is open, and clicking anywhere outside the modal closes it.


**GIFs or Screenshots:** 

![ezgif com-optimize](https://user-images.githubusercontent.com/31250892/49646490-3b565080-fa45-11e8-9365-f3f9c69871f7.gif)