### PR TITLE
search: Update styling and text for no search results.

### DIFF
--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -755,9 +755,10 @@ function show_search_query() {
     var query_words = search_query.split(" ");
 
     var search_string_display = $("#empty_search_stop_words_string");
+    var query_contains_stop_words = false;
 
-    // Removes previous search_string if any and resets display to only "Searched for:".
-    search_string_display.text(i18n.t("Searched for:"));
+    // Also removes previous search_string if any
+    search_string_display.text(i18n.t("You searched for:"));
 
     _.each(query_words, function (query_word) {
         search_string_display.append(' ');
@@ -766,11 +767,17 @@ function show_search_query() {
         if (_.contains(page_params.stop_words, query_word)) {
             // stop_words do not need sanitization so this is unnecesary but it is fail-safe.
             search_string_display.append($('<del>').text(query_word));
+            query_contains_stop_words = true;
         } else {
             // We use .text("...") to sanitize the user-given query_string.
             search_string_display.append($('<span>').text(query_word));
         }
     });
+
+    if (query_contains_stop_words) {
+        search_string_display.html(i18n.t(
+            "Some common words were excluded from your search.") + "<br/>" + search_string_display.html());
+    }
 }
 
 function pick_empty_narrow_banner() {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2061,17 +2061,6 @@ nav a .no-style {
     }
 }
 
-.empty_search_text {
-    span {
-        color: hsl(200, 100%, 40%);
-        font-weight: bold;
-    }
-    del {
-        color: hsl(200, 100%, 40%);
-        font-weight: normal;
-    }
-}
-
 div.floating_recipient {
     border-collapse: separate;
     width: 100%;

--- a/templates/zerver/app/home.html
+++ b/templates/zerver/app/home.html
@@ -142,8 +142,8 @@
         </p>
     </div>
     <div id="empty_search_narrow_message" class="empty_feed_notice">
-        <h5><span id="empty_search_stop_words_string" class="empty_search_text"></span></h5>
-        <h4>{{ _('Nobody has talked about that yet!') }}</h4>
+        <h4>{{ _('No search results') }}</h4>
+        <p><span id="empty_search_stop_words_string" class="empty_search_text"></span></p>
     </div>
     <div class="message_table focused_table" id="zhome" role="list" aria-live="polite" aria-label="{{ _('Messages') }}">
     </div>


### PR DESCRIPTION
Changed `<h5>` to `<p>`, and removed the special formatting of
`.empty_search_text` to make this more in line with the formatting we
generally use with empty narrows.

New:
![image](https://user-images.githubusercontent.com/890911/52766824-439ab100-2fdd-11e9-9973-a239105d7759.png)

![image](https://user-images.githubusercontent.com/890911/52766837-557c5400-2fdd-11e9-9262-164206e3fd6c.png)

Old:
![image](https://user-images.githubusercontent.com/890911/52766876-76dd4000-2fdd-11e9-9160-2b5f481b1806.png)


![image](https://user-images.githubusercontent.com/890911/52766855-65943380-2fdd-11e9-837a-7818fd8a6c02.png)

Travis failure seems unrelated.