### PR TITLE
topic edit: Topic editing when propagate mode is change all.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -169,6 +169,11 @@ exports.save = function (row, from_topic_edited_only) {
             request.propagate_mode = selected_topic_propagation;
         }
         changed = true;
+        var top_target_message = current_msg_list.get_first_message_of_stream_topic(
+            message.stream,
+            message.topic
+        );
+        request.client_oldest_message_id = top_target_message.id;
     }
 
     if (new_content !== message.raw_content && !from_topic_edited_only) {

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -435,6 +435,10 @@ exports.MessageList.prototype = {
     get_last_message_sent_by_me: function () {
         return this.data.get_last_message_sent_by_me();
     },
+
+    get_first_message_of_stream_topic: function (stream_name, topic_name) {
+        return this.data.get_first_message_of_stream_topic(stream_name, topic_name);
+    },
 };
 
 exports.all = new exports.MessageList({

--- a/static/js/message_list_data.js
+++ b/static/js/message_list_data.js
@@ -568,6 +568,15 @@ MessageListData.prototype = {
         var msg = this._items[msg_index];
         return msg;
     },
+
+    get_first_message_of_stream_topic: function (stream_name, topic_name) {
+        var msg_index = _.findIndex(this._items, {topic: topic_name, stream: stream_name});
+        if (msg_index === -1) {
+            return;
+        }
+        var msg = this._items[msg_index];
+        return msg;
+    },
 };
 
 if (typeof module !== 'undefined') {

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4333,7 +4333,8 @@ def do_update_embedded_data(user_profile: UserProfile,
 def do_update_message(user_profile: UserProfile, message: Message, topic_name: Optional[str],
                       propagate_mode: str, content: Optional[str],
                       rendered_content: Optional[str], prior_mention_user_ids: Set[int],
-                      mention_user_ids: Set[int]) -> int:
+                      mention_user_ids: Set[int],
+                      client_oldest_message: Optional[Message]) -> int:
     """
     The main function for message editing.  A message edit event can
     modify:
@@ -4439,6 +4440,7 @@ def do_update_message(user_profile: UserProfile, message: Message, topic_name: O
                 propagate_mode=propagate_mode,
                 orig_topic_name=orig_topic_name,
                 topic_name=topic_name,
+                client_oldest_message=client_oldest_message,
             )
 
             changed_messages += messages_list

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -733,12 +733,13 @@ class EventsRegisterTest(ZulipTestCase):
         rendered_content = render_markdown(message, content)
         prior_mention_user_ids = set()  # type: Set[int]
         mentioned_user_ids = set()  # type: Set[int]
+        client_oldest_message = message
 
         events = self.do_test(
             lambda: do_update_message(self.user_profile, message, topic,
                                       propagate_mode, content, rendered_content,
-                                      prior_mention_user_ids,
-                                      mentioned_user_ids),
+                                      prior_mention_user_ids, mentioned_user_ids,
+                                      client_oldest_message),
             state_change_expected=True,
         )
         error = schema_checker('events[0]', events[0])


### PR DESCRIPTION
When user changes the topic of any message and select "Change previous and following messages to this topic", it did not change the topic of all the message, instead it changes topic of selected message and any message sent in last 2 days. This gives a broken feeling to the user.

To fix this issue, we are sending the id of the oldest message visible on the client (so far loaded on the screen which maps to "current_message_list") and has same topic and stream as the message which is currently being edited. When propagate mode is "change_all", update the topic of only those messages which are either sent after the oldest message or sent within recent 7 days.

**Testing Plan:**
Manually tested it by generating messages for past 3 months and changing topic of recent message with propagate mode 'change_all' without loading all message of that topic. Topic got changed for all messages sent in past 7 days and messages which were loaded on the client at that time.

Full discussion here -  https://chat.zulip.org/#narrow/stream/91-code-review/topic/.2311512

Fixes: #11475.