### PR TITLE
docs: Add logo and favicon.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,6 +127,7 @@ else:
 # documentation.
 html_theme_options = {
     'collapse_navigation': False,
+    'logo_only': True,
 }
 
 # Add any paths that contain custom themes here, relative to this directory.
@@ -141,7 +142,7 @@ html_theme_options = {
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+html_logo = '../static/images/logo/zulip-org-logo.png'
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32


### PR DESCRIPTION
Add the Zulip logo and favicon to the docs that will appear on
readthedocs.

Fixes: #11700.

The documentation (built with Sphinx) now looks like this:

![image](https://user-images.githubusercontent.com/7549858/53518464-ffbda680-3ac8-11e9-99f8-e07bcec35e58.png)
