### PR TITLE
messagebox: Refactor `message_body` to introduce three column structure.

### DIFF
--- a/static/js/archive.js
+++ b/static/js/archive.js
@@ -85,12 +85,12 @@ exports.initialize = function () {
     $('.recipient_row').each(function () {
         if (prev_sender !== undefined) {
             var first_group_msg = $(this).find('.message_row').first();
-            var message_sender = first_group_msg.find('.message_sender');
+            var message_sender = first_group_msg.find('.sender_info_hover');
             if (!message_sender.find('.inline_profile_picture').length) {
                 message_sender.replaceWith(prev_sender.clone());
             }
         }
-        var all_senders = $(this).find('.message_sender').has('.inline_profile_picture');
+        var all_senders = $(this).find('.sender_info_hover').has('.inline_profile_picture');
         prev_sender = all_senders.last();
     });
 

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -261,7 +261,7 @@ function timer_text(seconds_left) {
 function edit_message(row, raw_content) {
     row.find(".message_reactions").hide();
     condense.hide_message_expander(row);
-    var content_top = row.find('.message_top_line')[0]
+    var content_top = row.find('.left-col')[0]
         .getBoundingClientRect().top;
 
     var message = current_msg_list.get(rows.id(row));

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -669,7 +669,7 @@ exports.user_info_popover_handle_keyboard = function (key) {
 
 exports.show_sender_info = function () {
     var $message = $(".selected_message");
-    var $sender = $message.find('.sender_info_hover');
+    var $sender = $message.find('.left-col');
 
     var message = current_msg_list.get(rows.id($message));
     var user = people.get_person_from_user_id(message.sender_id);

--- a/static/styles/drafts.scss
+++ b/static/styles/drafts.scss
@@ -1,3 +1,6 @@
+$draft_controls_div_width: 115px;
+$draft_message_box_width: calc(100% - #{$draft_controls_div_width});
+
 .drafts-container {
     position: relative;
     height: 95%;
@@ -100,14 +103,14 @@
     padding-top: 10px;
     padding-bottom: 10px;
     margin-left: 0px;
+    width: $draft_message_box_width;
 }
 
 .draft-row .draft-info-box .draft_controls {
-    display: inline-block;
-    position: absolute;
-    top: 9px;
-    right: -80px;
     font-size: 0.9em;
+    width: $draft_controls_div_width;
+    text-align: center;
+    padding-top: 9px;
 }
 
 .draft_controls .restore-draft {

--- a/static/styles/media.scss
+++ b/static/styles/media.scss
@@ -265,39 +265,47 @@
         top: 30px;
     }
 
-    .messagebox-content {
-        padding-right: 15px;
+    /* Message controls overlap over the message content
+    We currently have no better way to express the controls
+    in mobile view (and you don't have a mouse so hovering
+    isn't the correct UI mechanism anyway).
+    The following code makes the controls position absolute
+    until the overlap bug is resolved. */
+
+    // These dimentions should be in sync with the actual dimensions
+    $message_left_column_width: 46px;
+    $message_right_column_width: 47px + 5px; // 5px for space between message content and time
+    $message_middle_column_width: calc(100% - #{$message_left_column_width} - #{$message_right_column_width});
+
+    .messagebox-content .left-col {
+        width: $message_left_column_width;
     }
 
-    .message_time {
-        right: auto;
-        left: -3px;
+    .messagebox-content .right-col {
+        min-width: $message_right_column_width;
+    }
+
+    .messagebox-content .middle-col {
+        max-width: $message_middle_column_width;
     }
 
     .message_controls {
+        position: absolute;
         width: 56px;
-        right: -10px;
-        top: 0px;
+        z-index: 1;
+        display: inline-block;
+        top: 0;
+        right: 47px;
     }
 
     .include-sender .message_controls {
         background: none !important;
         padding: none !important;
         border: none !important;
-        top: -3px;
-    }
-
-    .message_time {
-        left: auto;
-        right: -5px;
-    }
-
-    .message_controls {
-        right: 40px;
     }
 
     .sender_name {
-        max-width: 250px;
+        max-width: 100%;
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
@@ -315,10 +323,6 @@
 
     #floating_recipient_bar {
         top: 40px;
-    }
-
-    .message_content {
-        padding-right: 50px;
     }
 }
 

--- a/static/styles/reactions.scss
+++ b/static/styles/reactions.scss
@@ -1,5 +1,4 @@
 .message_reactions {
-    padding-left: 46px;
     overflow: hidden;
 
     -webkit-user-select: none;

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1,5 +1,13 @@
 @import './reuseable_components.scss';
 
+// Width of the message box left and right columns
+// These should be in sync with ones in media.scss
+$message_left_column_width: 46px;
+// For right column the calculations are as follows:
+// 47px (timestamp) + 5px (space between right-col and message) + rest for message controls = 105px
+$message_right_column_width: 105px;
+$message_middle_column_width: calc(100% - #{$message_left_column_width} - #{$message_right_column_width});
+
 body,
 html {
     width: 100%;
@@ -557,35 +565,26 @@ td.pointer {
 .message_edit_notice {
     font-size: 10px;
     opacity: 0.5;
-    line-height: 0px;
-    text-align: right;
-    width: 45px;
-    position: absolute;
-    left: 0px;
-    top: 16px;
+    line-height: 23px;
     @include prefixed-user-select(none);
 }
 
 .include-sender .message_time {
-    top: -4px;
+    line-height: 1;
 }
 
 .message_time {
     display: block;
     font-size: 12px;
     opacity: 0.4;
-    vertical-align: middle;
     padding: 1px;
     font-weight: 400;
-    position: absolute;
-    right: -105px;
     line-height: 20px;
-    text-align: right;
     transition: background-color 1.5s ease-in, color 1.5s ease-in;
 }
 
 #message-edit-history .message_time {
-    position: static;
+    text-align: right;
 }
 
 /* The way this overrides the menus with a background-color and a high
@@ -593,13 +592,12 @@ td.pointer {
    but it works. */
 .alert-msg {
     position: absolute;
-    right: -110px;
     font-size: 14px;
     color: hsl(170, 48%, 54%);
     background-color: hsl(0, 0%, 100%);
     z-index: 999;
-    padding-left: 20px;
-    padding-right: 40px;
+    width: 100%;
+    text-align: center;
     font-weight: 400;
     display: none;
 }
@@ -612,16 +610,13 @@ td.pointer {
     top: -3px;
 }
 
-.status-time {
-    top: 8px !important;
+.include-sender .message_controls {
+    line-height: 1;
 }
 
 .message_controls {
-    display: inline-block;
-    position: absolute;
-    top: 1px;
-    right: -56px;
-    z-index: 1;
+    line-height: 22px;
+    margin-left: 5px;
 
     > div {
         opacity: 0;
@@ -696,10 +691,6 @@ td.pointer {
         opacity: 1;
         pointer-events: all;
     }
-}
-
-.include-sender .message_controls {
-    top: -3px;
 }
 
 .message_header {
@@ -1022,10 +1013,6 @@ td.pointer {
     background-color: hsl(8, 94%, 94%);
 }
 
-.messagebox .message_top_line {
-    position: relative;
-}
-
 .recipient_row .message_row:first-child .unread_marker {
     top: 0px;
 }
@@ -1077,24 +1064,17 @@ td.pointer {
         1px -1px 0px 0px hsl(215, 47%, 50%);
 }
 
-.message_sender {
-    height: 0px;
-    vertical-align: top;
-    position: relative;
-}
-
 .sender_name {
     display: inline-block;
     font-weight: 700;
     vertical-align: top;
     line-height: 12px;
     font-size: 14px;
-    margin-left: -3px;
 }
 
 .sender-status {
     display: inline-block;
-    margin: 8px 0px 8px -3px;
+    margin: 8px 0px 8px;
     /* this normalizes the margin of the emoji reactions with normal messages. */
     padding-bottom: 5px;
     vertical-align: middle;
@@ -1114,14 +1094,14 @@ td.pointer {
     color: hsl(200, 100%, 40%);
 }
 
-.message_sender i.zulip-icon.bot,
+.sender_info_hover i.zulip-icon.bot,
 .popover_info i.zulip-icon.bot {
     color: hsl(180, 5%, 74%);
     vertical-align: top;
     padding: 0 2px;
 }
 
-.message_sender i.zulip-icon.bot {
+.sender_info_hover i.zulip-icon.bot {
     font-size: 12px;
 }
 
@@ -1190,14 +1170,6 @@ a.dark_background:hover,
     color: hsl(200, 99%, 60%);
 }
 
-.message_top_line {
-    position: relative;
-}
-
-.include-sender .message_top_line {
-    margin-top: 6px;
-}
-
 .small {
     font-size: 80%;
 }
@@ -1245,14 +1217,13 @@ div.focused_table {
 }
 
 .include-sender .message_content:not(:empty) {
-    margin-top: -18px;
+    margin-top: -3px;
 }
 
 .message_content {
     line-height: 1.214;
     min-height: 17px;
     font-size: 14px;
-    margin-left: 46px;
     display: block;
     position: relative;
 }
@@ -1355,11 +1326,6 @@ div.focused_table {
     display: none;
     text-align: center;
     color: hsl(200, 100%, 40%);
-
-    /* to match .message_content */
-    margin-left: 5px;
-    margin-right: 35px;
-    /* to make message-uncollapse easier */
     margin-top: 10px;
 }
 
@@ -1376,7 +1342,42 @@ div.focused_table {
 }
 
 .messagebox-content {
-    padding: 4px 115px 1px 10px;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    box-sizing: border-box;
+    padding: 4px 10px 1px;
+}
+
+.draft-row .messagebox-content {
+    padding-right: 0;
+}
+
+#message-history .messagebox-content {
+    flex-direction: column;
+    justify-content: flex-start;
+}
+
+.include-sender .messagebox-content {
+    padding-top: 10px;
+}
+
+.messagebox-content .left-col {
+    width: $message_left_column_width;
+}
+
+.messagebox-content .right-col {
+    min-width: $message_right_column_width;
+    position: relative;
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: space-between;
+    box-sizing: border-box;
+}
+
+.messagebox-content .middle-col {
+    max-width: $message_middle_column_width;
+    flex: 1;
 }
 
 #message-edit-history .messagebox-content {
@@ -2400,14 +2401,9 @@ div.topic_edit_spinner .loading_indicator_spinner {
     margin-right: -50%;
 }
 
-.include-sender .message_edit {
-    margin-top: -14px;
-}
-
 .message_edit {
     display: none;
     margin-top: 5px;
-    margin-left: 47px;
     position: relative;
 }
 

--- a/static/templates/draft.hbs
+++ b/static/templates/draft.hbs
@@ -30,13 +30,11 @@
         <div class="message_row{{^is_stream}} private-message{{/is_stream}}" role="listitem">
             <div class="messagebox">
                 <div class="messagebox-content">
-                    <div class="message_top_line">
-                        <div class="draft_controls">
-                            <i class="fa fa-pencil fa-lg restore-draft" aria-hidden="true" data-toggle="tooltip" title="{{t 'Restore draft' }}"></i>
-                            <i class="fa fa-trash-o fa-lg delete-draft" aria-hidden="true" data-toggle="tooltip" title="{{t 'Delete draft' }} (Backspace)"></i>
-                        </div>
-                    </div>
                     <div class="message_content rendered_markdown restore-draft" data-toggle="tooltip" title="{{t 'Restore draft' }}">{{{content}}}</div>
+                    <div class="draft_controls">
+                        <i class="fa fa-pencil fa-lg restore-draft" aria-hidden="true" data-toggle="tooltip" title="{{t 'Restore draft' }}"></i>
+                        <i class="fa fa-trash-o fa-lg delete-draft" aria-hidden="true" data-toggle="tooltip" title="{{t 'Delete draft' }} (Backspace)"></i>
+                    </div>
                 </div>
             </div>
         </div>

--- a/static/templates/me_message.hbs
+++ b/static/templates/me_message.hbs
@@ -1,8 +1,4 @@
 <span class="message_sender no-select">
-    <span class="sender_info_hover">
-        {{> message_avatar}}
-    </span>
-
     <span class="sender-status">
         <span class="sender_info_hover sender_name-in-status auto-select" role="button" tabindex="0">{{msg/sender_full_name}}</span>
         {{#if sender_is_bot}}

--- a/static/templates/message_body.hbs
+++ b/static/templates/message_body.hbs
@@ -1,51 +1,57 @@
-<div class="message_top_line">
-    {{#unless status_message}}
-    <span class="message_sender sender_info_hover no-select">
-        {{#if include_sender}}
-
-            {{> message_avatar}}
-
-            <span class="sender_name auto-select" role="button" tabindex="0">{{msg/sender_full_name}}</span>
-            {{#if sender_is_bot}}
-            <i class="zulip-icon bot" aria-label="{{t 'Bot' }}"></i>
-            {{/if}}
-
-        {{/if}}
+<div class="left-col">
+    {{#if include_sender}}
+    <span class="sender_info_hover">
+        {{> "message_avatar"}}
     </span>
-    {{/unless}}
-
-    {{#if status_message}}
-    {{> me_message}}
     {{/if}}
 
-    <span class="alert-msg pull-right"></span>
+    {{#if edited_in_left_col}}
+    {{> "edited_notice"}}
+    {{/if}}
+</div>
 
-    <span class="message_time{{#if msg.locally_echoed}} notvisible{{/if}}{{#if status_message}} status-time{{/if}}">
+<div class="middle-col">
+    {{#if include_sender}}
+        {{#if status_message}}
+        {{> "me_message"}}
+        {{/if}}
+
+        {{#unless status_message}}
+            <span class="sender_info_hover">
+                <span class="sender_name auto-select" role="button" tabindex="0">{{msg/sender_full_name}}</span>
+                {{#if sender_is_bot}}
+                <i class="zulip-icon bot" aria-label="{{t 'Bot' }}"></i>
+                {{/if}}
+            </span>
+
+            {{#if edited_alongside_sender}}
+            {{> "edited_notice"}}
+            {{/if}}
+        {{/unless}}
+    {{/if}}
+
+    <div class="message_content rendered_markdown">{{#unless status_message}}{{#if use_match_properties}}{{{msg/match_content}}}{{else}}{{{msg/content}}}{{/if}}{{/unless}}</div>
+
+    <div class="message_edit">
+        <div class="message_edit_form"></div>
+    </div>
+
+    <div class="message_expander message_length_controller" title="{{t 'Expand message (-)' }}">{{t "[More...]" }}</div>
+
+    <div class="message_condenser message_length_controller" title="{{t 'Condense message (-)' }}">{{t "[Condense message]" }}</div>
+
+    <div class="message_reactions">{{> message_reactions }}</div>
+</div>
+
+<div class="right-col{{#if status_message}} sender-status-right-col{{/if}}">
+    <span class="alert-msg"></span>
+
+    <span class="message_time{{#if msg.locally_echoed}} notvisible{{/if}}">
         {{#unless include_sender}}
         <span class="copy-paste-text">&nbsp;</span>
         {{/unless}}
         {{timestr}}
     </span>
 
-    {{#if edited_alongside_sender}}
-    {{> edited_notice}}
-    {{/if}}
-
-    {{> message_controls}}
-
+    {{> "message_controls"}}
 </div>
-
-{{#unless status_message}}
-<div class="message_content rendered_markdown">{{#if use_match_properties}}{{{msg/match_content}}}{{else}}{{{msg/content}}}{{/if}}</div>
-{{/unless}}
-
-{{#if edited_in_left_col}}
-{{> edited_notice}}
-{{/if}}
-
-<div class="message_edit">
-    <div class="message_edit_form"></div>
-</div>
-<div class="message_expander message_length_controller" title="{{t 'Expand message (-)' }}">{{t "[More...]" }}</div>
-<div class="message_condenser message_length_controller" title="{{t 'Condense message (-)' }}">{{t "[Condense message]" }}</div>
-<div class="message_reactions">{{> message_reactions }}</div>

--- a/static/templates/message_controls.hbs
+++ b/static/templates/message_controls.hbs
@@ -1,4 +1,4 @@
-<div class="message_controls{{#status_message}} sender-status-controls{{/status_message}} no-select">
+<div class="message_controls no-select">
     {{#if msg/sent_by_me}}
     <div class="edit_content"></div>
     {{/if}}

--- a/static/templates/message_edit_history.hbs
+++ b/static/templates/message_edit_history.hbs
@@ -5,7 +5,7 @@
     <div class="date_row"><span>{{ display_date }}</span></div>
     {{/if}}
     <div class="messagebox-content">
-        <div class="message_top_line"><span class="message_time">{{ timestamp }}</span></div>
+        <div class="message_time">{{ timestamp }}</div>
         {{#if topic_edited}}
         <div class="message_content message_edit_history_content"><p>Topic: <span class="highlight_text_inserted">{{ new_topic }}</span> <span class="highlight_text_deleted">{{ prev_topic }}</span></p></div>
         {{/if}}


### PR DESCRIPTION
This breaks the message box into a more code logical structure, i.e.,
three columns -> left, middle and right. Absolute positioning is removed
from elements like the "(EDITED)" label and message controls.

Original conversation: https://chat.zulip.org/#narrow/stream/9-issues/topic/off-center.20EDITED.20label