### PR TITLE
lazysizes: Load images 500px away from visible viewport.

### DIFF
--- a/static/js/bundles/commons.js
+++ b/static/js/bundles/commons.js
@@ -10,7 +10,7 @@ import "js/common.js";
 import "node_modules/moment/min/moment.min.js";
 import "node_modules/moment-timezone/builds/moment-timezone-with-data.min.js";
 import "node_modules/sortablejs/Sortable.js";
-import "node_modules/lazysizes/lazysizes.js";
+import "./lazysizes.js";
 import "third/bootstrap/css/bootstrap.css";
 import "third/bootstrap/css/bootstrap-btn.css";
 import "third/bootstrap/css/bootstrap-responsive.css";

--- a/static/js/bundles/lazysizes.js
+++ b/static/js/bundles/lazysizes.js
@@ -1,0 +1,7 @@
+/**
+  Seperate bundle for lazysizes since lazysizes requires
+  the config to defined before loading the actual library.
+*/
+
+import 'js/lazysizes_config.js';
+import 'node_modules/lazysizes/lazysizes.js';

--- a/static/js/lazysizes_config.js
+++ b/static/js/lazysizes_config.js
@@ -1,0 +1,2 @@
+window.lazySizesConfig = window.lazySizesConfig || {};
+window.lazySizesConfig.expand = 500; // load images 500px away from visible screen.


### PR DESCRIPTION
We add a lazysizes config option `expand` which loads images 500px away from
visual viewport. It makes sure that when we render new messages there is
no flash of grey rectangle and then image even though the image is in browser's cache.

**Testing Plan:** <!-- How have you tested? -->
I tried to compare the change with master and this fix I definitely see less triangles but its hard to tell if the glitch if 100% fixed because I can't remember which gravatars were loaded before. I think test-deploying this change and checking it on czo will be great here. If this still doesn't fix the glitch than we can try other option `lazySizesConfig.preloadAfterLoad`.