### PR TITLE
markdown: Disable definition/reference links in marked.

### DIFF
--- a/static/third/marked/lib/marked.js
+++ b/static/third/marked/lib/marked.js
@@ -356,14 +356,7 @@ Lexer.prototype.token = function(src, top, bq) {
     }
 
     // def
-    if ((!bq && top) && (cap = this.rules.def.exec(src))) {
-      src = src.substring(cap[0].length);
-      this.tokens.links[cap[1].toLowerCase()] = {
-        href: cap[2],
-        title: cap[3]
-      };
-      continue;
-    }
+    // We disable definition style links in Zulip.
 
     // table (gfm)
     if (top && (cap = this.rules.table.exec(src))) {

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -121,6 +121,16 @@
       "text_content": "notcode"
     },
     {
+      "name": "reference_links_disabled",
+      "input": "Hello [world]\n\n[world]: https://google.com",
+      "expected_output": "<p>Hello [world]</p>\n<p>[world]: <a href=\"https://google.com\" target=\"_blank\" title=\"https://google.com\">https://google.com</a></p>"
+    },
+    {
+      "name": "reference_links_disabled_2",
+      "input": "Hello [world][ref-name]\n\n[ref-name]: https://google.com",
+      "expected_output": "<p>Hello [world][ref-name]</p>\n<p>[ref-name]: <a href=\"https://google.com\" target=\"_blank\" title=\"https://google.com\">https://google.com</a></p>"
+    },
+    {
       "name": "ulist_standard",
       "input": "Some text with a list:\n\n* One item\n* Two items\n* Three items",
       "expected_output": "<p>Some text with a list:</p>\n<ul>\n<li>One item</li>\n<li>Two items</li>\n<li>Three items</li>\n</ul>",


### PR DESCRIPTION
We had disabled reference style links in bugdown, however,
we hadn't disabled them in marked. This commit rectifies
that and adds test cases for the same.

Fixes #11350.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
