### PR TITLE
markdown: Fix list indicators rendering for bullet list.

### DIFF
--- a/static/third/marked/lib/marked.js
+++ b/static/third/marked/lib/marked.js
@@ -135,7 +135,6 @@ Lexer.prototype.lex = function(src) {
     .replace(/\t/g, '    ')
     .replace(/\u00a0/g, ' ')
     .replace(/\u2424/g, '\n');
-
   return this.token(src, true);
 };
 
@@ -170,6 +169,13 @@ Lexer.prototype.token = function(src, top, bq) {
     , l;
 
   while (src) {
+
+    if ((this.rules.nptable.test(src)) || (this.rules.table.test(src))) {
+      this.rules = block.tables;
+    } else if (this.rules.list !== block.list) {
+      this.rules.list = block.list;
+    }
+
     // newline
     if (cap = this.rules.newline.exec(src)) {
       src = src.substring(cap[0].length);

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -137,6 +137,13 @@
       "text_content": "Some text with a list:\n\nOne item\nTwo items\nThree items\n"
     },
     {
+      "name": "ulist_with_different_indicators",
+      "input": "Some text with a list:\n\n* First list\n- Second list\n+ Third list",
+      "expected_output": "<p>Some text with a list:</p>\n<ul>\n<li>First list</li>\n<li>Second list</li>\n<li>Third list</li>\n</ul>",
+      "marked_expected_output": "<p>Some text with a list:</p>\n<ul>\n<li>First list</li>\n</ul>\n<ul>\n<li>Second list</li>\n</ul>\n<ul>\n<li>Third list</li>\n</ul>",
+      "text_content": "Some text with a list:\n\nFirst list\nSecond list\nThird list\n"
+    },
+    {
       "name": "ulist_hanging",
       "input": "Some text with a hanging list:\n* One item\n* Two items\n* Three items",
       "expected_output": "<p>Some text with a hanging list:</p>\n<ul>\n<li>One item</li>\n<li>Two items</li>\n<li>Three items</li>\n</ul>",


### PR DESCRIPTION
Previously, the frontend javascript processor didn't treat
`+ -` as bullet list indicators, thus rendering different
ouptut from that of backend.

This was due to the change in list definiton when we make
when rendering tables which results into removal of `+ -`
and only `*` is treated as bullet list indicator, added
conditions to change back to original bullet list regex
when table is not encountered.

Fixes #11860

![fix-list-indicators](https://user-images.githubusercontent.com/41135524/55695774-c3d70480-59d7-11e9-8dd6-ff086ebfd81d.gif)
