### PR TITLE
commands: Fix handling of keyword arguments in `query_ldap` command.

### DIFF
--- a/zerver/management/commands/query_ldap.py
+++ b/zerver/management/commands/query_ldap.py
@@ -12,6 +12,7 @@ class Command(BaseCommand):
                             help="email of user to query")
 
     def handle(self, *args: Any, **options: str) -> None:
-        values = query_ldap(**options)
+        email = options['email']
+        values = query_ldap(email)
         for value in values:
             print(value)


### PR DESCRIPTION
This bug seems to be introduced by me while doing the refactoring
in `94649f58f2fe0ed78d84e597ad6676522cfef9be`.

Fixes: #12006.