### PR TITLE
Python dependency upgrade

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -102,7 +102,7 @@ ndg-httpsclient==0.5.1
 pika==0.12.0
 
 # Needed to access our database
-psycopg2==2.7.6.1 --no-binary psycopg2
+psycopg2==2.7.7 --no-binary psycopg2
 
 pyasn1==0.4.5
 pyasn1-modules==0.2.3

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -23,7 +23,7 @@ ipython==6.5.0
 Pillow==5.4.1
 
 # Needed for building complex DB queries
-SQLAlchemy==1.2.15
+SQLAlchemy==1.2.17
 
 # Needed for password hashing
 argon2-cffi==19.1.0

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -91,7 +91,7 @@ markdown-include==0.5.1
 mock==2.0.0
 
 oauth2client==4.1.3
-oauthlib==2.1.0
+oauthlib==3.0.1
 
 # Enhanced HTTPS support for httplib and urllib2 using PyOpenSSL
 # Needed by requests to send https request to some sites.

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -162,7 +162,7 @@ python-twitter==3.5
 polib==1.1.0
 
 # Needed for cloning virtual environments
-virtualenv-clone==0.4.0
+virtualenv-clone==0.5.1
 
 # Needed for reading json as stream
 ijson==2.3

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -189,7 +189,7 @@ lxml==4.3.0
 
 # Needed for 2-factor authentication
 django-two-factor-auth==1.8.0
-twilio==6.22.1
+twilio==6.23.1
 
 # Needed for processing payments (in corporate)
 stripe==2.20.0

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -198,7 +198,7 @@ stripe==2.17.0
 django-sendfile==0.3.11
 
 # For checking whether email of the user is from a disposable email provider.
-disposable-email-domains==0.0.39
+disposable-email-domains==0.0.43
 
 # Needed for parsing YAML with JSON references from the REST API spec files
 yamole==2.1.6

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -46,7 +46,7 @@ chardet==3.0.4
 
 # Pinned version because older versions don't compile on newer Linux.
 # Not actually a direct dependency.
-cryptography==2.4.2
+cryptography==2.5
 
 # Needed for integrations
 defusedxml==0.5.0

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -32,7 +32,7 @@ argon2-cffi==19.1.0
 backports-abc==0.5
 
 # Needed for Tornado 4 compatibility
-backports.ssl-match-hostname==3.5.0.1
+backports.ssl-match-hostname==3.7.0.1
 
 # Needed for S3 file uploads
 boto==2.49.0

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -192,7 +192,7 @@ django-two-factor-auth==1.8.0
 twilio==6.22.1
 
 # Needed for processing payments (in corporate)
-stripe==2.17.0
+stripe==2.20.0
 
 # Needed for serving uploaded files from nginx but perform auth checks in django.
 django-sendfile==0.3.11

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -105,7 +105,7 @@ pika==0.12.0
 psycopg2==2.7.7 --no-binary psycopg2
 
 pyasn1==0.4.5
-pyasn1-modules==0.2.3
+pyasn1-modules==0.2.4
 pycrypto==2.6.1
 
 # Needed for memcached usage

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -26,7 +26,7 @@ Pillow==5.4.1
 SQLAlchemy==1.2.15
 
 # Needed for password hashing
-argon2-cffi==18.3.0
+argon2-cffi==19.1.0
 
 # Needed for Tornado >3.2 compatibility
 backports-abc==0.5

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -11,7 +11,7 @@ moto==1.3.7
 Twisted==18.9.0
 
 # Needed for documentation links test
-Scrapy==1.5.1
+Scrapy==1.5.2
 
 # Needed to compute test coverage
 coverage==4.5.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -45,7 +45,7 @@ cssselect==1.0.3          # via parsel, premailer, scrapy
 cssutils==1.0.2           # via premailer
 decorator==4.3.2          # via ipython, traitlets
 defusedxml==0.5.0
-disposable-email-domains==0.0.39
+disposable-email-domains==0.0.43
 django-auth-ldap==1.7.0
 django-formtools==2.1     # via django-two-factor-auth
 django-otp==0.5.1         # via django-two-factor-auth

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -119,7 +119,7 @@ psycopg2==2.7.7
 ptyprocess==0.6.0         # via pexpect
 py3dns==3.2.0
 pyaml==18.11.0            # via moto
