### PR TITLE
css: Add spacing between info and image on /apps.

### DIFF
--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -2118,11 +2118,14 @@ nav ul li.active::after {
 .portico-landing.apps .hero .image img[src="/static/images/app-screenshots/zulip-android.png"] {
     height: 100%;
 }
-
 .portico-landing.apps .hero .info .flex,
 .portico-landing.apps .hero .image .flex {
     height: 500px;
     min-height: 0px;
+}
+
+.portico-landing.apps .hero .info .flex {
+    width: 90%;
 }
 
 .portico-landing.apps .hero .info button {
@@ -3777,6 +3780,7 @@ nav ul li.active::after {
     .portico-landing.apps .hero .image .flex {
         height: 300px;
         min-height: 0px;
+        width: 100%;
     }
 
     .portico-landing.apps .other-apps {


### PR DESCRIPTION
Fixes: #11811.

**Screenshots:** 
Before my changes:
<img width="1231" alt="Screen Shot 2019-03-31 at 15 22 20" src="https://user-images.githubusercontent.com/18381652/55292361-30f00600-53ea-11e9-9adc-bdb2d4da0afa.png">

After my changes:
<img width="976" alt="Screen Shot 2019-03-31 at 19 11 44" src="https://user-images.githubusercontent.com/18381652/55292363-36e5e700-53ea-11e9-8f6a-c1ec323f0767.png">

I added `width: 90%;` on the information next to the picture. 