### PR TITLE
FacebookOAuth2 Integration

### DIFF
--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -29,6 +29,7 @@ authentication providers:
 * Google accounts, with `GoogleMobileOauth2Backend`
 * GitHub accounts, with `GitHubAuthBackend`
 * Microsoft Azure Active Directory, with `AzureADAuthBackend`
+* Facebook Oauth2, with `FacebookAuthBackend`
 
 Each of these requires one to a handful of lines of configuration in
 `settings.py`, as well as a secret in `zulip-secrets.conf`.  Details

--- a/static/styles/portico-signin.scss
+++ b/static/styles/portico-signin.scss
@@ -635,6 +635,14 @@ button.login-google-button {
     transform: translateX(15px) translateY(13px);
 }
 
+.facebook-wrapper::before {
+    content:"\F230";
+    position:absolute;
+    font-family:"FontAwesome";
+    font-size:2rem;color:#3b5998;
+    transform: translateX(15px) translateY(13px);
+}
+
 .azure-wrapper::before {
     content: "\f17a";
     position: absolute;

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -165,6 +165,18 @@
                             </div>
                             {% endif %}
 
+                            
+                            {% if facebook_auth_enabled %}
+                            <div class="login-social">
+                                <form id='social_login_form' class="form-inline facebook-wrapper" action="{{ url('login-social', args=('facebook',)) }}" method="get">
+                                    <input type="hidden" name="next" value="{{ next }}">
+                                    <button class="login-social-button">
+                                        {{ _('Log in with %(identity_provider)s', identity_provider="Facebook") }}
+                                    </button>
+                                </form>
+                            </div>
+                            {% endif %}
+
                             <div class="actions">
                                 {% if email_auth_enabled %}
                                 <a class="forgot-password" href="/accounts/password/reset/">{{ _('Forgot your password?') }}</a>

--- a/zerver/migrations/0197_azure_active_directory_auth.py
+++ b/zerver/migrations/0197_azure_active_directory_auth.py
@@ -16,6 +16,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='realm',
             name='authentication_methods',
-            field=bitfield.models.BitField(['Google', 'Email', 'GitHub', 'LDAP', 'Dev', 'RemoteUser', 'AzureAD'], default=2147483647),
+            field=bitfield.models.BitField(['Google', 'Email', 'GitHub', 'LDAP', 'Dev', 'RemoteUser', 'AzureAD', 'Facebook'], default=2147483647),
         ),
     ]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -145,7 +145,7 @@ class Realm(models.Model):
     INVITES_STANDARD_REALM_DAILY_MAX = 3000
     MESSAGE_VISIBILITY_LIMITED = 10000
     VIDEO_CHAT_PROVIDERS = [u"Jitsi", u"Google Hangouts"]
-    AUTHENTICATION_FLAGS = [u'Google', u'Email', u'GitHub', u'LDAP', u'Dev', u'RemoteUser', u'AzureAD']
+    AUTHENTICATION_FLAGS = [u'Google', u'Email', u'GitHub', u'LDAP', u'Dev', u'RemoteUser', u'AzureAD', u'Facebook']
     SUBDOMAIN_FOR_ROOT_DOMAIN = ''
 
     # User-visible display name and description used on e.g. the organization homepage

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -319,6 +319,10 @@ def start_social_login(request: HttpRequest, backend: str) -> HttpResponse:
     if (backend == "github") and not (settings.SOCIAL_AUTH_GITHUB_KEY and
                                       settings.SOCIAL_AUTH_GITHUB_SECRET):
         return redirect_to_config_error("github")
+
+    if (backend == "facebook") and not (settings.SOCIAL_AUTH_GITHUB_KEY and
+                                      settings.SOCIAL_AUTH_GITHUB_SECRET):
+        return redirect_to_config_error("facebook")
     # TODO: Add a similar block of AzureAD.
 
     return oauth_redirect_to_root(request, backend_url, 'social')

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -12,6 +12,7 @@ from requests import HTTPError
 from social_core.backends.github import GithubOAuth2, GithubOrganizationOAuth2, \
     GithubTeamOAuth2
 from social_core.backends.azuread import AzureADOAuth2
