### PR TITLE
Reset the RegExp state on new searches

### DIFF
--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -246,6 +246,8 @@ function python_to_js_filter(pattern, url) {
         // Replace named reference in url to numbered reference
         url = url.replace('%(' + name + ')s', '\\' + current_group);
 
+        // Reset the RegExp state
+        named_group_re.lastIndex = 0; 
         match = named_group_re.exec(pattern);
 
         current_group += 1;


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://chat.zulip.org/#narrow/stream/9-issues/topic/unresponsive.20frontend

Regular Expression with multiple named capture blocks were not completely parsed out from `python_to_js_filter`.

The reason is when `RegExp.exec` is called multiple times, it maintains a `lastIndex` state and only search from there so that multiple calls don't return the same result.
When the target string is modified, this behaviour sometimes causes skipped matches.

The sample RegExp I posted on the Zulip server's topic:
```regexp
#cf(?P<contest>[0-9]+)(?P<problem>[A-Z][0-9A-Z]*) 
```
would originally panic from RegExp build error:
```js
> python_to_js_filter("#cf(?P<contest>[0-9]+)(?P<problem>[A-Z][0-9A-Z]*)", "https://xxxxxxx.xxx/xxx/%(contest)s/xxx/%(problem)s")

Thrown:
SyntaxError: Invalid regular expression: /#cf([0-9]+)(?P<problem>[A-Z][0-9A-Z]*)(?![\w])/: Invalid group
```
because the second capturing group was not matched and replaced.

The new code's output is
```js
> python_to_js_filter("#cf(?P<contest>[0-9]+)(?P<problem>[A-Z][0-9A-Z]*)", "https://xxxxxxx.xxx/xxx/%(contest)s/xxx/%(problem)s")
[ /#cf([0-9]+)([A-Z][0-9A-Z]*)(?![\w])/g,
  'https://xxxxxxx.xxx/xxx/\\1/xxx/\\2' ]
```

**Testing Plan:** <!-- How have you tested? -->

The code has only been tested with the example above.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zulip/zulip/11527)
<!-- Reviewable:end -->
