### PR TITLE
node tests: Get stream_data back to 100%.

### DIFF
--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -842,4 +842,11 @@ run_test('all_topics_in_cache', () => {
 
     sub.first_message_id = 2;
     assert.equal(stream_data.all_topics_in_cache(sub), true);
+
+    // Test code that is possibly unreachable--I am not sure how
+    // you would get an undefined message from `first()` without
+    // exiting early for the `empty()` check.
+
+    message_list.all.first = () => undefined;
+    assert.equal(stream_data.all_topics_in_cache(sub), false);
 });

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -69,8 +69,7 @@ enforce_fully_covered = {
     # 'static/js/settings_ui.js',
     'static/js/settings_muting.js',
     'static/js/settings_user_groups.js',
-    # Removed temporarily
-    # 'static/js/stream_data.js',
+    'static/js/stream_data.js',
     'static/js/stream_events.js',
     'static/js/stream_sort.js',
     'static/js/top_left_corner.js',


### PR DESCRIPTION
I am a little skeptical of the code under test here,
but it's important to keep stream_data at 100%.
