### PR TITLE
stream settings: Refactor subscriptions update functions. 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -169,6 +169,7 @@
         "stream_muting": false,
         "stream_popover": false,
         "stream_sort": false,
+        "stream_ui_updates": false,
         "StripeCheckout": false,
         "submessage": false,
         "subs": false,

--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -203,6 +203,7 @@ import "js/panels.js";
 import 'js/settings_ui.js';
 import 'js/search_pill.js';
 import 'js/search_pill_widget.js';
+import 'js/stream_ui_updates.js';
 
 // Import Styles
 

--- a/static/js/js_typings/zulip/index.d.ts
+++ b/static/js/js_typings/zulip/index.d.ts
@@ -137,6 +137,7 @@ declare var stream_list: any;
 declare var stream_muting: any;
 declare var stream_popover: any;
 declare var stream_sort: any;
+declare var stream_ui_updates: any;
 declare var submessage: any;
 declare var subs: any;
 declare var tab_bar: any;

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -63,26 +63,6 @@ exports.rerender_subscribers_list = function (sub) {
     }
 };
 
-exports.hide_sub_settings = function (sub) {
-    var $settings = $(".subscription_settings[data-stream-id='" + sub.stream_id + "']");
-    $settings.find(".regular_subscription_settings").removeClass('in');
-    // Clear email address widget
-    $settings.find(".email-address").html("");
-};
-
-exports.show_sub_settings = function (sub) {
-    if (!exports.is_sub_settings_active(sub)) {
-        return;
-    }
-    var $settings = $(".subscription_settings[data-stream-id='" + sub.stream_id + "']");
-    if ($settings.find(".email-address").val().length === 0) {
-        // Rerender stream email address, if not.
-        $settings.find(".email-address").text(sub.email_address);
-        $settings.find(".stream-email-box").show();
-    }
-    $settings.find(".regular_subscription_settings").addClass('in');
-};
-
 function clear_edit_panel() {
     $(".display-type #add_new_stream_title").hide();
     $(".display-type #stream_settings_title, .right .settings").show();
@@ -658,14 +638,10 @@ exports.initialize = function () {
         var sub = get_sub_for_target(e.target);
         var stream_row = $(this).parent();
         subs.sub_or_unsub(sub);
-        var sub_settings = settings_for_sub(sub);
-        var regular_sub_settings = sub_settings.find(".regular_subscription_settings");
         if (!sub.subscribed) {
-            regular_sub_settings.addClass("in");
             exports.open_edit_panel_for_row(stream_row);
-        } else {
-            regular_sub_settings.removeClass("in");
         }
+        stream_ui_updates.update_regular_sub_settings(sub);
 
         e.preventDefault();
         e.stopPropagation();

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -384,9 +384,7 @@ function change_stream_privacy(e) {
 
             // For auto update, without rendering whole template
             stream_data.update_calculated_fields(sub);
-            if (!sub.can_change_stream_permissions) {
-                $(".change-stream-privacy").hide();
-            }
+            stream_ui_updates.update_change_stream_privacy_settings(sub);
         },
         error: function () {
             $("#change-stream-privacy-button").text(i18n.t("Try again"));

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -125,8 +125,10 @@ exports.open_edit_panel_for_row = function (stream_row) {
 };
 
 exports.open_edit_panel_empty = function () {
+    var tab_key = subs.get_active_data().tab.attr("data-tab-key");
     clear_edit_panel();
     subs.show_subs_pane.nothing_selected();
+    exports.setup_subscriptions_tab_hash(tab_key);
 };
 
 function format_member_list_elem(email) {

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -7,6 +7,16 @@ function setup_subscriptions_stream_hash(sub) {
     hashchange.update_browser_history(hash);
 }
 
+exports.setup_subscriptions_tab_hash = function (tab_key_value) {
+    if (tab_key_value === "all-streams") {
+        hashchange.update_browser_history('#streams/all');
+    } else if (tab_key_value === "subscribed") {
+        hashchange.update_browser_history('#streams/subscribed');
+    } else {
+        blueslip.debug("Unknown tab_key_value: " + tab_key_value);
+    }
+};
+
 function settings_for_sub(sub) {
     var id = parseInt(sub.stream_id, 10);
     return $("#subscription_overlay .subscription_settings[data-stream-id='" + id + "']");

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -68,9 +68,6 @@ exports.hide_sub_settings = function (sub) {
     $settings.find(".regular_subscription_settings").removeClass('in');
     // Clear email address widget
     $settings.find(".email-address").html("");
-    if (!sub.can_change_stream_permissions) {
-        $settings.find(".change-stream-privacy").hide();
-    }
 };
 
 exports.show_sub_settings = function (sub) {

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -11,6 +11,20 @@ exports.update_check_button_for_sub = function (sub) {
     }
 };
 
+exports.update_settings_button_for_sub = function (sub) {
+    var settings_button = subs.settings_button_for_sub(sub);
+    if (sub.subscribed) {
+        settings_button.text(i18n.t("Unsubscribe")).removeClass("unsubscribed");
+    } else {
+        settings_button.text(i18n.t("Subscribe")).addClass("unsubscribed");
+    }
+    if (sub.should_display_subscription_button) {
+        settings_button.show();
+    } else {
+        settings_button.hide();
+    }
+};
+
 return exports;
 }());
 

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -2,6 +2,15 @@ var stream_ui_updates = (function () {
 
 var exports = {};
 
+exports.update_check_button_for_sub = function (sub) {
+    var button = subs.check_button_for_sub(sub);
+    if (sub.subscribed) {
+        button.addClass("checked");
+    } else {
+        button.removeClass("checked");
+    }
+};
+
 return exports;
 }());
 

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -44,6 +44,16 @@ exports.update_regular_sub_settings = function (sub) {
     }
 };
 
+exports.update_change_stream_privacy_settings = function (sub) {
+    var stream_privacy_btn = $(".change-stream-privacy");
+
+    if (sub.can_change_stream_permissions) {
+        stream_privacy_btn.show();
+    } else {
+        stream_privacy_btn.hide();
+    }
+};
+
 return exports;
 }());
 

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -1,0 +1,11 @@
+var stream_ui_updates = (function () {
+
+var exports = {};
+
+return exports;
+}());
+
+if (typeof module !== 'undefined') {
+    module.exports = stream_ui_updates;
+}
+window.stream_ui_updates = stream_ui_updates;

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -25,6 +25,25 @@ exports.update_settings_button_for_sub = function (sub) {
     }
 };
 
