### PR TITLE
poll-widget: Change "Edit question" UI to edit-pencil button.

### DIFF
--- a/static/styles/widgets.scss
+++ b/static/styles/widgets.scss
@@ -105,3 +105,35 @@ button.poll-question:hover {
     color: hsl(1, 45%, 50%);
     font-size: 12px;
 }
+
+.d-none {
+    display: none;
+}
+
+.poll-question-check,
+.poll-question-remove {
+    width: 28px !important;
+    height: 28px;
+    border-radius: 3px;
+    border: 1px solid hsl(0, 0%, 80%);
+    background-color: hsl(0, 0%, 100%);
+}
+
+.poll-question-check:hover,
+.poll-question-remove:hover {
+    border-color: hsl(0, 0%, 60%);
+}
+
+.poll-edit-question {
+    opacity: 0.4;
+    display: inline-block;
+    margin-left: 5px;
+}
+
+.poll-edit-question:hover {
+    opacity: 1.0;
+}
+
+.poll-question-header {
+    display: inline-block;
+}

--- a/static/templates/widgets/poll-widget.handlebars
+++ b/static/templates/widgets/poll-widget.handlebars
@@ -1,10 +1,11 @@
 <div class="poll-widget">
-    <h4 class="poll-question-header"></h4>
+    <h4 class="poll-question-header"></h4><i class="fa fa-pencil poll-edit-question"></i>
     <ul class="poll-widget">
     </ul>
     <div class="poll-question-bar">
         <input type="text" class="poll-question" placeholder="{{t 'Question'}}" />
         <button class="poll-question">{{t "Add question" }}</button>
+        <button class="poll-question-remove d-none"><i class="fa fa-remove"></i></button>
     </div>
     <div class="poll-comment-bar">
         <input type="text" class="poll-comment" placeholder="{{t 'New choice'}}" />


### PR DESCRIPTION
This changes the "Edit question" UI to be just an edit-pencil button
rather than a large "Edit question" button for a poll.
Fixes part of #11010.
**Before:**
![screenshot-2](https://user-images.githubusercontent.com/31144462/50367714-0cdd8700-05a8-11e9-90e3-c662bbd16e52.png)

**After:**
![screenshot-1](https://user-images.githubusercontent.com/31144462/50367731-2ed70980-05a8-11e9-8821-7c6dce5dd733.png)
