### PR TITLE
upgrade-zulip: Added argument to skip purging old deployments.

### DIFF
--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -41,6 +41,8 @@ parser.add_argument("--skip-migrations", dest="skip_migrations", action='store_t
                     help="Skip doing migrations.")
 parser.add_argument("--from-git", dest="from_git", action='store_true',
                     help="Upgrading from git, so run update-prod-static.")
+parser.add_argument("--skip-purge-old-deployments", dest="skip_purge_old_deployments",
+                    action="store_true", help="Skip purging old deployments.")
 args = parser.parse_args()
 
 deploy_path = args.deploy_path
@@ -178,4 +180,8 @@ logging.info("Restarting Zulip...")
 subprocess.check_output(["./scripts/restart-server"], preexec_fn=su_to_zulip)
 logging.info("Upgrade complete!")
 
-subprocess.check_call(["./scripts/purge-old-deployments"])
+if not args.skip_purge_old_deployments:
+    logging.info("Purging old deployments...")
+    subprocess.check_call(["./scripts/purge-old-deployments"])
+else:
+    logging.info("Skipping purging old deployments.")


### PR DESCRIPTION
Added the option `--skip-purge-old-deployments`  which skips cleaning up old deployments saving time in an orchestration framework. 

(@timabbott Hello. You also talk about setting this as a part of `/etc/zulip/zulip.conf`. I did not understand what you meant by that. Can you please review and tell me if its necessary.)

On an inquisitive note, how can one do a test for patches like this which involve scripts which upgrade versions?

Fixes: #10946 

