### PR TITLE
settings_org: Fix visibility time of `Saved` state and `Discard` buttons.

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -167,7 +167,7 @@ function test_realms_domain_modal(add_realm_domain) {
 
 function createSaveButtons(subsection) {
     const stub_save_button_header = $('.subsection-header');
-    const save_btn_controls = $('.save-btn-controls');
+    const save_button_controls = $('.save-btn-controls');
     const stub_save_button = $(`#org-submit-${subsection}`);
     const stub_discard_button = $(`#org-submit-${subsection}`);
     const stub_save_button_text = $('.icon-button-text');
@@ -175,27 +175,27 @@ function createSaveButtons(subsection) {
         '.subsection-failed-status p', $('<failed status element>')
     );
     stub_save_button.closest = () => stub_save_button_header;
-    save_btn_controls.set_find_results(
+    save_button_controls.set_find_results(
         '.save-button', stub_save_button
     );
     stub_save_button.set_find_results(
         '.icon-button-text', stub_save_button_text
     );
     stub_save_button_header.set_find_results(
-        '.save-button-controls', save_btn_controls
+        '.save-button-controls', save_button_controls
     );
     stub_save_button_header.set_find_results(
         '.subsection-changes-discard .button', $(`#org-discard-${subsection}`)
     );
-    save_btn_controls.set_find_results(
+    save_button_controls.set_find_results(
         '.discard-button', stub_discard_button
     );
     const props  = {};
     props.hidden = false;
-    save_btn_controls.fadeIn = () => {
+    save_button_controls.fadeIn = () => {
         props.hidden = false;
     };
-    save_btn_controls.fadeOut = () => {
+    save_button_controls.fadeOut = () => {
         props.hidden = true;
     };
     return {
@@ -203,7 +203,7 @@ function createSaveButtons(subsection) {
         save_button: stub_save_button,
         discard_button: stub_discard_button,
         save_button_header: stub_save_button_header,
-        save_button_controls: save_btn_controls,
+        save_button_controls: save_button_controls,
         save_button_text: stub_save_button_text,
     };
 }
@@ -276,37 +276,51 @@ function test_submit_settings_form(submit_form) {
 }
 
 function test_change_save_button_state() {
-    var stubs = createSaveButtons('msg-editing');
-    var $save_btn_controls = stubs.save_button_controls;
-    var $save_btn_text = stubs.save_button_text;
-    var $save_btn = stubs.save_button;
-    var $discard_btn = stubs.discard_button;
-    $save_btn.attr("id", "org-submit-msg-editing");
-    var props = stubs.props;
-    settings_org.change_save_button_state($save_btn_controls, "unsaved");
-    assert.equal($save_btn_text.text(), 'translated: Save changes');
-    assert.equal(props.hidden, false);
-    assert.equal($save_btn.attr("data-status"), "unsaved");
-    assert.equal($discard_btn.visible(), true);
-    settings_org.change_save_button_state($save_btn_controls, "saved");
-    assert.equal($save_btn_text.text(), 'translated: Save changes');
-    assert.equal(props.hidden, true);
-    assert.equal($save_btn.attr("data-status"), "");
-    settings_org.change_save_button_state($save_btn_controls, "saving");
-    assert.equal($save_btn_text.text(), 'translated: Saving');
-    assert.equal($save_btn.attr("data-status"), "saving");
-    assert.equal($save_btn.hasClass('saving'), true);
-    assert.equal($discard_btn.visible(), false);
-    settings_org.change_save_button_state($save_btn_controls, "discarded");
-    assert.equal(props.hidden, true);
-    settings_org.change_save_button_state($save_btn_controls, "succeeded");
-    assert.equal(props.hidden, true);
-    assert.equal($save_btn.attr("data-status"), "saved");
-    assert.equal($save_btn_text.text(), 'translated: Saved');
-    settings_org.change_save_button_state($save_btn_controls, "failed");
-    assert.equal(props.hidden, false);
-    assert.equal($save_btn.attr("data-status"), "failed");
-    assert.equal($save_btn_text.text(), 'translated: Save changes');
+    var {
+        save_button_controls,
+        save_button_text,
+        save_button,
+        discard_button,
+        props,
+    } = createSaveButtons('msg-editing');
+    save_button.attr("id", "org-submit-msg-editing");
+
+    {
+        settings_org.change_save_button_state(save_button_controls, "unsaved");
+        assert.equal(save_button_text.text(), 'translated: Save changes');
+        assert.equal(props.hidden, false);
+        assert.equal(save_button.attr("data-status"), "unsaved");
+        assert.equal(discard_button.visible(), true);
+    }
+    {
+        settings_org.change_save_button_state(save_button_controls, "saved");
+        assert.equal(save_button_text.text(), 'translated: Save changes');
+        assert.equal(props.hidden, true);
+        assert.equal(save_button.attr("data-status"), "");
+    }
+    {
+        settings_org.change_save_button_state(save_button_controls, "saving");
+        assert.equal(save_button_text.text(), 'translated: Saving');
+        assert.equal(save_button.attr("data-status"), "saving");
+        assert.equal(save_button.hasClass('saving'), true);
+        assert.equal(discard_button.visible(), false);
+    }
+    {
+        settings_org.change_save_button_state(save_button_controls, "discarded");
+        assert.equal(props.hidden, true);
+    }
+    {
+        settings_org.change_save_button_state(save_button_controls, "succeeded");
+        assert.equal(props.hidden, true);
+        assert.equal(save_button.attr("data-status"), "saved");
+        assert.equal(save_button_text.text(), 'translated: Saved');
+    }
+    {
+        settings_org.change_save_button_state(save_button_controls, "failed");
+        assert.equal(props.hidden, false);
+        assert.equal(save_button.attr("data-status"), "failed");
+        assert.equal(save_button_text.text(), 'translated: Save changes');
+    }
 }
 
 function test_upload_realm_icon(upload_realm_icon) {
@@ -626,7 +640,7 @@ function test_discard_changes_button(discard_changes) {
     $('#org-discard-msg-editing').closest = () => discard_button_parent;
 
     const stubbed_function = settings_org.change_save_button_state;
-    settings_org.change_save_button_state = (save_btn_controls, state) => {
+    settings_org.change_save_button_state = (save_button_controls, state) => {
         assert.equal(state, "discarded");
     };
 

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -169,6 +169,7 @@ function createSaveButtons(subsection) {
     const stub_save_button_header = $('.subsection-header');
     const save_btn_controls = $('.save-btn-controls');
     const stub_save_button = $(`#org-submit-${subsection}`);
+    const stub_discard_button = $(`#org-submit-${subsection}`);
     const stub_save_button_text = $('.icon-button-text');
     stub_save_button_header.set_find_results(
         '.subsection-failed-status p', $('<failed status element>')
@@ -186,6 +187,9 @@ function createSaveButtons(subsection) {
     stub_save_button_header.set_find_results(
         '.subsection-changes-discard .button', $(`#org-discard-${subsection}`)
     );
+    save_btn_controls.set_find_results(
+        '.discard-button', stub_discard_button
+    );
     const props  = {};
     props.hidden = false;
     save_btn_controls.fadeIn = () => {
@@ -197,6 +201,7 @@ function createSaveButtons(subsection) {
     return {
         props: props,
         save_button: stub_save_button,
+        discard_button: stub_discard_button,
         save_button_header: stub_save_button_header,
         save_button_controls: save_btn_controls,
         save_button_text: stub_save_button_text,
@@ -275,12 +280,14 @@ function test_change_save_button_state() {
     var $save_btn_controls = stubs.save_button_controls;
     var $save_btn_text = stubs.save_button_text;
     var $save_btn = stubs.save_button;
+    var $discard_btn = stubs.discard_button;
     $save_btn.attr("id", "org-submit-msg-editing");
     var props = stubs.props;
     settings_org.change_save_button_state($save_btn_controls, "unsaved");
     assert.equal($save_btn_text.text(), 'translated: Save changes');
     assert.equal(props.hidden, false);
     assert.equal($save_btn.attr("data-status"), "unsaved");
+    assert.equal($discard_btn.visible(), true);
     settings_org.change_save_button_state($save_btn_controls, "saved");
     assert.equal($save_btn_text.text(), 'translated: Save changes');
     assert.equal(props.hidden, true);
@@ -289,9 +296,9 @@ function test_change_save_button_state() {
     assert.equal($save_btn_text.text(), 'translated: Saving');
     assert.equal($save_btn.attr("data-status"), "saving");
     assert.equal($save_btn.hasClass('saving'), true);
+    assert.equal($discard_btn.visible(), false);
     settings_org.change_save_button_state($save_btn_controls, "discarded");
     assert.equal(props.hidden, true);
-    assert.equal($save_btn.hasClass('saving'), false);
     settings_org.change_save_button_state($save_btn_controls, "succeeded");
     assert.equal(props.hidden, true);
     assert.equal($save_btn.attr("data-status"), "saved");

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -535,20 +535,31 @@ exports.sync_realm_settings = function (property) {
         discard_property_element_changes(element);
     }
 };
-function show_hide_element($element, show) {
-    if (show) {
-        $element.removeClass('hide').addClass('.show').fadeIn(300);
-        return;
-    }
-    $element.fadeOut(300);
-}
+
 
 exports.change_save_button_state = function ($element, state) {
+    function show_hide_element($element, show, fadeout_delay) {
+        if (show) {
+            $element.removeClass('hide').addClass('.show').fadeIn(300);
+            return;
+        }
+        setTimeout(function () {
+            $element.fadeOut(300);
+        }, fadeout_delay);
+    }
+
     var $saveBtn = $element.find('.save-button');
     var $textEl = $saveBtn.find('.icon-button-text');
+
     if (state !== "saving") {
         $saveBtn.removeClass('saving');
     }
+
+    if (state === "discarded") {
+        show_hide_element($element, false);
+        return;
+    }
+
     var button_text;
     var data_status;
     var is_show;
@@ -556,17 +567,18 @@ exports.change_save_button_state = function ($element, state) {
         button_text = i18n.t("Save changes");
         data_status = "unsaved";
         is_show = true;
+
+        $element.find('.discard-button').show();
     } else if (state === "saved") {
         button_text = i18n.t("Save changes");
         data_status = "";
-        is_show = false;
-    } else if (state === "discarded") {
-        $element.removeClass('saving');
         is_show = false;
     } else if (state === "saving") {
         button_text = i18n.t("Saving");
         data_status = "saving";
         is_show = true;
+
+        $element.find('.discard-button').hide();
         $saveBtn.addClass('saving');
     } else if (state === "failed") {
         button_text = i18n.t("Save changes");
@@ -578,13 +590,9 @@ exports.change_save_button_state = function ($element, state) {
         is_show = false;
     }
 
-    if (button_text) {
-        $textEl.text(button_text);
-    }
-    if (data_status) {
-        $saveBtn.attr("data-status", data_status);
-    }
-    show_hide_element($element, is_show);
+    $textEl.text(button_text);
+    $saveBtn.attr("data-status", data_status);
+    show_hide_element($element, is_show, 800);
 };
 
 exports.set_up = function () {
@@ -704,9 +712,7 @@ exports.build_page = function () {
             data: data,
             success: function (response_data) {
                 failed_alert_elem.hide();
-                setTimeout(function () {
-                    exports.change_save_button_state(save_btn_container, "succeeded");
-                }, 500);
+                exports.change_save_button_state(save_btn_container, "succeeded");
                 if (success_continuation !== undefined) {
                     success_continuation(response_data);
                 }

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -535,45 +535,56 @@ exports.sync_realm_settings = function (property) {
         discard_property_element_changes(element);
     }
 };
+function show_hide_element($element, show) {
+    if (show) {
+        $element.removeClass('hide').addClass('.show').fadeIn(300);
+        return;
+    }
+    $element.fadeOut(300);
+}
 
 exports.change_save_button_state = function ($element, state) {
-    var show_hide_element = function (state) {
-        if (state === 'show') {
-            $element.removeClass('hide').addClass('.show').fadeIn(300);
-        } else {
-            $element.fadeOut(300);
-        }
-    };
     var $saveBtn = $element.find('.save-button');
     var $textEl = $saveBtn.find('.icon-button-text');
     if (state !== "saving") {
         $saveBtn.removeClass('saving');
     }
+    var button_text;
+    var data_status;
+    var is_show;
     if (state === "unsaved") {
-        $textEl.text(i18n.t("Save changes"));
-        $saveBtn.attr("data-status", "unsaved");
-        show_hide_element('show');
+        button_text = i18n.t("Save changes");
+        data_status = "unsaved";
+        is_show = true;
     } else if (state === "saved") {
-        $textEl.text(i18n.t("Save changes"));
-        $saveBtn.attr("data-status", "");
-        show_hide_element('hide');
+        button_text = i18n.t("Save changes");
+        data_status = "";
+        is_show = false;
     } else if (state === "discarded") {
         $element.removeClass('saving');
-        show_hide_element('hide');
+        is_show = false;
     } else if (state === "saving") {
+        button_text = i18n.t("Saving");
+        data_status = "saving";
+        is_show = true;
         $saveBtn.addClass('saving');
-        $textEl.text(i18n.t("Saving"));
-        $saveBtn.attr("data-status", "saving");
-        show_hide_element('show');
     } else if (state === "failed") {
-        show_hide_element('show');
-        $textEl.text(i18n.t("Save changes"));
-        $saveBtn.attr("data-status", "failed");
+        button_text = i18n.t("Save changes");
+        data_status = "failed";
+        is_show = true;
     } else if (state === 'succeeded') {
-        show_hide_element('hide');
-        $textEl.text(i18n.t("Saved"));
-        $saveBtn.attr("data-status", "saved");
+        button_text = i18n.t("Saved");
+        data_status = "saved";
+        is_show = false;
     }
+
+    if (button_text) {
+        $textEl.text(button_text);
+    }
+    if (data_status) {
+        $saveBtn.attr("data-status", data_status);
+    }
+    show_hide_element($element, is_show);
 };
 
 exports.set_up = function () {


### PR DESCRIPTION
This fixes the bug where the `Saved` state fades out almost instantly(that
is actually 300 ms, by default). Now, we fixed the bug and defined the
`fadeout_duration` for `Saved` state to be 500 ms.

Fixes: #11737.

Let me know if it still gets fade out quickly, then I'm thinking to change the time limit from 500 ms to 800 ms, or if to any other intermediate value.
Here are the two GIF's for the same
- **GIF1** : with fadeout_duration `500 ms`.
![mar-07-2019 22-51-02](https://user-images.githubusercontent.com/40331304/53976548-45174f00-412d-11e9-9786-d2125a1e20b5.gif)
- **GIF2** : with fadeout_duration `800 ms`
![mar-07-2019 23-18-51](https://user-images.githubusercontent.com/40331304/53977840-ea332700-412f-11e9-9fb5-8e30b92baa9b.gif)

