### PR TITLE
[WIP] Implement Message Edit Echoing

### DIFF
--- a/docs/subsystems/sending-messages.md
+++ b/docs/subsystems/sending-messages.md
@@ -190,6 +190,15 @@ messages.
   primarily done in `exports.process_from_server` in
   `static/js/echo.js`.
 
+### Local echo in message editing
+
+Zulip also supports local echo in the message editing code path for
+edits to just the content of a message.  The approach is analogous
+(using `markdown.contains_backend_only_syntax`, etc.)), except we
+don't need any of the `local_id` tracking logic, because the message
+already has a permanent message id; as a result, the whole
+implementation was under 150 lines of code.
+
 ## Putting it all together
 
 This section just has a brief review of the sequence of steps all in

--- a/frontend_tests/casper_tests/08-edit.js
+++ b/frontend_tests/casper_tests/08-edit.js
@@ -1,5 +1,8 @@
 var common = require('../casper_lib/common.js');
 
+casper.options.verbose = true;
+casper.options.logLevel = "debug";
+
 common.start_and_log_in();
 
 function then_edit_last_message() {
@@ -100,8 +103,9 @@ casper.then(function () {
 // 37 is left arrow key code
 casper.then(function () {
     casper.test.assertNotVisible('form.message_edit_form', 'Message edit box not visible');
-
-    common.keypress(37);
+    casper.waitUntilVisible(".message_edit_notice", function () {
+        common.keypress(37);
+    });
     casper.waitUntilVisible(".message_edit_content", function () {
         var fieldVal = common.get_form_field_value('.message_edit_content');
         casper.test.assertEquals(fieldVal, "test edited pm", "Opened editing last own message");

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -134,10 +134,12 @@ exports.try_deliver_locally = function try_deliver_locally(message_request) {
     return insert_local_message(message_request, next_local_id);
 };
 
-exports.edit_locally = function edit_locally(message, raw_content, new_topic) {
+exports.edit_locally = function edit_locally(message, request) {
+    const raw_content = request.raw_content;
     const message_content_edited = raw_content !== undefined && message.raw_content !== raw_content;
 
-    if (new_topic !== undefined) {
+    if (request.new_topic !== undefined) {
+        const new_topic = request.new_topic;
         topic_data.remove_message({
             stream_id: message.stream_id,
             topic_name: util.get_message_topic(message),

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -152,7 +152,10 @@ exports.save = function (row, from_topic_edited_only) {
     // just results in the in-memory message being changed
     if (message.locally_echoed) {
         if (new_content !== message.raw_content || topic_changed) {
-            echo.edit_locally(message, new_content, topic_changed ? new_topic : undefined);
+            echo.edit_locally(message, {
+                raw_content: new_content,
+                new_topic: new_topic,
+            });
             row = current_msg_list.get_row(message_id);
         }
         exports.end(row);

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -110,6 +110,9 @@ exports.update_messages = function update_messages(events) {
         if (msg === undefined) {
             return;
         }
+
+        delete msg.local_edit_timestamp;
+
         msgs_to_rerender.push(msg);
 
         message_store.update_booleans(msg, event.flags);

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -195,8 +195,14 @@ MessageListView.prototype = {
     _RENDER_THRESHOLD: 50,
 
     _get_msg_timestring: function (message_container) {
-        if (message_container.msg.last_edit_timestamp !== undefined) {
-            const last_edit_time = new XDate(message_container.msg.last_edit_timestamp * 1000);
+        let last_edit_timestamp;
+        if (message_container.msg.local_edit_timestamp !== undefined) {
+            last_edit_timestamp = message_container.msg.local_edit_timestamp;
+        } else {
+            last_edit_timestamp = message_container.msg.last_edit_timestamp;
+        }
+        if (last_edit_timestamp !== undefined) {
+            const last_edit_time = new XDate(last_edit_timestamp * 1000);
             const today = new XDate();
             return timerender.render_date(last_edit_time, undefined, today)[0].textContent +
                 " at " + timerender.stringify_time(last_edit_time);
@@ -219,6 +225,11 @@ MessageListView.prototype = {
             message_container.edited_in_left_col = !include_sender;
             message_container.edited_alongside_sender = include_sender && !status_message;
             message_container.edited_status_msg = include_sender && status_message;
+        } else {
+            delete message_container.last_edit_timestr;
+            message_container.edited_in_left_col = false;
+            message_container.edited_alongside_sender = false;
+            message_container.edited_status_msg = false;
         }
     },
 

--- a/static/templates/edited_notice.hbs
+++ b/static/templates/edited_notice.hbs
@@ -1,3 +1,9 @@
+{{#if msg/local_edit_timestamp}}
+<div class="message_edit_notice auto-select" title="{{#tr this}}Edited (__last_edit_timestr__){{/tr}}">
+    ({{t "SAVING" }})
+</div>
+{{else}}
 <div class="message_edit_notice auto-select" title="{{#tr this}}Edited (__last_edit_timestr__){{/tr}}">
     ({{t "EDITED" }})
 </div>
+{{/if}}


### PR DESCRIPTION
Updates the message editing process to do a local 'echo' edit of the message as it waits to see if the server will confirm it. This is so on slow connections, there is visual confirmation that the edit is in the process of being made. This is the same rationale as the current echoing system for sending messages.

If it receives a success from the server, the time stamp and word "(EDITED)" appear.
https://gfycat.com/faroffhugegnat

If it receives a error, it will re-open the edit-message window and display the error.
https://gfycat.com/vapidmealyblackrhino

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

Fixes #3530 

**Testing Plan:** <!-- How have you tested? -->
Currently passing all test cases after I had to make an edit, see comment below. Also have written my own test cases that it is passing. Also have done manual testing in browser of different scenarios. 
Things I’ve tested:
Adding/Removing attachments: Works correctly, when editing one with attachment, you cannot see the thumbnail until the message is confirmed edited, consistent with current echo.
Mentions: Rendered correctly.
Reactions: Rendered correctly.
Emojis: Rendered correctly.
Starred: Rendered correctly.
Here is a quick gif of testing these, they have also been tested more thoroughly. https://gfycat.com/smoggynicehypacrosaurus