### PR TITLE
Email mirror improvements

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -4,7 +4,7 @@ import logging
 import re
 
 from email.header import decode_header, make_header
-from email.utils import getaddresses
+from email.utils import getaddresses, parseaddr
 import email.message as message
 
 from django.conf import settings
@@ -144,8 +144,9 @@ def construct_zulip_body(message: message.Message, realm: Realm, show_sender: bo
     if not body:
         body = '(No email body)'
 
-    if show_sender:
-        sender = message.get("From")
+    sender = message.get("From")
+    assert isinstance(sender, str)
+    if show_sender and parseaddr(sender)[0].lower() != 'hide sender':
         body = "From: %s\n%s" % (sender, body)
 
     return body

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -39,6 +39,7 @@ from zerver.lib.send_email import FromAddress
 from email.mime.text import MIMEText
 from email.mime.image import MIMEImage
 from email.mime.multipart import MIMEMultipart
+from email.utils import formataddr
 
 import ujson
 import mock
@@ -261,6 +262,17 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
 
         self.assertEqual(message.content, "From: %s\n%s" % (self.example_email('hamlet'),
                                                             "TestStreamEmailMessages Body"))
+        self.assertEqual(get_display_recipient(message.recipient), stream.name)
+        self.assertEqual(message.topic_name(), incoming_valid_message['Subject'])
+
+        # make sure From: <sender> line isn't included if the sender name is 'Hide sender'
+        address_tuple = ('Hide sender', self.example_email('hamlet'))
+        del incoming_valid_message['From']
+        incoming_valid_message['From'] = formataddr(address_tuple)
+        process_message(incoming_valid_message)
+        message = most_recent_message(user_profile)
+
+        self.assertEqual(message.content, "TestStreamEmailMessages Body")
         self.assertEqual(get_display_recipient(message.recipient), stream.name)
         self.assertEqual(message.topic_name(), incoming_valid_message['Subject'])
 


### PR DESCRIPTION
First 2 commits are just random, minor cleanups of test_email_mirror.py

Then we have a commit finishing part 3 of #10612
Then the next 2 commits address part 2.

I'd do part 4 here too, but first I have a question about it at https://chat.zulip.org/#narrow/stream/49-development-help/topic/email_mirror.3A.20missed.20message.20email.20reply_to.20addresses/near/716467