### PR TITLE
Textbox: decrease max-height to stop overlapping.

### DIFF
--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -63,6 +63,11 @@ function get_new_heights() {
         - $("#global_filters").safeOuterHeight(true)
         - $("#streams_header").safeOuterHeight(true);
 
+    $(".new_message_textarea").css("max-height", viewport_height * 0.439 - 119);
+    // The above code is a linear equation between viewport_height and required max-height of
+    // new_message_textarea which is formed by logging the values of each of them and then using
+    // the logged values to form an equation.
+
     // Don't let us crush the stream sidebar completely out of view
     res.stream_filters_max_height = Math.max(80, res.stream_filters_max_height);
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes: #4374

<!--**Testing Plan:**  How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
When max-height is 22em:

![without max-height](https://user-images.githubusercontent.com/39990232/52955380-84fed800-33b2-11e9-88f9-7560f89674e8.gif)

When max-height is 10em:

![with max-height](https://user-images.githubusercontent.com/39990232/52955391-8c25e600-33b2-11e9-8c3e-0c9fa60eeb03.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
