### PR TITLE
Align top-left icons better.

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -157,7 +157,6 @@ li.active-sub-filter {
 #global_filters .filter-icon {
     display: inline-block;
     min-width: $left_col_size;
-    text-align: center;
 }
 
 #global_filters .global-filter {
@@ -274,7 +273,6 @@ a.conversation-partners:hover {
     text-decoration: underline;
 }
 
-.filter-icon i,
 .all-messages-arrow i,
 .stream-sidebar-arrow i,
 .starred-messages-sidebar-arrow i,
@@ -448,7 +446,6 @@ li.show-more-private-messages {
     height: 8px;
     margin-top: 0px;
     margin-bottom: 0px;
-    margin-left: 2px;
     position: relative;
     top: 0px;
 }


### PR DESCRIPTION
Instead of centering them and adding margin, we just
left-align the envelope, @, and * icons.

We continue to offset the home icon by a pixel, since
the "roof" part of the house isn't what we really want
to use for alignment.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
