### PR TITLE
Fixes #11137 Constraint maxlength added to edit message

### DIFF
--- a/static/templates/message_edit_form.handlebars
+++ b/static/templates/message_edit_form.handlebars
@@ -24,7 +24,7 @@
                     <path fill="#777" d="M128 768h256v64H128v-64z m320-384H128v64h320v-64z m128 192V448L384 640l192 192V704h320V576H576z m-288-64H128v64h160v-64zM128 704h160v-64H128v64z m576 64h64v128c-1 18-7 33-19 45s-27 18-45 19H64c-35 0-64-29-64-64V192c0-35 29-64 64-64h192C256 57 313 0 384 0s128 57 128 128h192c35 0 64 29 64 64v320h-64V320H64v576h640V768zM128 256h512c0-35-29-64-64-64h-64c-35 0-64-29-64-64s-29-64-64-64-64 29-64 64-29 64-64 64h-64c-35 0-64 29-64 64z" />
                 </svg>
             </button>
-            <textarea class="message_edit_content" id="message_edit_content_{{message_id}}">{{content}}</textarea>
+            <textarea class="message_edit_content" maxlength="10000" id="message_edit_content_{{message_id}}">{{content}}</textarea>
         </div>
     </div>
     <div class="control-group action-buttons">


### PR DESCRIPTION
Fixes #11137 

**Testing Plan:** Tested manually


**GIFs or Screenshots:** 
![constraint_bug_fixed](https://user-images.githubusercontent.com/41135524/50540792-8126b480-0bbe-11e9-8379-d7e969c8f051.gif)
