### PR TITLE
keyboard_help: Replace capital Alphabets with Shift + Alphabet.

### DIFF
--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -33,7 +33,7 @@
                     <td class="definition">{% trans %}Next message{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">End, G</td>
+                    <td class="hotkey">End, Shift + g</td>
                     <td class="definition">{% trans %}Last message{% endtrans %}</td>
                 </tr>
                 <tr>
@@ -45,7 +45,7 @@
                     <td class="definition">{% trans %}Next unread private message{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">P</td>
+                    <td class="hotkey">Shift + p</td>
                     <td class="definition">{% trans %}All private messages{% endtrans %}</td>
                 </tr>
                 <tr>
@@ -89,15 +89,15 @@
                     <td class="definition">{% trans %}Next message{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">PgUp, K</td>
+                    <td class="hotkey">PgUp, Shift + k</td>
                     <td class="definition">{% trans %}Scroll up{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">PgDn, J, Space</td>
+                    <td class="hotkey">PgDn, Shift + j, Space</td>
                     <td class="definition">{% trans %}Scroll down{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">End, G</td>
+                    <td class="hotkey">End, Shift + g</td>
                     <td class="definition">{% trans %}Last message{% endtrans %}</td>
                 </tr>
                 <tr>
@@ -117,7 +117,7 @@
                     <td class="definition">{% trans %}Reply to message{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">R</td>
+                    <td class="hotkey">Shift + r</td>
                     <td class="definition">{% trans %}Reply to author{% endtrans %}</td>
                 </tr>
                 <tr>
@@ -163,11 +163,11 @@
                     <td class="definition">{% trans %}Narrow by stream{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">S</td>
+                    <td class="hotkey">Shift + s</td>
                     <td class="definition">{% trans %}Narrow by topic{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">P</td>
+                    <td class="hotkey">Shift + p</td>
                     <td class="definition">{% trans %}Narrow to all private messages{% endtrans %}</td>
                 </tr>
                 <tr>
@@ -179,7 +179,7 @@
                     <td class="definition">{% trans %}Narrow to next unread private message{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">A, D</td>
+                    <td class="hotkey">Shift + a, Shift + d</td>
                     <td class="definition">{% trans %}Cycle between stream narrows{% endtrans %}</td>
                 </tr>
                 <tr>
@@ -232,7 +232,7 @@
                     <td class="definition">{% trans %}Collapse/show selected message{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">M</td>
+                    <td class="hotkey">Shift + m</td>
                     <td class="definition">{% trans %}Toggle topic mute{% endtrans %}</td>
                 </tr>
             </table>
@@ -299,11 +299,11 @@
                     <td class="definition">{% trans %}Switch between tabs{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">V</td>
+                    <td class="hotkey">Shift + v</td>
                     <td class="definition">{% trans %}View stream messages{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">S</td>
+                    <td class="hotkey">Shift + s</td>
                     <td class="definition">{% trans %}Subscribe to/unsubscribe from selected stream{% endtrans %}</td>
                 </tr>
                 <tr>

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -22,7 +22,7 @@
                             <i class="fa fa-envelope" aria-hidden="true"></i>
                         </span>
                         {#- squash whitespace -#}
-                        <span title="{{ _('Private messages') }} (P)">{{ _('Private messages') }}</span>
+                        <span title="{{ _('Private messages') }} (Shift + p)">{{ _('Private messages') }}</span>
                         <span class="count">
                             <span class="value"></span>
                         </span>


### PR DESCRIPTION
As discussed here - https://chat.zulip.org/#narrow/stream/9-issues/topic/Keyboard.20shortcut.20(P).20for.20Private.20Messages/near/716259

Also fixed a typo in ./tools/test-js-with-node