### PR TITLE
docs: Stop people from reading ReadTheDocs docs on github.

### DIFF
--- a/docs/subsystems/two-factor-auth.md
+++ b/docs/subsystems/two-factor-auth.md
@@ -1,5 +1,11 @@
 # Two Factor Authentication
 
+```eval_rst
+.. only:: false
+    This documentation is meant to be read on ReadTheDocs, go there:
+    https://zulip.readthedocs.io/en/latest/subsystems/two-factor-auth.html
+```
+
 Zulip uses [django-two-factor-auth][0] to integrate 2FA.
 
 To enable 2FA, set `TWO_FACTOR_AUTHENTICATION_ENABLED` in settings to `True`,


### PR DESCRIPTION
Add a block that's invisible on ReadTheDocs but visible on
Github Markdown indicating warning that folks should read
it on ReadTheDocs instead.

_Added block is:_
```
eval_rst
.. only:: false
    This documentation is meant to be read on ReadTheDocs, go there:
    https://zulip.readthedocs.io/en/latest/subsystems/two-factor-auth.html
```