### PR TITLE
Python dependency upgrade

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -101,7 +101,7 @@ pika==0.12.0
 # Needed to access our database
 psycopg2==2.7.6.1 --no-binary psycopg2
 
-pyasn1==0.4.4
+pyasn1==0.4.5
 pyasn1-modules==0.2.2
 pycrypto==2.6.1
 

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -198,7 +198,7 @@ django-sendfile==0.3.11
 disposable-email-domains==0.0.39
 
 # Needed for parsing YAML with JSON references from the REST API spec files
-yamole==2.1.5
+yamole==2.1.6
 
 # Needed for signing thumbnail requests so that they can be authenticated on the
 # other end.  Using a fork to eliminate a really slow pkgresources import.

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -72,7 +72,7 @@ google-api-python-client==1.7.4
 
 # Needed for the email mirror
 html2text==2018.1.9
-httplib2==0.11.3
+httplib2==0.12.0
 -e git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
 
 # Needed for inlining the CSS in emails

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -46,7 +46,7 @@ chardet==3.0.4
 
 # Pinned version because older versions don't compile on newer Linux.
 # Not actually a direct dependency.
-cryptography==2.4.1
+cryptography==2.4.2
 
 # Needed for integrations
 defusedxml==0.5.0

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -23,7 +23,7 @@ ipython==6.5.0
 Pillow==5.4.1
 
 # Needed for building complex DB queries
-SQLAlchemy==1.2.14
+SQLAlchemy==1.2.15
 
 # Needed for password hashing
 argon2-cffi==18.3.0

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -37,7 +37,7 @@ backports.ssl-match-hostname==3.5.0.1
 # Needed for S3 file uploads
 boto==2.49.0
 
-certifi==2018.10.15
+certifi==2018.11.29
 
 # Used for scrapy as well as argon2
 cffi==1.11.5

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -3,7 +3,7 @@
 # and requirements/prod.txt.
 # See requirements/README.md for more detail.
 # Django itself
-Django==1.11.16
+Django==1.11.18
 
 # needed for mypy TypedDict
 mypy_extensions==0.4.1

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -124,7 +124,7 @@ requests_oauthlib==1.0.0
 rsa==4.0
 
 # Needed for Python 2+3 compatibility
-six==1.11.0
+six==1.12.0
 smmap==0.9.0
 
 # Needed for Tornado websockets support

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -79,7 +79,7 @@ httplib2==0.12.0
 premailer==3.2.0
 
 # Needed for JWT-based auth
-PyJWT==1.6.4
+PyJWT==1.7.1
 
 # Needed for including other markdown files for user docs
 markdown-include==0.5.1

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -165,7 +165,7 @@ virtualenv-clone==0.4.0
 ijson==2.3
 
 # Needed for link preview
-beautifulsoup4==4.6.3
+beautifulsoup4==4.7.1
 pyoembed==0.1.2
 
 # The Zulip API bindings, from its own repository.  We integrate with

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -102,7 +102,7 @@ pika==0.12.0
 psycopg2==2.7.6.1 --no-binary psycopg2
 
 pyasn1==0.4.5
-pyasn1-modules==0.2.2
+pyasn1-modules==0.2.3
 pycrypto==2.6.1
 
 # Needed for memcached usage

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -112,7 +112,7 @@ pylibmc==1.6.0
 django-pylibmc==0.6.1
 
 # Needed for zerver/tests/test_timestamp.py
-python-dateutil==2.6.1
+python-dateutil==2.7.5
 
 # Needed for timezone work
 pytz==2018.5

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -14,7 +14,7 @@ Jinja2==2.10
 # Needed for markdown processing
 Markdown==2.6.11
 MarkupSafe==1.1.0
-Pygments==2.2.0
+Pygments==2.3.1
 
 # Needed for manage.py
 ipython==6.5.0

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -195,7 +195,7 @@ stripe==2.16.0
 django-sendfile==0.3.11
 
 # For checking whether email of the user is from a disposable email provider.
-disposable-email-domains==0.0.38
+disposable-email-domains==0.0.39
 
 # Needed for parsing YAML with JSON references from the REST API spec files
 yamole==2.1.5

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -186,7 +186,7 @@ lxml==4.3.0
 
 # Needed for 2-factor authentication
 django-two-factor-auth==1.8.0
