### PR TITLE
[WIP] Make starred message count style subtle.

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -193,6 +193,12 @@ li.active-sub-filter {
     margin-right: 15px;
 }
 
+#starred_messages_filter .count {
+    background-color: transparent;
+    border-width: 0;
+    color: inherit;
+}
+
 .topic-box {
     padding-left: 5px;
     margin-right: 30px;

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -25,13 +25,13 @@
                     </span>
                 </a>
             </li>
-            <li class="top_left_starred_messages global-filter">
+            <li id="starred_messages_filter" class="top_left_starred_messages global-filter">
                 <a href="#narrow/is/starred">
                     <span class="filter-icon">
                         <i class="fa fa-star" aria-hidden="true"></i>
                     </span>
                     <span class="hover-underline">{{ _('Starred messages') }}</span>
-                    <span class="count">
+                    <span id="starred_messages_count" class="count">
                         <span class="value"></span>
                     </span>
                 </a>


### PR DESCRIPTION
Makes the starred message counter show only a number
with transparent background and no border.

The style is not finalised and up for discussion hence the WIP tag. 
Please review the style: @timabbott @showell @borisyankov @rishig 

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/11400

**Testing Plan:** <!-- How have you tested? -->
Start dev. server. Login and open the display settings and enable the show starred message count setting checkbox. Star some messages. You will see the starred message count at upper left sidebar. Next to the Starred Messages link. Tested both for light and dark theme.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
<img width="1440" alt="screenshot 2019-01-31 at 4 51 03 pm" src="https://user-images.githubusercontent.com/23462580/52052607-f9491700-257c-11e9-8d58-f74bee8af2d4.png">
<img width="1437" alt="screenshot 2019-01-31 at 4 50 39 pm" src="https://user-images.githubusercontent.com/23462580/52052622-ffd78e80-257c-11e9-909a-7ca2280268e6.png">


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->