### PR TITLE
Support page followup

### DIFF
--- a/analytics/views.py
+++ b/analytics/views.py
@@ -40,7 +40,7 @@ from zerver.lib.realm_icon import realm_icon_url
 from zerver.views.invite import get_invitee_emails_set
 from zerver.lib.subdomains import get_subdomain_from_hostname
 from zerver.lib.actions import do_change_plan_type, do_deactivate_realm, \
-    do_reactivate_realm
+    do_reactivate_realm, do_scrub_realm
 
 if settings.BILLING_ENABLED:
     from corporate.lib.stripe import attach_discount_to_realm, get_discount_for_realm
@@ -1059,6 +1059,12 @@ def support(request: HttpRequest) -> HttpResponse:
             elif status == "deactive":
                 do_deactivate_realm(realm)
                 context["message"] = "{} deactivated.".format(realm.name)
+
+        scrub_realm = request.POST.get("scrub_realm", None)
+        if scrub_realm is not None:
+            if scrub_realm == "scrub_realm":
+                do_scrub_realm(realm)
+                context["message"] = "{} scrubbed.".format(realm.name)
 
     query = request.GET.get("q", None)
     if query:

--- a/frontend_tests/node_tests/support.js
+++ b/frontend_tests/node_tests/support.js
@@ -1,0 +1,18 @@
+const fs = require("fs");
+const { JSDOM } = require("jsdom");
+const template = fs.readFileSync("templates/analytics/support.html", "utf-8");
+const dom = new JSDOM(template, { pretendToBeVisual: true });
+const document = dom.window.document;
+
+var jquery_init;
+global.$ = (f) => {jquery_init = f;};
+zrequire('support', "js/analytics/support");
+set_global('$', global.make_zjquery());
+
+run_test('scrub_realm', () => {
+    jquery_init();
+    var click_handler = $('body').get_on_handler('click', '.scrub-realm-button');
+    assert.equal(typeof click_handler, 'function');
+
+    assert.equal(document.querySelectorAll(".scrub-realm-button").length, 2);
+});

--- a/static/js/analytics/support.js
+++ b/static/js/analytics/support.js
@@ -1,0 +1,10 @@
+$(function () {
+    $("body").on("click", ".scrub-realm-button", function (e) {
+        e.preventDefault();
+        var string_id = $(this).data("string-id");
+        var message = 'Do you really want to scrub the realm "' + string_id + '"? This action is irreversible.';
+        if (confirm(message)) { // eslint-disable-line no-alert
+            this.form.submit();
+        }
+    });
+});

--- a/static/styles/activity.scss
+++ b/static/styles/activity.scss
@@ -75,6 +75,11 @@ tr.admin td:first-child {
     top: -25px;
 }
 
