### PR TITLE
Added alt attributes to <img> tags in e-mail templates

### DIFF
--- a/templates/zerver/emails/confirm_new_email.source.html
+++ b/templates/zerver/emails/confirm_new_email.source.html
@@ -1,7 +1,7 @@
 {% extends "zerver/emails/compiled/email_base_default.html" %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/email_logo.png"/>
+<img src="{{ email_images_base_uri }}/email_logo.png" alt="{{ _('Zulip logo') }}"/>
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/emails/confirm_registration.source.html
+++ b/templates/zerver/emails/confirm_registration.source.html
@@ -1,7 +1,7 @@
 {% extends "zerver/emails/compiled/email_base_default.html" %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/registration_confirmation.png"/>
+<img src="{{ email_images_base_uri }}/registration_confirmation.png" alt="{{ _('Turtle with envelope') }}"/>
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/emails/email_base_default.source.html
+++ b/templates/zerver/emails/email_base_default.source.html
@@ -27,7 +27,7 @@
                                             </td>
                                         </tr>
                                     </table>
-                                    <img src="{{ email_images_base_uri }}/footer.png"/>
+                                    <img src="{{ email_images_base_uri }}/footer.png" alt="{{ _('Swimming fish') }}"/>
                                 </td>
                             </tr>
                         </table>

--- a/templates/zerver/emails/find_team.source.html
+++ b/templates/zerver/emails/find_team.source.html
@@ -1,7 +1,7 @@
 {% extends "zerver/emails/compiled/email_base_default.html" %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/email_logo.png"/>
+<img src="{{ email_images_base_uri }}/email_logo.png" alt="{{ _('Zulip logo') }}"/>
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/emails/followup_day1.source.html
+++ b/templates/zerver/emails/followup_day1.source.html
@@ -1,7 +1,7 @@
 {% extends "zerver/emails/compiled/email_base_default.html" %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/email_logo.png"/>
+<img src="{{ email_images_base_uri }}/email_logo.png" alt="{{ _('Zulip logo') }}"/>
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/emails/followup_day2.source.html
+++ b/templates/zerver/emails/followup_day2.source.html
@@ -1,7 +1,7 @@
 {% extends "zerver/emails/compiled/email_base_default.html" %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/day2_1.png"/>
+<img src="{{ email_images_base_uri }}/day2_1.png" alt="{{ _('Octopus box with heart') }}"/>
 {% endblock %}
 
 {% block content %}
@@ -9,7 +9,7 @@
 
 <p>{{ _("I wanted to share one last thing with you: a few tips about topics, since mastering topics is a key part of being a Zulip power user.") }}</p>
 
-<img src="{{ email_images_base_uri }}/day2_2.png"/>
+<img src="{{ email_images_base_uri }}/day2_2.png" alt="{{ _('Examples of short topics') }}"/>
 
 <p>{{ _("Topics are like email subject lines. The big difference, though, is that they're really short and lightweight. Two or three words will do it. Don't overthink 'em&mdash;you can always edit the message later!") }}</p>
 
@@ -18,7 +18,7 @@
     <li>{% trans %}Not recommended: "What do people think of this new design mockup?", "I'm looking at Bug 345", "Is Acme Burgers open for lunch?"{% endtrans %}</li>
 </ul>
 
-<img src="{{ email_images_base_uri }}/day2_3.png"/>
+<img src="{{ email_images_base_uri }}/day2_3.png" alt="{{ _('Example of a topic that is too long') }}"/>
 
 <p>{{ _("Why bother with topics? Well, two reasons: it makes conversations clearer (imagine if email didn't have them!), and it lets you more efficiently catch up on what's happened while you're away&mdash;read the topics that are relevant to you, and ignore the ones that aren't!") }}</p>
 

--- a/templates/zerver/emails/invitation.source.html
+++ b/templates/zerver/emails/invitation.source.html
@@ -1,7 +1,7 @@
 {% extends "zerver/emails/compiled/email_base_default.html" %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/registration_confirmation.png"/>
+<img src="{{ email_images_base_uri }}/registration_confirmation.png" alt="{{ _('Turtle with envelope') }}"/>
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/emails/invitation_reminder.source.html
+++ b/templates/zerver/emails/invitation_reminder.source.html
@@ -1,7 +1,7 @@
 {% extends "zerver/emails/compiled/email_base_default.html" %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/invitation_reminder.png"/>
+<img src="{{ email_images_base_uri }}/invitation_reminder.png" alt="{{ _('Mailbox with envelope') }}"/>
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/emails/notify_change_in_email.source.html
+++ b/templates/zerver/emails/notify_change_in_email.source.html
@@ -1,7 +1,7 @@
 {% extends "zerver/emails/compiled/email_base_default.html" %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/email_logo.png"/>
+<img src="{{ email_images_base_uri }}/email_logo.png" alt="{{ _('Zulip logo') }}"/>
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/emails/notify_new_login.source.html
+++ b/templates/zerver/emails/notify_new_login.source.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/email_logo.png"/>
+<img src="{{ email_images_base_uri }}/email_logo.png" alt="{{ _('Zulip logo') }}"/>
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/emails/password_reset.source.html
+++ b/templates/zerver/emails/password_reset.source.html
@@ -1,7 +1,7 @@
 {% extends "zerver/emails/compiled/email_base_default.html" %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/email_logo.png"/>
+<img src="{{ email_images_base_uri }}/email_logo.png" alt="{{ _('Zulip logo') }}"/>
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/emails/realm_reactivation.source.html
+++ b/templates/zerver/emails/realm_reactivation.source.html
@@ -1,7 +1,7 @@
 {% extends "zerver/emails/compiled/email_base_default.html" %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/registration_confirmation.png"/>
+<img src="{{ email_images_base_uri }}/registration_confirmation.png" alt="{{ _('Turtle with envelope') }}"/>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
* for better readability of e-mails
* some spam filters penalize <img> tags without alt's, you can test by sending invitation to the mail returned by https://www.mail-tester.com for example.