### PR TITLE
refactor: Remove dead code in PM list.

### DIFF
--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -152,8 +152,6 @@ exports.rebuild_recent = function (active_conversation) {
 };
 
 exports.update_private_messages = function () {
-    exports._build_private_messages_list();
-
     if (!narrow_state.active()) {
         return;
     }


### PR DESCRIPTION
The function that was called here has no side
effects.  If you don't use its value, it's just
wasted computation.  The real action happens
in the subsequent calls to `rebuild_recent`.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
