### PR TITLE
[WIP] Issue #1070 test_bugdown.py : used subTest in test_bugdown_fixtures

### DIFF
--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -302,7 +302,7 @@ class BugdownTest(ZulipTestCase):
             else:
                 converted = bugdown_convert(test['input'])
 
-            with self.subTest(test=test):    
+            with self.subTest(test=test):
                 print("Running Bugdown test %s" % (name,))
                 self.assertEqual(converted, test['expected_output'])
 

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -302,8 +302,9 @@ class BugdownTest(ZulipTestCase):
             else:
                 converted = bugdown_convert(test['input'])
 
-            print("Running Bugdown test %s" % (name,))
-            self.assertEqual(converted, test['expected_output'])
+            with self.subTest(test=test):    
+                print("Running Bugdown test %s" % (name,))
+                self.assertEqual(converted, test['expected_output'])
 
         def replaced(payload: str, url: str, phrase: str='') -> str:
             target = " target=\"_blank\""


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/11070

**Testing Plan:** <!-- How have you tested? -->
In test_bugdown_fixtures function, I have passed test['input'] instead of test['expected_output'] in assert_equal function which gives failed testcase. Now with using subTest , the information of test is displayed on terminal window , which was not displayed earlier.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before :
![issue11070 before](https://user-images.githubusercontent.com/32800267/52511397-c3173180-2c25-11e9-859c-f324a94f5208.png)

After : 
![issue11070 after](https://user-images.githubusercontent.com/32800267/52511408-ce6a5d00-2c25-11e9-8a32-9b3ed7f0c3cc.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
