### PR TITLE
[WIP] Check redis server status before backend tests (for issue #11079).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,12 +137,12 @@ jobs:
 
       - *create_cache_directories
 
-      - run:
-          name: do Bionic hack
-          command: |
-              # Temporary hack till `sudo service redis-server start` gets fixes in Bionic. See
-              # https://chat.zulip.org/#narrow/stream/3-backend/topic/Ubuntu.20bionic.20CircleCI
-              redis-server --daemonize yes
+      # - run:
+      #     name: do Bionic hack
+      #     command: |
+      #         # Temporary hack till `sudo service redis-server start` gets fixes in Bionic. See
+      #         # https://chat.zulip.org/#narrow/stream/3-backend/topic/Ubuntu.20bionic.20CircleCI
+      #         redis-server --daemonize yes
 
       - *restore_cache_package_json
       - *restore_cache_requirements
@@ -156,6 +156,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - "trusty-python-3.4"
-      - "xenial-python-3.5"
+      #- "trusty-python-3.4"
+      #- "xenial-python-3.5"
       - "bionic-python-3.6"

--- a/tools/restart-redis
+++ b/tools/restart-redis
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+sudo service redis-server restart

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -211,7 +211,7 @@ def check_redis_status():
 
 if __name__ == "__main__":
     block_internet()
-    check_redis_status()
+    # check_redis_status()
 
     TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
     os.chdir(os.path.dirname(TOOLS_DIR))

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -11,6 +11,8 @@ import ujson
 import httplib2
 import httpretty
 import requests
+import redis
+import time
 
 # check for the venv
 from lib import sanity_check
@@ -184,8 +186,33 @@ def block_internet():
                         "https://zulip.readthedocs.io/en/latest/testing/testing.html#internet-access-inside-test-suites")
     httplib2.Http.request = internet_guard_httplib2
 
+def check_redis_status():
+    # type: () -> None
+    # This is to start redis up if it ever crashes during CircleCI tests.
+    attempts = 0
+    redis_server = redis.Redis()  # during testing redis runs on localhost:6379
+    try:
+        running_status = redis_server.ping()
+    except redis.exceptions.ConnectionError:
+        running_status = False
+    while not running_status:
+        try:
+            attempts += 1
+            running_status = redis_server.ping()
+        except redis.exceptions.ConnectionError:
+            if attempts < 10:
+                print("Unable to connect to the redis server. Trying to restart...")
+                os.system(os.path.join(os.path.dirname(os.path.abspath(__file__)), "restart-redis"))
+                time.sleep(1)
+            else:
+                print("Unable to connect to the redis server. Please check the /var/log/redis directory for some hints.")
+                sys.exit(1)
+    print("Redis server running.")
+
 if __name__ == "__main__":
     block_internet()
+    check_redis_status()
+
     TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
     os.chdir(os.path.dirname(TOOLS_DIR))
     sys.path.insert(0, os.path.dirname(TOOLS_DIR))


### PR DESCRIPTION
This is my admittedly unrefined approach to try to fix the Redis issue that we've been facing on the CircleCI tests on Ubuntu bionic. This is currently a WIP, and I would like some advice on how to progress from this point onward.

The shell script I used for restarting the redis server is something that seriously bothers me (especially since I had to use "sudo") and I'd really appreciate advice on better alternatives.

Finally, as far as testing is concerned, I've done some manual testing but I haven't added any automated tests. I'm not exactly sure on how to test the changes made to the tests automatically.