### PR TITLE
stream-edit: Empty edit stream-name makes the span styling ineffective 

### DIFF
--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -843,6 +843,7 @@ form#add_new_subscription {
 
 .editable-section[contenteditable=true] {
     display: inline-block;
+    vertical-align: top;
     color: hsl(170, 48%, 54%);
 }
 


### PR DESCRIPTION

![zulip](https://user-images.githubusercontent.com/26672113/56047041-dd17e200-5d44-11e9-951f-0d098518c1ab.gif)

Added vertical-align in subscriptions.scss to fix broken span styling in stream-name edit.

Fixes: #11923 