### PR TITLE
Copy handler bind to hotkeys

### DIFF
--- a/frontend_tests/casper_tests/16-copy-and-paste.js
+++ b/frontend_tests/casper_tests/16-copy-and-paste.js
@@ -69,9 +69,7 @@ function copy_messages(start_message, end_message) {
         $('#copytempdiv').remove();
 
         // emulate copy event
-        var event = document.createEvent('Event');
-        event.initEvent('copy', true, true);
-        document.dispatchEvent(event);
+        $('body').trigger($.Event('keydown', { which: 67, ctrlKey: true }));
 
         // find temp div with copied text
         var temp_div = $('#copytempdiv');

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -99,6 +99,7 @@ run_test('mappings', () => {
     assert.equal(map_press(106).name, 'vim_down'); // j
 
     assert.equal(map_down(219, false, true).name, 'escape'); // ctrl + [
+    assert.equal(map_down(67, false, true).name, 'copy_with_c'); // ctrl + c
     assert.equal(map_down(75, false, true).name, 'search_with_k'); // ctrl + k
     assert.equal(map_down(83, false, true).name, 'star_message'); // ctrl + s
     assert.equal(map_down(190, false, true).name, 'narrow_to_compose_target'); // ctrl + .
@@ -107,7 +108,6 @@ run_test('mappings', () => {
     assert.equal(map_down(47), undefined);
     assert.equal(map_press(27), undefined);
     assert.equal(map_down(27, true), undefined);
-    assert.equal(map_down(67, false, true), undefined); // ctrl + c
     assert.equal(map_down(86, false, true), undefined); // ctrl + v
     assert.equal(map_down(90, false, true), undefined); // ctrl + z
     assert.equal(map_down(84, false, true), undefined); // ctrl + t
@@ -120,6 +120,7 @@ run_test('mappings', () => {
     assert.equal(map_down(88, false, true), undefined); // ctrl + x
     assert.equal(map_down(78, false, true), undefined); // ctrl + n
     assert.equal(map_down(77, false, true), undefined); // ctrl + m
+    assert.equal(map_down(67, false, false, true), undefined); // cmd + c
     assert.equal(map_down(75, false, false, true), undefined); // cmd + k
     assert.equal(map_down(83, false, false, true), undefined); // cmd + s
     assert.equal(map_down(75, true, true), undefined); // shift + ctrl + k
@@ -130,6 +131,8 @@ run_test('mappings', () => {
     global.navigator.userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.167 Safari/537.36";
     assert.equal(map_down(219, false, true, false).name, 'escape'); // ctrl + [
     assert.equal(map_down(219, false, false, true), undefined); // cmd + [
+    assert.equal(map_down(67, false, true, true).name, 'copy_with_c'); // ctrl + c
+    assert.equal(map_down(67, false, true, false), undefined); // cmd + c
     assert.equal(map_down(75, false, false, true).name, 'search_with_k'); // cmd + k
     assert.equal(map_down(75, false, true, false), undefined); // ctrl + k
     assert.equal(map_down(83, false, false, true).name, 'star_message'); // cmd + s

--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -102,12 +102,14 @@ exports.copy_handler = function () {
         // message is not defined, so this is definitely not a
         // multi-message selection and we can let the browser handle
         // the copy.
+        document.execCommand('copy');
         return;
     }
 
     if (!skip_same_td_check && start_id === end_id) {
         // Check whether the selection both starts and ends in the
         // same message.  If so, Let the browser handle this.
+        document.execCommand('copy');
         return;
     }
 
@@ -140,6 +142,11 @@ exports.copy_handler = function () {
         .attr('id', 'copytempdiv');
     $('body').append(div);
     selection.selectAllChildren(div[0]);
+    // This is the point where we've selected the content from our
+    // temp div and we exec the "copy" command.
+    // Once we copy the content from temp div, we want to change
+    // the selection to the original selection
+    document.execCommand('copy');
 
     /*
     The techniques we use in this code date back to
@@ -337,7 +344,6 @@ exports.paste_handler = function (event) {
 };
 
 exports.initialize = function () {
-    $(document).on('copy', exports.copy_handler);
     $("#compose-textarea").bind('paste', exports.paste_handler);
     $('body').on('paste', '#message_edit_form', exports.paste_handler);
 };

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -53,6 +53,7 @@ var keydown_ctrl_mappings = {
 };
 
 var keydown_cmd_or_ctrl_mappings = {
+    67: {name: 'copy_with_c', message_view_only: false}, // 'C'
     75: {name: 'search_with_k', message_view_only: false}, // 'K'
     83: {name: 'star_message', message_view_only: true}, // 's'
     190: {name: 'narrow_to_compose_target', message_view_only: true}, // '.'
@@ -684,6 +685,9 @@ exports.process_hotkey = function (e, hotkey) {
         return true;
     case 'star_deprecated':
         ui.maybe_show_deprecation_notice('*');
+        return true;
+    case 'copy_with_c':
+        copy_and_paste.copy_handler();
         return true;
     }
 


### PR DESCRIPTION
Follow the discussion here: https://chat.zulip.org/#narrow/stream/49-development-help/topic/Binding.20Copy.20paste.20behavior.20to.20another.20clickhandler/near/723074

This PR removes the default copy event listener and binds the `Ctrl+C` behaviour to hotkeys.