### PR TITLE
fix: Use padding, not margin, for the date separator.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2652,7 +2652,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
 }
 
 .date_row {
-    margin-left: 2px;
+    padding-left: 2px;
 }
 
 .date_row .date-direction {


### PR DESCRIPTION
My very recent margin fix was tested on a slightly
stale version of master.

    see c7e03f9a7185bf7bbde6ea4443b2eed630f84c44

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
