### PR TITLE
Invitations: Improve experience around reactivating users.

### DIFF
--- a/static/js/invite.js
+++ b/static/js/invite.js
@@ -70,14 +70,35 @@ function submit_invitation_form() {
                 // Some users were not invited.
                 var invitee_emails_errored = [];
                 var error_list = [];
+                var is_invitee_deactivated = false;
+
                 arr.errors.forEach(function (value) {
                     error_list.push(value.join(': '));
+                    if (value[1] === "Account has been deactivated.") {
+                        is_invitee_deactivated = true;
+                    }
                     invitee_emails_errored.push(value[0]);
                 });
+
+                // The non_admin_error is the error which has to be sent when a non_admin
+                // is trying to invite a deactivated user. admin_error is the error which
+                // has to be sent when a admin is trying to invite a deactivated user.
+                // is_invitee_deactivated is used to check if the invitee is deactivated
+                // or not. check_if_admin is used to check if the user is a admin or not.
+                var non_admin_error = i18n.t('Organization administrators can reactivate deactivated users.');
+                var admin_error = i18n.t('You can reactivate deactivated users from <a href="#organization/deactivated-users-admin"> organization settings.</a>');
+                var check_if_admin = false;
+                if (page_params.is_admin) {
+                    check_if_admin = true;
+                }
 
                 var error_response = templates.render("invitation_failed_error", {
                     error_message: arr.msg,
                     error_list: error_list,
+                    admin_error: admin_error,
+                    non_admin_error: non_admin_error,
+                    check_if_admin: check_if_admin,
+                    is_invitee_deactivated: is_invitee_deactivated,
                 });
                 ui_report.message(error_response, invite_status, "alert-warning");
                 invitee_emails_group.addClass('warning');

--- a/static/templates/invitation_failed_error.handlebars
+++ b/static/templates/invitation_failed_error.handlebars
@@ -4,3 +4,10 @@
     <li>{{this}}</li>
     {{/each}}
 </ul>
+{{#if is_invitee_deactivated}}
+    {{#if check_if_admin}}
+    <p>{{{admin_error}}}</p>
+    {{else}}
+    <p>{{non_admin_error}}</p>
+    {{/if}}
+{{/if}}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Invitations: Improve experience around reactivating users. #8144

**Testing Plan:** <!-- How have you tested? -->

First,deactivate a user and log in as admin and try to invite the same user and then login as a user and try to invite the deactivated user.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
If the logged in person is an admin and Aaron has been deactivated then :

![admin](https://user-images.githubusercontent.com/39990232/52787136-ea855880-3082-11e9-8070-7616f78ab17d.jpg)

If the logged in person is a user then:

![not_admin](https://user-images.githubusercontent.com/39990232/52787144-f2dd9380-3082-11e9-934e-1e25410cd5f8.jpg)





<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
