### PR TITLE
left-sidebar: Add scrollbar to the list of private messages.

### DIFF
--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -8,10 +8,8 @@ var private_messages_open = false;
 // way to zoom back out other than re-narrowing out and in of the
 // PM list.
 var zoomed_in = false;
-
 // This module manages the "Private Messages" section in the upper
 // left corner of the app.  This was split out from stream_list.js.
-
 function get_filter_li() {
     return $("#global_filters > li[data-name='private']");
 }
@@ -123,11 +121,12 @@ exports._build_private_messages_list = function (active_conversation, max_privat
     } else {
         zoom_class = "zoomed-out";
     }
-
-    var recipients_dom = templates.render('sidebar_private_message_list',
-                                          {messages: display_messages,
-                                           zoom_class: zoom_class,
-                                           want_show_more_messages_links: hiding_messages});
+    var recipients_dom = '<div id="private-container" class="scrolling_list">';
+    recipients_dom += templates.render('sidebar_private_message_list',
+                                       {messages: display_messages,
+                                        zoom_class: zoom_class,
+                                        want_show_more_messages_links: hiding_messages});
+    recipients_dom += '</div>';
     return recipients_dom;
 };
 
@@ -157,7 +156,6 @@ exports.update_private_messages = function () {
     if (!narrow_state.active()) {
         return;
     }
-
     var is_pm_filter = _.contains(narrow_state.filter().operands('is'), "private");
     var conversation = narrow_state.filter().operands('pm-with');
     if (conversation.length === 1) {
@@ -169,6 +167,15 @@ exports.update_private_messages = function () {
         exports.rebuild_recent("");
         $("#global_filters li[data-name='private']").addClass('active-filter');
     }
+    var number_of_containers = $('#pm')[0]['children'].length - 1;
+    var container = $($('#pm')[0]['children'][number_of_containers]);
+    var key = 1;
+    while (key < number_of_containers - 1) {
+        $($('#pm')[0]['children'][key]).remove();
+        key += 1;
+    }
+    $($('#pm')[0]['children'][1]).remove();
+    ui.set_up_scrollbar(container);
 };
 
 exports.set_click_handlers = function () {

--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -169,14 +169,14 @@ exports.update_private_messages = function () {
         exports.rebuild_recent("");
         $("#global_filters li[data-name='private']").addClass('active-filter');
     }
-    var number_of_containers = $('#pm')[0]['children'].length - 1;
-    var container = $($('#pm')[0]['children'][number_of_containers]);
+    var number_of_containers = $('#private_li')[0]['children'].length - 1;
+    var container = $($('#private_li')[0]['children'][number_of_containers]);
     var key = 1;
     while (key < number_of_containers - 1) {
-        $($('#pm')[0]['children'][key]).remove();
+        $($('#private_li')[0]['children'][key]).remove();
         key += 1;
     }
-    $($('#pm')[0]['children'][1]).remove();
+    $($('#private_li')[0]['children'][1]).remove();
     ui.set_up_scrollbar(container);
 };
 

--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -8,8 +8,10 @@ var private_messages_open = false;
 // way to zoom back out other than re-narrowing out and in of the
 // PM list.
 var zoomed_in = false;
+
 // This module manages the "Private Messages" section in the upper
 // left corner of the app.  This was split out from stream_list.js.
+
 function get_filter_li() {
     return $("#global_filters > li[data-name='private']");
 }

--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -158,6 +158,7 @@ exports.update_private_messages = function () {
     if (!narrow_state.active()) {
         return;
     }
+    
     var is_pm_filter = _.contains(narrow_state.filter().operands('is'), "private");
     var conversation = narrow_state.filter().operands('pm-with');
     if (conversation.length === 1) {

--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -158,7 +158,7 @@ exports.update_private_messages = function () {
     if (!narrow_state.active()) {
         return;
     }
-    
+
     var is_pm_filter = _.contains(narrow_state.filter().operands('is'), "private");
     var conversation = narrow_state.filter().operands('pm-with');
     if (conversation.length === 1) {

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -72,12 +72,17 @@
     padding: 2px 0px 2px 29px;
 }
 
+#private-container,
 #stream-filters-container {
     overflow-x: hidden;
     overflow-y: hidden;
     position: relative;
     z-index: 0;
     width: 100%;
+}
+
+#private-container {
+    max-height: 200px;
 }
 
 .input-append input[type=text].stream-list-filter {

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -14,7 +14,7 @@
                 </a>
                 <span class="arrow stream-sidebar-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
             </li>
-            <li data-name="private" class="global-filter" title="{{ _('Private messages') }} (P)">
+            <li data-name="private" class="global-filter" title="{{ _('Private messages') }} (P)" id="pm">
                 <a href="#narrow/is/private">
                     <span class="filter-icon">
                         <i class="fa fa-envelope" aria-hidden="true"></i>

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -14,7 +14,7 @@
                 </a>
                 <span class="arrow stream-sidebar-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
             </li>
-            <li data-name="private" class="global-filter" title="{{ _('Private messages') }} (P)" id="pm">
+            <li data-name="private" class="global-filter" title="{{ _('Private messages') }} (P)" id="private_li">
                 <a href="#narrow/is/private">
                     <span class="filter-icon">
                         <i class="fa fa-envelope" aria-hidden="true"></i>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
**Recent PM's list doesn't have scrollbar** [#5384](https://github.com/zulip/zulip/issues/5384)

**Testing Plan:** <!-- How have you tested? -->
Created a lot of private messages and placed a scrollbar on the list, restricted it's width and observed that the scrollbar is working.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![screenshot from 2019-01-26 15-36-41](https://user-images.githubusercontent.com/39990232/51788007-c549ac80-219e-11e9-8f4e-e12288b8a842.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html -->


 
