### PR TITLE
management: Support sending custom headers when testing a webhook.

### DIFF
--- a/templates/zerver/api/incoming-webhooks-walkthrough.md
+++ b/templates/zerver/api/incoming-webhooks-walkthrough.md
@@ -217,6 +217,11 @@ Using either method will create a message in Zulip:
 
 <img class="screenshot" src="/static/images/api/helloworld-webhook.png" />
 
+Additionally, If you ever need to pass custom headers along with the webhook message when using `./manage.py send_webhook_fixture_message` you can always use the --custom-headers command line option.
+For example:
+    --custom-headers='{"X-Custom-Header": "value"}'
+Just make sure that the headers do not contain any spaces in them and that all of the headers are enclosed like "X-Custom-Header" instead of 'X-Custom-Header'.
+
 ## Step 4: Create tests
 
 Every webhook integration should have a corresponding test file:

--- a/zerver/management/commands/send_webhook_fixture_message.py
+++ b/zerver/management/commands/send_webhook_fixture_message.py
@@ -1,7 +1,7 @@
-
 import os
-
 import ujson
+from typing import Union, Dict
+
 from django.conf import settings
 from django.core.management.base import CommandParser
 from django.test import Client
@@ -18,6 +18,12 @@ Example:
     --fixture=zerver/webhooks/integration/fixtures/name.json \
     '--url=/api/v1/external/integration?stream=stream_name&api_key=api_key'
 
+To pass custom headers along with the webhook message use the --custom-headers
+command line option.
+Example:
+    --custom-headers='{"X-Custom-Header": "value"}'
+The headers should not contain any spaces in them and should be enclosed within ""
+instead of ''.
 """
 
     def add_arguments(self, parser: CommandParser) -> None:
@@ -33,7 +39,29 @@ Example:
                             help='The url on your Zulip server that you want '
                                  'to post the fixture to')
 
+        parser.add_argument('-H', '--custom-headers',
+                            dest='custom-headers',
+                            type=str,
+                            help='The headers you want to provide along with '
+                                 'your mock request to Zulip.')
+
         self.add_realm_args(parser, help="Specify which realm/subdomain to connect to; default is zulip")
+
+    def parse_headers(self, custom_headers: Union[None, str]) -> Union[None, Dict[str, str]]:
+        headers = {}
+        if not custom_headers:
+            return None
+        try:
+            custom_headers_dict = ujson.loads(custom_headers)
+            for header in custom_headers_dict:
+                if len(header.split(" ")) > 1:
+                    raise ValueError("custom header '%s' contains a space." % (header))
+                headers["HTTP_" + header.upper().replace("-", "_")] = str(custom_headers_dict[header])
+            return headers
+        except ValueError as ve:
+            print('Encountered an error while attempting to parse custom headers: %s' % (ve))
+            print('Note: all strings must be enclosed within "" instead of \'\'')
+            exit(1)
 
     def handle(self, **options: str) -> None:
         if options['fixture'] is None or options['url'] is None:
@@ -46,14 +74,19 @@ Example:
             print('Fixture {} does not exist'.format(options['fixture']))
             exit(1)
 
+        headers = self.parse_headers(options['custom-headers'])
         json = self._get_fixture_as_json(full_fixture_path)
         realm = self.get_realm(options)
         if realm is None:
             realm = get_realm("zulip")
 
         client = Client()
-        result = client.post(options['url'], json, content_type="application/json",
-                             HTTP_HOST=realm.host)
+        if headers:
+            result = client.post(options['url'], json, content_type="application/json",
+                                 HTTP_HOST=realm.host, **headers)
+        else:
+            result = client.post(options['url'], json, content_type="application/json",
+                                 HTTP_HOST=realm.host)
         if result.status_code != 200:
             print('Error status %s: %s' % (result.status_code, result.content))
             exit(1)


### PR DESCRIPTION
When testing a webhook with `./manage.py send_webhook_fixture_message` there are some occasions where we would need to specify custom headers, else we'd get an error message.

For example:
![before](https://user-images.githubusercontent.com/29123352/54069998-bec05180-4281-11e9-9521-136eb0d48687.png)

This commit adds support for such an option by allowing the user to specify the custom headers they wish to include as a valid json string by using the '--custom-headers' or '-H' command line option. Unlike the --url and --fixture arguments, this argument is optional.
![after](https://user-images.githubusercontent.com/29123352/54070003-cd0e6d80-4281-11e9-87e4-374b569434a1.png)
