### PR TITLE
documentation: Add missing link to upgrade-zulip-from-git doc

### DIFF
--- a/docs/production/export-and-import.md
+++ b/docs/production/export-and-import.md
@@ -110,6 +110,8 @@ cd /home/zulip/deployments/current
 This could take several minutes to run, depending on how much data you're
 importing.
 
+[upgrade-zulip-from-git]: ../production/maintain-secure-upgrade.html#upgrading-from-a-git-repository
+
 **Import options**
 
 The commands above create an imported organization on the root domain


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR adds missing link to Upgrading zulip from Git documentation in export-import doc.
