### PR TITLE
Renable digest emails for soft deactivated users.

### DIFF
--- a/zerver/lib/digest.py
+++ b/zerver/lib/digest.py
@@ -12,9 +12,8 @@ from confirmation.models import one_click_unsubscribe_link
 from zerver.lib.email_notifications import build_message_list
 from zerver.lib.send_email import send_future_email, FromAddress
 from zerver.lib.url_encoding import encode_stream
-from zerver.models import UserProfile, UserMessage, Recipient, \
-    Subscription, UserActivity, get_active_streams, get_user_profile_by_id, \
-    Realm, Message
+from zerver.models import UserProfile, Recipient, Subscription, UserActivity, \
+    get_active_streams, get_user_profile_by_id, Realm, Message, RealmAuditLog
 from zerver.context_processors import common_context
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.logging_util import log_to_file
@@ -166,18 +165,8 @@ def handle_digest_email(user_profile_id: int, cutoff: float,
                         render_to_web: bool = False) -> Union[None, Dict[str, Any]]:
     user_profile = get_user_profile_by_id(user_profile_id)
 
-    # We are disabling digest emails for soft deactivated users for the time.
-    # TODO: Find an elegant way to generate digest emails for these users.
-    if user_profile.long_term_idle:
-        return None
-
     # Convert from epoch seconds to a datetime object.
     cutoff_date = datetime.datetime.fromtimestamp(int(cutoff), tz=pytz.utc)
-
-    all_messages = UserMessage.objects.filter(
-        user_profile=user_profile,
-        message__pub_date__gt=cutoff_date
-    ).select_related('message').order_by("message__pub_date")
 
     context = common_context(user_profile)
 
@@ -186,16 +175,22 @@ def handle_digest_email(user_profile_id: int, cutoff: float,
         'unsubscribe_link': one_click_unsubscribe_link(user_profile, "digest")
     })
 
-    home_view_recipients = Subscription.objects.filter(
+    home_view_streams = Subscription.objects.filter(
         user_profile=user_profile,
+        recipient__type=Recipient.STREAM,
         active=True,
-        in_home_view=True).values_list('recipient_id', flat=True)
+        in_home_view=True).values_list('recipient__type_id', flat=True)
 
-    stream_messages = all_messages.filter(
-        message__recipient__type=Recipient.STREAM,
-        message__recipient__in=home_view_recipients)
+    if not user_profile.long_term_idle:
+        stream_ids = home_view_streams
+    else:
+        stream_ids = exclude_subscription_modified_streams(user_profile, home_view_streams, cutoff_date)
 
-    messages = [um.message for um in stream_messages]
+    # Fetch list of all messages sent after cutoff_date where the user is subscribed
+    messages = Message.objects.filter(
+        recipient__type=Recipient.STREAM,
+        recipient__type_id__in=stream_ids,
+        pub_date__gt=cutoff_date).select_related('recipient', 'sender', 'sending_client')
 
     # Gather hot conversations.
     context["hot_conversations"] = gather_hot_conversations(
@@ -217,3 +212,23 @@ def handle_digest_email(user_profile_id: int, cutoff: float,
         send_future_email('zerver/emails/digest', user_profile.realm, to_user_ids=[user_profile.id],
                           from_name="Zulip Digest", from_address=FromAddress.NOREPLY, context=context)
     return None
+
+def exclude_subscription_modified_streams(user_profile: UserProfile,
+                                          stream_ids: List[int],
+                                          cutoff_date: datetime.datetime) -> List[int]:
+    """Exclude streams from given list where users' subscription was modified."""
+
+    events = [
+        RealmAuditLog.SUBSCRIPTION_CREATED,
+        RealmAuditLog.SUBSCRIPTION_ACTIVATED,
+        RealmAuditLog.SUBSCRIPTION_DEACTIVATED
+    ]
+
+    # Streams where the user's subscription was changed
+    modified_streams = RealmAuditLog.objects.filter(
+        realm=user_profile.realm,
+        modified_user=user_profile,
+        event_time__gt=cutoff_date,
+        event_type__in=events).values_list('modified_stream_id', flat=True)
+
+    return list(set(stream_ids) - set(modified_streams))

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -29,9 +29,9 @@ class TestDigestEmailMessages(ZulipTestCase):
 
         one_day_ago = timezone_now() - datetime.timedelta(days=1)
         Message.objects.all().update(pub_date=one_day_ago)
-        one_sec_ago = timezone_now() - datetime.timedelta(seconds=1)
+        one_hour_ago = timezone_now() - datetime.timedelta(seconds=3600)
 
-        cutoff = time.mktime(one_sec_ago.timetuple())
+        cutoff = time.mktime(one_hour_ago.timetuple())
 
         senders = ['hamlet', 'cordelia',  'iago', 'prospero', 'ZOE']
         for sender_name in senders:


### PR DESCRIPTION
Digest emails were disabled for soft deactivated users, since UserMessage
objects are created for such users lazily when they return.

We now compute the message list for gathering hot conversations by looking at
all the messages sent to the streams where the user is subscribed, while they
were subscribed.

- Also includes a minor fix where context variables already computed are not updated again. 
- Also, a minor query optimization for computing the list of `home_view_recipients`