### PR TITLE
Render Stream Descriptions from the Backend - Frontend and UI Update

### DIFF
--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -570,19 +570,6 @@ run_test('remove_default_stream', () => {
     assert.equal(page_params.realm_default_streams.length, 0);
 });
 
-run_test('render_stream_description', () => {
-    var desc = {
-        name: 'no_desc',
-        stream_id: 1002,
-        description: '<p>rendered desc</p>',
-    };
-
-    stream_data.add_sub('desc', desc);
-    var sub = stream_data.get_sub_by_name('desc');
-    stream_data.render_stream_description(sub);
-    assert.deepStrictEqual(sub.rendered_description, "rendered desc");
-});
-
 run_test('canonicalized_name', () => {
     assert.deepStrictEqual(
         stream_data.canonicalized_name('Stream_Bar'),

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -626,6 +626,11 @@ exports.initialize = function () {
                 edit_area.attr("data-prev-text", edit_area.text().trim())
                     .attr("contenteditable", true);
 
+                if (selector === ".stream-description-editable") {
+                    var sub = stream_edit.get_sub_for_target(this);
+                    edit_area.text(sub.description);
+                }
+
                 ui_util.place_caret_at_end(edit_area[0]);
 
                 $(this).html("&times;");

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -579,8 +579,14 @@ exports.initialize = function () {
 
     (function () {
         var map = {
-            ".stream-description-editable": stream_edit.change_stream_description,
-            ".stream-name-editable": stream_edit.change_stream_name,
+            ".stream-description-editable": {
+                on_start: stream_edit.set_raw_description,
+                on_save: stream_edit.change_stream_description,
+            },
+            ".stream-name-editable": {
+                on_start: null,
+                on_save: stream_edit.change_stream_name,
+            },
         };
 
         $(document).on("keydown", ".editable-section", function (e) {
@@ -626,9 +632,8 @@ exports.initialize = function () {
                 edit_area.attr("data-prev-text", edit_area.text().trim())
                     .attr("contenteditable", true);
 
-                if (selector === ".stream-description-editable") {
-                    var sub = stream_edit.get_sub_for_target(this);
-                    edit_area.text(sub.description);
+                if (map[selector].on_start) {
+                    map[selector].on_start(this, edit_area);
                 }
 
                 ui_util.place_caret_at_end(edit_area[0]);
@@ -639,8 +644,8 @@ exports.initialize = function () {
 
         $("body").on("click", "[data-finish-editing]", function (e) {
             var selector = $(this).attr("data-finish-editing");
-            if (map[selector]) {
-                map[selector](e);
+            if (map[selector].on_save) {
+                map[selector].on_save(e);
                 $(this).hide();
                 $(this).parent().find(selector).attr("contenteditable", false);
                 $("[data-make-editable='" + selector + "']").html("");

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -247,7 +247,8 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             stream_events.update_property(
                 event.stream_id,
                 event.property,
-                event.value
+                event.value,
+                event.rendered_description
             );
             settings_streams.update_default_streams_table();
         } else if (event.op === 'create') {

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -242,12 +242,6 @@ exports.get_subscriber_count = function (stream_name) {
     return sub.subscribers.num_items();
 };
 
-exports.render_stream_description = function (sub) {
-    if (sub.description !== undefined) {
-        sub.rendered_description = marked(sub.description).replace('<p>', '').replace('</p>', '');
-    }
-};
-
 exports.update_calculated_fields = function (sub) {
     sub.is_admin = page_params.is_admin;
     // Admin can change any stream's name & description either stream is public or
@@ -268,7 +262,9 @@ exports.update_calculated_fields = function (sub) {
                                  !sub.invite_only;
     sub.preview_url = hash_util.by_stream_uri(sub.stream_id);
     sub.can_add_subscribers = !page_params.is_guest && (!sub.invite_only || sub.subscribed);
-    exports.render_stream_description(sub);
+    if (sub.rendered_description !== undefined) {
+        sub.rendered_description = sub.rendered_description.replace('<p>', '').replace('</p>', '');
+    }
     exports.update_subscribers_count(sub);
 };
 
@@ -499,6 +495,7 @@ exports.create_sub_from_server_data = function (stream_name, attrs) {
         push_notifications: page_params.enable_stream_push_notifications,
         email_notifications: page_params.enable_stream_email_notifications,
         description: '',
+        rendered_description: '',
     });
 
     exports.set_subscribers(sub, subscriber_user_ids);

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -149,7 +149,8 @@ function get_stream_id(target) {
     return target.closest(".stream-row, .subscription_settings").attr("data-stream-id");
 }
 
-function get_sub_for_target(target) {
+
+exports.get_sub_for_target = function (target) {
     var stream_id = get_stream_id(target);
     if (!stream_id) {
         blueslip.error('Cannot find stream id for target');
@@ -162,7 +163,7 @@ function get_sub_for_target(target) {
         return;
     }
     return sub;
-}
+};
 
 exports.sort_but_pin_current_user_on_top = function (emails) {
     if (emails === undefined) {
@@ -269,7 +270,7 @@ exports.show_settings_for = function (node) {
 };
 
 function stream_home_view_clicked(e) {
-    var sub = get_sub_for_target(e.target);
+    var sub = exports.get_sub_for_target(e.target);
     if (!sub) {
         blueslip.error('stream_home_view_clicked() fails');
         return;
@@ -403,31 +404,31 @@ function change_stream_privacy(e) {
 }
 
 function stream_desktop_notifications_clicked(e) {
-    var sub = get_sub_for_target(e.target);
+    var sub = exports.get_sub_for_target(e.target);
     sub.desktop_notifications = !sub.desktop_notifications;
     exports.set_stream_property(sub, 'desktop_notifications', sub.desktop_notifications);
 }
 
 function stream_audible_notifications_clicked(e) {
-    var sub = get_sub_for_target(e.target);
+    var sub = exports.get_sub_for_target(e.target);
     sub.audible_notifications = !sub.audible_notifications;
     exports.set_stream_property(sub, 'audible_notifications', sub.audible_notifications);
 }
 
 function stream_push_notifications_clicked(e) {
-    var sub = get_sub_for_target(e.target);
+    var sub = exports.get_sub_for_target(e.target);
     sub.push_notifications = !sub.push_notifications;
     exports.set_stream_property(sub, 'push_notifications', sub.push_notifications);
 }
 
 function stream_email_notifications_clicked(e) {
-    var sub = get_sub_for_target(e.target);
+    var sub = exports.get_sub_for_target(e.target);
     sub.email_notifications = !sub.email_notifications;
     exports.set_stream_property(sub, 'email_notifications', sub.email_notifications);
 }
 
 function stream_pin_clicked(e) {
-    var sub = get_sub_for_target(e.target);
+    var sub = exports.get_sub_for_target(e.target);
     if (!sub) {
         blueslip.error('stream_pin_clicked() fails');
         return;
@@ -463,7 +464,7 @@ exports.change_stream_description = function (e) {
     e.preventDefault();
 
     var sub_settings = $(e.target).closest('.subscription_settings');
-    var sub = get_sub_for_target(sub_settings);
+    var sub = exports.get_sub_for_target(sub_settings);
     if (!sub) {
         blueslip.error('change_stream_description() fails');
         return;
@@ -560,7 +561,7 @@ exports.initialize = function () {
     $("#subscriptions_table").on("submit", ".subscriber_list_add form", function (e) {
         e.preventDefault();
         var settings_row = $(e.target).closest('.subscription_settings');
-        var sub = get_sub_for_target(settings_row);
+        var sub = exports.get_sub_for_target(settings_row);
         if (!sub) {
             blueslip.error('.subscriber_list_add form submit fails');
             return;
@@ -599,7 +600,7 @@ exports.initialize = function () {
         var principal = list_entry.children(".subscriber-email").text();
         var settings_row = $(e.target).closest('.subscription_settings');
 
-        var sub = get_sub_for_target(settings_row);
+        var sub = exports.get_sub_for_target(settings_row);
         if (!sub) {
             blueslip.error('.subscriber_list_remove form submit fails');
             return;
@@ -632,7 +633,7 @@ exports.initialize = function () {
     // This handler isn't part of the normal edit interface; it's the convenient
     // checkmark in the subscriber list.
     $("#subscriptions_table").on("click", ".sub_unsub_button", function (e) {
-        var sub = get_sub_for_target(e.target);
+        var sub = exports.get_sub_for_target(e.target);
         var stream_row = $(this).parent();
         subs.sub_or_unsub(sub);
         var sub_settings = settings_for_sub(sub);

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -150,7 +150,7 @@ function get_stream_id(target) {
 }
 
 
-exports.get_sub_for_target = function (target) {
+function get_sub_for_target(target) {
     var stream_id = get_stream_id(target);
     if (!stream_id) {
         blueslip.error('Cannot find stream id for target');
@@ -163,7 +163,7 @@ exports.get_sub_for_target = function (target) {
         return;
     }
     return sub;
-};
+}
 
 exports.sort_but_pin_current_user_on_top = function (emails) {
     if (emails === undefined) {
@@ -270,7 +270,7 @@ exports.show_settings_for = function (node) {
 };
 
 function stream_home_view_clicked(e) {
-    var sub = exports.get_sub_for_target(e.target);
+    var sub = get_sub_for_target(e.target);
     if (!sub) {
         blueslip.error('stream_home_view_clicked() fails');
         return;
@@ -404,31 +404,31 @@ function change_stream_privacy(e) {
 }
 
 function stream_desktop_notifications_clicked(e) {
-    var sub = exports.get_sub_for_target(e.target);
+    var sub = get_sub_for_target(e.target);
     sub.desktop_notifications = !sub.desktop_notifications;
     exports.set_stream_property(sub, 'desktop_notifications', sub.desktop_notifications);
 }
 
 function stream_audible_notifications_clicked(e) {
-    var sub = exports.get_sub_for_target(e.target);
+    var sub = get_sub_for_target(e.target);
     sub.audible_notifications = !sub.audible_notifications;
     exports.set_stream_property(sub, 'audible_notifications', sub.audible_notifications);
 }
 
 function stream_push_notifications_clicked(e) {
-    var sub = exports.get_sub_for_target(e.target);
+    var sub = get_sub_for_target(e.target);
     sub.push_notifications = !sub.push_notifications;
     exports.set_stream_property(sub, 'push_notifications', sub.push_notifications);
 }
 
 function stream_email_notifications_clicked(e) {
-    var sub = exports.get_sub_for_target(e.target);
+    var sub = get_sub_for_target(e.target);
     sub.email_notifications = !sub.email_notifications;
     exports.set_stream_property(sub, 'email_notifications', sub.email_notifications);
 }
 
 function stream_pin_clicked(e) {
-    var sub = exports.get_sub_for_target(e.target);
+    var sub = get_sub_for_target(e.target);
     if (!sub) {
         blueslip.error('stream_pin_clicked() fails');
         return;
@@ -460,11 +460,21 @@ exports.change_stream_name = function (e) {
     });
 };
 
+exports.set_raw_description = function (target, destination) {
+    var sub_settings = $(target).closest('.subscription_settings');
+    var sub = get_sub_for_target(sub_settings);
+    if (!sub) {
+        blueslip.error('set_raw_description() fails');
+        return;
+    }
+    destination.text(sub.description);
+};
+
 exports.change_stream_description = function (e) {
     e.preventDefault();
 
     var sub_settings = $(e.target).closest('.subscription_settings');
-    var sub = exports.get_sub_for_target(sub_settings);
+    var sub = get_sub_for_target(sub_settings);
     if (!sub) {
         blueslip.error('change_stream_description() fails');
         return;
@@ -561,7 +571,7 @@ exports.initialize = function () {
     $("#subscriptions_table").on("submit", ".subscriber_list_add form", function (e) {
         e.preventDefault();
         var settings_row = $(e.target).closest('.subscription_settings');
-        var sub = exports.get_sub_for_target(settings_row);
+        var sub = get_sub_for_target(settings_row);
         if (!sub) {
             blueslip.error('.subscriber_list_add form submit fails');
             return;
@@ -600,7 +610,7 @@ exports.initialize = function () {
         var principal = list_entry.children(".subscriber-email").text();
         var settings_row = $(e.target).closest('.subscription_settings');
 
-        var sub = exports.get_sub_for_target(settings_row);
+        var sub = get_sub_for_target(settings_row);
         if (!sub) {
             blueslip.error('.subscriber_list_remove form submit fails');
             return;
@@ -633,7 +643,7 @@ exports.initialize = function () {
     // This handler isn't part of the normal edit interface; it's the convenient
     // checkmark in the subscriber list.
     $("#subscriptions_table").on("click", ".sub_unsub_button", function (e) {
-        var sub = exports.get_sub_for_target(e.target);
+        var sub = get_sub_for_target(e.target);
         var stream_row = $(this).parent();
         subs.sub_or_unsub(sub);
         var sub_settings = settings_for_sub(sub);

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -32,7 +32,7 @@ function update_stream_pin(sub, value) {
     sub.pin_to_top = value;
 }
 
-exports.update_property = function (stream_id, property, value) {
+exports.update_property = function (stream_id, property, value, rendered_description) {
     var sub = stream_data.get_sub_by_id(stream_id);
     if (sub === undefined) {
         // This isn't a stream we know about, so ignore it.
@@ -65,7 +65,7 @@ exports.update_property = function (stream_id, property, value) {
         subs.update_stream_name(sub, value);
         break;
     case 'description':
-        subs.update_stream_description(sub, value);
+        subs.update_stream_description(sub, value, rendered_description);
         break;
     case 'email_address':
         sub.email_address = value;

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -123,12 +123,12 @@ exports.update_stream_name = function (sub, new_name) {
     message_live_update.update_stream_name(stream_id, new_name);
 };
 
-exports.update_stream_description = function (sub, description) {
+exports.update_stream_description = function (sub, description, rendered_description) {
     sub.description = description;
+    sub.rendered_description = rendered_description.replace('<p>', '').replace('</p>', '');
 
     // Update stream row
     var sub_row = row_for_stream_id(sub.stream_id);
-    stream_data.render_stream_description(sub);
     sub_row.find(".description").html(sub.rendered_description);
 
     // Update stream settings


### PR DESCRIPTION
**Purpose:**
This PR completes delegating the responsibility of rendering of stream descriptions to the backend. Particularly, this PR contains 2 commits both of which are frontend changes which build upon the work done in PR #11284.

The first commit involves removing the existing system for rendering stream descriptions via. the marked.js library. Instead, we use the 'rendered_description' attribute now provided stream update and creation events.

The second commit is a UI change where when editing a stream description, instead of presenting the rendered HTML form of the text for the user to edit, the un-rendered form of the description is presented to be edited. This is a much needed change as before the when editing the stream description, all of the markdown data would be lost (see screenshots for a visual explanation).

Please read issue #11272, as well as the individual commit messages, for more details.

**Testing Done:**
Not many changes were required to be made to the automated frontend test suite. The main change here is the removal of the test for `stream_data.render_stream_description()`.

**GIFs or Screenshots:**
After:
![](https://user-images.githubusercontent.com/29123352/52423433-20c05680-2b1e-11e9-98e7-89e4b581f76b.png)

Before:
![](https://user-images.githubusercontent.com/29123352/52423503-451c3300-2b1e-11e9-9c28-c861695a7966.png)


**Additional Notes:**
1. `stream_data.get_sub_for_target()` is now an exportable function.