-pyasn1-modules==0.2.3
+pyasn1-modules==0.2.4
 pyasn1==0.4.5
 pycodestyle==2.4.0
 pycparser==2.19           # via cffi

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -173,7 +173,7 @@ sphinx==1.8.3
 sphinxcontrib-websupport==1.1.0  # via sphinx
 sqlalchemy==1.2.17
 statsd==3.3.0             # via django-statsd-mozilla
-stripe==2.17.0
+stripe==2.20.0
 tblib==1.3.2
 tornado==4.5.3
 traitlets==4.3.2          # via ipython

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -155,7 +155,7 @@ requests[security]==2.21.0  # via aws-xray-sdk, docker, hypchat, matrix-client, 
 responses==0.10.5         # via moto
 rsa==4.0
 s3transfer==0.1.13        # via boto3
-scrapy==1.5.1
+scrapy==1.5.2
 service-identity==18.1.0  # via scrapy
 sh==1.11                  # via gitlint
 simplegeneric==0.8.1      # via ipython

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -178,7 +178,7 @@ tblib==1.3.2
 tornado==4.5.3
 traitlets==4.3.2          # via ipython
 transifex-client==0.12.5
-twilio==6.22.1
+twilio==6.23.1
 twisted==18.9.0
 typed-ast==1.1.2          # via mypy
 typing==3.6.6

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -185,7 +185,7 @@ typing==3.6.6
 typing_extensions==3.6.6
 uritemplate==3.0.0
 urllib3==1.24.1           # via botocore, requests, transifex-client
-virtualenv-clone==0.4.0
+virtualenv-clone==0.5.1
 w3lib==1.20.0             # via parsel, scrapy
 wcwidth==0.1.7            # via prompt-toolkit
 websocket-client==0.54.0  # via docker

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -115,7 +115,7 @@ pip-tools==2.0.2
 polib==1.1.0
 premailer==3.2.0
 prompt-toolkit==1.0.15    # via ipython
-psycopg2==2.7.6.1
+psycopg2==2.7.7
 ptyprocess==0.6.0         # via pexpect
 py3dns==3.2.0
 pyaml==18.11.0            # via moto

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -171,7 +171,7 @@ sourcemap==0.2.1
 sphinx-rtd-theme==0.4.2
 sphinx==1.8.3
 sphinxcontrib-websupport==1.1.0  # via sphinx
-sqlalchemy==1.2.15
+sqlalchemy==1.2.17
 statsd==3.3.0             # via django-statsd-mozilla
 stripe==2.17.0
 tblib==1.3.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,7 +17,7 @@ git+https://github.com/zulip/python-zulip-api.git@0.5.8#egg=zulip==0.5.8_git&sub
 git+https://github.com/zulip/python-zulip-api.git@0.5.8#egg=zulip_bots==0.5.8+git&subdirectory=zulip_bots
 alabaster==0.7.12
 apns2==0.4.1
-argon2-cffi==18.3.0
+argon2-cffi==19.1.0
 arrow==0.10.0             # via gitlint
 asn1crypto==0.24.0        # via cryptography
 attrs==18.2.0             # via automat, service-identity, twisted
@@ -28,10 +28,10 @@ backcall==0.1.0           # via ipython
 backports-abc==0.5
 backports.ssl-match-hostname==3.5.0.1
 beautifulsoup4==4.7.1
-boto3==1.9.74             # via moto
+boto3==1.9.86             # via moto
 boto==2.49.0
-botocore==1.12.74         # via boto3, moto, s3transfer
-cachetools==3.0.0         # via google-auth
+botocore==1.12.86         # via boto3, moto, s3transfer
+cachetools==3.1.0         # via google-auth
 cchardet==2.1.4
 certifi==2018.11.29
 cffi==1.11.5
@@ -43,7 +43,7 @@ coverage==4.5.2
 cryptography==2.4.2
 cssselect==1.0.3          # via parsel, premailer, scrapy
 cssutils==1.0.2           # via premailer
-decorator==4.3.0          # via ipython, traitlets
+decorator==4.3.2          # via ipython, traitlets
 defusedxml==0.5.0
 disposable-email-domains==0.0.39
 django-auth-ldap==1.7.0
@@ -58,7 +58,7 @@ django-two-factor-auth==1.8.0
 django-webpack-loader==0.6.0
 django==1.11.18
 docker-pycreds==0.4.0     # via docker
