### PR TITLE
image-action: Fix open and download hover highlight in night mode.

### DIFF
--- a/static/styles/lightbox.scss
+++ b/static/styles/lightbox.scss
@@ -259,7 +259,7 @@
     opacity: 1;
 }
 
-.image-actions .button {
+#lightbox_overlay .image-actions .button {
     font-size: 0.8rem;
     min-width: inherit;
     padding: 4px 10px;
@@ -269,17 +269,17 @@
     border-radius: 4px;
 }
 
-.image-actions .button:hover {
+#lightbox_overlay .image-actions .button:hover {
     background-color: hsl(0, 0%, 100%);
     border-color: hsl(0, 0%, 100%);
     color: hsl(227, 40%, 16%);
 }
 
-.image-actions a.button {
+#lightbox_overlay .image-actions a.button {
     text-decoration: none;
 }
 
-.button .download {
+#lightbox_overlay .button .download {
     top: 1px;
 }
 


### PR DESCRIPTION
Fixes #11887.
When we try to hover over Open or Download they were not highlighted
in night mode. This commit adds highlighting in night mode by adding lightbox_overlay to increase the specificity of the hover code in light_box.scss.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot from 2019-03-14 00-17-41](https://user-images.githubusercontent.com/21038781/54306092-9f615580-45ee-11e9-8b54-020df9f48cb8.png)
