### PR TITLE
left-sidebar: Increase the width of link in global_filters.

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -492,6 +492,11 @@ li.expanded_private_message a {
     opacity: .5;
 }
 
+#global_filters .global_filters_link {
+    display: block;
+    width: 100%;
+}
+
 .zero_count {
     visibility: hidden;
 }

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -3,7 +3,7 @@
         <ul id="global_filters" class="filters">
             {# Special-case this link so we don't actually go to page top. #}
             <li class="top_left_all_messages top_left_row active-filter" title="{{ _('All messages') }} (Esc)">
-                <a href="#">
+                <a href="#" class="global_filters_link">
                     <span class="filter-icon">
                         <i class="fa fa-home" aria-hidden="true"></i>
                     </span>
@@ -17,7 +17,7 @@
             </li>
             <li class="top_left_private_messages">
                 <div class="private_messages_header top_left_row">
-                    <a href="#narrow/is/private">
+                    <a href="#narrow/is/private" class="global_filters_link">
                         <span class="filter-icon">
                             <i class="fa fa-envelope" aria-hidden="true"></i>
                         </span>
@@ -30,7 +30,7 @@
                 </div>
             </li>
             <li class="top_left_mentions top_left_row">
-                <a href="#narrow/is/mentioned">
+                <a href="#narrow/is/mentioned" class="global_filters_link">
                     <span class="filter-icon">
                         <i class="fa fa-at" aria-hidden="true"></i>
                     </span>
@@ -42,7 +42,7 @@
                 </a>
             </li>
             <li class="top_left_starred_messages top_left_row">
-                <a href="#narrow/is/starred">
+                <a href="#narrow/is/starred" class="global_filters_link">
                     <span class="filter-icon">
                         <i class="fa fa-star" aria-hidden="true"></i>
                     </span>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Solves #12045.

**Testing Plan:** <!-- How have you tested? -->
When we click beside global_filters the link should activate.

 <!-- If a UI change.  See:**GIFs or Screenshots:**
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
