### PR TITLE
 upgrade-zulip: Use deploy_options specified in zulip.conf.

### DIFF
--- a/scripts/lib/upgrade-zulip
+++ b/scripts/lib/upgrade-zulip
@@ -5,13 +5,19 @@ import sys
 import subprocess
 import logging
 import time
+import configparser
+from typing import List
 
 TARBALL_ARCHIVE_PATH = "/home/zulip/archives"
 os.environ["PYTHONUNBUFFERED"] = "y"
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 from scripts.lib.zulip_tools import DEPLOYMENTS_DIR, FAIL, WARNING, ENDC, \
-    su_to_zulip, get_deployment_lock, release_deployment_lock, assert_running_as_root
+    su_to_zulip, get_deployment_lock, release_deployment_lock, assert_running_as_root, \
+    get_config_file, get_deploy_options
+
+config_file = get_config_file()  # type: configparser.RawConfigParser
+deploy_options = get_deploy_options(config_file)  # type: List[str]
 
 assert_running_as_root(strip_lib_from_paths=True)
 
@@ -49,6 +55,7 @@ try:
     # version is much better for fixing bugs in the upgrade process).
     deploy_path = deploy_path.strip()
     os.chdir(deploy_path)
-    subprocess.check_call([os.path.abspath("./scripts/lib/upgrade-zulip-stage-2"), deploy_path])
+    subprocess.check_call([os.path.abspath("./scripts/lib/upgrade-zulip-stage-2"), deploy_path]
+                          + deploy_options)
 finally:
     release_deployment_lock()

--- a/scripts/lib/upgrade-zulip-from-git
+++ b/scripts/lib/upgrade-zulip-from-git
@@ -6,25 +6,20 @@ import subprocess
 import logging
 import time
 import argparse
+from typing import List
+import configparser
 
-config_file = configparser.RawConfigParser()
-config_file.read("/etc/zulip/zulip.conf")
 LOCAL_GIT_CACHE_DIR = '/srv/zulip.git'
-
-try:
-    remote_url = config_file.get('deployment', 'git_repo_url')
-except (configparser.NoSectionError, configparser.NoOptionError):
-    remote_url = "https://github.com/zulip/zulip.git"
-try:
-    deploy_options = config_file.get('deployment', 'deploy_options').strip().split()
-except (configparser.NoSectionError, configparser.NoOptionError):
-    deploy_options = []
-
 os.environ["PYTHONUNBUFFERED"] = "y"
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 from scripts.lib.zulip_tools import DEPLOYMENTS_DIR, FAIL, WARNING, ENDC, make_deploy_path, \
-    get_deployment_lock, overwrite_symlink, release_deployment_lock, su_to_zulip, assert_running_as_root
+    get_deployment_lock, overwrite_symlink, release_deployment_lock, su_to_zulip, assert_running_as_root, \
+    get_config_file, get_deploy_options, get_config
+
+config_file = get_config_file()
+deploy_options = get_deploy_options(config_file)
+remote_url = get_config(config_file, 'deployment', 'git_repo_url', "https://github.com/zulip/zulip.git")
 
 assert_running_as_root(strip_lib_from_paths=True)
 

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -15,9 +15,10 @@ import tempfile
 import time
 import json
 import uuid
+import configparser
 
 if False:
-    from typing import Sequence, Set, Any, Dict, List
+    from typing import Sequence, Set, Any, Dict, List, Optional
 
 DEPLOYMENTS_DIR = "/home/zulip/deployments"
 LOCK_DIR = os.path.join(DEPLOYMENTS_DIR, "lock")
@@ -410,3 +411,18 @@ def assert_running_as_root(strip_lib_from_paths: bool=False) -> None:
     if not is_root():
         print("{} must be run as root.".format(script_name))
         sys.exit(1)
+
+def get_config(config_file, section, key, default_value=""):
+    # type: (configparser.RawConfigParser, str, str, str) -> str
+    if config_file.has_option(section, key):
+        return config_file.get(section, key)
+    return default_value
+
+def get_config_file() -> configparser.RawConfigParser:
+    config_file = configparser.RawConfigParser()
+    config_file.read("/etc/zulip/zulip.conf")
+    return config_file
+
+def get_deploy_options(config_file):
+    # type: (configparser.RawConfigParser) -> List[str]
+    return get_config(config_file, 'deployment', 'deploy_options', "").strip().split()


### PR DESCRIPTION
Fixes #10534.

Manual testing:

- Commit 1: Use `upgrade-zulip-from-git` to deploy the `deploy_options` (the branch for this PR) branch. Add `--skip-migrations` to zulip.conf and run `upgrade-zulip-from-git` again and manually check that migrations were skipped (by making sure `Checking for needed migrations` statement is not printed)
- Commit 2: Use `upgrade-zulip-from-git` to deploy the `deploy_options` (the branch for this PR) branch. Add `--skip-migrations` to zulip.conf and run `upgrade-zulip` with the latest 1.9.1 tarball