### PR TITLE
provision: Avoid spending time on update-authors-json.

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -317,7 +317,12 @@ def main(options):
         print("No need to run `tools/setup/build_pygments_data`.")
 
     run(["scripts/setup/generate_secrets.py", "--development"])
-    run(["tools/update-authors-json", "--use-fixture"])
+
+    update_authors_json_paths = ["zerver/tests/fixtures/authors.json"]
+    if file_or_package_hash_updated(update_authors_json_paths, "update_authors_json_hash", options.is_force):
+        run(["tools/update-authors-json", "--use-fixture"])
+    else:
+        print("No need to run `tools/update-authors-json`.")
 
     email_source_paths = ["tools/inline-email-css", "templates/zerver/emails/email.css"]
     email_source_paths += glob.glob('templates/zerver/emails/*.source.html')


### PR DESCRIPTION
This optimizes tools/provision by not running
`tools/update-authors-json --use-fixture`
unless appriopriate file (zerver/tests/fixtures/authors.json)
was changed.

Fixes #10991.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

Testing: It saves ~300ms when running ./tools/provision if nothing was changed.


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
