### PR TITLE
message view: Fix margin for date separator.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2661,6 +2661,10 @@ div.topic_edit_spinner .loading_indicator_spinner {
     margin-bottom: 10px;
 }
 
+.date_row {
+    margin-left: 2px;
+}
+
 .date_row .date-direction {
     display: inline-block;
     padding-right: 5px;


### PR DESCRIPTION
Without this tweak the date separator overlaps
the left borner.
