### PR TITLE
unread list: Allow toggling of streams view (2nd approach)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -78,6 +78,7 @@
         "jQuery": false,
         "katex": false,
         "keydown_util": false,
+        "left_sidebar": false,
         "lightbox": false,
         "list_cursor": false,
         "list_render": false,

--- a/frontend_tests/casper_tests/03-narrow.js
+++ b/frontend_tests/casper_tests/03-narrow.js
@@ -308,7 +308,7 @@ un_narrow();
 casper.then(function () {
     casper.test.info('Search streams using left sidebar');
     casper.test.assertExists('.input-append.notdisplayed', 'Stream filter box not visible initially');
-    casper.click('#streams_header .sidebar-title');
+    casper.click('#streams_header');
 });
 
 casper.waitWhileSelector('#streams_list .input-append.notdisplayed', function () {
@@ -421,7 +421,7 @@ casper.waitUntilVisible('#stream_filters [data-stream-name="Verona"]', function 
 });
 
 
-casper.thenClick('#streams_header .sidebar-title');
+casper.thenClick('#streams_header');
 
 casper.waitForSelector('.input-append.notdisplayed', function () {
     casper.test.assertExists('.input-append.notdisplayed',

--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -572,6 +572,7 @@ run_test('unread_ops', () => {
 
 set_global('topic_list', {});
 
+zrequire('left_sidebar');
 zrequire('stream_sort');
 zrequire('stream_list');
 

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -123,6 +123,7 @@ run_test('mappings', () => {
     assert.equal(map_down(88, false, true), undefined); // ctrl + x
     assert.equal(map_down(78, false, true), undefined); // ctrl + n
     assert.equal(map_down(77, false, true), undefined); // ctrl + m
+    assert.equal(map_down(76, false, true), undefined); // ctrl + m
     assert.equal(map_down(75, false, false, true), undefined); // cmd + k
     assert.equal(map_down(83, false, false, true), undefined); // cmd + s
     assert.equal(map_down(75, true, true), undefined); // shift + ctrl + k
@@ -174,7 +175,7 @@ run_test('basic_chars', () => {
     // Unmapped keys should immediately return false, without
     // calling any functions outside of hotkey.js.
     assert_unmapped('abfhlmotyz');
-    assert_unmapped('BEFHILNOQTUWXYZ');
+    assert_unmapped('BEFHINOQTUWXYZ');
 
     // We have to skip some checks due to the way the code is
     // currently organized for mapped keys.

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -7,6 +7,7 @@ zrequire('unread_ui');
 zrequire('Filter', 'js/filter');
 zrequire('util');
 zrequire('topic_data');
+zrequire('left_sidebar');
 zrequire('stream_sort');
 zrequire('colorspace');
 zrequire('stream_color');
@@ -396,9 +397,6 @@ run_test('focus_user_filter', () => {
 
 run_test('sort_streams', () => {
     stream_data.clear_subscriptions();
-
-    // Get coverage on early-exit.
-    stream_list.build_stream_list();
 
     initialize_stream_data();
 

--- a/frontend_tests/node_tests/stream_sort.js
+++ b/frontend_tests/node_tests/stream_sort.js
@@ -1,10 +1,18 @@
 zrequire('util');
+zrequire('left_sidebar');
 zrequire('stream_data');
 zrequire('stream_sort');
 var with_overrides = global.with_overrides;
 
 run_test('no_subscribed_streams', () => {
-    assert.equal(stream_sort.sort_groups(''), undefined);
+    const empty_result = {
+        same_as_before: false,
+        pinned_streams: [],
+        normal_streams: [],
+        dormant_streams: [],
+    };
+
+    assert.deepEqual(stream_sort.sort_groups(''), empty_result);
     assert.equal(stream_sort.first_stream_id(), undefined);
 });
 

--- a/frontend_tests/node_tests/top_left_corner.js
+++ b/frontend_tests/node_tests/top_left_corner.js
@@ -10,20 +10,20 @@ zrequire('top_left_corner');
 run_test('narrowing', () => {
     // activating narrow
 
-    var pm_expanded;
-    var pm_closed;
+    var pm_updated;
 
     set_global('pm_list', {
-        close: function () { pm_closed = true; },
-        expand: function () { pm_expanded = true; },
+        update_private_messages: () => {
+            pm_updated = true;
+        },
     });
 
-    assert(!pm_expanded);
+    assert(!pm_updated);
     var filter = new Filter([
         {operator: 'is', operand: 'private'},
     ]);
     top_left_corner.handle_narrow_activated(filter);
-    assert(pm_expanded);
+    assert(pm_updated);
 
     const alice = {
         email: 'alice@example.com',
@@ -39,26 +39,26 @@ run_test('narrowing', () => {
     people.add_in_realm(alice);
     people.add_in_realm(bob);
 
-    pm_expanded = false;
+    pm_updated = false;
     filter = new Filter([
         {operator: 'pm-with', operand: 'alice@example.com'},
     ]);
     top_left_corner.handle_narrow_activated(filter);
-    assert(pm_expanded);
+    assert(pm_updated);
 
-    pm_expanded = false;
+    pm_updated = false;
     filter = new Filter([
         {operator: 'pm-with', operand: 'bob@example.com,alice@example.com'},
     ]);
     top_left_corner.handle_narrow_activated(filter);
-    assert(pm_expanded);
+    assert(pm_updated);
 
-    pm_expanded = false;
+    pm_updated = false;
     filter = new Filter([
         {operator: 'pm-with', operand: 'not@valid.com'},
     ]);
     top_left_corner.handle_narrow_activated(filter);
-    assert(!pm_expanded);
+    assert(pm_updated);
 
     filter = new Filter([
         {operator: 'is', operand: 'mentioned'},
@@ -80,14 +80,14 @@ run_test('narrowing', () => {
 
     // deactivating narrow
 
-    pm_closed = false;
+    pm_updated = false;
     top_left_corner.handle_narrow_deactivated();
 
     assert($('.top_left_all_messages').hasClass('active-filter'));
     assert(!$('.top_left_mentions').hasClass('active-filter'));
     assert(!$('.top_left_private_messages').hasClass('active-filter'));
     assert(!$('.top_left_starred_messages').hasClass('active-filter'));
-    assert(pm_closed);
+    assert(pm_updated);
 });
 
 run_test('update_count_in_dom', () => {

--- a/frontend_tests/node_tests/topic_list.js
+++ b/frontend_tests/node_tests/topic_list.js
@@ -8,6 +8,7 @@ set_global('stream_popover', {});
 set_global('templates', {});
 set_global('message_list', {});
 
+zrequire('left_sidebar');
 zrequire('hash_util');
 zrequire('stream_data');
 zrequire('unread');

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -110,6 +110,7 @@ zrequire('pm_list');
 zrequire('list_cursor');
 zrequire('keydown_util');
 zrequire('stream_sort');
+zrequire('left_sidebar');
 zrequire('stream_list');
 zrequire('topic_list');
 zrequire('topic_zoom');
@@ -152,6 +153,7 @@ $("#stream_message_recipient_topic").typeahead = () => {};
 $("#private_message_recipient").typeahead = () => {};
 $("#compose-textarea").typeahead = () => {};
 $("#search_query").typeahead = () => {};
+$('#stream_filters').append = () => {};
 
 
 const value_stub = $.create('value');

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -34,6 +34,9 @@ set_global('resize', {});
 set_global('feature_flags', {});
 set_global('page_params', {});
 set_global('templates', {});
+set_global('stream_popover', {});
+
+stream_popover.hide_topic_popover = () => {};
 
 const ignore_modules = [
     'activity',
@@ -121,6 +124,7 @@ zrequire('starred_messages');
 zrequire('user_status');
 zrequire('user_status_ui');
 zrequire('ui_init');
+zrequire('pm_conversations');
 
 set_global('$', global.make_zjquery());
 
@@ -147,6 +151,7 @@ $('#compose').filedrop = () => {};
 server_events.home_view_loaded = () => true;
 
 resize.watch_manual_resize = () => {};
+resize.resize_stream_filters_container = () => {};
 
 $("#stream_message_recipient_stream").typeahead = () => {};
 $("#stream_message_recipient_topic").typeahead = () => {};
@@ -154,7 +159,9 @@ $("#private_message_recipient").typeahead = () => {};
 $("#compose-textarea").typeahead = () => {};
 $("#search_query").typeahead = () => {};
 $('#stream_filters').append = () => {};
+$(".top_left_private_messages").append = () => {};
 
+ui.set_up_scrollbar = () => {};
 
 const value_stub = $.create('value');
 const count_stub = $.create('count');

--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -98,6 +98,7 @@ import "js/compose.js";
 import "js/upload.js";
 import "js/color_data.js";
 import "js/stream_color.js";
+import "js/left_sidebar.js";
 import "js/stream_data.js";
 import "js/topic_data.js";
 import "js/stream_muting.js";

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -90,6 +90,7 @@ var keypress_mappings = {
     71: {name: 'G_end', message_view_only: true}, // 'G'
     74: {name: 'vim_page_down', message_view_only: true}, // 'J'
     75: {name: 'vim_page_up', message_view_only: true}, // 'K'
+    76: {name: 'toggle_stream_view', message_view_only: true}, // 'L'
     77: {name: 'toggle_mute', message_view_only: true}, // 'M'
     80: {name: 'narrow_private', message_view_only: true}, // 'P'
     82: {name: 'respond_to_author', message_view_only: true}, // 'R'
@@ -646,6 +647,9 @@ exports.process_hotkey = function (e, hotkey) {
         });
     case 'query_streams':
         stream_list.initiate_search();
+        return true;
+    case 'toggle_stream_view':
+        left_sidebar.toggle_stream_view();
         return true;
     case 'query_users':
         activity.initiate_search();

--- a/static/js/left_sidebar.js
+++ b/static/js/left_sidebar.js
@@ -1,0 +1,109 @@
+var left_sidebar = (function () {
+
+var exports = {};
+
+var using_unread_view_for_streams = false;
+
+exports.keep_topics_open = function () {
+    return using_unread_view_for_streams;
+};
+
+exports.sub_in_unread_view = function (sub) {
+    var stream_id = sub.stream_id;
+
+    if (stream_id === narrow_state.stream_id()) {
+        return true;
+    }
+
+    if (!stream_data.in_home_view(stream_id)) {
+        return false;
+    }
+
+    var num_topics = exports.get_topic_names(stream_id).length;
+
+    return num_topics >= 1;
+};
+
+exports.get_stream_names = function () {
+    var stream_names;
+
+    if (!using_unread_view_for_streams) {
+        stream_names = stream_data.subscribed_streams();
+        return stream_names;
+    }
+
+    var subs = stream_data.subscribed_subs();
+    subs = _.filter(subs, exports.sub_in_unread_view);
+
+    stream_names = _.pluck(subs, 'name');
+
+    return stream_names;
+
+};
+
+exports.topic_name_in_unread_view = function (stream_id, topic_name) {
+    var curr_stream_id = narrow_state.stream_id();
+
+    if (curr_stream_id === stream_id) {
+        if (topic_name === narrow_state.topic()) {
+            return true;
+        }
+    }
+
+    if (muting.is_topic_muted(stream_id, topic_name)) {
+        return false;
+    }
+
+    return unread.topic_has_any_unread(stream_id, topic_name);
+};
+
+exports.get_topic_names = function (stream_id) {
+    var topic_names = topic_data.get_recent_names(stream_id);
+
+    if (using_unread_view_for_streams) {
+        topic_names = _.filter(topic_names, function (topic_name) {
+            return exports.topic_name_in_unread_view(stream_id, topic_name);
+        });
+    }
+
+    return topic_names;
+};
+
+exports.show_topics = function (stream_id) {
+    if (!using_unread_view_for_streams) {
+        return false;
+    }
+
+    var topic_names = exports.get_topic_names(stream_id);
+    return topic_names.length >= 1;
+};
+
+
+exports.toggle_stream_view = function () {
+    using_unread_view_for_streams = !using_unread_view_for_streams;
+
+    if (using_unread_view_for_streams) {
+        $('.stream_sidebar_title').text(i18n.t('UNREAD STREAMS'));
+        $('#stream_list_toggle').attr('title', i18n.t('Show all streams (L)'));
+    } else {
+        $('.stream_sidebar_title').text(i18n.t('ALL STREAMS'));
+        $('#stream_list_toggle').attr('title', i18n.t('Only show unread streams (L)'));
+    }
+
+    stream_list.update_streams_sidebar();
+};
+
+exports.initialize = function () {
+    $(".stream_list_toggle,.stream_sidebar_title").click(function (e) {
+        e.stopPropagation();
+        exports.toggle_stream_view();
+    });
+};
+
+return exports;
+
+}());
+if (typeof module !== 'undefined') {
+    module.exports = left_sidebar;
+}
+window.left_sidebar = left_sidebar;

--- a/static/js/left_sidebar.js
+++ b/static/js/left_sidebar.js
@@ -3,6 +3,7 @@ var left_sidebar = (function () {
 var exports = {};
 
 var using_unread_view_for_streams = false;
+var using_unread_view_for_pms = true;
 
 exports.keep_topics_open = function () {
     return using_unread_view_for_streams;
@@ -22,6 +23,14 @@ exports.sub_in_unread_view = function (sub) {
     var num_topics = exports.get_topic_names(stream_id).length;
 
     return num_topics >= 1;
+};
+
+exports.get_pm_conversations = function () {
+    var private_messages = pm_conversations.recent.get();
+    private_messages.push('FRED');
+    console.info(private_messages);
+
+    return private_messages;
 };
 
 exports.get_stream_names = function () {

--- a/static/js/left_sidebar.js
+++ b/static/js/left_sidebar.js
@@ -25,10 +25,16 @@ exports.sub_in_unread_view = function (sub) {
     return num_topics >= 1;
 };
 
-exports.get_pm_conversations = function () {
-    var private_messages = pm_conversations.recent.get();
-    private_messages.push('FRED');
-    console.info(private_messages);
+exports.get_pm_conversations = function (active_conversation) {
+    var pm_objs = pm_conversations.recent.get();
+
+    var private_messages = _.pluck(pm_objs, 'user_ids_string');
+
+    if (active_conversation) {
+        if (private_messages.indexOf(active_conversation) < 0) {
+            private_messages.unshift(active_conversation);
+        }
+    }
 
     return private_messages;
 };

--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -55,7 +55,6 @@ function set_pm_conversation_count(user_ids_string, count) {
 
 exports._build_private_messages_list = function (active_conversation) {
 
-    var private_messages = left_sidebar.get_pm_conversations();
     var display_messages = [];
 
     // SHIM
@@ -63,8 +62,9 @@ exports._build_private_messages_list = function (active_conversation) {
         active_conversation = people.emails_strings_to_user_ids_string(active_conversation);
     }
 
-    _.each(private_messages, function (private_message_obj) {
-        var user_ids_string = private_message_obj.user_ids_string;
+    var private_messages = left_sidebar.get_pm_conversations(active_conversation);
+
+    _.each(private_messages, function (user_ids_string) {
         var reply_to = people.user_ids_string_to_emails_string(user_ids_string);
         var recipients_string = people.get_recipients(user_ids_string);
 

--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -55,7 +55,7 @@ function set_pm_conversation_count(user_ids_string, count) {
 
 exports._build_private_messages_list = function (active_conversation) {
 
-    var private_messages = pm_conversations.recent.get();
+    var private_messages = left_sidebar.get_pm_conversations();
     var display_messages = [];
 
     // SHIM

--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -2,8 +2,6 @@ var pm_list = (function () {
 
 var exports = {};
 
-var private_messages_open = false;
-
 // This module manages the "Private Messages" section in the upper
 // left corner of the app.  This was split out from stream_list.js.
 
@@ -55,17 +53,6 @@ function set_pm_conversation_count(user_ids_string, count) {
     update_count_in_dom(count_span, value_span, count);
 }
 
-function remove_expanded_private_messages() {
-    stream_popover.hide_topic_popover();
-    $("#private-container").remove();
-    resize.resize_stream_filters_container();
-}
-
-exports.close = function () {
-    private_messages_open = false;
-    remove_expanded_private_messages();
-};
-
 exports._build_private_messages_list = function (active_conversation) {
 
     var private_messages = pm_conversations.recent.get();
@@ -115,13 +102,12 @@ exports.rebuild_recent = function (active_conversation) {
     stream_popover.hide_topic_popover();
     $("#private-container").remove();
 
-    if (private_messages_open) {
-        var private_li = get_filter_li();
-        var private_messages_dom = exports._build_private_messages_list(
-            active_conversation);
+    var private_li = get_filter_li();
+    var private_messages_dom = exports._build_private_messages_list(
+        active_conversation);
 
-        private_li.append(private_messages_dom);
-    }
+    private_li.append(private_messages_dom);
+
     if (active_conversation) {
         var active_li = exports.get_conversation_li(active_conversation);
         if (active_li) {
@@ -133,10 +119,6 @@ exports.rebuild_recent = function (active_conversation) {
 };
 
 exports.update_private_messages = function () {
-    if (!narrow_state.active()) {
-        return;
-    }
-
     var is_pm_filter = false;
     var pm_with = '';
     var filter = narrow_state.filter();
@@ -165,18 +147,6 @@ exports.update_private_messages = function () {
     }
 };
 
-exports.expand = function (op_pm) {
-    private_messages_open = true;
-    if (op_pm.length === 1) {
-        exports.rebuild_recent(op_pm[0]);
-    } else if (op_pm.length !== 0) {
-        // TODO: Should pass the reply-to of the thread
-        exports.rebuild_recent("");
-    } else {
-        exports.rebuild_recent("");
-    }
-};
-
 exports.update_dom_with_unread_counts = function (counts) {
     set_count(counts.private_message_count);
     counts.pm_count.each(function (count, user_ids_string) {
@@ -189,9 +159,8 @@ exports.update_dom_with_unread_counts = function (counts) {
                                       counts.private_message_count);
 };
 
-
 exports.initialize = function () {
-    // will add back soon
+    exports.update_private_messages();
 };
 
 return exports;

--- a/static/js/stream_sort.js
+++ b/static/js/stream_sort.js
@@ -38,10 +38,7 @@ function filter_streams_by_search(streams, search_term) {
 }
 
 exports.sort_groups = function (search_term) {
-    var streams = stream_data.subscribed_streams();
-    if (streams.length === 0) {
-        return;
-    }
+    var streams = left_sidebar.get_stream_names();
 
     streams = filter_streams_by_search(streams, search_term);
 

--- a/static/js/top_left_corner.js
+++ b/static/js/top_left_corner.js
@@ -74,38 +74,12 @@ exports.handle_narrow_activated = function (filter) {
         }
     }
 
-    if (exports.should_expand_pm_list(filter)) {
-        var op_pm = filter.operands('pm-with');
-        pm_list.expand(op_pm);
-    } else {
-        pm_list.close();
-    }
-};
-
-exports.should_expand_pm_list = function (filter) {
-    var op_is = filter.operands('is');
-
-    if (op_is.length >= 1 && _.contains(op_is, "private")) {
-        return true;
-    }
-
-    var op_pm = filter.operands('pm-with');
-
-    if (op_pm.length !== 1) {
-        return false;
-    }
-
-    var emails_strings = op_pm[0];
-    var emails = emails_strings.split(',');
-
-    var has_valid_emails = people.is_valid_bulk_emails_for_compose(emails);
-
-    return has_valid_emails;
+    pm_list.update_private_messages();
 };
 
 exports.handle_narrow_deactivated = function () {
     deselect_top_left_corner_items();
-    pm_list.close();
+    pm_list.update_private_messages();
 
     var filter_li = $('.top_left_all_messages');
     filter_li.addClass('active-filter');

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -18,6 +18,10 @@ var active_widgets = new Dict();
 var zoomed = false;
 
 exports.remove_expanded_topics = function () {
+    if (left_sidebar.keep_topics_open()) {
+        return;
+    }
+
     stream_popover.hide_topic_popover();
 
     _.each(active_widgets.values(), function (widget) {
@@ -89,7 +93,7 @@ exports.widget = function (parent_elem, my_stream_id) {
         self.topic_items = new Dict({fold_case: true});
 
         var max_topics = 5;
-        var topic_names = topic_data.get_recent_names(my_stream_id);
+        var topic_names = left_sidebar.get_topic_names(my_stream_id);
 
         var ul = $('<ul class="topic-list">');
 
@@ -122,11 +126,13 @@ exports.widget = function (parent_elem, my_stream_id) {
         // widget.  We need it if there are at least 5 topics in the
         // frontend's cache, or if we (possibly) don't have all
         // historical topics in the browser's cache.
-        var show_more = self.build_more_topics_section();
         var sub = stream_data.get_sub_by_id(my_stream_id);
 
         if (topic_names.length > max_topics || !stream_data.all_topics_in_cache(sub)) {
-            ul.append(show_more);
+            if (!left_sidebar.keep_topics_open()) {
+                var show_more = self.build_more_topics_section();
+                ul.append(show_more);
+            }
         }
         return ul;
     };
@@ -260,6 +266,11 @@ exports.rebuild = function (stream_li, stream_id) {
     var no_more_topics = exports.need_to_show_no_more_topics(stream_id);
 
     exports.remove_expanded_topics();
+
+    if (active_widgets.has(stream_id)) {
+        active_widgets.get(stream_id).remove();
+    }
+
     var widget = exports.widget(stream_li, stream_id);
     widget.build(active_topic, no_more_topics);
 

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -286,6 +286,7 @@ exports.initialize_everything = function () {
     stream_data.initialize();
     muting.initialize();
     subs.initialize();
+    left_sidebar.initialize();
     stream_list.initialize();
     condense.initialize();
     lightbox.initialize();

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -12,6 +12,10 @@ $topic_indent: $far_left_gutter_size + $left_col_size + 4px;
     display: none;
 }
 
+.left_sidebar_stream_preference {
+    width: auto;
+}
+
 .hashtag:empty::after {
     font-size: 18px;
     font-weight: 800;
@@ -28,6 +32,14 @@ $topic_indent: $far_left_gutter_size + $left_col_size + 4px;
 .stream-privacy span.hashtag,
 #left-sidebar .filter-icon i {
     padding-right: 3px;
+}
+
+.stream_list_toggle {
+    opacity: 0.50;
+    display: inline-block;
+    min-width: $left_col_size;
+    text-align: center;
+    font-size: 11px;
 }
 
 .pm_left_col {
@@ -57,6 +69,8 @@ li.show-more-topics a {
     margin-left: 10px;
 }
 
+.stream_list_toggle:hover,
+.stream_sidebar_title:hover,
 #streams_inline_cog:hover,
 #streams_filter_icon:hover {
     opacity: 1;
@@ -489,8 +503,7 @@ li.expanded_private_message a {
 
 #streams_header {
     margin-right: 0px;
-    padding-left: $far_left_gutter_size;
-    cursor: pointer;
+    margin-left: $far_left_gutter_size;
 }
 
 #stream_filters .inactive_stream {

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -56,15 +56,25 @@
             </li>
         </ul>
         <div id="streams_list" class="zoom-out">
-            <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title" data-toggle="tooltip" title="{{ _('Filter streams') }}">{{ _('STREAMS') }}</h4>
+            <div id="streams_header" class="zoom-in-hide">
+
+                <span class="stream_list_toggle">
+                    <i class='fa fa-reorder'></i>
+                </span>
+                {#- squash whitespace -#}
+
+                <span class="stream_sidebar_title">{{ _('ALL STREAMS') }}</span>
+
                 <i id="streams_inline_cog" class='fa fa-cog' aria-hidden="true" data-toggle="tooltip" title="{{ _('Subscribe, add, or configure streams') }}"></i>
                 <i id="streams_filter_icon" class='fa fa-search' aria-hidden="true" data-toggle="tooltip" title="{{ _('Filter streams') }} (q)"></i>
+
                 <div class="input-append notdisplayed stream_search_section">
                     <input class="stream-list-filter" type="text" autocomplete="off" placeholder="{{ _('Search streams') }}" />
                     <button type="button" class="btn clear_search_button" id="clear_search_stream_button">
                         <i class="fa fa-remove" aria-hidden="true"></i>
                     </button>
                 </div>
+
             </div>
             <div id="topics_header">
                 <a href="" class="show-all-streams"> <i class="fa fa-chevron-left" aria-hidden="true"></i>{{ _('All streams') }}</a>


### PR DESCRIPTION
This is a somewhat more moderate approach to emulating the mobile unreads view on the main webapp while still playing nice with the old layout.

The first four commits, particularly the **first one**, should be ready to merge to master, regardless of where we go with the unreads view.

The fifth commit could also be merged, although it's mostly orthogonal to this effort, and we are still having conversation about making our search vs. filter terminology consistent.

The sixth commit is **ready to test deploy**, and it turns on unread-filtering for streams only.

The last couple commits are related to PMs, and I'm fine either way on test-deploying them.  (There's still more work to do there, but the commits are coherent.)

Before test deploying, please ping me so we can communicate what's been done on this branch to czo users.