### PR TITLE
context_processors: Do not render inline previews for realm description.

### DIFF
--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -64,7 +64,8 @@ def zulip_default_context(request: HttpRequest) -> Dict[str, Any]:
         realm_name = realm.name
         realm_icon = get_realm_icon_url(realm)
         realm_description_raw = realm.description or "The coolest place in the universe."
-        realm_description = bugdown_convert(realm_description_raw, message_realm=realm)
+        realm_description = bugdown_convert(realm_description_raw, message_realm=realm,
+                                            no_previews=True)
         realm_invite_required = realm.invite_required
         realm_plan_type = realm.plan_type
 

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -583,6 +583,18 @@ class LoginTest(ZulipTestCase):
             do_two_factor_login(request, user_profile)
             mock_login.assert_called_once()
 
+    def test_zulip_default_context_does_not_load_inline_previews(self) -> None:
+        realm = get_realm("zulip")
+        description = "https://www.google.com/images/srpr/logo4w.png"
+        realm.description = description
+        realm.save(update_fields=["description"])
+        response = self.client_get("/login/")
+        expected_response = """<p><a href="https://www.google.com/images/srpr/logo4w.png" \
+target="_blank" title="https://www.google.com/images/srpr/logo4w.png">\
+https://www.google.com/images/srpr/logo4w.png</a></p>"""
+        self.assertEqual(response.context_data["realm_description"], expected_response)
+        self.assertEqual(response.status_code, 200)
+
 class InviteUserBase(ZulipTestCase):
     def check_sent_emails(self, correct_recipients: List[str],
                           custom_from_name: Optional[str]=None) -> None:


### PR DESCRIPTION
Fix issue #11889.

_Note: I have placed the test in test_signup.py because this issue occurs during login/signup. There probably might be a more apt place to put the test though..._