### PR TITLE
markdown preview: Fix `code` style for preview in night mode.

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -484,6 +484,7 @@ on a dark background, and don't change the dark labels dark either. */
     #feedback_container,
     .message_content code,
     .message_edit_content code,
+    #preview_content code,
     #settings_page code,
     .typeahead.dropdown-menu {
         background-color: hsl(212, 25%, 15%);


### PR DESCRIPTION
When in night mode, `code` style was still the same as in the light mode;
The fix is for the same.

Fixes #11269

**GIFs or Screenshots:**

Old:

![screenshot 2019-01-14 at 11 35 33 am](https://user-images.githubusercontent.com/33068691/51098740-712fe700-17f2-11e9-883e-750d57170912.png)

Now:

![screenshot 2019-01-14 at 11 38 51 am](https://user-images.githubusercontent.com/33068691/51098744-7ab94f00-17f2-11e9-831e-70663b83d06a.png)