### PR TITLE
Replace generated U+202A LEFT-TO-RIGHT EMBEDDING with CSS properties

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -437,16 +437,8 @@ code {
     /* 12/14 em, so bootstrap's default 12 px,
        when body is the default 14 px */
     font-size: 0.857em;
-}
-
-code::before {
-    /* Add a left-to-right embedding character before each code block */
-    content: '\202a';
-}
-
-code::after {
-    /* And add a pop directional formatting character after each code block */
-    content: '\202c';
+    unicode-bidi: embed;
+    direction: ltr;
 }
 
 .message_content code {


### PR DESCRIPTION
These generated characters (added in #9889) were causing poor wrapping behavior, at least in Firefox:

![screenshot](https://user-images.githubusercontent.com/26471/53675926-a84a4280-3c50-11e9-85bb-b1401429a371.png)

@Shayan-To What was the motivation for adding these rules at all? Does this satisfy your use case?