### PR TITLE
Bitbucket Server: Complete Support and Add Enhancements

### DIFF
--- a/zerver/webhooks/bitbucket3/fixtures/pull_request_add_reviewer.json
+++ b/zerver/webhooks/bitbucket3/fixtures/pull_request_add_reviewer.json
@@ -1,0 +1,251 @@
+{
+    "addedReviewers": [
+        {
+            "active": true,
+            "type": "NORMAL",
+            "links": {
+                "self": [
+                    {
+                        "href": "http://139.59.64.214:7990/users/shimura"
+                    }
+                ]
+            },
+            "displayName": "Shimura Shinpachi",
+            "emailAddress": "shimura_shinpachi@gmail.com",
+            "slug": "shimura",
+            "id": 2,
+            "name": "shimura"
+        }
+    ],
+    "actor": {
+        "active": true,
+        "type": "NORMAL",
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/users/hypro999"
+                }
+            ]
+        },
+        "displayName": "Hemanth V. Alluri",
+        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+        "slug": "hypro999",
+        "id": 1,
+        "name": "hypro999"
+    },
+    "pullRequest": {
+        "locked": false,
+        "state": "OPEN",
+        "description": "* Add file2.txt\n* Add file3.txt\nBoth of these files would be important additions to the project!",
+        "closed": false,
+        "open": true,
+        "title": "Branch1",
+        "toRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "slug": "sandbox",
+                "project": {
+                    "key": "SBOX",
+                    "public": false,
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX"
+                            }
+                        ]
+                    },
+                    "id": 2,
+                    "type": "NORMAL",
+                    "name": "Sandbox"
+                },
+                "id": 2,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "508d1b67f1f8f3a25f543a030a7a178894aa9907"
+        },
+        "reviewers": [
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/shimura"
+                            }
+                        ]
+                    },
+                    "displayName": "Shimura Shinpachi",
+                    "emailAddress": "shimura_shinpachi@gmail.com",
+                    "slug": "shimura",
+                    "id": 2,
+                    "name": "shimura"
+                },
+                "approved": false
+            }
+        ],
+        "author": {
+            "status": "UNAPPROVED",
+            "role": "AUTHOR",
+            "user": {
+                "active": true,
+                "type": "NORMAL",
+                "links": {
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999"
+                        }
+                    ]
+                },
+                "displayName": "Hemanth V. Alluri",
+                "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                "slug": "hypro999",
+                "id": 1,
+                "name": "hypro999"
+            },
+            "approved": false
+        },
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1"
+                }
+            ]
+        },
+        "createdDate": 1553172738844,
+        "fromRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/~hypro999/sandbox-fork.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/~hypro999/sandbox-fork.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999/repos/sandbox-fork/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "origin": {
+                    "state": "AVAILABLE",
+                    "links": {
+                        "clone": [
+                            {
+                                "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                                "name": "ssh"
+                            },
+                            {
+                                "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                                "name": "http"
+                            }
+                        ],
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                            }
+                        ]
+                    },
+                    "forkable": true,
+                    "slug": "sandbox",
+                    "project": {
+                        "key": "SBOX",
+                        "public": false,
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/projects/SBOX"
+                                }
+                            ]
+                        },
+                        "id": 2,
+                        "type": "NORMAL",
+                        "name": "Sandbox"
+                    },
+                    "id": 2,
+                    "scmId": "git",
+                    "public": false,
+                    "name": "sandbox",
+                    "statusMessage": "Available"
+                },
+                "slug": "sandbox-fork",
+                "project": {
+                    "key": "~HYPRO999",
+                    "type": "PERSONAL",
+                    "owner": {
+                        "active": true,
+                        "type": "NORMAL",
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/users/hypro999"
+                                }
+                            ]
+                        },
+                        "displayName": "Hemanth V. Alluri",
+                        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                        "slug": "hypro999",
+                        "id": 1,
+                        "name": "hypro999"
+                    },
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/hypro999"
+                            }
+                        ]
+                    },
+                    "id": 3,
+                    "name": "Hemanth V. Alluri"
+                },
+                "id": 4,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox fork",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/branch1",
+            "displayId": "branch1",
+            "latestCommit": "3980c2be32a7e23c795741d5dc1a2eecb9b85d6d"
+        },
+        "version": 1,
+        "id": 1,
+        "updatedDate": 1553337991505,
+        "participants": []
+    },
+    "removedReviewers": [],
+    "eventKey": "pr:reviewer:updated",
+    "date": "2019-03-23T16:16:31+0530"
+}

--- a/zerver/webhooks/bitbucket3/fixtures/pull_request_add_two_reviewers.json
+++ b/zerver/webhooks/bitbucket3/fixtures/pull_request_add_two_reviewers.json
@@ -1,0 +1,288 @@
+{
+    "addedReviewers": [
+        {
+            "active": true,
+            "type": "NORMAL",
+            "links": {
+                "self": [
+                    {
+                        "href": "http://139.59.64.214:7990/users/shimura"
+                    }
+                ]
+            },
+            "displayName": "Shimura Shinpachi",
+            "emailAddress": "shimura_shinpachi@gmail.com",
+            "slug": "shimura",
+            "id": 2,
+            "name": "shimura"
+        },
+        {
+            "active": true,
+            "type": "NORMAL",
+            "links": {
+                "self": [
+                    {
+                        "href": "http://139.59.64.214:7990/users/sougo"
+                    }
+                ]
+            },
+            "displayName": "Okita Sougo",
+            "emailAddress": "okita_sougo@gmail.com",
+            "slug": "sougo",
+            "id": 3,
+            "name": "sougo"
+        }
+    ],
+    "actor": {
+        "active": true,
+        "type": "NORMAL",
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/users/hypro999"
+                }
+            ]
+        },
+        "displayName": "Hemanth V. Alluri",
+        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+        "slug": "hypro999",
+        "id": 1,
+        "name": "hypro999"
+    },
+    "pullRequest": {
+        "locked": false,
+        "state": "OPEN",
+        "description": "* Add file2.txt\n* Add file3.txt\nBoth of these files would be important additions to the project!",
+        "closed": false,
+        "open": true,
+        "title": "Branch1",
+        "toRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "slug": "sandbox",
+                "project": {
+                    "key": "SBOX",
+                    "public": false,
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX"
+                            }
+                        ]
+                    },
+                    "id": 2,
+                    "type": "NORMAL",
+                    "name": "Sandbox"
+                },
+                "id": 2,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "508d1b67f1f8f3a25f543a030a7a178894aa9907"
+        },
+        "reviewers": [
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/shimura"
+                            }
+                        ]
+                    },
+                    "displayName": "Shimura Shinpachi",
+                    "emailAddress": "shimura_shinpachi@gmail.com",
+                    "slug": "shimura",
+                    "id": 2,
+                    "name": "shimura"
+                },
+                "approved": false
+            },
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/sougo"
+                            }
+                        ]
+                    },
+                    "displayName": "Okita Sougo",
+                    "emailAddress": "okita_sougo@gmail.com",
+                    "slug": "sougo",
+                    "id": 3,
+                    "name": "sougo"
+                },
+                "approved": false
+            }
+        ],
+        "author": {
+            "status": "UNAPPROVED",
+            "role": "AUTHOR",
+            "user": {
+                "active": true,
+                "type": "NORMAL",
+                "links": {
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999"
+                        }
+                    ]
+                },
+                "displayName": "Hemanth V. Alluri",
+                "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                "slug": "hypro999",
+                "id": 1,
+                "name": "hypro999"
+            },
+            "approved": false
+        },
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1"
+                }
+            ]
+        },
+        "createdDate": 1553172738844,
+        "fromRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/~hypro999/sandbox-fork.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/~hypro999/sandbox-fork.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999/repos/sandbox-fork/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "origin": {
+                    "state": "AVAILABLE",
+                    "links": {
+                        "clone": [
+                            {
+                                "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                                "name": "ssh"
+                            },
+                            {
+                                "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                                "name": "http"
+                            }
+                        ],
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                            }
+                        ]
+                    },
+                    "forkable": true,
+                    "slug": "sandbox",
+                    "project": {
+                        "key": "SBOX",
+                        "public": false,
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/projects/SBOX"
+                                }
+                            ]
+                        },
+                        "id": 2,
+                        "type": "NORMAL",
+                        "name": "Sandbox"
+                    },
+                    "id": 2,
+                    "scmId": "git",
+                    "public": false,
+                    "name": "sandbox",
+                    "statusMessage": "Available"
+                },
+                "slug": "sandbox-fork",
+                "project": {
+                    "key": "~HYPRO999",
+                    "type": "PERSONAL",
+                    "owner": {
+                        "active": true,
+                        "type": "NORMAL",
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/users/hypro999"
+                                }
+                            ]
+                        },
+                        "displayName": "Hemanth V. Alluri",
+                        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                        "slug": "hypro999",
+                        "id": 1,
+                        "name": "hypro999"
+                    },
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/hypro999"
+                            }
+                        ]
+                    },
+                    "id": 3,
+                    "name": "Hemanth V. Alluri"
+                },
+                "id": 4,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox fork",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/branch1",
+            "displayId": "branch1",
+            "latestCommit": "91c9c6998c9768ca678048ddee7f9e480e6d54de"
+        },
+        "version": 4,
+        "id": 1,
+        "updatedDate": 1553344009793,
+        "participants": []
+    },
+    "removedReviewers": [],
+    "eventKey": "pr:reviewer:updated",
+    "date": "2019-03-23T17:56:50+0530"
+}

--- a/zerver/webhooks/bitbucket3/fixtures/pull_request_approved.json
+++ b/zerver/webhooks/bitbucket3/fixtures/pull_request_approved.json
@@ -1,0 +1,298 @@
+{
+    "actor": {
+        "active": true,
+        "type": "NORMAL",
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/users/zura"
+                }
+            ]
+        },
+        "displayName": "Katsura Kotarou",
+        "emailAddress": "katsura_kotarou@gmail.com",
+        "slug": "zura",
+        "id": 4,
+        "name": "zura"
+    },
+    "previousStatus": "UNAPPROVED",
+    "participant": {
+        "status": "APPROVED",
+        "role": "REVIEWER",
+        "user": {
+            "active": true,
+            "type": "NORMAL",
+            "links": {
+                "self": [
+                    {
+                        "href": "http://139.59.64.214:7990/users/zura"
+                    }
+                ]
+            },
+            "displayName": "Katsura Kotarou",
+            "emailAddress": "katsura_kotarou@gmail.com",
+            "slug": "zura",
+            "id": 4,
+            "name": "zura"
+        },
+        "lastReviewedCommit": "556bde1a2442562568fce6016de570516ac1c4f6",
+        "approved": true
+    },
+    "pullRequest": {
+        "locked": false,
+        "state": "OPEN",
+        "description": "Add a simple text file for further testing purposes.",
+        "closed": false,
+        "open": true,
+        "title": "sample_file: Add sample_file.txt.",
+        "toRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "slug": "sandbox",
+                "project": {
+                    "key": "SBOX",
+                    "public": false,
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX"
+                            }
+                        ]
+                    },
+                    "id": 2,
+                    "type": "NORMAL",
+                    "name": "Sandbox"
+                },
+                "id": 2,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "d46b4d2e3326e106147c0ea748f7defba29d9e1e"
+        },
+        "reviewers": [
+            {
+                "status": "APPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/zura"
+                            }
+                        ]
+                    },
+                    "displayName": "Katsura Kotarou",
+                    "emailAddress": "katsura_kotarou@gmail.com",
+                    "slug": "zura",
+                    "id": 4,
+                    "name": "zura"
+                },
+                "lastReviewedCommit": "556bde1a2442562568fce6016de570516ac1c4f6",
+                "approved": true
+            },
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/sougo"
+                            }
+                        ]
+                    },
+                    "displayName": "Okita Sougo",
+                    "emailAddress": "okita_sougo@gmail.com",
+                    "slug": "sougo",
+                    "id": 3,
+                    "name": "sougo"
+                },
+                "approved": false
+            },
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/shimura"
+                            }
+                        ]
+                    },
+                    "displayName": "Shimura Shinpachi",
+                    "emailAddress": "shimura_shinpachi@gmail.com",
+                    "slug": "shimura",
+                    "id": 2,
+                    "name": "shimura"
+                },
+                "approved": false
+            }
+        ],
+        "author": {
+            "status": "UNAPPROVED",
+            "role": "AUTHOR",
+            "user": {
+                "active": true,
+                "type": "NORMAL",
+                "links": {
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999"
+                        }
+                    ]
+                },
+                "displayName": "Hemanth V. Alluri",
+                "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                "slug": "hypro999",
+                "id": 1,
+                "name": "hypro999"
+            },
+            "approved": false
+        },
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6"
+                }
+            ]
+        },
+        "createdDate": 1553572666612,
+        "fromRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/~hypro999/sandbox-fork.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/~hypro999/sandbox-fork.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999/repos/sandbox-fork/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "origin": {
+                    "state": "AVAILABLE",
+                    "links": {
+                        "clone": [
+                            {
+                                "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                                "name": "ssh"
+                            },
+                            {
+                                "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                                "name": "http"
+                            }
+                        ],
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                            }
+                        ]
+                    },
+                    "forkable": true,
+                    "slug": "sandbox",
+                    "project": {
+                        "key": "SBOX",
+                        "public": false,
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/projects/SBOX"
+                                }
+                            ]
+                        },
+                        "id": 2,
+                        "type": "NORMAL",
+                        "name": "Sandbox"
+                    },
+                    "id": 2,
+                    "scmId": "git",
+                    "public": false,
+                    "name": "sandbox",
+                    "statusMessage": "Available"
+                },
+                "slug": "sandbox-fork",
+                "project": {
+                    "key": "~HYPRO999",
+                    "type": "PERSONAL",
+                    "owner": {
+                        "active": true,
+                        "type": "NORMAL",
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/users/hypro999"
+                                }
+                            ]
+                        },
+                        "displayName": "Hemanth V. Alluri",
+                        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                        "slug": "hypro999",
+                        "id": 1,
+                        "name": "hypro999"
+                    },
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/hypro999"
+                            }
+                        ]
+                    },
+                    "id": 3,
+                    "name": "Hemanth V. Alluri"
+                },
+                "id": 4,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox fork",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "556bde1a2442562568fce6016de570516ac1c4f6"
+        },
+        "version": 0,
+        "id": 6,
+        "updatedDate": 1553572666612,
+        "participants": []
+    },
+    "eventKey": "pr:reviewer:approved",
+    "date": "2019-03-26T15:47:11+0530"
+}

