### PR TITLE
Change styling for STREAMS, USERS, and GROUP PMs

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -538,7 +538,7 @@ a:hover code {
 
 .sidebar-title {
     font-size: 14px;
-    color: hsl(0, 0%, 43%);
+    color: hsl(0, 0%, 25%);
     font-weight: normal;
     display: inline;
 }

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -539,7 +539,7 @@ a:hover code {
 .sidebar-title {
     font-size: 14px;
     color: hsl(0, 0%, 25%);
-    font-weight: normal;
+    font-weight: 600;
     display: inline;
 }
 

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -54,7 +54,7 @@
             </li>
         </ul>
         <div id="streams_list" class="zoom-out">
-            <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title" data-toggle="tooltip" title="{{ _('Subscribed streams') }}">{{ _('STREAMS') }}</h4>
+            <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title" data-toggle="tooltip" title="{{ _('Subscribed streams') }}">{{ _('Streams') }}</h4>
                 <i id="streams_inline_cog" class='fa fa-cog' aria-hidden="true" data-toggle="tooltip" title="{{ _('Subscribe, add, or configure streams') }}"></i>
                 <i id="streams_filter_icon" class='fa fa-search' aria-hidden="true" data-toggle="tooltip" title="{{ _('Filter streams') }} (q)"></i>
                 <div class="input-append notdisplayed stream_search_section">

--- a/templates/zerver/app/right_sidebar.html
+++ b/templates/zerver/app/right_sidebar.html
@@ -9,7 +9,7 @@
         {% endif %}
         <div id="user-list">
             <div id="userlist-header">
-                <h4 class='sidebar-title' id='userlist-title' data-toggle="tooltip" title="{{ _('Filter users') }}">{{ _('USERS') }}</h4>
+                <h4 class='sidebar-title' id='userlist-title' data-toggle="tooltip" title="{{ _('Filter users') }}">{{ _('Users') }}</h4>
                 <i id="user_filter_icon" class='fa fa-search' aria-hidden="true" aria-label="{{ _('Filter users') }}" data-toggle="tooltip" title="{{ _('Filter users') }} (w)"></i>
             </div>
             <div class="input-append notdisplayed" id="user_search_section">
@@ -25,7 +25,7 @@
         </div>
         <div id="group-pm-list">
             <div id="group-pm-header">
-                <h4 class='sidebar-title' id='group-pm-title'>{{ _('GROUP PMs') }}</h4>
+                <h4 class='sidebar-title' id='group-pm-title'>{{ _('Group PMs') }}</h4>
             </div>
             <ul id="group-pms" class="filters scrolling_list">
             </ul>

--- a/tools/lib/capitalization.py
+++ b/tools/lib/capitalization.py
@@ -23,6 +23,7 @@ IGNORED_PHRASES = [
     r"G Suite",
     r"Google",
     r"Gravatar",
+    r"Group PMs",
     r"Hamlet",
     r"Help Center",
     r"HTTP",


### PR DESCRIPTION
This makes our fonts more explicit and consistent, which allows us to align the top left corner and streams lists a bit more nicely.  (See the experiment I did on chat asking folks to see what's different--nobody complained, it just felt vaguely cleaner to them.)

I also attempt to clean up the sidebar titles--I haven't user tested that yet.