### PR TITLE
[test deploy] Use "Timeline" instead of "All messages".

### DIFF
--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -2,18 +2,6 @@
     <div class="narrows_panel">
         <ul id="global_filters" class="filters">
             {# Special-case this link so we don't actually go to page top. #}
-            <li class="top_left_all_messages global-filter active-filter" title="{{ _('All messages') }} (Esc)">
-                <a href="#">
-                    <span class="filter-icon">
-                        <i class="fa fa-home" aria-hidden="true"></i>
-                    </span>
-                    <span class="hover-underline">{{ _('All messages') }}</span>
-                    <span class="count">
-                        <span class="value"></span>
-                    </span>
-                </a>
-                <span class="arrow stream-sidebar-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
-            </li>
             <li class="top_left_private_messages global-filter" title="{{ _('Private messages') }} (P)">
                 <a href="#narrow/is/private">
                     <span class="filter-icon">
@@ -46,6 +34,18 @@
                         <span class="value"></span>
                     </span>
                 </a>
+            </li>
+            <li class="top_left_all_messages global-filter active-filter" title="{{ _('Timeline') }} (Esc)">
+                <a href="#">
+                    <span class="filter-icon">
+                        <i class="fa fa-clock-o" aria-hidden="true"></i>
+                    </span>
+                    <span class="hover-underline">{{ _('Timeline') }}</span>
+                    <span class="count">
+                        <span class="value"></span>
+                    </span>
+                </a>
+                <span class="arrow stream-sidebar-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
             </li>
         </ul>
         <div id="streams_list" class="zoom-out">


### PR DESCRIPTION
This does three things:

    * rename "All Messages" to "Timeline"
    * replace home icon with clock icon
    * move "Timeline" below "Starred messages"

It would be good to deploy this to CZO to get some
quick reactions from folks.


![image](https://user-images.githubusercontent.com/142908/53270254-16669680-36a0-11e9-91ce-a2511ac4e801.png)


<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
