### PR TITLE
drafts: Fix date-sensitive test.

### DIFF
--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -233,6 +233,8 @@ run_test('remove_old_drafts', () => {
 });
 
 run_test('format_drafts', () => {
+    drafts.remove_old_drafts = noop;
+
     draft_1.updatedAt = new Date(1549958107000).getTime();      // 2/12/2019 07:55:07 AM (UTC+0)
     draft_2.updatedAt = new Date(1549958107000).setDate(-1);
     var draft_3 = {

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -188,7 +188,7 @@ exports.restore_draft = function (draft_id) {
 
 var DRAFT_LIFETIME = 30;
 
-function remove_old_drafts() {
+exports.remove_old_drafts = function () {
     var old_date  = new Date().setDate(new Date().getDate() - DRAFT_LIFETIME);
     var drafts = draft_model.get();
     _.each(drafts, function (draft, id) {
@@ -196,7 +196,7 @@ function remove_old_drafts() {
             draft_model.deleteDraft(id);
         }
     });
-}
+};
 
 exports.format_draft = function (draft) {
     var id = draft.id;
@@ -295,9 +295,6 @@ function remove_draft(draft_row) {
     }
 }
 
-// Exporting for testing purpose
-exports.remove_old_drafts = remove_old_drafts;
-
 exports.launch = function () {
     function format_drafts(data) {
         _.each(data, function (draft, id) {
@@ -343,7 +340,7 @@ exports.launch = function () {
         });
     }
 
-    remove_old_drafts();
+    exports.remove_old_drafts();
     var drafts = format_drafts(draft_model.get());
     render_widgets(drafts);
     exports.open_modal();


### PR DESCRIPTION
To test formatting we want a hard coded date, so we
can verify the date arithmetic with stable dates.

To make the test less brittle, we disable the
feature to remove old drafts.

This was an emergency fix.  We should probably just
remove the last N drafts instead of having the 30-day
limit.  Or we should have a better way to stub the cutoff
date.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
