### PR TITLE
Migrate Mobile notifications always to other notifications settings

### DIFF
--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -13,12 +13,12 @@ var pm_mention_notification_settings = [
     "enable_desktop_notifications",
     "enable_offline_email_notifications",
     "enable_offline_push_notifications",
-    "enable_online_push_notifications",
     "enable_sounds",
     "pm_content_in_desktop_notifications",
 ];
 
 var other_notification_settings = [
+    "enable_online_push_notifications",
     "notification_sound",
     "enable_digest_emails",
     "enable_login_emails",

--- a/static/templates/settings/notification-settings.handlebars
+++ b/static/templates/settings/notification-settings.handlebars
@@ -71,19 +71,18 @@
               "label" settings_label.enable_offline_push_notifications
               "push_notifications_tooltip" true}}
 
-            {{partial "settings_checkbox"
-              "setting_name" "enable_online_push_notifications"
-              "is_checked" page_params.enable_online_push_notifications
-              "is_parent_setting_enabled" page_params.enable_offline_push_notifications
-              "is_nested" true
-              "label" settings_label.enable_online_push_notifications
-              "push_notifications_tooltip" true}}
         </div>
 
         <div id="other_notifications">
 
             <h3 class="inline-block">{{t "Other notification settings" }}</h3>
             <div class="alert-notification" id="other-notify-settings-status"></div>
+
+            {{partial "settings_checkbox"
+              "setting_name" "enable_online_push_notifications"
+              "is_checked" page_params.enable_online_push_notifications
+              "label" settings_label.enable_online_push_notifications
+              "push_notifications_tooltip" true}}
 
             {{partial "settings_checkbox"
               "setting_name" "enable_digest_emails"


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Online mobile notifications setting should not be under "PM and @mentions" section. Also, this setting should not be dependent on its parent setting.

**Testing Plan:** <!-- How have you tested? -->
I've just updated the UI. As we discussed in #10381, the backend works independently for both the settings. 
In development environment, since we are not allowed to check mobile notifications, I could not test if we can check both settings independently. 
But I think this should work good, since, I've remove two parameters from dependent setting, namely : `is_nested` and `is_parent_checked`. Moreover, the tests are passing. 