### PR TITLE
Fix Admin UI Bug from PR #10471

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -369,6 +369,12 @@ exports.on_load_success = function (realm_people_data) {
         }
 
         var user_info_form_modal = open_user_info_form_modal(person);
+        var element = "#user-info-form-modal .custom-profile-field-form";
+        $(element).html("");
+        settings_account.append_custom_profile_fields(element, user_id);
+        settings_account.initialize_custom_date_type_fields(element);
+        var fields_user_pills = settings_account.intialize_custom_user_type_fields(element, user_id,
+                                                                                   true, false);
 
         var url;
         var data;
@@ -391,11 +397,33 @@ exports.on_load_success = function (realm_people_data) {
                     data.bot_owner_id = people.get_by_email(owner_select_value).user_id;
                 }
             } else {
+                var new_profile_data = [];
+                $("#user-info-form-modal .custom_user_field_value").each(function () {
+                    // Remove duplicate datepicker input element genearted flatpicker library
+                    if (!$(this).hasClass("form-control")) {
+                        new_profile_data.push({
+                            id: parseInt($(this).closest(".custom_user_field").attr("data-field-id"), 10),
+                            value: $(this).val(),
+                        });
+                    }
+                });
+                // Append user type field values also
+                _.each(fields_user_pills, function (field_pills, field_id) {
+                    if (field_pills) {
+                        var user_ids = user_pill.get_user_ids(field_pills);
+                        new_profile_data.push({
+                            id: parseInt(field_id, 10),
+                            value: user_ids,
+                        });
+                    }
+                });
+
                 url = "/json/users/" + encodeURIComponent(user_id);
                 data = {
                     full_name: JSON.stringify(full_name.val()),
                     is_admin: JSON.stringify(user_role_select_value === 'admin'),
                     is_guest: JSON.stringify(user_role_select_value === 'guest'),
+                    profile_data: JSON.stringify(new_profile_data),
                 };
             }
 

--- a/static/templates/user-info-form-modal.handlebars
+++ b/static/templates/user-info-form-modal.handlebars
@@ -28,6 +28,7 @@
                         <option value="admin" {{#if is_admin}}selected{{/if}}>{{t 'Administrator' }}</option>
                     </select>
                 </div>
+                <div class="custom-profile-field-form"></div>
                 {{/if}}
             </form>
         </div>


### PR DESCRIPTION
**Purpose of this PR:**
This PR extends upon @YJDave's work from PR #10471 by fixing the bug noted during it's discussion. Thus, this will allow Zulip to have a complete "Admin UI - Edit Users' Custom Profile Field" section.

***The Bug Itself (In a Nutshell):***
Of all the custom profile field types, for "choice fields" as well as "URL" and "date fields", when the value is reset/deleted/cleared by the admin in the new _Admin UI_, the frontend would send a null (empty string) value to the backend for that custom profile field (as this is, after all, the new value in this case). This then triggers the backend validators to return an error message.

**The Solution:**
What I did was essentially adopt an already existing solution. What happens when a user "clears" their own custom profile field (i.e. choosing no option for a choice field, or giving a blank long/short text field value, etc.) is that a DELETE request would be sent to one of the API endpoints which ultimately ran the `remove_user_custom_profile_data()` method in "zerver/views/custom_profile_fields.py". What this method did was remove the custom profile field data for that custom profile field for that user by deleting the CustomProfileFieldValue involved. Thus, taking this as a pre-existing standard, I did essentially the same with when an admin would clear a user's custom profile field.

This PR comes with 2 commits. The first one is a prep commit where I take this common deleting the field value functionality and create a separate method for it (to improve "DRYness" and modularity). That method is `do_remove_custom_profile_field_value()` in "zerver/lib/actions.py" The second PR is the fix itself where this bug has been eliminated.