--- a/zerver/webhooks/bitbucket3/fixtures/pull_request_comment_added.json
+++ b/zerver/webhooks/bitbucket3/fixtures/pull_request_comment_added.json
@@ -1,0 +1,302 @@
+{
+    "comment": {
+        "author": {
+            "active": true,
+            "type": "NORMAL",
+            "links": {
+                "self": [
+                    {
+                        "href": "http://139.59.64.214:7990/users/zura"
+                    }
+                ]
+            },
+            "displayName": "Katsura Kotarou",
+            "emailAddress": "katsura_kotarou@gmail.com",
+            "slug": "zura",
+            "id": 4,
+            "name": "zura"
+        },
+        "id": 2,
+        "updatedDate": 1553585547535,
+        "tasks": [],
+        "comments": [],
+        "version": 0,
+        "text": "This seems like a pretty good idea.",
+        "createdDate": 1553585547535,
+        "properties": {
+            "repositoryId": 2
+        }
+    },
+    "actor": {
+        "active": true,
+        "type": "NORMAL",
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/users/zura"
+                }
+            ]
+        },
+        "displayName": "Katsura Kotarou",
+        "emailAddress": "katsura_kotarou@gmail.com",
+        "slug": "zura",
+        "id": 4,
+        "name": "zura"
+    },
+    "eventKey": "pr:comment:added",
+    "date": "2019-03-26T13:02:27+0530",
+    "pullRequest": {
+        "locked": false,
+        "state": "OPEN",
+        "description": "Add a simple text file for further testing purposes.",
+        "closed": false,
+        "open": true,
+        "title": "sample_file: Add sample_file.txt.",
+        "toRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "slug": "sandbox",
+                "project": {
+                    "key": "SBOX",
+                    "public": false,
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX"
+                            }
+                        ]
+                    },
+                    "id": 2,
+                    "type": "NORMAL",
+                    "name": "Sandbox"
+                },
+                "id": 2,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "d46b4d2e3326e106147c0ea748f7defba29d9e1e"
+        },
+        "reviewers": [
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/sougo"
+                            }
+                        ]
+                    },
+                    "displayName": "Okita Sougo",
+                    "emailAddress": "okita_sougo@gmail.com",
+                    "slug": "sougo",
+                    "id": 3,
+                    "name": "sougo"
+                },
+                "approved": false
+            },
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/shimura"
+                            }
+                        ]
+                    },
+                    "displayName": "Shimura Shinpachi",
+                    "emailAddress": "shimura_shinpachi@gmail.com",
+                    "slug": "shimura",
+                    "id": 2,
+                    "name": "shimura"
+                },
+                "approved": false
+            },
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/zura"
+                            }
+                        ]
+                    },
+                    "displayName": "Katsura Kotarou",
+                    "emailAddress": "katsura_kotarou@gmail.com",
+                    "slug": "zura",
+                    "id": 4,
+                    "name": "zura"
+                },
+                "approved": false
+            }
+        ],
+        "author": {
+            "status": "UNAPPROVED",
+            "role": "AUTHOR",
+            "user": {
+                "active": true,
+                "type": "NORMAL",
+                "links": {
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999"
+                        }
+                    ]
+                },
+                "displayName": "Hemanth V. Alluri",
+                "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                "slug": "hypro999",
+                "id": 1,
+                "name": "hypro999"
+            },
+            "approved": false
+        },
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6"
+                }
+            ]
+        },
+        "createdDate": 1553572666612,
+        "fromRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/~hypro999/sandbox-fork.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/~hypro999/sandbox-fork.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999/repos/sandbox-fork/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "origin": {
+                    "state": "AVAILABLE",
+                    "links": {
+                        "clone": [
+                            {
+                                "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                                "name": "ssh"
+                            },
+                            {
+                                "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                                "name": "http"
+                            }
+                        ],
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                            }
+                        ]
+                    },
+                    "forkable": true,
+                    "slug": "sandbox",
+                    "project": {
+                        "key": "SBOX",
+                        "public": false,
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/projects/SBOX"
+                                }
+                            ]
+                        },
+                        "id": 2,
+                        "type": "NORMAL",
+                        "name": "Sandbox"
+                    },
+                    "id": 2,
+                    "scmId": "git",
+                    "public": false,
+                    "name": "sandbox",
+                    "statusMessage": "Available"
+                },
+                "slug": "sandbox-fork",
+                "project": {
+                    "key": "~HYPRO999",
+                    "type": "PERSONAL",
+                    "owner": {
+                        "active": true,
+                        "type": "NORMAL",
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/users/hypro999"
+                                }
+                            ]
+                        },
+                        "displayName": "Hemanth V. Alluri",
+                        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                        "slug": "hypro999",
+                        "id": 1,
+                        "name": "hypro999"
+                    },
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/hypro999"
+                            }
+                        ]
+                    },
+                    "id": 3,
+                    "name": "Hemanth V. Alluri"
+                },
+                "id": 4,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox fork",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "556bde1a2442562568fce6016de570516ac1c4f6"
+        },
+        "version": 0,
+        "id": 6,
+        "updatedDate": 1553572666612,
+        "participants": []
+    }
+}

--- a/zerver/webhooks/bitbucket3/fixtures/pull_request_comment_deleted.json
+++ b/zerver/webhooks/bitbucket3/fixtures/pull_request_comment_deleted.json
@@ -1,0 +1,299 @@
+{
+    "comment": {
+        "author": {
+            "active": true,
+            "type": "NORMAL",
+            "links": {
+                "self": [
+                    {
+                        "href": "http://139.59.64.214:7990/users/zura"
+                    }
+                ]
+            },
+            "displayName": "Katsura Kotarou",
+            "emailAddress": "katsura_kotarou@gmail.com",
+            "slug": "zura",
+            "id": 4,
+            "name": "zura"
+        },
+        "id": 2,
+        "updatedDate": 1553585861365,
+        "tasks": [],
+        "comments": [],
+        "version": 4,
+        "text": "This seems like a pretty good idea. @shimura what do you think?",
+        "createdDate": 1553585547535
+    },
+    "actor": {
+        "active": true,
+        "type": "NORMAL",
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/users/zura"
+                }
+            ]
+        },
+        "displayName": "Katsura Kotarou",
+        "emailAddress": "katsura_kotarou@gmail.com",
+        "slug": "zura",
+        "id": 4,
+        "name": "zura"
+    },
+    "eventKey": "pr:comment:deleted",
+    "date": "2019-03-26T13:08:41+0530",
+    "pullRequest": {
+        "locked": false,
+        "state": "OPEN",
+        "description": "Add a simple text file for further testing purposes.",
+        "closed": false,
+        "open": true,
+        "title": "sample_file: Add sample_file.txt.",
+        "toRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "slug": "sandbox",
+                "project": {
+                    "key": "SBOX",
+                    "public": false,
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX"
+                            }
+                        ]
+                    },
+                    "id": 2,
+                    "type": "NORMAL",
+                    "name": "Sandbox"
+                },
+                "id": 2,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "d46b4d2e3326e106147c0ea748f7defba29d9e1e"
+        },
+        "reviewers": [
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/sougo"
+                            }
+                        ]
+                    },
+                    "displayName": "Okita Sougo",
+                    "emailAddress": "okita_sougo@gmail.com",
+                    "slug": "sougo",
+                    "id": 3,
+                    "name": "sougo"
+                },
+                "approved": false
+            },
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/shimura"
+                            }
+                        ]
+                    },
+                    "displayName": "Shimura Shinpachi",
+                    "emailAddress": "shimura_shinpachi@gmail.com",
+                    "slug": "shimura",
+                    "id": 2,
+                    "name": "shimura"
+                },
+                "approved": false
+            },
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/zura"
+                            }
+                        ]
+                    },
+                    "displayName": "Katsura Kotarou",
+                    "emailAddress": "katsura_kotarou@gmail.com",
+                    "slug": "zura",
+                    "id": 4,
+                    "name": "zura"
+                },
+                "approved": false
+            }
+        ],
+        "author": {
+            "status": "UNAPPROVED",
+            "role": "AUTHOR",
+            "user": {
+                "active": true,
+                "type": "NORMAL",
+                "links": {
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999"
+                        }
+                    ]
+                },
+                "displayName": "Hemanth V. Alluri",
+                "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                "slug": "hypro999",
+                "id": 1,
+                "name": "hypro999"
+            },
+            "approved": false
+        },
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6"
+                }
+            ]
+        },
+        "createdDate": 1553572666612,
+        "fromRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/~hypro999/sandbox-fork.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/~hypro999/sandbox-fork.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999/repos/sandbox-fork/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "origin": {
+                    "state": "AVAILABLE",
+                    "links": {
+                        "clone": [
+                            {
+                                "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                                "name": "ssh"
+                            },
+                            {
+                                "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                                "name": "http"
+                            }
+                        ],
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                            }
+                        ]
+                    },
+                    "forkable": true,
+                    "slug": "sandbox",
+                    "project": {
+                        "key": "SBOX",
+                        "public": false,
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/projects/SBOX"
+                                }
+                            ]
+                        },
+                        "id": 2,
+                        "type": "NORMAL",
+                        "name": "Sandbox"
+                    },
+                    "id": 2,
+                    "scmId": "git",
+                    "public": false,
+                    "name": "sandbox",
+                    "statusMessage": "Available"
+                },
+                "slug": "sandbox-fork",
+                "project": {
+                    "key": "~HYPRO999",
+                    "type": "PERSONAL",
+                    "owner": {
+                        "active": true,
+                        "type": "NORMAL",
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/users/hypro999"
+                                }
+                            ]
+                        },
+                        "displayName": "Hemanth V. Alluri",
+                        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                        "slug": "hypro999",
+                        "id": 1,
+                        "name": "hypro999"
+                    },
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/hypro999"
+                            }
+                        ]
+                    },
+                    "id": 3,
+                    "name": "Hemanth V. Alluri"
+                },
+                "id": 4,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox fork",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "556bde1a2442562568fce6016de570516ac1c4f6"
+        },
+        "version": 0,
+        "id": 6,
+        "updatedDate": 1553572666612,
+        "participants": []
+    }
+}

--- a/zerver/webhooks/bitbucket3/fixtures/pull_request_comment_edited.json
+++ b/zerver/webhooks/bitbucket3/fixtures/pull_request_comment_edited.json
@@ -1,0 +1,303 @@
+{
+    "actor": {
+        "active": true,
+        "type": "NORMAL",
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/users/zura"
+                }
+            ]
+        },
+        "displayName": "Katsura Kotarou",
+        "emailAddress": "katsura_kotarou@gmail.com",
+        "slug": "zura",
+        "id": 4,
+        "name": "zura"
+    },
+    "comment": {
+        "author": {
+            "active": true,
+            "type": "NORMAL",
+            "links": {
+                "self": [
+                    {
+                        "href": "http://139.59.64.214:7990/users/zura"
+                    }
+                ]
+            },
+            "displayName": "Katsura Kotarou",
+            "emailAddress": "katsura_kotarou@gmail.com",
+            "slug": "zura",
+            "id": 4,
+            "name": "zura"
+        },
+        "id": 2,
+        "updatedDate": 1553585861365,
+        "tasks": [],
+        "comments": [],
+        "version": 4,
+        "text": "This seems like a pretty good idea. @shimura what do you think?",
+        "createdDate": 1553585547535,
+        "properties": {
+            "repositoryId": 2
+        }
+    },
+    "previousComment": "This seems like a pretty good idea.",
+    "pullRequest": {
+        "locked": false,
+        "state": "OPEN",
+        "description": "Add a simple text file for further testing purposes.",
+        "closed": false,
+        "open": true,
+        "title": "sample_file: Add sample_file.txt.",
+        "toRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "slug": "sandbox",
+                "project": {
+                    "key": "SBOX",
+                    "public": false,
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX"
+                            }
+                        ]
+                    },
+                    "id": 2,
+                    "type": "NORMAL",
+                    "name": "Sandbox"
+                },
+                "id": 2,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "d46b4d2e3326e106147c0ea748f7defba29d9e1e"
+        },
+        "reviewers": [
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/sougo"
+                            }
+                        ]
+                    },
+                    "displayName": "Okita Sougo",
+                    "emailAddress": "okita_sougo@gmail.com",
+                    "slug": "sougo",
+                    "id": 3,
+                    "name": "sougo"
+                },
+                "approved": false
+            },
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/zura"
+                            }
+                        ]
+                    },
+                    "displayName": "Katsura Kotarou",
+                    "emailAddress": "katsura_kotarou@gmail.com",
+                    "slug": "zura",
+                    "id": 4,
+                    "name": "zura"
+                },
+                "approved": false
+            },
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/shimura"
+                            }
+                        ]
+                    },
+                    "displayName": "Shimura Shinpachi",
+                    "emailAddress": "shimura_shinpachi@gmail.com",
+                    "slug": "shimura",
+                    "id": 2,
+                    "name": "shimura"
+                },
+                "approved": false
+            }
+        ],
+        "author": {
+            "status": "UNAPPROVED",
+            "role": "AUTHOR",
+            "user": {
+                "active": true,
+                "type": "NORMAL",
+                "links": {
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999"
+                        }
+                    ]
+                },
+                "displayName": "Hemanth V. Alluri",
+                "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                "slug": "hypro999",
+                "id": 1,
+                "name": "hypro999"
+            },
+            "approved": false
+        },
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6"
+                }
+            ]
+        },
+        "createdDate": 1553572666612,
+        "fromRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/~hypro999/sandbox-fork.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/~hypro999/sandbox-fork.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999/repos/sandbox-fork/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "origin": {
+                    "state": "AVAILABLE",
+                    "links": {
+                        "clone": [
+                            {
+                                "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                                "name": "ssh"
+                            },
+                            {
+                                "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                                "name": "http"
+                            }
+                        ],
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                            }
+                        ]
+                    },
+                    "forkable": true,
+                    "slug": "sandbox",
+                    "project": {
+                        "key": "SBOX",
+                        "public": false,
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/projects/SBOX"
+                                }
+                            ]
+                        },
+                        "id": 2,
+                        "type": "NORMAL",
+                        "name": "Sandbox"
+                    },
+                    "id": 2,
+                    "scmId": "git",
+                    "public": false,
+                    "name": "sandbox",
+                    "statusMessage": "Available"
+                },
+                "slug": "sandbox-fork",
+                "project": {
+                    "key": "~HYPRO999",
+                    "type": "PERSONAL",
+                    "owner": {
+                        "active": true,
+                        "type": "NORMAL",
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/users/hypro999"
+                                }
+                            ]
+                        },
+                        "displayName": "Hemanth V. Alluri",
+                        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                        "slug": "hypro999",
+                        "id": 1,
+                        "name": "hypro999"
+                    },
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/hypro999"
+                            }
+                        ]
+                    },
+                    "id": 3,
+                    "name": "Hemanth V. Alluri"
+                },
+                "id": 4,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox fork",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "556bde1a2442562568fce6016de570516ac1c4f6"
+        },
+        "version": 0,
+        "id": 6,
+        "updatedDate": 1553572666612,
+        "participants": []
+    },
+    "eventKey": "pr:comment:edited",
+    "date": "2019-03-26T13:07:41+0530"
+}

