### PR TITLE
Modals: Fix modal background parent container.

### DIFF
--- a/static/third/bootstrap/js/bootstrap.js
+++ b/static/third/bootstrap/js/bootstrap.js
@@ -1042,12 +1042,13 @@
     , backdrop: function (callback) {
         var that = this
           , animate = this.$element.hasClass('fade') ? 'fade' : ''
+          , bgContainer = this.options.bgContainer || document.body;
 
         if (this.isShown && this.options.backdrop) {
           var doAnimate = $.support.transition && animate
 
           this.$backdrop = $('<div class="modal-backdrop ' + animate + '" />')
-            .appendTo(document.body)
+            .appendTo($(this.options.bgContainer).get(0));
 
           if (this.options.backdrop != 'static') {
             this.$backdrop.click($.proxy(this.hide, this))
@@ -1093,6 +1094,7 @@
       backdrop: true
     , keyboard: true
     , show: true
+    , bgContainer: '.app'
   }
 
   $.fn.modal.Constructor = Modal


### PR DESCRIPTION
This commit changes where the backdrop of our bootstrap modal
component is rendered. The issue was that our modal component
was being rendered after the .app div which contains the contents
of the application. This was causing a problem in webkit browsers
on mobile where the z-index of the backdrop was being read as being
higher than that of the modal contents.

Fixes #11509

See https://chat.zulip.org/#narrow/stream/6-frontend/topic/Problem.20with.20catch.20up.20overlay.20on.20mobile.20site

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
