### PR TITLE
media: Fix sender name clipping in mobile.

### DIFF
--- a/static/styles/media.scss
+++ b/static/styles/media.scss
@@ -305,6 +305,7 @@
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
+        line-height: 15px;
     }
 
     textarea.new_message_textarea {


### PR DESCRIPTION
In mobile devices, letters like g, y, p etc. in sender name were clipped from bottom.
Fixed by adding line height to sender name.

Fixes: #11445


**Testing Plan:** 
Tested in local system


**GIFs or Screenshots:**
 Earlier:
![clipped](https://user-images.githubusercontent.com/19911594/52192910-69ec7e00-2872-11e9-9156-259aa01d76eb.png)
Now:
![unclipped](https://user-images.githubusercontent.com/19911594/52192914-6f49c880-2872-11e9-9e75-f7271a40e799.png)
