### PR TITLE
zapier_app: Add support for private/huddle messages.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1974,6 +1974,15 @@ def check_send_private_message(sender: UserProfile, client: Client,
 
     return do_send_messages([message])[0]
 
+def check_send_private_message_from_emails(
+        sender: UserProfile, client: Client,
+        receiving_emails: Sequence[str], body: str
+) -> int:
+    addressee = Addressee.for_private(receiving_emails, sender.realm)
+    message = check_message(sender, client, addressee, body)
+
+    return do_send_messages([message])[0]
+
 # check_send_message:
 # Returns the id of the sent message.  Has same argspec as check_message.
 def check_send_message(sender: UserProfile, client: Client, message_type_name: str,

--- a/zerver/webhooks/zapier/fixtures/zapier_zulip_app_private.json
+++ b/zerver/webhooks/zapier/fixtures/zapier_zulip_app_private.json
@@ -1,0 +1,8 @@
+{
+    "type": "private",
+    "content": "Sample content for private huddle message",
+    "to": [
+        "iago@zulip.com",
+        "cordelia@zulip.com"
+    ]
+}

--- a/zerver/webhooks/zapier/tests.py
+++ b/zerver/webhooks/zapier/tests.py
@@ -40,3 +40,15 @@ class ZapierZulipAppTests(WebhookTestCase):
         self.send_and_test_stream_message('zapier_zulip_app_stream',
                                           expected_topic, expected_message,
                                           HTTP_USER_AGENT='ZapierZulipApp')
+
+    def test_private(self) -> None:
+        payload = self.get_body('zapier_zulip_app_private')
+        headers = {'HTTP_USER_AGENT': 'ZapierZulipApp'}
+        result = self.client_post(self.url, payload,
+                                  content_type='application/json',
+                                  **headers)
+        self.assert_json_success(result)
+
+        expected_message = "Sample content for private huddle message"
+        msg = self.get_last_message()
+        self.assertEqual(msg.content, expected_message)

--- a/zerver/webhooks/zapier/view.py
+++ b/zerver/webhooks/zapier/view.py
@@ -4,6 +4,7 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
 
 from zerver.decorator import api_key_only_webhook_view
+from zerver.lib.actions import check_send_private_message_from_emails
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_error, json_success
 from zerver.lib.webhooks.common import check_send_webhook_message, \
@@ -27,6 +28,11 @@ def api_zapier_webhook(request: HttpRequest, user_profile: UserProfile,
             check_send_webhook_message(
                 request, user_profile,
                 payload['topic'], payload['content']
+            )
+        elif event_type == 'private':
+            check_send_private_message_from_emails(
+                user_profile, request.client,
+                payload['to'], payload['content']
             )
 
         return json_success()


### PR DESCRIPTION
@timabbott: I'd really appreciate a review on this one, I had to write a separate helper, but I'm not sure if it necessary for our purposes here (we've never had to send a group PM in webhooks). Maybe just `internal_send_huddle_message` would suffice? Although that doesn't take `request.client` into account, from what I can tell! :)