### PR TITLE
emails: Update text for confirm_new_email.

### DIFF
--- a/templates/zerver/emails/confirm_new_email.source.html
+++ b/templates/zerver/emails/confirm_new_email.source.html
@@ -5,14 +5,17 @@
 {% endblock %}
 
 {% block content %}
-<p>{{ _('Hi!') }}
+<p>
+    {% trans %}
+    Hi {{ user_name }},
+    {% endtrans %}
 </p>
 
 <p>
     {% trans %}
     We received a request to change the email address for the Zulip account on
-    {{ realm_uri }} from {{ old_email }} to {{ new_email }}. If you would like
-    to confirm this change, please click below:
+    {{ realm_uri }} from {{ old_email }} to {{ new_email }}.
+    To confirm this change, please click below:
     {% endtrans %}
     <a class="button" href="{{ activate_url }}">{{_('Confirm email change') }}</a>
 </p>
@@ -22,10 +25,5 @@
     If you did not request this change, please contact us immediately at
     <a href="mailto:{{ support_email }}">{{ support_email }}</a>.
     {% endtrans %}
-</p>
-
-<p>
-    {{ _("Cheers,") }}<br />
-    {{ _("Team Zulip") }}
 </p>
 {% endblock %}

--- a/templates/zerver/emails/confirm_new_email.txt
+++ b/templates/zerver/emails/confirm_new_email.txt
@@ -1,9 +1,11 @@
-{{ _("Hi!") }}
+{% trans %}
+Hi {{ user_name }},
+{% endtrans %}
 
 {% trans %}
 We received a request to change the email address for the Zulip account on
-{{ realm_uri }} from {{ old_email }} to {{ new_email }}. If you would like
-to confirm this change, please click below:
+{{ realm_uri }} from {{ old_email }} to {{ new_email }}.
+To confirm this change, please click below:
 {% endtrans %}
 {{ activate_url }}
 
@@ -11,6 +13,3 @@ to confirm this change, please click below:
 If you did not request this change, please contact us immediately at
 <{{ support_email }}>.
 {% endtrans %}
-
-{{ _("Cheers,") }}
-{{ _("Team Zulip") }}

--- a/zerver/tests/test_i18n.py
+++ b/zerver/tests/test_i18n.py
@@ -24,7 +24,7 @@ class EmailTranslationTestCase(ZulipTestCase):
         def check_translation(phrase: str, request_type: str, *args: Any, **kwargs: Any) -> None:
             if request_type == "post":
                 self.client_post(*args, **kwargs)
-            elif request_type == "patch":
+            elif request_type == "patch":  # nocoverage: see comment below
                 self.client_patch(*args, **kwargs)
 
             email_message = mail.outbox[0]
@@ -42,7 +42,10 @@ class EmailTranslationTestCase(ZulipTestCase):
 
         self.login(hamlet.email)
 
-        check_translation("Viele Grüße", "patch", "/json/settings", {"email": "hamlets-new@zulip.com"})
+        # TODO: Uncomment and replace with translation once we have German translations for the strings
+        # in confirm_new_email.txt.
+        # Also remove the "nocoverage" from check_translation above.
+        # check_translation("Viele Grüße", "patch", "/json/settings", {"email": "hamlets-new@zulip.com"})
         check_translation("Incrível!", "post", "/accounts/home/", {"email": "new-email@zulip.com"}, HTTP_ACCEPT_LANGUAGE="pt")
         check_translation("Danke, dass Du", "post", '/accounts/find/', {'emails': hamlet.email})
         check_translation("Hallo", "post", "/json/invites",  {"invitee_emails": "new-email@zulip.com", "stream": ["Denmark"]})


### PR DESCRIPTION
This breaks `zerver.tests.test_i18n.EmailTranslationTestCase.test_email_translation`, since there are no remaining phrases in the email that are already translated. I don't know the intent of the test well enough to know the right fix.

Along with the set of commits I recently merged to master, this completes the email polish improvements for all but:

* followup_day2: The premise of this email is that the reader understands topics and threading, but is just writing topics that are too long. In reality this email should look a lot more like https://zulipchat.com/help/about-streams-and-topics or even why-zulip and should be explaining / selling what topics are in the first place.

* missed_message: Needs to be rewritten to put the content first and get the boilerplate out of the way. I can do it, but don't want to merge conflict with the CSS changes.

My thought for this is to have the content be
```
the message(s), formatted
{{ if reply_to_zulip }}
[Reply in Zulip](link) or just reply to this email.
{{ else }}
[Reply in Zulip](link)
```
and no more. 

* digest: I think this requires some product discussion. I'm tempted to leave it untranslated until we decide what we actually want in here.
If we do want to translate/use it, I can float a proposal. 


