### PR TITLE
portico: Fix trapsarent gradient styling inconsistencies.

### DIFF
--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -702,23 +702,23 @@ nav ul li.active::after {
 }
 
 .portico-landing.hello .gradients .gradient.dark-blue {
-    background: linear-gradient(10deg, transparent 50%, rgba(15, 46, 57, 0.7));
+    background: linear-gradient(10deg, rgba(15, 46, 57, 0) 50%, rgba(15, 46, 57, 0.7));
 }
 
 .portico-landing.hello .gradients .gradient.green {
-    background: linear-gradient(-25deg, transparent 40%, hsl(156, 47%, 47%));
+    background: linear-gradient(-25deg, hsla(156, 47%, 47%, 0) 40%, hsl(156, 47%, 47%));
 }
 
 .portico-landing.hello .gradients .gradient.blue {
-    background: linear-gradient(25deg, transparent 40%, hsl(196, 38%, 51%));
+    background: linear-gradient(25deg, hsla(196, 38%, 51%, 0) 40%, hsl(196, 38%, 51%));
 }
 
 .portico-landing.hello .gradients .gradient.sunburst {
-    background: linear-gradient(5deg, transparent 20%, hsl(49, 71%, 68%));
+    background: linear-gradient(5deg, hsla(49, 71%, 68%, 0) 20%, hsl(49, 71%, 68%));
 }
 
 .portico-landing.hello .gradients .gradient.white-fade {
-    background: linear-gradient(0deg, hsl(0, 0%, 98%) 0%, transparent 40%);
+    background: linear-gradient(0deg, hsl(0, 0%, 98%) 0%, hsla(0, 0%, 98%, 0) 40%);
 }
 
 .portico-landing.hello .hero .waves {
@@ -2792,23 +2792,23 @@ nav ul li.active::after {
 }
 
 .gradients .gradient.dark-blue {
-    background: linear-gradient(10deg, transparent 50%, rgba(15, 46, 57, 0.7));
+    background: linear-gradient(10deg, rgba(15, 46, 57, 0) 50%, rgba(15, 46, 57, 0.7));
 }
 
 .gradients .gradient.green {
-    background: linear-gradient(-25deg, transparent 40%, hsl(156, 47%, 47%));
+    background: linear-gradient(-25deg, hsla(156, 47%, 47%, 0) 40%, hsl(156, 47%, 47%));
 }
 
 .gradients .gradient.blue {
-    background: linear-gradient(25deg, transparent 40%, hsl(196, 38%, 51%));
+    background: linear-gradient(25deg, hsla(196, 38%, 51%, 0) 40%, hsl(196, 38%, 51%));
 }
 
 .gradients .gradient.sunburst {
-    background: linear-gradient(5deg, transparent 20%, hsl(49, 71%, 68%));
+    background: linear-gradient(5deg, hsla(49, 71%, 68%, 0) 20%, hsl(49, 71%, 68%));
 }
 
 .gradients .gradient.white-fade {
-    background: linear-gradient(0deg, hsl(0, 0%, 98%) 0%, transparent 40%);
+    background: linear-gradient(0deg, hsl(0, 0%, 98%) 0%, hsla(0, 0%, 98%, 0) 40%);
 }
 
 /* -- pricing css -- */


### PR DESCRIPTION
This PR fixes some inconsistencies in how the homepage gradients are rendered across Safari and Chrome. Safari seems to interpret `transparent` as being the same as `rgba(0, 0, 0, 0)`, which leads to a much darker background compared to how it is rendered on Chrome and Firefox.

This is fixed by using the gradient colors themselves instead of `transparent`, in order to lead to a single color gradient. The Chrome and Firefox versions maintain the same exact look as before, but the Safari rendering now also looks the same as the other two.

Fixes #11985.

**Screenshots:**

*Before (Safari left, Chrome right)*

<img width="1680" alt="Safari vs. Chrome Before" src="https://user-images.githubusercontent.com/17259768/54959627-f7fdf000-4f16-11e9-8811-e109da09b724.png">

*After (Safari left, Chrome right)*

<img width="1680" alt="Safari vs. Chrome After" src="https://user-images.githubusercontent.com/17259768/54959736-49a67a80-4f17-11e9-8240-8b28ae9310ec.png">
