### PR TITLE
settings: Don't check mobile notifications if they are disabled.

### DIFF
--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -109,6 +109,9 @@ exports.set_up = function () {
 
 exports.update_page = function () {
     _.each(exports.notification_settings, function (setting) {
+        if (setting === 'enable_offline_push_notifications' && !page_params.realm_push_notifications_enabled) {
+            return;
+        }
         $("#" + setting).prop('checked', page_params[setting]);
     });
 };


### PR DESCRIPTION
Fixes #12198.
AFAIK there are no unit tests for settings_notifications, please let me know if that's not the case.

![Peek 2019-04-30 12-04](https://user-images.githubusercontent.com/13910561/56940310-1a031780-6b40-11e9-89a9-48aa0de1057b.gif)
