### PR TITLE
messagebox: Change alert message background to dark in night mode.

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -59,6 +59,14 @@ body.night-mode {
         color: inherit !important;
     }
 
+    .alert-msg {
+        background-color: hsl(212, 28%, 18%);
+    }
+
+    .private-message .alert-msg {
+        background-color: hsl(208, 17%, 29%);
+    }
+
     /* this one makes the border of the reactions highlighted on hovering. */
     .message_reaction:hover,
     .reaction_button:hover {


### PR DESCRIPTION
When copying a message by clicking on "copy and close" button in
message edit box an alert appears that says "Copied!"; Background
of the message is set corresponding with the day mode but not the
night mode. This changes the background of the alert message to
the dark color in night mode.

**Before**
![screenshot 2019-02-15 at 8 41 30 pm](https://user-images.githubusercontent.com/33068691/52865515-cc8f2500-3162-11e9-83ae-68341cbc4bcb.png)

**After**
![screenshot 2019-02-15 at 8 40 21 pm](https://user-images.githubusercontent.com/33068691/52865532-da44aa80-3162-11e9-8e39-d65386ac053e.png)
