### PR TITLE
[WIP] Added-subTest-in-BugdownTest,RealmAPITest,PermissionTest

### DIFF
--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -302,8 +302,9 @@ class BugdownTest(ZulipTestCase):
             else:
                 converted = bugdown_convert(test['input'])
 
-            print("Running Bugdown test %s" % (name,))
-            self.assertEqual(converted, test['expected_output'])
+            with self.subTest(markdown_test_case=name):
+                print("Running Bugdown test %s" % (name,))
+                self.assertEqual(converted, test['expected_output'])
 
         def replaced(payload: str, url: str, phrase: str='') -> str:
             target = " target=\"_blank\""

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -540,7 +540,8 @@ class RealmAPITest(ZulipTestCase):
     @slow("Tests a dozen properties in a loop")
     def test_update_realm_properties(self) -> None:
         for prop in Realm.property_types:
-            self.do_test_realm_update_api(prop)
+            with self.subTest(property=prop):
+                self.do_test_realm_update_api(prop)
 
     def test_update_realm_allow_message_editing(self) -> None:
         """Tests updating the realm property 'allow_message_editing'."""

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -360,7 +360,8 @@ class PermissionTest(ZulipTestCase):
 
         cordelia = self.example_user("cordelia")
         for field_dict in cordelia.profile_data:
-            self.assertEqual(field_dict['value'], fields[field_dict['name']])  # type: ignore # Reason in comment
+            with self.subTest(field_name=field_dict['name']):
+                self.assertEqual(field_dict['value'], fields[field_dict['name']])  # type: ignore # Reason in comment
             # Invalid index type for dict key, it must be str but field_dict values can be anything
 
         # Test admin user cannot set invalid profile data
@@ -416,7 +417,8 @@ class PermissionTest(ZulipTestCase):
                                    {'profile_data': ujson.dumps(empty_profile_data)})
         self.assert_json_success(result)
         for field_dict in cordelia.profile_data:
-            self.assertEqual(field_dict['value'], None)
+            with self.subTest(field_name=field_dict['name']):
+                self.assertEqual(field_dict['value'], None)
 
         # Test adding some of the field values after removing all.
         hamlet = self.example_user("hamlet")
@@ -443,7 +445,8 @@ class PermissionTest(ZulipTestCase):
                                    {'profile_data': ujson.dumps(new_profile_data)})
         self.assert_json_success(result)
         for field_dict in cordelia.profile_data:
-            self.assertEqual(field_dict['value'], new_fields[str(field_dict['name'])])
+            with self.subTest(field_name=field_dict['name']):
+                self.assertEqual(field_dict['value'], new_fields[str(field_dict['name'])])
 
     def test_non_admin_user_cannot_change_profile_data(self) -> None:
         self.login(self.example_email("cordelia"))


### PR DESCRIPTION
In This PR I have changed the following tests :- 
1. BugdownTest - test_bugdown_fixtures
2. PermissionTest - test_admin_user_can_change_profile_data
3. RealmAPITest - test_update_realm_properties
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#11070 

**Testing Plan:** <!-- How have you tested? -->
I have changed the output and then checked it on terminal by running the particular test.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![zulip issue 11070 - 1](https://user-images.githubusercontent.com/32800267/52667928-32e42f80-2f38-11e9-9503-822c479d6d7c.png)
![zulip issue 11070 - 2](https://user-images.githubusercontent.com/32800267/52667936-35df2000-2f38-11e9-9f5a-163ebaeaa4a2.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
