### PR TITLE
user status: Change last seen to "recently" when "away" status is set.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -80,6 +80,9 @@ function load_medium_avatar(user, elt) {
 function user_last_seen_time_status(user_id) {
     var status = presence.get_status(user_id);
     if (status === "active") {
+        if (user_status.is_away(user_id)) {
+            return i18n.t("Recently");
+        }
         return i18n.t("Active now");
     }
 


### PR DESCRIPTION
Previously, even if the user has explicitly set "away" status, last
scene status still displayed "Active now". This changes the display
text to "Recently" when status is "away".

![screenshot 2019-02-13 at 2 42 30 am](https://user-images.githubusercontent.com/33068691/52668238-067ce300-2f39-11e9-9923-772a7d152041.png)
