### PR TITLE
Added Markdown Support for Custom Profile Fields - Frontend

### DIFF
--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -244,7 +244,7 @@ run_test('set_custom_profile_field_data', () => {
     people.set_custom_profile_field_data(person.user_id, {});
     assert.deepEqual(person.profile_data, {});
     people.set_custom_profile_field_data(person.user_id, field);
-    assert.equal(person.profile_data[field.id], 'Field value');
+    assert.equal(person.profile_data[field.id].value, 'Field value');
 });
 
 run_test('get_rest_of_realm', () => {

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -240,11 +240,12 @@ initialize();
 run_test('set_custom_profile_field_data', () => {
     var person = people.get_by_email(me.email);
     me.profile_data = {};
-    var field = {id: 3, name: 'Custom long field', type: 'text', value: 'Field value'};
+    var field = {id: 3, name: 'Custom long field', type: 'text', value: 'Field value', rendered_value: '<p>Field value</p>'};
     people.set_custom_profile_field_data(person.user_id, {});
     assert.deepEqual(person.profile_data, {});
     people.set_custom_profile_field_data(person.user_id, field);
     assert.equal(person.profile_data[field.id].value, 'Field value');
+    assert.equal(person.profile_data[field.id].rendered_value, '<p>Field value</p>');
 });
 
 run_test('get_rest_of_realm', () => {

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -591,7 +591,7 @@ run_test('compose_private_stream_alert', () => {
 
 run_test('custom_user_profile_field', () => {
     var field = {name: "GitHub user name", id: 2, hint: "Or link to profile"};
-    var args = {field: field, field_value: {value: "@GitHub"}, field_type: "text"};
+    var args = {field: field, field_value: {value: "@GitHub", rendered_value: "<p>@GitHub</p>"}, field_type: "text"};
     var html = render('custom-user-profile-field', args);
     assert.equal($(html).attr('data-field-id'), 2);
     assert.equal($(html).find('.custom_user_field_value').val(), "@GitHub");

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -591,7 +591,7 @@ run_test('compose_private_stream_alert', () => {
 
 run_test('custom_user_profile_field', () => {
     var field = {name: "GitHub user name", id: 2, hint: "Or link to profile"};
-    var args = {field: field, field_value: "@GitHub", field_type: "text"};
+    var args = {field: field, field_value: {value: "@GitHub"}, field_type: "text"};
     var html = render('custom-user-profile-field', args);
     assert.equal($(html).attr('data-field-id'), 2);
     assert.equal($(html).find('.custom_user_field_value').val(), "@GitHub");

--- a/frontend_tests/node_tests/user_events.js
+++ b/frontend_tests/node_tests/user_events.js
@@ -159,7 +159,7 @@ run_test('updates', () => {
     me.profile_data = {};
     user_events.update_person({user_id: me.user_id, custom_profile_field: {id: 3, value: 'Value'}});
     person = people.get_by_email(me.email);
-    assert.equal(person.profile_data[3], 'Value');
+    assert.equal(person.profile_data[3].value, 'Value');
 
     var updated = false;
     settings_account.update_email = (email) => {

--- a/frontend_tests/node_tests/user_events.js
+++ b/frontend_tests/node_tests/user_events.js
@@ -157,9 +157,10 @@ run_test('updates', () => {
     blueslip.clear_test_data();
 
     me.profile_data = {};
-    user_events.update_person({user_id: me.user_id, custom_profile_field: {id: 3, value: 'Value'}});
+    user_events.update_person({user_id: me.user_id, custom_profile_field: {id: 3, value: 'Value', rendered_value: '<p>Value</p>'}});
     person = people.get_by_email(me.email);
     assert.equal(person.profile_data[3].value, 'Value');
+    assert.equal(person.profile_data[3].rendered_value, '<p>Value</p>');
 
     var updated = false;
     settings_account.update_email = (email) => {

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -981,7 +981,9 @@ exports.set_custom_profile_field_data = function (user_id, field) {
         blueslip.error("Unknown field id " + field.id);
         return;
     }
-    people_by_user_id_dict.get(user_id).profile_data[field.id] = field.value;
+    people_by_user_id_dict.get(user_id).profile_data[field.id] = {
+        value: field.value,
+    };
 };
 
 exports.is_current_user = function (email) {

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -983,6 +983,7 @@ exports.set_custom_profile_field_data = function (user_id, field) {
     }
     people_by_user_id_dict.get(user_id).profile_data[field.id] = {
         value: field.value,
+        rendered_value: field.rendered_value,
     };
 };
 

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -235,21 +235,28 @@ exports.show_user_profile = function (user) {
         profile_field.is_user_field = false;
         profile_field.is_link = field_type === field_types.URL.id;
         profile_field.type = field_type;
+
+        if (!field_value) {
+            return;
+        }
+        if (!field_value.value) {
+            return;
+        }
         switch (field_type) {
         case field_types.DATE.id:
-            profile_field.value = moment(field_value).format(localFormat);
+            profile_field.value = moment(field_value.value).format(localFormat);
             break;
         case field_types.USER.id:
             profile_field.id = field.id;
             profile_field.is_user_field = true;
-            profile_field.value = field_value;
+            profile_field.value = field_value.value;
             break;
         case field_types.CHOICE.id:
             var field_choice_dict = JSON.parse(field.field_data);
-            profile_field.value = field_choice_dict[field_value].text;
+            profile_field.value = field_choice_dict[field_value.value].text;
             break;
         default:
-            profile_field.value = field_value;
+            profile_field.value = field_value.value;
             break;
         }
         profile_data.push(profile_field);

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -255,9 +255,13 @@ exports.show_user_profile = function (user) {
             var field_choice_dict = JSON.parse(field.field_data);
             profile_field.value = field_choice_dict[field_value.value].text;
             break;
+        case field_types.SHORT_TEXT.id:
+        case field_types.LONG_TEXT.id:
+            profile_field.value = field_value.value;
+            profile_field.rendered_value = field_value.rendered_value;
+            break;
         default:
             profile_field.value = field_value.value;
-            break;
         }
         profile_data.push(profile_field);
     });

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -70,7 +70,10 @@ exports.append_custom_profile_fields = function (element_id, user_id) {
     all_custom_fields.forEach(function (field) {
         var field_type = field.type;
         var type;
-        var value = people.get_custom_profile_data(user_id, field.id);
+        var values = people.get_custom_profile_data(user_id, field.id);
+        if (values === undefined || values === null) {
+            values = {value: "", rendered_value: ""};
+        }
         var is_long_text = field_type === field_types.LONG_TEXT.id;
         var is_choice_field = field_type === field_types.CHOICE.id;
         var is_user_field = field_type === field_types.USER.id;
@@ -87,7 +90,7 @@ exports.append_custom_profile_fields = function (element_id, user_id) {
                     field_choices[field_choice_dict[choice].order] = {
                         value: choice,
                         text: field_choice_dict[choice].text,
-                        selected: choice === value,
+                        selected: choice === values.value,
                     };
                 }
             }
@@ -96,23 +99,16 @@ exports.append_custom_profile_fields = function (element_id, user_id) {
         } else if (field_type === field_types.URL.id) {
             type = "url";
         } else if (is_user_field) {
-            if (value) {
-                value = JSON.parse(value);
-            }
+
             type = "user";
         } else {
             blueslip.error("Undefined field type.");
         }
 
-        if (value === undefined || value === null) {
-            // If user has not set value for field.
-            value = "";
-        }
-
         var html = templates.render("custom-user-profile-field", {
             field: field,
             field_type: type,
-            field_value: value,
+            field_value: values,
             is_long_text_field: is_long_text,
             is_choice_field: is_choice_field,
             is_user_field: is_user_field,
@@ -136,6 +132,10 @@ exports.intialize_custom_user_type_fields = function (element_id, user_id, is_ed
 
     page_params.custom_profile_fields.forEach(function (field) {
         var field_value_raw = people.get_custom_profile_data(user_id, field.id);
+
+        if (field_value_raw) {
+            field_value_raw = field_value_raw.value;
+        }
 
         // If field is not editable and field value is null, we don't expect
         // pill container for that field and proceed further

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -99,7 +99,6 @@ exports.append_custom_profile_fields = function (element_id, user_id) {
         } else if (field_type === field_types.URL.id) {
             type = "url";
         } else if (is_user_field) {
-
             type = "user";
         } else {
             blueslip.error("Undefined field type.");
@@ -165,6 +164,7 @@ exports.intialize_custom_user_type_fields = function (element_id, user_id, is_ed
                     });
                 }
             }
+
             if (is_editable) {
                 var input = pill_container.children('.input');
                 if (set_handler_on_update) {

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -73,6 +73,8 @@ exports.append_custom_profile_fields = function (element_id, user_id) {
         var values = people.get_custom_profile_data(user_id, field.id);
         if (values === undefined || values === null) {
             values = {value: "", rendered_value: ""};
+        } else {  // obtain a copy of the values, and not an object reference
+            values =  Object.create(values);
         }
         var is_long_text = field_type === field_types.LONG_TEXT.id;
         var is_choice_field = field_type === field_types.CHOICE.id;
@@ -99,6 +101,9 @@ exports.append_custom_profile_fields = function (element_id, user_id) {
         } else if (field_type === field_types.URL.id) {
             type = "url";
         } else if (is_user_field) {
+            if (values.value) {
+                values.value = JSON.parse(values.value);
+            }
             type = "user";
         } else {
             blueslip.error("Undefined field type.");

--- a/static/templates/settings/custom-user-profile-field.handlebars
+++ b/static/templates/settings/custom-user-profile-field.handlebars
@@ -1,7 +1,7 @@
 <div class="user-name-section custom_user_field" name="{{ field.name }}" data-field-id="{{ field.id }}">
     <label for="{{ field.name }}" class="title">{{ field.name }}</label>
     {{#if is_long_text_field}}
-    <textarea maxlength="500" class="custom_user_field_value">{{ field_value }}</textarea>
+    <textarea maxlength="500" class="custom_user_field_value">{{ field_value.value }}</textarea>
     {{else if is_choice_field}}
     <select class="custom_user_field_value">
         <option value=""></option>
@@ -15,10 +15,10 @@
     </div>
     {{else if is_date_field }}
     <input class="custom_user_field_value datepicker" data-field-id="{{ field.id }}" type="text"
-      value="{{ field_value }}" />
+      value="{{ field_value.value }}" />
     <span class="remove_date"><i class="fa fa-close"></i></span>
     {{else}}
-    <input class="custom_user_field_value" type="{{ field_type }}" value="{{ field_value }}" maxlength="50" />
+    <input class="custom_user_field_value" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" />
     {{/if}}
     <div class="field_hint">{{ field.hint }}</div>
 </div>

--- a/static/templates/user_profile_modal.handlebars
+++ b/static/templates/user_profile_modal.handlebars
@@ -44,13 +44,17 @@
             <div data-type="{{this.type}}" class="field-section custom_user_field" data-field-id="{{this.id}}">
                 <div class="name">{{this.name}}</div>
                 {{#if this.is_user_field}}
-                <div class="pill-container not-editable" data-field-id="{{this.id}}">
-                    <div class="input" contenteditable="false" style="display: none;"></div>
-                </div>
-                {{else if this.is_link}}
-                <a href={{this.value}} target="_blank" class="value">{{this.value}}</a>
+                    <div class="pill-container not-editable" data-field-id="{{this.id}}">
+                        <div class="input" contenteditable="false" style="display: none;"></div>
+                    </div>
+                    {{else if this.is_link}}
+                    <a href={{this.value}} target="_blank" class="value">{{this.value}}</a>
                 {{else}}
-                <div class="value">{{this.value}}</div>
+                    {{#if this.rendered_value}}
+                    <div class="value">{{{this.rendered_value}}}</div>
+                    {{else}}
+                    <div class="value">{{this.value}}</div>
+                    {{/if}}
                 {{/if}}
             </div>
             {{/each}}

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -63,9 +63,15 @@ def get_raw_user_data(realm_id: int, client_gravatar: bool) -> Dict[int, Dict[st
     profiles_by_user_id = defaultdict(dict)  # type: Dict[int, Dict[str, Any]]
     for profile_field in custom_profile_field_values:
         user_id = profile_field.user_profile_id
-        profiles_by_user_id[user_id][profile_field.field_id] = {
-            "value": profile_field.value
-        }
+        if profile_field.field.is_renderable():
+            profiles_by_user_id[user_id][profile_field.field_id] = {
+                "value": profile_field.value,
+                "rendered_value": profile_field.rendered_value
+            }
+        else:
+            profiles_by_user_id[user_id][profile_field.field_id] = {
+                "value": profile_field.value
+            }
 
     def user_data(row: Dict[str, Any]) -> Dict[str, Any]:
         avatar_url = get_avatar_field(
@@ -407,9 +413,15 @@ def apply_event(state: Dict[str, Any],
                     if 'custom_profile_field' in person:
                         custom_field_id = person['custom_profile_field']['id']
                         custom_field_new_value = person['custom_profile_field']['value']
-                        p['profile_data'][custom_field_id] = {
-                            'value': custom_field_new_value
-                        }
+                        if 'rendered_value' in person['custom_profile_field']:
+                            p['profile_data'][custom_field_id] = {
+                                'value': custom_field_new_value,
+                                'rendered_value': person['custom_profile_field']['rendered_value']
+                            }
+                        else:
+                            p['profile_data'][custom_field_id] = {
+                                'value': custom_field_new_value
+                            }
 
     elif event['type'] == 'realm_bot':
         if event['op'] == 'add':

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -58,11 +58,14 @@ def get_raw_user_data(realm_id: int, client_gravatar: bool) -> Dict[int, Dict[st
     user_dicts = get_realm_user_dicts(realm_id)
 
     # TODO: Consider optimizing this query away with caching.
-    custom_profile_field_values = CustomProfileFieldValue.objects.filter(user_profile__realm_id=realm_id)
+    custom_profile_field_values = CustomProfileFieldValue.objects.select_related(
+        "field").filter(user_profile__realm_id=realm_id)
     profiles_by_user_id = defaultdict(dict)  # type: Dict[int, Dict[str, Any]]
     for profile_field in custom_profile_field_values:
         user_id = profile_field.user_profile_id
-        profiles_by_user_id[user_id][profile_field.field_id] = profile_field.value
+        profiles_by_user_id[user_id][profile_field.field_id] = {
+            "value": profile_field.value
+        }
 
     def user_data(row: Dict[str, Any]) -> Dict[str, Any]:
         avatar_url = get_avatar_field(
@@ -404,7 +407,9 @@ def apply_event(state: Dict[str, Any],
                     if 'custom_profile_field' in person:
                         custom_field_id = person['custom_profile_field']['id']
                         custom_field_new_value = person['custom_profile_field']['value']
-                        p['profile_data'][custom_field_id] = custom_field_new_value
+                        p['profile_data'][custom_field_id] = {
+                            'value': custom_field_new_value
+                        }
 
     elif event['type'] == 'realm_bot':
         if event['op'] == 'add':


### PR DESCRIPTION
**Purpose:** <!-- What's this PR for?  (Just a link to an issue is fine.) -->
This is an extension upon issue #10131 where the frontend for the web client has been added for this feature. Also, the custom profile field data is now pushed with the initial state.

**Testing Plan:** <!-- How have you tested? -->
I've done both manual and automated testing for this PR for both the frontend and backend. For automated tests, I've made sure that the new code conforms to pass them, else if needed I modified the old tests. For the frontend aspect no new tests have been created.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![new_feature](https://user-images.githubusercontent.com/29123352/50150326-a58fb080-02e3-11e9-81cd-06f2036158bf.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