-twilio==6.19.2
+twilio==6.22.1
 
 # Needed for processing payments (in corporate)
 stripe==2.17.0

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -96,7 +96,7 @@ ndg-httpsclient==0.5.1
 
 # Needed to access rabbitmq
 # See #8466 for why we're not using the latest version.
-pika==0.11.0
+pika==0.12.0
 
 # Needed to access our database
 psycopg2==2.7.6.1 --no-binary psycopg2

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -115,7 +115,7 @@ django-pylibmc==0.6.1
 python-dateutil==2.7.5
 
 # Needed for timezone work
-pytz==2018.5
+pytz==2018.9
 
 # Needed for redis
 redis==2.10.6

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -20,7 +20,7 @@ Pygments==2.2.0
 ipython==6.5.0
 
 # Needed for Image Processing
-Pillow==5.3.0
+Pillow==5.4.1
 
 # Needed for building complex DB queries
 SQLAlchemy==1.2.14

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -182,7 +182,7 @@ py3dns==3.2.0
 social-auth-app-django==3.1.0
 
 # Needed for messages' rendered content parsing in push notifications.
-lxml==4.2.5
+lxml==4.3.0
 
 # Needed for 2-factor authentication
 django-two-factor-auth==1.8.0

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -189,7 +189,7 @@ django-two-factor-auth==1.8.0
 twilio==6.19.2
 
 # Needed for processing payments (in corporate)
-stripe==2.16.0
+stripe==2.17.0
 
 # Needed for serving uploaded files from nginx but perform auth checks in django.
 django-sendfile==0.3.11

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -5,7 +5,7 @@
 -r docs.in
 
 # moto s3 mock
-moto==1.3.3
+moto==1.3.7
 
 # Needed for running tools/run-dev.py
 Twisted==18.9.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -168,7 +168,7 @@ sockjs-tornado==1.0.6
 soupsieve==1.6.2          # via beautifulsoup4
 sourcemap==0.2.1
 sphinx-rtd-theme==0.4.2
-sphinx==1.8.2
+sphinx==1.8.3
 sphinxcontrib-websupport==1.1.0  # via sphinx
 sqlalchemy==1.2.15
 statsd==3.3.0             # via django-statsd-mozilla

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -72,7 +72,7 @@ google-auth==1.6.2        # via google-api-python-client, google-auth-httplib2
 h2==2.6.2                 # via hyper
 hpack==3.0.0              # via h2
 html2text==2018.1.9
-httplib2==0.11.3
+httplib2==0.12.0
 httpretty==0.9.6
 hyper==0.7.0              # via apns2
 hyperframe==3.2.0         # via h2, hyper

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -170,7 +170,7 @@ sourcemap==0.2.1
 sphinx-rtd-theme==0.4.2
 sphinx==1.8.2
 sphinxcontrib-websupport==1.1.0  # via sphinx
-sqlalchemy==1.2.14
+sqlalchemy==1.2.15
 statsd==3.3.0             # via django-statsd-mozilla
 stripe==2.16.0
 tblib==1.3.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -119,7 +119,7 @@ ptyprocess==0.6.0         # via pexpect
 py3dns==3.2.0
 pyaml==18.11.0            # via moto
 pyasn1-modules==0.2.2
-pyasn1==0.4.4
+pyasn1==0.4.5
 pycodestyle==2.4.0
 pycparser==2.19           # via cffi
 pycrypto==2.6.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -142,7 +142,7 @@ python-jose==2.0.2        # via moto
 python-ldap==3.1.0        # via django-auth-ldap, pyldap
 python-twitter==3.5
 python3-openid==3.1.0     # via social-auth-core
-pytz==2018.5
+pytz==2018.9
 pyyaml==3.13              # via pyaml, yamole
 qrcode==6.0               # via django-two-factor-auth
 queuelib==1.5.0           # via scrapy

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -41,7 +41,7 @@ commonmark==0.5.4
 constantly==15.1.0        # via twisted
 cookies==2.2.1            # via moto
 coverage==4.5.2
-cryptography==2.4.1
+cryptography==2.4.2
 cssselect==1.0.3          # via parsel, premailer, scrapy
 cssutils==1.0.2           # via premailer
 decorator==4.3.0          # via ipython, traitlets

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -158,7 +158,7 @@ scrapy==1.5.1
 service-identity==18.1.0  # via scrapy
 sh==1.11                  # via gitlint
 simplegeneric==0.8.1      # via ipython
