### PR TITLE
Remove more unused imports

### DIFF
--- a/puppet/zulip_ops/files/zulip-ec2-configure-interfaces
+++ b/puppet/zulip_ops/files/zulip-ec2-configure-interfaces
@@ -48,8 +48,6 @@ import logging
 import logging.handlers
 import subprocess
 
-import sys
-
 import boto.utils
 import netifaces
 if False:

--- a/tools/lib/sanity_check.py
+++ b/tools/lib/sanity_check.py
@@ -8,6 +8,9 @@ def check_venv(filename):
         import django
         import ujson
         import zulip
+        django
+        ujson
+        zulip
     except ImportError:
         print("You need to run %s inside a Zulip dev environment." % (filename,))
         user_id = os.getuid()

--- a/tools/linter_lib/pyflakes.py
+++ b/tools/linter_lib/pyflakes.py
@@ -9,8 +9,8 @@ from zulint.printer import print_err, colors
 from typing import List
 
 suppress_patterns = [
-    (b'', b'imported but unused'),
-    (b'', b'redefinition of unused'),
+    (b"scripts/lib/pythonrc.py", b"imported but unused"),
+    (b'', b"'scripts.lib.setup_path_on_import' imported but unused"),
 
     # Our ipython startup pythonrc file intentionally imports *
     (b"scripts/lib/pythonrc.py",

--- a/zerver/apps.py
+++ b/zerver/apps.py
@@ -22,6 +22,7 @@ class ZerverConfig(AppConfig):
         # running that code too early in Django's setup process, but
         # in any case, this is an intentionally unused import.
         import zerver.signals
+        zerver.signals
 
         if settings.POST_MIGRATION_CACHE_FLUSHING:
             post_migrate.connect(flush_cache, sender=self)

--- a/zerver/apps.py
+++ b/zerver/apps.py
@@ -1,6 +1,6 @@
 
 import logging
-from typing import Any, Dict
+from typing import Any
 
 from django.apps import AppConfig
 from django.conf import settings

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -13,7 +13,6 @@ import ujson
 import subprocess
 import tempfile
 import shutil
-import sys
 from scripts.lib.zulip_tools import overwrite_symlink
 from zerver.lib.avatar_hash import user_avatar_path_from_ids
 from analytics.models import RealmCount, UserCount, StreamCount

--- a/zerver/lib/transfer.py
+++ b/zerver/lib/transfer.py
@@ -7,7 +7,7 @@ from mimetypes import guess_type
 
 from zerver.models import UserProfile, Attachment, RealmEmoji
 from zerver.lib.avatar_hash import user_avatar_path
-from zerver.lib.upload import read_local_file, S3UploadBackend, upload_image_to_s3
+from zerver.lib.upload import S3UploadBackend, upload_image_to_s3
 from zerver.lib.parallel import run_parallel
 
 s3backend = S3UploadBackend()

--- a/zerver/lib/url_preview/preview.py
+++ b/zerver/lib/url_preview/preview.py
@@ -1,6 +1,4 @@
 import re
-import logging
-import traceback
 from typing import Any, Optional, Dict
 from typing.re import Match
 import requests

--- a/zerver/management/commands/generate_invite_links.py
+++ b/zerver/management/commands/generate_invite_links.py
@@ -7,7 +7,7 @@ from django.core.management.base import CommandError
 from confirmation.models import Confirmation, create_confirmation_link
 from zerver.lib.management import ZulipBaseCommand
 from zerver.models import PreregistrationUser, email_allowed_for_realm, \
-    email_allowed_for_realm, DomainNotAllowedForRealmError
+    DomainNotAllowedForRealmError
 
 class Command(ZulipBaseCommand):
     help = "Generate activation links for users and print them to stdout."

--- a/zerver/management/commands/transfer_uploads_to_s3.py
+++ b/zerver/management/commands/transfer_uploads_to_s3.py
@@ -1,7 +1,3 @@
-
-import argparse
-import os
-import tempfile
 from typing import Any
 
 from django.core.management.base import BaseCommand, CommandParser, CommandError

--- a/zerver/migrations/0182_set_initial_value_is_private_flag.py
+++ b/zerver/migrations/0182_set_initial_value_is_private_flag.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import sys
-from django.db import migrations
 
 from django.db import migrations
 from django.db.backends.postgresql_psycopg2.schema import DatabaseSchemaEditor

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -8,7 +8,7 @@ from zerver.lib.actions import get_realm, try_add_realm_custom_profile_field, \
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.bugdown import convert as bugdown_convert
 from zerver.models import CustomProfileField, \
-    custom_profile_fields_for_realm, get_realm, CustomProfileFieldValue
+    custom_profile_fields_for_realm, CustomProfileFieldValue
 import ujson
 
 class CustomProfileFieldTest(ZulipTestCase):

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -8,7 +8,6 @@ from mock import call
 from typing import Any, Dict, List, Optional
 
 import base64
-import gcm
 import os
 import ujson
 import uuid

--- a/zerver/tests/test_unread.py
+++ b/zerver/tests/test_unread.py
@@ -3,7 +3,6 @@
 from typing import Any, List, Mapping
 
 from django.db import connection
-from django.test import override_settings
 
 from zerver.models import (
     get_realm,

--- a/zerver/views/invite.py
+++ b/zerver/views/invite.py
@@ -5,11 +5,11 @@ from typing import List, Optional, Set
 from zerver.decorator import require_realm_admin, require_non_guest_human_user
 from zerver.lib.actions import do_invite_users, do_revoke_user_invite, \
     do_revoke_multi_use_invite, do_resend_user_invite_email, \
-    get_default_subs, do_get_user_invites, do_create_multiuse_invite_link
+    do_get_user_invites, do_create_multiuse_invite_link
 from zerver.lib.request import REQ, has_request_variables, JsonableError
-from zerver.lib.response import json_success, json_error, json_response
+from zerver.lib.response import json_success, json_error
 from zerver.lib.streams import access_stream_by_id
-from zerver.lib.validator import check_string, check_list, check_bool, check_int
+from zerver.lib.validator import check_list, check_int
 from zerver.models import PreregistrationUser, Stream, UserProfile, MultiuseInvite
 
 import re

--- a/zerver/views/realm_logo.py
+++ b/zerver/views/realm_logo.py
@@ -2,10 +2,8 @@ from django.conf import settings
 from django.shortcuts import redirect
 from django.utils.translation import ugettext as _
 from django.http import HttpResponse, HttpRequest
-from typing import Optional, Callable, Any
 
-from zerver.lib.validator import check_string, check_int, check_list, check_dict, \
-    check_bool, check_variable_type, check_capped_string, check_color
+from zerver.lib.validator import check_bool
 from zerver.lib.request import REQ, has_request_variables
 from zerver.decorator import require_realm_admin
 from zerver.lib.actions import do_change_logo_source

--- a/zproject/wsgi.py
+++ b/zproject/wsgi.py
@@ -28,6 +28,7 @@ django.setup()  # We need to call setup to load applications.
 # need to import zerver.models first before the middleware tries to import it.
 
 import zerver.models
+zerver.models
 
 # This application object is used by any WSGI server configured to use this
 # file. This includes Django's development server, if the WSGI_APPLICATION


### PR DESCRIPTION
Remove unused imports that I missed in #11442 (or maybe have become unused since then). Verify that there are no other unexpected unused imports by turning the lint check back on.

We’ve talked before about reasons we might not want to turn the lint check back on yet, so feel free to hold off merging that last commit. Maybe we should write down somewhere what it would take to make us comfortable turning it on. I know a big part of it was lots of false positives due to PyFlakes previously missing support for PEP 484 `# type` comments, fixed in PyFlakes 2.1.0 which we pulled in with #11427.