### PR TITLE
list_render: Extend test to verify that list sorting is case insensitive.

### DIFF
--- a/frontend_tests/node_tests/list_render.js
+++ b/frontend_tests/node_tests/list_render.js
@@ -219,7 +219,7 @@ run_test('sorting', () => {
     };
 
     const alice = { name: 'alice', salary: 50 };
-    const bob = { name: 'bob', salary: 40 };
+    const bob = { name: 'Bob', salary: 40 };
     const cal = { name: 'cal', salary: 30 };
     const dave = { name: 'dave', salary: 25 };
 


### PR DESCRIPTION
The alphabetic sorting of lists in the User/Organization settings was changed in fa0a5ec to be case insensitive.
This commit makes changes to the `list_render.js` test to verify that the sorting of these lists is indeed case insensitive.

This is in relation to the commit [here](https://github.com/zulip/zulip/pull/12111#issuecomment-482861446).