### PR TITLE
streams-creation-form: Prevent newline characters in the description.

### DIFF
--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -195,6 +195,14 @@ function create_stream() {
     var announce = !!page_params.notifications_stream &&
         $('#announce-new-stream input').prop('checked');
 
+    // Even though we already check to make sure that while typing the user cannot enter
+    // newline characters (by pressing the enter key) it would still be possible to copy
+    // and paste over a description with newline characters in it. Prevent that.
+    if (description.indexOf('\n') !== -1) {
+        ui_report.message(i18n.t("The stream description cannot contain newline characters."), $(".stream_create_info"), 'alert-error');
+        return;
+    }
+
     loading.make_indicator($('#stream_creating_indicator'), {text: i18n.t('Creating stream...')});
 
     ajaxSubscribeForCreation(
@@ -435,6 +443,14 @@ exports.set_up_handlers = function () {
     container.on("mouseout", "#announce-stream-docs", function (e) {
         $("#announce-stream-docs").popover('hide');
         e.stopPropagation();
+    });
+
+    // Do not allow the user to enter newline characters while typing out the
+    // stream's description during it's creation.
+    container.on("keydown", "#create_stream_description", function (e) {
+        if ((e.keyCode || e.which) === 13) {
+            e.preventDefault();
+        }
     });
 
 };

--- a/static/templates/stream_creation_form.handlebars
+++ b/static/templates/stream_creation_form.handlebars
@@ -16,8 +16,8 @@
                 <div class="stream-title">
                     {{t "Stream description (optional)"}}
                 </div>
-                <textarea name="stream_description" id="create_stream_description"
-                  placeholder="{{t 'Stream description' }}" value="" autocomplete="off" maxlength="{{ max_description_length }}"></textarea>
+                <input type="text" name="stream_description" id="create_stream_description"
+                  placeholder="{{t 'Stream description' }}" value="" autocomplete="off" maxlength="{{ max_description_length }}" />
             </section>
             <section class="block" id="make-invite-only">
                 <div class="stream-title">


### PR DESCRIPTION
This commit achieves two things:
  1. Changes the UI of the "Create stream" form to make the
     textarea previously used to get the stream description
     a simple input field of type text (to suggest a single
     line description).

  2. Adds an extra check on the frontend side to make sure that
     when users create a new stream via. the "Create stream"
     option in the settings panel, they can't enter any newline
     characters (i.e. we disallow the enter key from being
     registered when typing out the stream description).
     We must also make sure that they cannot copy-and-paste over
     descriptions containing newline characters.

NOTE: Because of the 1st change (UI change) for the most part, users are already prohibited from entering newline characters making the 2nd change partially redundant. However, since these extra checks are particularly expensive, they would be a good idea to keep. 

resolves issue #11617.