### PR TITLE
billing: Fix plan input bug in upgrade

### DIFF
--- a/static/js/billing/billing.js
+++ b/static/js/billing/billing.js
@@ -84,7 +84,11 @@ $(function () {
             locale: 'auto',
             token: function (stripe_token) {
                 function get_form_input(name) {
-                    return JSON.stringify($("#autopay-form input[name='" + name + "']").val());
+                    var input = $("#autopay-form input[name='" + name + "']");
+                    if (input.attr('type') === "radio") {
+                        return JSON.stringify($("#autopay-form input[name='" + name + "']:checked").val());
+                    }
+                    return JSON.stringify(input.val());
                 }
 
                 loading.make_indicator($('#autopay_loading_indicator'),


### PR DESCRIPTION
There is a bug in get_form_input function. get_form_input  always returns the value "annual" for plan . The bug was introduced in #10988