### PR TITLE
Update some remaining sources and docs for TypeScript support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,14 +6,14 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{sh,py,pyi,js,json,yml,xml,css,md,markdown,handlebars,html}]
+[*.{sh,py,pyi,js,ts,json,yml,xml,css,md,markdown,handlebars,html}]
 indent_style = space
 indent_size = 4
 
 [*.{py}]
 max_line_length = 110
 
-[*.{js}]
+[*.{js,ts}]
 max_line_length = 120
 
 [*.{svg,rb,pp,pl}]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,8 +107,8 @@ on.
   [#new members](https://chat.zulip.org/#narrow/stream/95-new-members) with a
   bit about your background and interests, and we'll help you out. The most
   important thing to say is whether you're looking for a backend (Python),
-  frontend (JavaScript), mobile (React Native), desktop (Electron),
-  documentation (English) or visual design (JavaScript + CSS) issue, and a
+  frontend (JavaScript and TypeScript), mobile (React Native), desktop (Electron),
+  documentation (English) or visual design (JavaScript/TypeScript + CSS) issue, and a
   bit about your programming experience and available time.
 
 We also welcome suggestions of features that you feel would be valuable or

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -145,15 +145,15 @@ string, use the `id` function, as it will simplify future code changes.
 In most contexts in JavaScript where a string is needed, you can pass a
 number without any explicit conversion.
 
-### JavaScript var
+### JavaScript and Typescript `var`
 
-Always declare JavaScript variables using `var`.  JavaScript has
+Always declare JavaScript and TypeScript variables using `var`.  These languages have
 function scope only, not block scope. This means that a `var`
 declaration inside a `for` or `if` acts the same as a `var`
 declaration at the beginning of the surrounding `function`. To avoid
 confusion, declare all variables at the top of a function.
 
-### JavaScript `for (i in myArray)`
+### JavaScript and TypeScript `for (i in myArray)`
 
 Don't use it:
 [[1]](http://stackoverflow.com/questions/500504/javascript-for-in-with-arrays),
@@ -164,7 +164,7 @@ Don't use it:
 
 Remember to
 [tag all user-facing strings for translation](../translating/translating.html), whether
-they are in HTML templates or JavaScript editing the HTML (e.g. error
+they are in HTML templates or JavaScript/TypeScript editing the HTML (e.g. error
 messages).
 
 ### State and logs files
@@ -212,7 +212,7 @@ we should still avoid extremely long lines. A general guideline is:
 refactor stuff to get it under 85 characters, unless that makes the
 code a lot uglier, in which case it's fine to go up to 120 or so.
 
-### JavaScript
+### JavaScript and TypeScript
 
 When calling a function with an anonymous function as an argument, use
 this style:

--- a/docs/git/cheat-sheet.md
+++ b/docs/git/cheat-sheet.md
@@ -24,7 +24,7 @@ See also [fixing commits][fix-commit]
     - `git fetch origin`
     - `git fetch upstream`
 - grep
-    - `git grep update_unread_counts -- '*.js'`
+    - `git grep update_unread_counts -- '*.js' '*.ts'`
 - log
     - `git log`
 - pull
@@ -79,7 +79,8 @@ See also [fixing commits][fix-commit]
     - `git fetch origin`: fetch origin repository
     - `git fetch upstream`: fetch upstream repository
 - grep
-    - `git grep update_unread_counts -- '*.js'`: search all files (ending in `.js`) for `update_unread_counts`
+    - `git grep update_unread_counts -- '*.js' '*.ts'`: search all
+      files (ending in `.js` or in `.ts`) for `update_unread_counts`
 - log
     - `git log`: show commit logs
     - `git log --oneline | head`: To quickly see the latest ten commits on a branch.

--- a/docs/overview/directory-structure.md
+++ b/docs/overview/directory-structure.md
@@ -52,9 +52,9 @@ templating systems.
 
 ----------------------------------------
 
-### JavaScript and other static assets
+### JavaScript, TypeScript, and other static assets
 
-* `static/js/` Zulip's own JavaScript.
+* `static/js/` Zulip's own JavaScript and TypeScript sources.
 
 * `static/styles/` Zulip's own CSS.
 

--- a/docs/testing/linters.md
+++ b/docs/testing/linters.md
@@ -3,7 +3,7 @@
 ## Overview
 
 Zulip does extensive linting of much of its source code, including
-Python/JavaScript files, HTML templates (Django/handlebars), CSS files,
+Python/JavaScript/TypeScript files, HTML templates (Django/handlebars), CSS files,
 JSON fixtures, Markdown documents, puppet manifests, and shell scripts.
 
 For some files we simply check for small things like trailing whitespace,
@@ -92,7 +92,7 @@ Most of our lint checks get performed by `./tools/lint`.  These include the
 following checks:
 
 - Check Python code with pyflakes.
-- Check JavaScript code with eslint.
+- Check JavaScript and TypeScript code with eslint.
 - Check Python code for custom Zulip rules.
 - Check non-Python code for custom Zulip rules.
 - Check puppet manifests with the puppet validator.

--- a/docs/testing/testing-with-node.md
+++ b/docs/testing/testing-with-node.md
@@ -1,7 +1,7 @@
-# JavaScript unit tests
+# JavaScript and TypeScript unit tests
 
 As an alternative to the black-box whole-app testing, you can unit test
-individual JavaScript files.
+individual JavaScript and TypeScript files.
 
 You can run tests as follow:
 ```

--- a/docs/tutorials/new-feature-tutorial.md
+++ b/docs/tutorials/new-feature-tutorial.md
@@ -114,10 +114,10 @@ Realm setting, in `test_realm.py`).
 
 ### Frontend changes
 
-**JavaScript:** Zulip's JavaScript is located in the directory
-`static/js/`. The exact files you may need to change depend on your
-feature. If you've added a new event that is sent to clients, be sure to
-add a handler for it in `static/js/server_events_dispatch.js`.
+**JavaScript/TypeScript:** Zulip's JavaScript and TypeScript sources are
+located in the directory `static/js/`. The exact files you may need to change
+depend on your feature. If you've added a new event that is sent to clients,
+be sure to add a handler for it in `static/js/server_events_dispatch.js`.
 
 **CSS:** The primary CSS file is `static/styles/zulip.css`. If your new
 feature requires UI changes, you may need to add additional CSS to this
@@ -129,7 +129,7 @@ Handlebars templates located in `static/templates`. Templates are
 precompiled as part of the build/deploy process.
 
 Zulip is fully internationalized, so when writing both HTML templates
-or JavaScript code that generates user-facing strings, be sure to
+or JavaScript/TypeScript code that generates user-facing strings, be sure to
 [tag those strings for translation](../translating/translating.html).
 
 **Testing:** There are two types of frontend tests: node-based unit

--- a/docs/tutorials/reading-list.md
+++ b/docs/tutorials/reading-list.md
@@ -140,6 +140,20 @@ Some titles have been shortened for organizational purposes.
 
 [TypeScript vs. CoffeeScript vs. ES6]: http://www.slideshare.net/NeilGreen1/type-script-vs-coffeescript-vs-es6
 
+## TypeScript
+
+*Tutorial* - [TypeScript in 5 minutes][]
+
+[TypeScript in 5 minutes]: https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html
+
+*Book* - [TypeScript Deep Dive][]
+
+[TypeScript Deep Dive]: https://basarat.gitbooks.io/typescript/
+
+*Guide* - [TypeScript Declaration Files Introduction][]
+
+[TypeScript Declaration Files Introduction]: https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html
+
 ## Git/Version Control Systems (VCS)
 
 You may want to take a look first at our [Git and GitHub guide][].

--- a/tools/js-dep-visualizer.py
+++ b/tools/js-dep-visualizer.py
@@ -36,9 +36,9 @@ def get_js_edges():
     names = set()
     modules = []  # type: List[Dict[str, Any]]
     for js_file in os.listdir(JS_FILES_DIR):
-        if not js_file.endswith('.js'):
+        if not js_file.endswith('.js') and not js_file.endswith('.ts'):
             continue
-        name = js_file[:-3]  # remove .js
+        name = js_file[:-3]  # Remove .js or .ts
         path = os.path.join(JS_FILES_DIR, js_file)
         names.add(name)
         modules.append(dict(
@@ -266,11 +266,14 @@ def report_roadmap(edges, methods):
             callers[(child, method)].add(parent)
 
     for child in sorted(child_modules):
-        print(child + '.js')
+        # Since children are found using the regex pattern, it is difficult
+        # to know if they are JS or TS files without checking which files
+        # exist. Instead, just print the name of the module.
+        print(child)
         for method in module_methods[child]:
             print('    ' + child + '.' + method)
             for caller in sorted(callers[(child, method)]):
-                print('        ' + caller + '.js')
+                print('        ' + caller)
             print()
         print()
 

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -39,7 +39,7 @@ enforce_fully_covered = {
     'static/js/compose_ui.js',
     # Temporarily removed until we finish merging emoji commits.
     # 'static/js/composebox_typeahead.js',
-    'static/js/dict.js',
+    'static/js/dict.ts',
     'static/js/emoji.js',
     'static/js/fenced_code.js',
     'static/js/fetch_status.js',
@@ -119,7 +119,9 @@ INDEX_JS = 'frontend_tests/zjsunit/index.js'
 # Add ".js" to the end of all the file arguments, so index.js
 # can actually verify if the file exists or not.
 for index, arg in enumerate(options.args):
-    if not arg.endswith('.js'):
+    if not arg.endswith('.js') and not arg.endswith('.ts'):
+        # If it doesn't end with ".js" or ".ts", assume it is a JS file,
+        # since most files are currently JS files.
         options.args[index] = arg + '.js'
 
 individual_files = options.args


### PR DESCRIPTION
This PR contains some changes to documentation and source files in order to increase support for TypeScript in the future. Changes include:

 - Updating JS tests to support the `.ts` file extension.
 - Including TypeScript files in the dependency visualizer.
 - Replacing references to "JavaScript" with references to both JS and TypeScript.
 - Add a section to the Reading List for TypeScript resources.

Fixes #12000.