### PR TITLE
Fixes the issue of displaying success message  even after switching to other settings.

### DIFF
--- a/static/js/settings_invites.js
+++ b/static/js/settings_invites.js
@@ -12,7 +12,7 @@ exports.reset = function () {
 
 function failed_listing_invites(xhr) {
     loading.destroy_indicator($('#admin_page_invites_loading_indicator'));
-    ui_report.error(i18n.t("Error listing invites"), xhr, $("#organization-status"));
+    ui_report.error(i18n.t("Error listing invites"), xhr, $("#invites-field-status"));
 }
 
 exports.invited_as_values = {

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -78,7 +78,7 @@ exports.update_user_data = function (user_id, new_data) {
 
 function failed_listing_users(xhr) {
     loading.destroy_indicator($('#subs_page_loading_indicator'));
-    ui_report.error(i18n.t("Error listing users or bots"), xhr, $("#organization-status"));
+    ui_report.error(i18n.t("Error listing users or bots"), xhr, $("#user-field-status"));
 }
 
 function populate_users(realm_people_data) {
@@ -252,7 +252,7 @@ exports.on_load_success = function (realm_people_data) {
         channel.del({
             url: '/json/users/' + encodeURIComponent(user_id),
             error: function (xhr) {
-                var status = $("#organization-status").expectOne();
+                var status = $("#user-field-status").expectOne();
                 ui_report.error(i18n.t("Failed"), xhr, status);
                 var button = meta.current_deactivate_user_modal_row.find("button.deactivate");
                 button.text(i18n.t("Deactivate"));
@@ -345,7 +345,7 @@ exports.on_load_success = function (realm_people_data) {
 
         var url;
         var data;
-        var admin_status = $('#organization-status').expectOne();
+        var admin_status;
         var full_name = user_info_form_modal.find("input[name='full_name']");
 
         user_info_form_modal.find('.submit_user_info_change').on("click", function (e) {
@@ -356,6 +356,7 @@ exports.on_load_success = function (realm_people_data) {
 
             if (person.is_bot) {
                 url = "/json/bots/" + encodeURIComponent(user_id);
+                admin_status = $('#bot-field-status').expectOne();
                 data = {
                     full_name: full_name.val(),
                 };
@@ -364,6 +365,7 @@ exports.on_load_success = function (realm_people_data) {
                     data.bot_owner_id = people.get_by_email(owner_select_value).user_id;
                 }
             } else {
+                admin_status = $('#user-field-status').expectOne();
                 url = "/json/users/" + encodeURIComponent(user_id);
                 data = {
                     full_name: JSON.stringify(full_name.val()),
@@ -372,18 +374,9 @@ exports.on_load_success = function (realm_people_data) {
                 };
             }
 
-            channel.patch({
-                url: url,
-                data: data,
-                success: function () {
-                    ui_report.success(i18n.t('Updated successfully!'), admin_status);
-                    overlays.close_modal('user-info-form-modal');
-                },
-                error: function (xhr) {
-                    ui_report.error(i18n.t('Failed'), xhr, admin_status);
-                    overlays.close_modal('user-info-form-modal');
-                },
-            });
+            settings_ui.do_settings_change(channel.patch, url,
+                                           data, admin_status);
+            overlays.close_modal('user-info-form-modal');
         });
     });
 

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -14,7 +14,8 @@ function get_user_info_row(user_id) {
     return $("tr.user_row[data-user-id='" + user_id + "']");
 }
 
-function update_view_on_deactivate(row) {
+function update_view_on_deactivate() {
+    var row = meta.current_deactivate_bot_modal_row;
     var button = row.find("button.deactivate");
     row.find('button.open-user-form').hide();
     button.addClass("btn-warning");
@@ -24,8 +25,13 @@ function update_view_on_deactivate(row) {
     button.text(i18n.t("Reactivate"));
     row.addClass("deactivated_user");
 }
+function update_view_on_deactivate_reactivate_failure(xhr) {
+    ui_report.generic_row_button_error(xhr, meta.current_bot_element);
 
-function update_view_on_reactivate(row) {
+}
+
+function update_view_on_reactivate() {
+    var row = meta.current_bot_element.closest(".user_row");
     row.find(".user-admin-settings").show();
     var button = row.find("button.reactivate");
     row.find("button.open-user-form").show();
@@ -238,6 +244,20 @@ exports.on_load_success = function (realm_people_data) {
         meta.current_deactivate_user_modal_row = row;
     });
 
+    function update_button_on_success() {
+        var button = meta.current_deactivate_user_modal_row.find("button.deactivate");
+        button.prop("disabled", false);
+        button.addClass("btn-warning reactivate").removeClass("btn-danger deactivate");
+        button.text(i18n.t("Reactivate"));
+        meta.current_deactivate_user_modal_row.addClass("deactivated_user");
+        meta.current_deactivate_user_modal_row.find('button.open-user-form').hide();
+        meta.current_deactivate_user_modal_row.find(".user-admin-settings").hide();
+    }
+    function update_button_on_failure() {
+        var button = meta.current_deactivate_user_modal_row.find("button.deactivate");
+        button.text(i18n.t("Deactivate"));
+    }
+
     $("#do_deactivate_user_button").expectOne().click(function () {
         var email = meta.current_deactivate_user_modal_row.attr("data-email");
         var user_id = meta.current_deactivate_user_modal_row.attr("data-user-id");
@@ -249,24 +269,16 @@ exports.on_load_success = function (realm_people_data) {
         }
         $("#deactivation_user_modal").modal("hide");
         meta.current_deactivate_user_modal_row.find("button").eq(0).prop("disabled", true).text(i18n.t("Working…"));
-        channel.del({
-            url: '/json/users/' + encodeURIComponent(user_id),
-            error: function (xhr) {
-                var status = $("#user-field-status").expectOne();
-                ui_report.error(i18n.t("Failed"), xhr, status);
-                var button = meta.current_deactivate_user_modal_row.find("button.deactivate");
-                button.text(i18n.t("Deactivate"));
-            },
-            success: function () {
-                var button = meta.current_deactivate_user_modal_row.find("button.deactivate");
-                button.prop("disabled", false);
-                button.addClass("btn-warning reactivate").removeClass("btn-danger deactivate");
-                button.text(i18n.t("Reactivate"));
-                meta.current_deactivate_user_modal_row.addClass("deactivated_user");
-                meta.current_deactivate_user_modal_row.find('button.open-user-form').hide();
-                meta.current_deactivate_user_modal_row.find(".user-admin-settings").hide();
-            },
-        });
+        var data = {
+        };
+        var opts = {
+            success_continuation: update_button_on_success,
+            error_continuation: update_button_on_failure,
+        };
+        var status = $("#user-field-status").expectOne();
+        var url = '/json/users/' + encodeURIComponent(user_id);
+        settings_ui.do_settings_change(channel.del, url, data, status, opts);
+
     });
 
     $(".admin_bot_table").on("click", ".deactivate", function (e) {
@@ -274,37 +286,42 @@ exports.on_load_success = function (realm_people_data) {
         e.stopPropagation();
 
         var row = $(e.target).closest(".user_row");
-
+        meta.current_deactivate_bot_modal_row = row;
+        meta.current_bot_element = $(e.target);
         var bot_id = row.attr("data-user-id");
+        var url = '/json/bots/' + encodeURIComponent(bot_id);
+        var data = {
+        };
+        var opts = {
+            success_continuation: update_view_on_deactivate,
+            error_continuation: update_view_on_deactivate_reactivate_failure,
+        };
+        var status = $("#bot-field-status").expectOne();
+        settings_ui.do_settings_change(channel.del, url, data, status, opts);
 
-        channel.del({
-            url: '/json/bots/' + encodeURIComponent(bot_id),
-            error: function (xhr) {
-                ui_report.generic_row_button_error(xhr, $(e.target));
-            },
-            success: function () {
-                update_view_on_deactivate(row);
-            },
-        });
     });
 
     $(".admin_user_table, .admin_bot_table").on("click", ".reactivate", function (e) {
         e.preventDefault();
         e.stopPropagation();
-
+        meta.current_bot_element = $(e.target);
         // Go up the tree until we find the user row, then grab the email element
         var row = $(e.target).closest(".user_row");
         var user_id = row.attr("data-user-id");
-
-        channel.post({
-            url: '/json/users/' + encodeURIComponent(user_id) + "/reactivate",
-            error: function (xhr) {
-                ui_report.generic_row_button_error(xhr, $(e.target));
-            },
-            success: function () {
-                update_view_on_reactivate(row);
-            },
-        });
+        var person = people.get_person_from_user_id(user_id);
+        var status;
+        if (person.is_bot) {
+            status =  $("#bot-field-status").expectOne();
+        } else {
+            status =  $("#deactivated-user-field-status").expectOne();
+        }
+        var url = '/json/users/' + encodeURIComponent(user_id) + "/reactivate";
+        var data = {};
+        var opts = {
+            success_continuation: update_view_on_reactivate,
+            error_continuation: update_view_on_deactivate_reactivate_failure,
+        };
+        settings_ui.do_settings_change(channel.post, url, data, status, opts);
     });
 
     function open_user_info_form_modal(person) {

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1347,7 +1347,7 @@ input[type=checkbox].inline-block {
 
 #settings_page input.search {
     font-size: 0.9rem;
-    margin: 0px 0px 20px 0px;
+    margin: 10px 0px 20px 0px;
 }
 
 #settings_page .form-sidebar {

--- a/static/templates/settings/bot-list-admin.handlebars
+++ b/static/templates/settings/bot-list-admin.handlebars
@@ -1,6 +1,8 @@
 <div id="admin-bot-list" class="settings-section" data-name="bot-list-admin">
     <div class="tip bot-settings-tip"></div>
+    <h3 class="inline-block">{{t "Bots" }}</h3>
     <input type="text" class="search" placeholder="{{t 'Filter bots' }}" aria-label="{{t 'Filter bots' }}"/>
+    <div class="alert-notification" id="bot-field-status"></div>
     <div class="clear-float"></div>
     <table class="table table-condensed table-striped wrapped-table">
         <thead>

--- a/static/templates/settings/deactivated-users-admin.handlebars
+++ b/static/templates/settings/deactivated-users-admin.handlebars
@@ -1,5 +1,7 @@
 <div id="admin-deactivated-users-list" class="settings-section" data-name="deactivated-users-admin">
+    <h3 class="inline-block">{{t "Deactivated users" }}</h3>
     <input type="text" class="search" placeholder="{{t 'Filter deactivated users' }}" aria-label="{{t 'Filter deactivated users' }}"/>
+    <div class="alert-notification" id="deactivated-user-field-status"></div>
     <div class="clear-float"></div>
 
     <div class="progressive-table-wrapper">

--- a/static/templates/settings/invites-list-admin.handlebars
+++ b/static/templates/settings/invites-list-admin.handlebars
@@ -1,6 +1,10 @@
 <div id="admin-invites-list" class="settings-section" data-name="invites-list-admin">
     <a class="invite-user-link" href="#invite"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{t "Invite more users" }}</a>
-    <input type="text" class="search" placeholder="{{t 'Filter invites' }}" aria-label="{{t 'Filter invites' }}"/>
+    <div>
+        <h3 class="inline-block">{{t "Invites" }}</h3>
+        <input type="text" class="search" placeholder="{{t 'Filter invites' }}" aria-label="{{t 'Filter invites' }}"/>
+        <div class="alert-notification" id="invites-field-status"></div>
+    </div>
     <div class="clear-float"></div>
 
     <div class="progressive-table-wrapper">

--- a/static/templates/settings/user-list-admin.handlebars
+++ b/static/templates/settings/user-list-admin.handlebars
@@ -1,5 +1,8 @@
 <div id="admin-user-list" class="settings-section" data-name="user-list-admin">
+    <h3 class="inline-block">{{t "Users" }}</h3>
+
     <input type="text" class="search" placeholder="{{t 'Filter users' }}" aria-label="{{t 'Filter users' }}"/>
+    <div class="alert-notification" id="user-field-status"></div>
     <div class="clear-float"></div>
 
     <table class="table table-condensed table-striped wrapped-table">

--- a/static/templates/user-info-form-modal.handlebars
+++ b/static/templates/user-info-form-modal.handlebars
@@ -1,7 +1,11 @@
 <div id="user-info-form-modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog" aria-labelledby="user-info-form-modal-label" aria-hidden="true">
     <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+        {{#if is_bot}}
+        <h3 id="user-info-form-modal-label">{{t "Change bot info and owner" }}</h3>
+        {{else}}
         <h3 id="user-info-form-modal-label">{{t "Change user info and roles" }}</h3>
+        {{/if}}
     </div>
     <div class="modal-body">
         <div id="user-name-form" data-user-id="{{user_id}}">


### PR DESCRIPTION
Fixes the issue of displaying success message  even after switching to other settings on Org settings > Users.

The commit removes the old method of showing success message
("Updated Successfully").The new message shows "saving" along
with a spiral ,which then turns into a "saved" and then disappears.
This is implememnted by using the method 'settings_ui.do_settings_change()'
 instead of direct 'ui_report'.

Fixes: #11177

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/11177

**Testing Plan:** <!-- How have you tested? -->
Manually through browser.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![save](https://user-images.githubusercontent.com/27897288/50740521-a1392200-1215-11e9-919e-f2999ae54843.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
