### PR TITLE
css: Align left sidebar icons horizontally and fix the spaces.

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -21,6 +21,11 @@ $topic_indent: $far_left_gutter_size + $left_col_size + 4px;
     font-size: 15px;
     font-weight: 800;
     min-width: $left_col_size;
+    text-align: center;
+    span.hashtag,
+    i.fa-lock {
+        padding-right: 3px;
+    }
 }
 
 .pm_left_col {
@@ -193,12 +198,16 @@ li.show-more-private-messages {
 .top_left_all_messages i.fa-home {
     position: relative;
     top: 1px;
-    left: -1px;
-    font-size: 17px;
+    font-size: 15px;
 }
 
 .top_left_private_messages i.fa-envelope {
-    font-size: 12px;
+    font-size: 10px;
+}
+
+.top_left_mentions i.fa-at,
+.top_left_starred_messages i.fa-star {
+    font-size: 13px;
 }
 
 /* We are mostly consistent in how we style
@@ -273,7 +282,10 @@ li.show-more-private-messages {
     line-height: 1.1;
 }
 
-.filter-icon i,
+.filter-icon i {
+    padding-right: 3px;
+}
+
 .all-messages-arrow i,
 .stream-sidebar-arrow i,
 .starred-messages-sidebar-arrow i,


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
fixes #11917 

This is how it looks like. **Screenshot:** 
![Screen Shot 2019-03-23 at 17 13 29](https://user-images.githubusercontent.com/18381652/54869238-fb1da280-4d95-11e9-8841-ac06e19441a1.png)
There is this commit ed30b45afd23d01804c7c28260744bb735d750d5 that delets the `margin-right: 3px;` from the global filters. I added it back, as the issue requested bigger space there, not sure if there was a reason why it was removed. More, I centered the `#`s and added the same spacings as for the globa; filters.