--- a/zerver/webhooks/bitbucket3/fixtures/pull_request_declined.json
+++ b/zerver/webhooks/bitbucket3/fixtures/pull_request_declined.json
@@ -1,0 +1,254 @@
+{
+    "actor": {
+        "active": true,
+        "type": "NORMAL",
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/users/zura"
+                }
+            ]
+        },
+        "displayName": "Katsura Kotarou",
+        "emailAddress": "katsura_kotarou@gmail.com",
+        "slug": "zura",
+        "id": 4,
+        "name": "zura"
+    },
+    "eventKey": "pr:declined",
+    "date": "2019-03-26T15:53:42+0530",
+    "pullRequest": {
+        "locked": false,
+        "state": "DECLINED",
+        "description": "I just got a crazy idea, how 'bout we just delete everything?",
+        "closed": true,
+        "open": false,
+        "title": "Crazy Idea",
+        "toRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "slug": "sandbox",
+                "project": {
+                    "key": "SBOX",
+                    "public": false,
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX"
+                            }
+                        ]
+                    },
+                    "id": 2,
+                    "type": "NORMAL",
+                    "name": "Sandbox"
+                },
+                "id": 2,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "1015204bf62881c5ef9e18e6e73e0211a667a00c"
+        },
+        "closedDate": 1553595822665,
+        "reviewers": [
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/zura"
+                            }
+                        ]
+                    },
+                    "displayName": "Katsura Kotarou",
+                    "emailAddress": "katsura_kotarou@gmail.com",
+                    "slug": "zura",
+                    "id": 4,
+                    "name": "zura"
+                },
+                "approved": false
+            },
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/shimura"
+                            }
+                        ]
+                    },
+                    "displayName": "Shimura Shinpachi",
+                    "emailAddress": "shimura_shinpachi@gmail.com",
+                    "slug": "shimura",
+                    "id": 2,
+                    "name": "shimura"
+                },
+                "approved": false
+            }
+        ],
+        "author": {
+            "status": "UNAPPROVED",
+            "role": "AUTHOR",
+            "user": {
+                "active": true,
+                "type": "NORMAL",
+                "links": {
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999"
+                        }
+                    ]
+                },
+                "displayName": "Hemanth V. Alluri",
+                "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                "slug": "hypro999",
+                "id": 1,
+                "name": "hypro999"
+            },
+            "approved": false
+        },
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/7"
+                }
+            ]
+        },
+        "createdDate": 1553595372759,
+        "fromRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/~hypro999/sandbox-fork.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/~hypro999/sandbox-fork.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999/repos/sandbox-fork/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "origin": {
+                    "state": "AVAILABLE",
+                    "links": {
+                        "clone": [
+                            {
+                                "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                                "name": "ssh"
+                            },
+                            {
+                                "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                                "name": "http"
+                            }
+                        ],
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                            }
+                        ]
+                    },
+                    "forkable": true,
+                    "slug": "sandbox",
+                    "project": {
+                        "key": "SBOX",
+                        "public": false,
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/projects/SBOX"
+                                }
+                            ]
+                        },
+                        "id": 2,
+                        "type": "NORMAL",
+                        "name": "Sandbox"
+                    },
+                    "id": 2,
+                    "scmId": "git",
+                    "public": false,
+                    "name": "sandbox",
+                    "statusMessage": "Available"
+                },
+                "slug": "sandbox-fork",
+                "project": {
+                    "key": "~HYPRO999",
+                    "type": "PERSONAL",
+                    "owner": {
+                        "active": true,
+                        "type": "NORMAL",
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/users/hypro999"
+                                }
+                            ]
+                        },
+                        "displayName": "Hemanth V. Alluri",
+                        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                        "slug": "hypro999",
+                        "id": 1,
+                        "name": "hypro999"
+                    },
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/hypro999"
+                            }
+                        ]
+                    },
+                    "id": 3,
+                    "name": "Hemanth V. Alluri"
+                },
+                "id": 4,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox fork",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/crazy_idea",
+            "displayId": "crazy_idea",
+            "latestCommit": "dd17f2eaad634e292068ef7f353b3538334d31f1"
+        },
+        "version": 2,
+        "id": 7,
+        "updatedDate": 1553595822665,
+        "participants": []
+    }
+}

--- a/zerver/webhooks/bitbucket3/fixtures/pull_request_deleted.json
+++ b/zerver/webhooks/bitbucket3/fixtures/pull_request_deleted.json
@@ -1,0 +1,209 @@
+{
+    "actor": {
+        "active": true,
+        "type": "NORMAL",
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/users/hypro999"
+                }
+            ]
+        },
+        "displayName": "Hemanth V. Alluri",
+        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+        "slug": "hypro999",
+        "id": 1,
+        "name": "hypro999"
+    },
+    "eventKey": "pr:deleted",
+    "date": "2019-03-21T19:29:49+0530",
+    "pullRequest": {
+        "locked": false,
+        "state": "OPEN",
+        "closed": false,
+        "open": true,
+        "title": "Add notes feature.",
+        "toRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "slug": "sandbox",
+                "project": {
+                    "key": "SBOX",
+                    "public": false,
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX"
+                            }
+                        ]
+                    },
+                    "id": 2,
+                    "type": "NORMAL",
+                    "name": "Sandbox"
+                },
+                "id": 2,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "508d1b67f1f8f3a25f543a030a7a178894aa9907"
+        },
+        "reviewers": [],
+        "author": {
+            "status": "UNAPPROVED",
+            "role": "AUTHOR",
+            "user": {
+                "active": true,
+                "type": "NORMAL",
+                "links": {
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999"
+                        }
+                    ]
+                },
+                "displayName": "Hemanth V. Alluri",
+                "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                "slug": "hypro999",
+                "id": 1,
+                "name": "hypro999"
+            },
+            "approved": false
+        },
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/2"
+                }
+            ]
+        },
+        "createdDate": 1553176436660,
+        "fromRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/~hypro999/sandbox-fork.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/~hypro999/sandbox-fork.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999/repos/sandbox-fork/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "origin": {
+                    "state": "AVAILABLE",
+                    "links": {
+                        "clone": [
+                            {
+                                "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                                "name": "ssh"
+                            },
+                            {
+                                "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                                "name": "http"
+                            }
+                        ],
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                            }
+                        ]
+                    },
+                    "forkable": true,
+                    "slug": "sandbox",
+                    "project": {
+                        "key": "SBOX",
+                        "public": false,
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/projects/SBOX"
+                                }
+                            ]
+                        },
+                        "id": 2,
+                        "type": "NORMAL",
+                        "name": "Sandbox"
+                    },
+                    "id": 2,
+                    "scmId": "git",
+                    "public": false,
+                    "name": "sandbox",
+                    "statusMessage": "Available"
+                },
+                "slug": "sandbox-fork",
+                "project": {
+                    "key": "~HYPRO999",
+                    "type": "PERSONAL",
+                    "owner": {
+                        "active": true,
+                        "type": "NORMAL",
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/users/hypro999"
+                                }
+                            ]
+                        },
+                        "displayName": "Hemanth V. Alluri",
+                        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                        "slug": "hypro999",
+                        "id": 1,
+                        "name": "hypro999"
+                    },
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/hypro999"
+                            }
+                        ]
+                    },
+                    "id": 3,
+                    "name": "Hemanth V. Alluri"
+                },
+                "id": 4,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox fork",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "1a8de2fd34dcf6c9c2117b62eb17a266736aad7f"
+        },
+        "version": 0,
+        "id": 2,
+        "updatedDate": 1553176436660,
+        "participants": []
+    }
+}

--- a/zerver/webhooks/bitbucket3/fixtures/pull_request_merged.json
+++ b/zerver/webhooks/bitbucket3/fixtures/pull_request_merged.json
@@ -1,0 +1,282 @@
+{
+    "actor": {
+        "active": true,
+        "type": "NORMAL",
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/users/zura"
+                }
+            ]
+        },
+        "displayName": "Katsura Kotarou",
+        "emailAddress": "katsura_kotarou@gmail.com",
+        "slug": "zura",
+        "id": 4,
+        "name": "zura"
+    },
+    "eventKey": "pr:merged",
+    "date": "2019-03-26T15:52:24+0530",
+    "pullRequest": {
+        "locked": false,
+        "state": "MERGED",
+        "description": "Add a simple text file for further testing purposes.",
+        "closed": true,
+        "open": false,
+        "title": "sample_file: Add sample_file.txt.",
+        "toRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "slug": "sandbox",
+                "project": {
+                    "key": "SBOX",
+                    "public": false,
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX"
+                            }
+                        ]
+                    },
+                    "id": 2,
+                    "type": "NORMAL",
+                    "name": "Sandbox"
+                },
+                "id": 2,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "d46b4d2e3326e106147c0ea748f7defba29d9e1e"
+        },
+        "closedDate": 1553595743394,
+        "reviewers": [
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/shimura"
+                            }
+                        ]
+                    },
+                    "displayName": "Shimura Shinpachi",
+                    "emailAddress": "shimura_shinpachi@gmail.com",
+                    "slug": "shimura",
+                    "id": 2,
+                    "name": "shimura"
+                },
+                "approved": false
+            },
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/sougo"
+                            }
+                        ]
+                    },
+                    "displayName": "Okita Sougo",
+                    "emailAddress": "okita_sougo@gmail.com",
+                    "slug": "sougo",
+                    "id": 3,
+                    "name": "sougo"
+                },
+                "approved": false
+            },
+            {
+                "status": "APPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/zura"
+                            }
+                        ]
+                    },
+                    "displayName": "Katsura Kotarou",
+                    "emailAddress": "katsura_kotarou@gmail.com",
+                    "slug": "zura",
+                    "id": 4,
+                    "name": "zura"
+                },
+                "lastReviewedCommit": "556bde1a2442562568fce6016de570516ac1c4f6",
+                "approved": true
+            }
+        ],
+        "author": {
+            "status": "UNAPPROVED",
+            "role": "AUTHOR",
+            "user": {
+                "active": true,
+                "type": "NORMAL",
+                "links": {
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999"
+                        }
+                    ]
+                },
+                "displayName": "Hemanth V. Alluri",
+                "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                "slug": "hypro999",
+                "id": 1,
+                "name": "hypro999"
+            },
+            "approved": false
+        },
+        "properties": {
+            "mergeCommit": {
+                "id": "1015204bf62881c5ef9e18e6e73e0211a667a00c",
+                "displayId": "1015204bf62"
+            }
+        },
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6"
+                }
+            ]
+        },
+        "createdDate": 1553572666612,
+        "fromRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/~hypro999/sandbox-fork.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/~hypro999/sandbox-fork.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999/repos/sandbox-fork/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "origin": {
+                    "state": "AVAILABLE",
+                    "links": {
+                        "clone": [
+                            {
+                                "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                                "name": "ssh"
+                            },
+                            {
+                                "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                                "name": "http"
+                            }
+                        ],
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                            }
+                        ]
+                    },
+                    "forkable": true,
+                    "slug": "sandbox",
+                    "project": {
+                        "key": "SBOX",
+                        "public": false,
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/projects/SBOX"
+                                }
+                            ]
+                        },
+                        "id": 2,
+                        "type": "NORMAL",
+                        "name": "Sandbox"
+                    },
+                    "id": 2,
+                    "scmId": "git",
+                    "public": false,
+                    "name": "sandbox",
+                    "statusMessage": "Available"
+                },
+                "slug": "sandbox-fork",
+                "project": {
+                    "key": "~HYPRO999",
+                    "type": "PERSONAL",
+                    "owner": {
+                        "active": true,
+                        "type": "NORMAL",
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/users/hypro999"
+                                }
+                            ]
+                        },
+                        "displayName": "Hemanth V. Alluri",
+                        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                        "slug": "hypro999",
+                        "id": 1,
+                        "name": "hypro999"
+                    },
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/hypro999"
+                            }
+                        ]
+                    },
+                    "id": 3,
+                    "name": "Hemanth V. Alluri"
+                },
+                "id": 4,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox fork",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "556bde1a2442562568fce6016de570516ac1c4f6"
+        },
+        "version": 2,
+        "id": 6,
+        "updatedDate": 1553595743394,
+        "participants": []
+    }
+}

