### PR TITLE
left sidebar: Fix closing stream search.

### DIFF
--- a/frontend_tests/node_tests/stream_search.js
+++ b/frontend_tests/node_tests/stream_search.js
@@ -50,6 +50,10 @@ function toggle_filter() {
     stream_list.toggle_filter_displayed({preventDefault: noop});
 }
 
+function clear_search_input() {
+    stream_list.clear_search({stopPropagation: noop});
+}
+
 run_test('basics', () => {
     var cursor_helper;
     const input = $('.stream-list-filter');
@@ -129,7 +133,7 @@ run_test('basics', () => {
     verify_focused();
 
     // Clear an empty search.
-    stream_list.clear_search();
+    clear_search_input();
     verify_collapsed();
 
     // Expand the widget.
@@ -139,7 +143,7 @@ run_test('basics', () => {
     // Clear a non-empty search.
     input.val('foo');
     verify_list_updated(() => {
-        stream_list.clear_search();
+        clear_search_input();
     });
     verify_expanded();
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -559,10 +559,11 @@ exports.escape_search = function () {
     update_streams_for_search();
 };
 
-exports.clear_search = function () {
+exports.clear_search = function (e) {
     var filter = $('.stream-list-filter').expectOne();
     if (filter.val() === '') {
         exports.clear_and_hide_search();
+        e.stopPropagation();
         return;
     }
     filter.val('');


### PR DESCRIPTION
Fixed issue where closing stream search was not working if
the user does not enter any search term and try to close the
search box by clicking on the close icon.

Fixes: #11636.