### PR TITLE
webhooks/bitbucket: Support empty push payloads with no user info.

### DIFF
--- a/zerver/webhooks/bitbucket/fixtures/force_push_without_user_info.json
+++ b/zerver/webhooks/bitbucket/fixtures/force_push_without_user_info.json
@@ -1,0 +1,15 @@
+{
+    "canon_url": "https://bitbucket.org/",
+    "commits":[],
+    "repository":{
+        "name": "Repository name",
+        "absolute_url": "kolaszek/repository-name/",
+        "fork": false,
+        "is_private": true,
+        "scm": "git",
+        "owner": "kolaszek",
+        "website": ""
+    },
+    "truncated": false,
+    "user_uuid": "387gs94h-2lk0-4sdb-b23f-71234rhty871"
+}

--- a/zerver/webhooks/bitbucket/tests.py
+++ b/zerver/webhooks/bitbucket/tests.py
@@ -61,6 +61,13 @@ class BitbucketHookTests(WebhookTestCase):
         self.api_stream_message(self.TEST_USER_EMAIL, fixture_name, self.EXPECTED_TOPIC,
                                 expected_message)
 
+    def test_bitbucket_on_force_push_event_without_user_info(self) -> None:
+        fixture_name = 'force_push_without_user_info'
+        self.url = self.build_webhook_url(payload=self.get_body(fixture_name))
+        expected_message = u"Someone [force pushed](https://bitbucket.org/kolaszek/repository-name/)"
+        self.api_stream_message(self.TEST_USER_EMAIL, fixture_name, self.EXPECTED_TOPIC,
+                                expected_message)
+
     @patch('zerver.webhooks.bitbucket.view.check_send_webhook_message')
     def test_bitbucket_on_push_event_filtered_by_branches_ignore(self, check_send_webhook_message_mock: MagicMock) -> None:
         fixture_name = 'push'

--- a/zerver/webhooks/bitbucket/view.py
+++ b/zerver/webhooks/bitbucket/view.py
@@ -36,7 +36,7 @@ def api_bitbucket_webhook(request: HttpRequest, user_profile: UserProfile,
         # a useful message :/
         subject = repository['name']
         content = (u"%s [force pushed](%s)"
-                   % (payload['user'],
+                   % (payload.get('user', 'Someone'),
                       payload['canon_url'] + repository['absolute_url']))
     else:
         branch = payload['commits'][-1]['branch']


### PR DESCRIPTION
@timabbott: So this one is kinda weird. Apparently, the original author of this integration characterized push payloads with zero commits as force pushes. We really don't have an easy way to verify the correctness of that, so I just applied the same kind of logic here that I did in my last commit to this integration where I accounted for missing user info. :) Thanks!