### PR TITLE
api docs: Fix showing correct link to install Python bindings.

### DIFF
--- a/templates/zerver/api/installation-instructions.md
+++ b/templates/zerver/api/installation-instructions.md
@@ -8,10 +8,6 @@ writing interactive bots that react to messages), so we recommend it
 if you're trying to decide.
 
 {start_tabs}
-{tab|curl}
-
-No download required!
-
 {tab|python}
 
 Install the Python API with [pip](https://pypi.python.org/pypi/zulip/):
@@ -35,5 +31,9 @@ Install the JavaScript API with [npm](https://www.npmjs.com/package/zulip-js):
 ```
 npm install zulip-js
 ```
+
+{tab|curl}
+
+No download required!
 
 {end_tabs}


### PR DESCRIPTION
This Fixes #9575, a bug where the url for installing Python bindings does not links to the python tab.
![screenshot 2019-01-15 at 8 16 55 pm](https://user-images.githubusercontent.com/36725774/51191068-a2e7a180-1909-11e9-8739-b3af5887f10e.png)

