### PR TITLE
compose.js: Add support for using video call link in message edit.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1410,7 +1410,7 @@ run_test('on_events', () => {
             called = true;
         };
 
-        var handler = $("#compose").get_on_handler("click", "#video_link");
+        var handler = $("body").get_on_handler("click", ".video_link");
         $('#compose-textarea').val('');
 
         handler(event);

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -688,9 +688,9 @@ exports.needs_subscribe_warning = function (email) {
     return true;
 };
 
-function insert_video_call_url(url) {
+function insert_video_call_url(url, target_textarea) {
     var video_call_link_text = '[' + _('Click to join video call') + '](' + url + ')';
-    compose_ui.insert_syntax_and_focus(video_call_link_text);
+    compose_ui.insert_syntax_and_focus(video_call_link_text, target_textarea);
 }
 
 exports.initialize = function () {
@@ -933,8 +933,18 @@ exports.initialize = function () {
         }
     }
 
-    $('#compose').on('click', '#video_link', function (e) {
+    $('body').on('click', '.video_link', function (e) {
         e.preventDefault();
+
+        var target_textarea;
+        // The data-message-id atribute is only present in the video
+        // call icon present in the message edit form.  If present,
+        // the request is for the edit UI; otherwise, it's for the
+        // compose box.
+        if ($(e).attr("data-message-id") !== undefined) {
+            var edit_message_id = $(e).attr("data-message-id");
+            target_textarea = $("#message_edit_content_" + edit_message_id);
+        }
 
         if (page_params.jitsi_server_url === null) {
             return;
@@ -944,17 +954,17 @@ exports.initialize = function () {
         var video_call_id = util.random_int(100000000000000, 999999999999999);
         if (page_params.realm_video_chat_provider === "Google Hangouts") {
             video_call_link = "https://hangouts.google.com/hangouts/_/" + page_params.realm_google_hangouts_domain + "/" + video_call_id;
-            insert_video_call_url(video_call_link);
+            insert_video_call_url(video_call_link, target_textarea);
         } else if (page_params.realm_video_chat_provider === "Zoom") {
             channel.get({
                 url: '/json/calls/create',
                 success: function (response) {
-                    insert_video_call_url(response.zoom_url);
+                    insert_video_call_url(response.zoom_url, target_textarea);
                 },
             });
         } else {
             video_call_link = page_params.jitsi_server_url + "/" +  video_call_id;
-            insert_video_call_url(video_call_link);
+            insert_video_call_url(video_call_link, target_textarea);
         }
     });
 

--- a/static/templates/message_edit_form.handlebars
+++ b/static/templates/message_edit_form.handlebars
@@ -38,6 +38,7 @@
             {{#if has_been_editable}}
             <div class="message-edit-feature-group">
                 <input type="file" id="message_edit_file_input_{{message_id}}" class="notvisible pull-left" multiple />
+                <a class="message-control-button fa fa-video-camera video_link" aria-hidden="true" href="#" data-message-id="{{message_id}}" title="{{t "Add video call" }}"></a>
                 <a class="message-control-button fa fa-font" aria-hidden="true" title="{{t 'Formatting' }}" data-overlay-trigger="message-formatting" ></a>
                 <a class="message-control-button fa fa-paperclip notdisplayed" aria-hidden="true" id="attach_files_{{message_id}}" href="#" title="{{t "Attach files" }}"></a>
                 <a class="message-control-button fa fa-smile-o" aria-hidden="true" id="emoji_map" href="#" data-message-id="{{message_id}}" title="{{t 'Add emoji'  }}"></a>

--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -98,7 +98,7 @@
                                     <a class="message-control-button fa fa-smile-o" aria-hidden="true" id="emoji_map" href="#" title="{{ _('Add emoji') }}"></a>
                                     <a class="message-control-button fa fa-font" aria-hidden="true" title="{{ _('Formatting') }}" data-overlay-trigger="message-formatting"></a>
                                     <a class="message-control-button fa fa-paperclip notdisplayed" aria-hidden="true" id="attach_files" href="#" title="{{ _('Attach files') }}"></a> {% if jitsi_server_url %}
-                                    <a class="message-control-button fa fa-video-camera" aria-hidden="true" id="video_link" href="#" title="{{ _('Add video call') }}"></a> {% endif %}
+                                    <a class="message-control-button fa fa-video-camera video_link" aria-hidden="true" href="#" title="{{ _('Add video call') }}"></a> {% endif %}
                                     <a id="undo_markdown_preview" class="message-control-button fa fa-edit" aria-hidden="true" style="display:none;" title="{{ _('Write') }}"></a>
                                     <a id="markdown_preview" class="message-control-button fa fa-eye" aria-hidden="true" title="{{ _('Preview') }}"></a>
                                     <a class="drafts-link" href="#drafts" title="{{ _('Drafts') }} (d)">{{ _('Drafts') }}</a>


### PR DESCRIPTION
This code will correctly add video call link to the message
textarea based on whether 'Add video call' was selected from
message composition form or message edit form.

Fixes #11188.



**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
