### PR TITLE
hotkeys: Add `e` for edit selected message.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -48,6 +48,9 @@ set_global('current_msg_list', {
         };
     },
     selected_row: function () {},
+    get_row: function () {
+        return 101;
+    },
 });
 
 function return_true() { return true; }
@@ -170,7 +173,7 @@ run_test('basic_chars', () => {
 
     // Unmapped keys should immediately return false, without
     // calling any functions outside of hotkey.js.
-    assert_unmapped('abefhlmotyz');
+    assert_unmapped('abfhlmotyz');
     assert_unmapped('BEFHILNOQTUWXYZ');
 
     // We have to skip some checks due to the way the code is
@@ -289,6 +292,7 @@ run_test('basic_chars', () => {
     assert_mapping('i', 'popovers.open_message_menu');
     assert_mapping(':', 'reactions.open_reactions_popover', true);
     assert_mapping('>', 'compose_actions.quote_and_reply');
+    assert_mapping('e', 'message_edit.start');
 
     overlays.is_active = return_true;
     overlays.lightbox_open = return_true;

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -97,6 +97,7 @@ var keypress_mappings = {
     86: {name: 'view_selected_stream', message_view_only: false}, //'V'
     99: {name: 'compose', message_view_only: true}, // 'c'
     100: {name: 'open_drafts', message_view_only: true}, // 'd'
+    101: {name: 'edit_message', message_view_only: true}, // 'e'
     103: {name: 'gear_menu', message_view_only: true}, // 'g'
     105: {name: 'message_actions', message_view_only: true}, // 'i'
     106: {name: 'vim_down', message_view_only: true}, // 'j'
@@ -761,6 +762,10 @@ exports.process_hotkey = function (e, hotkey) {
         return true;
     case 'compose_quote_reply': // > : respond to selected message with quote
         compose_actions.quote_and_reply({trigger: 'hotkey'});
+        return true;
+    case 'edit_message':
+        var row = current_msg_list.get_row(msg.id);
+        message_edit.start(row);
         return true;
     }
 

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -210,7 +210,7 @@
                     <td class="definition">{% trans %}Show images in thread{% endtrans %}</td>
                 </tr>
                 <tr id="edit-message-hotkey-help">
-                    <td class="hotkey">i then Enter</td>
+                    <td class="hotkey">e</td>
                     <td class="definition">{% trans %}Edit selected message{% endtrans %}</td>
                 </tr>
                 <tr>


### PR DESCRIPTION
Fixes #11866.

Pressing `e` opens the `Edit message` box for the currently highlighted message.

GIFs or Screenshots:

![hotkey_e](https://user-images.githubusercontent.com/25329595/55670563-b7518f80-58a3-11e9-964b-af2a4ddd6796.gif)
