### PR TITLE
Fix sidebar css/resize glitches.

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -249,7 +249,7 @@ a.conversation-partners:hover {
     line-height: 1.1;
 }
 
-.left-sidebar li a.topic-name:hover {
+a.topic-name:hover {
     text-decoration: underline;
 }
 

--- a/templates/zerver/app/right_sidebar.html
+++ b/templates/zerver/app/right_sidebar.html
@@ -22,9 +22,6 @@
                 <ul id="user_presences" class="filters"></ul>
                 <div id="buddy_list_wrapper_padding"></div>
             </div>
-            {% if show_invites %}
-            <a id="invite-user-link" href="#invite"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{ _('Invite more users') }}</a>
-            {% endif %}
         </div>
         <div id="group-pm-list">
             <div id="group-pm-header">
@@ -33,6 +30,9 @@
             <ul id="group-pms" class="filters scrolling_list">
             </ul>
         </div>
+        {% if show_invites %}
+        <a id="invite-user-link" href="#invite"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{ _('Invite more users') }}</a>
+        {% endif %}
         <a id="sidebar-keyboard-shortcuts" data-overlay-trigger="keyboard-shortcuts">
             <i class="fa fa-keyboard-o fa-2x" id="keyboard-icon" data-html="true" data-toggle="tooltip" title="{{ _('Keyboard shortcuts') }} <span class='hotkey-hint'>(?)</span>"></i>
         </a>


### PR DESCRIPTION
There are sort a few problems here that are intertwined:

* putting streams/users in the left sidebar causes side effects for the buddy list
* our sidebar-resize calculations are slightly bitrotten and janky/buggy
* our CSS is hard to reason about
* we have the upcoming mobile view where we don't want to leak in CSS

This mostly moves CSS around and fixes resize stuff.