### PR TITLE
css: Remove unnecessary 'prefixed-transition' mixin.

### DIFF
--- a/static/styles/reuseable_components.scss
+++ b/static/styles/reuseable_components.scss
@@ -1,11 +1,3 @@
-@mixin prefixed-transition($property, $timing, $timing-functions...) {
-    -webkit-transition: $property $timing $timing-functions;
-    -moz-transition: $property $timing $timing-functions;
-    -o-transition: $property $timing $timing-functions;
-    -ms-transition: $property $timing $timing-functions;
-    transition: $property $timing $timing-functions;
-}
-
 @mixin prefixed-user-select($value) {
     -webkit-touch-callout: $value;
     -webkit-user-select: $value;

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -22,7 +22,7 @@ body {
 body,
 #tab_bar_underpadding {
     background-color: hsl(0, 0%, 100%);
-    @include prefixed-transition(background-color, 200ms, linear);
+    transition: background-color 200ms linear;
 }
 
 input,
@@ -611,7 +611,7 @@ td.pointer {
 
 .new_messages,
 .new_messages_fadeout {
-    @include prefixed-transition(all, 3s, ease-in-out);
+    transition: all 3s ease-in-out;
 }
 
 .include-sender .message_edit_notice {
@@ -655,7 +655,7 @@ td.pointer {
     right: -105px;
     line-height: 20px;
     text-align: right;
-    @include prefixed-transition(background-color, 1.5s, ease-in, color 1.5s ease-in);
+    transition: background-color 1.5s ease-in, color 1.5s ease-in;
 }
 
 #message-edit-history .message_time {
@@ -1106,7 +1106,7 @@ td.pointer {
     opacity: 0;
     z-index: 1;
     bottom: 1px;
-    @include prefixed-transition(all, 0.3s, ease-out);
+    transition: all 0.3s ease-out;
 }
 
 .unread-marker-fill {
@@ -1120,16 +1120,16 @@ td.pointer {
 }
 
 .unread .unread_marker {
-    @include prefixed-transition(all, 0.3s, ease-out);
+    transition: all 0.3s ease-out;
     opacity: 1;
 }
 
 .unread_marker.slow_fade {
-    @include prefixed-transition(all, 2s, ease-out);
+    transition: all 2s ease-out;
 }
 
 .unread_marker.fast_fade {
-    @include prefixed-transition(all, 0.3s, ease-out);
+    transition: all 0.3s ease-out;
 }
 
 .selected_message .messagebox {


### PR DESCRIPTION
The `transition` property does not need prefixing. In fact, very
few properties need that nowadays. So remove it to simplify the code.

Many of these styles shouldn't have been prefixed even if needed.
The prefixes exist exactly because the implementations might differ
from the incoming standard.

Looking at the supported browsers:
https://caniuse.com/#search=transition

We see that this property has had mainstream support from 2012 and
was supported on Firefox in 2006 !!!