### PR TITLE
Run-dev: Start redis-server.

### DIFF
--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import time
 import traceback
+import redis
 
 from urllib.parse import urlunparse
 
@@ -155,6 +156,14 @@ cmds = [['./manage.py', 'runserver'] +
         ['./manage.py', 'deliver_scheduled_messages'],
         ['/srv/zulip-thumbor-venv/bin/thumbor', '-c', './zthumbor/thumbor.conf',
          '-p', '%s' % (thumbor_port,)]]
+
+#start redis-server if it is not already running
+try:
+    rs = redis.Redis("localhost")
+    rs.get(None)  # getting None returns None or throws an exception
+except (redis.exceptions.RedisError):
+    cmds.insert(0, ['redis-server'])
+
 if options.test:
     # We just need to compile handlebars templates and webpack assets
     # once at startup, not run a daemon, in test mode.  Additionally,


### PR DESCRIPTION
Add an import to "redis", check if redis is running;
if not, insert into "cmds" to run.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This allows run-dev.py to checks if redis is running and starts it if not.

**Testing Plan:** <!-- How have you tested? -->
I've tested this on my local system when redis-server was not running and when it was running.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
