### PR TITLE
navbar: Fix bugs caused by zulip.scss refactor.

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -183,7 +183,7 @@ on a dark background, and don't change the dark labels dark either. */
 
     .message-header-contents,
     .message_header_private_message .message-header-contents,
-    #tab_list li.active {
+    #tab_bar #tab_list li.active {
         background-color: hsla(0, 0%, 0%, 0.2);
     }
 

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1793,7 +1793,6 @@ a:hover code {
         }
 
         li.inactive {
-            background-color: hsl(0, 0%, 88%);
             border-width: 0px;
             margin-right: -4px;
             font-size: 14px;


### PR DESCRIPTION
A few bugs were caused by 7d4cebbc1eea3e249265cb7e0d63ae0d864936ea.
In night mode:
- home icon was hidden by grey box on "All messages" narrow.
- inactive tabs (eg "mentions" and "stars") were hidden behind grey box.
- topic tab was hidden behind grey box in topic narrow.
In both, night mode and normal mode:
- "private messages" tab in individual/group pm narrows was illegible.

These were all results of unexpected differences in precedence rules
caused by the refactor.

CZO discussion: https://chat.zulip.org/#narrow/stream/9-issues/topic/night.20mode.3A.20home-icon.20missing

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/33805964/56116036-68ca8200-5f82-11e9-94ab-7dbe07feb388.png)

![image](https://user-images.githubusercontent.com/33805964/56116064-87307d80-5f82-11e9-89ec-e58973bdc939.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
