### PR TITLE
scripts: Add argparse option to `restart-zerver` for `--fill-cache`.

### DIFF
--- a/puppet/zulip/files/cron.d/restart-zulip
+++ b/puppet/zulip/files/cron.d/restart-zulip
@@ -4,4 +4,4 @@ USER=zulip
 
 # Cron job to restart the Zulip server weekly, with the goal of
 # minimizing the impact of any memory leaks that we might grow.
-0 6 * * 7 zulip /home/zulip/deployments/current/scripts/restart-server
+0 6 * * 7 zulip /home/zulip/deployments/current/scripts/restart-server --fill-cache

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -177,7 +177,7 @@ if migrations_needed:
 subprocess.check_call(["./manage.py", "create_realm_internal_bots"], preexec_fn=su_to_zulip)
 
 logging.info("Restarting Zulip...")
-subprocess.check_output(["./scripts/restart-server"], preexec_fn=su_to_zulip)
+subprocess.check_output(["./scripts/restart-server", "--fill-cache"], preexec_fn=su_to_zulip)
 logging.info("Upgrade complete!")
 
 if not args.skip_purge_old_deployments:

--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import argparse
 import configparser
 import os
 import sys
@@ -14,6 +15,11 @@ logging.Formatter.converter = time.gmtime
 logging.basicConfig(format="%(asctime)s restart-server: %(message)s",
                     level=logging.INFO)
 
+parser = argparse.ArgumentParser()
+parser.add_argument('--fill-cache', action='store_true', dest='fill_cache', default=False,
+                    help='Fill the memcached caches')
+args = parser.parse_args()
+
 deploy_path = os.path.realpath(os.path.join(os.path.dirname(__file__), '..'))
 os.chdir(deploy_path)
 
@@ -24,8 +30,9 @@ if pwd.getpwuid(os.getuid()).pw_name != "zulip":
 # Send a statsd event on restarting the server
 subprocess.check_call(["./manage.py", "send_stats", "incr", "events.server_restart", str(int(time.time()))])
 
-logging.info("Filling memcached caches")
-subprocess.check_call(["./manage.py", "fill_memcached_caches"])
+if args.fill_cache:
+    logging.info("Filling memcached caches")
+    subprocess.check_call(["./manage.py", "fill_memcached_caches"])
 
 core_server_services = ["zulip-django", "zulip-senders:*"]
 if os.path.exists("/etc/supervisor/conf.d/thumbor.conf"):


### PR DESCRIPTION
@timabbott I changed only certain places in documentation where I felt it was good to fill the cache and left the remaining places as it is. Please verify that the changes are fine.

Fixes: #10900.