### PR TITLE
Add "unstar all messages" feature

### DIFF
--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -35,6 +35,7 @@ set_global('stream_popover', {
     hide_stream_popover: noop,
     hide_topic_popover: noop,
     hide_all_messages_popover: noop,
+    hide_starred_messages_popover: noop,
     restore_stream_list_size: noop,
 });
 

--- a/static/js/message_flags.js
+++ b/static/js/message_flags.js
@@ -113,6 +113,19 @@ exports.toggle_starred_and_update_server = function (message) {
     }
 };
 
+exports.unstar_all_messages = function () {
+    var starred_msg_ids = starred_messages.get_starred_msg_ids();
+    channel.post({
+        url: '/json/messages/flags',
+        idempotent: true,
+        data: {
+            messages: JSON.stringify(starred_msg_ids),
+            flag: 'starred',
+            op: 'remove',
+        },
+    });
+};
+
 return exports;
 }());
 

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1036,6 +1036,7 @@ exports.hide_all_except_userlist_sidebar = function () {
     stream_popover.hide_stream_popover();
     stream_popover.hide_topic_popover();
     stream_popover.hide_all_messages_popover();
+    stream_popover.hide_starred_messages_popover();
     popovers.hide_user_sidebar_popover();
     popovers.hide_mobile_message_buttons_popover();
     stream_popover.restore_stream_list_size();

--- a/static/js/starred_messages.js
+++ b/static/js/starred_messages.js
@@ -32,6 +32,10 @@ exports.count = function () {
     return exports.ids.num_items();
 };
 
+exports.get_starred_msg_ids = function () {
+    return exports.ids.keys();
+};
+
 exports.rerender_ui = function () {
     var count = exports.count();
 

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -7,6 +7,7 @@ var exports = {};
 var current_stream_sidebar_elem;
 var current_topic_sidebar_elem;
 var all_messages_sidebar_elem;
+var starred_messages_sidebar_elem;
 
 exports.stream_popped = function () {
     return current_stream_sidebar_elem !== undefined;
@@ -18,6 +19,10 @@ exports.topic_popped = function () {
 
 exports.all_messages_popped = function () {
     return all_messages_sidebar_elem !== undefined;
+};
+
+exports.starred_messages_popped = function () {
+    return starred_messages_sidebar_elem !== undefined;
 };
 
 exports.hide_stream_popover = function () {
@@ -38,6 +43,13 @@ exports.hide_all_messages_popover = function () {
     if (exports.all_messages_popped()) {
         $(all_messages_sidebar_elem).popover("destroy");
         all_messages_sidebar_elem = undefined;
+    }
+};
+
+exports.hide_starred_messages_popover = function () {
+    if (exports.starred_messages_popped()) {
+        $(starred_messages_sidebar_elem).popover("destroy");
+        starred_messages_sidebar_elem = undefined;
     }
 };
 
@@ -205,6 +217,34 @@ function build_all_messages_popover(e) {
 
 }
 
+function build_starred_messages_popover(e) {
+    var elt = e.target;
+
+    if (exports.starred_messages_popped()
+        && starred_messages_sidebar_elem === elt) {
+        exports.hide_starred_messages_popover();
+        e.stopPropagation();
+        return;
+    }
+
+    popovers.hide_all();
+
+    var content = templates.render(
+        'starred_messages_sidebar_actions'
+    );
+
+    $(elt).popover({
+        content: content,
+        trigger: "manual",
+        fixed: true,
+    });
+
+    $(elt).popover("show");
+    starred_messages_sidebar_elem = elt;
+    e.stopPropagation();
+
+}
+
 exports.register_click_handlers = function () {
     $('#stream_filters').on('click', '.stream-sidebar-arrow', build_stream_popover);
 
@@ -223,6 +263,8 @@ exports.register_click_handlers = function () {
     });
 
     $('#global_filters').on('click', '.all-messages-arrow', build_all_messages_popover);
+
+    $('#global_filters').on('click', '.starred-messages-sidebar-arrow', build_starred_messages_popover);
 
     exports.register_stream_handlers();
     exports.register_topic_handlers();
@@ -258,6 +300,22 @@ exports.register_stream_handlers = function () {
     $('body').on('click', '#mark_all_messages_as_read', function (e) {
         exports.hide_all_messages_popover();
         pointer.fast_forward_pointer();
+        e.stopPropagation();
+    });
+
+    // Unstar all messages
+    $('body').on('click', '#unstar_all_messages', function (e) {
+        exports.hide_starred_messages_popover();
+        e.preventDefault();
+        e.stopPropagation();
+        $(".left-sidebar-modal-holder").empty();
+        $(".left-sidebar-modal-holder").html(templates.render("unstar-messages-modal"));
+        $("#unstar-messages-modal").modal("show");
+    });
+
+    $('body').on('click', '#do_unstar_messages_button', function (e) {
+        $("#unstar-messages-modal").modal("hide");
+        message_flags.unstar_all_messages();
         e.stopPropagation();
     });
 

--- a/static/templates/starred_messages_sidebar_actions.handlebars
+++ b/static/templates/starred_messages_sidebar_actions.handlebars
@@ -1,0 +1,9 @@
+{{! Contents of the "starred messages sidebar" popup }}
+<ul class="nav nav-list">
+    <li>
+        <a id="unstar_all_messages">
+            <i class="fa fa-star-o" aria-hidden="true"></i>
+            {{#tr this}}Unstar all messages{{/tr}}
+        </a>
+    </li>
+</ul>

--- a/static/templates/unstar-messages-modal.handlebars
+++ b/static/templates/unstar-messages-modal.handlebars
@@ -1,0 +1,14 @@
+<div id="unstar-messages-modal" class="modal new-style modal-bg hide fade" tabindex="-1" role="dialog" aria-labelledby="unstar_messages_modal_label" aria-hidden="true">
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+        <h3 id="unstar_messages_modal_label">{{t "Unstar all messages" }}</h3>
+    </div>
+    <div class="modal-body">
+        <p>{{t "This will unstar all your messages" }}</p> <br>
+        <p>{{t "This action can not be undone" }}</p>
+    </div>
+    <div class="modal-footer">
+        <button type="button" class="button rounded" data-dismiss="modal">{{t "Cancel" }}</button>
+        <button type="button" class="button rounded btn-danger" id="do_unstar_messages_button">{{t "Unstar all messages" }}</button>
+    </div>
+</div>

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -168,5 +168,6 @@
     <div id="user-profile-modal-holder"></div>
     <div class='notifications top-right'></div>
     <div id="delete-topic-modal-holder"></div>
+    <div class="left-sidebar-modal-holder"></div>
 </div>
 {% endblock %}

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -46,6 +46,7 @@
                         <span class="value"></span>
                     </span>
                 </a>
+                <span class="arrow starred-messages-sidebar-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
             </li>
         </ul>
         <div id="streams_list" class="zoom-out">


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
In this PR, I have added a feature to unstar all starred messages. 

- I have added a popover near "starred messages" section on top-left, which has option to unstar all messages.

**Testing Plan:** <!-- How have you tested? -->
Works after reloading page, tested on development environment. Works as expected.

**GIFs or screenshots**
![screenshot 2019-02-27 at 12 28 07 am](https://user-images.githubusercontent.com/39343253/53438970-085da080-3a27-11e9-9d31-2bce77dc836b.png)
![screenrecording20190227at1](https://user-images.githubusercontent.com/39343253/53444250-a9eaef00-3a33-11e9-89ca-a4d9eccab27d.gif)

