### PR TITLE
refactor: Use a Dict to track active topic widgets.

### DIFF
--- a/frontend_tests/node_tests/topic_list.js
+++ b/frontend_tests/node_tests/topic_list.js
@@ -89,7 +89,7 @@ run_test('topic_list_build_widget', () => {
 
     widget.build();
 
-    assert(widget.is_for_stream(devel.stream_id));
+    assert(widget.get_stream_id(), devel.stream_id);
     assert.equal(widget.get_parent(), parent_elem);
 
     assert(checked_mutes);


### PR DESCRIPTION
Even though there are only ever zero or one active
topic widgets in our current sidebar, it's almost the
same amount of code to just manage them with a Dict.

Also, we can more easily do possible future features
like setting streams to be always-open.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
