### PR TITLE
api_docs: Add explicit '-X GET' to curl examples.

### DIFF
--- a/templates/zerver/api/get-all-streams.md
+++ b/templates/zerver/api/get-all-streams.md
@@ -32,14 +32,14 @@ zulip(config).then((client) => {
 {tab|curl}
 
 ```
-curl {{ api_url }}/v1/streams -u BOT_EMAIL_ADDRESS:BOT_API_KEY
+curl -X GET {{ api_url }}/v1/streams -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```
 
 You may pass in one or more of the parameters mentioned above
 as URL query parameters, like so:
 
 ```
-curl {{ api_url }}/v1/streams?include_public=false \
+curl -X GET {{ api_url }}/v1/streams?include_public=false \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```
 

--- a/templates/zerver/api/get-all-users.md
+++ b/templates/zerver/api/get-all-users.md
@@ -34,13 +34,13 @@ zulip(config).then((client) => {
 {tab|curl}
 
 ```
-curl {{ api_url }}/v1/users -u BOT_EMAIL_ADDRESS:BOT_API_KEY
+curl -X GET {{ api_url }}/v1/users -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```
 
 You may pass the `client_gravatar` query parameter as follows:
 
 ```
-curl {{ api_url }}/v1/users?client_gravatar=true \
+curl -X GET {{ api_url }}/v1/users?client_gravatar=true \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```
 

--- a/templates/zerver/api/get-message-history.md
+++ b/templates/zerver/api/get-message-history.md
@@ -19,7 +19,7 @@ Note that edit history may be disabled in some organizations; see the
 {tab|curl}
 
 ```
-curl {{ api_url }}/v1/messages/<message_id>/history \
+curl -X GET {{ api_url }}/v1/messages/<message_id>/history \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```
 

--- a/templates/zerver/api/get-messages.md
+++ b/templates/zerver/api/get-messages.md
@@ -64,7 +64,7 @@ zulip(config).then((client) => {
 {tab|curl}
 
 ```
-curl {{ api_url }}/v1/messages \
+curl -X GET {{ api_url }}/v1/messages \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     -d "anchor=42" \
     -d "use_first_unread_anchor=false" \

--- a/templates/zerver/api/get-org-emoji.md
+++ b/templates/zerver/api/get-org-emoji.md
@@ -30,7 +30,7 @@ zulip(config).then((client) => {
 {tab|curl}
 
 ```
-curl {{ api_url }}/v1/realm/emoji \
+curl -X GET {{ api_url }}/v1/realm/emoji \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```
 

--- a/templates/zerver/api/get-presence.md
+++ b/templates/zerver/api/get-presence.md
@@ -24,7 +24,7 @@ for details on the data model for presence in Zulip.
 {tab|curl}
 
 ```
-curl {{ api_url }}/v1/users/<email>/presence \
+curl -X GET {{ api_url }}/v1/users/<email>/presence \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```
 

--- a/templates/zerver/api/get-profile.md
+++ b/templates/zerver/api/get-profile.md
@@ -32,7 +32,7 @@ zulip(config).then((client) => {
 {tab|curl}
 
 ```
-curl {{ api_url }}/v1/users/me \
+curl -X GET {{ api_url }}/v1/users/me \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```
 

--- a/templates/zerver/api/get-raw-message.md
+++ b/templates/zerver/api/get-raw-message.md
@@ -19,7 +19,7 @@ UI).
 {tab|curl}
 
 ```
-curl {{ api_url }}/v1/messages/<msg_id> \
+curl -X GET {{ api_url }}/v1/messages/<msg_id> \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
 ```
 

--- a/templates/zerver/api/get-stream-id.md
+++ b/templates/zerver/api/get-stream-id.md
@@ -31,7 +31,7 @@ zulip(config).then((client) => {
 {tab|curl}
 
 ```
-curl {{ api_url }}/v1/get_stream_id?stream=Denmark \
+curl X GET {{ api_url }}/v1/get_stream_id?stream=Denmark \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```
 

--- a/templates/zerver/api/get-stream-topics.md
+++ b/templates/zerver/api/get-stream-topics.md
@@ -32,7 +32,7 @@ zulip(config).then((client) => {
 {tab|curl}
 
 ```
-curl {{ api_url }}/v1/users/me/<stream_id>/topics \
+curl -X GET {{ api_url }}/v1/users/me/<stream_id>/topics \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```
 

--- a/templates/zerver/api/get-subscribed-streams.md
+++ b/templates/zerver/api/get-subscribed-streams.md
@@ -33,7 +33,7 @@ zulip(config).then((client) => {
 {tab|curl}
 
 ```
-curl {{ api_url }}/v1/users/me/subscriptions \
+curl -X GET {{ api_url }}/v1/users/me/subscriptions \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```
 

--- a/templates/zerver/api/get-user-groups.md
+++ b/templates/zerver/api/get-user-groups.md
@@ -16,7 +16,7 @@ Fetches all of the user groups in the organization.
 <div data-language="curl" markdown="1">
 
 ```
-curl {{ api_url }}/v1/user_groups \
+curl -X GET {{ api_url }}/v1/user_groups \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```
 


### PR DESCRIPTION
Specifying the -X GET as the curl request type in the endpoints.
