### PR TITLE
css: Consolidate some widths in left sidebar.

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -1,3 +1,7 @@
+$far_left_gutter_size: 10px;
+$left_col_size: 19px;
+$topic_indent: $far_left_gutter_size + $left_col_size + 4px;
+
 #left-sidebar #group-pm-list {
     display: none;
 }
@@ -10,7 +14,11 @@
 .stream-privacy {
     font-size: 15px;
     font-weight: 800;
-    min-width: 17px;
+    min-width: $left_col_size;
+}
+
+.pm_left_col {
+    min-width: $left_col_size;
 }
 
 #stream_filters,
@@ -90,7 +98,10 @@ li.show-more-private-messages a {
 }
 
 #stream_filters li ul.topic-list li {
-    padding: 2px 0px 2px 29px;
+    padding-top: 2px;
+    padding-right: 0px;
+    padding-bottom: 2px;
+    padding-left: $topic_indent;
 }
 
 #private-container,
@@ -139,7 +150,7 @@ li.active-sub-filter {
 
 #global_filters .filter-icon {
     display: inline-block;
-    min-width: 17px;
+    min-width: $left_col_size;
     text-align: center;
 }
 
@@ -147,7 +158,7 @@ li.active-sub-filter {
     position: relative;
     padding-top: 1px;
     padding-bottom: 1px;
-    padding-left: 8px;
+    padding-left: $far_left_gutter_size;
     padding-right: 10px;
 }
 
@@ -345,7 +356,7 @@ ul.filters li.out_of_home_view li.muted_topic {
 #stream_filters .subscription_block {
     padding: 0px;
     margin-right: 25px;
-    margin-left: 10px;
+    margin-left: $far_left_gutter_size;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -398,9 +409,7 @@ li.show-more-private-messages,
 li.expanded_private_message {
     position: relative;
     padding-top: 1px;
-    padding-right: 0px;
     padding-bottom: 1px;
-    padding-left: 0px;
 }
 
 li.expanded_private_message a {
@@ -408,7 +417,7 @@ li.expanded_private_message a {
 }
 
 li.show-more-private-messages {
-    padding-left: 21px;
+    padding-left: $left_col_size;
 }
 
 .show-all-streams a {
@@ -434,7 +443,6 @@ li.show-more-private-messages {
     margin-top: 0px;
     margin-bottom: 0px;
     margin-left: 2px;
-    margin-right: 9px;
     position: relative;
     top: 0px;
 }
@@ -475,7 +483,7 @@ li.show-more-private-messages {
 
 #streams_header {
     margin-right: 0px;
-    padding-left: 10px;
+    padding-left: $far_left_gutter_size;
     cursor: pointer;
 }
 

--- a/static/templates/sidebar_private_message_list.handlebars
+++ b/static/templates/sidebar_private_message_list.handlebars
@@ -4,15 +4,17 @@
         <li class='{{#if is_zero}}zero-pm-unreads{{/if}} {{#if zoom_out_hide}}zoom-out-hide{{/if}} expanded_private_message' data-user-ids-string='{{user_ids_string}}'>
             <span class='pm-box'>
 
-                {{#if is_group}}
-                    {{#if fraction_present}}
-                    <span class="{{user_circle_class}} user_circle" style="background:rgba(68,194,29,{{fraction_present}});"></span>
+                <div class="pm_left_col">
+                    {{#if is_group}}
+                        {{#if fraction_present}}
+                        <span class="{{user_circle_class}} user_circle" style="background:rgba(68,194,29,{{fraction_present}});"></span>
+                        {{else}}
+                        <span class="{{user_circle_class}} user_circle" style="background:none; border-color:rgb(127,127,127);"></span>
+                        {{/if}}
                     {{else}}
-                    <span class="{{user_circle_class}} user_circle" style="background:none; border-color:rgb(127,127,127);"></span>
+                        <span class="{{user_circle_class}} user_circle"></span>
                     {{/if}}
-                {{else}}
-                    <span class="{{user_circle_class}} user_circle"></span>
-                {{/if}}
+                </div>
 
                 <a href='{{url}}' class="conversation-partners" title="{{ recipients }}">
                     {{recipients}}

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -7,6 +7,7 @@
                     <span class="filter-icon">
                         <i class="fa fa-home" aria-hidden="true"></i>
                     </span>
+                    {#- squash whitespace -#}
                     <span>{{ _('All messages') }}</span>
                     <span class="count">
                         <span class="value"></span>
@@ -19,6 +20,7 @@
                     <span class="filter-icon">
                         <i class="fa fa-envelope" aria-hidden="true"></i>
                     </span>
+                    {#- squash whitespace -#}
                     <span title="{{ _('Private messages') }} (P)">{{ _('Private messages') }}</span>
                     <span class="count">
                         <span class="value"></span>
@@ -30,6 +32,7 @@
                     <span class="filter-icon">
                         <i class="fa fa-at" aria-hidden="true"></i>
                     </span>
+                    {#- squash whitespace -#}
                     <span>{{ _('Mentions') }}</span>
                     <span class="count">
                         <span class="value"></span>
@@ -41,6 +44,7 @@
                     <span class="filter-icon">
                         <i class="fa fa-star" aria-hidden="true"></i>
                     </span>
+                    {#- squash whitespace -#}
                     <span>{{ _('Starred messages') }}</span>
                     <span class="count">
                         <span class="value"></span>


### PR DESCRIPTION
We now use 10px to the left of major elements in
left sidebar.

And we then explicitly use 19px for the following:

    icons in top left
    indent for (more conversations)
    stream hashtag icons
    stream lock icons

We also kill off 2px of gutter that was caused
by whitespace in the HTML.

And then there are minor tweaks to things that
haven't been consolidated yet, like the indentation
of topics.
