### PR TITLE
[regression fix] popovers: Remove call to hide_uselist_sidebar from hide_all.

### DIFF
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -36,6 +36,7 @@ const _scroll_util = {
 };
 
 const _popovers = {
+    hide_all_except_userlist_sidebar: function () {},
     hide_all: function () {},
     show_userlist_sidebar: function () {
         $('.column-right').addClass('expanded');

--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -246,8 +246,9 @@ exports.build_user_sidebar = function () {
 };
 
 function do_update_users_for_search() {
-    // Hide user detail popover when the user is searching.
-    popovers.hide_all();
+    // Hide all the popovers but not userlist sidebar
+    // when the user is searching.
+    popovers.hide_all_except_userlist_sidebar();
     exports.build_user_sidebar();
     exports.user_cursor.reset();
 }

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1035,7 +1035,8 @@ exports.any_active = function () {
         $("[class^='column-'].expanded").length;
 };
 
-exports.hide_all = function () {
+// This function will hide all the popovers but not userlist sidebar.
+exports.hide_all_except_userlist_sidebar = function () {
     $('.has_popover').removeClass('has_popover has_actions_popover has_emoji_popover');
     popovers.hide_actions_popover();
     popovers.hide_message_info_popover();
@@ -1044,7 +1045,6 @@ exports.hide_all = function () {
     stream_popover.hide_topic_popover();
     stream_popover.hide_all_messages_popover();
     popovers.hide_user_sidebar_popover();
-    popovers.hide_userlist_sidebar();
     popovers.hide_mobile_message_buttons_popover();
     stream_popover.restore_stream_list_size();
     popovers.hide_user_profile();
@@ -1056,6 +1056,12 @@ exports.hide_all = function () {
         }
     });
     list_of_popovers = [];
+};
+
+// This function will hide all the popovers plus userlist sidebar.
+exports.hide_all = function () {
+    popovers.hide_userlist_sidebar();
+    popovers.hide_all_except_userlist_sidebar();
 };
 
 exports.set_userlist_placement = function (placement) {

--- a/static/js/user_search.js
+++ b/static/js/user_search.js
@@ -50,8 +50,9 @@ var user_search = function (opts) {
     };
 
     self.show_widget = function () {
-        // Hide user detail popover when the user wants to search.
-        popovers.hide_all();
+        // Hide all the popovers but not userlist sidebar
+        // when the user wants to search.
+        popovers.hide_all_except_userlist_sidebar();
         $widget.removeClass('notdisplayed');
     };
 


### PR DESCRIPTION
This commit fixes the case when hide_all function calls
hide_userlist_sidebar function in the cases when it not required,
by using hide_userlist_sidebar as a standalone function. For example,
in small screen size when the user presses shortcut w to search another
user, this hides the right sidebar, which is not required.

Fixes #11463.