### PR TITLE
Disable draggability of left-sidebar components

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -609,6 +609,11 @@ exports.initialize = function () {
     });
     // End Webathena code
 
+    // disable the draggability for left-sidebar components
+    $('#stream_filters, #global_filters').on('dragstart', function () {
+        return false;
+    });
+
     (function () {
         var map = {
             ".stream-description-editable": {


### PR DESCRIPTION


<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR disable the draggability of left-sidebar components, which misleads users into thinking we might have drag and drop feature. discussed on  [#CZO](https://chat.zulip.org/#narrow/stream/137-feedback/topic/drag.20streams.20according.20to.20user.20priority/near/727374) 

**Testing Plan:** <!-- How have you tested? -->
Ubuntu 18.10

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![disable-drag-leftsidebar](https://user-images.githubusercontent.com/36422396/56056973-57fbef80-5d7b-11e9-9691-6a348d1bf1d6.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