-six==1.11.0
+six==1.12.0
 smmap==0.9.0
 snakeviz==1.0.0
 snowballstemmer==1.2.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -172,7 +172,7 @@ sphinx==1.8.2
 sphinxcontrib-websupport==1.1.0  # via sphinx
 sqlalchemy==1.2.15
 statsd==3.3.0             # via django-statsd-mozilla
-stripe==2.16.0
+stripe==2.17.0
 tblib==1.3.2
 tornado==4.5.3
 traitlets==4.3.2          # via ipython

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -109,7 +109,7 @@ pexpect==4.6.0            # via ipython
 phonenumberslite==8.10.2  # via django-phonenumber-field
 pickleshare==0.7.5        # via ipython
 pika==0.12.0
-pillow==5.3.0
+pillow==5.4.1
 pip-tools==2.0.2
 polib==1.1.0
 premailer==3.2.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -135,7 +135,7 @@ pyoembed==0.1.2
 pyopenssl==18.0.0         # via ndg-httpsclient, requests, scrapy
 pyparsing==2.3.0          # via packaging
 pysocks==1.6.8            # via twilio
-python-dateutil==2.6.1
+python-dateutil==2.7.5
 python-digitalocean==1.14.0
 python-gcm==0.4
 python-jose==2.0.2        # via moto

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -33,7 +33,7 @@ boto==2.49.0
 botocore==1.12.74         # via boto3, moto, s3transfer
 cachetools==3.0.0         # via google-auth
 cchardet==2.1.4
-certifi==2018.10.15
+certifi==2018.11.29
 cffi==1.11.5
 chardet==3.0.4
 click==6.6                # via gitlint, pip-tools

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -177,7 +177,7 @@ tblib==1.3.2
 tornado==4.5.3
 traitlets==4.3.2          # via ipython
 transifex-client==0.12.5
-twilio==6.19.2
+twilio==6.22.1
 twisted==18.9.0
 typed-ast==1.1.1          # via mypy
 typing==3.6.6

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -118,7 +118,7 @@ psycopg2==2.7.6.1
 ptyprocess==0.6.0         # via pexpect
 py3dns==3.2.0
 pyaml==18.11.0            # via moto
-pyasn1-modules==0.2.2
+pyasn1-modules==0.2.3
 pyasn1==0.4.5
 pycodestyle==2.4.0
 pycparser==2.19           # via cffi

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -89,7 +89,7 @@ jinja2==2.10
 jmespath==0.9.3           # via boto3, botocore
 jsondiff==1.1.1           # via moto
 jsonpickle==1.0           # via aws-xray-sdk, python-digitalocean
-lxml==4.2.5
+lxml==4.3.0
 markdown-include==0.5.1
 markdown==2.6.11
 markupsafe==1.1.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -46,7 +46,7 @@ cssselect==1.0.3          # via parsel, premailer, scrapy
 cssutils==1.0.2           # via premailer
 decorator==4.3.0          # via ipython, traitlets
 defusedxml==0.5.0
-disposable-email-domains==0.0.38
+disposable-email-domains==0.0.39
 django-auth-ldap==1.7.0
 django-formtools==2.1     # via django-two-factor-auth
 django-otp==0.5.1         # via django-two-factor-auth

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -27,10 +27,10 @@ babel==2.5.3
 backcall==0.1.0           # via ipython
 backports-abc==0.5
 backports.ssl-match-hostname==3.5.0.1
-beautifulsoup4==4.6.3
-boto3==1.9.43             # via moto
+beautifulsoup4==4.7.1
+boto3==1.9.74             # via moto
 boto==2.49.0
-botocore==1.12.43         # via boto3, moto, s3transfer
+botocore==1.12.74         # via boto3, moto, s3transfer
 cachetools==3.0.0         # via google-auth
 cchardet==2.1.4
 certifi==2018.10.15
@@ -58,8 +58,8 @@ django-statsd-mozilla==0.4.0
 django-two-factor-auth==1.8.0
 django-webpack-loader==0.6.0
 django==1.11.16
-docker-pycreds==0.3.0     # via docker
-docker==3.5.1             # via moto
+docker-pycreds==0.4.0     # via docker
+docker==3.6.0             # via moto
 docopt==0.6.2
 docutils==0.14
 fakeldap==0.6.1
