### PR TITLE
version.py: Bump provision number to 30.1.

### DIFF
--- a/version.py
+++ b/version.py
@@ -11,4 +11,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '30.0'
+PROVISION_VERSION = '30.1'


### PR DESCRIPTION
Directly related to upgrading yarn in the commit ending in d67dc2e.
