### PR TITLE
Clean up email_mirror code.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -8,7 +8,6 @@ import django.db.utils
 from django.db.models import Count
 from django.contrib.contenttypes.models import ContentType
 from django.utils.html import escape
-from django.utils.text import slugify
 from django.utils.translation import ugettext as _
 from django.conf import settings
 from django.core import validators
@@ -35,6 +34,7 @@ from zerver.lib.cache import (
     user_profile_by_api_key_cache_key,
 )
 from zerver.lib.context_managers import lockfile
+from zerver.lib.email_mirror_helpers import encode_email_address, encode_email_address_helper
 from zerver.lib.emoji import emoji_name_to_emoji_code, get_emoji_file_name
 from zerver.lib.exceptions import StreamDoesNotExistError, \
     StreamWithIDDoesNotExistError
@@ -155,7 +155,6 @@ if settings.BILLING_ENABLED:
 
 import ujson
 import time
-import re
 import datetime
 import os
 import platform
@@ -4460,76 +4459,6 @@ def get_average_weekly_stream_traffic(stream_id: int, stream_date_created: datet
 def is_old_stream(stream_date_created: datetime.datetime) -> bool:
     return (timezone_now() - stream_date_created).days \
         >= STREAM_TRAFFIC_CALCULATION_MIN_AGE_DAYS
-
-def encode_email_address(stream: Stream) -> str:
-    return encode_email_address_helper(stream.name, stream.email_token)
-
-def encode_email_address_helper(name: str, email_token: str) -> str:
-    # Some deployments may not use the email gateway
-    if settings.EMAIL_GATEWAY_PATTERN == '':
-        return ''
-
-    # Given the fact that we have almost no restrictions on stream names and
-    # that what characters are allowed in e-mail addresses is complicated and
-    # dependent on context in the address, we opt for a simple scheme:
-    # 1. Replace all substrings of non-alphanumeric characters with a single hyphen.
-    # 2. Use Django's slugify to convert the resulting name to ascii.
-    # 3. If the resulting name is shorter than the name we got in step 1,
-    # it means some letters can't be reasonably turned to ascii and have to be dropped,
-    # which would mangle the name, so we just skip the name part of the address.
-    name = re.sub(r"\W+", '-', name)
-    slug_name = slugify(name)
-    encoded_name = slug_name if len(slug_name) == len(name) else ''
-
-    # If encoded_name ends up empty, we just skip this part of the address:
-    if encoded_name:
-        encoded_token = "%s+%s" % (encoded_name, email_token)
-    else:
-        encoded_token = email_token
-
-    return settings.EMAIL_GATEWAY_PATTERN % (encoded_token,)
-
-def get_email_gateway_message_string_from_address(address: str) -> Optional[str]:
-    pattern_parts = [re.escape(part) for part in settings.EMAIL_GATEWAY_PATTERN.split('%s')]
-    if settings.EMAIL_GATEWAY_EXTRA_PATTERN_HACK:
-        # Accept mails delivered to any Zulip server
-        pattern_parts[-1] = settings.EMAIL_GATEWAY_EXTRA_PATTERN_HACK
-    match_email_re = re.compile("(.*?)".join(pattern_parts))
-    match = match_email_re.match(address)
-
-    if not match:
-        return None
-
-    msg_string = match.group(1)
-
-    return msg_string
-
-def decode_email_address(email: str) -> Optional[Tuple[str, bool]]:
-    # Perform the reverse of encode_email_address. Returns a tuple of
-    # (email_token, show_sender)
-    msg_string = get_email_gateway_message_string_from_address(email)
-    if msg_string is None:
-        return None
-
-    if msg_string.endswith(('+show-sender', '.show-sender')):
-        show_sender = True
-        msg_string = msg_string[:-12]  # strip "+show-sender"
-    else:
-        show_sender = False
-
-    # Workaround for Google Groups and other programs that don't accept emails
-    # that have + signs in them (see Trac #2102)
-    splitting_char = '.' if '.' in msg_string else '+'
-
-    parts = msg_string.split(splitting_char)
-    # msg_string may have one or two parts:
-    # [stream_name, email_token] or just [email_token]
-    if len(parts) == 1:
-        token = parts[0]
-    else:
-        token = parts[1]
-
-    return token, show_sender
 
 SubHelperT = Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]
 

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -9,10 +9,11 @@ import email.message as message
 
 from django.conf import settings
 
-from zerver.lib.actions import decode_email_address, get_email_gateway_message_string_from_address, \
-    internal_send_message, internal_send_private_message, \
+from zerver.lib.actions import internal_send_message, internal_send_private_message, \
     internal_send_stream_message, internal_send_huddle_message, \
     truncate_body, truncate_topic
