### PR TITLE
auth: Redirect deactivated user to /login when attempting social login.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -98,7 +98,7 @@ class AuthBackendTest(ZulipTestCase):
         if isinstance(backend, SocialAuthMixin):
             # Returns a redirect to login page with an error.
             self.assertEqual(result.status_code, 302)
-            self.assertEqual(result.url, "/accounts/login/?is_deactivated=true")
+            self.assertEqual(result.url, "/login/?is_deactivated=true")
         else:
             # Just takes you back to the login page treating as
             # invalid auth; this is correct because the form will
@@ -581,7 +581,7 @@ class SocialAuthBase(ZulipTestCase):
         result = self.social_auth_test(account_data_dict,
                                        subdomain='zulip')
         self.assertEqual(result.status_code, 302)
-        self.assertEqual(result.url, "/accounts/login/?is_deactivated=true")
+        self.assertEqual(result.url, "/login/?is_deactivated=true")
         # TODO: verify whether we provide a clear error message
 
     def test_social_auth_invalid_realm(self) -> None:

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -638,7 +638,9 @@ class DevAuthBackend(ZulipAuthMixin):
         return common_get_active_user(dev_auth_username, realm, return_data=return_data)
 
 def redirect_deactivated_user_to_login() -> HttpResponseRedirect:
-    login_url = reverse('django.contrib.auth.views.login')
+    # Specifying the template name makes sure that the user is not redirected to dev_login in case of
+    # a deactivated account on a test server.
+    login_url = reverse('zerver.views.auth.login_page', kwargs = {'template_name': 'zerver/login.html'})
     redirect_url = login_url + '?is_deactivated=true'
     return HttpResponseRedirect(redirect_url)
 


### PR DESCRIPTION
Addresses Follow-up No. 2 from https://github.com/zulip/zulip/pull/12104#issuecomment-482915087