### PR TITLE
digest: Couple of minor unread PMs related fixes 

### DIFF
--- a/templates/zerver/emails/digest.source.html
+++ b/templates/zerver/emails/digest.source.html
@@ -25,8 +25,9 @@
         </div>
         {% endfor %}
 
-        {% if remaining_unread_pms_count > 0 %}<p>+ {{ remaining_unread_pms_count }} more new private message{{ remaining_unread_pms_count|pluralize }}</p>{% endif %}
+        {% if remaining_unread_pms_count > 0 %}<p>+ {{ remaining_unread_pms_count }} more new private message{{ remaining_unread_pms_count|pluralize }}</p>
         <p><a href="{{ realm_uri }}/#narrow/is/private">Catch up on the rest of your PMs.</a></p>
+        {% endif %}
     </div>
     {% endif %}
 

--- a/templates/zerver/emails/digest.txt
+++ b/templates/zerver/emails/digest.txt
@@ -13,8 +13,8 @@ You have some missed private messages. Here are some of them:
 {% for message_block in sender_block.content %}{{ message_block.plain }}
 {% endfor %}
 {% endfor %}{% endfor %}
-{% if remaining_unread_pms_count > 0 %}+ {{ remaining_unread_pms_count }} more new private message{{ remaining_unread_pms_count|pluralize }}{% endif %}
-Catch up on the rest of your PMs: {{ realm_uri }}/#narrow/is/private{% endif %}
+{% if remaining_unread_pms_count > 0 %}+ {{ remaining_unread_pms_count }} more new private message{{ remaining_unread_pms_count|pluralize }}
+Catch up on the rest of your PMs: {{ realm_uri }}/#narrow/is/private{% endif %}{% endif %}
 
 {% if hot_conversations %}
 ** Hot conversations **

--- a/zerver/lib/digest.py
+++ b/zerver/lib/digest.py
@@ -230,7 +230,7 @@ def handle_digest_email(user_profile_id: int, cutoff: float,
 
     context['unread_pms'] = build_message_list(
         user_profile, [pm.message for pm in pms[:pms_limit]])
-    context['remaining_unread_pms_count'] = min(0, len(pms) - pms_limit)
+    context['remaining_unread_pms_count'] = max(0, len(pms) - pms_limit)
 
     home_view_recipients = [sub.recipient for sub in
                             Subscription.objects.filter(


### PR DESCRIPTION
- Trivial bug fix when trying to calculate the number of unread PMs not shown in the digest

- The second commit is a change that doesn't link to the PMs narrow, if all the PMs are already included in the digest. This may be a debatable change. 