### PR TITLE
Ensure correct textarea is focus when upload finishes

### DIFF
--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -124,8 +124,11 @@ exports.options = function (config) {
         var filename = split_uri[split_uri.length - 1];
         // Urgh, yet another hack to make sure we're "composing"
         // when text gets added into the composebox.
-        if (!compose_state.composing()) {
+        if (config.mode === 'compose' && !compose_state.composing()) {
             compose_actions.start('stream');
+        } else if (config.mode === 'edit' && document.activeElement !== textarea) {
+            // If we are editing, focus on the edit message box
+            textarea.focus();
         }
 
         var uri = make_upload_absolute(response.uri);


### PR DESCRIPTION
The `uploadFinished` code switches on the composing mode, if we aren't in the
composing mode already. This causes the focus to be incorrect when this code
path runs due to an upload from the message edit box. This commit turns on the
composing mode or switches focus to the message edit box, based on where the
upload was triggered.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