@@ -68,7 +68,7 @@ gitdb==0.6.4
 gitlint==0.10.0
 google-api-python-client==1.7.4
 google-auth-httplib2==0.0.3  # via google-api-python-client
-google-auth==1.6.1        # via google-api-python-client, google-auth-httplib2
+google-auth==1.6.2        # via google-api-python-client, google-auth-httplib2
 h2==2.6.2                 # via hyper
 hpack==3.0.0              # via h2
 html2text==2018.1.9
@@ -77,14 +77,14 @@ httpretty==0.9.6
 hyper==0.7.0              # via apns2
 hyperframe==3.2.0         # via h2, hyper
 hyperlink==18.0.0         # via twisted
-idna==2.7                 # via cryptography, hyperlink, requests
+idna==2.8                 # via cryptography, hyperlink, requests
 ijson==2.3
 imagesize==1.1.0
 incremental==17.5.0       # via twisted
 ipython-genutils==0.2.0   # via traitlets
 ipython==6.5.0
 isort==4.3.4
-jedi==0.13.1              # via ipython
+jedi==0.13.2              # via ipython
 jinja2==2.10
 jmespath==0.9.3           # via boto3, botocore
 jsondiff==1.1.1           # via moto
@@ -106,7 +106,7 @@ parsel==1.5.1             # via scrapy
 parso==0.3.1              # via jedi
 pbr==5.1.1                # via mock
 pexpect==4.6.0            # via ipython
-phonenumberslite==8.9.16  # via django-phonenumber-field
+phonenumberslite==8.10.2  # via django-phonenumber-field
 pickleshare==0.7.5        # via ipython
 pika==0.11.0
 pillow==5.3.0
@@ -117,7 +117,7 @@ prompt-toolkit==1.0.15    # via ipython
 psycopg2==2.7.6.1
 ptyprocess==0.6.0         # via pexpect
 py3dns==3.2.0
-pyaml==17.12.1            # via moto
+pyaml==18.11.0            # via moto
 pyasn1-modules==0.2.2
 pyasn1==0.4.4
 pycodestyle==2.4.0
@@ -131,7 +131,7 @@ pyjwt==1.6.4
 pyldap==3.0.0.post1       # via fakeldap
 pylibmc==1.6.0
 pyoembed==0.1.2
-pyopenssl==18.0.0         # via ndg-httpsclient, requests, scrapy, service-identity
+pyopenssl==18.0.0         # via ndg-httpsclient, requests, scrapy
 pyparsing==2.3.0          # via packaging
 pysocks==1.6.8            # via twilio
 python-dateutil==2.6.1
@@ -146,14 +146,14 @@ qrcode==6.0               # via django-two-factor-auth
 queuelib==1.5.0           # via scrapy
 recommonmark==0.4.0
 redis==2.10.6
-regex==2018.11.7
+regex==2018.11.22
 requests-oauthlib==1.0.0
-requests[security]==2.20.1  # via aws-xray-sdk, docker, matrix-client, moto, premailer, pyoembed, python-digitalocean, python-gcm, python-twitter, requests-oauthlib, responses, social-auth-core, sphinx, stripe, twilio
-responses==0.10.3         # via moto
+requests[security]==2.21.0  # via aws-xray-sdk, docker, matrix-client, moto, premailer, pyoembed, python-digitalocean, python-gcm, python-twitter, requests-oauthlib, responses, social-auth-core, sphinx, stripe, twilio
+responses==0.10.5         # via moto
 rsa==4.0
 s3transfer==0.1.13        # via boto3
 scrapy==1.5.1
-service-identity==17.0.0  # via scrapy
+service-identity==18.1.0  # via scrapy
 sh==1.11                  # via gitlint
 simplegeneric==0.8.1      # via ipython
 six==1.11.0
@@ -163,6 +163,7 @@ snowballstemmer==1.2.1
 social-auth-app-django==3.1.0
 social-auth-core==2.0.0   # via social-auth-app-django
 sockjs-tornado==1.0.6
+soupsieve==1.6.2          # via beautifulsoup4
 sourcemap==0.2.1
 sphinx-rtd-theme==0.4.2
 sphinx==1.8.2
@@ -176,7 +177,7 @@ traitlets==4.3.2          # via ipython
 transifex-client==0.12.5
 twilio==6.19.2
 twisted==18.9.0
