### PR TITLE
invite: Fix some minor styling things.

### DIFF
--- a/templates/zerver/app/invite_user.html
+++ b/templates/zerver/app/invite_user.html
@@ -25,7 +25,6 @@
                         {% endif %}
                     </div>
                 </div>
-                <hr>
                 <div class="control-group">
                     <label class="control-label" for="invite_as">{{ _('User(s) join as') }}</label>
                     <div class="controls">

--- a/templates/zerver/app/invite_user.html
+++ b/templates/zerver/app/invite_user.html
@@ -8,7 +8,6 @@
         <form id="invite_user_form" class="form-horizontal">{{ csrf_input }}
             <div class="modal-body">
                 <div class="control-group">
-                    <div id="invite-result"></div>
                     <label class="control-label" for="invitee_emails">{{ _('Emails (one on each line or comma-separated)') }}</label>
                     <div class="controls">
                         <textarea rows="2" id="invitee_emails" name="invitee_emails" placeholder="{{ _('One or more email addresses...') }}"></textarea>

--- a/templates/zerver/app/invite_user.html
+++ b/templates/zerver/app/invite_user.html
@@ -7,6 +7,10 @@
         </div>
         <form id="invite_user_form" class="form-horizontal">{{ csrf_input }}
             <div class="modal-body">
+                <div class="alert" id="invite_status"></div>
+                {% if development_environment %}
+                <div class="alert" id="dev_env_msg"></div>
+                {% endif %}
                 <div class="control-group">
                     <label class="control-label" for="invitee_emails">{{ _('Emails (one on each line or comma-separated)') }}</label>
                     <div class="controls">
@@ -37,10 +41,6 @@
                         </select>
                     </div>
                 </div>
-                <div class="alert" id="invite_status"></div>
-                {% if development_environment %}
-                <div class="alert" id="dev_env_msg"></div>
-                {% endif %}
                 <div class="control-group">
                     <label class="control-label">{{ _('Streams they should join') }}</label>
                     <div class="controls" id="streams_to_add"></div>


### PR DESCRIPTION
Two things I noticed while working on this:
* Changing our background from light-greyish to white makes it look less "old"
* Changing the transition animation from .3s to .2s or even .1s made it feel a lot snappier.

I didn't make those changes, since I think it would make sense for someone focused on design to do a pass on all our modals and unify these details.

Success:
![image](https://user-images.githubusercontent.com/890911/52596112-5c9c3a00-2e04-11e9-9085-b292608b9b1b.png)

Error:
![image](https://user-images.githubusercontent.com/890911/52596128-6a51bf80-2e04-11e9-99bf-ac7f5036ac82.png)

Old:
![image](https://user-images.githubusercontent.com/890911/52596637-a5a0be00-2e05-11e9-8f73-a9d585bb1a83.png)