-docker==3.6.0             # via moto
+docker==3.7.0             # via moto
 docopt==0.6.2
 docutils==0.14
 ecdsa==0.13               # via python-jose
@@ -89,7 +89,7 @@ jedi==0.13.2              # via ipython
 jinja2==2.10
 jmespath==0.9.3           # via boto3, botocore
 jsondiff==1.1.1           # via moto
-jsonpickle==1.0           # via aws-xray-sdk, python-digitalocean
+jsonpickle==1.1           # via aws-xray-sdk, python-digitalocean
 lxml==4.3.0
 markdown-include==0.5.1
 markdown==3.0.1
@@ -102,12 +102,12 @@ mypy==0.650
 ndg-httpsclient==0.5.1
 oauth2client==4.1.3
 oauthlib==2.1.0
-packaging==18.0           # via sphinx
+packaging==19.0           # via sphinx
 parsel==1.5.1             # via scrapy
-parso==0.3.1              # via jedi
+parso==0.3.2              # via jedi
 pbr==5.1.1                # via mock
 pexpect==4.6.0            # via ipython
-phonenumberslite==8.10.2  # via django-phonenumber-field
+phonenumberslite==8.10.4  # via django-phonenumber-field
 pickleshare==0.7.5        # via ipython
 pika==0.12.0
 pillow==5.4.1
@@ -124,7 +124,7 @@ pyasn1==0.4.5
 pycodestyle==2.4.0
 pycparser==2.19           # via cffi
 pycrypto==2.6.1
-pycryptodome==3.7.2       # via python-jose
+pycryptodome==3.7.3       # via python-jose
 pydispatcher==2.0.5       # via scrapy
 pyflakes==2.0.0
 pygments==2.3.1
@@ -133,8 +133,8 @@ pyjwt==1.7.1
 pyldap==3.0.0.post1       # via fakeldap
 pylibmc==1.6.0
 pyoembed==0.1.2
-pyopenssl==18.0.0         # via ndg-httpsclient, requests, scrapy
-pyparsing==2.3.0          # via packaging
+pyopenssl==19.0.0         # via ndg-httpsclient, requests, scrapy
+pyparsing==2.3.1          # via packaging
 pysocks==1.6.8            # via twilio
 python-dateutil==2.7.5
 python-digitalocean==1.14.0
@@ -145,11 +145,11 @@ python-twitter==3.5
 python3-openid==3.1.0     # via social-auth-core
 pytz==2018.9
 pyyaml==3.13              # via pyaml, yamole
-qrcode==6.0               # via django-two-factor-auth
+qrcode==6.1               # via django-two-factor-auth
 queuelib==1.5.0           # via scrapy
 recommonmark==0.4.0
 redis==2.10.6
-regex==2018.11.22
+regex==2019.1.24
 requests-oauthlib==1.0.0
 requests[security]==2.21.0  # via aws-xray-sdk, docker, hypchat, matrix-client, moto, premailer, pyoembed, python-digitalocean, python-gcm, python-twitter, requests-oauthlib, responses, social-auth-core, sphinx, stripe, twilio
 responses==0.10.5         # via moto
@@ -164,9 +164,9 @@ smmap==0.9.0
 snakeviz==1.0.0
 snowballstemmer==1.2.1
 social-auth-app-django==3.1.0
-social-auth-core==2.0.0   # via social-auth-app-django
+social-auth-core==3.0.0   # via social-auth-app-django
 sockjs-tornado==1.0.6
-soupsieve==1.6.2          # via beautifulsoup4
+soupsieve==1.7.3          # via beautifulsoup4
 sourcemap==0.2.1
 sphinx-rtd-theme==0.4.2
 sphinx==1.8.3
@@ -180,17 +180,17 @@ traitlets==4.3.2          # via ipython
 transifex-client==0.12.5
 twilio==6.22.1
 twisted==18.9.0
-typed-ast==1.1.1          # via mypy
+typed-ast==1.1.2          # via mypy
 typing==3.6.6
 typing_extensions==3.6.6
 uritemplate==3.0.0
 urllib3==1.24.1           # via botocore, requests, transifex-client
 virtualenv-clone==0.4.0
-w3lib==1.19.0             # via parsel, scrapy
+w3lib==1.20.0             # via parsel, scrapy
 wcwidth==0.1.7            # via prompt-toolkit
 websocket-client==0.54.0  # via docker
 werkzeug==0.14.1          # via moto
