### PR TITLE
bugfix: Hide tooltips when switching a narrow.

### DIFF
--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -68,6 +68,10 @@ exports.activate = function (raw_operators, opts) {
     // and expect to visit a list of narrows, so let's get these out of the way.
     notifications.clear_compose_notifications();
 
+    // Open tooltips are only interesting for current narrow,
+    // so hide them when activating a new one.
+    $(".tooltip").hide();
+
     if (raw_operators.length === 0) {
         return exports.deactivate();
     }


### PR DESCRIPTION
Fixes #4639.

This closes all open tooltips when activating a new narrow, as otherwise they are stuck on the screen (see the bugfix description).