### PR TITLE
check_rabbitmq_queue: Fix the time period when we ignore long queues.

### DIFF
--- a/puppet/zulip/files/cron.d/send-digest-emails
+++ b/puppet/zulip/files/cron.d/send-digest-emails
@@ -1,4 +1,6 @@
 MAILTO=root
 
 # Send digest emails once a day. Time is in UTC.
+# NOTE: If the time of this cron job is changed, fix the ignore long queue time
+# period in `check-rabbitmq-queue`.
 0 18 * * *   zulip cd /home/zulip/deployments/current && ./manage.py enqueue_digest_emails

--- a/scripts/nagios/check-rabbitmq-queue
+++ b/scripts/nagios/check-rabbitmq-queue
@@ -52,12 +52,12 @@ warn_about = ", ".join(warn_queues)
 now = int(time.time())
 now_struct = time.gmtime(now)
 
-# While we are sending digest emails, at 11am each weekday, the mail
-# queues can get backed up; don't alert on those.  Additionally,
-# certain workers (slow_queries and digest_emails) have a polling
-# algorithm that means it's normal for them to accumulate items.
+# While we are sending digest emails, at 1800 hrs (UTC) each weekday, the mail
+# queues can get backed up; don't alert on those. Additionally, certain workers
+# (slow_queries and digest_emails) have a polling algorithm that means it's
+# normal for them to accumulate items.
 if not set(warn_queues) - set(("missedmessage_emails", "digest_emails", "slow_queries")) and \
-        now_struct.tm_hour == 15 and now_struct.tm_min < 25:
+        now_struct.tm_hour == 18 and now_struct.tm_min < 25:
     status = 0
     print("%s|%s|%s|processing digests, not alerting on elevated mail queues" % (
         now, status, states[status]))


### PR DESCRIPTION
The commit 87d180965709a47039d29f226646f739ebcdbbc6 changed the time when
digests are sent by 3 hours to account for moving from the US East Coast to the
West Coast, but didn't change the time period exception in the
`check-rabbitmq-queue` script.

Closes #5415

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->

I haven't really tested this, but seems like the right fix based on the history of changes to the file. 

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
