### PR TITLE
Nginx Proxy Pass settings

### DIFF
--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -137,7 +137,7 @@ server {
                 proxy_http_version      1.1;
                 proxy_buffering         off;
                 proxy_read_timeout      20m;
-                proxy_pass              https://zulip-upstream-host;
+                proxy_pass              http://zulip-upstream-host-ip;
         }
 }
 ```


### PR DESCRIPTION
Updating NGINX config for a reverse proxy deployment.

- For me, this had to be `HTTP://`. Which makes sense if you are telling the server to listen on http:
```
[application_server]
http_only = true
```
- I also added the word "IP" for an extra hint for nginx newbies that this value should be an IP address.

