### PR TITLE
Alignment of first line of text in message view

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1234,7 +1234,7 @@ div.focused_table {
 }
 
 .include-sender .message_content:not(:empty) {
-    margin-top: -16px;
+    margin-top: -18px;
 }
 
 .message_content {


### PR DESCRIPTION
Decreased the top margin of messages to align better with the profile picture of the user in the message view.

[Relevant conversation](https://chat.zulip.org/#narrow/stream/101-design/topic/alignment.20of.20first.20line.20of.20text/near/736021)

**Screenshots**:
![Screenshot from 2019-04-28 00-04-24](https://user-images.githubusercontent.com/25329595/56900076-9b13cd80-6ab2-11e9-993c-fa74d9eb004b.png)


![Screenshot from 2019-04-28 00-04-59](https://user-images.githubusercontent.com/25329595/56900081-a0711800-6ab2-11e9-97a1-baaac713ee89.png)
