### PR TITLE
test-help-documentation: Skips checking external links test.

### DIFF
--- a/tools/ci/backend
+++ b/tools/ci/backend
@@ -21,7 +21,7 @@ set -x
 ./tools/setup/optimize-svg
 # In CI, we only test links we control in test-documentation to avoid flakes
 ./tools/test-documentation --skip-external-links
-./tools/test-help-documentation
+./tools/test-help-documentation --skip-external-links
 ./tools/test-api
 ./tools/test-locked-requirements
 ./tools/test-run-dev

--- a/tools/documentation_crawler/documentation_crawler/commands/crawl_with_status.py
+++ b/tools/documentation_crawler/documentation_crawler/commands/crawl_with_status.py
@@ -11,9 +11,12 @@ class StatusCommand(Command):
             raise UsageError(
                 "running 'scrapy crawl' with more than one spider is no longer supported")
         spname = args[0]
-
+        if len(vars(opts)['spargs']) > 0:
+            skip_external = vars(opts)['spargs']['skip_external']
+        else:
+            skip_external = None
         crawler = self.crawler_process.create_crawler(spname)
-        self.crawler_process.crawl(crawler)
+        self.crawler_process.crawl(crawler, skip_external=skip_external)
         self.crawler_process.start()
         # Get exceptions quantity from crawler stat data
 

--- a/tools/documentation_crawler/documentation_crawler/spiders/common/spiders.py
+++ b/tools/documentation_crawler/documentation_crawler/spiders/common/spiders.py
@@ -87,7 +87,7 @@ class BaseDocumentationSpider(scrapy.Spider):
             elif '#' in link.url:
                 dont_filter = True
                 callback = self.check_permalink
-            if (self.skip_external is not None):   # checks if flag is set to skip external link check.
+            if self.skip_external:
                 if (self._is_external_link(link.url)):
                     continue
             yield Request(link.url, method=method, callback=callback, dont_filter=dont_filter,

--- a/tools/test-documentation
+++ b/tools/test-documentation
@@ -41,27 +41,17 @@ if [ -n "$skip_check_links" ]; then
     exit 0
 fi
 
-if [ -n "$skip_external_links" ]; then
-    color_message 94 "Testing only internal links in documentation..."
-    cd ../tools/documentation_crawler
-    set +e
-    scrapy crawl documentation_crawler -a skip_external=set "${loglevel[@]}"
-    # calling crawl directly as parameter needs to be passed
-    result=$?
-    if [ "$result" = 1 ]; then
-        color_message 91 "Failed!"
-        exit 1
-    else
-        color_message 92 "Passed!"
-        exit 0
-    fi
-fi
-
-color_message 94 "Testing links in documentation..."
-
 cd ../tools/documentation_crawler
 set +e
-scrapy crawl_with_status documentation_crawler "${loglevel[@]}"
+if [ -n "$skip_external_links" ]; then
+    color_message 94 "Testing only internal links in documentation..."
+    scrapy crawl_with_status documentation_crawler -a skip_external=set "${loglevel[@]}"
+    # calling crawl directly as parameter needs to be passed
+else
+    color_message 94 "Testing links in documentation..."
+    scrapy crawl_with_status documentation_crawler "${loglevel[@]}"
+fi
+
 result=$?
 if [ "$result" = 1 ]; then
     color_message 91 "Failed!"

--- a/tools/test-help-documentation
+++ b/tools/test-help-documentation
@@ -3,6 +3,7 @@ import argparse
 import os
 import sys
 import subprocess
+from typing import List
 
 ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -14,6 +15,10 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--force', default=False,
                     action="store_true",
                     help='Run tests despite possible problems.')
+parser.add_argument('--skip-external-links', default=False,
+                    dest="skip_external_link_check",
+                    action="store_true",
+                    help='Skip checking of external links.')
 options = parser.parse_args()
 
 os.chdir(ZULIP_PATH)
@@ -25,13 +30,21 @@ os.makedirs('var/help-documentation', exist_ok=True)
 LOG_FILE = 'var/help-documentation/server.log'
 external_host = "localhost:9981"
 
+extra_args = []  # type: List[str]
+
+if options.skip_external_link_check:
+    extra_args = ['-a', 'skip_external=set']
+
 with test_server_running(options.force, external_host, log_file=LOG_FILE,
                          dots=True, use_db=True):
-    ret_help_doc = subprocess.call(('scrapy', 'crawl_with_status', 'help_documentation_crawler'),
+    ret_help_doc = subprocess.call(['scrapy', 'crawl_with_status'] + extra_args +
+                                   ['help_documentation_crawler'],
                                    cwd='tools/documentation_crawler')
-    ret_api_doc = subprocess.call(('scrapy', 'crawl_with_status', 'api_documentation_crawler'),
+    ret_api_doc = subprocess.call(['scrapy', 'crawl_with_status'] + extra_args +
+                                  ['api_documentation_crawler'],
                                   cwd='tools/documentation_crawler')
-    ret_portico_doc = subprocess.call(('scrapy', 'crawl_with_status', 'portico_documentation_crawler'),
+    ret_portico_doc = subprocess.call(['scrapy', 'crawl_with_status'] + extra_args +
+                                      ['portico_documentation_crawler'],
                                       cwd='tools/documentation_crawler')
 
 if ret_help_doc != 0 or ret_api_doc != 0 or ret_portico_doc != 0:


### PR DESCRIPTION
This option causes test-help-documentation to verify internal links only.
This prevents documentation from flaking in CI due to links from
external websites having failed in the documentation.
**Before:**
![flake_old](https://user-images.githubusercontent.com/30312566/50374343-a5105600-0612-11e9-9418-99838564f049.png)

**After:**
![flake_new](https://user-images.githubusercontent.com/30312566/50374332-72665d80-0612-11e9-9518-260c28ce2f89.png)
Based on conversation: https://chat.zulip.org/#narrow/stream/43-automated-testing/subject/quora.20404/near/674997