### PR TITLE
[test deploy] Use "Timeline" instead of "All messages".

### DIFF
--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -2,18 +2,6 @@
     <div class="narrows_panel">
         <ul id="global_filters" class="filters">
             {# Special-case this link so we don't actually go to page top. #}
-            <li class="top_left_all_messages global-filter active-filter" title="{{ _('All messages') }} (Esc)">
-                <a href="#">
-                    <span class="filter-icon">
-                        <i class="fa fa-home" aria-hidden="true"></i>
-                    </span>
-                    <span class="hover-underline">{{ _('All messages') }}</span>
-                    <span class="count">
-                        <span class="value"></span>
-                    </span>
-                </a>
-                <span class="arrow stream-sidebar-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
-            </li>
             <li class="top_left_private_messages global-filter" title="{{ _('Private messages') }} (P)">
                 <a href="#narrow/is/private">
                     <span class="filter-icon">
@@ -35,6 +23,18 @@
                         <span class="value"></span>
                     </span>
                 </a>
+            </li>
+            <li class="top_left_all_messages global-filter active-filter" title="{{ _('Timeline') }} (Esc)">
+                <a href="#">
+                    <span class="filter-icon">
+                        <i class="fa fa-clock-o" aria-hidden="true"></i>
+                    </span>
+                    <span class="hover-underline">{{ _('Timeline') }}</span>
+                    <span class="count">
+                        <span class="value"></span>
+                    </span>
+                </a>
+                <span class="arrow stream-sidebar-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_starred_messages global-filter">
                 <a href="#narrow/is/starred">


### PR DESCRIPTION
This does three things:

    * rename "All Messages" to "Timeline"
    * replace home icon with clock icon
    * move "Timeline" down in the sidebar

It would be good to deploy this to CZO to get some
quick reactions from folks.

![image](https://user-images.githubusercontent.com/142908/53270535-d653e380-36a0-11e9-8d90-40659c6e906f.png)

