### PR TITLE
Cleanup `single_message.handlebars`

### DIFF
--- a/static/styles/drafts.scss
+++ b/static/styles/drafts.scss
@@ -93,6 +93,7 @@
 
 .draft-info-box .messagebox {
     cursor: auto;
+    box-shadow: none;
 }
 
 .draft-info-box .message_content {

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -376,7 +376,6 @@ on a dark background, and don't change the dark labels dark either. */
     }
 
     .draft-row .draft-info-box,
-    .private-message .messagebox,
     .message_header_private_message .message-header-contents {
         box-shadow: none;
     }

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -991,11 +991,17 @@ td.pointer {
     position: relative;
 }
 
-.private-message .messagebox,
-.private-message .date_row,
 .message_header_private_message .message-header-contents {
     background-color: hsla(192, 19%, 75%, 0.2);
     box-shadow: inset 1px 1px 0px hsl(0, 0%, 88%);
+}
+
+.private-message .messagebox,
+.private-message .date_row {
+    background-color: hsla(192, 19%, 75%, 0.2);
+    box-shadow:
+        inset 2px 0px 0px 0px rgb(68, 68, 68),
+        -1px 0px 0px 0px rgb(68, 68, 68);
 }
 
 .message-header-contents {

--- a/static/templates/single_message.handlebars
+++ b/static/templates/single_message.handlebars
@@ -3,10 +3,10 @@
   role="listitem">
     <div class="unread_marker"><div class="unread-marker-fill"></div></div>
     {{#if want_date_divider}}
-    <div class="date_row no-select" style="box-shadow: inset 2px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}}, -1px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}};">{{{date_divider_html}}}</div>
+    <div class="date_row no-select" {{#if msg/is_stream}}style="box-shadow: inset 2px 0px 0px 0px {{background_color}}, -1px 0px 0px 0px {{background_color}};"{{/if}}>{{{date_divider_html}}}</div>
     {{/if}}
-    <div class="messagebox{{^msg/is_stream}} private-message{{/msg/is_stream}} {{#if next_is_same_sender}}next_is_same_sender{{/if}}"
-      style="box-shadow: inset 2px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}}, -1px 0px 0px 0px {{#if msg/is_stream}}{{background_color}}{{else}}#444444{{/if}};">
+    <div class="messagebox {{#if next_is_same_sender}}next_is_same_sender{{/if}}"
+      {{#if msg/is_stream}}style="box-shadow: inset 2px 0px 0px 0px {{background_color}}, -1px 0px 0px 0px {{background_color}};"{{/if}}>
         <div class="messagebox-content">
             {{partial "message_body"}}
         </div>


### PR DESCRIPTION
Cleans up `single_message.handlebars` by removing conditionals
in templates and calculate background color for private messages
in JS.