### PR TITLE
settings: Fix broken headers in night mode.

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -329,6 +329,7 @@ on a dark background, and don't change the dark labels dark either. */
         background-color: hsla(0, 0%, 0%, 0.2);
     }
 
+    thead,
     #searchbox,
     #searchbox_legacy,
     .drafts-header,
@@ -341,12 +342,16 @@ on a dark background, and don't change the dark labels dark either. */
     #settings_page .form-sidebar .title,
     #settings_page .sidebar li.active,
     #settings_page .sidebar .tab-container,
-    .table-striped tbody tr:nth-child(odd) td,
+    .table-striped tbody tr:nth-child(even) td,
     .table-striped tbody tr:nth-child(odd) th,
     .modal-footer,
     .modal-bg .modal-header {
         border-color: hsla(0, 0%, 0%, 0.2);
         background-color: hsla(0, 0%, 0%, 0.2);
+    }
+
+    .table-striped tbody tr:nth-child(odd) td {
+        background-color: hsl(212, 28%, 18%);
     }
 
     .modal-footer {

--- a/static/templates/settings/auth-methods-settings-admin.handlebars
+++ b/static/templates/settings/auth-methods-settings-admin.handlebars
@@ -5,10 +5,11 @@
             <div class="alert-notification" id="admin-realm-authentication-methods-status"></div>
             <p>{{#tr this}}Configure the authentication methods for your organization.{{/tr}}</p>
             <table class="table table-condensed table-striped">
-                <tbody id="admin_auth_methods_table" class=" admin_auth_methods_table">
+                <thead>
                     <th>{{t "Method" }}</th>
                     <th>{{t "Enabled" }}</th>
-                </tbody>
+                </thead>
+                <tbody id="admin_auth_methods_table" class=" admin_auth_methods_table"></tbody>
             </table>
         </div>
         <div id="admin_page_auth_methods_loading_indicator"></div>

--- a/static/templates/settings/emoji-settings-admin.handlebars
+++ b/static/templates/settings/emoji-settings-admin.handlebars
@@ -25,15 +25,16 @@
             <span id="emoji_file_input_error" class="text-error"></span>
         </div>
     </form>
+    <p>{{#tr this}}Add extra emoji for members of the __realm_name__ organization.{{/tr}}</p>
     <div class="admin-table-wrapper">
-        <p>{{#tr this}}Add extra emoji for members of the __realm_name__ organization.{{/tr}}</p>
-        <table class="table table-condensed table-striped admin_emoji_table">
-            <tbody id="admin_emoji_table">
+        <table class="table table-condensed table-striped wrapped-table admin_emoji_table">
+            <thead>
                 <th>{{t "Name" }}</th>
                 <th class="image">{{t "Image" }}</th>
                 <th class="image">{{t "Author" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
-            </tbody>
+            </thead>
+            <tbody id="admin_emoji_table"></tbody>
         </table>
     </div>
 </div>


### PR DESCRIPTION
This bug turned out to pop up wherever a table existed in both
'settings' and 'organization settings', notably *excluding* both
'Custom Emoji' and 'Authentication Methods'.

The first thought to the solution was to simply add `thead` to the css
rule that applies the appropiate color for headers and the like.  This
was successful, however it brought attention to a sub-problem:

`emoji-settings-admin` and `auth-mehtod-settings-admin` were both
creating table headers in the body of the table. This was causing the
rows in these two tables to be colored inversely from all the others.
This is also the reason why these tables are the only ones correctly
styled. These handlebars were updated with the headers moved out of the
body.

The even and odd rows of the tables were then colored appropriately.

Fixes: #12209

All tables are now styled similarly to the following:
<img width="811" alt="Screen Shot 2019-04-26 at 9 25 54 PM" src="https://user-images.githubusercontent.com/39782863/56846528-1172be80-686c-11e9-957e-69e860a7b21e.png">


