### PR TITLE
thumbnails: Fix bug with use of filters in thumbnail generation.

### DIFF
--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -47,11 +47,16 @@ def generate_thumbnail_url(path: str, size: str='0x0') -> str:
     image_url = '%s/source_type/%s' % (safe_url, source_type)
     width, height = map(int, size.split('x'))
     crypto = CryptoURL(key=settings.THUMBOR_KEY)
+
+    apply_filters = ['no_upscale()']
+    if size != '0x0':
+        apply_filters.append('sharpen(0.5,0.2,true)')
+
     encrypted_url = crypto.generate(
         width=width,
         height=height,
         smart=True,
-        filters=['no_upscale()', 'sharpen(0.5,0.2,true)'],
+        filters=apply_filters,
         image_url=image_url
     )
 

--- a/zerver/tests/test_thumbnail.py
+++ b/zerver/tests/test_thumbnail.py
@@ -21,11 +21,13 @@ class ThumbnailTest(ZulipTestCase):
     @use_s3_backend
     def test_s3_source_type(self) -> None:
         def get_file_path_urlpart(uri: str, size: str='') -> str:
-            url_in_result = 'smart/filters:no_upscale():sharpen(0.5,0.2,true)/%s/source_type/s3'
+            url_in_result = 'smart/filters:no_upscale()%s/%s/source_type/s3'
+            sharpen_filter = ''
             if size:
                 url_in_result = '/%s/%s' % (size, url_in_result)
+                sharpen_filter = ':sharpen(0.5,0.2,true)'
             hex_uri = base64.urlsafe_b64encode(uri.encode()).decode('utf-8')
-            return url_in_result % (hex_uri)
+            return url_in_result % (sharpen_filter, hex_uri)
 
         create_s3_buckets(
             settings.S3_AUTH_UPLOADS_BUCKET,
@@ -98,7 +100,7 @@ class ThumbnailTest(ZulipTestCase):
             encoded_url = base64.urlsafe_b64encode(image_url.encode()).decode('utf-8')
             result = self.client_get("/thumbnail?url=%s&size=full" % (quoted_url))
             self.assertEqual(result.status_code, 302, result)
-            expected_part_url = '/smart/filters:no_upscale():sharpen(0.5,0.2,true)/' + encoded_url + '/source_type/external'
+            expected_part_url = '/smart/filters:no_upscale()/' + encoded_url + '/source_type/external'
             self.assertIn(expected_part_url, result.url)
 
             # Test thumbnail size.
@@ -137,7 +139,7 @@ class ThumbnailTest(ZulipTestCase):
             self.login(self.example_email("iago"))
             result = self.client_get("/thumbnail?url=%s&size=full" % (quoted_url))
             self.assertEqual(result.status_code, 302, result)
-            expected_part_url = '/smart/filters:no_upscale():sharpen(0.5,0.2,true)/' + encoded_url + '/source_type/external'
+            expected_part_url = '/smart/filters:no_upscale()/' + encoded_url + '/source_type/external'
             self.assertIn(expected_part_url, result.url)
 
         image_url = 'https://images.foobar.com/12345'
@@ -148,11 +150,13 @@ class ThumbnailTest(ZulipTestCase):
 
     def test_local_file_type(self) -> None:
         def get_file_path_urlpart(uri: str, size: str='') -> str:
-            url_in_result = 'smart/filters:no_upscale():sharpen(0.5,0.2,true)/%s/source_type/local_file'
+            url_in_result = 'smart/filters:no_upscale()%s/%s/source_type/local_file'
+            sharpen_filter = ''
             if size:
                 url_in_result = '/%s/%s' % (size, url_in_result)
+                sharpen_filter = ':sharpen(0.5,0.2,true)'
             hex_uri = base64.urlsafe_b64encode(uri.encode()).decode('utf-8')
-            return url_in_result % (hex_uri)
+            return url_in_result % (sharpen_filter, hex_uri)
 
         self.login(self.example_email("hamlet"))
         fp = StringIO("zulip!")
@@ -307,16 +311,18 @@ class ThumbnailTest(ZulipTestCase):
         self.assertEqual(result.status_code, 302, result)
         base = 'http://test-thumborhost.com/'
         self.assertEqual(base, result.url[:len(base)])
-        expected_part_url = '/smart/filters:no_upscale():sharpen(0.5,0.2,true)/' + hex_uri + '/source_type/local_file'
+        expected_part_url = '/smart/filters:no_upscale()/' + hex_uri + '/source_type/local_file'
         self.assertIn(expected_part_url, result.url)
 
     def test_with_different_sizes(self) -> None:
         def get_file_path_urlpart(uri: str, size: str='') -> str:
-            url_in_result = 'smart/filters:no_upscale():sharpen(0.5,0.2,true)/%s/source_type/local_file'
+            url_in_result = 'smart/filters:no_upscale()%s/%s/source_type/local_file'
+            sharpen_filter = ''
             if size:
                 url_in_result = '/%s/%s' % (size, url_in_result)
+                sharpen_filter = ':sharpen(0.5,0.2,true)'
             hex_uri = base64.urlsafe_b64encode(uri.encode()).decode('utf-8')
-            return url_in_result % (hex_uri)
+            return url_in_result % (sharpen_filter, hex_uri)
 
         self.login(self.example_email("hamlet"))
         fp = StringIO("zulip!")


### PR DESCRIPTION
We used to add sharpen filter for all the image sizes whereas it was
intended for resized images only which would have been smoothened
out a bit by the resize operation.
This unnecessary use of the filter used to result in weird issues
with full size images.
For example: Image located at this url:-
http://arqex.com/wp-content/uploads/2015/02/trees.png
When rendered in full size would have just boundaries visible.


Before fix:
![image](https://user-images.githubusercontent.com/17237412/50691567-1e6a6880-1057-11e9-8c57-f997e7c1d316.png)

After Fix:
![image](https://user-images.githubusercontent.com/17237412/50691607-3f32be00-1057-11e9-8085-4580bebf1101.png)