+exports.update_regular_sub_settings = function (sub) {
+    if (!stream_edit.is_sub_settings_active(sub)) {
+        return;
+    }
+    var $settings = $(".subscription_settings[data-stream-id='" + sub.stream_id + "']");
+    if (sub.subscribed) {
+        if ($settings.find(".email-address").val().length === 0) {
+            // Rerender stream email address, if not.
+            $settings.find(".email-address").text(sub.email_address);
+            $settings.find(".stream-email-box").show();
+        }
+        $settings.find(".regular_subscription_settings").addClass('in');
+    } else {
+        $settings.find(".regular_subscription_settings").removeClass('in');
+        // Clear email address widget
+        $settings.find(".email-address").html("");
+    }
+};
+
 return exports;
 }());
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -266,10 +266,8 @@ exports.update_settings_for_subscribed = function (sub) {
         exports.rerender_subscribers_count(sub, true);
         stream_ui_updates.update_check_button_for_sub(sub);
         stream_ui_updates.update_settings_button_for_sub(sub);
+        stream_ui_updates.update_change_stream_privacy_settings(sub);
 
-        if (sub.can_change_stream_permissions) {
-            $(".change-stream-privacy").show();
-        }
     } else {
         exports.add_sub_to_table(sub);
     }
@@ -348,9 +346,7 @@ exports.update_settings_for_unsubscribed = function (sub) {
     stream_ui_updates.update_check_button_for_sub(sub);
     stream_ui_updates.update_settings_button_for_sub(sub);
     stream_ui_updates.update_regular_sub_settings(sub);
-    if (!sub.can_change_stream_permissions) {
-        $(".change-stream-privacy").hide();
-    }
+    stream_ui_updates.update_change_stream_privacy_settings(sub);
 
     stream_data.update_stream_email_address(sub, "");
     if (stream_edit.is_sub_settings_active(sub)) {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -348,6 +348,9 @@ exports.update_settings_for_unsubscribed = function (sub) {
     exports.rerender_subscriptions_settings(sub);
     stream_ui_updates.update_check_button_for_sub(sub);
     stream_ui_updates.update_settings_button_for_sub(sub);
+    if (!sub.can_change_stream_permissions) {
+        $(".change-stream-privacy").hide();
+    }
 
     stream_data.update_stream_email_address(sub, "");
     if (stream_edit.is_sub_settings_active(sub)) {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -534,12 +534,7 @@ exports.switch_stream_tab = function (tab_name) {
     }
 
     exports.actually_filter_streams();
-
-    if (tab_name === "all-streams") {
-        hashchange.update_browser_history('#streams/all');
-    } else if (tab_name === "subscribed") {
-        hashchange.update_browser_history('#streams/subscribed');
-    }
+    stream_edit.setup_subscriptions_tab_hash(tab_name);
 };
 
 exports.setup_page = function (callback) {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -13,10 +13,10 @@ exports.show_subs_pane = {
     },
 };
 
-function check_button_for_sub(sub) {
+exports.check_button_for_sub = function (sub) {
     var id = parseInt(sub.stream_id, 10);
     return $(".stream-row[data-stream-id='" + id + "'] .check");
-}
+};
 
 function row_for_stream_id(stream_id) {
     return $(".stream-row[data-stream-id='" + stream_id + "']");
@@ -240,7 +240,7 @@ exports.add_sub_to_table = function (sub) {
 exports.is_sub_already_present = function (sub) {
     // This checks if a stream is already listed the "Manage streams"
     // UI, by checking for its subscribe/unsubscribe checkmark button.
-    var button = check_button_for_sub(sub);
+    var button = exports.check_button_for_sub(sub);
     if (button.length !== 0) {
         return true;
     }
@@ -259,16 +259,15 @@ exports.remove_stream = function (stream_id) {
 };
 
 exports.update_settings_for_subscribed = function (sub) {
-    var button = check_button_for_sub(sub);
     var settings_button = settings_button_for_sub(sub).removeClass("unsubscribed").show();
     exports.update_add_subscriptions_elements(sub.can_add_subscribers);
     $(".subscription_settings[data-stream-id='" + sub.stream_id + "'] #preview-stream-button").show();
 
-    if (button.length !== 0) {
+    if (exports.is_sub_already_present(sub)) {
         exports.rerender_subscribers_count(sub, true);
 
-        button.toggleClass("checked");
         settings_button.text(i18n.t("Unsubscribe"));
+        stream_ui_updates.update_check_button_for_sub(sub);
 
         if (sub.can_change_stream_permissions) {
             $(".change-stream-privacy").show();
@@ -347,13 +346,12 @@ exports.update_add_subscriptions_elements = function (allow_user_to_add_subs) {
 };
 
 exports.update_settings_for_unsubscribed = function (sub) {
-    var button = check_button_for_sub(sub);
     var settings_button = settings_button_for_sub(sub).addClass("unsubscribed").show();
 
-    button.toggleClass("checked");
     settings_button.text(i18n.t("Subscribe"));
     stream_edit.hide_sub_settings(sub);
     exports.rerender_subscriptions_settings(sub);
+    stream_ui_updates.update_check_button_for_sub(sub);
 
     stream_data.update_stream_email_address(sub, "");
     if (stream_edit.is_sub_settings_active(sub)) {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -22,12 +22,12 @@ function row_for_stream_id(stream_id) {
     return $(".stream-row[data-stream-id='" + stream_id + "']");
 }
 
-function settings_button_for_sub(sub) {
+exports.settings_button_for_sub = function (sub) {
     // We don't do expectOne() here, because this button is only
     // visible if the user has that stream selected in the streams UI.
     var id = parseInt(sub.stream_id, 10);
     return $(".subscription_settings[data-stream-id='" + id + "'] .subscribe-button");
-}
+};
 
 function get_row_data(row) {
     var row_id = row.attr('data-stream-id');
@@ -259,15 +259,13 @@ exports.remove_stream = function (stream_id) {
 };
 
 exports.update_settings_for_subscribed = function (sub) {
-    var settings_button = settings_button_for_sub(sub).removeClass("unsubscribed").show();
     exports.update_add_subscriptions_elements(sub.can_add_subscribers);
     $(".subscription_settings[data-stream-id='" + sub.stream_id + "'] #preview-stream-button").show();
 
     if (exports.is_sub_already_present(sub)) {
         exports.rerender_subscribers_count(sub, true);
-
-        settings_button.text(i18n.t("Unsubscribe"));
         stream_ui_updates.update_check_button_for_sub(sub);
+        stream_ui_updates.update_settings_button_for_sub(sub);
 
         if (sub.can_change_stream_permissions) {
             $(".change-stream-privacy").show();
@@ -346,19 +344,16 @@ exports.update_add_subscriptions_elements = function (allow_user_to_add_subs) {
 };
 
 exports.update_settings_for_unsubscribed = function (sub) {
-    var settings_button = settings_button_for_sub(sub).addClass("unsubscribed").show();
-
-    settings_button.text(i18n.t("Subscribe"));
     stream_edit.hide_sub_settings(sub);
     exports.rerender_subscriptions_settings(sub);
     stream_ui_updates.update_check_button_for_sub(sub);
+    stream_ui_updates.update_settings_button_for_sub(sub);
 
     stream_data.update_stream_email_address(sub, "");
     if (stream_edit.is_sub_settings_active(sub)) {
         // If user unsubscribed from private stream then user cannot subscribe to
         // stream without invitation and cannot add subscribers to stream.
         if (!sub.should_display_subscription_button) {
-            settings_button.hide();
             exports.update_add_subscriptions_elements(sub.can_add_subscribers);
         }
     }

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -279,7 +279,7 @@ exports.update_settings_for_subscribed = function (sub) {
     }
 
     // Display the swatch and subscription stream_settings
-    stream_edit.show_sub_settings(sub);
+    stream_ui_updates.update_regular_sub_settings(sub);
 };
 
 exports.show_active_stream_in_left_panel = function () {
@@ -344,10 +344,10 @@ exports.update_add_subscriptions_elements = function (allow_user_to_add_subs) {
 };
 
 exports.update_settings_for_unsubscribed = function (sub) {
-    stream_edit.hide_sub_settings(sub);
     exports.rerender_subscriptions_settings(sub);
     stream_ui_updates.update_check_button_for_sub(sub);
     stream_ui_updates.update_settings_button_for_sub(sub);
+    stream_ui_updates.update_regular_sub_settings(sub);
     if (!sub.can_change_stream_permissions) {
         $(".change-stream-privacy").hide();
     }

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -40,7 +40,7 @@ function get_row_data(row) {
     }
 }
 
-function get_active_data() {
+exports.get_active_data = function () {
     var active_row = $('div.stream-row.active');
     var valid_active_id = active_row.attr('data-stream-id');
     var active_tab = $('.subscriptions-container').find('div.ind-tab.selected');
@@ -49,7 +49,7 @@ function get_active_data() {
         id: valid_active_id,
         tab: active_tab,
     };
-}
+};
 
 function get_hash_safe() {
     if (typeof window !== "undefined" && typeof window.location.hash === "string") {
@@ -612,14 +612,14 @@ exports.setup_page = function (callback) {
 exports.switch_to_stream_row = function (stream_id) {
     var stream_row = row_for_stream_id(stream_id);
 
-    get_active_data().row.removeClass("active");
+    exports.get_active_data().row.removeClass("active");
     stream_row.addClass("active");
 
     scroll_util.scroll_element_into_container(stream_row, stream_row.parent());
 
     // It's dubious that we need this timeout any more.
     setTimeout(function () {
-        if (stream_id === get_active_data().id) {
+        if (stream_id === exports.get_active_data().id) {
             stream_row.click();
         }
     }, 100);
@@ -666,7 +666,7 @@ exports.launch = function (section) {
         ui.set_up_scrollbar($("#subscription_overlay .settings"));
 
     });
-    if (!get_active_data().id) {
+    if (!exports.get_active_data().id) {
         $('#search_stream_name').focus();
     }
 };
@@ -676,7 +676,7 @@ exports.close = function () {
 };
 
 exports.switch_rows = function (event) {
-    var active_data = get_active_data();
+    var active_data = exports.get_active_data();
     var switch_row;
     if (window.location.hash === '#streams/new') {
         // Prevent switching stream rows when creating a new stream
@@ -710,7 +710,7 @@ exports.switch_rows = function (event) {
 };
 
 exports.keyboard_sub = function () {
-    var active_data = get_active_data();
+    var active_data = exports.get_active_data();
     var row_data = get_row_data(active_data.row);
     if (row_data) {
         subs.sub_or_unsub(row_data.object);
@@ -722,7 +722,7 @@ exports.keyboard_sub = function () {
 };
 
 exports.toggle_view = function (event) {
-    var active_data = get_active_data();
+    var active_data = exports.get_active_data();
 
     if (event === 'right_arrow' && active_data.tab.text() === 'Subscribed') {
         exports.toggler.goto('all-streams');
@@ -732,7 +732,7 @@ exports.toggle_view = function (event) {
 };
 
 exports.view_stream = function () {
-    var active_data = get_active_data();
+    var active_data = exports.get_active_data();
     var row_data = get_row_data(active_data.row);
     if (row_data) {
         var stream_narrow_hash = '#narrow/stream/' + hash_util.encode_stream_name(row_data.object.name);

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -72,6 +72,7 @@ enforce_fully_covered = {
     'static/js/stream_data.js',
     'static/js/stream_events.js',
     'static/js/stream_sort.js',
+    'static/js/stream_ui_updates.js',
     'static/js/top_left_corner.js',
     'static/js/topic_data.js',
     'static/js/topic_generator.js',


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

There are multiple elements in subscription page(sub button, subscriber list, privacy button, delete button), and whether the user is authorized to click or even see the element, depends on various different conditions. Currently our templates also includes this complex conditions when rendering these elements. After elements are rendered, when subscription data(`sub.subscribed`, `sub.invite_only` etc.) is changed, we again hide/show/disable these elements. 
This PR refactors the functions which updates/rerenders the subscriptions/stream templates on different events(subscribe/unsubscribe/changes stream privacy) etc.
New file `stream_ui_updates.js` includes different update-stream-settings-ui-elements functions. 

This PR is currently WIP as there is still some functions to migrate. However, starting commits can be merged. 

**Testing Plan:** <!-- How have you tested? -->
As I extract new function for any stream-ui-element, I carefully tests the ui-element behavior in all possible cases(Non admin/Admin/Guest user user subscribed to public, private streams, previously private streams), although if others test the PR locally please left a comment, it would be really helpful!
