### PR TITLE
help: A few miscellaneous updates.

### DIFF
--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -390,6 +390,7 @@ body {
     top: -2px;
 }
 
+.help-center ol,
 .portico-landing.integrations ol {
     margin-left: 0;
 }

--- a/templates/zerver/for/open-source.md
+++ b/templates/zerver/for/open-source.md
@@ -22,7 +22,7 @@ support@zulipchat.com.
 
 Allow anyone to
 [join without an invitation](/help/allow-anyone-to-join-without-an-invitation).
-You can also link to your Zulip with a [badge](/help/join-zulip-chat-badge)
+You can also link to your Zulip with a [badge](/help/linking-to-zulip)
 in your readme document.
 
 ### Moderate your community

--- a/templates/zerver/help/getting-your-organization-started-with-zulip.md
+++ b/templates/zerver/help/getting-your-organization-started-with-zulip.md
@@ -119,7 +119,7 @@ expert teaching other users how to use Zulip.
   [set a default language for your organization](/help/change-the-default-language-for-your-organization).
 - [Add custom emoji](/help/add-custom-emoji), at the very least for
   your organization's logo.
-- Link to your Zulip instance with a [nice badge](/help/join-zulip-chat-badge).
+- Link to your Zulip instance with a [nice badge](/help/linking-to-zulip).
 - Send feedback to the Zulip development community!  We love hearing
   about problems (however minor) and feature ideas that could make
   Zulip even better.

--- a/templates/zerver/help/import-from-hipchat.md
+++ b/templates/zerver/help/import-from-hipchat.md
@@ -138,13 +138,13 @@ While the import tool will correctly import the subscribers of private
 rooms, HipChat does not store or export the list of subscribers for public
 rooms.  You can pick one of the following options for handling this:
 
-* Subscribe all users to all public streams (the default, which is good for small organizations).
+1. Subscribe all users to all public streams (the default, which is good for small organizations).
 