-typed-ast==1.1.0          # via mypy
+typed-ast==1.1.1          # via mypy
 typing==3.6.6
 typing_extensions==3.6.6
 uritemplate==3.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -126,7 +126,7 @@ pycrypto==2.6.1
 pycryptodome==3.7.2       # via python-jose
 pydispatcher==2.0.5       # via scrapy
 pyflakes==2.0.0
-pygments==2.2.0
+pygments==2.3.1
 pyhamcrest==1.9.0         # via twisted
 pyjwt==1.6.4
 pyldap==3.0.0.post1       # via fakeldap

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -39,7 +39,6 @@ chardet==3.0.4
 click==6.6                # via gitlint, pip-tools
 commonmark==0.5.4
 constantly==15.1.0        # via twisted
-cookies==2.2.1            # via moto
 coverage==4.5.2
 cryptography==2.4.2
 cssselect==1.0.3          # via parsel, premailer, scrapy
@@ -62,6 +61,7 @@ docker-pycreds==0.4.0     # via docker
 docker==3.6.0             # via moto
 docopt==0.6.2
 docutils==0.14
+ecdsa==0.13               # via python-jose
 fakeldap==0.6.1
 first==2.0.1              # via pip-tools
 gitdb==0.6.4
@@ -95,7 +95,7 @@ markdown==2.6.11
 markupsafe==1.1.0
 matrix-client==0.3.2
 mock==2.0.0
-moto==1.3.3
+moto==1.3.7
 mypy-extensions==0.4.1
 mypy==0.650
 ndg-httpsclient==0.5.1
@@ -123,6 +123,7 @@ pyasn1==0.4.4
 pycodestyle==2.4.0
 pycparser==2.19           # via cffi
 pycrypto==2.6.1
+pycryptodome==3.7.2       # via python-jose
 pydispatcher==2.0.5       # via scrapy
 pyflakes==2.0.0
 pygments==2.2.0
@@ -137,6 +138,7 @@ pysocks==1.6.8            # via twilio
 python-dateutil==2.6.1
 python-digitalocean==1.14.0
 python-gcm==0.4
+python-jose==2.0.2        # via moto
 python-ldap==3.1.0        # via django-auth-ldap, pyldap
 python-twitter==3.5
 python3-openid==3.1.0     # via social-auth-core

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -56,7 +56,7 @@ django-sendfile==0.3.11
 django-statsd-mozilla==0.4.0
 django-two-factor-auth==1.8.0
 django-webpack-loader==0.6.0
-django==1.11.16
+django==1.11.18
 docker-pycreds==0.4.0     # via docker
 docker==3.6.0             # via moto
 docopt==0.6.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -128,7 +128,7 @@ pydispatcher==2.0.5       # via scrapy
 pyflakes==2.0.0
 pygments==2.3.1
 pyhamcrest==1.9.0         # via twisted
-pyjwt==1.6.4
+pyjwt==1.7.1
 pyldap==3.0.0.post1       # via fakeldap
 pylibmc==1.6.0
 pyoembed==0.1.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -191,5 +191,5 @@ websocket-client==0.54.0  # via docker
 werkzeug==0.14.1          # via moto
 wrapt==1.10.11            # via aws-xray-sdk
 xmltodict==0.11.0         # via moto
-yamole==2.1.5
+yamole==2.1.6
 zope.interface==4.6.0     # via twisted

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -108,7 +108,7 @@ pbr==5.1.1                # via mock
 pexpect==4.6.0            # via ipython
 phonenumberslite==8.10.2  # via django-phonenumber-field
 pickleshare==0.7.5        # via ipython
-pika==0.11.0
+pika==0.12.0
 pillow==5.3.0
 pip-tools==2.0.2
 polib==1.1.0

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -8,7 +8,7 @@
 # See requirements/README.md for more detail.
 
 # Needed to build RTD docs
-sphinx==1.8.2
+sphinx==1.8.3
 sphinx-rtd-theme==0.4.2
 
 # Needed to build markdown docs

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -9,21 +9,21 @@
 #
 alabaster==0.7.12
 babel==2.5.3
-certifi==2018.10.15       # via requests
+certifi==2018.11.29       # via requests
 chardet==3.0.4            # via requests
 commonmark==0.5.4
 docutils==0.14
