### PR TITLE
webhooks/stripe: Handle invoice and payout events explicitly.

### DIFF
--- a/zerver/webhooks/stripe/fixtures/payout_canceled.json
+++ b/zerver/webhooks/stripe/fixtures/payout_canceled.json
@@ -1,0 +1,34 @@
+{
+    "created": 1326853478,
+    "livemode": false,
+    "id": "payout.canceled_00000000000000",
+    "type": "payout.canceled",
+    "object": "event",
+    "request": null,
+    "pending_webhooks": 1,
+    "api_version": "2018-11-08",
+    "data": {
+        "object": {
+            "id": "po_00000000000000",
+            "object": "payout",
+            "amount": 1100,
+            "arrival_date": 1547032379,
+            "automatic": true,
+            "balance_transaction": "txn_00000000000000",
+            "created": 1547032379,
+            "currency": "usd",
+            "description": "STRIPE PAYOUT",
+            "destination": "ba_1DqezXHOC2HiLzOVUKe5z51g",
+            "failure_balance_transaction": null,
+            "failure_code": null,
+            "failure_message": null,
+            "livemode": false,
+            "metadata": {},
+            "method": "standard",
+            "source_type": "card",
+            "statement_descriptor": null,
+            "status": "in_transit",
+            "type": "bank_account"
+        }
+    }
+}

--- a/zerver/webhooks/stripe/fixtures/payout_created.json
+++ b/zerver/webhooks/stripe/fixtures/payout_created.json
@@ -1,0 +1,34 @@
+{
+    "created": 1326853478,
+    "livemode": false,
+    "id": "payout.created_00000000000000",
+    "type": "payout.created",
+    "object": "event",
+    "request": null,
+    "pending_webhooks": 1,
+    "api_version": "2018-11-08",
+    "data": {
+        "object": {
+            "id": "po_00000000000000",
+            "object": "payout",
+            "amount": 1100,
+            "arrival_date": 1547035911,
+            "automatic": true,
+            "balance_transaction": "txn_00000000000000",
+            "created": 1547035911,
+            "currency": "usd",
+            "description": "STRIPE PAYOUT",
+            "destination": "ba_1DqfuVHOC2HiLzOVWGXN8yi0",
+            "failure_balance_transaction": null,
+            "failure_code": null,
+            "failure_message": null,
+            "livemode": false,
+            "metadata": {},
+            "method": "standard",
+            "source_type": "card",
+            "statement_descriptor": null,
+            "status": "in_transit",
+            "type": "bank_account"
+        }
+    }
+}

--- a/zerver/webhooks/stripe/fixtures/payout_failed.json
+++ b/zerver/webhooks/stripe/fixtures/payout_failed.json
@@ -1,0 +1,34 @@
+{
+    "created": 1326853478,
+    "livemode": false,
+    "id": "payout.failed_00000000000000",
+    "type": "payout.failed",
+    "object": "event",
+    "request": null,
+    "pending_webhooks": 1,
+    "api_version": "2018-11-08",
+    "data": {
+        "object": {
+            "id": "po_00000000000000",
+            "object": "payout",
+            "amount": 1100,
+            "arrival_date": 1547035978,
+            "automatic": true,
+            "balance_transaction": "txn_00000000000000",
+            "created": 1547035978,
+            "currency": "usd",
+            "description": "STRIPE PAYOUT",
+            "destination": "ba_1DqfvaHOC2HiLzOVYVjkm3D2",
+            "failure_balance_transaction": null,
+            "failure_code": null,
+            "failure_message": null,
+            "livemode": false,
+            "metadata": {},
+            "method": "standard",
+            "source_type": "card",
+            "statement_descriptor": null,
+            "status": "in_transit",
+            "type": "bank_account"
+        }
+    }
+}

