### PR TITLE
requirements: Upgrade Pyflakes

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -29,7 +29,7 @@ isort==4.3.4
 pycodestyle==2.5.0
 
 # Needed to run pyflakes linter
-pyflakes==2.0.0
+pyflakes==2.1.0
 
 # Needed to run tests in parallel
 tblib==1.3.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -126,7 +126,7 @@ pycparser==2.19           # via cffi
 pycrypto==2.6.1
 pycryptodome==3.7.3       # via python-jose
 pydispatcher==2.0.5       # via scrapy
-pyflakes==2.0.0
+pyflakes==2.1.0
 pygments==2.3.1
 pyhamcrest==1.9.0         # via twisted
 pyjwt==1.7.1

--- a/version.py
+++ b/version.py
@@ -11,4 +11,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2018/11/07/zulip-1-9-relea
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '27.5'
+PROVISION_VERSION = '27.6'

--- a/zerver/lib/request.py
+++ b/zerver/lib/request.py
@@ -126,7 +126,10 @@ class REQ:
 # expected to call json_error or json_success, as it uses json_error
 # internally when it encounters an error
 def has_request_variables(view_func):
-    # type: (Callable[[HttpRequest, Any, Any], HttpResponse]) -> Callable[[HttpRequest, *Any, **Any], HttpResponse]
+    '''
+    type: (Callable[[HttpRequest, Any, Any], HttpResponse]) ->
+    Callable[[HttpRequest, *Any, **Any], HttpResponse]
+    '''
     num_params = view_func.__code__.co_argcount
     if view_func.__defaults__ is None:
         num_default_params = 0

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -620,7 +620,7 @@ class TestStreamEmailMessagesSubjectStripping(ZulipTestCase):
             process_message(incoming_valid_message)
             message = most_recent_message(user_profile)
 
-            if subject['stripped_subject'] is not "":
+            if subject['stripped_subject'] != "":
                 expected_topic = subject['stripped_subject']
             else:
                 expected_topic = "(no topic)"

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -136,7 +136,7 @@ class ChangeSettingsTest(ZulipTestCase):
             # doesn't work for it.
             #
             # TODO: Make this work more like do_test_realm_update_api
-            if notification_setting is not 'notification_sound':
+            if notification_setting != 'notification_sound':
                 self.check_for_toggle_param_patch("/json/settings/notifications",
                                                   notification_setting)
 


### PR DESCRIPTION
Pyflakes has been upgraded from 2.0.0 to 2.1.0 and
a few linter errors have been fixed.

Fixes: #11397

https://github.com/zulip/zulip/issues/11397


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
