### PR TITLE
Open images and videos from message preview in lightbox.

### DIFF
--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -95,6 +95,8 @@ exports.open = function (image, options) {
     var is_youtube_video = !!$image.closest(".youtube-video").length;
     var is_vimeo_video = !!$image.closest(".vimeo-video").length;
 
+    // check if image is descendent of #preview_content
+    var is_message_preview_img = $image.closest("#preview_content").length === 1;
     var payload;
     // if the asset_map already contains the metadata required to display the
     // asset, just recall that metadata.
@@ -122,12 +124,16 @@ exports.open = function (image, options) {
             }
         }
         var sender_full_name;
-        var $message = $parent.closest("[zid]");
-        var message = message_store.get($message.attr("zid"));
-        if (message === undefined) {
-            blueslip.error("Lightbox for unknown message " + $message.attr("zid"));
+        if (is_message_preview_img) {
+            sender_full_name = people.my_full_name();
+        } else {
+            var $message = $parent.closest("[zid]");
+            var message = message_store.get($message.attr("zid"));
+            if (message === undefined) {
+                blueslip.error("Lightbox for unknown message " + $message.attr("zid"));
+            }
+            sender_full_name = message.sender_full_name;
         }
-        sender_full_name = message.sender_full_name;    
         payload = {
             user: sender_full_name,
             title: $parent.attr("title"),
@@ -218,7 +224,7 @@ exports.next = function () {
 
 // this is a block of events that are required for the lightbox to work.
 exports.initialize = function () {
-    $("#main_div").on("click", ".message_inline_image a", function (e) {
+    $("#main_div, #preview_content").on("click", ".message_inline_image a", function (e) {
         // prevent the link from opening in a new page.
         e.preventDefault();
         // prevent the message compose dialog from happening.

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -104,7 +104,6 @@ exports.open = function (image, options) {
     // otherwise retrieve the metadata from the DOM and store into the asset_map.
     } else {
         var $parent = $image.parent();
-        var $message = $parent.closest("[zid]");
         var $type;
         var $source;
         if (is_youtube_video) {
@@ -122,13 +121,16 @@ exports.open = function (image, options) {
                 $source = $image.attr("src");
             }
         }
+        var sender_full_name;
+        var $message = $parent.closest("[zid]");
         var message = message_store.get($message.attr("zid"));
         if (message === undefined) {
             blueslip.error("Lightbox for unknown message " + $message.attr("zid"));
         }
+        sender_full_name = message.sender_full_name;    
         payload = {
-            user: message.sender_full_name,
-            title: $image.parent().attr("title"),
+            user: sender_full_name,
+            title: $parent.attr("title"),
             type: $type,
             preview: $image.attr("src"),
             source: $source,
@@ -217,13 +219,11 @@ exports.next = function () {
 // this is a block of events that are required for the lightbox to work.
 exports.initialize = function () {
     $("#main_div").on("click", ".message_inline_image a", function (e) {
-        var $img = $(this).find("img");
-
         // prevent the link from opening in a new page.
         e.preventDefault();
         // prevent the message compose dialog from happening.
         e.stopPropagation();
-
+        var $img = $(this).find("img");
         exports.open($img);
     });
 


### PR DESCRIPTION
Improve user experience by opening images and videos from
message preview in lightbox instead of new window.

Fixes #11424.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
**Testing Plan:** <!-- How have you tested? -->
In the compose message box, attach an image. After the image is uploaded, click on the Preview option of the compose box and then click on the image previewed. The image should open in lightbox.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![feb-02-2019 05-05-43](https://user-images.githubusercontent.com/23462580/52155411-9d7bac80-26a8-11e9-99e0-8dbb0c17c800.gif)
![feb-02-2019 05-09-35](https://user-images.githubusercontent.com/23462580/52155436-d1ef6880-26a8-11e9-80bc-cf3eff6d1a13.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->