### PR TITLE
portico: Fix overlap of server and frontend errors.

### DIFF
--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -116,6 +116,12 @@ $(function () {
             // by the server.
             $("#login_form .alert.alert-error").remove();
         },
+        showErrors: function (error_map) {
+            if (error_map.password) {
+                $("#login_form .alert.alert-error").remove();
+            }
+            this.defaultShowErrors();
+        },
     });
 
     function check_subdomain_avilable(subdomain) {


### PR DESCRIPTION
Clears the errors received from the server whenever there is a chance of
overlap among them.

Fixes #10831

**GIFs or Screenshots:**

![ezgif-4-fdaf66d12d85](https://user-images.githubusercontent.com/33068691/50884349-ad3d0380-1410-11e9-8ab8-dc5c54cde5ee.gif)

The server errors only clear up when the errors overlap, not when there's an error in another field...

![screenshot 2019-01-09 at 12 44 04 pm](https://user-images.githubusercontent.com/33068691/50884391-c9d93b80-1410-11e9-90eb-645f2aee6c86.png)