### PR TITLE
compose_box: Fix alignment of eye/preview icon.

### DIFF
--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -476,6 +476,7 @@ a#undo_markdown_preview {
     position: relative;
     font-size: 16px;
     color: hsl(0, 0%, 47%);
+    margin-top: -1.5px;
 }
 
 #markdown_preview_spinner {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
CZO description: https://chat.zulip.org/#narrow/stream/9-issues/topic/compose.20icons
Before:
![image](https://user-images.githubusercontent.com/33805964/56099183-33447b00-5f27-11e9-949a-972df1b74d35.png)

![image](https://user-images.githubusercontent.com/33805964/56099151-e95b9500-5f26-11e9-807e-ed7cf3174234.png)
After:
![image](https://user-images.githubusercontent.com/33805964/56099143-ce892080-5f26-11e9-9758-05f597c5193c.png)
![image](https://user-images.githubusercontent.com/33805964/56099193-52dba380-5f27-11e9-882c-7fd0bf7db8e3.png)
