### PR TITLE
bugfix: Hide tooltips when switching a narrow.

### DIFF
--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -136,6 +136,10 @@ exports.activate = function (raw_operators, opts) {
         unread.messages_read_in_narrow = false;
     }
 
+    // Open tooltips are only interesting for current stream,
+    // so hide them.
+    $('[data-toggle=tooltip]').tooltip("hide");
+
     // IMPORTANT!  At this point we are heavily committed to
     // populating the new narrow, so we update our narrow_state.
     // From here on down, any calls to the narrow_state API will


### PR DESCRIPTION
Fixes #4639.

Closes all open tooltips when activating a narrow.