### PR TITLE
Fix hotspot intro_compose issue #11670

### DIFF
--- a/static/js/hotspots.js
+++ b/static/js/hotspots.js
@@ -35,11 +35,6 @@ var HOTSPOT_LOCATIONS = {
         offset_y: 1.2,
         popover: LEFT_BOTTOM,
     },
-    intro_compose: {
-        element: '#left_bar_compose_stream_button_big',
-        offset_x: 0,
-        offset_y: 0,
-    },
 };
 
 // popover illustration url(s)

--- a/zerver/lib/hotspots.py
+++ b/zerver/lib/hotspots.py
@@ -26,11 +26,6 @@ ALL_HOTSPOTS = {
         'description': _('Go to Settings to configure your '
                          'notifications and display settings.'),
     },
-    'intro_compose': {
-        'title': _('Compose'),
-        'description': _('Click here to start a new conversation. Pick a topic '
-                         '(2-3 words is best), and give it a go!'),
-    },
 }  # type: Dict[str, Dict[str, str]]
 
 def get_next_hotspots(user: UserProfile) -> List[Dict[str, object]]:
@@ -49,7 +44,7 @@ def get_next_hotspots(user: UserProfile) -> List[Dict[str, object]]:
         return []
 
     seen_hotspots = frozenset(UserHotspot.objects.filter(user=user).values_list('hotspot', flat=True))
-    for hotspot in ['intro_reply', 'intro_streams', 'intro_topics', 'intro_gear', 'intro_compose']:
+    for hotspot in ['intro_reply', 'intro_streams', 'intro_topics', 'intro_gear']:
         if hotspot not in seen_hotspots:
             return [{
                 'name': hotspot,


### PR DESCRIPTION
Fixes the issue #11670 by removing intro_compose from zerver/lib/hotspots.py and static/js/hotspots.js.


**Testing Plan:** Tested on the local development environment by setting ALWAYS_SEND_ALL_HOTSPOTS = True in zproject/dev_settings.py.