### PR TITLE
webhooks/bitbucket: Account for missing user info.

### DIFF
--- a/zerver/webhooks/bitbucket/fixtures/push_without_user_info.json
+++ b/zerver/webhooks/bitbucket/fixtures/push_without_user_info.json
@@ -1,0 +1,15 @@
+{
+    "repository":{
+        "name": "Repository name",
+        "absolute_url": "kolaszek/repository-name/"
+    },
+    "commits":[
+        {
+            "author": "eeshangarg",
+            "message": "c\n",
+            "raw_node": "25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12",
+            "branch": "master"
+        }
+    ],
+    "canon_url": "https://bitbucket.org/"
+}

--- a/zerver/webhooks/bitbucket/tests.py
+++ b/zerver/webhooks/bitbucket/tests.py
@@ -20,6 +20,14 @@ class BitbucketHookTests(WebhookTestCase):
         self.api_stream_message(self.TEST_USER_EMAIL, fixture_name, self.EXPECTED_TOPIC_BRANCH_EVENTS,
                                 expected_message)
 
+    def test_bitbucket_on_push_event_without_user_info(self) -> None:
+        fixture_name = 'push_without_user_info'
+        self.url = self.build_webhook_url(payload=self.get_body(fixture_name))
+        commit_info = u'* c ([25f93d2](https://bitbucket.org/kolaszek/repository-name/commits/25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12))'
+        expected_message = u"Someone pushed 1 commit to branch master. Commits by eeshangarg (1).\n\n{}".format(commit_info)
+        self.api_stream_message(self.TEST_USER_EMAIL, fixture_name, self.EXPECTED_TOPIC_BRANCH_EVENTS,
+                                expected_message)
+
     def test_bitbucket_on_push_event_filtered_by_branches(self) -> None:
         fixture_name = 'push'
         self.url = self.build_webhook_url(payload=self.get_body(fixture_name),

--- a/zerver/webhooks/bitbucket/view.py
+++ b/zerver/webhooks/bitbucket/view.py
@@ -20,7 +20,7 @@ def api_bitbucket_webhook(request: HttpRequest, user_profile: UserProfile,
 
     commits = [
         {
-            'name': payload.get('user'),
+            'name': commit.get('author') or payload.get('user'),
             'sha': commit.get('raw_node'),
             'message': commit.get('message'),
             'url': u'{}{}commits/{}'.format(
@@ -42,7 +42,11 @@ def api_bitbucket_webhook(request: HttpRequest, user_profile: UserProfile,
         branch = payload['commits'][-1]['branch']
         if branches is not None and branches.find(branch) == -1:
             return json_success()
-        content = get_push_commits_event_message(payload['user'], None, branch, commits)
+
+        committer = payload.get('user')
+        content = get_push_commits_event_message(
+            committer if committer is not None else 'Someone',
+            None, branch, commits)
         subject = TOPIC_WITH_BRANCH_TEMPLATE.format(repo=repository['name'], branch=branch)
 
     check_send_webhook_message(request, user_profile, subject, content,


### PR DESCRIPTION
According to our logs, some BitBucket enterprise payloads may
not contain the name of the user who pushed all the commits.

@timabbott: FYI :)