### PR TITLE
Use #!/usr/bin/env for bash shebangs

### DIFF
--- a/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_email_deliverer_backlog
+++ b/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_email_deliverer_backlog
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 #"OK": 0

--- a/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_email_deliverer_process
+++ b/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_email_deliverer_process
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #"OK": 0
 #"WARNING": 1

--- a/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_worker_memory
+++ b/puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_worker_memory
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Checks for any Zulip queue workers that are leaking memory and thus have a high vsize
 datafile=$(mktemp)
 

--- a/scripts/lib/build-pgroonga
+++ b/scripts/lib/build-pgroonga
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 set -e
 

--- a/scripts/lib/build-tsearch-extras
+++ b/scripts/lib/build-tsearch-extras
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 set -e
 

--- a/scripts/lib/certbot-maybe-renew
+++ b/scripts/lib/certbot-maybe-renew
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 zulip_conf_get_boolean() {
     # Get a boolean flag from zulip.conf, using the Python

--- a/scripts/lib/check-upstart
+++ b/scripts/lib/check-upstart
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 release=$(lsb_release -sc)
 
 if [ "$release" = "xenial" ] && [ -x /sbin/start ] && [ -x /sbin/stop ] && [ -x /sbin/restart ] && [ -x /sbin/status ] && [ -x /sbin/initctl ]; then

--- a/scripts/lib/create-zulip-admin
+++ b/scripts/lib/create-zulip-admin
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if { [ "$ZULIP_USER_CREATION_ENABLED" == "True" ] || [ "$ZULIP_USER_CREATION_ENABLED" == "true" ]; } && \
    { [ -z "$ZULIP_USER_DOMAIN" ]   || \

--- a/scripts/lib/install-shellcheck
+++ b/scripts/lib/install-shellcheck
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 version=0.6.0

--- a/scripts/lib/setup-apt-repo
+++ b/scripts/lib/setup-apt-repo
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 set -e
 

--- a/scripts/lib/setup-apt-repo-debathena
+++ b/scripts/lib/setup-apt-repo-debathena
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 set -e
 

--- a/scripts/lib/setup-yum-repo
+++ b/scripts/lib/setup-yum-repo
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 set -e
 

--- a/scripts/setup/install
+++ b/scripts/setup/install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Thin wrapper around the actual install script (scripts/lib/install).
 # The purpose of this wrapper is to log the full install script output

--- a/scripts/setup/postgres-create-db
+++ b/scripts/setup/postgres-create-db
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/scripts/setup/postgres-init-db
+++ b/scripts/setup/postgres-init-db
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [ "$EUID" -ne 0 ]; then

--- a/scripts/upgrade-zulip
+++ b/scripts/upgrade-zulip
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 "$(dirname "$0")/lib/upgrade-zulip" "$@" 2>&1 | tee -a /var/log/zulip/upgrade.log

--- a/scripts/upgrade-zulip-from-git
+++ b/scripts/upgrade-zulip-from-git
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 "$(dirname "$0")/lib/upgrade-zulip-from-git" "$@" 2>&1 | tee -a /var/log/zulip/upgrade.log

--- a/tools/ci/activate-venv
+++ b/tools/ci/activate-venv
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source /srv/zulip-py3-venv/bin/activate
 echo "Using $VIRTUAL_ENV"

--- a/tools/ci/backend
+++ b/tools/ci/backend
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source tools/ci/activate-venv
 echo "Test suite is running under $(python --version)."

--- a/tools/ci/frontend
+++ b/tools/ci/frontend
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source tools/ci/activate-venv
 

--- a/tools/ci/production
+++ b/tools/ci/production
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/tools/ci/production-helper
+++ b/tools/ci/production-helper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This test installs a Zulip production environment (from the release
 # tarball from setup-production), and then runs some Nagios checks and
 # other tools to verify that everything is working properly.

--- a/tools/ci/setup-backend
+++ b/tools/ci/setup-backend
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/tools/ci/setup-production
+++ b/tools/ci/setup-production
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # In short, this provisions a Zulip development environment and then
 # builds a Zulip release tarball (the same way we build them for an
 # actual release).  The actual test job will then install that.

--- a/tools/commit-message-lint
+++ b/tools/commit-message-lint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Lint all commit messages that are newer than upstream/master if running
 # locally or the commits in the push or PR if in Travis CI.

--- a/tools/commit-msg
+++ b/tools/commit-msg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This hook runs gitlint on your commit message.
 

--- a/tools/deploy-branch
+++ b/tools/deploy-branch
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function error_out {
     echo -en '\e[0;31m'

--- a/tools/fetch-pull-request
+++ b/tools/fetch-pull-request
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/tools/fetch-rebase-pull-request
+++ b/tools/fetch-rebase-pull-request
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/tools/find-unused-css
+++ b/tools/find-unused-css
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Hackish tool for attempting to find unused IDs / classes in our CSS
 
 for n in $(perl -lne 'print $1 while /[#.]([a-zA-Z0-9_-]+)/g' static/styles/zulip.css | sort -u); do

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -179,10 +179,15 @@ def custom_check_file(fn: str,
             shebang_rules = [{'pattern': '^#!',
                               'description': "zerver library code shouldn't have a shebang line."}]
         else:
-            shebang_rules = [{'pattern': '#!/usr/bin/python',
-                              'description': "Use `#!/usr/bin/env python3` instead of `#!/usr/bin/python`"},
-                             {'pattern': '#!/usr/bin/env python$',
-                              'description': "Use `#!/usr/bin/env python3` instead of `#!/usr/bin/env python`."}]
+            shebang_rules = [
+                # /bin/sh and /usr/bin/env are the only two binaries
+                # that NixOS provides at a fixed path (outside a
+                # buildFHSUserEnv sandbox).
+                {'pattern': '^#!(?! *(?:/usr/bin/env|/bin/sh)(?: |$))',
+                 'description': "Use `#!/usr/bin/env foo` instead of `#!/path/foo` for interpreters other than sh."},
+                {'pattern': '^#!/usr/bin/env python$',
+                 'description': "Use `#!/usr/bin/env python3` instead of `#!/usr/bin/env python`."}
+            ]
         for rule in shebang_rules:
             if re.search(rule['pattern'], firstline):
                 print_err(identifier, color,

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This hook runs the Zulip code linter ./tools/lint and returns true
 # regardless of linter results so that your commit may continue.

--- a/tools/provision
+++ b/tools/provision
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Use this script to provision dependencies for your Zulip installation.
 # This script is idempotent, so it can be restarted at any time, and it

--- a/tools/push-to-pull-request
+++ b/tools/push-to-pull-request
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 usage () {

--- a/tools/reset-to-pull-request
+++ b/tools/reset-to-pull-request
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if ! git diff-index --quiet HEAD; then

--- a/tools/setup-git-repo
+++ b/tools/setup-git-repo
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if ! [ -d ".git/hooks/" ]; then
     echo "Error: Could not find .git/hooks directory"

--- a/tools/setup/optimize-svg
+++ b/tools/setup/optimize-svg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$(node_modules/.bin/svgo -f static/images/integrations/logos | grep -o '\.[0-9]% = ' | wc -l)" -ge 1 ]
  then

--- a/tools/start-dockers
+++ b/tools/start-dockers
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 sudo service rabbitmq-server restart
 sudo service postgresql restart

--- a/tools/test-all-docker
+++ b/tools/test-all-docker
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 sudo service rabbitmq-server restart
 sudo service postgresql restart

--- a/tools/test-install/destroy-all
+++ b/tools/test-install/destroy-all
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 usage() {

--- a/tools/test-install/install
+++ b/tools/test-install/install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 usage() {

--- a/tools/test-install/lxc-wait
+++ b/tools/test-install/lxc-wait
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 usage() {

--- a/tools/test-install/prepare-base
+++ b/tools/test-install/prepare-base
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [ "$EUID" -ne 0 ]; then

--- a/tools/test-migrations
+++ b/tools/test-migrations
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 echo 'Testing whether migrations are consistent with models'
 


### PR DESCRIPTION
`/bin/sh` and `/usr/bin/env` are the only two binaries that NixOS provides at a fixed path (outside a buildFHSUserEnv sandbox).

This discussion was split from #11004.