### PR TITLE
Create Wrapper for Rendering Stream Descriptions [Refactor]

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -18,7 +18,7 @@ from analytics.lib.counts import COUNT_STATS, do_increment_logging_stat, \
 from zerver.lib.bugdown import (
     version as bugdown_version,
     url_embed_preview_enabled,
-    convert as bugdown_convert
+    convert as bugdown_convert,
 )
 from zerver.lib.addressee import Addressee
 from zerver.lib.bot_config import (
@@ -1726,6 +1726,9 @@ def get_default_value_for_history_public_to_subscribers(
 
     return history_public_to_subscribers
 
+def render_stream_description(text: str) -> str:
+    return bugdown_convert(text, no_previews=True)
+
 def create_stream_if_needed(realm: Realm,
                             stream_name: str,
                             *,
@@ -1751,7 +1754,7 @@ def create_stream_if_needed(realm: Realm,
     )
 
     if created:
-        stream.rendered_description = bugdown_convert(stream.description, no_previews=True)
+        stream.rendered_description = render_stream_description(stream_description)
         stream.save(update_fields=["rendered_description"])
         Recipient.objects.create(type_id=stream.id, type=Recipient.STREAM)
         if stream.is_public():
@@ -3496,7 +3499,7 @@ def do_rename_stream(stream: Stream,
 
 def do_change_stream_description(stream: Stream, new_description: str) -> None:
     stream.description = new_description
-    stream.rendered_description = bugdown_convert(new_description, no_previews=True)
+    stream.rendered_description = render_stream_description(new_description)
     stream.save(update_fields=['description', 'rendered_description'])
 
     event = dict(
@@ -5334,7 +5337,7 @@ def do_update_user_custom_profile_data(user_profile: UserProfile,
                 field_id=field['id'])
             field_value.value = field['value']
             if field_value.field.is_renderable():
-                field_value.rendered_value = bugdown_convert(str(field['value']))
+                field_value.rendered_value = render_stream_description(str(field['value']))
                 field_value.save(update_fields=['value', 'rendered_value'])
             else:
                 field_value.save(update_fields=['value'])

--- a/zerver/lib/bulk_create.py
+++ b/zerver/lib/bulk_create.py
@@ -4,7 +4,6 @@ from zerver.lib.initial_password import initial_password
 from zerver.models import Realm, Stream, UserProfile, \
     Subscription, Recipient, RealmAuditLog
 from zerver.lib.create_user import create_user_profile
-from zerver.lib.bugdown import convert as bugdown_convert
 
 def bulk_create_users(realm: Realm,
                       users_raw: Set[Tuple[str, str, str, bool]],
@@ -75,12 +74,13 @@ def bulk_create_streams(realm: Realm,
             options['history_public_to_subscribers'] = (
                 not options.get("invite_only", False) and not realm.is_zephyr_mirror_realm)
         if name.lower() not in existing_streams:
+            from zerver.lib.actions import render_stream_description
             streams_to_create.append(
                 Stream(
                     realm=realm,
                     name=name,
                     description=options["description"],
-                    rendered_description=bugdown_convert(options["description"], no_previews=True),
+                    rendered_description=render_stream_description(options["description"]),
                     invite_only=options.get("invite_only", False),
                     is_announcement_only=options.get("is_announcement_only", False),
                     history_public_to_subscribers=options["history_public_to_subscribers"],

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -22,7 +22,8 @@ from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.export import DATE_FIELDS, \
     Record, TableData, TableName, Field, Path
 from zerver.lib.message import do_render_markdown
-from zerver.lib.bugdown import version as bugdown_version, convert as bugdown_convert
+from zerver.lib.bugdown import version as bugdown_version
+from zerver.lib.actions import render_stream_description
 from zerver.lib.upload import random_name, sanitize_name, \
     guess_type, BadImageError
 from zerver.lib.utils import generate_api_key, process_list_in_batches
@@ -746,8 +747,7 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int=1) -> Realm
     for stream in data['zerver_stream']:
         if 'rendered_description' in stream:
             continue
-        stream["rendered_description"] = bugdown_convert(stream["description"],
-                                                         no_previews=True)
+        stream["rendered_description"] = render_stream_description(stream["description"])
     bulk_import_model(data, Stream)
 
     realm.notifications_stream_id = notifications_stream_id

--- a/zerver/migrations/0206_stream_rendered_description.py
+++ b/zerver/migrations/0206_stream_rendered_description.py
@@ -6,14 +6,13 @@ from django.db import migrations, models
 from django.db.migrations.state import StateApps
 from django.db.backends.postgresql_psycopg2.schema import DatabaseSchemaEditor
 
-from zerver.lib.bugdown import convert as bugdown_convert
+from zerver.lib.actions import render_stream_description
 
 def render_all_stream_descriptions(apps: StateApps, schema_editor: DatabaseSchemaEditor) -> None:
     Stream = apps.get_model('zerver', 'Stream')
     all_streams = Stream.objects.exclude(description='')
     for stream in all_streams:
-        stream.rendered_description = bugdown_convert(stream.description,
-                                                      no_previews=True)
+        stream.rendered_description = render_stream_description(stream.description)
         stream.save(update_fields=["rendered_description"])
 
 


### PR DESCRIPTION
In commit #de65a04 we can see that if the need ever arises to modify
how stream descriptions are rendered, we would need to make changes
at 5 different call points which can be quite cumbersome. So this
functionality has been extracted to a new module aptly named
'bugdown_wrappers'. A simple test has been added as well based on the
new test introduced in commit #de65a04.

The need for a new module is that in the future as Zulip adds markdown
rendering to more areas, we would want to ensure that we can easily
enforce any restrictions for that area in a simple wrapper around the
bugdown engine's convert method and then reuse that wrapper.

Though I'm not 100% sure if making the new file/module was the best
thing to do. I *do* think that it's a good measure which does some future
planning, but as I just said, I'm not sure. 

I'd greatly appreciate some feedback on this choice.