### PR TITLE
Portico Sidenav: Redesign mobile web portico navbar (bug fix already merged)

### DIFF
--- a/static/images/zulip-logo.svg
+++ b/static/images/zulip-logo.svg
@@ -1,6 +1,6 @@
-<svg xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 40" version="1.1">
+<svg class="brand-logo" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 40" version="1.1">
     <g transform="translate(-297.14285,-466.64792)">
-        <circle cx="317.14285" cy="486.64792" r="19.030317" style="fill:#444;stroke-width:1.93936479;stroke:#444"></circle>
-        <path d="m309.24286 477.14791 14.2 0 1.6 3.9-11.2 11.9 9.6 0 1.6 3.2-14.2 0-1.6-3.9 11.2-11.9-9.6 0z" style="fill:#fff;stroke:#fff"></path>
+        <circle cx="317.14285" cy="486.64792" r="19.030317" style="fill:#fff;stroke-width:1.93936479;stroke:transparent"></circle>
+        <path d="m309.24286 477.14791 14.2 0 1.6 3.9-11.2 11.9 9.6 0 1.6 3.2-14.2 0-1.6-3.9 11.2-11.9-9.6 0z" style="fill:#52c2af;stroke:#52c2af"></path>
     </g>
 </svg>

--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -3863,6 +3863,7 @@ nav ul li.active::after {
         height: 40px;
 
         font-size: 1.5rem;
+        line-height: 30px;
         text-align: right;
         color: hsl(0, 0%, 27%);
 

--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -3865,7 +3865,7 @@ nav ul li.active::after {
         font-size: 1.5rem;
         line-height: 30px;
         text-align: right;
-        color: hsl(0, 0%, 27%);
+        color: hsl(0, 0%, 100%);
 
         background-size: 40px auto;
         background-image: url(/static/images/zulip-logo.svg);
@@ -3888,7 +3888,7 @@ nav ul li.active::after {
         width: 300px;
         padding-left: 30px;
 
-        background-color: hsl(0, 0%, 100%);
+        background: linear-gradient(to right, hsl(171, 43%, 55%), hsl(194, 39%, 44%));
         transform: translate(-350px, 0px);
 
 
@@ -3906,14 +3906,20 @@ nav ul li.active::after {
     }
 
     nav ul .exit {
-        display: block;
+        display: flex;
+        justify-content: center;
+        align-items: center;
         position: absolute;
-        top: 10px;
+        top: 20px;
         right: 25px;
+        width: 35px;
+        height: 35px;
 
         font-weight: 100;
         font-size: 3em;
         color: initial;
+        background-color: hsl(0, 0%, 100%);
+        border-radius: 100%;
     }
 
     nav ul li:first-of-type {
@@ -3926,6 +3932,11 @@ nav ul li.active::after {
         font-size: 1.5em;
         font-weight: 300;
         line-height: 1.5;
+    }
+
+    .portico-header > .content > ul > li,
+    .portico-header > .content > ul > li > a {
+        color: hsl(0, 0%, 100%) !important;
     }
 
     nav ul li,


### PR DESCRIPTION
This vertically aligns the text "Zulip" with Zulip's logo in Portico sidenav.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixed #12140 

Screenshot:

![image](https://user-images.githubusercontent.com/31413407/56468021-1e467b00-6444-11e9-8267-b582962b3f33.png)

New UI:
![image](https://user-images.githubusercontent.com/31413407/56767337-1c284780-67c9-11e9-9339-a1e4a196bc73.png)
