### PR TITLE
email_mirror: strip subject lines and add sender name to message

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4462,20 +4462,28 @@ def get_email_gateway_message_string_from_address(address: str) -> Optional[str]
 
     return msg_string
 
-def decode_email_address(email: str) -> Optional[Tuple[str, str]]:
-    # Perform the reverse of encode_email_address. Returns a tuple of (streamname, email_token)
+def decode_email_address(email: str) -> Optional[Tuple[str, str, bool]]:
+    # Perform the reverse of encode_email_address. Returns a tuple of
+    # (streamname, email_token, show_sender)
     msg_string = get_email_gateway_message_string_from_address(email)
-
     if msg_string is None:
         return None
-    elif '.' in msg_string:
+
+    if msg_string.endswith(('+show-sender', '.show-sender')):
+        show_sender = True
+        msg_string = msg_string[:-12]  # strip "+show-sender"
+    else:
+        show_sender = False
+
+    if '.' in msg_string:
         # Workaround for Google Groups and other programs that don't accept emails
         # that have + signs in them (see Trac #2102)
         encoded_stream_name, token = msg_string.split('.')
     else:
         encoded_stream_name, token = msg_string.split('+')
+
     stream_name = re.sub(r"%\d{4}", lambda x: chr(int(x.group(0)[1:])), encoded_stream_name)
-    return stream_name, token
+    return stream_name, token, show_sender
 
 SubHelperT = Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]
 


### PR DESCRIPTION
Addresses point 1 and 3 of https://github.com/zulip/zulip/issues/10612. Adds test_email_mirror.py to the list of exceptions from the linting rule prohibiting using the word "subject" in names (its use is justified in the context of emails and email_mirror.py is already an exception).

We use a regex to remove RE: FWD: (and various equivalents) from email subjects before posting them to a stream. We add subjects.json in test fixtures for the purpose of testing and it can be looked at to see what forms of RE and FWD we're able to strip.

We add "From: <sender email>" to the beginning of messages. This was a bit problematic for testing, because many tests do `` self.assertEqual(message.content, "some body string") ``,
so in each of them a change was needed to adjust for the fact that message.content now begins with sender's address - and any future changes to this format will require adjusting all these tests again.