### PR TITLE
minor: Fix an artifact of delivery email migration in `populate_analytics_db`.

### DIFF
--- a/analytics/management/commands/populate_analytics_db.py
+++ b/analytics/management/commands/populate_analytics_db.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
                     date_joined: datetime,
                     realm: Realm) -> UserProfile:
         user = UserProfile.objects.create(
-            email=email, full_name=full_name, is_staff=is_staff,
+            delivery_email=email, email=email, full_name=full_name, is_staff=is_staff,
             realm=realm, short_name=full_name, pointer=-1, last_pointer_updater='none',
             api_key='42', date_joined=date_joined)
         RealmAuditLog.objects.create(


### PR DESCRIPTION
See: https://chat.zulip.org/#narrow/stream/49-development-help/topic/login.20error/near/712226

Probably we should do a cleanup to only have a single way of creating users.