### PR TITLE
Update zulip-enterprise.template.erb

### DIFF
--- a/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
+++ b/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
@@ -2,6 +2,7 @@
 <% else -%>
 server {
     listen 80;
+    listen [::]:80;
     return 301 https://$host$request_uri;
 }
 <% end -%>
@@ -13,7 +14,7 @@ server {
     listen 80;
 <% else -%>
     listen 443;
-
+    listen [::]:443 ssl http2;
     ssl on;
     ssl_certificate <%= @ssl_dir %>/certs/zulip.combined-chain.crt;
     ssl_certificate_key <%= @ssl_dir %>/private/zulip.key;


### PR DESCRIPTION
added additional listen parameters for nginx to also listen on ipv6-devices and make zulip accessible from ipv6-networks

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
