### PR TITLE
management: Extend `sync_ldap_user_data` to allow update of a single user.

### DIFF
--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -179,6 +179,14 @@ This feature works by checking for the `ACCOUNTDISABLE` flag on the
 [this handy resource](https://jackstromberg.com/2013/01/useraccountcontrol-attributeflag-values/)
 for details on the various `userAccountControl` flags.
 
+#### Deactivating non-matching users
+
+Starting with Zulip 2.0, Zulip supports automatically deactivating
+users if they are not present in LDAP/Active Directory. To enable
+this feature you need to set `LDAP_DEACTIVATE_NON_MATCHING_USERS`
+flag to `True`. The users will be fully deactivated the next time
+your `manage.py sync_ldap_user_data` cron job runs.
+
 #### Other fields
 
 Other fields you may want to sync from LDAP include:

--- a/zerver/lib/dev_ldap_directory.py
+++ b/zerver/lib/dev_ldap_directory.py
@@ -46,3 +46,20 @@ def generate_dev_ldap_dir(mode: str, num_users: int=8) -> Dict[str, Dict[str, An
             }
 
     return ldap_dir
+
+def init_fakeldap() -> None:  # nocoverage
+    # We only use this in development.  Importing mock inside
+    # this function is an import time optimization, which
+    # avoids the expensive import of the mock module (slow
+    # because its dependency pbr uses pkgresources, which is
+    # really slow to import.)
+    import mock
+    from fakeldap import MockLDAP
+
+    ldap_patcher = mock.patch('django_auth_ldap.config.ldap.initialize')
+    mock_initialize = ldap_patcher.start()
+    mock_ldap = MockLDAP()
+    mock_initialize.return_value = mock_ldap
+
+    mock_ldap.directory = generate_dev_ldap_dir(settings.FAKE_LDAP_MODE,
+                                                settings.FAKE_LDAP_NUM_USERS)

--- a/zerver/lib/management.py
+++ b/zerver/lib/management.py
@@ -88,7 +88,8 @@ You can use the command list_realms to find ID of the realms in this server."""
             raise CommandError("There is no realm with id '%s'. Aborting." %
                                (options["realm_id"],))
 
-    def get_users(self, options: Dict[str, Any], realm: Optional[Realm]) -> List[UserProfile]:
+    def get_users(self, options: Dict[str, Any], realm: Optional[Realm],
+                  is_bot: Optional[bool]=None) -> List[UserProfile]:
         if "all_users" in options:
             all_users = options["all_users"]
 
@@ -102,7 +103,10 @@ You can use the command list_realms to find ID of the realms in this server."""
                 raise CommandError("The --all-users option requires a realm; please pass --realm.")
 
             if all_users:
-                return UserProfile.objects.filter(realm=realm)
+                user_profiles = UserProfile.objects.filter(realm=realm)
+                if is_bot is not None:
+                    return user_profiles.filter(is_bot=is_bot)
+                return user_profiles
 
         if options["users"] is None:
             return []

--- a/zerver/management/commands/sync_ldap_user_data.py
+++ b/zerver/management/commands/sync_ldap_user_data.py
@@ -28,6 +28,8 @@ def sync_ldap_user_data(user_profiles: List[UserProfile]) -> None:
                 logger.info("Updated %s." % (u.email,))
             else:
                 logger.warning("Did not find %s in LDAP." % (u.email,))
+                if settings.LDAP_DEACTIVATE_NON_MATCHING_USERS:
+                    logger.info("Deactivated non-matching user: %s" % (u.email,))
         except ZulipLDAPException as e:
             logger.error("Error attempting to update user %s:" % (u.email,))
             logger.error(e)

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -2587,6 +2587,19 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
             hamlet = self.example_user('hamlet')
             self.assertEqual(hamlet.avatar_source, UserProfile.AVATAR_FROM_USER)
 
+    def test_deactivate_non_matching_users(self) -> None:
+        self.mock_ldap.directory = {}
+
+        with self.settings(LDAP_APPEND_DOMAIN='zulip.com',
+                           AUTH_LDAP_BIND_PASSWORD='',
+                           AUTH_LDAP_USER_DN_TEMPLATE='uid=%(user)s,ou=users,dc=zulip,dc=com',
+                           LDAP_DEACTIVATE_NON_MATCHING_USERS=True):
+            result = sync_user_from_ldap(self.example_user('hamlet'))
+
+            self.assertFalse(result)
+            hamlet = self.example_user('hamlet')
+            self.assertFalse(hamlet.is_active)
+
 class TestZulipAuthMixin(ZulipTestCase):
     def test_get_user(self) -> None:
         backend = ZulipAuthMixin()

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -443,7 +443,11 @@ class ZulipLDAPUserPopulator(ZulipLDAPAuthBackendBase):
 def sync_user_from_ldap(user_profile: UserProfile) -> bool:
     backend = ZulipLDAPUserPopulator()
     updated_user = backend.populate_user(backend.django_to_ldap_username(user_profile.email))
-    return updated_user is not None
+    if not updated_user:
+        if settings.LDAP_DEACTIVATE_NON_MATCHING_USERS:
+            do_deactivate_user(user_profile)
+        return False
+    return True
 
 class DevAuthBackend(ZulipAuthMixin):
     # Allow logging in as any user without a password.

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -414,6 +414,11 @@ class ZulipLDAPUserPopulator(ZulipLDAPAuthBackendBase):
                      return_data: Optional[Dict[str, Any]]=None) -> None:
         return None
 
+def sync_user_from_ldap(user_profile: UserProfile) -> bool:
+    backend = ZulipLDAPUserPopulator()
+    updated_user = backend.populate_user(backend.django_to_ldap_username(user_profile.email))
+    return updated_user is not None
+
 class DevAuthBackend(ZulipAuthMixin):
     # Allow logging in as any user without a password.
     # This is used for convenience when developing Zulip.

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -307,7 +307,7 @@ class ZulipLDAPAuthBackendBase(ZulipAuthMixin, LDAPBackend):
             upload_avatar_image(BytesIO(ldap_user.attrs[avatar_attr_name][0]), user, user)
             do_change_avatar_fields(user, UserProfile.AVATAR_FROM_USER)
 
-    def is_account_control_disabled_user(self, ldap_user: _LDAPUser) -> bool:  # nocoverage
+    def is_account_control_disabled_user(self, ldap_user: _LDAPUser) -> bool:
         account_control_value = ldap_user.attrs[settings.AUTH_LDAP_USER_ATTR_MAP['userAccountControl']][0]
         ldap_disabled = bool(int(account_control_value) & LDAP_USER_ACCOUNT_CONTROL_DISABLED_MASK)
         return ldap_disabled
@@ -331,7 +331,7 @@ class ZulipLDAPAuthBackendBase(ZulipAuthMixin, LDAPBackend):
         return full_name, short_name
 
     def sync_full_name_from_ldap(self, user_profile: UserProfile,
-                                 ldap_user: _LDAPUser) -> None:  # nocoverage
+                                 ldap_user: _LDAPUser) -> None:
         from zerver.lib.actions import do_change_full_name
         full_name, _ = self.get_mapped_name(ldap_user)
         if full_name != user_profile.full_name:
