### PR TITLE
test-backend: Rename '--processes' option to '--parallel'.

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -228,7 +228,7 @@ if __name__ == "__main__":
                         action="store_true",
                         default=False, help='Enable verbose print of coverage report.')
 
-    parser.add_argument('--processes', dest='processes',
+    parser.add_argument('--parallel', dest='processes',
                         type=int,
                         action='store',
                         default=4,


### PR DESCRIPTION
This change is being made to simply match up our naming conventions
with django's test framework.


