### PR TITLE
setup_virtualenv: Do not activate the virtualenv on creation

### DIFF
--- a/scripts/lib/create-production-venv
+++ b/scripts/lib/create-production-venv
@@ -48,4 +48,3 @@ cached_venv_path = setup_virtualenv(
 
 current_venv_path = os.path.join(args.deploy_path, 'zulip-current-venv')
 overwrite_symlink(venv_name, current_venv_path)
-# Now the virtualenv has been activated

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -390,10 +390,11 @@ def main(options):
     # Install shellcheck.
     run(["sudo", "scripts/lib/install-shellcheck"])
 
-    # Import tools/setup_venv.py instead of running it so that we get an
-    # activated virtualenv for the rest of the provisioning process.
     from tools.setup import setup_venvs
     setup_venvs.main()
+
+    activate_this = "/srv/zulip-py3-venv/bin/activate_this.py"
+    exec(open(activate_this).read(), {}, dict(__file__=activate_this))
 
     setup_shell_profile('~/.bash_profile')
     setup_shell_profile('~/.zprofile')


### PR DESCRIPTION
Instead, manually activate it in the one place where this functionality was used (`tools/lib/provision.py`).  This way we avoid trying to activate the Python 2 thumbor virtualenv from Python 3.

**Testing Plan:** Did `vagrant destroy; vagrant up` in a development environment.