### PR TITLE
[WIP] Fix user popover positioning Issue #1469

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -831,6 +831,14 @@ exports.register_click_handlers = function () {
         current_user_sidebar_popover = target.data('popover');
     });
 
+    // hiding user popover when the user list side bar is
+    // expanded/expandable in small screen
+    $('body').on('click', '.right-sidebar', function (e) {
+        popovers.hide_user_sidebar_popover();
+        e.stopPropagation();
+        e.preventDefault();
+    });
+
     $('body').on("mouseenter", ".user_popover_email", function () {
         var tooltip_holder = $(this).find('div');
 

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -203,7 +203,17 @@ on a dark background, and don't change the dark labels dark either. */
     .popover-content {
         background-color: hsl(212, 32%, 14%);
     }
-
+    @media (max-width: 768px) {
+        .message-info-popover,
+        .user_popover {
+            background-color: hsla(0, 0%, 0%, 0.7);
+        }
+        .message-info-popover .popover-inner,
+        .user_popover .popover-inner {
+            background-color: hsl(212, 32%, 14%);
+            pointer-events: all;
+        }
+    }
     .dropdown-menu a {
         color: inherit;
     }

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -260,7 +260,8 @@ ul.remind_me_popover .remind_icon {
 }
 
 @media (max-width: 768px) {
-    .message-info-popover {
+    .message-info-popover,
+    .user_popover {
         display: flex !important;
         justify-content: center;
         align-items: center;
@@ -278,12 +279,11 @@ ul.remind_me_popover .remind_icon {
 
         pointer-events: none;
     }
-
-    .message-info-popover .popover-inner {
+    .message-info-popover .popover-inner,
+    .user_popover .popover-inner {
         background-color: hsl(0, 0%, 100%);
         pointer-events: all;
     }
-
     .popover-flex {
         position: absolute;
         top: 0 !important;


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/11469
Right now this PR fixed just the popover in buddylist. Other user popover which opens on clicking message sender user avatar in messages is still WIP
Another fix in this PR is a fix for making sure that the background of user popover is translucent in dark theme just as it is for light theme for screen size < 768px

**Testing Plan:** <!-- How have you tested? -->
Reduce the width of the window (<768px) and then open the buddylist and click on user chevron to open popover. The popover should appear properly.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
**Before the fix**
<img width="313" alt="before_user_sidebar_cutt" src="https://user-images.githubusercontent.com/23462580/52444158-9db6f480-2b4d-11e9-97f9-526ca1b4e3db.png">


**After the fix** (including the dark theme fix)
<img width="324" alt="image" src="https://user-images.githubusercontent.com/23462580/52444119-837d1680-2b4d-11e9-8a8d-b129e60e3516.png">



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->