### PR TITLE
left sidebar: Remove border from starred messages count.

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -196,11 +196,8 @@ a.conversation-partners:hover {
 */
 .top_left_starred_messages .count {
     background-color: transparent;
-    border-width: 1px;
-    border-style: solid;
     color: inherit;
-    padding-left: 3px;
-    padding-right: 3px;
+    padding: 2px 1px 0px 3px;
     border-color: hsl(105, 2%, 50%);
 }
 


### PR DESCRIPTION
The padding changes move the number a bit to the right and down, towards
where the bottom right corner of an unread count box would have been. This
makes the number look better aligned with the unread count boxes above it.

![image](https://user-images.githubusercontent.com/890911/52665409-5e2b3800-2ec0-11e9-800b-8ed151edf99b.png)

![image](https://user-images.githubusercontent.com/890911/52665427-697e6380-2ec0-11e9-8ddc-e08cb21b6ae5.png)

![image](https://user-images.githubusercontent.com/890911/52665464-7dc26080-2ec0-11e9-8bb8-f96c6103d713.png)

![image](https://user-images.githubusercontent.com/890911/52665491-8e72d680-2ec0-11e9-9a60-d921421a4118.png)

@showell fyi.

Ideally I'd be able to move the number up by .5 pixel, but I think that's not possible?