### PR TITLE
Add guest avatar markers to the Zulip user interface.

### DIFF
--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -44,6 +44,7 @@ var alice = {
     email: 'alice@example.com',
     full_name: 'Alice Smith',
     user_id: 42,
+    is_guest: false,
 };
 
 var me = {
@@ -136,6 +137,7 @@ run_test('sender_hover', () => {
         case 'user_info_popover_title':
             assert.deepEqual(opts, {
                 user_avatar: 'avatar/alice@example.com',
+                user_is_guest: false,
             });
             return 'title-html';
 

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -141,7 +141,8 @@ function render_user_info_popover(user, popover_element, is_sender_popover, priv
         placement: popover_placement,
         template: templates.render('user_info_popover', {class: template_class}),
         title: templates.render('user_info_popover_title',
-                                {user_avatar: "avatar/" + user.email}),
+                                {user_avatar: "avatar/" + user.email,
+                                 user_is_guest: user.is_guest}),
         trigger: "manual",
     });
     popover_element.popover("show");

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -266,6 +266,7 @@ exports.show_user_profile = function (user) {
         last_seen: user_last_seen_time_status(user.user_id),
         user_time: people.get_user_time(user.user_id),
         user_type: people.get_user_type(user.user_id),
+        user_is_guest: user.is_guest,
     };
 
     $("#user-profile-modal-holder").html(templates.render("user_profile_modal", args));

--- a/static/js/user_events.js
+++ b/static/js/user_events.js
@@ -78,7 +78,7 @@ exports.update_person = function update(person) {
             page_params.avatar_source = person.avatar_source;
             page_params.avatar_url = url;
             page_params.avatar_url_medium = person.avatar_url_medium;
-            $("#user-avatar-block").attr("src", person.avatar_url_medium);
+            $("#user-avatar-block").attr("style", "background-image:url(" + person.avatar_url_medium + ")");
         }
 
         message_live_update.update_avatar(person_obj.user_id, person.avatar_url);

--- a/static/styles/app_components.scss
+++ b/static/styles/app_components.scss
@@ -345,3 +345,24 @@
     background-color: hsl(0, 0%, 100%);
     border: 1px solid hsl(0, 0%, 87%);
 }
+
+.guest-avatar {
+    position: relative;
+    background-size: 100%;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+
+    &::after {
+        content: " ";
+        background-color: hsl(0, 0%, 47%);
+        position: absolute;
+        bottom: -30%;
+        right: -30%;
+        width: 50%;
+        height: 50%;
+        -webkit-transform: rotate(45deg);
+        -moz-transform: rotate(45deg);
+        transform: rotate(45deg);
+    }
+}

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -172,6 +172,10 @@ ul.remind_me_popover .remind_icon {
         border-radius: 5px;
         margin-right: 10px;
         border: 1px solid hsla(0, 0%, 0%, 0.2);
+
+        &.guest-avatar::after {
+            outline: 9px solid hsl(0, 0%, 100%);
+        }
     }
 
     #default-section {

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -150,6 +150,10 @@ ul.remind_me_popover .remind_icon {
     background-size: cover;
     background-position: center;
     position: relative;
+
+    &.guest-avatar::after {
+        outline: 10px solid hsl(0, 0%, 100%);
+    }
 }
 
 #user-profile-modal {

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1058,6 +1058,15 @@ input[type=checkbox].inline-block {
     height: 200px;
 
     transition: all 0.3s ease;
+
+    #user-avatar-block {
+        background-size: 100%;
+        height: 100%;
+    }
+
+    .guest-avatar::after {
+        outline: 9px solid hsl(0, 0%, 100%);
+    }
 }
 
 #user-settings-avatar:hover #user-avatar-block {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1545,6 +1545,10 @@ blockquote p {
     vertical-align: top;
     border-radius: 4px;
     overflow: hidden;
+
+    &.guest-avatar::after {
+        outline: 2px solid hsl(0, 0%, 100%);
+    }
 }
 
 .home-error-bar {

--- a/static/templates/settings/account-settings.handlebars
+++ b/static/templates/settings/account-settings.handlebars
@@ -160,7 +160,7 @@
 
             <div class="inline-block">
                 <div id="user-settings-avatar">
-                    <img id="user-avatar-block" src="{{ page_params.avatar_url_medium }}" />
+                    <div id="user-avatar-block" style="background-image: url({{ page_params.avatar_url_medium }})" {{#if page_params.is_guest}} class="guest-avatar"{{/if}}/>
                     <div id="user-avatar-source">
                         <a href="https://en.gravatar.com/" target="_blank" class="white-color">{{t "Avatar from Gravatar" }}</a>
                     </div>

--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -10,8 +10,8 @@
                     <span class="message_sender{{^status_message}} sender_info_hover{{/status_message}} no-select">
                         {{#include_sender}}
                             {{! See ../js/notifications.js for another user of avatar_url. }}
-                            <div class="u-{{msg/sender_id}} inline_profile_picture{{#status_message}} sender_info_hover{{/status_message}}" aria-hidden="true">
-                                <img src="{{small_avatar_url}}" alt="" class="no-drag{{#if sender_is_guest}} guest_user_avatar{{/if}}"/>
+                            <div class="u-{{msg/sender_id}} inline_profile_picture{{#status_message}} sender_info_hover{{/status_message}}{{#sender_is_guest}} guest-avatar{{/sender_is_guest}}" aria-hidden="true">
+                                <img src="{{small_avatar_url}}" alt="" class="no-drag"/>
                             </div>
                             {{#if status_message}}
                                 <span class="sender-status">

--- a/static/templates/user_info_popover_title.handlebars
+++ b/static/templates/user_info_popover_title.handlebars
@@ -1,2 +1,2 @@
-<div class="popover-avatar" style="background-image: url('{{user_avatar}}');" >
+<div class="popover-avatar{{#if user_is_guest}} guest-avatar{{/if}}" style="background-image: url('{{user_avatar}}');" >
 </div>

--- a/static/templates/user_profile_modal.handlebars
+++ b/static/templates/user_profile_modal.handlebars
@@ -4,7 +4,7 @@
         <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}">
             <span aria-hidden="true" id="exit-sign">&times;</span>
         </button>
-        <div id="avatar" style="background-image: url('{{user_avatar}}');" ></div>
+        <div id="avatar"{{#if user_is_guest}} class="guest-avatar"{{/if}} style="background-image: url('{{user_avatar}}');" ></div>
         <div id="default-section">
             <div id="name">
                 {{full_name}}


### PR DESCRIPTION
![screenshot at dec 29 16-32-07](https://user-images.githubusercontent.com/15116870/50543419-2d4fa780-0b8d-11e9-949f-480399305bd2.png)
![screenshot at dec 29 16-32-25](https://user-images.githubusercontent.com/15116870/50543420-2d4fa780-0b8d-11e9-8527-c622552af36d.png)
![screenshot at dec 29 16-32-37](https://user-images.githubusercontent.com/15116870/50543421-2d4fa780-0b8d-11e9-8817-29e410903151.png)
![screenshot at dec 29 16-32-49](https://user-images.githubusercontent.com/15116870/50543422-2de83e00-0b8d-11e9-9884-b6cd09812fd7.png)

Fixes #10754.

---
If I've missed any locations where avatars are displayed, let me know! 

Note: Outlines only accept specifications in pixels, and thus they have to be manually applied to each guest avatar element.