### PR TITLE
notifications: Refactor code using logic from message_viewport.

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -562,17 +562,9 @@ function get_message_header(message) {
                   {recipient: message.display_reply_to});
 }
 
-exports.get_echo_not_in_view_reason = function (message) {
-    // Check the offset of last message in the current message list;
-    // if it's placement is such that it's below the compose box, we
-    // notify the user.
-    var row = current_msg_list.get_row(message.local_id);
-    var echo_offset_y = row.offset().top;
-    var compose_box_y = $('#compose-container').offset().top;
-
-    if (echo_offset_y > 0 && echo_offset_y < compose_box_y) {
-        // If it lies between top and above the compose box
-        // Message can be said to be visible
+exports.get_echo_not_in_view_reason = function () {
+    if (message_viewport.bottom_message_visible()) {
+        // If the message is visible, we do not want to notify user
         return;
     }
 
@@ -628,7 +620,7 @@ exports.notify_local_mixes = function (messages) {
 
         if (!reason) {
             // Check if local_echo is not in view
-            reason = exports.get_echo_not_in_view_reason(message);
+            reason = exports.get_echo_not_in_view_reason();
             if (reason) {
                 exports.notify_above_composebox(reason, "", null, "");
                 setTimeout(function () {


### PR DESCRIPTION
Logic for checking if the last message in the current table is visible was
already written in `message_viewport.js`; Code in `notifications.js` is changed
to reduce redundancy.

---

@timabbott I have made the changes. Turns out the same logic was already there in `message_viewport.js` as function `bottom_message_visible`. It is not the same as you did (getting the message by its `local_id`; it is similar to what I did - getting the last message in the `.focused_table`) but it is already being used in other places, so I thought it made sense to use the same logic.