### PR TITLE
Add responsive styling for individual /integrations/doc/ pages.

### DIFF
--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -1158,10 +1158,20 @@ input#terminal:checked ~ #tab-terminal {
     padding-top: 10px;
 }
 
-.integration-instructions {
-    margin-left: 220px;
-}
+@media (min-width: 768px) {
+    .integration-instructions {
+        margin-left: 220px;
+    }
 
+    #integration-list-link {
+        position: absolute;
+        top: 200px;
+        left: 30px;
+        text-align: center;
+        display: none;
+        margin-left: 5px;
+    }
+}
 .api-page-header,
 .authors-page-header,
 .integrations-page-header,
@@ -1233,8 +1243,6 @@ input#terminal:checked ~ #tab-terminal {
 
 #integration-list-link {
     position: absolute;
-    top: 200px;
-    left: 30px;
     text-align: center;
     display: none;
     margin-left: 5px;


### PR DESCRIPTION
@timabbott @rishig 

This is ready for review.
![Screenshot from 2019-03-21 14-47-18](https://user-images.githubusercontent.com/25278879/54742791-590c8780-4be8-11e9-827e-f3088e20e909.png)

I went through all of this - https://chat.zulip.org/#narrow/stream/137-feedback/topic/Zulip.20Integration.20Docs.20on.20Mobile/near/708632 

The reason why I didn't use a logo because there was a particular a `div` that contained the logo along with the box and all and it was appearing on the web version of the page and by default, it was hidden for mobile pages(`display:none`). Making any changes to that div was altering the whole design. So, I instead copied the `img` tag and tried using the place, I wanted the logo to appear. But, it was not working. So, I opted to use this.

I think the current design is simple and does the work. Let me know.
This PR closes the https://github.com/zulip/zulip/issues/11701