### PR TITLE
Shorten GitHub links

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -181,13 +181,13 @@ def get_compiled_github_link_regex() -> str:
                              # (Double-negative lookbehind to allow start-of-string)
         (?P<url>             # Main group
             https://github\.com/        # Domain
-            (?P<organization>[\w.-]+)/  # Organization name
-            (?P<repository>[\w.-]+)   # Name of repository
+            (?P<organization>[\w-]+)/  # Organization name
+            (?P<repository>[\w-]+)   # Name of repository
             (
-                (/[\w.-]+)*/
-                (?P<artifact>[\w.-]+)/  # Last artifact in the URL such as pull request, issue, commit
-                (?P<id>[\w.-]+)         # Identifier for artifiact
-                (\#[\w.-]*)?
+                (/[\w-]+)*/
+                (?P<artifact>[\w-]+)/  # Last artifact in the URL such as pull request, issue, commit
+                (?P<id>[\w-]+)         # Identifier for artifiact
+                (\#[\w-]*)?
             )?
         )/?
 
@@ -1380,12 +1380,12 @@ class GithubLink(CompiledPattern):
 
         if artifact is None or artifact_id is None:
             return url_to_a(db_data, url, shortened_repo_url)
-        elif artifact == 'commits':
+        elif artifact == 'commit' or artifact == 'commits':
             return url_to_a(db_data, url, '{0}@{1}'.format(shortened_repo_url, artifact_id[0:7]))
-        elif artifact == 'pulls' or artifact == 'issues':
+        elif artifact == 'pull' or artifact == 'issues':
             return url_to_a(db_data, url, '{0}#{1}'.format(shortened_repo_url, artifact_id))
         else:
-            return url_to_a(db_data, url, shortened_repo_url)
+            return url_to_a(db_data, url, url)
 
 class UListProcessor(markdown.blockprocessors.UListProcessor):
     """ Process unordered list blocks.

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1890,8 +1890,8 @@ class Bugdown(markdown.Markdown):
         reg.register(Avatar(GRAVATAR_REGEX, self), 'gravatar', 75)
         reg.register(UserGroupMentionPattern(mention.user_group_mentions, self), 'usergroupmention', 70)
         reg.register(AtomicLinkPattern(get_link_re(), self), 'link', 65)
-        reg.register(AutoLink(get_web_link_regex(), self), 'autolink', 55)
         reg.register(GithubLink(get_compiled_github_link_regex(), self), 'github_link', 60)
+        reg.register(AutoLink(get_web_link_regex(), self), 'autolink', 55)
         # Reserve priority 45-54 for Realm Filters
         reg = self.register_realm_filters(reg)
         reg.register(markdown.inlinepatterns.HtmlInlineProcessor(ENTITY_RE, self), 'entity', 40)

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -89,7 +89,6 @@ ElementStringNone = Union[Element, Optional[str]]
 AVATAR_REGEX = r'!avatar\((?P<email>[^)]*)\)'
 GRAVATAR_REGEX = r'!gravatar\((?P<email>[^)]*)\)'
 EMOJI_REGEX = r'(?P<syntax>:[\w\-\+]+:)'
-GITHUB_REGEX = r'https://github\.com/(?P<organization>[^/\s]+)/(?P<repository>[^/\s]+?(/))?((/[^/\s]+)*/(?P<artifact>[^/\s]+)/(?P<id>[^/\s]+)?(#[^\s]*))?(\s)'
 
 def verbose_compile(pattern: str) -> Any:
     return re.compile(
@@ -1047,7 +1046,7 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
                 div.set("class", "inline-preview-twitter")
                 div.insert(0, twitter_data)
                 continue
-            
+
             youtube = self.youtube_image(url)
             if youtube is not None:
                 yt_id = self.youtube_id(url)

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1379,8 +1379,8 @@ class GithubLink(CompiledPattern):
 
         if artifact is None or artifact_id is None:
             return url_to_a(db_data, url, shortened_repo_url)
-        elif artifact == 'commit' or artifact == 'commits':
-            return url_to_a(db_data, url, '{0}@{1}'.format(shortened_repo_url, artifact_id[0:7]))
+        elif artifact == 'commit':
+            return url_to_a(db_data, url, '{0}@{1}'.format(shortened_repo_url, artifact_id[0:10]))
         elif artifact == 'pull' or artifact == 'issues':
             return url_to_a(db_data, url, '{0}#{1}'.format(shortened_repo_url, artifact_id))
         else:
@@ -1879,18 +1879,18 @@ class Bugdown(markdown.Markdown):
         # rules, that preserves the order from upstream but leaves
         # space for us to add our own.
         reg = markdown.util.Registry()
-        reg.register(BacktickPattern(BACKTICK_RE), 'backtick', 110)
-        reg.register(markdown.inlinepatterns.DoubleTagPattern(STRONG_EM_RE, 'strong,em'), 'strong_em', 105)
-        reg.register(UserMentionPattern(mention.find_mentions, self), 'usermention', 100)
-        reg.register(Tex(r'\B(?<!\$)\$\$(?P<body>[^\n_$](\\\$|[^$\n])*)\$\$(?!\$)\B'), 'tex', 95)
-        reg.register(StreamPattern(get_compiled_stream_link_regex(), self), 'stream', 90)
-        reg.register(Avatar(AVATAR_REGEX, self), 'avatar', 85)
-        reg.register(ModalLink(r'!modal_link\((?P<relative_url>[^)]*), (?P<text>[^)]*)\)'), 'modal_link', 80)
+        reg.register(BacktickPattern(BACKTICK_RE), 'backtick', 105)
+        reg.register(markdown.inlinepatterns.DoubleTagPattern(STRONG_EM_RE, 'strong,em'), 'strong_em', 100)
+        reg.register(UserMentionPattern(mention.find_mentions, self), 'usermention', 95)
+        reg.register(Tex(r'\B(?<!\$)\$\$(?P<body>[^\n_$](\\\$|[^$\n])*)\$\$(?!\$)\B'), 'tex', 90)
+        reg.register(StreamPattern(get_compiled_stream_link_regex(), self), 'stream', 85)
+        reg.register(Avatar(AVATAR_REGEX, self), 'avatar', 80)
+        reg.register(ModalLink(r'!modal_link\((?P<relative_url>[^)]*), (?P<text>[^)]*)\)'), 'modal_link', 75)
         # Note that !gravatar syntax should be deprecated long term.
-        reg.register(Avatar(GRAVATAR_REGEX, self), 'gravatar', 75)
-        reg.register(UserGroupMentionPattern(mention.user_group_mentions, self), 'usergroupmention', 70)
-        reg.register(AtomicLinkPattern(get_link_re(), self), 'link', 65)
-        reg.register(GithubLink(get_compiled_github_link_regex(), self), 'github_link', 60)
+        reg.register(Avatar(GRAVATAR_REGEX, self), 'gravatar', 70)
+        reg.register(UserGroupMentionPattern(mention.user_group_mentions, self), 'usergroupmention', 65)
+        reg.register(AtomicLinkPattern(get_link_re(), self), 'link', 60)
+        reg.register(GithubLink(get_compiled_github_link_regex(), self), 'github_link', 56)
         reg.register(AutoLink(get_web_link_regex(), self), 'autolink', 55)
         # Reserve priority 45-54 for Realm Filters
         reg = self.register_realm_filters(reg)

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -1638,6 +1638,41 @@ class BugdownTest(ZulipTestCase):
             '<p><a href="#narrow/stream/999-hello" title="#narrow/stream/999-hello">hello</a></p>'
         )
 
+    def test_github_link(self) -> None:
+        realm = get_realm("zulip")
+        sender_user_profile = self.example_user('othello')
+        message = Message(sender=sender_user_profile, sending_client=get_client("test"))
+
+        msg = "https://github.com/zulip/zulip"
+        self.assertEqual(
+            bugdown.convert(msg, message_realm=realm, message=message),
+            '<p><a href="https://github.com/zulip/zulip" target="_blank" title="https://github.com/zulip/zulip">zulip/zulip</a></p>'
+        )
+
+        msg = "https://github.com/zulip/zulip/issues/11895"
+        self.assertEqual(
+            bugdown.convert(msg, message_realm=realm, message=message),
+            '<p><a href="https://github.com/zulip/zulip/issues/11895" target="_blank" title="https://github.com/zulip/zulip/issues/11895">zulip/zulip#11895</a></p>'
+        )
+
+        msg = "https://github.com/zulip/zulip/pull/11922"
+        self.assertEqual(
+            bugdown.convert(msg, message_realm=realm, message=message),
+            '<p><a href="https://github.com/zulip/zulip/pull/11922" target="_blank" title="https://github.com/zulip/zulip/pull/11922">zulip/zulip#11922</a></p>'
+        )
+
+        msg = "https://github.com/zulip/zulip/commit/a47edd4fc8a1b115e979bef6fc372ddf360cdcef"
+        self.assertEqual(
+            bugdown.convert(msg, message_realm=realm, message=message),
+            '<p><a href="https://github.com/zulip/zulip/commit/a47edd4fc8a1b115e979bef6fc372ddf360cdcef" target="_blank" title="https://github.com/zulip/zulip/commit/a47edd4fc8a1b115e979bef6fc372ddf360cdcef">zulip/zulip@a47edd4</a></p>'
+        )
+
+        msg = "https://github.com/zulip/zulip/pull/11922/commits/623ee15beef4bd8745e9f4746fcc11093909dcc3"
+        self.assertEqual(
+            bugdown.convert(msg, message_realm=realm, message=message),
+            '<p><a href="https://github.com/zulip/zulip/pull/11922/commits/623ee15beef4bd8745e9f4746fcc11093909dcc3" target="_blank" title="https://github.com/zulip/zulip/pull/11922/commits/623ee15beef4bd8745e9f4746fcc11093909dcc3">zulip/zulip@623ee15</a></p>'
+        )
+
 class BugdownApiTests(ZulipTestCase):
     def test_render_message_api(self) -> None:
         content = 'That is a **bold** statement'

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -1664,13 +1664,7 @@ class BugdownTest(ZulipTestCase):
         msg = "https://github.com/zulip/zulip/commit/a47edd4fc8a1b115e979bef6fc372ddf360cdcef"
         self.assertEqual(
             bugdown.convert(msg, message_realm=realm, message=message),
-            '<p><a href="https://github.com/zulip/zulip/commit/a47edd4fc8a1b115e979bef6fc372ddf360cdcef" target="_blank" title="https://github.com/zulip/zulip/commit/a47edd4fc8a1b115e979bef6fc372ddf360cdcef">zulip/zulip@a47edd4</a></p>'
-        )
-
-        msg = "https://github.com/zulip/zulip/pull/11922/commits/623ee15beef4bd8745e9f4746fcc11093909dcc3"
-        self.assertEqual(
-            bugdown.convert(msg, message_realm=realm, message=message),
-            '<p><a href="https://github.com/zulip/zulip/pull/11922/commits/623ee15beef4bd8745e9f4746fcc11093909dcc3" target="_blank" title="https://github.com/zulip/zulip/pull/11922/commits/623ee15beef4bd8745e9f4746fcc11093909dcc3">zulip/zulip@623ee15</a></p>'
+            '<p><a href="https://github.com/zulip/zulip/commit/a47edd4fc8a1b115e979bef6fc372ddf360cdcef" target="_blank" title="https://github.com/zulip/zulip/commit/a47edd4fc8a1b115e979bef6fc372ddf360cdcef">zulip/zulip@a47edd4fc8</a></p>'
         )
 
 class BugdownApiTests(ZulipTestCase):


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

This adds support to automatically shorten GitHub links into a shorter form (https://github.com/zulip/zulip/issues/11895).

**Testing Plan:** <!-- How have you tested? -->

I added some unit tests in `test_inline_github_preview` to `zerver/test/test_bugdown.py`.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

An example of what the shortened GitHub URLs look like when the message is sent (originally the full-length URLs were pasted when writing the message):

<img width="893" alt="Screenshot 2019-03-16 at 7 36 18 PM" src="https://user-images.githubusercontent.com/1239705/54484379-dddf5600-4822-11e9-9e6a-266898c823be.png">


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
