### PR TITLE
email-log: Handle checkbox saying "Show text only version".

### DIFF
--- a/templates/zerver/email_log.html
+++ b/templates/zerver/email_log.html
@@ -9,7 +9,7 @@
         </div>
         <div style="text-align:right">
             <label>
-                <input type="checkbox" id="toggle"/>
+                <input type="checkbox" autocomplete="off" id="toggle"/>
                 <strong>Show text only version</strong>
             </label>
             <a href="#" data-toggle="modal" data-target="#forward_email_modal">


### PR DESCRIPTION
After clicking on checkbox saying "Show text only version" UI was rendered
correctly but after refreshing page keeping checkbox checked, emails were
shown without "text only version" but checkbox value remained checked.

Now after refreshing page checkbox value changes to its default value.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
