### PR TITLE
webhooks/stripe: Ignore account updates with insufficient data.

### DIFF
--- a/zerver/webhooks/stripe/fixtures/account_updated_without_previous_attributes.json
+++ b/zerver/webhooks/stripe/fixtures/account_updated_without_previous_attributes.json
@@ -1,0 +1,108 @@
+{
+    "created": 1326853478,
+    "livemode": false,
+    "id": "evt_00000000000000",
+    "type": "account.updated",
+    "object": "event",
+    "request": null,
+    "pending_webhooks": 1,
+    "api_version": "2018-02-28",
+    "data": {
+        "object": {
+            "id": "acct_00000000000000",
+            "object": "account",
+            "business_logo": null,
+            "business_logo_large": null,
+            "business_name": null,
+            "business_primary_color": null,
+            "business_url": null,
+            "charges_enabled": false,
+            "country": "CA",
+            "created": 1523744779,
+            "debit_negative_balances": true,
+            "decline_charge_on": {
+                "avs_failure": false,
+                "cvc_failure": true
+            },
+            "default_currency": "cad",
+            "details_submitted": true,
+            "display_name": null,
+            "email": "test@stripe.com",
+            "external_accounts": {
+                "object": "list",
+                "data": [
+                ],
+                "has_more": false,
+                "total_count": 0,
+                "url": "/v1/accounts/acct_1CGwp5HSaWXyvFpK/external_accounts"
+            },
+            "legal_entity": {
+                "additional_owners": [
+                ],
+                "address": {
+                    "city": null,
+                    "country": "CA",
+                    "line1": null,
+                    "line2": null,
+                    "postal_code": null,
+                    "state": null
+                },
+                "business_name": null,
+                "business_tax_id_provided": false,
+                "dob": {
+                    "day": null,
+                    "month": null,
+                    "year": null
+                },
+                "first_name": null,
+                "last_name": null,
+                "personal_address": {
+                    "city": null,
+                    "country": "CA",
+                    "line1": null,
+                    "line2": null,
+                    "postal_code": null,
+                    "state": null
+                },
+                "personal_id_number_provided": false,
+                "type": null,
+                "verification": {
+                    "details": null,
+                    "details_code": null,
+                    "document": null,
+                    "document_back": null,
+                    "status": "unverified"
+                }
+            },
+            "mcc": null,
+            "metadata": {
+            },
+            "payout_schedule": {
+                "delay_days": 7,
+                "interval": "daily"
+            },
+            "payout_statement_descriptor": null,
+            "payouts_enabled": false,
+            "product_description": null,
+            "statement_descriptor": "TEST",
+            "support_address": null,
+            "support_email": null,
+            "support_phone": null,
+            "support_url": null,
+            "timezone": "America/St_Johns",
+            "tos_acceptance": {
+                "date": null,
+                "ip": null,
+                "user_agent": null
+            },
+            "type": "standard",
+            "verification": {
+                "disabled_reason": "fields_needed",
+                "due_by": 1554669463,
+                "fields_needed": [
+                    "legal_entity.verification.document"
+                ]
+            }
+        }
+    }
+}

--- a/zerver/webhooks/stripe/tests.py
+++ b/zerver/webhooks/stripe/tests.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import mock
+from mock import MagicMock, patch
 
 from zerver.lib.test_classes import WebhookTestCase
 
@@ -127,3 +128,12 @@ Billing method: send invoice"""
             expected_message,
             content_type="application/x-www-form-urlencoded"
         )
+
+    @patch('zerver.webhooks.stripe.view.check_send_webhook_message')
+    def test_account_updated_without_previous_attributes_ignore(
+            self, check_send_webhook_message_mock: MagicMock) -> None:
+        self.url = self.build_webhook_url()
+        payload = self.get_body('account_updated_without_previous_attributes')
+        result = self.client_post(self.url, payload, content_type="application/json")
+        self.assertFalse(check_send_webhook_message_mock.called)
+        self.assert_json_success(result)

--- a/zerver/webhooks/stripe/view.py
+++ b/zerver/webhooks/stripe/view.py
@@ -70,6 +70,8 @@ def topic_and_body(payload: Dict[str, Any]) -> Tuple[str, str]:
     if category == 'account':  # nocoverage
         if resource == 'account':
             if event == 'updated':
+                if 'previous_attributes' not in payload['data']:
+                    raise SuppressedEvent()
                 topic = "account updates"
                 body = update_string()
         else:


### PR DESCRIPTION
Certain payloads for account updates do not include the
previous_attributes that allow us to figure out what was actually
updated. So, we just ignore just payloads.

@rishig, @timabbott: FYI :)
