### PR TITLE
Fix Learn more about mentions link

### DIFF
--- a/templates/zerver/app/home.html
+++ b/templates/zerver/app/home.html
@@ -136,7 +136,7 @@
 
         <p>
             {% trans %}
-            Learn more about mentions <a href="/help/at-mention-a-user">
+            Learn more about mentions <a href="/help/mention-a-user-or-group">
             here</a>.
             {% endtrans %}
         </p>


### PR DESCRIPTION
New Zulip user here so let me know if I need to do anything differently. Found this 404 just after I created an account.

It seems like 1871d00bb251458f6f22e4921cc946c8015e186f renamed `/help/at-mention-a-user` to `/help/mention-a-user-or-group` but missed this link that shows up on the "You haven't been mentioned yet!" screen. Right now it leads to a "no such article page".

I haven't built Zulip or tested this change.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
