### PR TITLE
webhooks/clubhouse: Extract story labels from references.

### DIFF
--- a/zerver/webhooks/clubhouse/fixtures/story_update_add_label.json
+++ b/zerver/webhooks/clubhouse/fixtures/story_update_add_label.json
@@ -1,17 +1,17 @@
 {
-    "id":"5b295c2c-f734-4a1a-a3a5-03c2594ef2d8",
-    "changed_at":"2018-06-19T19:40:28.185Z",
-    "primary_id":11,
+    "id":"5c37d3a3-6e3d-4b17-963c-adfa0a023d84",
+    "changed_at":"2019-01-10T23:22:11.694Z",
+    "primary_id":23,
     "version":"v1",
     "member_id":"5b1fda16-626f-487f-9ecf-f3a4abf42b8b",
     "actions":[
         {
-            "id":11,
+            "id":23,
             "entity_type":"story",
             "action":"update",
-            "name":"Add cool feature!",
-            "story_type":"bug",
-            "app_url":"https://app.clubhouse.io/zulip/story/11",
+            "name":"An epic story!",
+            "story_type":"feature",
+            "app_url":"https://app.clubhouse.io/zulip/story/23",
             "changes":{
                 "label_ids":{
                     "adds":[
@@ -19,11 +19,12 @@
                     ]
                 }
             }
-        },
+        }
+    ],
+    "references":[
         {
             "id":18,
             "entity_type":"label",
-            "action":"create",
             "name":"mockup"
         }
     ]

--- a/zerver/webhooks/clubhouse/fixtures/story_update_remove_label.json
+++ b/zerver/webhooks/clubhouse/fixtures/story_update_remove_label.json
@@ -1,17 +1,17 @@
 {
-    "id":"5b295cc0-242a-4ecf-b75c-e2467c25513c",
-    "changed_at":"2018-06-19T19:42:56.825Z",
-    "primary_id":11,
+    "id":"5c37d3f8-4a7e-4cdd-a066-7ced3ace1bd7",
+    "changed_at":"2019-01-10T23:23:36.331Z",
+    "primary_id":23,
     "version":"v1",
     "member_id":"5b1fda16-626f-487f-9ecf-f3a4abf42b8b",
     "actions":[
         {
-            "id":11,
+            "id":23,
             "entity_type":"story",
             "action":"update",
-            "name":"Add cool feature!",
-            "story_type":"bug",
-            "app_url":"https://app.clubhouse.io/zulip/story/11",
+            "name":"An epic story!",
+            "story_type":"feature",
+            "app_url":"https://app.clubhouse.io/zulip/story/23",
             "changes":{
                 "label_ids":{
                     "removes":[

--- a/zerver/webhooks/clubhouse/tests.py
+++ b/zerver/webhooks/clubhouse/tests.py
@@ -178,8 +178,8 @@ class ClubhouseWebhookTest(WebhookTestCase):
         self.assert_json_success(result)
 
     def test_story_label_added(self) -> None:
-        expected_message = u"The label **mockup** was added to the story [Add cool feature!](https://app.clubhouse.io/zulip/story/11)."
-        self.send_and_test_stream_message('story_update_add_label', "Add cool feature!",
+        expected_message = u"The label **mockup** was added to the story [An epic story!](https://app.clubhouse.io/zulip/story/23)."
+        self.send_and_test_stream_message('story_update_add_label', "An epic story!",
                                           expected_message)
 
     @patch('zerver.lib.webhooks.common.check_send_webhook_message')

--- a/zerver/webhooks/clubhouse/view.py
+++ b/zerver/webhooks/clubhouse/view.py
@@ -352,9 +352,9 @@ def get_story_label_body(payload: Dict[str, Any]) -> Optional[str]:
         return None
 
     label_id = label_ids_added[0]
-    for action in payload["actions"]:
-        if action["id"] == label_id:
-            kwargs.update({"label_name": action["name"]})
+    for reference in payload["references"]:
+        if reference["id"] == label_id:
+            kwargs.update({"label_name": reference["name"]})
 
     return STORY_LABEL_TEMPLATE.format(**kwargs)
 


### PR DESCRIPTION
It looks like Clubhouse has moved where they store the label name
from the "actions" list to the "references" list.

@timabbott: Their API is in beta still! If you look at the other events, the label name is stored in the `references` as well! Maybe this was a one-off anomaly that they forgot to fix or something! 
