### PR TITLE
Strict optional actions

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -163,8 +163,6 @@ strict_optional = False
 strict_optional = False
 [mypy-zerver.lib.push_notifications]
 strict_optional = False
-[mypy-zerver.lib.actions]
-strict_optional = False
 [mypy-zerver.worker.queue_processors]
 strict_optional = False
 [mypy-zerver.tornado.websocket_client]

--- a/zerver/lib/addressee.py
+++ b/zerver/lib/addressee.py
@@ -42,8 +42,6 @@ def get_user_profiles_by_ids(user_ids: Iterable[int], realm: Realm) -> List[User
     return user_profiles
 
 def validate_topic(topic: str) -> str:
-    if topic is None:
-        raise JsonableError(_("Missing topic"))
     topic = topic.strip()
     if topic == "":
         raise JsonableError(_("Topic can't be empty"))
@@ -69,6 +67,8 @@ class Addressee:
                  stream_id: Optional[int]=None,
                  topic: Optional[str]=None) -> None:
         assert(msg_type in ['stream', 'private'])
+        if msg_type == 'stream' and topic is None:
+            raise JsonableError(_("Missing topic"))
         self._msg_type = msg_type
         self._user_profiles = user_profiles
         self._stream = stream
@@ -107,7 +107,7 @@ class Addressee:
     def legacy_build(sender: UserProfile,
                      message_type_name: str,
                      message_to: Union[Sequence[int], Sequence[str]],
-                     topic_name: str,
+                     topic_name: Optional[str],
                      realm: Optional[Realm]=None) -> 'Addressee':
 
         # For legacy reason message_to used to be either a list of
@@ -131,6 +131,9 @@ class Addressee:
                     stream_name_or_id = sender.default_sending_stream.id
                 else:
                     raise JsonableError(_('Missing stream'))
+
+            if topic_name is None:
+                raise JsonableError(_("Missing topic"))
 
             if isinstance(stream_name_or_id, int):
                 stream_id = cast(int, stream_name_or_id)


### PR DESCRIPTION
This aims to finish up some work in #10735 for actions.py, enabling strict-optional to apply fully.

The commits are mostly very small to isolate the changes for discussion, but can be squashed later.

Currently this does NOT fully pass the tests, due to one outstanding issue, namely `do_resend_user_invite_email` uses `referred_by` and `realm` properties of the `PreregistrationUser` instance, which are both `Optional`.

Other comments:
- The first 3 commits concern `Addressee`s; these should be straightforward though see below for potential simplification to consider
- 4th commit: fixes some missing `Optional` tags where the default values are `None`
- 5th commit: fixes the default parameter for color_map to be `None` rather than `{}`, which I would assume to be the original intent, and changes the code accordingly to match (in `bulk_add_subscriptions`)
- 6th commit: solves the mypy complaint by assert'ing `rendered_content is not None` if `content is not None` in `do_update_message`; I'm not sure of what can be assumed at this point - perhaps even the function parameter can be non-`Optional`?
- 7th commit: specifies the `event` dict to allow a `None` value, which arises in `do_set_user_display_setting` due to `get_language_name` potentially returning `None`; perhaps that could be replaced by improved error handling instead?
- last commit: fixes mypy.ini to test actions.py *with* strict-optional (ie. lock in the testing)

One thought from this is that I think that `Addressee` improvements would really help with making things easier!