### PR TITLE
subscriptions: Fix error when guest user is subscribed to public stream.

### DIFF
--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -140,7 +140,7 @@ exports.update_subscribers_count = function (sub, just_subscribed) {
         return;
     }
     var stream_row = subs.row_for_stream_id(sub.stream_id);
-    if (!sub.can_access_subscribers || just_subscribed && sub.invite_only) {
+    if (!sub.can_access_subscribers || just_subscribed && sub.invite_only || page_params.is_guest) {
         var rendered_sub_count = templates.render("subscription_count", sub);
         stream_row.find('.subscriber-count').expectOne().html(rendered_sub_count);
     } else {


### PR DESCRIPTION
When guest user is subscribed to public stream, it throws json
error. Because when guest user is subscribed to public stream,
the `stream-sub-count` element is not initialized.
This commit fix this error, by editing the function
`rerender_subscribers_count` to intialize the element
first, when guest user is subscribed.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
* Login with iago in one browser
* Login with guest user in another
* Subscribe guest user to any of public stream from Iago
* Errors in guest user client

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
