### PR TITLE
docs: List the bug raised in case of using GitHub Desktop.

### DIFF
--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -270,6 +270,10 @@ winsymlinks:native
 
 Now you are ready for [Step 2: Get Zulip Code.](#step-2-get-zulip-code)
 
+(Note: **Do not use GitHub Desktop client** for cloning or any such future operations
+on the zulip code since it disables the symlinks and ignores the above configuration
+resulting into raising errors in the zulip development environment.)
+
 ### Step 2: Get Zulip Code
 
 1. In your browser, visit <https://github.com/zulip/zulip>


### PR DESCRIPTION
Add the recommendation in docs for not using GitHub Desktop client for
zulip code as it has a bug of keeping the symlinks disabled and ignoring
any configuration done to re-enable it resulting into failure to identify
the received symlinks leading to failing test cases in the zulip development
environment.

For reference I had submitted an issue at GitHub-Desktop at that time [here](https://github.com/desktop/desktop/issues/7083)
