### PR TITLE
night mode: Alter compose warning background to fit night mode.

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -369,6 +369,12 @@ on a dark background, and don't change the dark labels dark either. */
         border: 1px solid hsl(49, 38%, 46%);
     }
 
+    .alert.home-error-bar {
+        color: hsl(236, 33%, 90%);
+        background-color: hsla(35, 84%, 62%, 0.25);
+        border: 1px solid hsl(11, 46%, 54%);
+    }
+
     .alert {
         text-shadow: none;
     }


### PR DESCRIPTION
Fixes #10916.
![screenshot at dec 12 18-36-51](https://user-images.githubusercontent.com/15116870/49912308-a2597800-fe3e-11e8-854c-3a00cba56670.png)
