### PR TITLE
message view: Reduce extra white space above quotes and unordered lists.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1475,6 +1475,14 @@ blockquote p {
     font-size: inherit;
 }
 
+.message_content p + ul {
+    margin-top: -7px;
+}
+
+.message_content p + blockquote {
+    margin-top: -4px;
+}
+
 .messagebox {
     word-wrap: break-word;
     cursor: pointer;


### PR DESCRIPTION
Blockquotes and unordered lists had a large amount of space above them when preceded by a `p` tag.
This change reduces this white space with negative margins.

Fixes #11631.

**Screenshots :** [UPDATED]

**Before** : (czo)

![Screenshot_1](https://user-images.githubusercontent.com/25329595/55759290-95f4cd00-5a76-11e9-84f0-4cea20e1e2fb.png)

**After** :

![vertical spacing](https://user-images.githubusercontent.com/25329595/55759165-5cbc5d00-5a76-11e9-8ff1-6e054cb2e824.png)

