### PR TITLE
left sidebar : Add 'Display starred count' option in starred messages popover

### DIFF
--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -228,7 +228,8 @@ function build_starred_messages_popover(e) {
     popovers.hide_all();
 
     var content = templates.render(
-        'starred_messages_sidebar_actions'
+        'starred_messages_sidebar_actions',
+        {starred_message_counts: page_params.starred_message_counts}
     );
 
     $(elt).popover({
@@ -327,6 +328,19 @@ exports.register_stream_handlers = function () {
         e.stopPropagation();
     });
 
+    // Toggle displaying starred message count
+    $('body').on('click', '#toggle_display_starred_msg_count', function (e) {
+        exports.hide_starred_messages_popover();
+        e.preventDefault();
+        e.stopPropagation();
+        var starred_msg_counts = page_params.starred_message_counts;
+        var data = {};
+        data.starred_message_counts = JSON.stringify(!starred_msg_counts);
+        channel.patch({
+            url: '/json/settings/display',
+            data: data,
+        });
+    });
     // Mute/unmute
     $('body').on('click', '.toggle_home', function (e) {
         var sub = stream_popover_sub(e);

--- a/static/templates/starred_messages_sidebar_actions.handlebars
+++ b/static/templates/starred_messages_sidebar_actions.handlebars
@@ -6,4 +6,15 @@
             {{#tr this}}Unstar all messages{{/tr}}
         </a>
     </li>
+    <li>
+        <a id="toggle_display_starred_msg_count">
+            {{#if starred_message_counts}}
+                <i class="fa fa-eye-slash" aria-hidden="true"></i>
+                {{#tr this}}Hide starred message count{{/tr}}
+            {{else}}
+                <i class="fa fa-eye" aria-hidden="true"></i>
+                {{#tr this}}Show starred message count{{/tr}}
+            {{/if}}
+        </a>
+    </li>
 </ul>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This is followup PR of #11645. Adds option to toggle displaying counts for starred messages in popover of Starred messages

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![ScreenRecording20190322at1](https://user-images.githubusercontent.com/39343253/54807099-26bf6080-4ca2-11e9-9835-d80bcbb572db.gif)

