### PR TITLE
Validate HTML in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,25 +82,6 @@ aliases:
          || echo "Error in uploading coverage reports to codecov.io."
 
 jobs:
-  "trusty-backend-python3.4":
-    docker:
-      # This is built from tools/circleci/images/trusty/Dockerfile .
-      # Trusty ships with Python 3.4.
-      - image: gregprice/circleci:trusty-python-5.test
-
-    working_directory: ~/zulip
-
-    steps:
-      - checkout
-
-      - *create_cache_directories
-      - *restore_cache_package_json
-      - *restore_cache_requirements
-      - *install_dependencies
-      - *save_cache_package_json
-      - *save_cache_requirements
-      - *run_backend_tests
-
   "xenial-backend-frontend-python3.5":
     docker:
       # This is built from tools/circleci/images/xenial/Dockerfile .
@@ -160,6 +141,5 @@ workflows:
   version: 2
   build:
     jobs:
-      - "trusty-backend-python3.4"
       - "xenial-backend-frontend-python3.5"
       - "bionic-backend-python3.6"

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You might be interested in:
 
 * **Running a Zulip server**. Setting up a server takes just a couple
   of minutes. Zulip runs on Ubuntu 18.04 Bionic, Ubuntu 16.04 Xenial,
-  Ubuntu 14.04 Trusty, and Debian 9 Stretch. The installation process is
+  and Debian 9 Stretch. The installation process is
   [documented here](https://zulip.readthedocs.io/en/stable/production/install.html).
   Commercial support is available; see <https://zulipchat.com/plans>
   for details.

--- a/docs/testing/continuous-integration.md
+++ b/docs/testing/continuous-integration.md
@@ -53,7 +53,6 @@ uses those SSH keys for authentication.
 The main CircleCI configuration file is
 [./circleci/config.yml](https://github.com/zulip/zulip/blob/master/.circleci/config.yml).
 We currently run several jobs during a CircleCI build. They are:
-* trusty-python-3.4
 * xenial-python-3.5
 * bionic-python-3.6
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "stylelint": "10.0.1",
     "svgo": "1.2.2",
     "swagger-parser": "6.0.5",
+    "vnu-jar": "^19.6.7",
     "webpack-dev-server": "3.5.1"
   },
   "scripts": {

--- a/tools/circleci/images.yml
+++ b/tools/circleci/images.yml
@@ -1,7 +1,3 @@
-trusty:
-  base_image: buildpack-deps:trusty-scm
-  extra_packages: python-virtualenv postgresql-9.3
-
 xenial:
   base_image: buildpack-deps:xenial-scm
   extra_packages: virtualenv postgresql-9.5

--- a/tools/documentation.vnufilter
+++ b/tools/documentation.vnufilter
@@ -1,0 +1,10 @@
+# Real errors that should be fixed.
+
+Bad value “” for attribute “id” on element “div”: Bad id: An ID must not be the empty string\.
+Duplicate ID “[^”]*”\.
+The first occurrence of ID “[^”]*” was here\.
+
+# Warnings that are probably less important.
+
+The “type” attribute is unnecessary for JavaScript resources\.
+Section lacks heading\. Consider using “h2”-“h6” elements to add identifying headings to all sections\.

--- a/tools/test-documentation
+++ b/tools/test-documentation
@@ -41,27 +41,35 @@ rm -rf _build
 # The crawler would take a very long time to finish and TravisCI would fail as a result.
 sphinx-build -j8 -b html -d _build/doctrees -D html_theme_options.collapse_navigation=True . _build/html
 
+err=0
+
+check() {
+    if "$@"; then
+        color_message 92 "Passed!"
+    else
+        color_message 91 "Failed!"
+        err=1
+    fi
+}
+
+color_message 94 "Validating HTML..."
+check java -jar ../node_modules/vnu-jar/build/dist/vnu.jar \
+    --filterfile ../tools/documentation.vnufilter \
+    --skip-non-html \
+    _build/html
+
 if [ -n "$skip_check_links" ]; then
     color_message 94 "Skipped testing links in documentation."
-    exit 0
+else
+    cd ../tools/documentation_crawler
+    if [ -n "$skip_external_links" ]; then
+        color_message 94 "Testing only internal links in documentation..."
+        check scrapy crawl_with_status documentation_crawler -a skip_external=set "${loglevel[@]}"
+        # calling crawl directly as parameter needs to be passed
+    else
+        color_message 94 "Testing links in documentation..."
+        check scrapy crawl_with_status documentation_crawler "${loglevel[@]}"
+    fi
 fi
 
-cd ../tools/documentation_crawler
-set +e
-if [ -n "$skip_external_links" ]; then
-    color_message 94 "Testing only internal links in documentation..."
-    scrapy crawl_with_status documentation_crawler -a skip_external=set "${loglevel[@]}"
-    # calling crawl directly as parameter needs to be passed
-else
-    color_message 94 "Testing links in documentation..."
-    scrapy crawl_with_status documentation_crawler "${loglevel[@]}"
-fi
-
-result=$?
-if [ "$result" -ne 0 ]; then
-    color_message 91 "Failed!"
-    exit 1
-else
-    color_message 92 "Passed!"
-    exit 0
-fi
+exit "$err"

--- a/tools/test-help-documentation
+++ b/tools/test-help-documentation
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 import argparse
+import contextlib
 import os
 import sys
 import subprocess
-from typing import List
+from typing import Iterator
 
 ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -30,13 +31,28 @@ os.makedirs('var/help-documentation', exist_ok=True)
 LOG_FILE = 'var/help-documentation/server.log'
 external_host = "localhost:9981"
 
-extra_args = []  # type: List[str]
+extra_args = ['-a', 'validate_html=set']
 
 if options.skip_external_link_check:
-    extra_args = ['-a', 'skip_external=set']
+    extra_args += ['-a', 'skip_external=set']
 
-with test_server_running(options.force, external_host, log_file=LOG_FILE,
-                         dots=True, use_db=True):
+@contextlib.contextmanager
+def vnu_servlet() -> Iterator[None]:
+    with subprocess.Popen([
+        'java', '-cp',
+        os.path.join(
+            os.path.dirname(__file__),
+            '../node_modules/vnu-jar/build/dist/vnu.jar',
+        ),
+        'nu.validator.servlet.Main',
+        '9988',
+    ]) as proc:
+        yield
+        proc.terminate()
+
+with vnu_servlet(), \
+    test_server_running(options.force, external_host, log_file=LOG_FILE,
+                        dots=True, use_db=True):
     ret_help_doc = subprocess.call(['scrapy', 'crawl_with_status'] + extra_args +
                                    ['help_documentation_crawler'],
                                    cwd='tools/documentation_crawler')

--- a/version.py
+++ b/version.py
@@ -21,4 +21,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '35.0'
+PROVISION_VERSION = '35.1'

--- a/yarn.lock
+++ b/yarn.lock
@@ -11220,6 +11220,11 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
+vnu-jar@^19.6.7:
+  version "19.6.7"
+  resolved "https://registry.yarnpkg.com/vnu-jar/-/vnu-jar-19.6.7.tgz#b93bf99c11b64b2405d298dae3f511debece7db9"
+  integrity sha512-uBI4pvolFIbhVQuYempGKsV86kNV5bCH1wVsHPbPCuEtAMk4IovdksO2bdPERUiPRGWgHmJ9A9O/N8FydP4JOg==
+
 void-elements@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"


### PR DESCRIPTION
The first three commits resolve many but not all of the outstanding HTML validation problems. They can be merged at any time.

The last two commits add HTML validation to `test-documentation` and `test-help-documentation`, but they’ll have to wait until we kill Trusty because `vnu.jar` requires Java 8. Many real HTML errors remain whitelisted for now, but at least we can start making sure we don’t get new ones.

**Testing Plan:** Run `tools/test-documentation --skip-check-links`, `tools/test-help-documentation --skip-external-links`.