### PR TITLE
user status: Make "unavailable" status circle grey.

### DIFF
--- a/static/styles/user_circles.scss
+++ b/static/styles/user_circles.scss
@@ -38,11 +38,11 @@
 }
 
 .user_circle_empty_line {
-    border-color: hsl(0, 90%, 40%);
+    border-color: hsl(0, 0%, 50%);
 
     &::after {
         content: '';
-        background: hsl(0, 90%, 40%);
+        background: hsl(0, 0%, 50%);
         height: 1.5px; // 1px is too thin, 2px is too thick
         width: 6px;
         display: block;


### PR DESCRIPTION
After discussion, we decided that the red color is too distinct
and does not convey the idea of "almost offline".

This changes the new "unavailable" status circle's color from dark
red to grey, the same color used by the "offline" status circle.

|**Before**|**After**|
|---|---|
|<img width="198" alt="Before" src="https://user-images.githubusercontent.com/867242/53665741-f5401000-3c74-11e9-9928-f5f8f726132d.png">|<img width="195" alt="After" src="https://user-images.githubusercontent.com/867242/53665758-025cff00-3c75-11e9-83e1-9996a105489c.png">|