### PR TITLE
ui: Fix wrong usage of scrolling to top in ui.updateScrollbar.

### DIFF
--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -25,7 +25,7 @@ exports.set_up_scrollbar = function (element) {
 };
 
 exports.update_scrollbar = function (element) {
-    element.scrollTop = 0;
+    element.scrollTop(0);
     if (element[0].perfectScrollbar !== undefined) {
         element[0].perfectScrollbar.update();
     }


### PR DESCRIPTION
Fixes: #11141.

An alternate solution could be `element[0].scrollTop = 0`, both works fine. Since `ui.update_scrollbar` is used at many places so before merging it would great if this is tested manually (I've tested a few places).
GIFs:
Before:
![peek 2019-01-02 15-33 before](https://user-images.githubusercontent.com/22238472/50587402-cf300680-0ea3-11e9-8765-1ca957750f77.gif)

After:
![peek 2019-01-02 15-32](https://user-images.githubusercontent.com/22238472/50587410-d525e780-0ea3-11e9-8c9d-ca2e76c160b2.gif)
