### PR TITLE
Message View: Changes to vertical spacing for uls and blockquotes.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1456,7 +1456,20 @@ a:hover code {
         margin-left: 0;
     }
 
-    p + ul {
+    /* Ensure ordered lists are nicely centered in 1-line messages */
+    ol {
+        margin: 2px 0 5px 6px;
+    }
+
+    /* Swap the left and right margins of ordered list for Right-To-Left languages */
+    &.rtl ol {
+        margin-right: 8px;
+        margin-left: 0;
+    }
+
+    /* Reduce top-margin when a paragraph is followed by an ordered or bulleted list */
+    p + ul,
+    p + ol {
         margin-top: -2px;
     }
 

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1447,7 +1447,7 @@ a:hover code {
 
     /* Ensure bulleted lists are nicely centered in 1-line messages */
     ul {
-        margin: 5px 0 5px 20px;
+        margin: 2px 0 5px 20px;
     }
 
     /* Swap the left and right margins of bullets for Right-To-Left languages */
@@ -1456,10 +1456,15 @@ a:hover code {
         margin-left: 0;
     }
 
+    p + ul {
+        margin-top: -2px;
+    }
+
     /* Formatting for blockquotes */
     blockquote {
         padding-left: 5px;
         margin-left: 10px;
+        margin-top: 5px;
         margin-bottom: 6px;
         border-left-color: hsl(0, 0%, 87%);
 


### PR DESCRIPTION
This change decreases the spacing at the top and bottom of bulleted lists
and blockquotes.

**GIFs or Screenshots:** 

Current master :

![Current master](https://user-images.githubusercontent.com/25329595/56072794-47b63580-5db8-11e9-8d7f-76e8eb235748.png)

Changed:

![Screenshot from 2019-04-14 01-19-59](https://user-images.githubusercontent.com/25329595/56084645-759c8800-5e53-11e9-98cc-cb0b37515d38.png)

---
The second commit adds rules for ordered lists that makes them visually similar
to bulleted lists.

**GIFs or Screenshots:** 

Current master:

![Screenshot from 2019-04-14 02-01-35](https://user-images.githubusercontent.com/25329595/56084977-41c46100-5e59-11e9-9e0d-eaec2c42196c.png)

Changed: 

![Screenshot from 2019-04-14 02-07-40](https://user-images.githubusercontent.com/25329595/56085048-a338ff80-5e5a-11e9-8f41-f5740fcb999b.png)


