### PR TITLE
notifications: Fix styling for sending group PM to several people

### DIFF
--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -288,7 +288,7 @@ div[id^="message-edit-send-status"],
 }
 
 .compose-notifications-content {
-    padding: 4px 10px 4px 10px;
+    padding: 4px 22px 4px 22px;
     text-align: center;
 }
 
@@ -298,7 +298,7 @@ div[id^="message-edit-send-status"],
 
 #out-of-view-notification .close {
     position: absolute;
-    right: 14px;
+    right: 8px;
     top: 4px;
     font-size: 17px;
     font-weight: bold;


### PR DESCRIPTION
Fixes #11058.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes styling for sending group PMs to several people out-of-view.



**GIFs or Screenshots:** 
![screenshot from 2018-12-30 00-15-41](https://user-images.githubusercontent.com/5001704/50541285-488bd880-0bc8-11e9-9ec0-88b3bfd4a40a.png)
![screenshot from 2018-12-30 00-15-51](https://user-images.githubusercontent.com/5001704/50541286-488bd880-0bc8-11e9-8eb8-c19d21728a87.png)
![screenshot from 2018-12-30 00-16-01](https://user-images.githubusercontent.com/5001704/50541287-49246f00-0bc8-11e9-9fce-9644dc5049cb.png)
