### PR TITLE
subs: Update Default streams data while renaming streams.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -104,6 +104,16 @@ exports.toggle_pin_to_top_stream = function (sub) {
     stream_edit.set_stream_property(sub, 'pin_to_top', !sub.pin_to_top);
 };
 
+exports.maybe_update_realm_default_stream_name  = function (stream_id, new_name) {
+    var idx = _.findIndex(page_params.realm_default_streams, function (stream) {
+        return stream.stream_id === stream_id;
+    });
+    if (idx === -1) {
+        return;
+    }
+    page_params.realm_default_streams[idx].name = new_name;
+};
+
 exports.update_stream_name = function (sub, new_name) {
     // Rename the stream internally.
     stream_data.rename_sub(sub, new_name);
@@ -111,6 +121,9 @@ exports.update_stream_name = function (sub, new_name) {
 
     // Update the left sidebar.
     stream_list.rename_stream(sub, new_name);
+
+    // Update the default streams page in organization settings.
+    exports.maybe_update_realm_default_stream_name(stream_id, new_name);
 
     // Update the stream settings
     stream_edit.update_stream_name(sub, new_name);


### PR DESCRIPTION
If a stream is a default stream, this updates its name at `Default Streams`
section of `Organization settings` page.

Fixes: #11466


**GIFs or Screenshots:** 
![feb-13-2019 18-33-54](https://user-images.githubusercontent.com/40331304/52713723-11c62200-2fbe-11e9-85ce-5bb550b0fd05.gif)