-wrapt==1.10.11            # via aws-xray-sdk
+wrapt==1.11.1             # via aws-xray-sdk
 xmltodict==0.11.0         # via moto
 yamole==2.1.6
 zope.interface==4.6.0     # via twisted

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -26,7 +26,7 @@ aws-xray-sdk==0.95        # via moto
 babel==2.5.3
 backcall==0.1.0           # via ipython
 backports-abc==0.5
-backports.ssl-match-hostname==3.5.0.1
+backports.ssl-match-hostname==3.7.0.1
 beautifulsoup4==4.7.1
 boto3==1.9.86             # via moto
 boto==2.49.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -40,7 +40,7 @@ click==6.6                # via gitlint, pip-tools
 commonmark==0.5.4
 constantly==15.1.0        # via twisted
 coverage==4.5.2
-cryptography==2.4.2
+cryptography==2.5
 cssselect==1.0.3          # via parsel, premailer, scrapy
 cssutils==1.0.2           # via premailer
 decorator==4.3.2          # via ipython, traitlets
@@ -78,7 +78,7 @@ hypchat==0.21
 hyper==0.7.0              # via apns2
 hyperframe==3.2.0         # via h2, hyper
 hyperlink==18.0.0         # via twisted
-idna==2.8                 # via cryptography, hyperlink, requests
+idna==2.8                 # via hyperlink, requests
 ijson==2.3
 imagesize==1.1.0
 incremental==17.5.0       # via twisted

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -101,7 +101,7 @@ mypy-extensions==0.4.1
 mypy==0.650
 ndg-httpsclient==0.5.1
 oauth2client==4.1.3
-oauthlib==2.1.0
+oauthlib==3.0.1
 packaging==19.0           # via sphinx
 parsel==1.5.1             # via scrapy
 parso==0.3.2              # via jedi

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -17,9 +17,9 @@ idna==2.8                 # via requests
 imagesize==1.1.0
 jinja2==2.10              # via sphinx
 markupsafe==1.1.0         # via jinja2
-packaging==18.0           # via sphinx
+packaging==19.0           # via sphinx
 pygments==2.3.1           # via sphinx
-pyparsing==2.3.0          # via packaging
+pyparsing==2.3.1          # via packaging
 pytz==2018.9              # via babel
 recommonmark==0.4.0
 requests==2.21.0          # via sphinx

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,4 +1,4 @@
 # Dependencies for setting up pip to install our requirements.txt file.
-pip==18.1
+pip==19.0.1
 setuptools==40.6.3
 wheel==0.32.3

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,4 +1,4 @@
 # Dependencies for setting up pip to install our requirements.txt file.
 pip==19.0.1
-setuptools==40.6.3
+setuptools==40.7.1
 wheel==0.32.3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -34,7 +34,7 @@ cssselect==1.0.3          # via premailer
 cssutils==1.0.2           # via premailer
 decorator==4.3.2          # via ipython, traitlets
 defusedxml==0.5.0
-disposable-email-domains==0.0.39
+disposable-email-domains==0.0.43
 django-auth-ldap==1.7.0
 django-formtools==2.1     # via django-two-factor-auth
 django-otp==0.5.1         # via django-two-factor-auth

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -120,7 +120,7 @@ soupsieve==1.7.3          # via beautifulsoup4
 sourcemap==0.2.1
 sqlalchemy==1.2.17
 statsd==3.3.0             # via django-statsd-mozilla
-stripe==2.17.0
+stripe==2.20.0
 tornado==4.5.3
 traitlets==4.3.2          # via ipython
 twilio==6.22.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -16,7 +16,7 @@ git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
 git+https://github.com/zulip/python-zulip-api.git@0.5.8#egg=zulip==0.5.8_git&subdirectory=zulip
 git+https://github.com/zulip/python-zulip-api.git@0.5.8#egg=zulip_bots==0.5.8+git&subdirectory=zulip_bots
 apns2==0.4.1
-argon2-cffi==18.3.0
+argon2-cffi==19.1.0
 asn1crypto==0.24.0        # via cryptography
 babel==2.6.0              # via django-phonenumber-field
 backcall==0.1.0           # via ipython
@@ -24,7 +24,7 @@ backports-abc==0.5
 backports.ssl-match-hostname==3.5.0.1
 beautifulsoup4==4.7.1
 boto==2.49.0
