### PR TITLE
emails: Use ugettext instead of ugettext_lazy in signals

### DIFF
--- a/zerver/signals.py
+++ b/zerver/signals.py
@@ -8,7 +8,7 @@ from django.template import loader
 from django.utils.timezone import \
     get_current_timezone_name as timezone_get_current_timezone_name
 from django.utils.timezone import now as timezone_now
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext as _
 
 from confirmation.models import one_click_unsubscribe_link
 from zerver.lib.queue import queue_json_publish


### PR DESCRIPTION
Using ugettext_lazy would result in printing the strings as arrays.
![local_file](https://user-images.githubusercontent.com/7190633/50304202-59946580-04b5-11e9-9a7a-72d126511bc8.png)
