### PR TITLE
auth: Redirect deactivated users with error for social auth backend.

### DIFF
--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -116,6 +116,12 @@
                                     </div>
                                     {% endif %}
 
+                                    {% if is_deactivated %}
+                                    <div class="alert">
+                                        {{ deactivated_account_error }}
+                                    </div>
+                                    {% endif %}
+
                                     {% if subdomain %}
                                     <div class="alert">
                                         {{ wrong_subdomain_error }}

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -43,6 +43,8 @@ MIT_VALIDATION_ERROR = u'That user does not exist at MIT or is a ' + \
 WRONG_SUBDOMAIN_ERROR = "Your Zulip account is not a member of the " + \
                         "organization associated with this subdomain.  " + \
                         "Please contact %s with any questions!" % (FromAddress.SUPPORT,)
+DEACTIVATED_ACCOUNT_ERROR = u"Your account is no longer active. " + \
+                            u"Please contact your organization administrator to reactivate it."
 
 def email_is_not_mit_mailing_list(email: str) -> None:
     """Prevent MIT mailing lists from signing up for Zulip"""
@@ -289,10 +291,7 @@ class OurAuthenticationForm(AuthenticationForm):
                 # We exclude mirror dummy accounts here. They should be treated as the
                 # user never having had an account, so we let them fall through to the
                 # normal invalid_login case below.
-                error_msg = (
-                    u"Your account is no longer active. "
-                    u"Please contact your organization administrator to reactivate it.")
-                raise ValidationError(mark_safe(error_msg))
+                raise ValidationError(mark_safe(DEACTIVATED_ACCOUNT_ERROR))
 
             if return_data.get("invalid_subdomain"):
                 logging.warning("User %s attempted to password login to wrong subdomain %s" %

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -94,7 +94,11 @@ class AuthBackendTest(ZulipTestCase):
 
         # Verify auth fails with a deactivated user
         do_deactivate_user(user_profile)
-        self.assertIsNone(backend.authenticate(**good_kwargs))
+        if not isinstance(backend, GitHubAuthBackend):
+            # Returns a redirect to login page with an error.
+            # SocialAuthBase.test_social_auth_deactivated_user already covers this use case
+            # for GithubAuthBackend
+            self.assertIsNone(backend.authenticate(**good_kwargs))
 
         # Reactivate the user and verify auth works again
         do_reactivate_user(user_profile)
@@ -571,7 +575,7 @@ class SocialAuthBase(ZulipTestCase):
         result = self.social_auth_test(account_data_dict,
                                        subdomain='zulip')
         self.assertEqual(result.status_code, 302)
-        self.assertEqual(result.url, "/login/")
+        self.assertEqual(result.url, "/accounts/login/?is_deactivated=true")
         # TODO: verify whether we provide a clear error message
 
     def test_social_auth_invalid_realm(self) -> None:

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -23,7 +23,8 @@ from confirmation.models import Confirmation, create_confirmation_link
 from zerver.context_processors import zulip_default_context, get_realm_from_request, \
     login_context
 from zerver.forms import HomepageForm, OurAuthenticationForm, \
-    WRONG_SUBDOMAIN_ERROR, ZulipPasswordResetForm, AuthenticationTokenForm
+    WRONG_SUBDOMAIN_ERROR, DEACTIVATED_ACCOUNT_ERROR, ZulipPasswordResetForm, \
+    AuthenticationTokenForm
 from zerver.lib.mobile_auth_otp import is_valid_otp, otp_encrypt_api_key
 from zerver.lib.push_notifications import push_notifications_enabled
 from zerver.lib.request import REQ, has_request_variables, JsonableError
@@ -613,12 +614,13 @@ def add_dev_login_context(realm: Realm, context: Dict[str, Any]) -> None:
     context['direct_users'] = [u for u in users if not (u.is_realm_admin or u.is_guest)]
 
 def update_login_page_context(request: HttpRequest, context: Dict[str, Any]) -> None:
-    for key in ('email', 'subdomain', 'already_registered'):
+    for key in ('email', 'subdomain', 'already_registered', 'is_deactivated'):
         try:
             context[key] = request.GET[key]
         except KeyError:
             pass
 
+    context['deactivated_account_error'] = DEACTIVATED_ACCOUNT_ERROR
     context['wrong_subdomain_error'] = WRONG_SUBDOMAIN_ERROR
 
 class TwoFactorLoginView(BaseTwoFactorLoginView):


### PR DESCRIPTION
Also extracts the error message for a deactivated account to
`DEACTIVATED_ACCOUNT_ERROR`.

Fixes #11937 

I was unable to find any user facing errors for the conditions in the following code block:
``` Python
if auth_backend_disabled or inactive_realm or no_verified_email:
        # Redirect to login page. We can't send to registration
        # workflow with these errors. We will redirect to login page.
        return None
```
Please let me know if we display errors in the above cases and I'll add additional commits for the same.

![deactivation_error](https://user-images.githubusercontent.com/13910561/56014821-5f92a880-5d29-11e9-8eb9-69203a7e8c34.png)
