### PR TITLE
Audio calls

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -1018,6 +1018,31 @@ exports.initialize = function () {
         }
     });
 
+        $('body').on('click', '.audio_link', function (e) {
+        e.preventDefault();
+
+        var target_textarea;
+        // The data-message-id atribute is only present in the video
+        // call icon present in the message edit form.  If present,
+        // the request is for the edit UI; otherwise, it's for the
+        // compose box.
+        var edit_message_id = $(e.target).attr('data-message-id');
+        if (edit_message_id !== undefined) {
+            target_textarea = $("#message_edit_content_" + edit_message_id);
+        }
+
+        if (page_params.jitsi_server_url === null) {
+            return;
+        }
+
+        var video_call_link;
+        var video_call_id = util.random_int(100000000000000, 999999999999999);
+        // This is currently only enabled for jitsi servers, so we don't need
+        // any logic to determine provider.
+        video_call_link = page_params.jitsi_server_url + "/" +  video_call_id + "#config.startWithVideoMuted=true";
+        insert_video_call_url(video_call_link, target_textarea);
+    });
+
     $("#compose").on("click", "#markdown_preview", function (e) {
         e.preventDefault();
         var content = $("#compose-textarea").val();

--- a/static/templates/message_edit_form.handlebars
+++ b/static/templates/message_edit_form.handlebars
@@ -43,6 +43,7 @@
                     <a class="message-control-button fa fa-font" aria-hidden="true" title="{{t 'Formatting' }}" data-overlay-trigger="message-formatting" ></a>
                     <a class="message-control-button fa fa-paperclip notdisplayed" aria-hidden="true" id="attach_files_{{message_id}}" href="#" title="{{t "Attach files" }}"></a>
                     <a class="message-control-button fa fa-video-camera video_link" aria-hidden="true" href="#" data-message-id="{{message_id}}" title="{{t "Add video call" }}"></a>
+                    <a class="message-control-button fa fa-video-camera audio_link" aria-hidden="true" href="#" data-message-id="{{message_id}}" title="{{t "Add audio call" }}"></a>
                     <a id="undo_markdown_preview_{{message_id}}" class="message-control-button fa fa-edit" aria-hidden="true" style="display:none;" title="{{t 'Write' }}"></a>
                     <a id="markdown_preview_{{message_id}}" class="message-control-button fa fa-eye" aria-hidden="true" title="{{t 'Preview' }}"></a>
                 </div>

--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -98,7 +98,8 @@
                                     <a class="message-control-button fa fa-smile-o" aria-hidden="true" id="emoji_map" href="#" title="{{ _('Add emoji') }}"></a>
                                     <a class="message-control-button fa fa-font" aria-hidden="true" title="{{ _('Formatting') }}" data-overlay-trigger="message-formatting"></a>
                                     <a class="message-control-button fa fa-paperclip notdisplayed" aria-hidden="true" id="attach_files" href="#" title="{{ _('Attach files') }}"></a> {% if jitsi_server_url %}
-                                    <a class="message-control-button fa fa-video-camera video_link" aria-hidden="true" href="#" title="{{ _('Add video call') }}"></a> {% endif %}
+                                    <a class="message-control-button fa fa-video-camera video_link" aria-hidden="true" href="#" title="{{ _('Add video call') }}"></a>
+                                    {% if realm_video_chat_provider == 'Jitsi' %}<a class="message-control-button fa fa-phone audio_link" aria-hidden="true" href="#" title="{{ _('Add audio call') }}"></a> {% endif %}{% endif %}
                                     <a id="undo_markdown_preview" class="message-control-button fa fa-edit" aria-hidden="true" style="display:none;" title="{{ _('Write') }}"></a>
                                     <a id="markdown_preview" class="message-control-button fa fa-eye" aria-hidden="true" title="{{ _('Preview') }}"></a>
                                     <a class="drafts-link" href="#drafts" title="{{ _('Drafts') }} (d)">{{ _('Drafts') }}</a>

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -279,7 +279,6 @@ def home_real(request: HttpRequest) -> HttpResponse:
         emojiset = UserProfile.GOOGLE_BLOB_EMOJISET
 
     navbar_logo_url = compute_navbar_logo_url(page_params)
-
     response = render(request, 'zerver/app/index.html',
                       context={'user_profile': user_profile,
                                'emojiset': emojiset,
@@ -295,6 +294,7 @@ def home_real(request: HttpRequest) -> HttpResponse:
                                'show_plans': show_plans,
                                'is_admin': user_profile.is_realm_admin,
                                'is_guest': user_profile.is_guest,
+                               'realm_video_chat_provider': page_params.get('realm_video_chat_provider'),
                                'night_mode': user_profile.night_mode,
                                'navbar_logo_url': navbar_logo_url,
                                'show_webathena': user_profile.realm.webathena_enabled,


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
PR for https://github.com/zulip/zulip/issues/12207

**Testing Plan:** <!-- How have you tested? -->
Open chat with jitsi as video provider and see that the phone icon is available and the link generated includes the parameter.

Change chat provider to something else and verify that the icon is no longer present

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
With hangouts configured as video provider:
<img width="903" alt="hangouts" src="https://user-images.githubusercontent.com/1089738/56795395-b6f84480-6810-11e9-83bd-8c2d9d70773a.png">

With jitsi configured as video provider:
<img width="921" alt="jitsi" src="https://user-images.githubusercontent.com/1089738/56795396-b6f84480-6810-11e9-9d48-9301f41d2027.png">


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->

One issue I was not able to resolve is removing the phone icon dynamically when the video provider is changed. So, if you change from jitsi to hangouts the icon will be visible until the next refresh. Any tips on how to resolve that?
