### PR TITLE
dev provision: Improve Fedora support.

### DIFF
--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -16,6 +16,7 @@ that's running one of:
 * Debian 9 Stretch
 * Centos 7 (beta)
 * Fedora 29 (beta)
+* RHEL 7 (beta)
 
 You can just run the Zulip provision script on your machine.
 
@@ -38,7 +39,7 @@ git remote add -f upstream https://github.com/zulip/zulip.git
 ```
 
 ```
-# On CentOS, you must first install epel-release, and then python34
+# On CentOS/RHEL, you must first install epel-release, and then python34
 # On Fedora, you must first install python3
 # From a clone of zulip.git
 ./tools/provision

--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -39,7 +39,7 @@ git remote add -f upstream https://github.com/zulip/zulip.git
 ```
 
 ```
-# On CentOS/RHEL, you must first install epel-release, and then python34
+# On CentOS/RHEL, you must first install epel-release, and then python36
 # On Fedora, you must first install python3
 # From a clone of zulip.git
 ./tools/provision

--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -62,6 +62,20 @@ COMMON_YUM_VENV_DEPENDENCIES = [
     "jq",
 ]
 
+REDHAT_VENV_DEPENDENCIES = COMMON_YUM_VENV_DEPENDENCIES + [
+    "python34-devel",
+    "python34-pip",
+    "python34-six",
+    "python-virtualenv",
+]
+
+FEDORA_VENV_DEPENDENCIES = COMMON_YUM_VENV_DEPENDENCIES + [
+    "python3-devel",
+    "python3-pip",
+    "python3-six",
+    "virtualenv",  # see https://unix.stackexchange.com/questions/27877/install-virtualenv-on-fedora-16
+]
+
 codename = parse_lsb_release()["DISTRIB_CODENAME"]
 
 if codename != "trusty":

--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -45,19 +45,16 @@ VENV_DEPENDENCIES = [
     "jq",                   # Used by scripts/lib/install-node to check yarn version
 ]
 
-YUM_VENV_DEPENDENCIES = [
+COMMON_YUM_VENV_DEPENDENCIES = [
     "libffi-devel",
     "freetype-devel",
     "zlib-devel",
     "libjpeg-turbo-devel",
     "openldap-devel",
     "libmemcached-devel",
-    "python34-devel",
     "python-devel",
-    "python34-pip",
     "python2-pip",
     "python-virtualenv",
-    "python34-six",
     "python-six",
     "libxml2-devel",
     "libxslt-devel",

--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -54,7 +54,6 @@ COMMON_YUM_VENV_DEPENDENCIES = [
     "libmemcached-devel",
     "python-devel",
     "python2-pip",
-    "python-virtualenv",
     "python-six",
     "libxml2-devel",
     "libxslt-devel",

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -191,6 +191,7 @@ elif vendor in ["CentOS", "RedHat"]:
         "python34-devel",
         "python34-pip",
         "python34-six",
+        "python-virtualenv",
     ]
 elif vendor == "Fedora":
     SYSTEM_DEPENDENCIES = COMMON_YUM_DEPENDENCIES + [
@@ -203,6 +204,7 @@ elif vendor == "Fedora":
         "python3-devel",
         "python3-pip",
         "python3-six",
+        "virtualenv",  # see https://unix.stackexchange.com/questions/27877/install-virtualenv-on-fedora-16
     ]
 
 if family == 'redhat':

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -290,6 +290,10 @@ def install_yum_deps(deps_to_install, retry=False):
                 print("Unrecognized output. `subscription-manager` might not be available")
 
     run(["sudo", "yum", "install", "-y"] + yum_extra_flags + deps_to_install)
+    if vendor in ["CentOS", "RedHat"]:
+        # This is how a pip3 is installed to /usr/bin in CentOS/RHEL
+        # for python35 and later.
+        run(["sudo", "python36", "-m", "ensurepip"])
     postgres_dir = 'pgsql-%s' % (POSTGRES_VERSION,)
     for cmd in ['pg_config', 'pg_isready', 'psql']:
         # Our tooling expects these postgres scripts to be at

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -17,7 +17,7 @@ sys.path.append(ZULIP_PATH)
 from scripts.lib.zulip_tools import run, subprocess_text_output, OKBLUE, ENDC, WARNING, \
     get_dev_uuid_var_path, FAIL, parse_lsb_release, file_or_package_hash_updated
 from scripts.lib.setup_venv import (
-    setup_virtualenv, VENV_DEPENDENCIES, YUM_VENV_DEPENDENCIES,
+    setup_virtualenv, VENV_DEPENDENCIES, COMMON_YUM_VENV_DEPENDENCIES,
     THUMBOR_VENV_DEPENDENCIES, YUM_THUMBOR_VENV_DEPENDENCIES
 )
 from scripts.lib.node_cache import setup_node_modules, NODE_MODULES_CACHE_PATH
@@ -169,7 +169,7 @@ COMMON_YUM_DEPENDENCIES = COMMON_DEPENDENCIES + [
     "freetype-devel",
     "fontconfig-devel",
     "libstdc++"
-] + YUM_VENV_DEPENDENCIES + YUM_THUMBOR_VENV_DEPENDENCIES
+] + COMMON_YUM_VENV_DEPENDENCIES + YUM_THUMBOR_VENV_DEPENDENCIES
 
 if vendor in ["Ubuntu", "Debian"]:
     SYSTEM_DEPENDENCIES = UBUNTU_COMMON_APT_DEPENDENCIES + [
@@ -187,6 +187,10 @@ elif vendor in ["CentOS", "RedHat"]:
             "postgresql{0}-devel",
             "postgresql{0}-pgroonga",
         ]
+    ] + [  # venv dependencies
+        "python34-devel",
+        "python34-pip",
+        "python34-six",
     ]
 elif vendor == "Fedora":
     SYSTEM_DEPENDENCIES = COMMON_YUM_DEPENDENCIES + [
@@ -195,6 +199,10 @@ elif vendor == "Fedora":
             "postgresql{0}",
             "postgresql{0}-devel",
         ]
