### PR TITLE
markdown: Fix bullet list indentation bug

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -351,6 +351,10 @@ li,
     line-height: inherit;
 }
 
+.table .bullet-list-indentation {
+    font-family: monospace;
+}
+
 .btn {
     font-size: inherit;
     height: auto;

--- a/static/third/marked/lib/marked.js
+++ b/static/third/marked/lib/marked.js
@@ -272,6 +272,10 @@ Lexer.prototype.token = function(src, top, bq) {
       src = src.substring(cap[0].length);
       bull = cap[2];
 
+      // Reduces the odd number of spaces
+      // to even.
+      cap[0] = cap[0].replace(/^((  )*) ?/gm, "$1");
+
       this.tokens.push({
         type: 'list_start',
         ordered: bull.length > 1

--- a/templates/zerver/app/markdown_help.html
+++ b/templates/zerver/app/markdown_help.html
@@ -28,12 +28,13 @@
                         <td><a href="https://zulip.org" target="_blank">Zulip website</a></td>
                     </tr>
                     <tr>
-                        <td>* Milk<br/>
+                        <td><span class="bullet-list-indentation">* Milk<br/>
                             * Tea<br/>
                             &nbsp;&nbsp;* Green tea<br/>
                             &nbsp;&nbsp;* Black tea<br/>
                             &nbsp;&nbsp;* Oolong tea<br/>
                             * Coffee
+                            </span>
                         </td>
                         <td>
                             <ul>

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -169,6 +169,12 @@
       "text_content": "\nI am outer list\n  I am something inside\n"
     },
     {
+      "name": "ulist_nested_ulist_with_odd_even_space_indent",
+      "input": "Nested list\n* I am outer list first item\n * I am outer list second item\n   * I am inner nested list first item",
+      "expected_output": "<p>Nested list</p>\n<ul>\n<li>I am outer list first item</li>\n<li>I am outer list second item<ul>\n<li>I am inner nested list first item</li>\n</ul>\n</li>\n</ul>",
+      "text_content": "Nested list\n\nI am outer list first item\nI am outer list second item\nI am inner nested list first item\n\n\n"
+    },
+    {
       "name": "ulist_codeblock",
       "input": "~~~\nint x = 3\n* 4;\n~~~",
       "expected_output": "<div class=\"codehilite\"><pre><span></span>int x = 3\n* 4;\n</pre></div>",


### PR DESCRIPTION
Previously, the frontend-only javascript processor didn't show the same
output as the backend, resulting in wrong output shown in drafts.

Fixes #10966

Tested various changes to the list implementation in marked.js and the final working solution that I came up with was, since we follow 2 spaces for the next item in a list why not replace all the odd number of spaces to even by reducing 1 space from them, thus adding a replace statement.

![list_identation_bug_fixed](https://user-images.githubusercontent.com/41135524/54044116-2760ed00-41f4-11e9-94cf-69a75b94bee0.gif)