--- a/zerver/webhooks/bitbucket3/fixtures/pull_request_modified.json
+++ b/zerver/webhooks/bitbucket3/fixtures/pull_request_modified.json
@@ -1,0 +1,241 @@
+{
+    "actor": {
+        "active": true,
+        "type": "NORMAL",
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/users/hypro999"
+                }
+            ]
+        },
+        "displayName": "Hemanth V. Alluri",
+        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+        "slug": "hypro999",
+        "id": 1,
+        "name": "hypro999"
+    },
+    "previousDescription": "* Add file2.txt\r\n* Add file3.txt",
+    "pullRequest": {
+        "locked": false,
+        "state": "OPEN",
+        "description": "* Add file2.txt\n* Add file3.txt\nBoth of these files would be important additions to the project!",
+        "closed": false,
+        "open": true,
+        "title": "Branch1",
+        "toRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "slug": "sandbox",
+                "project": {
+                    "key": "SBOX",
+                    "public": false,
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX"
+                            }
+                        ]
+                    },
+                    "id": 2,
+                    "type": "NORMAL",
+                    "name": "Sandbox"
+                },
+                "id": 2,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "508d1b67f1f8f3a25f543a030a7a178894aa9907"
+        },
+        "reviewers": [
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/shimura"
+                            }
+                        ]
+                    },
+                    "displayName": "Shimura Shinpachi",
+                    "emailAddress": "shimura_shinpachi@gmail.com",
+                    "slug": "shimura",
+                    "id": 2,
+                    "name": "shimura"
+                },
+                "approved": false
+            }
+        ],
+        "author": {
+            "status": "UNAPPROVED",
+            "role": "AUTHOR",
+            "user": {
+                "active": true,
+                "type": "NORMAL",
+                "links": {
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999"
+                        }
+                    ]
+                },
+                "displayName": "Hemanth V. Alluri",
+                "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                "slug": "hypro999",
+                "id": 1,
+                "name": "hypro999"
+            },
+            "approved": false
+        },
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1"
+                }
+            ]
+        },
+        "createdDate": 1553172738844,
+        "fromRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/~hypro999/sandbox-fork.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/~hypro999/sandbox-fork.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999/repos/sandbox-fork/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "origin": {
+                    "state": "AVAILABLE",
+                    "links": {
+                        "clone": [
+                            {
+                                "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                                "name": "ssh"
+                            },
+                            {
+                                "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                                "name": "http"
+                            }
+                        ],
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                            }
+                        ]
+                    },
+                    "forkable": true,
+                    "slug": "sandbox",
+                    "project": {
+                        "key": "SBOX",
+                        "public": false,
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/projects/SBOX"
+                                }
+                            ]
+                        },
+                        "id": 2,
+                        "type": "NORMAL",
+                        "name": "Sandbox"
+                    },
+                    "id": 2,
+                    "scmId": "git",
+                    "public": false,
+                    "name": "sandbox",
+                    "statusMessage": "Available"
+                },
+                "slug": "sandbox-fork",
+                "project": {
+                    "key": "~HYPRO999",
+                    "type": "PERSONAL",
+                    "owner": {
+                        "active": true,
+                        "type": "NORMAL",
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/users/hypro999"
+                                }
+                            ]
+                        },
+                        "displayName": "Hemanth V. Alluri",
+                        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                        "slug": "hypro999",
+                        "id": 1,
+                        "name": "hypro999"
+                    },
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/hypro999"
+                            }
+                        ]
+                    },
+                    "id": 3,
+                    "name": "Hemanth V. Alluri"
+                },
+                "id": 4,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox fork",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/branch1",
+            "displayId": "branch1",
+            "latestCommit": "3980c2be32a7e23c795741d5dc1a2eecb9b85d6d"
+        },
+        "version": 1,
+        "id": 1,
+        "updatedDate": 1553337991505,
+        "participants": []
+    },
+    "previousTitle": "Branch1",
+    "previousTarget": {
+        "latestChangeset": "508d1b67f1f8f3a25f543a030a7a178894aa9907",
+        "type": "BRANCH",
+        "id": "refs/heads/master",
+        "displayId": "master",
+        "latestCommit": "508d1b67f1f8f3a25f543a030a7a178894aa9907"
+    },
+    "eventKey": "pr:modified",
+    "date": "2019-03-23T16:16:31+0530"
+}

--- a/zerver/webhooks/bitbucket3/fixtures/pull_request_needs_work.json
+++ b/zerver/webhooks/bitbucket3/fixtures/pull_request_needs_work.json
@@ -1,0 +1,298 @@
+{
+    "actor": {
+        "active": true,
+        "type": "NORMAL",
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/users/zura"
+                }
+            ]
+        },
+        "displayName": "Katsura Kotarou",
+        "emailAddress": "katsura_kotarou@gmail.com",
+        "slug": "zura",
+        "id": 4,
+        "name": "zura"
+    },
+    "previousStatus": "UNAPPROVED",
+    "participant": {
+        "status": "NEEDS_WORK",
+        "role": "REVIEWER",
+        "user": {
+            "active": true,
+            "type": "NORMAL",
+            "links": {
+                "self": [
+                    {
+                        "href": "http://139.59.64.214:7990/users/zura"
+                    }
+                ]
+            },
+            "displayName": "Katsura Kotarou",
+            "emailAddress": "katsura_kotarou@gmail.com",
+            "slug": "zura",
+            "id": 4,
+            "name": "zura"
+        },
+        "lastReviewedCommit": "556bde1a2442562568fce6016de570516ac1c4f6",
+        "approved": false
+    },
+    "pullRequest": {
+        "locked": false,
+        "state": "OPEN",
+        "description": "Add a simple text file for further testing purposes.",
+        "closed": false,
+        "open": true,
+        "title": "sample_file: Add sample_file.txt.",
+        "toRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "slug": "sandbox",
+                "project": {
+                    "key": "SBOX",
+                    "public": false,
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX"
+                            }
+                        ]
+                    },
+                    "id": 2,
+                    "type": "NORMAL",
+                    "name": "Sandbox"
+                },
+                "id": 2,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "d46b4d2e3326e106147c0ea748f7defba29d9e1e"
+        },
+        "reviewers": [
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/sougo"
+                            }
+                        ]
+                    },
+                    "displayName": "Okita Sougo",
+                    "emailAddress": "okita_sougo@gmail.com",
+                    "slug": "sougo",
+                    "id": 3,
+                    "name": "sougo"
+                },
+                "approved": false
+            },
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/shimura"
+                            }
+                        ]
+                    },
+                    "displayName": "Shimura Shinpachi",
+                    "emailAddress": "shimura_shinpachi@gmail.com",
+                    "slug": "shimura",
+                    "id": 2,
+                    "name": "shimura"
+                },
+                "approved": false
+            },
+            {
+                "status": "NEEDS_WORK",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/zura"
+                            }
+                        ]
+                    },
+                    "displayName": "Katsura Kotarou",
+                    "emailAddress": "katsura_kotarou@gmail.com",
+                    "slug": "zura",
+                    "id": 4,
+                    "name": "zura"
+                },
+                "lastReviewedCommit": "556bde1a2442562568fce6016de570516ac1c4f6",
+                "approved": false
+            }
+        ],
+        "author": {
+            "status": "UNAPPROVED",
+            "role": "AUTHOR",
+            "user": {
+                "active": true,
+                "type": "NORMAL",
+                "links": {
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999"
+                        }
+                    ]
+                },
+                "displayName": "Hemanth V. Alluri",
+                "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                "slug": "hypro999",
+                "id": 1,
+                "name": "hypro999"
+            },
+            "approved": false
+        },
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6"
+                }
+            ]
+        },
+        "createdDate": 1553572666612,
+        "fromRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/~hypro999/sandbox-fork.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/~hypro999/sandbox-fork.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999/repos/sandbox-fork/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "origin": {
+                    "state": "AVAILABLE",
+                    "links": {
+                        "clone": [
+                            {
+                                "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                                "name": "ssh"
+                            },
+                            {
+                                "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                                "name": "http"
+                            }
+                        ],
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                            }
+                        ]
+                    },
+                    "forkable": true,
+                    "slug": "sandbox",
+                    "project": {
+                        "key": "SBOX",
+                        "public": false,
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/projects/SBOX"
+                                }
+                            ]
+                        },
+                        "id": 2,
+                        "type": "NORMAL",
+                        "name": "Sandbox"
+                    },
+                    "id": 2,
+                    "scmId": "git",
+                    "public": false,
+                    "name": "sandbox",
+                    "statusMessage": "Available"
+                },
+                "slug": "sandbox-fork",
+                "project": {
+                    "key": "~HYPRO999",
+                    "type": "PERSONAL",
+                    "owner": {
+                        "active": true,
+                        "type": "NORMAL",
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/users/hypro999"
+                                }
+                            ]
+                        },
+                        "displayName": "Hemanth V. Alluri",
+                        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                        "slug": "hypro999",
+                        "id": 1,
+                        "name": "hypro999"
+                    },
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/hypro999"
+                            }
+                        ]
+                    },
+                    "id": 3,
+                    "name": "Hemanth V. Alluri"
+                },
+                "id": 4,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox fork",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "556bde1a2442562568fce6016de570516ac1c4f6"
+        },
+        "version": 0,
+        "id": 6,
+        "updatedDate": 1553572666612,
+        "participants": []
+    },
+    "eventKey": "pr:reviewer:needs_work",
+    "date": "2019-03-26T15:50:44+0530"
+}

--- a/zerver/webhooks/bitbucket3/fixtures/pull_request_opened_with_multiple_reviewers.json
+++ b/zerver/webhooks/bitbucket3/fixtures/pull_request_opened_with_multiple_reviewers.json
@@ -1,0 +1,274 @@
+{
+    "actor": {
+        "active": true,
+        "type": "NORMAL",
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/users/hypro999"
+                }
+            ]
+        },
+        "displayName": "Hemanth V. Alluri",
+        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+        "slug": "hypro999",
+        "id": 1,
+        "name": "hypro999"
+    },
+    "eventKey": "pr:opened",
+    "date": "2019-03-26T09:27:46+0530",
+    "pullRequest": {
+        "locked": false,
+        "state": "OPEN",
+        "description": "Add a simple text file for further testing purposes.",
+        "closed": false,
+        "open": true,
+        "title": "sample_file: Add sample_file.txt.",
+        "toRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "slug": "sandbox",
+                "project": {
+                    "key": "SBOX",
+                    "public": false,
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX"
+                            }
+                        ]
+                    },
+                    "id": 2,
+                    "type": "NORMAL",
+                    "name": "Sandbox"
+                },
+                "id": 2,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "d46b4d2e3326e106147c0ea748f7defba29d9e1e"
+        },
+        "reviewers": [
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/sougo"
+                            }
+                        ]
+                    },
+                    "displayName": "Okita Sougo",
+                    "emailAddress": "okita_sougo@gmail.com",
+                    "slug": "sougo",
+                    "id": 3,
+                    "name": "sougo"
+                },
+                "approved": false
+            },
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/zura"
+                            }
+                        ]
+                    },
+                    "displayName": "Katsura Kotarou",
+                    "emailAddress": "katsura_kotarou@gmail.com",
+                    "slug": "zura",
+                    "id": 4,
+                    "name": "zura"
+                },
+                "approved": false
+            },
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/shimura"
+                            }
+                        ]
+                    },
+                    "displayName": "Shimura Shinpachi",
+                    "emailAddress": "shimura_shinpachi@gmail.com",
+                    "slug": "shimura",
+                    "id": 2,
+                    "name": "shimura"
+                },
+                "approved": false
+            }
+        ],
+        "author": {
+            "status": "UNAPPROVED",
+            "role": "AUTHOR",
+            "user": {
+                "active": true,
+                "type": "NORMAL",
+                "links": {
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999"
+                        }
+                    ]
+                },
+                "displayName": "Hemanth V. Alluri",
+                "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                "slug": "hypro999",
+                "id": 1,
+                "name": "hypro999"
+            },
+            "approved": false
+        },
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6"
+                }
+            ]
+        },
+        "createdDate": 1553572666612,
+        "fromRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/~hypro999/sandbox-fork.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/~hypro999/sandbox-fork.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999/repos/sandbox-fork/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "origin": {
+                    "state": "AVAILABLE",
+                    "links": {
+                        "clone": [
+                            {
+                                "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                                "name": "ssh"
+                            },
+                            {
+                                "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                                "name": "http"
+                            }
+                        ],
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                            }
+                        ]
+                    },
+                    "forkable": true,
+                    "slug": "sandbox",
+                    "project": {
+                        "key": "SBOX",
+                        "public": false,
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/projects/SBOX"
+                                }
+                            ]
+                        },
+                        "id": 2,
+                        "type": "NORMAL",
+                        "name": "Sandbox"
+                    },
+                    "id": 2,
+                    "scmId": "git",
+                    "public": false,
+                    "name": "sandbox",
+                    "statusMessage": "Available"
+                },
+                "slug": "sandbox-fork",
+                "project": {
+                    "key": "~HYPRO999",
+                    "type": "PERSONAL",
+                    "owner": {
+                        "active": true,
+                        "type": "NORMAL",
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/users/hypro999"
+                                }
+                            ]
+                        },
+                        "displayName": "Hemanth V. Alluri",
+                        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                        "slug": "hypro999",
+                        "id": 1,
+                        "name": "hypro999"
+                    },
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/hypro999"
+                            }
+                        ]
+                    },
+                    "id": 3,
+                    "name": "Hemanth V. Alluri"
+                },
+                "id": 4,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox fork",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "556bde1a2442562568fce6016de570516ac1c4f6"
+        },
+        "version": 0,
+        "id": 6,
+        "updatedDate": 1553572666612,
+        "participants": []
+    }
+}

--- a/zerver/webhooks/bitbucket3/fixtures/pull_request_opened_with_two_reviewers.json
+++ b/zerver/webhooks/bitbucket3/fixtures/pull_request_opened_with_two_reviewers.json
@@ -1,0 +1,252 @@
+{
+    "actor": {
+        "active": true,
+        "type": "NORMAL",
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/users/hypro999"
+                }
+            ]
+        },
+        "displayName": "Hemanth V. Alluri",
+        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+        "slug": "hypro999",
+        "id": 1,
+        "name": "hypro999"
+    },
+    "eventKey": "pr:opened",
+    "date": "2019-03-24T13:54:58+0530",
+    "pullRequest": {
+        "locked": false,
+        "state": "OPEN",
+        "closed": false,
+        "open": true,
+        "title": "Add Notes Feature",
+        "toRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "slug": "sandbox",
+                "project": {
+                    "key": "SBOX",
+                    "public": false,
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX"
+                            }
+                        ]
+                    },
+                    "id": 2,
+                    "type": "NORMAL",
+                    "name": "Sandbox"
+                },
+                "id": 2,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "508d1b67f1f8f3a25f543a030a7a178894aa9907"
+        },
+        "reviewers": [
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/shimura"
+                            }
+                        ]
+                    },
+                    "displayName": "Shimura Shinpachi",
+                    "emailAddress": "shimura_shinpachi@gmail.com",
+                    "slug": "shimura",
+                    "id": 2,
+                    "name": "shimura"
+                },
+                "approved": false
+            },
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/sougo"
+                            }
+                        ]
+                    },
+                    "displayName": "Okita Sougo",
+                    "emailAddress": "okita_sougo@gmail.com",
+                    "slug": "sougo",
+                    "id": 3,
+                    "name": "sougo"
+                },
+                "approved": false
+            }
+        ],
+        "author": {
+            "status": "UNAPPROVED",
+            "role": "AUTHOR",
+            "user": {
+                "active": true,
+                "type": "NORMAL",
+                "links": {
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999"
+                        }
+                    ]
+                },
+                "displayName": "Hemanth V. Alluri",
+                "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                "slug": "hypro999",
+                "id": 1,
+                "name": "hypro999"
+            },
+            "approved": false
+        },
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/5"
+                }
+            ]
+        },
+        "createdDate": 1553415897966,
+        "fromRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/~hypro999/sandbox-fork.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/~hypro999/sandbox-fork.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999/repos/sandbox-fork/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "origin": {
+                    "state": "AVAILABLE",
+                    "links": {
+                        "clone": [
+                            {
+                                "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                                "name": "ssh"
+                            },
+                            {
+                                "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                                "name": "http"
+                            }
+                        ],
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                            }
+                        ]
+                    },
+                    "forkable": true,
+                    "slug": "sandbox",
+                    "project": {
+                        "key": "SBOX",
+                        "public": false,
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/projects/SBOX"
+                                }
+                            ]
+                        },
+                        "id": 2,
+                        "type": "NORMAL",
+                        "name": "Sandbox"
+                    },
+                    "id": 2,
+                    "scmId": "git",
+                    "public": false,
+                    "name": "sandbox",
+                    "statusMessage": "Available"
+                },
+                "slug": "sandbox-fork",
+                "project": {
+                    "key": "~HYPRO999",
+                    "type": "PERSONAL",
+                    "owner": {
+                        "active": true,
+                        "type": "NORMAL",
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/users/hypro999"
+                                }
+                            ]
+                        },
+                        "displayName": "Hemanth V. Alluri",
+                        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                        "slug": "hypro999",
+                        "id": 1,
+                        "name": "hypro999"
+                    },
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/hypro999"
+                            }
+                        ]
+                    },
+                    "id": 3,
+                    "name": "Hemanth V. Alluri"
+                },
+                "id": 4,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox fork",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "1a8de2fd34dcf6c9c2117b62eb17a266736aad7f"
+        },
+        "version": 0,
+        "id": 5,
+        "updatedDate": 1553415897966,
+        "participants": []
+    }
+}

