### PR TITLE
zapier_app: Support returning bot owner's subscribed streams.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1976,11 +1976,11 @@ def check_send_private_message(sender: UserProfile, client: Client,
 
     return do_send_messages([message])[0]
 
-def check_send_private_message_from_emails(
+def check_send_private_message_from_user_ids(
         sender: UserProfile, client: Client,
-        receiving_emails: Sequence[str], body: str
+        recipient_user_ids: Sequence[int], body: str
 ) -> int:
-    addressee = Addressee.for_private(receiving_emails, sender.realm)
+    addressee = Addressee.for_user_ids(recipient_user_ids, sender.realm)
     message = check_message(sender, client, addressee, body)
 
     return do_send_messages([message])[0]

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -388,9 +388,10 @@ def get_bots_backend(request: HttpRequest, user_profile: UserProfile) -> HttpRes
 
     return json_success({'bots': list(map(bot_info, bot_profiles))})
 
-@has_request_variables
-def get_members_backend(request: HttpRequest, user_profile: UserProfile,
-                        client_gravatar: bool=REQ(validator=check_bool, default=False)) -> HttpResponse:
+def do_get_members(
+        user_profile: UserProfile,
+        client_gravatar: bool=False
+) -> List[Dict[str, Any]]:
     '''
     The client_gravatar field here is set to True if clients can compute
     their own gravatars, which saves us bandwidth.  We want to eventually
@@ -448,7 +449,18 @@ def get_members_backend(request: HttpRequest, user_profile: UserProfile,
         return result
 
     members = [get_member(row) for row in query]
+    return members
 
+@has_request_variables
+def get_members_backend(request: HttpRequest, user_profile: UserProfile,
+                        client_gravatar: bool=REQ(validator=check_bool, default=False)) -> HttpResponse:
+    '''
+    The client_gravatar field here is set to True if clients can compute
+    their own gravatars, which saves us bandwidth.  We want to eventually
+    make this the default behavior, but we have old clients that expect
+    the server to compute this for us.
+    '''
+    members = do_get_members(user_profile, client_gravatar)
     return json_success({'members': members})
 
 @require_realm_admin

--- a/zerver/webhooks/zapier/fixtures/zapier_zulip_app_list_streams.json
+++ b/zerver/webhooks/zapier/fixtures/zapier_zulip_app_list_streams.json
@@ -1,0 +1,3 @@
+{
+    "type": "list_streams"
+}

--- a/zerver/webhooks/zapier/fixtures/zapier_zulip_app_list_users.json
+++ b/zerver/webhooks/zapier/fixtures/zapier_zulip_app_list_users.json
@@ -1,0 +1,3 @@
+{
+    "type": "list_users"
+}

--- a/zerver/webhooks/zapier/fixtures/zapier_zulip_app_private.json
+++ b/zerver/webhooks/zapier/fixtures/zapier_zulip_app_private.json
@@ -1,8 +1,5 @@
 {
     "type": "private",
     "content": "Sample content for private huddle message",
-    "to": [
-        "iago@zulip.com",
-        "cordelia@zulip.com"
-    ]
+    "to": [5, 3]
 }

--- a/zerver/webhooks/zapier/tests.py
+++ b/zerver/webhooks/zapier/tests.py
@@ -47,6 +47,24 @@ class ZapierZulipAppTests(WebhookTestCase):
         expected = set(['Verona', 'Venice', 'Scotland', 'Rome', 'Denmark'])
         self.assertEqual(set(json_result['streams']), expected)
 
+    def test_list_users(self) -> None:
+        payload = self.get_body('zapier_zulip_app_list_users')
+        headers = {'HTTP_USER_AGENT': 'ZapierZulipApp'}
+        result = self.client_post(self.url, payload,
+                                  content_type='application/json',
+                                  **headers)
+        json_result = self.assert_json_success(result)
+        expected = [
+            'Welcome Bot', 'Cordelia Lear',
+            'Othello, the Moor of Venice', 'Zulip New User Bot',
+            'Zoe', 'Prospero from The Tempest', 'Nagios Receive Bot',
+            'Iago', 'King Hamlet', 'Polonius', 'Zulip Webhook Bot',
+            'Zulip Default Bot', 'Email Gateway', 'Zulip Feedback Bot',
+            'aaron', 'Zulip Error Bot', 'Notification Bot',
+            'Outgoing Webhook', 'Nagios Send Bot'
+        ]
+        self.assertEqual(set(json_result['users'].values()), set(expected))
+
     def test_stream(self) -> None:
         expected_topic = u"Sample message from Zapier!"
         expected_message = u"Hi! I am a new sample message from Zapier!"

--- a/zerver/webhooks/zapier/tests.py
+++ b/zerver/webhooks/zapier/tests.py
@@ -37,6 +37,16 @@ class ZapierZulipAppTests(WebhookTestCase):
         self.assertEqual(json_result['bot_email'], 'webhook-bot@zulip.com')
         self.assertIn('bot_id', json_result)
 
+    def test_list_streams(self) -> None:
+        payload = self.get_body('zapier_zulip_app_list_streams')
+        headers = {'HTTP_USER_AGENT': 'ZapierZulipApp'}
+        result = self.client_post(self.url, payload,
+                                  content_type='application/json',
+                                  **headers)
+        json_result = self.assert_json_success(result)
+        expected = set(['Verona', 'Venice', 'Scotland', 'Rome', 'Denmark'])
+        self.assertEqual(set(json_result['streams']), expected)
+
     def test_stream(self) -> None:
         expected_topic = u"Sample message from Zapier!"
         expected_message = u"Hi! I am a new sample message from Zapier!"

--- a/zerver/webhooks/zapier/view.py
+++ b/zerver/webhooks/zapier/view.py
@@ -4,7 +4,7 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
 
 from zerver.decorator import api_key_only_webhook_view
-from zerver.lib.actions import check_send_private_message_from_emails, \
+from zerver.lib.actions import check_send_private_message_from_user_ids, \
     do_get_streams
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_error, json_success
@@ -53,7 +53,7 @@ def api_zapier_webhook(request: HttpRequest, user_profile: UserProfile,
                 payload['topic'], payload['content']
             )
         elif event_type == 'private':
-            check_send_private_message_from_emails(
+            check_send_private_message_from_user_ids(
                 user_profile, request.client,
                 payload['to'], payload['content']
             )

--- a/zerver/webhooks/zapier/view.py
+++ b/zerver/webhooks/zapier/view.py
@@ -1,15 +1,22 @@
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
 
 from zerver.decorator import api_key_only_webhook_view
-from zerver.lib.actions import check_send_private_message_from_emails
+from zerver.lib.actions import check_send_private_message_from_emails, \
+    do_get_streams
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_error, json_success
 from zerver.lib.webhooks.common import check_send_webhook_message, \
     validate_extract_webhook_http_header
 from zerver.models import UserProfile
+
+def get_available_streams_for_bot_owner(bot: UserProfile) -> List[str]:
+    assert bot.bot_owner is not None
+    streams = do_get_streams(bot.bot_owner)
+    stream_names = [s['name'] for s in streams]
+    return stream_names
 
 @api_key_only_webhook_view('Zapier', notify_bot_owner_on_invalid_json=False)
 @has_request_variables
@@ -41,6 +48,12 @@ def api_zapier_webhook(request: HttpRequest, user_profile: UserProfile,
                 user_profile, request.client,
                 payload['to'], payload['content']
             )
+        elif event_type == 'list_streams':
+            # The list of stream names is used to pre-populate input fields
+            # in Zapier's UI
+            return json_success({
+                'streams': get_available_streams_for_bot_owner(user_profile)
+            })
 
         return json_success()
 

--- a/zerver/webhooks/zapier/view.py
+++ b/zerver/webhooks/zapier/view.py
@@ -11,12 +11,21 @@ from zerver.lib.response import json_error, json_success
 from zerver.lib.webhooks.common import check_send_webhook_message, \
     validate_extract_webhook_http_header
 from zerver.models import UserProfile
+from zerver.views.users import do_get_members
 
 def get_available_streams_for_bot_owner(bot: UserProfile) -> List[str]:
     assert bot.bot_owner is not None
     streams = do_get_streams(bot.bot_owner)
     stream_names = [s['name'] for s in streams]
     return stream_names
+
+def get_all_users(user_profile: UserProfile) -> Dict[str, Any]:
+    members = do_get_members(user_profile)
+    # The format raw:label is what Zapier expects, where `raw` (user ID)
+    # is the value associated with the `label` (name of user) that the
+    # message will be sent to.
+    result = {member['user_id']: member['full_name'] for member in members}
+    return result
 
 @api_key_only_webhook_view('Zapier', notify_bot_owner_on_invalid_json=False)
 @has_request_variables
@@ -53,6 +62,12 @@ def api_zapier_webhook(request: HttpRequest, user_profile: UserProfile,
             # in Zapier's UI
             return json_success({
                 'streams': get_available_streams_for_bot_owner(user_profile)
+            })
+        elif event_type == 'list_users':
+            # The list of users is used to pre-populate input fields in
+            # Zapier's UI
+            return json_success({
+                'users': get_all_users(user_profile)
             })
 
         return json_success()


### PR DESCRIPTION
This list of stream names is used to pre-populate input fields in
Zapier's UI for configuring a stream message.

@timabbott: FYI :) I had a chat with @rishig about whether we should cache the results of such a query. This query would only be performed once per Zap-setup, so Rishi and I concluded that caching wouldn't be necessary in this case.