### PR TITLE
provision: Run generate_secrets earlier

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -398,6 +398,9 @@ def main(options):
     setup_shell_profile('~/.bash_profile')
     setup_shell_profile('~/.zprofile')
 
+    # This needs to happen before anything that imports zproject.settings.
+    run(["scripts/setup/generate_secrets.py", "--development"])
+
     run(["sudo", "cp", REPO_STOPWORDS_PATH, TSEARCH_STOPWORDS_PATH])
 
     # create log directory `zulip/var/log`
@@ -436,8 +439,6 @@ def main(options):
         run(["tools/setup/build_pygments_data"])
     else:
         print("No need to run `tools/setup/build_pygments_data`.")
-
-    run(["scripts/setup/generate_secrets.py", "--development"])
 
     update_authors_json_paths = ["tools/update-authors-json", "zerver/tests/fixtures/authors.json"]
     if file_or_package_hash_updated(update_authors_json_paths, "update_authors_json_hash", options.is_force):


### PR DESCRIPTION
Commit 7d12e2019de5bc2311ea8b1060ff917f8aa5c7c2 (#10994) broke fresh provisions by importing `zproject.settings` before we were done modifying settings.  Fix it by moving the `generate_secrets` invocation to the earliest reasonable place.

**Testing Plan:** Ran `vagrant destroy --force; git clean -xdf; vagrant up`

(#11417 had failed to address the issue because the testing plan was missing the `git clean -xdf` step.)