### PR TITLE
help: Update .help CSS and open graph description. 

### DIFF
--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -109,12 +109,21 @@ body {
     border-radius: 4px 4px 0px 0px;
 }
 
+.code-section.no-tabs ul.nav {
+    display: none;
+}
+
 .code-section .blocks {
     padding: 10px;
-
     border: 1px solid hsl(0, 0%, 87%);
+}
 
-    border-radius: 0px 4px 4px 4px;
+.code-section.has-tabs .blocks {
+    border-radius: 0px 6px 6px 6px;
+}
+
+.code-section.no-tabs .blocks {
+    border-radius: 6px;
 }
 
 /* The API tabbed content tends to have a lot of code blocks,
@@ -138,7 +147,8 @@ body {
     display: none;
 }
 
-.code-section .blocks > .active {
+.code-section.no-tabs .blocks > div,
+.code-section.has-tabs .blocks > .active {
     display: block;
 }
 

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -94,27 +94,44 @@ body {
 
 .code-section ul.nav li {
     display: inline-block;
-    padding: 3px 10px;
+    padding: 5px 14px;
     margin: 0;
-
-    border: 1px solid hsl(0, 0%, 87%);
-    border-bottom: none;
-    border-radius: 4px 4px 0px 0px;
 
     cursor: pointer;
 }
 
 .code-section ul.nav li.active {
     color: hsl(176, 46%, 41%);
+    margin-bottom: -1px;
+
+    border: 1px solid hsl(0, 0%, 87%);
+    border-bottom: 1px solid hsl(0, 0%, 100%);
+    border-radius: 4px 4px 0px 0px;
 }
 
 .code-section .blocks {
-    padding: 20px;
+    padding: 10px;
 
-    background-color: hsl(0, 0%, 98%);
     border: 1px solid hsl(0, 0%, 87%);
 
     border-radius: 0px 4px 4px 4px;
+}
+
+/* The API tabbed content tends to have a lot of code blocks,
+   which look nicer against a different background */
+.api-center .code-section .blocks {
+    background-color: hsl(0, 0%, 98%);
+}
+
+.api-center .code-section ul.nav li.active {
+    background-color: hsl(0, 0%, 98%);
+    border-bottom: 1px solid hsl(0, 0%, 98%);
+}
+
+/* The Help Center tabbed content tends to be a lot short sentences.
+   We also want the Help Center tabbed content to pop more. */
+.help-center .code-section .blocks {
+    max-width: 500px;
 }
 
 .code-section .blocks > div {
@@ -123,6 +140,10 @@ body {
 
 .code-section .blocks > .active {
     display: block;
+}
+
+.markdown .code-section ol {
+    margin-left: 15px;
 }
 
 .digest-container {

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -115,6 +115,7 @@ body {
 
 .code-section .blocks {
     padding: 10px;
+    margin-bottom: 10px;
     border: 1px solid hsl(0, 0%, 87%);
 }
 
@@ -154,6 +155,7 @@ body {
 
 .markdown .code-section ol {
     margin-left: 15px;
+    margin-top: 10px;
 }
 
 .digest-container {
@@ -185,6 +187,11 @@ body {
     overflow: auto;
 
     color: hsl(0, 0%, 27%);
+}
+
+/* Markdown processor generates lots of spurious <p></p> */
+.help p:empty {
+    margin: 0px;
 }
 
 .help .sidebar {

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -1686,14 +1686,16 @@ input.new-organization-button {
 .markdown h2,
 .why-page h2 {
     font-size: 1.5em;
-    margin: 5px 0 0 0;
+    line-height: 1.25;
+    margin: 20px 0px 5px 0px;
 }
 
 .markdown h3,
 .why-page h3 {
-    font-size: 1.1em;
+    font-size: 1.25em;
+    line-height: 1.25;
     opacity: 1;
-    margin-bottom: 0px;
+    margin-bottom: 7px;
 }
 
 .markdown img {

--- a/templates/zerver/documentation_main.html
+++ b/templates/zerver/documentation_main.html
@@ -22,11 +22,7 @@
 
             <div id="footer" class="documentation-footer">
                 <hr />
-                <p>
-                    We're here to help! Email us at
-                    <a href="mailto:{{ support_email }}">{{ support_email }}</a>
-                    with questions, feedback, or feature requests.
-                </p>
+                <p>We're here to help! Email us at <a href="mailto:{{ support_email }}">{{ support_email }}</a> with questions, feedback, or feature requests.</p>
             </div>
         </div>
     </div>

--- a/templates/zerver/documentation_main.html
+++ b/templates/zerver/documentation_main.html
@@ -3,7 +3,7 @@
 {# Zulip User and API Documentation. #}
 
 {% block portico_content %}
-<div class="app help terms-page inline-block">
+<div class="app help terms-page inline-block{% if page_is_help_center %} help-center{% endif %}{% if page_is_api_center %} api-center{% endif %}">
     <div class="{{ sidebar_class }}">
         <div class="content">
             <h1><a href="{{ doc_root }}" class="no-underline">Home</a></h1>

--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -346,7 +346,7 @@
         <div class="flex">
             <img src="/static/images/landing-page/opensource.svg" alt=""/>
             <div class="il-block">
-                <h2>Open Source</h2>
+                <h1>Open Source</h1>
                 <p>
                     Zulip is <a href="https://github.com/zulip/zulip">100% open source software</a>,
                     built by a vibrant community of hundreds of developers

--- a/templates/zerver/help/change-the-time-format.md
+++ b/templates/zerver/help/change-the-time-format.md
@@ -3,6 +3,12 @@
 By default, messages in Zulip are displayed with a 12-hour time format
 (e.g. 3:00 PM, not 15:00).
 
+### Change the time format
+
+{start_tabs}
+
 {settings_tab|display-settings}
 
 1. Under **Time settings**, click on **24-hour time**.
+
+{end_tabs}

--- a/templates/zerver/help/change-your-avatar.md
+++ b/templates/zerver/help/change-your-avatar.md
@@ -1,4 +1,4 @@
-# Change your avatar
+# Set your avatar
 
 By default, Zulip uses avatars from [Gravatar](https://en.gravatar.com/).
 If your email address already has a gravatar associated with it, Zulip will
@@ -6,6 +6,12 @@ use your existing gravatar.
 
 You can also upload a custom avatar to Zulip.
 
+### Set your avatar
+
+{start_tabs}
+
 {settings_tab|your-account}
 
 2. Under **User Avatar**, click **Upload new avatar** and choose an image to upload.
+
+{end_tabs}

--- a/templates/zerver/help/change-your-email-address.md
+++ b/templates/zerver/help/change-your-email-address.md
@@ -6,6 +6,10 @@ Organization adminstrators can
 [restrict users to certain email domains](/help/change-a-users-name), or
 [prevent users from changing their email](/help/restrict-name-and-email-changes).
 
+### Change your email address
+
+{start_tabs}
+
 {settings_tab|your-account}
 
 2. Under **User settings**, click on the button with your email address.
@@ -13,6 +17,8 @@ Organization adminstrators can
 3. Enter your new email, and click **Change**.
 
 4. You will receive a confirmation email within a few minutes. Open it and click **Confirm email change**.
+
+{end_tabs}
 
 !!! warn ""
     **Note:** If you are unable to click on the button with your email address, check

--- a/templates/zerver/help/change-your-language.md
+++ b/templates/zerver/help/change-your-language.md
@@ -1,4 +1,4 @@
-# Change your language
+# Change your default language
 
 Zulip has been translated or partially translated into a number of different
 languages. You can see which languages Zulip supports, and help add support
@@ -9,6 +9,10 @@ If your entire organization speaks a language other than English, an administrat
 
 [change-org-lang]: change-the-default-language-for-your-organization
 
+### Change your default language
+
+{start_tabs}
+
 {settings_tab|display-settings}
 
 2. Under **Language Settings**, click the button next to **Default language**.
@@ -16,6 +20,8 @@ If your entire organization speaks a language other than English, an administrat
 3. Click on a language.
 
 4. Click **Reload**.
+
+{end_tabs}
 
 !!! tip ""
     You can always send and read messages in any language.

--- a/templates/zerver/help/change-your-name.md
+++ b/templates/zerver/help/change-your-name.md
@@ -7,11 +7,15 @@ Organization administrators can [change anyone's name](/help/change-a-users-name
 [prevent users from changing their names](/help/restrict-name-and-email-changes). This
 is useful when users' names are managed via LDAP or another data source.
 
+{start_tabs}
+
 {settings_tab|your-account}
 
 1. Under **User settings**, click on the button with your name in it.
 
 1. Change your name, and click **Save**.
+
+{end_tabs}
 
 !!! warn ""
     **Note:** If you are unable to click on the button with your name, check

--- a/templates/zerver/help/change-your-name.md
+++ b/templates/zerver/help/change-your-name.md
@@ -7,6 +7,8 @@ Organization administrators can [change anyone's name](/help/change-a-users-name
 [prevent users from changing their names](/help/restrict-name-and-email-changes). This
 is useful when users' names are managed via LDAP or another data source.
 
+### Change your name
+
 {start_tabs}
 
 {settings_tab|your-account}

--- a/templates/zerver/help/change-your-password.md
+++ b/templates/zerver/help/change-your-password.md
@@ -6,6 +6,8 @@ account.
 
 ### If you've forgotten or never had a password
 
+{start_tabs}
+
 1. Log out.
 
 1. Go to your organization's login page.
@@ -16,10 +18,16 @@ account.
 
 4. You will receive a confirmation email within a few minutes. Open it and click **Reset password**.
 
+{end_tabs}
+
 ### If you know your current password
+
+{start_tabs}
 
 {settings_tab|your-account}
 
 2. Under **User settings**, click on the password field (it should look like `********`).
 
 3. Enter your old password and your new password, and click **Change**.
+
+{end_tabs}

--- a/templates/zerver/help/deactivate-your-account.md
+++ b/templates/zerver/help/deactivate-your-account.md
@@ -1,10 +1,14 @@
 # Deactivate your account
 
+{start_tabs}
+
 {settings_tab|your-account}
 
 1. Under **Deactivate account**, click **Deactivate account**.
 
 1. Confirm by clicking **Deactivate now**.
+
+{end_tabs}
 
 ## What happens when you deactivate an account
 

--- a/templates/zerver/help/edit-your-profile.md
+++ b/templates/zerver/help/edit-your-profile.md
@@ -8,14 +8,19 @@ Organization administrators can also
 fields are always optional, and will not appear in your profile unless you
 fill them out.
 
-## Edit your profile
+### Edit your profile
+
+{start_tabs}
 
 {settings_tab|your-account}
 
 1. Edit the fields under **Profile**.
 
-Note: The **Profile** section will only appear if an organization
-administrator has added custom profile fields.
+{end_tabs}
+
+!!! warn ""
+    Note: The **Profile** section will only appear if an organization
+    administrator has added custom profile fields.
 
 ## Related articles
 

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -1,6 +1,8 @@
 ## Guides
 * [Getting started with Zulip](/help/getting-started-with-zulip)
 * [Setting up your organization](/help/getting-your-organization-started-with-zulip)
+* [Streams and topics](/help/about-streams-and-topics)
+* [Moderating open organizations](/help/moderating-open-organizations)
 
 # Using Zulip
 
@@ -109,7 +111,6 @@
 * [Roles and permissions](/help/roles-and-permissions)
 * [Set the default language for new users](/help/change-the-default-language-for-your-organization)
 * [Export your organization](/help/export-your-organization)
-* [Moderating open organizations](/help/moderating-open-organizations)
 * [Deactivate your organization](/help/deactivate-your-organization)
 * [GDPR Compliance](/help/gdpr-compliance)
 

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -10,7 +10,7 @@
 * [Change your name](/help/change-your-name)
 * [Change your email address](/help/change-your-email-address)
 * [Edit your profile](/help/edit-your-profile)
-* [Manage your password](/help/change-your-password)
+* [Change your password](/help/change-your-password)
 * [Review your settings](/help/review-your-settings)
 * [Set your avatar](/help/change-your-avatar)
 * [Change your default language](/help/change-your-language)

--- a/templates/zerver/help/join-a-zulip-organization.md
+++ b/templates/zerver/help/join-a-zulip-organization.md
@@ -1,4 +1,4 @@
-# Join a Zulip organization
+# Joining a Zulip organization
 
 By default, Zulip organizations require an invitation to join.
 
@@ -6,7 +6,9 @@ Organization administrators can also allow anyone to join without an
 invitation, and/or restrict user email addresses to a company domain. See
 [manage who can join and invite](/help/manage-who-can-join-and-invite).
 
-## See if you need an invitation to join
+## Check if you need an invitation to join
+
+{start_tabs}
 
 1. Go to the Zulip URL of the organization.
 
@@ -15,7 +17,11 @@ invitation, and/or restrict user email addresses to a company domain. See
 1. If you see a sign up form, invitations are not required! Otherwise, the
   page will say that you need an invitation to join.
 
-## See if you need an email from a specific domain
+{end_tabs}
+
+## Check if you need an email from a specific domain
+
+{start_tabs}
 
 1. Go to the Zulip URL of the organization.
 
@@ -25,6 +31,8 @@ invitation, and/or restrict user email addresses to a company domain. See
 
 1. If your email address is not from an allowed domain, you will get an
    error message to that effect.
+
+{end_tabs}
 
 ## Accept an invitation
 

--- a/templates/zerver/help/moderating-open-organizations.md
+++ b/templates/zerver/help/moderating-open-organizations.md
@@ -1,7 +1,8 @@
 # Moderating open organizations
 
-Zulip aims to be the best chat possible for open organizations. Moderation
-is a big part of making an open community work.
+An **open organization** is one where
+[anyone can join without an invitation](/help/manage-who-can-join-and-invite).
+Moderation is a big part of making an open community work.
 
 ## Prevention
 

--- a/templates/zerver/help/review-your-settings.md
+++ b/templates/zerver/help/review-your-settings.md
@@ -4,6 +4,12 @@ We recommend reviewing all of your settings when you start using Zulip, and
 then once again a few weeks later once you've gotten a better feel for how
 you use Zulip.
 
+### Review your settings
+
+{start_tabs}
+
 {relative|gear|settings}
 
 1. Click on each tab on the left.
+
+{end_tabs}

--- a/templates/zerver/tests/markdown/test_tabbed_sections.md
+++ b/templates/zerver/tests/markdown/test_tabbed_sections.md
@@ -20,3 +20,9 @@ Desktop/browser instructions
 {tab|android}
 Android instructions
 {end_tabs}
+
+## Heading 3
+
+{start_tabs}
+Instructions for all platforms
+{end_tabs}

--- a/zerver/lib/bugdown/tabbed_sections.py
+++ b/zerver/lib/bugdown/tabbed_sections.py
@@ -10,7 +10,7 @@ END_TABBED_SECTION_REGEX = re.compile(r'^\{end_tabs\}$')
 TAB_CONTENT_REGEX = re.compile(r'^\{tab\|\s*(.+?)\s*\}$')
 
 CODE_SECTION_TEMPLATE = """
-<div class="code-section" markdown="1">
+<div class="code-section {tab_class}" markdown="1">
 {nav_bar}
 <div class="blocks">
 {blocks}
@@ -65,10 +65,16 @@ class TabbedSectionsPreprocessor(Preprocessor):
     def run(self, lines: List[str]) -> List[str]:
         tab_section = self.parse_tabs(lines)
         while tab_section:
+            if 'tabs' in tab_section:
+                tab_class = 'has-tabs'
+            else:
+                tab_class = 'no-tabs'
+                tab_section['tabs'] = [{'tab_name': 'null_tab',
+                                        'start': tab_section['start_tabs_index']}]
             nav_bar = self.generate_nav_bar(tab_section)
             content_blocks = self.generate_content_blocks(tab_section, lines)
             rendered_tabs = CODE_SECTION_TEMPLATE.format(
-                nav_bar=nav_bar, blocks=content_blocks)
+                tab_class=tab_class, nav_bar=nav_bar, blocks=content_blocks)
 
             start = tab_section['start_tabs_index']
             end = tab_section['end_tabs_index'] + 1

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -467,10 +467,10 @@ class FinalizeOpenGraphDescription(MiddlewareMixin):
             text = ''
             for paragraph in bs.find_all('p'):
                 # .text converts it from HTML to text
-                text = text + paragraph.text.replace('\n', ' ') + ' '
+                text = text + paragraph.text + ' '
                 if len(text) > 500:
-                    return text.strip()
-            return text.strip()
+                    return ' '.join(text.split())
+            return ' '.join(text.split())
 
         def alter_content(content: bytes) -> bytes:
             first_paragraph_text = get_content_description(content, request)

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -460,9 +460,13 @@ class FinalizeOpenGraphDescription(MiddlewareMixin):
             for tag in bs.find_all('div', class_="admonition"):
                 tag.clear()
 
-            # Find the first paragraph after that, and convert it from HTML to text.
-            first_paragraph_text = bs.find('p').text.replace('\n', ' ')
-            return first_paragraph_text
+            text = ''
+            for paragraph in bs.find_all('p'):
+                # .text converts it from HTML to text
+                text = text + paragraph.text.replace('\n', ' ') + ' '
+                if len(text) > 500:
+                    return text.strip()
+            return text.strip()
 
         def alter_content(content: bytes) -> bytes:
             first_paragraph_text = get_content_description(content, request)

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -460,6 +460,10 @@ class FinalizeOpenGraphDescription(MiddlewareMixin):
             for tag in bs.find_all('div', class_="admonition"):
                 tag.clear()
 
+            # Skip code-sections, which just contains navigation instructions.
+            for tag in bs.find_all('div', class_="code-section"):
+                tag.clear()
+
             text = ''
             for paragraph in bs.find_all('p'):
                 # .text converts it from HTML to text

--- a/zerver/tests/test_middleware.py
+++ b/zerver/tests/test_middleware.py
@@ -95,7 +95,8 @@ class OpenGraphTest(ZulipTestCase):
         self.check_title_and_description(
             '/help/deactivate-your-account',
             "Deactivate your account (Zulip Help Center)",
-            ["Go to Your account. Under Deactivate account, click"], [])
+            ["Any bots that you maintain will be disabled. Deactivating "],
+            ["Confirm by clicking"])
 
     def test_tabs(self) -> None:
         # logging-out starts with {start_tabs}

--- a/zerver/tests/test_middleware.py
+++ b/zerver/tests/test_middleware.py
@@ -1,4 +1,6 @@
+import re
 import time
+from typing import List
 
 from django.test import override_settings
 from unittest.mock import Mock, patch
@@ -51,16 +53,29 @@ class SlowQueryTest(ZulipTestCase):
         mock_internal_send_message.assert_not_called()
 
 class OpenGraphTest(ZulipTestCase):
-    def check_title_and_description(self, path: str, title: str, description: str) -> None:
+    def check_title_and_description(self, path: str, title: str,
+                                    in_description: List[str],
+                                    not_in_description: List[str]) -> None:
         response = self.client_get(path)
-        self.assert_in_success_response([
-            # Open graph
-            '<meta property="og:title" content="{}">'.format(title),
-            '<meta property="og:description" content="{}">'.format(description),
-            # Twitter
-            '<meta property="twitter:title" content="{}">'.format(title),
-            '<meta name="twitter:description" content="{}">'.format(description),
-        ], response)
+        self.assertEqual(response.status_code, 200)
+        decoded = response.content.decode('utf-8')
+        for title_string in [
+                '<meta property="og:title" content="{}">'.format(title),
+                '<meta property="twitter:title" content="{}">'.format(title)]:
+            self.assertIn(title_string, decoded)
+
+        open_graph_description = re.search(  # type: ignore
+            r'<meta property="og:description" content="(?P<description>[^>]*)">',
+            decoded).group('description')
+        twitter_description = re.search(  # type: ignore
+            r'<meta name="twitter:description" content="(?P<description>[^>]*)">',
+            decoded).group('description')
+        for substring in in_description:
+            self.assertIn(substring, open_graph_description)
+            self.assertIn(substring, twitter_description)
+        for substring in not_in_description:
+            self.assertNotIn(substring, open_graph_description)
+            self.assertNotIn(substring, twitter_description)
 
     def test_admonition_and_link(self) -> None:
         # disable-message-edit-history starts with an {!admin-only.md!}, and has a link
@@ -68,17 +83,19 @@ class OpenGraphTest(ZulipTestCase):
         self.check_title_and_description(
             '/help/disable-message-edit-history',
             "Disable message edit history (Zulip Help Center)",
-            "By default, Zulip displays messages that have been edited with an EDITED tag, " +
-            "and users can view the edit history of a message.")
+            ["By default, Zulip displays messages",
+             "users can view the edit history of a message. To remove the",
+             "best to delete the message entirely. "],
+            ["Disable message edit history", "feature is only available", "Related articles",
+             "Restrict message editing"]
+        )
 
     def test_settings_tab(self) -> None:
         # deactivate-your-account starts with {settings_tab|your-account}
         self.check_title_and_description(
             '/help/deactivate-your-account',
             "Deactivate your account (Zulip Help Center)",
-            # Ideally, we'd grab the second and third paragraphs as well, if
-            # the first paragraph is this short
-            "Go to Your account.")
+            ["Go to Your account. Under Deactivate account, click"], [])
 
     def test_tabs(self) -> None:
         # logging-out starts with {start_tabs}
@@ -86,22 +103,20 @@ class OpenGraphTest(ZulipTestCase):
             '/help/logging-out',
             "Logging out (Zulip Help Center)",
             # Ideally we'd do something better here
-            "")
+            ["Click on the gear () icon in", "Click Log out.  Tap the menu"], [])
 
     def test_index_pages(self) -> None:
         self.check_title_and_description(
             '/help/',
             "Zulip Help Center",
-            ("Zulip is a group chat app. Its most distinctive characteristic is that "
-             "conversation within an organization is divided into “streams” and further "
-             "subdivided into “topics”, so that much finer-grained conversations are possible "
-             "than with IRC or other chat tools."))
+            [("Zulip is a group chat app. Its most distinctive characteristic is that "
+              "conversation within an organization is divided into “streams” and further ")], [])
 
         self.check_title_and_description(
             '/api/',
             "Zulip API Documentation",
-            ("Zulip's APIs allow you to integrate other services with Zulip.  This "
-             "guide should help you find the API you need:"))
+            [("Zulip's APIs allow you to integrate other services with Zulip.  This "
+              "guide should help you find the API you need:")], [])
 
     def test_nonexistent_page(self) -> None:
         response = self.client_get('/help/not-a-real-page')
@@ -110,4 +125,6 @@ class OpenGraphTest(ZulipTestCase):
         self.assert_in_response(
             # Probably we should make this "Zulip Help Center"
             '<meta property="og:title" content="No such article. (Zulip Help Center)">', response)
-        self.assert_in_response('<meta property="og:description" content="No such article.">', response)
+        self.assert_in_response('<meta property="og:description" content="No such article. '
+                                'We\'re here to help! Email us at zulip-admin@example.com with questions, '
+                                'feedback, or feature requests.">', response)

--- a/zerver/tests/test_middleware.py
+++ b/zerver/tests/test_middleware.py
@@ -96,7 +96,7 @@ class OpenGraphTest(ZulipTestCase):
             '/help/deactivate-your-account',
             "Deactivate your account (Zulip Help Center)",
             ["Any bots that you maintain will be disabled. Deactivating "],
-            ["Confirm by clicking"])
+            ["Confirm by clicking", "  ", "\n"])
 
     def test_tabs(self) -> None:
         # logging-out starts with {start_tabs}
@@ -118,7 +118,7 @@ class OpenGraphTest(ZulipTestCase):
         self.check_title_and_description(
             '/api/',
             "Zulip API Documentation",
-            [("Zulip's APIs allow you to integrate other services with Zulip.  This "
+            [("Zulip's APIs allow you to integrate other services with Zulip. This "
               "guide should help you find the API you need:")], [])
 
     def test_nonexistent_page(self) -> None:

--- a/zerver/tests/test_middleware.py
+++ b/zerver/tests/test_middleware.py
@@ -103,7 +103,9 @@ class OpenGraphTest(ZulipTestCase):
             '/help/logging-out',
             "Logging out (Zulip Help Center)",
             # Ideally we'd do something better here
-            ["Click on the gear () icon in", "Click Log out.  Tap the menu"], [])
+            ["We're here to help! Email us at zulip-admin@example.com with questions, feedback, or " +
+             "feature requests."],
+            ["Click on the gear"])
 
     def test_index_pages(self) -> None:
         self.check_title_and_description(

--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -239,7 +239,7 @@ header
 
 <h1 id="heading">Heading</h1>
 <p>
-  <div class="code-section" markdown="1">
+  <div class="code-section has-tabs" markdown="1">
     <ul class="nav">
       <li data-language="ios">iOS</li>
       <li data-language="desktop-web">Desktop/Web</li>
@@ -257,7 +257,7 @@ header
 
 <h2 id="heading-2">Heading 2</h2>
 <p>
-  <div class="code-section" markdown="1">
+  <div class="code-section has-tabs" markdown="1">
     <ul class="nav">
       <li data-language="desktop-web">Desktop/Web</li>
       <li data-language="android">Android</li>
@@ -268,6 +268,20 @@ header
       <p></div>
       <div data-language="android" markdown="1"></p>
         <p>Android instructions</p>
+      <p></div>
+    </div>
+  </div>
+</p>
+
+<h2 id="heading-3">Heading 3</h2>
+<p>
+  <div class="code-section no-tabs" markdown="1">
+    <ul class="nav">
+      <li data-language="null_tab">None</li>
+    </ul>
+    <div class="blocks">
+      <div data-language="null_tab" markdown="1"></p>
+        <p>Instructions for all platforms</p>
       <p></div>
     </div>
   </div>


### PR DESCRIPTION
Doesn't need a deep review, but figured I'd post it here. 

For the styling, the new thing looks like
![image](https://user-images.githubusercontent.com/890911/52550515-456e3580-2d8d-11e9-8e06-91e3367a3120.png)

![image](https://user-images.githubusercontent.com/890911/52550529-528b2480-2d8d-11e9-88b2-f57314c31ce3.png)

Old:
https://zulipchat.com/help/change-your-name
https://zulipchat.com/help/logging-out

I did some looking through /api, /integrations, and the landing pages. I don't think I made adverse changes, but very hard to follow the code :/.