### PR TITLE
Add no-select to trash icon

### DIFF
--- a/static/templates/admin_filter_list.handlebars
+++ b/static/templates/admin_filter_list.handlebars
@@ -7,7 +7,7 @@
         <span class="filter_url_format_string">{{url_format_string}}</span>
     </td>
     {{#if ../can_modify}}
-    <td>
+    <td class="no-select">
         <button class="button small delete btn-danger" data-filter-id="{{id}}">
             <i class="fa fa-trash-o" aria-hidden="true"></i>
         </button>


### PR DESCRIPTION
Addresses https://github.com/zulip/zulip/issues/10828#issuecomment-470807901

**Testing Plan:**

Since it's just a CSS change, I just ran it in my browser and tested.


**GIFs or Screenshots:**

![Recording of no-select behavior](http://g.recordit.co/sSJHBnFJTC.gif)

Happy to either:

- Add this class at a different level of the DOM (e.g. the button tag)
- Add this class to other reference to icons, and perhaps refactor it into a re-useable template which automatically adds no-select to icons (or just modify the css to do that)
