### PR TITLE
message view: Replace reactions title with on-hover tooltips. 

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -189,6 +189,40 @@ exports.initialize = function () {
         var local_id = $(this).attr('data-reaction-id');
         var message_id = rows.get_message_id(this);
         reactions.process_reaction_click(message_id, local_id);
+        $(".tooltip").remove();
+    });
+
+    // TOOLTIP FOR MESSAGE REACTIONS
+
+    $('#main_div').on('mouseenter', '.message_reaction', function (e) {
+        e.stopPropagation();
+        var elem = $(e.currentTarget);
+        var local_id = elem.attr('data-reaction-id');
+        var message_id = rows.get_message_id(e.currentTarget);
+        var title = reactions.get_reaction_title_data(message_id, local_id);
+
+        elem.tooltip({
+            title: title,
+            trigger: 'hover',
+            placement: 'bottom',
+            animation: false,
+        });
+        elem.tooltip('show');
+        $(".tooltip, .tooltip-inner").css('max-width', "600px");
+        // Remove the arrow from the tooltip.
+        $(".tooltip-arrow").remove();
+    });
+
+    $('#main_div').on('mouseleave', '.message_reaction', function (e) {
+        e.stopPropagation();
+        $(e.currentTarget).tooltip('destroy');
+    });
+
+    // DESTROY PERSISTING TOOLTIPS ON HOVER
+
+    $("body").on('mouseenter', '.tooltip', function (e) {
+        e.stopPropagation();
+        $(e.currentTarget).remove();
     });
 
     $("#main_div").on("click", "a.stream", function (e) {

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -693,6 +693,26 @@ exports.register_click_handlers = function () {
         emoji_picker.toggle_emoji_popover(this, message_id);
     });
 
+    $("#main_div").on("mouseenter", ".reaction_button", function (e) {
+        e.stopPropagation();
+
+        var elem = $(this);
+        var title = i18n.t("Add emoji reaction");
+        elem.tooltip({
+            title: title + " (:)",
+            trigger: 'hover',
+            placement: 'bottom',
+            animation: false,
+        });
+        elem.tooltip('show');
+        $(".tooltip-arrow").remove();
+    });
+
+    $('#main_div').on('mouseleave', '.reaction_button', function (e) {
+        e.stopPropagation();
+        $(this).tooltip('hide');
+    });
+
     $("body").on("click", ".actions_popover .reaction_button", function (e) {
         var msgid = $(e.currentTarget).data('message-id');
         e.preventDefault();

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -696,7 +696,7 @@ exports.register_click_handlers = function () {
     $("#main_div").on("mouseenter", ".reaction_button", function (e) {
         e.stopPropagation();
 
-        var elem = $(this);
+        var elem = $(e.currentTarget);
         var title = i18n.t("Add emoji reaction");
         elem.tooltip({
             title: title + " (:)",
@@ -710,7 +710,7 @@ exports.register_click_handlers = function () {
 
     $('#main_div').on('mouseleave', '.reaction_button', function (e) {
         e.stopPropagation();
-        $(this).tooltip('hide');
+        $(e.currentTarget).tooltip('hide');
     });
 
     $("body").on("click", ".actions_popover .reaction_button", function (e) {

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -172,6 +172,16 @@ function generate_title(emoji_name, user_ids) {
     return _.initial(user_names).join(', ') + ' and ' + _.last(user_names) + reacted_with_string;
 }
 
+// Add a tooltip showing who reacted to a message.
+exports.get_reaction_title_data = function (message_id, local_id) {
+    var message = get_message(message_id);
+    var user_list = get_user_list_for_message_reaction(message, local_id);
+    var emoji_name = exports.get_reaction_info(local_id).emoji_name;
+    var title = generate_title(emoji_name, user_list);
+
+    return title;
+};
+
 exports.get_reaction_section = function (message_id) {
     var message_element = $('.message_table').find("[zid='" + message_id + "']");
     var section = message_element.find('.message_reactions');
@@ -249,8 +259,8 @@ exports.view.update_existing_reaction = function (opts) {
 
     exports.set_reaction_count(reaction, user_list.length);
 
-    var new_title = generate_title(emoji_name, user_list);
-    reaction.prop('title', new_title);
+    var new_label = generate_title(emoji_name, user_list);
+    reaction.attr('aria-label', new_label);
 
     if (user_id === page_params.user_id) {
         reaction.addClass("reacted");
@@ -275,7 +285,7 @@ exports.view.insert_new_reaction = function (opts) {
         emoji_code: emoji_code,
     };
 
-    var new_title = generate_title(emoji_name, user_list);
+    var new_label = generate_title(emoji_name, user_list);
 
     if (opts.reaction_type !== 'unicode_emoji') {
         context.is_realm_emoji = true;
@@ -283,7 +293,7 @@ exports.view.insert_new_reaction = function (opts) {
     }
 
     context.count = 1;
-    context.title = new_title;
+    context.label = new_label;
     context.local_id = exports.get_local_reaction_id(opts);
     context.emoji_alt_code = page_params.emojiset === 'text';
 
@@ -369,8 +379,10 @@ exports.view.remove_reaction = function (opts) {
     // the title/count and, if the user is the current user, turn off the
     // "reacted" class.
 
-    var new_title = generate_title(emoji_name, user_list);
-    reaction.prop('title', new_title);
+    var new_label = generate_title(emoji_name, user_list);
+    reaction.attr('aria-label', new_label);
+
+    // If the user is the current user, turn off the "reacted" class.
 
     exports.set_reaction_count(reaction, user_list.length);
 
@@ -414,7 +426,7 @@ exports.get_message_reactions = function (message) {
         reaction.emoji_name = reaction.emoji_name;
         reaction.emoji_code = reaction.emoji_code;
         reaction.count = reaction.user_ids.length;
-        reaction.title = generate_title(reaction.emoji_name, reaction.user_ids);
+        reaction.label = generate_title(reaction.emoji_name, reaction.user_ids);
         reaction.emoji_alt_code = page_params.emojiset === 'text';
 
         if (reaction.reaction_type !== 'unicode_emoji') {

--- a/static/templates/message_reaction.hbs
+++ b/static/templates/message_reaction.hbs
@@ -1,4 +1,4 @@
-<div class="{{this.class}}" title="{{this.title}}" data-reaction-id={{this.local_id}}>
+<div class="{{this.class}}" aria-label="{{this.label}}" data-reaction-id={{this.local_id}}>
     {{#if this.emoji_alt_code}}
         <div class="emoji_alt_code">&nbsp:{{this.emoji_name}}:</div>
     {{else}}

--- a/static/templates/message_reactions.hbs
+++ b/static/templates/message_reactions.hbs
@@ -1,7 +1,7 @@
 {{#each this/msg/message_reactions}}
 {{> message_reaction}}
 {{/each}}
-<div class="reaction_button" title="{{t 'Add emoji reaction' }} (:)">
+<div class="reaction_button" aria-label="{{t 'Add emoji reaction' }} (:)">
     <i class="fa fa-smile-o" role="button" aria-haspopup="true" tabindex="0" aria-label="{{t 'Add emoji reaction' }} (:)"></i>
     <div class="message_reaction_count">+</div>
 </div>


### PR DESCRIPTION
This PR fixes  #8679.

The first commit is a fix for the `reaction button` in the message view, replacing the html title with a JS Tooltip. I added this to maintain consistency in that section.

The second commit deals with this problem statement in the Issue, i.e., `emoji reactions`. Replacing the html titles with JS tooltips and adding tests for the same.

**GIFs or Screenshots:** 

![Reaction_tooltips_large](https://user-images.githubusercontent.com/25329595/55656480-ac9be980-5814-11e9-8c06-5c7b9320e812.gif)

