### PR TITLE
outgoing webhooks: Set a Zulip-specific user-agent.

### DIFF
--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -21,6 +21,8 @@ from zerver.lib.url_encoding import near_message_url
 from zerver.lib.validator import check_dict, check_string
 from zerver.decorator import JsonableError
 
+from version import ZULIP_VERSION
+
 class OutgoingWebhookServiceInterface:
 
     def __init__(self, token: str, user_profile: UserProfile, service_name: str) -> None:
@@ -41,7 +43,11 @@ class GenericOutgoingWebhookService(OutgoingWebhookServiceInterface):
     def send_data_to_server(self,
                             base_url: str,
                             request_data: Any) -> Response:
-        headers = {'content-type': 'application/json'}
+        user_agent = 'ZulipOutgoingWebhook/' + ZULIP_VERSION
+        headers = {
+            'content-type': 'application/json',
+            'user-agent': user_agent,
+        }
         response = requests.request('POST', base_url, data=request_data, headers=headers)
         return response
 

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -20,6 +20,8 @@ from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.topic import TOPIC_NAME
 from zerver.models import get_realm, get_user, UserProfile, get_display_recipient
 
+from version import ZULIP_VERSION
+
 class ResponseMock:
     def __init__(self, status_code: int, content: Optional[Any]=None) -> None:
         self.status_code = status_code
@@ -95,6 +97,19 @@ The webhook got a response with status code *500*.''')
                              '''[A message](http://zulip.testserver/#narrow/stream/999-Verona/topic/Foo/near/) triggered an outgoing webhook.
 The webhook got a response with status code *400*.''')
             self.assertEqual(bot_owner_notification.recipient_id, self.bot_user.bot_owner.id)
+
+    def test_headers(self) -> None:
+        with mock.patch('requests.request') as mock_request:
+            do_rest_call('', 'payload-stub', self.mock_event, service_handler)
+            kwargs = mock_request.call_args[1]
+            self.assertEqual(kwargs['data'], 'payload-stub')
+
+            user_agent = 'ZulipOutgoingWebhook/' + ZULIP_VERSION
+            headers = {
+                'content-type': 'application/json',
+                'user-agent': user_agent,
+            }
+            self.assertEqual(kwargs['headers'], headers)
 
     def test_error_handling(self) -> None:
         def helper(side_effect: Any, error_text: str) -> None:


### PR DESCRIPTION
This now sets the user-agent to something like:

    ZulipOutgoingWebhook/2.0

(It uses the current ZULIP_VERSION.)

Before this change, the user-agent would be
something like `python-requests/2.18.4`.

Fixes #10741

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
