### PR TITLE
provision.py: Add a conditional to remove '.eslintcache'.

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -557,6 +557,11 @@ def main(options):
 
     run(["scripts/lib/clean-unused-caches"])
 
+    # Keeping this cache file around can cause eslint to throw
+    # random TypeErrors when new/updated dependencies are added
+    if os.path.isfile('.eslintcache'):
+        os.remove('.eslintcache')
+
     version_file = os.path.join(UUID_VAR_PATH, 'provision_version')
     print('writing to %s\n' % (version_file,))
     open(version_file, 'w').write(PROVISION_VERSION + '\n')


### PR DESCRIPTION
It was discovered that the '.eslintcache' file was causing eslint to
throw a TypeError after a recent update/addition to the dependencies.
It makes sense to remove this file as part of the provisioning process
to avoid such exceptions.

Tested with the following:

`tools/provision` and `tools/lint`