--- a/zerver/webhooks/stripe/fixtures/payout_paid.json
+++ b/zerver/webhooks/stripe/fixtures/payout_paid.json
@@ -1,0 +1,34 @@
+{
+    "created": 1326853478,
+    "livemode": false,
+    "id": "payout.paid_00000000000000",
+    "type": "payout.paid",
+    "object": "event",
+    "request": null,
+    "pending_webhooks": 1,
+    "api_version": "2018-11-08",
+    "data": {
+        "object": {
+            "id": "po_00000000000000",
+            "object": "payout",
+            "amount": 1100,
+            "arrival_date": 1547036078,
+            "automatic": true,
+            "balance_transaction": "txn_00000000000000",
+            "created": 1547036078,
+            "currency": "usd",
+            "description": "STRIPE PAYOUT",
+            "destination": "ba_1DqfxCHOC2HiLzOVa9bsCDHn",
+            "failure_balance_transaction": null,
+            "failure_code": null,
+            "failure_message": null,
+            "livemode": false,
+            "metadata": {},
+            "method": "standard",
+            "source_type": "card",
+            "statement_descriptor": null,
+            "status": "in_transit",
+            "type": "bank_account"
+        }
+    }
+}

--- a/zerver/webhooks/stripe/fixtures/payout_updated.json
+++ b/zerver/webhooks/stripe/fixtures/payout_updated.json
@@ -1,0 +1,39 @@
+{
+    "created": 1326853478,
+    "livemode": false,
+    "id": "payout.updated_00000000000000",
+    "type": "payout.updated",
+    "object": "event",
+    "request": null,
+    "pending_webhooks": 1,
+    "api_version": "2018-11-08",
+    "data": {
+        "object": {
+            "id": "po_00000000000000",
+            "object": "payout",
+            "amount": 1100,
+            "arrival_date": 1547036115,
+            "automatic": true,
+            "balance_transaction": "txn_00000000000000",
+            "created": 1547036115,
+            "currency": "usd",
+            "description": "STRIPE PAYOUT",
+            "destination": "ba_1DqfxnHOC2HiLzOVeNGrHmV8",
+            "failure_balance_transaction": null,
+            "failure_code": null,
+            "failure_message": null,
+            "livemode": false,
+            "metadata": {},
+            "method": "standard",
+            "source_type": "card",
+            "statement_descriptor": null,
+            "status": "in_transit",
+            "type": "bank_account"
+        },
+        "previous_attributes": {
+            "metadata": {
+                "description": "Old description"
+            }
+        }
+    }
+}

