### PR TITLE
styles: Fix compose options hidden when editing.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1352,6 +1352,12 @@ div.focused_table {
 .message-edit-timer-control-group {
     float: right;
     display: none;
+    margin-top: 5px;
+}
+
+.message-edit-feature-group {
+    display: inline-block;
+    margin-bottom: -5px;
 }
 
 .topic_edit {

--- a/static/templates/message_edit_form.handlebars
+++ b/static/templates/message_edit_form.handlebars
@@ -36,13 +36,13 @@
             <button type="button" class="button small rounded message_edit_close">{{t "Close" }}</button>
             {{/if}}
             {{#if has_been_editable}}
+            <div class="message-edit-feature-group">
+                <input type="file" id="message_edit_file_input_{{message_id}}" class="notvisible pull-left" multiple />
+                <a class="message-control-button fa fa-font" aria-hidden="true" title="{{t 'Formatting' }}" data-overlay-trigger="message-formatting" ></a>
+                <a class="message-control-button fa fa-paperclip notdisplayed" aria-hidden="true" id="attach_files_{{message_id}}" href="#" title="{{t "Attach files" }}"></a>
+            </div>
             <div class="message-edit-timer-control-group">
                 <span class="message_edit_countdown_timer"></span>
-                <div class="message-edit-timer-control-group">
-                    <input type="file" id="message_edit_file_input_{{message_id}}" class="notvisible pull-left" multiple />
-                    <a class="message-control-button fa fa-font" aria-hidden="true" title="{{t 'Formatting' }}" data-overlay-trigger="message-formatting" ></a>
-                    <a class="message-control-button fa fa-paperclip notdisplayed" aria-hidden="true" id="attach_files_{{message_id}}" href="#" title="{{t "Attach files" }}"></a>
-                </div>
                 <span><i id="message_edit_tooltip" class="message_edit_tooltip fa fa-question-circle" aria-hidden="true" data-toggle="tooltip"
                     title="{{#tr this}}This organization is configured to restrict editing of message content to __minutes_to_edit__ minutes after it is sent.{{/tr}}"></i>
                 </span>


### PR DESCRIPTION
This PR fixes an issue that when a message is being edited, sometimes compose options are hidden if there is no time limit. This also moves the options further from the time limit to make them more noticeable.

Fixes #11056.

**Screenshots:**

*With Time Limit:*

<img width="911" alt="with time limit" src="https://user-images.githubusercontent.com/17259768/50058763-fe1f4c00-0131-11e9-8f50-11db907d9584.png">

*Without Time Limit:*

<img width="913" alt="without time limit" src="https://user-images.githubusercontent.com/17259768/50058765-01b2d300-0132-11e9-8cd7-8fbf7a21c6a7.png">
