### PR TITLE
[wip] Don't show "Invite more users" link when not required.

### DIFF
--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -252,6 +252,9 @@ def home_real(request: HttpRequest) -> HttpResponse:
         show_invites = False
     if user_profile.is_guest:
         show_invites = False
+    # If no invitation is required to join organization.
+    if not user_profile.realm.invite_required:
+        show_invites = False
 
     show_billing = False
     show_plans = False


### PR DESCRIPTION
Related to the issue #11685.
The first solves the case when no invitation is required to join the organization.

@timabbott @rishig please review this pr. 