### PR TITLE
Some virtualenv improvements

### DIFF
--- a/scripts/lib/create-production-venv
+++ b/scripts/lib/create-production-venv
@@ -40,7 +40,7 @@ python_version = sys.version_info[0]
 # relative path in requirements/common.in works.
 os.chdir(ZULIP_PATH)
 
-venv_name = "zulip-venv" if sys.version_info[0] == 2 else "zulip-py3-venv"
+venv_name = "zulip-py3-venv"
 cached_venv_path = setup_virtualenv(
     os.path.join(args.deploy_path, venv_name),
     os.path.join(ZULIP_PATH, "requirements", "prod.txt"),

--- a/scripts/lib/setup_path_on_import.py
+++ b/scripts/lib/setup_path_on_import.py
@@ -7,12 +7,13 @@ import os
 import sys
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-activate_this = os.path.join(
-    BASE_DIR,
-    "zulip-py3-venv",
-    "bin",
-    "activate_this.py")
-if os.path.exists(activate_this):
+
+venv = os.path.join(BASE_DIR, "zulip-py3-venv")
+if sys.prefix != venv:
+    activate_this = os.path.join(venv, "bin", "activate_this.py")
     # this file will exist in production
-    exec(open(activate_this).read(), {}, dict(__file__=activate_this))
+    if os.path.exists(activate_this):
+        activate_locals = dict(__file__=activate_this)
+        exec(open(activate_this).read(), {}, activate_locals)
+
 sys.path.append(BASE_DIR)

--- a/scripts/lib/setup_path_on_import.py
+++ b/scripts/lib/setup_path_on_import.py
@@ -15,5 +15,7 @@ if sys.prefix != venv:
     if os.path.exists(activate_this):
         activate_locals = dict(__file__=activate_this)
         exec(open(activate_this).read(), {}, activate_locals)
+        if not os.path.exists(activate_locals["site_packages"]):
+            raise RuntimeError(venv + " was not set up for this Python version")
 
 sys.path.append(BASE_DIR)

--- a/templates/zerver/api/incoming-webhooks-walkthrough.md
+++ b/templates/zerver/api/incoming-webhooks-walkthrough.md
@@ -191,7 +191,7 @@ Now you can test using Zulip itself, or curl on the command line.
 Using `manage.py` from within the Zulip development environment:
 
 ```
-(zulip-venv)vagrant@vagrant-ubuntu-trusty-64:/srv/zulip$
+(zulip-py3-venv)vagrant@vagrant-ubuntu-trusty-64:/srv/zulip$
 ./manage.py send_webhook_fixture_message \
     --fixture=zerver/webhooks/helloworld/fixtures/hello.json \
     '--url=http://localhost:9991/api/v1/external/helloworld?api_key=<api_key>'
@@ -303,7 +303,7 @@ Once you have written some tests, you can run just these new tests from within
 the Zulip development environment with this command:
 
 ```
-(zulip-venv)vagrant@vagrant-ubuntu-trusty-64:/srv/zulip$
+(zulip-py3-venv)vagrant@vagrant-ubuntu-trusty-64:/srv/zulip$
 ./tools/test-backend zerver/webhooks/helloworld
 ```
 
@@ -352,7 +352,7 @@ stream name:
 To trigger a notification using this webhook, use
 `send_webhook_fixture_message` from the Zulip command line:
 
-    (zulip-venv)vagrant@vagrant-ubuntu-trusty-64:/srv/zulip$
+    (zulip-py3-venv)vagrant@vagrant-ubuntu-trusty-64:/srv/zulip$
     ./manage.py send_webhook_fixture_message \
         --fixture=zerver/tests/fixtures/helloworld/hello.json \
         '--url=http://localhost:9991/api/v1/external/helloworld?api_key=&lt;api_key&gt;'

--- a/tools/droplets/README.md
+++ b/tools/droplets/README.md
@@ -97,7 +97,7 @@ Your remote Zulip dev server has been created!
   `ssh zulipdev@<username>.zulipdev.org` on the command line
   (Terminal for macOS and Linux, Bash for Git on Windows).
 - There is no password; your account is configured to use your ssh keys.
-- Once you log in, you should see `(zulip-venv) ~$`.
+- Once you log in, you should see `(zulip-py3-venv) ~$`.
 - To start the dev server, `cd zulip` and then run `./tools/run-dev.py`.
 - While the dev server is running, you can see the Zulip server in your browser
   at http://<username>.zulipdev.org:9991.

--- a/tools/droplets/create.py
+++ b/tools/droplets/create.py
@@ -206,7 +206,7 @@ Your remote Zulip dev server has been created!
   `ssh zulipdev@{0}.zulipdev.org` on the command line
   (Terminal for macOS and Linux, Bash for Git on Windows).
 - There is no password; your account is configured to use your ssh keys.
-- Once you log in, you should see `(zulip-venv) ~$`.
+- Once you log in, you should see `(zulip-py3-venv) ~$`.
 - To start the dev server, `cd zulip` and then run `./tools/run-dev.py`.
 - While the dev server is running, you can see the Zulip server in your browser at
   http://{0}.zulipdev.org:9991.

--- a/zerver/webhooks/helloworld/doc.md
+++ b/zerver/webhooks/helloworld/doc.md
@@ -15,7 +15,7 @@ To trigger a notification using this webhook, use
 `send_webhook_fixture_message` from the Zulip command line:
 
 ```
-(zulip-venv)vagrant@vagrant-ubuntu-trusty-64:/srv/zulip$
+(zulip-py3-venv)vagrant@vagrant-ubuntu-trusty-64:/srv/zulip$
 ./manage.py send_webhook_fixture_message \
 > --fixture=zerver/tests/fixtures/helloworld/hello.json \
 > '--url=http://localhost:9991/api/v1/external/helloworld?api_key=&lt;api_key&gt;'


### PR DESCRIPTION
* Remove some traces of the old Python 2 virtualenv (`zulip-venv`, not to be confused with the still used `zulip-thumbor-venv`).
* In `setup_path_on_import`, only load `activate_this.py` if the virtualenv wasn’t already activated. If we did, check that the virtualenv we activated is compatible with the currently running Python version. (Test case: `deactivate; python2 -m scripts.lib.setup_path_on_import` vs. the same with `python3`, or with `python3.4` vs. `python3.6`.)