### PR TITLE
Rate limit mirror

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -793,7 +793,7 @@ def rate_limit_user(request: HttpRequest, user: UserProfile, domain: str) -> Non
 
     try:
         incr_ratelimit(entity)
-    except RateLimiterLockingException:  # nocoverage # Should add on next rate limit pass
+    except RateLimiterLockingException:
         logging.warning("Deadlock trying to incr_ratelimit for %s on %s" % (
             user.id, request.path))
         # rate-limit users who are hitting the API so hard we can't update our stats.

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, List
 
 import logging
 import re
@@ -17,8 +17,11 @@ from zerver.lib.email_notifications import convert_html_to_markdown
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.redis_utils import get_redis_client
 from zerver.lib.upload import upload_message_file
-from zerver.lib.utils import generate_random_token
+from zerver.lib.utils import generate_random_token, statsd
 from zerver.lib.send_email import FromAddress
+from zerver.lib.rate_limiter import RateLimitedObject, RateLimiterLockingException, \
+    is_ratelimited, incr_ratelimit
+from zerver.lib.exceptions import RateLimited
 from zerver.models import Stream, Recipient, \
     get_user_profile_by_id, get_display_recipient, get_personal_recipient, \
     Message, Realm, UserProfile, get_system_bot, get_user, get_stream_by_id_in_realm
@@ -406,3 +409,33 @@ def mirror_email_message(data: Dict[str, str]) -> Dict[str, str]:
         }
     )
     return {"status": "success"}
+
+# Email mirror rate limiter code:
+
+class RateLimitedRealmMirror(RateLimitedObject):
+    def __init__(self, realm: Realm) -> None:
+        self.realm = realm
+
+    def key_fragment(self) -> str:
+        return "emailmirror:{}:{}".format(type(self.realm), self.realm.id)
+
+    def rules(self) -> List[Tuple[int, int]]:
+        return settings.RATE_LIMITING_MIRROR_REALM_RULES
+
+
+def rate_limit_mirror_by_realm(recipient_realm: Realm) -> None:
+    # Code based on the rate_limit_user function:
+    entity = RateLimitedRealmMirror(recipient_realm)
+    ratelimited, time = is_ratelimited(entity)
+
+    if ratelimited:
+        statsd.incr("ratelimiter.limited.%s.%s" % (type(recipient_realm),
+                                                   recipient_realm.id))
+        raise RateLimited()
+
+    try:
+        incr_ratelimit(entity)
+    except RateLimiterLockingException:
+        logger.warning("Email mirror rate limiter: Deadlock trying to "
+                       "incr_ratelimit for realm %s" % (recipient_realm.name,))
+        raise RateLimited()

--- a/zerver/management/commands/send_to_email_mirror.py
+++ b/zerver/management/commands/send_to_email_mirror.py
@@ -10,10 +10,12 @@ from django.conf import settings
 from django.core.management.base import CommandParser
 
 from zerver.lib.actions import encode_email_address
-from zerver.lib.email_mirror import process_message
+from zerver.lib.email_mirror import mirror_email_message
 from zerver.lib.management import ZulipBaseCommand
 
 from zerver.models import Realm, get_stream, get_realm
+
+from typing import Dict
 
 # This command loads an email from a specified file and sends it
 # to the email mirror. Simple emails can be passed in a JSON file,
@@ -72,7 +74,10 @@ Example:
         message = self._parse_email_fixture(full_fixture_path)
         self._prepare_message(message, realm, stream)
 
-        process_message(message)
+        data = {}  # type: Dict[str, str]
+        data['recipient'] = str(message['To'])  # Need str() here to avoid mypy throwing an error
+        data['msg_text'] = message.as_string()
+        mirror_email_message(data)
 
     def _does_fixture_path_exist(self, fixture_path: str) -> bool:
         return os.path.exists(fixture_path)

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -687,6 +687,13 @@ CACHES = {
 RATE_LIMITING_RULES = [
     (60, 200),  # 200 requests max every minute
 ]
+
+RATE_LIMITING_MIRROR_REALM_RULES = [
+    (60, 50),  # 50 emails per minute
+    (300, 120),  # 120 emails per 5 minutes
+    (3600, 600),  # 600 emails per hour
+]
+
 DEBUG_RATE_LIMITING = DEBUG
 REDIS_PASSWORD = get_secret('redis_password')
 


### PR DESCRIPTION
This is a PR for https://github.com/zulip/zulip/issues/2420

This rate limits the email mirror per realm using the same mechanism as the original rate limiter for views. Detailed explanation in the message in the first commit. This is implemented per-realm as Tim suggested this as a reasonable approach in a chat.

Testing: First of all test_mirror_worker_rate_limiting should be doing a decent job at testing this works as it should. Beyond that, with the aid of the second commit this can be tested manually in the dev environment, by setting RATE_LIMITING_MIRROR_REALM_RULES to something low, like "max 2 emails per 3 minutes" and then using send_to_email_mirror:
`` ./manage.py send_to_email_mirror --fixture=zerver/tests/fixtures/email/1.txt ``
multiple times while the server is running and seeing that emails get blocked after the limit is reached, and then after the appropriate amount of time passes, they start going through again, and rate limiting works as it should.

NOTE: I have no idea what is a sensible default for this. I just set it to "50 emails max (per realm) every 5 minutes" in settings.py, but this should probably be adjusted by someone who has a better sense here.