### PR TITLE
export: Write analytics data to a separate json.

### DIFF
--- a/analytics/management/commands/populate_analytics_db.py
+++ b/analytics/management/commands/populate_analytics_db.py
@@ -11,10 +11,10 @@ from analytics.lib.fixtures import generate_time_series_data
 from analytics.lib.time_utils import time_range
 from analytics.models import BaseCount, FillState, RealmCount, UserCount, \
     StreamCount, InstallationCount
-from zerver.lib.actions import do_change_is_admin
+from zerver.lib.actions import do_change_is_admin, STREAM_ASSIGNMENT_COLORS
 from zerver.lib.timestamp import floor_to_day
 from zerver.models import Realm, UserProfile, Stream, Message, Client, \
-    RealmAuditLog, Recipient
+    RealmAuditLog, Recipient, Subscription
 
 class Command(BaseCommand):
     help = """Populates analytics tables with randomly generated data."""
@@ -72,7 +72,16 @@ class Command(BaseCommand):
         do_change_is_admin(shylock, True)
         stream = Stream.objects.create(
             name='all', realm=realm, date_created=installation_time)
-        Recipient.objects.create(type_id=stream.id, type=Recipient.STREAM)
+
+        # Subscribe shylock to the stream to enable functionality for the export tool.
+        subs = []
+        recipient = Recipient.objects.create(type_id=stream.id, type=Recipient.STREAM)
+        s = Subscription(
+            recipient=recipient,
+            user_profile=shylock,
+            color=STREAM_ASSIGNMENT_COLORS[0])
+        subs.append(s)
+        Subscription.objects.bulk_create(subs)
 
         def insert_fixture_data(stat: CountStat,
                                 fixture_data: Mapping[Optional[str], List[int]],

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -206,6 +206,13 @@ MESSAGE_TABLES = {
     'zerver_reaction',
 }
 
+ANALYTICS_TABLES = {
+    # These get their own file as analytics data can be quite large
+    'analytics_realmcount',
+    'analytics_streamcount',
+    'analytics_usercount',
+}
+
 DATE_FIELDS = {
     'zerver_attachment': ['create_time'],
     'zerver_message': ['last_edit_time', 'pub_date'],
@@ -249,12 +256,14 @@ def sanity_check_output(data: TableData) -> None:
     assert NON_EXPORTED_TABLES.issubset(ALL_ZULIP_TABLES)
     assert IMPLICIT_TABLES.issubset(ALL_ZULIP_TABLES)
     assert ATTACHMENT_TABLES.issubset(ALL_ZULIP_TABLES)
+    assert ANALYTICS_TABLES.issubset(ALL_ZULIP_TABLES)
 
     tables = set(ALL_ZULIP_TABLES)
     tables -= NON_EXPORTED_TABLES
     tables -= IMPLICIT_TABLES
     tables -= MESSAGE_TABLES
     tables -= ATTACHMENT_TABLES
+    tables -= ANALYTICS_TABLES
 
     for table in tables:
         if table not in data:
@@ -728,28 +737,6 @@ def get_realm_config() -> Config:
             '_stream_subscription',
             '_huddle_subscription',
         ]
-    )
-
-    # Analytics tables
-    Config(
-        table='analytics_realmcount',
-        model=RealmCount,
-        normal_parent=realm_config,
-        parent_key='realm_id__in',
-    )
-
-    Config(
-        table='analytics_usercount',
-        model=UserCount,
-        normal_parent=realm_config,
-        parent_key='realm_id__in',
-    )
-
-    Config(
-        table='analytics_streamcount',
-        model=StreamCount,
-        normal_parent=realm_config,
-        parent_key='realm_id__in',
     )
 
     return realm_config
@@ -1315,8 +1302,9 @@ def do_write_stats_file_for_realm_export(output_dir: Path) -> None:
     stats_file = os.path.join(output_dir, 'stats.txt')
     realm_file = os.path.join(output_dir, 'realm.json')
     attachment_file = os.path.join(output_dir, 'attachment.json')
+    analytics_file = os.path.join(output_dir, 'analytics.json')
     message_files = glob.glob(os.path.join(output_dir, 'messages-*.json'))
-    fns = sorted([attachment_file] + message_files + [realm_file])
+    fns = sorted([analytics_file] + [attachment_file] + message_files + [realm_file])
 
     logging.info('Writing stats file: %s\n' % (stats_file,))
     with open(stats_file, 'w') as f:
@@ -1386,6 +1374,9 @@ def do_export_realm(realm: Realm, output_dir: Path, threads: int,
     export_file = os.path.join(output_dir, "realm.json")
     write_data_to_file(output_file=export_file, data=response)
     logging.info('Writing realm data to %s' % (export_file,))
+
+    # Write analytics data
+    export_analytics_tables(realm=realm, output_dir=output_dir)
 
     # zerver_attachment
     export_attachment_table(realm=realm, output_dir=output_dir, message_ids=message_ids)
@@ -1528,3 +1519,46 @@ def export_messages_single_user(user_profile: UserProfile, output_dir: Path,
         write_message_export(message_filename, message_output)
         min_id = max(user_message_ids)
         dump_file_id += 1
+
+def export_analytics_tables(realm: Realm, output_dir: Path) -> None:
+    response = {}  # type: TableData
+
+    export_file = os.path.join(output_dir, "analytics.json")
+    logging.info("Writing analytics table data to %s", (export_file))
+    config = get_analytics_config()
+    export_from_config(
+        response=response,
+        config=config,
+        seed_object=realm,
+    )
+    write_data_to_file(output_file=export_file, data=response)
+
+def get_analytics_config() -> Config:
+
+    analytics_config = Config(
+        table='zerver_analytics',
+        is_seeded=True,
+    )
+
+    Config(
+        table='analytics_realmcount',
+        model=RealmCount,
+        normal_parent=analytics_config,
+        parent_key='realm_id__in',
+    )
+
+    Config(
+        table='analytics_usercount',
+        model=UserCount,
+        normal_parent=analytics_config,
+        parent_key='realm_id__in',
+    )
+
+    Config(
+        table='analytics_streamcount',
+        model=StreamCount,
+        normal_parent=analytics_config,
+        parent_key='realm_id__in',
+    )
+
+    return analytics_config


### PR DESCRIPTION
This PR fixes Issue: #11220 

The changes contained in this commit were made as a means to reduce
the interaction cost of the realm.json file, which is where the
analytics data were previously ending up.  The changes were accomplished
by refactoring the analytics Config objects into a separate subroutine
to be called by an exporter function that writes the data by being
called in do_export_realm.

**Testing Plan:** 
Apart from passing automated testing, manual testing was done with both the import
and export tools to ensure that the analytics data was being correctly processed.   
A modification was required to the ```populate_analytics_db```file in order to export
the ```analytics``` realm successfully.  This modification included simply subscribing 
a user to the stream to enable use of the export tool.

