### PR TITLE
settings_panel_menu.js: Add code to hide Change user info and roles form

### DIFF
--- a/static/js/settings_panel_menu.js
+++ b/static/js/settings_panel_menu.js
@@ -94,6 +94,12 @@ exports.make_menu = function (opts) {
     };
 
     main_elem.on("click", "li[data-section]", function (e) {
+        // This code will hide the Change user info and roles form
+        // when navigating to new tab in case the form is visible.
+        if ($('#user-info-form-modal').attr('aria-hidden')) {
+            overlays.close_modal('user-info-form-modal');
+        }
+
         var section = $(this).attr('data-section');
 
         self.activate_section(section);


### PR DESCRIPTION
This code will hide the Change user info and roles form when navigating
to new tab in case the form is visible.

Before:
![51072325-c817ae00-1684-11e9-9569-e0eea6c42d05](https://user-images.githubusercontent.com/30211121/51788069-bfa09680-219f-11e9-900e-7e9f60d85d91.gif)

After:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/30211121/51788281-14dda780-21a2-11e9-894f-45efd6813113.gif)


