### PR TITLE
emoji: Fix traceback on opening emoji popover in quick succession.

### DIFF
--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -591,9 +591,10 @@ exports.render_emoji_popover = function (elt, id) {
     });
     elt.popover("show");
     elt.prop("title", i18n.t("Add emoji reaction (:)"));
-    $('.emoji-popover-filter').focus();
-    ui.set_up_scrollbar($(".emoji-popover-emoji-map"));
-    ui.set_up_scrollbar($(".emoji-search-results-container"));
+    var popover = elt.data('popover').$tip;
+    popover.find('.emoji-popover-filter').focus();
+    ui.set_up_scrollbar(popover.find(".emoji-popover-emoji-map"));
+    ui.set_up_scrollbar(popover.find(".emoji-search-results-container"));
     current_message_emoji_popover_elem = elt;
 
     emoji_catalog_last_coordinates = {
@@ -602,7 +603,6 @@ exports.render_emoji_popover = function (elt, id) {
     };
     show_emoji_catalog();
 
-    var popover = elt.data('popover').$tip;
     refill_section_head_offsets(popover);
     register_popover_events(popover);
 };


### PR DESCRIPTION
Since the bootstrap popovers are destroyed asynchronously so opening
a emoji popover in quick succession like by clicking the reaction
button on another message was causing a race condition which was
causing some operations to be applied on a destroyed emoji popover.
This commit fixes it by making sure to apply any operations on the
currently active popover.

Fixes: #9851.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
