### PR TITLE
scripts: Fix exec invocation for in-process virtualenv activation.

### DIFF
--- a/scripts/lib/setup_path_on_import.py
+++ b/scripts/lib/setup_path_on_import.py
@@ -13,6 +13,6 @@ if sys.prefix != venv:
     # this file will exist in production
     if os.path.exists(activate_this):
         activate_locals = dict(__file__=activate_this)
-        exec(open(activate_this).read(), {}, activate_locals)
+        exec(open(activate_this).read(), activate_locals)
         if not os.path.exists(activate_locals["site_packages"]):
             raise RuntimeError(venv + " was not set up for this Python version")

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -421,7 +421,7 @@ def main(options):
     setup_venvs.main()
 
     activate_this = "/srv/zulip-py3-venv/bin/activate_this.py"
-    exec(open(activate_this).read(), {}, dict(__file__=activate_this))
+    exec(open(activate_this).read(), dict(__file__=activate_this))
 
     setup_shell_profile('~/.bash_profile')
     setup_shell_profile('~/.zprofile')


### PR DESCRIPTION
`activate_this.py` has always documented that it should be `exec()`ed with `locals` = `globals`, and in virtualenv 16.0.0 it raises a `NameError` otherwise.

As a simplified demonstration of the weird things that can go wrong when `locals` ≠ `globals`:

```pycon
>>> exec('a = 1; print([a])', {}, {})
[1]
>>> exec('a = 1; print([a for b in [1]])', {}, {})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 1, in <module>
  File "<string>", line 1, in <listcomp>
NameError: name 'a' is not defined
>>> exec('a = 1; print([a for b in [1]])', {})
[1]
```

Top-level assignments go into `locals`, but from inside a new scope like a list comprehension, they’re read out of `globals`, which doesn’t work.

Fixes #12030.

**Testing Plan:** Ran the relevant `exec()` invocations manually.