### PR TITLE
[WIP]stream settings: Disable Mobile notifications if push bouncer not set up.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -556,18 +556,23 @@ exports.initialize = function () {
         e.stopPropagation();
     });
 
-    $("#subscriptions_table").on("click", "#sub_setting_not_in_home_view",
-                                 stream_home_view_clicked);
-    $("#subscriptions_table").on("click", "#sub_desktop_notifications_setting",
-                                 stream_desktop_notifications_clicked);
-    $("#subscriptions_table").on("click", "#sub_audible_notifications_setting",
-                                 stream_audible_notifications_clicked);
-    $("#subscriptions_table").on("click", "#sub_push_notifications_setting",
-                                 stream_push_notifications_clicked);
-    $("#subscriptions_table").on("click", "#sub_email_notifications_setting",
-                                 stream_email_notifications_clicked);
-    $("#subscriptions_table").on("click", "#sub_pin_setting",
-                                 stream_pin_clicked);
+    $("#subscriptions_table").on("click", function (e) {
+        var checkbox_div_elem = $(e.target).closest('.sub_setting_checkbox');
+        var checkbox_id = checkbox_div_elem.attr("id");
+        if (checkbox_id === "sub_setting_not_in_home_view") {
+            stream_home_view_clicked(e);
+        } else if (checkbox_id === "sub_desktop_notifications_setting") {
+            stream_desktop_notifications_clicked(e);
+        } else if (checkbox_id === "sub_audible_notifications_setting") {
+            stream_audible_notifications_clicked(e);
+        } else if (checkbox_id === "sub_push_notifications_setting") {
+            stream_push_notifications_clicked(e);
+        } else if (checkbox_id === "sub_email_notifications_setting") {
+            stream_email_notifications_clicked(e);
+        } else if (checkbox_id === "sub_pin_setting") {
+            stream_pin_clicked(e);
+        }
+    });
 
     $("#subscriptions_table").on("submit", ".subscriber_list_add form", function (e) {
         e.preventDefault();

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -569,6 +569,9 @@ exports.initialize = function () {
         } else if (checkbox_id === "sub_audible_notifications_setting") {
             stream_audible_notifications_clicked(e);
         } else if (checkbox_id === "sub_push_notifications_setting") {
+            if (!page_params.realm_push_notifications_enabled) {
+                return;
+            }
             stream_push_notifications_clicked(e);
         } else if (checkbox_id === "sub_email_notifications_setting") {
             stream_email_notifications_clicked(e);

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -558,6 +558,9 @@ exports.initialize = function () {
 
     $("#subscriptions_table").on("click", function (e) {
         var checkbox_div_elem = $(e.target).closest('.sub_setting_checkbox');
+        if (checkbox_div_elem.hasClass('muted-sub')) {
+            return;
+        }
         var checkbox_id = checkbox_div_elem.attr("id");
         if (checkbox_id === "sub_setting_not_in_home_view") {
             stream_home_view_clicked(e);

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -885,6 +885,9 @@ exports.initialize = function () {
         if ($(e.target).closest('.sub_setting_checkbox').hasClass('muted-sub')) {
             return false;
         }
+        if (!page_params.realm_push_notifications_enabled) {
+            return ;
+        }
         // A hack.  Don't change the state of the checkbox if we
         // clicked on the checkbox itself.
         if (control[0] !== e.target) {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -882,6 +882,9 @@ exports.initialize = function () {
 
     $("#subscriptions_table").on("click", ".sub_setting_checkbox", function (e) {
         var control = $(e.target).closest('.sub_setting_checkbox').find('.sub_setting_control');
+        if ($(e.target).closest('.sub_setting_checkbox').hasClass('muted-sub')) {
+            return false;
+        }
         // A hack.  Don't change the state of the checkbox if we
         // clicked on the checkbox itself.
         if (control[0] !== e.target) {

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -65,9 +65,12 @@
                     </li>
                     <li>
                         <div id="sub_push_notifications_setting"
-                          class="sub_setting_checkbox sub_notification_setting {{#unless in_home_view}}muted-sub{{/unless}}">
-                            <input id="push-notifystream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if push_notifications}}checked{{/if}} {{#unless in_home_view}}disabled="disabled"{{/unless}}/>
+                          class="sub_setting_checkbox sub_notification_setting {{#unless in_home_view}}muted-sub{{/unless}} {{#unless page_params.realm_push_notifications_enabled}}control-label-disabled{{/unless}}">
+                            <input id="push-notifystream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if push_notifications}}checked{{/if}} {{#unless in_home_view}}disabled="disabled"{{/unless}}
+                              {{#unless page_params.realm_push_notifications_enabled}}disabled="disabled"{{/unless}}/>
                             <label class="subscription-control-label">{{t "Mobile notifications" }}</label>
+                            <i class="fa fa-question-circle settings-info-icon {{#if page_params.realm_push_notifications_enabled}}hide{{/if}}"   data-toggle="tooltip"
+                              title="{{t 'Mobile push notifications are not configured on this server.' }}"></i>
                         </div>
                     </li>
                     <li>


### PR DESCRIPTION
This commit disables "Mobile notifications" if `push_notifications` are not
enabled. It also adds a tooltip explaining why this is disabled.


**GIFs or Screenshots:** 
![image](https://user-images.githubusercontent.com/40331304/56810983-52130d80-6855-11e9-8dc3-150b6f8b40f8.png)

Fixes : #12208 .