### PR TITLE
left sidebar: Move search out of scroll container.

### DIFF
--- a/frontend_tests/node_tests/stream_search.js
+++ b/frontend_tests/node_tests/stream_search.js
@@ -8,6 +8,7 @@ const noop = () => {};
 
 set_global('resize', {
     resize_page_components: noop,
+    resize_stream_filters_container: noop,
 });
 
 set_global('popovers', {});
@@ -38,11 +39,11 @@ function simulate_search_expanded() {
     // The way we check if the search widget is expanded
     // is kind of awkward.
 
-    $('#stream-filters-container .input-append.notdisplayed').length = 0;
+    $('.stream_search_section.notdisplayed').length = 0;
 }
 
 function simulate_search_collapsed() {
-    $('#stream-filters-container .input-append.notdisplayed').length = 1;
+    $('.stream_search_section.notdisplayed').length = 1;
 }
 
 function toggle_filter() {
@@ -52,17 +53,15 @@ function toggle_filter() {
 run_test('basics', () => {
     var cursor_helper;
     const input = $('.stream-list-filter');
-    const header = $.create('header stub');
-
-    input.parent = () => header;
+    const section = $('.stream_search_section');
 
     expand_sidebar();
-    header.addClass('notdisplayed');
+    section.addClass('notdisplayed');
 
     cursor_helper = make_cursor_helper();
 
     function verify_expanded() {
-        assert(!header.hasClass('notdisplayed'));
+        assert(!section.hasClass('notdisplayed'));
         simulate_search_expanded();
     }
 
@@ -77,7 +76,7 @@ run_test('basics', () => {
     }
 
     function verify_collapsed() {
-        assert(header.hasClass('notdisplayed'));
+        assert(section.hasClass('notdisplayed'));
         assert(!input.is_focused());
         assert(!stream_list.searching());
         simulate_search_collapsed();

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -570,9 +570,21 @@ exports.clear_search = function () {
     update_streams_for_search();
 };
 
+exports.show_search_section = function () {
+    $('.stream_search_section').expectOne().removeClass('notdisplayed');
+    resize.resize_stream_filters_container();
+};
+
+exports.hide_search_section = function () {
+    $('.stream_search_section').expectOne().addClass('notdisplayed');
+    resize.resize_stream_filters_container();
+};
+
 exports.initiate_search = function () {
+    exports.show_search_section();
+
     var filter = $('.stream-list-filter').expectOne();
-    filter.parent().removeClass('notdisplayed');
+
     if (!$(".app-main .column-left").hasClass("expanded")) {
         popovers.hide_all();
         stream_popover.show_streamlist_sidebar();
@@ -590,11 +602,12 @@ exports.clear_and_hide_search = function () {
     }
     exports.stream_cursor.clear();
     filter.blur();
-    filter.parent().addClass('notdisplayed');
+
+    exports.hide_search_section();
 };
 
 exports.toggle_filter_displayed = function (e) {
-    if ($('#stream-filters-container .input-append.notdisplayed').length === 0) {
+    if ($('.stream_search_section.notdisplayed').length === 0) {
         exports.clear_and_hide_search();
     } else {
         exports.initiate_search();

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -85,10 +85,6 @@
     width: 100%;
 }
 
-.input-append input[type=text].stream-list-filter {
-    margin-left: 10px;
-}
-
 #global_filters li:hover,
 #stream_filters li:hover,
 #stream_filters li.highlighted_stream {

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -52,17 +52,17 @@
             <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title" data-toggle="tooltip" title="{{ _('Subscribed streams') }}">{{ _('STREAMS') }}</h4>
                 <i id="streams_inline_cog" class='fa fa-cog' aria-hidden="true" data-toggle="tooltip" title="{{ _('Subscribe, add, or configure streams') }}"></i>
                 <i id="streams_filter_icon" class='fa fa-search' aria-hidden="true" data-toggle="tooltip" title="{{ _('Filter streams') }} (q)"></i>
-            </div>
-            <div id="topics_header">
-                <a href="" class="show-all-streams"> <i class="fa fa-chevron-left" aria-hidden="true"></i>{{ _('All streams') }}</a>
-            </div>
-            <div id="stream-filters-container" class="scrolling_list">
-                <div class="input-append notdisplayed">
+                <div class="input-append notdisplayed stream_search_section">
                     <input class="stream-list-filter" type="text" autocomplete="off" placeholder="{{ _('Search streams') }}" />
                     <button type="button" class="btn clear_search_button" id="clear_search_stream_button">
                         <i class="fa fa-remove" aria-hidden="true"></i>
                     </button>
                 </div>
+            </div>
+            <div id="topics_header">
+                <a href="" class="show-all-streams"> <i class="fa fa-chevron-left" aria-hidden="true"></i>{{ _('All streams') }}</a>
+            </div>
+            <div id="stream-filters-container" class="scrolling_list">
                 <ul id="stream_filters" class="filters"></ul>
             </div>
         </div>


### PR DESCRIPTION
We want the search widget, when visible, to be
outside the scroll container for the stream list.

One obvious use case is if you start scrolling, and
then realize it might be less effort to search.

Also, for user search, it already worked this way.

We have to add a couple resizing hooks here, but
it's not necessary to change the actual resize
calculation, since we move the section inside
of #streams_header, which is already accounted
for.

The only markup change here is to add
a `stream_search_section` class.  I don't
know why we use `notdisplayed` here instead of
jQuery, or what `input-append` is for, but I
considered them outside the scope of this change.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
