### PR TITLE
markdown: Handle multiple python regex capture groups properly.

### DIFF
--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -519,6 +519,11 @@ run_test('python_to_js_filter', () => {
     var actual_value = marked.InlineLexer.rules.zulip.realm_filters;
     var expected_value = [/\/aa\/g(?![\w])/gim, /\/aa\/g(?![\w])/g];
     assert.deepEqual(actual_value, expected_value);
+    // Test case with multiple replacements.
+    markdown.set_realm_filters([['#cf(?P<contest>[0-9]+)(?P<problem>[A-Z][0-9A-Z]*)', 'http://google.com']]);
+    actual_value = marked.InlineLexer.rules.zulip.realm_filters;
+    expected_value = [/#cf([0-9]+)([A-Z][0-9A-Z]*)(?![\w])/g];
+    assert.deepEqual(actual_value, expected_value);
 });
 
 run_test('katex_throws_unexpected_exceptions', () => {

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -524,6 +524,14 @@ run_test('python_to_js_filter', () => {
     actual_value = marked.InlineLexer.rules.zulip.realm_filters;
     expected_value = [/#cf([0-9]+)([A-Z][0-9A-Z]*)(?![\w])/g];
     assert.deepEqual(actual_value, expected_value);
+    // Test incorrect syntax.
+    blueslip.set_test_data('warn', 'python_to_js_filter: Invalid regular expression: /!@#@(!#&((!&(@#((?![\\w])/: Unterminated group');
+    markdown.set_realm_filters([['!@#@(!#&((!&(@#(', 'http://google.com']]);
+    actual_value = marked.InlineLexer.rules.zulip.realm_filters;
+    expected_value = [];
+    assert.deepEqual(actual_value, expected_value);
+    assert(blueslip.get_test_logs('warn').length, 1);
+    blueslip.clear_test_data();
 });
 
 run_test('katex_throws_unexpected_exceptions', () => {

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -246,6 +246,8 @@ function python_to_js_filter(pattern, url) {
         // Replace named reference in url to numbered reference
         url = url.replace('%(' + name + ')s', '\\' + current_group);
 
+        // Reset the RegExp state
+        named_group_re.lastIndex = 0;
         match = named_group_re.exec(pattern);
 
         current_group += 1;

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -277,7 +277,16 @@ function python_to_js_filter(pattern, url) {
     // message is rendered on the backend which has proper support
     // for negative lookbehind.
     pattern = pattern + /(?![\w])/.source;
-    return [new RegExp(pattern, js_flags), url];
+    var final_regex = null;
+    try {
+        final_regex = new RegExp(pattern, js_flags);
+    } catch (ex) {
+        // We have an error in the generated regex syntax.
+        // We'll ignore this realm filter for now, but log
+        // this failure for debugging later.
+        blueslip.warn('python_to_js_filter: ' + ex.message);
+    }
+    return [final_regex, url];
 }
 
 exports.set_realm_filters = function (realm_filters) {
@@ -290,6 +299,9 @@ exports.set_realm_filters = function (realm_filters) {
         var pattern = realm_filter[0];
         var url = realm_filter[1];
         var js_filters = python_to_js_filter(pattern, url);
+        if (!js_filters[0]) {
+            return;
+        }
 
         realm_filter_map[js_filters[0]] = js_filters[1];
         realm_filter_list.push([js_filters[0], js_filters[1]]);


### PR DESCRIPTION
Since on replacing the first 'P<>' group, we remove this text from
the string, we have to make the RegExp start looking from index 0
again to properly convert later 'P<>' groups to JS regex syntax.

**Testing Plan:** <!-- How have you tested? -->
Adds automated test.

This PR extends #11527.
