### PR TITLE
Inserted compulsory setting for postfix ≥ 2.10

### DIFF
--- a/puppet/zulip/templates/postfix/main.cf.erb
+++ b/puppet/zulip/templates/postfix/main.cf.erb
@@ -15,6 +15,7 @@ smtpd_use_tls=yes
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 
+smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated reject_unauth_destination
 myhostname = <%= @fqdn %>
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases


### PR DESCRIPTION
One of smtpd_relay_restrictions or smtpd_recipient_restrictions is required by postfix ≥ 2.10 (see http://www.postfix.org/SMTPD_ACCESS_README.html).

**Testing Plan:**
I have tested on a single instance running Ubuntu 18.04.2 LTS.