### PR TITLE
user settings: Fix the position of get api key text and button.

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -944,7 +944,6 @@ input[type=checkbox].inline-block {
 
 #create_bot_form .control-label,
 #create_alert_word_form .control-label,
-#get_api_key_box .control-label,
 .admin-emoji-form .control-label,
 .admin-filter-form .control-label,
 .admin-profile-field-form .control-label,
@@ -1882,4 +1881,8 @@ thead .actions {
     -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
     -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
     box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
+}
+
+#get_api_key_button {
+    display: block;
 }


### PR DESCRIPTION
Fix the alignment of "Current password" and move the
"Get API key" button to next line.

Fixes: #10535.

**GIFs or Screenshots:** 
Previously:
![screen shot 2019-01-04 at 1 36 34 am](https://user-images.githubusercontent.com/29421208/50659930-2200df80-0fc4-11e9-9df2-fa752c7ca45a.png)

Changed:
![screen shot 2019-01-04 at 1 33 10 am](https://user-images.githubusercontent.com/29421208/50659938-27f6c080-0fc4-11e9-8e49-b64682bb8033.png)
