### PR TITLE
Fix overlap between gradients and integrations footer.

### DIFF
--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -717,7 +717,7 @@ nav ul li.active::after {
 }
 
 .portico-landing.hello .gradients .gradient.white-fade {
-    background: linear-gradient(0deg, hsl(0, 0%, 100%) 0%, transparent 40%);
+    background: linear-gradient(0deg, hsl(0, 0%, 98%) 0%, transparent 40%);
 }
 
 .portico-landing.hello .hero .waves {
@@ -2795,7 +2795,7 @@ nav ul li.active::after {
 }
 
 .gradients .gradient.white-fade {
-    background: linear-gradient(0deg, hsl(0, 0%, 100%) 0%, transparent 40%);
+    background: linear-gradient(0deg, hsl(0, 0%, 98%) 0%, transparent 40%);
 }
 
 /* -- pricing css -- */

--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -2498,7 +2498,7 @@ nav ul li.active::after {
 
 .portico-landing.integrations .padded-content .inner-content {
     transition: all 0.3s ease;
-    min-height: 800px;
+    min-height: 870px;
 }
 
 .portico-landing.integrations .padded-content .inner-content.show {


### PR DESCRIPTION
Before:
![screenshot at feb 17 12-28-30](https://user-images.githubusercontent.com/15116870/52918757-8b585b80-32af-11e9-8307-835e3e3aefac.png)
Note that the end of the white gradient (`hsl(0, 0%, 100%)`) isn't the same color as the background of the footer (`hsl(0, 0%, 98%)`, hence the changes in the 1st commit.

After:
![screenshot at feb 17 12-27-30](https://user-images.githubusercontent.com/15116870/52918751-711e7d80-32af-11e9-9bec-49126e15998e.png)

Fixes #11591.