### PR TITLE
message_edit: Fix message edit history breakdown on large messages.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1347,6 +1347,10 @@ div.focused_table {
     max-height: 24em;
 }
 
+.message_edit_history_content {
+    max-height: none;
+}
+
 .message_edit_countdown_timer {
     text-align: right;
     display: inline;

--- a/static/templates/message_edit_history.handlebars
+++ b/static/templates/message_edit_history.handlebars
@@ -7,7 +7,7 @@
     <div class="messagebox-border">
         <div class="messagebox-content">
             <div class="message_top_line"><span class="message_time">{{ timestamp }}</span></div>
-            <div class="message_edit_content">{{{ body_to_render }}}</div>
+            <div class="message_edit_content message_edit_history_content">{{{ body_to_render }}}</div>
             <div class="message_author"><div class="author_details">{{ posted_or_edited }} {{ edited_by }}</div></div>
         </div>
     </div>


### PR DESCRIPTION
This removes max_height from .message_edit_content in
static/styles/zulip.scss.

Fixes: #5629.