### PR TITLE
Fix IntegrityError handling in analytics code path

### DIFF
--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -368,6 +368,16 @@ class AnalyticsBouncerTest(BouncerTestCase):
                                subdomain="")
         self.assert_json_error(result, "Data is out of order.")
 
+        print(realm_count_data)
+        print(installation_count_data)
+        with mock.patch("zilencer.views.validate_count_stats"):
+            result = self.api_post(self.server_uuid,
+                                   '/api/v1/remotes/server/analytics',
+                                   {'realm_counts': ujson.dumps(realm_count_data),
+                                    'installation_counts': ujson.dumps(installation_count_data)},
+                                   subdomain="")
+            self.assert_json_error(result, "Data is out of order.")
+
     @override_settings(PUSH_NOTIFICATION_BOUNCER_URL='https://push.zulip.org.example.com')
     @mock.patch('zerver.lib.push_notifications.requests.request')
     def test_analytics_api_invalid(self, mock_request: Any) -> None:

--- a/zilencer/models.py
+++ b/zilencer/models.py
@@ -64,4 +64,4 @@ class RemoteRealmCount(BaseCount):
         ]
 
     def __str__(self) -> str:
-        return "%s %s %s %s %s" % (self.server, self.realm_id, self.property, self.subgroup, self.value)
+        return "%s %s %s %s %s %s" % (self.server, self.realm_id, self.property, self.subgroup, self.value, self.end_time)

--- a/zilencer/views.py
+++ b/zilencer/views.py
@@ -153,6 +153,7 @@ def remote_server_notify_push(request: HttpRequest, entity: Union[UserProfile, R
 
 def validate_count_stats(server: RemoteZulipServer, model: Any,
                          counts: List[Dict[str, Any]]) -> None:
+    print("HERE")
     last_id = get_last_id_from_server(server, model)
     for item in counts:
         if item['property'] not in COUNT_STATS:
@@ -203,7 +204,10 @@ def remote_server_post_analytics(request: HttpRequest,
                 subgroup=item['subgroup'],
                 value=item['value']))
         try:
+            print(RemoteRealmCount.objects.all())
+            print(objects_to_create)
             RemoteRealmCount.objects.bulk_create(objects_to_create)
+            print("B")
         except IntegrityError:
             logging.warning("Invalid data saving RemoteRealmCount for server %s/%s" % (
                 server.hostname, server.uuid))


### PR DESCRIPTION
This PR is busted only in that the second commit, which should test the IntegrityError code path, does not, apparently because the `mock.patch` line isn't actually mocking the function it should be (apparently through the print statements in the test).

I'd love it if someone could help debug that issue so we can integrate this.