### PR TITLE
help: Reorganize stream-permissions table.

### DIFF
--- a/templates/zerver/help/stream-permissions.md
+++ b/templates/zerver/help/stream-permissions.md
@@ -43,45 +43,48 @@ private stream messages:
 
 ### Public streams
 
-|                       | Org admins | Stream members | Org members | Guests
-|---                    |---         |---             |---          |---
-| Join                  | &#10004;   | &mdash;        | &#10004;    |
-| Add others            | &#10004;   | [1]            | &#10004;    |
-| See subscriber list   | &#10004;   | &#10004;       | &#10004;    |
-| See full history      | &#10004;   | &#10004;       | &#10004;    |
-| See estimated traffic | &#10004;   | &#10004;       | &#10004;    |
-| Post                  | &#10004;   | [2]            |             |
-| Change the privacy    | &#10004;   |                |             |
-| Rename                | &#10004;   |                |             |
-| Edit the description  | &#10004;   |                |             |
-| Remove others         | &#10004;   |                |             |
-| Delete                | &#10004;   |                |             |
+|                       | Org admins | Members   | Guests
+|---                    |---         |---        |---
+| Join                  | &#10004;   | &#10004;  |
+| Unsubscribe           | &#9726;    | &#9726;   | &#9726;
+| Add others            | &#10004;   | &#10004;  |
+| See subscriber list   | &#10004;   | &#10004;  | &#9726;
+| See full history      | &#10004;   | &#10004;  | &#9726;
+| See estimated traffic | &#10004;   | &#10004;  | &#9726;
+| Post                  | &#9726;    | &#10038;  | &#10038;
+| Change the privacy    | &#10004;   |           |
+| Rename                | &#10004;   |           |
+| Edit the description  | &#10004;   |           |
+| Remove others         | &#10004;   |           |
+| Delete                | &#10004;   |           |
 
-[1] Yes, except for guests.
+&#10004; Always
 
-[2] Configurable.
+&#9726; &nbsp; If subscribed to the stream
+
+&#10038; Configurable, but at minimum must be subscribed to the stream
+
 
 ### Private streams
 
-|                       | Org admins | Stream members | Org members | Guests
-|---                    |---         |---             |---          |---
-| Join                  |            | &mdash;        |             |
-| Add others            |            | [1]            |             |
-| See subscriber list   | &#10004;   | &#10004;       |             |
-| See full history      |            | [3]            |             |
-| See estimated traffic | &#10004;   | &#10004;       |             |
-| Post                  | &#10004;   | [2]            |             |
-| Change the privacy    | [4]        |                |             |
-| Rename                | &#10004;   |                |             |
-| Edit the description  | &#10004;   |                |             |
-| Remove others         | &#10004;   |                |             |
-| Delete                | &#10004;   |                |             |
 
-[1] Yes, except for guests.
+|                       | Org admins | Members   | Guests
+|---                    |---         |---        |---
+| Join                  |            |           |
+| Unsubscribe           | &#9726;    | &#9726;   | &#9726;
+| Add others            | &#9726;    | &#9726;   |
+| See subscriber list   | &#10004;   | &#9726;   | &#9726;
+| See full history      | &#10038;   | &#10038;  | &#10038;
+| See estimated traffic | &#10004;   | &#9726;   | &#9726;
+| Post                  | &#9726;    | &#10038;  | &#10038;
+| Change the privacy    | &#9726;    |           |
+| Rename                | &#10004;   |           |
+| Edit the description  | &#10004;   |           |
+| Remove others         | &#10004;   |           |
+| Delete                | &#10004;   |           |
 
-[2] Configurable.
+&#10004; Always
 
-[3] Depends on the stream type.
+&#9726; &nbsp; If subscribed to the stream
 
-[4] Yes, but only if subscribed. If you have a private stream without an
-admin, you'll have to add an admin in order to change the stream's privacy.
+&#10038; Configurable, but at minimum must be subscribed to the stream


### PR DESCRIPTION
Needs some styling help, but should be more clear. Given that we're going to have a few more of these tables, possibly the right thing is to add some markdown syntax specific to these kinds of tables, that uses CSS to make nice checkmarks, squares, etc.

![image](https://user-images.githubusercontent.com/890911/53679335-3be73780-3c80-11e9-8fa7-0c147a09e86c.png)
