### PR TITLE
stream settings: Add unsubscribe button for guests

### DIFF
--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -270,8 +270,7 @@ exports.update_calculated_fields = function (sub) {
     // If stream is public then any user can subscribe. If stream is private then only
     // subscribed users can unsubscribe.
     // Guest users can't subscribe themselves to any stream.
-    sub.should_display_subscription_button = sub.subscribed ||
-        !page_params.is_guest && !sub.invite_only;
+    sub.should_display_subscription_button = sub.subscribed && !sub.invite_only;
     sub.should_display_preview_button = sub.subscribed || !sub.invite_only ||
                                         sub.previously_subscribed;
     sub.can_change_stream_permissions = page_params.is_admin && (


### PR DESCRIPTION
Fixes: #11743

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Added visibility of Unsubscribe button for guests in stream settings.
In below screen shot, I've logged in as a guest user

**GIFs or Screenshots:** 
![screenshot 2019-03-02 at 6 10 43 pm](https://user-images.githubusercontent.com/39343253/53682280-10b12680-3d1a-11e9-9f25-652d4a35173b.png)
