### PR TITLE
Fix pasting images copied from the web

### DIFF
--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -235,8 +235,16 @@ exports.paste_handler = function (event) {
     if (clipboardData.getData) {
         var paste_html = clipboardData.getData('text/html');
         if (paste_html && page_params.development_environment) {
-            event.preventDefault();
             var text = exports.paste_handler_converter(paste_html);
+            var mdImageRegex = /^!\[.*\]\(.*\)$/;
+            if (text.match(mdImageRegex)) {
+                // This block catches cases where we are pasting an
+                // image into Zulip, which should be handled by the
+                // jQuery filedrop library, not this code path.
+                return;
+            }
+            event.preventDefault();
+            event.stopPropagation();
             compose_ui.insert_syntax_and_focus(text);
         }
     }

--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -253,6 +253,7 @@ exports.paste_handler = function (event) {
 exports.initialize = function () {
     $(document).on('copy', copy_handler);
     $("#compose-textarea").bind('paste', exports.paste_handler);
+    $('body').on('paste', '#message_edit_form', exports.paste_handler);
 };
 
 return exports;


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

This PR fixes #7130

**Testing Plan:** <!-- How have you tested? -->

- Open an image in a tab of the browser
- Right click on the image and select Copy Image
- Paste the image in the compose box. 

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