--- a/zerver/webhooks/stripe/tests.py
+++ b/zerver/webhooks/stripe/tests.py
@@ -117,3 +117,38 @@ Billing method: send invoice"""
         expected_message = u"[Invoice](https://dashboard.stripe.com/invoices/in_00000000000000) payment failed"
         self.send_and_test_stream_message('invoice_payment_failed', expected_topic, expected_message,
                                           content_type="application/x-www-form-urlencoded")
+
+    def test_payout_canceled(self) -> None:
+        expected_topic = u"Payout po_00000000000000"
+        expected_message = u"**[Payout](https://dashboard.stripe.com/payout/po_00000000000000)** for amount **$11.00** has been canceled."
+
+        self.send_and_test_stream_message('payout_canceled', expected_topic, expected_message,
+                                          content_type="application/x-www-form-urlencoded")
+
+    def test_payout_created(self) -> None:
+        expected_topic = u"Payout po_00000000000000"
+        expected_message = u"**[Payout](https://dashboard.stripe.com/payout/po_00000000000000)** for amount **$11.00** has been created."
+
+        self.send_and_test_stream_message('payout_created', expected_topic, expected_message,
+                                          content_type="application/x-www-form-urlencoded")
+
+    def test_payout_failed(self) -> None:
+        expected_topic = u"Payout po_00000000000000"
+        expected_message = u"**[Payout](https://dashboard.stripe.com/payout/po_00000000000000)** for amount **$11.00** has failed."
+
+        self.send_and_test_stream_message('payout_failed', expected_topic, expected_message,
+                                          content_type="application/x-www-form-urlencoded")
+
+    def test_payout_paid(self) -> None:
+        expected_topic = u"Payout po_00000000000000"
+        expected_message = u"**[Payout](https://dashboard.stripe.com/payout/po_00000000000000)** for amount **$11.00** has been paid."
+
+        self.send_and_test_stream_message('payout_paid', expected_topic, expected_message,
+                                          content_type="application/x-www-form-urlencoded")
+
+    def test_payout_updated(self) -> None:
+        expected_topic = u"Payout po_00000000000000"
+        expected_message = u"**[Payout](https://dashboard.stripe.com/payout/po_00000000000000)** for amount **$11.00** has been updated."
+
+        self.send_and_test_stream_message('payout_updated', expected_topic, expected_message,
+                                          content_type="application/x-www-form-urlencoded")

--- a/zerver/webhooks/stripe/view.py
+++ b/zerver/webhooks/stripe/view.py
@@ -112,7 +112,8 @@ def topic_and_body(payload: Dict[str, Any]) -> Tuple[str, str]:
             # Running into the 60 character topic limit.
             # topic = '[{}](https://dashboard.stripe.com/customers/{})' % (object_['id'], object_['id'])
             topic = object_['id']
-            body = default_body(update_blacklist=['delinquent', 'currency', 'default_source'])
+            body = default_body(
+                update_blacklist=['delinquent', 'currency', 'default_source'])
             if event == 'created':
                 if object_['email']:
                     body += '\nEmail: {}'.format(object_['email'])
@@ -141,7 +142,8 @@ def topic_and_body(payload: Dict[str, Any]) -> Tuple[str, str]:
                 if object_['quantity']:
                     body += '\nQuantity: {}'.format(object_['quantity'])
                 if 'billing' in object_:  # nocoverage
-                    body += '\nBilling method: {}'.format(object_['billing'].replace('_', ' '))
+                    body += '\nBilling method: {}'.format(
+                        object_['billing'].replace('_', ' '))
     if category == 'file':  # nocoverage
         topic = 'files'
         body = default_body() + ' ({purpose}). \nTitle: {title}'.format(
@@ -168,7 +170,35 @@ def topic_and_body(payload: Dict[str, Any]) -> Tuple[str, str]:
     if category.startswith('order'):  # nocoverage
         # Not implemented
         raise NotImplementedEventType()
-    if category in ['payment_intent', 'payout', 'plan', 'product', 'recipient',
+
+    if category.startswith('payout'):
+        object_id = object_['id']
+        link = "https://dashboard.stripe.com/payout/{}".format(object_id)
+        amount = amount_string(object_["amount"], object_["currency"])
+        body_t = "**[Payout]({link})** for amount **{amount}** has {end}."
+
+        if event == "canceled":
+            end = "been canceled"
+            topic = "Payout {}".format(object_id)
+        if event == "created":
+            end = "been created"
+            topic = "Payout {}".format(object_id)
+        if event == "failed":
+            end = "failed"
+            topic = "Payout {}".format(object_id)
+        if event == "paid":
+            end = "been paid"
+            topic = "Payout {}".format(object_id)
+        if event == "updated":
+            end = "been updated"
+            topic = "Payout {}".format(object_id)
+
+        body = body_t.format(
+            link=link,
+            amount=amount,
+            end=end
+        )
+    if category in ['payment_intent', 'plan', 'product', 'recipient',
                     'reporting', 'review', 'sigma', 'sku', 'source', 'subscription_schedule',
                     'topup', 'transfer']:  # nocoverage
         # Not implemented. In theory doing something like


### PR DESCRIPTION
I have added the support payout events. The changes in the view.py and tests.py file is in a separate commit and the new fixtures files are in a separate commit.

Please review and let me know what you think.

@eeshangarg @timabbott

Thanks
Sameer