### PR TITLE
decorator.py: Add `max_int_size` param to `to_non_negative_int()`.

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -25,6 +25,7 @@ from zerver.lib.utils import statsd, is_remote_server
 from zerver.lib.exceptions import RateLimited, JsonableError, ErrorCode, \
     InvalidJSONError, InvalidAPIKeyError
 from zerver.lib.types import ViewFuncT
+from zerver.lib.validator import to_non_negative_int
 
 from zerver.lib.rate_limiter import incr_ratelimit, is_ratelimited, \
     api_calls_left, RateLimitedUser, RateLimiterLockingException
@@ -749,13 +750,6 @@ def internal_notify_view(is_tornado_view: bool) -> Callable[[ViewFuncT], ViewFun
             return view_func(request, *args, **kwargs)
         return _wrapped_func_arguments
     return _wrapped_view_func
-
-# Converter functions for use with has_request_variables
-def to_non_negative_int(s: str) -> int:
-    x = int(s)
-    if x < 0:
-        raise ValueError("argument is negative")
-    return x
 
 
 def to_not_negative_int_or_none(s: str) -> Optional[int]:

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -303,3 +303,13 @@ def check_widget_content(widget_content: object) -> Optional[str]:
         return 'unknown zform type: ' + extra_data['type']
 
     return 'unknown widget type: ' + widget_type
+
+
+# Converter functions for use with has_request_variables
+def to_non_negative_int(s: str, max_int_size: int=2**32-1) -> int:
+    x = int(s)
+    if x < 0:
+        raise ValueError("argument is negative")
+    if x > max_int_size:
+        raise ValueError('%s is too large (max %s)' % (x, max_int_size))
+    return x

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -44,7 +44,7 @@ from zerver.lib.cache import ignore_unhashable_lru_cache
 from zerver.lib.validator import (
     check_string, check_dict, check_dict_only, check_bool, check_float, check_int, check_list, Validator,
     check_variable_type, equals, check_none_or, check_url, check_short_string,
-    check_string_fixed_length, check_capped_string, check_color
+    check_string_fixed_length, check_capped_string, check_color, to_non_negative_int,
 )
 from zerver.models import \
     get_realm, get_user, UserProfile, Realm
@@ -745,6 +745,15 @@ class ValidatorTestCase(TestCase):
 
         x = [{}]
         self.assertEqual(check_int('x', x), 'x is not an integer')
+
+    def test_to_non_negative_int(self) -> None:
+        self.assertEqual(to_non_negative_int('5'), 5)
+        with self.assertRaisesRegex(ValueError, 'argument is negative'):
+            self.assertEqual(to_non_negative_int('-1'))
+        with self.assertRaisesRegex(ValueError, re.escape('5 is too large (max 4)')):
+            self.assertEqual(to_non_negative_int('5', max_int_size=4))
+        with self.assertRaisesRegex(ValueError, re.escape('%s is too large (max %s)' % (2**32, 2**32-1))):
+            self.assertEqual(to_non_negative_int(str(2**32)))
 
     def test_check_to_not_negative_int_or_none(self) -> None:
         self.assertEqual(to_not_negative_int_or_none('5'), 5)


### PR DESCRIPTION
Add `max_int_size` parameter to `to_non_negative_int()` in
decorator.py so it will be able to validate that the integer doesn't
exceed the integer maximum limit.

Fixes #11451

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
