### PR TITLE
[WIP] notification: Show wrong narrow notification for non locally echoed messages

### DIFF
--- a/frontend_tests/node_tests/server_events.js
+++ b/frontend_tests/node_tests/server_events.js
@@ -9,6 +9,7 @@ global.stub_out_jquery();
 zrequire('message_store');
 zrequire('server_events_dispatch');
 zrequire('server_events');
+zrequire('sent_messages');
 
 set_global('blueslip', global.make_zblueslip());
 set_global('channel', {});

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -55,7 +55,7 @@ function maybe_add_narrowed_messages(messages, msg_list) {
 }
 
 
-exports.insert_new_messages = function insert_new_messages(messages, locally_echoed) {
+exports.insert_new_messages = function insert_new_messages(messages, sent_by_this_client) {
     messages = _.map(messages, message_store.add_message_metadata);
 
     unread.process_loaded_messages(messages);
@@ -83,7 +83,7 @@ exports.insert_new_messages = function insert_new_messages(messages, locally_ech
     }
 
 
-    if (locally_echoed) {
+    if (sent_by_this_client) {
         var need_user_to_scroll = render_info && render_info.need_user_to_scroll;
         notifications.notify_local_mixes(messages, need_user_to_scroll);
     }

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -588,12 +588,13 @@ exports.get_local_notify_mix_reason = function (message) {
 
 exports.notify_local_mixes = function (messages, need_user_to_scroll) {
     /*
-        This code should only be called when we are locally echoing
-        messages.  It notifies users that their messages aren't
-        actually in the view that they composed to.
+        This code should only be called when we are displaying
+        messages sent by current client. It notifies users that
+        their messages aren't actually in the view that they
+        composed to.
 
         This code is called after we insert messages into our
-        message list widgets.  All of the conditions here are
+        message list widgets. All of the conditions here are
         checkable locally, so we may want to execute this code
         earlier in the codepath at some point and possibly punt
         on local rendering.

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -104,7 +104,14 @@ function get_events_success(events) {
         try {
             messages = echo.process_from_server(messages);
             _.each(messages, message_store.set_message_booleans);
-            message_events.insert_new_messages(messages);
+            var sent_by_this_client = false;
+            _.each(messages, function (msg) {
+                var msg_state = sent_messages.messages[msg.local_id];
+                if (msg_state) {
+                    sent_by_this_client = true;
+                }
+            });
+            message_events.insert_new_messages(messages, sent_by_this_client);
         } catch (ex2) {
             blueslip.error('Failed to insert new messages\n' +
                            blueslip.exception_msg(ex2),


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#11488 
I think this PR covers the points raised here https://chat.zulip.org/#narrow/stream/9-issues/topic/message.20sent.20to.20other.20narrow/near/696689

- Messages when received from server are processed in echo.process_from_server and only non locally echoed messages were being passed to `insert_new_messages` function in server_events.js (if messages were locally echoed an empty array is passed). So Next thing to check was if the messages were sent by current client before passing it to insert_new_messages.
- The sent_messages object as far as I have understood tracks the messages sent by current client only. So just checking if the non locally rendered messages are in sent_messages we can achieve our goal.

@timabbott @showell Please review if all the cases discussed in chat have been covered or not.

**Testing Plan:** <!-- How have you tested? -->
Open a different narrow:
1. send a locally echoed message to another narrow and ensure the notification occurs.
2. send a message with server only markdown and and ensure the notification occurs.
3. tested that for locally echoed message the sent_by_client variable in message_events.js is not becoming true using console.log.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->