### PR TITLE
Update show_invites in zerver/views/home.

### DIFF
--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -5,10 +5,12 @@ import ujson
 
 from django.http import HttpResponse
 from django.utils.timezone import now as timezone_now
+from django.test import override_settings
 from mock import MagicMock, patch
 import urllib
 from typing import Any, Dict
 
+from zproject.backends import ZulipLDAPAuthBackend
 from zerver.lib.actions import do_create_user
 from zerver.lib.actions import do_change_logo_source
 from zerver.lib.events import add_realm_logo_fields
@@ -18,6 +20,7 @@ from zerver.lib.test_helpers import (
 )
 from zerver.lib.soft_deactivation import do_soft_deactivate_users
 from zerver.lib.test_runner import slow
+from zerver.lib.test_helpers import MockLDAP
 from zerver.models import (
     get_realm, get_stream, get_user, UserProfile,
     flush_per_request_caches, DefaultStream, Realm,
@@ -645,6 +648,47 @@ class HomeTest(ZulipTestCase):
         result = self._get_home_page()
         html = result.content.decode('utf-8')
         self.assertNotIn('Invite more users', html)
+
+    @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
+    def test_show_invites_for_LDAP_only(self) -> None:
+        user_profile = self.example_user('hamlet')
+        email = user_profile.email
+
+        ldap_patcher = patch('django_auth_ldap.config.ldap.initialize')
+        self.mock_initialize = ldap_patcher.start()
+        self.mock_ldap = MockLDAP()
+        self.mock_initialize.return_value = self.mock_ldap
+        self.backend = ZulipLDAPAuthBackend()
+
+        self.mock_ldap.directory = {
+            'uid=hamlet,ou=users,dc=zulip,dc=com': {
+                'userPassword': ['testing', ]
+            }
+        }
+
+        realm = user_profile.realm
+        realm.invite_required = True
+        realm.save()
+
+        with self.settings(
+                LDAP_APPEND_DOMAIN='zulip.com',
+                AUTH_LDAP_BIND_PASSWORD='',
+                AUTH_LDAP_USER_DN_TEMPLATE='uid=%(user)s,ou=users,dc=zulip,dc=com'):
+
+            self.login(email, password='testing')
+            result = self._get_home_page()
+            html = result.content.decode('utf-8')
+            self.assertIn('Invite more users', html)
+
+            realm.invite_required = False
+            realm.save()
+
+            result = self._get_home_page()
+            html = result.content.decode('utf-8')
+            self.assertNotIn('Invite more users', html)
+
+        self.mock_ldap.reset()
+        self.mock_initialize.stop()
 
     def test_show_billing(self) -> None:
         customer = Customer.objects.create(realm=get_realm("zulip"), stripe_customer_id="cus_id")

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -11,8 +11,9 @@ import urllib
 from typing import Any, Dict
 
 from zproject.backends import ZulipLDAPAuthBackend
-from zerver.lib.actions import do_create_user
-from zerver.lib.actions import do_change_logo_source
+from zerver.lib.actions import (
+    do_create_user, do_change_logo_source, do_set_realm_property
+)
 from zerver.lib.events import add_realm_logo_fields
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import (
@@ -667,8 +668,7 @@ class HomeTest(ZulipTestCase):
         }
 
         realm = user_profile.realm
-        realm.invite_required = True
-        realm.save()
+        do_set_realm_property(realm, 'invite_required', True)
 
         with self.settings(
                 LDAP_APPEND_DOMAIN='zulip.com',
@@ -680,8 +680,7 @@ class HomeTest(ZulipTestCase):
             html = result.content.decode('utf-8')
             self.assertIn('Invite more users', html)
 
-            realm.invite_required = False
-            realm.save()
+            do_set_realm_property(realm, 'invite_required', False)
 
             result = self._get_home_page()
             html = result.content.decode('utf-8')

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -27,6 +27,7 @@ from zerver.lib.push_notifications import num_push_devices_for_user
 from zerver.lib.streams import access_stream_by_name
 from zerver.lib.subdomains import get_subdomain
 from zerver.lib.utils import statsd, generate_random_token
+from zproject.backends import only_auth_enabled
 from two_factor.utils import default_device
 
 import calendar
@@ -251,6 +252,8 @@ def home_real(request: HttpRequest) -> HttpResponse:
     if user_profile.realm.invite_by_admins_only and not user_profile.is_realm_admin:
         show_invites = False
     if user_profile.is_guest:
+        show_invites = False
+    if only_auth_enabled(['LDAP'], user_profile.realm) and not user_profile.realm.invite_required:
         show_invites = False
 
     show_billing = False

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -56,19 +56,35 @@ def pad_method_dict(method_dict: Dict[str, bool]) -> Dict[str, bool]:
             method_dict[key] = False
     return method_dict
 
-def auth_enabled_helper(backends_to_check: List[str], realm: Optional[Realm]) -> bool:
+def build_method_dict(realm: Optional[Realm]) -> Dict[str, bool]:
     if realm is not None:
         enabled_method_dict = realm.authentication_methods_dict()
         pad_method_dict(enabled_method_dict)
     else:
         enabled_method_dict = dict((method, True) for method in Realm.AUTHENTICATION_FLAGS)
         pad_method_dict(enabled_method_dict)
+    return enabled_method_dict
+
+def auth_enabled_helper(backends_to_check: List[str], realm: Optional[Realm]) -> bool:
+    enabled_method_dict = build_method_dict(realm)
     for supported_backend in supported_auth_backends():
         for backend_name in backends_to_check:
             backend = AUTH_BACKEND_NAME_MAP[backend_name]
             if enabled_method_dict[backend_name] and isinstance(supported_backend, backend):
                 return True
     return False
+
+def only_auth_enabled(backends_to_check: List[str], realm: Optional[Realm]) -> bool:
+    enabled_method_dict = build_method_dict(realm)
+    check_method_dict = dict()
+    for supported_backend in supported_auth_backends():
+        for backend_name in backends_to_check:
+            backend = AUTH_BACKEND_NAME_MAP[backend_name]
+            if isinstance(supported_backend, backend):
+                check_method_dict[backend_name] = True
+                break
+    pad_method_dict(check_method_dict)
+    return check_method_dict == enabled_method_dict
 
 def ldap_auth_enabled(realm: Optional[Realm]=None) -> bool:
     return auth_enabled_helper(['LDAP'], realm)


### PR DESCRIPTION
Added a new function in zproject.backends that enables checking for
certain realms only.

Added a new condition to not show invites for LDAP-only realms that
don't allow invites inside zerver.views.home that uses the function from
above.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR is for https://github.com/zulip/zulip/issues/11685


**Testing Plan:** <!-- How have you tested? -->
Haven't tested _yet_, but wanted to ensure the changes we're making
are on the right track.
We've created a "only_auth_enabled" function that checks if the list
of backends_to_check are the only backends offered by the server.
This is needed in the case of checking for LDAP-only realms.
Then, we added a secondary check within the views to ensure that
show_invites is False when the above condition is satisfied.