### PR TITLE
alert_words: Performance improvements in looking for alert_words.

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -209,3 +209,6 @@ yamole==2.1.6
 # Needed for signing thumbnail requests so that they can be authenticated on the
 # other end.  Using a fork to eliminate a really slow pkgresources import.
 -e "git+https://github.com/zulip/libthumbor.git@60ed2431c07686a12f2770b2d852c5650f3ccfc6#egg=libthumbor==1.3.2zulip"
+
+# Needed for string matching in AlertWordProcessor
+pyahocorasick==1.4.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -119,6 +119,7 @@ prompt-toolkit==1.0.15    # via ipython
 psycopg2==2.7.7
 ptyprocess==0.6.0         # via pexpect
 py3dns==3.2.0
+pyahocorasick==1.4.0
 pyaml==18.11.0            # via moto
 pyasn1-modules==0.2.4
 pyasn1==0.4.5

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -88,6 +88,7 @@ prompt-toolkit==1.0.15    # via ipython
 psycopg2==2.7.7
 ptyprocess==0.6.0         # via pexpect
 py3dns==3.2.0
+pyahocorasick==1.4.0
 pyasn1-modules==0.2.4
 pyasn1==0.4.5
 pycparser==2.19           # via cffi

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -107,7 +107,7 @@ from zerver.models import Realm, RealmEmoji, Stream, UserProfile, UserActivity, 
     get_user_including_cross_realm, get_user_by_id_in_realm_including_cross_realm, \
     get_stream_by_id_in_realm
 
-from zerver.lib.alert_words import alert_words_in_realm
+from zerver.lib.alert_words import get_alert_word_automaton
 from zerver.lib.avatar import avatar_url, avatar_url_from_dict
 from zerver.lib.stream_recipient import StreamRecipientMap
 from zerver.lib.validator import check_widget_content
@@ -891,13 +891,13 @@ def render_incoming_message(message: Message,
                             realm: Realm,
                             mention_data: Optional[bugdown.MentionData]=None,
                             email_gateway: Optional[bool]=False) -> str:
