### PR TITLE
api docs: Formatting  arguments table for long examples.

### DIFF
--- a/static/third/bootstrap/css/bootstrap.css
+++ b/static/third/bootstrap/css/bootstrap.css
@@ -2008,6 +2008,16 @@ table {
   vertical-align: bottom;
 }
 
+.table .json-api-example {
+  width: fit-content;
+  max-width: 300px;
+  word-wrap: break-word;
+}
+
+.table .json-api-example code {
+  white-space: pre-wrap;
+}
+
 .table caption + thead tr:first-child th,
 .table caption + thead tr:first-child td,
 .table colgroup + thead tr:first-child th,

--- a/zerver/lib/bugdown/api_arguments_table_generator.py
+++ b/zerver/lib/bugdown/api_arguments_table_generator.py
@@ -105,7 +105,7 @@ class APIArgumentsTablePreprocessor(Preprocessor):
         tr = """
 <tr>
   <td><code>{argument}</code></td>
-  <td><code>{example}</code></td>
+  <td class="json-api-example"><code>{example}</code></td>
   <td>{required}</td>
   <td>{description}</td>
 </tr>


### PR DESCRIPTION
This Fixes #10673, An issue with proper formatting of arguments table for long example codes.
![screenshot 2019-01-19 at 5 18 16 pm](https://user-images.githubusercontent.com/36725774/51427711-ff580300-1c20-11e9-92b4-78ee1b829cd2.png)
![screenshot 2019-01-19 at 5 22 27 pm](https://user-images.githubusercontent.com/36725774/51427720-139c0000-1c21-11e9-801a-035086c46ba7.png)
![screenshot 2019-01-19 at 5 24 17 pm](https://user-images.githubusercontent.com/36725774/51427723-1a2a7780-1c21-11e9-971e-3d696b27c151.png)
![screenshot 2019-01-19 at 5 21 25 pm](https://user-images.githubusercontent.com/36725774/51427727-20b8ef00-1c21-11e9-8895-171f26500e1e.png)


