### PR TITLE
messagebox: Remove on-message-row-hover controls visible rules.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1233,9 +1233,7 @@ a.message_label_clickable:hover {
     color: hsl(200, 100%, 40%);
 }
 
-.message_hovered .info,
-.has_actions_popover .info,
-.message_hovered .empty-star {
+.has_actions_popover .info {
     opacity: 1;
 }
 


### PR DESCRIPTION
Date separator exists inside the message_row, which causes the
message controls to be visible even when hovering on date
separator. These two rules are redundant and cause this buggy
action. Other rules handle the behaviour of message controls
being visible on message box hover. Hence these can be removed.

https://chat.zulip.org/#narrow/stream/65-checkins/topic/Vaibhav/near/701989