### PR TITLE
test_bugdown.py: Used Subtest for test_bugdown_fixtures

### DIFF
--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -302,8 +302,9 @@ class BugdownTest(ZulipTestCase):
             else:
                 converted = bugdown_convert(test['input'])
 
-            print("Running Bugdown test %s" % (name,))
-            self.assertEqual(converted, test['expected_output'])
+            with self.subTest(test=test):    
+                print("Running Bugdown test %s" % (name,))
+                self.assertEqual(converted, test['expected_output'])
 
         def replaced(payload: str, url: str, phrase: str='') -> str:
             target = " target=\"_blank\""


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/11070

**Testing Plan:** <!-- How have you tested? -->
In test_bugdown_fixtures function, I have passed test['input'] instead of test['expected_output'] in assert_equal function which gives failed testcase. Now with using Subtest we get the information of test in the terminal which was not displayed earlier.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
before : 
![issue11070 before](https://user-images.githubusercontent.com/32800267/52510063-96145000-2c20-11e9-9c02-827c03950abf.png)

after :
  
![issue11070 after](https://user-images.githubusercontent.com/32800267/52510081-a3313f00-2c20-11e9-9140-75ed43aebef1.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