-idna==2.7                 # via requests
+idna==2.8                 # via requests
 imagesize==1.1.0
 jinja2==2.10              # via sphinx
 markupsafe==1.1.0         # via jinja2
 packaging==18.0           # via sphinx
-pygments==2.2.0           # via sphinx
+pygments==2.3.1           # via sphinx
 pyparsing==2.3.0          # via packaging
 pytz==2018.7              # via babel
 recommonmark==0.4.0
-requests==2.20.1          # via sphinx
-six==1.11.0               # via packaging, sphinx
+requests==2.21.0          # via sphinx
+six==1.12.0               # via packaging, sphinx
 snowballstemmer==1.2.1
 sphinx-rtd-theme==0.4.2
 sphinx==1.8.2

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -26,7 +26,7 @@ requests==2.21.0          # via sphinx
 six==1.12.0               # via packaging, sphinx
 snowballstemmer==1.2.1
 sphinx-rtd-theme==0.4.2
-sphinx==1.8.2
+sphinx==1.8.3
 sphinxcontrib-websupport==1.1.0  # via sphinx
 typing==3.6.6
 urllib3==1.24.1           # via requests

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -20,7 +20,7 @@ markupsafe==1.1.0         # via jinja2
 packaging==18.0           # via sphinx
 pygments==2.3.1           # via sphinx
 pyparsing==2.3.0          # via packaging
-pytz==2018.7              # via babel
+pytz==2018.9              # via babel
 recommonmark==0.4.0
 requests==2.21.0          # via sphinx
 six==1.12.0               # via packaging, sphinx

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,4 +1,4 @@
 # Dependencies for setting up pip to install our requirements.txt file.
 pip==18.1
-setuptools==40.6.1
+setuptools==40.6.3
 wheel==0.32.2

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,4 +1,4 @@
 # Dependencies for setting up pip to install our requirements.txt file.
 pip==18.1
 setuptools==40.6.3
-wheel==0.32.2
+wheel==0.32.3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -101,7 +101,7 @@ python-gcm==0.4
 python-ldap==3.1.0        # via django-auth-ldap
 python-twitter==3.5
 python3-openid==3.1.0     # via social-auth-core
-pytz==2018.5
+pytz==2018.9
 pyyaml==3.13              # via yamole
 qrcode==6.0               # via django-two-factor-auth
 redis==2.10.6

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -117,7 +117,7 @@ social-auth-core==2.0.0   # via social-auth-app-django
 sockjs-tornado==1.0.6
 soupsieve==1.6.2          # via beautifulsoup4
 sourcemap==0.2.1
-sqlalchemy==1.2.14
+sqlalchemy==1.2.15
 statsd==3.3.0             # via django-statsd-mozilla
 stripe==2.16.0
 tornado==4.5.3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -78,7 +78,7 @@ pbr==5.1.1                # via mock
 pexpect==4.6.0            # via ipython
 phonenumberslite==8.10.2  # via django-phonenumber-field
 pickleshare==0.7.5        # via ipython
-pika==0.11.0
+pika==0.12.0
 pillow==5.3.0
 polib==1.1.0
 premailer==3.2.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -91,7 +91,7 @@ pyasn1==0.4.5
 pycparser==2.19           # via cffi
 pycrypto==2.6.1
 pygments==2.3.1
-pyjwt==1.6.4
+pyjwt==1.7.1
 pylibmc==1.6.0
 pyoembed==0.1.2
 pyopenssl==18.0.0         # via ndg-httpsclient, requests

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -122,7 +122,7 @@ statsd==3.3.0             # via django-statsd-mozilla
 stripe==2.17.0
 tornado==4.5.3
 traitlets==4.3.2          # via ipython
-twilio==6.19.2
+twilio==6.22.1
 typing==3.6.6
 uritemplate==3.0.0
 urllib3==1.24.1           # via requests

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -29,7 +29,7 @@ cchardet==2.1.4
 certifi==2018.11.29
 cffi==1.11.5
 chardet==3.0.4
-cryptography==2.4.1
+cryptography==2.4.2
 cssselect==1.0.3          # via premailer
 cssutils==1.0.2           # via premailer
 decorator==4.3.0          # via ipython, traitlets

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -22,7 +22,7 @@ babel==2.6.0              # via django-phonenumber-field
 backcall==0.1.0           # via ipython
 backports-abc==0.5
 backports.ssl-match-hostname==3.5.0.1
