### PR TITLE
Stream and user search: Change click target for searching users and streams in the sidebar. 

### DIFF
--- a/frontend_tests/casper_tests/03-narrow.js
+++ b/frontend_tests/casper_tests/03-narrow.js
@@ -333,7 +333,7 @@ un_narrow();
 casper.then(function () {
     casper.test.info('Search streams using left sidebar');
     casper.test.assertExists('.input-append.notdisplayed', 'Stream filter box not visible initially');
-    casper.click('#streams_header .sidebar-title');
+    casper.click('#streams_click_target');
 });
 
 casper.waitWhileSelector('#streams_list .input-append.notdisplayed', function () {
@@ -448,7 +448,7 @@ casper.then(function () {
 });
 
 
-casper.thenClick('#streams_header .sidebar-title');
+casper.thenClick('#streams_click_target');
 
 casper.waitForSelector('.input-append.notdisplayed', function () {
     casper.test.assertExists('.input-append.notdisplayed',

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -444,10 +444,10 @@ run_test('handlers', () => {
         handler(e);
     }());
 
-    (function test_click_header_filter() {
+    (function test_click_target_filter() {
         init();
         const e = {};
-        const handler = $('#userlist-header').get_on_handler('click');
+        const handler = $('#users_click_target').get_on_handler('click');
 
         simulate_right_column_buddy_list();
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -501,7 +501,7 @@ exports.set_event_handlers = function () {
 
     $('#clear_search_stream_button').on('click', exports.clear_search);
 
-    $("#streams_header").expectOne().click(function (e) {
+    $("#streams_click_target").expectOne().click(function (e) {
         exports.toggle_filter_displayed(e);
     });
 

--- a/static/js/user_search.js
+++ b/static/js/user_search.js
@@ -106,7 +106,7 @@ const user_search = function (opts) {
     }
 
     $('#clear_search_people_button').on('click', self.clear_search);
-    $('#userlist-header').on('click', self.toggle_filter_displayed);
+    $('#users_click_target').on('click', self.toggle_filter_displayed);
 
     $input.on('input', opts.update_list);
     $input.on('focus', on_focus);

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -62,8 +62,8 @@ li.show-more-topics {
 #streams_filter_icon {
     float: right;
     opacity: 0.50;
-    font-size: 13px;
-    margin-top: 3px;
+    font-size: 15px;
+    margin-top: 2px;
     margin-left: 10px;
 
     &:hover {
@@ -74,6 +74,20 @@ li.show-more-topics {
 
 #streams_inline_cog {
     margin-right: 10px;
+}
+
+#streams_click_target {
+    margin-right: 30px;
+
+    &:hover {
+        .fa-search {
+            opacity: 1;
+        }
+
+        .sidebar-title {
+            color: hsl(0, 0%, 0%);
+        }
+    }
 }
 
 .tooltip {

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -102,6 +102,12 @@ on a dark background, and don't change the dark labels dark either. */
         opacity: 0.5;
     }
 
+    #streams_click_target:hover .sidebar-title,
+    #users_click_target:hover .sidebar-title {
+        color: inherit;
+        opacity: 1.0;
+    }
+
     .rendered_markdown button,
     .new-style .button {
         background-color: hsla(0, 0%, 0%, 0.2);

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -206,11 +206,15 @@
     margin-right: 10px;
 }
 
+#users_click_target:hover .sidebar-title {
+    color: hsl(0, 0%, 0%);
+}
+
 .right-sidebar-items:first-of-type #userlist-header {
     border-top: none;
 }
 
-#userlist-header {
+#users_click_target {
     cursor: pointer;
     display: flex;
     flex-direction: row;
@@ -222,10 +226,20 @@
     }
 
     #user_filter_icon {
-        font-size: 13px;
+        font-size: 15px;
         opacity: 0.50;
-        margin-right: 5px;
     }
+}
+
+#users_click_target:hover #user_filter_icon {
+    opacity: 1;
+}
+
+#feedback_section {
+    text-align: left;
+    padding-bottom: 15px;
+    border-bottom: 1px solid hsl(0, 0%, 88%);
+    margin-right: 10px;
 }
 
 #keyboard-icon {

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -58,9 +58,12 @@
             </li>
         </ul>
         <div id="streams_list" class="zoom-out">
-            <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title" data-toggle="tooltip" title="{{ _('Filter streams') }}">{{ _('STREAMS') }}</h4>
+            <div id="streams_header" class="zoom-in-hide">
                 <i id="streams_inline_cog" class='fa fa-cog' aria-hidden="true" data-toggle="tooltip" title="{{ _('Subscribe, add, or configure streams') }}"></i>
-                <i id="streams_filter_icon" class='fa fa-search' aria-hidden="true" data-toggle="tooltip" title="{{ _('Filter streams') }} (q)"></i>
+                <div id="streams_click_target" title="{{ _('Search streams') }} (q)">
+                    <h4 class="sidebar-title">{{ _('STREAMS') }}</h4>
+                    <i id="streams_filter_icon" class='fa fa-search' aria-hidden="true"></i>
+                </div>
                 <div class="input-append notdisplayed stream_search_section">
                     <input class="stream-list-filter" type="text" autocomplete="off" placeholder="{{ _('Search streams') }}" />
                     <button type="button" class="btn clear_search_button" id="clear_search_stream_button">

--- a/templates/zerver/app/right_sidebar.html
+++ b/templates/zerver/app/right_sidebar.html
@@ -2,11 +2,13 @@
     <div class="right-sidebar-items">
         <div id="user-list">
             <div id="userlist-header">
-                <h4 class='sidebar-title' id='userlist-title' data-toggle="tooltip" title="{{ _('Filter users') }}">{{ _('USERS') }}</h4>
-                <i id="user_filter_icon" class='fa fa-search' aria-hidden="true" aria-label="{{ _('Filter users') }}" data-toggle="tooltip" title="{{ _('Filter users') }} (w)"></i>
+                <div id="users_click_target" title="{{ _('Search users') }} (w)">
+                    <h4 class='sidebar-title' id='userlist-title'>{{ _('USERS') }}</h4>
+                    <i id="user_filter_icon" class='fa fa-search' aria-hidden="true" aria-label="{{ _('Search users') }}"></i>
+                </div>
             </div>
             <div class="input-append notdisplayed" id="user_search_section">
-                <input class="user-list-filter" type="text" autocomplete="off" placeholder="{{ _('Search people') }}" />
+                <input class="user-list-filter" type="text" autocomplete="off" placeholder="{{ _('Search users') }}" />
                 <button type="button" class="btn clear_search_button" id="clear_search_people_button">
                     <i class="fa fa-remove" aria-hidden="true"></i>
                 </button>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Click target is changed for opening the search boxes for users and streams and search box not opens on clicking the right side of the search icon. 
Also the title and icon becomes dark on hovering over click target and arrow of tooltip is removed.

Fixes #11494 
**Testing Plan:** <!-- How have you tested? -->
I have tested it manually and node and casper tests have also been changed accordingly.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![normal](https://user-images.githubusercontent.com/35494118/56062800-402c6780-5d8b-11e9-8024-156c3b2c2d8a.gif)
![night](https://user-images.githubusercontent.com/35494118/56062803-415d9480-5d8b-11e9-8b62-eaeb6cac5cfa.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
