### PR TITLE
message view: Fix spacing of last paragraph's bulleted list and quote.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1483,6 +1483,14 @@ blockquote p {
     margin-top: -4px;
 }
 
+.rendered_markdown p:last-of-type + ul {
+    margin-top: 2px;
+}
+
+.rendered_markdown p:last-of-type + blockquote {
+    margin-top: 6px;
+}
+
 .messagebox {
     word-wrap: break-word;
     cursor: pointer;


### PR DESCRIPTION
Changes made in 62f2396 caused a regression where the spacing above bulleted lists and blockquotes in the last paragraph was very small due to an already existing separate rule for "p:last-of-type".
This commit addresses these specific cases and adds spacing that is inline with the changes made in the aforementioned commit.

**GIFs or Screenshots:** 

![Screenshot from 2019-04-12 04-13-36](https://user-images.githubusercontent.com/25329595/55998196-e66c6480-5cda-11e9-8bf8-08f3ae2e0482.png)

![Screenshot from 2019-04-12 04-16-27](https://user-images.githubusercontent.com/25329595/55998198-e8362800-5cda-11e9-8527-7d1b85e59496.png)
