### PR TITLE
Remove broken animation for new PMs.

### DIFF
--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -256,8 +256,6 @@ run_test('update_dom_with_unread_counts', () => {
         assert.equal(count, 10);
     };
 
-    unread_ui.animate_private_message_changes = function () {};
-
     pm_list.update_dom_with_unread_counts(counts);
 
     assert(toggle_button_set);

--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -216,9 +216,6 @@ exports.update_dom_with_unread_counts = function (counts) {
 
     unread_ui.set_count_toggle_button($("#userlist-toggle-unreadcount"),
                                       counts.private_message_count);
-
-    unread_ui.animate_private_message_changes(get_filter_li(),
-                                              counts.private_message_count);
 };
 
 

--- a/static/js/unread_ui.js
+++ b/static/js/unread_ui.js
@@ -2,7 +2,6 @@ var unread_ui = (function () {
 
 var exports = {};
 
-var last_private_message_count = 0;
 var last_mention_count = 0;
 
 function do_new_messages_animation(li) {
@@ -17,13 +16,6 @@ function do_new_messages_animation(li) {
     setTimeout(mid_animation, 3000);
     setTimeout(end_animation, 6000);
 }
-
-exports.animate_private_message_changes = function (li, new_private_message_count) {
-    if (new_private_message_count > last_private_message_count) {
-        do_new_messages_animation(li);
-    }
-    last_private_message_count = new_private_message_count;
-};
 
 exports.animate_mention_changes = function (li, new_mention_count) {
     if (new_mention_count > last_mention_count) {


### PR DESCRIPTION
When new PMs came in, we would do a little
animation to show you the incoming message.
Unfortunately, it was broken and would animate
too many things, and it was kind of hard code
to maintain.

We still animate incoming mentions.
