### PR TITLE
portico: Fix styling of dropdown menu in nav bar.

### DIFF
--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -806,13 +806,14 @@ input.text-error {
 }
 
 .portico-header .dropdown ul li:hover {
-    background: linear-gradient(to bottom, hsl(163, 92%, 39%), hsl(200, 100%, 35%));
+    background-color: hsl(190, 10%, 90%);
     transition: none;
 }
 
 .portico-header .dropdown ul li a {
     display: block;
     margin: 2px 0px;
+    padding: 0px;
 
     transition: none;
     font-size: 0.9em;
@@ -823,7 +824,6 @@ input.text-error {
 
 .portico-header .dropdown ul li:hover a {
     background-color: transparent;
-    color: hsl(0, 0%, 100%);
 }
 
 .portico-header .dropdown ul li a i {

--- a/templates/zerver/portico-header-dropdown.html
+++ b/templates/zerver/portico-header-dropdown.html
@@ -7,13 +7,13 @@
         <li>
             <a href="/">
                 <i class="fa fa-home"></i>
-                Go home
+                Home
             </a>
         </li>
         <li class="logout">
             {% include 'zerver/app/logout.html' %}
             <a href="#logout">
-                <i class="fa fa-off"></i>
+                <i class="fa fa-sign-out"></i>
                 Log out
             </a>
         </li>


### PR DESCRIPTION
The previous gradient must have been from a previous design; it looked kind
of crazy against our current homepage. This widget also appears on /help,
/integrations, and other pages with a variety of different backgrounds, so a
neutral, muted style is probably safest.

The icon change is just because fa-off seems to be broken/missing. Maybe it
was in Font Awesome 3?

The extra padding line is to supercede padding (I assume) unintentionally
added by `.top-links a` to this widget on /help.

New:
![image](https://user-images.githubusercontent.com/890911/53922739-70654580-402a-11e9-9d82-4be53fe9c66a.png)

![image](https://user-images.githubusercontent.com/890911/53922750-7d823480-402a-11e9-988c-1d54128d3237.png)

Old:
![image](https://user-images.githubusercontent.com/890911/53922785-9ab70300-402a-11e9-9d3d-754cbe74f8bd.png)