@@ -342,7 +342,7 @@ class ZulipLDAPAuthBackendBase(ZulipAuthMixin, LDAPBackend):
             do_change_full_name(user_profile, full_name, None)
 
     def get_or_build_user(self, username: str,
-                          ldap_user: _LDAPUser) -> Tuple[UserProfile, bool]:  # nocoverage
+                          ldap_user: _LDAPUser) -> Tuple[UserProfile, bool]:
         (user, built) = super().get_or_build_user(username, ldap_user)
         self.sync_avatar_from_ldap(user, ldap_user)
         self.sync_full_name_from_ldap(user, ldap_user)

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -462,7 +462,12 @@ LDAP_EMAIL_ATTR = None  # type: Optional[str]
 # LDAP database uses for the same concept.
 AUTH_LDAP_USER_ATTR_MAP = {
     # full_name is required; common values include "cn" or "displayName".
+    # If names are encoded in your LDAP directory as first and last
+    # name, you can instead specify first_name and last_name, and
+    # Zulip will combine those to construct a full_name automatically.
     "full_name": "cn",
+    # "first_name": "fn",
+    # "last_name": "ln",
 
     # User avatars can be pulled from the LDAP "thumbnailPhoto"/"jpegPhoto" field.
     # "avatar": "thumbnailPhoto",

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -478,6 +478,10 @@ AUTH_LDAP_USER_ATTR_MAP = {
     # "userAccountControl": "userAccountControl",
 }
 
+# Whether to automatically deactivate users not found in LDAP. If LDAP is the only
+# authentication method then this setting defaults to True otherwise to False.
+# LDAP_DEACTIVATE_NON_MATCHING_USERS = True
+
 
 ################
 # Miscellaneous settings.

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1345,6 +1345,12 @@ if REGISTER_LINK_DISABLED is None:
     else:
         REGISTER_LINK_DISABLED = False
 
+if 'LDAP_DEACTIVATE_NON_MATCHING_USERS' not in vars():
+    if AUTHENTICATION_BACKENDS == ('zproject.backends.ZulipLDAPAuthBackend',):
+        LDAP_DEACTIVATE_NON_MATCHING_USERS = True
+    else:
+        LDAP_DEACTIVATE_NON_MATCHING_USERS = False
+
 ########################################################################
 # SOCIAL AUTHENTICATION SETTINGS
 ########################################################################


### PR DESCRIPTION
Part of series of PRs to improve LDAP auth. A sub-issue of issue #11041.