### PR TITLE
[WIP] Webapp feature for public data export 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -148,6 +148,7 @@
         "settings_bots": false,
         "settings_display": false,
         "settings_emoji": false,
+        "settings_exports": false,
         "settings_linkifiers": false,
         "settings_invites": false,
         "settings_muting": false,

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -56,6 +56,12 @@ set_global('settings_bots', {
     update_bot_permissions_ui: noop,
 });
 
+set_global('settings_exports', {
+    populate_exports_table: function (exports) {
+        return exports;
+    },
+});
+
 // page_params is highly coupled to dispatching now
 set_global('page_params', {test_suite: false});
 var page_params = global.page_params;
@@ -711,6 +717,14 @@ var event_fixtures = {
         type: 'user_status',
         user_id: test_user.user_id,
         status_text: 'out to lunch',
+    },
+    realm_export: {
+        type: 'realm_export',
+        exports: {
+            acting_user_id: 55,
+            event_time: 'noon',
+            path: 'some_path',
+        },
     },
 };
 
@@ -1510,5 +1524,20 @@ with_overrides(function (override) {
         assert_same(args.user_id, test_user.user_id);
         var status_text = user_status.get_status_text(test_user.user_id);
         assert.equal(status_text, 'out to lunch');
+    });
+});
+
+with_overrides(function (override) {
+    var event = event_fixtures.realm_export;
+    override('settings_exports.populate_exports_table', noop);
+    dispatch(event);
+    global.with_stub(function (stub) {
+        override('settings_exports.populate_exports_table', stub.f);
+        dispatch(event);
+
+        var args = stub.get_args('exports');
+        assert.equal(args.exports.acting_user_id, 55);
+        assert.equal(args.exports.event_time, 'noon');
+        assert.equal(args.exports.path, 'some_path');
     });
 });

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -838,6 +838,10 @@ run_test('set_up', () => {
     const allow_topic_edit_label_parent = $.create('allow-topic-edit-label-parent');
     $('#id_realm_allow_community_topic_editing_label').set_parent(allow_topic_edit_label_parent);
 
+    channel.get = function (opts) {
+        assert.equal(opts.url, '/json/export/realm');
+    };
+
     // TEST set_up() here, but this mostly just allows us to
     // get access to the click handlers.
     settings_org.maybe_disable_widgets = noop;

--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -174,6 +174,7 @@ import "../settings_bots.js";
 import "../settings_muting.js";
 import "../settings_sections.js";
 import "../settings_emoji.js";
+import "../settings_exports.js";
 import "../settings_org.js";
 import "../settings_users.js";
 import "../settings_streams.js";

--- a/static/js/js_typings/zulip/index.d.ts
+++ b/static/js/js_typings/zulip/index.d.ts
@@ -111,6 +111,7 @@ declare var settings_account: any;
 declare var settings_bots: any;
 declare var settings_display: any;
 declare var settings_emoji: any;
+declare var settings_exports: any;
 declare var settings_invites: any;
 declare var settings: any;
 declare var settings_linkifiers: any;

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -510,6 +510,9 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             activity.redraw_user(event.user_id);
         }
         break;
+    case 'realm_export':
+        settings_exports.populate_exports_table(event.exports);
+        break;
     }
 
 };

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -24,6 +24,7 @@ var header_map = {
     "invites-list-admin": i18n.t("Invitations"),
     "user-groups-admin": i18n.t("User groups"),
     "profile-field-settings": i18n.t("Profile field settings"),
+    "data-exports-admin": i18n.t("Data exports"),
 };
 
 $("body").ready(function () {

--- a/static/js/settings_exports.js
+++ b/static/js/settings_exports.js
@@ -1,0 +1,89 @@
+var render_admin_export_list = require('../templates/admin_export_list.hbs');
+
+var settings_exports = (function () {
+
+var exports = {};
+
+var meta = {
+    loaded: false,
+};
+
+exports.reset = function () {
+    meta.loaded = false;
+};
+
+exports.populate_exports_table = function (exports) {
+    if (!meta.loaded) {
+        return;
+    }
+
+    var exports_table = $('#admin_exports_table').expectOne();
+    exports_table.find('tr.export_row').remove();
+    _.each(exports, function (data) {
+        if (data.export_data.deleted_timestamp === undefined) {
+            exports_table.append(render_admin_export_list({
+                realm_export: {
+                    id: data.id,
+                    acting_user: people.my_full_name(data.acting_user_id),
+                    // Convert seconds -> milliseconds
+                    event_time: timerender.last_seen_status_from_date(
+                        new XDate(data.export_time * 1000)
+                    ),
+                    path: data.export_data.export_path,
+                },
+            }));
+        }
+    });
+};
+
+exports.set_up = function () {
+    meta.loaded = true;
+
+    $("#export-data").on('click', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        var export_status = $('#export_status');
+
+        channel.post({
+            url: '/json/export/realm',
+            success: function () {
+                ui_report.success(i18n.t("Export started. Check back in a few minutes."), export_status);
+            },
+            error: function (xhr) {
+                ui_report.error(i18n.t("Export failed"), xhr, export_status);
+            },
+        });
+    });
+
+    // Do an initial population of the table
+    channel.get({
+        url: '/json/export/realm',
+        success: function (data) {
+            exports.populate_exports_table(data.exports);
+        },
+    });
+
+    $('.admin_exports_table').on('click', '.delete', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        var btn = $(this);
+
+        channel.del({
+            url: '/json/export/realm/' + encodeURIComponent(btn.attr('data-export-id')),
+            error: function (xhr) {
+                ui_report.generic_row_button_error(xhr, btn);
+            },
+            success: function () {
+                var row = btn.parents('tr');
+                row.remove();
+            },
+        });
+    });
+};
+
+return exports;
+}());
+if (typeof modules !== 'undefined') {
+    module.exports = settings_exports;
+}
+window.settings_exports = settings_exports;

