### PR TITLE
Add organization profile preview option. 

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -495,6 +495,7 @@ input[type=checkbox] + .inline-block {
     margin-bottom: 20px;
 }
 
+#id_org_profile_preview,
 .realm-icon-section {
     margin-bottom: 20px;
 }

--- a/static/templates/settings/organization-profile-admin.handlebars
+++ b/static/templates/settings/organization-profile-admin.handlebars
@@ -45,6 +45,10 @@
                   id="realm_icon_delete_button">{{t 'Delete profile picture' }}</button>
             </div>
         </div>
+        <a href="/login/?preview=true" target="_blank" class="button rounded sea-green w-200 block" id="id_org_profile_preview">
+            {{t 'Preview organization profile' }}
+            <i class="fa fa-external-link" aria-hidden="true" title="{{t 'Preview organization profile' }}"></i>
+        </a>
 
         <div class="subsection-header">
             <h3>{{t "Organization logo" }}

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -689,10 +689,16 @@ class TwoFactorLoginView(BaseTwoFactorLoginView):
             return super().done(form_list, **kwargs)
 
 def login_page(request: HttpRequest, **kwargs: Any) -> HttpResponse:
+    # To support previewing the Zulip login pages, we have a special option
+    # that disables the default behavior of redirecting logged-in users to the
+    # logged-in app.
+    is_preview = False
+    if request.method == "GET" and request.GET and request.GET.get('preview'):
+        is_preview = True
     if settings.TWO_FACTOR_AUTHENTICATION_ENABLED:
         if request.user and request.user.is_verified():
             return HttpResponseRedirect(request.user.realm.uri)
-    elif request.user.is_authenticated:
+    elif request.user.is_authenticated and not is_preview:
         return HttpResponseRedirect(request.user.realm.uri)
     if is_subdomain_root_or_alias(request) and settings.ROOT_DOMAIN_LANDING_PAGE:
         redirect_url = reverse('zerver.views.registration.realm_redirect')


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
The first two commit fixes organization-description cache issue. @Hypro999 It would be great if you can review these changes, since you have worked on this part of codebase previously. 

Organization description was not get deleted from cache when description was updated. The first two commit fixes this issue. 

Third commit adds button for organization profile preview. 

Fixes #12105