-* Subscribe only HipChat room owners to public streams (and plan for users
+1. Subscribe only HipChat room owners to public streams (and plan for users
   to subscribe to the imported Zulip streams manually after the import
   completes) using the `--slim-mode` option to `manage.py convert_hipchat_data`.
 
-* Use the [HipChat API][hipchat-api-tokens] to fetch each room's current
+1. Use the [HipChat API][hipchat-api-tokens] to fetch each room's current
   room subscribers as of the moment the import is run.  Because HipChat
   doesn't store subscribers to a room when clients are not connected, these
   subscriptons will be incomplete for users who don't have an actively

--- a/templates/zerver/help/import-from-mattermost.md
+++ b/templates/zerver/help/import-from-mattermost.md
@@ -10,9 +10,11 @@ into an existing Zulip organization.
 
 ## Import from Mattermost
 
-First, export your data from Mattermost.  The instructions below have
-the commands for the various common ways to run Mattermost.  Replace
-`<username>` and `<server_ip>` with appropriate values accordingly.
+First, export your data from Mattermost.
+The instructions below correspond to various common ways Mattermost is installed; if
+yours isn't covered contact support@zulipchat.com and we'll help you out.
+
+Replace `<username>` and `<server_ip>` with the appropriate values below.
 
 {start_tabs}
 
@@ -21,7 +23,7 @@ the commands for the various common ways to run Mattermost.  Replace
 1. SSH into your Mattermost production server.
 
     ```
-    ssh <username>@><server_ip>
+    ssh <username>@<server_ip>
     ```
 
 2. Navigate to the directory which contains the Mattermost executable.
@@ -31,7 +33,7 @@ the commands for the various common ways to run Mattermost.  Replace
     cd /opt/mattermost/bin
     ```
 
-3. Run the following commands to export the data:
+3. Create an export of all your Mattermost teams, as a tar file.
 
     ```
     sudo ./mattermost export bulk export.json --all-teams
@@ -57,7 +59,7 @@ the commands for the various common ways to run Mattermost.  Replace
 1. SSH into the server hosting your Mattermost docker container.
 
     ```
-    ssh <username>@><server_ip>
+    ssh <username>@<server_ip>
     ```
 
 2. Navigate to the the Mattermost docker directory. On most installs the
@@ -67,7 +69,7 @@ the commands for the various common ways to run Mattermost.  Replace
     cd mattermost-docker/
     ```
 
-3. Run the following commands to export the data from all teams on your server as a tar file.
+3. Create an export of all your Mattermost teams, as a tar file.
 
     ```
     docker exec -it mattermost-docker_app_1 mattermost \
@@ -94,7 +96,7 @@ the commands for the various common ways to run Mattermost.  Replace
 
 1. SSH into your GitLab Omnibus server.
 
-2. Run the following commands to export the data from all teams on your server as a tar file.
+2. Create an export of all your Mattermost teams, as a tar file.
 
     ```
     cd /opt/gitlab/embedded/service/mattermost
@@ -107,11 +109,11 @@ the commands for the various common ways to run Mattermost.  Replace
         exported_emoji/ export.json
     ```
 
-3. Now exit out of the server.
+3. Exit your shell on the Gitlab Omnibus server.
 
     `exit`
 
-4. Finally copy the exported tar file from GitLab Omnibus to your local computer.
+4. Finally, copy the exported tar file from GitLab Omnibus to your local computer.
 
     ```
     scp <username>@<server_ip>:/opt/gitlab/embedded/bin/mattermost/export.tar.gz .
@@ -120,7 +122,8 @@ the commands for the various common ways to run Mattermost.  Replace
 
 ### Import into zulipchat.com
 
-Email support@zulipchat.com with your exported archive and your desired Zulip
+Email support@zulipchat.com with your exported archive,
+the name of the Mattermost team you want to import, and your desired Zulip
 subdomain. Your imported organization will be hosted at
 `<subdomain>.zulipchat.com`.
 
@@ -138,20 +141,13 @@ create your Zulip organization via the data import tool instead).
 Use [upgrade-zulip-from-git][upgrade-zulip-from-git] to
 upgrade your Zulip server to the latest `master` branch.
 
-Log in to a shell on your Zulip server as the `zulip` user.
+Log in to a shell on your Zulip server as the `zulip` user. To import with
+the most common configuration, run the following commands, replacing
+`<team-name>` with the name of the Mattermost team you want to import.
 
-Extract the `export.tar.gz` to `/home/zulip/mattermost` as follows.
-
-```bash
+```
 cd /home/zulip
 tar -xzvf export.tar.gz
-```
-
-To import with the most common configuration, run the following commands
-replacing `<team-name>` with the name of the team you want to import from
-Mattermost export.
-
-```
 cd /home/zulip/deployments/current
 ./manage.py convert_mattermost_data /home/zulip/mattermost --output /home/zulip/converted_mattermost_data
 ./manage.py import "" /home/zulip/converted_mattermost_data/<team-name>
@@ -176,7 +172,7 @@ root domain. Replace the last line above with the following, after replacing
 
 [upgrade-zulip-from-git]: https://zulip.readthedocs.io/en/latest/production/maintain-secure-upgrade.html#upgrading-from-a-git-repository
 
-## Limitations
+## Caveats
 
 Mattermost's export tool is incomplete and does not support exporting
 the following data:

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -91,6 +91,7 @@
 * [Change your timezone](/help/change-your-timezone)
 * [Display the buddy list on narrow screens](/help/move-the-users-list-to-the-left-sidebar)
 * [View organization statistics](/help/analytics)
+* [Linking to Zulip](/help/linking-to-zulip)
 * [Connect through a proxy](/help/connect-through-a-proxy)
 * [Add a custom certificate](/help/custom-certificates)
 
@@ -103,7 +104,6 @@
 ## Organization basics
 * [Review your organization's settings](/help/review-your-organization-settings)
 * [Create your organization profile](/help/create-your-organization-profile)
-* [Link to your Zulip from the web](/help/join-zulip-chat-badge)
 * [Import from HipChat/Stride](/help/import-from-hipchat)
 * [Import from Mattermost](/help/import-from-mattermost)
 * [Import from Slack](/help/import-from-slack)

--- a/templates/zerver/help/linking-to-zulip.md
+++ b/templates/zerver/help/linking-to-zulip.md
@@ -1,4 +1,4 @@
-# Link to Zulip from the web
+# Linking to Zulip
 
 You can link to your Zulip from the web with a Zulip
 [shields.io](https://github.com/badges/shields) badge:
@@ -20,3 +20,8 @@ HTML
 ```
 <a href="https://chat.zulip.org"><img src="https://img.shields.io/badge/zulip-join_chat-brightgreen.svg"></a>
 ```
+
+## Link to a stream or topic
+
+You can also link to a specific stream, topic, message, or search inside of
+Zulip. See [link to a message or conversation](/help/link-to-a-message-or-conversation).

--- a/templates/zerver/help/stream-notifications.md
+++ b/templates/zerver/help/stream-notifications.md
@@ -1,34 +1,7 @@
 # Stream notifications
 
 You can configure desktop, mobile, and email notifications on a stream by
-stream basis. You can also set default notification preferences for streams
-you join in the future.
-
-## Set a default for new streams
-
-{start_tabs}
-
-{settings_tab|notifications}
-
-1. Toggle the notification settings under **Stream messages**.
-
-1. Under **Apply this change to all current stream subscriptions**, click
-   **No**.
-
-{end_tabs}
-
-## Change settings for current and future streams
-
-{start_tabs}
-
-{settings_tab|notifications}
-
-1. Toggle the notification settings under **Stream messages**.
-
-1. Under **Apply this change to all current stream subscriptions**, click
-   **Yes**.
-
-{end_tabs}
+stream basis.
 
 ## Set notifications for a single stream
 
@@ -44,6 +17,21 @@ you join in the future.
 4. Toggle the notifications settings on the right.
 
 {end_tabs}
+
+These settings will override any default stream notification settings.
+
+## Set default notifications for all streams
+
+{start_tabs}
+
+{settings_tab|notifications}
+
+1. Toggle the notification settings under **Stream messages**.
+
+{end_tabs}
+
+These settings only apply to streams where you have not
+explicitly set a notification preference.
 
 ## Related articles
 

--- a/zerver/lib/bugdown/tabbed_sections.py
+++ b/zerver/lib/bugdown/tabbed_sections.py
@@ -57,7 +57,7 @@ TAB_DISPLAY_NAMES = {
     'stride': 'Stride',
 
     'mm-default': 'Default installation',
-    'mm-docker': 'Docker installation',
+    'mm-docker': 'Docker',
     'mm-gitlab-omnibus': 'Gitlab Omnibus',
 
     'send-email-invitations': 'Send email invitations',


### PR DESCRIPTION
Mostly responding to comments from Tim. 

The one I didn't act on was
> For dc98359fcfb1ae8c759c5369a0da0716941e7644, the "logging in" section, I wonder if we should add or link to a document on finding your Zulip URL (mentioning both searching for "zulip url" in your email and /accounts/find)?

It's in the "logging in" article, linked to in the header text. 

![image](https://user-images.githubusercontent.com/890911/56249969-9dae0600-6062-11e9-87fb-0b2f989a4f56.png)
