### PR TITLE
User status: JS tooltips for Buddy list and PM list, changes to full user profile's last seen field.

### DIFF
--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -149,7 +149,7 @@ run_test('build_private_messages_list_bot', () => {
                 is_zero: false,
                 url: '#narrow/pm-with/314-outgoingwebhook',
                 user_circle_class: 'user_circle_green',
-                fraction_present: undefined,
+                fraction_present: false,
                 is_group: false,
             },
             {

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1589,6 +1589,20 @@ run_test('user_presence_rows', () => {
     assert.equal(a.text().trim(), 'King Lear');
 });
 
+run_test('buddy_list_tooltip_content', () => {
+    var args = {
+        status_text: 'out to lunch',
+        last_seen: 'Active now',
+        is_away: false,
+        name: 'Iago',
+        online_now: true,
+    };
+
+    var html = render('buddy_list_tooltip_content', args);
+    var tooltip_content = $(html).find(".tooltip_inner_content");
+    assert.equal(tooltip_content.text().trim(), 'Iagoout to lunchActive now');
+});
+
 run_test('user_profile_modal', () => {
     let args = {
         full_name: "Iago",

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -1,4 +1,7 @@
-// You won't find every click handler here, but it's a good place to start!
+var render_buddy_list_tooltip = require('../templates/buddy_list_tooltip.hbs');
+var render_buddy_list_tooltip_content = require('../templates/buddy_list_tooltip_content.hbs');
+
+// // You won't find every click handler here, but it's a good place to start!
 
 exports.initialize = function () {
 
@@ -458,6 +461,7 @@ exports.initialize = function () {
         e.preventDefault();
         e.stopPropagation();
         popovers.hide_all();
+        $(".tooltip").remove();
     });
 
     $('#group-pms').expectOne().on('click', '.selectable_sidebar_block', function (e) {
@@ -467,12 +471,60 @@ exports.initialize = function () {
         e.preventDefault();
         e.stopPropagation();
         popovers.hide_all();
+        $(".tooltip").remove();
     });
 
     $("#subscriptions_table").on("click", ".exit, #subscription_overlay", function (e) {
         if ($(e.target).is(".exit, .exit-sign, #subscription_overlay, #subscription_overlay > .flex")) {
             subs.close();
         }
+    });
+
+    function do_render_buddy_list_tooltip(elem, title_data) {
+        elem.tooltip({
+            template: render_buddy_list_tooltip(),
+            title: render_buddy_list_tooltip_content(title_data),
+            html: true,
+            trigger: 'hover',
+            placement: 'bottom',
+            animation: false,
+        });
+        elem.tooltip('show');
+
+        $(".tooltip").css('left', elem.pageX + 'px');
+        $(".tooltip").css('top', elem.pageY + 'px');
+    }
+
+    // BUDDY LIST TOOLTIPS
+    $('#user_presences').on('mouseenter', '.user-presence-link, .user_sidebar_entry .user_circle, .user_sidebar_entry .selectable_sidebar_block', function (e) {
+        e.stopPropagation();
+        var elem = $(e.currentTarget).closest(".user_sidebar_entry").find(".user-presence-link");
+        var user_id = elem.attr('data-user-id');
+        var title_data = buddy_data.get_title_data(user_id, 'false');
+        do_render_buddy_list_tooltip(elem, title_data);
+    });
+
+    $('#user_presences').on('mouseleave click', '.user-presence-link, .user_sidebar_entry .user_circle, .user_sidebar_entry .selectable_sidebar_block', function (e) {
+        e.stopPropagation();
+        var elem = $(e.currentTarget).closest(".user_sidebar_entry").find(".user-presence-link");
+        $(elem).tooltip('destroy');
+    });
+
+    // PM LIST TOOLTIPS
+    $("body").on('mouseenter', '#pm_user_status, #group_pms_right_sidebar', function (e) {
+        $(".tooltip").remove();
+        e.stopPropagation();
+        var elem = $(e.currentTarget);
+        var user_ids_string = elem.attr('data-user-ids-string');
+        var is_group = elem.attr('data-is-group');
+
+        var title_data = buddy_data.get_title_data(user_ids_string, is_group);
+        do_render_buddy_list_tooltip(elem, title_data);
+    });
+
+    $("body").on('mouseleave', '#pm_user_status, #group_pms_right_sidebar', function (e) {
+        e.stopPropagation();
+        $(e.currentTarget).tooltip('destroy');
     });
 
     // HOME

--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -85,7 +85,7 @@ exports._build_private_messages_list = function (active_conversation) {
 
         let user_circle_class = buddy_data.get_user_circle_class(user_ids_string);
 
-        let fraction_present;
+        let fraction_present = false;
         if (is_group) {
             user_circle_class = 'user_circle_fraction';
             fraction_present = buddy_data.huddle_fraction_present(user_ids_string);

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -77,7 +77,7 @@ li.show-more-topics a {
 }
 
 .tooltip {
-    max-width: 10em;
+    max-width: 18em;
 }
 
 #stream_filters {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -487,6 +487,10 @@ strong {
     padding: 3px 5px;
 }
 
+.buddy_list_tooltip_content {
+    text-align: left;
+}
+
 #message_edit_tooltip {
     float: right;
     color: hsl(0, 0%, 0%);

--- a/static/templates/buddy_list_tooltip.hbs
+++ b/static/templates/buddy_list_tooltip.hbs
@@ -1,0 +1,6 @@
+<div class="tooltip">
+    <div class="tooltip-inner">
+        <div class="tooltip-content">
+        </div>
+    </div>
+</div>

--- a/static/templates/buddy_list_tooltip_content.hbs
+++ b/static/templates/buddy_list_tooltip_content.hbs
@@ -1,0 +1,31 @@
+<div class="buddy_list_tooltip_content">
+    {{#if is_group}}
+        <span class="tooltip_inner_content">{{recipients}}</span>
+    {{else}}
+        {{#if is_bot}}
+            <span class="tooltip_inner_content">{{name}}<br />{{#if bot_owner_exists}}Owner: {{bot_owner_name}}{{/if}}</span>
+        {{else}}
+            {{#if status_text}}
+                {{#if is_away}}
+                    <span class="tooltip_inner_content">{{name}}<br />{{status_text}}<br />Last active: Today</span>
+                {{else}}
+                    {{#if online_now}}
+                    <span class="tooltip_inner_content">{{name}}<br />{{status_text}}<br />{{last_seen}}</span>
+                    {{else}}
+                    <span class="tooltip_inner_content">{{name}}<br />{{status_text}}<br />Last active: {{last_seen}}</span>
+                    {{/if}}
+                {{/if}}
+            {{else}}
+                {{#if is_away}}
+                    <span class="tooltip_inner_content">{{name}}<br />Last active: Today</span>
+                {{else}}
+                    {{#if online_now}}
+                    <span class="tooltip_inner_content">{{name}}<br />{{last_seen}}</span>
+                    {{else}}
+                    <span class="tooltip_inner_content">{{name}}<br />Last active: {{last_seen}}</span>
+                    {{/if}}
+                {{/if}}
+            {{/if}}
+        {{/if}}
+    {{/if}}
+</div>

--- a/static/templates/group_pms.hbs
+++ b/static/templates/group_pms.hbs
@@ -1,13 +1,13 @@
 {{! User Presence rows }}
 {{#each group_pms}}
 <li data-user-ids="{{user_ids_string}}" class="group-pms-sidebar-entry narrow-filter">
-    <div class="selectable_sidebar_block">
+    <div class="selectable_sidebar_block" id="group_pms_right_sidebar" data-user-ids-string="{{user_ids_string}}" data-is-group="true">
         {{#if fraction_present}}
         <span class="user_circle_fraction" style="background:hsla(106, 74%, 44%, {{fraction_present}});"></span>
         {{else}}
         <span class="user_circle_fraction" style="background:none; border-color:hsl(0, 0%, 50%);"></span>
         {{/if}}
-        <a href="{{href}}" data-name="{{name}}" title="{{name}}" class="group-pm-link">{{short_name}}</a>
+        <a href="{{href}}" data-name="{{name}}" class="group-pm-link">{{short_name}}</a>
         <span class="count"><span class="value"></span></span>
     </div>
 </li>

--- a/static/templates/sidebar_private_message_list.hbs
+++ b/static/templates/sidebar_private_message_list.hbs
@@ -1,7 +1,7 @@
 <ul class='expanded_private_messages' data-name='private'>
     {{#each messages}}
     <li class='{{#if is_zero}}zero-pm-unreads{{/if}} top_left_row expanded_private_message' data-user-ids-string='{{user_ids_string}}'>
-        <span class='pm-box'>
+        <span class='pm-box' id='pm_user_status' data-user-ids-string='{{user_ids_string}}' data-is-group='{{is_group}}'>
 
             <div class="pm_left_col">
                 {{#if is_group}}
@@ -15,7 +15,7 @@
                 {{/if}}
             </div>
 
-            <a href='{{url}}' class="conversation-partners" title="{{ recipients }}">
+            <a href='{{url}}' class="conversation-partners">
                 {{recipients}}
             </a>
             <div class="private_message_count {{#if is_zero}}zero_count{{/if}}">

--- a/static/templates/user_presence_row.hbs
+++ b/static/templates/user_presence_row.hbs
@@ -4,8 +4,7 @@
         <a class="user-presence-link"
           href="{{href}}"
           data-user-id="{{user_id}}"
-          data-name="{{name}}"
-          title="{{title}}">
+          data-name="{{name}}">
             {{name}}
             {{#if my_user_status}}
             <span class="my_user_status">{{my_user_status}}</span>


### PR DESCRIPTION
>A cleaner PR that resolves #11607 

### Added JS Tooltips for User circles and user names in the Buddy List (right side bar) and the Private Messages List (left side bar).

1. Hovering on a User Circle reveals Active/Idle/Offline/Unavailable for green/orange/white/white-with-line user circle.
2. Hovering on the Names of Individual users in either list reveals:
    - Name
    - Status Message (if set)
    - Last online (Eg: "Online now" or "Last online: 10 minutes ago")
3. Hovering on Group Names reveals the name of all users in the group.

*Update: Example GIFs in a comment below.*
