### PR TITLE
Move inline date separators from messagebox to message_row

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -355,7 +355,7 @@ on a dark background, and don't change the dark labels dark either. */
         text-shadow: none;
     }
 
-    .mention .messagebox-content {
+    .mention .messagebox {
         background-color: hsla(8, 78%, 43%, 0.15);
     }
 

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1038,6 +1038,7 @@ td.pointer {
 }
 
 .private-message .messagebox,
+.private-message .date_row,
 .message_header_private_message .message-header-contents {
     background-color: hsla(192, 19%, 75%, 0.2);
     box-shadow: inset 1px 1px 0px hsl(0, 0%, 88%);
@@ -1047,7 +1048,7 @@ td.pointer {
     border-right: 1px solid hsl(0, 0%, 88%);
 }
 
-.mention .messagebox-content {
+.mention .messagebox {
     background-color: hsl(8, 94%, 94%);
 }
 
@@ -2653,7 +2654,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
 .sub-unsub-message,
 .date_row {
     text-align: center;
-    margin-bottom: 10px;
+    padding-bottom: 10px;
 }
 
 .date_row .date-direction {
@@ -2673,7 +2674,6 @@ div.topic_edit_spinner .loading_indicator_spinner {
 .sub-unsub-message span,
 .date_row span {
     display: block;
-    background: inherit;
     padding: 4px;
     overflow: hidden;
     text-transform: uppercase;

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -728,14 +728,6 @@ td.pointer {
     top: -3px;
 }
 
-.message_data {
-    vertical-align: top;
-    text-align: left;
-    padding: 0px;
-    background-color: hsl(0, 0%, 100%);
-    position: relative;
-}
-
 .message_header {
     vertical-align: middle;
     text-align: left;
@@ -1520,14 +1512,6 @@ blockquote p {
 .bookend {
     margin-top: 10px;
     background-color: transparent;
-}
-
-.prev_is_same_sender.messagebox {
-    padding-top: 0px;
-}
-
-.prev_is_same_sender.message_data {
-    padding-top: 0px;
 }
 
 .next_is_same_sender {

--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -2,7 +2,7 @@
   class="message_row{{^msg/is_stream}} private-message{{/msg/is_stream}}{{#include_sender}} include-sender{{/include_sender}}{{#contains_mention}} mention{{/contains_mention}}{{#include_footer}} last_message{{/include_footer}}{{#msg.unread}} unread{{/msg.unread}} {{#if msg.locally_echoed}}local{{/if}} selectable_row"
   role="listitem">
     <div class="unread_marker"><div class="unread-marker-fill"></div></div>
-    <div class="messagebox{{^include_sender}} prev_is_same_sender{{/include_sender}}{{^msg/is_stream}} private-message{{/msg/is_stream}} {{#if next_is_same_sender}}next_is_same_sender{{/if}}"
+    <div class="messagebox{{^msg/is_stream}} private-message{{/msg/is_stream}} {{#if next_is_same_sender}}next_is_same_sender{{/if}}"
       style="box-shadow: inset 2px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}}, -1px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}};">
         {{#if want_date_divider}}
         <div class="date_row no-select">{{{date_divider_html}}}</div>

--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -2,11 +2,11 @@
   class="message_row{{^msg/is_stream}} private-message{{/msg/is_stream}}{{#include_sender}} include-sender{{/include_sender}}{{#contains_mention}} mention{{/contains_mention}}{{#include_footer}} last_message{{/include_footer}}{{#msg.unread}} unread{{/msg.unread}} {{#if msg.locally_echoed}}local{{/if}} selectable_row"
   role="listitem">
     <div class="unread_marker"><div class="unread-marker-fill"></div></div>
+    {{#if want_date_divider}}
+    <div class="date_row no-select" style="box-shadow: inset 2px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}}, -1px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}};">{{{date_divider_html}}}</div>
+    {{/if}}
     <div class="messagebox{{^msg/is_stream}} private-message{{/msg/is_stream}} {{#if next_is_same_sender}}next_is_same_sender{{/if}}"
       style="box-shadow: inset 2px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}}, -1px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}};">
-        {{#if want_date_divider}}
-        <div class="date_row no-select">{{{date_divider_html}}}</div>
-        {{/if}}
         <div class="messagebox-border">
             <div class="messagebox-content">
                 <div class="message_top_line">


### PR DESCRIPTION
Fixes border-related glitches introduced by commit 51c6c82003b0428f887bbf3c8d6cf79abc0e333d (#10820).  Alternative to #11534.