--- a/static/js/settings_sections.js
+++ b/static/js/settings_sections.js
@@ -46,6 +46,7 @@ exports.initialize = function () {
     load_func_dict.set('invites-list-admin', settings_invites.set_up);
     load_func_dict.set('user-groups-admin', settings_user_groups.set_up);
     load_func_dict.set('profile-field-settings', settings_profile_fields.set_up);
+    load_func_dict.set('data-exports-admin', settings_exports.set_up);
 };
 
 exports.load_settings_section = function (section) {
@@ -72,6 +73,7 @@ exports.load_settings_section = function (section) {
 exports.reset_sections = function () {
     is_loaded.clear();
     settings_emoji.reset();
+    settings_exports.reset();
     settings_linkifiers.reset();
     settings_invites.reset();
     settings_org.reset();

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -723,13 +723,15 @@ input[type=checkbox].inline-block {
 
 .add-new-emoji-box,
 .add-new-user-group-box,
-.add-new-alert-word-box {
+.add-new-alert-word-box,
+.add-new-export-box {
     margin-bottom: 20px;
 }
 
 .add-new-emoji-box .new-emoji-form,
 .add-new-user-group-box .new-user-group-form,
-.add-new-alert-word-box .new-alert-word-form {
+.add-new-alert-word-box .new-alert-word-form,
+.add-new-export-box {
     margin: 10px 0px;
 }
 
@@ -1948,4 +1950,8 @@ thead .actions {
 #toggle_collapse {
     margin-left: 2px;
     display: inline-block;
+}
+
+.admin_exports_table {
+    margin: 20px;
 }

--- a/static/templates/admin_export_list.hbs
+++ b/static/templates/admin_export_list.hbs
@@ -1,0 +1,22 @@
+{{#with realm_export}}
+<tr class="export_row" id="export_{{id}}">
+    <td>
+        <span class="acting_user">{{acting_user}}</span>
+    </td>
+    <td>
+        <span class="export_time">{{event_time}}</span>
+    </td>
+    <td>
+        {{#if path}}
+        <span class="export_url"><a href="{{path}}">{{t 'Download' }}</a></span>
+        {{else}}
+        <span class="export_url">{{t 'The export URL is not yet available... Check back soon.' }}</span>
+        {{/if}}
+    </td>
+    <td>
+        <button class="button rounded small delete btn-danger" data-export-id="{{id}}">
+            <i class="fa fa-trash-o" aria-hidden="true"></i>
+        </button>
+    </td>
+</tr>
+{{/with}}

--- a/static/templates/admin_tab.hbs
+++ b/static/templates/admin_tab.hbs
@@ -28,3 +28,5 @@
 {{> user_groups_admin }}
 
 {{> settings/profile_field_settings_admin }}
+
+{{> settings/data_exports_admin }}

--- a/static/templates/settings/data_exports_admin.hbs
+++ b/static/templates/settings/data_exports_admin.hbs
@@ -1,0 +1,36 @@
+<div id="data-exports" class="settings-section" data-name="data-exports-admin">
+    <p class="alert-word-settings-note">{{#tr this}}Depending on the size of your organization, the time to complete an export can range from several minutes to an hour.{{/tr}}</p>
+    <h3>{{t "Data exports" }}
+        <a href="/help/export-your-organization" target="_blank">
+            <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+        </a>
+    </h3>
+
+    {{#if is_admin}}
+    <div class="alert" id="export_status" role="alert">
+        <span class="export_status_text"></span>
+    </div>
+    <form class="form-horizontal">
+        <div class="add-new-export-box grey-box">
+            <div class="wrapper">
+                <button type="submit" class="button rounded sea-green" id="export-data">
+                    {{t 'Start public export' }}
+                </button>
+            </div>
+            <p class="alert-word-settings-note">{{#tr this}}Zulip also supports exporting private streams and messages under some circumstances. <a href="/help/export-your-organization" target="_blank">Read more</a>{{/tr}}</p>
+        </div>
+    </form>
+    {{/if}}
+    <p class="alert-word-settings-note">{{#tr this}}Any member with administrative access can conduct an export.  Please note that individual organizations are limited to five exports per week.{{/tr}}</p>
+    <div class="admin-table-wrapper">
+        <table class="table table-condensed table-striped wrapped-table admin_exports_table">
+            <thead>
+                <th>{{t "Requesting user" }}</th>
+                <th>{{t "Time" }}</th>
+                <th>{{t "File" }}</th>
+                <th>{{t "Actions" }}</th>
+            </thead>
+            <tbody id="admin_exports_table" class="required-text" data-empty="{{t 'No exports.' }}"></tbody>
+        </table>
+    </div>
+</div>

--- a/templates/zerver/app/settings_overlay.html
+++ b/templates/zerver/app/settings_overlay.html
@@ -145,6 +145,10 @@
                     <i class="icon fa fa-user" aria-hidden="true"></i>
                     <div class="text">{{ _('Invitations') }}</div>
                 </li>
+                <li tabindex="0" data-section="data-exports-admin">
+                    <i class="icon fa fa-database" aria-hidden="true"></i>
+                    <div class="text">{{ _('Data exports') }}</div>
+                </li>
                 {% endif %}
                 {% if not is_admin %}
                 <div class="collapse-settings-btn">

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -145,7 +145,8 @@ from zerver.lib.email_notifications import enqueue_welcome_emails
 from zerver.lib.exceptions import JsonableError, ErrorCode, BugdownRenderingException
 from zerver.lib.sessions import delete_user_sessions
 from zerver.lib.upload import attachment_url_re, attachment_url_to_path_id, \
-    claim_attachment, delete_message_image, upload_emoji_image, delete_avatar_image
+    claim_attachment, delete_message_image, upload_emoji_image, delete_avatar_image, \
+    delete_export_tarball
 from zerver.lib.video_calls import request_zoom_video_call_url
 from zerver.tornado.event_queue import send_event
 from zerver.lib.types import ProfileFieldData
@@ -5680,3 +5681,16 @@ def notify_realm_export(user_profile: UserProfile) -> None:
     event = dict(type='realm_export',
                  exports=get_realm_exports_serialized(user_profile))
     send_event(user_profile.realm, event, [user_profile.id])
+
+def do_delete_realm_export(user_profile: UserProfile, export: RealmAuditLog) -> None:
+    # Give mypy a hint so it knows `ujson.loads`
+    # isn't being passed an `Optional[str]`.
+    export_extra_data = export.extra_data
+    assert export_extra_data is not None
+    export_data = ujson.loads(export_extra_data)
+
+    delete_export_tarball(export_data.get('export_path'))
+    export_data.update({'deleted_timestamp': timezone_now().timestamp()})
+    export.extra_data = ujson.dumps(export_data)
+    export.save(update_fields=['extra_data'])
+    notify_realm_export(user_profile)

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -1709,7 +1709,7 @@ def get_realm_exports_serialized(user: UserProfile) -> List[Dict[str, Any]]:
     for export in all_exports:
         exports_dict[export.id] = dict(
             id=export.id,
-            event_time=export.event_time.ctime(),
+            export_time=export.event_time.timestamp(),
             acting_user_id=export.acting_user.id,
             extra_data=ujson.loads(export.extra_data)
         )

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -1711,6 +1711,6 @@ def get_realm_exports_serialized(user: UserProfile) -> List[Dict[str, Any]]:
             id=export.id,
             export_time=export.event_time.timestamp(),
             acting_user_id=export.acting_user.id,
-            extra_data=ujson.loads(export.extra_data)
+            export_data=ujson.loads(export.extra_data)
         )
     return sorted(exports_dict.values(), key=lambda export_dict: export_dict['id'])

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2777,7 +2777,7 @@ class EventsRegisterTest(ZulipTestCase):
         with mock.patch('zerver.lib.export.do_export_realm',
                         return_value=create_dummy_file('test-export.tar.gz')):
             events = self.do_test(
-                lambda: print(self.client_post('/json/export/realm').content),
+                lambda: self.client_post('/json/export/realm'),
                 state_change_expected=True, num_events=2)
 
         # The first event is a message from notification-bot.

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2765,7 +2765,7 @@ class EventsRegisterTest(ZulipTestCase):
                 ('id', check_int),
                 ('export_time', check_float),
                 ('acting_user_id', check_int),
-                ('extra_data', check_dict_only([
+                ('export_data', check_dict_only([
                     ('export_path', check_string),
                     ('deleted_timestamp', equals(None))
                 ])),

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2767,7 +2767,6 @@ class EventsRegisterTest(ZulipTestCase):
                 ('acting_user_id', check_int),
                 ('export_data', check_dict_only([
                     ('export_path', check_string),
-                    ('deleted_timestamp', equals(None))
                 ])),
             ]))),
         ])

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2763,13 +2763,13 @@ class EventsRegisterTest(ZulipTestCase):
             ('type', equals('realm_export')),
             ('exports', check_list(check_dict_only([
                 ('id', check_int),
-                ('event_time', check_string),
+                ('export_time', check_float),
                 ('acting_user_id', check_int),
                 ('extra_data', check_dict_only([
                     ('export_path', check_string),
                     ('deleted_timestamp', equals(None))
                 ])),
-            ])))
+            ]))),
         ])
 
         do_change_is_admin(self.user_profile, True)

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -183,6 +183,7 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         '/attachments',
         '/calls/create',
         '/export/realm',
+        '/export/realm/{export_id}',
         '/zcommand',
         '/realm',
         '/realm/deactivate',

--- a/zerver/tests/test_realm_export.py
+++ b/zerver/tests/test_realm_export.py
@@ -54,7 +54,7 @@ class RealmExportTest(ZulipTestCase):
         self.assert_json_success(result)
 
         export_dict = result.json()['exports']
-        self.assertEqual(export_dict[0]['extra_data'].get('export_path'), path_id)
+        self.assertEqual(export_dict[0]['export_data'].get('export_path'), path_id)
         self.assertEqual(export_dict[0]['acting_user_id'], admin.id)
         self.assert_length(export_dict,
                            RealmAuditLog.objects.filter(
@@ -95,7 +95,7 @@ class RealmExportTest(ZulipTestCase):
         self.assert_json_success(result)
 
         export_dict = result.json()['exports']
-        self.assertEqual(export_dict[0]['extra_data'].get('export_path'), path_id)
+        self.assertEqual(export_dict[0]['export_data'].get('export_path'), path_id)
         self.assertEqual(export_dict[0]['acting_user_id'], admin.id)
         self.assert_length(export_dict,
                            RealmAuditLog.objects.filter(

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -619,10 +619,11 @@ class DeferredWorker(QueueProcessingWorker):
                                               delete_after_upload=True)
             assert public_url is not None
 
-            # Store the relative URL of the export.
+            # Update the extra_data field now that the export is complete.
             export_event = RealmAuditLog.objects.get(id=event['id'])
-            export_event.extra_data = ujson.dumps({'export_path': urllib.parse.urlparse(public_url).path,
-                                                   'deleted_timestamp': None})
+            export_event.extra_data = ujson.dumps(dict(
+                export_path=urllib.parse.urlparse(public_url).path,
+            ))
             export_event.save(update_fields=['extra_data'])
 
             # Send a private message notification letting the user who

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -398,10 +398,12 @@ v1_api_and_json_patterns = [
     url(r'^calls/create$', rest_dispatch,
         {'GET': 'zerver.views.video_calls.get_zoom_url'}),
 
-    # Used realm data exporting
+    # export/realm -> zerver.views.realm_export
     url(r'^export/realm$', rest_dispatch,
         {'POST': 'zerver.views.realm_export.export_realm',
          'GET': 'zerver.views.realm_export.get_realm_exports'}),
+    url(r'^export/realm/(?P<export_id>.*)$', rest_dispatch,
+        {'DELETE': 'zerver.views.realm_export.delete_realm_export'}),
 ]
 
 # These views serve pages (HTML). As such, their internationalization


### PR DESCRIPTION
## What is this PR for
Fixes: #11930, which adds a public only realm export feature for the webapp.

*Demo of tentative UI*:
![demo](https://user-images.githubusercontent.com/39782863/62760765-7370c180-ba20-11e9-8ab7-b59330b538c0.gif)



## Commits

### Previous commits
* *(merged)*: This commit serves as the first step in supporting "public export" as a
webapp feature.  The refactoring was done as a means to allow calling
the export logic from elsewhere in the codebase.

* *(merged)*: This allows for removal of the local tarball upon a successful s3 export.

* *(merged)*: An endpoint was created in zerver/views.  Basic rate-limiting was
implemented using RealmAuditLog. The event is then published to the ```deferred_work``` queue processor to prevent the export process from being killed after 60s. Finally, upon completion of the export the realm admin(s) are notified via ```send_event```.

* (Plus a handful of clean up commits).

**Complete** *(re-posting of Tim's comment below)*:
- [x] We need to add LOCAL_UPLOADS_DIR support to the --upload-to-s3 option. First, a commit should rename it to --upload since it's no longer going to be just S3. And then a commit that changes export_realm_wrapper to support upload via the LOCAL_UPLOADS_DIR backend (likely, this will be just a shutil.copyfile call with the right construction), and then we can remove the AssertionError and fill out the test for the LOCAL_UPLOADS_DIR backend.

- [x] There are several TODOs in test_realm_export.py that need to be completed.

- [x] We probably should arrange to store the ID of the RealmAuditLog row created in public_only_realm_export in the event sent to the deferred_work queue, and then have the queue processor add the public_url to the RealmAuditLog event in the extra_data field. This will enable support for deleting the uploaded exports later once they've been accessed.

