### PR TITLE
Issue- #11766: Fix JavaScript on-hover explanation on the Keyboard Shortcut icon shows doubling effect

### DIFF
--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -271,8 +271,8 @@ exports.initialize_kitchen_sink_stuff = function () {
 
     $('.copy_message[data-toggle="tooltip"]').tooltip();
 
-    $('#keyboard-icon').tooltip();
-
+    $('#keyboard-icon').tooltip({placement: 'top',
+                                 animation: false});
     $("body").on("mouseover", ".message_edit_content", function () {
         $(this).closest(".message_row").find(".copy_message").show();
     });


### PR DESCRIPTION
**PR for issue:-** JavaScript on-hover explanation on the Keyboard Shortcut icon shows doubling effect. #11766


**Testing Plan:** I have tested it vigrously in the Zulip's Development Environment, on multiple browsers(like Chrome, Mozilla Firefox, Firefox Developer edition) and multiple operating systems(Linux, Mac OS, Windows).



**GIFs or Screenshots:** 
1). On and off hover it used to show doubling effect on the keyboard shortcut icon.
![keybfr](https://user-images.githubusercontent.com/35079024/53698812-abd3fa00-3e07-11e9-8170-860f7fa2a609.gif)

2). Now after fixing the issue it is more clear(UI basis) and the doubling effect is removed.
![final](https://user-images.githubusercontent.com/35079024/53698932-f144f700-3e08-11e9-8bbb-5fcfd5a178a3.gif)

3). I have a suggestion: If we could change the placement of the on-hover explanation on the keyboard to left instead of top, as now the on-hover explanation coincides with the vertical right scroll-bar (Refer the gif in point 2). This suggestion would help in enhancing the overall UI (refer the gif bellow).

**Suggestion:**
![ll](https://user-images.githubusercontent.com/35079024/53698959-379a5600-3e09-11e9-9d81-fc2bcb405e75.gif)

Regards.


