### PR TITLE
Fix the partial visibility of zulip-octopus on landing page.

### DIFF
--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -2016,7 +2016,7 @@ nav ul li.active::after {
 
 .portico-landing.hello .call-to-action-bottom .zulip-octopus {
     margin: 130px auto 0 auto;
-    width: 30px;
+    width: 32px;
     height: 30px;
     background-image: url(/static/images/landing-page/zulip-octopus.png);
     background-size: cover;


### PR DESCRIPTION
The image zulip-octopus.png was not fully visible on the
landing-page due to lesser width thus resulting into an incomplete
image.

![octo](https://user-images.githubusercontent.com/41135524/54373888-0a209880-46a4-11e9-979a-003c419ab1a0.PNG)

Increased the width to 32 to make it fully visible.