### PR TITLE
Fix unread marker gap in night mode.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1065,10 +1065,9 @@ td.pointer {
     position: absolute;
     left: 2px;
     top: 0px;
-    padding-bottom: 2px;
     opacity: 0;
     z-index: 1;
-    height: 100%;
+    bottom: 1px;
     @include prefixed-transition(all, 0.3s, ease-out);
 }
 
@@ -1076,11 +1075,10 @@ td.pointer {
     background-color: hsl(107, 74%, 29%);
     width: 3px;
     height: 100%;
-    box-shadow: inset 0px -1px 0px 0px hsl(0, 0%, 100%);
 }
 
-.last_message .unread-marker-fill {
-    box-shadow: none;
+.last_message .unread_marker {
+    bottom: 0;
 }
 
 .unread .unread_marker {


### PR DESCRIPTION
Instead of drawing a white border between unread markers, leave a real space.

Before:

![screenshot from 2019-02-22 12-46-04](https://user-images.githubusercontent.com/26471/53270195-e9b27f00-369f-11e9-90cc-e9933ed1b1c1.png)

After:

![screenshot from 2019-02-22 12-45-09](https://user-images.githubusercontent.com/26471/53270188-e28b7100-369f-11e9-8b5a-6e5ca655a7db.png)
