### PR TITLE
poll-widget: Add syntax for adding options when creating poll.

### DIFF
--- a/docs/subsystems/widgets.md
+++ b/docs/subsystems/widgets.md
@@ -34,7 +34,6 @@ messages).
 Here are some code entities used in the above
 features:
 
-- `ALLOW_SUB_MESSAGES` setting
 - `SubMessage` database table
 - `/json/zcommand` API endpoint
 - `/json/submessage` API endpoint
@@ -109,13 +108,10 @@ launch widgets by sending one of the following messages:
 - /todo
 - /tictactoe
 
-These widgets are only turned on if you set the `ALLOW_SUB_MESSAGES`
-boolean to `True` in the appropriate `settings.py`.
-Currently the setting is only enabled for dev and
-our main community realm (chat.zulip.org).  Also,
-only the webapp client provides the "widget experience".
-Other clients just show raw messages like "/poll"
-or "/ticactoe".
+The webapp client provides the "widget experience" by
+default. Other clients just show raw messages like
+"/poll" or "/ticactoe", and should be adding support
+for widgets soon.
 
 Our customers have long requested a poll/survey widget.
 See [this issue](https://github.com/zulip/zulip/issues/9736).
@@ -301,8 +297,7 @@ and grades the answer using ordinary chat-bot coding.
 The beautiful thing is that any thrid party developer
 can enhance bots that are similar to the **trivia_quiz**
 bot without touching any Zulip code, because **zforms**
-are completely generic.  (The only caveat is that
-the server must turn on `ALLOW_SUB_MESSAGES`.)
+are completely generic.
 
 ## Data flow
 

--- a/frontend_tests/node_tests/voting_widget.js
+++ b/frontend_tests/node_tests/voting_widget.js
@@ -23,7 +23,7 @@ run_test('poll_data_holder my question', () => {
     let data = data_holder.get_widget_data();
 
     assert.deepEqual(data, {
-        comments: [],
+        options: [],
         question: 'Favorite color?',
     });
 
@@ -36,25 +36,25 @@ run_test('poll_data_holder my question', () => {
     data = data_holder.get_widget_data();
 
     assert.deepEqual(data, {
-        comments: [],
+        options: [],
         question: 'best plan?',
     });
 
-    const comment_event = {
-        type: 'new_comment',
+    const option_event = {
+        type: 'new_option',
         idx: 1,
-        comment: 'release now',
+        option: 'release now',
     };
 
     people.safe_full_names = () => '';
 
-    data_holder.handle_event(sender_id, comment_event);
+    data_holder.handle_event(sender_id, option_event);
     data = data_holder.get_widget_data();
 
     assert.deepEqual(data, {
-        comments: [
+        options: [
             {
-                comment: 'release now',
+                option: 'release now',
                 names: '',
                 count: 0,
                 key: '99,1',
@@ -73,9 +73,9 @@ run_test('poll_data_holder my question', () => {
     data = data_holder.get_widget_data();
 
     assert.deepEqual(data, {
-        comments: [
+        options: [
             {
-                comment: 'release now',
+                option: 'release now',
                 names: '',
                 count: 1,
                 key: '99,1',
@@ -96,11 +96,11 @@ run_test('poll_data_holder my question', () => {
     data_holder.handle_event(sender_id, invalid_vote_event);
     data = data_holder.get_widget_data();
 
-    const comment_outbound_event = data_holder.handle.new_comment.outbound('new comment');
-    assert.deepEqual(comment_outbound_event, {
-        type: 'new_comment',
+    const option_outbound_event = data_holder.handle.new_option.outbound('new option');
+    assert.deepEqual(option_outbound_event, {
+        type: 'new_option',
         idx: 2,
-        comment: 'new comment',
+        option: 'new option',
     });
 
     const new_question = 'Any new plan?';
@@ -123,9 +123,9 @@ run_test('poll_data_holder my question', () => {
     data = data_holder.get_widget_data();
 
     assert.deepEqual(data, {
-        comments: [
+        options: [
             {
-                comment: 'release now',
+                option: 'release now',
                 names: '',
                 count: 0,
                 key: '99,1',
@@ -170,15 +170,15 @@ run_test('activate another person poll', () => {
         return elem;
     };
 
-    const poll_comment = set_widget_find_result('button.poll-comment');
-    const poll_comment_input = set_widget_find_result('input.poll-comment');
-    const widget_comment_container = set_widget_find_result('ul.poll-widget');
+    const poll_option = set_widget_find_result('button.poll-option');
+    const poll_option_input = set_widget_find_result('input.poll-option');
+    const widget_option_container = set_widget_find_result('ul.poll-widget');
 
     const poll_question_submit = set_widget_find_result('button.poll-question-check');
     const poll_edit_question = set_widget_find_result('.poll-edit-question');
     const poll_question_header = set_widget_find_result('.poll-question-header');
     const poll_question_container = set_widget_find_result('.poll-question-bar');
-    const poll_comment_container = set_widget_find_result('.poll-comment-bar');
+    const poll_option_container = set_widget_find_result('.poll-option-bar');
 
     const poll_vote_button = set_widget_find_result('button.poll-vote');
     const poll_please_wait = set_widget_find_result('.poll-please-wait');
@@ -187,12 +187,12 @@ run_test('activate another person poll', () => {
     set_widget_find_result('button.poll-question-remove');
     set_widget_find_result('input.poll-question');
 
-    let comment_button_callback;
+    let option_button_callback;
     let vote_button_callback;
 
-    poll_comment.on = (event, func) => {
+    poll_option.on = (event, func) => {
         assert.equal(event, 'click');
-        comment_button_callback = func;
+        option_button_callback = func;
     };
 
     poll_vote_button.on = (event, func) => {
@@ -217,7 +217,7 @@ run_test('activate another person poll', () => {
         assert(!show);
     };
 
-    poll_comment_container.toggle = (show) => {
+    poll_option_container.toggle = (show) => {
         assert.equal(show, true);
     };
 
@@ -232,7 +232,7 @@ run_test('activate another person poll', () => {
     poll_widget.activate(opts);
 
     assert.equal(widget_elem.html(), 'poll-widget');
-    assert.equal(widget_comment_container.html(), 'poll-widget-results');
+    assert.equal(widget_option_container.html(), 'poll-widget-results');
     assert.equal(poll_question_header.text(), 'What do you want?');
 
     const e = {
@@ -240,15 +240,15 @@ run_test('activate another person poll', () => {
     };
 
     {
-        /* Testing data sent to server on adding comment */
-        poll_comment_input.val('cool choice');
+        /* Testing data sent to server on adding option */
+        poll_option_input.val('cool choice');
         out_data = undefined;
-        comment_button_callback(e);
-        assert.deepEqual(out_data,  { type: 'new_comment', idx: 1, comment: 'cool choice' });
+        option_button_callback(e);
+        assert.deepEqual(out_data,  { type: 'new_option', idx: 1, option: 'cool choice' });
 
-        poll_comment_input.val('');
+        poll_option_input.val('');
         out_data = undefined;
-        comment_button_callback(e);
+        option_button_callback(e);
         assert.deepEqual(out_data, undefined);
     }
 
@@ -256,9 +256,9 @@ run_test('activate another person poll', () => {
         {
             sender_id: 100,
             data: {
-                type: 'new_comment',
+                type: 'new_option',
                 idx: 1,
-                comment: 'release now',
+                option: 'release now',
             },
         },
         {
@@ -333,16 +333,16 @@ run_test('activate own poll', () => {
         return elem;
     };
 
-    const poll_comment = set_widget_find_result('button.poll-comment');
-    const poll_comment_input = set_widget_find_result('input.poll-comment');
-    const widget_comment_container = set_widget_find_result('ul.poll-widget');
+    const poll_option = set_widget_find_result('button.poll-option');
+    const poll_option_input = set_widget_find_result('input.poll-option');
+    const widget_option_container = set_widget_find_result('ul.poll-widget');
 
     const poll_question_submit = set_widget_find_result('button.poll-question-check');
     const poll_edit_question = set_widget_find_result('.poll-edit-question');
     const poll_question_input = set_widget_find_result('input.poll-question');
     const poll_question_header = set_widget_find_result('.poll-question-header');
     const poll_question_container = set_widget_find_result('.poll-question-bar');
-    const poll_comment_container = set_widget_find_result('.poll-comment-bar');
+    const poll_option_container = set_widget_find_result('.poll-option-bar');
 
     const poll_vote_button = set_widget_find_result('button.poll-vote');
     const poll_please_wait = set_widget_find_result('.poll-please-wait');
@@ -359,7 +359,7 @@ run_test('activate own poll', () => {
 
     // Following event handler are already tested and doesn't make sense
     // to test them again
-    poll_comment.on = noop;
+    poll_option.on = noop;
     poll_vote_button.on = noop;
 
     poll_question_header.toggle = (show) => {
@@ -379,7 +379,7 @@ run_test('activate own poll', () => {
         assert(!show);
     };
 
-    poll_comment_container.toggle = (show) => {
+    poll_option_container.toggle = (show) => {
         assert(show);
     };
 
@@ -394,7 +394,7 @@ run_test('activate own poll', () => {
     poll_widget.activate(opts);
 
     assert.equal(widget_elem.html(), 'poll-widget');
-    assert.equal(widget_comment_container.html(), 'poll-widget-results');
+    assert.equal(widget_option_container.html(), 'poll-widget-results');
     assert.equal(poll_question_header.text(), 'Where to go?');
 
     {
@@ -409,7 +409,7 @@ run_test('activate own poll', () => {
         question_button_callback(e);
         assert.deepEqual(out_data,  { type: 'question', question: 'Is it new?' });
 
-        poll_comment_input.val('');
+        poll_option_input.val('');
         out_data = undefined;
         question_button_callback(e);
         assert.deepEqual(out_data, undefined);

--- a/frontend_tests/node_tests/voting_widget.js
+++ b/frontend_tests/node_tests/voting_widget.js
@@ -4,7 +4,7 @@ set_global('$', global.make_zjquery());
 set_global('i18n', global.stub_i18n);
 
 set_global('people', {});
-set_global('blueslip', {});
+set_global('blueslip', global.make_zblueslip());
 set_global('templates', {});
 
 const noop = () => {};
@@ -90,11 +90,11 @@ run_test('poll_data_holder my question', () => {
         vote: 1,
     };
 
-    blueslip.error = (msg) => {
-        assert.equal(msg, `unknown key for poll: ${invalid_vote_event.key}`);
-    };
+    blueslip.set_test_data('warn', `unknown key for poll: ${invalid_vote_event.key}`);
     data_holder.handle_event(sender_id, invalid_vote_event);
     data = data_holder.get_widget_data();
+    assert.equal(blueslip.get_test_logs('warn').length, 1);
+    blueslip.clear_test_data();
 
     const option_outbound_event = data_holder.handle.new_option.outbound('new option');
     assert.deepEqual(option_outbound_event, {

--- a/frontend_tests/node_tests/widgetize.js
+++ b/frontend_tests/node_tests/widgetize.js
@@ -29,25 +29,25 @@ run_test('activate', () => {
     const events = [
         {
             data: {
-                comment: "First option",
+                option: "First option",
                 idx: 1,
-                type: "new_comment",
+                type: "new_option",
             },
             sender_id: 101,
         },
         {
             data: {
-                comment: "Second option",
+                option: "Second option",
                 idx: 1,
-                type: "new_comment",
+                type: "new_option",
             },
             sender_id: 102,
         },
         {
             data: {
-                comment: "Third option",
+                option: "Third option",
                 idx: 1,
-                type: "new_comment",
+                type: "new_option",
             },
             sender_id: 102,
         },
@@ -145,7 +145,7 @@ run_test('activate', () => {
     const post_activate_event = {
         data: {
             idx: 1,
-            type: "new_comment",
+            type: "new_option",
         },
         message_id: 2001,
         sender_id: 102,

--- a/static/js/poll_widget.js
+++ b/static/js/poll_widget.js
@@ -138,7 +138,7 @@ exports.poll_data_holder = function (is_my_poll, question, options) {
                 var option = key_to_option[key];
 
                 if (option === undefined) {
-                    blueslip.error('unknown key for poll: ' + key);
+                    blueslip.warn('unknown key for poll: ' + key);
                     return;
                 }
 

--- a/static/js/poll_widget.js
+++ b/static/js/poll_widget.js
@@ -2,7 +2,7 @@ var poll_widget = (function () {
 
 var exports = {};
 
-exports.poll_data_holder = function (is_my_poll, question) {
+exports.poll_data_holder = function (is_my_poll, question, options) {
     // This object just holds data for a poll, although it
     // works closely with the widget's concept of how data
     // should be represented for rendering, plus how the
@@ -167,6 +167,14 @@ exports.poll_data_holder = function (is_my_poll, question) {
         });
     };
 
+    // function to add all comments added along with the /poll command
+    _.each(options, function (option, i) {
+        self.handle.new_comment.inbound('canned', {
+            idx: i,
+            comment: option,
+        });
+    });
+
     return self;
 };
 
@@ -175,12 +183,14 @@ exports.activate = function (opts) {
     var callback = opts.callback;
 
     var question = '';
+    var options = [];
     if (opts.extra_data) {
         question = opts.extra_data.question || '';
+        options = opts.extra_data.options || [];
     }
 
     var is_my_poll = people.is_my_user_id(opts.message.sender_id);
-    var poll_data = exports.poll_data_holder(is_my_poll, question);
+    var poll_data = exports.poll_data_holder(is_my_poll, question, options);
 
     function update_edit_controls() {
         var has_question = elem.find('input.poll-question').val().trim() !== '';

--- a/static/styles/widgets.scss
+++ b/static/styles/widgets.scss
@@ -78,8 +78,8 @@ img.task-completed {
 
 input.add-task,
 button.add-task,
-input.poll-comment,
-button.poll-comment,
+input.poll-option,
+button.poll-option,
 input.poll-question,
 button.poll-question {
     padding: 4px 6px;
@@ -87,7 +87,7 @@ button.poll-question {
 }
 
 button.add-task,
-button.poll-comment,
+button.poll-option,
 button.poll-question {
     border-radius: 3px;
     border: 1px solid hsl(0, 0%, 80%);
@@ -96,7 +96,7 @@ button.poll-question {
 }
 
 button.add-task:hover,
-button.poll-comment:hover,
+button.poll-option:hover,
 button.poll-question:hover {
     border-color: hsl(0, 0%, 60%);
 }

--- a/static/templates/widgets/poll-widget-results.handlebars
+++ b/static/templates/widgets/poll-widget-results.handlebars
@@ -1,9 +1,9 @@
-{{#each comments}}
+{{#each options}}
 <li>
     <button class="poll-vote" data-key="{{ key }}">
         {{ count }}
     </button>
-    <span class="poll-option">{{ comment }}</span>
+    <span class="poll-option">{{ option }}</span>
     {{#if names}}
     <span class="poll-names">({{ names }})</span>
     {{/if}}

--- a/static/templates/widgets/poll-widget.handlebars
+++ b/static/templates/widgets/poll-widget.handlebars
@@ -14,9 +14,9 @@
     </div>
     <ul class="poll-widget">
     </ul>
-    <div class="poll-comment-bar">
-        <input type="text" class="poll-comment" placeholder="{{t 'New choice'}}" />
-        <button class="poll-comment">{{t "Add choice" }}</button>
+    <div class="poll-option-bar">
+        <input type="text" class="poll-option" placeholder="{{t 'New choice'}}" />
+        <button class="poll-option">{{t "Add choice" }}</button>
     </div>
     <br />
 </div>

--- a/zerver/lib/widget.py
+++ b/zerver/lib/widget.py
@@ -34,7 +34,7 @@ def get_extra_data_from_widget_type(content: str,
         for line in lines:
             # If someone is using the list syntax, we remove it
             # before adding an option.
-            option = re.sub(r'(\s*[-*]?\s*)', '', line.strip())
+            option = re.sub(r'(\s*[-*]?\s*)', '', line.strip(), 1)
             if len(option) > 0:
                 options.append(option)
         extra_data = {

--- a/zerver/lib/widget.py
+++ b/zerver/lib/widget.py
@@ -46,11 +46,9 @@ def get_extra_data_from_widget_type(content: str,
 
 def do_widget_post_save_actions(message: MutableMapping[str, Any]) -> None:
     '''
-    This is experimental code that only works with the
-    webapp for now.
+    This code works with the webapp; mobile and other
+    clients should also start supporting this soon.
     '''
-    if not settings.ALLOW_SUB_MESSAGES:
-        return
     content = message['message'].content
     sender_id = message['message'].sender_id
     message_id = message['message'].id

--- a/zerver/tests/test_widgets.py
+++ b/zerver/tests/test_widgets.py
@@ -182,7 +182,9 @@ class WidgetContentTestCase(ZulipTestCase):
     def test_poll_command_extra_data(self) -> None:
         sender_email = self.example_email('cordelia')
         stream_name = 'Verona'
-        content = '/poll What is your favorite color?'
+        # We test for both trailing and leading spaces, along with blank lines
+        # for the poll options.
+        content = '/poll What is your favorite color?\n\nRed\nGreen  \n\n   Blue\n - Yellow'
 
         payload = dict(
             type="stream",
@@ -201,6 +203,7 @@ class WidgetContentTestCase(ZulipTestCase):
         expected_submessage_content = dict(
             widget_type="poll",
             extra_data=dict(
+                options=['Red', 'Green', 'Blue', 'Yellow'],
                 question="What is your favorite color?",
             ),
         )
@@ -219,7 +222,8 @@ class WidgetContentTestCase(ZulipTestCase):
         expected_submessage_content = dict(
             widget_type="poll",
             extra_data=dict(
-                question="",
+                options=[],
+                question='',
             ),
         )
 

--- a/zerver/tests/test_widgets.py
+++ b/zerver/tests/test_widgets.py
@@ -232,12 +232,3 @@ class WidgetContentTestCase(ZulipTestCase):
         submessage = SubMessage.objects.get(message_id=message.id)
         self.assertEqual(submessage.msg_type, 'widget')
         self.assertEqual(ujson.loads(submessage.content), expected_submessage_content)
-
-        # Now test the feature flag.
-        with self.settings(ALLOW_SUB_MESSAGES=False):
-            result = self.api_post(sender_email, "/api/v1/messages", payload)
-        self.assert_json_success(result)
-
-        message = self.get_last_message()
-        self.assertEqual(message.content, content)
-        self.assertFalse(SubMessage.objects.filter(message_id=message.id).exists())

--- a/zerver/views/submessage.py
+++ b/zerver/views/submessage.py
@@ -27,10 +27,6 @@ def process_submessage(request: HttpRequest,
                        ) -> HttpResponse:
     message, user_message = access_message(user_profile, message_id)
 
-    if not settings.ALLOW_SUB_MESSAGES:  # nocoverage
-        msg = 'Feature not enabled'
-        return json_error(msg)
-
     try:
         ujson.loads(content)
     except Exception:

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -246,10 +246,6 @@ DEFAULT_SETTINGS = {
     # In-development search pills feature.
     'SEARCH_PILLS_ENABLED': False,
 
-    # We use SubMessage for now-experimental features like
-    # slash commands.
-    'ALLOW_SUB_MESSAGES': DEVELOPMENT,
-
     # We log emails in development environment for accessing
     # them easily through /emails page
     'DEVELOPMENT_LOG_EMAILS': DEVELOPMENT,


### PR DESCRIPTION
We add a new syntax which converts the messages like the following:

```
/poll Who do you support?

Nadal
Djokovic
```

to a poll with the two names as options. We do not have parse for list
syntax, and directly add all non-empty lines as options.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->

Extends existing test to check for poll options.

Ping @showell .