### PR TITLE
Fix hovers in left sidebar

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -126,7 +126,7 @@ li.show-more-private-messages a {
 #global_filters li:hover,
 #stream_filters li:hover,
 #stream_filters li.highlighted_stream {
-    background-color: hsl(93, 19%, 88%);
+    background-color: hsl(93, 18%, 82%);
 }
 
 #stream_filters li.active-sub-filter:hover {

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -175,10 +175,6 @@ li.active-sub-filter {
     border-radius: 4px;
 }
 
-#global_filters .global-filter a {
-    display: block;
-}
-
 .conversation-partners {
     line-height: 1.25;
 }

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -123,7 +123,7 @@ li.show-more-private-messages a {
     max-height: 200px;
 }
 
-#global_filters li:hover,
+.top_left_row:hover,
 #stream_filters li:hover,
 #stream_filters li.highlighted_stream {
     background-color: hsl(93, 18%, 82%);

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -160,14 +160,25 @@ li.active-sub-filter {
     text-align: center;
 }
 
-#global_filters .global-filter {
+li.top_left_all_messages,
+.private_messages_header,
+li.top_left_mentions,
+li.top_left_starred_messages {
     position: relative;
     padding-top: 1px;
     padding-bottom: 1px;
+}
+
+.top_left_row {
     padding-left: $far_left_gutter_size;
     padding-right: 10px;
 }
 
+li.show-more-private-messages {
+    padding-left: $far_left_gutter_size + $left_col_size;
+}
+
+.top_left_row,
 .narrows_panel li {
     border-radius: 4px;
 }
