### PR TITLE
info-overlay: improve styling of hotkeys.

### DIFF
--- a/static/styles/informational-overlays.scss
+++ b/static/styles/informational-overlays.scss
@@ -58,12 +58,44 @@
 .hotkeys_table {
     table-layout: fixed;
     width: 100%;
-    display: inline-block;
-    vertical-align: top;
+    vertical-align: middle;
     display: table;
     td.definition {
         // keeps dividing line at same width for all tables in model.
         width: calc(50% - 11px);
+        text-align: right;
+    }
+
+    .hotkey {
+        font-weight: normal;
+    }
+
+    .small_hotkey {
+        font-size: 0.9em !important;
+        kbd {
+            font-size: 0.9em;
+        }
+    }
+
+    kbd {
+        display: inline-block;
+        border: 1px solid hsl(0, 0%, 80%);
+        border-radius: 4px;
+        font-weight: 600;
+        white-space: nowrap;
+        background-color: hsl(0, 0%, 98%);
+        color: hsl(0, 0%, 20%);
+        margin: 0 0.1em;
+        padding: 0.1em 0.4em;
+        text-shadow: 0 1px 0 hsl(0, 0%, 100%);
+
+        /* Prevent selection */
+        -webkit-touch-callout: none;
+        -webkit-user-select: none;
+        -khtml-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
     }
 }
 
@@ -74,12 +106,12 @@
 }
 
 .hotkeys_table td:not(.definition) {
-    text-align: center;
+    text-align: left;
     white-space: nowrap;
-}
-
-.hotkeys_table .hotkey {
     font-weight: bold;
+}
+.hotkeys_table td:not(.definition) :not(kbd) {
+    font-size: 14px;
 }
 
 #keyboard-shortcuts table {

--- a/static/styles/informational-overlays.scss
+++ b/static/styles/informational-overlays.scss
@@ -50,40 +50,37 @@
     font-size: 0.9em;
 }
 
-.hotkeys_table {
-    width: 247px;
-    /* this is because some generic setting for striped tables in settings.css
-       overrides this. */
-    margin: 5px !important;
-    font-size: 90%;
-    display: inline-block;
-    vertical-align: top;
+
+.help-table {
+    table-layout: fixed;
 }
 
-.hotkeys_table:not(.hotkeys_full_table) th {
+.hotkeys_table {
+    table-layout: fixed;
+    width: 100%;
+    display: inline-block;
+    vertical-align: top;
+    display: table;
+    td.definition {
+        // keeps dividing line at same width for all tables in model.
+        width: calc(50% - 11px);
+    }
+}
+
+.hotkeys_table th {
     width: 245px;
+    text-align: center;
+    // aligns table name with dividing line
 }
 
 .hotkeys_table .hotkey {
-    font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
     text-align: right;
     font-weight: bold;
-    font-size: 90%;
     white-space: nowrap;
 }
 
-.hotkeys_full_table {
-    display: table;
-    width: calc(100% - 11px) !important;
-}
-
-.hotkeys_full_table td.hotkey {
-    /* this is to keep the <td> for hotkey the same width as the two-col layout. */
-    width: 131px;
-}
-
 #keyboard-shortcuts table {
-    margin-bottom: 10px;
+    margin-bottom: 10px !important;
 }
 
 @media only screen and (max-width: 768px) {

--- a/static/styles/informational-overlays.scss
+++ b/static/styles/informational-overlays.scss
@@ -74,7 +74,7 @@
 }
 
 .hotkeys_table .hotkey {
-    text-align: right;
+    text-align: center;
     font-weight: bold;
     white-space: nowrap;
 }

--- a/static/styles/informational-overlays.scss
+++ b/static/styles/informational-overlays.scss
@@ -73,10 +73,13 @@
     // aligns table name with dividing line
 }
 
-.hotkeys_table .hotkey {
+.hotkeys_table td:not(.definition) {
     text-align: center;
-    font-weight: bold;
     white-space: nowrap;
+}
+
+.hotkeys_table .hotkey {
+    font-weight: bold;
 }
 
 #keyboard-shortcuts table {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2501,10 +2501,6 @@ li .message_inline_image img {
     color: hsl(0, 0%, 100%);
 }
 
-.help-table {
-    table-layout: fixed;
-}
-
 #user-checkboxes {
     margin-top: 10px;
 }

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -9,48 +9,48 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="hotkey">Enter or r</td>
                     <td class="definition">{% trans %}Reply to message{% endtrans %}</td>
+                    <td class="hotkey">Enter or r</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">c</td>
                     <td class="definition">{% trans %}New stream message{% endtrans %}</td>
+                    <td class="hotkey">c</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">x</td>
                     <td class="definition">{% trans %}New private message{% endtrans %}</td>
