### PR TITLE
copy_and_paste: Change copy div css to match "day mode".

### DIFF
--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -192,7 +192,19 @@ function copy_handler() {
 
     // Select div so that the browser will copy it
     // instead of copying the original selection
-    div.css({position: 'absolute', left: '-99999px'})
+    div.css({
+        position: 'absolute',
+        left: '-99999px',
+        // Color and background is made according to "day mode"
+        // exclusively here because when copying the content
+        // into, say, Gmail compose box, the styles come along.
+        // This is done to avoid copying the content with dark
+        // background when using the app in night mode.
+        // We can avoid other custom styles since they are wrapped
+        // inside another parent such as `.message_content`.
+        color: '#333',
+        background: '#FFF',
+    })
         .attr('id', 'copytempdiv');
     $('body').append(div);
     selection.selectAllChildren(div[0]);

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -513,11 +513,7 @@ on a dark background, and don't change the dark labels dark either. */
     }
 
     #feedback_container,
-    .message_content code,
-    .message_edit_content code,
-    .preview_content code,
-    #settings_page code,
-    #message-formatting code,
+    .rendered_markdown code,
     .typeahead.dropdown-menu {
         background-color: hsl(212, 25%, 15%);
         border-color: hsla(0, 0%, 0%, 0.5);

--- a/static/styles/pygments.scss
+++ b/static/styles/pygments.scss
@@ -213,7 +213,7 @@
 
 
 /* Syntx Highlighting for night-mode */
-body.night-mode {
+body.night-mode .rendered_markdown {
 
     .codehilite code,
     .codehilite pre {

--- a/static/templates/draft.handlebars
+++ b/static/templates/draft.handlebars
@@ -36,7 +36,7 @@
                             <i class="fa fa-trash-o fa-lg delete-draft" aria-hidden="true" data-toggle="tooltip" title="{{t 'Delete draft' }} (Backspace)"></i>
                         </div>
                     </div>
-                    <div class="message_content restore-draft" data-toggle="tooltip" title="{{t 'Restore draft' }}">{{{content}}}</div>
+                    <div class="message_content rendered_markdown restore-draft" data-toggle="tooltip" title="{{t 'Restore draft' }}">{{{content}}}</div>
                 </div>
             </div>
         </div>

--- a/static/templates/message_body.handlebars
+++ b/static/templates/message_body.handlebars
@@ -38,7 +38,7 @@
 </div>
 
 {{#unless status_message}}
-<div class="message_content">{{#if use_match_properties}}{{{msg/match_content}}}{{else}}{{{msg/content}}}{{/if}}</div>
+<div class="message_content rendered_markdown">{{#if use_match_properties}}{{{msg/match_content}}}{{else}}{{{msg/content}}}{{/if}}</div>
 {{/unless}}
 
 {{#if last_edit_timestr}}

--- a/static/templates/message_edit_form.handlebars
+++ b/static/templates/message_edit_form.handlebars
@@ -24,10 +24,10 @@
                     <path fill="#777" d="M128 768h256v64H128v-64z m320-384H128v64h320v-64z m128 192V448L384 640l192 192V704h320V576H576z m-288-64H128v64h160v-64zM128 704h160v-64H128v64z m576 64h64v128c-1 18-7 33-19 45s-27 18-45 19H64c-35 0-64-29-64-64V192c0-35 29-64 64-64h192C256 57 313 0 384 0s128 57 128 128h192c35 0 64 29 64 64v320h-64V320H64v576h640V768zM128 256h512c0-35-29-64-64-64h-64c-35 0-64-29-64-64s-29-64-64-64-64 29-64 64-29 64-64 64h-64c-35 0-64 29-64 64z" />
                 </svg>
             </button>
-            <textarea class="message_edit_content" maxlength="10000" id="message_edit_content_{{message_id}}">{{content}}</textarea>
+            <textarea class="message_edit_content rendered_markdown" maxlength="10000" id="message_edit_content_{{message_id}}">{{content}}</textarea>
             <div class="scrolling_list preview_message_area" id="preview_message_area_{{message_id}}" style="display:none;">
                 <div id="markdown_preview_spinner_{{message_id}}"></div>
-                <div id="preview_content_{{message_id}}" class="preview_content"></div>
+                <div id="preview_content_{{message_id}}" class="preview_content rendered_markdown"></div>
             </div>
         </div>
     </div>

--- a/static/templates/message_edit_history.handlebars
+++ b/static/templates/message_edit_history.handlebars
@@ -10,7 +10,7 @@
         <div class="message_content message_edit_history_content"><p>Topic: <span class="highlight_text_inserted">{{ new_topic }}</span> <span class="highlight_text_deleted">{{ prev_topic }}</span></p></div>
         {{/if}}
         {{#if body_to_render}}
-        <div class="message_content message_edit_history_content">{{{ body_to_render }}}</div>
+        <div class="message_content rendered_markdown message_edit_history_content">{{{ body_to_render }}}</div>
         {{/if}}
         <div class="message_author"><div class="author_details">{{ posted_or_edited }} {{ edited_by }}</div></div>
     </div>

--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -90,7 +90,7 @@
                                 <textarea class="new_message_textarea" name="content" id='compose-textarea' placeholder="{{ _('Compose your message here') }}" tabindex="0" maxlength="10000" aria-label="{{ _('Compose your message here...') }}"></textarea>
                                 <div class="scrolling_list preview_message_area" id="preview_message_area" style="display:none;">
                                     <div id="markdown_preview_spinner"></div>
-                                    <div id="preview_content" class="preview_content"></div>
+                                    <div id="preview_content" class="preview_content rendered_markdown"></div>
                                 </div>
                                 <div class="drag"></div>
                                 <div id="below-compose-content">

--- a/templates/zerver/app/markdown_help.html
+++ b/templates/zerver/app/markdown_help.html
@@ -1,4 +1,4 @@
-<div class="overlay-modal hide" id="message-formatting" tabindex="-1" role="dialog"
+<div class="overlay-modal hide rendered_markdown" id="message-formatting" tabindex="-1" role="dialog"
     aria-label="{{ _('Message formatting') }}">
     <div class="modal-body" tabindex="0">
         <div id="markdown-instructions">

--- a/templates/zerver/app/settings_overlay.html
+++ b/templates/zerver/app/settings_overlay.html
@@ -1,4 +1,4 @@
-<div id="settings_page" class="new-style overlay-content modal-bg">
+<div id="settings_page" class="new-style overlay-content modal-bg rendered_markdown">
     <div class="settings-header mobile">
         <i class="fa fa-chevron-left" aria-hidden="true"></i>
         <h1>{{ _('Settings') }}<span class="section"></span></h1>


### PR DESCRIPTION
Color and background is made according to "day mode" exclusively here because when copying the content into, say, Gmail compose box, the styles come along.

This is done to avoid copying the content with dark background when using the app in night mode.