### PR TITLE
Add a cron job to catch-up soft deactivated users

### DIFF
--- a/zerver/management/commands/soft_deactivate_users.py
+++ b/zerver/management/commands/soft_deactivate_users.py
@@ -7,7 +7,7 @@ from django.core.management.base import CommandError
 
 from zerver.lib.management import ZulipBaseCommand
 from zerver.lib.soft_deactivation import do_soft_activate_users, \
-    do_soft_deactivate_users, get_users_for_soft_deactivation, logger
+    do_soft_deactivate_users, do_auto_soft_deactivate_users, logger
 from zerver.models import Realm, UserProfile
 
 def get_users_from_emails(emails: Any,
@@ -73,15 +73,12 @@ class Command(ZulipBaseCommand):
             if user_emails:
                 users_to_deactivate = get_users_from_emails(user_emails, filter_kwargs)
                 print('Soft deactivating forcefully...')
-            else:
-                if realm is not None:
-                    filter_kwargs = dict(user_profile__realm=realm)
-                users_to_deactivate = get_users_for_soft_deactivation(int(options['inactive_for']),
-                                                                      filter_kwargs)
-
-            if users_to_deactivate:
                 users_deactivated = do_soft_deactivate_users(users_to_deactivate)
-                logger.info('Soft Deactivated %d user(s)' % (len(users_deactivated)))
+            else:
+                users_deactivated = do_auto_soft_deactivate_users(int(options['inactive_for']),
+                                                                  realm)
+            logger.info('Soft Deactivated %d user(s)' % (len(users_deactivated)))
+
         else:
             self.print_help("./manage.py", "soft_deactivate_users")
             sys.exit(1)

--- a/zerver/tests/test_soft_deactivation.py
+++ b/zerver/tests/test_soft_deactivation.py
@@ -10,7 +10,8 @@ from zerver.lib.soft_deactivation import (
     get_users_for_soft_deactivation,
     do_soft_activate_users,
     get_soft_deactivated_users_for_catch_up,
-    do_catch_up_soft_deactivated_users
+    do_catch_up_soft_deactivated_users,
+    do_auto_soft_deactivate_users
 )
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.models import (
@@ -149,3 +150,70 @@ class UserSoftDeactivationTests(ZulipTestCase):
             user.refresh_from_db()
             self.assertTrue(user.long_term_idle)
             self.assertEqual(user.last_active_message_id, message_id)
+
+    def test_do_auto_soft_deactivate_users(self) -> None:
+        users = [
+            self.example_user('iago'),
+            self.example_user('cordelia'),
+            self.example_user('ZOE'),
+            self.example_user('othello'),
+            self.example_user('prospero'),
+            self.example_user('aaron'),
+            self.example_user('polonius'),
+        ]
+        sender = self.example_user('hamlet')
+        realm = get_realm('zulip')
+        stream_name = 'announce'
+        for user in users + [sender]:
+            self.subscribe(user, stream_name)
+
+        client, _ = Client.objects.get_or_create(name='website')
+        query = '/json/users/me/pointer'
+        last_visit = timezone_now()
+        count = 150
+        for user_profile in users:
+            UserActivity.objects.get_or_create(
+                user_profile=user_profile,
+                client=client,
+                query=query,
+                count=count,
+                last_visit=last_visit
+            )
+
+        with mock.patch('logging.info'):
+            users_deactivated = do_auto_soft_deactivate_users(-1, realm)
+        self.assert_length(users_deactivated, len(users))
+        for user in users:
+            self.assertTrue(user in users_deactivated)
+
+        # Verify that deactivated users are caught up automatically
+
+        message_id = self.send_stream_message(sender.email, stream_name)
+        received_count = UserMessage.objects.filter(user_profile__in=users,
+                                                    message_id=message_id).count()
+        self.assertEqual(0, received_count)
+
+        with mock.patch('logging.info'):
+            users_deactivated = do_auto_soft_deactivate_users(-1, realm)
+
+        self.assert_length(users_deactivated, 0)   # all users are already deactivated
+        received_count = UserMessage.objects.filter(user_profile__in=users,
+                                                    message_id=message_id).count()
+        self.assertEqual(len(users), received_count)
+
+        # Verify that deactivated users are NOT caught up if
+        # AUTO_CATCH_UP_SOFT_DEACTIVATED_USERS is off
+
+        message_id = self.send_stream_message(sender.email, stream_name)
+        received_count = UserMessage.objects.filter(user_profile__in=users,
+                                                    message_id=message_id).count()
+        self.assertEqual(0, received_count)
+
+        with self.settings(AUTO_CATCH_UP_SOFT_DEACTIVATED_USERS=False):
+            with mock.patch('logging.info'):
+                users_deactivated = do_auto_soft_deactivate_users(-1, realm)
+
+        self.assert_length(users_deactivated, 0)   # all users are already deactivated
+        received_count = UserMessage.objects.filter(user_profile__in=users,
+                                                    message_id=message_id).count()
+        self.assertEqual(0, received_count)

--- a/zerver/tests/test_soft_deactivation.py
+++ b/zerver/tests/test_soft_deactivation.py
@@ -133,9 +133,10 @@ class UserSoftDeactivationTests(ZulipTestCase):
         message_id = self.send_stream_message(hamlet.email, stream, 'Hello world!')
         already_received = UserMessage.objects.filter(message_id=message_id).count()
         do_catch_up_soft_deactivated_users(users)
+        catch_up_received = UserMessage.objects.filter(message_id=message_id).count()
+        self.assertEqual(already_received + len(users), catch_up_received)
 
         for user in users:
             user.refresh_from_db()
             self.assertTrue(user.long_term_idle)
-            catch_up_received = UserMessage.objects.filter(message_id=message_id).count()
-            self.assertEqual(already_received + len(users), catch_up_received)
+            self.assertEqual(user.last_active_message_id, message_id)

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -454,6 +454,12 @@ DEFAULT_SETTINGS.update({
     # Enables billing pages and plan-based feature gates. If False, all features
     # are available to all realms.
     'BILLING_ENABLED': False,
+
+    # Automatically catch-up soft deactivated users when running the
+    # `soft-deactivate-users` cron. Turn this off if the server has 10Ks of
+    # users, and you would like to save some disk space. Soft-deactivated
+    # returning users would still be caught-up normally.
+    'AUTO_CATCH_UP_SOFT_DEACTIVATED_USERS': True,
 })
 
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

This PR adds a cron job to catch-up soft deactivated users.  The cron job can be turned off by turning off the `AUTO_CATCH_UP_SOFT_DEACTIVATED_USERS` flag. 

It also adds pagination to bulk creation of missing UserMessage rows. 

