### PR TITLE
push notif: Send a batch of message IDs in one `remove` payload.

### DIFF
--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -555,6 +555,26 @@ def bulk_access_messages(user_profile: UserProfile, messages: Sequence[Message])
             filtered_messages.append(message)
     return filtered_messages
 
+def bulk_access_messages_expect_usermessage(
+        user_profile_id: int, message_ids: Sequence[int]) -> List[int]:
+    '''
+    Like bulk_access_messages, but faster and potentially stricter.
+
+    Returns a subset of `message_ids` containing only messages the
+    user can access.  Makes O(1) database queries.
+
+    Use this function only when the user is expected to have a
+    UserMessage row for every message in `message_ids`.  If a
+    UserMessage row is missing, the message will be omitted even if
+    the user has access (e.g. because it went to a public stream.)
+
+    See also: `access_message`, `bulk_access_messages`.
+    '''
+    return UserMessage.objects.filter(
+        user_profile_id=user_profile_id,
+        message_id__in=message_ids,
+    ).values_list('message_id', flat=True)
+
 def render_markdown(message: Message,
                     content: str,
                     realm: Optional[Realm]=None,

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -584,8 +584,10 @@ def get_message_payload_apns(user_profile: UserProfile, message: Message) -> Dic
     }
     return apns_data
 
-def get_message_payload_gcm(user_profile: UserProfile, message: Message) -> Dict[str, Any]:
-    '''A `message` payload for Android, via GCM/FCM.'''
+def get_message_payload_gcm(
+        user_profile: UserProfile, message: Message,
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    '''A `message` payload + options, for Android via GCM/FCM.'''
     data = get_message_payload(message)
     content, truncated = truncate_content(get_mobile_push_content(message.rendered_content))
     data.update({
@@ -599,16 +601,20 @@ def get_message_payload_gcm(user_profile: UserProfile, message: Message) -> Dict
         'sender_full_name': message.sender.full_name,
         'sender_avatar_url': absolute_avatar_url(message.sender),
     })
-    return data
+    gcm_options = {'priority': 'high'}
+    return data, gcm_options
 
-def get_remove_payload_gcm(user_profile: UserProfile, message_id: int) -> Dict[str, Any]:
-    '''A `remove` payload for Android, via GCM/FCM.'''
+def get_remove_payload_gcm(
+        user_profile: UserProfile, message_id: int,
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    '''A `remove` payload + options, for Android via GCM/FCM.'''
     gcm_payload = get_base_payload(user_profile.realm)
     gcm_payload.update({
         'event': 'remove',
         'zulip_message_id': message_id,  # message_id is reserved for CCS
     })
-    return gcm_payload
+    gcm_options = {'priority': 'normal'}
+    return gcm_payload, gcm_options
 
 def handle_remove_push_notification(user_profile_id: int, message_id: int) -> None:
     """This should be called when a message that had previously had a
@@ -619,8 +625,7 @@ def handle_remove_push_notification(user_profile_id: int, message_id: int) -> No
     """
     user_profile = get_user_profile_by_id(user_profile_id)
     message, user_message = access_message(user_profile, message_id)
-    gcm_payload = get_remove_payload_gcm(user_profile, message_id)
-    gcm_options = {'priority': 'normal'}  # type: Dict[str, Any]
+    gcm_payload, gcm_options = get_remove_payload_gcm(user_profile, message_id)
 
     if uses_notification_bouncer():
         try:
@@ -693,8 +698,7 @@ def handle_push_notification(user_profile_id: int, missed_message: Dict[str, Any
     message.trigger = missed_message['trigger']
 
     apns_payload = get_message_payload_apns(user_profile, message)
-    gcm_payload = get_message_payload_gcm(user_profile, message)
-    gcm_options = {'priority': 'high'}  # type: Dict[str, Any]
+    gcm_payload, gcm_options = get_message_payload_gcm(user_profile, message)
     logger.info("Sending push notifications to mobile clients for user %s" % (user_profile_id,))
 
     if uses_notification_bouncer():

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -723,7 +723,7 @@ class HandlePushNotificationTest(PushNotificationTest):
         with self.settings(PUSH_NOTIFICATION_BOUNCER_URL=True), \
                 mock.patch('zerver.lib.push_notifications'
                            '.send_notifications_to_bouncer') as mock_send_android, \
-                mock.patch('zerver.lib.push_notifications.get_common_payload',
+                mock.patch('zerver.lib.push_notifications.get_base_payload',
                            return_value={'gcm': True}):
             handle_remove_push_notification(user_profile.id, message.id)
             mock_send_android.assert_called_with(user_profile.id, {},
@@ -751,7 +751,7 @@ class HandlePushNotificationTest(PushNotificationTest):
 
         with mock.patch('zerver.lib.push_notifications'
                         '.send_android_push_notification') as mock_send_android, \
-                mock.patch('zerver.lib.push_notifications.get_common_payload',
+                mock.patch('zerver.lib.push_notifications.get_base_payload',
                            return_value={'gcm': True}):
             handle_remove_push_notification(self.user_profile.id, message.id)
             mock_send_android.assert_called_with(android_devices,

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -360,7 +360,10 @@ class PushNotificationsWorker(QueueProcessingWorker):  # nocoverage
 
     def consume(self, data: Mapping[str, Any]) -> None:
         if data.get("type", "add") == "remove":
-            handle_remove_push_notification(data['user_profile_id'], data['message_id'])
+            message_ids = data.get('message_ids')
+            if message_ids is None:  # legacy task across an upgrade
+                message_ids = [data['message_id']]
+            handle_remove_push_notification(data['user_profile_id'], message_ids)
         else:
             handle_push_notification(data['user_profile_id'], data)
 

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -339,6 +339,13 @@ DEFAULT_SETTINGS.update({
     'APNS_CERT_FILE': None,
     'APNS_SANDBOX': True,
 
+    # Max number of "remove notification" FCM/GCM messages to send separately
+    # in one burst; the rest are batched.  Older clients ignore the batched
+    # portion, so only receive this many removals.  Lower values mitigate
+    # server congestion and client battery use.  To batch unconditionally,
+    # set to 1.
+    'MAX_UNBATCHED_REMOVE_NOTIFICATIONS': 10,
+
     # Limits related to the size of file uploads; last few in MB.
     'DATA_UPLOAD_MAX_MEMORY_SIZE': 25 * 1024 * 1024,
     'MAX_AVATAR_FILE_SIZE': 5,


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

When a bunch of messages with active notifications are all read at once -- e.g. by the user choosing to mark all messages, or all in a stream, as read, or just scrolling quickly through a PM conversation there can be a large batch of this information to convey.  Doing it in a single GCM/FCM message is better for server congestion, and for the device's battery.

Corresponds to zulip/zulip-mobile#3343 on the client side.

**Testing Plan:** <!-- How have you tested? -->

Needs tests, and fixups of existing tests; WIP.
