### PR TITLE
muting: Use stream_id for internal data structures.

### DIFF
--- a/frontend_tests/node_tests/hash_util.js
+++ b/frontend_tests/node_tests/hash_util.js
@@ -20,12 +20,12 @@ var hamlet = {
 
 people.add_in_realm(hamlet);
 
-var sub = {
+var frontend = {
     stream_id: 99,
     name: 'frontend',
 };
 
-stream_data.add_sub(sub.name, sub);
+stream_data.add_sub('frontend', frontend);
 
 run_test('hash_util', () => {
     // Test encodeHashComponent
@@ -131,7 +131,7 @@ run_test('test_stream_edit_uri', () => {
 run_test('test_by_conversation_and_time_uri', () => {
     var message = {
         type: 'stream',
-        stream: 'frontend',
+        stream_id: frontend.stream_id,
         subject: 'testing',
         id: 42,
     };

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -396,29 +396,31 @@ run_test('bookend', () => {
 run_test('unmuted_messages', () => {
     var list = new MessageList({});
 
+    var muted_stream_id = 999;
+
     var unmuted = [
         {
             id: 50,
-            stream: 'bad',
-            mentioned: true,
+            stream_id: muted_stream_id,
+            mentioned: true, // overrides mute
         },
         {
             id: 60,
-            stream: 'good',
+            stream_id: 42,
             mentioned: false,
         },
     ];
     var muted = [
         {
             id: 70,
-            stream: 'bad',
+            stream_id: muted_stream_id,
             mentioned: false,
         },
     ];
 
     with_overrides(function (override) {
-        override('muting.is_topic_muted', function (stream) {
-            return stream === 'bad';
+        override('muting.is_topic_muted', function (stream_id) {
+            return stream_id === muted_stream_id;
         });
 
         // Make sure unmuted_message filters out the "muted" entry,

--- a/frontend_tests/node_tests/message_list_data.js
+++ b/frontend_tests/node_tests/message_list_data.js
@@ -128,7 +128,7 @@ run_test('muting enabled', () => {
 });
 
 run_test('more muting', () => {
-    muting.is_topic_muted = function (stream, topic) {
+    muting.is_topic_muted = function (stream_id, topic) {
         return topic === 'muted';
     };
 

--- a/frontend_tests/node_tests/muting.js
+++ b/frontend_tests/node_tests/muting.js
@@ -66,8 +66,8 @@ run_test('get_and_set_muted_topics', () => {
     muting.add_muted_topic(office.stream_id, 'gossip');
     muting.add_muted_topic(devel.stream_id, 'java');
     assert.deepEqual(muting.get_muted_topics().sort(), [
-        ['devel', 'java'],
-        ['office', 'gossip'],
+        [devel.stream_id, 'java'],
+        [office.stream_id, 'gossip'],
     ]);
 
     blueslip.set_test_data('warn', 'Unknown stream in set_muted_topics: BOGUS STREAM');
@@ -82,8 +82,8 @@ run_test('get_and_set_muted_topics', () => {
 
 
     assert.deepEqual(muting.get_muted_topics().sort(), [
-        ['design', 'typography'],
-        ['social', 'breakfast'],
+        [design.stream_id, 'typography'],
+        [social.stream_id, 'breakfast'],
     ]);
 });
 

--- a/frontend_tests/node_tests/muting.js
+++ b/frontend_tests/node_tests/muting.js
@@ -1,4 +1,6 @@
 zrequire('muting');
+zrequire('stream_data');
+set_global('blueslip', global.make_zblueslip());
 
 run_test('edge_cases', () => {
     // private messages
@@ -8,40 +10,77 @@ run_test('edge_cases', () => {
     assert(!muting.is_topic_muted('nonexistent', undefined));
 });
 
+var design = {
+    stream_id: 100,
+    name: 'design',
+};
+
+var devel = {
+    stream_id: 101,
+    name: 'devel',
+};
+
+var office = {
+    stream_id: 102,
+    name: 'office',
+};
+
+var social = {
+    stream_id: 103,
+    name: 'social',
+};
+
+var unknown = {
+    stream_id: 999,
+    name: 'whatever',
+};
+
+stream_data.add_sub(design.name, design);
+stream_data.add_sub(devel.name, devel);
+stream_data.add_sub(office.name, office);
+stream_data.add_sub(social.name, social);
+
 run_test('basics', () => {
-    assert(!muting.is_topic_muted('devel', 'java'));
-    muting.add_muted_topic('devel', 'java');
-    assert(muting.is_topic_muted('devel', 'java'));
+    assert(!muting.is_topic_muted(devel.stream_id, 'java'));
+    muting.add_muted_topic(devel.stream_id, 'java');
+    assert(muting.is_topic_muted(devel.stream_id, 'java'));
 
     // test idempotentcy
-    muting.add_muted_topic('devel', 'java');
-    assert(muting.is_topic_muted('devel', 'java'));
+    muting.add_muted_topic(devel.stream_id, 'java');
+    assert(muting.is_topic_muted(devel.stream_id, 'java'));
 
-    muting.remove_muted_topic('devel', 'java');
-    assert(!muting.is_topic_muted('devel', 'java'));
+    muting.remove_muted_topic(devel.stream_id, 'java');
+    assert(!muting.is_topic_muted(devel.stream_id, 'java'));
 
     // test idempotentcy
-    muting.remove_muted_topic('devel', 'java');
-    assert(!muting.is_topic_muted('devel', 'java'));
+    muting.remove_muted_topic(devel.stream_id, 'java');
+    assert(!muting.is_topic_muted(devel.stream_id, 'java'));
 
     // test unknown stream is harmless too
-    muting.remove_muted_topic('unknown', 'java');
-    assert(!muting.is_topic_muted('unknown', 'java'));
+    muting.remove_muted_topic(unknown.stream_id, 'java');
+    assert(!muting.is_topic_muted(unknown.stream_id, 'java'));
 });
 
 run_test('get_and_set_muted_topics', () => {
     assert.deepEqual(muting.get_muted_topics(), []);
-    muting.add_muted_topic('office', 'gossip');
-    muting.add_muted_topic('devel', 'java');
+    muting.add_muted_topic(office.stream_id, 'gossip');
+    muting.add_muted_topic(devel.stream_id, 'java');
     assert.deepEqual(muting.get_muted_topics().sort(), [
         ['devel', 'java'],
         ['office', 'gossip'],
     ]);
 
+    blueslip.set_test_data('warn', 'Unknown stream in set_muted_topics: BOGUS STREAM');
+
     muting.set_muted_topics([
         ['social', 'breakfast'],
         ['design', 'typography'],
+        ['BOGUS STREAM', 'whatever'],
     ]);
+
+    blueslip.clear_test_data();
+
+
     assert.deepEqual(muting.get_muted_topics().sort(), [
         ['design', 'typography'],
         ['social', 'breakfast'],
@@ -50,11 +89,10 @@ run_test('get_and_set_muted_topics', () => {
 
 run_test('case_insensitivity', () => {
     muting.set_muted_topics([]);
-    assert(!muting.is_topic_muted('SOCial', 'breakfast'));
+    assert(!muting.is_topic_muted(social.stream_id, 'breakfast'));
     muting.set_muted_topics([
         ['SOCial', 'breakfast'],
     ]);
-    assert(muting.is_topic_muted('SOCial', 'breakfast'));
-    assert(muting.is_topic_muted('social', 'breakfast'));
-    assert(muting.is_topic_muted('social', 'breakFAST'));
+    assert(muting.is_topic_muted(social.stream_id, 'breakfast'));
+    assert(muting.is_topic_muted(social.stream_id, 'breakFAST'));
 });

--- a/frontend_tests/node_tests/settings_muting.js
+++ b/frontend_tests/node_tests/settings_muting.js
@@ -18,7 +18,7 @@ run_test('settings', () => {
     muting.add_muted_topic(frontend.stream_id, 'js');
     var set_up_ui_called = false;
     muting_ui.set_up_muted_topics_ui = function (opts) {
-        assert.deepEqual(opts, [['frontend', 'js']]);
+        assert.deepEqual(opts, [[frontend.stream_id, 'js']]);
         set_up_ui_called = true;
     };
 

--- a/frontend_tests/node_tests/settings_muting.js
+++ b/frontend_tests/node_tests/settings_muting.js
@@ -39,12 +39,12 @@ run_test('settings', () => {
     };
 
     var data_called = 0;
-    tr_html.data = function (opts) {
-        if (opts === 'stream') {
+    tr_html.attr = function (opts) {
+        if (opts === 'data-stream-id') {
             data_called += 1;
-            return 'frontend';
+            return frontend.stream_id;
         }
-        if (opts === 'topic') {
+        if (opts === 'data-topic') {
             data_called += 1;
             return 'js';
         }

--- a/frontend_tests/node_tests/settings_muting.js
+++ b/frontend_tests/node_tests/settings_muting.js
@@ -1,14 +1,21 @@
 set_global('$', global.make_zjquery());
 
 zrequire('settings_muting');
+zrequire('stream_data');
 zrequire('muting');
 set_global('muting_ui', {});
 
 var noop = function () {};
 
+var frontend = {
+    stream_id: 101,
+    name: 'frontend',
+};
+stream_data.add_sub('frontend', frontend);
+
 run_test('settings', () => {
 
-    muting.add_muted_topic('frontend', 'js');
+    muting.add_muted_topic(frontend.stream_id, 'js');
     var set_up_ui_called = false;
     muting_ui.set_up_muted_topics_ui = function (opts) {
         assert.deepEqual(opts, [['frontend', 'js']]);

--- a/frontend_tests/node_tests/settings_muting.js
+++ b/frontend_tests/node_tests/settings_muting.js
@@ -51,8 +51,8 @@ run_test('settings', () => {
     };
 
     var unmute_called = false;
-    muting_ui.unmute = function (stream, topic) {
-        assert.equal(stream, 'frontend');
+    muting_ui.unmute = function (stream_id, topic) {
+        assert.equal(stream_id, frontend.stream_id);
         assert.equal(topic, 'js');
         unmute_called = true;
     };

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -629,14 +629,10 @@ run_test('update_count_in_dom', () => {
 narrow_state.active = () => false;
 
 run_test('rename_stream', () => {
-    const old_stream_id = stream_data.get_stream_id('devel');
-    const renamed_devel = {
-        name: 'Development',
-        stream_id: old_stream_id,
-        color: 'blue',
-        subscribed: true,
-        pin_to_top: true,
-    };
+    const sub = stream_data.get_sub_by_name('devel');
+    const new_name = 'Development';
+
+    stream_data.rename_sub(sub, new_name);
 
     const li_stub = $.create('li stub');
     templates.render = (name, payload) => {
@@ -644,7 +640,7 @@ run_test('rename_stream', () => {
         assert.deepEqual(payload, {
             name: 'Development',
             id: 1000,
-            uri: '#narrow/stream/Development',
+            uri: '#narrow/stream/1000-Development',
             not_in_home_view: false,
             invite_only: undefined,
             color: payload.color,
@@ -660,7 +656,7 @@ run_test('rename_stream', () => {
         count_updated = true;
     };
 
-    stream_list.rename_stream(renamed_devel);
+    stream_list.rename_stream(sub);
     assert(count_updated);
 });
 

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1547,7 +1547,8 @@ run_test('user_profile_modal', () => {
 run_test('muted_topic_ui_row', () => {
     var args = {
         stream: 'Verona',
-        topic: 'Verona2',
+        stream_id: 99,
+        topic: 'pizza',
     };
 
     var html = '<table id="muted-topics-table">';
@@ -1556,8 +1557,8 @@ run_test('muted_topic_ui_row', () => {
     html += '</tbody>';
     html += '</table>';
 
-    assert.equal($(html).find("tr").data("stream"), "Verona");
-    assert.equal($(html).find("tr").data("topic"), "Verona2");
+    assert.equal($(html).find("tr").attr("data-stream-id"), 99);
+    assert.equal($(html).find("tr").attr("data-topic"), "pizza");
 });
 
 run_test('embedded_bot_config_item', () => {

--- a/frontend_tests/node_tests/topic_list.js
+++ b/frontend_tests/node_tests/topic_list.js
@@ -2,7 +2,6 @@ set_global('$', global.make_zjquery());
 set_global('i18n', global.stub_i18n);
 
 set_global('narrow_state', {});
-set_global('stream_data', {});
 set_global('unread', {});
 set_global('muting', {});
 set_global('stream_popover', {});
@@ -14,12 +13,18 @@ zrequire('unread');
 zrequire('topic_data');
 zrequire('topic_list');
 
+var devel = {
+    stream_id: 555,
+    name: 'devel',
+};
+
+stream_data.add_sub('devel', devel);
+
 run_test('topic_list_build_widget', () => {
-    var stream_id = 555;
 
     topic_data.reset();
     topic_data.add_message({
-        stream_id: stream_id,
+        stream_id: devel.stream_id,
         topic_name: 'coding',
         message_id: 400,
     });
@@ -34,13 +39,6 @@ run_test('topic_list_build_widget', () => {
         return 3;
     };
 
-    stream_data.get_sub_by_id = function (stream_id) {
-        assert.equal(stream_id, 555);
-        return {
-            name: 'devel',
-        };
-    };
-
     var checked_mutes;
     var rendered;
 
@@ -51,15 +49,15 @@ run_test('topic_list_build_widget', () => {
             unread: 3,
             is_zero: false,
             is_muted: false,
-            url: '#narrow/stream/devel/subject/coding',
+            url: '#narrow/stream/555-devel/subject/coding',
         };
         assert.deepEqual(info, expected);
         rendered = true;
         return '<topic list item>';
     };
 
-    muting.is_topic_muted = function (stream_name, topic_name) {
-        assert.equal(stream_name, 'devel');
+    muting.is_topic_muted = function (stream_id, topic_name) {
+        assert.equal(stream_id, devel.stream_id);
         assert.equal(topic_name, 'coding');
         checked_mutes = true;
         return false;
@@ -83,7 +81,7 @@ run_test('topic_list_build_widget', () => {
 
     assert.equal(topic_list.active_stream_id(), undefined);
 
-    var widget = topic_list.widget(parent_elem, stream_id);
+    var widget = topic_list.widget(parent_elem, devel.stream_id);
 
     widget.build_more_topics_section = function () {
         return $('<more topics>');
@@ -91,7 +89,7 @@ run_test('topic_list_build_widget', () => {
 
     widget.build();
 
-    assert(widget.is_for_stream(stream_id));
+    assert(widget.is_for_stream(devel.stream_id));
     assert.equal(widget.get_parent(), parent_elem);
 
     assert(checked_mutes);

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -22,6 +22,14 @@ var me = {
 people.add(me);
 people.initialize_current_user(me.user_id);
 
+var social = {
+    stream_id: 200,
+    name: 'social',
+    subscribed: true,
+    in_home_view: true,
+};
+stream_data.add_sub('social', social);
+
 var zero_counts = {
     private_message_count: 0,
     home_unread_messages: 0,
@@ -177,24 +185,10 @@ run_test('changing_subjects', () => {
 });
 
 run_test('muting', () => {
-    stream_data.is_subscribed = function () {
-        return true;
-    };
-
-    stream_data.in_home_view = function () {
-        return true;
-    };
-
     unread.declare_bankruptcy();
 
-    var stream_id = 101;
+    var stream_id = social.stream_id;
     var unknown_stream_id = 555;
-
-    stream_data.get_sub_by_id = function (stream_id) {
-        if (stream_id === 101) {
-            return {name: 'social'};
-        }
-    };
 
     var message = {
         id: 15,
@@ -211,7 +205,7 @@ run_test('muting', () => {
     assert.equal(unread.num_unread_for_stream(stream_id), 1);
     assert.deepEqual(unread.get_msg_ids_for_stream(stream_id), [message.id]);
 
-    muting.add_muted_topic('social', 'test_muting');
+    muting.add_muted_topic(social.stream_id, 'test_muting');
     counts = unread.get_counts();
     assert.equal(counts.stream_count.get(stream_id), 0);
     assert.equal(counts.home_unread_messages, 0);

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -195,9 +195,9 @@ exports.initialize = function () {
         e.preventDefault();
         // Note that we may have an href here, but we trust the stream id more,
         // so we re-encode the hash.
-        var stream = stream_data.get_sub_by_id($(this).attr('data-stream-id'));
-        if (stream) {
-            hashchange.go_to_location(hash_util.by_stream_uri(stream.name));
+        var stream_id = $(this).attr('data-stream-id');
+        if (stream_id) {
+            hashchange.go_to_location(hash_util.by_stream_uri(stream_id));
             return;
         }
         window.location.href = $(this).attr('href');

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -289,8 +289,7 @@ exports.initialize = function () {
         e.stopPropagation();
         var stream_id = $(e.currentTarget).attr('data-stream-id');
         var topic = $(e.currentTarget).attr('data-topic-name');
-        var stream = stream_data.get_sub_by_id(stream_id);
-        muting_ui.mute(stream.name, topic);
+        muting_ui.mute(stream_id, topic);
     });
 
     // RECIPIENT BARS

--- a/static/js/hash_util.js
+++ b/static/js/hash_util.js
@@ -43,6 +43,14 @@ exports.encode_operand = function (operator, operand) {
     return exports.encodeHashComponent(operand);
 };
 
+exports.encode_stream_id = function (stream_id) {
+    // stream_data appends the stream name, but it does not do the
+    // URI encoding piece
+    var slug = stream_data.id_to_slug(stream_id);
+
+    return exports.encodeHashComponent(slug);
+};
+
 exports.encode_stream_name = function (operand) {
     // stream_data prefixes the stream id, but it does not do the
     // URI encoding piece
@@ -76,8 +84,8 @@ exports.by_stream_uri = function (stream) {
     return "#narrow/stream/" + exports.encode_stream_name(stream);
 };
 
-exports.by_stream_topic_uri = function (stream, subject) {
-    return "#narrow/stream/" + exports.encode_stream_name(stream) +
+exports.by_stream_topic_uri = function (stream_id, subject) {
+    return "#narrow/stream/" + exports.encode_stream_id(stream_id) +
            "/subject/" + exports.encodeHashComponent(subject);
 };
 
@@ -132,7 +140,7 @@ exports.by_conversation_and_time_uri = function (message) {
 
     if (message.type === "stream") {
         return absolute_url +
-            exports.by_stream_topic_uri(message.stream, message.subject) +
+            exports.by_stream_topic_uri(message.stream_id, message.subject) +
             suffix;
     }
 

--- a/static/js/hash_util.js
+++ b/static/js/hash_util.js
@@ -80,8 +80,8 @@ exports.decode_operand = function (operator, operand) {
     return operand;
 };
 
-exports.by_stream_uri = function (stream) {
-    return "#narrow/stream/" + exports.encode_stream_name(stream);
+exports.by_stream_uri = function (stream_id) {
+    return "#narrow/stream/" + exports.encode_stream_id(stream_id);
 };
 
 exports.by_stream_topic_uri = function (stream_id, subject) {

--- a/static/js/message_list_data.js
+++ b/static/js/message_list_data.js
@@ -166,7 +166,7 @@ MessageListData.prototype = {
 
     unmuted_messages: function (messages) {
         return _.reject(messages, function (message) {
-            return muting.is_topic_muted(message.stream, message.subject) &&
+            return muting.is_topic_muted(message.stream_id, message.subject) &&
                    !message.mentioned;
         });
     },

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -243,7 +243,7 @@ MessageListView.prototype = {
                         hash_util.by_stream_uri(message_container.msg.stream);
                     message_container.topic_url =
                         hash_util.by_stream_topic_uri(
-                            message_container.msg.stream,
+                            message_container.msg.stream_id,
                             message_container.msg.subject);
                 } else {
                     message_container.pm_with_url =

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -240,7 +240,7 @@ MessageListView.prototype = {
 
                 if (message_container.msg.stream) {
                     message_container.stream_url =
-                        hash_util.by_stream_uri(message_container.msg.stream);
+                        hash_util.by_stream_uri(message_container.msg.stream_id);
                     message_container.topic_url =
                         hash_util.by_stream_topic_uri(
                             message_container.msg.stream_id,

--- a/static/js/muting.js
+++ b/static/js/muting.js
@@ -2,50 +2,62 @@ var muting = (function () {
 
 var exports = {};
 
-var muted_topics = new Dict({fold_case: true});
+var muted_topics = new Dict();
 
-exports.add_muted_topic = function (stream, topic) {
-    var sub_dict = muted_topics.get(stream);
+exports.add_muted_topic = function (stream_id, topic) {
+    var sub_dict = muted_topics.get(stream_id);
     if (!sub_dict) {
         sub_dict = new Dict({fold_case: true});
-        muted_topics.set(stream, sub_dict);
+        muted_topics.set(stream_id, sub_dict);
     }
     sub_dict.set(topic, true);
 };
 
-exports.remove_muted_topic = function (stream, topic) {
-    var sub_dict = muted_topics.get(stream);
+exports.remove_muted_topic = function (stream_id, topic) {
+    var sub_dict = muted_topics.get(stream_id);
     if (sub_dict) {
         sub_dict.del(topic);
     }
 };
 
-exports.is_topic_muted = function (stream, topic) {
-    if (stream === undefined) {
+exports.is_topic_muted = function (stream_id, topic) {
+    if (stream_id === undefined) {
         return false;
     }
-    var sub_dict = muted_topics.get(stream);
+    var sub_dict = muted_topics.get(stream_id);
     return sub_dict && sub_dict.get(topic);
 };
 
 exports.get_muted_topics = function () {
     var topics = [];
-    muted_topics.each(function (sub_dict, stream) {
+    muted_topics.each(function (sub_dict, stream_id) {
         _.each(sub_dict.keys(), function (topic) {
-            topics.push([stream, topic]);
+            // TODO: make it so that callees can work w/stream_id
+            var stream_name = stream_data.maybe_get_stream_name(stream_id);
+
+            if (stream_name) {
+                topics.push([stream_name, topic]);
+            }
         });
     });
     return topics;
 };
 
 exports.set_muted_topics = function (tuples) {
-    muted_topics = new Dict({fold_case: true});
+    muted_topics = new Dict();
 
     _.each(tuples, function (tuple) {
-        var stream = tuple[0];
+        var stream_name = tuple[0];
         var topic = tuple[1];
 
-        exports.add_muted_topic(stream, topic);
+        var stream_id = stream_data.get_stream_id(stream_name);
+
+        if (!stream_id) {
+            blueslip.warn('Unknown stream in set_muted_topics: ' + stream_name);
+            return;
+        }
+
+        exports.add_muted_topic(stream_id, topic);
     });
 };
 

--- a/static/js/muting.js
+++ b/static/js/muting.js
@@ -32,12 +32,7 @@ exports.get_muted_topics = function () {
     var topics = [];
     muted_topics.each(function (sub_dict, stream_id) {
         _.each(sub_dict.keys(), function (topic) {
-            // TODO: make it so that callees can work w/stream_id
-            var stream_name = stream_data.maybe_get_stream_name(stream_id);
-
-            if (stream_name) {
-                topics.push([stream_name, topic]);
-            }
+            topics.push([stream_id, topic]);
         });
     });
     return topics;

--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -154,8 +154,15 @@ exports.set_up_muted_topics_ui = function (muted_topics) {
 };
 
 exports.mute = function (stream, topic) {
+    // TODO: have callers pass in stream_id
+    var stream_id = stream_data.get_stream_id(stream);
+
+    if (!stream_id) {
+        return;
+    }
+
     stream_popover.hide_topic_popover();
-    muting.add_muted_topic(stream, topic);
+    muting.add_muted_topic(stream_id, topic);
     unread_ui.update_unread_counts();
     exports.rerender();
     exports.persist_mute(stream, topic);
@@ -164,11 +171,18 @@ exports.mute = function (stream, topic) {
 };
 
 exports.unmute = function (stream, topic) {
+    // TODO: have callers pass in stream_id
+    var stream_id = stream_data.get_stream_id(stream);
+
+    if (!stream_id) {
+        return;
+    }
+
     // we don't run a unmute_notify function because it isn't an issue as much
     // if someone accidentally unmutes a stream rather than if they mute it
     // and miss out on info.
     stream_popover.hide_topic_popover();
-    muting.remove_muted_topic(stream, topic);
+    muting.remove_muted_topic(stream_id, topic);
     unread_ui.update_unread_counts();
     exports.rerender();
     exports.persist_unmute(stream, topic);
@@ -177,7 +191,7 @@ exports.unmute = function (stream, topic) {
 };
 
 exports.toggle_mute = function (msg) {
-    if (muting.is_topic_muted(msg.stream, msg.subject)) {
+    if (muting.is_topic_muted(msg.stream_id, msg.subject)) {
         exports.unmute(msg.stream, msg.subject);
     } else if (msg.type === 'stream') {
         exports.mute(msg.stream, msg.subject);

--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -62,7 +62,7 @@ exports.notify_with_undo_option = (function () {
             meta.$mute.find("#unmute").click(function () {
                 // it should reference the meta variable and not get stuck with
                 // a pass-by-value of stream, topic.
-                exports.unmute(stream_name, topic);
+                exports.unmute(stream_id, topic);
                 animate.fadeOut();
             });
         }
@@ -165,14 +165,7 @@ exports.set_up_muted_topics_ui = function (muted_topics) {
     });
 };
 
-exports.mute = function (stream, topic) {
-    // TODO: have callers pass in stream_id
-    var stream_id = stream_data.get_stream_id(stream);
-
-    if (!stream_id) {
-        return;
-    }
-
+exports.mute = function (stream_id, topic) {
     stream_popover.hide_topic_popover();
     muting.add_muted_topic(stream_id, topic);
     unread_ui.update_unread_counts();
@@ -182,14 +175,7 @@ exports.mute = function (stream, topic) {
     exports.set_up_muted_topics_ui(muting.get_muted_topics());
 };
 
-exports.unmute = function (stream, topic) {
-    // TODO: have callers pass in stream_id
-    var stream_id = stream_data.get_stream_id(stream);
-
-    if (!stream_id) {
-        return;
-    }
-
+exports.unmute = function (stream_id, topic) {
     // we don't run a unmute_notify function because it isn't an issue as much
     // if someone accidentally unmutes a stream rather than if they mute it
     // and miss out on info.
@@ -204,9 +190,9 @@ exports.unmute = function (stream, topic) {
 
 exports.toggle_mute = function (msg) {
     if (muting.is_topic_muted(msg.stream_id, msg.subject)) {
-        exports.unmute(msg.stream, msg.subject);
+        exports.unmute(msg.stream_id, msg.subject);
     } else if (msg.type === 'stream') {
-        exports.mute(msg.stream, msg.subject);
+        exports.mute(msg.stream_id, msg.subject);
     }
 };
 

--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -159,8 +159,24 @@ exports.update_muted_topics = function (muted_topics) {
 exports.set_up_muted_topics_ui = function (muted_topics) {
     var muted_topics_table = $("#muted_topics_table tbody");
     muted_topics_table.empty();
-    _.each(muted_topics, function (list) {
-        var row = templates.render('muted_topic_ui_row', {stream: list[0], topic: list[1]});
+    _.each(muted_topics, function (tup) {
+        var stream = tup[0];
+        var topic = tup[1];
+
+        var stream_id = stream_data.get_stream_id(stream);
+
+        if (!stream_id) {
+            blueslip.warn('Unknown stream in set_up_muted_topics_ui: ' + stream);
+            return;
+        }
+
+        var template_data = {
+            stream: stream,
+            stream_id: stream_id,
+            topic: topic,
+        };
+
+        var row = templates.render('muted_topic_ui_row', template_data);
         muted_topics_table.append(row);
     });
 };

--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -99,7 +99,14 @@ exports.dismiss_mute_confirmation = function () {
     }
 };
 
-exports.persist_mute = function (stream_name, topic_name) {
+exports.persist_mute = function (stream_id, topic_name) {
+    var stream_name = stream_data.maybe_get_stream_name(stream_id);
+
+    if (!stream_name) {
+        blueslip.error('Trying to mute bogus stream id: ' + stream_id);
+        return;
+    }
+
     var data = {
         stream: stream_name,
         topic: topic_name,
@@ -113,7 +120,14 @@ exports.persist_mute = function (stream_name, topic_name) {
     });
 };
 
-exports.persist_unmute = function (stream_name, topic_name) {
+exports.persist_unmute = function (stream_id, topic_name) {
+    var stream_name = stream_data.maybe_get_stream_name(stream_id);
+
+    if (!stream_name) {
+        blueslip.error('Trying to unmute bogus stream id: ' + stream_id);
+        return;
+    }
+
     var data = {
         stream: stream_name,
         topic: topic_name,
@@ -165,7 +179,7 @@ exports.mute = function (stream, topic) {
     muting.add_muted_topic(stream_id, topic);
     unread_ui.update_unread_counts();
     exports.rerender();
-    exports.persist_mute(stream, topic);
+    exports.persist_mute(stream_id, topic);
     exports.notify_with_undo_option(stream, topic);
     exports.set_up_muted_topics_ui(muting.get_muted_topics());
 };
@@ -185,7 +199,7 @@ exports.unmute = function (stream, topic) {
     muting.remove_muted_topic(stream_id, topic);
     unread_ui.update_unread_counts();
     exports.rerender();
-    exports.persist_unmute(stream, topic);
+    exports.persist_unmute(stream_id, topic);
     exports.set_up_muted_topics_ui(muting.get_muted_topics());
     exports.dismiss_mute_confirmation();
 };

--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -25,8 +25,6 @@ exports.rerender = function () {
 
 exports.notify_with_undo_option = (function () {
     var meta = {
-        stream: null,
-        topic: null,
         hide_me_time: null,
         alert_hover_state: false,
         $mute: null,
@@ -49,7 +47,9 @@ exports.notify_with_undo_option = (function () {
         }
     }, 100);
 
-    return function (stream, topic) {
+    return function (stream_id, topic) {
+        var stream_name = stream_data.maybe_get_stream_name(stream_id);
+
         var $exit = $("#unmute_muted_topic_notification .exit-me");
 
         if (!meta.$mute) {
@@ -62,18 +62,16 @@ exports.notify_with_undo_option = (function () {
             meta.$mute.find("#unmute").click(function () {
                 // it should reference the meta variable and not get stuck with
                 // a pass-by-value of stream, topic.
-                exports.unmute(meta.stream, meta.topic);
+                exports.unmute(stream_name, topic);
                 animate.fadeOut();
             });
         }
 
-        meta.stream = stream;
-        meta.topic = topic;
         // add a four second delay before closing up.
         meta.hide_me_time = new Date().getTime() + 4000;
 
+        meta.$mute.find(".stream").text(stream_name);
         meta.$mute.find(".topic").text(topic);
-        meta.$mute.find(".stream").text(stream);
 
         animate.fadeIn();
 
@@ -180,7 +178,7 @@ exports.mute = function (stream, topic) {
     unread_ui.update_unread_counts();
     exports.rerender();
     exports.persist_mute(stream_id, topic);
-    exports.notify_with_undo_option(stream, topic);
+    exports.notify_with_undo_option(stream_id, topic);
     exports.set_up_muted_topics_ui(muting.get_muted_topics());
 };
 

--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -160,13 +160,13 @@ exports.set_up_muted_topics_ui = function (muted_topics) {
     var muted_topics_table = $("#muted_topics_table tbody");
     muted_topics_table.empty();
     _.each(muted_topics, function (tup) {
-        var stream = tup[0];
+        var stream_id = tup[0];
         var topic = tup[1];
 
-        var stream_id = stream_data.get_stream_id(stream);
+        var stream = stream_data.maybe_get_stream_name(stream_id);
 
-        if (!stream_id) {
-            blueslip.warn('Unknown stream in set_up_muted_topics_ui: ' + stream);
+        if (!stream) {
+            blueslip.warn('Unknown stream_id in set_up_muted_topics_ui: ' + stream_id);
             return;
         }
 

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -446,7 +446,7 @@ exports.message_is_notifiable = function (message) {
     }
 
     if (message.type === "stream" &&
-        muting.is_topic_muted(message.stream, message.subject)) {
+        muting.is_topic_muted(message.stream_id, message.subject)) {
         return false;
     }
 
@@ -568,7 +568,7 @@ exports.get_local_notify_mix_reason = function (message) {
         return;
     }
 
-    if (message.type === "stream" && muting.is_topic_muted(message.stream, message.subject)) {
+    if (message.type === "stream" && muting.is_topic_muted(message.stream_id, message.subject)) {
         return "Sent! Your message was sent to a topic you have muted.";
     }
 

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -380,11 +380,11 @@ exports.toggle_actions_popover = function (element, id) {
         var can_mute_topic =
                 message.stream &&
                 message.subject &&
-                !muting.is_topic_muted(message.stream, message.subject);
+                !muting.is_topic_muted(message.stream_id, message.subject);
         var can_unmute_topic =
                 message.stream &&
                 message.subject &&
-                muting.is_topic_muted(message.stream, message.subject);
+                muting.is_topic_muted(message.stream_id, message.subject);
 
         var should_display_edit_history_option = _.any(message.edit_history, function (entry) {
             return entry.prev_content !== undefined;

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -900,8 +900,16 @@ exports.register_click_handlers = function () {
     $('body').on('click', '.popover_mute_topic', function (e) {
         var stream = $(e.currentTarget).data('msg-stream');
         var topic = $(e.currentTarget).data('msg-topic');
+
+        // TODO: use stream_id in markup
+        var stream_id = stream_data.get_stream_id(stream);
+
+        if (!stream_id) {
+            return;
+        }
+
         popovers.hide_actions_popover();
-        muting_ui.mute(stream, topic);
+        muting_ui.mute(stream_id, topic);
         e.stopPropagation();
         e.preventDefault();
     });
@@ -909,8 +917,15 @@ exports.register_click_handlers = function () {
     $('body').on('click', '.popover_unmute_topic', function (e) {
         var stream = $(e.currentTarget).data('msg-stream');
         var topic = $(e.currentTarget).data('msg-topic');
+
+        var stream_id = stream_data.get_stream_id(stream);
+
+        if (!stream_id) {
+            return;
+        }
+
         popovers.hide_actions_popover();
-        muting_ui.unmute(stream, topic);
+        muting_ui.unmute(stream_id, topic);
         e.stopPropagation();
         e.preventDefault();
     });

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -898,15 +898,8 @@ exports.register_click_handlers = function () {
     });
 
     $('body').on('click', '.popover_mute_topic', function (e) {
-        var stream = $(e.currentTarget).data('msg-stream');
-        var topic = $(e.currentTarget).data('msg-topic');
-
-        // TODO: use stream_id in markup
-        var stream_id = stream_data.get_stream_id(stream);
-
-        if (!stream_id) {
-            return;
-        }
+        var stream_id = $(e.currentTarget).attr('data-msg-stream-id');
+        var topic = $(e.currentTarget).attr('data-msg-topic');
 
         popovers.hide_actions_popover();
         muting_ui.mute(stream_id, topic);
@@ -915,14 +908,8 @@ exports.register_click_handlers = function () {
     });
 
     $('body').on('click', '.popover_unmute_topic', function (e) {
-        var stream = $(e.currentTarget).data('msg-stream');
-        var topic = $(e.currentTarget).data('msg-topic');
-
-        var stream_id = stream_data.get_stream_id(stream);
-
-        if (!stream_id) {
-            return;
-        }
+        var stream_id = $(e.currentTarget).attr('data-msg-stream-id');
+        var topic = $(e.currentTarget).attr('data-msg-topic');
 
         popovers.hide_actions_popover();
         muting_ui.unmute(stream_id, topic);

--- a/static/js/settings_muting.js
+++ b/static/js/settings_muting.js
@@ -8,9 +8,16 @@ exports.set_up = function () {
         var stream = $row.data("stream");
         var topic = $row.data("topic");
 
-        muting_ui.unmute(stream, topic);
-        $row.remove();
         e.stopImmediatePropagation();
+
+        var stream_id = stream_data.get_stream_id(stream);
+
+        if (!stream_id) {
+            return;
+        }
+
+        muting_ui.unmute(stream_id, topic);
+        $row.remove();
     });
 
     muting_ui.set_up_muted_topics_ui(muting.get_muted_topics());

--- a/static/js/settings_muting.js
+++ b/static/js/settings_muting.js
@@ -5,16 +5,10 @@ var exports = {};
 exports.set_up = function () {
     $('body').on('click', '.settings-unmute-topic', function (e) {
         var $row = $(this).closest("tr");
-        var stream = $row.data("stream");
-        var topic = $row.data("topic");
+        var stream_id = $row.attr("data-stream-id");
+        var topic = $row.attr("data-topic");
 
         e.stopImmediatePropagation();
-
-        var stream_id = stream_data.get_stream_id(stream);
-
-        if (!stream_id) {
-            return;
-        }
 
         muting_ui.unmute(stream_id, topic);
         $row.remove();

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -242,7 +242,7 @@ exports.update_calculated_fields = function (sub) {
     // Guest users can't access subscribers of any(public or private) non-subscribed streams.
     sub.can_access_subscribers = page_params.is_admin || sub.subscribed || !page_params.is_guest &&
                                  !sub.invite_only;
-    sub.preview_url = hash_util.by_stream_uri(sub.name);
+    sub.preview_url = hash_util.by_stream_uri(sub.stream_id);
     exports.render_stream_description(sub);
     exports.update_subscribers_count(sub);
 };

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -97,6 +97,16 @@ exports.get_sub_by_name = function (name) {
     return subs_by_stream_id.get(stream_id);
 };
 
+exports.id_to_slug = function (stream_id) {
+    var name = exports.maybe_get_stream_name(stream_id) || 'unknown';
+
+    // The name part of the URL doesn't really matter, so we try to
+    // make it pretty.
+    name = name.replace(' ', '-');
+
+    return stream_id + '-' + name;
+};
+
 exports.name_to_slug = function (name) {
     var stream_id = exports.get_stream_id(name);
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -212,7 +212,7 @@ function build_stream_sidebar_li(sub) {
     var args = {
         name: name,
         id: sub.stream_id,
-        uri: hash_util.by_stream_uri(name),
+        uri: hash_util.by_stream_uri(sub.stream_id),
         not_in_home_view: stream_data.in_home_view(sub.stream_id) === false,
         invite_only: sub.invite_only,
         color: stream_data.get_color(name),

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -142,7 +142,7 @@ function build_topic_popover(e) {
     popovers.hide_all();
     exports.show_streamlist_sidebar();
 
-    var is_muted = muting.is_topic_muted(sub.name, topic_name);
+    var is_muted = muting.is_topic_muted(sub.stream_id, topic_name);
     var can_mute_topic = !is_muted;
     var can_unmute_topic = is_muted;
 

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -293,9 +293,16 @@ exports.register_stream_handlers = function () {
 
 };
 
-function topic_popover_sub(e) {
+function topic_popover_stream_id(e) {
     // TODO: use data-stream-id in stream list
     var stream_id = $(e.currentTarget).attr('data-stream-id');
+
+    return stream_id;
+}
+
+function topic_popover_sub(e) {
+    // TODO: use data-stream-id in stream list
+    var stream_id = topic_popover_stream_id(e);
     if (!stream_id) {
         blueslip.error('cannot find stream id');
         return;
@@ -332,26 +339,26 @@ exports.register_topic_handlers = function () {
 
     // Mute the topic
     $('body').on('click', '.sidebar-popover-mute-topic', function (e) {
-        var sub = topic_popover_sub(e);
-        if (!sub) {
+        var stream_id = topic_popover_stream_id(e);
+        if (!stream_id) {
             return;
         }
 
         var topic = $(e.currentTarget).attr('data-topic-name');
-        muting_ui.mute(sub.name, topic);
+        muting_ui.mute(stream_id, topic);
         e.stopPropagation();
         e.preventDefault();
     });
 
     // Unmute the topic
     $('body').on('click', '.sidebar-popover-unmute-topic', function (e) {
-        var sub = topic_popover_sub(e);
-        if (!sub) {
+        var stream_id = topic_popover_stream_id(e);
+        if (!stream_id) {
             return;
         }
 
         var topic = $(e.currentTarget).attr('data-topic-name');
-        muting_ui.unmute(sub.name, topic);
+        muting_ui.unmute(stream_id, topic);
         e.stopPropagation();
         e.preventDefault();
     });

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -365,14 +365,14 @@ exports.register_topic_handlers = function () {
 
     // Mark all messages as read
     $('body').on('click', '.sidebar-popover-mark-topic-read', function (e) {
-        var sub = topic_popover_sub(e);
-        if (!sub) {
+        var stream_id = topic_popover_stream_id(e);
+        if (!stream_id) {
             return;
         }
 
         var topic = $(e.currentTarget).attr('data-topic-name');
         exports.hide_topic_popover();
-        unread_ops.mark_topic_as_read(sub.stream_id, topic);
+        unread_ops.mark_topic_as_read(stream_id, topic);
         e.stopPropagation();
     });
 };

--- a/static/js/topic_generator.js
+++ b/static/js/topic_generator.js
@@ -213,7 +213,7 @@ exports.get_next_topic = function (curr_stream, curr_topic) {
         var stream_id = stream_data.get_stream_id(stream_name);
         var topics = topic_data.get_recent_names(stream_id);
         topics = _.reject(topics, function (topic) {
-            return muting.is_topic_muted(stream_name, topic);
+            return muting.is_topic_muted(stream_id, topic);
         });
         return topics;
     }

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -86,7 +86,7 @@ exports.widget = function (parent_elem, my_stream_id) {
                 topic_name: topic_name,
                 unread: num_unread,
                 is_zero: num_unread === 0,
-                is_muted: muting.is_topic_muted(my_stream_name, topic_name),
+                is_muted: muting.is_topic_muted(my_stream_id, topic_name),
                 url: hash_util.by_stream_topic_uri(my_stream_name, topic_name),
             };
             var li = $(templates.render('topic_list_item', topic_info));

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -87,7 +87,7 @@ exports.widget = function (parent_elem, my_stream_id) {
                 unread: num_unread,
                 is_zero: num_unread === 0,
                 is_muted: muting.is_topic_muted(my_stream_id, topic_name),
-                url: hash_util.by_stream_topic_uri(my_stream_name, topic_name),
+                url: hash_util.by_stream_topic_uri(my_stream_id, topic_name),
             };
             var li = $(templates.render('topic_list_item', topic_info));
             self.topic_items.set(topic_name, li);

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -64,10 +64,8 @@ exports.widget = function (parent_elem, my_stream_id) {
 
         var max_topics = 5;
         var topic_names = topic_data.get_recent_names(my_stream_id);
-        var my_stream_name = stream_data.get_sub_by_id(my_stream_id).name;
 
         var ul = $('<ul class="topic-list">');
-        ul.attr('data-stream', my_stream_name);
 
         _.each(topic_names, function (topic_name, idx) {
             var num_unread = unread.num_unread_for_topic(my_stream_id, topic_name);

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -298,7 +298,7 @@ exports.unread_topic_counter = (function () {
             per_stream_bucketer.each(function (msgs, topic) {
                 var topic_count = msgs.count();
                 res.topic_count.get(stream_id).set(topic, topic_count);
-                if (!muting.is_topic_muted(sub.name, topic)) {
+                if (!muting.is_topic_muted(stream_id, topic)) {
                     stream_count += topic_count;
                 }
             });
@@ -350,7 +350,7 @@ exports.unread_topic_counter = (function () {
 
         var sub = stream_data.get_sub_by_id(stream_id);
         per_stream_bucketer.each(function (msgs, topic) {
-            if (sub && !muting.is_topic_muted(sub.name, topic)) {
+            if (sub && !muting.is_topic_muted(stream_id, topic)) {
                 stream_count += msgs.count();
             }
         });
@@ -382,7 +382,7 @@ exports.unread_topic_counter = (function () {
         var topic_lists = [];
         var sub = stream_data.get_sub_by_id(stream_id);
         per_stream_bucketer.each(function (msgs, topic) {
-            if (sub && !muting.is_topic_muted(sub.name, topic)) {
+            if (sub && !muting.is_topic_muted(stream_id, topic)) {
                 topic_lists.push(msgs.members());
             }
         });

--- a/static/templates/actions_popover_content.handlebars
+++ b/static/templates/actions_popover_content.handlebars
@@ -61,7 +61,7 @@
     {{/if}}
     {{#if can_mute_topic}}
     <li>
-        <a href="#" class="popover_mute_topic" data-msg-stream="{{message.stream}}" data-msg-topic="{{message.subject}}">
+        <a href="#" class="popover_mute_topic" data-msg-stream-id="{{message.stream_id}}" data-msg-topic="{{message.subject}}">
             <i class="fa fa-eye-slash" aria-hidden="true"></i>
             {{#tr message}}Mute the topic <b>__subject__</b>{{/tr}} <span class="hotkey-hint">(M)</span>
         </a>
@@ -70,7 +70,7 @@
 
     {{#if can_unmute_topic}}
     <li>
-        <a href="#" class="popover_unmute_topic" data-msg-stream="{{message.stream}}" data-msg-topic="{{message.subject}}">
+        <a href="#" class="popover_unmute_topic" data-msg-stream-id="{{message.stream_id}}" data-msg-topic="{{message.subject}}">
             <i class="fa fa-eye" aria-hidden="true"></i>
             {{#tr message}}Unmute the topic <b>__subject__</b>{{/tr}}
         </a>

--- a/static/templates/muted_topic_ui_row.handlebars
+++ b/static/templates/muted_topic_ui_row.handlebars
@@ -1,4 +1,4 @@
-<tr data-stream="{{stream}}" data-topic="{{topic}}">
+<tr data-stream-id="{{stream_id}}" data-topic="{{topic}}">
     <td>{{stream}}</td>
     <td>{{topic}}</td>
     <td><a class="settings-unmute-topic">Unmute</a></td>

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -66,7 +66,7 @@ enforce_fully_covered = {
     'static/js/search_util.js',
     # Removed because we're migrating code from uncovered other settings pages to here.
     # 'static/js/settings_ui.js',
-    # 'static/js/settings_muting.js',
+    'static/js/settings_muting.js',
     'static/js/settings_user_groups.js',
     'static/js/stream_data.js',
     'static/js/stream_events.js',

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -66,7 +66,7 @@ enforce_fully_covered = {
     'static/js/search_util.js',
     # Removed because we're migrating code from uncovered other settings pages to here.
     # 'static/js/settings_ui.js',
-    'static/js/settings_muting.js',
+    # 'static/js/settings_muting.js',
     'static/js/settings_user_groups.js',
     'static/js/stream_data.js',
     'static/js/stream_events.js',


### PR DESCRIPTION
This fixes the most core data structures inside of
muting.js.  We still use stream names for incoming
data to set_muted_topics and outgoing data from
get_muted_topics.

I haven't tested this manually yet, but otherwise I'm confident in it.