+from zerver.lib.email_mirror_helpers import decode_email_address, \
+    get_email_gateway_message_string_from_address
 from zerver.lib.email_notifications import convert_html_to_markdown
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.redis_utils import get_redis_client
@@ -58,7 +59,6 @@ def log_and_report(email_message: message.Message, error_message: str, debug_inf
 
     logger.error(scrubbed_error)
     report_to_zulip(scrubbed_error)
-
 
 # Temporary missed message addresses
 

--- a/zerver/lib/email_mirror_helpers.py
+++ b/zerver/lib/email_mirror_helpers.py
@@ -1,0 +1,78 @@
+import re
+
+from django.conf import settings
+from django.utils.text import slugify
+
+from zerver.models import Stream
+
+from typing import Optional, Tuple
+
+def get_email_gateway_message_string_from_address(address: str) -> Optional[str]:
+    pattern_parts = [re.escape(part) for part in settings.EMAIL_GATEWAY_PATTERN.split('%s')]
+    if settings.EMAIL_GATEWAY_EXTRA_PATTERN_HACK:
+        # Accept mails delivered to any Zulip server
+        pattern_parts[-1] = settings.EMAIL_GATEWAY_EXTRA_PATTERN_HACK
+    match_email_re = re.compile("(.*?)".join(pattern_parts))
+    match = match_email_re.match(address)
+
+    if not match:
+        return None
+
+    msg_string = match.group(1)
+
+    return msg_string
+
+def encode_email_address(stream: Stream) -> str:
+    return encode_email_address_helper(stream.name, stream.email_token)
+
+def encode_email_address_helper(name: str, email_token: str) -> str:
+    # Some deployments may not use the email gateway
+    if settings.EMAIL_GATEWAY_PATTERN == '':
+        return ''
+
+    # Given the fact that we have almost no restrictions on stream names and
+    # that what characters are allowed in e-mail addresses is complicated and
+    # dependent on context in the address, we opt for a simple scheme:
+    # 1. Replace all substrings of non-alphanumeric characters with a single hyphen.
+    # 2. Use Django's slugify to convert the resulting name to ascii.
+    # 3. If the resulting name is shorter than the name we got in step 1,
+    # it means some letters can't be reasonably turned to ascii and have to be dropped,
+    # which would mangle the name, so we just skip the name part of the address.
+    name = re.sub(r"\W+", '-', name)
+    slug_name = slugify(name)
+    encoded_name = slug_name if len(slug_name) == len(name) else ''
+
+    # If encoded_name ends up empty, we just skip this part of the address:
+    if encoded_name:
+        encoded_token = "%s+%s" % (encoded_name, email_token)
+    else:
+        encoded_token = email_token
+
+    return settings.EMAIL_GATEWAY_PATTERN % (encoded_token,)
+
+def decode_email_address(email: str) -> Optional[Tuple[str, bool]]:
+    # Perform the reverse of encode_email_address. Returns a tuple of
+    # (email_token, show_sender)
+    msg_string = get_email_gateway_message_string_from_address(email)
+    if msg_string is None:
+        return None
+
+    if msg_string.endswith(('+show-sender', '.show-sender')):
+        show_sender = True
+        msg_string = msg_string[:-12]  # strip "+show-sender"
+    else:
+        show_sender = False
+
+    # Workaround for Google Groups and other programs that don't accept emails
+    # that have + signs in them (see Trac #2102)
+    splitting_char = '.' if '.' in msg_string else '+'
+
+    parts = msg_string.split(splitting_char)
+    # msg_string may have one or two parts:
+    # [stream_name, email_token] or just [email_token]
+    if len(parts) == 1:
+        token = parts[0]
+    else:
+        token = parts[1]
+
+    return token, show_sender

--- a/zerver/management/commands/send_to_email_mirror.py
+++ b/zerver/management/commands/send_to_email_mirror.py
@@ -9,8 +9,8 @@ from email.mime.text import MIMEText
 from django.conf import settings
 from django.core.management.base import CommandParser
 
-from zerver.lib.actions import encode_email_address
 from zerver.lib.email_mirror import mirror_email_message
+from zerver.lib.email_mirror_helpers import encode_email_address
 from zerver.lib.management import ZulipBaseCommand
 
 from zerver.models import Realm, get_stream, get_realm

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -20,18 +20,20 @@ from zerver.models import (
     Recipient,
 )
 
-from zerver.lib.actions import (
-    encode_email_address,
-    ensure_stream,
-    decode_email_address,
-    get_email_gateway_message_string_from_address,
-)
+from zerver.lib.actions import ensure_stream
+
 from zerver.lib.email_mirror import (
     process_message, process_stream_message, ZulipEmailForwardError,
     create_missed_message_address,
     get_missed_message_token_from_address,
     strip_from_subject,
     is_forwarded,
+)
+
+from zerver.lib.email_mirror_helpers import (
+    decode_email_address,
+    encode_email_address,
+    get_email_gateway_message_string_from_address,
 )
 
 from zerver.lib.email_notifications import convert_html_to_markdown

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -9,8 +9,8 @@ from django.test import override_settings
 from mock import patch, MagicMock
 from typing import Any, Callable, Dict, List, Mapping, Tuple
 
-from zerver.lib.actions import encode_email_address
 from zerver.lib.email_mirror import RateLimitedRealmMirror
+from zerver.lib.email_mirror_helpers import encode_email_address
 from zerver.lib.rate_limiter import RateLimiterLockingException, clear_history
 from zerver.lib.send_email import FromAddress
 from zerver.lib.test_helpers import simulated_queue_client


### PR DESCRIPTION
PR to fix https://github.com/zulip/zulip/issues/1836

We clean out some email mirror-relevant functions out of actions.py. To avoid circular imports, we put them in email_mirror_helpers.py.  Then we make the change to `` get_email_gateway_message_string_from_address `` to make it raise `` ZulipEmailForwardError `` if the email doesn't fit the email gateway address pattern, and appropriate modifications in places that use this function. This also allows some minor cleanups of code in test_email_mirror.py - we can get rid of lots of asserts whose only purpose is to avoid mypy throwing an error about Optional[...] type (`` get_email_gateway_message_string_from_address `` no longer returns None, so we can get rid of the Optional[...] on it and `` decode_email_address ``).