+    ] + [  # venv dependencies
+        "python3-devel",
+        "python3-pip",
+        "python3-six",
     ]
 
 if family == 'redhat':

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -17,8 +17,9 @@ sys.path.append(ZULIP_PATH)
 from scripts.lib.zulip_tools import run, subprocess_text_output, OKBLUE, ENDC, WARNING, \
     get_dev_uuid_var_path, FAIL, parse_lsb_release, file_or_package_hash_updated
 from scripts.lib.setup_venv import (
-    setup_virtualenv, VENV_DEPENDENCIES, COMMON_YUM_VENV_DEPENDENCIES,
-    THUMBOR_VENV_DEPENDENCIES, YUM_THUMBOR_VENV_DEPENDENCIES
+    setup_virtualenv, VENV_DEPENDENCIES, REDHAT_VENV_DEPENDENCIES,
+    THUMBOR_VENV_DEPENDENCIES, YUM_THUMBOR_VENV_DEPENDENCIES,
+    FEDORA_VENV_DEPENDENCIES
 )
 from scripts.lib.node_cache import setup_node_modules, NODE_MODULES_CACHE_PATH
 
@@ -169,7 +170,7 @@ COMMON_YUM_DEPENDENCIES = COMMON_DEPENDENCIES + [
     "freetype-devel",
     "fontconfig-devel",
     "libstdc++"
-] + COMMON_YUM_VENV_DEPENDENCIES + YUM_THUMBOR_VENV_DEPENDENCIES
+] + YUM_THUMBOR_VENV_DEPENDENCIES
 
 if vendor in ["Ubuntu", "Debian"]:
     SYSTEM_DEPENDENCIES = UBUNTU_COMMON_APT_DEPENDENCIES + [
@@ -187,12 +188,7 @@ elif vendor in ["CentOS", "RedHat"]:
             "postgresql{0}-devel",
             "postgresql{0}-pgroonga",
         ]
-    ] + [  # venv dependencies
-        "python34-devel",
-        "python34-pip",
-        "python34-six",
-        "python-virtualenv",
-    ]
+    ] + REDHAT_VENV_DEPENDENCIES
 elif vendor == "Fedora":
     SYSTEM_DEPENDENCIES = COMMON_YUM_DEPENDENCIES + [
         pkg.format(POSTGRES_VERSION) for pkg in [
@@ -200,12 +196,7 @@ elif vendor == "Fedora":
             "postgresql{0}",
             "postgresql{0}-devel",
         ]
-    ] + [  # venv dependencies
-        "python3-devel",
-        "python3-pip",
-        "python3-six",
-        "virtualenv",  # see https://unix.stackexchange.com/questions/27877/install-virtualenv-on-fedora-16
-    ]
+    ] + FEDORA_VENV_DEPENDENCIES
 
 if family == 'redhat':
     TSEARCH_STOPWORDS_PATH = "/usr/pgsql-%s/share/tsearch_data/" % (POSTGRES_VERSION,)


### PR DESCRIPTION
- [ ] Bump pika to 0.12
- [ ] Bump django to 1.11.7

~- Update CircleCI images to not use python3-pip~
Ubuntu/Debian does not ship its `python3` with `ensurepip`: https://launchpad.net/ubuntu/trusty/+source/python3.4/+changelog, https://askubuntu.com/questions/879437/ensurepip-is-disabled-in-debian-ubuntu-for-the-system-python, but on CentOS/RHEL, `ensurepip` exists specifically for python35 and later https://stackoverflow.com/questions/50408941/recommended-way-to-install-pip3-on-centos7/52518512#52518512.
