### PR TITLE
docs: Update links to skip help.github.com redirects

### DIFF
--- a/docs/contributing/version-control.md
+++ b/docs/contributing/version-control.md
@@ -128,7 +128,7 @@ commit message.
     performance.
 -   When you fix a GitHub issue, [mark that you've fixed the issue in
     your commit
-    message](https://help.github.com/articles/closing-issues-via-commit-messages/)
+    message](https://help.github.com/en/articles/closing-issues-via-commit-messages)
     so that the issue is automatically closed when your code is merged.
     Zulip's preferred style for this is to have the final paragraph of
     the commit message read e.g. "Fixes: \#123."

--- a/docs/contributing/zulipbot-usage.md
+++ b/docs/contributing/zulipbot-usage.md
@@ -43,7 +43,7 @@ followed by the desired labels enclosed within double quotes (`""`).
     (`""`).
 
 * **Find unclaimed issues** — Use the [GitHub search
-feature](https://help.github.com/articles/using-search-to-filter-issues-and-pull-requests/)
+feature](https://help.github.com/en/articles/using-search-to-filter-issues-and-pull-requests)
 to find unclaimed issues by adding one of the following filters to your search:
 
     * `-label: "in progress"` (excludes issues labeled with the **in progress** label)

--- a/docs/development/request-remote.md
+++ b/docs/development/request-remote.md
@@ -77,7 +77,7 @@ Next, read the following to learn more about developing for Zulip:
 * [Testing](../testing/testing.html)
 
 [github-join]: https://github.com/join
-[github-help-add-ssh-key]: https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/
+[github-help-add-ssh-key]: https://help.github.com/en/articles/adding-a-new-ssh-key-to-your-github-account
 [github-zulip-zulip]: https://github.com/zulip/zulip/
-[github-help-fork]: https://help.github.com/articles/fork-a-repo/
+[github-help-fork]: https://help.github.com/en/articles/fork-a-repo
 [gitbook-rebase]: https://git-scm.com/book/en/v2/Git-Branching-Rebasing

--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -66,7 +66,7 @@ Follow our [Git Guide][set-up-git] in order to install Git, set up a
 GitHub account, create an SSH key to access code on GitHub
 efficiently, etc.  Be sure to create an ssh key and add it to your
 GitHub account using
-[these instructions](https://help.github.com/articles/generating-an-ssh-key/).
+[these instructions](https://help.github.com/en/articles/generating-an-ssh-key).
 
 ### Step 1: Install Prerequisites
 

--- a/docs/git/cloning.md
+++ b/docs/git/cloning.md
@@ -143,10 +143,10 @@ Zulip.
 ![Screencast of Travis CI setup](../_static/zulip-travisci.gif)
 
 [gitbook-rebase]: https://git-scm.com/book/en/v2/Git-Branching-Rebasing
-[github-help-add-ssh-key]: https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/
-[github-help-conf-remote]: https://help.github.com/articles/configuring-a-remote-for-a-fork/
-[github-help-fork]: https://help.github.com/articles/fork-a-repo/
-[github-help-sync-fork]: https://help.github.com/articles/syncing-a-fork/
+[github-help-add-ssh-key]: https://help.github.com/en/articles/adding-a-new-ssh-key-to-your-github-account
+[github-help-conf-remote]: https://help.github.com/en/articles/configuring-a-remote-for-a-fork
+[github-help-fork]: https://help.github.com/en/articles/fork-a-repo
+[github-help-sync-fork]: https://help.github.com/en/articles/syncing-a-fork
 [github-zulip]: https://github.com/zulip/
 [github-zulip-zulip]: https://github.com/zulip/zulip/
 [travis-ci]: https://travis-ci.org/

--- a/docs/git/collaborate.md
+++ b/docs/git/collaborate.md
@@ -53,5 +53,5 @@ tools/fetch-rebase-pull-request <PR-number>
 tools/fetch-pull-request <PR-number>
 ```
 
-[github-help-co-pr-locally]: https://help.github.com/articles/checking-out-pull-requests-locally/
+[github-help-co-pr-locally]: https://help.github.com/en/articles/checking-out-pull-requests-locally
 [tools-PR]: ../git/zulip-tools.html#fetch-a-pull-request-and-rebase

--- a/docs/git/fixing-commits.md
+++ b/docs/git/fixing-commits.md
@@ -1,6 +1,6 @@
 # Fixing Commits
 This is mostly from
-[here](https://help.github.com/articles/changing-a-commit-message/#rewriting-the-most-recent-commit-message).
+[here](https://help.github.com/en/articles/changing-a-commit-message#rewriting-the-most-recent-commit-message).
 
 ## Fixing the last commit
 ### Changing the last commit message

--- a/docs/git/pull-requests.md
+++ b/docs/git/pull-requests.md
@@ -143,8 +143,8 @@ explain to the reviewer how you solved any problems they mentioned, and c) ask
 for another review.
 
 [edx-howto-rebase-pr]: https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request
-[github-help-about-pr]: https://help.github.com/articles/about-pull-requests/
-[github-help-create-pr-fork]: https://help.github.com/articles/creating-a-pull-request-from-a-fork/
+[github-help-about-pr]: https://help.github.com/en/articles/about-pull-requests
+[github-help-create-pr-fork]: https://help.github.com/en/articles/creating-a-pull-request-from-a-fork
 [images-create-pr]: ../images/zulip-open-pr.png
 [keep-up-to-date]: ../git/using.html#keep-your-fork-up-to-date
 [push-commits]: ../git/using.html#push-your-commits-to-github

--- a/docs/git/setup.md
+++ b/docs/git/setup.md
@@ -63,5 +63,5 @@ And, if none of the above are to your liking, try [one of these][gitbook-guis].
 [gitgui-gitk]: https://git-scm.com/docs/gitk
 [gitgui-gitxdev]: https://rowanj.github.io/gitx/
 [gitgui-sourcetree]: https://www.sourcetreeapp.com/
-[github-help-add-ssh-key]: https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/
+[github-help-add-ssh-key]: https://help.github.com/en/articles/adding-a-new-ssh-key-to-your-github-account
 [tig]: http://jonas.nitro.dk/tig/

--- a/docs/git/troubleshooting.md
+++ b/docs/git/troubleshooting.md
@@ -277,4 +277,4 @@ whichever branch you need to update.
 [gitbook-basic-merge-conflicts]: https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging#Basic-Merge-Conflicts
 [gitbook-git-cherry-pick]: https://git-scm.com/docs/git-cherry-pick
 [gitbook-reset]: https://git-scm.com/docs/git-reset
-[github-help-resolve-merge-conflict]: https://help.github.com/articles/resolving-a-merge-conflict-using-the-command-line/
+[github-help-resolve-merge-conflict]: https://help.github.com/en/articles/resolving-a-merge-conflict-using-the-command-line

--- a/docs/git/using.md
+++ b/docs/git/using.md
@@ -442,10 +442,10 @@ complicated rebase.
 [gitbook-other-envs-bash]: https://git-scm.com/book/en/v2/Git-in-Other-Environments-Git-in-Bash
 [gitbook-other-envs-zsh]: https://git-scm.com/book/en/v2/Git-in-Other-Environments-Git-in-Zsh
 [gitbook-rm]: https://git-scm.com/docs/git-rm
-[github-help-closing-issues]: https://help.github.com/articles/closing-issues-via-commit-messages/
-[github-help-push]: https://help.github.com/articles/pushing-to-a-remote/
-[github-help-rebase]: https://help.github.com/articles/using-git-rebase/
-[github-help-sync-fork]: https://help.github.com/articles/syncing-a-fork/
+[github-help-closing-issues]: https://help.github.com/en/articles/closing-issues-via-commit-messages
+[github-help-push]: https://help.github.com/en/articles/pushing-to-a-remote
+[github-help-rebase]: https://help.github.com/en/articles/using-git-rebase
+[github-help-sync-fork]: https://help.github.com/en/articles/syncing-a-fork
 [how-git-is-different]: ./the-git-difference.html
 [zulip-git-guide-up-to-date]: ../git/using.html#keep-your-fork-up-to-date
 [zulip-rtd-commit-discipline]: ../contributing/version-control.html#commit-discipline

--- a/docs/subsystems/dependencies.md
+++ b/docs/subsystems/dependencies.md
@@ -233,7 +233,7 @@ from the SSH session.
 [mypy-docs]: ../testing/mypy.html
 [requirements-readme]: https://github.com/zulip/zulip/blob/master/requirements/README.md
 [stack-overflow]: https://askubuntu.com/questions/8653/how-to-keep-processes-running-after-ending-ssh-session
-[caching]: https://help.github.com/articles/caching-your-github-password-in-git/
+[caching]: https://help.github.com/en/articles/caching-your-github-password-in-git
 
 ## JavaScript and other frontend packages
 


### PR DESCRIPTION
help.github.com seems to have a bug where HEAD on a redirected page returns 404.  This causes tools/test-documentation to fail.  Fix it by skipping the redirects.