### PR TITLE
Correctly label the shortcut for starting a PM as "(x)" instead of "(c)"

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -115,7 +115,7 @@ exports.update_closed_compose_buttons_for_private = function () {
     var text_stream = i18n.t("New stream message");
     var title_stream = text_stream + " (c)";
     var text_conversation = i18n.t("New conversation");
-    var title_conversation = text_conversation + " (c)";
+    var title_conversation = text_conversation + " (x)";
     update_stream_button(text_stream, title_stream);
     update_conversation_button(text_conversation, title_conversation);
 };
@@ -124,7 +124,7 @@ exports.update_closed_compose_buttons_for_stream = function () {
     var text_stream = i18n.t("New topic");
     var title_stream = text_stream + " (c)";
     var text_conversation = i18n.t("New private message");
-    var title_conversation = text_conversation + " (c)";
+    var title_conversation = text_conversation + " (x)";
     update_stream_button(text_stream, title_stream);
     update_conversation_button(text_conversation, title_conversation);
 };


### PR DESCRIPTION
This was likely a copy-and-paste error made in 0d25baedfa.