### PR TITLE
Scroll feed immediately when expanding the compose box.

### DIFF
--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -164,7 +164,7 @@ exports.maybe_scroll_up_selected_message = function () {
     var cover = selected_row.offset().top + selected_row.height()
         - $("#compose").offset().top;
     if (cover > 0) {
-        message_viewport.user_initiated_animate_scroll(cover + 20);
+        message_viewport.scroll_message_feed(cover + 20);
     }
 };
 

--- a/static/js/message_viewport.js
+++ b/static/js/message_viewport.js
@@ -267,15 +267,12 @@ exports.system_initiated_animate_scroll = function (scroll_amount) {
     });
 };
 
-exports.user_initiated_animate_scroll = function (scroll_amount) {
+exports.scroll_message_feed = function (scroll_amount) {
     pointer.suppress_scroll_pointer_update = true; // Gets set to false in the scroll handler.
-    in_stoppable_autoscroll = false; // defensive
 
     var viewport_offset = exports.scrollTop();
 
-    exports.message_pane.animate({
-        scrollTop: viewport_offset + scroll_amount,
-    });
+    exports.message_pane.scrollTop(viewport_offset + scroll_amount);
 };
 
 exports.recenter_view = function (message, opts) {


### PR DESCRIPTION
The previous animation effect just made the app feel
sluggish.

This was moved from #10490.