### PR TITLE
Revert "user-profiles: Lazy load profile pictures when in view."

### DIFF
--- a/static/js/bundles/commons.js
+++ b/static/js/bundles/commons.js
@@ -10,7 +10,6 @@ import "js/common.js";
 import "node_modules/moment/min/moment.min.js";
 import "node_modules/moment-timezone/builds/moment-timezone-with-data.min.js";
 import "node_modules/sortablejs/Sortable.js";
-import "node_modules/lazysizes/lazysizes.js";
 import "third/bootstrap/css/bootstrap.css";
 import "third/bootstrap/css/bootstrap-btn.css";
 import "third/bootstrap/css/bootstrap-responsive.css";

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1543,7 +1543,6 @@ blockquote p {
     vertical-align: top;
     border-radius: 4px;
     overflow: hidden;
-    background-color: hsl(0, 0%, 90%);
 
     &.guest-avatar::after {
         outline: 2px solid hsl(0, 0%, 100%);

--- a/static/templates/message_avatar.handlebars
+++ b/static/templates/message_avatar.handlebars
@@ -1,3 +1,3 @@
 <div class="u-{{msg/sender_id}} inline_profile_picture {{#sender_is_guest}} guest-avatar{{/sender_is_guest}}" aria-hidden="true">
-    <img data-src="{{small_avatar_url}}" alt="" class="lazyload no-drag"/>
+    <img src="{{small_avatar_url}}" alt="" class="no-drag"/>
 </div>


### PR DESCRIPTION
This reverts commit 6441ad06777a83f5ccc61c534dafd18be2ee57ed since it
causes two bugs: (1) when rendering new message there is a glitch where
the profile picture flashes (2) when someone sends a new message their
profile picture flickers.
