### PR TITLE
Avoid empty message_content div for /me messages.

### DIFF
--- a/static/templates/message_body.handlebars
+++ b/static/templates/message_body.handlebars
@@ -38,7 +38,9 @@
 
 </div>
 
-<div class="message_content">{{#unless status_message}}{{#if use_match_properties}}{{{msg/match_content}}}{{else}}{{{msg/content}}}{{/if}}{{/unless}}</div>
+{{#unless status_message}}
+<div class="message_content">{{#if use_match_properties}}{{{msg/match_content}}}{{else}}{{{msg/content}}}{{/if}}</div>
+{{/unless}}
 
 {{#if last_edit_timestr}}
     {{#unless include_sender}}


### PR DESCRIPTION
This also makes the template a bit more readable.

(As an aside, copy/paste is broken for /me messages,
but that precedes this commit.)
