### PR TITLE
markdown: Fix unordered list not rendering in blockquote.

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1411,9 +1411,11 @@ class BugdownUListPreprocessor(markdown.preprocessors.Preprocessor):
         copy = lines[:]
         for i in range(len(lines) - 1):
             # Ignore anything that is inside a fenced code block
+            # but not quoted
             m = FENCE_RE.match(lines[i])
             if not fence and m:
-                fence = m.group('fence')
+                quote = m.group('lang') in ('quote', 'quoted')
+                fence = m.group('fence') and not quote
             elif fence and m and fence == m.group('fence'):
                 fence = None
 

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -156,6 +156,12 @@
       "text_content": "Plain list\n\nAlpha\nBeta\n\nAnd Again:\n\nA\nB\nC\n\nOnce more for feeling:\n\nQ\nE\nD\n"
     },
     {
+      "name": "ulist_hanging_quoted",
+      "input": "```quote\nSome text with a hanging list inside quote:\n* one\n* two\n* three\n```",
+      "expected_output": "<blockquote>\n<p>Some text with a hanging list inside quote:</p>\n<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n</blockquote>",
+      "text_content": "> Some text with a hanging list inside quote:\n> one\n> two\n> three\n"
+    },
+    {
       "name": "ulist_nested_ulist_two_space_indent",
       "input": "Nested list\n* I am outer list\n  * I am inner nested list first item\n  * I am inner nested list second item",
       "expected_output": "<p>Nested list</p>\n<ul>\n<li>I am outer list<ul>\n<li>I am inner nested list first item</li>\n<li>I am inner nested list second item</li>\n</ul>\n</li>\n</ul>",


### PR DESCRIPTION
This fixes an issue where the hanging unordered list was not
rendering in blockquote; the problem was that we were not
adding an empty line(to satisfy the markdown) for hanging
unordered list if it is in blockquote. Both blockquote
and code block is fenced but we want to avoid rendering
the list if it's in the code block but not in blockquote.

Fixes: #11916.

**Testing Plan:** 
Tested manually and updated automated test
