### PR TITLE
Fix bugs on Apps-Zulip page

### DIFF
--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -63,12 +63,14 @@ var apps_events = function () {
         android: {
             image: "/static/images/app-screenshots/zulip-android.png",
             alt: "Android",
+            show_instructions: false,
             description: "Zulip's native Android app makes it easy to keep up while on the go.",
             link: "https://play.google.com/store/apps/details?id=com.zulipmobile",
         },
         ios: {
             image: "/static/images/app-screenshots/zulip-iphone-rough.png",
             alt: "iOS",
+            show_instructions: false,
             description: "Zulip's native iOS app makes it easy to keep up while on the go.",
             link: "https://itunes.apple.com/us/app/zulip/id1203036395",
         },

--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -134,7 +134,7 @@ var apps_events = function () {
 
     $(".apps a .icon").click(function (e) {
         var next_version = $(e.target).closest('a')
-            .attr('href')
+            .attr('data-href')
             .replace('/apps/', '');
         version = next_version;
 
@@ -168,7 +168,7 @@ var events = function () {
         // if the pathname is different than what we are already on, run the
         // custom transition function.
         if (window.location.pathname !== this.pathname && !this.hasAttribute("download") &&
-            !/no-action/.test(this.className)) {
+            !/no-action/.test(this.className) && this.hasAttribute("href")) {
             e.preventDefault();
 
             setTimeout(function () {

--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -140,8 +140,10 @@ var apps_events = function () {
 
         update_path();
         update_page();
-        $("body").animate({ scrollTop: 0 }, 200);
-
+        // Jquery code for scrolling on top with animation when click on apps icon
+        $('html, body').animate({
+            scrollTop: $('body').offset().top,
+        }, 500);
         return false;
     });
 

--- a/templates/zerver/apps.html
+++ b/templates/zerver/apps.html
@@ -42,19 +42,19 @@
         <h2>Apps for every platform.</h2>
 
         <div class="apps">
-            <a class="" href="/apps/mac">
+            <a class="" data-href="/apps/mac">
                 <i class="icon fa fa-apple" data-label="macOS"></i>
             </a>
-            <a class="" href="/apps/windows">
+            <a class="" data-href="/apps/windows">
                 <i class="icon fa fa-windows" data-label="Windows"></i>
             </a>
-            <a class="" href="/apps/linux">
+            <a class="" data-href="/apps/linux">
                 <i class="icon fa fa-linux" data-label="Linux"></i>
             </a>
-            <a class="" href="/apps/android">
+            <a class="" data-href="/apps/android">
                 <i class="icon fa fa-android" data-label="Android"></i>
             </a>
-            <a class="" href="/apps/ios">
+            <a class="" data-href="/apps/ios">
                 <i class="icon fa fa-mobile-phone" data-label="iOS"></i>
             </a>
         </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR fix following bugs on [Apps-Zulip](https://zulipchat.com/apps/) page
1 Icon click scroll to download button
2 Fix a tag click event that refresh page
3 Fix download-instruction for ios and android

**Testing Plan:** <!-- How have you tested? -->
Ubuntu 18.10, Firefox

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

***Scroll to download buton***
![ezgif com-resize](https://user-images.githubusercontent.com/36422396/55292899-c0f37700-540d-11e9-856f-63b125a02595.gif)


***remove a tag click event that refresh page***
![ezgif com-resize(1)](https://user-images.githubusercontent.com/36422396/55292932-1596f200-540e-11e9-9cca-7965830f3260.gif)


***Fix download-instruction for ios and android***
![ezgif com-resize(2)](https://user-images.githubusercontent.com/36422396/55293095-f8fbb980-540f-11e9-870f-466840d41626.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
