### PR TITLE
push notif: Unconditionally remove notifications on message read.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -585,15 +585,6 @@ def handle_remove_push_notification(user_profile_id: int, message_id: int) -> No
     user_profile = get_user_profile_by_id(user_profile_id)
     message, user_message = access_message(user_profile, message_id)
 
-    if not settings.SEND_REMOVE_PUSH_NOTIFICATIONS:
-        # It's a little annoying that we duplicate this flag-clearing
-        # code (also present below), but this block is scheduled to be
-        # removed in a few weeks, once the app has supported the
-        # feature for long enough.
-        user_message.flags.active_mobile_push_notification = False
-        user_message.save(update_fields=["flags"])
-        return
-
     gcm_payload = get_common_payload(message)
     gcm_payload.update({
         'event': 'remove',

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -712,7 +712,6 @@ class HandlePushNotificationTest(PushNotificationTest):
             mock_send_android.assert_called_with(android_devices, {'gcm': True}, {'priority': 'high'})
             mock_push_notifications.assert_called_once()
 
-    @override_settings(SEND_REMOVE_PUSH_NOTIFICATIONS=True)
     def test_send_remove_notifications_to_bouncer(self) -> None:
         user_profile = self.example_user('hamlet')
         message = self.get_message(Recipient.PERSONAL, type_id=1)
@@ -733,7 +732,6 @@ class HandlePushNotificationTest(PushNotificationTest):
                                                   'zulip_message_id': message.id},
                                                  {'priority': 'normal'})
 
-    @override_settings(SEND_REMOVE_PUSH_NOTIFICATIONS=True)
     def test_non_bouncer_push_remove(self) -> None:
         self.setup_apns_tokens()
         self.setup_gcm_tokens()

--- a/zerver/tests/test_unread.py
+++ b/zerver/tests/test_unread.py
@@ -482,7 +482,6 @@ class PushNotificationMarkReadFlowsTest(ZulipTestCase):
             flags=UserMessage.flags.active_mobile_push_notification).order_by(
                 "message_id").values_list("message_id", flat=True))
 
-    @override_settings(SEND_REMOVE_PUSH_NOTIFICATIONS=True)
     @mock.patch('zerver.lib.push_notifications.push_notifications_enabled', return_value=True)
     def test_track_active_mobile_push_notifications(self, mock_push_notifications: mock.MagicMock) -> None:
         mock_push_notifications.return_value = True

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -230,11 +230,6 @@ DEFAULT_SETTINGS = {
     'SEND_LOGIN_EMAILS': True,
     'EMBEDDED_BOTS_ENABLED': False,
 
-    # Temporary setting while we wait for app support for removing
-    # push notifications.  Controls whether the Zulip server sends
-    # cancellation notices for previously sent push notifications.
-    'SEND_REMOVE_PUSH_NOTIFICATIONS': False,
-
     # Two Factor Authentication is not yet implementation-complete
     'TWO_FACTOR_AUTHENTICATION_ENABLED': False,
 


### PR DESCRIPTION
The client-side fix to make these not a problem was in release
16.2.96, of 2018-08-22.  We've been sending them from the
development community server chat.zulip.org since 2018-11-29.
We started forcing clients to upgrade with commit fb7bfbe9a,
deployed 2018-12-05 to zulipchat.com.

(The mobile app unconditionally makes a request to a route on
zulipchat.com to check for this kind of forced upgrade, so that
applies to mobile users of any Zulip server.)

So at this point it's long past safe for us to unconditionally
send these.  Hardwire the old `SEND_REMOVE_PUSH_NOTIFICATIONS`
setting to True, and simplify it out.
