### PR TITLE
Reduce usage of hardcoded paths in /tmp and /var/tmp

### DIFF
--- a/zerver/lib/feedback.py
+++ b/zerver/lib/feedback.py
@@ -24,15 +24,6 @@ def has_enough_time_expired_since_last_message(sender_email: str, min_delay: flo
     delay = t - int(last_time)
     return delay > min_delay
 
-def get_ticket_number() -> int:
-    num_file = '/var/tmp/.feedback-bot-ticket-number'
-    try:
-        ticket_number = int(open(num_file).read()) + 1
-    except Exception:
-        ticket_number = 1
-    open(num_file, 'w').write('%d' % (ticket_number,))
-    return ticket_number
-
 def deliver_feedback_by_zulip(message: Mapping[str, Any]) -> None:
     subject = "%s" % (message["sender_email"],)
 
@@ -48,7 +39,7 @@ def deliver_feedback_by_zulip(message: Mapping[str, Any]) -> None:
     need_ticket = has_enough_time_expired_since_last_message(sender_email, 180)
 
     if need_ticket:
-        ticket_number = get_ticket_number()
+        ticket_number = message['id']
         content += '\n~~~'
         content += '\nticket Z%03d (@support please ack)' % (ticket_number,)
         content += '\nsender: %s' % (message['sender_full_name'],)

--- a/zerver/management/commands/deliver_scheduled_messages.py
+++ b/zerver/management/commands/deliver_scheduled_messages.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 from typing import Any, Dict
 from datetime import timedelta
@@ -8,7 +9,6 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 from django.utils.timezone import now as timezone_now
 
-from zerver.lib.context_managers import lockfile
 from zerver.lib.logging_util import log_to_file
 from zerver.lib.management import sleep_forever
 from zerver.models import ScheduledMessage, Message, get_user_by_delivery_email
@@ -58,19 +58,18 @@ Usage: ./manage.py deliver_scheduled_messages
             # the comment in zproject/settings.py file about renaming this setting.
             sleep_forever()
 
-        with lockfile("/tmp/zulip_scheduled_message_deliverer.lockfile"):
-            while True:
-                messages_to_deliver = ScheduledMessage.objects.filter(
-                    scheduled_timestamp__lte=timezone_now(),
-                    delivered=False)
-                if messages_to_deliver:
-                    for message in messages_to_deliver:
-                        with transaction.atomic():
-                            do_send_messages([self.construct_message(message)])
-                            message.delivered = True
-                            message.save(update_fields=['delivered'])
+        while True:
+            messages_to_deliver = ScheduledMessage.objects.filter(
+                scheduled_timestamp__lte=timezone_now(),
+                delivered=False)
+            if messages_to_deliver:
+                for message in messages_to_deliver:
+                    with transaction.atomic():
+                        do_send_messages([self.construct_message(message)])
+                        message.delivered = True
+                        message.save(update_fields=['delivered'])
 
-                cur_time = timezone_now()
-                time_next_min = (cur_time + timedelta(minutes=1)).replace(second=0, microsecond=0)
-                sleep_time = (time_next_min - cur_time).total_seconds()
-                time.sleep(sleep_time)
+            cur_time = timezone_now()
+            time_next_min = (cur_time + timedelta(minutes=1)).replace(second=0, microsecond=0)
+            sleep_time = (time_next_min - cur_time).total_seconds()
+            time.sleep(sleep_time)


### PR DESCRIPTION
Using hardcoded paths in `/tmp` and `/var/tmp` can be a security problem. For the most part, Zulip only used them in debug/test/CI code and code that runs in controlled build environments, but avoiding them in all code makes auditing for real problems easier.

(There are still other uses of `/tmp` so this may just be “part 1”.)