### PR TITLE
Left sidebar improvements

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -22,10 +22,12 @@ $topic_indent: $far_left_gutter_size + $left_col_size + 4px;
     font-weight: 800;
     min-width: $left_col_size;
     text-align: center;
-    span.hashtag,
-    i.fa-lock {
-        padding-right: 3px;
-    }
+}
+
+.stream-privacy span.hashtag,
+.stream-privacy i.fa-lock,
+.filter-icon i {
+    padding-right: 3px;
 }
 
 .pm_left_col {
@@ -281,10 +283,6 @@ li.top_left_starred_messages {
 .topic-name {
     /* TODO: We should figure out how to remove this without changing the spacing */
     line-height: 1.1;
-}
-
-.filter-icon i {
-    padding-right: 3px;
 }
 
 .all-messages-arrow i,

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -313,7 +313,7 @@ li.top_left_starred_messages {
 .all-messages-arrow,
 .starred-messages-sidebar-arrow,
 .stream-sidebar-arrow {
-    top: 2px;
+    top: 1px;
     right: 10px;
     font-size: 0.8em;
 }

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -190,9 +190,15 @@ li.top_left_starred_messages {
     line-height: 1.25;
 }
 
+.top_left_private_messages i.fa-envelope,
+.top_left_mentions i.fa-at,
+.top_left_starred_messages i.fa-star {
+    position: relative;
+    top: -1px;
+}
+
 .top_left_all_messages i.fa-home {
     position: relative;
-    top: 1px;
     font-size: 15px;
 }
 


### PR DESCRIPTION
This PR changes 3 things:
- Moved the global-filters icons 1px up.
- Changed css to remove duplicate addition of padding-right: 3px.
- Moved the arrows from global-filters and streams 1px up because they were not centered.

**Screenshots:**
<img width="300" alt="before changes" src="https://user-images.githubusercontent.com/18381652/56084081-0a8c8a80-5e2e-11e9-82a0-d36bdf6699d4.png"><img width="310" alt="after changes" src="https://user-images.githubusercontent.com/18381652/56084021-43782f80-5e2d-11e9-89f7-870f2dd4c2dc.png">