### PR TITLE
list_render: Change alphabetic sorting to be case insensitive.

### DIFF
--- a/static/js/list_render.js
+++ b/static/js/list_render.js
@@ -295,10 +295,14 @@ var list_render = (function () {
         // add built-in generic sort functions.
         prototype.add_generic_sort_function("alphabetic", function (prop) {
             return function (a, b) {
-                if (a[prop] > b[prop]) {
-                    return 1;
-                } else if (a[prop] === b[prop]) {
+                // The conversion to uppercase helps make the sorting case insensitive.
+                var str1 = a[prop].toUpperCase();
+                var str2 = b[prop].toUpperCase();
+
+                if (str1 === str2) {
                     return 0;
+                } else if (str1 > str2) {
+                    return 1;
                 }
 
                 return -1;


### PR DESCRIPTION
This change makes the sorting of alphabetic columns case insensitive.

Related to the discussion [here](https://chat.zulip.org/#narrow/stream/6-frontend/topic/Sorting.20tables.20by.20column.20in.20Admin.20Settings.20Pages/near/731969).