### PR TITLE
api docs: Stop mentioning "dev servers" in JS code examples.

### DIFF
--- a/templates/zerver/api/add-subscriptions.md
+++ b/templates/zerver/api/add-subscriptions.md
@@ -22,9 +22,9 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 ```js
 const zulip = require('zulip-js');
 
-// Download zuliprc-dev from your dev server
+// Pass the path to your zuliprc file here.
 const config = {
-    zuliprc: 'zuliprc-dev',
+    zuliprc: 'zuliprc',
 };
 
 zulip(config).then((client) => {

--- a/templates/zerver/api/create-user.md
+++ b/templates/zerver/api/create-user.md
@@ -19,7 +19,7 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 ```js
 const zulip = require('zulip-js');
 
-// You need a zuliprc-admin with administrator credentials
+// The user for this zuliprc file must be an organization administrator.
 const config = {
     zuliprc: 'zuliprc-admin',
 };

--- a/templates/zerver/api/delete-queue.md
+++ b/templates/zerver/api/delete-queue.md
@@ -18,9 +18,9 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 ```js
 const zulip = require('zulip-js');
 
-// Download zuliprc-dev from your dev server
+// Pass the path to your zuliprc file here.
 const config = {
-    zuliprc: 'zuliprc-dev',
+    zuliprc: 'zuliprc',
 };
 
 zulip(config).then((client) => {

--- a/templates/zerver/api/get-all-streams.md
+++ b/templates/zerver/api/get-all-streams.md
@@ -17,9 +17,9 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 ```js
 const zulip = require('zulip-js');
 
