### PR TITLE
css: Add explicit padding below the navbar.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -187,8 +187,13 @@ p.n-margin {
     position: fixed;
     z-index: 102; /* Needs to be higher than .alert-bar-container */
     width: 100%;
-    border-bottom: 1px solid hsla(0, 0%, 0%, 0.2);
     height: 40px;
+    padding-bottom: 10px;
+    background-color: inherit;
+}
+
+#top_navbar {
+    border-bottom: 1px solid hsla(0, 0%, 0%, 0.2);
 }
 
 #panels {


### PR DESCRIPTION
We have always intended to have 10px of whitespace
below the navbar, and this enforces it directly
and explicitly in the CSS.

Note that the three major panels still should
have a margin of 50px, which is equal to
the safe outer height of the header (40px + 10px).

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
