### PR TITLE
Fix recent regression with mute undo.

### DIFF
--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -52,6 +52,12 @@ exports.notify_with_undo_option = (function () {
 
         var $exit = $("#unmute_muted_topic_notification .exit-me");
 
+        meta.undo = function () {
+            // it should reference the meta variable and not get stuck with
+            // a pass-by-value of stream, topic.
+            exports.unmute(stream_id, topic);
+        };
+
         if (!meta.$mute) {
             meta.$mute = $("#unmute_muted_topic_notification");
 
@@ -62,7 +68,7 @@ exports.notify_with_undo_option = (function () {
             meta.$mute.find("#unmute").click(function () {
                 // it should reference the meta variable and not get stuck with
                 // a pass-by-value of stream, topic.
-                exports.unmute(stream_id, topic);
+                meta.undo();
                 animate.fadeOut();
             });
         }


### PR DESCRIPTION
The undo button was bound to the stream id
and topic for only the first call, when
the click handler was set.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
