### PR TITLE
compose.scss: Fix alignment of "markdown preview" icons.

### DIFF
--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -470,12 +470,17 @@ a.message-control-button:hover {
     min-height: 42px;
 }
 
-a#markdown_preview,
+a#markdown_preview {
+    margin-left: 2px;
+    color: hsl(0, 0%, 47%);
+}
+
 a#undo_markdown_preview {
     text-decoration: none;
     position: relative;
-    font-size: 16px;
+    font-size: 15px;
     color: hsl(0, 0%, 47%);
+    margin-left: 2px;
 }
 
 #markdown_preview_spinner {


### PR DESCRIPTION
Removed the preview tag from the css rule, reduced the undo preview tag
to a font-size of 15px. 

The preview tag being attached to the rule proved unnecessary. The icon
for reverting back to an editing state also dipped below the horizontal
level of the icon row.  The screenshots below demonstrate 2px added to the left
margin of the icons.

<img width="366" alt="Screen Shot 2019-04-14 at 11 38 12 AM" src="https://user-images.githubusercontent.com/39782863/56099524-cfc83800-5ea9-11e9-8ace-7e9648733d94.png">

<img width="366" alt="Screen Shot 2019-04-14 at 11 38 04 AM" src="https://user-images.githubusercontent.com/39782863/56099528-d22a9200-5ea9-11e9-9573-5908e18ae10f.png">