--- a/zerver/webhooks/bitbucket3/fixtures/pull_request_opened_without_description.json
+++ b/zerver/webhooks/bitbucket3/fixtures/pull_request_opened_without_description.json
@@ -1,0 +1,209 @@
+{
+    "actor": {
+        "active": true,
+        "type": "NORMAL",
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/users/hypro999"
+                }
+            ]
+        },
+        "displayName": "Hemanth V. Alluri",
+        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+        "slug": "hypro999",
+        "id": 1,
+        "name": "hypro999"
+    },
+    "eventKey": "pr:opened",
+    "date": "2019-03-21T19:23:56+0530",
+    "pullRequest": {
+        "locked": false,
+        "state": "OPEN",
+        "closed": false,
+        "open": true,
+        "title": "Add notes feature.",
+        "toRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "slug": "sandbox",
+                "project": {
+                    "key": "SBOX",
+                    "public": false,
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX"
+                            }
+                        ]
+                    },
+                    "id": 2,
+                    "type": "NORMAL",
+                    "name": "Sandbox"
+                },
+                "id": 2,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "508d1b67f1f8f3a25f543a030a7a178894aa9907"
+        },
+        "reviewers": [],
+        "author": {
+            "status": "UNAPPROVED",
+            "role": "AUTHOR",
+            "user": {
+                "active": true,
+                "type": "NORMAL",
+                "links": {
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999"
+                        }
+                    ]
+                },
+                "displayName": "Hemanth V. Alluri",
+                "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                "slug": "hypro999",
+                "id": 1,
+                "name": "hypro999"
+            },
+            "approved": false
+        },
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/2"
+                }
+            ]
+        },
+        "createdDate": 1553176436660,
+        "fromRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/~hypro999/sandbox-fork.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/~hypro999/sandbox-fork.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999/repos/sandbox-fork/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "origin": {
+                    "state": "AVAILABLE",
+                    "links": {
+                        "clone": [
+                            {
+                                "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                                "name": "ssh"
+                            },
+                            {
+                                "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                                "name": "http"
+                            }
+                        ],
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                            }
+                        ]
+                    },
+                    "forkable": true,
+                    "slug": "sandbox",
+                    "project": {
+                        "key": "SBOX",
+                        "public": false,
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/projects/SBOX"
+                                }
+                            ]
+                        },
+                        "id": 2,
+                        "type": "NORMAL",
+                        "name": "Sandbox"
+                    },
+                    "id": 2,
+                    "scmId": "git",
+                    "public": false,
+                    "name": "sandbox",
+                    "statusMessage": "Available"
+                },
+                "slug": "sandbox-fork",
+                "project": {
+                    "key": "~HYPRO999",
+                    "type": "PERSONAL",
+                    "owner": {
+                        "active": true,
+                        "type": "NORMAL",
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/users/hypro999"
+                                }
+                            ]
+                        },
+                        "displayName": "Hemanth V. Alluri",
+                        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                        "slug": "hypro999",
+                        "id": 1,
+                        "name": "hypro999"
+                    },
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/hypro999"
+                            }
+                        ]
+                    },
+                    "id": 3,
+                    "name": "Hemanth V. Alluri"
+                },
+                "id": 4,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox fork",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "1a8de2fd34dcf6c9c2117b62eb17a266736aad7f"
+        },
+        "version": 0,
+        "id": 2,
+        "updatedDate": 1553176436660,
+        "participants": []
+    }
+}

--- a/zerver/webhooks/bitbucket3/fixtures/pull_request_opened_without_reviewers.json
+++ b/zerver/webhooks/bitbucket3/fixtures/pull_request_opened_without_reviewers.json
@@ -1,0 +1,210 @@
+{
+    "actor": {
+        "active": true,
+        "type": "NORMAL",
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/users/hypro999"
+                }
+            ]
+        },
+        "displayName": "Hemanth V. Alluri",
+        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+        "slug": "hypro999",
+        "id": 1,
+        "name": "hypro999"
+    },
+    "eventKey": "pr:opened",
+    "date": "2019-03-21T18:22:20+0530",
+    "pullRequest": {
+        "locked": false,
+        "state": "OPEN",
+        "description": "* Add file2.txt\r\n* Add file3.txt",
+        "closed": false,
+        "open": true,
+        "title": "Branch1",
+        "toRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "slug": "sandbox",
+                "project": {
+                    "key": "SBOX",
+                    "public": false,
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX"
+                            }
+                        ]
+                    },
+                    "id": 2,
+                    "type": "NORMAL",
+                    "name": "Sandbox"
+                },
+                "id": 2,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "508d1b67f1f8f3a25f543a030a7a178894aa9907"
+        },
+        "reviewers": [],
+        "author": {
+            "status": "UNAPPROVED",
+            "role": "AUTHOR",
+            "user": {
+                "active": true,
+                "type": "NORMAL",
+                "links": {
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999"
+                        }
+                    ]
+                },
+                "displayName": "Hemanth V. Alluri",
+                "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                "slug": "hypro999",
+                "id": 1,
+                "name": "hypro999"
+            },
+            "approved": false
+        },
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1"
+                }
+            ]
+        },
+        "createdDate": 1553172738844,
+        "fromRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/~hypro999/sandbox-fork.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/~hypro999/sandbox-fork.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999/repos/sandbox-fork/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "origin": {
+                    "state": "AVAILABLE",
+                    "links": {
+                        "clone": [
+                            {
+                                "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                                "name": "ssh"
+                            },
+                            {
+                                "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                                "name": "http"
+                            }
+                        ],
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                            }
+                        ]
+                    },
+                    "forkable": true,
+                    "slug": "sandbox",
+                    "project": {
+                        "key": "SBOX",
+                        "public": false,
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/projects/SBOX"
+                                }
+                            ]
+                        },
+                        "id": 2,
+                        "type": "NORMAL",
+                        "name": "Sandbox"
+                    },
+                    "id": 2,
+                    "scmId": "git",
+                    "public": false,
+                    "name": "sandbox",
+                    "statusMessage": "Available"
+                },
+                "slug": "sandbox-fork",
+                "project": {
+                    "key": "~HYPRO999",
+                    "type": "PERSONAL",
+                    "owner": {
+                        "active": true,
+                        "type": "NORMAL",
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/users/hypro999"
+                                }
+                            ]
+                        },
+                        "displayName": "Hemanth V. Alluri",
+                        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                        "slug": "hypro999",
+                        "id": 1,
+                        "name": "hypro999"
+                    },
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/hypro999"
+                            }
+                        ]
+                    },
+                    "id": 3,
+                    "name": "Hemanth V. Alluri"
+                },
+                "id": 4,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox fork",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/branch1",
+            "displayId": "branch1",
+            "latestCommit": "3980c2be32a7e23c795741d5dc1a2eecb9b85d6d"
+        },
+        "version": 0,
+        "id": 1,
+        "updatedDate": 1553172738844,
+        "participants": []
+    }
+}

--- a/zerver/webhooks/bitbucket3/fixtures/pull_request_remove_reviewer.json
+++ b/zerver/webhooks/bitbucket3/fixtures/pull_request_remove_reviewer.json
@@ -1,0 +1,229 @@
+{
+    "addedReviewers": [],
+    "actor": {
+        "active": true,
+        "type": "NORMAL",
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/users/hypro999"
+                }
+            ]
+        },
+        "displayName": "Hemanth V. Alluri",
+        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+        "slug": "hypro999",
+        "id": 1,
+        "name": "hypro999"
+    },
+    "pullRequest": {
+        "locked": false,
+        "state": "OPEN",
+        "description": "* Add file2.txt\n* Add file3.txt\nBoth of these files would be important additions to the project!",
+        "closed": false,
+        "open": true,
+        "title": "Branch1",
+        "toRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "slug": "sandbox",
+                "project": {
+                    "key": "SBOX",
+                    "public": false,
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX"
+                            }
+                        ]
+                    },
+                    "id": 2,
+                    "type": "NORMAL",
+                    "name": "Sandbox"
+                },
+                "id": 2,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "508d1b67f1f8f3a25f543a030a7a178894aa9907"
+        },
+        "reviewers": [],
+        "author": {
+            "status": "UNAPPROVED",
+            "role": "AUTHOR",
+            "user": {
+                "active": true,
+                "type": "NORMAL",
+                "links": {
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999"
+                        }
+                    ]
+                },
+                "displayName": "Hemanth V. Alluri",
+                "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                "slug": "hypro999",
+                "id": 1,
+                "name": "hypro999"
+            },
+            "approved": false
+        },
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1"
+                }
+            ]
+        },
+        "createdDate": 1553172738844,
+        "fromRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/~hypro999/sandbox-fork.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/~hypro999/sandbox-fork.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999/repos/sandbox-fork/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "origin": {
+                    "state": "AVAILABLE",
+                    "links": {
+                        "clone": [
+                            {
+                                "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                                "name": "ssh"
+                            },
+                            {
+                                "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                                "name": "http"
+                            }
+                        ],
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                            }
+                        ]
+                    },
+                    "forkable": true,
+                    "slug": "sandbox",
+                    "project": {
+                        "key": "SBOX",
+                        "public": false,
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/projects/SBOX"
+                                }
+                            ]
+                        },
+                        "id": 2,
+                        "type": "NORMAL",
+                        "name": "Sandbox"
+                    },
+                    "id": 2,
+                    "scmId": "git",
+                    "public": false,
+                    "name": "sandbox",
+                    "statusMessage": "Available"
+                },
+                "slug": "sandbox-fork",
+                "project": {
+                    "key": "~HYPRO999",
+                    "type": "PERSONAL",
+                    "owner": {
+                        "active": true,
+                        "type": "NORMAL",
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/users/hypro999"
+                                }
+                            ]
+                        },
+                        "displayName": "Hemanth V. Alluri",
+                        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                        "slug": "hypro999",
+                        "id": 1,
+                        "name": "hypro999"
+                    },
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/hypro999"
+                            }
+                        ]
+                    },
+                    "id": 3,
+                    "name": "Hemanth V. Alluri"
+                },
+                "id": 4,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox fork",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/branch1",
+            "displayId": "branch1",
+            "latestCommit": "91c9c6998c9768ca678048ddee7f9e480e6d54de"
+        },
+        "version": 3,
+        "id": 1,
+        "updatedDate": 1553340384837,
+        "participants": []
+    },
+    "removedReviewers": [
+        {
+            "active": true,
+            "type": "NORMAL",
+            "links": {
+                "self": [
+                    {
+                        "href": "http://139.59.64.214:7990/users/shimura"
+                    }
+                ]
+            },
+            "displayName": "Shimura Shinpachi",
+            "emailAddress": "shimura_shinpachi@gmail.com",
+            "slug": "shimura",
+            "id": 2,
+            "name": "shimura"
+        }
+    ],
+    "eventKey": "pr:reviewer:updated",
+    "date": "2019-03-23T16:56:25+0530"
+}

