### PR TITLE
search_users: Use Enter key to start group PM.

### DIFF
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -501,6 +501,22 @@ run_test('handlers', () => {
         filter_key_handlers.enter_key();
     }());
 
+    (function test_enter_key_with_or() {
+        init();
+        var narrowed;
+
+        narrow.by = (method, emails) => {
+            assert.deepEqual(emails, ['me@zulip.com', 'alice@zulip.com', 'fred@zulip.com']);
+            narrowed = true;
+        };
+
+        $('.user-list-filter').val('alice,fred|me');
+        activity.user_cursor.go_to(alice.user_id);
+
+        filter_key_handlers.enter_key();
+        assert(narrowed);
+    }());
+
     (function test_click_handler() {
         init();
         // We wire up the click handler in click_handlers.js,

--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -416,13 +416,34 @@ exports.narrow_for_user_id = function (opts) {
     exports.user_filter.clear_and_hide_search();
 };
 
+exports.narrow_for_user_ids = function (opts) {
+    var emails = _.map(opts.user_ids, function (user_id) {
+        var person = people.get_person_from_user_id(user_id);
+        return person.email;
+    });
+
+    narrow.by('pm-with', emails, {trigger: 'sidebar'});
+    exports.user_filter.clear_and_hide_search();
+};
+
 function keydown_enter_key() {
-    var user_id = exports.user_cursor.get_key();
-    if (user_id === undefined) {
-        return;
+    var filter_text = exports.get_filter_text();
+
+    // If someone searched for multiple users, try to start a
+    // group PM. Else, start a PM with the highlighted user
+    if (/[|,]+/.test(filter_text)) {
+        var user_ids = buddy_list.keys;
+        exports.narrow_for_user_ids({user_ids: user_ids});
+    } else {
+        var user_id = exports.user_cursor.get_key();
+
+        if (user_id === undefined) {
+            return;
+        }
+
+        exports.narrow_for_user_id({user_id: user_id});
     }
 
-    exports.narrow_for_user_id({user_id: user_id});
     popovers.hide_all();
 }
 


### PR DESCRIPTION
These changes allow the user to use the Enter key to start a group conversation with multiple other users when searching for multiple users. Currently the Enter key starts a private conversation with the highlighted user in the buddy list. 

Possible discussion is needed to discuss whether this feature is desirable or not. 

This PR is split off from PR #11763 and relates to issue #4109 . 
