### PR TITLE
left sidebar: Add a bit of margin below stream list.

### DIFF
--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -58,7 +58,8 @@ function get_new_heights() {
 
     res.bottom_sidebar_height = viewport_height
                                 - parseInt($("#left-sidebar").css("marginTop"), 10)
-                                - parseInt($(".bottom_sidebar").css("marginTop"), 10);
+                                - parseInt($(".bottom_sidebar").css("marginTop"), 10)
+                                - parseInt($(".bottom_sidebar").css("marginBottom"), 10);
 
     res.right_sidebar_height = viewport_height - parseInt($("#right-sidebar").css("marginTop"), 10);
 
@@ -123,7 +124,8 @@ function left_userlist_get_new_heights() {
 
     res.bottom_sidebar_height = viewport_height
                                 - parseInt($("#left-sidebar").css("marginTop"), 10)
-                                - parseInt($(".bottom_sidebar").css("marginTop"), 10);
+                                - parseInt($(".bottom_sidebar").css("marginTop"), 10)
+                                - parseInt($(".bottom_sidebar").css("marginBottom"), 10);
 
 
     res.total_leftlist_height = res.bottom_sidebar_height

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -47,9 +47,14 @@
 #stream_filters {
     overflow: visible;
     /* The -1px here prevents the scrollbar from going above the top of the container */
-    margin: -1px 0px 22px 0px;
+    margin-top: -1px;
+    margin-bottom: 18px;
     padding: 0;
     font-weight: normal;
+}
+
+.bottom_sidebar {
+    margin-bottom: 4px;
 }
 
 .left-sidebar li {


### PR DESCRIPTION
Having a tiny bit of margin below the stream list
makes it possible to see the bottom of the scrollbar.

It also makes it so that the scrollbar activates
for a tiny range of list sizes where before the
last element would have been right up against the
bottom of the page, but we wouldn't scroll.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
