### PR TITLE
markdown: Fix numbered list handling of blank lines between blocks.

### DIFF
--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -361,13 +361,16 @@ var preprocess_auto_olists = (function () {
         _.each(src.split('\n'), function (line) {
             var m = line.match(re);
             var isNextItem = m && currentList.length && currentIndent === getIndent(m);
-            if (!isNextItem) {
+            var isBlankLine = line.trim() === "";
+            if (!isNextItem && !isBlankLine) {
                 extendArray(newLines, renumber(currentList));
                 currentList = [];
             }
 
             if (!m) {
-                newLines.push(line);
+                if (!currentList.length) {
+                    newLines.push(line);
+                }
             } else if (isNextItem) {
                 currentList.push(m);
             } else {

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1415,14 +1415,21 @@ class AutoNumberOListPreprocessor(markdown.preprocessors.Preprocessor):
             is_next_item = (m and current_list
                             and current_indent == len(m.group(1)) // self.TAB_LENGTH)
 
-            if not is_next_item:
+            is_blank_line = line.strip() == ""
+
+            if not is_next_item and not is_blank_line:
                 # There is no more items in the list we were processing
                 new_lines.extend(self.renumber(current_list))
                 current_list = []
 
             if not m:
-                # Ordinary line
-                new_lines.append(line)
+                # If current list still has items and current line
+                # is a blank line then do not push it to new line,
+                # otherwise push it to the new line regardless of
+                # whether line is blank line or ordinary line
+                if not current_list:
+                    # Ordinary line
+                    new_lines.append(line)
             elif is_next_item:
                 # Another list item
                 current_list.append(m)

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -707,6 +707,12 @@
       "input": "$$\\<script type='text/javascript'>alert('xss');</script>$$\n\n~~~math\n\\<script type='text/javascript'>alert('xss');</script>\n~~~",
       "expected_output": "<p><span class=\"tex-error\">$$\\&lt;script type='text/javascript'&gt;alert('xss');&lt;/script&gt;$$</span></p>\n<p><span class=\"tex-error\">\\&lt;script type=&#39;text/javascript&#39;&gt;alert(&#39;xss&#39;);&lt;/script&gt;</span></p>",
       "marked_expected_output": "<p><span class=\"tex-error\">$$\\&lt;script type=&#39;text/javascript&#39;&gt;alert(&#39;xss&#39;);&lt;/script&gt;$$</span></p>\n<span class=\"tex-error\">\\&lt;script type=&#39;text/javascript&#39;&gt;alert(&#39;xss&#39;);&lt;/script&gt;</span>"
+    },
+    {
+      "name": "auto_renumbered_list_blankline",
+      "input": "1. A\n\n1. B\n\n1. C\n\n1. D\nordinary paragraph\n1. AA\n\n1. BB",
+      "expected_output": "<p>1. A<br>\n2. B<br>\n3. C<br>\n4. D<br>\nordinary paragraph<br>\n1. AA<br>\n2. BB</p>",
+      "text_content": "1. A\n2. B\n3. C\n4. D\nordinary paragraph\n1. AA\n2. BB"
     }
   ],
   "linkify_tests": [


### PR DESCRIPTION
This fixes an issue where blank lines between blocks were causing
auto-numbering of the list to stop before the blank line resulting
in two separate numbered list instead of one.

Fixes: #11651.