### PR TITLE
settings: Fix alignment of left-side icons in org setting tab.

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1646,6 +1646,7 @@ input[type=text]#settings_search {
     width: 18px;
     height: 18px;
     margin: 10px 10px;
+    text-align: center;
 
     font-size: 1.4em;
     color: hsl(0, 0%, 53%);


### PR DESCRIPTION
This fixes a part of #10954.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
