### PR TITLE
typeahead: Add typeahead for slash commands.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -123,6 +123,11 @@ const me_slash = {
     text: "translated: /me is excited (Display action text)",
 };
 
+const my_slash = {
+    name: "my",
+    text: "translated: /my (Test)",
+};
+
 var sweden_stream = {
     name: 'Sweden',
     description: 'Cold, mountains and home decor.',
@@ -821,6 +826,11 @@ run_test('initialize', () => {
         actual_value = options.sorter.call(fake_this, [make_emoji(emoji_headphones),
                                                        make_emoji(emoji_heart)]);
         expected_value = [make_emoji(emoji_heart), make_emoji(emoji_headphones)];
+        assert.deepEqual(actual_value, expected_value);
+
+        fake_this = { completing: 'slash', token: 'm' };
+        actual_value = options.sorter.call(fake_this, [my_slash, me_slash]);
+        expected_value = [me_slash, my_slash];
         assert.deepEqual(actual_value, expected_value);
 
         fake_this = { completing: 'mention', token: 'co' };

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -544,6 +544,25 @@ run_test('render_emoji', () => {
     assert(rendered);
 });
 
+run_test('sort_slash_commands', () => {
+    var slash_commands = [
+        { name: 'my' },
+        { name: 'poll' },
+        { name: 'me' },
+        { name: 'mine' },
+        { name: 'test' },
+        { name: 'ping' },
+    ];
+    assert.deepEqual(th.sort_slash_commands(slash_commands, 'm'), [
+        { name: 'me' },
+        { name: 'mine' },
+        { name: 'my' },
+        { name: 'ping' },
+        { name: 'poll' },
+        { name: 'test' },
+    ]);
+});
+
 run_test('sort_emojis', () => {
     var emoji_list = [
         { emoji_name: '+1' },

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -323,7 +323,7 @@ exports.tokenize_compose_str = function (s) {
         case '~':
             // Code block must start on a new line
             if (i === 2) {
-                return s.slice(0);
+                return s;
             } else if (i > 2 && s[i - 3] === "\n") {
                 return s.slice(i - 2);
             }
@@ -333,7 +333,7 @@ exports.tokenize_compose_str = function (s) {
         case ':':
         case '_':
             if (i === 0) {
-                return s.slice(i);
+                return s;
             } else if (/[\s(){}\[\]]/.test(s[i - 1])) {
                 return s.slice(i);
             }

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -625,7 +625,7 @@ exports.compose_matches_sorter = function (matches) {
     } else if (this.completing === 'mention' || this.completing === 'silent_mention') {
         return typeahead_helper.sort_people_and_user_groups(this.token, matches);
     } else if (this.completing === 'slash') {
-        return matches;
+        return typeahead_helper.sort_slash_commands(matches, this.token);
     } else if (this.completing === 'stream') {
         return typeahead_helper.sort_streams(matches, this.token);
     } else if (this.completing === 'syntax') {

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -329,6 +329,20 @@ exports.sort_recipients = function (users, query, current_stream, current_topic,
     return result.concat(rest_sorted);
 };
 
+function slash_function_comaparator(slash_command_a, slash_command_b) {
+    if (slash_command_a.name < slash_command_b.name) {
+        return -1;
+    } else if (slash_command_a.name > slash_command_b.name) {
+        return 1;
+    }
+}
+exports.sort_slash_commands = function (matches, query) {
+    var results = util.prefix_sort(query, matches, function (x) { return x.name; });
+    results.matches = results.matches.sort(slash_function_comaparator);
+    results.rest = results.rest.sort(slash_function_comaparator);
+    return results.matches.concat(results.rest);
+};
+
 exports.sort_emojis = function (matches, query) {
     // TODO: sort by category in v2
     var results = emoji_prefix_sort(query, matches, function (x) { return x.emoji_name; });


### PR DESCRIPTION
This is the follow-up of PR #10267.
Here, we add typeahead for slash commands in compose box. We exclude "/day"
and "/light" if you're in day mode already, and we exclude "/night" and
"/dark" if you are in night mode.

The slash typeahead will open only when `/` is the first character. This
also adds a description of what the slash command does in the typeahead.