### PR TITLE
[WIP]: Change consider_bankruptcy to use UserPresence instead of pointer. 

### DIFF
--- a/static/js/unread_ui.js
+++ b/static/js/unread_ui.js
@@ -78,9 +78,7 @@ function consider_bankruptcy() {
         return;
     }
 
-    var now = new XDate(true).getTime() / 1000;
-    if (page_params.unread_msgs.count > 500 &&
-            now - page_params.furthest_read_time > 60 * 60 * 24 * 2) { // 2 days.
+    if (page_params.should_consider_bankruptcy) {
         var rendered_modal = templates.render('bankruptcy_modal', {
             unread_count: page_params.unread_msgs.count});
         $('#bankruptcy-unread-count').html(rendered_modal);

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -787,6 +787,29 @@ class EventsRegisterTest(ZulipTestCase):
         error = schema_checker('events[0]', events[0])
         self.assert_on_error(error)
 
+    def test_should_consider_bankruptcy(self) -> None:
+        user = self.example_user('hamlet')
+
+        msg_id = self.send_stream_message(
+            self.example_email('hamlet'),
+            'Verona',
+            'Test'
+        )
+        user.pointer = msg_id
+        state = fetch_initial_state_data(user, ['update_message_flags', 'message'],
+                                         '', client_gravatar=False)
+        self.assertEqual(state['should_consider_bankruptcy'], False)
+
+        for i in range(501):
+            self.send_stream_message(
+                self.example_email('othello'),
+                'Verona',
+                'Test'
+            )
+        state = fetch_initial_state_data(user, ['update_message_flags', 'message'],
+                                         '', client_gravatar=False)
+        self.assertEqual(state['should_consider_bankruptcy'], False)
+
     def test_update_read_flag_removes_unread_msg_ids(self) -> None:
 
         user_profile = self.example_user('hamlet')
@@ -3312,7 +3335,7 @@ class FetchQueriesTest(ZulipTestCase):
                     client_gravatar=False,
                 )
 
-        self.assert_length(queries, 33)
+        self.assert_length(queries, 34)
 
         expected_counts = dict(
             alert_words=0,
@@ -3339,7 +3362,7 @@ class FetchQueriesTest(ZulipTestCase):
             subscription=6,
             update_display_settings=0,
             update_global_notifications=0,
-            update_message_flags=5,
+            update_message_flags=6,
             user_status=1,
             zulip_version=0,
         )

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -185,6 +185,7 @@ class HomeTest(ZulipTestCase):
             "server_generation",
             "server_inline_image_preview",
             "server_inline_url_embed_preview",
+            "should_consider_bankruptcy",
             "starred_message_counts",
             "starred_messages",
             "stop_words",
@@ -228,7 +229,7 @@ class HomeTest(ZulipTestCase):
             with patch('zerver.lib.cache.cache_set') as cache_mock:
                 result = self._get_home_page(stream='Denmark')
 
-        self.assert_length(queries, 45)
+        self.assert_length(queries, 46)
         self.assert_length(cache_mock.call_args_list, 7)
 
         html = result.content.decode('utf-8')
@@ -294,7 +295,7 @@ class HomeTest(ZulipTestCase):
                 result = self._get_home_page()
                 self.assertEqual(result.status_code, 200)
                 self.assert_length(cache_mock.call_args_list, 6)
-            self.assert_length(queries, 42)
+            self.assert_length(queries, 43)
 
     @slow("Creates and subscribes 10 users in a loop.  Should use bulk queries.")
     def test_num_queries_with_streams(self) -> None:
@@ -326,7 +327,7 @@ class HomeTest(ZulipTestCase):
         with queries_captured() as queries2:
             result = self._get_home_page()
 
-        self.assert_length(queries2, 39)
+        self.assert_length(queries2, 40)
 
         # Do a sanity check that our new streams were in the payload.
         html = result.content.decode('utf-8')


### PR DESCRIPTION
https://github.com/zulip/zulip/issues/4120

Currently in the process of moving the bankruptcy check from the frontend to backend as detailed in 
https://github.com/zulip/zulip/issues/4120#issuecomment-321090438. 

