### PR TITLE
portico: Add /api links to /integrations.

### DIFF
--- a/templates/zerver/integrations/index.html
+++ b/templates/zerver/integrations/index.html
@@ -59,6 +59,16 @@
                             </h4>
                         </a>
                         {% endfor %}
+                        <h4 class="selected">{% trans %}Custom{% endtrans %}</h4>
+                        <a href="/api/incoming-webhooks-overview">
+                            <h4>{% trans %}Incoming webhooks{% endtrans %}</h4>
+                        </a>
+                        <a href="/api/writing-bots">
+                            <h4>{% trans %}Interactive bots{% endtrans %}</h4>
+                        </a>
+                        <a href="/api/rest">
+                            <h4>{% trans %}REST API{% endtrans %}</h4>
+                        </a>
                     </div>
                 </div>
 
@@ -75,7 +85,19 @@
                             </h4>
                         </a>
                         {% endfor %}
+                        <hr/>
+                        <h3>{% trans %}Custom{% endtrans %}</h3>
+                        <a href="/api/incoming-webhooks-overview">
+                            <h4>{% trans %}Incoming webhooks{% endtrans %}</h4>
+                        </a>
+                        <a href="/api/writing-bots">
+                            <h4>{% trans %}Interactive bots{% endtrans %}</h4>
+                        </a>
+                        <a href="/api/rest">
+                            <h4>{% trans %}REST API{% endtrans %}</h4>
+                        </a>
                     </div>
+
 
                     <div class="integration-lozenges">
                         {% for integration in integrations_dict.values() %}


### PR DESCRIPTION
Thir PR closes #11803 

I did the following in this PR.
a) Add the custom section with all the links on the /integrations page.
b) Added the /api links, in the mobile drop down as well.
c) I broke down the .integration-category class into two parts named .integration-category_css and .integration-category_js

@rishig Please review.

Thanks



