### PR TITLE
refactoring: Remove unnecessary _allow_only_listed_keys in test_events.

### DIFF
--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1077,7 +1077,7 @@ class EventsRegisterTest(ZulipTestCase):
                 ('custom_profile_field', check_dict([
                     ('id', check_int),
                     ('value', check_none_or(check_string)),
-                ], _allow_only_listed_keys=False)),
+                ])),
             ])),
         ])
 
@@ -1090,7 +1090,7 @@ class EventsRegisterTest(ZulipTestCase):
                     ('id', check_int),
                     ('value', check_none_or(check_string)),
                     ('rendered_value', check_none_or(check_string)),
-                ], _allow_only_listed_keys=False)),
+                ])),
             ])),
         ])
 


### PR DESCRIPTION
### Purpose of the PR:
In `test_events.EventsRegisterTest.test_custom_profile_field_data_events`
there is an unnecessary usage of _allow_only_listed_keys in the
event dictionary validators. This commit should remove that.

*Note:* In issue #10892 we might need to remove this line:
> See the handling of rendered_value in test_custom_profile_field_data_events following #10775 for details.