### PR TITLE
docs: Add nginx restart reference.

### DIFF
--- a/docs/production/ssl-certificates.md
+++ b/docs/production/ssl-certificates.md
@@ -125,3 +125,9 @@ sudo -s  # If not already root
 ```
 where HOSTNAME is the domain name (or IP address) to use on the
 generated certificate.
+
+If you replace the certificates, you need to restart nginx. In order
+to do that, run the following command:
+```
+service nginx restart
+```


### PR DESCRIPTION
This adds reference for restarting nginx when
the certificates are replaced so that the server
works with the new certificates instead of the
old ones.

Fixes: #4849.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
