### PR TITLE
scrollbar pixels  (Fixes: #8731)

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -46,7 +46,7 @@
 
 #stream_filters {
     overflow: visible;
-    margin: 2px 0px 22px 0px;
+    margin: 0px 0px 22px 0px;
     padding: 0;
     font-weight: normal;
 }


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixed the issue on scrollbar top ending a few pixels high.

**Testing Plan:** <!-- How have you tested? -->
Tried it out on my localhost 

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![screenshot from 2019-01-23 02-21-39](https://user-images.githubusercontent.com/32872276/51746564-93681580-20cc-11e9-9b98-c196d2622aa3.png)
![screenshot from 2019-01-23 02-23-49](https://user-images.githubusercontent.com/32872276/51746575-9e22aa80-20cc-11e9-957c-e43d502dc06c.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
