### PR TITLE
open graph: Use the complete URL for open graph URLs.

### DIFF
--- a/templates/zerver/meta_tags.html
+++ b/templates/zerver/meta_tags.html
@@ -6,7 +6,7 @@
 {% endif %}
 
 <!-- Open Graph / Facebook Meta Tags -->
-<meta property="og:url" content="{{ realm_uri }}">
+<meta property="og:url" content="{{ OPEN_GRAPH_URL }}">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Zulip">
 {% if OPEN_GRAPH_TITLE %}

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -133,6 +133,7 @@ def zulip_default_context(request: HttpRequest) -> Dict[str, Any]:
         'allow_search_engine_indexing': allow_search_engine_indexing,
     }
 
+    context['OPEN_GRAPH_URL'] = '%s%s' % (realm_uri, request.path)
     if realm is not None and realm.icon_source == realm.ICON_UPLOADED:
         context['OPEN_GRAPH_IMAGE'] = '%s%s' % (realm_uri, realm_icon)
 

--- a/zerver/tests/test_middleware.py
+++ b/zerver/tests/test_middleware.py
@@ -184,3 +184,13 @@ class OpenGraphTest(ZulipTestCase):
         twitter_image = bs.select_one('meta[name="twitter:image"]').get('content')
         self.assertTrue(open_graph_image.endswith(realm_icon))
         self.assertTrue(twitter_image.endswith(realm_icon))
+
+    def test_no_realm_api_page_og_url(self) -> None:
+        response = self.client_get('/api/', subdomain='')
+        self.assertEqual(response.status_code, 200)
+
+        decoded = response.content.decode('utf-8')
+        bs = BeautifulSoup(decoded, features='lxml')
+        open_graph_url = bs.select_one('meta[property="og:url"]').get('content')
+
+        self.assertTrue(open_graph_url.endswith('/api/'))


### PR DESCRIPTION
Closes #12199

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

The og:url parameter is a [required parameter](http://ogp.me/) and should be the canonical URL for the page.  This PR changes the value of og:url from just the realm URL to the full URL of the page. 

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
