### PR TITLE
vagrant: Add option to specify system settings.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -76,6 +76,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   http_proxy = https_proxy = no_proxy = nil
   host_ip_addr = "127.0.0.1"
 
+  # System settings for the virtual machine.
+  vm_num_cpus = "2"
+  vm_memory = "2048"
+
   config.vm.synced_folder ".", "/vagrant", disabled: true
   if (/darwin/ =~ RUBY_PLATFORM) != nil
     config.vm.synced_folder ".", "/srv/zulip", type: "nfs",
@@ -97,6 +101,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       when "NO_PROXY"; no_proxy = value
       when "HOST_PORT"; host_port = value.to_i
       when "HOST_IP_ADDR"; host_ip_addr = value
+      when "GUEST_CPUS"; vm_num_cpus = value
+      when "GUEST_MEMORY_MB"; vm_memory = value
       end
     end
   end
@@ -143,14 +149,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |vb, override|
     override.vm.box = "ubuntu/trusty64"
     # It's possible we can get away with just 1.5GB; more testing needed
-    vb.memory = 2048
-    vb.cpus = 2
+    vb.memory = vm_memory
+    vb.cpus = vm_num_cpus
   end
 
   config.vm.provider "vmware_fusion" do |vb, override|
     override.vm.box = "puphpet/ubuntu1404-x64"
-    vb.vmx["memsize"] = "2048"
-    vb.vmx["numvcpus"] = "2"
+    vb.vmx["memsize"] = vm_memory
+    vb.vmx["numvcpus"] = vm_num_cpus
   end
 
 $provision_script = <<SCRIPT

--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -18,6 +18,7 @@ Contents:
 * [Step 4: Developing](#step-4-developing)
 * [Troubleshooting and Common Errors](#troubleshooting-and-common-errors)
 * [Specifying a proxy](#specifying-a-proxy)
+* [Customize the virtual system settings](#customizing-the-virtual-system-settings)
 
 **If you encounter errors installing the Zulip development
 environment,** check
@@ -1091,6 +1092,41 @@ HOST_IP_ADDR 0.0.0.0
 (and restart the Vagrant guest), your host IP would be 0.0.0.0, a special value
 for the IP address that means any IP address can connect to your development server.
 
+### Customizing the virtual system settings
+
+When running Vagrant using a VM-based provider such as VirtualBox or VMWare Fusion,
+configuration determines what resources are allocated to the guest system.
+
+*With LXC (or another container setup), one just inherits the host system values.*
+
+The default system settings allocate two cpus with two GiB of memory for the guest, which is sufficient
+to run everything in the development environment.  If your host machine has the means to
+augment these defaults, you can change the system settings by adding lines in the
+`~/.zulip-vagrant-config` file just like the technique for assigning values described above
+in *Specifying a proxy*.
+
+If you have not already, create a '~/.zulip-vagrant-config' file, then add the
+following lines:
+
+```
+GUEST_CPUS <number of cpus>
+GUEST_MEMORY_MB <system memory (in MB)>
+```
+
+For example, adding the lines:
+
+```
+GUEST_CPUS 4
+GUEST_MEMORY_MB 8192
+```
+
+would result in an allocation of 4 cpus and 8 GiB of memory for the VM.
+
+Run the command `vagrant reload` (the same as running halt and then up). Your VM is
+now configured with your specified system settings.
+
+If at any time you wish to revert back to the default settings, simply remove
+the `GUEST_CPUS` and `GUEST_MEMORY_MB` lines from the '~/.zulip-vagrant-config' file.
 
 [cygwin-dl]: http://cygwin.com/
 [vagrant-dl]: https://www.vagrantup.com/downloads.html


### PR DESCRIPTION
Discussion on [czo](https://chat.zulip.org/#narrow/stream/92-learning/topic/Increase.20specs.20vagrant-virtualbox/near/730661).

Two variables were declared and assigned the respective values of the
default settings for the system. If the keyword is used in the
~/.zulip-vagrant-config file, the value is assigned to the variable.

There is no straightforward way to customize the virtual machine's
number of cpus or amount of memory, this commit addresses that fact.

The settings were verified by checking the ```/proc``` directory, along with verifying settings in the actual VM program.

cpu count: ```cat /proc/cpuinfo | grep 'processor' | wc -l```

memory: ```cat /proc/meminfo | grep 'MemTotal' | sed 's/[a-z|A-Z]*://' | sed 's/^ *//'```