@@ -413,10 +424,6 @@ li.expanded_private_message {
 
 li.expanded_private_message a {
     margin: 1px 0px;
-}
-
-li.show-more-private-messages {
-    padding-left: $left_col_size;
 }
 
 .show-all-streams a {

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -190,10 +190,6 @@ li.show-more-private-messages {
     line-height: 1.25;
 }
 
-a.conversation-partners:hover {
-    text-decoration: underline;
-}
-
 .top_left_all_messages i.fa-home {
     position: relative;
     top: 1px;
@@ -275,10 +271,6 @@ a.conversation-partners:hover {
 .topic-name {
     /* TODO: We should figure out how to remove this without changing the spacing */
     line-height: 1.1;
-}
-
-.narrows_panel li a.topic-name:hover {
-    text-decoration: underline;
 }
 
 .filter-icon i,

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -169,9 +169,6 @@ li.active-sub-filter {
 }
 
 .narrows_panel li {
-    padding-top: 2px;
-    padding-bottom: 2px;
-
     border-radius: 4px;
 }
 

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -180,14 +180,14 @@ a.conversation-partners:hover {
     text-decoration: underline;
 }
 
-#global_filters .global-filter i.fa-home {
+.top_left_all_messages i.fa-home {
     position: relative;
     top: 1px;
     left: -1px;
     font-size: 17px;
 }
 
-#global_filters .global-filter i.fa-envelope {
+.top_left_private_messages i.fa-envelope {
     font-size: 12px;
 }
 

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -124,9 +124,10 @@ li.show-more-private-messages a {
 }
 
 .top_left_row:hover,
-#stream_filters li:hover,
+.bottom_left_row:hover,
 #stream_filters li.highlighted_stream {
     background-color: hsl(93, 18%, 82%);
+    border-radius: 4px;
 }
 
 #stream_filters li.active-sub-filter:hover {
@@ -152,6 +153,7 @@ li.active-sub-filter {
     font-weight: 600 !important;
     background-color: hsl(202, 56%, 91%);
     position: relative;
+    border-radius: 4px;
 }
 
 #global_filters .filter-icon {
@@ -179,7 +181,8 @@ li.show-more-private-messages {
 }
 
 .top_left_row,
-.narrows_panel li {
+.bottom_left_row,
+.top_left_private_messages {
     border-radius: 4px;
 }
 

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -305,7 +305,7 @@ on a dark background, and don't change the dark labels dark either. */
         background-color: hsla(199, 33%, 46%, 0.2);
     }
 
-    #global_filters li:hover,
+    .top_left_row:hover,
     #stream_filters li:hover,
     #stream_filters li.highlighted_stream,
     #group-pms li:hover,

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -306,7 +306,7 @@ on a dark background, and don't change the dark labels dark either. */
     }
 
     .top_left_row:hover,
-    #stream_filters li:hover,
+    .bottom_left_row:hover,
     #stream_filters li.highlighted_stream,
     #group-pms li:hover,
     #user_presences li:hover,

--- a/static/templates/more_topics.handlebars
+++ b/static/templates/more_topics.handlebars
@@ -1,4 +1,4 @@
-<li class="show-more-topics">
+<li class="show-more-topics bottom_left_row">
     <a href="#">{{t "more topics" }}</a>
 </li>
 <li class="searching-for-more-topics">

--- a/static/templates/sidebar_private_message_list.handlebars
+++ b/static/templates/sidebar_private_message_list.handlebars
@@ -1,7 +1,7 @@
 <div id="private-container" class="scrolling_list">
     <ul class='expanded_private_messages {{zoom_class}}' data-name='private'>
         {{#each messages}}
-        <li class='{{#if is_zero}}zero-pm-unreads{{/if}} {{#if zoom_out_hide}}zoom-out-hide{{/if}} expanded_private_message' data-user-ids-string='{{user_ids_string}}'>
+        <li class='{{#if is_zero}}zero-pm-unreads{{/if}} {{#if zoom_out_hide}}zoom-out-hide{{/if}} top_left_row expanded_private_message' data-user-ids-string='{{user_ids_string}}'>
             <span class='pm-box'>
 
                 <div class="pm_left_col">
@@ -26,7 +26,7 @@
         </li>
         {{/each}}
         {{#if want_show_more_messages_links}}
-        <li class="show-more-private-messages" data-name='more-private-messages'>
+        <li class="show-more-private-messages top_left_row" data-name='more-private-messages'>
             <a href="#">({{t "more conversations" }})</a>
         </li>
         {{/if}}

--- a/static/templates/stream_sidebar_row.handlebars
+++ b/static/templates/stream_sidebar_row.handlebars
@@ -2,17 +2,18 @@
 
 <li class="narrow-filter{{#if not_in_home_view}} out_of_home_view{{/if}}"
   data-stream-id="{{id}}" data-stream-name="{{name}}">
-    <div class="subscription_block selectable_sidebar_block">
+    <div class="bottom_left_row">
+        <div class="subscription_block selectable_sidebar_block">
 
-        <span id="stream_sidebar_privacy_swatch_{{id}}" class="stream-privacy" style="color: {{color}}">
-            {{! This controls whether the swatchnext to streams in the left sidebar has a lock icon. }}
-            {{ partial "stream_privacy" }}
-        </span>
+            <span id="stream_sidebar_privacy_swatch_{{id}}" class="stream-privacy" style="color: {{color}}">
+                {{! This controls whether the swatchnext to streams in the left sidebar has a lock icon. }}
+                {{ partial "stream_privacy" }}
+            </span>
 
-        <a href="{{uri}}" class="stream-name">{{name}}</a>
+            <a href="{{uri}}" class="stream-name">{{name}}</a>
 
-        <div class="count"><div class="value"></div></div>
+            <div class="count"><div class="value"></div></div>
+        </div>
+        <span class="stream-sidebar-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
     </div>
-    <span class="stream-sidebar-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
-
 </li>

--- a/static/templates/topic_list_item.handlebars
+++ b/static/templates/topic_list_item.handlebars
@@ -1,4 +1,4 @@
-<li class='{{#if is_zero}}zero-topic-unreads{{/if}} {{#if is_muted}}muted_topic{{/if}} topic-list-item' data-topic-name='{{topic_name}}'>
+<li class='bottom_left_row {{#if is_zero}}zero-topic-unreads{{/if}} {{#if is_muted}}muted_topic{{/if}} topic-list-item' data-topic-name='{{topic_name}}'>
     <span class='topic-box'>
         <a href='{{url}}' class="topic-name" title="{{topic_name}}">
             {{topic_name}}

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -2,7 +2,7 @@
     <div class="narrows_panel">
         <ul id="global_filters" class="filters">
             {# Special-case this link so we don't actually go to page top. #}
-            <li class="top_left_all_messages global-filter active-filter" title="{{ _('All messages') }} (Esc)">
+            <li class="top_left_all_messages top_left_row active-filter" title="{{ _('All messages') }} (Esc)">
                 <a href="#">
                     <span class="filter-icon">
                         <i class="fa fa-home" aria-hidden="true"></i>
@@ -15,19 +15,21 @@
                 </a>
                 <span class="arrow all-messages-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
             </li>
-            <li class="top_left_private_messages global-filter">
-                <a href="#narrow/is/private">
-                    <span class="filter-icon">
-                        <i class="fa fa-envelope" aria-hidden="true"></i>
-                    </span>
-                    {#- squash whitespace -#}
-                    <span title="{{ _('Private messages') }} (P)">{{ _('Private messages') }}</span>
-                    <span class="count">
-                        <span class="value"></span>
-                    </span>
-                </a>
+            <li class="top_left_private_messages">
+                <div class="private_messages_header top_left_row">
+                    <a href="#narrow/is/private">
+                        <span class="filter-icon">
+                            <i class="fa fa-envelope" aria-hidden="true"></i>
+                        </span>
+                        {#- squash whitespace -#}
+                        <span title="{{ _('Private messages') }} (P)">{{ _('Private messages') }}</span>
+                        <span class="count">
+                            <span class="value"></span>
+                        </span>
+                    </a>
+                </div>
             </li>
-            <li class="top_left_mentions global-filter">
+            <li class="top_left_mentions top_left_row">
                 <a href="#narrow/is/mentioned">
                     <span class="filter-icon">
                         <i class="fa fa-at" aria-hidden="true"></i>
@@ -39,7 +41,7 @@
                     </span>
                 </a>
             </li>
-            <li class="top_left_starred_messages global-filter">
+            <li class="top_left_starred_messages top_left_row">
                 <a href="#narrow/is/starred">
                     <span class="filter-icon">
                         <i class="fa fa-star" aria-hidden="true"></i>


### PR DESCRIPTION
This makes hovers wider is some cases, and less tall in other cases.

If you narrow to a particular PM or topic on master, the hover is way too broad as you go over the elements.  Now we hover individual rows.

You'll want to test this in both day and night mode.