### PR TITLE
right sidebar: Hide user detail popover correctly.

### DIFF
--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -246,6 +246,8 @@ exports.build_user_sidebar = function () {
 };
 
 function do_update_users_for_search() {
+    // Hide user detail popover when the user is searching.
+    popovers.hide_all();
     exports.build_user_sidebar();
     exports.user_cursor.reset();
 }

--- a/static/js/user_search.js
+++ b/static/js/user_search.js
@@ -50,6 +50,8 @@ var user_search = function (opts) {
     };
 
     self.show_widget = function () {
+        // Hide user detail popover when the user wants to search.
+        popovers.hide_all();
         $widget.removeClass('notdisplayed');
     };
 


### PR DESCRIPTION
This code will hide the user popover correctly.
**Before:**
![before](https://user-images.githubusercontent.com/30211121/51994913-bc771480-24d7-11e9-8d3b-8adb8e53d1c8.gif)

**After:**
If the user clicks on the USERS bar to get the search input field, the popover will hide as shown below (the code for this is added in `user_search.js`) :
![general](https://user-images.githubusercontent.com/30211121/51994974-da447980-24d7-11e9-8ba4-675836d0e2d5.gif)

If the search input field is already open and the user starts typing in, then also the popover will close. The code for this is added in `activity.js`
![open](https://user-images.githubusercontent.com/30211121/51995124-255e8c80-24d8-11e9-91b4-886d898ec375.gif)