-beautifulsoup4==4.6.3
+beautifulsoup4==4.7.1
 boto==2.49.0
 cachetools==3.0.0         # via google-auth
 cchardet==2.1.4
@@ -50,18 +50,18 @@ docopt==0.6.2
 gitdb==0.6.4
 google-api-python-client==1.7.4
 google-auth-httplib2==0.0.3  # via google-api-python-client
-google-auth==1.6.1        # via google-api-python-client, google-auth-httplib2
+google-auth==1.6.2        # via google-api-python-client, google-auth-httplib2
 h2==2.6.2                 # via hyper
 hpack==3.0.0              # via h2
 html2text==2018.1.9
 httplib2==0.11.3
 hyper==0.7.0              # via apns2
 hyperframe==3.2.0         # via h2, hyper
-idna==2.7                 # via cryptography, requests
+idna==2.8                 # via cryptography, requests
 ijson==2.3
 ipython-genutils==0.2.0   # via traitlets
 ipython==6.5.0
-jedi==0.13.1              # via ipython
+jedi==0.13.2              # via ipython
 jinja2==2.10
 lxml==4.2.5
 markdown-include==0.5.1
@@ -76,7 +76,7 @@ oauthlib==2.1.0
 parso==0.3.1              # via jedi
 pbr==5.1.1                # via mock
 pexpect==4.6.0            # via ipython
-phonenumberslite==8.9.16  # via django-phonenumber-field
+phonenumberslite==8.10.2  # via django-phonenumber-field
 pickleshare==0.7.5        # via ipython
 pika==0.11.0
 pillow==5.3.0
@@ -105,9 +105,9 @@ pytz==2018.5
 pyyaml==3.13              # via yamole
 qrcode==6.0               # via django-two-factor-auth
 redis==2.10.6
-regex==2018.11.7
+regex==2018.11.22
 requests-oauthlib==1.0.0
-requests[security]==2.20.1  # via matrix-client, premailer, pyoembed, python-gcm, python-twitter, requests-oauthlib, social-auth-core, stripe, twilio
+requests[security]==2.21.0  # via matrix-client, premailer, pyoembed, python-gcm, python-twitter, requests-oauthlib, social-auth-core, stripe, twilio
 rsa==4.0
 simplegeneric==0.8.1      # via ipython
 six==1.11.0
@@ -115,6 +115,7 @@ smmap==0.9.0
 social-auth-app-django==3.1.0
 social-auth-core==2.0.0   # via social-auth-app-django
 sockjs-tornado==1.0.6
+soupsieve==1.6.2          # via beautifulsoup4
 sourcemap==0.2.1
 sqlalchemy==1.2.14
 statsd==3.3.0             # via django-statsd-mozilla

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -26,7 +26,7 @@ beautifulsoup4==4.7.1
 boto==2.49.0
 cachetools==3.0.0         # via google-auth
 cchardet==2.1.4
-certifi==2018.10.15
+certifi==2018.11.29
 cffi==1.11.5
 chardet==3.0.4
 cryptography==2.4.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -86,7 +86,7 @@ prompt-toolkit==1.0.15    # via ipython
 psycopg2==2.7.6.1
 ptyprocess==0.6.0         # via pexpect
 py3dns==3.2.0
-pyasn1-modules==0.2.2
+pyasn1-modules==0.2.3
 pyasn1==0.4.5
 pycparser==2.19           # via cffi
 pycrypto==2.6.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -119,7 +119,7 @@ soupsieve==1.6.2          # via beautifulsoup4
 sourcemap==0.2.1
 sqlalchemy==1.2.15
 statsd==3.3.0             # via django-statsd-mozilla
-stripe==2.16.0
+stripe==2.17.0
 tornado==4.5.3
 traitlets==4.3.2          # via ipython
 twilio==6.19.2

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -129,4 +129,4 @@ urllib3==1.24.1           # via requests
 uwsgi==2.0.17.1
 virtualenv-clone==0.4.0
 wcwidth==0.1.7            # via prompt-toolkit
-yamole==2.1.5
+yamole==2.1.6

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -54,7 +54,7 @@ google-auth==1.6.2        # via google-api-python-client, google-auth-httplib2
 h2==2.6.2                 # via hyper
 hpack==3.0.0              # via h2
 html2text==2018.1.9