+                    <td class="hotkey">x</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Esc or Ctrl + [</td>
                     <td class="definition">{% trans %}Cancel compose{% endtrans %}</td>
+                    <td class="hotkey">Esc or Ctrl + [</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">d</td>
                     <td class="definition">{% trans %}View drafts{% endtrans %}</td>
+                    <td class="hotkey">d</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Down or j</td>
                     <td class="definition">{% trans %}Next message{% endtrans %}</td>
+                    <td class="hotkey">Down or j</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">End or G</td>
                     <td class="definition">{% trans %}Last message{% endtrans %}</td>
+                    <td class="hotkey">End or G</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">n</td>
                     <td class="definition">{% trans %}Next unread topic{% endtrans %}</td>
+                    <td class="hotkey">n</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">p</td>
                     <td class="definition">{% trans %}Next unread private message{% endtrans %}</td>
+                    <td class="hotkey">p</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Ctrl + k or /</td>
                     <td class="definition">{% trans %}Initiate a search{% endtrans %}</td>
+                    <td class="hotkey">Ctrl + k or /</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">?</td>
                     <td class="definition">{% trans %}Show keyboard shortcuts{% endtrans %}</td>
+                    <td class="hotkey">?</td>
                 </tr>
             </table>
         </div>
@@ -62,40 +62,40 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="hotkey">Ctrl + k or /</td>
                     <td class="definition">{% trans %}Initiate a search{% endtrans %}</td>
+                    <td class="hotkey">Ctrl + k or /</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">q</td>
                     <td class="definition">{% trans %}Search streams{% endtrans %}</td>
+                    <td class="hotkey">q</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">w</td>
                     <td class="definition">{% trans %}Search people{% endtrans %}</td>
+                    <td class="hotkey">w</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Up or k</td>
                     <td class="definition">{% trans %}Previous message{% endtrans %}</td>
+                    <td class="hotkey">Up or k</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Down or j</td>
                     <td class="definition">{% trans %}Next message{% endtrans %}</td>
+                    <td class="hotkey">Down or j</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">PgUp or K</td>
                     <td class="definition">{% trans %}Scroll up{% endtrans %}</td>
+                    <td class="hotkey">PgUp or K</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">PgDn or J or Space</td>
                     <td class="definition">{% trans %}Scroll down{% endtrans %}</td>
+                    <td class="hotkey">PgDn or J or Space</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">End or G</td>
                     <td class="definition">{% trans %}Last message{% endtrans %}</td>
+                    <td class="hotkey">End or G</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Home</td>
                     <td class="definition">{% trans %}First message{% endtrans %}</td>
+                    <td class="hotkey">Home</td>
                 </tr>
             </table>
         </div>
@@ -107,40 +107,40 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="hotkey">Enter or r</td>
                     <td class="definition">{% trans %}Reply to message{% endtrans %}</td>
+                    <td class="hotkey">Enter or r</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">R</td>
                     <td class="definition">{% trans %}Reply to author{% endtrans %}</td>
+                    <td class="hotkey">R</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">></td>
                     <td class="definition">{% trans %}Quote and reply to message{% endtrans %}</td>
+                    <td class="hotkey">></td>
                 </tr>
                 <tr>
-                    <td class="hotkey">c</td>
                     <td class="definition">{% trans %}New stream message{% endtrans %}</td>
+                    <td class="hotkey">c</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">x</td>
                     <td class="definition">{% trans %}New private message{% endtrans %}</td>
+                    <td class="hotkey">x</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">@</td>
                     <td class="definition">{% trans %}Compose a reply @-mentioning author{% endtrans %}</td>
+                    <td class="hotkey">@</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Tab then Enter or Ctrl + Enter</td>
                     <td class="definition">{% trans %}Send message{% endtrans %}</td>
+                    <td class="hotkey">Tab then Enter or Ctrl + Enter</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Shift + Enter</td>
                     <td class="definition">{% trans %}Insert new line{% endtrans %}</td>
+                    <td class="hotkey">Shift + Enter</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Esc or Ctrl + [</td>
                     <td class="definition">{% trans %}Cancel compose{% endtrans %}</td>
+                    <td class="hotkey">Esc or Ctrl + [</td>
                 </tr>
             </table>
         </div>
@@ -152,36 +152,36 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="hotkey">s</td>
                     <td class="definition">{% trans %}Narrow to stream{% endtrans %}</td>
+                    <td class="hotkey">s</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">S</td>
                     <td class="definition">{% trans %}Narrow to topic or PM conversation{% endtrans %}</td>
+                    <td class="hotkey">S</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">shift + p</td>
                     <td class="definition">{% trans %}Narrow to all private messages{% endtrans %}</td>
+                    <td class="hotkey">shift + p</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">n</td>
                     <td class="definition">{% trans %}Narrow to next unread topic{% endtrans %}</td>
+                    <td class="hotkey">n</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">p</td>
                     <td class="definition">{% trans %}Narrow to next unread private message{% endtrans %}</td>
+                    <td class="hotkey">p</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">A or D</td>
                     <td class="definition">{% trans %}Cycle between stream narrows{% endtrans %}</td>
+                    <td class="hotkey">A or D</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Esc or Ctrl + [</td>
                     <td class="definition">{% trans %}Narrow to all unmuted messages{% endtrans %}</td>
+                    <td class="hotkey">Esc or Ctrl + [</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Ctrl + .</td>
                     <td class="definition">{% trans %}Narrow to current compose box recipient{% endtrans %}</td>
+                    <td class="hotkey">Ctrl + .</td>
                 </tr>
             </table>
         </div>
@@ -193,27 +193,26 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="hotkey">Left</td>
                     <td class="definition">{% trans %}Edit your last message{% endtrans %}</td>
+                    <td class="hotkey">Left</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">u</td>
                     <td class="definition">{% trans %}Show message sender's profile{% endtrans %}</td>
+                    <td class="hotkey">u</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">v</td>
                     <td class="definition">{% trans %}Show images in thread{% endtrans %}</td>
+                    <td class="hotkey">v</td>
                 </tr>
                 <tr id="edit-message-hotkey-help">
-                    <td class="hotkey">e</td>
                     <td class="definition">{% trans %}Edit selected message{% endtrans %}</td>
+                    <td class="hotkey">e</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Ctrl + s</td>
                     <td class="definition">{% trans %}Star selected message{% endtrans %}</td>
+                    <td class="hotkey">Ctrl + s</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">+</td>
                     <td class="definition">
                         {% trans %}React to selected message with{% endtrans %}
                         <img alt=":thumbs_up:"
@@ -221,14 +220,15 @@
                           src="/static/generated/emoji/images/emoji/unicode/1f44d.png"
                           title=":thumbs_up:"/>
                     </td>
+                    <td class="hotkey">+</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">-</td>
                     <td class="definition">{% trans %}Collapse/show selected message{% endtrans %}</td>
+                    <td class="hotkey">-</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">M</td>
                     <td class="definition">{% trans %}Toggle topic mute{% endtrans %}</td>
+                    <td class="hotkey">M</td>
                 </tr>
             </table>
         </div>
@@ -240,16 +240,16 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="hotkey">d</td>
                     <td class="definition">{% trans %}View drafts{% endtrans %}</td>
+                    <td class="hotkey">d</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Enter</td>
                     <td class="definition">{% trans %}Edit selected draft{% endtrans %}</td>
+                    <td class="hotkey">Enter</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Backspace</td>
                     <td class="definition">{% trans %}Delete selected draft{% endtrans %}</td>
+                    <td class="hotkey">Backspace</td>
                 </tr>
             </table>
         </div>
@@ -261,20 +261,20 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="hotkey">g</td>
                     <td class="definition">{% trans %}Toggle the gear menu{% endtrans %}</td>
+                    <td class="hotkey">g</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">i</td>
                     <td class="definition">{% trans %}Open message menu{% endtrans %}</td>
+                    <td class="hotkey">i</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">:</td>
                     <td class="definition">{% trans %}Open reactions menu{% endtrans %}</td>
+                    <td class="hotkey">:</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">?</td>
                     <td class="definition">{% trans %}Show keyboard shortcuts{% endtrans %}</td>
+                    <td class="hotkey">?</td>
                 </tr>
             </table>
         </div>
@@ -286,24 +286,24 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="hotkey">Up or Down</td>
                     <td class="definition">{% trans %}Scroll through streams{% endtrans %}</td>
+                    <td class="hotkey">Up or Down</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Left or Right</td>
                     <td class="definition">{% trans %}Switch between tabs{% endtrans %}</td>
+                    <td class="hotkey">Left or Right</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">V</td>
                     <td class="definition">{% trans %}View stream messages{% endtrans %}</td>
+                    <td class="hotkey">V</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">S</td>
                     <td class="definition">{% trans %}Subscribe to/unsubscribe from selected stream{% endtrans %}</td>
+                    <td class="hotkey">S</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">n</td>
                     <td class="definition">{% trans %}Create new stream{% endtrans %}</td>
+                    <td class="hotkey">n</td>
                 </tr>
             </table>
         </div>

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -10,47 +10,47 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Reply to message{% endtrans %}</td>
-                    <td><span class="hotkey">Enter</span> or  <span class="hotkey">r</span></td>
+                    <td><span class="hotkey"><kbd>Enter</kbd> or  <kbd>r</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}New stream message{% endtrans %}</td>
-                    <td><span class="hotkey">c</span></td>
+                    <td><span class="hotkey"><kbd>c</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}New private message{% endtrans %}</td>
-                    <td><span class="hotkey">x</span></td>
+                    <td><span class="hotkey"><kbd>x</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Cancel compose{% endtrans %}</td>
-                    <td><span class="hotkey">Esc</span> or <span class="hotkey">Ctrl + [</span></td>
+                    <td><span class="hotkey"><kbd>Esc</kbd> or <kbd>Ctrl</kbd> + <kbd>[</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}View drafts{% endtrans %}</td>
-                    <td><span class="hotkey">d</span></td>
+                    <td><span class="hotkey"><kbd>d</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Next message{% endtrans %}</td>
-                    <td><span class="hotkey">Down</span> or <span class="hotkey">j</span></td>
+                    <td><span class="hotkey"><kbd>Down</kbd> or <kbd>j</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Last message{% endtrans %}</td>
-                    <td><span class="hotkey">End</span> or <span class="hotkey">G</span></td>
+                    <td><span class="hotkey"><kbd>End</kbd> or <kbd>G</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Next unread topic{% endtrans %}</td>
-                    <td><span class="hotkey">n</span></td>
+                    <td><span class="hotkey"><kbd>n</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Next unread private message{% endtrans %}</td>
-                    <td><span class="hotkey">p</span></td>
+                    <td><span class="hotkey"><kbd>p</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Initiate a search{% endtrans %}</td>
-                    <td><span class="hotkey">Ctrl + k</span> or <span class="hotkey">/</span></td>
+                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>k</kbd> or <kbd>/</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Show keyboard shortcuts{% endtrans %}</td>
-                    <td><span class="hotkey">?</span></td>
+                    <td><span class="hotkey"><kbd>?</kbd></span></td>
                 </tr>
             </table>
         </div>
@@ -63,39 +63,39 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Initiate a search{% endtrans %}</td>
-                    <td><span class="hotkey">Ctrl + k</span> or <span class="hotkey">/</span></td>
+                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>k</kbd> or <kbd>/</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Search streams{% endtrans %}</td>
-                    <td><span class="hotkey">q</span></td>
+                    <td><span class="hotkey"><kbd>q</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Search people{% endtrans %}</td>
-                    <td><span class="hotkey">w</span></td>
+                    <td><span class="hotkey"><kbd>w</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Previous message{% endtrans %}</td>
-                    <td><span class="hotkey">Up</span> or <span class="hotkey">k</span></td>
+                    <td><span class="hotkey"><kbd>Up</kbd> or <kbd>k</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Next message{% endtrans %}</td>
-                    <td><span class="hotkey">Down</span> or <span class="hotkey">j</span></td>
+                    <td><span class="hotkey"><kbd>Down</kbd> or <kbd>j</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Scroll up{% endtrans %}</td>
-                    <td><span class="hotkey">PgUp</span> or <span class="hotkey">K</span></td>
+                    <td><span class="hotkey"><kbd>PgUp</kbd> or <kbd>K</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Scroll down{% endtrans %}</td>
-                    <td><span class="hotkey">PgDn</span> or <span class="hotkey">J</span> or <span class="hotkey">Space</span></td>
+                    <td><span class="hotkey"><kbd>PgDn</kbd> or <kbd>J</kbd> or <kbd>Space</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Last message{% endtrans %}</td>
-                    <td><span class="hotkey">End</span> or <span class="hotkey">G</span></td>
+                    <td><span class="hotkey"><kbd>End</kbd> or <kbd>G</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}First message{% endtrans %}</td>
-                    <td><span class="hotkey">Home</span></td>
+                    <td><span class="hotkey"><kbd>Home</kbd></span></td>
                 </tr>
             </table>
         </div>
@@ -108,39 +108,39 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Reply to message{% endtrans %}</td>
-                    <td><span class="hotkey">Enter</span> or <span class="hotkey">r</span></td>
+                    <td><span class="hotkey"><kbd>Enter</kbd> or <kbd>r</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Reply to author{% endtrans %}</td>
-                    <td><span class="hotkey">R</span></td>
+                    <td><span class="hotkey"><kbd>R</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Quote and reply to message{% endtrans %}</td>
-                    <td><span class="hotkey">></span></td>
+                    <td><span class="hotkey"><kbd>></kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}New stream message{% endtrans %}</td>
-                    <td><span class="hotkey">c</span></td>
+                    <td><span class="hotkey"><kbd>c</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}New private message{% endtrans %}</td>
-                    <td><span class="hotkey">x</span></td>
+                    <td><span class="hotkey"><kbd>x</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Compose a reply @-mentioning author{% endtrans %}</td>
-                    <td><span class="hotkey">@</span></td>
+                    <td><span class="hotkey"><kbd>@</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Send message{% endtrans %}</td>
-                    <td><span class="hotkey">Tab then Enter</span> or <span class="hotkey">Ctrl + Enter</span></td>
+                    <td><span class="hotkey"><span class="small_hotkey"><kbd>Tab</kbd> then <kbd>Enter</kbd> or <kbd>Ctrl</kbd> + <kbd>Enter</kbd></span></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Insert new line{% endtrans %}</td>
-                    <td><span class="hotkey">Shift + Enter</span></td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>Enter</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Cancel compose{% endtrans %}</td>
-                    <td><span class="hotkey">Esc</span> or <span class="hotkey">Ctrl + [</span></td>
+                    <td><span class="hotkey"><kbd>Esc</kbd> or <kbd>Ctrl</kbd> + <kbd>[</kbd></span></td>
                 </tr>
             </table>
         </div>
@@ -153,35 +153,35 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Narrow to stream{% endtrans %}</td>
-                    <td><span class="hotkey">s</span></td>
+                    <td><span class="hotkey"><kbd>s</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Narrow to topic or PM conversation{% endtrans %}</td>
-                    <td><span class="hotkey">S</span></td>
+                    <td><span class="hotkey"><kbd>S</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Narrow to all private messages{% endtrans %}</td>
-                    <td><span class="hotkey">shift + p</span></td>
+                    <td><span class="hotkey"><kbd>shift</kbd> + <kbd>p</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Narrow to next unread topic{% endtrans %}</td>
-                    <td><span class="hotkey">n</span></td>
+                    <td><span class="hotkey"><kbd>n</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Narrow to next unread private message{% endtrans %}</td>
-                    <td><span class="hotkey">p</span></td>
+                    <td><span class="hotkey"><kbd>p</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Cycle between stream narrows{% endtrans %}</td>
-                    <td><span class="hotkey">A</span> or <span class="hotkey">D</span></td>
+                    <td><span class="hotkey"><kbd>A</kbd> or <kbd>D</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Narrow to all unmuted messages{% endtrans %}</td>
-                    <td><span class="hotkey">Esc</span> or <span class="hotkey">Ctrl + [</span></td>
+                    <td><span class="hotkey"><kbd>Esc</kbd> or <kbd>Ctrl</kbd> + <kbd>[</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Narrow to current compose box recipient{% endtrans %}</td>
-                    <td><span class="hotkey">Ctrl + .</span></td>
+                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>.</kbd></span></td>
                 </tr>
             </table>
         </div>
@@ -194,23 +194,23 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Edit your last message{% endtrans %}</td>
-                    <td><span class="hotkey">Left</span></td>
+                    <td><span class="hotkey"><kbd>Left</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Show message sender's profile{% endtrans %}</td>
-                    <td><span class="hotkey">u</span></td>
+                    <td><span class="hotkey"><kbd>u</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Show images in thread{% endtrans %}</td>
-                    <td><span class="hotkey">v</span></td>
+                    <td><span class="hotkey"><kbd>v</kbd></span></td>
                 </tr>
                 <tr id="edit-message-hotkey-help">
                     <td class="definition">{% trans %}Edit selected message{% endtrans %}</td>
-                    <td><span class="hotkey">e</span></td>
+                    <td><span class="hotkey"><kbd>e</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Star selected message{% endtrans %}</td>
-                    <td><span class="hotkey">Ctrl + s</span></td>
+                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>s</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">
@@ -220,15 +220,15 @@
                           src="/static/generated/emoji/images/emoji/unicode/1f44d.png"
                           title=":thumbs_up:"/>
                     </td>
-                    <td><span class="hotkey">+</span></td>
+                    <td><span class="hotkey"><kbd>+</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Collapse/show selected message{% endtrans %}</td>
-                    <td><span class="hotkey">-</span></td>
+                    <td><span class="hotkey"><kbd>-</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Toggle topic mute{% endtrans %}</td>
-                    <td><span class="hotkey">M</span></td>
+                    <td><span class="hotkey"><kbd>M</kbd></span></td>
                 </tr>
             </table>
         </div>
@@ -241,15 +241,15 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}View drafts{% endtrans %}</td>
-                    <td><span class="hotkey">d</span></td>
+                    <td><span class="hotkey"><kbd>d</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Edit selected draft{% endtrans %}</td>
-                    <td><span class="hotkey">Enter</span></td>
+                    <td><span class="hotkey"><kbd>Enter</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Delete selected draft{% endtrans %}</td>
-                    <td><span class="hotkey">Backspace</span></td>
+                    <td><span class="hotkey"><kbd>Backspace</kbd></span></td>
                 </tr>
             </table>
         </div>
@@ -262,19 +262,19 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Toggle the gear menu{% endtrans %}</td>
-                    <td><span class="hotkey">g</span></td>
+                    <td><span class="hotkey"><kbd>g</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Open message menu{% endtrans %}</td>
-                    <td><span class="hotkey">i</span></td>
+                    <td><span class="hotkey"><kbd>i</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Open reactions menu{% endtrans %}</td>
-                    <td><span class="hotkey">:</span></td>
+                    <td><span class="hotkey"><kbd>:</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Show keyboard shortcuts{% endtrans %}</td>
-                    <td><span class="hotkey">?</span></td>
+                    <td><span class="hotkey"><kbd>?</kbd></span></td>
                 </tr>
             </table>
         </div>
@@ -287,23 +287,23 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Scroll through streams{% endtrans %}</td>
-                    <td><span class="hotkey">Up</span> or <span class="hotkey">Down</span></td>
+                    <td><span class="hotkey"><kbd>Up</kbd> or <kbd>Down</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Switch between tabs{% endtrans %}</td>
-                    <td><span class="hotkey">Left</span> or <span class="hotkey">Right</span></td>
+                    <td><span class="hotkey"><kbd>Left</kbd> or <kbd>Right</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}View stream messages{% endtrans %}</td>
-                    <td><span class="hotkey">V</span></td>
+                    <td><span class="hotkey"><kbd>V</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Subscribe to/unsubscribe from selected stream{% endtrans %}</td>
-                    <td><span class="hotkey">S</span></td>
+                    <td><span class="hotkey"><kbd>S</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Create new stream{% endtrans %}</td>
-                    <td><span class="hotkey">n</span></td>
+                    <td><span class="hotkey"><kbd>n</kbd></span></td>
                 </tr>
             </table>
         </div>

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -34,7 +34,7 @@
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Last message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>End</kbd> or <kbd>G</kbd></span></td>
+                    <td><span class="hotkey"><kbd>End</kbd> or <kbd>Shift</kbd> + <kbd>g</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Next unread topic{% endtrans %}</td>
@@ -83,15 +83,15 @@
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Scroll up{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>PgUp</kbd> or <kbd>K</kbd></span></td>
+                    <td><span class="hotkey"><kbd>PgUp</kbd> or <kbd>Shift</kbd> + <kbd>k</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Scroll down{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>PgDn</kbd> or <kbd>J</kbd> or <kbd>Space</kbd></span></td>
+                    <td><span class="hotkey"><kbd>PgDn</kbd> or <kbd>Shift</kbd> + <kbd>j</kbd> or <kbd>Space</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Last message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>End</kbd> or <kbd>G</kbd></span></td>
+                    <td><span class="hotkey"><kbd>End</kbd> or <kbd>Shift</kbd> + <kbd>g</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}First message{% endtrans %}</td>
@@ -112,7 +112,7 @@
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Reply to author{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>R</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>r</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Quote and reply to message{% endtrans %}</td>
@@ -157,11 +157,11 @@
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Narrow to topic or PM conversation{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>S</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>s</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Narrow to all private messages{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>shift</kbd> + <kbd>p</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>p</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Narrow to next unread topic{% endtrans %}</td>
@@ -173,7 +173,7 @@
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Cycle between stream narrows{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>A</kbd> or <kbd>D</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>a</kbd> or <kbd>Shift</kbd> + <kbd>d</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Narrow to all unmuted messages{% endtrans %}</td>
@@ -228,7 +228,7 @@
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Toggle topic mute{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>M</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>m</kbd></span></td>
                 </tr>
             </table>
         </div>
@@ -295,11 +295,11 @@
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}View stream messages{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>V</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>v</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Subscribe to/unsubscribe from selected stream{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>S</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>s</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Create new stream{% endtrans %}</td>

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -2,14 +2,14 @@
   aria-label="{{ _('Keyboard shortcuts') }}">
     <div class="modal-body" tabindex="0">
         <div>
-            <table class="hotkeys_full_table hotkeys_table wide table table-striped table-bordered table-condensed">
+            <table class="hotkeys_table table table-striped table-bordered table-condensed">
                 <thead>
                     <tr>
                         <th colspan="2">{{ _("The basics") }}</th>
                     </tr>
                 </thead>
                 <tr>
-                    <td class="hotkey">Enter, r</td>
+                    <td class="hotkey">Enter or r</td>
                     <td class="definition">{% trans %}Reply to message{% endtrans %}</td>
                 </tr>
                 <tr>
@@ -21,7 +21,7 @@
                     <td class="definition">{% trans %}New private message{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Esc, Ctrl + [</td>
+                    <td class="hotkey">Esc or Ctrl + [</td>
                     <td class="definition">{% trans %}Cancel compose{% endtrans %}</td>
                 </tr>
                 <tr>
@@ -29,11 +29,11 @@
                     <td class="definition">{% trans %}View drafts{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Down, j</td>
+                    <td class="hotkey">Down or j</td>
                     <td class="definition">{% trans %}Next message{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">End, G</td>
+                    <td class="hotkey">End or G</td>
                     <td class="definition">{% trans %}Last message{% endtrans %}</td>
                 </tr>
                 <tr>
@@ -45,7 +45,7 @@
                     <td class="definition">{% trans %}Next unread private message{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Ctrl + k, /</td>
+                    <td class="hotkey">Ctrl + k or /</td>
                     <td class="definition">{% trans %}Initiate a search{% endtrans %}</td>
                 </tr>
                 <tr>
@@ -54,9 +54,6 @@
                 </tr>
             </table>
         </div>
-
-        <hr />
-
         <div>
             <table class="hotkeys_table table table-striped table-bordered table-condensed">
                 <thead>
@@ -65,7 +62,7 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="hotkey">Ctrl + k, /</td>
+                    <td class="hotkey">Ctrl + k or /</td>
                     <td class="definition">{% trans %}Initiate a search{% endtrans %}</td>
                 </tr>
                 <tr>
@@ -77,23 +74,23 @@
                     <td class="definition">{% trans %}Search people{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Up, k</td>
+                    <td class="hotkey">Up or k</td>
                     <td class="definition">{% trans %}Previous message{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Down, j</td>
+                    <td class="hotkey">Down or j</td>
                     <td class="definition">{% trans %}Next message{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">PgUp, K</td>
+                    <td class="hotkey">PgUp or K</td>
                     <td class="definition">{% trans %}Scroll up{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">PgDn, J, Space</td>
+                    <td class="hotkey">PgDn or J or Space</td>
                     <td class="definition">{% trans %}Scroll down{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">End, G</td>
+                    <td class="hotkey">End or G</td>
                     <td class="definition">{% trans %}Last message{% endtrans %}</td>
                 </tr>
                 <tr>
@@ -101,7 +98,8 @@
                     <td class="definition">{% trans %}First message{% endtrans %}</td>
                 </tr>
             </table>
-
+        </div>
+        <div>
             <table class="hotkeys_table table table-striped table-bordered table-condensed">
                 <thead>
                     <tr>
@@ -109,7 +107,7 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="hotkey">Enter, r</td>
+                    <td class="hotkey">Enter or r</td>
                     <td class="definition">{% trans %}Reply to message{% endtrans %}</td>
                 </tr>
                 <tr>
@@ -133,7 +131,7 @@
                     <td class="definition">{% trans %}Compose a reply @-mentioning author{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Tab then Enter,<br/>Ctrl + Enter</td>
+                    <td class="hotkey">Tab then Enter or Ctrl + Enter</td>
                     <td class="definition">{% trans %}Send message{% endtrans %}</td>
                 </tr>
                 <tr>
@@ -141,12 +139,11 @@
                     <td class="definition">{% trans %}Insert new line{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Esc, Ctrl + [</td>
+                    <td class="hotkey">Esc or Ctrl + [</td>
                     <td class="definition">{% trans %}Cancel compose{% endtrans %}</td>
                 </tr>
             </table>
         </div>
-
         <div>
             <table class="hotkeys_table table table-striped table-bordered table-condensed">
                 <thead>
@@ -163,7 +160,7 @@
                     <td class="definition">{% trans %}Narrow to topic or PM conversation{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">P</td>
+                    <td class="hotkey">shift + p</td>
                     <td class="definition">{% trans %}Narrow to all private messages{% endtrans %}</td>
                 </tr>
                 <tr>
@@ -175,11 +172,11 @@
                     <td class="definition">{% trans %}Narrow to next unread private message{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">A, D</td>
+                    <td class="hotkey">A or D</td>
                     <td class="definition">{% trans %}Cycle between stream narrows{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Esc, Ctrl + [</td>
+                    <td class="hotkey">Esc or Ctrl + [</td>
                     <td class="definition">{% trans %}Narrow to all unmuted messages{% endtrans %}</td>
                 </tr>
                 <tr>
@@ -187,6 +184,8 @@
                     <td class="definition">{% trans %}Narrow to current compose box recipient{% endtrans %}</td>
                 </tr>
             </table>
+        </div>
+        <div>
             <table class="hotkeys_table table table-striped table-bordered table-condensed">
                 <thead>
                     <tr>
@@ -233,7 +232,6 @@
                 </tr>
             </table>
         </div>
-
         <div>
             <table class="hotkeys_table table table-striped table-bordered table-condensed">
                 <thead>
@@ -254,6 +252,8 @@
                     <td class="definition">{% trans %}Delete selected draft{% endtrans %}</td>
                 </tr>
             </table>
+        </div>
+        <div>
             <table class="hotkeys_table table table-striped table-bordered table-condensed">
                 <thead>
                     <tr>
@@ -278,7 +278,6 @@
                 </tr>
             </table>
         </div>
-
         <div>
             <table class="hotkeys_table table table-striped table-bordered table-condensed">
                 <thead>
@@ -287,11 +286,11 @@
                     </tr>
                 </thead>
                 <tr>
-                    <td class="hotkey">Up, Down</td>
+                    <td class="hotkey">Up or Down</td>
                     <td class="definition">{% trans %}Scroll through streams{% endtrans %}</td>
                 </tr>
                 <tr>
-                    <td class="hotkey">Left, Right</td>
+                    <td class="hotkey">Left or Right</td>
                     <td class="definition">{% trans %}Switch between tabs{% endtrans %}</td>
                 </tr>
                 <tr>

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -10,47 +10,47 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Reply to message{% endtrans %}</td>
-                    <td class="hotkey">Enter or r</td>
+                    <td><span class="hotkey">Enter</span> or  <span class="hotkey">r</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}New stream message{% endtrans %}</td>
-                    <td class="hotkey">c</td>
+                    <td><span class="hotkey">c</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}New private message{% endtrans %}</td>
-                    <td class="hotkey">x</td>
+                    <td><span class="hotkey">x</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Cancel compose{% endtrans %}</td>
-                    <td class="hotkey">Esc or Ctrl + [</td>
+                    <td><span class="hotkey">Esc</span> or <span class="hotkey">Ctrl + [</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}View drafts{% endtrans %}</td>
-                    <td class="hotkey">d</td>
+                    <td><span class="hotkey">d</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Next message{% endtrans %}</td>
-                    <td class="hotkey">Down or j</td>
+                    <td><span class="hotkey">Down</span> or <span class="hotkey">j</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Last message{% endtrans %}</td>
-                    <td class="hotkey">End or G</td>
+                    <td><span class="hotkey">End</span> or <span class="hotkey">G</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Next unread topic{% endtrans %}</td>
-                    <td class="hotkey">n</td>
+                    <td><span class="hotkey">n</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Next unread private message{% endtrans %}</td>
-                    <td class="hotkey">p</td>
+                    <td><span class="hotkey">p</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Initiate a search{% endtrans %}</td>
-                    <td class="hotkey">Ctrl + k or /</td>
+                    <td><span class="hotkey">Ctrl + k</span> or <span class="hotkey">/</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Show keyboard shortcuts{% endtrans %}</td>
-                    <td class="hotkey">?</td>
+                    <td><span class="hotkey">?</span></td>
                 </tr>
             </table>
         </div>
@@ -63,39 +63,39 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Initiate a search{% endtrans %}</td>
-                    <td class="hotkey">Ctrl + k or /</td>
+                    <td><span class="hotkey">Ctrl + k</span> or <span class="hotkey">/</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Search streams{% endtrans %}</td>
-                    <td class="hotkey">q</td>
+                    <td><span class="hotkey">q</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Search people{% endtrans %}</td>
-                    <td class="hotkey">w</td>
+                    <td><span class="hotkey">w</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Previous message{% endtrans %}</td>
-                    <td class="hotkey">Up or k</td>
+                    <td><span class="hotkey">Up</span> or <span class="hotkey">k</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Next message{% endtrans %}</td>
-                    <td class="hotkey">Down or j</td>
+                    <td><span class="hotkey">Down</span> or <span class="hotkey">j</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Scroll up{% endtrans %}</td>
-                    <td class="hotkey">PgUp or K</td>
+                    <td><span class="hotkey">PgUp</span> or <span class="hotkey">K</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Scroll down{% endtrans %}</td>
-                    <td class="hotkey">PgDn or J or Space</td>
+                    <td><span class="hotkey">PgDn</span> or <span class="hotkey">J</span> or <span class="hotkey">Space</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Last message{% endtrans %}</td>
-                    <td class="hotkey">End or G</td>
+                    <td><span class="hotkey">End</span> or <span class="hotkey">G</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}First message{% endtrans %}</td>
-                    <td class="hotkey">Home</td>
+                    <td><span class="hotkey">Home</span></td>
                 </tr>
             </table>
         </div>
@@ -108,39 +108,39 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Reply to message{% endtrans %}</td>
-                    <td class="hotkey">Enter or r</td>
+                    <td><span class="hotkey">Enter</span> or <span class="hotkey">r</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Reply to author{% endtrans %}</td>
-                    <td class="hotkey">R</td>
+                    <td><span class="hotkey">R</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Quote and reply to message{% endtrans %}</td>
-                    <td class="hotkey">></td>
+                    <td><span class="hotkey">></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}New stream message{% endtrans %}</td>
-                    <td class="hotkey">c</td>
+                    <td><span class="hotkey">c</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}New private message{% endtrans %}</td>
-                    <td class="hotkey">x</td>
+                    <td><span class="hotkey">x</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Compose a reply @-mentioning author{% endtrans %}</td>
-                    <td class="hotkey">@</td>
+                    <td><span class="hotkey">@</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Send message{% endtrans %}</td>
-                    <td class="hotkey">Tab then Enter or Ctrl + Enter</td>
+                    <td><span class="hotkey">Tab then Enter</span> or <span class="hotkey">Ctrl + Enter</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Insert new line{% endtrans %}</td>
-                    <td class="hotkey">Shift + Enter</td>
+                    <td><span class="hotkey">Shift + Enter</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Cancel compose{% endtrans %}</td>
-                    <td class="hotkey">Esc or Ctrl + [</td>
+                    <td><span class="hotkey">Esc</span> or <span class="hotkey">Ctrl + [</span></td>
                 </tr>
             </table>
         </div>
@@ -153,35 +153,35 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Narrow to stream{% endtrans %}</td>
-                    <td class="hotkey">s</td>
+                    <td><span class="hotkey">s</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Narrow to topic or PM conversation{% endtrans %}</td>
-                    <td class="hotkey">S</td>
+                    <td><span class="hotkey">S</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Narrow to all private messages{% endtrans %}</td>
-                    <td class="hotkey">shift + p</td>
+                    <td><span class="hotkey">shift + p</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Narrow to next unread topic{% endtrans %}</td>
-                    <td class="hotkey">n</td>
+                    <td><span class="hotkey">n</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Narrow to next unread private message{% endtrans %}</td>
-                    <td class="hotkey">p</td>
+                    <td><span class="hotkey">p</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Cycle between stream narrows{% endtrans %}</td>
-                    <td class="hotkey">A or D</td>
+                    <td><span class="hotkey">A</span> or <span class="hotkey">D</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Narrow to all unmuted messages{% endtrans %}</td>
-                    <td class="hotkey">Esc or Ctrl + [</td>
+                    <td><span class="hotkey">Esc</span> or <span class="hotkey">Ctrl + [</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Narrow to current compose box recipient{% endtrans %}</td>
-                    <td class="hotkey">Ctrl + .</td>
+                    <td><span class="hotkey">Ctrl + .</span></td>
                 </tr>
             </table>
         </div>
@@ -194,23 +194,23 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Edit your last message{% endtrans %}</td>
-                    <td class="hotkey">Left</td>
+                    <td><span class="hotkey">Left</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Show message sender's profile{% endtrans %}</td>
-                    <td class="hotkey">u</td>
+                    <td><span class="hotkey">u</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Show images in thread{% endtrans %}</td>
-                    <td class="hotkey">v</td>
+                    <td><span class="hotkey">v</span></td>
                 </tr>
                 <tr id="edit-message-hotkey-help">
                     <td class="definition">{% trans %}Edit selected message{% endtrans %}</td>
-                    <td class="hotkey">e</td>
+                    <td><span class="hotkey">e</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Star selected message{% endtrans %}</td>
-                    <td class="hotkey">Ctrl + s</td>
+                    <td><span class="hotkey">Ctrl + s</span></td>
                 </tr>
                 <tr>
                     <td class="definition">
@@ -220,15 +220,15 @@
                           src="/static/generated/emoji/images/emoji/unicode/1f44d.png"
                           title=":thumbs_up:"/>
                     </td>
-                    <td class="hotkey">+</td>
+                    <td><span class="hotkey">+</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Collapse/show selected message{% endtrans %}</td>
-                    <td class="hotkey">-</td>
+                    <td><span class="hotkey">-</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Toggle topic mute{% endtrans %}</td>
-                    <td class="hotkey">M</td>
+                    <td><span class="hotkey">M</span></td>
                 </tr>
             </table>
         </div>
@@ -241,15 +241,15 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}View drafts{% endtrans %}</td>
-                    <td class="hotkey">d</td>
+                    <td><span class="hotkey">d</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Edit selected draft{% endtrans %}</td>
-                    <td class="hotkey">Enter</td>
+                    <td><span class="hotkey">Enter</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Delete selected draft{% endtrans %}</td>
-                    <td class="hotkey">Backspace</td>
+                    <td><span class="hotkey">Backspace</span></td>
                 </tr>
             </table>
         </div>
@@ -262,19 +262,19 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Toggle the gear menu{% endtrans %}</td>
-                    <td class="hotkey">g</td>
+                    <td><span class="hotkey">g</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Open message menu{% endtrans %}</td>
-                    <td class="hotkey">i</td>
+                    <td><span class="hotkey">i</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Open reactions menu{% endtrans %}</td>
-                    <td class="hotkey">:</td>
+                    <td><span class="hotkey">:</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Show keyboard shortcuts{% endtrans %}</td>
-                    <td class="hotkey">?</td>
+                    <td><span class="hotkey">?</span></td>
                 </tr>
             </table>
         </div>
@@ -287,23 +287,23 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Scroll through streams{% endtrans %}</td>
-                    <td class="hotkey">Up or Down</td>
+                    <td><span class="hotkey">Up</span> or <span class="hotkey">Down</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Switch between tabs{% endtrans %}</td>
-                    <td class="hotkey">Left or Right</td>
+                    <td><span class="hotkey">Left</span> or <span class="hotkey">Right</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}View stream messages{% endtrans %}</td>
-                    <td class="hotkey">V</td>
+                    <td><span class="hotkey">V</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Subscribe to/unsubscribe from selected stream{% endtrans %}</td>
-                    <td class="hotkey">S</td>
+                    <td><span class="hotkey">S</span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Create new stream{% endtrans %}</td>
-                    <td class="hotkey">n</td>
+                    <td><span class="hotkey">n</span></td>
                 </tr>
             </table>
         </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes: #11573


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
New:
![new keyboard shortcuts](https://user-images.githubusercontent.com/33805964/54750375-6d0eb400-4bfd-11e9-9984-9db5fd81b249.png)

Old:
![old-keyboard-shortcuts-style](https://user-images.githubusercontent.com/33805964/52815342-6f449680-30c4-11e9-8c25-e4b94d643464.png)

Other tab's appearance (same as before):
![search-op-infooverlay](https://user-images.githubusercontent.com/33805964/54693183-34fb6880-4b4c-11e9-8b78-1767ac0cc3bf.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
