### PR TITLE
Message container vars

### DIFF
--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -200,7 +200,7 @@ MessageListView.prototype = {
         }
     },
 
-    _add_msg_timestring: function (message_container) {
+    _add_msg_edited_vars: function (message_container) {
         var last_edit_timestr = this._get_msg_timestring(message_container);
         if (last_edit_timestr !== undefined) {
             message_container.last_edit_timestr = last_edit_timestr;
@@ -321,7 +321,7 @@ MessageListView.prototype = {
             message_container.sender_is_bot = people.sender_is_bot(message_container.msg);
             message_container.sender_is_guest = people.sender_is_guest(message_container.msg);
 
-            self._add_msg_timestring(message_container);
+            self._add_msg_edited_vars(message_container);
 
             message_container.small_avatar_url = people.small_avatar_url(message_container.msg);
             if (message_container.msg.stream !== undefined) {
@@ -1153,7 +1153,7 @@ MessageListView.prototype = {
         var was_selected = this.list.selected_message() === message_container.msg;
 
         // Re-render just this one message
-        this._add_msg_timestring(message_container);
+        this._add_msg_edited_vars(message_container);
         this._maybe_format_me_message(message_container);
 
         // Make sure the right thing happens if the message was edited to mention us.

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -201,9 +201,21 @@ MessageListView.prototype = {
     },
 
     _add_msg_edited_vars: function (message_container) {
+        // This adds variables to message_container object which calculate bools for
+        // checking position of "(EDITED)" label as well as the edited timestring
+        // The bools can be defined only when the message is edited
+        // (or when the `last_edit_timestr` is defined). The bools are:
+        //   * `edited_in_left_col`      -- when label appears in left column.
+        //   * `edited_alongside_sender` -- when label appears alongside sender info.
+        //   * `edited_status_msg`       -- when label appears for a "/me" message.
         var last_edit_timestr = this._get_msg_timestring(message_container);
+        var include_sender = message_container.include_sender;
+        var status_message = Boolean(message_container.status_message);
         if (last_edit_timestr !== undefined) {
             message_container.last_edit_timestr = last_edit_timestr;
+            message_container.edited_in_left_col = !include_sender;
+            message_container.edited_alongside_sender = include_sender && !status_message;
+            message_container.edited_status_msg = include_sender && status_message;
         }
     },
 
@@ -321,8 +333,6 @@ MessageListView.prototype = {
             message_container.sender_is_bot = people.sender_is_bot(message_container.msg);
             message_container.sender_is_guest = people.sender_is_guest(message_container.msg);
 
-            self._add_msg_edited_vars(message_container);
-
             message_container.small_avatar_url = people.small_avatar_url(message_container.msg);
             if (message_container.msg.stream !== undefined) {
                 message_container.background_color =
@@ -331,6 +341,8 @@ MessageListView.prototype = {
 
             message_container.contains_mention = message_container.msg.mentioned;
             self._maybe_format_me_message(message_container);
+            // Once all other variables are updated
+            self._add_msg_edited_vars(message_container);
 
             prev = message_container;
         });
@@ -1153,8 +1165,8 @@ MessageListView.prototype = {
         var was_selected = this.list.selected_message() === message_container.msg;
 
         // Re-render just this one message
-        this._add_msg_edited_vars(message_container);
         this._maybe_format_me_message(message_container);
+        this._add_msg_edited_vars(message_container);
 
         // Make sure the right thing happens if the message was edited to mention us.
         message_container.contains_mention = message_container.msg.mentioned;

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -191,6 +191,15 @@ MessageListView.prototype = {
     // trigger a re-render
     _RENDER_THRESHOLD: 50,
 
+    _get_msg_timestring: function (message_container) {
+        if (message_container.msg.last_edit_timestamp !== undefined) {
+            var last_edit_time = new XDate(message_container.msg.last_edit_timestamp * 1000);
+            var today = new XDate();
+            return timerender.render_date(last_edit_time, undefined, today)[0].textContent +
+                " at " + timerender.stringify_time(last_edit_time);
+        }
+    },
+
     _add_msg_timestring: function (message_container) {
         if (message_container.msg.last_edit_timestamp !== undefined) {
             // Add or update the last_edit_timestr

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -201,13 +201,9 @@ MessageListView.prototype = {
     },
 
     _add_msg_timestring: function (message_container) {
-        if (message_container.msg.last_edit_timestamp !== undefined) {
-            // Add or update the last_edit_timestr
-            var last_edit_time = new XDate(message_container.msg.last_edit_timestamp * 1000);
-            var today = new XDate();
-            message_container.last_edit_timestr =
-                timerender.render_date(last_edit_time, undefined, today)[0].textContent
-                + " at " + timerender.stringify_time(last_edit_time);
+        var last_edit_timestr = this._get_msg_timestring(message_container);
+        if (last_edit_timestr !== undefined) {
+            message_container.last_edit_timestr = last_edit_timestr;
         }
     },
 

--- a/static/templates/me_message.handlebars
+++ b/static/templates/me_message.handlebars
@@ -13,8 +13,8 @@
             {{{ status_message }}}
         </span>
 
-        {{#if_and last_edit_timestr include_sender}}
+        {{#if edited_status_msg}}
         {{partial "edited_notice"}}
-        {{/if_and}}
+        {{/if}}
     </span>
 </span>

--- a/static/templates/message_body.handlebars
+++ b/static/templates/message_body.handlebars
@@ -27,11 +27,9 @@
         {{timestr}}
     </span>
 
-    {{#if_and last_edit_timestr include_sender}}
-        {{#unless status_message}}
-        {{partial "edited_notice"}}
-        {{/unless}}
-    {{/if_and}}
+    {{#if edited_alongside_sender}}
+    {{partial "edited_notice"}}
+    {{/if}}
 
     {{partial "message_controls"}}
 
@@ -41,10 +39,8 @@
 <div class="message_content">{{#if use_match_properties}}{{{msg/match_content}}}{{else}}{{{msg/content}}}{{/if}}</div>
 {{/unless}}
 
-{{#if last_edit_timestr}}
-    {{#unless include_sender}}
-    {{partial "edited_notice"}}
-    {{/unless}}
+{{#if edited_in_left_col}}
+{{partial "edited_notice"}}
 {{/if}}
 
 <div class="message_edit">


### PR DESCRIPTION
This adds three bools to message_container object which calculate bools
where the "(EDITED)" label should appear:

* `edited_in_left_col` -- when label appears in left column.
* `edited_along_sender` -- when label appears alongside sender info.
* `edited_status_msg` -- when label appears for a "/me" message.