### PR TITLE
subscriptions: Disable sub-check-btn if user is not allowed to subscribe. 

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -164,6 +164,9 @@ function show_subscription_settings(sub_row) {
     if (!sub.render_subscribers) {
         return;
     }
+    if (!sub.should_display_subscription_button) {
+        stream_ui_updates.initialize_cant_subscribe_popover(sub);
+    }
     // fetch subscriber list from memory.
     var list = get_subscriber_list(sub_settings);
     list.empty();

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -9,6 +9,11 @@ exports.update_check_button_for_sub = function (sub) {
     } else {
         button.removeClass("checked");
     }
+    if (sub.should_display_subscription_button) {
+        button.removeClass("disabled");
+    } else {
+        button.addClass("disabled");
+    }
 };
 
 exports.update_settings_button_for_sub = function (sub) {

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -16,6 +16,34 @@ exports.update_check_button_for_sub = function (sub) {
     }
 };
 
+exports.initialize_cant_subscribe_popover = function (sub) {
+    var button_wrapper = stream_edit.settings_for_sub(sub).find('.sub_unsub_button_wrapper');
+    var settings_button = subs.settings_button_for_sub(sub);
+
+    // Disabled button blocks mouse events(hover) from reaching
+    // to it's parent div element, so popover don't get triggered.
+    // Add css to prevent this.
+    settings_button.css("pointer-events", "none");
+    settings_button.popover({
+        placement: "bottom",
+        content: "<div class='cant_subscribe_hint'>%s</div>".replace(
+            '%s', i18n.t('You can not join private streams without invitation.')),
+        trigger: "manual",
+        html: true,
+        animation: false,
+    });
+
+    button_wrapper.on('mouseover', function (e) {
+        settings_button.popover('show');
+        e.stopPropagation();
+    });
+
+    button_wrapper.on('mouseout', function (e) {
+        settings_button.popover('hide');
+        e.stopPropagation();
+    });
+};
+
 exports.update_settings_button_for_sub = function (sub) {
     var settings_button = subs.settings_button_for_sub(sub);
     if (sub.subscribed) {
@@ -24,9 +52,13 @@ exports.update_settings_button_for_sub = function (sub) {
         settings_button.text(i18n.t("Subscribe")).addClass("unsubscribed");
     }
     if (sub.should_display_subscription_button) {
-        settings_button.show();
+        settings_button.prop("disabled", false);
+        settings_button.popover('destroy');
+        settings_button.css("pointer-events", "");
     } else {
-        settings_button.hide();
+        settings_button.attr("title", "");
+        exports.initialize_cant_subscribe_popover(sub);
+        settings_button.attr("disabled", "disabled");
     }
 };
 

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -337,6 +337,7 @@ ul.remind_me_popover .remind_icon {
     top: 1px;
 }
 
+.popover .cant_subscribe_hint,
 .popover .cant_add_subs_hint {
     padding-left: 5px;
     padding-right: 5px;

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -612,6 +612,11 @@ form#add_new_subscription {
     opacity: 0.5;
 }
 
+.stream-row .check.disabled {
+    pointer-events: none;
+    visibility: hidden;
+}
+
 .stream-row .icon {
     width: 35px;
     height: 35px;

--- a/static/templates/subscription.handlebars
+++ b/static/templates/subscription.handlebars
@@ -1,7 +1,8 @@
 {{! Client-side Mustache template for rendering subscriptions.}}
 {{#with this}}
 <div class="stream-row" data-stream-id="{{stream_id}}" data-stream-name="{{name}}">
-    <div class="check {{#if subscribed }}checked{{/if}} sub_unsub_button">
+
+    <div class="check {{#if subscribed }}checked{{/if}} sub_unsub_button {{#unless should_display_subscription_button}}disabled{{/unless}}">
         <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100%" height="100%" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
             <path d="M448,71.9c-17.3-13.4-41.5-9.3-54.1,9.1L214,344.2l-99.1-107.3c-14.6-16.6-39.1-17.4-54.7-1.8 c-15.6,15.5-16.4,41.6-1.7,58.1c0,0,120.4,133.6,137.7,147c17.3,13.4,41.5,9.3,54.1-9.1l206.3-301.7 C469.2,110.9,465.3,85.2,448,71.9z"/>
         </svg>

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -21,8 +21,10 @@
                 {{#if is_admin}}
                 <button class="button small rounded btn-danger deactivate" type="button" name="delete_button" title="{{t 'Delete stream'}}"> <i class="fa fa-trash-o" aria-hidden="true"></i></button>
                 {{/if}}
-                <button class="button small rounded subscribe-button sub_unsub_button {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button" title="{{t 'Toggle subscription'}} (S)" {{#unless should_display_subscription_button}}style="display: none"{{/unless}}>
-                    {{#if subscribed }}{{#tr oneself }}Unsubscribe{{/tr}}{{else}}{{#tr oneself }}Subscribe{{/tr}}{{/if}}</button>
+                <div class="sub_unsub_button_wrapper inline-block">
+                    <button class="button small rounded subscribe-button sub_unsub_button {{#unless subscribed }}unsubscribed{{/unless}}" type="button" name="button" {{#if should_display_subscription_button}}title="{{t 'Toggle subscription'}} (S)" {{else}}disabled="disabled"{{/if}}>
+                        {{#if subscribed }}{{#tr oneself }}Unsubscribe{{/tr}}{{else}}{{#tr oneself }}Subscribe{{/tr}}{{/if}}</button>
+                </div>
                 <a href="{{preview_url}}" class="button small rounded" id="preview-stream-button" role="button" title="{{t 'View stream'}} (V)" {{#unless should_display_preview_button }}style="display: none"{{/unless}}>{{t "View stream"}}</a>
             </div>
         </div>

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -827,7 +827,8 @@ class StreamAdminTest(ZulipTestCase):
             "/json/users/me/subscriptions",
             {"subscriptions": ujson.dumps([{"name": deactivated_stream_name}])})
         self.assert_json_error(
-            result, "Unable to access stream (%s)." % (deactivated_stream_name,))
+            result, "Unable to access stream (%s). Admin can not access unsubscribed private streams." % (
+                deactivated_stream_name))
 
     def test_you_must_be_realm_admin(self) -> None:
         """
@@ -3272,6 +3273,12 @@ class InviteOnlyStreamTest(ZulipTestCase):
         self.login(email)
         result = self.common_subscribe_to_streams(email, [stream_name])
         self.assert_json_error(result, 'Unable to access stream (Saxony).')
+        # Even relam admin is not allowed to subscribe to private stream
+        user_profile = self.example_user('iago')
+        email = user_profile.email
+        self.login(email)
+        result = self.common_subscribe_to_streams(email, [stream_name])
+        self.assert_json_error(result, 'Unable to access stream (Saxony). Admin can not access unsubscribed private streams.')
 
         # authorization_errors_fatal=False works
         user_profile = self.example_user('othello')

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -323,7 +323,12 @@ def add_subscriptions_backend(
     authorized_streams, unauthorized_streams = \
         filter_stream_authorization(user_profile, existing_streams)
     if len(unauthorized_streams) > 0 and authorization_errors_fatal:
-        return json_error(_("Unable to access stream (%s).") % unauthorized_streams[0].name)
+        if user_profile.is_realm_admin and unauthorized_streams[0].invite_only:
+            return json_error(_("Unable to access stream (%s). "
+                                "Admin can not access unsubscribed private streams.")
+                              % (unauthorized_streams[0].name))
+        else:
+            return json_error(_("Unable to access stream (%s).") % unauthorized_streams[0].name)
     # Newly created streams are also authorized for the creator
     streams = authorized_streams + created_streams
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

- [X] subscriptions: Return precise error msg on unauthorized subscriptions.**

    Return more precise error message when realm admins tries
    to subscribe to private streams.

- [X] subscriptions: Disable sub-check-btn if user is not allowed to subscribe.**

    This commit disable the subscription checkmark button in stream list
    view, if user is not allowed to subscribe to stream.

- [X] Add a greyed out "View stream" or "Subscribe" button on the right sidebar, with an on-hover explanation.



**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![DisableSubCheck](https://user-images.githubusercontent.com/25907420/55285618-f6b44380-53ac-11e9-9665-1c4fa1a0a616.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
