### PR TITLE
get_dev_uuid_var_path: Fix theoretical shell quoting problem

### DIFF
--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -150,8 +150,8 @@ def get_dev_uuid_var_path(create_if_missing=False):
             zulip_uuid = str(uuid.uuid4())
             # We need root access here, since the path will be under /srv/ in the
             # development environment.
-            run_as_root(["/bin/bash", "-c",
-                         "echo %s > %s" % (zulip_uuid, uuid_path)])
+            run_as_root(["sh", "-c", 'echo "$1" > "$2"', "-",
+                         zulip_uuid, uuid_path])
         else:
             raise AssertionError("Missing UUID file; please run tools/provision!")
 


### PR DESCRIPTION
**Testing Plan:** After `sudo rm /srv/.zulip-dev-uuid`, tested

```pycon
>>> scripts.lib.zulip_tools.get_dev_uuid_var_path(True)
+ sudo -- sh -c 'echo "$1" > "$2"' - e4377bfc-7535-44e1-bc9e-f760b240d68f /srv/.zulip-dev-uuid
'/srv/zulip/var/e4377bfc-7535-44e1-bc9e-f760b240d68f'
>>> scripts.lib.zulip_tools.get_dev_uuid_var_path()
'/srv/zulip/var/e4377bfc-7535-44e1-bc9e-f760b240d68f'
```
