### PR TITLE
search_streams: Add | as OR-operator.

### DIFF
--- a/frontend_tests/node_tests/stream_sort.js
+++ b/frontend_tests/node_tests/stream_sort.js
@@ -92,4 +92,10 @@ with_overrides(function (override) {
     assert.deepEqual(sorted.pinned_streams, []);
     assert.deepEqual(sorted.normal_streams, ['fast tortoise']);
     assert.deepEqual(sorted.dormant_streams, []);
+
+    // Test searching stream with , and |
+    sorted = stream_sort.sort_groups("clarinet| tortoise, scalene");
+    assert.deepEqual(sorted.pinned_streams, ['scalene']);
+    assert.deepEqual(sorted.normal_streams, ['clarinet', 'fast tortoise']);
+    assert.deepEqual(sorted.dormant_streams, []);
 });

--- a/static/js/stream_sort.js
+++ b/static/js/stream_sort.js
@@ -18,7 +18,7 @@ function filter_streams_by_search(streams, search_term) {
         return streams;
     }
 
-    var search_terms = search_term.toLowerCase().split(",");
+    var search_terms = search_term.toLowerCase().split(/[|,]+/);
     search_terms = _.map(search_terms, function (s) {
         return s.trim();
     });


### PR DESCRIPTION
As requested in #11797 I also added `|` as an OR-operator when searching streams. 

@timabbott When I looked for all occurrences of `split(",")` I actually found two more places where this is used. One is when creating a new stream and searching for users to add and the other one is used in `subs.js` on line 384 (to be exact, this is where a method is called from `search_util.js` which splits the search term using a `,`), but it's not exactly clear to me where this is used. Do you want these two occurrences to also use both `|` and `,` as an OR-operator? And if so, should I just add that to this commit or make 2 separate commits and PRs for it?
