### PR TITLE
script: Add ready-to-run tooling for doing backups.

### DIFF
--- a/docs/production/maintain-secure-upgrade.md
+++ b/docs/production/maintain-secure-upgrade.md
@@ -239,6 +239,58 @@ dependencies are installed by default.
 
 ## Backups
 
+Starting with Zulip 2.0, Zulip has a built-in backup tool:
+
+```
+# As the zulip user
+/home/zulip/deployments/current/manage.py backup
+# Or as root
+su zulip -c '/home/zulip/deployments/current/manage.py backup'
+```
+
+This will generate a `.tar.gz` archive containing all the data stored
+on your Zulip server that would be needed to restore your Zulip
+server's state on another machine perfectly.
+
+**Caveats**.  The following data present on a Zulip server is not
+included in these backup archives:
+
+* Certain highly transient state that Zulip doesn't store in a
+  database, such as typing status, API rate-limiting counters,
+  etc. that would have no value 1 minute after the backup is
+  completed.
+
+* The server access/error logs from `/var/log/zulip`, because a Zulip
+  server only appends to those log files (i.e. they aren't necessarily
+  to precisely restore your Zulip data), and they can be very large
+  compared to the rest of the data for a Zulip server.
+
+* Files uploaded with the Zulip
+  [S3 file upload backend](../production/upload-backends.html).  We
+  don't include these for two reasons. First, the uploaded file data
+  in S3 can easily be many times larger than the rest of the backup,
+  and downloading it all to a server doing a backup could easily
+  exceed its disk capacity.  Additionally, S3 is a reliable persistent
+  storage system with its own high-quality tools for doing backups.
+  Contributions of (documentation on) ready-to-use scripting for S3
+  backups are welcome.
+
+* SSL certificates.  Since these are either trivially replaced (if
+  generated via Certbot) or provided by the system administrator, we
+  do not include them in these backups.
+
+### Backup restoration
+
+Backups generated using the above backup tool can be restored as
+follows:
+
+```
+# First, install a Zulip server through Step 3.  Then, run:
+/home/zulip/deployments/current/scripts/setup/restore-backup /path/to/backup
+```
+
+### Backup details
+
 There are several pieces of data that you might want to back up:
 
 * The postgres database.  That you can back up like any postgres

--- a/scripts/setup/restore-backup
+++ b/scripts/setup/restore-backup
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -e
+set -x
+
+DATABASE_NAME="zulip"
+files_path="/home/zulip/uploads"
+settings_path="/etc/zulip"
+POSTGRES_USER="postgres"
+
+backup_path="$1"
+
+temp_dir=$(mktemp -d)
+tar -C "$temp_dir" --strip-components=1 -zxf "$backup_path"
+
+mkdir -p "$files_path" "$settings_path"
+tar -C "$files_path" -zxf "$temp_dir/files.tar.gz"
+tar -C "$settings_path" -zxf "$temp_dir/settings.tar.gz"
+
+sudo chown -R "$POSTGRES_USER" "$temp_dir"
+
+./scripts/setup/terminate-psql-sessions zulip zulip zulip_base
+sudo -u "$POSTGRES_USER" /usr/bin/env bash -x <<EOF
+dropdb "$DATABASE_NAME"
+createdb -T template0 "$DATABASE_NAME"
+pg_restore -d "$DATABASE_NAME" "$temp_dir/database"
+EOF
+
+# Apply server-level configuration settings to /etc/.
+/home/zulip/deployments/current/scripts/zulip-puppet-apply -f
+
+# Restart the server, and clear caches.
+supervisorctl restart all
+./scripts/setup/flush-memcached

--- a/zerver/management/commands/backup.py
+++ b/zerver/management/commands/backup.py
@@ -1,0 +1,59 @@
+
+import os
+import shutil
+import subprocess
+import tempfile
+from argparse import ArgumentParser, RawTextHelpFormatter
+from typing import Any
+
+from django.conf import settings
+from django.core.management.base import CommandError
+from django.utils.timezone import now as timezone_now
+
+from zerver.lib.management import ZulipBaseCommand
+from scripts.lib.zulip_tools import run, TIMESTAMP_FORMAT
+
+class Command(ZulipBaseCommand):
+    # Fix support for multi-line usage strings
+    def create_parser(self, *args: Any, **kwargs: Any) -> ArgumentParser:
+        parser = super().create_parser(*args, **kwargs)
+        parser.formatter_class = RawTextHelpFormatter
+        return parser
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        parser.add_argument('--output',
+                            dest='output_dir',
+                            action="store",
+                            default=None,
+                            help='Directory to write backup tarball to.')
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        output_dir = options["output_dir"]
+        if output_dir is None:
+            timestamp = timezone_now().strftime(TIMESTAMP_FORMAT)
+            output_dir = tempfile.mkdtemp(prefix="/tmp/zulip-backup-%s-" % (timestamp,))
+        else:
+            output_dir = os.path.realpath(os.path.expanduser(output_dir))
+
+        os.makedirs(output_dir, exist_ok=True)
+
+        DATABASES = settings.DATABASES['default']
+        postgres_dir = os.path.join(output_dir, "database")
+        run(["pg_dump", "--format=directory", DATABASES['NAME'],
+             "--file", postgres_dir])
+
+        if settings.LOCAL_UPLOADS_DIR is not None:
+            uploads_tarball = os.path.join(output_dir, "files.tar.gz")
+            run(["tar", "-czf", uploads_tarball,
+                 '-C', settings.LOCAL_UPLOADS_DIR, '.'])
+
+        settings_path = "/etc/zulip"
+        if settings.DEVELOPMENT:
+            settings_path = os.path.join(settings.DEPLOY_ROOT, "zproject")
+        settings_tarball = os.path.join(output_dir, "settings.tar.gz")
+        run(["tar", "-C", settings_path, "-czf", settings_tarball, '.'])
+
+        tarball_path = output_dir.rstrip('/') + '.tar.gz'
+        os.chdir(os.path.dirname(output_dir))
+        subprocess.check_call(["tar", "-czf", tarball_path, os.path.basename(output_dir)])
+        print("Backup tarball written to %s" % (tarball_path,))


### PR DESCRIPTION
This work is incomplete:

* The backup tool is pretty reasonable.  It could benefit from some
  sort of automated test, but it's also the kind of tool that's likely
  to be stable for the long term.

* The restoration tool needs to (1) process arguments, (2) make it a
  hard to accidentally destroy all your data without confirmation or a
  `-f` flag, and (3) could probably benefit from being rewritten in
  Python.  And maybe (4) to not require sudo.

* The documentation for this subsystem needs to cover restoration and
  could use some restructing to properly weight the different pieces.
  Probably deserves to be extracted to its own page.

But it should provide everything we need, and I've tested a successful backup+restoration in my Zulip development environment.