### PR TITLE
refactor: Simplify build_popover().

### DIFF
--- a/frontend_tests/node_tests/topic_list.js
+++ b/frontend_tests/node_tests/topic_list.js
@@ -45,6 +45,7 @@ run_test('topic_list_build_widget', () => {
     templates.render = function (name, info) {
         assert.equal(name, 'topic_list_item');
         var expected = {
+            stream_id: devel.stream_id,
             topic_name: 'coding',
             unread: 3,
             is_zero: false,

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -119,19 +119,16 @@ function build_stream_popover(e) {
     e.stopPropagation();
 }
 
-function build_topic_popover(e) {
-    var elt = e.target;
-
+function build_topic_popover(elt) {
     if (exports.topic_popped()
         && current_topic_sidebar_elem === elt) {
         // If the popover is already shown, clicking again should toggle it.
         exports.hide_topic_popover();
-        e.stopPropagation();
         return;
     }
 
-    var stream_id = $(elt).closest('.narrow-filter').expectOne().attr('data-stream-id');
-    var topic_name = $(elt).closest('li').expectOne().attr('data-topic-name');
+    var stream_id = $(elt).attr('data-stream-id');
+    var topic_name = $(elt).attr('data-topic-name');
 
     var sub = stream_data.get_sub_by_id(stream_id);
     if (!sub) {
@@ -164,7 +161,6 @@ function build_topic_popover(e) {
     $(elt).popover("show");
 
     current_topic_sidebar_elem = elt;
-    e.stopPropagation();
 }
 
 function build_all_messages_popover(e) {
@@ -197,7 +193,14 @@ function build_all_messages_popover(e) {
 
 exports.register_click_handlers = function () {
     $('#stream_filters').on('click', '.stream-sidebar-arrow', build_stream_popover);
-    $('#stream_filters').on('click', '.topic-sidebar-arrow', build_topic_popover);
+
+    $('#stream_filters').on('click', '.topic-sidebar-arrow', function (e) {
+        e.stopPropagation();
+
+        var elt = $(e.target).closest('.topic-sidebar-arrow').expectOne()[0];
+        build_topic_popover(elt);
+    });
+
     $('#global_filters').on('click', '.stream-sidebar-arrow', build_all_messages_popover);
 
     exports.register_stream_handlers();

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -81,6 +81,7 @@ exports.widget = function (parent_elem, my_stream_id) {
             }
 
             var topic_info = {
+                stream_id: my_stream_id,
                 topic_name: topic_name,
                 unread: num_unread,
                 is_zero: num_unread === 0,

--- a/static/templates/topic_list_item.handlebars
+++ b/static/templates/topic_list_item.handlebars
@@ -7,7 +7,7 @@
             <div class="value">{{unread}}</div>
         </div>
     </span>
-    <span class="arrow topic-sidebar-arrow">
+    <span class="arrow topic-sidebar-arrow" data-stream-id="{{stream_id}}" data-topic-name="{{topic_name}}">
         <i class="fa fa-chevron-down" aria-hidden="true"></i>
     </span>
 </li>


### PR DESCRIPTION
We make it easy to launch a popover by putting
the data elements on the same element you click,
so we are not dependent on the markup hierarchy.

We also call stopPropagate unconditionally from
the click handler.

Finally, we compute the element that eventually
becomes `current_topic_sidebar_elem` the same
way every time.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
