### PR TITLE
Email mirror - advertise and document "+show-sender"

### DIFF
--- a/static/templates/email_address_hint.handlebars
+++ b/static/templates/email_address_hint.handlebars
@@ -6,5 +6,9 @@
         <li>{{t "The email will be forwarded to this stream" }}</li>
         <li>{{#tr this}}The email subject will become the Zulip topic{{/tr}}</li>
         <li>{{#tr this}}The email body will become the Zulip message{{/tr}}</li>
+        <li>
+            {{#tr this}}The message will begin with "From: &lt;Your email address&gt;" <br />
+            as long as you include the +show-sender part of the address{{/tr}}
+        </li>
     </ul>
 </div>

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2650,7 +2650,7 @@ def notify_subscriptions_added(user_profile: UserProfile,
                     invite_only=stream.invite_only,
                     is_announcement_only=stream.is_announcement_only,
                     color=subscription.color,
-                    email_address=encode_email_address(stream),
+                    email_address=encode_email_address(stream, show_sender=True),
                     desktop_notifications=subscription.desktop_notifications,
                     audible_notifications=subscription.audible_notifications,
                     push_notifications=subscription.push_notifications,
@@ -3480,7 +3480,7 @@ def do_rename_stream(stream: Stream,
     # date field in all cases.
     cache_delete_many(
         to_dict_cache_key_id(message.id) for message in messages)
-    new_email = encode_email_address(stream)
+    new_email = encode_email_address(stream, show_sender=True)
 
     # We will tell our users to essentially
     # update stream.name = new_name where name = old_name
@@ -4598,6 +4598,8 @@ def gather_subscriptions_helper(user_profile: UserProfile,
         if not sub["active"] and user_profile.is_guest:
             subscribers = None
 
+        email_address = encode_email_address_helper(stream["name"], stream["email_token"],
+                                                    show_sender=True)
         stream_dict = {'name': stream["name"],
                        'in_home_view': sub["in_home_view"],
                        'invite_only': stream["invite_only"],
@@ -4616,7 +4618,7 @@ def gather_subscriptions_helper(user_profile: UserProfile,
                        'stream_weekly_traffic': get_average_weekly_stream_traffic(stream["id"],
                                                                                   stream["date_created"],
                                                                                   recent_traffic),
-                       'email_address': encode_email_address_helper(stream["name"], stream["email_token"]),
+                       'email_address': email_address,
                        'history_public_to_subscribers': stream['history_public_to_subscribers']}
         if subscribers is not None:
             stream_dict['subscribers'] = subscribers

--- a/zerver/lib/email_mirror_helpers.py
+++ b/zerver/lib/email_mirror_helpers.py
@@ -24,10 +24,10 @@ def get_email_gateway_message_string_from_address(address: str) -> str:
 
     return msg_string
 
-def encode_email_address(stream: Stream) -> str:
-    return encode_email_address_helper(stream.name, stream.email_token)
+def encode_email_address(stream: Stream, show_sender: bool=False) -> str:
+    return encode_email_address_helper(stream.name, stream.email_token, show_sender)
 
-def encode_email_address_helper(name: str, email_token: str) -> str:
+def encode_email_address_helper(name: str, email_token: str, show_sender: bool=False) -> str:
     # Some deployments may not use the email gateway
     if settings.EMAIL_GATEWAY_PATTERN == '':
         return ''
@@ -49,6 +49,9 @@ def encode_email_address_helper(name: str, email_token: str) -> str:
         encoded_token = "%s+%s" % (encoded_name, email_token)
     else:
         encoded_token = email_token
+
+    if show_sender:
+        encoded_token += "+show-sender"
 
     return settings.EMAIL_GATEWAY_PATTERN % (encoded_token,)
 

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -63,9 +63,9 @@ class TestEncodeDecode(ZulipTestCase):
         self.assertFalse(show_sender)
         self.assertEqual(token, stream.email_token)
 
-        parts = email_address.split('@')
-        parts[0] += "+show-sender"
-        email_address_show = '@'.join(parts)
+        email_address_show = encode_email_address(stream, show_sender=True)
+        self.assertTrue(email_address_show.split('@')[0].endswith('+show-sender'))
+
         token, show_sender = decode_email_address(email_address_show)
         self.assertTrue(show_sender)
         self.assertEqual(token, stream.email_token)
@@ -117,6 +117,12 @@ class TestEncodeDecode(ZulipTestCase):
         # Correctly decode the resulting address that doesn't have the stream name:
         token, show_sender = decode_email_address(email_address)
         self.assertFalse(show_sender)
+        self.assertEqual(token, stream.email_token)
+
+        # Make sure show_sender works:
+        email_address = encode_email_address(stream, show_sender=True)
+        token, show_sender = decode_email_address(email_address)
+        self.assertTrue(show_sender)
         self.assertEqual(token, stream.email_token)
 
         asciiable_stream_name = "ąężć"

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -4,6 +4,7 @@ import glob
 import os
 import re
 from datetime import timedelta
+from email import message_from_binary_file
 from email.utils import parseaddr
 from mock import MagicMock, patch, call
 from typing import List, Dict, Any, Optional
@@ -374,6 +375,18 @@ class TestSendToEmailMirror(ZulipTestCase):
         stream_id = get_stream("Denmark2", message.sender.realm).id
         self.assertEqual(message.recipient.type, Recipient.STREAM)
         self.assertEqual(message.recipient.type_id, stream_id)
+
+    def test_show_sender(self) -> None:
+        fixture_path = "zerver/tests/fixtures/email/1.txt"
+        user_profile = self.example_user('hamlet')
+        self.login(user_profile.email)
+        self.subscribe(user_profile, "Denmark")
+
+        call_command(self.COMMAND_NAME, "--fixture={}".format(fixture_path), "--show-sender")
+        message = most_recent_message(user_profile)
+
+        file = open(fixture_path, "rb")
+        self.assertIn(message_from_binary_file(file)['From'], message.content)
 
 class TestConvertMattermostData(ZulipTestCase):
     COMMAND_NAME = 'convert_mattermost_data'


### PR DESCRIPTION

Commit one, based on https://github.com/zulip/zulip/pull/11191#issuecomment-457829217 , includes the +show-sender tag in the stream email address displayed to users in stream settings.
![zulip_emailshowsender](https://user-images.githubusercontent.com/45007152/54271454-d3eaf800-4581-11e9-91db-aefbcee85855.png)


Commit two, addressing point 4 of https://github.com/zulip/zulip/issues/10612 takes adventage of the already existing email_address_hint to explain what +show-sender does.
![zulip_emailhint](https://user-images.githubusercontent.com/45007152/54271386-b158df00-4581-11e9-8107-75d48966cb36.png)