-httplib2==0.11.3
+httplib2==0.12.0
 hyper==0.7.0              # via apns2
 hyperframe==3.2.0         # via h2, hyper
 idna==2.8                 # via cryptography, requests

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -90,7 +90,7 @@ pyasn1-modules==0.2.3
 pyasn1==0.4.5
 pycparser==2.19           # via cffi
 pycrypto==2.6.1
-pygments==2.2.0
+pygments==2.3.1
 pyjwt==1.6.4
 pylibmc==1.6.0
 pyoembed==0.1.2

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -63,7 +63,7 @@ ipython-genutils==0.2.0   # via traitlets
 ipython==6.5.0
 jedi==0.13.2              # via ipython
 jinja2==2.10
-lxml==4.2.5
+lxml==4.3.0
 markdown-include==0.5.1
 markdown==2.6.11
 markupsafe==1.1.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -96,7 +96,7 @@ pylibmc==1.6.0
 pyoembed==0.1.2
 pyopenssl==18.0.0         # via ndg-httpsclient, requests
 pysocks==1.6.8            # via twilio
-python-dateutil==2.6.1
+python-dateutil==2.7.5
 python-gcm==0.4
 python-ldap==3.1.0        # via django-auth-ldap
 python-twitter==3.5

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -34,7 +34,7 @@ cssselect==1.0.3          # via premailer
 cssutils==1.0.2           # via premailer
 decorator==4.3.0          # via ipython, traitlets
 defusedxml==0.5.0
-disposable-email-domains==0.0.38
+disposable-email-domains==0.0.39
 django-auth-ldap==1.7.0
 django-formtools==2.1     # via django-two-factor-auth
 django-otp==0.5.1         # via django-two-factor-auth

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -79,7 +79,7 @@ pexpect==4.6.0            # via ipython
 phonenumberslite==8.10.2  # via django-phonenumber-field
 pickleshare==0.7.5        # via ipython
 pika==0.12.0
-pillow==5.3.0
+pillow==5.4.1
 polib==1.1.0
 premailer==3.2.0
 prompt-toolkit==1.0.15    # via ipython

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -45,7 +45,7 @@ django-sendfile==0.3.11
 django-statsd-mozilla==0.4.0
 django-two-factor-auth==1.8.0
 django-webpack-loader==0.6.0
-django==1.11.16
+django==1.11.18
 docopt==0.6.2
 gitdb==0.6.4
 google-api-python-client==1.7.4

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -87,7 +87,7 @@ psycopg2==2.7.6.1
 ptyprocess==0.6.0         # via pexpect
 py3dns==3.2.0
 pyasn1-modules==0.2.2
-pyasn1==0.4.4
+pyasn1==0.4.5
 pycparser==2.19           # via cffi
 pycrypto==2.6.1
 pygments==2.2.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -110,7 +110,7 @@ requests-oauthlib==1.0.0
 requests[security]==2.21.0  # via matrix-client, premailer, pyoembed, python-gcm, python-twitter, requests-oauthlib, social-auth-core, stripe, twilio
 rsa==4.0
 simplegeneric==0.8.1      # via ipython
-six==1.11.0
+six==1.12.0
 smmap==0.9.0
 social-auth-app-django==3.1.0
 social-auth-core==2.0.0   # via social-auth-app-django

--- a/version.py
+++ b/version.py
@@ -11,4 +11,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2018/11/07/zulip-1-9-relea
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '26.21'
+PROVISION_VERSION = '26.22'


### PR DESCRIPTION
Output of `./tools/list-outdated-packages` 

|Pkg| Version| Latest| Status|
|-------|-----|---------|---------|
CommonMark | 0.5.4 | 0.8.1| Known
google-api-python-client | 1.7.4 | 1.7.7| #11211
h2 | 2.6.2 | 3.0.1| recursive dep
ipython | 6.5.0 | 7.2.0| #10801
Markdown | 2.6.11 | 3.0.1| #10800 
pip-tools | 2.0.2 | 3.2.0| #10802 
redis | 2.10.6 | 3.0.1| #11209
sh | 1.11 | 1.12.14|  Recursive dep
tornado | 4.5.3 | 5.1.1| #8913
transifex-client | 0.12.5 | 0.13.5| #8914
talon | 1.2.11 | 1.4.4| Known
