### PR TITLE
Hide the message control icons when we are in message edit or view source mode

### DIFF
--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -293,13 +293,13 @@ exports.MessageList.prototype = {
 
     show_edit_message: function MessageList_show_edit_message(row, edit_obj) {
         row.find(".message_edit_form").empty().append(edit_obj.form);
-        row.find(".message_content, .status-message").hide();
+        row.find(".message_content, .status-message, .message_controls").hide();
         row.find(".message_edit").css("display", "block");
         row.find(".message_edit_content").autosize();
     },
 
     hide_edit_message: function MessageList_hide_edit_message(row) {
-        row.find(".message_content, .status-message").show();
+        row.find(".message_content, .status-message, .message_controls").show();
         row.find(".message_edit").hide();
         row.trigger("mouseleave");
     },


### PR DESCRIPTION
Fixes #3802.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/3802#issuecomment-304733440
View Source icon misbehaves for the message source being viewed. So the proposal is to hide the 3 message control icons when the message is being edited or source being viewed.


**GIFs or Screenshots:** 
![screenshot from 2018-12-30 00-57-06](https://user-images.githubusercontent.com/5001704/50541534-e59d4000-0bcd-11e9-96eb-5dd4b15baeb0.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