--- a/zerver/webhooks/bitbucket3/fixtures/pull_request_unapproved.json
+++ b/zerver/webhooks/bitbucket3/fixtures/pull_request_unapproved.json
@@ -1,0 +1,298 @@
+{
+    "actor": {
+        "active": true,
+        "type": "NORMAL",
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/users/zura"
+                }
+            ]
+        },
+        "displayName": "Katsura Kotarou",
+        "emailAddress": "katsura_kotarou@gmail.com",
+        "slug": "zura",
+        "id": 4,
+        "name": "zura"
+    },
+    "previousStatus": "APPROVED",
+    "participant": {
+        "status": "UNAPPROVED",
+        "role": "REVIEWER",
+        "user": {
+            "active": true,
+            "type": "NORMAL",
+            "links": {
+                "self": [
+                    {
+                        "href": "http://139.59.64.214:7990/users/zura"
+                    }
+                ]
+            },
+            "displayName": "Katsura Kotarou",
+            "emailAddress": "katsura_kotarou@gmail.com",
+            "slug": "zura",
+            "id": 4,
+            "name": "zura"
+        },
+        "lastReviewedCommit": "556bde1a2442562568fce6016de570516ac1c4f6",
+        "approved": false
+    },
+    "pullRequest": {
+        "locked": false,
+        "state": "OPEN",
+        "description": "Add a simple text file for further testing purposes.",
+        "closed": false,
+        "open": true,
+        "title": "sample_file: Add sample_file.txt.",
+        "toRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "slug": "sandbox",
+                "project": {
+                    "key": "SBOX",
+                    "public": false,
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX"
+                            }
+                        ]
+                    },
+                    "id": 2,
+                    "type": "NORMAL",
+                    "name": "Sandbox"
+                },
+                "id": 2,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "d46b4d2e3326e106147c0ea748f7defba29d9e1e"
+        },
+        "reviewers": [
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/shimura"
+                            }
+                        ]
+                    },
+                    "displayName": "Shimura Shinpachi",
+                    "emailAddress": "shimura_shinpachi@gmail.com",
+                    "slug": "shimura",
+                    "id": 2,
+                    "name": "shimura"
+                },
+                "approved": false
+            },
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/zura"
+                            }
+                        ]
+                    },
+                    "displayName": "Katsura Kotarou",
+                    "emailAddress": "katsura_kotarou@gmail.com",
+                    "slug": "zura",
+                    "id": 4,
+                    "name": "zura"
+                },
+                "lastReviewedCommit": "556bde1a2442562568fce6016de570516ac1c4f6",
+                "approved": false
+            },
+            {
+                "status": "UNAPPROVED",
+                "role": "REVIEWER",
+                "user": {
+                    "active": true,
+                    "type": "NORMAL",
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/sougo"
+                            }
+                        ]
+                    },
+                    "displayName": "Okita Sougo",
+                    "emailAddress": "okita_sougo@gmail.com",
+                    "slug": "sougo",
+                    "id": 3,
+                    "name": "sougo"
+                },
+                "approved": false
+            }
+        ],
+        "author": {
+            "status": "UNAPPROVED",
+            "role": "AUTHOR",
+            "user": {
+                "active": true,
+                "type": "NORMAL",
+                "links": {
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999"
+                        }
+                    ]
+                },
+                "displayName": "Hemanth V. Alluri",
+                "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                "slug": "hypro999",
+                "id": 1,
+                "name": "hypro999"
+            },
+            "approved": false
+        },
+        "links": {
+            "self": [
+                {
+                    "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6"
+                }
+            ]
+        },
+        "createdDate": 1553572666612,
+        "fromRef": {
+            "repository": {
+                "state": "AVAILABLE",
+                "links": {
+                    "clone": [
+                        {
+                            "href": "ssh://git@139.59.64.214:7999/~hypro999/sandbox-fork.git",
+                            "name": "ssh"
+                        },
+                        {
+                            "href": "http://139.59.64.214:7990/scm/~hypro999/sandbox-fork.git",
+                            "name": "http"
+                        }
+                    ],
+                    "self": [
+                        {
+                            "href": "http://139.59.64.214:7990/users/hypro999/repos/sandbox-fork/browse"
+                        }
+                    ]
+                },
+                "forkable": true,
+                "origin": {
+                    "state": "AVAILABLE",
+                    "links": {
+                        "clone": [
+                            {
+                                "href": "ssh://git@139.59.64.214:7999/sbox/sandbox.git",
+                                "name": "ssh"
+                            },
+                            {
+                                "href": "http://139.59.64.214:7990/scm/sbox/sandbox.git",
+                                "name": "http"
+                            }
+                        ],
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/projects/SBOX/repos/sandbox/browse"
+                            }
+                        ]
+                    },
+                    "forkable": true,
+                    "slug": "sandbox",
+                    "project": {
+                        "key": "SBOX",
+                        "public": false,
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/projects/SBOX"
+                                }
+                            ]
+                        },
+                        "id": 2,
+                        "type": "NORMAL",
+                        "name": "Sandbox"
+                    },
+                    "id": 2,
+                    "scmId": "git",
+                    "public": false,
+                    "name": "sandbox",
+                    "statusMessage": "Available"
+                },
+                "slug": "sandbox-fork",
+                "project": {
+                    "key": "~HYPRO999",
+                    "type": "PERSONAL",
+                    "owner": {
+                        "active": true,
+                        "type": "NORMAL",
+                        "links": {
+                            "self": [
+                                {
+                                    "href": "http://139.59.64.214:7990/users/hypro999"
+                                }
+                            ]
+                        },
+                        "displayName": "Hemanth V. Alluri",
+                        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+                        "slug": "hypro999",
+                        "id": 1,
+                        "name": "hypro999"
+                    },
+                    "links": {
+                        "self": [
+                            {
+                                "href": "http://139.59.64.214:7990/users/hypro999"
+                            }
+                        ]
+                    },
+                    "id": 3,
+                    "name": "Hemanth V. Alluri"
+                },
+                "id": 4,
+                "scmId": "git",
+                "public": false,
+                "name": "sandbox fork",
+                "statusMessage": "Available"
+            },
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "556bde1a2442562568fce6016de570516ac1c4f6"
+        },
+        "version": 0,
+        "id": 6,
+        "updatedDate": 1553572666612,
+        "participants": []
+    },
+    "eventKey": "pr:reviewer:unapproved",
+    "date": "2019-03-26T15:49:39+0530"
+}

--- a/zerver/webhooks/bitbucket3/tests.py
+++ b/zerver/webhooks/bitbucket3/tests.py
@@ -10,69 +10,69 @@ class Bitbucket3HookTests(WebhookTestCase):
 
     # Core Repo Events:
     def test_commit_comment_added(self) -> None:
-        expected_message = """hypro999 commented on [508d1b6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/commits/508d1b67f1f8f3a25f543a030a7a178894aa9907)\n~~~ quote\nJust an arbitrary comment on a commit.\n~~~"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) commented on [508d1b6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/commits/508d1b67f1f8f3a25f543a030a7a178894aa9907)\n~~~ quote\nJust an arbitrary comment on a commit.\n~~~"""
         self.send_and_test_stream_message("commit_comment_added",
                                           self.EXPECTED_TOPIC,
                                           expected_message)
 
     def test_commit_comment_edited(self) -> None:
-        expected_message = """hypro999 edited their comment on [508d1b6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/commits/508d1b67f1f8f3a25f543a030a7a178894aa9907)\n~~~ quote\nJust an arbitrary comment on a commit. Nothing to see here...\n~~~"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) edited their comment on [508d1b6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/commits/508d1b67f1f8f3a25f543a030a7a178894aa9907)\n~~~ quote\nJust an arbitrary comment on a commit. Nothing to see here...\n~~~"""
         self.send_and_test_stream_message("commit_comment_edited",
                                           self.EXPECTED_TOPIC,
                                           expected_message)
 
     def test_commit_comment_deleted(self) -> None:
-        expected_message = """hypro999 deleted their comment on [508d1b6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/commits/508d1b67f1f8f3a25f543a030a7a178894aa9907)\n~~~ quote\nJust an arbitrary comment on a commit. Nothing to see here...\n~~~"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) deleted their comment on [508d1b6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/commits/508d1b67f1f8f3a25f543a030a7a178894aa9907)\n~~~ quote\nJust an arbitrary comment on a commit. Nothing to see here...\n~~~"""
         self.send_and_test_stream_message("commit_comment_deleted",
                                           self.EXPECTED_TOPIC,
                                           expected_message)
 
     def test_bitbucket3_repo_forked(self) -> None:
-        expected_message = """User Hemanth V. Alluri(login: hypro999) forked the repository into [sandbox fork](http://139.59.64.214:7990/users/hypro999/repos/sandbox-fork/browse)."""
+        expected_message = """User Hemanth V. Alluri(login: [hypro999](http://139.59.64.214:7990/users/hypro999)) forked the repository into [sandbox fork](http://139.59.64.214:7990/users/hypro999/repos/sandbox-fork/browse)."""
         self.send_and_test_stream_message("repo_forked", self.EXPECTED_TOPIC, expected_message)
 
     def test_bitbucket3_repo_modified(self) -> None:
-        expected_message = """hypro999 changed the name of the **sandbox** repo from **sandbox** to **sandbox v2**"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) changed the name of the **sandbox** repo from **sandbox** to **sandbox v2**"""
         expected_topic = "sandbox v2"
         self.send_and_test_stream_message("repo_modified", expected_topic, expected_message)
 
     # Repo Push Events:
     def test_push_add_branch(self) -> None:
-        expected_message = """hypro999 created branch2 branch"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) created branch2 branch"""
         expected_topic = self.EXPECTED_TOPIC_BRANCH_EVENTS.format(branch="branch2")
         self.send_and_test_stream_message("repo_push_add_branch",
                                           expected_topic,
                                           expected_message)
 
     def test_push_add_tag(self) -> None:
-        expected_message = """hypro999 pushed tag newtag"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) pushed tag newtag"""
         self.send_and_test_stream_message("repo_push_add_tag",
                                           self.EXPECTED_TOPIC,
                                           expected_message)
 
     def test_push_delete_branch(self) -> None:
-        expected_message = """hypro999 deleted branch branch2"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) deleted branch branch2"""
         expected_topic = self.EXPECTED_TOPIC_BRANCH_EVENTS.format(branch="branch2")
         self.send_and_test_stream_message("repo_push_delete_branch",
                                           expected_topic,
                                           expected_message)
 
     def test_push_delete_tag(self) -> None:
-        expected_message = """hypro999 removed tag test-tag"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) removed tag test-tag"""
         self.send_and_test_stream_message("repo_push_delete_tag",
                                           self.EXPECTED_TOPIC,
                                           expected_message)
 
     def test_push_update_single_branch(self) -> None:
