### PR TITLE
stream settings: Remove ability for members to create admin-only streams.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1230,6 +1230,7 @@ run_test('subscription_stream_privacy_modal', () => {
     var args = {
         stream_id: 999,
         is_private: true,
+        is_admin: true,
     };
     var html = render('subscription_stream_privacy_modal', args);
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -580,6 +580,7 @@ exports.setup_page = function (callback) {
             hide_all_streams: !should_list_all_streams(),
             max_name_length: page_params.stream_name_max_length,
             max_description_length: page_params.stream_description_max_length,
+            is_admin: page_params.is_admin,
         };
 
         var rendered = templates.render('subscription_table_body', template_data);

--- a/static/templates/stream_types.handlebars
+++ b/static/templates/stream_types.handlebars
@@ -17,6 +17,7 @@
             {{t '<b>Private, protected history:</b> must be invited by a member; new members can only see messages sent after they join; hidden from non-administrator users' }}
         </label>
     </li>
+    {{#if is_admin}}
     <li>
         <label class="checkbox">
             <input type="checkbox" name="is-announcement-only" value="is-announcement-only" {{#if is_announcement_only}}checked{{/if}}/>
@@ -24,4 +25,5 @@
             {{t 'Restrict posting to organization administrators' }}
         </label>
     </li>
+    {{/if}}
 </ul>

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2303,6 +2303,30 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assertEqual(add_event['event']['op'], 'add')
         self.assertEqual(add_event['users'], [self.example_user("iago").id])
 
+    def test_subscibe_to_announce_only_stream(self) -> None:
+        """
+        Members can subscribe to streams where only admins can post
+        but not create those streams, only realm admins can
+        """
+        member = self.example_user("AARON")
+        result = self.common_subscribe_to_streams(member.email, ["announce"])
+        self.assert_json_success(result)
+
+        streams_raw = [{
+            'name': 'new_stream',
+            'is_announcement_only': True,
+        }]
+        with self.assertRaisesRegex(
+                JsonableError, "Members cannot create streams where only admins can post."):
+            list_to_streams(streams_raw, member, autocreate=True)
+
+        admin = self.example_user("iago")
+        result = list_to_streams(streams_raw, admin, autocreate=True)
+        self.assert_length(result[0], 0)
+        self.assert_length(result[1], 1)
+        self.assertEqual(result[1][0].name, 'new_stream')
+        self.assertEqual(result[1][0].is_announcement_only, True)
+
     def test_guest_user_subscribe(self) -> None:
         """Guest users cannot subscribe themselves to anything"""
         guest_user = self.example_user("polonius")


### PR DESCRIPTION
This commit takes away the ability for non-admin members to create streams
where only admins can post messages by hiding the option from them.

Fixes #11290

**Admin**
![screenshot 2019-01-16 at 2 59 28 am](https://user-images.githubusercontent.com/33068691/51211198-d4c52c00-193a-11e9-8d65-aaf752d36ca3.png)

**Member**
![screenshot 2019-01-16 at 2 59 47 am](https://user-images.githubusercontent.com/33068691/51211207-dee72a80-193a-11e9-92bf-9e40cc63fde4.png)
