### PR TITLE
integration tests: Add check for new messages.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -631,11 +631,22 @@ class ZulipTestCase(TestCase):
         if stream_name is not None:
             self.subscribe(user_profile, stream_name)
 
+        prior_msg = self.get_last_message()
+
         result = self.client_post(url, payload, **post_params)
         self.assert_json_success(result)
 
         # Check the correct message was sent
         msg = self.get_last_message()
+
+        if msg.id == prior_msg.id:
+            raise Exception('''
+                Your test code called an endpoint that did
+                not write any new messages.  It is probably
+                broken (but still returns 200 due to exception
+                handling).
+                ''')  # nocoverage
+
         self.assertEqual(msg.sender.email, user_profile.email)
         if stream_name is not None:
             self.assertEqual(get_display_recipient(msg.recipient), stream_name)


### PR DESCRIPTION
This commit should make it a bit easier to debug
integrations that silently don't send any messages.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
