### PR TITLE
topic: Change topic update limit from 2 to 7 days.

### DIFF
--- a/static/templates/message_edit_form.handlebars
+++ b/static/templates/message_edit_form.handlebars
@@ -12,7 +12,7 @@
             <select class='message_edit_topic_propagate' style='display:none;'>
                 <option selected="selected" value="change_one"> {{t "Change only this message topic" }}</option>
                 <option value="change_later"> {{t "Change later messages to this topic" }}</option>
-                <option value="change_all"> {{t "Change previous and following messages to this topic" }}</option>
+                <option value="change_all"> {{t "Change recent messages to this topic" }}</option>
             </select>
         </div>
     </div>

--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -119,10 +119,10 @@ def update_messages_for_topic_edit(message: Message,
                                    orig_topic_name: str,
                                    topic_name: str) -> List[Message]:
     propagate_query = Q(recipient = message.recipient, subject = orig_topic_name)
-    # We only change messages up to 2 days in the past, to avoid hammering our
+    # We only change messages up to 7 days in the past, to avoid hammering our
     # DB by changing an unbounded amount of messages
     if propagate_mode == 'change_all':
-        before_bound = timezone_now() - datetime.timedelta(days=2)
+        before_bound = timezone_now() - datetime.timedelta(days=7)
 
         propagate_query = (propagate_query & ~Q(id = message.id) &
                            Q(pub_date__range=(before_bound, timezone_now())))


### PR DESCRIPTION
Changed topic update limit from 2 days to 7 days when the propagate mode
is 'change_all'. Relevant option label in the frontend is changed as well
to avoid confusion.

**Testing Plan:**
Manually tested it by generating messages for past 3 months and changing
topic of 3 months old message with propagate mode 'change_all'. Topic got
changed only for the selected message and messages sent in recent 7 days.

Fixes: #11475.