### PR TITLE
Fix scrollbar regressions.

### DIFF
--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -104,7 +104,7 @@ run_test('filter_table', () => {
     };
 
     var ui_called = false;
-    ui.update_scrollbar = function (elem) {
+    ui.reset_scrollbar = function (elem) {
         ui_called = true;
         assert.equal(elem, $("#subscription_overlay .streams-list"));
     };

--- a/static/js/attachments_ui.js
+++ b/static/js/attachments_ui.js
@@ -50,7 +50,7 @@ function render_attachments_ui() {
                 return item.name.toLocaleLowerCase().indexOf(value) >= 0;
             },
             onupdate: function () {
-                ui.update_scrollbar(uploaded_files_table.closest(".progressive-table-wrapper"));
+                ui.reset_scrollbar(uploaded_files_table.closest(".progressive-table-wrapper"));
             },
         },
         parent_container: $('#attachments-settings').expectOne(),
@@ -74,7 +74,7 @@ function render_attachments_ui() {
         return -1;
     });
 
-    ui.update_scrollbar(uploaded_files_table.closest(".progressive-table-wrapper"));
+    ui.reset_scrollbar(uploaded_files_table.closest(".progressive-table-wrapper"));
 }
 
 function format_attachment_data(new_attachments) {

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -226,7 +226,7 @@ function filter_emojis() {
             message_id: message_id,
         });
         $('.emoji-search-results').html(rendered_search_results);
-        ui.update_scrollbar($(".emoji-search-results-container"));
+        ui.reset_scrollbar($(".emoji-search-results-container"));
         if (!search_results_visible) {
             show_search_results();
         }

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -421,7 +421,7 @@ exports.populate_notifications_stream_dropdown = function (stream_list) {
                 return item.name.toLowerCase().indexOf(value) >= 0;
             },
             onupdate: function () {
-                ui.update_scrollbar(dropdown_list_body);
+                ui.reset_scrollbar(dropdown_list_body);
             },
         },
     }).init();

--- a/static/js/settings_streams.js
+++ b/static/js/settings_streams.js
@@ -39,7 +39,7 @@ exports.build_default_stream_table = function (streams_data) {
                 return item.name.toLowerCase().indexOf(value) >= 0;
             },
             onupdate: function () {
-                ui.update_scrollbar(table);
+                ui.reset_scrollbar(table);
             },
         },
     }).init();

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -102,9 +102,9 @@ function populate_users(realm_people_data) {
     deactivated_users = _.sortBy(deactivated_users, 'full_name');
     bots = _.sortBy(bots, 'full_name');
 
-    var update_scrollbar = function ($sel) {
+    var reset_scrollbar = function ($sel) {
         return function () {
-            ui.update_scrollbar($sel);
+            ui.reset_scrollbar($sel);
         };
     };
 
@@ -122,7 +122,7 @@ function populate_users(realm_people_data) {
                     item.email.toLowerCase().indexOf(value) >= 0
                 );
             },
-            onupdate: update_scrollbar($bots_table),
+            onupdate: reset_scrollbar($bots_table),
         },
     }).init();
 
@@ -162,7 +162,7 @@ function populate_users(realm_people_data) {
                     item.email.toLowerCase().indexOf(value) >= 0
                 );
             },
-            onupdate: update_scrollbar($users_table),
+            onupdate: reset_scrollbar($users_table),
         },
     }).init();
 
@@ -180,7 +180,7 @@ function populate_users(realm_people_data) {
                     item.email.toLowerCase().indexOf(value) >= 0
                 );
             },
-            onupdate: update_scrollbar($deactivated_users_table),
+            onupdate: reset_scrollbar($deactivated_users_table),
         },
     }).init();
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -466,7 +466,7 @@ exports.filter_table = function (query) {
 
     exports.add_tooltips_to_left_panel();
 
-    ui.update_scrollbar($("#subscription_overlay .streams-list"));
+    ui.reset_scrollbar($("#subscription_overlay .streams-list"));
 
     var all_stream_ids = [].concat(
         buckets.name,

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -26,6 +26,13 @@ exports.set_up_scrollbar = function (element) {
 
 exports.update_scrollbar = function (element_selector) {
     var element = element_selector[0];
+    if (element.perfectScrollbar !== undefined) {
+        element.perfectScrollbar.update();
+    }
+};
+
+exports.reset_scrollbar = function (element_selector) {
+    var element = element_selector[0];
     element.scrollTop = 0;
     if (element.perfectScrollbar !== undefined) {
         element.perfectScrollbar.update();


### PR DESCRIPTION
In between releases, the following commit introduced
a bug where we agressively scroll to the top every
place we call `ui.update_scrollbar`:

    092b73d0b7b45628b463f2ec5594445fe25589d7

The main symptoms were that the left and right sidebars
would go to the top for things like selecting a topic,
getting activity updates from the server, and resizing
the window.  It was very jarring.

The recent commit looked innocuous--the root of the problem
was the original API expressed an intent to scroll to the
top, but didn't actually do it, so it was a bug in hiding.

There are **some** occasions where it's actually appropriate
to scroll to the top, mostly around search filtering, and
in those places we now call the new `ui.reset_scrollbar`
function.

This is a bit of an emergency fix, so particularly with
the settings stuff, we may get more reports of glitches here.

The important thing here is that you almost never want to
reset the scrollTop for sidebars.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
