### PR TITLE
zjquery: Improve on/off handling for events.

### DIFF
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -324,7 +324,7 @@ function clear_buddy_list() {
 }
 
 function reset_setup() {
-    set_global('$', global.make_zjquery());
+    $.clear_all_elements();
     activity.set_cursor_and_filter();
 
     buddy_list.container = $('#user_presences');
@@ -826,6 +826,15 @@ run_test('update_presence_info', () => {
 });
 
 run_test('initialize', () => {
+    function clear() {
+        $.clear_all_elements();
+        buddy_list.container = $('#user_presences');
+        buddy_list.container.append = () => {};
+        clear_buddy_list();
+    }
+
+    clear();
+
     $.stub_selector('html', {
         on: function (name, func) {
             func();
@@ -847,7 +856,10 @@ run_test('initialize', () => {
     };
 
     activity.has_focus = false;
+
     activity.initialize();
+    clear();
+
     assert(scroll_handler_started);
     assert(!activity.new_user_input);
     assert(!$('#zephyr-mirror-error').hasClass('show'));
@@ -864,9 +876,12 @@ run_test('initialize', () => {
     global.setInterval = (func) => func();
 
     activity.initialize();
+
     assert($('#zephyr-mirror-error').hasClass('show'));
     assert(!activity.new_user_input);
     assert(!activity.has_focus);
+
+    clear();
 
     // Now execute the reload-in-progress code path
     _reload_state.is_in_progress = function () {
@@ -874,6 +889,7 @@ run_test('initialize', () => {
     };
 
     activity.initialize();
+    clear();
 });
 
 run_test('away_status', () => {


### PR DESCRIPTION
We no longer store handlers as an array of functions,
and instead we assume that code will only ever set up
one handler per sel/event or sel/event/child.  This is
almost always a sane policy for the app itself.

We also try to improve error handling when devs write
incorrect tests.

The only tests that required changes here are the
activity tests, which were a little careless about how
data got reset between tests.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
