### PR TITLE
search: Preserve selected message.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -788,7 +788,9 @@ exports.initialize = function () {
                 // of overlays or selecting text (for copy+paste) trigger cancelling.
                 // Check if the click is within the body to prevent extensions from
                 // interfering with the compose box.
-                compose_actions.cancel();
+                if ($('#search_query_box').is(':focus') || !$('#search_query').is(':focus')) {
+                    compose_actions.cancel();
+                }
             }
         }
     });

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -37,6 +37,7 @@ function narrow_or_search_for_term(search_string) {
     // Narrowing will have already put some operators in the search box,
     // so leave the current text in.
     search_query_box.blur();
+    compose_actions.cancel();
     return search_query_box.val();
 }
 
@@ -153,6 +154,7 @@ exports.initialize = function () {
             // indicate that they've done what they need to do)
             narrow.activate(Filter.parse(search_query_box.val()), {trigger: 'search'});
             search_query_box.blur();
+            compose_actions.cancel();
             update_buttons_with_focus(false);
         }
     });


### PR DESCRIPTION
This preserve selected message when you have selected a message
and trying to renarrow by editing search filters.

Fix #11754

<!-- What's this PR for?  (Just a link to an issue is fine.) -->



**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![Peek 2019-04-11 06-17](https://user-images.githubusercontent.com/32260593/55923121-bd3bcd80-5c21-11e9-8b41-db65defa9ccc.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
