### PR TITLE
user status: Fix stray "info" reference.

### DIFF
--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -466,7 +466,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             }
         }
 
-        if (event.info !== undefined) {
+        if (event.status_text !== undefined) {
             user_status.set_status_text({
                 user_id: event.user_id,
                 status_text: event.info,


### PR DESCRIPTION
This fixes a section of code that hasn't really
been turned on yet.  We decided to rename
"info" to "status_text", and I apparently missed
this.  We don't have any UI to set these yet,
so it was a harmless bug.

I'll try to get some better test coverage on this
when I tweak the buddy list to show user status.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
