### PR TITLE
markdown: Parse '/me' for multi-line messages.

### DIFF
--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -438,7 +438,7 @@ run_test('message_flags', () => {
     message = {subject: "No links here", raw_content: input};
     markdown.apply_markdown(message);
 
-    assert.equal(message.is_me_message, false);
+    assert.equal(message.is_me_message, true);
 
     input = "testing this @**all** @**Cordelia Lear**";
     message = {subject: "No links here", raw_content: input};

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -915,7 +915,7 @@ exports.initialize = function () {
         var rendered_preview_html;
         if (content !== undefined && markdown.is_status_message(content, rendered_content)) {
             // Handle previews of /me messages
-            rendered_preview_html = "<strong>" + page_params.full_name + "</strong> " + rendered_content.slice(4 + 3, -4);
+            rendered_preview_html = "<p><strong>" + page_params.full_name + "</strong>" + rendered_content.slice("<p>/me".length);
         } else {
             rendered_preview_html = rendered_content;
         }

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -136,9 +136,8 @@ exports.add_topic_links = function (message) {
 
 exports.is_status_message = function (raw_content, content) {
     return raw_content.indexOf('/me ') === 0 &&
-            raw_content.indexOf('\n') === -1 &&
             content.indexOf('<p>') === 0 &&
-            content.lastIndexOf('</p>') === content.length - 4;
+            content.indexOf('</p>') !== -1;
 };
 
 function handleUnicodeEmoji(unicode_emoji) {

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -1106,8 +1106,13 @@ MessageListView.prototype = {
 
     _maybe_format_me_message: function (message_container) {
         if (message_container.msg.is_me_message) {
-            // Slice the '<p>/me ' off the front, and '</p>' off the end
-            message_container.status_message = message_container.msg.content.slice(4 + 3, -4);
+            // Slice the '<p>/me ' off the front, and '</p>' off the first line
+            // 'p' tag is sliced off to get sender in the same line as the
+            // first line of the message
+            var msg_content = message_container.msg.content;
+            var p_index = msg_content.indexOf('</p>');
+            message_container.status_message = msg_content.slice('<p>/me '.length, p_index) +
+                                                msg_content.slice(p_index + '</p>'.length);
             message_container.include_sender = true;
         } else {
             message_container.status_message = false;


### PR DESCRIPTION
Previously, messages with more than one line did not parse `/me` at the
beginning of the message; This commit adds support for the same.

Fixes issue #11025 