### PR TITLE
Add Shift+c back for "compose private message".  Fixes #9020 .

### DIFF
--- a/frontend_tests/casper_tests/04-compose.js
+++ b/frontend_tests/casper_tests/04-compose.js
@@ -63,6 +63,21 @@ casper.then(function () {
 casper.then(function () {
     casper.waitUntilVisible('#private_message_recipient', function () {
         common.pm_recipient.expect("");
+        // Cancel current message and re-try using alternative shortcut
+        common.keypress(27);
+    });
+});
+
+casper.then(function () {
+    casper.waitWhileVisible('#private-message', function () {
+        casper.test.assertNotVisible('#private-message', 'PM compose box closed');
+        casper.page.sendEvent('keypress', 'C');
+    });
+});
+
+casper.then(function () {
+    casper.waitUntilVisible('#private_message_recipient', function () {
+        common.pm_recipient.expect("");
         casper.click('body');
         casper.page.sendEvent('keypress', 'c');
     });

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -107,7 +107,6 @@ run_test('mappings', () => {
     assert.equal(map_down(47), undefined);
     assert.equal(map_press(27), undefined);
     assert.equal(map_down(27, true), undefined);
-    assert.equal(map_down(67, false, true), undefined); // ctrl + c
     assert.equal(map_down(86, false, true), undefined); // ctrl + v
     assert.equal(map_down(90, false, true), undefined); // ctrl + z
     assert.equal(map_down(84, false, true), undefined); // ctrl + t
@@ -247,6 +246,7 @@ run_test('basic_chars', () => {
 
     assert_mapping('c', 'compose_actions.start');
     assert_mapping('x', 'compose_actions.start');
+    assert_mapping('C', 'compose_actions.start'); // Private message
     assert_mapping('P', 'narrow.by');
     assert_mapping('g', 'gear_menu.open');
 

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -85,7 +85,7 @@ var keypress_mappings = {
     63: {name: 'show_shortcuts', message_view_only: false}, // '?'
     64: {name: 'compose_reply_with_mention', message_view_only: true}, // '@'
     65: {name: 'stream_cycle_backward', message_view_only: true}, // 'A'
-    67: {name: 'C_deprecated', message_view_only: true}, // 'C'
+    67: {name: 'compose_private_message', message_view_only: true}, // 'C'
     68: {name: 'stream_cycle_forward', message_view_only: true}, // 'D'
     71: {name: 'G_end', message_view_only: true}, // 'G'
     74: {name: 'vim_page_down', message_view_only: true}, // 'J'
@@ -678,9 +678,6 @@ exports.process_hotkey = function (e, hotkey) {
         // Note that you can "enter" to respond to messages as well,
         // but that is handled in process_enter_key().
         compose_actions.respond_to_message({trigger: 'hotkey'});
-        return true;
-    case 'C_deprecated':
-        ui.maybe_show_deprecation_notice('C');
         return true;
     case 'star_deprecated':
         ui.maybe_show_deprecation_notice('*');

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -143,9 +143,7 @@ var shown_deprecation_notices = [];
 exports.maybe_show_deprecation_notice = function (key) {
     var message;
     var isCmdOrCtrl = /Mac/i.test(navigator.userAgent) ? "Cmd" : "Ctrl";
-    if (key === 'C') {
-        message = exports.get_hotkey_deprecation_notice('C', 'x');
-    } else if (key === '*') {
+    if (key === '*') {
         message = exports.get_hotkey_deprecation_notice("*", isCmdOrCtrl + " + s");
     } else {
         blueslip.error("Unexpected deprecation notice for hotkey:", key);

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -17,7 +17,7 @@
                     <td class="definition">{% trans %}New stream message{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">x</td>
+                    <td class="hotkey">x, C</td>
                     <td class="definition">{% trans %}New private message{% endtrans %}</td>
                 </tr>
                 <tr>

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -20,7 +20,7 @@ below, and add more to your repertoire as needed.
 
 * **New stream message**: `c` — Start a new topic in the current stream.
 
-* **New private message**: `x`
+* **New private message**: `x` or `C` 
 
 * **Cancel compose**: `Esc` or `Ctrl + [` — Close the compose box and save
   the unsent message as a draft.

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -20,7 +20,7 @@ below, and add more to your repertoire as needed.
 
 * **New stream message**: `c` — Start a new topic in the current stream.
 
-* **New private message**: `x` or `C` 
+* **New private message**: `x` or `C`
 
 * **Cancel compose**: `Esc` or `Ctrl + [` — Close the compose box and save
   the unsent message as a draft.


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Issue #9020:
Restored Shift+c shortcut for "Compose private message" and removed deprecation notice for that particular shortcut.

**Testing Plan:** <!-- How have you tested? -->
I have tested both manually and modified automated tests for shift+c.