### PR TITLE
[WIP] internal stream messages: Minimize unnecessary database queries.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2400,10 +2400,18 @@ def internal_send_private_message(realm: Realm,
         return
     do_send_messages([message])
 
-def internal_send_stream_message(realm: Realm, sender: UserProfile, stream_name: str,
-                                 topic: str, content: str) -> None:
-    message = internal_prep_stream_message(realm, sender, topic,
-                                           content, stream_name=stream_name)
+def internal_send_stream_message(
+        realm: Realm, sender: UserProfile,
+        topic: str, content: str,
+        stream_name: Optional[str]=None,
+        stream: Optional[Stream]=None
+) -> None:
+    message = internal_prep_stream_message(
+        realm, sender, topic,
+        content, stream_name=stream_name,
+        stream=stream
+    )
+
     if message is None:
         return
     do_send_messages([message])
@@ -3443,11 +3451,11 @@ def do_rename_stream(stream: Stream,
     internal_send_stream_message(
         stream.realm,
         sender,
-        new_name,
         "welcome",
         "_@**%s|%d** renamed stream **%s** to **%s**" % (user_profile.full_name,
                                                          user_profile.id,
-                                                         old_name, new_name)
+                                                         old_name, new_name),
+        stream=stream
     )
     # Even though the token doesn't change, the web client needs to update the
     # email forwarding address to display the correctly-escaped new name.

--- a/zerver/lib/bot_lib.py
+++ b/zerver/lib/bot_lib.py
@@ -71,8 +71,11 @@ class EmbeddedBotHandler:
             self._rate_limit.show_error_and_exit()
 
         if message['type'] == 'stream':
-            internal_send_stream_message(self.user_profile.realm, self.user_profile, message['to'],
-                                         message['topic'], message['content'])
+            internal_send_stream_message(
+                self.user_profile.realm, self.user_profile,
+                message['topic'], message['content'],
+                stream_name=message['to']
+            )
             return
 
         assert message['type'] == 'private'

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -109,7 +109,9 @@ def send_initial_realm_messages(realm: Realm) -> None:
     ]  # type: List[Dict[str, str]]
     messages = [internal_prep_stream_message(
         realm, welcome_bot,
-        message['stream'], message['topic'], message['content']) for message in welcome_messages]
+        message['topic'], message['content'],
+        stream_name=message['stream']
+    ) for message in welcome_messages]
     message_ids = do_send_messages(messages)
 
     # We find the one of our just-sent messages with turtle.png in it,

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -508,7 +508,7 @@ class InternalPrepTest(ZulipTestCase):
         cordelia = self.example_user('cordelia')
         hamlet = self.example_user('hamlet')
         othello = self.example_user('othello')
-        stream_name = 'Verona'
+        stream = get_stream('Verona', realm)
 
         with mock.patch('logging.exception') as m:
             internal_send_private_message(
@@ -536,9 +536,9 @@ class InternalPrepTest(ZulipTestCase):
             internal_send_stream_message(
                 realm=realm,
                 sender=cordelia,
-                stream_name=stream_name,
                 topic='whatever',
                 content=bad_content,
+                stream=stream
             )
 
         arg = m.call_args_list[0][0][0]
@@ -549,7 +549,7 @@ class InternalPrepTest(ZulipTestCase):
                 realm=realm,
                 sender_email=settings.ERROR_BOT,
                 recipient_type_name='stream',
-                recipients=stream_name,
+                recipients=stream.name,
                 topic_name='whatever',
                 content=bad_content,
             )

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2183,7 +2183,7 @@ class SubscriptionAPITest(ZulipTestCase):
                     streams_to_sub,
                     dict(principals=ujson.dumps([user1.email, user2.email])),
                 )
-        self.assert_length(queries, 45)
+        self.assert_length(queries, 43)
 
         self.assert_length(events, 7)
         for ev in [x for x in events if x['event']['type'] not in ('message', 'stream')]:
@@ -2944,7 +2944,7 @@ class SubscriptionAPITest(ZulipTestCase):
                 [new_streams[0]],
                 dict(principals=ujson.dumps([user1.email, user2.email])),
             )
-        self.assert_length(queries, 45)
+        self.assert_length(queries, 43)
 
         # Test creating private stream.
         with queries_captured() as queries:
@@ -2954,7 +2954,7 @@ class SubscriptionAPITest(ZulipTestCase):
                 dict(principals=ujson.dumps([user1.email, user2.email])),
                 invite_only=True,
             )
-        self.assert_length(queries, 40)
+        self.assert_length(queries, 38)
 
         # Test creating a public stream with announce when realm has a notification stream.
         notifications_stream = get_stream(self.streams[0], self.test_realm)
@@ -2969,7 +2969,7 @@ class SubscriptionAPITest(ZulipTestCase):
                     principals=ujson.dumps([user1.email, user2.email])
                 )
             )
-        self.assert_length(queries, 55)
+        self.assert_length(queries, 51)
 
 class GetPublicStreamsTest(ZulipTestCase):
 

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -392,16 +392,17 @@ def add_subscriptions_backend(
             msg = ("_@**%s|%d** just created %s" % (user_profile.full_name, user_profile.id, stream_msg))
 
             sender = get_system_bot(settings.NOTIFICATION_BOT)
-            stream_name = notifications_stream.name
             topic = 'Streams'
 
             notifications.append(
                 internal_prep_stream_message(
                     realm=user_profile.realm,
                     sender=sender,
-                    stream_name=stream_name,
                     topic=topic,
-                    content=msg))
+                    content=msg,
+                    stream=notifications_stream
+                )
+            )
 
     if not user_profile.realm.is_zephyr_mirror_realm:
         for stream in created_streams:

--- a/zilencer/management/commands/add_mock_conversation.py
+++ b/zilencer/management/commands/add_mock_conversation.py
@@ -78,7 +78,9 @@ From image editing program:
         ]  # type: List[Dict[str, Any]]
 
         messages = [internal_prep_stream_message(
-            realm, message['sender'], stream.name, 'message formatting', message['content']
+            realm, message['sender'],
+            'message formatting', message['content'],
+            stream=stream
         ) for message in staged_messages]
 
         message_ids = do_send_messages(messages)


### PR DESCRIPTION
This is a follow-up to #10391. This is a WIP in the sense that I'll be adding more commits to this PR which look at `internal_send_message` and `internal_send_stream_message` to see if we implement similar improvements there.

@timabbott: FYI :) I'd really appreciate it if you could please critique my commit message/description style and etiquette with commits like this! Thanks! 
