### PR TITLE
do_update_message: Send message update notification to um users and subscribers

### DIFF
--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -22,6 +22,7 @@ from zerver.lib.actions import (
     do_create_user,
     do_deactivate_user,
     do_send_messages,
+    do_update_message,
     do_set_realm_property,
     extract_recipients,
     get_active_presence_idle_user_ids,
@@ -2763,6 +2764,69 @@ class EditMessageTest(ZulipTestCase):
         message.save()
         self.login(self.example_email("cordelia"))
         do_edit_message_assert_success(id_, 'D')
+
+    @mock.patch("zerver.lib.actions.send_event")
+    def test_edit_topic_public_history_stream(self, mock_send_event: mock.MagicMock) -> None:
+        stream_name = "Macbeth"
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        self.make_stream(stream_name, history_public_to_subscribers=True)
+        self.subscribe(hamlet, stream_name)
+        self.login(hamlet.email)
+        message_id = self.send_stream_message(hamlet.email, stream_name, "Where am I?")
+
+        self.login(cordelia.email)
+        self.subscribe(cordelia, stream_name)
+        message = Message.objects.get(id=message_id)
+
+        def do_update_message_topic_success(user_profile: UserProfile, message: Message,
+                                            topic_name: str, users_to_be_notified: List[Dict[str, Any]]) -> None:
+            do_update_message(
+                user_profile=user_profile,
+                message=message,
+                topic_name=topic_name,
+                propagate_mode="change_later",
+                content=None,
+                rendered_content=None,
+                prior_mention_user_ids=set(),
+                mention_user_ids=set()
+            )
+
+            mock_send_event.assert_called_with(mock.ANY, mock.ANY, users_to_be_notified)
+
+        # Returns the users that need to be notified when a message topic is changed
+        def notify(user_id: int) -> Dict[str, Any]:
+            um = UserMessage.objects.get(message=message_id)
+            if um.user_profile_id == user_id:
+                return {
+                    "id": user_id,
+                    "flags": um.flags_list()
+                }
+
+            else:
+                return {
+                    "id": user_id,
+                    "flags": ["read"]
+                }
+
+        users_to_be_notified = list(map(notify, [hamlet.id, cordelia.id]))
+        # Edit topic of a message sent before Cordelia subscribed the stream
+        do_update_message_topic_success(cordelia, message, "Othello eats apple", users_to_be_notified)
+
+        # Even if Hamlet unsubscribes the stream, he should be notified when the topic is changed
+        # because he has a UserMessage row.
+        self.unsubscribe(hamlet, stream_name)
+        users_to_be_notified = list(map(notify, [hamlet.id, cordelia.id]))
+        do_update_message_topic_success(cordelia, message, "Another topic", users_to_be_notified)
+
+        # Hamlet subscribes to the stream again and Cordelia unsubscribes, then Hamlet changes
+        # the message topic. Cordelia won't receive any updates when a message on that stream is
+        # changed because she is not a subscriber and doesn't have a UserMessage row.
+        self.subscribe(hamlet, stream_name)
+        self.unsubscribe(cordelia, stream_name)
+        self.login(hamlet.email)
+        users_to_be_notified = list(map(notify, [hamlet.id]))
+        do_update_message_topic_success(hamlet, message, "Change again", users_to_be_notified)
 
     def test_propagate_topic_forward(self) -> None:
         self.login(self.example_email("hamlet"))


### PR DESCRIPTION
If a subscriber of a public history stream edits a message's topic, the
update notification will be sent only for users who have a UserMessage
row. But is should also be sent to the rest of the users that are
subscribers to that stream.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Manual testing, changing a message's topic that was sent before a user was a subscriber, then
checking if the user is being notified.

Automated Tests:
Subscribe Hamlet to a stream.
Hamlet sends a message.
Subscribe Cordelia to that stream and make she changes the message topic sent by Hamlet.
Check if Cordelia and Hamlet are in the list users_to_be_notified.

Unsubscribe Hamlet.
Cordelia updates the message topic again.
Check if Cordelia and Hamlet are in the list users_to_be_notified (Both should be notified because Hamlet has a UserMessage row and Cordelia is a subscriber)

Subscribe Hamlet to the stream.
Unsubscribe Cordelia to the stream.
Hamlet sends a message.
Check if only Hamlet is notified (Cordelia is no longer a subscriber and she doesn't have a UserMessage, so she shouldn't be notified)


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
Fixes: [8750](https://github.com/zulip/zulip/issues/8750)