### PR TITLE
[undecided] Add warning for ambiguous quote/reply targets

### DIFF
--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -2,6 +2,8 @@ var noop = function () {};
 var return_false = function () { return false; };
 var return_true = function () { return true; };
 
+set_global('i18n', global.stub_i18n);
+
 set_global('document', {
     location: {}, // we need this to load compose.js
 });
@@ -14,6 +16,8 @@ set_global('$', global.make_zjquery());
 
 set_global('compose_pm_pill', {
 });
+
+set_global('notifications', {});
 
 zrequire('people');
 zrequire('compose_ui');
@@ -284,6 +288,10 @@ run_test('quote_and_reply', () => {
 
     $('#compose-textarea').caret = (pos) => {
         assert.equal(pos, 0);
+    };
+
+    notifications.notify_above_composebox = (reason) => {
+        assert.equal(reason, 'translated: Please check your message destination.');
     };
 
     quote_and_reply(opts);

--- a/frontend_tests/node_tests/compose_state.js
+++ b/frontend_tests/node_tests/compose_state.js
@@ -1,0 +1,45 @@
+set_global('$', global.make_zjquery());
+zrequire('util');
+zrequire('compose_state');
+
+/*
+    For legacy reasons we mostly cover
+    static/js/compose_state.js in
+    frontend/node_tests/compose.js, but
+    we should eventually migrate some of those
+    tests to here.
+*/
+
+run_test('replying_to_message', () => {
+    compose_state.stream_name('Social');
+    compose_state.topic('lunch');
+
+    assert(compose_state.replying_to_message({
+        type: 'stream',
+        stream: 'SoCIAl',
+        topic: 'lunch',
+    }));
+
+    assert(!compose_state.replying_to_message({
+        type: 'stream',
+        stream: 'Social',
+        topic: 'bogus',
+    }));
+
+    compose_state.recipient = () => 'hamlet@example.com';
+
+    assert(compose_state.replying_to_message({
+        type: 'private',
+        reply_to: 'hamlet@example.com',
+    }));
+
+    assert(!compose_state.replying_to_message({
+        type: 'private',
+        reply_to: 'bogus@bogus.com',
+    }));
+
+    // Test defensive code.
+    assert(!compose_state.replying_to_message({
+        type: 'bogus',
+    }));
+});

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -407,6 +407,10 @@ exports.quote_and_reply = function (opts) {
         // we'll need to make `insert_syntax_and_focus`
         // smarter about newlines.
         textarea.caret(0);
+        if (!compose_state.replying_to_message(message)) {
+            var reason = i18n.t('Please check your message destination.');
+            notifications.notify_above_composebox(reason);
+        }
     } else {
         exports.respond_to_message(opts);
     }

--- a/static/js/compose_state.js
+++ b/static/js/compose_state.js
@@ -25,6 +25,21 @@ exports.focus_in_empty_compose = function () {
         $('#compose-textarea').is(':focus'));
 };
 
+exports.replying_to_message = function (message) {
+    if (message.type === 'stream') {
+        return util.same_stream_name(message.stream,
+                                     exports.stream_name()) &&
+                util.same_topic(util.get_message_topic(message),
+                                exports.topic());
+    }
+
+    if (message.type === 'private') {
+        return message.reply_to.toLowerCase() === exports.recipient().toLowerCase();
+    }
+
+    return false;
+};
+
 function get_or_set(fieldname, keep_leading_whitespace) {
     // We can't hoist the assignment of 'elem' out of this lambda,
     // because the DOM element might not exist yet when get_or_set

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -60,7 +60,15 @@ function lower_same(a, b) {
     return a.toLowerCase() === b.toLowerCase();
 }
 
-exports.same_stream_and_topic = function util_same_stream_and_topic(a, b) {
+exports.same_stream_name = function (a, b) {
+    return lower_same(a, b);
+};
+
+exports.same_topic = function (a, b) {
+    return lower_same(a, b);
+};
+
+exports.same_stream_and_topic = function (a, b) {
     // Streams and topics are case-insensitive.
     return a.stream_id === b.stream_id &&
             lower_same(


### PR DESCRIPTION
Please test on FF and Chrome.

The main scenario to test here is:
* type something in compose box
* use Quote/Reply from another message than you replied to

I tested this on FF and IE.