### PR TITLE
General UI: Add a clear status option in user popover.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -771,6 +771,18 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
 
+    $('body').on('click', '.info_popover_actions .clear_status', function (e) {
+        e.preventDefault();
+        var me = $(e.target).parents('ul').attr('data-user-id');
+        user_status.server_update({
+            user_id: me,
+            status_text: '',
+            success: function () {
+                $('.info_popover_actions #status_message').html('');
+            },
+        });
+    });
+
     $('body').on('click', '#user-profile-modal #name #edit-button', function () {
         exports.hide_user_profile();
     });

--- a/static/templates/user_info_popover_content.handlebars
+++ b/static/templates/user_info_popover_content.handlebars
@@ -62,7 +62,10 @@
     {{#if status_text}}
         {{#unless is_me}}<hr />{{/unless}}
         <li class="user_info_status_text">
-            {{status_text}}
+            <span id="status_message">
+                {{status_text}}
+                {{#if is_me}}(<a href="#" class="clear_status">{{#tr this}}clear{{/tr}}</a>){{/if}}
+            </span>
         </li>
     {{/if}}
 

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -126,6 +126,8 @@ IGNORED_PHRASES = [
     r"^new_emoji$",
     # Used to refer custom time limits
     r"\bN\b",
+    # Capital c feels obtrusive in clear status option
+    r"clear",
 
     r"group private messages with __recipient__",
     r"private messages with __recipient__",


### PR DESCRIPTION
Accomplished by adding a function to clear the status message with
an empty string. The html is then updated to reflect changes without a
refresh.

Currently, it's a small hassle to clear a status message.  This option
makes things a bit easier. See issue: #11630.

![clear-status](https://user-images.githubusercontent.com/39782863/53278631-7b28ed80-36ae-11e9-9844-3ac7790bb0fd.gif)
