### PR TITLE
context_processors: Extract keys from zulip_default_context for login.

### DIFF
--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -228,7 +228,7 @@ class HomeTest(ZulipTestCase):
                 result = self._get_home_page(stream='Denmark')
 
         self.assert_length(queries, 43)
-        self.assert_length(cache_mock.call_args_list, 8)
+        self.assert_length(cache_mock.call_args_list, 7)
 
         html = result.content.decode('utf-8')
 
@@ -292,7 +292,7 @@ class HomeTest(ZulipTestCase):
             with patch('zerver.lib.cache.cache_set') as cache_mock:
                 result = self._get_home_page()
                 self.assertEqual(result.status_code, 200)
-                self.assert_length(cache_mock.call_args_list, 7)
+                self.assert_length(cache_mock.call_args_list, 6)
             self.assert_length(queries, 40)
 
     @slow("Creates and subscribes 10 users in a loop.  Should use bulk queries.")

--- a/zerver/tests/test_presence.py
+++ b/zerver/tests/test_presence.py
@@ -59,21 +59,21 @@ class ActivityTest(ZulipTestCase):
             result = self.client_get('/activity')
             self.assertEqual(result.status_code, 200)
 
-        self.assert_length(queries, 15)
+        self.assert_length(queries, 14)
 
         flush_per_request_caches()
         with queries_captured() as queries:
             result = self.client_get('/realm_activity/zulip/')
             self.assertEqual(result.status_code, 200)
 
-        self.assert_length(queries, 9)
+        self.assert_length(queries, 8)
 
         flush_per_request_caches()
         with queries_captured() as queries:
             result = self.client_get('/user_activity/iago@zulip.com/')
             self.assertEqual(result.status_code, 200)
 
-        self.assert_length(queries, 5)
+        self.assert_length(queries, 4)
 
 class TestClientModel(ZulipTestCase):
     def test_client_stringification(self) -> None:

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -7,7 +7,7 @@ from django.shortcuts import redirect, render
 from django.utils import translation
 from django.utils.cache import patch_cache_control
 
-from zerver.context_processors import get_realm_from_request
+from zerver.context_processors import get_realm_from_request, latest_info_context
 from zerver.decorator import zulip_login_required, \
     redirect_to_login
 from zerver.forms import ToSForm
@@ -96,7 +96,7 @@ def home(request: HttpRequest) -> HttpResponse:
     if subdomain != Realm.SUBDOMAIN_FOR_ROOT_DOMAIN:
         return home_real(request)
 
-    return render(request, 'zerver/hello.html')
+    return render(request, 'zerver/hello.html', latest_info_context())
 
 @zulip_login_required
 def home_real(request: HttpRequest) -> HttpResponse:
@@ -317,9 +317,11 @@ def apps_view(request: HttpRequest, _: str) -> HttpResponse:
 
 def plans_view(request: HttpRequest) -> HttpResponse:
     realm = get_realm_from_request(request)
+    realm_plan_type = 0
     if realm is not None:
+        realm_plan_type = realm.plan_type
         if realm.plan_type == Realm.SELF_HOSTED:
             return HttpResponseRedirect('https://zulipchat.com/plans')
         if not request.user.is_authenticated():
             return redirect_to_login(next="plans")
-    return render(request, "zerver/plans.html")
+    return render(request, "zerver/plans.html", context={"realm_plan_type": realm_plan_type})

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -9,7 +9,7 @@ from django.http import HttpResponseRedirect, HttpResponse, HttpRequest
 from django.shortcuts import redirect, render
 from django.core.exceptions import ValidationError
 from django.core import validators
-from zerver.context_processors import get_realm_from_request
+from zerver.context_processors import get_realm_from_request, login_context
 from zerver.models import UserProfile, Realm, Stream, MultiuseInvite, \
     name_changes_disabled, email_to_username, email_allowed_for_realm, \
     get_realm, get_user_by_delivery_email, get_default_stream_groups, DisposableEmailError, \
@@ -455,12 +455,11 @@ def accounts_home(request: HttpRequest, multiuse_object_key: Optional[str]="",
             return redirect_to_email_login_url(email)
     else:
         form = HomepageForm(realm=realm)
-    return render(request,
-                  'zerver/accounts_home.html',
-                  context={'form': form, 'current_url': request.get_full_path,
-                           'multiuse_object_key': multiuse_object_key,
-                           'from_multiuse_invite': from_multiuse_invite},
-                  )
+    context = login_context(request)
+    context.update({'form': form, 'current_url': request.get_full_path,
+                    'multiuse_object_key': multiuse_object_key,
+                    'from_multiuse_invite': from_multiuse_invite})
+    return render(request, 'zerver/accounts_home.html', context=context)
 
 def accounts_home_from_multiuse_invite(request: HttpRequest, confirmation_key: str) -> HttpResponse:
     multiuse_object = None

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -35,6 +35,7 @@ import zerver.views.muting
 import zerver.views.streams
 import zerver.views.realm
 import zerver.views.digest
+from zerver.context_processors import latest_info_context
 
 from zerver.lib.rest import rest_dispatch
 
@@ -521,7 +522,9 @@ i18n_urls = [
     url(r'^plans/$', zerver.views.home.plans_view, name='plans'),
 
     # Landing page, features pages, signup form, etc.
-    url(r'^hello/$', TemplateView.as_view(template_name='zerver/hello.html'), name='landing-page'),
+    url(r'^hello/$', TemplateView.as_view(template_name='zerver/hello.html',
+                                          get_context_data=latest_info_context),
+        name='landing-page'),
     url(r'^new-user/$', RedirectView.as_view(url='/hello', permanent=True)),
     url(r'^features/$', TemplateView.as_view(template_name='zerver/features.html')),
     url(r'^why-zulip/$', TemplateView.as_view(template_name='zerver/why-zulip.html')),


### PR DESCRIPTION
These keys will be moved to login_context and then this method will
be called as required by views which render login.html or accounts_home.html

Closes #11929.

I'm not *100%* sure if I did the partitioning of keys the right way and/or if the login_context was used *everywhere* it should have been. But I think that this is good enough to submit for a review now. I **have** reviewed it myself, but I can't shake a particular feeling of uncertainty.