### PR TITLE
Upgrade to mypy 0.700

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -182,7 +182,7 @@ traitlets==4.3.2          # via ipython
 transifex-client==0.12.5
 twilio==6.26.2
 twisted==19.2.0
-typed-ast==1.3.4          # via mypy
+typed-ast==1.3.5
 typing==3.6.6
 typing_extensions==3.6.6
 uritemplate==3.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -99,7 +99,7 @@ matrix-client==0.3.2
 mock==2.0.0
 moto==1.3.7
 mypy-extensions==0.4.1
-mypy==0.670
+mypy==0.700
 ndg-httpsclient==0.5.1
 oauth2client==4.1.3
 oauthlib==3.0.1

--- a/requirements/mypy.in
+++ b/requirements/mypy.in
@@ -3,6 +3,8 @@
 # and requirements/mypy.txt.
 # See requirements/README.md for more detail.
 mypy==0.700
+# For 0.700, include 1.3.5 specifically, to support Python 3.4
+typed_ast==1.3.5
 # Include typing explicitly, since it's needed on Python 3.4
 typing==3.6.6
 typing_extensions==3.6.6

--- a/requirements/mypy.in
+++ b/requirements/mypy.in
@@ -2,7 +2,7 @@
 # /tools/update-locked-requirements to update requirements/dev.txt
 # and requirements/mypy.txt.
 # See requirements/README.md for more detail.
-mypy==0.670
+mypy==0.700
 # Include typing explicitly, since it's needed on Python 3.4
 typing==3.6.6
 typing_extensions==3.6.6

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -8,7 +8,7 @@
 # For details, see requirements/README.md .
 #
 mypy-extensions==0.4.1    # via mypy
-mypy==0.670
+mypy==0.700
 typed-ast==1.3.1          # via mypy
 typing==3.6.6
 typing_extensions==3.6.6

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -9,6 +9,6 @@
 #
 mypy-extensions==0.4.1    # via mypy
 mypy==0.700
-typed-ast==1.3.1          # via mypy
+typed-ast==1.3.5
 typing==3.6.6
 typing_extensions==3.6.6

--- a/version.py
+++ b/version.py
@@ -11,4 +11,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '30.4'
+PROVISION_VERSION = '30.5'

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1,5 +1,5 @@
 from typing import Any, DefaultDict, Dict, List, Set, Tuple, TypeVar, \
-    Union, Optional, Sequence, AbstractSet, Callable, Iterable
+    Union, Optional, Sequence, AbstractSet, Callable, Iterable, cast
 from typing.re import Match
 
 from django.db import models
@@ -36,7 +36,7 @@ from zerver.lib.validator import check_int, \
 from zerver.lib.name_restrictions import is_disposable_domain
 from zerver.lib.types import Validator, ExtendedValidator, \
     ProfileDataElement, ProfileData, FieldTypeData, \
-    RealmUserValidator
+    RealmUserValidator, ExtendedFieldElement, UserFieldElement, FieldElement
 
 from bitfield import BitField
 from bitfield.types import BitHandler
@@ -2480,10 +2480,10 @@ class CustomProfileField(models.Model):
     # realm as argument.
     CHOICE_FIELD_TYPE_DATA = [
         (CHOICE, str(_('List of options')), validate_choice_field, str, "CHOICE"),
-    ]  # type: FieldTypeData
+    ]  # type: List[ExtendedFieldElement]
     USER_FIELD_TYPE_DATA = [
         (USER, str(_('Person picker')), check_valid_user_ids, eval, "USER"),
-    ]  # type: FieldTypeData
+    ]  # type: List[UserFieldElement]
 
     CHOICE_FIELD_VALIDATORS = {
         item[0]: item[2] for item in CHOICE_FIELD_TYPE_DATA
@@ -2498,9 +2498,11 @@ class CustomProfileField(models.Model):
         (LONG_TEXT, str(_('Long text')), check_long_string, str, "LONG_TEXT"),
         (DATE, str(_('Date picker')), check_date, str, "DATE"),
         (URL, str(_('Link')), check_url, str, "URL"),
-    ]  # type: FieldTypeData
+    ]  # type: List[FieldElement]
 
-    ALL_FIELD_TYPES = FIELD_TYPE_DATA + CHOICE_FIELD_TYPE_DATA + USER_FIELD_TYPE_DATA
+    ALL_FIELD_TYPES = (cast(FieldTypeData, FIELD_TYPE_DATA) +
+                       cast(FieldTypeData, CHOICE_FIELD_TYPE_DATA) +
+                       cast(FieldTypeData, USER_FIELD_TYPE_DATA))
 
     FIELD_VALIDATORS = {item[0]: item[2] for item in FIELD_TYPE_DATA}  # type: Dict[int, Validator]
     FIELD_CONVERTERS = {item[0]: item[3] for item in ALL_FIELD_TYPES}  # type: Dict[int, Callable[[Any], Any]]


### PR DESCRIPTION
This comprises three commits, which might be squashed (or simplified given the provision numbers), upgrading to 0.660, 0.670 and then 0.700. I separated them since an initial attempt at 0.700 failed, leaving:

* 0.660 requires no changes
* 0.670 was crashing mypy due to an accented variable name in `api_test_helpers.py`
* 0.700 would also have crashed, but also needed some minor type updates in `models.py`

This fixes #12058.

I can't say at this point if there is a significant performance improvement, but I got a core dump from the mypy crash!

I was going to report the bug in 0.670+, but that file still currently has python 2.x function type hints - which *could* have caused the issue based on some initial trials. As it is, just changing the variable name is fine.