### PR TITLE
Org settings: Make it harder to accidently deactivate yourself from Users tab.

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -169,8 +169,11 @@ function populate_users(realm_people_data) {
                 activity_rendered = $("<span></span>").text(i18n.t("Unknown"));
             }
 
-            var $row = $(templates.render("admin_user_list", {user: item, can_modify: page_params.is_admin}));
-
+            var $row = $(templates.render("admin_user_list", {
+                user: item,
+                can_modify: page_params.is_admin,
+                is_current_user: people.is_my_user_id(item.user_id),
+            }));
             $row.find(".last_active").append(activity_rendered);
 
             return $row;

--- a/static/templates/admin_user_list.handlebars
+++ b/static/templates/admin_user_list.handlebars
@@ -34,7 +34,7 @@
     <td>
         <span class="user-status-settings">
             {{#if is_active}}
-            <button class="button rounded small deactivate btn-danger">
+            <button class="button rounded small deactivate btn-danger" {{#if ../is_current_user}}disabled="disabled"{{/if}}>
                 {{t "Deactivate" }}
             </button>
             {{else}}


### PR DESCRIPTION
This is a follow up of PR #10702.
Here, we disabled the `Deactivate` button for the current user, so that the chances of you accidentally deactivating yourself reduces.

**Screenshot** 
![image](https://user-images.githubusercontent.com/40331304/54525749-e9ee2380-499a-11e9-900d-cbf69dd5e883.png)


