### PR TITLE
hotkeys: Disable "w" hotkey when settings dropdown is open.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -196,6 +196,9 @@ run_test('basic_chars', () => {
     set_global('hotspots', {
         is_open: return_false,
     });
+    set_global('gear_menu', {
+        is_open: return_false,
+    });
 
     // All letters should return false if we are composing text.
     hotkey.processing_text = return_true;

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -550,6 +550,12 @@ exports.process_hotkey = function (e, hotkey) {
         }
     }
 
+    // Disable out of message view hotkeys like: w, q, etc when
+    // settings gear menu is open.
+    if (!hotkey.message_view_only && gear_menu.is_open()) {
+        return false;
+    }
+
     // The next two sections date back to 00445c84 and are Mac/Chrome-specific,
     // and they should possibly be eliminated in favor of keeping standard
     // browser behavior.


### PR DESCRIPTION
Settings dropdown covers users searchbar when it's open. In that
case we don't want to initialize user search when "w" is pressed
with dropdown menu open on top of it.

Fixes #11990.

@timabbott please review this pr :)