### PR TITLE
backup: Set cwd while running pg_dump

### DIFF
--- a/zerver/management/commands/backup.py
+++ b/zerver/management/commands/backup.py
@@ -64,7 +64,10 @@ class Command(ZulipBaseCommand):
 
             db_name = settings.DATABASES["default"]["NAME"]
             db_dir = os.path.join(tmp, "zulip-backup", "database")
-            run(["pg_dump", "--format=directory", db_name, "--file", db_dir])
+            run(
+                ["pg_dump", "--format=directory", "--file", db_dir, "--", db_name],
+                cwd=tmp,
+            )
             members.append("zulip-backup/database")
 
             if settings.LOCAL_UPLOADS_DIR is not None and os.path.exists(


### PR DESCRIPTION
This avoids a spurious permission error inside the Postgres `resolve_symlinks` function if we don’t have access to the current working directory (e.g. we’re running with cwd /root inside `su zulip`).

While we’re here, add a defensive `--` argument.