### PR TITLE
away: Use correct user circle in user group popup.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -331,7 +331,7 @@ function fetch_group_members(member_ids) {
         })
         .map(function (p) {
             return Object.assign({}, p, {
-                presence_status: presence.get_status(p.user_id),
+                presence_status: buddy_data.buddy_status(p.user_id),
                 is_active: people.is_active_user_for_popover(p.user_id),
                 user_last_seen_time_status: user_last_seen_time_status(p.user_id),
             });


### PR DESCRIPTION
When you click on a user group mention, you see
the list of people with green/orange/empty circles
next to them.  We now correctly reflect away status.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
