### PR TITLE
prod provision: Add CentOS support.

### DIFF
--- a/puppet/zulip/manifests/app_frontend.pp
+++ b/puppet/zulip/manifests/app_frontend.pp
@@ -6,6 +6,10 @@ class zulip::app_frontend {
 
   $nginx_http_only = zulipconf('application_server', 'http_only', undef)
   $no_serve_uploads = zulipconf('application_server', 'no_serve_uploads', undef)
+  $ssl_dir = $::osfamily ? {
+    'debian' => '/etc/ssl',
+    'redhat' => '/etc/pki/tls',
+  }
   file { '/etc/nginx/sites-available/zulip-enterprise':
     ensure  => file,
     require => Package[$zulip::common::nginx],

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -5,11 +5,14 @@ class zulip::app_frontend_base {
   include zulip::nginx
   include zulip::supervisor
 
-  $web_packages = [
-    # Needed to access our database
-    "postgresql-client-${zulip::base::postgres_version}",
-  ]
-  zulip::safepackage { $web_packages: ensure => 'installed' }
+  if $::osfamily == 'debian' {
+    # This is not necessary on CentOS because $postgresql package already includes the client
+    $web_packages = [
+      # Needed to access our database
+      "postgresql-client-${zulip::base::postgres_version}",
+    ]
+    zulip::safepackage { $web_packages: ensure => 'installed' }
+  }
 
   file { '/etc/nginx/zulip-include/app':
     require => Package[$zulip::common::nginx],

--- a/puppet/zulip/manifests/nginx.pp
+++ b/puppet/zulip/manifests/nginx.pp
@@ -6,6 +6,19 @@ class zulip::nginx {
   ]
   package { $web_packages: ensure => 'installed' }
 
+  if $::osfamily == 'redhat' {
+    file { '/etc/nginx/sites-available':
+      ensure => 'directory',
+      owner  => 'root',
+      group  => 'root',
+    }
+    file { '/etc/nginx/sites-enabled':
+      ensure => 'directory',
+      owner  => 'root',
+      group  => 'root',
+    }
+  }
+
   file { '/etc/nginx/zulip-include/':
     require => Package[$zulip::common::nginx],
     recurse => true,

--- a/puppet/zulip/manifests/voyager.pp
+++ b/puppet/zulip/manifests/voyager.pp
@@ -27,7 +27,11 @@ class zulip::voyager {
   include zulip::memcached
   include zulip::rabbit
   include zulip::redis
-  include zulip::localhost_camo
+  if $::osfamily == debian {
+    # camo is only required on Debian-based systems as part of
+    # our migration towards not including camo at all.
+    include zulip::localhost_camo
+  }
   include zulip::static_asset_compiler
   include zulip::thumbor
 }

--- a/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
+++ b/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
@@ -15,8 +15,8 @@ server {
     listen 443;
 
     ssl on;
-    ssl_certificate /etc/ssl/certs/zulip.combined-chain.crt;
-    ssl_certificate_key /etc/ssl/private/zulip.key;
+    ssl_certificate <%= @ssl_dir %>/certs/zulip.combined-chain.crt;
+    ssl_certificate_key <%= @ssl_dir %>/private/zulip.key;
 <% end -%>
 
 <% if @no_serve_uploads == '' -%>

--- a/scripts/lib/create-production-venv
+++ b/scripts/lib/create-production-venv
@@ -8,15 +8,31 @@ ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__f
 if ZULIP_PATH not in sys.path:
     sys.path.append(ZULIP_PATH)
 
-from scripts.lib.zulip_tools import overwrite_symlink, run, subprocess_text_output
-from scripts.lib.setup_venv import setup_virtualenv, VENV_DEPENDENCIES
+from scripts.lib.zulip_tools import overwrite_symlink, run, parse_lsb_release
+from scripts.lib.setup_venv import (
+    setup_virtualenv, VENV_DEPENDENCIES, REDHAT_VENV_DEPENDENCIES,
+    FEDORA_VENV_DEPENDENCIES
+)
 
 parser = argparse.ArgumentParser(description="Create a production virtualenv with caching")
 parser.add_argument("deploy_path")
 args = parser.parse_args()
 
 # install dependencies for setting up the virtualenv
-run(["apt-get", "-y", "install"] + VENV_DEPENDENCIES)
+distro_info = parse_lsb_release()
+vendor = distro_info['DISTRIB_ID']
+family = distro_info['DISTRIB_FAMILY']
+if family == 'debian':
+    run(["apt-get", "-y", "install"] + VENV_DEPENDENCIES)
+elif family == 'redhat':
+    if vendor in ["CentOS", "RedHat"]:
+        _VENV_DEPS = REDHAT_VENV_DEPENDENCIES
+    elif vendor == "Fedora":
+        _VENV_DEPS = FEDORA_VENV_DEPENDENCIES
+    run(["yum", "-y", "install"] + _VENV_DEPS)
+else:
+    print("Unsupported platform: {}".format(vendor))
+    sys.exit(1)
 
 python_version = sys.version_info[0]
 

--- a/scripts/lib/create-thumbor-venv
+++ b/scripts/lib/create-thumbor-venv
@@ -8,15 +8,26 @@ ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__f
 if ZULIP_PATH not in sys.path:
     sys.path.append(ZULIP_PATH)
 
-from scripts.lib.zulip_tools import run
-from scripts.lib.setup_venv import setup_virtualenv, THUMBOR_VENV_DEPENDENCIES
+from scripts.lib.zulip_tools import run, parse_lsb_release
+from scripts.lib.setup_venv import (
+    setup_virtualenv, THUMBOR_VENV_DEPENDENCIES, YUM_THUMBOR_VENV_DEPENDENCIES
+)
 
 parser = argparse.ArgumentParser(description="Create a thumbor virtualenv with caching")
 parser.add_argument("deploy_path")
 args = parser.parse_args()
 
 # install dependencies for setting up the virtualenv
-run(["apt-get", "-y", "install"] + THUMBOR_VENV_DEPENDENCIES)
+distro_info = parse_lsb_release()
+vendor = distro_info['DISTRIB_ID']
+family = distro_info['DISTRIB_FAMILY']
+if family == 'debian':
+    run(["apt-get", "-y", "install"] + THUMBOR_VENV_DEPENDENCIES)
+elif family == 'redhat':
+    run(["yum", "-y", "install"] + YUM_THUMBOR_VENV_DEPENDENCIES)
+else:
+    print("Unsupported platform: {}".format(vendor))
+    sys.exit(1)
 
 venv_name = "zulip-thumbor-venv"
 cached_venv_path = setup_virtualenv(

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -341,7 +341,8 @@ def parse_lsb_release():
             codename = 'rhel' + info[6][0]  # 7
         distro_info = dict(
             DISTRIB_CODENAME=codename,
-            DISTRIB_ID=vendor
+            DISTRIB_ID=vendor,
+            DISTRIB_FAMILY='redhat',
         )
         return distro_info
     try:
@@ -356,6 +357,7 @@ def parse_lsb_release():
                 # from lsb_release in the exception code path.
                 continue
             distro_info[k] = v
+        distro_info['DISTRIB_FAMILY'] = 'debian'
     except FileNotFoundError:
         # Unfortunately, Debian stretch doesn't yet have an
         # /etc/lsb-release, so we instead fetch the pieces of data
@@ -364,7 +366,8 @@ def parse_lsb_release():
         codename = subprocess_text_output(["lsb_release", "-cs"])
         distro_info = dict(
             DISTRIB_CODENAME=codename,
-            DISTRIB_ID=vendor
+            DISTRIB_ID=vendor,
+            DISTRIB_FAMILY='debian',
         )
     return distro_info
 

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -120,7 +120,7 @@ if (not is_rhel_based) and (not os.path.exists("/usr/bin/lsb_release")):
 distro_info = parse_lsb_release()
 vendor = distro_info['DISTRIB_ID']
 codename = distro_info['DISTRIB_CODENAME']
-family = 'redhat' if vendor in ['CentOS', 'Fedora', 'RedHat'] else 'debian'
+family = distro_info['DISTRIB_FAMILY']
 if not (vendor in SUPPORTED_PLATFORMS and codename in SUPPORTED_PLATFORMS[vendor]):
     logging.critical("Unsupported platform: {} {}".format(vendor, codename))
     sys.exit(1)


### PR DESCRIPTION
This is built on top of #11084.

Remaining blocker:
- [x] ~option to not use camo, depends on #10731, or alternatively, make a script to install camo~ camo now disabled by default
- [x] add create `postgres` user with group `ssl-cert` (there is no `ssl-cert` package on CentOS 7)
- [x] `check-postgres` -- the package exists on CentOS 6 repo, but not CentOS 7, and so has to be compiled from scratch from https://github.com/bucardo/check_postgres
- [ ] Figure out postgresql cache dir on CentOS (not really a blocker)
- [ ] closure-compiler
- [ ] scripts/lib/install