### PR TITLE
onboarding: Move intro_compose hotspot to be activated on opening compose.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -745,11 +745,12 @@ exports.initialize = function () {
             .replace('hotspot_', '')
             .replace('_overlay', '');
 
-        // Comment below to disable marking hotspots as read in production
-        hotspots.post_hotspot_as_read(hotspot_name);
-
+        if (hotspot_name !== 'intro_compose') {
+            // Comment below to disable marking hotspots as read in production
+            hotspots.post_hotspot_as_read(hotspot_name);
+            $('#hotspot_' + hotspot_name + '_icon').remove();
+        }
         overlays.close_overlay(overlay_name);
-        $('#hotspot_' + hotspot_name + '_icon').remove();
     });
 
     $('body').on('click', '.hotspot-button', function (e) {

--- a/static/js/hotspots.js
+++ b/static/js/hotspots.js
@@ -2,6 +2,10 @@ var hotspots = (function () {
 
 var exports = {};
 
+// flag variable for hotspot_intro_compose to prevent
+// opening its overlay before it is closed
+var initialized_intro_compose = false;
+
 // popover orientations
 var TOP = 'top';
 var LEFT = 'left';
@@ -36,7 +40,7 @@ var HOTSPOT_LOCATIONS = {
         popover: LEFT_BOTTOM,
     },
     intro_compose: {
-        element: '#left_bar_compose_stream_button_big',
+        element: '#stream_message_recipient_topic',
         offset_x: 0,
         offset_y: 0,
     },
@@ -185,6 +189,23 @@ function place_popover(hotspot) {
 }
 
 function insert_hotspot_into_DOM(hotspot) {
+    if (!initialized_intro_compose) {
+        initialized_intro_compose = true;
+        $('#stream_message_recipient_topic').one('focus', function () {
+            var overlay_name = 'hotspot_' + 'intro_compose' + '_overlay';
+            overlays.open_overlay({
+                name: overlay_name,
+                overlay: $('#' + overlay_name),
+                on_close: function () {
+                    // close popover
+                    $('#stream_message_recipient_topic').css({ display: 'inline' });
+                    $('#stream_message_recipient_topic').animate({ opacity: 1 }, {
+                        duration: 300,
+                    });
+                }.bind('#stream_message_recipient_topic'),
+            });
+        });
+    }
     if (hotspot.name === "intro_reply") {
         $('#bottom_whitespace').append(templates.render('intro_reply_hotspot', {}));
         return;
@@ -196,13 +217,15 @@ function insert_hotspot_into_DOM(hotspot) {
         description: hotspot.description,
         img: WHALE,
     });
-
-    var hotspot_icon_HTML =
-        '<div class="hotspot-icon" id="hotspot_' + hotspot.name + '_icon">' +
-            '<span class="dot"></span>' +
-            '<span class="pulse"></span>' +
-            '<div class="bounce"><span class="bounce-icon">?</span></div>' +
-        '</div>';
+    var hotspot_icon_HTML;
+    if (hotspot.name !== 'intro_compose') {
+        hotspot_icon_HTML =
+            '<div class="hotspot-icon" id="hotspot_' + hotspot.name + '_icon">' +
+                '<span class="dot"></span>' +
+                '<span class="pulse"></span>' +
+                '<div class="bounce"><span class="bounce-icon">?</span></div>' +
+            '</div>';
+    }
 
     setTimeout(function () {
         $('body').prepend(hotspot_icon_HTML);

--- a/zerver/lib/hotspots.py
+++ b/zerver/lib/hotspots.py
@@ -52,15 +52,25 @@ def get_next_hotspots(user: UserProfile) -> List[Dict[str, object]]:
     if user.tutorial_status == UserProfile.TUTORIAL_FINISHED:
         return []
 
+    return_hotspots = []
+
     seen_hotspots = frozenset(UserHotspot.objects.filter(user=user).values_list('hotspot', flat=True))
-    for hotspot in ['intro_reply', 'intro_streams', 'intro_topics', 'intro_gear', 'intro_compose']:
+    if 'intro_compose' not in seen_hotspots:
+        return_hotspots.append({
+            'name': 'intro_compose',
+            'title': ALL_HOTSPOTS['intro_compose']['title'],
+            'description': ALL_HOTSPOTS['intro_compose']['description'],
+            'delay': 0.5,
+        })
+    for hotspot in ['intro_reply', 'intro_streams', 'intro_topics', 'intro_gear']:
         if hotspot not in seen_hotspots:
-            return [{
+            return_hotspots.append({
                 'name': hotspot,
                 'title': ALL_HOTSPOTS[hotspot]['title'],
                 'description': ALL_HOTSPOTS[hotspot]['description'],
                 'delay': 0.5,
-            }]
+            })
+            return return_hotspots
 
     user.tutorial_status = UserProfile.TUTORIAL_FINISHED
     user.save(update_fields=['tutorial_status'])

--- a/zerver/tests/test_hotspots.py
+++ b/zerver/tests/test_hotspots.py
@@ -16,8 +16,8 @@ class TestGetNextHotspots(ZulipTestCase):
 
     def test_first_hotspot(self) -> None:
         hotspots = get_next_hotspots(self.user)
-        self.assertEqual(len(hotspots), 1)
-        self.assertEqual(hotspots[0]['name'], 'intro_reply')
+        self.assertEqual(len(hotspots), 2)
+        self.assertEqual(hotspots[0]['name'], 'intro_compose')
 
     def test_some_done_some_not(self) -> None:
         do_mark_hotspot_as_read(self.user, 'intro_reply')


### PR DESCRIPTION
Fixes issue #11670 . The changes enable hotspot_intro_compose to be activated when the topic box gains focus and removes the hotspot icon for the same hotspot. As per the instructions in the issue, this hotspot can be visited in any order. The changes are only made in 'hotspots.js'.

**Testing Plan:** Tested on the local development server and enclosed a gif to demonstrate it:

**GIFs or Screenshots:** 
![hotspot_new](https://user-images.githubusercontent.com/37958393/54672670-a4f2fa00-4b1e-11e9-92f7-7716a42f4467.gif)
