### PR TITLE
spiders: Set error status for exceptions generated by spider.

### DIFF
--- a/tools/documentation_crawler/documentation_crawler/spiders/common/spiders.py
+++ b/tools/documentation_crawler/documentation_crawler/spiders/common/spiders.py
@@ -121,5 +121,6 @@ class BaseDocumentationSpider(scrapy.Spider):
         elif isinstance(failure.type, IOError):
             self._set_error_state()
         else:
+            self._set_error_state()
             raise Exception(failure.value)
         return None


### PR DESCRIPTION
**This PR is address the failure to detect errors by spider as in #11719.**
Spider  would raise exceptions for erros like FileNotFound. These did not set error state before exiting causing spider to fail silently.This patch sets the status before exiting.

**Failed Silently** 
![exceptions](https://user-images.githubusercontent.com/30312566/55664083-5e9fd980-5846-11e9-84a8-01dc4e42c452.png)

**Fix**
![fix_exception](https://user-images.githubusercontent.com/30312566/55664084-61023380-5846-11e9-8c3d-639ff245f9e2.png)

Tested with exceptions observed in #11719.