### PR TITLE
subscriptions: Update existing sub-row in sub settings on sub-events.

### DIFF
--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -54,6 +54,22 @@ exports.update_change_stream_privacy_settings = function (sub) {
     }
 };
 
+exports.update_stream_row_in_settings_tab = function (sub) {
+    // This function display/hide stream row in stream settings tab,
+    // used to display immediate effect of add/removal subscription event.
+    // If user is subscribed to stream, it will show sub row under
+    // "Subscribed" tab, otherwise if stream is not public hide
+    // stream row under tab.
+    if (subs.is_subscribed_stream_tab_active()) {
+        var sub_row = subs.row_for_stream_id(sub.stream_id);
+        if (sub.subscribed) {
+            sub_row.removeClass("notdisplayed");
+        } else if (sub.invite_only) {
+            sub_row.addClass("notdisplayed");
+        }
+    }
+};
+
 return exports;
 }());
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -114,6 +114,15 @@ exports.maybe_update_realm_default_stream_name  = function (stream_id, new_name)
     page_params.realm_default_streams[idx].name = new_name;
 };
 
+exports.is_subscribed_stream_tab_active = function () {
+    // Returns true if "Subscribed" tab in stream settings is open
+    // otherwise false.
+    if ($("#subscriptions_table .search-container .tab-switcher .first").hasClass("selected")) {
+        return true;
+    }
+    return false;
+};
+
 exports.update_stream_name = function (sub, new_name) {
     // Rename the stream internally.
     stream_data.rename_sub(sub, new_name);
@@ -358,8 +367,7 @@ exports.update_settings_for_unsubscribed = function (sub) {
     }
 
     // Remove private streams from subscribed streams list.
-    if ($("#subscriptions_table .search-container .tab-switcher .first").hasClass("selected")
-        && sub.invite_only) {
+    if (exports.is_subscribed_stream_tab_active() && sub.invite_only) {
         var sub_row = row_for_stream_id(sub.stream_id);
         sub_row.addClass("notdisplayed");
     }

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -218,10 +218,12 @@ function add_email_hint_handler() {
 exports.add_sub_to_table = function (sub) {
     if (exports.is_sub_already_present(sub)) {
         // If a stream is already listed/added in subscription modal,
-        // return.  This can happen in some corner cases (which might
+        // display stream in `Subscribed` tab and return.
+        // This can happen in some corner cases (which might
         // be backend bugs) where a realm adminsitrator is subscribed
         // to a private stream, in which case they might get two
         // stream-create events.
+        stream_ui_updates.update_stream_row_in_settings_tab(sub);
         return;
     }
 
@@ -272,6 +274,7 @@ exports.update_settings_for_subscribed = function (sub) {
     $(".subscription_settings[data-stream-id='" + sub.stream_id + "'] #preview-stream-button").show();
 
     if (exports.is_sub_already_present(sub)) {
+        stream_ui_updates.update_stream_row_in_settings_tab(sub);
         exports.rerender_subscribers_count(sub, true);
         stream_ui_updates.update_check_button_for_sub(sub);
         stream_ui_updates.update_settings_button_for_sub(sub);

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -18,9 +18,9 @@ exports.check_button_for_sub = function (sub) {
     return $(".stream-row[data-stream-id='" + id + "'] .check");
 };
 
-function row_for_stream_id(stream_id) {
+exports.row_for_stream_id = function (stream_id) {
     return $(".stream-row[data-stream-id='" + stream_id + "']");
-}
+};
 
 exports.settings_button_for_sub = function (sub) {
     // We don't do expectOne() here, because this button is only
@@ -138,7 +138,7 @@ exports.update_stream_name = function (sub, new_name) {
     stream_edit.update_stream_name(sub, new_name);
 
     // Update the subscriptions page
-    var sub_row = row_for_stream_id(stream_id);
+    var sub_row = exports.row_for_stream_id(stream_id);
     sub_row.find(".stream-name").text(new_name);
 
     // Update the message feed.
@@ -150,7 +150,7 @@ exports.update_stream_description = function (sub, description, rendered_descrip
     sub.rendered_description = rendered_description.replace('<p>', '').replace('</p>', '');
 
     // Update stream row
-    var sub_row = row_for_stream_id(sub.stream_id);
+    var sub_row = exports.row_for_stream_id(sub.stream_id);
     sub_row.find(".description").html(sub.rendered_description);
 
     // Update stream settings
@@ -167,7 +167,7 @@ exports.rerender_subscribers_count = function (sub, just_subscribed) {
         // If the streams overlay isn't open, we don't need to rerender anything.
         return;
     }
-    var stream_row = row_for_stream_id(sub.stream_id);
+    var stream_row = exports.row_for_stream_id(sub.stream_id);
     stream_data.update_subscribers_count(sub);
     if (!sub.can_access_subscribers || just_subscribed && sub.invite_only) {
         var rendered_sub_count = templates.render("subscription_count", sub);
@@ -241,7 +241,7 @@ exports.add_sub_to_table = function (sub) {
         // good way to associate with this request because the stream
         // ID isn't known yet.  These are appended to the top of the
         // list, so they are more visible.
-        row_for_stream_id(sub.stream_id).click();
+        exports.row_for_stream_id(sub.stream_id).click();
         stream_create.reset_created_stream();
     }
 };
@@ -259,7 +259,7 @@ exports.is_sub_already_present = function (sub) {
 exports.remove_stream = function (stream_id) {
     // It is possible that row is empty when we deactivate a
     // stream, but we let jQuery silently handle that.
-    var row = row_for_stream_id(stream_id);
+    var row = exports.row_for_stream_id(stream_id);
     row.remove();
     var sub = stream_data.get_sub_by_id(stream_id);
     if (stream_edit.is_sub_settings_active(sub)) {
@@ -293,7 +293,7 @@ exports.show_active_stream_in_left_panel = function () {
     var selected_row = get_hash_safe().split(/\//)[1];
 
     if (parseFloat(selected_row)) {
-        var sub_row = row_for_stream_id(selected_row);
+        var sub_row = exports.row_for_stream_id(selected_row);
         sub_row.addClass("active");
     }
 };
@@ -367,10 +367,7 @@ exports.update_settings_for_unsubscribed = function (sub) {
     }
 
     // Remove private streams from subscribed streams list.
-    if (exports.is_subscribed_stream_tab_active() && sub.invite_only) {
-        var sub_row = row_for_stream_id(sub.stream_id);
-        sub_row.addClass("notdisplayed");
-    }
+    stream_ui_updates.update_stream_row_in_settings_tab(sub);
 };
 
 function triage_stream(query, sub) {
@@ -617,7 +614,7 @@ exports.setup_page = function (callback) {
 };
 
 exports.switch_to_stream_row = function (stream_id) {
-    var stream_row = row_for_stream_id(stream_id);
+    var stream_row = exports.row_for_stream_id(stream_id);
 
     exports.get_active_data().row.removeClass("active");
     stream_row.addClass("active");


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Issue:
- Login to Iago
- Open different browser, login to AARON
- Open subscription settings page, click on "Subscribed" tab in AARON
- Subscribe AARON to any public stream from Iago login
- Stream doesn't appear under "Subscribed" tab in AARON

- reload the page or open the modal again will show the stream. 

This PR fixes this issue. So the stream will appear under "Subscribed" tab immediately after subscribed. Although this issue is rarely going to encounter by users, fixing this issue will help developers during testing. 


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![updatesubrow](https://user-images.githubusercontent.com/25907420/55408170-18642500-557d-11e9-92b8-8cfe4d5528e1.gif)

