### PR TITLE
Email mirror improvements

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -4,7 +4,7 @@ import logging
 import re
 
 from email.header import decode_header, make_header
-from email.utils import getaddresses
+from email.utils import getaddresses, parseaddr
 import email.message as message
 
 from django.conf import settings
@@ -144,8 +144,9 @@ def construct_zulip_body(message: message.Message, realm: Realm,
     if not body:
         body = '(No email body)'
 
-    if show_sender:
-        sender = message.get("From")
+    sender = message.get("From")
+    assert isinstance(sender, str)
+    if show_sender and parseaddr(sender)[0].lower() != 'hide sender':
         body = "From: %s\n%s" % (sender, body)
 
     return body

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -133,9 +133,9 @@ def mark_missed_message_address_as_used(address: str) -> None:
         redis_client.delete(key)
         raise ZulipEmailForwardError('Missed message address has already been used')
 
-def construct_zulip_body(message: message.Message, realm: Realm,
-                         show_sender: bool=False) -> str:
-    body = extract_body(message)
+def construct_zulip_body(message: message.Message, realm: Realm, show_sender: bool=False,
+                         remove_quotations: bool=True) -> str:
+    body = extract_body(message, remove_quotations)
     # Remove null characters, since Zulip will reject
     body = body.replace("\x00", "")
     body = filter_footer(body)
@@ -228,7 +228,7 @@ def get_message_part_by_type(message: message.Message, content_type: str) -> Opt
     return None
 
 talon_initialized = False
-def extract_body(message: message.Message) -> str:
+def extract_body(message: message.Message, remove_quotations: bool=True) -> str:
     import talon
     global talon_initialized
     if not talon_initialized:
@@ -239,12 +239,18 @@ def extract_body(message: message.Message) -> str:
     # that.
     plaintext_content = get_message_part_by_type(message, "text/plain")
     if plaintext_content:
-        return talon.quotations.extract_from_plain(plaintext_content)
+        if remove_quotations:
+            return talon.quotations.extract_from_plain(plaintext_content)
+        else:
+            return plaintext_content
 
     # If we only have an HTML version, try to make that look nice.
     html_content = get_message_part_by_type(message, "text/html")
     if html_content:
-        return convert_html_to_markdown(talon.quotations.extract_from_html(html_content))
+        if remove_quotations:
+            return convert_html_to_markdown(talon.quotations.extract_from_html(html_content))
+        else:
+            return convert_html_to_markdown(html_content)
 
     if plaintext_content is not None or html_content is not None:
         raise ZulipEmailForwardUserError("Email has no nonempty body sections; ignoring.")
@@ -254,7 +260,7 @@ def extract_body(message: message.Message) -> str:
 
 def filter_footer(text: str) -> str:
     # Try to filter out obvious footers.
-    possible_footers = [line for line in text.split("\n") if line.strip().startswith("--")]
+    possible_footers = [line for line in text.split("\n") if line.strip() == "--"]
     if len(possible_footers) != 1:
         # Be conservative and don't try to scrub content if there
         # isn't a trivial footer structure.
@@ -327,13 +333,21 @@ def strip_from_subject(subject: str) -> str:
     stripped = re.sub(reg, "", subject, flags = re.IGNORECASE | re.MULTILINE)
     return stripped.strip()
 
+def is_forwarded(subject: str) -> bool:
+    # regex taken from strip_from_subject, we use it to detect various forms
+    # of FWD at the beginning of the subject.
+    reg = r"([\[\(] *)?\b(FWD?) *([-:;)\]][ :;\])-]*|$)|\]+ *$"
+    return bool(re.match(reg, subject, flags=re.IGNORECASE))
+
 def process_stream_message(to: str, message: message.Message,
                            debug_info: Dict[str, Any]) -> None:
     subject_header = str(make_header(decode_header(message.get("Subject", ""))))
     subject = strip_from_subject(subject_header) or "(no topic)"
 
     stream, show_sender = extract_and_validate(to)
-    body = construct_zulip_body(message, stream.realm, show_sender)
+    # Don't remove quotations if message is forwarded:
+    remove_quotations = not is_forwarded(subject_header)
+    body = construct_zulip_body(message, stream.realm, show_sender, remove_quotations)
     debug_info["stream"] = stream
     send_zulip(settings.EMAIL_GATEWAY_BOT, stream, subject, body)
     logger.info("Successfully processed email to %s (%s)" % (

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -145,7 +145,7 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
 
         stream_to_address = encode_email_address(stream)
 
-        incoming_valid_message = MIMEText('TestStreamEmailMessages Body')  # type: Any # https://github.com/python/typeshed/issues/275
+        incoming_valid_message = MIMEText('TestStreamEmailMessages Body')
 
         incoming_valid_message['Subject'] = 'TestStreamEmailMessages Subject'
         incoming_valid_message['From'] = self.example_email('hamlet')
@@ -169,7 +169,7 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
 
         stream_to_address = encode_email_address(stream)
 
-        incoming_valid_message = MIMEText('TestStreamEmailMessages Body')  # type: Any # https://github.com/python/typeshed/issues/275
+        incoming_valid_message = MIMEText('TestStreamEmailMessages Body')
 
         incoming_valid_message['Subject'] = ''
         incoming_valid_message['From'] = self.example_email('hamlet')
@@ -194,7 +194,7 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
 
         stream_to_address = encode_email_address(stream)
 
-        incoming_valid_message = MIMEText('TestStreamEmailMessages Body')  # type: Any # https://github.com/python/typeshed/issues/275
+        incoming_valid_message = MIMEText('TestStreamEmailMessages Body')
 
         incoming_valid_message['Subject'] = 'TestStreamEmailMessages Subject'
         incoming_valid_message['From'] = self.example_email('hamlet')
@@ -220,7 +220,7 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
         stream_to_addresses = ["A.N. Other <another@example.org>",
                                "Denmark <{}>".format(encode_email_address(stream))]
 
-        incoming_valid_message = MIMEText('TestStreamEmailMessages Body')  # type: Any # https://github.com/python/typeshed/issues/275
+        incoming_valid_message = MIMEText('TestStreamEmailMessages Body')
 
         incoming_valid_message['Subject'] = 'TestStreamEmailMessages Subject'
         incoming_valid_message['From'] = self.example_email('hamlet')
@@ -276,7 +276,7 @@ class TestStreamEmailMessagesEmptyBody(ZulipTestCase):
         headers['Reply-To'] = self.example_email('othello')
 
         # empty body
-        incoming_valid_message = MIMEText('')  # type: Any # https://github.com/python/typeshed/issues/275
+        incoming_valid_message = MIMEText('')
 
         incoming_valid_message['Subject'] = 'TestStreamEmailMessages Subject'
         incoming_valid_message['From'] = self.example_email('hamlet')
@@ -289,8 +289,8 @@ class TestStreamEmailMessagesEmptyBody(ZulipTestCase):
         # process_message eats the exception & logs an error which can't be parsed here
         # so calling process_stream_message directly
         try:
-            process_stream_message(incoming_valid_message['To'],
-                                   incoming_valid_message['Subject'],
+            process_stream_message(str(incoming_valid_message['To']),  # need to insert str() or mypy throws type error
+                                   str(incoming_valid_message['Subject']),
                                    incoming_valid_message,
                                    debug_info)
         except ZulipEmailForwardError as e:
@@ -309,7 +309,7 @@ class TestStreamEmailMessagesEmptyBody(ZulipTestCase):
         headers['Reply-To'] = self.example_email('othello')
 
         # No textual body
-        incoming_valid_message = MIMEMultipart()  # type: Any # https://github.com/python/typeshed/issues/275
+        incoming_valid_message = MIMEMultipart()
         with open(os.path.join(settings.DEPLOY_ROOT, "static/images/default-avatar.png"), 'rb') as f:
             incoming_valid_message.attach(MIMEImage(f.read()))
 
@@ -325,8 +325,8 @@ class TestStreamEmailMessagesEmptyBody(ZulipTestCase):
         # so calling process_stream_message directly
         try:
             with mock.patch('logging.warning'):
-                process_stream_message(incoming_valid_message['To'],
-                                       incoming_valid_message['Subject'],
+                process_stream_message(str(incoming_valid_message['To']),  # need to insert str() or mypy throws type error
+                                       str(incoming_valid_message['Subject']),
                                        incoming_valid_message,
                                        debug_info)
         except ZulipEmailForwardError as e:
@@ -355,7 +355,7 @@ class TestMissedPersonalMessageEmailMessages(ZulipTestCase):
         # token for looking up who did reply.
         mm_address = create_missed_message_address(user_profile, usermessage.message)
 
-        incoming_valid_message = MIMEText('TestMissedMessageEmailMessages Body')  # type: Any # https://github.com/python/typeshed/issues/275
+        incoming_valid_message = MIMEText('TestMissedMessageEmailMessages Body')
 
         incoming_valid_message['Subject'] = 'TestMissedMessageEmailMessages Subject'
         incoming_valid_message['From'] = self.example_email('othello')
@@ -396,7 +396,7 @@ class TestMissedHuddleMessageEmailMessages(ZulipTestCase):
         # token for looking up who did reply.
         mm_address = create_missed_message_address(user_profile, usermessage.message)
 
-        incoming_valid_message = MIMEText('TestMissedHuddleMessageEmailMessages Body')  # type: Any # https://github.com/python/typeshed/issues/275
+        incoming_valid_message = MIMEText('TestMissedHuddleMessageEmailMessages Body')
 
         incoming_valid_message['Subject'] = 'TestMissedHuddleMessageEmailMessages Subject'
         incoming_valid_message['From'] = self.example_email('cordelia')
@@ -463,7 +463,7 @@ class TestReplyExtraction(ZulipTestCase):
 
         Quote"""
 
-        incoming_valid_message = MIMEText(text)  # type: Any # https://github.com/python/typeshed/issues/275
+        incoming_valid_message = MIMEText(text)
 
         incoming_valid_message['Subject'] = 'TestStreamEmailMessages Subject'
         incoming_valid_message['From'] = self.example_email('hamlet')
@@ -507,7 +507,7 @@ class TestReplyExtraction(ZulipTestCase):
         </html>
         """
 
-        incoming_valid_message = MIMEText(html, 'html')  # type: Any # https://github.com/python/typeshed/issues/275
+        incoming_valid_message = MIMEText(html, 'html')
 
         incoming_valid_message['Subject'] = 'TestStreamEmailMessages Subject'
         incoming_valid_message['From'] = self.example_email('hamlet')

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -303,7 +303,6 @@ class TestStreamEmailMessagesEmptyBody(ZulipTestCase):
         # so calling process_stream_message directly
         try:
             process_stream_message(str(incoming_valid_message['To']),  # need to insert str() or mypy throws type error
-                                   str(incoming_valid_message['Subject']),
                                    incoming_valid_message,
                                    debug_info)
         except ZulipEmailForwardError as e:
@@ -339,7 +338,6 @@ class TestStreamEmailMessagesEmptyBody(ZulipTestCase):
         try:
             with mock.patch('logging.warning'):
                 process_stream_message(str(incoming_valid_message['To']),  # need to insert str() or mypy throws type error
-                                       str(incoming_valid_message['Subject']),
                                        incoming_valid_message,
                                        debug_info)
         except ZulipEmailForwardError as e:

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -30,8 +30,10 @@ from zerver.lib.email_mirror import (
     create_missed_message_address,
     get_missed_message_token_from_address,
     strip_from_subject,
+    is_forwarded,
 )
 
+from zerver.lib.notifications import convert_html_to_markdown
 from zerver.lib.send_email import FromAddress
 
 from email.mime.text import MIMEText
@@ -488,6 +490,13 @@ class TestReplyExtraction(ZulipTestCase):
 
         self.assertEqual(message.content, "Reply")
 
+        # Don't extract if Subject indicates the email has been forwarded into the mirror:
+        del incoming_valid_message['Subject']
+        incoming_valid_message['Subject'] = 'FWD: TestStreamEmailMessages Subject'
+        process_message(incoming_valid_message)
+        message = most_recent_message(user_profile)
+        self.assertEqual(message.content, text)
+
     def test_reply_is_extracted_from_html(self) -> None:
 
         # build dummy messages for stream
@@ -532,6 +541,23 @@ class TestReplyExtraction(ZulipTestCase):
 
         self.assertEqual(message.content, 'Reply')
 
+        # Don't extract if Subject indicates the email has been forwarded into the mirror:
+        del incoming_valid_message['Subject']
+        incoming_valid_message['Subject'] = 'FWD: TestStreamEmailMessages Subject'
+        process_message(incoming_valid_message)
+        message = most_recent_message(user_profile)
+        self.assertEqual(message.content, convert_html_to_markdown(html))
+
+    def test_is_forwarded(self) -> None:
+        self.assertTrue(is_forwarded("FWD: hey"))
+        self.assertTrue(is_forwarded("fwd: hi"))
+        self.assertTrue(is_forwarded("[fwd] subject"))
+
+        self.assertTrue(is_forwarded("FWD: RE:"))
+        self.assertTrue(is_forwarded("Fwd: RE: fwd: re: subject"))
+
+        self.assertFalse(is_forwarded("subject"))
+        self.assertFalse(is_forwarded("RE: FWD: hi"))
 
 class TestScriptMTA(ZulipTestCase):
 


### PR DESCRIPTION
First 2 commits are just random, minor cleanups to test_email_mirror.py

Then we have a commit finishing part 3 of https://github.com/zulip/zulip/issues/10612
Then the next 2 commits address part 2.

I'd add do part 4 here too, but first I have a question about it at https://chat.zulip.org/#narrow/stream/49-development-help/topic/email_mirror.3A.20missed.20message.20email.20reply_to.20addresses/near/716467