### PR TITLE
Added front-end code to make linkifiers editable. 

### DIFF
--- a/static/js/settings_filters.js
+++ b/static/js/settings_filters.js
@@ -104,6 +104,45 @@ exports.set_up = function () {
             },
         });
     });
+    function open_linkifier_info_form_modal(filter){
+      var html = templates.render('linkifier-info-form-modal',{
+        pattern: filter[0],
+        url_format_string: filter[1],
+        filter_id: filter[2],
+      });
+      var linkifier_info_form_modal = $(html);
+      var modal_container = $('#user-info-form-modal-container');
+      modal_container.empty().append(linkifier_info_form_modal);
+      overlays.open_modal('linkifier-info-form-modal');
+
+      return linkifier_info_form_modal;
+    }
+
+    $(".admin_filters_table").on("click",".open-linkifier-form",function(e){
+      var filter_id = $(e.currentTarget).attr("data-filter-id");
+      var filter_pattern = $(e.currentTarget).attr("data-pattern");
+      var filter_url_format_string = $(e.currentTarget).attr("data-url-format-string");
+      var linkifier_info_form_modal = open_linkifier_info_form_modal([filter_pattern,filter_url_format_string,filter_id]);
+
+      linkifier_info_form_modal.find(".submit_linkifier_info_change").on("click", function (e){
+        e.preventDefault();
+        e.stopPropagation();
+        var new_pattern = $('#filter_pattern').val();
+        var new_url_format_string = $('#filter_url_format_string').val();
+
+        channel.patch({
+          url: "/json/realm/filters/update/"+ encodeURIComponent(filter_id),
+          data: {
+            pattern: JSON.stringify(new_pattern),
+            url_format_string: JSON.stringify(new_url_format_string)
+          },
+        });
+
+
+
+      });
+
+    });
 
 
 };

--- a/static/templates/admin_filter_list.handlebars
+++ b/static/templates/admin_filter_list.handlebars
@@ -11,6 +11,9 @@
         <button class="button small delete btn-danger" data-filter-id="{{id}}">
             <i class="fa fa-trash-o" aria-hidden="true"></i>
         </button>
+        <button class="button rounded small btn-warning open-linkifier-form" title="{{t 'Edit linkifier' }}" data-url-format-string="{{url_format_string}}" data-pattern="{{pattern}}" data-filter-id="{{id}}">
+            <i class="fa fa-pencil" aria-hidden="true"></i>
+        </button>
     </td>
     {{/if}}
 </tr>

--- a/static/templates/linkifier-info-form-modal.handlebars
+++ b/static/templates/linkifier-info-form-modal.handlebars
@@ -1,0 +1,24 @@
+<div id="linkifier-info-form-modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog" aria-labelledby="linkifier-info-form-modal-label" aria-hidden="true">
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+        <h3 id="linkifier-info-form-modal-label">{{t "Edit linkifiers" }}</h3>
+    </div>
+    <div class="modal-body">
+        <div id="linkifier-form" data-filter-id="{{filter_id}}">
+            <form class="form-horizontal linkifier-update-form">
+                <div class="input-group name_change_container">
+                    <label for="filter_pattern" >{{t "Pattern" }}</label>
+                    <input type="text" autocomplete="off" id="filter_pattern" name="pattern" value="{{ pattern }}" />
+                </div>
+                <div class="input-group name_change_container">
+                    <label for="filter_url_format_string" >{{t "URL format string" }}</label>
+                    <input type="text" autocomplete="off" id="filter_url_format_string" name="url_format_string" value="{{ url_format_string }}" />
+                </div>
+            </form>
+        </div>
+    </div>
+    <div class="modal-footer">
+        <button type="submit" class="button rounded sea-green submit_linkifier_info_change">{{t 'Save changes' }}</button>
+        <button type="button" class="button rounded reset_edit_user" data-dismiss="modal">{{t "Cancel" }}</button>
+    </div>
+</div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR adds these things to codebase:
(1) Adds button (a pencil icon) to edit linkifier, besides trashcan icon, in admin linkifiers table.
(2) Adds form which will open, when user clicks on button to edit linkifier.
(3) A required javascript function, which will help form to open when user clicks on the button.


**Testing Plan:** <!-- How have you tested? -->
Verified on local server.



**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![screenshot 2019-01-19 at 11 39 12 pm](https://user-images.githubusercontent.com/39343253/51430576-7c946f80-1c43-11e9-8b4f-8b0838a19295.png)
![screenshot 2019-01-19 at 11 39 20 pm](https://user-images.githubusercontent.com/39343253/51430583-8322e700-1c43-11e9-8c5a-631064b92158.png)



