### PR TITLE
Update the-git-difference.md

### DIFF
--- a/docs/git/the-git-difference.md
+++ b/docs/git/the-git-difference.md
@@ -34,7 +34,7 @@ Here are the top things to know:
 
 - **Git stores all data as objects, of which there are four types:** blob
   (file), tree (directory), commit (revision), and tag. Each of these objects
-  is named by a unique hash, the SHA-1 has of its contents. Most of the time
+  is named by a unique hash, the SHA-1 hash of its contents. Most of the time
   you'll refer to objects by their truncated hash or more human-readable
   reference like `HEAD` (the current branch). Blobs and trees represent files
   and directories. Tags are named references to other objects. A commit object


### PR DESCRIPTION
Fixed a small typing error, replacing 'has' by 'hash'.

https://zulip.readthedocs.io/en/latest/git/the-git-difference.html

