### PR TITLE
tools/webpack: Run webpack in the foreground

### DIFF
--- a/tools/webpack
+++ b/tools/webpack
@@ -2,9 +2,11 @@
 
 import argparse
 import os
-import subprocess
 import sys
 import json
+
+if False:
+    from typing import NoReturn
 
 # check for the venv
 from lib import sanity_check
@@ -19,7 +21,7 @@ STATIC_PATH = 'static/'
 
 
 def build_for_prod_or_casper(quiet):
-    # type: (bool) -> None
+    # type: (bool) -> NoReturn
     """Builds for production, writing the output to disk"""
 
     webpack_args = ['node', 'node_modules/.bin/webpack-cli',
@@ -28,10 +30,10 @@ def build_for_prod_or_casper(quiet):
     if quiet:
         webpack_args += ['--display', 'errors-only']
         print('Starting webpack compilation')
-    subprocess.check_call(webpack_args)
+    os.execvp(webpack_args[0], webpack_args)
 
 def build_for_dev_server(host, port, minify, disable_host_check):
-    # type: (str, str, bool, bool) -> None
+    # type: (str, str, bool, bool) -> NoReturn
     """watches and rebuilds on changes, serving files from memory via webpack-dev-server"""
 
     # This is our most dynamic configuration, which we use for our
@@ -53,7 +55,7 @@ def build_for_dev_server(host, port, minify, disable_host_check):
         webpack_args.append('--optimize-minimize')
     if disable_host_check:
         webpack_args.append('--disable-host-check')
-    subprocess.Popen(webpack_args)
+    os.execvp(webpack_args[0], webpack_args)
 
 def build_for_most_tests():
     # type: () -> None


### PR DESCRIPTION
`tools/run-dev.py` already backgrounds `tools/webpack` (and deals with cleaning it up on exit), so there’s no need for `tools/webpack` to also background the actual `webpack` process.  But when running `tools/webpack` by itself, it’s annoying to clean up the backgrounded process manually.

Run `webpack` in the foreground, using `os.execvp` so we don’t waste memory on an intermediate wrapper process.

**Testing Plan:** Checked that `tools/run-dev.py` still works, and that Ctrl-C now successfully cleans up `tools/webpack --watch`.