### PR TITLE
topic edit: Improve styling of topic edit icons (save and cancel) to match settings UI

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2416,29 +2416,36 @@ li .message_inline_image img {
     text-align: center;
 }
 
-button.primary {
-    background-color: hsl(207, 21%, 62%);
-    padding: 2px;
-    color: hsl(0, 0%, 100%);
+.small_square_button {
+    background-color: hsl(156, 30%, 50%);
+    padding: 0;
+    color: hsl(0, 0%, 95%);
     border: none;
-    border-radius: 0px;
-}
-
-button.primary:hover {
-    background-color: hsl(207, 25%, 65%);
-}
-
-button.primary:focus {
-    outline: none;
-}
-
-button.topic_edit_save,
-button.topic_edit_cancel {
     font-size: 12px;
     width: 18px;
     height: 18px;
-    vertical-align: baseline;
     border-radius: 4px;
+    margin-bottom: 3px;
+}
+
+.small_square_button:hover {
+    color: hsl(0, 0%, 100%);
+    box-shadow: 0 10px 41px 0 hsl(166, 35%, 48%);
+}
+
+.small_square_button:focus {
+    outline: none;
+}
+
+.small_square_x {
+    background-color: white;
+    color: hsl(0, 0%, 47%);
+}
+
+.small_square_x:hover {
+    background-color: hsl(0, 0%, 100%);
+    color: hsl(0, 0%, 18%);
+    box-shadow: 0 10px 41px 0 hsl(0, 0%, 48%);
 }
 
 div.topic_edit_spinner {

--- a/static/templates/topic_edit_form.handlebars
+++ b/static/templates/topic_edit_form.handlebars
@@ -3,8 +3,8 @@
 <form id="topic_edit_form" class="form-horizontal">
     <input type="text" value="" class="inline_topic_edit header-v" id="inline_topic_edit"
       autocomplete="off" />
-    <button type="button" class="topic_edit_save primary"><i class="fa fa-check" aria-hidden="true"></i></button>
-    <button type="button" class="topic_edit_cancel primary"><i class="fa fa-remove" aria-hidden="true"></i></button>
+    <button type="button" class="topic_edit_save small_square_button small_square_check"><i class="fa fa-check" aria-hidden="true"></i></button>
+    <button type="button" class="topic_edit_cancel small_square_button small_square_x"><i class="fa fa-remove" aria-hidden="true"></i></button>
     <div class="topic_edit_spinner"></div>
     <div class="alert alert-error edit_error hide"></div>
 </form>


### PR DESCRIPTION
The earlier styles were inconsistent with the rest of UI. The new styles are similar to "Organisation settings" UI.

Fixes #10983

**GIFs or Screenshots:** 
![screenshot from 2019-01-09 18-25-53](https://user-images.githubusercontent.com/5001704/50900709-0a01e380-143c-11e9-9fd4-0eda64a3891f.png)
