### PR TITLE
auth: Remove `invalid_subdomain` restriction from LDAP backend.

### DIFF
--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -451,12 +451,6 @@ class ZulipLDAPAuthBackend(ZulipLDAPAuthBackendBase):
             raise ZulipLDAPException("Realm has been deactivated")
         if return_data.get("inactive_user"):
             raise ZulipLDAPException("User has been deactivated")
-        if return_data.get("invalid_subdomain"):
-            # TODO: Implement something in the caller for this to
-            # provide a nice user-facing error message for this
-            # situation (right now it just acts like any other auth
-            # failure).
-            raise ZulipLDAPException("Wrong subdomain")
         if self._realm.deactivated:
             # This happens if no account exists, but the realm is
             # deactivated, so we shouldn't create a new user account


### PR DESCRIPTION
Fixes: #11692.