### PR TITLE
left sidebar: Tone down color for interleaved blocks.

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -151,9 +151,16 @@ ul.filters hr {
 li.active-filter,
 li.active-sub-filter {
     font-weight: 600 !important;
-    background-color: hsl(202, 56%, 91%);
     position: relative;
     border-radius: 4px;
+}
+
+li.active-filter {
+    background-color: hsl(202, 56%, 95%);
+}
+
+li.active-sub-filter {
+    background-color: hsl(202, 56%, 91%);
 }
 
 #global_filters .filter-icon {


### PR DESCRIPTION
If you are in an interleaved stream view, or in
the intervleaved view for "Private Messages", we now
use a less distracting color to group the elements.

All I did was make the color 4% lighter.


