### PR TITLE
message_edit: Disable edit save on enter press when file uploading.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -217,6 +217,15 @@ function handle_edit_keydown(from_topic_edited_only, e) {
         // Pressing enter to save edits is coupled with enter to send
         if (composebox_typeahead.should_enter_send(e)) {
             row = $(".message_edit_content").filter(":focus").closest(".message_row");
+            var message_edit_save_button = row.find(".message_edit_save");
+            if (message_edit_save_button.attr('disabled') === "disabled") {
+                // In cases when the save button is disabled
+                // we need to disable save on pressing enter
+                // Prevent default to avoid new-line on pressing
+                // enter inside the textarea in this case
+                e.preventDefault();
+                return;
+            }
         } else {
             composebox_typeahead.handle_enter($(e.target), e);
             return;

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -38,7 +38,7 @@ exports.options = function (config) {
         break;
     case 'edit':
         textarea = $('#message_edit_content_' + config.row);
-        send_button = textarea.closest('.message_edit_save');
+        send_button = textarea.closest('#message_edit_form').find('.message_edit_save');
         send_status = $('#message-edit-send-status-' + config.row);
         send_status_close = send_status.find('.send-status-close');
         error_msg = send_status.find('.error-msg');


### PR DESCRIPTION
Closes #12126 

@timabbott I noticed a bug in `upload.js`. The selector for send button in the case of message edit was faulty. I fixed it in 85e8cf4  
