### PR TITLE
hide emails: List of quick fixes.

### DIFF
--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -8,7 +8,10 @@ function stream_matches_query(stream_name, q) {
 
 function highlight_person(query, person) {
     var hilite = typeahead_helper.highlight_query_in_phrase;
-    return hilite(query, person.full_name) + " &lt;" + hilite(query, person.email) + "&gt;";
+    if (settings_org.show_email()) {
+        return hilite(query, person.full_name) + " &lt;" + hilite(query, person.email) + "&gt;";
+    }
+    return hilite(query, person.full_name);
 }
 
 function match_criteria(operators, criteria) {

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -176,9 +176,14 @@ function populate_users(realm_people_data) {
         filter: {
             element: $users_table.closest(".settings-section").find(".search"),
             callback: function (item, value) {
+                var email = item.email;
+                if (page_params.is_admin) {
+                    email = item.delivery_email;
+                }
+
                 return (
                     item.full_name.toLowerCase().indexOf(value) >= 0 ||
-                    item.email.toLowerCase().indexOf(value) >= 0
+                    email.toLowerCase().indexOf(value) >= 0
                 );
             },
             onupdate: reset_scrollbar($users_table),
@@ -194,9 +199,14 @@ function populate_users(realm_people_data) {
         filter: {
             element: $deactivated_users_table.closest(".settings-section").find(".search"),
             callback: function (item, value) {
+                var email = item.email;
+                if (page_params.is_admin) {
+                    email = item.delivery_email;
+                }
+
                 return (
                     item.full_name.toLowerCase().indexOf(value) >= 0 ||
-                    item.email.toLowerCase().indexOf(value) >= 0
+                    email.toLowerCase().indexOf(value) >= 0
                 );
             },
             onupdate: reset_scrollbar($deactivated_users_table),

--- a/static/templates/admin_user_list.handlebars
+++ b/static/templates/admin_user_list.handlebars
@@ -4,7 +4,11 @@
         <span class="user_name">{{full_name}}</span>
     </td>
     <td>
+        {{#if ../can_modify}}
+        <span class="email">{{delivery_email}}</span>
+        {{else}}
         <span class="email">{{email}}</span>
+        {{/if}}
     </td>
     {{#unless is_bot}}
     <td>
@@ -21,7 +25,11 @@
     {{/unless}}
     {{#if is_bot}}
     <td>
+        {{#if ../can_modify}}
+        <span class="owner">{{bot_owner_delivery_email}}</span>
+        {{else}}
         <span class="owner">{{bot_owner}}</span>
+        {{/if}}
     </td>
     <td>
         <span class="bot type">{{bot_type}}</span>

--- a/templates/zerver/dev_login.html
+++ b/templates/zerver/dev_login.html
@@ -22,7 +22,7 @@ page can be easily identified in it's respective JavaScript file -->
                         {% if direct_admins %}
                             {% for direct_admin in direct_admins %}
                             <p><input type="submit" formaction="{{ direct_admin.realm.uri }}{{ url('zerver.views.auth.dev_direct_login') }}?next={{ next }}"
-                                      name="direct_email" class="btn-direct btn-admin" value="{{ direct_admin.email }}" /></p>
+                                      name="direct_email" class="btn-direct btn-admin" value="{{ direct_admin.delivery_email }}" /></p>
                             {% endfor %}
                         {% else %}
                             <p>No administrators found in this realm</p>
@@ -31,7 +31,7 @@ page can be easily identified in it's respective JavaScript file -->
                         {% if guest_users %}
                             {% for guest_user in guest_users %}
                             <p><input type="submit" formaction="{{ guest_user.realm.uri }}{{ url('zerver.views.auth.dev_direct_login') }}?next={{ next }}"
-                                      name="direct_email" class="btn-direct btn-admin" value="{{ guest_user.email }}" /></p>
+                                      name="direct_email" class="btn-direct btn-admin" value="{{ guest_user.delivery_email }}" /></p>
                             {% endfor %}
                         {% else %}
                             <p>No guest users found in this realm</p>
@@ -43,7 +43,7 @@ page can be easily identified in it's respective JavaScript file -->
                         {% if direct_users %}
                             {% for direct_user in direct_users %}
                             <p><input type="submit" formaction="{{ direct_user.realm.uri }}{{ url('zerver.views.auth.dev_direct_login') }}?next={{ next }}"
-                                      name="direct_email" class="btn-direct btn-admin" value="{{ direct_user.email }}" /></p>
+                                      name="direct_email" class="btn-direct btn-admin" value="{{ direct_user.delivery_email }}" /></p>
                             {% endfor %}
                         {% else %}
                             <p>No normal users found in this realm</p>

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -819,6 +819,11 @@ def do_events_register(user_profile: UserProfile, user_client: Client,
     # handling perspective to do it before contacting Tornado
     check_supported_events_narrow_filter(narrow)
 
+    if user_profile.realm.email_address_visibility == Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS:
+        # If email addresses are only available to administrators,
+        # clients cannot compute gravatars, so we force-set it to false.
+        client_gravatar = False
+
     # Note that we pass event_types, not fetch_event_types here, since
     # that's what controls which future events are sent.
     queue_id = request_event_queue(user_profile, user_client, apply_markdown, client_gravatar,

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -13,6 +13,7 @@ from zerver.models import (
     get_display_recipient, get_personal_recipient, get_realm, get_stream,
     UserMessage, get_stream_recipient, Message
 )
+from zerver.lib.actions import do_set_realm_property
 from zerver.lib.message import (
     MessageDict,
 )
@@ -1052,6 +1053,13 @@ class GetOldMessagesTest(ZulipTestCase):
         result = self.get_and_check_messages(dict(client_gravatar=ujson.dumps(True)))
         message = result['messages'][0]
         self.assertEqual(message['avatar_url'], None)
+
+        # Now verify client_gravatar doesn't run with EMAIL_ADDRESS_VISIBILITY_ADMINS
+        do_set_realm_property(hamlet.realm, "email_address_visibility",
+                              Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS)
+        result = self.get_and_check_messages(dict(client_gravatar=ujson.dumps(True)))
+        message = result['messages'][0]
+        self.assertIn('gravatar.com', message['avatar_url'])
 
     def test_get_messages_with_narrow_pm_with(self) -> None:
         """

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -719,8 +719,13 @@ def get_messages_backend(request: HttpRequest, user_profile: UserProfile,
     if num_before + num_after > MAX_MESSAGES_PER_FETCH:
         return json_error(_("Too many messages requested (maximum %s).")
                           % (MAX_MESSAGES_PER_FETCH,))
-    include_history = ok_to_include_history(narrow, user_profile)
 
+    if user_profile.realm.email_address_visibility == Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS:
+        # If email addresses are only available to administrators,
+        # clients cannot compute gravatars, so we force-set it to false.
+        client_gravatar = False
+
+    include_history = ok_to_include_history(narrow, user_profile)
     if include_history:
         # The initial query in this case doesn't use `zerver_usermessage`,
         # and isn't yet limited to messages the user is entitled to see!

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -36,7 +36,7 @@ from zerver.lib.utils import generate_api_key, generate_random_token
 from zerver.models import UserProfile, Stream, Message, email_allowed_for_realm, \
     get_user_by_delivery_email, Service, get_user_including_cross_realm, \
     DomainNotAllowedForRealmError, DisposableEmailError, get_user_profile_by_id_in_realm, \
-    EmailContainsPlusError, get_user_by_id_in_realm_including_cross_realm
+    EmailContainsPlusError, get_user_by_id_in_realm_including_cross_realm, Realm
 
 def deactivate_user_backend(request: HttpRequest, user_profile: UserProfile,
                             user_id: int) -> HttpResponse:
@@ -399,6 +399,11 @@ def get_members_backend(request: HttpRequest, user_profile: UserProfile,
     '''
 
     realm = user_profile.realm
+
+    if realm.email_address_visibility == Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS:
+        # If email addresses are only available to administrators,
+        # clients cannot compute gravatars, so we force-set it to false.
+        client_gravatar = False
 
     query = UserProfile.objects.filter(
         realm_id=realm.id


### PR DESCRIPTION
In email hidden case (that is when `email_address_visibilty` is set to
everyone), for "non-admins", this commit hides emails from:
- compose box user typeahead.
- PM user typeahead
- user popover
- custom profile popover
In email hidden case, for admins, email is shown everywhere as it was before.

Fixes: #11455 .