### PR TITLE
django: Remove the Django contrib Sites app to fix 2FA QR codes.

### DIFF
--- a/zerver/management/commands/initialize_voyager_db.py
+++ b/zerver/management/commands/initialize_voyager_db.py
@@ -3,7 +3,6 @@ from argparse import ArgumentParser
 from typing import Any, Iterable, Tuple, Optional
 
 from django.conf import settings
-from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand
 
 from zerver.lib.bulk_create import bulk_create_users
@@ -58,7 +57,3 @@ class Command(BaseCommand):
         self.stdout.write("Successfully populated database with initial data.\n")
         self.stdout.write("Please run ./manage.py generate_realm_creation_link "
                           "to generate link for creating organization")
-
-    site = Site.objects.get_current()
-    site.domain = settings.EXTERNAL_HOST
-    site.save()

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -6,7 +6,6 @@ import re
 import django_otp
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.sites.models import Site
 from django.http import HttpResponse, HttpRequest
 from django.test import TestCase, override_settings
 from django.utils.timezone import now as timezone_now
@@ -459,7 +458,6 @@ class LoginTest(ZulipTestCase):
         # Clear all the caches.
         flush_per_request_caches()
         ContentType.objects.clear_cache()
-        Site.objects.clear_cache()
 
         with queries_captured() as queries:
             self.register(self.nonreg_email('test'), "test")

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -492,13 +492,6 @@ TIME_ZONE = 'UTC'
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = 'en-us'
 
-# The ID, as an integer, of the current site in the django_site database table.
-# This is used so that application data can hook into specific site(s) and a
-# single database can manage content for multiple sites.
-#
-# We set this site's string_id to 'zulip' in populate_db.
-SITE_ID = 1
-
 # If you set this to False, Django will make some optimizations so as not
 # to load the internationalization machinery.
 USE_I18N = True
@@ -566,7 +559,6 @@ INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
-    'django.contrib.sites',
     'django.contrib.staticfiles',
     'confirmation',
     'pipeline',


### PR DESCRIPTION
Apparently, Django's get_current_site function (used, e.g., in
django-two-factor to look up the domain to use in QR codes) first
tries to use the Sites framework, and if unavailable, does the right
thing (namely, using request.get_host()).

We don't use the Sites framework for anything in Zulip, so the correct
fix is to just remove it.

Fixes #11014.
