### PR TITLE
Makes it easier to figure out whether the user has clicked on a reaction in night mode

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -59,6 +59,12 @@ body.night-mode {
         color: inherit !important;
     }
 
+    /* this one makes the border of the reactions highlighted on hovering. */
+    .message_reaction:hover,
+    .reaction_button:hover {
+        border-color: white !important;
+    }
+
     /* do not turn the .message_header .stream_label text dark on hover because they're
 on a dark background, and don't change the dark labels dark either. */
     .message_header:not(.dark_background) a.stream_label:not(.dark_background):hover,
@@ -132,6 +138,11 @@ on a dark background, and don't change the dark labels dark either. */
     .message_reactions:hover .message_reaction + .reaction_button {
         background-color: hsla(0, 0%, 0%, 0.5);
         border-color: hsla(0, 0%, 0%, 0.9);
+    }
+
+    /* this one makes the reacted reactions appear differently for the logged in user. */
+    .message_reactions .message_reaction.reacted {
+        background-color: hsl(200, 100%, 25%);
     }
 
     .message_reactions .message_reaction {


### PR DESCRIPTION
**PR Fixes:** #10840 

![forcommit](https://user-images.githubusercontent.com/41135524/50362760-f6770180-058e-11e9-919a-6a72b955b6e8.PNG)

**Also Fixes:**  Earlier on hovering over a reaction in night mode there was no change in its behavior, now they show a white border distinguishing them from the non - hovered ones.