### PR TITLE
css: Clean up sidebar markup for chevrons.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -792,7 +792,7 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
 
-    $('#user_presences').on('click', 'span.arrow', function (e) {
+    $('#user_presences').on('click', '.user-list-arrow', function (e) {
         e.stopPropagation();
 
         // use email of currently selected user, rather than some elem comparison,

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -222,7 +222,7 @@ exports.register_click_handlers = function () {
         });
     });
 
-    $('#global_filters').on('click', '.stream-sidebar-arrow', build_all_messages_popover);
+    $('#global_filters').on('click', '.all-messages-arrow', build_all_messages_popover);
 
     exports.register_stream_handlers();
     exports.register_topic_handlers();

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -276,17 +276,6 @@ a.conversation-partners:hover {
                 ignores top, font-size, display
                 display would be none either way
 
-        buddy list
-            span:
-                #user_presences .arrow (ok, top=0)
-
-                ul.filters .arrow
-                    keeps all but top
-
-            i:
-                ul.filters i
-                ignores ul.filters arrow
-
 */
 
 ul.filters i {

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -248,36 +248,6 @@ a.conversation-partners:hover {
     text-decoration: underline;
 }
 
-/*
-
-    The .arrow class is used in Zulip for chevrons,
-    but it's also used by popover for the little
-    triangle in the popovers.  We are moving to
-    eliminating the arrow class and using more concrete
-    classes for chevrons.  Here is an audit of the existing
-    state:
-
-        All messages:
-            has stream-sidebar-arrow (why?????)
-            ul.filters .arrow (right: 10px, etc.)
-
-        Private messages:
-            no chevrons
-
-        stream chevron
-            has stream-sidebar-arrow (ok)
-            ul.filters .arrow (right: 10px, etc.)
-
-        topic chevron:
-            ul.filters .topic-sidebar-arrow (ok, smaller font)
-
-            ul.filters .arrow:
-                keeps position, right
-                ignores top, font-size, display
-                display would be none either way
-
-*/
-
 ul.filters i {
     padding-right: 0.25em;
     /* Make filter icons the same width so labels line up. */
@@ -285,42 +255,59 @@ ul.filters i {
     width: 13px;
 }
 
-ul.filters .arrow {
+/*
+    All of our left sidebar handlers use absolute
+    positioning.  We should fix that.
+*/
+.all-messages-arrow,
+.stream-sidebar-arrow,
+.topic-sidebar-arrow {
     position: absolute;
-    top: 2px;
-    right: 10px;
-    font-size: 0.8em;
     display: none;
 }
 
-ul.filters li:hover .arrow {
-    display: inline;
-    cursor: pointer;
-    color: hsl(0, 0%, 53%);
+/*
+    The All Messages and Stream chevrons are
+    pretty similar.
+*/
+.all-messages-arrow,
+.stream-sidebar-arrow {
+    top: 2px;
+    right: 10px;
+    font-size: 0.8em;
 }
 
-ul.filters li .arrow:hover {
-    display: inline;
-    cursor: pointer;
-    color: hsl(0, 0%, 0%);
-}
-
-ul.filters .topic-sidebar-arrow {
-    font-size: 0.7em;
+/*
+    For topic chevrons we use a slightly smaller
+    font to show they're "lower" in the hierarchy,
+    which also affects it positioning.
+*/
+.topic-sidebar-arrow {
     top: 1px;
-    display: none !important;
+    right: 10px;
+    font-size: 0.7em;
 }
 
+/*
+    When you hover over list items, we hover
+    the relevant chevrons in light gray.
+*/
+li.top_left_all_messages:hover .all-messages-arrow,
+#stream_filters li:hover .stream-sidebar-arrow,
 li.topic-list-item:hover .topic-sidebar-arrow {
-    display: inline !important;
+    display: inline;
     cursor: pointer;
     color: hsl(0, 0%, 53%);
 }
 
-li.topic-list-item .topic-sidebar-arrow:hover {
-    display: inline;
-    cursor: pointer;
-    color: hsl(0, 0%, 0%);
+/*
+    If you hover directly over the chevron itself,
+    show it in black.
+*/
+.all-messages-arrow:hover,
+.stream-sidebar-arrow:hover,
+.topic-sidebar-arrow:hover {
+    color: hsl(0, 0%, 0%) !important;
 }
 
 ul.filters li.muted_topic,

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -144,10 +144,6 @@ li.active-sub-filter {
     border-radius: 4px;
 }
 
-#global_filters .global-filter i {
-    font-size: 14px;
-}
-
 #global_filters .global-filter a {
     display: block;
 }

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -248,6 +248,47 @@ a.conversation-partners:hover {
     text-decoration: underline;
 }
 
+/*
+
+    The .arrow class is used in Zulip for chevrons,
+    but it's also used by popover for the little
+    triangle in the popovers.  We are moving to
+    eliminating the arrow class and using more concrete
+    classes for chevrons.  Here is an audit of the existing
+    state:
+
+        All messages:
+            has stream-sidebar-arrow (why?????)
+            ul.filters .arrow (right: 10px, etc.)
+
+        Private messages:
+            no chevrons
+
+        stream chevron
+            has stream-sidebar-arrow (ok)
+            ul.filters .arrow (right: 10px, etc.)
+
+        topic chevron:
+            ul.filters .topic-sidebar-arrow (ok, smaller font)
+
+            ul.filters .arrow:
+                keeps position, right
+                ignores top, font-size, display
+                display would be none either way
+
+        buddy list
+            span:
+                #user_presences .arrow (ok, top=0)
+
+                ul.filters .arrow
+                    keeps all but top
+
+            i:
+                ul.filters i
+                ignores ul.filters arrow
+
+*/
+
 ul.filters i {
     padding-right: 0.25em;
     /* Make filter icons the same width so labels line up. */

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -425,7 +425,7 @@ li.show-more-private-messages {
     top: 0px;
 }
 
-.zero-topic-unreads .pm-box,
+.zero-pm-unreads .pm-box,
 .zero-topic-unreads .topic-box {
     margin-right: 15px;
 }

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -244,9 +244,11 @@ a.conversation-partners:hover {
     text-decoration: underline;
 }
 
-ul.filters i {
+.filter-icon i,
+.all-messages-arrow i,
+.stream-sidebar-arrow i,
+.topic-sidebar-arrow i {
     padding-right: 0.25em;
-    /* Make filter icons the same width so labels line up. */
     display: inline-block;
     width: 13px;
 }

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -256,6 +256,7 @@ on a dark background, and don't change the dark labels dark either. */
     #searchbox a.search_icon,
     #searchbox .search_button,
     .close,
+    #user_presences li:hover .user-list-arrow,
     ul.filters li:hover .arrow {
         color: hsl(236, 33%, 80%);
     }
@@ -267,6 +268,7 @@ on a dark background, and don't change the dark labels dark either. */
     #searchbox a.search_icon:hover,
     #searchbox .search_button:hover,
     .close:hover,
+    #user_presences li .user-list-arrow:hover,
     ul.filters li .arrow:hover {
         color: hsl(0, 0%, 100%);
     }

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -257,7 +257,9 @@ on a dark background, and don't change the dark labels dark either. */
     #searchbox .search_button,
     .close,
     #user_presences li:hover .user-list-arrow,
-    ul.filters li:hover .arrow {
+    li.top_left_all_messages:hover .all-messages-arrow,
+    #stream_filters li:hover .stream-sidebar-arrow,
+    li.topic-list-item:hover .topic-sidebar-arrow {
         color: hsl(236, 33%, 80%);
     }
 
@@ -267,10 +269,15 @@ on a dark background, and don't change the dark labels dark either. */
     #searchbox_legacy .search_button:hover,
     #searchbox a.search_icon:hover,
     #searchbox .search_button:hover,
-    .close:hover,
-    #user_presences li .user-list-arrow:hover,
-    ul.filters li .arrow:hover {
+    .close:hover {
         color: hsl(0, 0%, 100%);
+    }
+
+    #user_presences li .user-list-arrow:hover,
+    .all-messages-arrow:hover,
+    .stream-sidebar-arrow:hover,
+    .topic-sidebar-arrow:hover {
+        color: hsl(0, 0%, 100%) !important;
     }
 
     #streamlist-toggle,

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -58,6 +58,12 @@
     display: none;
 }
 
+.user-list-arrow i {
+    padding-right: 0.25em;
+    display: inline-block;
+    width: 13px;
+}
+
 #user_presences li:hover .user-list-arrow {
     display: inline;
     cursor: pointer;

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -50,9 +50,26 @@
     padding-right: 15px;
 }
 
-#user_presences .arrow {
+#user_presences .user-list-arrow {
+    position: absolute;
     top: 0px;
+    right: 10px;
+    font-size: 0.8em;
+    display: none;
 }
+
+#user_presences li:hover .user-list-arrow {
+    display: inline;
+    cursor: pointer;
+    color: hsl(0, 0%, 53%);
+}
+
+#user_presences li .user-list-arrow:hover {
+    display: inline;
+    cursor: pointer;
+    color: hsl(0, 0%, 0%);
+}
+
 
 #group-pm-title {
     margin: 10px 0px 0px 0px;

--- a/static/templates/sidebar_private_message_list.handlebars
+++ b/static/templates/sidebar_private_message_list.handlebars
@@ -21,9 +21,6 @@
                     <div class="value">{{unread}}</div>
                 </div>
             </span>
-            <span class="arrow topic-sidebar-arrow">
-                <i class="fa fa-chevron-down" aria-hidden="true"></i>
-            </span>
         </li>
         {{/each}}
         {{#if want_show_more_messages_links}}

--- a/static/templates/sidebar_private_message_list.handlebars
+++ b/static/templates/sidebar_private_message_list.handlebars
@@ -1,7 +1,7 @@
 <div id="private-container" class="scrolling_list">
     <ul class='expanded_private_messages {{zoom_class}}' data-name='private'>
         {{#each messages}}
-        <li class='{{#if is_zero}}zero-topic-unreads{{/if}} {{#if zoom_out_hide}}zoom-out-hide{{/if}} expanded_private_message' data-user-ids-string='{{user_ids_string}}'>
+        <li class='{{#if is_zero}}zero-pm-unreads{{/if}} {{#if zoom_out_hide}}zoom-out-hide{{/if}} expanded_private_message' data-user-ids-string='{{user_ids_string}}'>
             <span class='pm-box'>
 
                 {{#if is_group}}

--- a/static/templates/stream_sidebar_row.handlebars
+++ b/static/templates/stream_sidebar_row.handlebars
@@ -13,6 +13,6 @@
 
         <div class="count"><div class="value"></div></div>
     </div>
-    <span class="arrow stream-sidebar-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
+    <span class="stream-sidebar-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
 
 </li>

--- a/static/templates/topic_list_item.handlebars
+++ b/static/templates/topic_list_item.handlebars
@@ -7,7 +7,7 @@
             <div class="value">{{unread}}</div>
         </div>
     </span>
-    <span class="arrow topic-sidebar-arrow">
+    <span class="topic-sidebar-arrow">
         <i class="fa fa-chevron-down" aria-hidden="true"></i>
     </span>
 </li>

--- a/static/templates/user_presence_row.handlebars
+++ b/static/templates/user_presence_row.handlebars
@@ -13,5 +13,5 @@
         </a>
         <span class="count"><span class="value">{{#if num_unread}}{{num_unread}}{{/if}}</span></span>
     </div>
-    <span class="arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
+    <span class="user-list-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
 </li>

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -12,7 +12,7 @@
                         <span class="value"></span>
                     </span>
                 </a>
-                <span class="arrow stream-sidebar-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
+                <span class="arrow all-messages-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_private_messages global-filter">
                 <a href="#narrow/is/private">


### PR DESCRIPTION
Test this by hovering over chevrons here:

* All Messages
* streams
* topics
* buddy list
* some other random chevrons in the app (for due diligence)

Try to open/close popovers in all cases.