### PR TITLE
Replace stream typeahead with dropdown.

### DIFF
--- a/frontend_tests/casper_tests/04-compose.js
+++ b/frontend_tests/casper_tests/04-compose.js
@@ -44,7 +44,6 @@ function check_compose_is_cleared() {
     common.check_form(
         '#send_message_form',
         {
-            stream_message_recipient_stream: '',
             stream_message_recipient_topic: '',
         },
         "Stream empty on new compose"
@@ -88,7 +87,6 @@ casper.then(function () {
         common.check_form(
             '#send_message_form',
             {
-                stream_message_recipient_stream: "Verona",
                 stream_message_recipient_topic: "Reply test",
             },
             "Stream populated after reply by click"
@@ -114,7 +112,6 @@ casper.then(function () {
         common.check_form(
             '#send_message_form',
             {
-                stream_message_recipient_stream: "Verona",
                 stream_message_recipient_topic: "Reply test",
             },
             "Stream populated after reply with `r`"

--- a/frontend_tests/casper_tests/11-mention.js
+++ b/frontend_tests/casper_tests/11-mention.js
@@ -8,8 +8,8 @@ casper.waitUntilVisible('#zhome', function () {
 });
 
 casper.then(function () {
+    casper.selectOptionByValue('#stream_message_recipient_stream', 'Verona');
     casper.fill('form[action^="/json/messages"]', {
-        stream_message_recipient_stream: 'Verona',
         stream_message_recipient_topic: 'Test mention all',
     });
 });

--- a/frontend_tests/casper_tests/14-drafts.js
+++ b/frontend_tests/casper_tests/14-drafts.js
@@ -47,9 +47,9 @@ casper.then(function () {
     casper.test.info('Creating Stream Message Draft');
     casper.click('body');
     casper.page.sendEvent('keypress', "c");
+    casper.selectOptionByValue('#stream_message_recipient_stream', 'all');
     casper.waitUntilVisible('#stream-message', function () {
         casper.fill('form#send_message_form', {
-            stream_message_recipient_stream: 'all',
             stream_message_recipient_topic: 'tests',
             content: 'Test Stream Message',
         }, false);
@@ -90,7 +90,6 @@ casper.then(function () {
     waitUntilDraftsVisible(function () {
         casper.test.assertElementCount('.draft-row', 2, 'Drafts loaded');
 
-        casper.test.assertSelectorHasText('.draft-row .message_header_stream .stream_label', 'all');
         casper.test.assertSelectorHasText('.draft-row .message_header_stream .stream_topic', 'tests');
         casper.test.assertTextExists('Test Stream Message', 'Stream draft contains message content');
 
@@ -103,11 +102,11 @@ casper.then(function () {
 casper.then(function () {
     casper.test.info('Restoring Stream Message Draft');
     casper.click("#drafts_table .message_row:not(.private-message) .restore-draft");
+    casper.selectOptionByValue('#stream_message_recipient_stream', 'all');
     waitWhileDraftsVisible(function () {
         casper.test.assertVisible('#stream-message', 'Stream Message Box Restored');
         casper.test.assertNotVisible('#preview_message_area', 'Preview Was Hidden');
         common.check_form('form#send_message_form', {
-            stream_message_recipient_stream: 'all',
             stream_message_recipient_topic: 'tests',
             content: 'Test Stream Message',
         }, "Stream message box filled with draft content");
@@ -117,8 +116,8 @@ casper.then(function () {
 
 casper.then(function () {
     casper.test.info('Editing Stream Message Draft');
+    casper.selectOptionByValue('#stream_message_recipient_stream', 'all');
     casper.fill('form#send_message_form', {
-        stream_message_recipient_stream: 'all',
         stream_message_recipient_topic: 'tests',
         content: 'Updated Stream Message',
     }, false);
@@ -133,7 +132,6 @@ casper.then(function () {
 
 casper.then(function () {
     waitUntilDraftsVisible(function () {
-        casper.test.assertSelectorHasText('.draft-row .message_header_stream .stream_label', 'all');
         casper.test.assertSelectorHasText('.draft-row .message_header_stream .stream_topic', 'tests');
         casper.test.assertTextExists('Updated Stream Message', 'Stream draft contains message content');
     });

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -868,6 +868,13 @@ run_test('initialize', () => {
     // normal workflow of the function. All the tests for the on functions are
     // done in subsequent tests directly below this test.
 
+    (function create_stream_dropdown() {
+        global.templates.render = function (template_name, streams) {
+            assert(template_name, 'compose_stream_dropdown');
+            assert.equal(streams.hasOwnProperty('streams'), true);
+        };
+    }());
+
     var resize_watch_manual_resize_checked = false;
     resize.watch_manual_resize = function (elem) {
         assert.equal('#compose-textarea', elem);

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -495,40 +495,6 @@ function sorted_names_from(subs) {
 run_test('initialize', () => {
     var expected_value;
 
-    var stream_typeahead_called = false;
-    $('#stream_message_recipient_stream').typeahead = function (options) {
-        // options.source()
-        //
-        var actual_value = options.source();
-        assert.deepEqual(actual_value.sort(), ['Denmark', 'Sweden']);
-
-        // options.highlighter()
-        options.query = 'De';
-        actual_value = options.highlighter('Denmark');
-        expected_value = '<strong>Denmark</strong>';
-        assert.equal(actual_value, expected_value);
-
-        options.query = 'the n';
-        actual_value = options.highlighter('The Netherlands');
-        expected_value = '<strong>The Netherlands</strong>';
-        assert.equal(actual_value, expected_value);
-
-        // options.matcher()
-        options.query = 'de';
-        assert.equal(options.matcher('Denmark'), true);
-        assert.equal(options.matcher('Sweden'), false);
-
-        options.query = 'De';
-        assert.equal(options.matcher('Denmark'), true);
-        assert.equal(options.matcher('Sweden'), false);
-
-        options.query = 'the ';
-        assert.equal(options.matcher('The Netherlands'), true);
-        assert.equal(options.matcher('Sweden'), false);
-
-        stream_typeahead_called = true;
-    };
-
     var subject_typeahead_called = false;
     $('#stream_message_recipient_topic').typeahead = function (options) {
         var topics = ['<&>', 'even more ice', 'furniture', 'ice', 'kronor', 'more ice'];
@@ -1091,7 +1057,6 @@ run_test('initialize', () => {
 
     // Now let's make sure that all the stub functions have been called
     // during the initialization.
-    assert(stream_typeahead_called);
     assert(subject_typeahead_called);
     assert(pm_recipient_typeahead_called);
     assert(pm_recipient_blur_called);

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1700,3 +1700,17 @@ run_test('archive_message_group', () => {
     assert.equal(last_message_text, 'This is message two.');
 
 });
+
+run_test('render_stream_dropdown', () => {
+    var args = [
+        'Denmark',
+        'Verona',
+    ];
+
+    var html = '<div>';
+    html += render('compose_stream_dropdown', {streams: args});
+    html += '</div>';
+
+    var first_option = $(html).find("#stream_message_recipient_stream>option:first-child").val();
+    assert.equal(first_option, 'Denmark');
+});

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -206,12 +206,11 @@ function handle_keydown(e) {
             target_sel = '#' + e.target.id;
         }
 
-        var on_stream = target_sel === "#stream_message_recipient_stream";
         var on_topic = target_sel  === "#stream_message_recipient_topic";
         var on_pm = target_sel === "#private_message_recipient";
         var on_compose = target_sel === '#compose-textarea';
 
-        if (on_stream || on_topic || on_pm) {
+        if (on_topic || on_pm) {
             // For enter, prevent the form from submitting
             // For tab, prevent the focus from changing again
             e.preventDefault();
@@ -222,9 +221,7 @@ function handle_keydown(e) {
             e.preventDefault();
         }
 
-        if (on_stream) {
-            nextFocus = "#stream_message_recipient_topic";
-        } else if (on_topic) {
+        if (on_topic) {
             if (code === 13) {
                 e.preventDefault();
             }
@@ -243,7 +240,6 @@ function handle_keydown(e) {
 
         // If no typeaheads are shown...
         if (!($("#stream_message_recipient_topic").data().typeahead.shown ||
-              $("#stream_message_recipient_stream").data().typeahead.shown ||
               $("#private_message_recipient").data().typeahead.shown ||
               $("#compose-textarea").data().typeahead.shown)) {
 
@@ -690,24 +686,6 @@ exports.initialize = function () {
     if (page_params.enter_sends) {
         $("#compose-send-button").hide();
     }
-
-    // limit number of items so the list doesn't fall off the screen
-    $("#stream_message_recipient_stream").typeahead({
-        source: function () {
-            return stream_data.subscribed_streams();
-        },
-        items: 3,
-        fixed: true,
-        highlighter: function (item) {
-            return typeahead_helper.render_typeahead_item({ primary: item });
-        },
-        matcher: function (item) {
-            // The matcher for "stream" is strictly prefix-based,
-            // because we want to avoid mixing up streams.
-            var q = this.query.trim().toLowerCase();
-            return item.toLowerCase().indexOf(q) === 0;
-        },
-    });
 
     $("#stream_message_recipient_topic").typeahead({
         source: function () {

--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -72,6 +72,7 @@
 .compose_table .message_header_colorblock.message_header_private_message {
     border-radius: 3px 0px 0px 3px;
     border-bottom: 0px;
+    height: 1.8em;
 }
 
 .compose_table .message_header_colorblock.message_header_private_message {
@@ -342,11 +343,27 @@ input.recipient_box {
     border-radius: 3px;
 }
 
+select.recipient_box {
+    margin: 0px;
+    height: 1.8em;
+    border-radius: 3px;
+}
+
 #stream_message_recipient_stream.recipient_box {
-    width: 20%;
     border-radius: 0px 3px 3px 0px;
     border-left: 0px;
     min-width: 120px;
+    max-width: 140px;
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    padding: 0em 0em 0em 0.4em;
+    background: url('../images/dropdown.png') right / 20px;
+    background-repeat: no-repeat;
+}
+
+#stream_message_recipient_stream.recipient_box > option {
+    overflow: hidden;
+    white-space: nowrap;
 }
 
 #stream_message_recipient_topic.recipient_box {
@@ -357,6 +374,12 @@ input.recipient_box {
 
 #stream_message_recipient_stream.recipient_box.lock-padding {
     padding-left: 18px;
+}
+
+@-moz-document url-prefix() {
+    #stream_message_recipient_stream.recipient_box.lock-padding {
+        padding-left: 14px;
+    }
 }
 
 #private_message_recipient.recipient_box {

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -580,6 +580,11 @@ on a dark background, and don't change the dark labels dark either. */
     }
 }
 
+body.night-mode #compose select {
+    background-color: hsla(0, 0%, 0%, 0.2);
+    border-color: hsla(0%, 0%, 0%, 0.5);
+}
+
 @-moz-document url-prefix() {
     body.night-mode #settings_page select {
         background-color: hsla(0, 0%, 0%, 0.2);

--- a/static/templates/compose_stream_dropdown.handlebars
+++ b/static/templates/compose_stream_dropdown.handlebars
@@ -1,0 +1,10 @@
+{{! Content of the stream drop-down }}
+<select name="streams" class="compose_stream_dropdown recipient_box" id="stream_message_recipient_stream">
+    {{#unless streams}}
+    <option></option>
+    {{/unless}}
+
+    {{#each streams}}
+    <option value="{{ this }}">{{ this }}</option>
+    {{/each}}
+</select>

--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -68,7 +68,7 @@
                                 <span id="compose-lock-icon">
                                     <i class="fa fa-lock" title="{{ _('This is a private stream') }}" aria-hidden="true"></i>
                                 </span>
-                                <input type="text" class="recipient_box" name="stream_message_recipient_stream" id="stream_message_recipient_stream" maxlength="30" value="" placeholder="{{ _('Stream') }}" autocomplete="off" tabindex="0" aria-label="{{ _('Stream') }}" />
+                                <div id="compose_stream_dropdown"></div>
                                 <i class="fa fa-angle-right" aria-hidden="true"></i>
                                 <input type="text" class="recipient_box" name="stream_message_recipient_topic" id="stream_message_recipient_topic" maxlength="60" value="" placeholder="{{ _('Topic') }}" autocomplete="off" tabindex="0" aria-label="{{ _('Topic') }}" />
                             </div>


### PR DESCRIPTION
This PR addresses issue #11832.
Discussion on [czo](https://chat.zulip.org/#narrow/stream/49-development-help/topic/.2311682/near/715962).

The stream typeahead in the compose box was replaced with a dropdown menu.  This feature helps with on-boarding issues, as well as serving as a replacement for somewhat inconsistent typeahead code.

There are a few points of uncertainty:

* Currently, it is a little hacky how the drop-up is being forced, i.e., by defaulting to the last element of the list if no default value exists.  FF behaves much better than chrome, but after researching, it seems Chrome hands off positioning of the dropdown to the OS. 

* Node tests are passing with branch coverage of 60%, which is pretty sub-par (need a little direction on how to improve this number).

* In terms of styling, unsure how to address the edge case of a long stream name.  Currently, the overflow is hidden, but it looks rather bad as the dropdown arrow overlaps.  Attempts were made to add right padding and trail with an ellipsis, but wasn't able to implement.


**Testing Plan:** <!-- How have you tested? -->

Manual tests were done extensively with regard to both functionality and consistent styling.

Casper tests and node tests were updated.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

Below demonstrates clicking on the dropdown from 'new topic' in all messages, along with composing solely with keyboard shortcuts...

![stream-dropdown](https://user-images.githubusercontent.com/39782863/57125795-69a33800-6d26-11e9-86c8-4b5f52f09641.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
