### PR TITLE
Fixing typo in the various markdown files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -21,7 +21,7 @@ The following behaviors are expected and requested of all community members:
 * Participate. In doing so, you contribute to the health and longevity of
   the community.
 * Exercise consideration and respect in your speech and actions.
-* Attempt collaboration before conflict. Assume good faith.
+* Attempt collaboration before a conflict. Assume good faith.
 * Refrain from demeaning, discriminatory, or harassing behavior and speech.
 * Take action or alert community leaders if you notice a dangerous
   situation, someone in distress, or violations of this code, even if they
@@ -78,7 +78,7 @@ something you can do while a violation is happening, do it. A lot of the
 harms of harassment and other violations can be mitigated by the victim
 knowing that the other people present are on their side.
 
-All reports will be kept confidential. In some cases we may determine that a
+All reports will be kept confidential. In some cases, we may determine that a
 public statement will need to be made. In such cases, the identities of all
 victims and reporters will remain confidential unless those individuals
 instruct us otherwise.

--- a/docs/production/email.md
+++ b/docs/production/email.md
@@ -1,6 +1,6 @@
 # Outgoing email
 
-Zulip needs to be able to send email so it can confirm new users'
+Zulip needs to be able to send email so it can confirm new user's
 email addresses and send notifications.
 
 ## How to configure

--- a/docs/production/export-and-import.md
+++ b/docs/production/export-and-import.md
@@ -47,7 +47,7 @@ accounts in the from logging in or accessing the API.  This is
 preferred for environments like Zulip Cloud where you might want to
 export a single organization without disrupting any other users, and
 the intent is to move hosting of the organization (and forcing users
-to re-login would be required as part of the hosting migrateion
+to re-login would be required as part of the hosting migrations
 anyway).
 
 We include both options in the instructions below, commented out so

--- a/docs/production/install.md
+++ b/docs/production/install.md
@@ -85,7 +85,7 @@ If the script gives an error, consult [Troubleshooting](#troubleshooting) below.
 On success, the install script prints a link.  If you're [restoring a
 backup][zulip-backups] or importing your data from [HipChat][hipchat-import],
 [Slack][slack-import], or another Zulip server, you should stop here
-and return to the the import instructions.
+and return to the import instructions.
 
 [hipchat-import]: https://zulipchat.com/help/import-from-hipchat
 [slack-import]: https://zulipchat.com/help/import-from-slack
@@ -133,7 +133,7 @@ The install script does several things:
 deployment (and future deployments when you upgrade) goes into.  At the
 very end of the install process, the script moves the Zulip code tree
 it's running from (which you unpacked from a tarball above) to a
-directory there, and makes `/home/zulip/deployments/current` as a
+directory there and makes `/home/zulip/deployments/current` as a
 symbolic link to it.
 * Installs Zulip's various dependencies.
 * Configures the various third-party services Zulip uses, including

--- a/docs/production/maintain-secure-upgrade.md
+++ b/docs/production/maintain-secure-upgrade.md
@@ -1,4 +1,4 @@
-# Secure, maintain, and upgrade
+# Secure, Maintain and Upgrade
 
 This page covers topics that will help you maintain a healthy, up-to-date, and
 secure Zulip installation, including:
@@ -196,7 +196,7 @@ command:
 ```
 
 and Zulip will automatically fetch the relevant Git commit and upgrade
-to the that version of Zulip.
+to that version of Zulip.
 
 By default, this uses the main upstream Zulip server repository
 (example below), but you can configure any other Git repository by
@@ -353,7 +353,7 @@ the `manage.py backup` system over the export/import process is that
 it's structurally very unlikely for the `postgres` process to ever
 develop bugs, whereas the import/export tool requires some work for
 every new feature we add to Zulip, and thus may occasionally have bugs
-aroun corner cases.  The export tool's advantage is that the export is
+around corner cases.  The export tool's advantage is that the export is
 more human-readable and easier to parse, and doesn't have the
 requirement that the same set of Zulip organizations exist on the two
 servers (which is critical for migrations to and from Zulip Cloud).


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
  Typo in the various document files.


#### Fixes #12090 

#### Files where typos are found
- `email.md`
- `export-and-import.md`
- `install.md`
- `main-secure-upgrade.md`


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
