### PR TITLE
media: Fix message controls overlap with message content on mobile.

### DIFF
--- a/static/styles/media.scss
+++ b/static/styles/media.scss
@@ -323,6 +323,11 @@
     .message_content {
         padding-right: 50px;
     }
+
+    .selected_message .message_content,
+    .message_hovered .message_content {
+        margin-top: 20px;
+    }
 }
 
 @media (max-width: 370px) {


### PR DESCRIPTION
In mobile devices, message controls were overlapping with the message content
when message is hovered or selected for messages which does not have sender name.
Added top margin to such messages so that there is a clear separation between
controls and content.

Fixes: #11406.

Earlier - 
![earlier](https://user-images.githubusercontent.com/19911594/52145466-07835a00-2687-11e9-8fd9-3ff297679324.png)

Now - 
![now](https://user-images.githubusercontent.com/19911594/52145486-136f1c00-2687-11e9-820a-ff2bfdc48b66.png)
