### PR TITLE
stats: Fix the bug in showing all time actives by default

### DIFF
--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -718,7 +718,7 @@ function populate_number_of_users(data) {
     });
 
     // Initial drawing of plot
-    draw_or_update_plot(_15day_trace, true);
+    draw_or_update_plot(all_time_trace, true);
     $('#all_time_actives_button').addClass("selected");
 }
 


### PR DESCRIPTION
Only the button was updated in b1e36d and not the actual graph itself.

![ezgif-4-4d2cd8d9f485](https://user-images.githubusercontent.com/7190633/52108817-454d9780-2621-11e9-8849-573ad0760e4e.gif)




