### PR TITLE
Email mirror - get to 100% test coverage

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -83,7 +83,6 @@ not_yet_fully_covered = {path for target in [
     'zerver/lib/camo.py',
     'zerver/lib/debug.py',
     'zerver/lib/digest.py',
-    'zerver/lib/email_mirror.py',
     'zerver/lib/error_notify.py',
     'zerver/lib/export.py',
     'zerver/lib/feedback.py',

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple, List
+from typing import Dict, Optional, Tuple, List
 
 import logging
 import re
@@ -28,12 +28,34 @@ from zerver.models import Stream, Recipient, \
 
 logger = logging.getLogger(__name__)
 
-def redact_stream(error_message: str) -> str:
-    domain = settings.EMAIL_GATEWAY_PATTERN.rsplit('@')[-1]
-    stream_match = re.search('\\b(.*?)@' + domain, error_message)
-    if stream_match:
-        stream_name = stream_match.groups()[0]
-        return error_message.replace(stream_name, "X" * len(stream_name))
+def redact_email_address(error_message: str) -> str:
+    if not settings.EMAIL_GATEWAY_EXTRA_PATTERN_HACK:
+        domain = settings.EMAIL_GATEWAY_PATTERN.rsplit('@')[-1]
+    else:
+        # EMAIL_GATEWAY_EXTRA_PATTERN_HACK is of the form '@example.com'
+        domain = settings.EMAIL_GATEWAY_EXTRA_PATTERN_HACK[1:]
+
+    address_match = re.search('\\b(\\S*?)@' + domain, error_message)
+    if address_match:
+        email_address = address_match.group(0)
+        # Annotate basic info about the address before scrubbing:
+        if is_missed_message_address(email_address):
+            redacted_message = error_message.replace(email_address,
+                                                     "{} <Missed message address>".format(email_address))
+        else:
+            try:
+                target_stream_id = extract_and_validate(email_address)[0].id
+                annotated_address = "{} <Address to stream id: {}>".format(email_address, target_stream_id)
+                redacted_message = error_message.replace(email_address, annotated_address)
+            except ZulipEmailForwardError:
+                redacted_message = error_message.replace(email_address,
+                                                         "{} <Invalid address>".format(email_address))
+
+        # Scrub the address from the message, to the form XXXXX@example.com:
+        string_to_scrub = address_match.groups()[0]
+        redacted_message = redacted_message.replace(string_to_scrub, "X" * len(string_to_scrub))
+        return redacted_message
+
     return error_message
 
 def report_to_zulip(error_message: str) -> None:
@@ -44,16 +66,14 @@ def report_to_zulip(error_message: str) -> None:
     send_zulip(settings.ERROR_BOT, error_stream, "email mirror error",
                """~~~\n%s\n~~~""" % (error_message,))
 
-def log_and_report(email_message: message.Message, error_message: str, debug_info: Dict[str, Any]) -> None:
-    scrubbed_error = u"Sender: %s\n%s" % (email_message.get("From"),
-                                          redact_stream(error_message))
+def log_and_report(email_message: message.Message, error_message: str, to: Optional[str]) -> None:
+    recipient = to or "No recipient found"
+    error_message = "Sender: {}\nTo: {}\n{}".format(email_message.get("From"),
+                                                    recipient, error_message)
 
-    if "to" in debug_info:
-        scrubbed_error = "Stream: %s\n%s" % (redact_stream(debug_info["to"]),
-                                             scrubbed_error)
-
-    logger.error(scrubbed_error)
-    report_to_zulip(scrubbed_error)
+    error_message = redact_email_address(error_message)
+    logger.error(error_message)
+    report_to_zulip(error_message)
 
 # Temporary missed message addresses
 
@@ -349,14 +369,13 @@ def process_missed_message(to: str, message: message.Message, pre_checked: bool)
     send_to_missed_message_address(to, message)
 
 def process_message(message: message.Message, rcpt_to: Optional[str]=None, pre_checked: bool=False) -> None:
-    debug_info = {}
+    to = None  # type: Optional[str]
 
     try:
         if rcpt_to is not None:
             to = rcpt_to
         else:
             to = find_emailgateway_recipient(message)
-        debug_info["to"] = to
 
         if is_missed_message_address(to):
             process_missed_message(to, message, pre_checked)
@@ -367,7 +386,7 @@ def process_message(message: message.Message, rcpt_to: Optional[str]=None, pre_c
             # TODO: notify sender of error, retry if appropriate.
             logging.warning(str(e))
         else:
-            log_and_report(message, str(e), debug_info)
+            log_and_report(message, str(e), to)
 
 def mirror_email_message(data: Dict[str, str]) -> Dict[str, str]:
     rcpt_to = data['recipient']


### PR DESCRIPTION
This PR gets the email mirror to 100% coverage - relevant for issues https://github.com/zulip/zulip/issues/7089 and point 3 in https://github.com/zulip/zulip/issues/6932

All the commits at the beginning just add tests, gradually increasing coverage, until commit `` 
email_mirror: Don't pass debug_info to process_stream_message. `` where we stop giving debug_info to process_stream_message call in process message, as it wasn't doing anything. In the following commit, we change log_and_report somewhat and give it test coverage (it had none). Then, a small adjustment to `` test_get_missed_message_token `` which gets us to 100% coverage, and finally the last commits removes the email mirror from the list of not-covered files in test-backend.
