### PR TITLE
Update tools/lint

### DIFF
--- a/circleci/config.yml
+++ b/circleci/config.yml
@@ -1,0 +1,55 @@
+# Python CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-python/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
+      - image: circleci/python:3.6.1
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "requirements.txt" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r requirements.txt
+
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-dependencies-{{ checksum "requirements.txt" }}
+
+      # run tests!
+      # this example uses Django's built-in test-runner
+      # other common Python testing frameworks include pytest and nose
+      # https://pytest.org
+      # https://nose.readthedocs.io
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            python manage.py test
+
+      - store_artifacts:
+          path: test-reports
+          destination: test-reports

--- a/tools/lint
+++ b/tools/lint
@@ -96,7 +96,6 @@ def run():
     linter_config.external_linter('puppet-lint',
                                   ['puppet-lint'] + PUPPET_CHECK_RULES_TO_EXCLUDE, ['pp'])
     linter_config.external_linter('templates', ['tools/check-templates'], ['handlebars', 'html'])
-    linter_config.external_linter('urls', ['tools/check-urls'], ['py'])
     linter_config.external_linter('swagger', ['node', 'tools/check-swagger'], ['yaml'])
     linter_config.external_linter('shellcheck', ['shellcheck', '-x'], ['sh'])
     if not args.no_mypy:


### PR DESCRIPTION
minor: Remove call check-urls funtcion


The function "Check-urls" was useful just for the migration to Django 1.10 
--
Verify all the calls to the function "Check-urls" were removed from the project.
--
