### PR TITLE
Modify dev SSL setup docs to match script

### DIFF
--- a/docs/development/remote.md
+++ b/docs/development/remote.md
@@ -243,7 +243,7 @@ different.
     mkdir -p /var/lib/zulip/certbot-webroot/
     # if nginx running this will fail and you need to run `service nginx stop`
     /home/zulipdev/zulip/scripts/setup/setup-certbot \
-      --hostname=hostname.example.com --no-zulip-conf \
+      hostname.example.com --no-zulip-conf \
       --email=username@example.com --method=standalone
     ```
 


### PR DESCRIPTION
The docs specify passing hostname with the --hostname flag, which
doesn't match the actual usage in scripts/setup/setup-certbot. This
change fixes the docs to match the actual usage.


**Testing Plan:** <!-- How have you tested? -->
I tried running the certbot script using the new command, and it worked. The old command fails immediately with "Unrecognized option"

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
I built the docs locally with `make html`; here's what the change looks like:
<img width="741" alt="Screen Shot 2019-03-19 at 9 34 37 AM" src="https://user-images.githubusercontent.com/538610/54624282-4ea48f00-4a2a-11e9-9376-a89606a6d641.png">

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
