### PR TITLE
setup-certbot: Remove --force-renewal.

### DIFF
--- a/scripts/setup/setup-certbot
+++ b/scripts/setup/setup-certbot
@@ -99,7 +99,7 @@ chmod a+x "$CERTBOT_PATH"
 # an annoying prompt we stifle with --no-eff-email.
 "$CERTBOT_PATH" certonly "${method_args[@]}" \
                 "${HOSTNAMES[@]}" -m "$EMAIL" \
-                $agree_tos --force-renewal \
+                $agree_tos \
                 "${deploy_hook[@]}" \
                 --force-interactive --no-eff-email
 


### PR DESCRIPTION
There’s no reason to do this unless you’re, like, trying to trip the Let’s Encrypt rate limits.