### PR TITLE
Normalize Slackbot String Comparison in Slack Import

### DIFF
--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -301,7 +301,7 @@ def get_user_email(user: ZerverFieldsT, domain_name: str) -> str:
         else:
             raise AssertionError("Could not identify bot type")
         return slack_bot_name.replace("Bot", "").replace(" ", "") + "-bot@%s" % (domain_name,)
-    if get_user_full_name(user) == "slackbot":
+    if get_user_full_name(user).lower() == "slackbot":
         return "imported-slackbot-bot@%s" % (domain_name,)
     raise AssertionError("Could not find email address for Slack user %s" % (user,))
 


### PR DESCRIPTION
In very old Slack workspaces, slackbot can appear as "Slackbot", and the import script only checks for "slackbot" (case sensitive).  This breaks the import--it throws the assert that immediately follows the test.  I don't know how common this is, but it definitely affected our import.

Easy fix is to compare against a lowercased-version of the user's full name.
