### PR TITLE
zapier_app: Include bot's full name in response to auth requests.

### DIFF
--- a/zerver/webhooks/zapier/tests.py
+++ b/zerver/webhooks/zapier/tests.py
@@ -32,7 +32,10 @@ class ZapierZulipAppTests(WebhookTestCase):
         result = self.client_post(self.url, payload,
                                   content_type='application/json',
                                   **headers)
-        self.assert_json_success(result)
+        json_result = self.assert_json_success(result)
+        self.assertEqual(json_result['bot_name'], 'Zulip Webhook Bot')
+        self.assertEqual(json_result['bot_email'], 'webhook-bot@zulip.com')
+        self.assertIn('bot_id', json_result)
 
     def test_stream(self) -> None:
         expected_topic = u"Sample message from Zapier!"

--- a/zerver/webhooks/zapier/view.py
+++ b/zerver/webhooks/zapier/view.py
@@ -23,7 +23,14 @@ def api_zapier_webhook(request: HttpRequest, user_profile: UserProfile,
     if user_agent == 'ZapierZulipApp':
         event_type = payload.get('type')
         if event_type == 'auth':
-            return json_success()
+            # The bot's details are used by Zapier to format a connection
+            # label for users to be able to distinguish between different
+            # Zulip bots and API keys in their UI
+            return json_success({
+                'bot_name': user_profile.full_name,
+                'bot_email': user_profile.email,
+                'bot_id': user_profile.id
+            })
         elif event_type == 'stream':
             check_send_webhook_message(
                 request, user_profile,


### PR DESCRIPTION
The bot's full name is used as a connection label by Zapier's UI.
This allows users to distinguish between different Zapier-to-Zulip
connections set up with different bots.

@timabbott, @rishig: FYI :) 
