### PR TITLE
Markdown update

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -12,7 +12,7 @@ mypy_extensions==0.4.1
 Jinja2==2.10
 
 # Needed for markdown processing
-Markdown==2.6.11
+Markdown==3.0.1
 MarkupSafe==1.1.0
 Pygments==2.3.1
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -92,7 +92,7 @@ jsondiff==1.1.1           # via moto
 jsonpickle==1.0           # via aws-xray-sdk, python-digitalocean
 lxml==4.3.0
 markdown-include==0.5.1
-markdown==2.6.11
+markdown==3.0.1
 markupsafe==1.1.0
 matrix-client==0.3.2
 mock==2.0.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -66,7 +66,7 @@ jedi==0.13.2              # via ipython
 jinja2==2.10
 lxml==4.3.0
 markdown-include==0.5.1
-markdown==2.6.11
+markdown==3.0.1
 markupsafe==1.1.0
 matrix-client==0.3.2
 mock==2.0.0

--- a/version.py
+++ b/version.py
@@ -11,4 +11,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2018/11/07/zulip-1-9-relea
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '26.22'
+PROVISION_VERSION = '26.23'

--- a/zerver/lib/bugdown/api_code_examples.py
+++ b/zerver/lib/bugdown/api_code_examples.py
@@ -158,4 +158,4 @@ class APICodeExamplesPreprocessor(Preprocessor):
         return fixture
 
 def makeExtension(*args: Any, **kwargs: str) -> APICodeExamplesGenerator:
-    return APICodeExamplesGenerator(kwargs)
+    return APICodeExamplesGenerator(**kwargs)

--- a/zerver/lib/bugdown/fenced_code.py
+++ b/zerver/lib/bugdown/fenced_code.py
@@ -322,7 +322,7 @@ class FencedBlockPreprocessor(markdown.preprocessors.Preprocessor):
         return "\n\n".join(tex_paragraphs)
 
     def placeholder(self, code: str) -> str:
-        return self.markdown.htmlStash.store(code, safe=True)
+        return self.markdown.htmlStash.store(code)
 
     def _escape(self, txt: str) -> str:
         """ basic html escaping """

--- a/zerver/lib/bugdown/nested_code_blocks.py
+++ b/zerver/lib/bugdown/nested_code_blocks.py
@@ -72,4 +72,4 @@ class NestedCodeBlocksRendererTreeProcessor(markdown.treeprocessors.Treeprocesso
                 parent.remove(element_to_replace)
 
 def makeExtension(*args: Any, **kwargs: str) -> NestedCodeBlocksRenderer:
-    return NestedCodeBlocksRenderer(kwargs)
+    return NestedCodeBlocksRenderer(**kwargs)

--- a/zerver/lib/bugdown/tabbed_sections.py
+++ b/zerver/lib/bugdown/tabbed_sections.py
@@ -127,4 +127,4 @@ class TabbedSectionsPreprocessor(Preprocessor):
         return block
 
 def makeExtension(*args: Any, **kwargs: str) -> TabbedSectionsGenerator:
-    return TabbedSectionsGenerator(kwargs)
+    return TabbedSectionsGenerator(**kwargs)


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR updates py-markdown from 2.6.11 to 3.0.1, with the immediate trigger being #11092 PR.

The main roadmap here is to replace the current `LinkPattern` with a rewritten `LinkProcessor` from upstream. If that doesn't look simple, then it would make sense to use the old `LINK_RE` with the existing `LinkPattern` and keep on maintaining that.

**Testing Plan:** <!-- How have you tested? -->

Working towards getting existing tests to pass.
