### PR TITLE
Improve TLS settings based on Mozilla config generator

### DIFF
--- a/puppet/zulip/files/nginx/nginx.conf
+++ b/puppet/zulip/files/nginx/nginx.conf
@@ -50,10 +50,16 @@ http {
         ''      close;
     }
 
-    ssl_prefer_server_ciphers On;
-    ssl_session_cache shared:SSL:10m;
+    # https://wiki.mozilla.org/Security/Server_Side_TLS intermediate profile
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:50m;
+    ssl_dhparam /etc/nginx/dhparam.pem;
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS;
+    ssl_prefer_server_ciphers on;
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
 
 
     include /etc/nginx/conf.d/*.conf;

--- a/puppet/zulip/manifests/nginx.pp
+++ b/puppet/zulip/manifests/nginx.pp
@@ -3,6 +3,8 @@ class zulip::nginx {
   $web_packages = [
     # Needed to run nginx with the modules we use
     $zulip::common::nginx,
+    'openssl',
+    'ca-certificates',
   ]
   package { $web_packages: ensure => 'installed' }
 
@@ -58,9 +60,15 @@ class zulip::nginx {
     source  => $uploads_route,
   }
 
+  exec { 'dhparam':
+    command => 'openssl dhparam -out /etc/nginx/dhparam.pem 2048',
+    creates => '/etc/nginx/dhparam.pem',
+    require => Package[$zulip::common::nginx, 'openssl'],
+  }
+
   file { '/etc/nginx/nginx.conf':
     ensure  => file,
-    require => Package[$zulip::common::nginx],
+    require => Package[$zulip::common::nginx, 'ca-certificates'],
     owner   => 'root',
     group   => 'root',
     mode    => '0644',


### PR DESCRIPTION
Lengthen the session timeout and enlarge the session cache.  Disable session tickets (see mozilla/server-side-tls#135).  Upgrade Diffie-Hellman parameters from fixed 1024-bit to custom 2048-bit.  Enable OCSP stapling.

**Testing Plan:** Running on https://andersk.zulipdev.org/.
* SSL Labs test: [A+](https://www.ssllabs.com/ssltest/analyze.html?d=andersk.zulipdev.org).
* Mozilla Observatory test: [intermediate compatibility](https://observatory.mozilla.org/analyze/andersk.zulipdev.org#tls).