### PR TITLE
mypy: Enable Strict-optional checks for auth (and other minor file)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -102,8 +102,6 @@ strict_optional = False
 [mypy-zerver.migrations.0077_add_file_name_field_to_realm_emoji]  #73: error: Argument 2 to "upload_files" of "Uploader" has incompatible type "Optional[bytes]"; expected "bytes"
 strict_optional = False
 
-[mypy-zilencer.management.commands.calculate_first_visible_message_id]  #33: error: Argument 1 to "maybe_update_first_visible_message_id" has incompatible type "Optional[Realm]"; expected "Realm"
-strict_optional = False
 [mypy-zilencer.management.commands.add_new_realm]  #22: error: List item 0 has incompatible type "Optional[Stream]"; expected "Stream"
 strict_optional = False
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -90,8 +90,6 @@ strict_optional = True
 [mypy-zerver.webhooks.gitlab.view]
 strict_optional = False
 
-[mypy-zerver.views.auth]  # Other issues in this file too
-strict_optional = False
 [mypy-zerver.views.realm]  # Other issues in this file too
 strict_optional = False
 [mypy-zerver.views.messages]  # Other issues in this file too

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -1,5 +1,5 @@
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 from django.http import HttpRequest
 from django.conf import settings
 from django.urls import reverse
@@ -35,7 +35,7 @@ def common_context(user: UserProfile) -> Dict[str, Any]:
         'user_name': user.full_name,
     }
 
-def get_realm_from_request(request: HttpRequest) -> Optional[Realm]:
+def get_realm_from_request(request: HttpRequest) -> Realm:
     if hasattr(request, "user") and hasattr(request.user, "realm"):
         return request.user.realm
     if not hasattr(request, "realm"):

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -147,7 +147,7 @@ def redirect_to_subdomain_login_url() -> HttpResponseRedirect:
 def redirect_to_config_error(error_type: str) -> HttpResponseRedirect:
     return HttpResponseRedirect("/config-error/%s" % (error_type,))
 
-def login_or_register_remote_user(request: HttpRequest, remote_username: Optional[str],
+def login_or_register_remote_user(request: HttpRequest, remote_username: str,
                                   user_profile: Optional[UserProfile], full_name: str='',
                                   invalid_subdomain: bool=False, mobile_flow_otp: Optional[str]=None,
                                   is_signup: bool=False, redirect_to: str='',
@@ -306,7 +306,7 @@ def google_oauth2_csrf(request: HttpRequest, value: str) -> str:
     token = _unsalt_cipher_token(get_token(request))
     return hmac.new(token.encode('utf-8'), value.encode("utf-8"), hashlib.sha256).hexdigest()
 
-def reverse_on_root(viewname: str, args: List[str]=None, kwargs: Dict[str, str]=None) -> str:
+def reverse_on_root(viewname: str, *args: str, **kwargs: str) -> str:
     return settings.ROOT_DOMAIN_URI + reverse(viewname, args=args, kwargs=kwargs)
 
 def oauth_redirect_to_root(request: HttpRequest, url: str,

--- a/zilencer/management/commands/calculate_first_visible_message_id.py
+++ b/zilencer/management/commands/calculate_first_visible_message_id.py
@@ -22,12 +22,12 @@ class Command(ZulipBaseCommand):
         )
 
     def handle(self, *args: Any, **options: Any) -> None:
-        realm = self.get_realm(options)
+        specific_realm = self.get_realm(options)
 
-        if realm is None:
+        if specific_realm is None:
             realms = Realm.objects.all()
         else:
-            realms = [realm]
+            realms = [specific_realm]
 
         for realm in realms:
             maybe_update_first_visible_message_id(realm, options['lookback_hours'])


### PR DESCRIPTION
* `calculate_first_visible_message_id.py` (commit) should be straightforward
* `reverse_on_root change` updated is likely necessary to avoid an old python-2-style args/kwargs which was migrated automatically
* `login_or_register_remote_user` being non-None seems OK?
* `context_processors.py` - this is the change I'm least sure of; without this, `login_page` has an issue on auth.py:687, the alternate solution may be to add an assert on the previous line that the realm is non-None?