### PR TITLE
Revert "Url encoded name of the file should be an ascii."

### DIFF
--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -284,8 +284,6 @@ def check_upload_within_quota(realm: Realm, uploaded_file_size: int) -> None:
 def get_file_info(request: HttpRequest, user_file: File) -> Tuple[str, int, Optional[str]]:
 
     uploaded_file_name = user_file.name
-    assert isinstance(uploaded_file_name, str)
-
     content_type = request.GET.get('mimetype')
     if content_type is None:
         guessed_type = guess_type(uploaded_file_name)[0]

--- a/zerver/views/upload.py
+++ b/zerver/views/upload.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from django.http import HttpRequest, HttpResponse, HttpResponseForbidden, \
     HttpResponseNotFound
 from django.shortcuts import redirect
@@ -72,31 +70,6 @@ def upload_file_backend(request: HttpRequest, user_profile: UserProfile) -> Http
         return json_error(_("Uploaded file is larger than the allowed limit of %s MB") % (
             settings.MAX_FILE_UPLOAD_SIZE))
     check_upload_within_quota(user_profile.realm, file_size)
-
-    if not isinstance(user_file.name, str):
-        # It seems that in Python 2 unicode strings containing bytes are
-        # rendered differently than ascii strings containing same bytes.
-        #
-        # Example:
-        # >>> print('\xd3\x92')
-        # Ӓ
-        # >>> print(u'\xd3\x92')
-        # Ó
-        #
-        # This is the cause of the problem as user_file.name variable
-        # is received as a unicode which is converted into unicode
-        # strings containing bytes and is rendered incorrectly.
-        #
-        # Example:
-        # >>> import urllib.parse
-        # >>> name = u'%D0%97%D0%B4%D1%80%D0%B0%D0%B2%D0%B5%D0%B8%CC%86%D1%82%D0%B5.txt'
-        # >>> print(urllib.parse.unquote(name))
-        # ÐÐ´ÑÐ°Ð²ÐµÐ¸ÌÑÐµ  # This is wrong
-        #
-        # >>> name = '%D0%97%D0%B4%D1%80%D0%B0%D0%B2%D0%B5%D0%B8%CC%86%D1%82%D0%B5.txt'
-        # >>> print(urllib.parse.unquote(name))
-        # Здравейте.txt  # This is correct
-        user_file.name = user_file.name.encode('ascii')
 
     uri = upload_message_image_from_request(request, user_file, user_profile)
     return json_success({'uri': uri})


### PR DESCRIPTION
This reverts commit fd9dd51d16790950e4b59f9e692d012ead23cc3f (#1815).

The issue described does not exist in Python 3, where `urllib.parse` now _only_ accepts (Unicode) `str` and does the right thing with it.  The workaround was not being triggered and would have failed if it were.

**Testing Plan:** Uploaded a file named `Здравейте.txt`.