### PR TITLE
settings: Use "guest" instead of "guest user".

### DIFF
--- a/static/js/settings_invites.js
+++ b/static/js/settings_invites.js
@@ -26,7 +26,7 @@ exports.invited_as_values = {
     },
     guest_user: {
         value: 3,
-        description: i18n.t("Guest user"),
+        description: i18n.t("Guest"),
     },
 };
 

--- a/static/templates/settings/emoji-settings-tip.handlebars
+++ b/static/templates/settings/emoji-settings-tip.handlebars
@@ -1,5 +1,5 @@
 {{#if is_guest}}
-    <div class='tip'>{{t "Guest users cannot edit custom emoji." }}</div>
+    <div class='tip'>{{t "Guests cannot edit custom emoji." }}</div>
 {{else}}
     {{#if realm_add_emoji_by_admins_only}}
     <div class='tip'>{{t "Only organization administrators can add custom emoji in this organization." }}</div>

--- a/templates/zerver/app/invite_user.html
+++ b/templates/zerver/app/invite_user.html
@@ -22,7 +22,7 @@
                             {% if is_admin %}
                             <option name="invite_as" value="{{ invite_as.REALM_ADMIN }}">{{ _('Organization administrators') }}</option>
                             {% endif %}
-                            <option name="invite_as" value="{{ invite_as.GUEST_USER }}">{{ _('Guest users') }}</option>
+                            <option name="invite_as" value="{{ invite_as.GUEST_USER }}">{{ _('Guests') }}</option>
                         </select>
                     </div>
                 </div>


### PR DESCRIPTION
In general I think we should standardize on "member, administrator, guest".