+.scrub-realm-form {
+    position: relative;
+    top: -50px;
+}
+
 .support-submit-button {
     position: relative;
     top: -5px;

--- a/static/styles/activity.scss
+++ b/static/styles/activity.scss
@@ -67,6 +67,11 @@ tr.admin td:first-child {
 
 .support-discount-form {
     position: relative;
+    top: -50px;
+}
+
+.support-plan-type-form {
+    position: relative;
     top: -25px;
 }
 

--- a/templates/analytics/support.html
+++ b/templates/analytics/support.html
@@ -22,18 +22,10 @@
         </center>
     </form>
 
-    {% if plan_type_msg %}
+    {% if message %}
     <div class="alert alert-success">
         <center>
-            {{ plan_type_msg }}
-        </center>
-    </div>
-    {% endif %}
-
-    {% if discount_msg %}
-    <div class="alert alert-success">
-        <center>
-            {{ discount_msg }}
+            {{ message }}
         </center>
     </div>
     {% endif %}
@@ -53,9 +45,18 @@
                 <h3><img src="{{ user.realm.realm_icon_url }}" class="support-realm-icon"> {{ user.realm.name }}</h3>
                 <b>URL</b>: <a target="_blank" href="{{ user.realm.uri }}">{{ user.realm.uri }}</a><br>
                 <b>Date created</b>: {{ user.realm.date_created|timesince }} ago<br>
-                <b>Is active</b>: {{ not user.realm.deactivated }}<br>
                 <b>Admins</b>: {% for admin in user.realm.admins %}{{ admin.email }} {% endfor %}<br>
                 <form method="POST">
+                    <b>Status</b>:<br>
+                    {{ csrf_input }}
+                    <input type="hidden" name="realm_id" value="{{ user.realm.id }}" />
+                    <select name="status">
+                        <option value="active" {% if not user.realm.deactivated %}selected{% endif %}>Active</option>
+                        <option value="deactive" {% if user.realm.deactivated %}selected{% endif %}>Deactive</option>
+                    </select>
+                    <button type="submit" class="btn btn-small support-submit-button">Update</button>
+                </form>
+                <form method="POST" class="support-plan-type-form">
                     {{ csrf_input }}
                     <input type="hidden" name="realm_id" value="{{ user.realm.id }}" />
                     <b>Plan type</b>:<br>
@@ -85,10 +86,19 @@
             <h3><img src="{{ realm.realm_icon_url }}" class="support-realm-icon"> {{ realm.name }}</h3>
             <b>URL</b>: <a target="_blank" href="{{ realm.uri }}">{{ realm.uri }}</a><br>
             <b>Date created</b>: {{ realm.date_created|timesince }} ago<br>
-            <b>Is active</b>: {{ not realm.deactivated }}<br>
             <b>Admins</b>: {% for admin in realm.admins %}{{ admin.email }} {% endfor %}<br>
-            <b>Plan type</b>:
             <form method="POST">
+                <b>Status</b>:<br>
+                {{ csrf_input }}
+                <input type="hidden" name="realm_id" value="{{ realm.id }}" />
+                <select name="status">
+                    <option value="active" {% if not realm.deactivated %}selected{% endif %}>Active</option>
+                    <option value="deactive" {% if realm.deactivated %}selected{% endif %}>Deactive</option>
+                </select>
+                <button type="submit" class="btn btn-small support-submit-button">Update</button>
+            </form>
+            <form method="POST" class="support-plan-type-form">
+                <b>Plan type</b>:<br>
                 {{ csrf_input }}
                 <input type="hidden" name="realm_id" value="{{ realm.id }}" />
                 <select name="plan_type">

--- a/templates/analytics/support.html
+++ b/templates/analytics/support.html
@@ -10,6 +10,7 @@
 {% block customhead %}
 {{ super() }}
 {{ render_bundle('activity') }}
+{{ render_bundle('support') }}
 {% endblock %}
 
 {% block content %}
@@ -32,7 +33,7 @@
 
     <div id="query-results">
         {% for user in users %}
-        <div class="support-query-result">
+        <div class="support-query-result new-style">
             <span class="label">user</span>
             <h3>{{ user.full_name }}</h3>
             <b>Email</b>: {{ user.email }}<br>
@@ -75,13 +76,19 @@
                     <input type="number" name="discount" value="{{user.realm.default_discount}}" required>
                     <button type="submit" class="btn btn-small support-submit-button">Update</button>
                 </form>
+                <form method="POST" class="scrub-realm-form">
+                    {{ csrf_input }}
+                    <input type="hidden" name="realm_id" value="{{ user.realm.id }}" />
+                    <input type="hidden" name="scrub_realm" value="scrub_realm" />
+                    <button data-string-id="{{user.realm.string_id}}" class="button rounded btn-danger small scrub-realm-button">Scrub realm</button>
+                </form>
             </div>
             <hr>
         </div>
         {% endfor %}
 
         {% for realm in realms %}
-        <div class="support-query-result">
+        <div class="support-query-result new-style">
             <span class="label">realm</span>
             <h3><img src="{{ realm.realm_icon_url }}" class="support-realm-icon"> {{ realm.name }}</h3>
             <b>URL</b>: <a target="_blank" href="{{ realm.uri }}">{{ realm.uri }}</a><br>
@@ -115,6 +122,12 @@
                 <input type="hidden" name="realm_id" value="{{ realm.id }}" />
                 <input type="number" name="discount" value="{{ realm.default_discount}}" required>
                 <button type="submit" class="btn btn-small support-submit-button">Update</button>
+            </form>
+            <form method="POST" class="scrub-realm-form">
+                {{ csrf_input }}
+                <input type="hidden" name="realm_id" value="{{ realm.id }}" />
+                <input type="hidden" name="scrub_realm" value="scrub_realm" />
+                <button data-string-id="{{realm.string_id}}" class="button rounded btn-danger small scrub-realm-button">Scrub realm</button>
             </form>
             <hr>
         </div>

--- a/templates/analytics/support.html
+++ b/templates/analytics/support.html
@@ -16,10 +16,10 @@
 {% block content %}
 <div class="container">
     <br>
-    <form>
+    <form class="new-style">
         <center>
             <input type="text" name="q" class="input-xxlarge search-query" placeholder="emails, string_ids, organization urls separated by commas" value="{{ request.GET.get('q', '') }}" autofocus>
-            <button type="submit" class="btn support-search-button">Search</button>
+            <button type="submit" class="button small support-search-button">Search</button>
         </center>
     </form>
 
@@ -55,7 +55,7 @@
                         <option value="active" {% if not user.realm.deactivated %}selected{% endif %}>Active</option>
                         <option value="deactive" {% if user.realm.deactivated %}selected{% endif %}>Deactive</option>
                     </select>
-                    <button type="submit" class="btn btn-small support-submit-button">Update</button>
+                    <button type="submit" class="button rounded small support-submit-button">Update</button>
                 </form>
                 <form method="POST" class="support-plan-type-form">
                     {{ csrf_input }}
@@ -67,14 +67,14 @@
                         <option value="3" {% if user.realm.plan_type == 3 %}selected{% endif %}>Standard</option>
                         <option value="4" {% if user.realm.plan_type == 4 %}selected{% endif %}>Standard Free</option>
                     </select>
-                    <button type="submit" class="btn btn-small support-submit-button">Update</button>
+                    <button type="submit" class="button rounded small support-submit-button">Update</button>
                 </form>
                 <form method="POST" class="support-discount-form">
                     <b>Discount (use 85 for nonprofits)</b>:<br>
                     {{ csrf_input }}
                     <input type="hidden" name="realm_id" value="{{ user.realm.id }}" />
                     <input type="number" name="discount" value="{{user.realm.default_discount}}" required>
-                    <button type="submit" class="btn btn-small support-submit-button">Update</button>
+                    <button type="submit" class="button rounded small support-submit-button">Update</button>
                 </form>
                 <form method="POST" class="scrub-realm-form">
                     {{ csrf_input }}
@@ -102,7 +102,7 @@
                     <option value="active" {% if not realm.deactivated %}selected{% endif %}>Active</option>
                     <option value="deactive" {% if realm.deactivated %}selected{% endif %}>Deactive</option>
                 </select>
-                <button type="submit" class="btn btn-small support-submit-button">Update</button>
+                <button type="submit" class="button rounded small support-submit-button">Update</button>
             </form>
             <form method="POST" class="support-plan-type-form">
                 <b>Plan type</b>:<br>
@@ -114,14 +114,14 @@
                     <option value="3" {% if realm.plan_type == 3 %}selected{% endif %}>Standard</option>
                     <option value="4" {% if realm.plan_type == 4 %}selected{% endif %}>Standard Free</option>
                 </select>
-                <button type="submit" class="btn btn-small support-submit-button">Update</button>
+                <button type="submit" class="button rounded small support-submit-button">Update</button>
             </form>
             <form method="POST" class="support-discount-form">
                 <b>Discount (use 85 for nonprofits)</b>:<br>
                 {{ csrf_input }}
                 <input type="hidden" name="realm_id" value="{{ realm.id }}" />
                 <input type="number" name="discount" value="{{ realm.default_discount}}" required>
-                <button type="submit" class="btn btn-small support-submit-button">Update</button>
+                <button type="submit" class="button rounded small support-submit-button">Update</button>
             </form>
             <form method="POST" class="scrub-realm-form">
                 {{ csrf_input }}

--- a/templates/analytics/support.html
+++ b/templates/analytics/support.html
@@ -68,7 +68,7 @@
                     <button type="submit" class="btn btn-small support-submit-button">Update</button>
                 </form>
                 <form method="POST" class="support-discount-form">
-                    <b>Discount</b>:<br>
+                    <b>Discount (use 85 for nonprofits)</b>:<br>
                     {{ csrf_input }}
                     <input type="hidden" name="realm_id" value="{{ user.realm.id }}" />
                     <input type="number" name="discount" value="{{user.realm.default_discount}}" required>
@@ -100,7 +100,7 @@
                 <button type="submit" class="btn btn-small support-submit-button">Update</button>
             </form>
             <form method="POST" class="support-discount-form">
-                <b>Discount</b>:<br>
+                <b>Discount (use 85 for nonprofits)</b>:<br>
                 {{ csrf_input }}
                 <input type="hidden" name="realm_id" value="{{ realm.id }}" />
                 <input type="number" name="discount" value="{{ realm.default_discount}}" required>

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -82,6 +82,10 @@
         "./node_modules/jquery-validation/dist/jquery.validate.min.js",
         "./static/js/portico/signup.js"
     ],
+    "support": [
+        "./static/js/analytics/support.js",
+        "./static/styles/app_components.scss"
+    ],
     "dev-login": "./static/js/portico/dev-login.js",
     "email-log": "./static/js/portico/email_log.js",
     "stats": [


### PR DESCRIPTION
Adds features mentioned in https://github.com/zulip/zulip/issues/10824#issuecomment-484314474

- [x]  Update discount label to include nonprofit discount %.

- [x] Add suport for activating and deactivating realm.

- [x] Add suport for scrubbing realm. 

- [x] Show the string_id of the realm to be scrubbed in confirmation modal.

- [x] Move javascript to a js file as well as add fronted tests.

 need to move the JS code to separate file to improve the scrub realm confirmation modal as well as add frontend tests. ~~I am thinking of asking to enter the correct string_id in the confirmation modal in-order to proceed with scrubbing~~.

@rishig Also instead of scrubbing the realm instantly do you think we should implement a Queue system to scrub the realm after 1 or 7 days? Just in case we accidentally scub the realm or the organization want to undo scrubbing(unlikely currently but if we implement a UI that allows organisations to scrub realms). We can mention that in our policy as well that the data would be actually scrubbed only after a few days. 

![Screenshot from 2019-04-19 21-51-14](https://user-images.githubusercontent.com/7190633/56433167-9cdcd480-62ed-11e9-9aaf-217244f4eb94.png)


![Screenshot from 2019-04-19 21-52-12](https://user-images.githubusercontent.com/7190633/56433146-9189a900-62ed-11e9-97dd-97b177082eb4.png)
