### PR TITLE
added errored to travis webhooks

### DIFF
--- a/zerver/webhooks/travis/view.py
+++ b/zerver/webhooks/travis/view.py
@@ -13,7 +13,7 @@ from zerver.lib.validator import check_bool, check_dict, check_string
 from zerver.models import UserProfile
 
 GOOD_STATUSES = ['Passed', 'Fixed']
-BAD_STATUSES = ['Failed', 'Broken', 'Still Failing']
+BAD_STATUSES = ['Failed', 'Broken', 'Still Failing', 'Errored']
 
 MESSAGE_TEMPLATE = (
     u'Author: {}\n'


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
I'm adding "Errored"  emoji to the Travis Webhook

**Testing Plan:** <!-- How have you tested? -->
I ran it in IDLE and it worked

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
