### PR TITLE
popovers: Maintain compose box on profile modal close.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -304,6 +304,12 @@ exports.show_user_profile = function (user) {
     $("#user-profile-modal").modal("show");
 
     settings_account.intialize_custom_user_type_fields("#user-profile-modal #content", user.user_id, false, false);
+
+    $(".modal-backdrop, #user-profile-modal .close").on('click', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        $("#user-profile-modal").modal('hide');
+    });
 };
 
 function get_user_info_popover_items() {


### PR DESCRIPTION
The modal-backdrop and user-profile-modal had their on-click behavior
overridden to simply hide the modal, such that the compose box is preserved.

Keeping the compose box open after viewing a user's profile feels like a 
natural UX.

See issue: #11585

![compose](https://user-images.githubusercontent.com/39782863/53679964-4dc4dc80-3c78-11e9-9861-100d611dd75a.gif)

