### PR TITLE
general UI: Preserve whitespace in message topic names.

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -296,6 +296,7 @@ li.top_left_starred_messages {
 .topic-name {
     /* TODO: We should figure out how to remove this without changing the spacing */
     line-height: 1.1;
+    white-space: pre;
 }
 
 .all-messages-arrow i,

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -794,6 +794,10 @@ td.pointer {
     line-height: 17px;
 }
 
+.stream_topic .message_label_clickable {
+    white-space: pre;
+}
+
 .recipient_row_date {
     position: absolute;
     right: 0;

--- a/static/templates/archive_recipient_row.hbs
+++ b/static/templates/archive_recipient_row.hbs
@@ -14,7 +14,7 @@
                 <a class="message_label_clickable narrows_by_topic"
                   href="{{topic_url}}"
                   title="{{#tr this}}Narrow to stream &quot;__display_recipient__&quot;, topic &quot;__topic__&quot;{{/tr}}">
-                    {{topic}}
+                    {{~ topic ~}}
                 </a>
             </span>
             <span class="recipient_row_date">{{{date}}}</span>

--- a/static/templates/draft.hbs
+++ b/static/templates/draft.hbs
@@ -9,9 +9,9 @@
                 </div>
 
                 <span class="stream_topic">
-                    <div class="message_label_clickable narrows_by_topic">
-                        {{topic}}
-                    </div>
+                    <span class="message_label_clickable narrows_by_topic">
+                        {{~ topic ~}}
+                    </span>
                 </span>
                 <div class="recipient_row_date" title="{{t 'Last modified'}}">{{ time_stamp }}</div>
             </div>

--- a/static/templates/recipient_row.hbs
+++ b/static/templates/recipient_row.hbs
@@ -22,11 +22,11 @@
                 <a class="message_label_clickable narrows_by_topic"
                     href="{{topic_url}}"
                     title="{{#tr this}}Narrow to stream &quot;__display_recipient__&quot;, topic &quot;__topic__&quot;{{/tr}}">
-                    {{#if use_match_properties}}
-                    {{{match_topic}}}
-                    {{else}}
-                    {{topic}}
-                    {{/if}}
+                    {{~#if use_match_properties~}}
+                    {{~{ match_topic }~}}
+                    {{~ else ~}}
+                    {{~ topic ~}}
+                    {{~/if~}}
                 </a>
                 <!-- The missing whitespace on the next line is a hack; ideally, would be user-select: none. -->
             </span><span class="recipient_bar_controls no-select">

--- a/static/templates/topic_list_item.hbs
+++ b/static/templates/topic_list_item.hbs
@@ -1,7 +1,7 @@
 <li class='bottom_left_row {{#if is_zero}}zero-topic-unreads{{/if}} {{#if is_muted}}muted_topic{{/if}} topic-list-item' data-topic-name='{{topic_name}}'>
     <span class='topic-box'>
         <a href='{{url}}' class="topic-name" title="{{topic_name}}">
-            {{topic_name}}
+            {{~ topic_name ~}}
         </a>
         <div class="topic-unread-count {{#if is_zero}}zero_count{{/if}}">
             <div class="value">{{unread}}</div>


### PR DESCRIPTION
This is rebased version of #10121 by @synicalsyntax, with some merge conflict resolution mistakes corrected. Original description:

> In order to preserve whitespace in message topic names, we change its `whitespace: nowrap` property to `white-space: pre` and modify Handlebars templates to eliminate extraneous whitespace using the `~` character.
>
> ![screenshot at jul 30 18-02-03](https://user-images.githubusercontent.com/15116870/43432368-5c1a442c-9427-11e8-95a0-e49a4be95f3f.png)