### PR TITLE
markdown: Fix emojis not rendering with :bogus: in the line.

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1179,7 +1179,7 @@ class Emoji(markdown.inlinepatterns.Pattern):
         elif name in name_to_codepoint:
             return make_emoji(name_to_codepoint[name], orig_syntax)
         else:
-            return None
+            return orig_syntax
 
 def content_has_emoji_syntax(content: str) -> bool:
     return re.search(EMOJI_REGEX, content) is not None

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -543,6 +543,11 @@
       "text_content": "Emojis like :man-girl-girl: which have ZWJ are banned for now."
     },
     {
+      "name": "valid_emoji_preceded_by_invalid_emoji",
+      "input": "This is :invalidemoji: which should not prevent rendering :smile:",
+      "expected_output": "<p>This is :invalidemoji: which should not prevent rendering <span aria-label=\"smile\" class=\"emoji emoji-263a\" role=\"img\" title=\"smile\">:smile:</span></p>"
+    },
+    {
       "name": "safe_html",
       "input": "<h1>stay normal</h1> thanks",
       "expected_output": "<p>&lt;h1&gt;stay normal&lt;/h1&gt; thanks</p>",


### PR DESCRIPTION
This fixes an issue where invalid emoji name prevents following
emojis from rendering.

Fixes: #11770.