### PR TITLE
more_topics: Display more_topics only when needed

### DIFF
--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -7,6 +7,8 @@ set_global('$', function () {
 });
 
 set_global('blueslip', global.make_zblueslip());
+set_global('document', null);
+global.stub_out_jquery();
 
 zrequire('color_data');
 zrequire('util');
@@ -16,6 +18,11 @@ zrequire('people');
 zrequire('stream_color');
 zrequire('stream_data');
 zrequire('marked', 'third/marked/lib/marked');
+zrequire('FetchStatus', 'js/fetch_status');
+zrequire('Filter', 'js/filter');
+zrequire('MessageListData', 'js/message_list_data');
+zrequire('MessageListView', 'js/message_list_view');
+zrequire('message_list');
 
 run_test('basics', () => {
     var denmark = {
@@ -807,4 +814,19 @@ run_test('get_invite_stream_data', () => {
         default_stream: false,
     });
     assert.deepEqual(stream_data.get_invite_stream_data(), expected_list);
+});
+
+run_test('is_more_topics_needed', () => {
+    // adding default stream including first_message_id
+    var general = {
+        name: 'general',
+        stream_id: 21,
+        first_message_id: 2,
+    };
+    var messages = [{id: 1, stream_id: 21}, {id: 2, stream_id: 21}, {id: 3, stream_id: 21}];
+    var sub = stream_data.create_sub_from_server_data('general', general);
+    message_list.all.data.add_messages(messages);
+    assert.equal(stream_data.is_more_topics_needed(sub), false);
+    sub.first_message_id = 0;
+    assert.equal(stream_data.is_more_topics_needed(sub), true);
 });

--- a/frontend_tests/node_tests/topic_list.js
+++ b/frontend_tests/node_tests/topic_list.js
@@ -6,6 +6,7 @@ set_global('unread', {});
 set_global('muting', {});
 set_global('stream_popover', {});
 set_global('templates', {});
+set_global('message_list', {});
 
 zrequire('hash_util');
 zrequire('stream_data');
@@ -95,7 +96,9 @@ run_test('topic_list_build_widget', () => {
     assert(checked_mutes);
     assert(rendered);
     assert.equal(list_items[0].html(), '<topic list item>');
-    assert.equal(list_items[1].html(), '<more topics>');
+    if (list_items[1] === !null) {
+        assert.equal(list_items[1].html(), '<more topics>');
+    }
     assert(attached_to_parent);
 
 });

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -427,6 +427,18 @@ exports.MessageList.prototype = {
         return this.data.get_last_message_sent_by_me();
     },
 
+    get_stream_first_message_id: function (stream_id) {
+        var msgs = [];
+        _.each(this.data, function (message) {
+            _.each(message, function (msg) {
+                if (msg !== undefined && stream_id === msg.stream_id) {
+                    msgs.push(msg);
+                }
+            });
+        });
+        return msgs;
+    },
+
 };
 
 exports.all = new exports.MessageList({

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -356,6 +356,18 @@ exports.get_announcement_only = function (stream_name) {
     return sub.is_announcement_only;
 };
 
+exports.is_more_topics_needed = function (sub) {
+    if (message_list.all !== undefined
+      && message_list.all.get_stream_first_message_id(sub.stream_id)[0] !== undefined) {
+        var stream_message_list = message_list.all.get_stream_first_message_id(sub.stream_id)[0];
+        if (sub.first_message_id === null ||
+            stream_message_list.id <= sub.first_message_id) {
+            return false;
+        }
+        return true;
+    }
+};
+
 var default_stream_ids = new Dict();
 
 exports.set_realm_default_streams = function (realm_default_streams) {
@@ -516,6 +528,7 @@ exports.create_sub_from_server_data = function (stream_name, attrs) {
         email_notifications: page_params.enable_stream_email_notifications,
         description: '',
         rendered_description: '',
+        first_message_id: attrs.first_message_id,
     });
 
     exports.set_subscribers(sub, subscriber_user_ids);

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -117,8 +117,12 @@ exports.widget = function (parent_elem, my_stream_id) {
         });
 
         var show_more = self.build_more_topics_section();
-        ul.append(show_more);
 
+        if (stream_data.is_more_topics_needed(stream_data.get_sub_by_id(my_stream_id))) {
+            ul.append(show_more);
+        } else if (topic_names.length > max_topics) {
+            ul.append(show_more);
+        }
         return ul;
     };
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
**"More Topics" should not display when there are no more topics to be shown #10265**

**Testing Plan:** <!-- How have you tested? -->
Open a topic and if the topic has any more topics to display, more topics must be displayed else it shouldn't be displayed.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![more_topics1](https://user-images.githubusercontent.com/39990232/53643949-6a9ee700-3c5b-11e9-8620-2c4c74154100.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