-        expected_message = """hypro999 pushed to branch master. Head is now e68c981ef53dbab0a5ca320a2d8d80e216c70528."""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) pushed to branch master. Head is now e68c981ef53dbab0a5ca320a2d8d80e216c70528."""
         expected_topic = self.EXPECTED_TOPIC_BRANCH_EVENTS.format(branch="master")
         self.send_and_test_stream_message("repo_push_update_single_branch",
                                           expected_topic,
                                           expected_message)
 
     def test_push_update_multiple_branches(self) -> None:
-        expected_message_first = """hypro999 pushed to branch branch1. Head is now 3980c2be32a7e23c795741d5dc1a2eecb9b85d6d."""
-        expected_message_second = """hypro999 pushed to branch master. Head is now fc43d13cff1abb28631196944ba4fc4ad06a2cf2."""
+        expected_message_first = """[hypro999](http://139.59.64.214:7990/users/hypro999) pushed to branch branch1. Head is now 3980c2be32a7e23c795741d5dc1a2eecb9b85d6d."""
+        expected_message_second = """[hypro999](http://139.59.64.214:7990/users/hypro999) pushed to branch master. Head is now fc43d13cff1abb28631196944ba4fc4ad06a2cf2."""
         self.send_and_test_stream_message("repo_push_update_multiple_branches")
 
         msg = self.get_last_message()
@@ -85,14 +85,14 @@ class Bitbucket3HookTests(WebhookTestCase):
 
     def test_push_update_multiple_branches_with_branch_filter(self) -> None:
         self.url = self.build_webhook_url(branches='master')
-        expected_message = """hypro999 pushed to branch master. Head is now fc43d13cff1abb28631196944ba4fc4ad06a2cf2."""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) pushed to branch master. Head is now fc43d13cff1abb28631196944ba4fc4ad06a2cf2."""
         expected_topic = self.EXPECTED_TOPIC_BRANCH_EVENTS.format(branch="master")
         self.send_and_test_stream_message("repo_push_update_multiple_branches",
                                           expected_topic,
                                           expected_message)
 
         self.url = self.build_webhook_url(branches='branch1')
-        expected_message = """hypro999 pushed to branch branch1. Head is now 3980c2be32a7e23c795741d5dc1a2eecb9b85d6d."""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) pushed to branch branch1. Head is now 3980c2be32a7e23c795741d5dc1a2eecb9b85d6d."""
         expected_topic = self.EXPECTED_TOPIC_BRANCH_EVENTS.format(branch="branch1")
         self.send_and_test_stream_message("repo_push_update_multiple_branches",
                                           expected_topic,
@@ -101,21 +101,21 @@ class Bitbucket3HookTests(WebhookTestCase):
     # Core PR Events:
     def test_pr_opened_without_reviewers(self) -> None:
         expected_topic = "sandbox / PR #1 Branch1"
-        expected_message = """hypro999 opened [PR #1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1)\nfrom `branch1` to `master`\n\n~~~ quote\n* Add file2.txt\r\n* Add file3.txt\n~~~"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) opened [PR #1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1)\nfrom `branch1` to `master`\n\n~~~ quote\n* Add file2.txt\r\n* Add file3.txt\n~~~"""
         self.send_and_test_stream_message("pull_request_opened_without_reviewers",
                                           expected_topic,
                                           expected_message)
 
     def test_pr_opened_without_description(self) -> None:
         expected_topic = "sandbox / PR #2 Add notes feature."
-        expected_message = """hypro999 opened [PR #2](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/2)\nfrom `master` to `master`"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) opened [PR #2](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/2)\nfrom `master` to `master`"""
         self.send_and_test_stream_message("pull_request_opened_without_description",
                                           expected_topic,
                                           expected_message)
 
     def test_pr_opened_with_two_reviewers(self) -> None:
         expected_topic = "sandbox / PR #5 Add Notes Feature"
-        expected_message = """hypro999 opened [PR #5](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/5)\nfrom `master` to `master` (assigned to [shimura](http://139.59.64.214:7990/users/shimura) and [sougo](http://139.59.64.214:7990/users/sougo) for review)"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) opened [PR #5](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/5)\nfrom `master` to `master` (assigned to [shimura](http://139.59.64.214:7990/users/shimura) and [sougo](http://139.59.64.214:7990/users/sougo) for review)"""
         self.send_and_test_stream_message("pull_request_opened_with_two_reviewers",
                                           expected_topic,
                                           expected_message)
@@ -124,28 +124,28 @@ class Bitbucket3HookTests(WebhookTestCase):
         expected_topic = "sandbox / PR #5 Add Notes Feature"
         expected_topic = "custom_topic"
         self.url = self.build_webhook_url(topic='custom_topic')
-        expected_message = """hypro999 opened [PR #5 Add Notes Feature](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/5)\nfrom `master` to `master` (assigned to [shimura](http://139.59.64.214:7990/users/shimura) and [sougo](http://139.59.64.214:7990/users/sougo) for review)"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) opened [PR #5 Add Notes Feature](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/5)\nfrom `master` to `master` (assigned to [shimura](http://139.59.64.214:7990/users/shimura) and [sougo](http://139.59.64.214:7990/users/sougo) for review)"""
         self.send_and_test_stream_message("pull_request_opened_with_two_reviewers",
                                           expected_topic,
                                           expected_message)
 
     def test_pr_opened_with_mulitple_reviewers(self) -> None:
         expected_topic = "sandbox / PR #6 sample_file: Add sample_file.txt."
-        expected_message = """hypro999 opened [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)\nfrom `master` to `master` (assigned to [sougo](http://139.59.64.214:7990/users/sougo), [zura](http://139.59.64.214:7990/users/zura) and [shimura](http://139.59.64.214:7990/users/shimura) for review)\n\n~~~ quote\nAdd a simple text file for further testing purposes.\n~~~"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) opened [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)\nfrom `master` to `master` (assigned to [sougo](http://139.59.64.214:7990/users/sougo), [zura](http://139.59.64.214:7990/users/zura) and [shimura](http://139.59.64.214:7990/users/shimura) for review)\n\n~~~ quote\nAdd a simple text file for further testing purposes.\n~~~"""
         self.send_and_test_stream_message("pull_request_opened_with_multiple_reviewers",
                                           expected_topic,
                                           expected_message)
 
     def test_pr_modified(self) -> None:
         expected_topic = "sandbox / PR #1 Branch1"
-        expected_message = """hypro999 modified [PR #1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1)\nfrom `branch1` to `master` (assigned to [shimura](http://139.59.64.214:7990/users/shimura) for review)\n\n~~~ quote\n* Add file2.txt\n* Add file3.txt\nBoth of these files would be important additions to the project!\n~~~"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) modified [PR #1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1)\nfrom `branch1` to `master` (assigned to [shimura](http://139.59.64.214:7990/users/shimura) for review)\n\n~~~ quote\n* Add file2.txt\n* Add file3.txt\nBoth of these files would be important additions to the project!\n~~~"""
         self.send_and_test_stream_message("pull_request_modified",
                                           expected_topic,
                                           expected_message)
 
     def test_pr_modified_with_include_title(self) -> None:
         expected_topic = "custom_topic"
-        expected_message = """hypro999 modified [PR #1 Branch1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1)\nfrom `branch1` to `master` (assigned to [shimura](http://139.59.64.214:7990/users/shimura) for review)\n\n~~~ quote\n* Add file2.txt\n* Add file3.txt\nBoth of these files would be important additions to the project!\n~~~"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) modified [PR #1 Branch1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1)\nfrom `branch1` to `master` (assigned to [shimura](http://139.59.64.214:7990/users/shimura) for review)\n\n~~~ quote\n* Add file2.txt\n* Add file3.txt\nBoth of these files would be important additions to the project!\n~~~"""
         self.url = self.build_webhook_url(topic='custom_topic')
         self.send_and_test_stream_message("pull_request_modified",
                                           expected_topic,
@@ -153,14 +153,14 @@ class Bitbucket3HookTests(WebhookTestCase):
 
     def test_pr_deleted(self) -> None:
         expected_topic = "sandbox / PR #2 Add notes feature."
-        expected_message = """hypro999 deleted [PR #2](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/2)"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) deleted [PR #2](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/2)"""
         self.send_and_test_stream_message("pull_request_deleted",
                                           expected_topic,
                                           expected_message)
 
     def test_pr_deleted_with_include_title(self) -> None:
         expected_topic = "custom_topic"
-        expected_message = """hypro999 deleted [PR #2 Add notes feature.](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/2)"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) deleted [PR #2 Add notes feature.](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/2)"""
         self.url = self.build_webhook_url(topic='custom_topic')
         self.send_and_test_stream_message("pull_request_deleted",
                                           expected_topic,
@@ -168,14 +168,14 @@ class Bitbucket3HookTests(WebhookTestCase):
 
     def test_pr_declined(self) -> None:
         expected_topic = "sandbox / PR #7 Crazy Idea"
-        expected_message = """zura declined [PR #7](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/7)"""
+        expected_message = """[zura](http://139.59.64.214:7990/users/zura) declined [PR #7](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/7)"""
         self.send_and_test_stream_message("pull_request_declined",
                                           expected_topic,
                                           expected_message)
 
     def test_pr_merged(self) -> None:
         expected_topic = "sandbox / PR #6 sample_file: Add sample_file.txt."
-        expected_message = """zura merged [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)"""
+        expected_message = """[zura](http://139.59.64.214:7990/users/zura) merged [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)"""
         self.send_and_test_stream_message("pull_request_merged",
                                           expected_topic,
                                           expected_message)
@@ -183,42 +183,42 @@ class Bitbucket3HookTests(WebhookTestCase):
     # PR Reviewer Events:
     def test_pr_approved(self) -> None:
         expected_topic = "sandbox / PR #6 sample_file: Add sample_file.txt."
-        expected_message = """zura approved [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)"""
+        expected_message = """[zura](http://139.59.64.214:7990/users/zura) approved [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)"""
         self.send_and_test_stream_message("pull_request_approved",
                                           expected_topic,
                                           expected_message)
 
     def test_pr_unapproved(self) -> None:
         expected_topic = "sandbox / PR #6 sample_file: Add sample_file.txt."
-        expected_message = """zura unapproved [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)"""
+        expected_message = """[zura](http://139.59.64.214:7990/users/zura) unapproved [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)"""
         self.send_and_test_stream_message("pull_request_unapproved",
                                           expected_topic,
                                           expected_message)
 
     def test_pr_marked_as_needs_review(self) -> None:
         expected_topic = "sandbox / PR #6 sample_file: Add sample_file.txt."
-        expected_message = """zura marked [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6) as \"needs work\""""
+        expected_message = """[zura](http://139.59.64.214:7990/users/zura) marked [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6) as \"needs work\""""
         self.send_and_test_stream_message("pull_request_needs_work",
                                           expected_topic,
                                           expected_message)
 
     def test_pr_marked_as_needs_review_and_include_title(self) -> None:
         expected_topic = "custom_topic"
-        expected_message = """zura marked [PR #6 sample_file: Add sample_file.txt.](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6) as \"needs work\""""
+        expected_message = """[zura](http://139.59.64.214:7990/users/zura) marked [PR #6 sample_file: Add sample_file.txt.](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6) as \"needs work\""""
         self.url = self.build_webhook_url(topic='custom_topic')
         self.send_and_test_stream_message("pull_request_needs_work",
                                           expected_topic,
                                           expected_message)
 
     def test_pull_request_reviewer_added(self) -> None:
-        expected_message = """hypro999 reassigned [PR #1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1) to [shimura](http://139.59.64.214:7990/users/shimura)"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) reassigned [PR #1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1) to [shimura](http://139.59.64.214:7990/users/shimura)"""
         expected_topic = "sandbox / PR #1 Branch1"
         self.send_and_test_stream_message("pull_request_add_reviewer",
                                           expected_topic,
                                           expected_message)
 
     def test_pull_request_reviewer_added_and_include_title(self) -> None:
-        expected_message = """hypro999 reassigned [PR #1 Branch1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1) to [shimura](http://139.59.64.214:7990/users/shimura)"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) reassigned [PR #1 Branch1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1) to [shimura](http://139.59.64.214:7990/users/shimura)"""
         expected_topic = "custom_topic"
         self.url = self.build_webhook_url(topic='custom_topic')
         self.send_and_test_stream_message("pull_request_add_reviewer",
@@ -226,21 +226,21 @@ class Bitbucket3HookTests(WebhookTestCase):
                                           expected_message)
 
     def test_pull_request_reviewers_added(self) -> None:
-        expected_message = """hypro999 reassigned [PR #1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1) to [shimura](http://139.59.64.214:7990/users/shimura) and [sougo](http://139.59.64.214:7990/users/sougo)"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) reassigned [PR #1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1) to [shimura](http://139.59.64.214:7990/users/shimura) and [sougo](http://139.59.64.214:7990/users/sougo)"""
         expected_topic = "sandbox / PR #1 Branch1"
         self.send_and_test_stream_message("pull_request_add_two_reviewers",
                                           expected_topic,
                                           expected_message)
 
     def test_pull_request_remove_all_reviewers(self) -> None:
-        expected_message = """hypro999 removed all reviewers from [PR #1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1)"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) removed all reviewers from [PR #1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1)"""
         expected_topic = "sandbox / PR #1 Branch1"
         self.send_and_test_stream_message("pull_request_remove_reviewer",
                                           expected_topic,
                                           expected_message)
 
     def test_pull_request_remove_all_reviewers_with_title(self) -> None:
-        expected_message = """hypro999 removed all reviewers from [PR #1 Branch1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1)"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) removed all reviewers from [PR #1 Branch1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1)"""
         expected_topic = "sandbox / PR #1 Branch1"
         expected_topic = "custom_topic"
         self.url = self.build_webhook_url(topic='custom_topic')
@@ -250,21 +250,21 @@ class Bitbucket3HookTests(WebhookTestCase):
 
     # PR Comment Events:
     def test_pull_request_comment_added(self) -> None:
-        expected_message = """zura commented on [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)\n\n~~~ quote\nThis seems like a pretty good idea.\n~~~"""
+        expected_message = """[zura](http://139.59.64.214:7990/users/zura) commented on [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)\n\n~~~ quote\nThis seems like a pretty good idea.\n~~~"""
         expected_topic = "sandbox / PR #6 sample_file: Add sample_file.txt."
         self.send_and_test_stream_message("pull_request_comment_added",
                                           expected_topic,
                                           expected_message)
 
     def test_pull_request_comment_edited(self) -> None:
-        expected_message = """zura edited their comment on [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)\n\n~~~ quote\nThis seems like a pretty good idea. @shimura what do you think?\n~~~"""
+        expected_message = """[zura](http://139.59.64.214:7990/users/zura) edited their comment on [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)\n\n~~~ quote\nThis seems like a pretty good idea. @shimura what do you think?\n~~~"""
         expected_topic = "sandbox / PR #6 sample_file: Add sample_file.txt."
         self.send_and_test_stream_message("pull_request_comment_edited",
                                           expected_topic,
                                           expected_message)
 
     def test_pull_request_comment_deleted(self) -> None:
-        expected_message = """zura deleted their comment on [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)\n\n~~~ quote\nThis seems like a pretty good idea. @shimura what do you think?\n~~~"""
+        expected_message = """[zura](http://139.59.64.214:7990/users/zura) deleted their comment on [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)\n\n~~~ quote\nThis seems like a pretty good idea. @shimura what do you think?\n~~~"""
         expected_topic = "sandbox / PR #6 sample_file: Add sample_file.txt."
         self.send_and_test_stream_message("pull_request_comment_deleted",
                                           expected_topic,

--- a/zerver/webhooks/bitbucket3/tests.py
+++ b/zerver/webhooks/bitbucket3/tests.py
@@ -8,41 +8,35 @@ class Bitbucket3HookTests(WebhookTestCase):
     EXPECTED_TOPIC = "sandbox"
     EXPECTED_TOPIC_BRANCH_EVENTS = "sandbox / {branch}"
 
+    # Core Repo Events:
     def test_commit_comment_added(self) -> None:
-        expected_message = """hypro999 commented on [508d1b6](http://139.59.64.214:7990/projects\
-/SBOX/repos/sandbox/commits/508d1b67f1f8f3a25f543a030a7a178894aa9907)\n~~~ quote\nJust an \
-arbitrary comment on a commit.\n~~~"""
+        expected_message = """hypro999 commented on [508d1b6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/commits/508d1b67f1f8f3a25f543a030a7a178894aa9907)\n~~~ quote\nJust an arbitrary comment on a commit.\n~~~"""
         self.send_and_test_stream_message("commit_comment_added",
                                           self.EXPECTED_TOPIC,
                                           expected_message)
 
     def test_commit_comment_edited(self) -> None:
-        expected_message = """hypro999 edited their comment on [508d1b6](http://139.59.64.214:7990\
-/projects/SBOX/repos/sandbox/commits/508d1b67f1f8f3a25f543a030a7a178894aa9907)\n~~~ quote\nJust \
-an arbitrary comment on a commit. Nothing to see here...\n~~~"""
+        expected_message = """hypro999 edited their comment on [508d1b6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/commits/508d1b67f1f8f3a25f543a030a7a178894aa9907)\n~~~ quote\nJust an arbitrary comment on a commit. Nothing to see here...\n~~~"""
         self.send_and_test_stream_message("commit_comment_edited",
                                           self.EXPECTED_TOPIC,
                                           expected_message)
 
     def test_commit_comment_deleted(self) -> None:
-        expected_message = """hypro999 deleted their comment on [508d1b6]\
-(http://139.59.64.214:7990/projects/SBOX/repos/sandbox/commits/508d1b67f1f8f3a25f543a030a7a178894a\
-a9907)\n~~~ quote\nJust an arbitrary comment on a commit. Nothing to see here...\n~~~"""
+        expected_message = """hypro999 deleted their comment on [508d1b6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/commits/508d1b67f1f8f3a25f543a030a7a178894aa9907)\n~~~ quote\nJust an arbitrary comment on a commit. Nothing to see here...\n~~~"""
         self.send_and_test_stream_message("commit_comment_deleted",
                                           self.EXPECTED_TOPIC,
                                           expected_message)
 
     def test_bitbucket3_repo_forked(self) -> None:
-        expected_message = """User Hemanth V. Alluri(login: hypro999) forked the repository into \
-[sandbox fork](http://139.59.64.214:7990/users/hypro999/repos/sandbox-fork/browse)."""
+        expected_message = """User Hemanth V. Alluri(login: hypro999) forked the repository into [sandbox fork](http://139.59.64.214:7990/users/hypro999/repos/sandbox-fork/browse)."""
         self.send_and_test_stream_message("repo_forked", self.EXPECTED_TOPIC, expected_message)
 
     def test_bitbucket3_repo_modified(self) -> None:
-        expected_message = """hypro999 changed the name of the **sandbox** repo from **sandbox** \
-to **sandbox v2**"""
+        expected_message = """hypro999 changed the name of the **sandbox** repo from **sandbox** to **sandbox v2**"""
         expected_topic = "sandbox v2"
         self.send_and_test_stream_message("repo_modified", expected_topic, expected_message)
 
+    # Repo Push Events:
     def test_push_add_branch(self) -> None:
         expected_message = """hypro999 created branch2 branch"""
         expected_topic = self.EXPECTED_TOPIC_BRANCH_EVENTS.format(branch="branch2")
@@ -70,18 +64,15 @@ to **sandbox v2**"""
                                           expected_message)
 
     def test_push_update_single_branch(self) -> None:
-        expected_message = """hypro999 pushed to branch master. Head is now \
-e68c981ef53dbab0a5ca320a2d8d80e216c70528"""
+        expected_message = """hypro999 pushed to branch master. Head is now e68c981ef53dbab0a5ca320a2d8d80e216c70528."""
         expected_topic = self.EXPECTED_TOPIC_BRANCH_EVENTS.format(branch="master")
         self.send_and_test_stream_message("repo_push_update_single_branch",
                                           expected_topic,
                                           expected_message)
 
     def test_push_update_multiple_branches(self) -> None:
-        expected_message_first = """hypro999 pushed to branch branch1. Head is now \
-3980c2be32a7e23c795741d5dc1a2eecb9b85d6d"""
-        expected_message_second = """hypro999 pushed to branch master. Head is now \
-fc43d13cff1abb28631196944ba4fc4ad06a2cf2"""
+        expected_message_first = """hypro999 pushed to branch branch1. Head is now 3980c2be32a7e23c795741d5dc1a2eecb9b85d6d."""
+        expected_message_second = """hypro999 pushed to branch master. Head is now fc43d13cff1abb28631196944ba4fc4ad06a2cf2."""
         self.send_and_test_stream_message("repo_push_update_multiple_branches")
 
         msg = self.get_last_message()
@@ -94,17 +85,187 @@ fc43d13cff1abb28631196944ba4fc4ad06a2cf2"""
 
     def test_push_update_multiple_branches_with_branch_filter(self) -> None:
         self.url = self.build_webhook_url(branches='master')
-        expected_message = """hypro999 pushed to branch master. Head is now \
-fc43d13cff1abb28631196944ba4fc4ad06a2cf2"""
+        expected_message = """hypro999 pushed to branch master. Head is now fc43d13cff1abb28631196944ba4fc4ad06a2cf2."""
         expected_topic = self.EXPECTED_TOPIC_BRANCH_EVENTS.format(branch="master")
         self.send_and_test_stream_message("repo_push_update_multiple_branches",
                                           expected_topic,
                                           expected_message)
 
         self.url = self.build_webhook_url(branches='branch1')
-        expected_message = """hypro999 pushed to branch branch1. Head is now \
-3980c2be32a7e23c795741d5dc1a2eecb9b85d6d"""
+        expected_message = """hypro999 pushed to branch branch1. Head is now 3980c2be32a7e23c795741d5dc1a2eecb9b85d6d."""
         expected_topic = self.EXPECTED_TOPIC_BRANCH_EVENTS.format(branch="branch1")
         self.send_and_test_stream_message("repo_push_update_multiple_branches",
+                                          expected_topic,
+                                          expected_message)
+
+    # Core PR Events:
+    def test_pr_opened_without_reviewers(self) -> None:
+        expected_topic = "sandbox / PR #1 Branch1"
+        expected_message = """hypro999 opened [PR #1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1)\nfrom `branch1` to `master`\n\n~~~ quote\n* Add file2.txt\r\n* Add file3.txt\n~~~"""
+        self.send_and_test_stream_message("pull_request_opened_without_reviewers",
+                                          expected_topic,
+                                          expected_message)
+
+    def test_pr_opened_without_description(self) -> None:
+        expected_topic = "sandbox / PR #2 Add notes feature."
+        expected_message = """hypro999 opened [PR #2](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/2)\nfrom `master` to `master`"""
+        self.send_and_test_stream_message("pull_request_opened_without_description",
+                                          expected_topic,
+                                          expected_message)
+
+    def test_pr_opened_with_two_reviewers(self) -> None:
+        expected_topic = "sandbox / PR #5 Add Notes Feature"
+        expected_message = """hypro999 opened [PR #5](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/5)\nfrom `master` to `master` (assigned to [shimura](http://139.59.64.214:7990/users/shimura) and [sougo](http://139.59.64.214:7990/users/sougo) for review)"""
+        self.send_and_test_stream_message("pull_request_opened_with_two_reviewers",
+                                          expected_topic,
+                                          expected_message)
+
+    def test_pr_opened_with_two_reviewers_and_user_defined_topic(self) -> None:
+        expected_topic = "sandbox / PR #5 Add Notes Feature"
+        expected_topic = "custom_topic"
+        self.url = self.build_webhook_url(topic='custom_topic')
+        expected_message = """hypro999 opened [PR #5 Add Notes Feature](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/5)\nfrom `master` to `master` (assigned to [shimura](http://139.59.64.214:7990/users/shimura) and [sougo](http://139.59.64.214:7990/users/sougo) for review)"""
+        self.send_and_test_stream_message("pull_request_opened_with_two_reviewers",
+                                          expected_topic,
+                                          expected_message)
+
+    def test_pr_opened_with_mulitple_reviewers(self) -> None:
+        expected_topic = "sandbox / PR #6 sample_file: Add sample_file.txt."
+        expected_message = """hypro999 opened [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)\nfrom `master` to `master` (assigned to [sougo](http://139.59.64.214:7990/users/sougo), [zura](http://139.59.64.214:7990/users/zura) and [shimura](http://139.59.64.214:7990/users/shimura) for review)\n\n~~~ quote\nAdd a simple text file for further testing purposes.\n~~~"""
+        self.send_and_test_stream_message("pull_request_opened_with_multiple_reviewers",
+                                          expected_topic,
+                                          expected_message)
+
+    def test_pr_modified(self) -> None:
+        expected_topic = "sandbox / PR #1 Branch1"
+        expected_message = """hypro999 modified [PR #1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1)\nfrom `branch1` to `master` (assigned to [shimura](http://139.59.64.214:7990/users/shimura) for review)\n\n~~~ quote\n* Add file2.txt\n* Add file3.txt\nBoth of these files would be important additions to the project!\n~~~"""
+        self.send_and_test_stream_message("pull_request_modified",
+                                          expected_topic,
+                                          expected_message)
+
+    def test_pr_modified_with_include_title(self) -> None:
+        expected_topic = "custom_topic"
+        expected_message = """hypro999 modified [PR #1 Branch1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1)\nfrom `branch1` to `master` (assigned to [shimura](http://139.59.64.214:7990/users/shimura) for review)\n\n~~~ quote\n* Add file2.txt\n* Add file3.txt\nBoth of these files would be important additions to the project!\n~~~"""
+        self.url = self.build_webhook_url(topic='custom_topic')
+        self.send_and_test_stream_message("pull_request_modified",
+                                          expected_topic,
+                                          expected_message)
+
+    def test_pr_deleted(self) -> None:
+        expected_topic = "sandbox / PR #2 Add notes feature."
+        expected_message = """hypro999 deleted [PR #2](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/2)"""
+        self.send_and_test_stream_message("pull_request_deleted",
+                                          expected_topic,
+                                          expected_message)
+
+    def test_pr_deleted_with_include_title(self) -> None:
+        expected_topic = "custom_topic"
+        expected_message = """hypro999 deleted [PR #2 Add notes feature.](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/2)"""
+        self.url = self.build_webhook_url(topic='custom_topic')
+        self.send_and_test_stream_message("pull_request_deleted",
+                                          expected_topic,
+                                          expected_message)
+
+    def test_pr_declined(self) -> None:
+        expected_topic = "sandbox / PR #7 Crazy Idea"
+        expected_message = """zura declined [PR #7](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/7)"""
+        self.send_and_test_stream_message("pull_request_declined",
+                                          expected_topic,
+                                          expected_message)
+
+    def test_pr_merged(self) -> None:
+        expected_topic = "sandbox / PR #6 sample_file: Add sample_file.txt."
+        expected_message = """zura merged [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)"""
+        self.send_and_test_stream_message("pull_request_merged",
+                                          expected_topic,
+                                          expected_message)
+
+    # PR Reviewer Events:
+    def test_pr_approved(self) -> None:
+        expected_topic = "sandbox / PR #6 sample_file: Add sample_file.txt."
+        expected_message = """zura approved [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)"""
+        self.send_and_test_stream_message("pull_request_approved",
+                                          expected_topic,
+                                          expected_message)
+
+    def test_pr_unapproved(self) -> None:
+        expected_topic = "sandbox / PR #6 sample_file: Add sample_file.txt."
+        expected_message = """zura unapproved [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)"""
+        self.send_and_test_stream_message("pull_request_unapproved",
+                                          expected_topic,
+                                          expected_message)
+
+    def test_pr_marked_as_needs_review(self) -> None:
+        expected_topic = "sandbox / PR #6 sample_file: Add sample_file.txt."
+        expected_message = """zura marked [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6) as \"needs work\""""
+        self.send_and_test_stream_message("pull_request_needs_work",
+                                          expected_topic,
+                                          expected_message)
+
+    def test_pr_marked_as_needs_review_and_include_title(self) -> None:
+        expected_topic = "custom_topic"
+        expected_message = """zura marked [PR #6 sample_file: Add sample_file.txt.](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6) as \"needs work\""""
+        self.url = self.build_webhook_url(topic='custom_topic')
+        self.send_and_test_stream_message("pull_request_needs_work",
+                                          expected_topic,
+                                          expected_message)
+
+    def test_pull_request_reviewer_added(self) -> None:
+        expected_message = """hypro999 reassigned [PR #1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1) to [shimura](http://139.59.64.214:7990/users/shimura)"""
+        expected_topic = "sandbox / PR #1 Branch1"
+        self.send_and_test_stream_message("pull_request_add_reviewer",
+                                          expected_topic,
+                                          expected_message)
+
+    def test_pull_request_reviewer_added_and_include_title(self) -> None:
+        expected_message = """hypro999 reassigned [PR #1 Branch1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1) to [shimura](http://139.59.64.214:7990/users/shimura)"""
+        expected_topic = "custom_topic"
+        self.url = self.build_webhook_url(topic='custom_topic')
+        self.send_and_test_stream_message("pull_request_add_reviewer",
+                                          expected_topic,
+                                          expected_message)
+
+    def test_pull_request_reviewers_added(self) -> None:
+        expected_message = """hypro999 reassigned [PR #1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1) to [shimura](http://139.59.64.214:7990/users/shimura) and [sougo](http://139.59.64.214:7990/users/sougo)"""
+        expected_topic = "sandbox / PR #1 Branch1"
+        self.send_and_test_stream_message("pull_request_add_two_reviewers",
+                                          expected_topic,
+                                          expected_message)
+
+    def test_pull_request_remove_all_reviewers(self) -> None:
+        expected_message = """hypro999 removed all reviewers from [PR #1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1)"""
+        expected_topic = "sandbox / PR #1 Branch1"
+        self.send_and_test_stream_message("pull_request_remove_reviewer",
+                                          expected_topic,
+                                          expected_message)
+
+    def test_pull_request_remove_all_reviewers_with_title(self) -> None:
+        expected_message = """hypro999 removed all reviewers from [PR #1 Branch1](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/1)"""
+        expected_topic = "sandbox / PR #1 Branch1"
+        expected_topic = "custom_topic"
+        self.url = self.build_webhook_url(topic='custom_topic')
+        self.send_and_test_stream_message("pull_request_remove_reviewer",
+                                          expected_topic,
+                                          expected_message)
+
+    # PR Comment Events:
+    def test_pull_request_comment_added(self) -> None:
+        expected_message = """zura commented on [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)\n\n~~~ quote\nThis seems like a pretty good idea.\n~~~"""
+        expected_topic = "sandbox / PR #6 sample_file: Add sample_file.txt."
+        self.send_and_test_stream_message("pull_request_comment_added",
+                                          expected_topic,
+                                          expected_message)
+
+    def test_pull_request_comment_edited(self) -> None:
+        expected_message = """zura edited their comment on [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)\n\n~~~ quote\nThis seems like a pretty good idea. @shimura what do you think?\n~~~"""
+        expected_topic = "sandbox / PR #6 sample_file: Add sample_file.txt."
+        self.send_and_test_stream_message("pull_request_comment_edited",
+                                          expected_topic,
+                                          expected_message)
+
+    def test_pull_request_comment_deleted(self) -> None:
+        expected_message = """zura deleted their comment on [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)\n\n~~~ quote\nThis seems like a pretty good idea. @shimura what do you think?\n~~~"""
+        expected_topic = "sandbox / PR #6 sample_file: Add sample_file.txt."
+        self.send_and_test_stream_message("pull_request_comment_deleted",
                                           expected_topic,
                                           expected_message)

--- a/zerver/webhooks/bitbucket3/tests.py
+++ b/zerver/webhooks/bitbucket3/tests.py
@@ -22,7 +22,7 @@ class Bitbucket3HookTests(WebhookTestCase):
                                           expected_message)
 
     def test_commit_comment_deleted(self) -> None:
-        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) deleted their comment on [508d1b6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/commits/508d1b67f1f8f3a25f543a030a7a178894aa9907)\n~~~ quote\nJust an arbitrary comment on a commit. Nothing to see here...\n~~~"""
+        expected_message = """[hypro999](http://139.59.64.214:7990/users/hypro999) deleted their comment on [508d1b6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/commits/508d1b67f1f8f3a25f543a030a7a178894aa9907)\n~~~ quote\n~~Just an arbitrary comment on a commit. Nothing to see here...~~\n~~~"""
         self.send_and_test_stream_message("commit_comment_deleted",
                                           self.EXPECTED_TOPIC,
                                           expected_message)
@@ -264,7 +264,7 @@ class Bitbucket3HookTests(WebhookTestCase):
                                           expected_message)
 
     def test_pull_request_comment_deleted(self) -> None:
-        expected_message = """[zura](http://139.59.64.214:7990/users/zura) deleted their comment on [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)\n\n~~~ quote\nThis seems like a pretty good idea. @shimura what do you think?\n~~~"""
+        expected_message = """[zura](http://139.59.64.214:7990/users/zura) deleted their comment on [PR #6](http://139.59.64.214:7990/projects/SBOX/repos/sandbox/pull-requests/6)\n\n~~~ quote\n~~This seems like a pretty good idea. @shimura what do you think?~~\n~~~"""
         expected_topic = "sandbox / PR #6 sample_file: Add sample_file.txt."
         self.send_and_test_stream_message("pull_request_comment_deleted",
                                           expected_topic,

--- a/zerver/webhooks/bitbucket3/view.py
+++ b/zerver/webhooks/bitbucket3/view.py
@@ -48,12 +48,15 @@ def repo_comment_handler(payload: Dict[str, Any], action: str) -> List[Dict[str,
     sha = payload["commit"]
     commit_url = payload["repository"]["links"]["self"][0]["href"][:-6]  # remove the "browse" at the end
     commit_url += "commits/%s" % (sha,)
+    message = payload["comment"]["text"]
+    if action == "deleted their comment":
+        message = "~~{message}~~".format(message=message)
     body = get_commits_comment_action_message(
         user_name=get_user_name(payload),
         action=action,
         commit_url=commit_url,
         sha=sha,
-        message=payload["comment"]["text"]
+        message=message
     )
     return [{"subject": subject, "body": body}]
 
@@ -275,6 +278,8 @@ def pr_comment_handler(payload: Dict[str, Any], action: str,
     subject = get_pr_subject(pr["toRef"]["repository"]["name"], type="PR", id=pr["id"],
                              title=pr["title"])
     message = payload["comment"]["text"]
+    if action == "deleted their comment on":
+        message = "~~{message}~~".format(message=message)
     body = get_pull_request_event_message(
         user_name=get_user_name(payload),
         action=action,


### PR DESCRIPTION
**Contents:**
This pull request consists of 2 commits.
1. Complete the Bitbucket server (bitbucket 3) incoming webhook integration by extending support for all pull request events. 
2. Enhance and refactor the code. From the commit message:
   "In terms of minor enhancements, this commit will now link each
    actor's name with the url to their profile thus giving the messages
    a much more complete feel. Also, for when comments on a commit are
    deleted, the quote will now use stikethrough text.
    
    In terms of refactoring, this commit removes the unnecessary line
    splitting in this integration's tests (mainly observed with the
    expected_message variables) thus making it easier to read."

**Testing Plan:** <!-- How have you tested? -->
A plethora of new automated tests have been added and additional testing has been done manually. Since this is quite a bit of code to review all at once, I've made a small script that could make the process of viewing the output a bit more enjoyable by generating all of the fixture messages at one go so that they can easily be viewed from the development environment - i.e. after running `./tools/run-dev.py` (see attachment: [visual-test.zip](https://github.com/zulip/zulip/files/3009417/visual-test.zip)) - some "macros" (just variables) need to be manually set and then this script can be run after placing in the top level zulip directory.