-    realm_alert_words = alert_words_in_realm(realm)
+    realm_alert_words_automaton = get_alert_word_automaton(realm)
     try:
         rendered_content = render_markdown(
             message=message,
             content=content,
             realm=realm,
-            realm_alert_words=realm_alert_words,
+            realm_alert_words_automaton = realm_alert_words_automaton,
             user_ids=user_ids,
             mention_data=mention_data,
             email_gateway=email_gateway,

--- a/zerver/lib/alert_words.py
+++ b/zerver/lib/alert_words.py
@@ -1,8 +1,10 @@
 
 from django.db.models import Q
 from zerver.models import UserProfile, Realm
-from zerver.lib.cache import cache_with_key, realm_alert_words_cache_key
+from zerver.lib.cache import cache_with_key, realm_alert_words_cache_key, \
+    realm_alert_words_automaton_cache_key
 import ujson
+import ahocorasick
 from typing import Dict, Iterable, List
 
 @cache_with_key(realm_alert_words_cache_key, timeout=3600*24)
@@ -12,6 +14,27 @@ def alert_words_in_realm(realm: Realm) -> Dict[int, List[str]]:
     all_user_words = dict((elt['id'], ujson.loads(elt['alert_words'])) for elt in alert_word_data)
     user_ids_with_words = dict((user_id, w) for (user_id, w) in all_user_words.items() if len(w))
     return user_ids_with_words
+
+@cache_with_key(realm_alert_words_automaton_cache_key, timeout=3600*24)
+def get_alert_word_automaton(realm: Realm) -> ahocorasick.Automaton:
+    user_id_with_words = alert_words_in_realm(realm)
+    alert_word_automaton  = ahocorasick.Automaton()
+    for (user_id, alert_words) in user_id_with_words.items():
+        for alert_word in alert_words:
+            alert_word_lower = alert_word.lower()
+            if alert_word_automaton.exists(alert_word_lower):
+                (key, user_ids_for_alert_word) = alert_word_automaton.get(alert_word_lower)
+                user_ids_for_alert_word.add(user_id)
+            else:
+                alert_word_automaton.add_word(alert_word_lower, (alert_word_lower, set([user_id])))
+    alert_word_automaton.make_automaton()
+    # If the kind is not AHOCORASICK after calling make_automaton, it means there is no key present
+    # and hence we cannot call items on the automaton yet. To avoid it we return None for such cases
+    # where there is no alert-words in the realm.
+    # https://pyahocorasick.readthedocs.io/en/latest/index.html?highlight=Automaton.kind#module-constants
+    if alert_word_automaton.kind != ahocorasick.AHOCORASICK:
+        return None
+    return alert_word_automaton
 
 def user_alert_words(user_profile: UserProfile) -> List[str]:
     return ujson.loads(user_profile.alert_words)

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -414,6 +414,7 @@ def flush_user_profile(sender: Any, **kwargs: Any) -> None:
     # alert words
     if changed(['alert_words']):
         cache_delete(realm_alert_words_cache_key(user_profile.realm))
+        cache_delete(realm_alert_words_automaton_cache_key(user_profile.realm))
 
 # Called by models.py to flush various caches whenever we save
 # a Realm object.  The main tricky thing here is that Realm info is
@@ -429,10 +430,14 @@ def flush_realm(sender: Any, **kwargs: Any) -> None:
         cache_delete(active_user_ids_cache_key(realm.id))
         cache_delete(bot_dicts_in_realm_cache_key(realm))
         cache_delete(realm_alert_words_cache_key(realm))
+        cache_delete(realm_alert_words_automaton_cache_key(realm))
         cache_delete(active_non_guest_user_ids_cache_key(realm.id))
 
 def realm_alert_words_cache_key(realm: 'Realm') -> str:
     return "realm_alert_words:%s" % (realm.string_id,)
+
+def realm_alert_words_automaton_cache_key(realm: 'Realm') -> str:
+    return "realm_alert_words_automaton:%s" % (realm.string_id,)
 
 # Called by models.py to flush the stream cache whenever we save a stream
 # object.

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -21,7 +21,7 @@ from zerver.lib.bulk_create import bulk_create_users
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.export import DATE_FIELDS, \
     Record, TableData, TableName, Field, Path
-from zerver.lib.message import do_render_markdown, RealmAlertWords
+from zerver.lib.message import do_render_markdown
 from zerver.lib.bugdown import version as bugdown_version, convert as bugdown_convert
 from zerver.lib.upload import random_name, sanitize_name, \
     guess_type, BadImageError
@@ -256,14 +256,14 @@ def fix_message_rendered_content(realm: Realm,
             # We don't handle alert words on import from third-party
             # platforms, since they generally don't have an "alert
             # words" type feature, and notifications aren't important anyway.
-            realm_alert_words = dict()  # type: RealmAlertWords
+            realm_alert_words_automaton = None
             message_user_ids = set()  # type: Set[int]
 
             rendered_content = do_render_markdown(
                 message=cast(Message, message_object),
                 content=content,
                 realm=realm,
-                realm_alert_words=realm_alert_words,
+                realm_alert_words_automaton=realm_alert_words_automaton,
                 message_user_ids=message_user_ids,
                 sent_by_bot=sent_by_bot,
                 translate_emoticons=translate_emoticons,


### PR DESCRIPTION
This commit leverages the ahocorasick algorithm to build a set of user_ids
that have their alert_words present in the message. It runs in linear time of
the order of length of the input message as opposed to number of alert_words.
This is after building a ahocorasick Automaton which runs in O(number of alert_words in entire realm)
which is usually cached.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Motivation and Implementation**
Currently the logic for finding alert-words in the message content include iterating over the entire alert-words in the realm multiple times i.e.) once to building `possible_words` and another time to check if the each of the `possible_words` is present in the message content. 

The runtime complexity of this is `O(number of words per user * number of users in a realm)` which keeps going up with increase in the users in the realm. 

Using [Aho-Corasick](https://en.wikipedia.org/wiki/Aho%E2%80%93Corasick_algorithm) algorithm we will be able to do this with a runtime complexity of `O(length of the message content)` after building the Automaton which takes time similar to building `possible_words` . The length of the message content is more or less fixed and smaller in size as opposed to the number of users which can grow as we scale. 

With is commit we can shift the runtime complexity of finding alert-words in message for the entire realm from depending on the number-of alert-words in the realm to length of the message.

I'm using a open-source python package [pyahocorasick](https://pypi.org/project/pyahocorasick/) with BSD License ( BSD-3-Clause and Public-Domain)

**Benchmarks**

I ran benchmarks by generating different number of alert-words with varying lengths of message content .I have created this large number of alert-words for a few users however this is equivalent to a larger number of users with lesser alert-words since the processing of alert-words happens after we take into account all the alert-words in the realm. 

I plotted the difference between the time taken using the regex implementation and the ahocorasick from my branch [here](https://imgur.com/a/WGTOOOb)

- For < 10 words the existing implementation does slightly better than the ahocorasick implementation (by 0.01s), due to the overhead of building the ahocorasick Automaton.
- The time taken to build the ahocorasick Automaton only takes around 0.7s on average for around 50k alert-words in realm. This slight bump in pre-processing helps us achieve linear time complexity later on. 
 - For all alert-words >10 for all varying lengths of content the ahocorasick implemntation does better than the existing implementation especially as the number of alert-words increases the time taken by the ahocorasick imlpementation remains pretty much the same. 
- We'll be able to extend this implementation to do more rules like matching opening/closing parenthesis, looking for substring etc easily without much changes.   
- Even if the time gains is minimal I feel it makes a significant impact as we add more processors to the markdown.

The code used to plot this is 
```
import matplotlib.pyplot as plt

word_counts = [2, 10, 50, 100, 200, 400, 600, 1000, 2000, 4000, 6000, 10000, 20000, 50000]
content_len = [35, 71, 129, 169, 383, 495]
build_aho = [0.020447, 0.002892, 0.003513, 0.003805, 0.004452, 0.006164, 0.013017, 0.016496, 0.024806, 0.042784, 0.071569, 0.284938, 0.234223, 0.74594]
build_regex = [0.006435, 0.003536, 0.002436, 0.002483, 0.002712, 0.005161, 0.003837, 0.00323, 0.0038, 0.004473, 0.005883, 0.00743, 0.015975, 0.026126]

render_regex = {
    2: [0.005892, 0.001907, 0.001913, 0.0026, 0.003792, 0.004224], 
    10: [0.003345, 0.001687, 0.001803, 0.001988, 0.003009, 0.003597], 
    50: [0.005937, 0.00321, 0.004728, 0.004926, 0.005838, 0.007086], 
    100: [0.010994, 0.004963, 0.004746, 0.005415, 0.012205, 0.012117],
    200: [0.024974, 0.005573, 0.007897, 0.012879, 0.018008, 0.021848], 
    400: [0.042395, 0.009812, 0.01635, 0.0182, 0.033834, 0.042116],
    600: [0.236198, 0.224675, 0.231092, 0.279574, 0.274141, 0.260315], 
    1000: [0.36318, 0.376752, 0.39425, 0.388934, 0.41369, 0.431552],
    2000: [0.722153, 0.733265, 0.7507, 0.8738, 0.889466, 0.856505], 
    4000: [1.477045, 1.460673, 1.608463, 1.608304, 1.657198, 1.708451],
    6000: [2.321693, 2.256089, 2.242533, 2.479063, 2.557636, 2.65806], 
    10000: [3.721901, 3.829667, 3.784397, 3.990301, 4.19365, 4.417512],
    20000: [7.463172, 7.506872, 7.769804, 7.816828, 8.463353, 8.690917], 
    50000: [18.545382, 18.795326, 19.23745, 20.234844, 21.262506, 21.989532]
}

render_aho = {
    2: [0.006329, 0.001723, 0.001735, 0.00195, 0.003017, 0.003363], 
    10: [0.0023, 0.001786, 0.001827, 0.001913, 0.0027, 0.00308], 
    50: [0.002272, 0.001851, 0.001926, 0.002137, 0.002944, 0.00319], 
    100: [0.002269, 0.001889, 0.001822, 0.00203, 0.002684, 0.003316], 
    200: [0.002403, 0.001651, 0.001962, 0.002053, 0.002916, 0.003215], 
    400: [0.002324, 0.00181, 0.001917, 0.002022, 0.002819, 0.003151], 
    600: [0.002432, 0.001528, 0.002005, 0.001911, 0.002929, 0.003176], 
    1000: [0.002458, 0.001748, 0.002057, 0.002246, 0.002642, 0.003164], 
    2000: [0.002259, 0.001574, 0.001721, 0.00166, 0.002294, 0.002789], 
    4000: [0.002199, 0.001641, 0.001668, 0.001788, 0.002589, 0.003142], 
    6000: [0.002635, 0.00148, 0.002044, 0.001891, 0.002638, 0.003037], 
    10000: [0.002695, 0.001518, 0.00167, 0.001917, 0.00254, 0.002788], 
    20000: [0.003481, 0.001554, 0.001851, 0.002014, 0.002651, 0.002988], 
    50000: [0.005321, 0.001839, 0.002014, 0.002219, 0.003049, 0.00341]
}

for i, v in enumerate(build_aho):
    word_count = word_counts[i]
    render_aho[word_count] = [x + v for x in render_aho[word_count]]

for i, v in enumerate(build_regex):
    word_count = word_counts[i]
    render_regex[word_count] = [x + v for x in render_regex[word_count]]

fig, ax = plt.subplots(nrows=4, ncols= 4)
index = 0
for row in ax:
    for col in row: 
        if index < len(word_counts):
            col.set_title('Alert word Count = %s' % word_counts[index])
            col.set_xlabel('message content length')
            col.set_ylabel('time taken')
            col.plot(content_len, render_aho[word_counts[index]], marker = 'o')
            col.plot(content_len, render_regex[word_counts[index]], marker = 'o', color='green')
            index += 1
fig.legend(['ahocorasick', 'regex'])

fig.delaxes(ax[3, 2])
fig.delaxes(ax[3, 3])

plt.subplots_adjust(hspace=1.3, wspace=0.4, left=0.07)
plt.show()

```
The code used to profile the ahocorasick implementation is 
```
def test_time_alert_words(self):
    current_times = defaultdict(lambda: defaultdict(float))
    build_times = []
    word_counts = [2, 10, 50, 100, 200, 400, 600, 1000, 2000, 4000, 6000, 10000, 20000, 50000]
    total_tries = 10
    content_len = []
    for word_count in word_counts:
        alert_words_for_users = {
            'hamlet': self.get_random_alert_words(word_count, 10)
        }  # type: Dict[str, List[str]]
        user_profiles = {}  # type: Dict[str, UserProfile]
        for (username, alert_words) in alert_words_for_users.items():
            user_profile = self.example_user(username)
            user_profiles.update({username: user_profile})
            do_set_alert_words(user_profile, alert_words)
        sender_user_profile = self.example_user('hamlet')
        user_ids = {user_profiles['hamlet'].id}
        msg = Message(sender=sender_user_profile, sending_client=get_client("test"))
        build_time_start = time()
        realm_alert_words_automaton = get_alert_word_automaton(sender_user_profile.realm)
        build_time_end = time()
        build_times.append(round(build_time_end - build_time_start, 6))
        def render(msg: Message, content: str) -> str:
            return render_markdown(msg,
                                content,
                                realm_alert_words_automaton=realm_alert_words_automaton,
                                user_ids={user_profile.id})
        content_strings = [
            "This is to test a empty alert words", "i.e. no user has any alert-words set",
            "And to profile how this piece of code stacks up to others ", "as opposed to regex based implementation",
            "This module is written in C. You need a C compiler installed to compile native CPython extensions. To install:"
            "you can use the Automaton class as a trie. Add some string keys and their associated value to this trie.",
            "Here we associate a tuple of (insertion index, original string) as a value to each key string we add to the trie"
        ]
        content = ""
        for content_string in content_strings:
            content = content + content_string
            render_time = 0
            for tries in range(total_tries):
                start_time = time()
                render(msg, content)
                end_time = time()
                render_time += (end_time - start_time)
            current_times[word_count][len(content)] = round(render_time / total_tries, 6)
    ordered_times = OrderedDict(sorted(current_times.items(), key = lambda k : k[0]))
    for (k, v) in ordered_times.items():
        ordered_times[k] = OrderedDict(sorted(v.items(), key = lambda k : k[0]))
        content_len = list(ordered_times[k].keys())
        ordered_times[k] = list(ordered_times[k].values())
    print(ordered_times.items())
    print(build_times)
    print(content_len)

```
And the regex based implementation(existing)
```
def test_time_alert_words(self):
    current_times = defaultdict(list)
    word_counts = [2, 10, 50, 100, 200, 400, 600, 1000, 2000, 4000, 6000, 10000, 20000, 50000]

    for word_count in word_counts:
        alert_words_for_users = {
            'hamlet': self.get_random_alert_words(word_count, 10)
        }  # type: Dict[str, List[str]]
        user_profiles = {}  # type: Dict[str, UserProfile]
        user_ids = set()  # type: Set[int]
        for (username, alert_words) in alert_words_for_users.items():
            user_profile = self.example_user(username)
            user_profiles.update({username: user_profile})
            do_set_alert_words(user_profile, alert_words)
        sender_user_profile = self.example_user('hamlet')
        user_ids = {user_profiles['hamlet'].id}
        msg = Message(sender=sender_user_profile, sending_client=get_client("test"))
        realm_alert_words = alert_words_in_realm(sender_user_profile.realm)

        def render(msg: Message, content: str) -> str:
            return render_markdown(msg,
                                content,
                                realm_alert_words=realm_alert_words,
                                user_ids={user_profile.id})
        content_strings = [
            "This is to test a empty alert words", "i.e. no user has any alert-words set",
            "And to profile how this piece of code stacks up to others ", "as opposed to regex based implementation",
            "This module is written in C. You need a C compiler installed to compile native CPython extensions. To install:"
            "you can use the Automaton class as a trie. Add some string keys and their associated value to this trie.",
            "Here we associate a tuple of (insertion index, original string) as a value to each key string we add to the trie"
        ]
        content = ""
        for content_string in content_strings:
            content = content + content_string
            start_time = time()
            render(msg, content)
            end_time = time()
            current_times[len(content)].append(end_time - start_time)
    print(sorted(current_times.items()))

```





**Testing Plan:** <!-- How have you tested? -->
- Added multiple unit tests in test_bugdown.py covering all scenarios and accented language.

