### PR TITLE
streams: Refactor multi-option helpers into separate functions.

### DIFF
--- a/zerver/lib/bot_lib.py
+++ b/zerver/lib/bot_lib.py
@@ -2,7 +2,7 @@ import json
 import os
 import importlib
 from zerver.lib.actions import internal_send_private_message, \
-    internal_send_stream_message, internal_send_huddle_message
+    internal_send_stream_message_by_name, internal_send_huddle_message
 from zerver.models import UserProfile, get_active_user
 from zerver.lib.bot_storage import get_bot_storage, set_bot_storage, \
     is_key_in_bot_storage, remove_bot_storage
@@ -71,10 +71,9 @@ class EmbeddedBotHandler:
             self._rate_limit.show_error_and_exit()
 
         if message['type'] == 'stream':
-            internal_send_stream_message(
+            internal_send_stream_message_by_name(
                 self.user_profile.realm, self.user_profile,
-                message['topic'], message['content'],
-                stream_name=message['to']
+                message['to'], message['topic'], message['content']
             )
             return
 

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -160,9 +160,8 @@ def send_to_missed_message_address(address: str, message: message.Message) -> No
     if recipient.type == Recipient.STREAM:
         stream = get_stream_by_id_in_realm(recipient.type_id, user_profile.realm)
         internal_send_stream_message(
-            user_profile.realm, user_profile,
-            subject_b.decode('utf-8'), body,
-            stream=stream
+            user_profile.realm, user_profile, stream,
+            subject_b.decode('utf-8'), body
         )
     elif recipient.type == Recipient.PERSONAL:
         display_recipient = get_display_recipient(recipient)

--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -2,7 +2,7 @@
 from django.conf import settings
 
 from zerver.lib.actions import set_default_streams, \
-    internal_prep_stream_message, internal_send_private_message, \
+    internal_prep_stream_message_by_name, internal_send_private_message, \
     create_streams_if_needed, do_send_messages, \
     do_add_reaction_legacy, create_users, missing_any_realm_internal_bots
 from zerver.lib.topic import get_turtle_message
@@ -107,10 +107,9 @@ def send_initial_realm_messages(realm: Realm) -> None:
          "in that each conversation should get its own topic. Keep them short, though; one "
          "or two words will do it!"},
     ]  # type: List[Dict[str, str]]
-    messages = [internal_prep_stream_message(
-        realm, welcome_bot,
-        message['topic'], message['content'],
-        stream_name=message['stream']
+    messages = [internal_prep_stream_message_by_name(
+        realm, welcome_bot, message['stream'],
+        message['topic'], message['content']
     ) for message in welcome_messages]
     message_ids = do_send_messages(messages)
 

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -29,11 +29,12 @@ from zerver.lib.actions import (
     get_last_message_id,
     get_user_info_for_message_updates,
     internal_prep_private_message,
-    internal_prep_stream_message,
+    internal_prep_stream_message_by_name,
     internal_send_huddle_message,
     internal_send_message,
     internal_send_private_message,
     internal_send_stream_message,
+    internal_send_stream_message_by_name,
     send_rate_limited_pm_notification_to_bot_owner,
 )
 
@@ -545,6 +546,18 @@ class InternalPrepTest(ZulipTestCase):
         self.assertIn('Message must not be empty', arg)
 
         with mock.patch('logging.exception') as m:
+            internal_send_stream_message_by_name(
+                realm=realm,
+                sender=cordelia,
+                stream_name=stream.name,
+                topic='whatever',
+                content=bad_content
+            )
+
+        arg = m.call_args_list[0][0][0]
+        self.assertIn('Message must not be empty', arg)
+
+        with mock.patch('logging.exception') as m:
             internal_send_message(
                 realm=realm,
                 sender_email=settings.ERROR_BOT,
@@ -598,7 +611,7 @@ class InternalPrepTest(ZulipTestCase):
         topic = 'whatever'
         content = 'hello'
 
-        internal_prep_stream_message(
+        internal_prep_stream_message_by_name(
             realm=realm,
             sender=sender,
             stream_name=stream_name,

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -398,9 +398,9 @@ def add_subscriptions_backend(
                 internal_prep_stream_message(
                     realm=user_profile.realm,
                     sender=sender,
+                    stream=notifications_stream,
                     topic=topic,
                     content=msg,
-                    stream=notifications_stream
                 )
             )
 

--- a/zilencer/management/commands/add_mock_conversation.py
+++ b/zilencer/management/commands/add_mock_conversation.py
@@ -78,9 +78,8 @@ From image editing program:
         ]  # type: List[Dict[str, Any]]
 
         messages = [internal_prep_stream_message(
-            realm, message['sender'],
-            'message formatting', message['content'],
-            stream=stream
+            realm, message['sender'], stream,
+            'message formatting', message['content']
         ) for message in staged_messages]
 
         message_ids = do_send_messages(messages)


### PR DESCRIPTION
For internal stream messages, most of the time, we have access to
a Stream object. For the few corner cases where we don't, it is a
much cleaner approach to have a separate function that accepts a
stream name than having one multi-option helper that accepts both
names and objects.

@timabbott: FYI :) Also, I investigated `internal_send_message`. Most of its callers don't have access to a stream object and that function is only used to send messages by system bots. We could potentially just change the code to get the `Stream` object in every instance if we really wanted, but do you think that would be worth it? If the callers don't have access to the Stream object, even if they did get it, it is the same query, it just happens earlier, so I don't see the benefit. :) Thanks!