### PR TITLE
[wip]user groups: Add edit pencils

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1162,35 +1162,13 @@ input[type=checkbox].inline-block {
     margin: 0;
 }
 
-#user-groups .spacer {
-    margin: 0 2px;
-}
-
 #user-groups .subscribers,
 #user-groups .user-group h4 > .name {
     font-weight: bold;
 }
 
-#user-groups .user-group span[contenteditable] {
-    display: inline-block;
-    word-break: break-all;
-}
-
 #user-groups .ntm {
     cursor: not-allowed;
-}
-
-#user-groups .user-group span[contenteditable]:empty::before {
-    opacity: 0.5;
-    display: inline-block;
-    content: attr(data-placeholder);
-}
-
-#user-groups .user-group span[contenteditable]:focus,
-#user-groups .user-group span[contenteditable="true"]:hover {
-    border-bottom: 1px solid hsl(0, 0%, 80%);
-    margin-bottom: -1px;
-    outline: none;
 }
 
 #user-groups .user-group .pill-container .input[contenteditable]:empty::after {
@@ -1205,6 +1183,66 @@ input[type=checkbox].inline-block {
 
 #user-groups .ntm h4 > .button:hover {
     border-color: hsl(4, 56%, 82%);
+}
+
+.editable-section {
+    position: relative;
+    display: inline;
+    min-width: 10px;
+    max-width: 100%;
+}
+
+.editable-section[contenteditable=true] {
+    display: inline-block;
+    color: hsl(170, 48%, 54%);
+}
+
+.editable-section[contenteditable=true]:focus {
+    outline: none;
+}
+
+#user-groups .editable {
+    position: relative;
+    top: -1px;
+    margin-left: 5px;
+    color: hsl(0, 0%, 67%);
+    cursor: pointer;
+    font-size: 1.4rem;
+    font-weight: 300;
+
+    transition: all 0.3s ease;
+}
+
+#user-groups .editable:empty::before {
+    content: "\f040";
+    font-family: "FontAwesome";
+    font-size: 0.8rem;
+    font-weight: normal;
+}
+
+#user-groups .group-description .group-description-editable:empty::after {
+    content: attr(data-no-description);
+    font-style: italic;
+    color: hsl(0, 0%, 67%);
+}
+
+#user-groups .editable:not(:empty) {
+    position: relative;
+    top: 2px;
+}
+
+#user-groups .editable:hover {
+    color: hsl(0, 0%, 27%);
+}
+
+#user-groups .checkmark {
+    display: none;
+    margin-left: 5px;
+    margin-bottom: 2px;
+    font-size: 0.9rem;
+    color: hsl(0, 0%, 67%);
+
+    cursor: pointer;
 }
 
 #user-groups .save-status {
@@ -1231,6 +1269,10 @@ input[type=checkbox].inline-block {
     opacity: 0;
     color: hsl(0, 0%, 20%);
     font-size: 0.9em;
+}
+
+.group-description {
+    font-size: 12px;
 }
 
 /* -- new settings overlay -- */

--- a/static/templates/admin_user_group_list.handlebars
+++ b/static/templates/admin_user_group_list.handlebars
@@ -1,10 +1,12 @@
 {{#with user_group}}
 <div class="user-group white-box" id="{{id}}">
     <div class="alert user-group-status"></div>
-    <h4>
-        <span class="name" data-placeholder="{{t 'Name' }}" contenteditable="true" spellcheck="false">{{name}}</span>
-        <span class="spacer">—</span>
-        <span class="description" data-placeholder="{{t 'Description' }}" contenteditable="true">{{description}}</span>
+    <h4 class="group-name">
+        <span class="group-name-editable editable-section name" data-placeholder="{{t 'Name' }}" contenteditable="false" spellcheck="false">{{name}}</span>
+        {{#if can_edit}}
+        <span class="editable" data-make-editable=".group-name-editable"></span>
+        <span class="checkmark" data-finish-editing=".group-name-editable">✓</span>
+        {{/if}}
         <button class="button save-status sea-green small">
             <img class="checkmark" src="/static/images/checkbox-green.svg" />
             {{t 'Saved' }}
@@ -15,6 +17,13 @@
         <button class="button rounded small delete btn-danger">
             {{t 'Delete' }}
         </button>
+    </h4>
+    <h4 class="group-description">
+        <span class="group-description-editable editable-section description" data-no-description="{{t 'No description.' }}">{{{description}}}</span>
+        {{#if can_edit}}
+        <span class="editable" data-make-editable=".group-description-editable"></span>
+        <span class="checkmark" data-finish-editing=".group-description-editable">✓</span>
+        {{/if}}
     </h4>
     <p class="subscribers">{{t 'Subscribers' }}</p>
     <div class="pill-container" data-group-pills="{{id}}">

--- a/static/templates/admin_user_group_list.handlebars
+++ b/static/templates/admin_user_group_list.handlebars
@@ -15,7 +15,7 @@
             {{t 'Discard changes' }}
         </button>
         <button class="button rounded small delete btn-danger">
-            {{t 'Delete' }}
+            <i class="fa fa-trash-o" aria-hidden="true"></i>
         </button>
     </h4>
     <h4 class="group-description">


### PR DESCRIPTION
Fixes #11721 
![add-edit-pencils](https://user-images.githubusercontent.com/41135524/54770853-14a1db80-4c2a-11e9-8376-957c55be454d.gif)
Added the elements and their respective css. Due to addition of edit-pencils, to mimic it's behavior had to change and modify the functionality of the currently used js which is leading to the failure of the related node-test cases, once the js implementation is final I will modify the node-tests accordingly.
 
- [ ] Modify the frontend node-tests according to the new implementation.