### PR TITLE
electron-bridge: Send PM count to Electron app

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -228,10 +228,15 @@ function flash_pms() {
 }
 
 exports.update_pm_count = function () {
-    // TODO: Add a `window.electron_bridge.updatePMCount(new_pm_count);` call?
     if (!flashing) {
         flashing = true;
         flash_pms();
+    }
+    if (window.electron_bridge !== undefined) {
+        window.electron_bridge.send_event('unread_pm_count', {
+            unread_pm_count: unread.get_counts().private_message_count,
+            realm_uri: page_params.realm_uri,
+        });
     }
 };
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

The discussion [here](https://chat.zulip.org/#narrow/stream/16-desktop/topic/macOS.20Bouncing.20Dock.20Icon/near/733520) says that users find a repeatedly bouncing dock icon irritating and controlling that would require a change of what events are sent to the desktop app. 

This PR sends the unread PM count along with the corresponding realm URI to the desktop app via `window.electron-bridge`. 


**Testing Plan:** <!-- How have you tested? -->

Ran `./tools/test-all`. 
Checked with desktop app console logs if the relevant event was being sent. 

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
