### PR TITLE
avatar: Add support for doing auth on avatar access.

### DIFF
--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -505,6 +505,13 @@ def get_local_file_path(path_id: str) -> Optional[str]:
     else:
         return None
 
+def get_local_avatar_path(path_id: str) -> Optional[str]:
+    local_path = os.path.join(settings.LOCAL_UPLOADS_DIR, 'files', path_id)
+    if os.path.isfile(local_path):
+        return local_path
+    else:
+        return None
+
 class LocalUploadBackend(ZulipUploadBackend):
     def upload_message_file(self, uploaded_file_name: str, uploaded_file_size: int,
                             content_type: Optional[str], file_data: bytes,

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -572,6 +572,14 @@ urls += [
                  {'override_api_url_scheme'})}),
 ]
 
+if settings.LOCAL_UPLOADS_DIR:
+    urls += [
+        url(r'^user_avatars/(?P<path_id>.*)',
+            rest_dispatch,
+            {'GET': ('zerver.views.users.serve_avatar_backend',
+                     {'override_api_url_scheme'})}),
+    ]
+
 # This url serves as a way to recieve CSP violation reports from the users.
 # We use this endpoint to just log these reports.
 urls += url(r'^report/csp_violations$', zerver.views.report.report_csp_violations,


### PR DESCRIPTION
This is a prototype of support for serving avatars using the `nginx` sendfile mechanism, so that they can use the same authentication mechanism as uploaded files.

It's totally untested, both manually and in terms of needing unit tests.