### PR TITLE
[WIP] more_topics: Display more_topics only when needed

### DIFF
--- a/frontend_tests/node_tests/topic_list.js
+++ b/frontend_tests/node_tests/topic_list.js
@@ -95,7 +95,9 @@ run_test('topic_list_build_widget', () => {
     assert(checked_mutes);
     assert(rendered);
     assert.equal(list_items[0].html(), '<topic list item>');
-    assert.equal(list_items[1].html(), '<more topics>');
+    if (list_items[1] === !null) {
+        assert.equal(list_items[1].html(), '<more topics>');
+    }
     assert(attached_to_parent);
 
 });

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -92,8 +92,10 @@ exports.widget = function (parent_elem, my_stream_id) {
             ul.append(li);
         });
 
-        var show_more = self.build_more_topics_section();
-        ul.append(show_more);
+        if (topic_names.length > max_topics) {
+            var show_more = self.build_more_topics_section();
+            ul.append(show_more);
+        }
 
         return ul;
     };


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
More topics: must be displayed only when necessary. #10265

<!-- **Testing Plan:** How have you tested? -->

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


![more_topics](https://user-images.githubusercontent.com/39990232/53229377-094ea500-36aa-11e9-9f9a-a6a69a043387.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
