### PR TITLE
Don’t hide popovers on mobile resize

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -644,6 +644,12 @@ exports.show_sender_info = function () {
     }
 };
 
+var suppress_scroll_hide = false;
+
+exports.set_suppress_scroll_hide = function () {
+    suppress_scroll_hide = true;
+};
+
 exports.register_click_handlers = function () {
     $("#main_div").on("click", ".actions_hover", function (e) {
         var row = $(this).closest(".message_row");
@@ -1002,6 +1008,11 @@ exports.register_click_handlers = function () {
         var last_scroll = 0;
 
         $('.app').on('scroll', function () {
+            if (suppress_scroll_hide) {
+                suppress_scroll_hide = false;
+                return;
+            }
+
             var date = new Date().getTime();
 
             // only run `popovers.hide_all()` if the last scroll was more

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -260,7 +260,13 @@ exports.handler = function () {
         condense.clear_message_content_height_cache();
     }
 
-    popovers.hide_all();
+    // On mobile, we want to avoid hiding a popover here, especially if
+    // this resize was triggered by a virtual keyboard popping up when
+    // the user opened that very popover.
+    var mobile = util.is_mobile();
+    if (!mobile) {
+        popovers.hide_all();
+    }
     exports.resize_page_components();
 
     // Re-compute and display/remove [More] links to messages
@@ -270,6 +276,10 @@ exports.handler = function () {
     // but before we've loaded in the messages; in that case, don't
     // try to scroll to one.
     if (current_msg_list.selected_id() !== -1) {
+        if (mobile) {
+            popovers.set_suppress_scroll_hide();
+        }
+
         navigate.scroll_to_selected();
     }
 };

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -48,34 +48,6 @@ function message_hover(message_row) {
     }
 }
 
-function should_skip_mobile_resize() {
-    // If we are in the mobile browser then we need to handle resize event
-    // more carefully because virtual keyboard causes resize event to
-    // trigger and this leads the input elements to loose focus.
-    if (util.is_mobile()) {
-        // If user is trying to search other users in right sidebar
-        // then don't resize due to opening of virtual keyboard in
-        // mobile browser because this leads the search bar to loose
-        // focus and it becomes impossible to type in the input field.
-        if ($('.user-list-filter').is(':focus')) {
-            return true;
-        }
-        // Don't resize when the user is filtering the streams due to the
-        // reasons mentioned in the previous comment.
-        if ($('.stream-list-filter').is(':focus')) {
-            return true;
-        }
-        // Don't resize in mobile browser when the user is trying to add
-        // emoji to the message or trying to react on other message due
-        // to the reasons mentioned above.
-        if ($('.emoji-popover-filter').is(':focus')) {
-            return true;
-        }
-    }
-    // resize in all other cases.
-    return false;
-}
-
 exports.initialize_kitchen_sink_stuff = function () {
     // TODO:
     //      This function is a historical dumping ground
@@ -111,11 +83,7 @@ exports.initialize_kitchen_sink_stuff = function () {
         // preventDefault, allowing the modal to scroll normally.
     });
 
-    $(window).resize(_.throttle(function () {
-        if (!should_skip_mobile_resize()) {
-            resize.handler();
-        }
-    }, 50));
+    $(window).resize(_.throttle(resize.handler, 50));
 
     // Scrolling in overlays. input boxes, and other elements that
     // explicitly scroll should not scroll the main view.  Stop


### PR DESCRIPTION
Then we don’t need a kludge that skips the resize handler in situations where it might hide popovers.

Wow.