### PR TITLE
message view: Fix Rerender left sidebar after changing hello topic.

### DIFF
--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -43,7 +43,6 @@ exports.is_active = function (sub) {
 
 exports.rename_sub = function (sub, new_name) {
     var old_name = sub.name;
-
     stream_ids_by_name.set(old_name, sub.stream_id);
 
     sub.name = new_name;

--- a/static/js/topic_data.js
+++ b/static/js/topic_data.js
@@ -53,7 +53,6 @@ exports.topic_history = function (stream_id) {
 
     self.maybe_remove = function (topic_name) {
         var existing = topics.get(topic_name);
-
         if (!existing) {
             return;
         }
@@ -112,8 +111,11 @@ exports.topic_history = function (stream_id) {
             topic_dict: topics,
         });
 
-        var recents = my_recents.concat(missing_topics);
+        var missing_topic = _.reject(missing_topics, function (miss_topics) {
+            return miss_topics.message_id === -Infinity;
+        });
 
+        var recents = my_recents.concat(missing_topic);
         recents.sort(function (a, b) {
             return b.message_id - a.message_id;
         });
@@ -135,7 +137,6 @@ exports.remove_message = function (opts) {
 
     // This is the special case of "removing" a message from
     // a topic, which happens when we edit topics.
-
     if (!history) {
         return;
     }

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -322,14 +322,12 @@ exports.unread_topic_counter = (function () {
         }
 
         var topic_names = per_stream_bucketer.keys();
-
         topic_names = _.reject(topic_names, function (topic_name) {
             return topic_dict.has(topic_name);
         });
 
         var result = _.map(topic_names, function (topic_name) {
             var msgs = per_stream_bucketer.get_bucket(topic_name);
-
             return {
                 pretty_name: topic_name,
                 message_id: msgs.max(),


### PR DESCRIPTION
So if we edit hello topic the message_id of hello topic goes
to -Infinity. If we ignore the topic with message_id equals to
-Infinity then this fixes issue.

Fix #11901


![Peek 2019-04-10 01-36](https://user-images.githubusercontent.com/32260593/55831719-6d7dd900-5b31-11e9-874e-b572e74aff78.gif)

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
