### PR TITLE
webpack: Fix node_modules path resolution.

### DIFF
--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -93,7 +93,7 @@ export default (env?: string): webpack.Configuration => {
         resolve: {
             modules: [
                 resolve(__dirname, "../static"),
-                resolve(__dirname, "../node_modules"),
+                "node_modules",
                 resolve(__dirname, "../"),
             ],
             extensions: [".tsx", ".ts", ".js", ".json", ".scss", ".css"],


### PR DESCRIPTION
Webpack applies special logic to relative paths provided in `resolve.modules`, and this logic is expected to be used for `node_modules`.  One case where this is important is when `node_modules/foo` wants to import a different version of package `bar` than the one at `node_modules/bar`, and so yarn gives it its own copy at `node_modules/foo/node_modules/bar`.

It would probably be better to avoid screwing with `resolve.modules` at all, but this at least brings us one step closer to the default of just `["node_modules"]`.

Required by #11792, but split off as a separate bug fix worth applying independently.

**Testing Plan:** Ran `run-dev.py`.