### PR TITLE
 Add timezone field to Get all users API endpoint.

### DIFF
--- a/templates/zerver/api/get-all-users.md
+++ b/templates/zerver/api/get-all-users.md
@@ -72,6 +72,7 @@ curl {{ api_url }}/v1/users?client_gravatar=true \
       is the email address of the user who created the bot.
     * `is_active`: A boolean specifying whether the user is active or not.
     * `is_guest`: A boolean specifying whether the user is a guest user or not.
+    * `timezone`: The time zone of the user.
 
 #### Example response
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -926,7 +926,8 @@ paths:
                                 "is_admin": false,
                                 "is_bot": false,
                                 "is_guest": false,
-                                "user_id": 1
+                                "user_id": 1,
+                                "timezone" : "Africa/Bujumbura"
                             },
                             {
                                 "avatar_url": "https://secure.gravatar.com/avatar/77c3871a68c8d70356156029fd0a4999?d=identicon&version=1",
@@ -937,7 +938,8 @@ paths:
                                 "is_admin": false,
                                 "is_bot": false,
                                 "is_guest": false,
-                                "user_id": 3
+                                "user_id": 3,
+                                "timezone" : "Asia/Calcutta"
                             },
                             {
                                 "avatar_url": "https://secure.gravatar.com/avatar/0cbf08f3a355995fa2ec542246e35123?d=identicon&version=1",
@@ -948,7 +950,8 @@ paths:
                                 "is_admin": false,
                                 "is_bot": false,
                                 "is_guest": true,
-                                "user_id": 24
+                                "user_id": 24,
+                                "timezone" : "Asia/Calcutta"
                             }
                         ],
                         "msg": "",

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -415,6 +415,7 @@ def get_members_backend(request: HttpRequest, user_profile: UserProfile,
         'avatar_source',
         'avatar_version',
         'bot_owner__email',
+        'timezone',
     )
 
     def get_member(row: Dict[str, Any]) -> Dict[str, Any]:
@@ -430,6 +431,7 @@ def get_members_backend(request: HttpRequest, user_profile: UserProfile,
             is_admin=row['is_realm_admin'],
             bot_type=row['bot_type'],
             is_guest=row['is_guest'],
+            timezone=row['timezone'],
         )
 
         result['avatar_url'] = get_avatar_field(


### PR DESCRIPTION
The `timezone` field was not present in the `Get all users` API endpoint. This PR for the including the time zone field and also for uploading the corresponding documentation.

Also, I would like to mention that this timestamp field is important for a bot that I would like to create. It is basically a reminder bot which sends private messages to all the users in a particular stream when a meeting or discussion is planned. The message consists of time for the meeting which will be according to the Time zone of the user. I need the timezone for this purpose. 

I discussed this with @hackerkid during HackInTheNorth (Hackathon) and found that this field was missing. Also, the bot is partially made except the time not converted in the private message sent to everyone in the stream. 
 
Following are the screenshots of the new documentation.

![Screenshot_20190404_033338](https://user-images.githubusercontent.com/21339090/55516460-e80aac80-568a-11e9-9a73-619d9c0ae408.png)
![Screenshot_20190404_033429](https://user-images.githubusercontent.com/21339090/55516462-e80aac80-568a-11e9-819e-00baa382b36f.png)