-cachetools==3.0.0         # via google-auth
+cachetools==3.1.0         # via google-auth
 cchardet==2.1.4
 certifi==2018.11.29
 cffi==1.11.5
@@ -32,7 +32,7 @@ chardet==3.0.4
 cryptography==2.4.2
 cssselect==1.0.3          # via premailer
 cssutils==1.0.2           # via premailer
-decorator==4.3.0          # via ipython, traitlets
+decorator==4.3.2          # via ipython, traitlets
 defusedxml==0.5.0
 disposable-email-domains==0.0.39
 django-auth-ldap==1.7.0
@@ -74,10 +74,10 @@ mypy_extensions==0.4.1
 ndg-httpsclient==0.5.1
 oauth2client==4.1.3
 oauthlib==2.1.0
-parso==0.3.1              # via jedi
+parso==0.3.2              # via jedi
 pbr==5.1.1                # via mock
 pexpect==4.6.0            # via ipython
-phonenumberslite==8.10.2  # via django-phonenumber-field
+phonenumberslite==8.10.4  # via django-phonenumber-field
 pickleshare==0.7.5        # via ipython
 pika==0.12.0
 pillow==5.4.1
@@ -95,7 +95,7 @@ pygments==2.3.1
 pyjwt==1.7.1
 pylibmc==1.6.0
 pyoembed==0.1.2
-pyopenssl==18.0.0         # via ndg-httpsclient, requests
+pyopenssl==19.0.0         # via ndg-httpsclient, requests
 pysocks==1.6.8            # via twilio
 python-dateutil==2.7.5
 python-gcm==0.4
@@ -104,9 +104,9 @@ python-twitter==3.5
 python3-openid==3.1.0     # via social-auth-core
 pytz==2018.9
 pyyaml==3.13              # via yamole
-qrcode==6.0               # via django-two-factor-auth
+qrcode==6.1               # via django-two-factor-auth
 redis==2.10.6
-regex==2018.11.22
+regex==2019.1.24
 requests-oauthlib==1.0.0
 requests[security]==2.21.0  # via hypchat, matrix-client, premailer, pyoembed, python-gcm, python-twitter, requests-oauthlib, social-auth-core, stripe, twilio
 rsa==4.0
@@ -114,9 +114,9 @@ simplegeneric==0.8.1      # via ipython
 six==1.12.0
 smmap==0.9.0
 social-auth-app-django==3.1.0
-social-auth-core==2.0.0   # via social-auth-app-django
+social-auth-core==3.0.0   # via social-auth-app-django
 sockjs-tornado==1.0.6
-soupsieve==1.6.2          # via beautifulsoup4
+soupsieve==1.7.3          # via beautifulsoup4
 sourcemap==0.2.1
 sqlalchemy==1.2.15
 statsd==3.3.0             # via django-statsd-mozilla

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -84,7 +84,7 @@ pillow==5.4.1
 polib==1.1.0
 premailer==3.2.0
 prompt-toolkit==1.0.15    # via ipython
-psycopg2==2.7.6.1
+psycopg2==2.7.7
 ptyprocess==0.6.0         # via pexpect
 py3dns==3.2.0
 pyasn1-modules==0.2.3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -87,7 +87,7 @@ prompt-toolkit==1.0.15    # via ipython
 psycopg2==2.7.7
 ptyprocess==0.6.0         # via pexpect
 py3dns==3.2.0
-pyasn1-modules==0.2.3
+pyasn1-modules==0.2.4
 pyasn1==0.4.5
 pycparser==2.19           # via cffi
 pycrypto==2.6.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -128,6 +128,6 @@ typing==3.6.6
 uritemplate==3.0.0
 urllib3==1.24.1           # via requests
 uwsgi==2.0.17.1
-virtualenv-clone==0.4.0
+virtualenv-clone==0.5.1
 wcwidth==0.1.7            # via prompt-toolkit
 yamole==2.1.6

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -118,7 +118,7 @@ social-auth-core==3.0.0   # via social-auth-app-django
 sockjs-tornado==1.0.6
 soupsieve==1.7.3          # via beautifulsoup4
 sourcemap==0.2.1
-sqlalchemy==1.2.15
+sqlalchemy==1.2.17
 statsd==3.3.0             # via django-statsd-mozilla
 stripe==2.17.0
 tornado==4.5.3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -29,7 +29,7 @@ cchardet==2.1.4
 certifi==2018.11.29
 cffi==1.11.5
 chardet==3.0.4
