### PR TITLE
ldap: Add support for syncing avatar images from LDAP.

### DIFF
--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -73,8 +73,8 @@ In either configuration, you will need to do the following:
    in your LDAP database.
 
 4. Tell Zulip how to map the user information in your LDAP database to
-   the form it needs.  There are three supported ways to set up the
-   username and/or email mapping:
+   the form it needs for authentication.  There are three supported
+   ways to set up the username and/or email mapping:
 
    (A) Using email addresses as usernames, if LDAP has each user's
       email address.  To do this, just set `AUTH_LDAP_USER_SEARCH` to
@@ -115,6 +115,16 @@ configuring this integration, you will need to run:
 ```
 to sync names for existing users.  You may want to run this in a cron
 job to pick up name changes made on your LDAP server.
+
+### Synchronizing avatars
+
+Starting with Zulip 2.0, Zulip supports syncing LDAP / Active
+Directory profile pictures (usually available in the `thumbnailPhoto`
+or `jpegPhoto` attribute in LDAP) by configuring the `avatar` key in
+`AUTH_LDAP_USER_ATTR_MAP`.  This uses the same mechanism as populating
+names: Users will automatically receive the appropriate avatar on
+account creation, and `manage.py sync_ldap_user_data` will
+automatically update their avatar from the data in LDAP.
 
 ### Multiple LDAP searches
 

--- a/zerver/management/commands/query_ldap.py
+++ b/zerver/management/commands/query_ldap.py
@@ -17,7 +17,11 @@ def query_ldap(**options: str) -> None:
                 print("No such user found")
             else:
                 for django_field, ldap_field in settings.AUTH_LDAP_USER_ATTR_MAP.items():
-                    print("%s: %s" % (django_field, ldap_attrs[ldap_field]))
+                    value = ldap_attrs[ldap_field]
+                    if django_field == "avatar":
+                        if isinstance(value[0], bytes):
+                            value = "(An avatar image file)"
+                    print("%s: %s" % (django_field, value))
                 if settings.LDAP_EMAIL_ATTR is not None:
                     print("%s: %s" % ('email', ldap_attrs[settings.LDAP_EMAIL_ATTR]))
 

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -445,6 +445,8 @@ LDAP_EMAIL_ATTR = None  # type: Optional[str]
 AUTH_LDAP_USER_ATTR_MAP = {
     # full_name is required; common values include "cn" or "displayName".
     "full_name": "cn",
+    # User avatars can be synced; common values are "thumbnailPhoto" and "jpegPhoto".
+    # "avatar": "thumbnailPhoto",
 }
 
 


### PR DESCRIPTION
ldap: Add support for syncing avatar images from LDAP.
    
This should make life a lot more convenient for organizations that use
the LDAP integration and have their avatars in LDAP already.
    
Fixes #286.
