### PR TITLE
Organization Settings: Fix error with undefined profile_field in bot settings.

### DIFF
--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -145,6 +145,20 @@ run_test('my_custom_profile_data', () => {
     assert.equal(people.my_custom_profile_data(undefined), undefined);
 });
 
+run_test('bot_custom_profile_data', () => {
+    // If this test fails, then try opening organization settings > bots
+    // http://localhost:9991/#organization/bot-list-admin
+    // and then try to edit any of the bots.
+    var bot = {
+        email: 'bot@example.com',
+        user_id: 31,
+        full_name: 'Bot',
+        is_bot: true,
+    };
+    people.add_in_realm(bot);
+    assert.equal(people.get_custom_profile_data(31, 3), null);
+});
+
 run_test('user_timezone', () => {
     var expected_pref = {
         timezone: 'US/Pacific',

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -1028,7 +1028,11 @@ exports.my_custom_profile_data = function (field_id) {
 };
 
 exports.get_custom_profile_data = function (user_id, field_id) {
-    return people_by_user_id_dict.get(user_id).profile_data[field_id];
+    var profile_data = people_by_user_id_dict.get(user_id).profile_data;
+    if (profile_data === undefined) {
+        return null;
+    }
+    return profile_data[field_id];
 };
 
 exports.is_my_user_id = function (user_id) {

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -279,7 +279,7 @@ exports.show_user_profile = function (user) {
     ui.set_up_scrollbar($("#user-profile-modal #body"));
     $("#user-profile-modal").modal("show");
 
-    settings_account.intialize_custom_user_type_fields("#user-profile-modal #content", user.user_id, false, false);
+    settings_account.initialize_custom_user_type_fields("#user-profile-modal #content", user.user_id, false, false);
 };
 
 function get_user_info_popover_items() {

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -64,6 +64,10 @@ function update_user_custom_profile_fields(fields, method) {
 }
 
 exports.append_custom_profile_fields = function (element_id, user_id) {
+    var person = people.get_person_from_user_id(user_id);
+    if (person.is_bot) {
+        return;
+    }
     var all_custom_fields = page_params.custom_profile_fields;
     var field_types = page_params.custom_profile_field_types;
 
@@ -129,6 +133,11 @@ exports.initialize_custom_user_type_fields = function (element_id, user_id, is_e
     var field_types = page_params.custom_profile_field_types;
     var user_pills = {};
 
+    var person = people.get_person_from_user_id(user_id);
+    if (person.is_bot) {
+        return [];
+    }
+
     page_params.custom_profile_fields.forEach(function (field) {
         var field_value_raw = people.get_custom_profile_data(user_id, field.id);
 
@@ -179,6 +188,7 @@ exports.initialize_custom_user_type_fields = function (element_id, user_id, is_e
             user_pills[field.id] = pills;
         }
     });
+
     return user_pills;
 };
 

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -124,8 +124,8 @@ exports.initialize_custom_date_type_fields = function (element_id) {
         altFormat: "F j, Y"});
 };
 
-exports.intialize_custom_user_type_fields = function (element_id, user_id, is_editable,
-                                                      set_handler_on_update) {
+exports.initialize_custom_user_type_fields = function (element_id, user_id, is_editable,
+                                                       set_handler_on_update) {
     var field_types = page_params.custom_profile_field_types;
     var user_pills = {};
 
@@ -196,7 +196,7 @@ exports.add_custom_profile_fields_to_settings = function () {
     }
 
     exports.append_custom_profile_fields(element_id, people.my_current_user_id());
-    exports.intialize_custom_user_type_fields(element_id, people.my_current_user_id(), true, true);
+    exports.initialize_custom_user_type_fields(element_id, people.my_current_user_id(), true, true);
     exports.initialize_custom_date_type_fields(element_id);
 };
 

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -367,8 +367,9 @@ exports.on_load_success = function (realm_people_data) {
         $(element).html("");
         settings_account.append_custom_profile_fields(element, user_id);
         settings_account.initialize_custom_date_type_fields(element);
-        var fields_user_pills = settings_account.intialize_custom_user_type_fields(element, user_id,
-                                                                                   true, false);
+        var fields_user_pills = settings_account.initialize_custom_user_type_fields(element,
+                                                                                    user_id,
+                                                                                    true, false);
 
         var url;
         var data;


### PR DESCRIPTION
### Purpose:
This is a small patch to fix the error message an admin would receive if
they tried to change bot info and owner from the "bots" setting of the
organization settings panel. Discovered it recently when I was playing around
with the bots settings. I didn't open an issue since this was a pretty small bug
which could be fixed quickly.

### Testing:
Added a new node test.

### Before the Patch:
![error1](https://user-images.githubusercontent.com/29123352/55688433-155e9f80-5996-11e9-9f71-95f6ce4b105a.gif)
![error2](https://user-images.githubusercontent.com/29123352/55688434-198abd00-5996-11e9-9744-8fd8827e5a13.gif)

### After the Patch:
![fixed](https://user-images.githubusercontent.com/29123352/55688435-1f809e00-5996-11e9-8342-04a31e36eca9.gif)
