### PR TITLE
fix_narrow_btn_text

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1690,9 +1690,11 @@ run_test('nonexistent_stream_reply_error', () => {
 run_test('narrow_button_titles', () => {
     util.is_mobile = () => { return false; };
 
-    compose.update_stream_button_for_private();
+    compose.update_closed_compose_buttons_for_private();
     assert.equal($("#left_bar_compose_stream_button_big").text(), i18n.t("New stream message"));
+    assert.equal($("#left_bar_compose_private_button_big").text(), i18n.t("New conversation"));
 
-    compose.update_stream_button_for_stream();
+    compose.update_closed_compose_buttons_for_stream();
     assert.equal($("#left_bar_compose_stream_button_big").text(), i18n.t("New topic"));
+    assert.equal($("#left_bar_compose_private_button_big").text(), i18n.t("New private message"));
 });

--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -81,8 +81,8 @@ function test_helper() {
     stub('typing_events', 'render_notifications_for_narrow');
     stub('ui_util', 'change_tab_to');
     stub('unread_ops', 'process_visible');
-    stub('compose', 'update_stream_button_for_stream');
-    stub('compose', 'update_stream_button_for_private');
+    stub('compose', 'update_closed_compose_buttons_for_stream');
+    stub('compose', 'update_closed_compose_buttons_for_private');
     stub('notifications', 'hide_history_limit_message');
 
     blueslip.debug = noop;
@@ -203,7 +203,7 @@ run_test('basics', () => {
         'message_scroll.hide_indicators',
         'unread_ops.process_visible',
         'hashchange.save_narrow',
-        'compose.update_stream_button_for_stream',
+        'compose.update_closed_compose_buttons_for_stream',
         'search.update_button_visibility',
         'compose_actions.on_narrow',
         'top_left_corner.handle_narrow_activated',

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -106,16 +106,27 @@ function update_stream_button(btn_text, title) {
     $("#left_bar_compose_stream_button_big").prop("title", title);
 }
 
-exports.update_stream_button_for_private = function () {
-    var text = i18n.t("New stream message");
-    var title = text + " (c)";
-    update_stream_button(text, title);
+function update_conversation_button(btn_text, title) {
+    $("#left_bar_compose_private_button_big").text(btn_text);
+    $("#left_bar_compose_private_button_big").prop("title", title);
+}
+
+exports.update_closed_compose_buttons_for_private = function () {
+    var text_stream = i18n.t("New stream message");
+    var title_stream = text_stream + " (c)";
+    var text_conversation = i18n.t("New conversation");
+    var title_conversation = text_conversation + " (c)";
+    update_stream_button(text_stream, title_stream);
+    update_conversation_button(text_conversation, title_conversation);
 };
 
-exports.update_stream_button_for_stream = function () {
-    var text = i18n.t("New topic");
-    var title = text + " (c)";
-    update_stream_button(text, title);
+exports.update_closed_compose_buttons_for_stream = function () {
+    var text_stream = i18n.t("New topic");
+    var title_stream = text_stream + " (c)";
+    var text_conversation = i18n.t("New private message");
+    var title_conversation = text_conversation + " (c)";
+    update_stream_button(text_stream, title_stream);
+    update_conversation_button(text_conversation, title_conversation);
 };
 
 function update_fade() {

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -255,9 +255,9 @@ exports.activate = function (raw_operators, opts) {
 
     if (filter.has_operator("is") && filter.operands("is")[0] === "private"
         || filter.has_operator("pm-with") || filter.has_operator("group-pm-with")) {
-        compose.update_stream_button_for_private();
+        compose.update_closed_compose_buttons_for_private();
     } else {
-        compose.update_stream_button_for_stream();
+        compose.update_closed_compose_buttons_for_stream();
     }
 
     // Put the narrow operators in the search bar.
@@ -651,7 +651,7 @@ function handle_post_narrow_deactivate_processes() {
 
     top_left_corner.handle_narrow_deactivated();
     stream_list.handle_narrow_deactivated();
-    compose.update_stream_button_for_stream();
+    compose.update_closed_compose_buttons_for_stream();
     message_edit.handle_narrow_deactivated();
     widgetize.set_widgets_for_list();
     typing_events.render_notifications_for_narrow();


### PR DESCRIPTION
This commit changes the narrow button text when you switch between PM and stream conversation.

![screenshot from 2019-03-07 04-39-12](https://user-images.githubusercontent.com/32801674/53920436-2a909780-4093-11e9-968e-8a3f2a7e6d23.png)
![screenshot from 2019-03-07 04-39-18](https://user-images.githubusercontent.com/32801674/53920437-2b292e00-4093-11e9-93ab-5f9539c5fc0f.png)

Fixes: https://github.com/zulip/zulip/issues/11679
