### PR TITLE
Small quoting fixes

### DIFF
--- a/scripts/lib/create-zulip-admin
+++ b/scripts/lib/create-zulip-admin
@@ -9,7 +9,5 @@ if { [ "$ZULIP_USER_CREATION_ENABLED" == "True" ] || [ "$ZULIP_USER_CREATION_ENA
     exit 1
 fi
 set +e
-sudo -H -u zulip -g zulip bash <<BASH
-/home/zulip/deployments/current/manage.py create_user --this-user-has-accepted-the-tos --realm "$ZULIP_USER_DOMAIN" --password "$ZULIP_USER_PASS" "$ZULIP_USER_EMAIL" "$ZULIP_USER_FULLNAME"
-/home/zulip/deployments/current/manage.py knight "$ZULIP_USER_EMAIL" -f
-BASH
+sudo -H -u zulip -g zulip /home/zulip/deployments/current/manage.py create_user --this-user-has-accepted-the-tos --realm "$ZULIP_USER_DOMAIN" --password "$ZULIP_USER_PASS" "$ZULIP_USER_EMAIL" "$ZULIP_USER_FULLNAME"
+sudo -H -u zulip -g zulip /home/zulip/deployments/current/manage.py knight "$ZULIP_USER_EMAIL" -f

--- a/scripts/setup/terminate-psql-sessions
+++ b/scripts/setup/terminate-psql-sessions
@@ -11,10 +11,11 @@ cd /
 username=$1
 
 shift
-tables=$(echo "'$*'" | sed "s/ /','/g")
+tables="$(printf "'%s'," "${@//\'/\'\'}")"
+tables="${tables%,}"
 
 if [ "$EUID" -eq 0 ]; then
-    sudo -u "$DEFAULT_USER" sh -c "psql postgres '$DEFAULT_USER'" <<EOF
+    sudo -u "$DEFAULT_USER" psql postgres "$DEFAULT_USER" <<EOF
 SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname IN ($tables);
 EOF
 else


### PR DESCRIPTION
Fix some unimportant shell and SQL quoting issues in `scripts/lib/create-zulip-admin` and `scripts/setup/terminate-psql-sessions`, on principle.