### PR TITLE
test_events: Update `realm` before fetching normal_states in `do_test`.

### DIFF
--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -524,6 +524,7 @@ class EventsRegisterTest(ZulipTestCase):
             if before != after:
                 raise AssertionError('Test is invalid--state actually does change here.')
 
+        self.user_profile.realm.refresh_from_db()
         normal_state = fetch_initial_state_data(
             self.user_profile, event_types, "",
             client_gravatar=True,


### PR DESCRIPTION
As a follow up of this commit (99a2c21ff3be445af005f46f55bdc3398a4bdc34),
we now are refreshing `realm` and its attributes before fetching
normal_state in `do_test` function using
`self.user_profile.realm.refresh_from_db()`, resulting in updated `realm`
values, so that now even if we use `get_realm` as before, tests wouldn't
fail as now any changes to `Realm` table after applying action get
reflected to `realm` attribute of `self.user_profile` by refreshing.