### PR TITLE
api/tests : Adding tests for untested endpoints.

### DIFF
--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -819,6 +819,14 @@ def add_alert_words(client):
 
     assert result['result'] == 'success'
 
+def remove_alert_words(client):
+    # type: (Client) -> None
+    word = ['foo']
+
+    result = client.remove_alert_words(word)
+
+    assert result['result'] == 'success'
+
 def test_invalid_api_key(client_with_invalid_key):
     # type: (Client) -> None
     result = client_with_invalid_key.list_subscriptions()
@@ -876,6 +884,7 @@ TEST_FUNCTIONS = {
     '/user_groups:get': get_user_groups,
     '/users/me/alert_words:get': get_alert_words,
     '/users/me/alert_words:post': add_alert_words,
+    '/users/me/alert_words:delete': remove_alert_words,
     '/messages/{message_id}/reactions:delete': remove_reaction
 }
 
@@ -960,6 +969,7 @@ def test_users(client):
     get_user_groups(client)
     get_alert_words(client)
     add_alert_words(client)
+    remove_alert_words(client)
 
 def test_streams(client, nonadmin_client):
     # type: (Client, Client) -> None

--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -872,6 +872,17 @@ def update_user_group_members(client, group_id):
 
     assert result['result'] == 'success'
 
+def update_notification_settings(client):
+    # type: (Client) -> None
+    request = {
+        'enable_stream_push_notifications': True,
+        'enable_offline_push_notifications': False
+    }
+
+    result = client.update_notification_settings(request)
+
+    assert result['result'] == 'success'
+
 def test_invalid_api_key(client_with_invalid_key):
     # type: (Client) -> None
     result = client_with_invalid_key.list_subscriptions()
