### PR TITLE
user status: Add icon for "unavailable".

### DIFF
--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -42,7 +42,7 @@ exports.get_user_circle_class = function (user_id) {
         return 'user_circle_orange';
     case 'away_them':
     case 'away_me':
-        return 'user_circle_empty';
+        return 'user_circle_empty_line';
     default:
         return 'user_circle_empty';
     }

--- a/static/styles/user_circles.scss
+++ b/static/styles/user_circles.scss
@@ -1,6 +1,7 @@
 .user_circle_green,
 .user_circle_orange,
 .user_circle_empty,
+.user_circle_empty_line,
 .user_circle_fraction {
     border-radius: 50%;
     border: 1px solid;
@@ -34,4 +35,17 @@
 .user_circle_empty {
     background-color: none;
     border-color: hsl(0, 0%, 50%);
+}
+
+.user_circle_empty_line {
+    border-color: hsl(0, 90%, 40%);
+  
+    &::after {
+        content: '';
+        background: hsl(0, 90%, 40%);
+        height: 1.5px; // 1px is too thin, 2px is too thick
+        width: 6px;
+        display: block;
+        margin: 3.25px auto 0 auto; // (total height - line height) / 2 = 3.25px
+    }
 }


### PR DESCRIPTION
Fixes #11589

Adds SCSS style for the "unavailable" user status and enables its
usage in `buddy_data.js`.

The style is a red circle with a horizontal line. The values might
look a bit 'magic' but they were considered carefully ` height` of
1px was too thin, 2px was too thick, thus 1.5px was chosen.

100%:
<img width="119" alt="screen shot 2019-03-01 at 6 31 11 pm" src="https://user-images.githubusercontent.com/867242/53653418-eac14e80-3c53-11e9-8b88-9ba54ac05218.png">

Zoomed in:
<img width="413" alt="screen shot 2019-03-01 at 6 30 22 pm" src="https://user-images.githubusercontent.com/867242/53653406-e7c65e00-3c53-11e9-89e1-2136c312e052.png">