### PR TITLE
test-suite:Optimize performance of push notifications code in test suite

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -649,6 +649,8 @@ def handle_push_notification(user_profile_id: int, missed_message: Dict[str, Any
     missed_message is the event received by the
     zerver.worker.queue_processors.PushNotificationWorker.consume function.
     """
+    if not push_notifications_enabled():
+        return
     user_profile = get_user_profile_by_id(user_profile_id)
     if not (receives_offline_push_notifications(user_profile) or
             receives_online_notifications(user_profile)):

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -462,7 +462,7 @@ class LoginTest(ZulipTestCase):
         with queries_captured() as queries:
             self.register(self.nonreg_email('test'), "test")
         # Ensure the number of queries we make is not O(streams)
-        self.assert_length(queries, 79)
+        self.assert_length(queries, 73)
         user_profile = self.nonreg_user('test')
         self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
         self.assertFalse(user_profile.enable_stream_desktop_notifications)

--- a/zerver/tests/test_unread.py
+++ b/zerver/tests/test_unread.py
@@ -208,11 +208,14 @@ class PointerTest(ZulipTestCase):
 
 class UnreadCountTests(ZulipTestCase):
     def setUp(self) -> None:
-        self.unread_msg_ids = [
-            self.send_personal_message(
-                self.example_email("iago"), self.example_email("hamlet"), "hello"),
-            self.send_personal_message(
-                self.example_email("iago"), self.example_email("hamlet"), "hello2")]
+        with mock.patch('zerver.lib.push_notifications.push_notifications_enabled',
+                        return_value = True) as mock_push_notifications_enabled:
+            self.unread_msg_ids = [
+                self.send_personal_message(
+                    self.example_email("iago"), self.example_email("hamlet"), "hello"),
+                self.send_personal_message(
+                    self.example_email("iago"), self.example_email("hamlet"), "hello2")]
+            mock_push_notifications_enabled.assert_called()
 
     # Sending a new message results in unread UserMessages being created
     def test_new_message(self) -> None:
@@ -482,7 +485,9 @@ class PushNotificationMarkReadFlowsTest(ZulipTestCase):
                 "message_id").values_list("message_id", flat=True))
 
     @override_settings(SEND_REMOVE_PUSH_NOTIFICATIONS=True)
-    def test_track_active_mobile_push_notifications(self) -> None:
+    @mock.patch('zerver.lib.push_notifications.push_notifications_enabled', return_value=True)
+    def test_track_active_mobile_push_notifications(self, mock_push_notifications: mock.MagicMock) -> None:
+        mock_push_notifications.return_value = True
         self.login(self.example_email("hamlet"))
         user_profile = self.example_user('hamlet')
         stream = self.subscribe(user_profile, "test_stream")
@@ -530,3 +535,4 @@ class PushNotificationMarkReadFlowsTest(ZulipTestCase):
         result = self.client_post("/json/mark_all_as_read", {})
         self.assertEqual(self.get_mobile_push_notification_ids(user_profile),
                          [])
+        mock_push_notifications.assert_called()


### PR DESCRIPTION

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

This checks if push_notification_enabled() is set to false in handle_push_notification
and adds an early return statement
it fixes the errors arising as a result by adding various mock patches in 2 files:
 -test_push_notifications.py
 -test_signup.py
fixes error in test_signup by changing query number from 79 to 73
reduces test timings

Fix zulip#10895
**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
