### PR TITLE
Stream settings: Last non-guest user cannot unsubscribe from private streams

### DIFF
--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -158,6 +158,7 @@ run_test('unsubscribe', () => {
     // make sure subsequent calls work
     sub = stream_data.get_sub('devel');
     assert(!sub.subscribed);
+
 });
 
 run_test('subscribers', () => {
@@ -623,6 +624,37 @@ run_test('get_subscriber_count', () => {
     const sub = stream_data.get_sub_by_name('India');
     delete sub.subscribers;
     assert.deepStrictEqual(stream_data.get_subscriber_count('India'), 0);
+});
+
+run_test('get_non_guest_subscriber_count', () => {
+    const india = {
+        stream_id: 102,
+        name: 'India',
+    };
+    stream_data.clear_subscriptions();
+    stream_data.add_sub(india);
+    const sub = stream_data.get_sub('India');
+
+    assert.equal(stream_data.get_non_guest_subscriber_count(sub), 0);
+
+    const fred = {
+        email: 'fred@zulip.com',
+        full_name: 'Fred',
+        user_id: 101,
+    };
+    people.add(fred);
+    stream_data.add_subscriber('India', 101);
+    assert.equal(stream_data.get_non_guest_subscriber_count(sub), 1);
+    const george = {
+        email: 'george@zulip.com',
+        full_name: 'George',
+        user_id: 103,
+        is_guest: true,
+    };
+    people.add(george);
+    stream_data.add_subscriber('India', 103);
+    assert.equal(stream_data.get_non_guest_subscriber_count(sub), 1);
+
 });
 
 run_test('notifications', () => {

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -441,6 +441,17 @@ exports.receives_notifications = function (stream_name, notification_name) {
     return page_params["enable_stream_" + notification_name];
 };
 
+exports.get_non_guest_subscriber_count = function (sub) {
+    const user_ids = Array.from(sub.subscribers.keys());
+    const non_guest_user_ids = [];
+    _.each (user_ids, function (user_id) {
+        if (people.get_user_type(user_id) !== i18n.t('Guest')) {
+            non_guest_user_ids.push(user_id);
+        }
+    });
+    return non_guest_user_ids.length;
+};
+
 exports.update_calculated_fields = function (sub) {
     sub.is_admin = page_params.is_admin;
     // Admin can change any stream's name & description either stream is public or

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -138,8 +138,12 @@ function build_stream_popover(opts) {
     popovers.hide_all();
     exports.show_streamlist_sidebar();
 
+    const sub = stream_data.get_sub_by_id(stream_id);
+    const show_unsubscribe = !(sub.invite_only &&
+        stream_data.get_non_guest_subscriber_count(sub) <= 1);
     const content = render_stream_sidebar_actions({
-        stream: stream_data.get_sub_by_id(stream_id),
+        stream: sub,
+        show_unsubscribe: show_unsubscribe,
     });
 
     $(elt).popover({

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -866,13 +866,22 @@ exports.open_create_stream = function () {
     hashchange.update_browser_history('#streams/new');
 };
 
-
 exports.sub_or_unsub = function (sub, stream_row) {
+    let ajax_called = true;
     if (sub.subscribed) {
-        ajaxUnsubscribe(sub, stream_row);
+        if (sub.invite_only === true) {
+            if (stream_data.get_non_guest_subscriber_count(sub) > 1) {
+                ajaxUnsubscribe(sub, stream_row);
+            } else {
+                ajax_called = false;
+            }
+        } else {
+            ajaxUnsubscribe(sub, stream_row);
+        }
     } else {
         ajaxSubscribe(sub.name, sub.color, stream_row);
     }
+    return ajax_called;
 };
 
 

--- a/static/templates/stream_sidebar_actions.hbs
+++ b/static/templates/stream_sidebar_actions.hbs
@@ -33,12 +33,14 @@
             {{/if}}
         </a>
     </li>
+    {{#if show_unsubscribe}}
     <li>
         <a class="popover_sub_unsub_button" data-name="{{stream.name}}">
             <i class='fa fa-envelope' aria-hidden="true"></i>
             {{t "Unsubscribe" }}
         </a>
     </li>
+    {{/if}}
     <li>
         <span class="colorpicker-container"><input stream_id="{{stream.stream_id}}" class="colorpicker" type="text" value="{{stream.color}}" /></span>
         <a class="custom_color">{{t "Choose custom color" }}</a>

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -225,6 +225,11 @@ def private_stream_user_ids(stream_id: int) -> Set[int]:
     subscriptions = get_active_subscriptions_for_stream_id(stream_id)
     return {sub['user_profile_id'] for sub in subscriptions.values('user_profile_id')}
 
+def private_stream_non_guest_user_count(stream_id: int) -> int:
+    user_ids = private_stream_user_ids(stream_id)
+    non_guest_users = [user_id for user_id in user_ids if not get_user_profile_by_id(user_id).is_guest]
+    return len(non_guest_users)
+
 def public_stream_user_ids(stream: Stream) -> Set[int]:
     guest_subscriptions = get_active_subscriptions_for_stream_id(
         stream.id).filter(user_profile__role=UserProfile.ROLE_GUEST)


### PR DESCRIPTION
This prevents the last non-guest user in a private stream to be unsubscribed from the stream.

Error is shown when last non-guest user tries to unsubscribe and the option of unsubscribe is removed from the stream popover in this case.

Fixes #11962

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
I have tested manually and have also written tests.

**GIFs or Screenshots:** <!-- If a UI ch
ange.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Peek 2019-03-30 09-49](https://user-images.githubusercontent.com/35494118/55279174-815c5a80-533b-11e9-82fd-e4eff2905da7.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
