### PR TITLE
streams: Sort streams by most recent activity.

### DIFF
--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -96,6 +96,7 @@ alert_words.process_message = noop;
 zrequire('recent_senders');
 zrequire('unread');
 zrequire('topic_data');
+zrequire('stream_sort');
 
 // And finally require the module that we will test directly:
 zrequire('message_store');

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -170,7 +170,7 @@ run_test('basic_chars', () => {
 
     // Unmapped keys should immediately return false, without
     // calling any functions outside of hotkey.js.
-    assert_unmapped('abefhlmotyz');
+    assert_unmapped('abefhlmotz');
     assert_unmapped('BEFHILNOQTUWXYZ');
 
     // We have to skip some checks due to the way the code is

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -2,6 +2,7 @@ zrequire('pm_conversations');
 zrequire('util');
 zrequire('people');
 zrequire('message_store');
+zrequire('stream_sort');
 
 var noop = function () {};
 var people = global.people;

--- a/frontend_tests/node_tests/stream_sort.js
+++ b/frontend_tests/node_tests/stream_sort.js
@@ -92,4 +92,17 @@ with_overrides(function (override) {
     assert.deepEqual(sorted.pinned_streams, []);
     assert.deepEqual(sorted.normal_streams, ['fast tortoise']);
     assert.deepEqual(sorted.dormant_streams, []);
+
+    // Test sorting of streams according to recency
+    stream_sort.set_stream_latest_message_id('scalene', 1);
+    stream_sort.set_stream_latest_message_id('clarinet', 2);
+    stream_sort.set_stream_latest_message_id('fast tortoise', 3);
+    stream_sort.set_stream_latest_message_id('weaving', 4);
+    weaving.subscribed = true;
+    stream_sort.set_sort_streams_by_recency();
+    sorted = stream_sort.sort_groups("");
+    assert.deepEqual(sorted.pinned_streams, ['scalene']);
+    assert.deepEqual(sorted.normal_streams, ['weaving', 'fast tortoise', 'clarinet']);
+    assert.deepEqual(sorted.dormant_streams, ['pneumonia']);
+    weaving.subscribed = false;
 });

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -138,6 +138,8 @@ exports.edit_locally = function edit_locally(message, raw_content, new_topic) {
             topic_name: util.get_message_topic(message),
             message_id: message.id,
         });
+
+        stream_sort.set_stream_latest_message_id(message.stream, message.id);
     }
 
     if (message_content_edited) {

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -110,6 +110,7 @@ var keypress_mappings = {
     118: {name: 'show_lightbox', message_view_only: true}, // 'v'
     119: {name: 'query_users', message_view_only: false}, // 'w'
     120: {name: 'compose_private_message', message_view_only: true}, // 'x'
+    121: {name: 'recent_streams', message_view_only: false}, // 'y'
 };
 
 exports.get_keydown_hotkey = function (e) {
@@ -684,6 +685,10 @@ exports.process_hotkey = function (e, hotkey) {
         return true;
     case 'star_deprecated':
         ui.maybe_show_deprecation_notice('*');
+        return true;
+    case 'recent_streams':
+        stream_sort.set_sort_streams_by_recency();
+        stream_list.build_stream_list();
         return true;
     }
 

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -202,6 +202,8 @@ exports.update_messages = function update_messages(events) {
                     topic_name: util.get_message_topic(msg),
                     message_id: msg.id,
                 });
+
+                stream_sort.set_stream_latest_message_id(msg.stream, msg.id);
             });
         }
 

--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -143,6 +143,8 @@ exports.add_message_metadata = function (message) {
             message_id: message.id,
         });
 
+        stream_sort.set_stream_latest_message_id(message.stream, message.id);
+
         recent_senders.process_message_for_senders(message);
         break;
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Hotkey 'y' toggles this feature.

Fixes #10794.


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![peek 2019-02-13 18-54](https://user-images.githubusercontent.com/32260605/52744694-6d66ce80-3003-11e9-9590-e79fcd64c8b4.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
