### PR TITLE
[WIP] onboarding: Keep 80 messages unread on start and after bankruptcy.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -299,6 +299,9 @@ def add_new_user_history(user_profile: UserProfile, streams: Iterable[Stream]) -
     """Give you the last 1000 messages on your public streams, so you have
     something to look at in your home view once you finish the
     tutorial."""
+    """Give you the last 1000 messages on your public streams, so you have
+    something to look at in your home view once you finish the
+    tutorial."""
     one_week_ago = timezone_now() - datetime.timedelta(weeks=1)
 
     stream_ids = [stream.id for stream in streams if not stream.invite_only]
@@ -317,7 +320,7 @@ def add_new_user_history(user_profile: UserProfile, streams: Iterable[Stream]) -
     ums_to_create = [UserMessage(user_profile=user_profile, message_id=message_id,
                                  flags=UserMessage.flags.read)
                      for message_id in message_ids_to_use
-                     if message_id not in already_ids]
+                     if message_id not in already_ids][-80:]
 
     UserMessage.objects.bulk_create(ums_to_create)
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -317,8 +317,7 @@ def add_new_user_history(user_profile: UserProfile, streams: Iterable[Stream]) -
     already_ids = set(UserMessage.objects.filter(message_id__in=message_ids_to_use,
                                                  user_profile=user_profile).values_list("message_id",
                                                                                         flat=True))
-    ums_to_create = [UserMessage(user_profile=user_profile, message_id=message_id,
-                                 flags=UserMessage.flags.read)
+    ums_to_create = [UserMessage(user_profile=user_profile, message_id=message_id)
                      for message_id in message_ids_to_use
                      if message_id not in already_ids][-80:]
 


### PR DESCRIPTION
https://github.com/zulip/zulip/issues/6512


I tested this on my local development environment.