+from social_core.backends.facebook import FacebookOAuth2
 from social_core.backends.base import BaseAuth
 from social_core.backends.oauth import BaseOAuth2
 from social_core.utils import handle_http_errors
@@ -645,6 +646,10 @@ class GitHubAuthBackend(SocialAuthMixin, GithubOAuth2):
 
 class AzureADAuthBackend(SocialAuthMixin, AzureADOAuth2):
     auth_backend_name = "AzureAD"
+
+class FacebookAuthBackend(SocialAuthMixin, FacebookOAuth2):
+    auth_backend_name = "Facebook"
+    REDIRECT_STATE = False
 
 AUTH_BACKEND_NAME_MAP = {
     'Dev': DevAuthBackend,

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -40,6 +40,7 @@ AUTHENTICATION_BACKENDS = (
     'zproject.backends.GitHubAuthBackend',
     'zproject.backends.GoogleMobileOauth2Backend',
     # 'zproject.backends.AzureADAuthBackend',
+    # 'zproject.backends.FacebookAuthBackend',
 )
 
 EXTERNAL_URI_SCHEME = "http://"

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -115,6 +115,7 @@ AUTHENTICATION_BACKENDS = (
     # 'zproject.backends.GoogleMobileOauth2Backend',  # Google Apps, setup below
     # 'zproject.backends.GitHubAuthBackend',  # GitHub auth, setup below
     # 'zproject.backends.AzureADAuthBackend',  # Microsoft Azure Active Directory auth, setup below
+    # 'zproject.backends.FacebookAuthBackend',  # Facebook auth, setup below
     # 'zproject.backends.ZulipLDAPAuthBackend',  # LDAP, setup below
     # 'zproject.backends.ZulipRemoteUserBackend',  # Local SSO, setup docs on readthedocs
 )
@@ -196,6 +197,26 @@ AUTHENTICATION_BACKENDS = (
 # (2) Enter the application ID for the app as SOCIAL_AUTH_AZUREAD_OAUTH2_KEY here
 # (3) Put the application password in zulip-secrets.conf as 'azure_oauth2_secret'.
 #SOCIAL_AUTH_AZUREAD_OAUTH2_KEY = ''
+
+
+# Facebook Active Directory OAuth.
+#
+# To set up Facebook, you'll need to do the following:
+#
+# (1) Register an OAuth2 application with Facebook at:
+# https://developers.facebook.com/
+# Generate a new key under Application Secrets
+# For the login application, supply authentic information about firm. 
+# For Redirect URL, enter:
+#   https://zulip.example.com/complete/facebook/
+# (2) Publish Application.
+# (3) Enter the application ID for the app as SOCIAL_AUTH_FACEBOOK_OAUTH2_KEY here
+# (4) Put the application password in zulip-secrets.conf as 'facebook_secret'.
+# Uncomment from here if you wish to enable facebook auth:
+
+#SOCIAL_AUTH_FACEBOOK_OAUTH2_KEY = ''
+
+
 
 ########
 # SSO via REMOTE_USER.

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -160,6 +160,15 @@ DEFAULT_SETTINGS = {
     'SOCIAL_AUTH_GITHUB_TEAM_ID': None,
     'SOCIAL_AUTH_SUBDOMAIN': None,
     'SOCIAL_AUTH_AZUREAD_OAUTH2_SECRET': get_secret('azure_oauth2_secret'),
+    'SOCIAL_AUTH_FACEBOOK_SECRET': get_secret('facebook_secret'),
+
+    #Facebook OAuth Settings, for developers who would like specific API version/define scope
+    SOCIAL_AUTH_FACEBOOK_API_VERSION = '3.2'
+    SOCIAL_AUTH_FACEBOOK_APP_NAMESPACE = ''
+    SOCIAL_AUTH_FACEBOOK_SCOPE = ['email']
+    SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS = {
+    'fields': 'id,name,email', 
+    }
 
     # Email gateway
     'EMAIL_GATEWAY_PATTERN': '',


### PR DESCRIPTION
Facebook Oauth2 integration using the mixin wrapper.

Needs a bit more parameters than other auth methods in settings.py. Needs HTTPS for successful login.
