### PR TITLE
user status: Change user status modal style to zulip's generic modal …

### DIFF
--- a/static/styles/user_status.scss
+++ b/static/styles/user_status.scss
@@ -1,24 +1,47 @@
 .user_status_overlay .overlay-content {
-    width: 320px;
+    width: 480px;
     margin: 0 auto;
-    padding-left: 30px;
-    padding-right: 30px;
-    padding-bottom: 30px;
-    padding-top: 10px;
     position: relative;
     top: calc((30vh - 50px) / 2);
     border-radius: 4px;
     overflow: hidden;
-
     background-color: hsl(0, 0%, 100%);
 }
 
-.user_status_overlay .user_status_change_title {
-    font-size: 130%;
-    font-weight: 600;
-    padding: 5px;
+.user_status_overlay input.user_status {
+    width: 420px;
+};
+
+.user-status-header {
+    padding: {
+        top: 4px;
+        bottom: 4px;
+    }
+    height: 5%;
+    width: 100%;
+    text-align: center;
+    border-bottom: 1px solid hsl(0, 0%, 87%);
 }
 
-.user_status_overlay input.user_status {
-    width: 170px;
-};
+.user-status-header h1 {
+    margin: 0;
+    font-size: 1.5em;
+}
+
+.user-status-header .exit {
+    font-weight: 400;
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    color: hsl(0, 0%, 67%);
+    cursor: pointer;
+}
+
+.user-status-header .exit-sign {
+    position: relative;
+    top: 3px;
+    margin-left: 3px;
+    font-size: 1.5rem;
+    font-weight: 600;
+    cursor: pointer;
+}

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -152,10 +152,19 @@
     </div>
     <div class="user_status_overlay overlay new-style" data-overlay="user_status_overlay" aria-hidden="true">
         <div class="overlay-content modal-bg">
-            <div class="user_status_change_title">Set a status message</div>
-            <div>
-                <input type="text" class="user_status" maxlength="60"/>
-                <button class="sea-green rounded button set_user_status">
+            <div class="user-status-header">
+                <h1>Set a status</h1>
+                <div class="exit">
+                    <span class="exit-sign">&times;</span>
+                </div>
+            </div>
+            <div class="modal-body">
+                <label for="user_status">Status message</label>
+                <input type="text" class="user_status" maxlength="60" />
+            </div>
+            <div class="modal-footer">
+                <button class="button exit small rounded">Cancel</button>
+                <button class="sea-green small rounded button set_user_status">
                     Save
                 </button>
             </div>


### PR DESCRIPTION
This is first step for issue #11629.
In this pr generic modal style is added to user status modal.
As mentioned by Rishi, width of box and input is enough to show 60 characters.

![Screenshot 2019-04-15 at 9 37 22 PM](https://user-images.githubusercontent.com/30211121/56148411-da78ef00-5fc7-11e9-95d9-f23946eb2716.png)


@timabbott @rishig please review this pr :)