### PR TITLE
Fix tab navigation to "Close" button in view source/message editing.

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -386,6 +386,7 @@ exports.process_tab_key = function () {
     if (focused_message_edit_content.length > 0) {
         message_edit_form = focused_message_edit_content.closest(".message_edit_form");
         message_edit_form.find(".message_edit_save").focus();
+        message_edit_form.find(".message_edit_close").focus();
         return true;
     }
 


### PR DESCRIPTION
Adds a line to static/js/hotkey.js for focusing "Close" button.

Fixes: #3830.