### PR TITLE
Split search of users using | 

### DIFF
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -592,6 +592,10 @@ run_test('filter_user_ids', () => {
     user_ids = get_user_ids();
     assert.deepEqual(user_ids, [alice.user_id, fred.user_id]);
 
+    user_filter.val('fr|al'); // test | as OR-operator
+    user_ids = get_user_ids();
+    assert.deepEqual(user_ids, [alice.user_id, fred.user_id]);
+
     presence.presence_info[alice.user_id] = { status: activity.IDLE };
     user_filter.val('fr,al'); // match fred and alice partials and idle user
     user_ids = get_user_ids();

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -112,7 +112,7 @@ function filter_user_ids(filter_text, user_ids) {
 
     user_ids = _.reject(user_ids, people.is_my_user_id);
 
-    var search_terms = filter_text.toLowerCase().split(",");
+    var search_terms = filter_text.toLowerCase().split(/[|,]+/);
     search_terms = _.map(search_terms, function (s) {
         return s.trim();
     });


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR solves #4109 . 

I have changed the search function to split the search string on either a `,` or a `|`, so both can be used as an OR-operator now. 

When searching for multiple users (so when the search string contains an OR-operator), pressing Enter starts a group PM with all the users that are found. Right now there is no check on the maximum number of people to start a group PM with, if wanted I could add a check. 