### PR TITLE
typeahead: Reset caret position immediately on typeahead success.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -260,7 +260,7 @@ run_test('topics_seen_for', () => {
 run_test('content_typeahead_selected', () => {
     var fake_this = {
         query: '',
-        $element: {},
+        $element: $('#compose-textarea'),
     };
     var caret_called1 = false;
     var caret_called2 = false;
@@ -269,21 +269,22 @@ run_test('content_typeahead_selected', () => {
             caret_called1 = true;
             return fake_this.query.length;
         }
-        // .caret() used in setTimeout
+        // .caret() used in $textbox.change()
         assert.equal(arg1, arg2);
         caret_called2 = true;
     };
+
+    const call_content_typeahead_selected = function (item) {
+        const actual_value = ct.content_typeahead_selected.call(fake_this, item);
+        fake_this.$element.trigger('change');
+        return actual_value;
+    };
+
     var autosize_called = false;
     set_global('compose_ui', {
         autosize_textarea: function () {
             autosize_called = true;
         },
-    });
-    var set_timeout_called = false;
-    global.patch_builtin('setTimeout', function (f, time) {
-        f();
-        assert.equal(time, 0);
-        set_timeout_called = true;
     });
     set_global('document', 'document-stub');
 
@@ -295,19 +296,19 @@ run_test('content_typeahead_selected', () => {
         emoji_name: 'octopus',
     };
 
-    var actual_value = ct.content_typeahead_selected.call(fake_this, item);
+    var actual_value = call_content_typeahead_selected(item);
     var expected_value = ':octopus: ';
     assert.equal(actual_value, expected_value);
 
     fake_this.query = ' :octo';
     fake_this.token = 'octo';
-    actual_value = ct.content_typeahead_selected.call(fake_this, item);
+    actual_value = call_content_typeahead_selected(item);
     expected_value = ' :octopus: ';
     assert.equal(actual_value, expected_value);
 
     fake_this.query = '{:octo';
     fake_this.token = 'octo';
-    actual_value = ct.content_typeahead_selected.call(fake_this, item);
+    actual_value = call_content_typeahead_selected(item);
     expected_value = '{ :octopus: ';
     assert.equal(actual_value, expected_value);
 
@@ -318,7 +319,7 @@ run_test('content_typeahead_selected', () => {
 
     fake_this.query = '@**Mark Tw';
     fake_this.token = 'Mark Tw';
-    actual_value = ct.content_typeahead_selected.call(fake_this, twin1);
+    actual_value = call_content_typeahead_selected(twin1);
     expected_value = '@**Mark Twin|105** ';
     assert.equal(actual_value, expected_value);
 
@@ -331,25 +332,25 @@ run_test('content_typeahead_selected', () => {
 
     fake_this.query = '@oth';
     fake_this.token = 'oth';
-    actual_value = ct.content_typeahead_selected.call(fake_this, othello);
+    actual_value = call_content_typeahead_selected(othello);
     expected_value = '@**Othello, the Moor of Venice** ';
     assert.equal(actual_value, expected_value);
 
     fake_this.query = 'Hello @oth';
     fake_this.token = 'oth';
-    actual_value = ct.content_typeahead_selected.call(fake_this, othello);
+    actual_value = call_content_typeahead_selected(othello);
     expected_value = 'Hello @**Othello, the Moor of Venice** ';
     assert.equal(actual_value, expected_value);
 
     fake_this.query = '@**oth';
     fake_this.token = 'oth';
-    actual_value = ct.content_typeahead_selected.call(fake_this, othello);
+    actual_value = call_content_typeahead_selected(othello);
     expected_value = '@**Othello, the Moor of Venice** ';
     assert.equal(actual_value, expected_value);
 
     fake_this.query = '@*oth';
     fake_this.token = 'oth';
-    actual_value = ct.content_typeahead_selected.call(fake_this, othello);
+    actual_value = call_content_typeahead_selected(othello);
     expected_value = '@**Othello, the Moor of Venice** ';
     assert.equal(actual_value, expected_value);
 
@@ -364,25 +365,25 @@ run_test('content_typeahead_selected', () => {
 
     fake_this.query = '@_kin';
     fake_this.token = 'kin';
-    actual_value = ct.content_typeahead_selected.call(fake_this, hamlet);
+    actual_value = call_content_typeahead_selected(hamlet);
     expected_value = '@_**King Hamlet** ';
     assert.equal(actual_value, expected_value);
 
     fake_this.query = 'Hello @_kin';
     fake_this.token = 'kin';
-    actual_value = ct.content_typeahead_selected.call(fake_this, hamlet);
+    actual_value = call_content_typeahead_selected(hamlet);
     expected_value = 'Hello @_**King Hamlet** ';
     assert.equal(actual_value, expected_value);
 
     fake_this.query = '@_*kin';
     fake_this.token = 'kin';
-    actual_value = ct.content_typeahead_selected.call(fake_this, hamlet);
+    actual_value = call_content_typeahead_selected(hamlet);
     expected_value = '@_**King Hamlet** ';
     assert.equal(actual_value, expected_value);
 
     fake_this.query =  '@_**kin';
     fake_this.token = 'kin';
-    actual_value = ct.content_typeahead_selected.call(fake_this, hamlet);
+    actual_value = call_content_typeahead_selected(hamlet);
     expected_value = '@_**King Hamlet** ';
     assert.equal(actual_value, expected_value);
 
@@ -396,19 +397,19 @@ run_test('content_typeahead_selected', () => {
 
     fake_this.query = '@back';
     fake_this.token = 'back';
-    actual_value = ct.content_typeahead_selected.call(fake_this, backend);
+    actual_value = call_content_typeahead_selected(backend);
     expected_value = '@*Backend* ';
     assert.equal(actual_value, expected_value);
 
     fake_this.query = '@*back';
     fake_this.token = 'back';
-    actual_value = ct.content_typeahead_selected.call(fake_this, backend);
+    actual_value = call_content_typeahead_selected(backend);
     expected_value = '@*Backend* ';
     assert.equal(actual_value, expected_value);
 
     fake_this.query = '/m';
     fake_this.completing = 'slash';
-    actual_value = ct.content_typeahead_selected.call(fake_this, me_slash);
+    actual_value = call_content_typeahead_selected(me_slash);
     expected_value = '/me ';
     assert.equal(actual_value, expected_value);
 
@@ -423,19 +424,19 @@ run_test('content_typeahead_selected', () => {
 
     fake_this.query = '#swed';
     fake_this.token = 'swed';
-    actual_value = ct.content_typeahead_selected.call(fake_this, sweden_stream);
+    actual_value = call_content_typeahead_selected(sweden_stream);
     expected_value = '#**Sweden** ';
     assert.equal(actual_value, expected_value);
 
     fake_this.query = 'Hello #swed';
     fake_this.token = 'swed';
-    actual_value = ct.content_typeahead_selected.call(fake_this, sweden_stream);
+    actual_value = call_content_typeahead_selected(sweden_stream);
     expected_value = 'Hello #**Sweden** ';
     assert.equal(actual_value, expected_value);
 
     fake_this.query = '#**swed';
     fake_this.token = 'swed';
-    actual_value = ct.content_typeahead_selected.call(fake_this, sweden_stream);
+    actual_value = call_content_typeahead_selected(sweden_stream);
     expected_value = '#**Sweden** ';
     assert.equal(actual_value, expected_value);
 
@@ -444,19 +445,19 @@ run_test('content_typeahead_selected', () => {
 
     fake_this.query = '~~~p';
     fake_this.token = 'p';
-    actual_value = ct.content_typeahead_selected.call(fake_this, 'python');
+    actual_value = call_content_typeahead_selected('python');
     expected_value = '~~~python\n\n~~~';
     assert.equal(actual_value, expected_value);
 
     fake_this.query = 'Hello ~~~p';
     fake_this.token = 'p';
-    actual_value = ct.content_typeahead_selected.call(fake_this, 'python');
+    actual_value = call_content_typeahead_selected('python');
     expected_value = 'Hello ~~~python\n\n~~~';
     assert.equal(actual_value, expected_value);
 
     fake_this.query = '```p';
     fake_this.token = 'p';
-    actual_value = ct.content_typeahead_selected.call(fake_this, 'python');
+    actual_value = call_content_typeahead_selected('python');
     expected_value = '```python\n\n```';
     assert.equal(actual_value, expected_value);
 
@@ -466,21 +467,20 @@ run_test('content_typeahead_selected', () => {
     fake_this.$element.caret = function () {
         return 4; // Put cursor right after ```p
     };
-    actual_value = ct.content_typeahead_selected.call(fake_this, 'python');
+    actual_value = call_content_typeahead_selected('python');
     expected_value = '```python\nsome existing code';
     assert.equal(actual_value, expected_value);
 
     fake_this.completing = 'something-else';
 
     fake_this.query = 'foo';
-    actual_value = ct.content_typeahead_selected.call(fake_this, {});
+    actual_value = call_content_typeahead_selected({});
     expected_value = fake_this.query;
     assert.equal(actual_value, expected_value);
 
     assert(caret_called1);
     assert(caret_called2);
     assert(autosize_called);
-    assert(set_timeout_called);
     assert(document_stub_trigger1_called);
     assert(document_stub_group_trigger_called);
     assert(document_stub_trigger2_called);

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -689,13 +689,16 @@ exports.content_typeahead_selected = function (item, event) {
         beginning = beginning.substring(0, start) + item + '** ';
     }
 
-    // Keep the cursor after the newly inserted text, as Bootstrap will call textbox.change() to
-    // overwrite the text in the textbox.
-    setTimeout(function () {
+    // Keep the cursor after the newly inserted text.  Because Bootstrap's default
+    // textbox.change() handler will end up jumping the cursor to the end of the
+    // textbox, we overwrite it with a custom version that puts the cursor at the
+    // end of the completion.
+    this.$element.off('change').on('change', function () {
         textbox.caret(beginning.length, beginning.length);
         // Also, trigger autosize to check if compose box needs to be resized.
         compose_ui.autosize_textarea();
-    }, 0);
+    });
+
     return beginning + rest;
 };
 


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/9-issues/topic/user.20typeahead.20regression.3F

Recommend deploying on CZO for testing without merging to see if there are any counter effects. Manual testing locally worked fine.