-// Download zuliprc-dev from your dev server
+// Pass the path to your zuliprc file here.
 const config = {
-    zuliprc: 'zuliprc-dev',
+    zuliprc: 'zuliprc',
 };
 
 zulip(config).then((client) => {

--- a/templates/zerver/api/get-all-users.md
+++ b/templates/zerver/api/get-all-users.md
@@ -17,9 +17,9 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 ```js
 const zulip = require('zulip-js');
 
-// Download zuliprc-dev from your dev server
+// Pass the path to your zuliprc file here.
 const config = {
-    zuliprc: 'zuliprc-dev',
+    zuliprc: 'zuliprc',
 };
 
 zulip(config).then((client) => {

--- a/templates/zerver/api/get-events-from-queue.md
+++ b/templates/zerver/api/get-events-from-queue.md
@@ -16,8 +16,8 @@ This endpoint allows you to receive new events from
 import sys
 import zulip
 
-# Download ~/zuliprc-dev from your dev server
-client = zulip.Client(config_file="~/zuliprc-dev")
+# Pass the path to your zuliprc file here.
+client = zulip.Client(config_file="~/zuliprc")
 
 # If you already have a queue registered and thus, have a queue_id
 # on hand, you may use client.get_events() and pass in the above
@@ -37,9 +37,9 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 ```js
 const zulip = require('zulip-js');
 
-// Download zuliprc-dev from your dev server
+// Pass the path to your zuliprc file here.
 const config = {
-    zuliprc: 'zuliprc-dev',
+    zuliprc: 'zuliprc',
 };
 
 zulip(config).then((client) => {

--- a/templates/zerver/api/get-messages.md
+++ b/templates/zerver/api/get-messages.md
@@ -42,9 +42,9 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 ```js
 const zulip = require('zulip-js');
 
-// Download zuliprc-dev from your dev server
+// Pass the path to your zuliprc file here.
 const config = {
-    zuliprc: 'zuliprc-dev',
+    zuliprc: 'zuliprc',
 };
 
 zulip(config).then((client) => {

--- a/templates/zerver/api/get-org-emoji.md
+++ b/templates/zerver/api/get-org-emoji.md
@@ -17,9 +17,9 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 ```js
 const zulip = require('zulip-js');
 
-// Download zuliprc-dev from your dev server
+// Pass the path to your zuliprc file here.
 const config = {
-    zuliprc: 'zuliprc-dev',
+    zuliprc: 'zuliprc',
 };
 
 zulip(config).then((client) => {

--- a/templates/zerver/api/get-profile.md
+++ b/templates/zerver/api/get-profile.md
@@ -17,9 +17,9 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 ```js
 const zulip = require('zulip-js');
 
-// Download zuliprc-dev from your dev server
+// Pass the path to your zuliprc file here.
 const config = {
-    zuliprc: 'zuliprc-dev',
+    zuliprc: 'zuliprc',
 };
 
 zulip(config).then((client) => {

--- a/templates/zerver/api/get-stream-id.md
+++ b/templates/zerver/api/get-stream-id.md
@@ -17,9 +17,9 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 ```js
 const zulip = require('zulip-js');
 
-// Download zuliprc-dev from your dev server
+// Pass the path to your zuliprc file here.
 const config = {
-    zuliprc: 'zuliprc-dev',
+    zuliprc: 'zuliprc',
 };
 
 zulip(config).then((client) => {

--- a/templates/zerver/api/get-stream-topics.md
+++ b/templates/zerver/api/get-stream-topics.md
@@ -17,9 +17,9 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 ```js
 const zulip = require('zulip-js');
 
-// Download zuliprc-dev from your dev server, assuming it's in the local dir
+// Pass the path to your zuliprc file here.
 const config = {
-    zuliprc: 'zuliprc-dev',
+    zuliprc: 'zuliprc',
 };
 
 zulip(config).then((client) => {

--- a/templates/zerver/api/get-subscribed-streams.md
+++ b/templates/zerver/api/get-subscribed-streams.md
@@ -18,9 +18,9 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 ```js
 const zulip = require('zulip-js');
 
-// Download zuliprc-dev from your dev server
+// Pass the path to your zuliprc file here.
 const config = {
-    zuliprc: 'zuliprc-dev',
+    zuliprc: 'zuliprc',
 };
 
 zulip(config).then((client) => {

--- a/templates/zerver/api/real-time-events.md
+++ b/templates/zerver/api/real-time-events.md
@@ -36,8 +36,8 @@ instead use the raw [register](/api/register-queue) and
 import sys
 import zulip
 
-# Download ~/zuliprc-dev from your dev server
-client = zulip.Client(config_file="~/zuliprc-dev")
+# Pass the path to your zuliprc file here.
+client = zulip.Client(config_file="~/zuliprc")
 
 # Print every message the current user would receive
 # This is a blocking call that will run forever

--- a/templates/zerver/api/register-queue.md
+++ b/templates/zerver/api/register-queue.md
@@ -58,9 +58,9 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 ```js
 const zulip = require('zulip-js');
 
-// Download zuliprc-dev from your dev server
+// Pass the path to your zuliprc file here.
 const config = {
-    zuliprc: 'zuliprc-dev',
+    zuliprc: 'zuliprc',
 };
 
 zulip(config).then((client) => {

--- a/templates/zerver/api/remove-subscriptions.md
+++ b/templates/zerver/api/remove-subscriptions.md
@@ -17,9 +17,9 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 ```js
 const zulip = require('zulip-js');
 
-// Download zuliprc-dev from your dev server
+// Pass the path to your zuliprc file here.
 const config = {
-    zuliprc: 'zuliprc-dev',
+    zuliprc: 'zuliprc',
 };
 
 zulip(config).then((client) => {

--- a/templates/zerver/api/render-message.md
+++ b/templates/zerver/api/render-message.md
@@ -17,9 +17,9 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 ```js
 const zulip = require('zulip-js');
 
-// Download zuliprc-dev from your dev server
+// Pass the path to your zuliprc file here.
 const config = {
-    zuliprc: 'zuliprc-dev',
+    zuliprc: 'zuliprc',
 };
 
 zulip(config).then((client) => {

--- a/templates/zerver/api/send-message.md
+++ b/templates/zerver/api/send-message.md
@@ -17,9 +17,9 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 ```js
 const zulip = require('zulip-js');
 
-// Download zuliprc-dev from your dev server
+// Pass the path to your zuliprc file here.
 const config = {
-    zuliprc: 'zuliprc-dev',
+    zuliprc: 'zuliprc',
 };
 
 // Send a stream message

--- a/templates/zerver/api/typing.md
+++ b/templates/zerver/api/typing.md
@@ -20,9 +20,9 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 ```js
 const zulip = require('zulip-js');
 
-// Download zuliprc-dev from your dev server
+// Pass the path to your zuliprc file here.
 const config = {
-    zuliprc: 'zuliprc-dev',
+    zuliprc: 'zuliprc',
 };
 
 const typingParams = {

--- a/templates/zerver/api/update-message-flags.md
+++ b/templates/zerver/api/update-message-flags.md
@@ -21,9 +21,9 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 ```js
 const zulip = require('zulip-js');
 
-// Download zuliprc-dev from your dev server
+// Pass the path to your zuliprc file here.
 const config = {
-    zuliprc: 'zuliprc-dev',
+    zuliprc: 'zuliprc',
 };
 
 const flagParams = {

--- a/templates/zerver/api/update-message.md
+++ b/templates/zerver/api/update-message.md
@@ -20,9 +20,9 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 ```js
 const zulip = require('zulip-js');
 
-// Download zuliprc-dev from your dev server
+// Pass the path to your zuliprc file here.
 const config = {
-    zuliprc: 'zuliprc-dev',
+    zuliprc: 'zuliprc',
 };
 
 zulip(config).then((client) => {


### PR DESCRIPTION
Since the Zulip API runs on both developement and production
servers, it is misleading to mention "dev servers" when discussing
zuliprc files.

Also, note that it is better to manually edit all of our JS
examples than to implement macro-like functionality that we use
for our Python examples. For our current purposes, it would be
too much work to build a full-blown testing framework for our
JS code examples just so that we can fix a minor wording issue.

@timabbott: FYI :)