### PR TITLE
typeahead: Fix accidental overwrite of message content on select.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -326,6 +326,12 @@ run_test('content_typeahead_selected', () => {
     expected_value = '@**Othello, the Moor of Venice** ';
     assert.equal(actual_value, expected_value);
 
+    fake_this.query = 'Hello @oth';
+    fake_this.token = 'oth';
+    actual_value = ct.content_typeahead_selected.call(fake_this, othello);
+    expected_value = 'Hello @**Othello, the Moor of Venice** ';
+    assert.equal(actual_value, expected_value);
+
     fake_this.query = '@**oth';
     fake_this.token = 'oth';
     actual_value = ct.content_typeahead_selected.call(fake_this, othello);
@@ -351,6 +357,12 @@ run_test('content_typeahead_selected', () => {
     fake_this.token = 'kin';
     actual_value = ct.content_typeahead_selected.call(fake_this, hamlet);
     expected_value = '@_**King Hamlet** ';
+    assert.equal(actual_value, expected_value);
+
+    fake_this.query = 'Hello @_kin';
+    fake_this.token = 'kin';
+    actual_value = ct.content_typeahead_selected.call(fake_this, hamlet);
+    expected_value = 'Hello @_**King Hamlet** ';
     assert.equal(actual_value, expected_value);
 
     fake_this.query = '@_*kin';
@@ -400,6 +412,12 @@ run_test('content_typeahead_selected', () => {
     expected_value = '#**Sweden** ';
     assert.equal(actual_value, expected_value);
 
+    fake_this.query = 'Hello #swed';
+    fake_this.token = 'swed';
+    actual_value = ct.content_typeahead_selected.call(fake_this, sweden_stream);
+    expected_value = 'Hello #**Sweden** ';
+    assert.equal(actual_value, expected_value);
+
     fake_this.query = '#**swed';
     fake_this.token = 'swed';
     actual_value = ct.content_typeahead_selected.call(fake_this, sweden_stream);
@@ -413,6 +431,12 @@ run_test('content_typeahead_selected', () => {
     fake_this.token = 'p';
     actual_value = ct.content_typeahead_selected.call(fake_this, 'python');
     expected_value = '~~~python\n\n~~~';
+    assert.equal(actual_value, expected_value);
+
+    fake_this.query = 'Hello ~~~p';
+    fake_this.token = 'p';
+    actual_value = ct.content_typeahead_selected.call(fake_this, 'python');
+    expected_value = 'Hello ~~~python\n\n~~~';
     assert.equal(actual_value, expected_value);
 
     fake_this.query = '```p';

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -507,12 +507,20 @@ exports.content_typeahead_selected = function (item) {
         }
     } else if (this.completing === 'mention' || this.completing === 'silent_mention') {
         var is_silent = this.completing === 'silent_mention';
+        beginning = beginning.substring(0, beginning.length - this.token.length - 1);
+        if (beginning.endsWith('@_*')) {
+            beginning = beginning.substring(0, beginning.length - 3);
+        } else if (beginning.endsWith('@*') || beginning.endsWith('@_')) {
+            beginning = beginning.substring(0, beginning.length - 2);
+        } else if (beginning.endsWith('@')) {
+            beginning = beginning.substring(0, beginning.length - 1);
+        }
         if (user_groups.is_user_group(item)) {
-            beginning =  '@*' + item.name + '* ';
+            beginning +=  '@*' + item.name + '* ';
             $(document).trigger('usermention_completed.zulip', {user_group: item});
         } else {
             var mention_text = people.get_mention_syntax(item.full_name, item.user_id, is_silent);
-            beginning = mention_text + ' ';
+            beginning += mention_text + ' ';
             $(document).trigger('usermention_completed.zulip', {mentioned: item});
         }
     } else if (this.completing === 'stream') {


### PR DESCRIPTION
Also adds tests to ensure that we do not accidentally overwrite
the 'beginning' variable that contains the message content upto
that point. These should prevent similar errors in the future.

The bug was added in 8119258c4d558e70a7d9f8361bc1c9fcf10605f6.
