### PR TITLE
test-backend: Change --parallel default to use `cpu_count`.

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -187,6 +187,8 @@ def main() -> None:
     os.chdir(os.path.dirname(TOOLS_DIR))
     sys.path.insert(0, os.path.dirname(TOOLS_DIR))
 
+    default_parallel = os.cpu_count()
+
     # Remove proxy settings for running backend tests
     os.environ["http_proxy"] = ""
     os.environ["https_proxy"] = ""
@@ -227,9 +229,9 @@ def main() -> None:
     parser.add_argument('--parallel', dest='processes',
                         type=int,
                         action='store',
-                        default=4,
+                        default=default_parallel,
                         help='Specify the number of processes to run the '
-                             'tests in. Default is 4.')
+                             'tests in. Default is the number of logical CPUs')
     parser.add_argument('--profile', dest='profile',
                         action="store_true",
                         default=False, help='Profile test runtime.')


### PR DESCRIPTION
The number of processes to run the backend tests is currently a
hardcoded value, this commit transistions the default to be based on the
number of CPUs available.

**Testing Plan:** Changed the number of CPUs and ran `tools/test-backend`
