### PR TITLE
drafts: Put the most recent draft at the top of the modal.

### DIFF
--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -257,27 +257,13 @@ run_test('format_drafts', () => {
 
     var expected = [
         {
-            draft_id: 'id3',
+            draft_id: 'id1',
             is_stream: true,
-            stream: 'stream 2',
+            stream: 'stream',
             stream_color: '#FFFFFF',
             topic: 'topic',
-            raw_content: 'Test Stream Message 2',
-            time_stamp: 'Jan 21',
-        },
-        {
-            draft_id: 'id4',
-            is_stream: false,
-            recipients: 'aaron',
-            raw_content: 'Test Private Message 2',
-            time_stamp: 'Jan 26',
-        },
-        {
-            draft_id: 'id5',
-            is_stream: false,
-            recipients: 'aaron',
-            raw_content: 'Test Private Message 3',
-            time_stamp: 'Jan 29',
+            raw_content: 'Test Stream Message',
+            time_stamp: '7:55 AM',
         },
         {
             draft_id: 'id2',
@@ -287,13 +273,27 @@ run_test('format_drafts', () => {
             time_stamp: 'Jan 30',
         },
         {
-            draft_id: 'id1',
+            draft_id: 'id5',
+            is_stream: false,
+            recipients: 'aaron',
+            raw_content: 'Test Private Message 3',
+            time_stamp: 'Jan 29',
+        },
+        {
+            draft_id: 'id4',
+            is_stream: false,
+            recipients: 'aaron',
+            raw_content: 'Test Private Message 2',
+            time_stamp: 'Jan 26',
+        },
+        {
+            draft_id: 'id3',
             is_stream: true,
-            stream: 'stream',
+            stream: 'stream 2',
             stream_color: '#FFFFFF',
             topic: 'topic',
-            raw_content: 'Test Stream Message',
-            time_stamp: '7:55 AM',
+            raw_content: 'Test Stream Message 2',
+            time_stamp: 'Jan 21',
         },
     ];
 

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -277,7 +277,7 @@ exports.launch = function () {
         var unsorted_raw_drafts = _.values(data);
 
         var sorted_raw_drafts = unsorted_raw_drafts.sort(function (draft_a, draft_b) {
-            return draft_a.updatedAt - draft_b.updatedAt;
+            return draft_b.updatedAt - draft_a.updatedAt;
         });
 
         var sorted_formatted_drafts = _.filter(_.map(sorted_raw_drafts, exports.format_draft));
@@ -463,12 +463,12 @@ exports.open_modal = function () {
 
 exports.set_initial_element = function (drafts) {
     if (drafts.length > 0) {
-        var curr_draft_id = drafts[drafts.length - 1].draft_id;
+        var curr_draft_id = drafts[0].draft_id;
         var selector = '[data-draft-id="' + curr_draft_id + '"]';
         var curr_draft_element = document.querySelectorAll(selector);
         var focus_element = curr_draft_element[0].children[0];
         activate_element(focus_element);
-        $(".drafts-list")[0].scrollTop = $('.drafts-list')[0].scrollHeight - $('.drafts-list').height();
+        $(".drafts-list")[0].scrollTop = 0;
     }
 };
 

--- a/static/styles/drafts.scss
+++ b/static/styles/drafts.scss
@@ -17,13 +17,13 @@
 .drafts-header {
     padding-top: 4px;
     text-align: center;
-    text-transform: uppercase;
     border-bottom: 1px solid hsl(0, 0%, 87%);
 }
 
 .drafts-header h1 {
     margin: 0;
     font-size: 1.1em;
+    text-transform: uppercase;
 }
 
 .drafts-container .exit {

--- a/static/templates/draft_table_body.handlebars
+++ b/static/templates/draft_table_body.handlebars
@@ -6,11 +6,11 @@
                 <div class="exit">
                     <span class="exit-sign">&times;</span>
                 </div>
+                <div class="removed-drafts">
+                    {{#tr this}} Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed. {{/tr}}
+                </div>
             </div>
             <div class="drafts-list">
-                <div class="removed-drafts">
-                    {{#tr this}} Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed {{/tr}}
-                </div>
                 <div class="no-drafts">
                     {{t 'No drafts.'}}
                 </div>

--- a/static/templates/draft_table_body.handlebars
+++ b/static/templates/draft_table_body.handlebars
@@ -9,6 +9,9 @@
                 <div class="removed-drafts">
                     {{#tr this}} Drafts older than <strong>__draft_lifetime__</strong> days are automatically removed. {{/tr}}
                 </div>
+                <div class="draft-hotkey-reminder">
+                    {{t "Pro tip: You can use 'd' to open your drafts."}}
+                </div>
             </div>
             <div class="drafts-list">
                 <div class="no-drafts">


### PR DESCRIPTION
The main bugs here were that we weren't showing the active element, and we were only showing the last draft if we were lucky.

The last commit here is optional, but I hope we can at least test-deploy it.