### PR TITLE
compose: Update error message when sending to non-existant stream.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -118,7 +118,7 @@ run_test('validate_stream_message_address_info', () => {
 
     $('#stream_message_recipient_stream').select(noop);
     assert(!compose.validate_stream_message_address_info('foobar'));
-    assert.equal($('#compose-error-msg').html(), "translated: <p>The stream <b>foobar</b> does not exist.</p><p>Manage your subscriptions <a href='#streams/all'>on your Streams page</a>.</p>");
+    assert.equal($('#compose-error-msg').html(), "translated: The stream <b>foobar</b> does not exist.");
 
     sub.subscribed = false;
     stream_data.add_sub('social', sub);
@@ -153,7 +153,7 @@ run_test('validate_stream_message_address_info', () => {
         payload.error({status: 404});
     };
     assert(!compose.validate_stream_message_address_info('Frontend'));
-    assert.equal($('#compose-error-msg').html(), "translated: <p>The stream <b>Frontend</b> does not exist.</p><p>Manage your subscriptions <a href='#streams/all'>on your Streams page</a>.</p>");
+    assert.equal($('#compose-error-msg').html(), "translated: The stream <b>Frontend</b> does not exist.");
 
     channel.post = function (payload) {
         assert.equal(payload.data.stream, 'social');

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -465,7 +465,7 @@ exports.validation_error = function (error_type, stream_name) {
 
     switch (error_type) {
     case "does-not-exist":
-        response = i18n.t("<p>The stream <b>__stream_name__</b> does not exist.</p><p>Manage your subscriptions <a href='#streams/all'>on your Streams page</a>.</p>", context);
+        response = i18n.t("The stream <b>__stream_name__</b> does not exist.", context);
         compose_error(response, $('#stream_message_recipient_stream'));
         return false;
     case "error":


### PR DESCRIPTION
This error message is more likely than it seems, since we don't show a
typeahead immediately for the streams box, and that typeahead doesn't do
substring matching. Also, if you're not confident about how streams and
topics work, it's easy to think you're supposed to enter both a custom
stream and a custom topic for your message, and that you're replying to your
current view.

In that scenario, having a very straightforward error message is better than
directing the user to the streams subscription modal.

![image](https://user-images.githubusercontent.com/890911/53377983-cf370a80-3918-11e9-909e-9f3c5837534c.png)
