### PR TITLE
webhooks/clubhouse: Extract story labels from actions.

### DIFF
--- a/zerver/webhooks/clubhouse/fixtures/story_update_add_label_name_in_action.json
+++ b/zerver/webhooks/clubhouse/fixtures/story_update_add_label_name_in_action.json
@@ -1,0 +1,30 @@
+{
+    "member_id":"5bc77d81-sdkf-23fk-sdkf-bfea45f0b806",
+    "version":"v1",
+    "primary_id":11200,
+    "id":"5c488ff2-d76e-4b34-8cdb-4f6098ae79ec",
+    "actions":[
+        {
+            "action":"update",
+            "story_type":"chore",
+            "entity_type":"story",
+            "changes":{
+                "label_ids":{
+                    "adds":[
+                        12135
+                    ]
+                }
+            },
+            "id":11200,
+            "app_url":"https:\/\/app.clubhouse.io\/zulip\/story\/28",
+            "name":"An emotional story!"
+        },
+        {
+            "action":"create",
+            "id":12135,
+            "entity_type":"label",
+            "name":"sad"
+        }
+    ],
+    "changed_at":"2019-01-23T16:01:54.470Z"
+}

--- a/zerver/webhooks/clubhouse/tests.py
+++ b/zerver/webhooks/clubhouse/tests.py
@@ -182,6 +182,12 @@ class ClubhouseWebhookTest(WebhookTestCase):
         self.send_and_test_stream_message('story_update_add_label', "An epic story!",
                                           expected_message)
 
+    def test_story_label_added_label_name_in_actions(self) -> None:
+        expected_message = u"The label **sad** was added to the story [An emotional story!](https://app.clubhouse.io/zulip/story/28)."
+        self.send_and_test_stream_message('story_update_add_label_name_in_action',
+                                          'An emotional story!',
+                                          expected_message)
+
     @patch('zerver.lib.webhooks.common.check_send_webhook_message')
     def test_story_label_removed_ignore(
             self, check_send_webhook_message_mock: MagicMock) -> None:

--- a/zerver/webhooks/clubhouse/view.py
+++ b/zerver/webhooks/clubhouse/view.py
@@ -392,9 +392,18 @@ def get_story_label_body(payload: Dict[str, Any]) -> Optional[str]:
         return None
 
     label_id = label_ids_added[0]
-    for reference in payload["references"]:
-        if reference["id"] == label_id:
-            kwargs.update({"label_name": reference["name"]})
+
+    label_name = ''
+    for action in payload["actions"]:
+        if action['id'] == label_id:
+            label_name = action.get('name', '')
+
+    if not label_name:
+        for reference in payload["references"]:
+            if reference["id"] == label_id:
+                label_name = reference.get('name', '')
+
+    kwargs.update({"label_name": label_name})
 
     return STORY_LABEL_TEMPLATE.format(**kwargs)
 


### PR DESCRIPTION
Apparently, Clubhouse has two different payloads for story label
changes, one where the label name lives inside the "references"
object, and the other where it lives inside the "actions" object.
Their webhook API is still in beta, so this could just be a bug.
Anyhow, we should support both.

@timabbott: FYI :)