### PR TITLE
Fix: #10830 : Making linkifiers editable

### DIFF
--- a/static/templates/admin-settings-modals.handlebars
+++ b/static/templates/admin-settings-modals.handlebars
@@ -7,3 +7,5 @@
 {{ partial "resend-invite-modal" }}
 
 <div id="user-info-form-modal-container"></div>
+
+<div id="linkifier-info-form-modal-container"></div>

--- a/static/templates/admin_filter_list.handlebars
+++ b/static/templates/admin_filter_list.handlebars
@@ -11,6 +11,9 @@
         <button class="button small delete btn-danger" data-filter-id="{{id}}">
             <i class="fa fa-trash-o" aria-hidden="true"></i>
         </button>
+        <button class="button rounded small btn-warning open-linkifier-form" title="{{t 'Edit linkifier' }}" data-url-format-string="{{url_format_string}}" data-pattern="{{pattern}}" data-filter-id="{{id}}">
+            <i class="fa fa-pencil" aria-hidden="true"></i>
+        </button>
     </td>
     {{/if}}
 </tr>

--- a/static/templates/linkifier-info-form-modal.handlebars
+++ b/static/templates/linkifier-info-form-modal.handlebars
@@ -1,0 +1,27 @@
+<div id="linkifier-info-form-modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog" aria-labelledby="linkifier-info-form-modal-label" aria-hidden="true">
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+        <h3 id="linkifier-info-form-modal-label">{{t "Edit linkifiers" }}</h3>
+    </div>
+    <div class="alert" id="edit-filter-status"></div>
+    <div class="modal-body">
+        <div id="linkifier-form" data-filter-id="{{filter_id}}">
+            <form class="form-horizontal linkifier-update-form">
+                <div class="alert" id="edit-filter-pattern-status"></div>
+                <div class="input-group name_change_container">
+                    <label for="filter_pattern" >{{t "Pattern" }}</label>
+                    <input type="text" autocomplete="off" id="filter_pattern" name="pattern" value="{{ pattern }}" />
+                </div>
+                <div class="alert" id="edit-filter-string-status"></div>
+                <div class="input-group name_change_container">
+                    <label for="filter_url_format_string" >{{t "URL format string" }}</label>
+                    <input type="text" autocomplete="off" id="filter_url_format_string" name="url_format_string" value="{{ url_format_string }}" />
+                </div>
+            </form>
+        </div>
+    </div>
+    <div class="modal-footer">
+        <button type="submit" class="button rounded sea-green submit_linkifier_info_change">{{t 'Save changes' }}</button>
+        <button type="button" class="button rounded reset_edit_user" data-dismiss="modal">{{t "Cancel" }}</button>
+    </div>
+</div>

--- a/static/templates/settings/linkifier-settings-admin.handlebars
+++ b/static/templates/settings/linkifier-settings-admin.handlebars
@@ -50,6 +50,7 @@
             </tbody>
         </table>
     </div>
