### PR TITLE
push notif: Don't forget to clear "active" flag on sending to bouncer.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -620,13 +620,11 @@ def handle_remove_push_notification(user_profile_id: int, message_id: int) -> No
                 logger.warning(
                     "Maximum retries exceeded for trigger:%s event:push_notification" % (
                         event['user_profile_id']))
-        return
-
-    android_devices = list(PushDeviceToken.objects.filter(user=user_profile,
-                                                          kind=PushDeviceToken.GCM))
-
-    if android_devices:
-        send_android_push_notification(android_devices, gcm_payload, gcm_options)
+    else:
+        android_devices = list(PushDeviceToken.objects.filter(
+            user=user_profile, kind=PushDeviceToken.GCM))
+        if android_devices:
+            send_android_push_notification(android_devices, gcm_payload, gcm_options)
 
     user_message.flags.active_mobile_push_notification = False
     user_message.save(update_fields=["flags"])


### PR DESCRIPTION
Since da8f4bc0e back in August, this control flow has caused
`flags.active_mobile_push_notification` to be cleared if we don't send
these `remove` messages at all, and if we send them directly to GCM...
but not if we send them via the Zulip notification bouncer.

As a result, on a server configured to send `remove` notification-messages
via the bouncer, we accumulate "active" messages and never clear them.

If the user then does `mark_all_as_read`, we end up sending a `remove`
for each of those messages again, and all in one giant burst.  We've
seen puzzling bursts of hundreds of removals pass through the bouncer
since turning on removals on chat.zulip.org; it's likely many of them
are caused by this bug.

This issue was made more acute with f4478aad5, which unconditionally
enabled removals.