@@ -914,6 +925,7 @@ TEST_FUNCTIONS = {
     '/users/me/subscriptions:delete': remove_subscriptions,
     '/users/me/subscriptions/muted_topics:patch': toggle_mute_topic,
     '/users/me/subscriptions/properties:post': update_subscription_settings,
+    '/settings/notifications:patch': update_notification_settings,
     '/users:get': get_members,
     '/realm/emoji:get': get_realm_emoji,
     '/realm/emoji/<emoji_name>:post': upload_custom_emoji,
@@ -1036,6 +1048,7 @@ def test_streams(client, nonadmin_client):
     remove_subscriptions(client)
     toggle_mute_topic(client)
     update_subscription_settings(client)
+    update_notification_settings(client)
     get_stream_topics(client, 1)
     delete_stream(client, stream_id)
 

--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -827,6 +827,18 @@ def remove_alert_words(client):
 
     assert result['result'] == 'success'
 
+def create_user_group(client):
+    # type: (Client) -> None
+    request = {
+        'name': 'Manchester United',
+        'description': "Ole's at the Wheel.",
+        'members': [1, 2, 3, 4]
+    }
+
+    result = client.create_user_group(request)
+
+    assert result['result'] == 'success'
+
 def test_invalid_api_key(client_with_invalid_key):
     # type: (Client) -> None
     result = client_with_invalid_key.list_subscriptions()
@@ -882,6 +894,7 @@ TEST_FUNCTIONS = {
     '/users/me/{stream_id}/topics:get': get_stream_topics,
     '/typing:post': set_typing_status,
     '/user_groups:get': get_user_groups,
+    '/user_groups/create:post': create_user_group,
     '/users/me/alert_words:get': get_alert_words,
     '/users/me/alert_words:post': add_alert_words,
     '/users/me/alert_words:delete': remove_alert_words,
@@ -967,6 +980,7 @@ def test_users(client):
     set_typing_status(client)
     get_user_presence(client)
     get_user_groups(client)
+    create_user_group(client)
     get_alert_words(client)
     add_alert_words(client)
     remove_alert_words(client)

--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -805,6 +805,12 @@ def upload_custom_emoji(client):
                                     '/realm/emoji/<emoji_name>',
                                     'post', '200')
 
+def get_alert_words(client):
+    # type: (Client) -> None
+    result = client.get_alert_words()
+
+    assert result['result'] == 'success'
+
 def test_invalid_api_key(client_with_invalid_key):
     # type: (Client) -> None
     result = client_with_invalid_key.list_subscriptions()
@@ -860,6 +866,7 @@ TEST_FUNCTIONS = {
     '/users/me/{stream_id}/topics:get': get_stream_topics,
     '/typing:post': set_typing_status,
     '/user_groups:get': get_user_groups,
+    '/users/me/alert_words:get': get_alert_words,
     '/messages/{message_id}/reactions:delete': remove_reaction
 }
 
@@ -942,6 +949,7 @@ def test_users(client):
     set_typing_status(client)
     get_user_presence(client)
     get_user_groups(client)
+    get_alert_words(client)
 
 def test_streams(client, nonadmin_client):
     # type: (Client, Client) -> None

--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -515,6 +515,19 @@ def add_reaction(client, message_id):
 
     assert result['result'] == 'success'
 
+def remove_reaction(client, message_id):
+    # type: (Client, int) -> None
+    request = {
+        'message_id': message_id,
+        'emoji_name': 'joy',
+        'emoji_code': '1f602',
+        'reaction_type': 'unicode_emoji'
+    }
+
+    result = client.remove_reaction(request)
+
+    assert result['result'] == 'success'
+
 def test_nonexistent_stream_error(client):
     # type: (Client) -> None
     request = {
@@ -835,6 +848,7 @@ TEST_FUNCTIONS = {
     '/users/me/{stream_id}/topics:get': get_stream_topics,
     '/typing:post': set_typing_status,
     '/user_groups:get': get_user_groups,
+    '/messages/{message_id}/reactions:delete': remove_reaction
 }
 
 # SETUP METHODS FOLLOW
@@ -890,6 +904,7 @@ def test_messages(client, nonadmin_client):
     render_message(client)
     message_id = send_message(client)
     add_reaction(client, message_id)
+    remove_reaction(client, message_id)
     update_message(client, message_id)
     get_raw_message(client, message_id)
     get_messages(client)

--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -860,6 +860,18 @@ def remove_user_group(client, group_id):
 
     assert result['result'] == 'success'
 
+def update_user_group_members(client, group_id):
+    # type: (Client, int) -> None
+    request = {
+        'group_id': group_id,
+        'delete': [3, 4],
+        'add': [1, 2]
+    }
+
+    result = client.update_user_group_members(request)
+
+    assert result['result'] == 'success'
+
 def test_invalid_api_key(client_with_invalid_key):
     # type: (Client) -> None
     result = client_with_invalid_key.list_subscriptions()
@@ -918,6 +930,7 @@ TEST_FUNCTIONS = {
     '/user_groups/create:post': create_user_group,
     '/user_groups/{group_id}:patch': update_user_group,
     '/user_groups/{group_id}:delete': remove_user_group,
+    '/user_groups/{group_id}/members:post': update_user_group_members,
     '/users/me/alert_words:get': get_alert_words,
     '/users/me/alert_words:post': add_alert_words,
     '/users/me/alert_words:delete': remove_alert_words,
@@ -1005,6 +1018,7 @@ def test_users(client):
     group_id = get_user_groups(client)
     create_user_group(client)
     update_user_group(client, group_id)
+    update_user_group_members(client, group_id)
     remove_user_group(client, group_id)
     get_alert_words(client)
     add_alert_words(client)

--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -256,6 +256,18 @@ def get_streams(client):
     validate_against_openapi_schema(result, '/streams', 'get', '200')
     assert len(result['streams']) == 4
 
+def update_stream(client, stream_id):
+    # type: (Client, int) -> None
+    request = {
+        'stream_id': stream_id,
+        'content': 'Venice is the capital of Italy',
+        'subject': 'Italy'
+    }
+
+    result = client.update_stream(request)
+
+    assert result['result'] == 'success'
+
 def get_user_groups(client):
     # type: (Client) -> int
 
@@ -928,6 +940,7 @@ TEST_FUNCTIONS = {
     '/messages/flags:post': update_message_flags,
     '/get_stream_id:get': get_stream_id,
     '/streams/{stream_id}:delete': delete_stream,
+    '/streams/{stream_id}:patch': update_stream,
     'get-subscribed-streams': list_subscriptions,
     '/streams:get': get_streams,
     '/users:post': create_user,
@@ -1057,6 +1070,7 @@ def test_streams(client, nonadmin_client):
     test_add_subscriptions_already_subscribed(client)
     list_subscriptions(client)
     stream_id = get_stream_id(client)
+    update_stream(client, stream_id)
     get_streams(client)
     get_subscribers(client)
     remove_subscriptions(client)

--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -202,7 +202,7 @@ def get_profile(client):
                          check_if_exists=check_if_exists)
 
 def get_stream_id(client):
-    # type: (Client) -> None
+    # type: (Client) -> int
 
     # {code_example|start}
     # Get the ID of a given stream
@@ -211,6 +211,17 @@ def get_stream_id(client):
     # {code_example|end}
 
     validate_against_openapi_schema(result, '/get_stream_id', 'get', '200')
+
+    return result['stream_id']
+
+def delete_stream(client, stream_id):
+    # type: (Client, int) -> None
+
+    result = client.delete_stream(stream_id)
+
+    validate_against_openapi_schema(result, '/streams/{stream_id}', 'delete', '200')
+
+    assert result['result'] == 'success'
 
 def get_streams(client):
     # type: (Client) -> None
@@ -826,6 +837,7 @@ TEST_FUNCTIONS = {
     '/messages/{message_id}/history:get': get_message_history,
     '/messages/flags:post': update_message_flags,
     '/get_stream_id:get': get_stream_id,
+    '/streams/{stream_id}:delete': delete_stream,
     'get-subscribed-streams': list_subscriptions,
     '/streams:get': get_streams,
     '/users:post': create_user,
@@ -937,13 +949,14 @@ def test_streams(client, nonadmin_client):
     add_subscriptions(client)
     test_add_subscriptions_already_subscribed(client)
     list_subscriptions(client)
-    get_stream_id(client)
+    stream_id = get_stream_id(client)
     get_streams(client)
     get_subscribers(client)
     remove_subscriptions(client)
     toggle_mute_topic(client)
     update_subscription_settings(client)
     get_stream_topics(client, 1)
+    delete_stream(client, stream_id)
 
     test_user_not_authorized_error(nonadmin_client)
     test_authorization_errors_fatal(client, nonadmin_client)

--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -108,6 +108,18 @@ def get_user_presence(client):
 
     validate_against_openapi_schema(result, '/users/{email}/presence', 'get', '200')
 
+def update_presence(client):
+    # type: (Client) -> None
+    request = {
+        'status': 'active',
+        'ping_only': False,
+        'new_user_input': False
+    }
+
+    result = client.update_presence(request)
+
+    assert result['result'] == 'success'
+
 def create_user(client):
     # type: (Client) -> None
 
@@ -922,6 +934,7 @@ TEST_FUNCTIONS = {
     'get-profile': get_profile,
     'add-subscriptions': add_subscriptions,
     '/users/{email}/presence:get': get_user_presence,
+    '/users/me/presence:post': update_presence,
     '/users/me/subscriptions:delete': remove_subscriptions,
     '/users/me/subscriptions/muted_topics:patch': toggle_mute_topic,
     '/users/me/subscriptions/properties:post': update_subscription_settings,
@@ -1027,6 +1040,7 @@ def test_users(client):
     upload_file(client)
     set_typing_status(client)
     get_user_presence(client)
+    update_presence(client)
     group_id = get_user_groups(client)
     create_user_group(client)
     update_user_group(client, group_id)

--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -245,7 +245,7 @@ def get_streams(client):
     assert len(result['streams']) == 4
 
 def get_user_groups(client):
-    # type: (Client) -> None
+    # type: (Client) -> int
 
     # {code_example|start}
     # Get all user groups of the realm
@@ -255,6 +255,9 @@ def get_user_groups(client):
     validate_against_openapi_schema(result, '/user_groups', 'get', '200')
     user_groups = [u for u in result['user_groups'] if u['name'] == "hamletcharacters"]
     assert user_groups[0]['description'] == 'Characters of Hamlet'
+
+    result = result['user_groups'][0]
+    return result['id']
 
 def test_user_not_authorized_error(nonadmin_client):
     # type: (Client) -> None
@@ -839,6 +842,18 @@ def create_user_group(client):
 
     assert result['result'] == 'success'
 
+def update_user_group(client, group_id):
+    # type: (Client, int) -> None
+    request = {
+        'group_id': group_id,
+        'name': 'MUFC',
+        'description': "Greatest of English football."
+    }
+
+    result = client.update_user_group(request)
+
+    assert result['result'] == 'success'
+
 def test_invalid_api_key(client_with_invalid_key):
     # type: (Client) -> None
     result = client_with_invalid_key.list_subscriptions()
@@ -895,6 +910,7 @@ TEST_FUNCTIONS = {
     '/typing:post': set_typing_status,
     '/user_groups:get': get_user_groups,
     '/user_groups/create:post': create_user_group,
+    '/user_groups/{group_id}:patch': update_user_group,
     '/users/me/alert_words:get': get_alert_words,
     '/users/me/alert_words:post': add_alert_words,
     '/users/me/alert_words:delete': remove_alert_words,
@@ -979,8 +995,9 @@ def test_users(client):
     upload_file(client)
     set_typing_status(client)
     get_user_presence(client)
-    get_user_groups(client)
+    group_id = get_user_groups(client)
     create_user_group(client)
+    update_user_group(client, group_id)
     get_alert_words(client)
     add_alert_words(client)
     remove_alert_words(client)

--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -854,6 +854,12 @@ def update_user_group(client, group_id):
 
     assert result['result'] == 'success'
 
+def remove_user_group(client, group_id):
+    # type: (Client, int) -> None
+    result = client.remove_user_group(group_id)
+
+    assert result['result'] == 'success'
+
 def test_invalid_api_key(client_with_invalid_key):
     # type: (Client) -> None
     result = client_with_invalid_key.list_subscriptions()
@@ -911,6 +917,7 @@ TEST_FUNCTIONS = {
     '/user_groups:get': get_user_groups,
     '/user_groups/create:post': create_user_group,
     '/user_groups/{group_id}:patch': update_user_group,
+    '/user_groups/{group_id}:delete': remove_user_group,
     '/users/me/alert_words:get': get_alert_words,
     '/users/me/alert_words:post': add_alert_words,
     '/users/me/alert_words:delete': remove_alert_words,
@@ -998,6 +1005,7 @@ def test_users(client):
     group_id = get_user_groups(client)
     create_user_group(client)
     update_user_group(client, group_id)
+    remove_user_group(client, group_id)
     get_alert_words(client)
     add_alert_words(client)
     remove_alert_words(client)

--- a/zerver/lib/api_test_helpers.py
+++ b/zerver/lib/api_test_helpers.py
@@ -811,6 +811,14 @@ def get_alert_words(client):
 
     assert result['result'] == 'success'
 
+def add_alert_words(client):
+    # type: (Client) -> None
+    word = ['foo', 'bar']
+
+    result = client.add_alert_words(word)
+
+    assert result['result'] == 'success'
+
 def test_invalid_api_key(client_with_invalid_key):
     # type: (Client) -> None
     result = client_with_invalid_key.list_subscriptions()
@@ -867,6 +875,7 @@ TEST_FUNCTIONS = {
     '/typing:post': set_typing_status,
     '/user_groups:get': get_user_groups,
     '/users/me/alert_words:get': get_alert_words,
+    '/users/me/alert_words:post': add_alert_words,
     '/messages/{message_id}/reactions:delete': remove_reaction
 }
 
@@ -950,6 +959,7 @@ def test_users(client):
     get_user_presence(client)
     get_user_groups(client)
     get_alert_words(client)
+    add_alert_words(client)
 
 def test_streams(client, nonadmin_client):
     # type: (Client, Client) -> None

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1910,6 +1910,37 @@ paths:
                         "msg": "User not authorized for this query",
                         "result": "error"
                     }
+  /streams/{stream_id}:
+    delete:
+      description: Delete the stream with the given ID.
+      parameters:
+      - name: stream_id
+        in: path
+        description: The ID of the stream to be deleted.
+        schema:
+          type: integer
+          required: true
+      security:
+      - basicAuth: []
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonSuccess'
+        '400':
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                - $ref: '#/components/schemas/JsonError'
+                - example:
+                    {
+                        "code": "BAD_REQUEST",
+                        "msg": "Invalid stream id",
+                        "result": "error"
+                    }
   /typing:
     post:
       description: Send an event indicating that the user has started or


### PR DESCRIPTION
This pull request adds tests for the untested endpoints from the python-zulip-api repository. 

The endpoints are mentioned below.
`remove_reaction`
`delete_stream`
`get_alert_words`
`add_alert_words`
`remove_alert_words`
`create_user_group`
`update_user_group`
`remove_user_group`
`update_user_group_members`
`update_notification_settings`
`update_presence`
`update_stream`