### PR TITLE
try_git_describe: Set cwd, not --git-dir.

### DIFF
--- a/zerver/logging_handlers.py
+++ b/zerver/logging_handlers.py
@@ -18,10 +18,9 @@ from version import ZULIP_VERSION
 def try_git_describe() -> Optional[str]:
     try:  # nocoverage
         return subprocess.check_output(
-            ['git',
-             '--git-dir', os.path.join(os.path.dirname(__file__), '../.git'),
-             'describe', '--tags', '--always', '--dirty', '--long'],
+            ['git', 'describe', '--tags', '--always', '--dirty', '--long'],
             stderr=subprocess.PIPE,
+            cwd=os.path.join(os.path.dirname(__file__), '..'),
         ).strip().decode('utf-8')
     except Exception:  # nocoverage
         return None


### PR DESCRIPTION
git describe --dirty requires a working tree, not just a repository.