### PR TITLE
WIPAdded some logic to the custom emoji resizing code to prevent resizin…

### DIFF
--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -35,6 +35,8 @@ import logging
 DEFAULT_AVATAR_SIZE = 100
 MEDIUM_AVATAR_SIZE = 500
 DEFAULT_EMOJI_SIZE = 64
+MAX_EMOJI_GIF_SIZE = DEFAULT_EMOJI_SIZE, DEFAULT_EMOJI_SIZE
+MAX_EMOJI_GIF_FILE_SIZE_BYTES = 16 * 1024 * 1024  # 16 kb
 
 # Performance Note:
 #
@@ -154,12 +156,22 @@ def resize_gif(im: GifImageFile, size: int=DEFAULT_EMOJI_SIZE) -> bytes:
                    loop=loop)
     return out.getvalue()
 
+
 def resize_emoji(image_data: bytes, size: int=DEFAULT_EMOJI_SIZE) -> bytes:
     try:
         im = Image.open(io.BytesIO(image_data))
         image_format = im.format
         if image_format == "GIF":
-            return resize_gif(im, size)
+            # There are a number of bugs in Pillow.GifImagePlugin which cause
+            # results in resized gifs being broken. To work around this we
+            # only resize under certain conditions to minimize the chance of
+            # creating ugly gifs.
+            should_resize = any((
+                im.size[0] != im.size[1],                            # not square
+                im.size > MAX_EMOJI_GIF_SIZE,                       # dimensions too large
+                len(image_data) > MAX_EMOJI_GIF_FILE_SIZE_BYTES,     # filesize too large
+            ))
+            return resize_gif(im, size) if should_resize else image_data
         else:
             im = exif_rotate(im)
             im = ImageOps.fit(im, (size, size), Image.ANTIALIAS)


### PR DESCRIPTION
…g in certain circumstances. This is because the pillow gif handling code seems to be rather flaky with regards to handling gif color palletes, causing broken gifs after resizing. The workaround is to only resize when absolutely necessary

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