+    <div class="alert" id="success-edit-status"></div>
     {{#if is_admin}}
     <form class="form-horizontal admin-filter-form">
         <div class="add-new-filter-box grey-box">

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5114,6 +5114,18 @@ def do_remove_realm_filter(realm: Realm, pattern: Optional[str]=None,
         RealmFilter.objects.get(realm=realm, pk=id).delete()
     notify_realm_filters(realm)
 
+def do_update_realm_filter(realm: Realm, pattern: str, url_format_string: str, id: int) -> int:
+    pattern = pattern.strip()
+    url_format_string = url_format_string.strip()
+    realm_filter = RealmFilter.objects.get(realm=realm, pk=id)
+    realm_filter.pattern = pattern
+    realm_filter.url_format_string = url_format_string
+    realm_filter.full_clean()
+    realm_filter.save(update_fields=["pattern", "url_format_string"])
+    notify_realm_filters(realm)
+
+    return realm_filter.id
+
 def get_emails_from_user_ids(user_ids: Sequence[int]) -> Dict[int, str]:
     # We may eventually use memcached to speed this up, but the DB is fast.
     return UserProfile.emails_from_ids(user_ids)

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -86,6 +86,7 @@ from zerver.lib.actions import (
     do_update_message_flags,
     do_update_outgoing_webhook_service,
     do_update_pointer,
+    do_update_realm_filter,
     do_update_user_presence,
     do_update_user_status,
     get_typing_user_profiles,
@@ -1879,6 +1880,14 @@ class EventsRegisterTest(ZulipTestCase):
         self.do_test(lambda: do_remove_realm_filter(self.user_profile.realm, "#(?P<id>[123])"))
         error = schema_checker('events[0]', events[0])
         self.assert_on_error(error)
+
+        filter_id = do_add_realm_filter(self.user_profile.realm, "#(?P<id>[123])",
+                                        "https://realm.com/my_realm_filter/%(id)s")
+        events = self.do_test(lambda: do_update_realm_filter(self.user_profile.realm, "#(?P<id>[1234])",
+                                                             "https://realm.com/my_realm_filter/%(id)s",
+                                                             filter_id))
+        self.assert_on_error(error)
+        do_remove_realm_filter(self.user_profile.realm, "#(?P<id>[1234])")
 
     def test_realm_domain_events(self) -> None:
         schema_checker = self.check_events_dict([

--- a/zerver/tests/test_realm_filters.py
+++ b/zerver/tests/test_realm_filters.py
@@ -119,3 +119,81 @@ class RealmFilterTest(ZulipTestCase):
         result = self.client_delete("/json/realm/filters/{0}".format(filter_id))
         self.assert_json_success(result)
         self.assertEqual(RealmFilter.objects.count(), filters_count - 1)
+
+    def test_update(self) -> None:
+        email = self.example_email('iago')
+        self.login(email)
+        realm = get_realm('zulip')
+        filter_id = do_add_realm_filter(
+            realm,
+            "#(?P<id>[123])",
+            "https://realm.com/my_realm_filter/%(id)s")
+
+        data = {"pattern": "", "url_format_string": "https://realm.com/my_realm_filter/%(id)s"}
+        result = self.client_patch("/json/realm/filters/{0}".format(filter_id), info=data)
+        self.assert_json_error(result, 'This field cannot be blank.')
+
+        data['pattern'] = '$a'
+        result = self.client_patch("/json/realm/filters/{0}".format(filter_id), info=data)
+        self.assert_json_error(result, 'Invalid filter pattern.  Valid characters are [ a-zA-Z_#=/:+!-].')
+
+        data['pattern'] = r'ZUL-(?P<id>\d++)'
+        result = self.client_patch("/json/realm/filters/{0}".format(filter_id), info=data)
+        self.assert_json_error(result, 'Invalid filter pattern.  Valid characters are [ a-zA-Z_#=/:+!-].')
+
+        data['pattern'] = r'ZUL-(?P<id>\d+)'
+        data['url_format_string'] = '$fgfg'
+        result = self.client_patch("/json/realm/filters/{0}".format(filter_id), info=data)
+        self.assert_json_error(result, 'Enter a valid URL.')
+
+        data['pattern'] = r'ZUL-(?P<id>\d+)'
+        data['url_format_string'] = 'https://realm.com/my_realm_filter/'
+        result = self.client_patch("/json/realm/filters/{0}".format(filter_id), info=data)
+        self.assert_json_error(result, 'Invalid URL format string.')
+
+        data['url_format_string'] = 'https://realm.com/my_realm_filter/#hashtag/%(id)s'
+        result = self.client_patch("/json/realm/filters/{0}".format(filter_id), info=data)
+        self.assert_json_success(result)
+        self.assertIsNotNone(re.match(data['pattern'], 'ZUL-15'))
+
+        data['pattern'] = r'ZUL2-(?P<id>\d+)'
+        data['url_format_string'] = 'https://realm.com/my_realm_filter/?value=%(id)s'
+        result = self.client_patch("/json/realm/filters/{0}".format(filter_id), info=data)
+        self.assert_json_success(result)
+        self.assertIsNotNone(re.match(data['pattern'], 'ZUL2-15'))
+
+        data['pattern'] = r'_code=(?P<id>[0-9a-zA-Z]+)'
+        data['url_format_string'] = 'https://realm.com/my_realm_filter/?value=%(id)s'
+        result = self.client_patch("/json/realm/filters/{0}".format(filter_id), info=data)
+        self.assert_json_success(result)
+        self.assertIsNotNone(re.match(data['pattern'], '_code=123abcdZ'))
+
+        data['pattern'] = r'PR (?P<id>[0-9]+)'
+        data['url_format_string'] = 'https://realm.com/my_realm_filter/?value=%(id)s'
+        result = self.client_patch("/json/realm/filters/{0}".format(filter_id), info=data)
+        self.assert_json_success(result)
+        self.assertIsNotNone(re.match(data['pattern'], 'PR 123'))
+
+        data['pattern'] = r'lp/(?P<id>[0-9]+)'
+        data['url_format_string'] = 'https://realm.com/my_realm_filter/?value=%(id)s'
+        result = self.client_patch("/json/realm/filters/{0}".format(filter_id), info=data)
+        self.assert_json_success(result)
+        self.assertIsNotNone(re.match(data['pattern'], 'lp/123'))
+
+        data['pattern'] = r'lp:(?P<id>[0-9]+)'
+        data['url_format_string'] = 'https://realm.com/my_realm_filter/?value=%(id)s'
+        result = self.client_patch("/json/realm/filters/{0}".format(filter_id), info=data)
+        self.assert_json_success(result)
+        self.assertIsNotNone(re.match(data['pattern'], 'lp:123'))
+
+        data['pattern'] = r'!(?P<id>[0-9]+)'
+        data['url_format_string'] = 'https://realm.com/my_realm_filter/?value=%(id)s'
+        result = self.client_patch("/json/realm/filters/{0}".format(filter_id), info=data)
+        self.assert_json_success(result)
+        self.assertIsNotNone(re.match(data['pattern'], '!123'))
+
+        data['pattern'] = r'(?P<org>[a-zA-Z0-9_-]+)/(?P<repo>[a-zA-Z0-9_-]+)#(?P<id>[0-9]+)'
+        data['url_format_string'] = 'https://github.com/%(org)s/%(repo)s/issue/%(id)s'
+        result = self.client_patch("/json/realm/filters/{0}".format(filter_id), info=data)
+        self.assert_json_success(result)
+        self.assertIsNotNone(re.match(data['pattern'], 'zulip/zulip#123'))

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -109,7 +109,8 @@ v1_api_and_json_patterns = [
         {'GET': 'zerver.views.realm_filters.list_filters',
          'POST': 'zerver.views.realm_filters.create_filter'}),
     url(r'^realm/filters/(?P<filter_id>\d+)$', rest_dispatch,
-        {'DELETE': 'zerver.views.realm_filters.delete_filter'}),
+        {'DELETE': 'zerver.views.realm_filters.delete_filter',
+         'PATCH': 'zerver.views.realm_filters.update_filter'}),
 
     # realm/profile_fields -> zerver.views.custom_profile_fields
     url(r'^realm/profile_fields$', rest_dispatch,


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

- This  PR adds functionality of making linkifiers editable. In present version, we can only create linkifier or remove linkifier. 
-  I have added one edit button, in actions column, in list of linkifiers in settings. 
-  Clicking on this edit button will open a dialog box, to edit that linkifier. 
-  If user enters correct information in edit form, then linkifier will be edited with success message, otherwise it will complain to user regarding wrong information.
- Besides, it fixes one issue, in which **"Custom linkifier added"** label was showing up continuously after user has added the linkifier, I have changed that time to 2 seconds. So, that message will be disappeared after 2 seconds of adding linkifier.

**Testing Plan:** <!-- How have you tested? -->
I wrote tests in `zerver/tests/test_realm_filters.py` to test `update_filter` function and in `zerver/tests/test_evens.py` to test `do_update_realm_filter` function. Both were successfully passing in terminal when I run them manually using `./tools/test/...`

** Screenshots **

![screenshot 2019-02-10 at 3 17 52 am](https://user-images.githubusercontent.com/39343253/52526703-91b06b80-2ce2-11e9-9f0d-308988aa543a.png)

![screenshot 2019-02-10 at 2 53 41 am](https://user-images.githubusercontent.com/39343253/52526705-91b06b80-2ce2-11e9-8210-0f76b36b276a.png)
![screenshot 2019-02-12 at 3 52 10 pm](https://user-images.githubusercontent.com/39343253/52628815-6b571f80-2ede-11e9-97bc-c02ce180d261.png)

