### PR TITLE
terminate-psql-sessions: Only terminate pids on which we have permissions

### DIFF
--- a/scripts/setup/terminate-psql-sessions
+++ b/scripts/setup/terminate-psql-sessions
@@ -26,6 +26,11 @@ root)
     ;;
 esac
 
-"${psql[@]}" <<EOF
-SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname IN ($tables);
+"${psql[@]}" -v ON_ERROR_STOP=1 <<EOF
+SELECT pg_terminate_backend(s.pid)
+    FROM pg_stat_activity s, pg_roles r
+    WHERE
+        s.datname IN ($tables)
+        AND r.rolname = CURRENT_USER
+        AND (s.usename = r.rolname OR r.rolsuper = 't');
 EOF


### PR DESCRIPTION
**Testing Plan:** Ran `terminate-psql-sessions zulip zulip` and `sudo terminate-psql-sessions zulip zulip` with `run-dev.py` running.