### PR TITLE
fix: Docker development environment unicode

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -11,7 +11,7 @@ RUN useradd -d /home/zulip -m zulip && echo 'zulip ALL=(ALL) NOPASSWD:ALL' >> /e
 USER zulip
 
 RUN ln -nsf /srv/zulip ~/zulip
-
+RUN echo 'export LC_ALL="en_US.UTF-8" LANG="en_US.UTF-8" LANGUAGE="en_US.UTF-8"' >> ~zulip/.bashrc
 RUN echo 'export LC_ALL="en_US.UTF-8" LANG="en_US.UTF-8" LANGUAGE="en_US.UTF-8"' >> ~zulip/.bash_profile
 
 WORKDIR /srv/zulip


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

fix: 11323

It seems we must export lang to `.bashrc`,everything can work well.

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