-cryptography==2.4.2
+cryptography==2.5
 cssselect==1.0.3          # via premailer
 cssutils==1.0.2           # via premailer
 decorator==4.3.2          # via ipython, traitlets
@@ -58,7 +58,7 @@ httplib2==0.12.0
 hypchat==0.21
 hyper==0.7.0              # via apns2
 hyperframe==3.2.0         # via h2, hyper
-idna==2.8                 # via cryptography, requests
+idna==2.8                 # via requests
 ijson==2.3
 ipython-genutils==0.2.0   # via traitlets
 ipython==6.5.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -21,7 +21,7 @@ asn1crypto==0.24.0        # via cryptography
 babel==2.6.0              # via django-phonenumber-field
 backcall==0.1.0           # via ipython
 backports-abc==0.5
-backports.ssl-match-hostname==3.5.0.1
+backports.ssl-match-hostname==3.7.0.1
 beautifulsoup4==4.7.1
 boto==2.49.0
 cachetools==3.1.0         # via google-auth

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -123,7 +123,7 @@ statsd==3.3.0             # via django-statsd-mozilla
 stripe==2.20.0
 tornado==4.5.3
 traitlets==4.3.2          # via ipython
-twilio==6.22.1
+twilio==6.23.1
 typing==3.6.6
 uritemplate==3.0.0
 urllib3==1.24.1           # via requests

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -73,7 +73,7 @@ mock==2.0.0
 mypy_extensions==0.4.1
 ndg-httpsclient==0.5.1
 oauth2client==4.1.3
-oauthlib==2.1.0
+oauthlib==3.0.1
 parso==0.3.2              # via jedi
 pbr==5.1.1                # via mock
 pexpect==4.6.0            # via ipython

--- a/requirements/thumbor.in
+++ b/requirements/thumbor.in
@@ -15,4 +15,4 @@ certifi==2018.10.15
 singledispatch==3.4.0.3
 
 # Needed for cloning virtual environments
-virtualenv-clone==0.4.0
+virtualenv-clone==0.5.1

--- a/requirements/thumbor.txt
+++ b/requirements/thumbor.txt
@@ -37,5 +37,5 @@ thumbor==6.5.1
 tornado-botocore==1.3.2   # via tc-aws
 tornado==4.5.3            # via thumbor, tornado-botocore
 typing==3.6.6
-virtualenv-clone==0.4.0
+virtualenv-clone==0.5.1
 webcolors==1.8.1          # via thumbor

--- a/requirements/unupgradable.json
+++ b/requirements/unupgradable.json
@@ -1,6 +1,6 @@
 {
     "CommonMark": {
-        "issue": "https://github.com/zulip/zulip/issues/10800",
+        "issue": "https://github.com/zulip/zulip/issues/10800"
     },
     "tornado": {
         "issue": "https://github.com/zulip/zulip/issues/8913"

--- a/version.py
+++ b/version.py
@@ -11,4 +11,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2018/11/07/zulip-1-9-relea
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '27.3'
+PROVISION_VERSION = '27.4'


### PR DESCRIPTION
Output of `./tools/list-outdated-packages` 

|Pkg| Version| Latest| Status|
|-------|-----|---------|---------|
CommonMark | 0.5.4 | 0.8.1| Known
google-api-python-client | 1.7.4 | 1.7.7| #11211
h2 | 2.6.2 |3.1.0| recursive dep
ipython | 6.5.0 | 7.2.0| #10801
Markdown | 2.6.11 | 3.0.1| #10800 
pip-tools | 2.0.2 | 3.2.2| #10802 
redis | 2.10.6 | 3.1.0| #11209
sh | 1.11 | 1.12.14|  Recursive dep
tornado | 4.5.3 | 5.1.1| #8913
transifex-client | 0.12.5 | 0.13.5| #8914
talon | 1.2.11 | 1.4.4| Known
mypy | 0.650 | 0.660|  
pika | 0.12.0 | 0.13.0| #11394
Django | 1.11.18 | 2.1.5| Open PR
pycodestyle | 2.4.0 | 2.5.0| #11396
pyflakes | 2.0.0 | 2.1.0| #11397
recommonmark | 0.4.0 | 0.5.0| #11395
stripe | 2.20.0 | 2.20.1| Would upgrade seperately
