### PR TITLE
[WIP] markdown: Reduce mentions inside blockquotes to be cosmetic only.

### DIFF
--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -304,6 +304,8 @@ run_test('marked', () => {
          expected: '<p>\u{1f6b2}</p>' },
         {input: 'Silent mention: _@**Cordelia Lear**',
          expected: '<p>Silent mention: <span class="user-mention silent" data-user-id="101">@Cordelia Lear</span></p>'},
+        {input: '> Mention in quote: @**Cordelia Lear**\n\nMention outside quote: @**Cordelia Lear**',
+         expected: '<blockquote>\n<p>Mention in quote: <span class="user-mention silent" data-user-id="101">@Cordelia Lear</span></p>\n</blockquote>\n<p>Mention outside quote: <span class="user-mention" data-user-id="101">@Cordelia Lear</span></p>'},
         // Test only those realm filters which don't return True for
         // `contains_backend_only_syntax()`. Those which return True
         // are tested separately.

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -302,6 +302,8 @@ run_test('marked', () => {
          expected: '<p><span class="emoji emoji-1f4a9" title="poop">:poop:</span></p>'},
         {input: '\u{1f6b2}',
          expected: '<p>\u{1f6b2}</p>' },
+        {input: 'Silent mention: _@**Cordelia Lear**',
+         expected: '<p>Silent mention: <span class="user-mention silent" data-user-id="101">@Cordelia Lear</span></p>'},
         // Test only those realm filters which don't return True for
         // `contains_backend_only_syntax()`. Those which return True
         // are tested separately.

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -59,7 +59,7 @@ exports.apply_markdown = function (message) {
 
     // Our python-markdown processor appends two \n\n to input
     var options = {
-        userMentionHandler: function (name) {
+        userMentionHandler: function (name, silently) {
             var person = people.get_by_name(name);
 
             var id_regex = /(.+)\|(\d+)$/g; // For @**user|id** syntax
@@ -74,13 +74,17 @@ exports.apply_markdown = function (message) {
             }
 
             if (person !== undefined) {
-                if (people.is_my_user_id(person.user_id)) {
+                if (people.is_my_user_id(person.user_id) && !silently) {
                     message.mentioned = true;
                     message.mentioned_me_directly = true;
                 }
-                return '<span class="user-mention" data-user-id="' + person.user_id + '">' +
-                       '@' + escape(person.full_name, true) +
-                       '</span>';
+                var str = '';
+                if (silently) {
+                    str += '<span class="user-mention silent" data-user-id="' + person.user_id + '">';
+                } else {
+                    str += '<span class="user-mention" data-user-id="' + person.user_id + '">';
+                }
+                return str + '@' + escape(person.full_name, true) + '</span>';
             } else if (name === 'all' || name === 'everyone' || name === 'stream') {
                 message.mentioned = true;
                 return '<span class="user-mention" data-user-id="*">' +

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -105,6 +105,20 @@ exports.apply_markdown = function (message) {
             }
             return;
         },
+        silencedMentionHandler: function (quote) {
+            // Silence quoted mentions.
+            var user_mention_re = /<span.*user-mention.*data-user-id="(\d+|\*)"[^>]*>/gm;
+            quote = quote.replace(user_mention_re, function (match) {
+                return match.replace(/"user-mention"/g, '"user-mention silent"');
+            });
+            // In most cases, if you are being mentioned in the message you're quoting, you wouldn't
+            // mention yourself outside of the blockquote (and, above it). If that you do that, the
+            // following mentioned status is false; the backend rendering is authoritative and the
+            // only side effect is the lack red flash on immediately sending the message.
+            message.mentioned = false;
+            message.mentioned_me_directly = false;
+            return quote;
+        },
     };
     message.content = marked(message.raw_content + '\n\n', options).trim();
     message.is_me_message = exports.is_status_message(message.raw_content, message.content);

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -369,7 +369,7 @@ on a dark background, and don't change the dark labels dark either. */
         box-shadow: 0px 0px 0px 1px hsla(0, 0%, 0%, 0.4);
     }
 
-    .user-mention-me {
+    .user-mention-me :not(.silent) {
         background-color: hsla(355, 37%, 31%, 1);
         box-shadow: 0px 0px 0px 1px hsla(330, 40%, 20%, 1);
     }

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2780,7 +2780,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
     margin-bottom: 1px;
 }
 
-.user-mention-me {
+.user-mention-me :not(.silent) {
     background-color: hsl(112, 88%, 87%);
 }
 

--- a/static/third/marked/lib/marked.js
+++ b/static/third/marked/lib/marked.js
@@ -516,7 +516,7 @@ inline.zulip = merge({}, inline.breaks, {
                        '\ud83d[\ude80-\udeff]|\ud83e[\udd00-\uddff]|' +
                        '[\u2000-\u206F]|[\u2300-\u27BF]|[\u2B00-\u2BFF]|' +
                        '[\u3000-\u303F]|[\u3200-\u32FF])'),
-  usermention: /^(@(?:\*\*([^\*]+)\*\*))/, // Match potentially multi-word string between @** **
+  usermention: /^((_?)@(?:\*\*([^\*]+)\*\*))/, // Match potentially multi-word string between @** **
   groupmention: /^@\*([^\*]+)\*/, // Match multi-word string between @* *
   stream: /^#\*\*([^\*]+)\*\*/,
   avatar: /^!avatar\(([^)]+)\)/,
@@ -708,7 +708,7 @@ InlineLexer.prototype.output = function(src) {
     // usermention (zulip)
     if (cap = this.rules.usermention.exec(src)) {
       src = src.substring(cap[0].length);
-      out += this.usermention(cap[2] || cap[3], cap[1]);
+      out += this.usermention(cap[3] || cap[4], cap[1], cap[2]);
       continue;
     }
 
@@ -870,14 +870,13 @@ InlineLexer.prototype.realm_filter = function (filter, matches, orig) {
   return this.options.realmFilterHandler(filter, matches);
 };
 
-InlineLexer.prototype.usermention = function (username, orig) {
+InlineLexer.prototype.usermention = function (username, orig, silent) {
   orig = escape(orig);
   if (typeof this.options.userMentionHandler !== 'function')
   {
     return orig;
   }
-
-  var handled = this.options.userMentionHandler(username);
+  var handled = this.options.userMentionHandler(username, silent === '_');
   if (handled !== undefined) {
     return handled;
   }

--- a/static/third/marked/lib/marked.js
+++ b/static/third/marked/lib/marked.js
@@ -988,6 +988,7 @@ Renderer.prototype.code = function(code, lang, escaped) {
 };
 
 Renderer.prototype.blockquote = function(quote) {
+  quote = this.options.silencedMentionHandler(quote);
   return '<blockquote>\n' + quote + '</blockquote>\n';
 };
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -252,8 +252,8 @@ def send_signup_message(sender: UserProfile, admin_realm_signup_notifications_st
             "stream",
             signup_notifications_stream.name,
             "signups",
-            "%s (%s) just signed up for Zulip. (total: %i)" % (
-                user_profile.full_name, user_profile.email, user_count
+            "_@**%s|%s** just signed up for Zulip. (total: %i)" % (
+                user_profile.full_name, user_profile.id, user_count
             )
         )
 
@@ -3350,7 +3350,9 @@ def do_rename_stream(stream: Stream,
         sender,
         new_name,
         "welcome",
-        "@**%s** renamed stream **%s** to **%s**" % (user_profile.full_name, old_name, new_name)
+        "_@**%s|%d** renamed stream **%s** to **%s**" % (user_profile.full_name,
+                                                         user_profile.id,
+                                                         old_name, new_name)
     )
     # Even though the token doesn't change, the web client needs to update the
     # email forwarding address to display the correctly-escaped new name.

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1318,6 +1318,31 @@ class ListIndentProcessor(markdown.blockprocessors.ListIndentProcessor):
         super().__init__(parser)
         parser.markdown.tab_length = 4
 
+class BlockQuoteProcessor(markdown.blockprocessors.BlockQuoteProcessor):
+    """ Process BlockQuotes.
+
+        Based on markdown.blockprocessors.BlockQuoteProcessor, but with 2-space indent
+    """
+
+    # Original regex for blockquote is RE = re.compile(r'(^|\n)[ ]{0,3}>[ ]?(.*)')
+    RE = re.compile(r'(^|\n)(?!(?:[ ]{0,3}>\s*(?:$|\n))*(?:$|\n))'
+                    r'[ ]{0,3}>[ ]?(.*)')
+
+    def clean(self, line: str) -> str:
+        # HACK: Silence all the mentions inside blockquotes while
+        # we also remove the '>' from beginning of each line.
+
+        mention_re = re.compile(mention.find_mentions)
+        line = re.sub(mention_re, lambda m: "_@{}".format(m.group('match')), line)
+
+        m = self.RE.match(line)
+        if line.strip() == ">":
+            return ""
+        elif m:
+            return m.group(2)
+        else:
+            return line
+
 class BugdownUListPreprocessor(markdown.preprocessors.Preprocessor):
     """ Allows unordered list blocks that come directly after a
         paragraph to be rendered as an unordered list
@@ -1713,16 +1738,12 @@ class Bugdown(markdown.Extension):
             '>strong')
 
     def extend_block_formatting(self, md: markdown.Markdown) -> None:
-        for k in ('hashheader', 'setextheader', 'olist', 'ulist', 'indent'):
+        for k in ('hashheader', 'setextheader', 'olist', 'ulist', 'indent', 'quote'):
             del md.parser.blockprocessors[k]
 
         md.parser.blockprocessors.add('ulist', UListProcessor(md.parser), '>hr')
         md.parser.blockprocessors.add('indent', ListIndentProcessor(md.parser), '<ulist')
-
-        # Original regex for blockquote is RE = re.compile(r'(^|\n)[ ]{0,3}>[ ]?(.*)')
-        md.parser.blockprocessors['quote'].RE = re.compile(
-            r'(^|\n)(?!(?:[ ]{0,3}>\s*(?:$|\n))*(?:$|\n))'
-            r'[ ]{0,3}>[ ]?(.*)')
+        md.parser.blockprocessors.add('quote', BlockQuoteProcessor(md.parser), '<ulist')
 
     def extend_avatars(self, md: markdown.Markdown) -> None:
         # Note that !gravatar syntax should be deprecated long term.

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1481,7 +1481,8 @@ class RealmFilterPattern(markdown.inlinepatterns.Pattern):
 
 class UserMentionPattern(markdown.inlinepatterns.Pattern):
     def handleMatch(self, m: Match[str]) -> Optional[Element]:
-        match = m.group(2)
+        match = m.group('match')
+        silent = m.group('silent') == '_'
 
         db_data = self.markdown.zulip_db_data
         if self.markdown.zulip_message and db_data is not None:
@@ -1503,7 +1504,8 @@ class UserMentionPattern(markdown.inlinepatterns.Pattern):
                 self.markdown.zulip_message.mentions_wildcard = True
                 user_id = "*"
             elif user:
-                self.markdown.zulip_message.mentions_user_ids.add(user['id'])
+                if not silent:
+                    self.markdown.zulip_message.mentions_user_ids.add(user['id'])
                 name = user['full_name']
                 user_id = str(user['id'])
             else:
@@ -1511,8 +1513,11 @@ class UserMentionPattern(markdown.inlinepatterns.Pattern):
                 return None
 
             el = markdown.util.etree.Element("span")
-            el.set('class', 'user-mention')
             el.set('data-user-id', user_id)
+            if silent:
+                el.set('class', 'user-mention silent')
+            else:
+                el.set('class', 'user-mention')
             el.text = "@%s" % (name,)
             return el
         return None

--- a/zerver/lib/mention.py
+++ b/zerver/lib/mention.py
@@ -1,11 +1,11 @@
 
-from typing import Optional, Set
+from typing import Optional, Set, Tuple
 
 import re
 
 # Match multi-word string between @** ** or match any one-word
 # sequences after @
-find_mentions = r'(?<![^\s\'\"\(,:<])@(\*\*[^\*]+\*\*|all|everyone|stream)'
+find_mentions = r'(?<![^\s\'\"\(,:<])(?P<silent>_?)@(?P<match>\*\*[^\*]+\*\*|all|everyone|stream)'
 user_group_mentions = r'(?<![^\s\'\"\(,:<])@(\*[^\*]+\*)'
 
 wildcards = ['all', 'everyone', 'stream']
@@ -13,7 +13,10 @@ wildcards = ['all', 'everyone', 'stream']
 def user_mention_matches_wildcard(mention: str) -> bool:
     return mention in wildcards
 
-def extract_mention_text(s: str) -> Optional[str]:
+def extract_mention_text(m: Tuple[str, str]) -> Optional[str]:
+    # re.findall provides tuples of match elements; we want the second
+    # to get the main mention content.
+    s = m[1]
     if s.startswith("**") and s.endswith("**"):
         text = s[2:-2]
         if text in wildcards:

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -996,6 +996,37 @@ class BugdownTest(ZulipTestCase):
                          'check this out</p>' % (hamlet.id, cordelia.id))
         self.assertEqual(msg.mentions_user_ids, set([hamlet.id, cordelia.id]))
 
+    def test_mention_in_quotes(self) -> None:
+        othello = self.example_user('othello')
+        hamlet = self.example_user('hamlet')
+        cordelia = self.example_user('cordelia')
+        msg = Message(sender=othello, sending_client=get_client("test"))
+
+        content = "> @**King Hamlet** and @**Othello, the Moor of Venice**\n\n @**King Hamlet** and @**Cordelia Lear**"
+        self.assertEqual(render_markdown(msg, content),
+                         '<blockquote>\n<p>'
+                         '<span class="user-mention silent" data-user-id="%s">@King Hamlet</span>'
+                         ' and '
+                         '<span class="user-mention silent" data-user-id="%s">@Othello, the Moor of Venice</span>'
+                         '</p>\n</blockquote>\n'
+                         '<p>'
+                         '<span class="user-mention" data-user-id="%s">@King Hamlet</span>'
+                         ' and '
+                         '<span class="user-mention" data-user-id="%s">@Cordelia Lear</span>'
+                         '</p>' % (hamlet.id, othello.id, hamlet.id, cordelia.id))
+        self.assertEqual(msg.mentions_user_ids, set([hamlet.id, cordelia.id]))
+
+        # Both fenced quote and > quote should be identical
+        expected = ('<blockquote>\n<p>'
+                    '<span class="user-mention silent" data-user-id="%s">@King Hamlet</span>'
+                    '</p>\n</blockquote>' % (hamlet.id))
+        content = "```quote\n@**King Hamlet**\n```"
+        self.assertEqual(render_markdown(msg, content), expected)
+        self.assertEqual(msg.mentions_user_ids, set())
+        content = "> @**King Hamlet**"
+        self.assertEqual(render_markdown(msg, content), expected)
+        self.assertEqual(msg.mentions_user_ids, set())
+
     def test_mention_duplicate_full_name(self) -> None:
         realm = get_realm('zulip')
 

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -952,6 +952,19 @@ class BugdownTest(ZulipTestCase):
                          '@King Hamlet</span></p>' % (user_id))
         self.assertEqual(msg.mentions_user_ids, set([user_profile.id]))
 
+    def test_mention_silent(self) -> None:
+        sender_user_profile = self.example_user('othello')
+        user_profile = self.example_user('hamlet')
+        msg = Message(sender=sender_user_profile, sending_client=get_client("test"))
+        user_id = user_profile.id
+
+        content = "_@**King Hamlet**"
+        self.assertEqual(render_markdown(msg, content),
+                         '<p><span class="user-mention silent" '
+                         'data-user-id="%s">'
+                         '@King Hamlet</span></p>' % (user_id))
+        self.assertEqual(msg.mentions_user_ids, set())
+
     def test_possible_mentions(self) -> None:
         def assert_mentions(content: str, names: Set[str]) -> None:
             self.assertEqual(possible_mentions(content), names)

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2094,7 +2094,7 @@ class EventsRegisterTest(ZulipTestCase):
         stream = self.make_stream('old_name')
         new_name = u'stream with a brand new name'
         self.subscribe(self.user_profile, stream.name)
-        notification = '<p><span class="user-mention" data-user-id="4">@King Hamlet</span> renamed stream <strong>old_name</strong> to <strong>stream with a brand new name</strong></p>'
+        notification = '<p><span class="user-mention silent" data-user-id="4">@King Hamlet</span> renamed stream <strong>old_name</strong> to <strong>stream with a brand new name</strong></p>'
         action = lambda: do_rename_stream(stream, new_name, self.user_profile)
         events = self.do_test(action, num_events=3)
         schema_checker = self.check_events_dict([
@@ -2118,9 +2118,7 @@ class EventsRegisterTest(ZulipTestCase):
         error = schema_checker('events[1]', events[1])
         self.assert_on_error(error)
         schema_checker = check_dict([
-            ('stream_email_notify', equals(False)),
             ('flags', check_list(check_string)),
-            ('email_notified', equals(True)),
             ('type', equals('message')),
             ('message', check_dict([
                 ('timestamp', check_int),
@@ -2144,9 +2142,7 @@ class EventsRegisterTest(ZulipTestCase):
                 (TOPIC_NAME, equals('welcome')),
                 ('recipient_id', check_int)
             ])),
-            ('id', check_int),
-            ('push_notified', equals(True)),
-            ('stream_push_notify', equals(False)),
+            ('id', check_int)
         ])
         error = schema_checker('events[2]', events[2])
         self.assert_on_error(error)

--- a/zerver/tests/test_new_users.py
+++ b/zerver/tests/test_new_users.py
@@ -194,3 +194,4 @@ class TestNotifyNewUser(ZulipTestCase):
         self.assertEqual(message.recipient.type, Recipient.STREAM)
         actual_stream = Stream.objects.get(id=message.recipient.type_id)
         self.assertEqual(actual_stream.name, Realm.INITIAL_PRIVATE_STREAM_NAME)
+        self.assertIn('_@**Cordelia Lear|%d** just signed up for Zulip.' % (new_user.id), message.content)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -621,7 +621,7 @@ class StreamAdminTest(ZulipTestCase):
         # Inspect the notification message sent
         message = self.get_last_message()
         actual_stream = Stream.objects.get(id=message.recipient.type_id)
-        message_content = '@**King Hamlet** renamed stream **stream_name1** to **stream_name2**'
+        message_content = '_@**King Hamlet|{}** renamed stream **stream_name1** to **stream_name2**'.format(user_profile.id)
         self.assertEqual(message.sender.realm, user_profile.realm)
         self.assertEqual(actual_stream.name, 'stream_name2')
         self.assertEqual(message.recipient.type, Recipient.STREAM)
@@ -1913,6 +1913,7 @@ class SubscriptionAPITest(ZulipTestCase):
         """
         invitee = self.example_email("iago")
         invitee_full_name = 'Iago'
+        invitee_user = self.example_user('iago')
 
         current_stream = self.get_streams(invitee, self.test_realm)[0]
         invite_streams = self.make_random_stream_names([current_stream])[:1]
@@ -1938,7 +1939,7 @@ class SubscriptionAPITest(ZulipTestCase):
         msg = self.get_second_to_last_message()
         self.assertEqual(msg.recipient.type, Recipient.STREAM)
         self.assertEqual(msg.sender_id, self.notification_bot().id)
-        expected_msg = "%s just created a new stream #**%s**." % (invitee_full_name, invite_streams[0])
+        expected_msg = "_@**%s|%d** just created a new stream #**%s**." % (invitee_full_name, invitee_user.id, invite_streams[0])
         self.assertEqual(msg.content, expected_msg)
 
     def test_successful_cross_realm_notification(self) -> None:
@@ -1976,8 +1977,8 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assertEqual(msg.recipient.type, Recipient.STREAM)
         self.assertEqual(msg.sender_id, self.notification_bot().id)
         stream_id = Stream.objects.latest('id').id
-        expected_rendered_msg = '<p>%s just created a new stream <a class="stream" data-stream-id="%d" href="/#narrow/stream/%s-%s">#%s</a>.</p>' % (
-            user.full_name, stream_id, stream_id, invite_streams[0], invite_streams[0])
+        expected_rendered_msg = '<p><span class="user-mention silent" data-user-id="%d">@%s</span> just created a new stream <a class="stream" data-stream-id="%d" href="/#narrow/stream/%s-%s">#%s</a>.</p>' % (
+            user.id, user.full_name, stream_id, stream_id, invite_streams[0], invite_streams[0])
         self.assertEqual(msg.rendered_content, expected_rendered_msg)
 
     def test_successful_subscriptions_notifies_with_escaping(self) -> None:
@@ -1986,6 +1987,7 @@ class SubscriptionAPITest(ZulipTestCase):
         """
         invitee = self.example_email("iago")
         invitee_full_name = 'Iago'
+        invitee_user = self.example_user('iago')
 
         current_stream = self.get_streams(invitee, self.test_realm)[0]
         notifications_stream = get_stream(current_stream, self.test_realm)
@@ -2005,7 +2007,7 @@ class SubscriptionAPITest(ZulipTestCase):
 
         msg = self.get_second_to_last_message()
         self.assertEqual(msg.sender_id, self.notification_bot().id)
-        expected_msg = "%s just created a new stream #**%s**." % (invitee_full_name, invite_streams[0])
+        expected_msg = "_@**%s|%d** just created a new stream #**%s**." % (invitee_full_name, invitee_user.id, invite_streams[0])
         self.assertEqual(msg.content, expected_msg)
 
     def test_non_ascii_stream_subscription(self) -> None:
@@ -2920,7 +2922,7 @@ class SubscriptionAPITest(ZulipTestCase):
                     principals=ujson.dumps([user1.email, user2.email])
                 )
             )
-        self.assert_length(queries, 52)
+        self.assert_length(queries, 53)
 
 class GetPublicStreamsTest(ZulipTestCase):
 

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -378,7 +378,7 @@ def add_subscriptions_backend(
                 stream_msg = "the following streams: %s" % (stream_strs,)
             else:
                 stream_msg = "a new stream #**%s**." % created_streams[0].name
-            msg = ("%s just created %s" % (user_profile.full_name, stream_msg))
+            msg = ("_@**%s|%d** just created %s" % (user_profile.full_name, user_profile.id, stream_msg))
 
             sender = get_system_bot(settings.NOTIFICATION_BOT)
             stream_name = notifications_stream.name


### PR DESCRIPTION
This commit replaces attribute data-user-id with data-silent-user-id for
user mentions that are inside block quotes, and removes the user_ids of
these users from the message object, thus leaving the mention to be merely
cosmetic.

The property data-silent-user-id is only used for displaying the correct
popover on clicking on the message, and thus we avoid changing rest of the
codepaths to be aware in ignoring these mentions.

On the backend, We do this by adding a new TreeProcessor at the end of the
rendering process, which can be further used to hold other similar functions
to perform a 'clean up' of the rendered message.

The frontend, however, has an edge case where if you are mentioned in some
message and you quote it while having mentioned yourself above the quoted
message, you wouldn't see the red highlight till we get the final rendered
message from the backend.

Fixes #8025.