### PR TITLE
settings: Scrollbar should always be visible.

### DIFF
--- a/static/js/settings_panel_menu.js
+++ b/static/js/settings_panel_menu.js
@@ -84,6 +84,8 @@ exports.make_menu = function (opts) {
         $settings_overlay_container.find(".settings-header.mobile").addClass("slide-left");
 
         settings.set_settings_header(section);
+        ui.update_scrollbar($("#settings_page .sidebar.left"));
+        ui.update_scrollbar($("#settings_content"));
     };
 
     self.get_panel = function () {

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1916,3 +1916,19 @@ thead .actions {
     margin-top: 13px;
     display: inline-block;
 }
+/* Modifications to PerfectScrollbar
+ to get rid of UI bug in settings-overlay scrollbar
+*/
+.ps__rail-y,
+.ps__rail-x {
+    opacity: 1;
+}
+
+.ps:hover > .ps__rail-x,
+.ps:hover > .ps__rail-y,
+.ps--focus > .ps__rail-x,
+.ps--focus > .ps__rail-y,
+.ps--scrolling-x > .ps__rail-x,
+.ps--scrolling-y > .ps__rail-y {
+    opacity: 1;
+}


### PR DESCRIPTION
Fix issue #11694.
This PR fixes issue #11694 and another issue which I came across while fixing this issue. The other issue was about the inconsistent overlapping of the perfectScrollbar, which is fixed by adding a few lines of CSS. The link to this other issue is : https://chat.zulip.org/#narrow/stream/9-issues/topic/SettingsScrollBar 

**Testing Plan:** Tested on the local development server.

**GIFs or Screenshots:** 

Before:

![scroll](https://user-images.githubusercontent.com/37958393/54913245-4f509000-4f18-11e9-89b6-d79602099d22.gif)

After:

![fixedScroll](https://user-images.githubusercontent.com/37958393/54913861-b6bb0f80-4f19-11e9-8879-af4fbeddfa95.gif)
