### PR TITLE
Add options to skip database backup or/and uploads

### DIFF
--- a/docs/production/maintain-secure-upgrade.md
+++ b/docs/production/maintain-secure-upgrade.md
@@ -345,6 +345,8 @@ su zulip -c '/home/zulip/deployments/current/manage.py backup'
 ```
 
 The backup tool provides the following options:
+- `--output`: Path where the output file should be stored. If no path is
+ provided, the output file would be saved to a temporary directory.
 - `--skip-db`: If set, the tool will skip the backup of your database.
 - `--skip-uploads`: If set, the tool will skip the backup of the uploads.
 

--- a/docs/production/maintain-secure-upgrade.md
+++ b/docs/production/maintain-secure-upgrade.md
@@ -346,6 +346,7 @@ su zulip -c '/home/zulip/deployments/current/manage.py backup'
 
 The backup tool provides the following options:
 - `--skip-db`: If set, the tool will skip the backup of your database.
+- `--skip-uploads`: If set, the tool will skip the backup of the uploads.
 
 This will generate a `.tar.gz` archive containing all the data stored
 on your Zulip server that would be needed to restore your Zulip

--- a/docs/production/maintain-secure-upgrade.md
+++ b/docs/production/maintain-secure-upgrade.md
@@ -344,6 +344,9 @@ Starting with Zulip 2.0, Zulip has a built-in backup tool:
 su zulip -c '/home/zulip/deployments/current/manage.py backup'
 ```
 
+The backup tool provides the following options:
+- `--skip-db`: If set, the tool will skip the backup of your database.
+
 This will generate a `.tar.gz` archive containing all the data stored
 on your Zulip server that would be needed to restore your Zulip
 server's state on another machine perfectly.

--- a/zerver/management/commands/backup.py
+++ b/zerver/management/commands/backup.py
@@ -26,6 +26,7 @@ class Command(ZulipBaseCommand):
             "output", default=None, nargs="?", help="Filename of output tarball"
         )
         parser.add_argument("--skip-db", action='store_true', help="Skip database backup")
+        parser.add_argument("--skip-uploads", action='store_true', help="Skip uploads backup")
 
     def handle(self, *args: Any, **options: Any) -> None:
         timestamp = timezone_now().strftime(TIMESTAMP_FORMAT)
@@ -74,7 +75,7 @@ class Command(ZulipBaseCommand):
                 )
                 members.append("zulip-backup/database")
 
-            if settings.LOCAL_UPLOADS_DIR is not None and os.path.exists(
+            if not options['skip_uploads'] and settings.LOCAL_UPLOADS_DIR is not None and os.path.exists(
                 os.path.join(settings.DEPLOY_ROOT, settings.LOCAL_UPLOADS_DIR)
             ):
                 members.append(

--- a/zerver/management/commands/backup.py
+++ b/zerver/management/commands/backup.py
@@ -23,7 +23,7 @@ class Command(ZulipBaseCommand):
 
     def add_arguments(self, parser: ArgumentParser) -> None:
         parser.add_argument(
-            "output", default=None, nargs="?", help="Filename of output tarball"
+            "--output", default=None, nargs="?", help="Filename of output tarball"
         )
         parser.add_argument("--skip-db", action='store_true', help="Skip database backup")
         parser.add_argument("--skip-uploads", action='store_true', help="Skip uploads backup")


### PR DESCRIPTION
Point `#3` of #11532.
Fixes #12150 .

- Feel free to change the documentation or the name of the arguments.
- For the 3rd commit, let me know if `output` should be kept as a positional argument and the docs should be changed instead.

Manually tested on development environment.

![Screenshot from 2019-04-17 16-23-01](https://user-images.githubusercontent.com/13910561/56272383-2c875500-612d-11e9-9fd1-a4f817d5cecd.png)
