### PR TITLE
bugdown: Fix double processed emoji tags inside inline tags.

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1153,7 +1153,7 @@ def make_emoji(codepoint: str, display_string: str) -> Element:
     span.set('title', title)
     span.set('role', 'img')
     span.set('aria-label', title)
-    span.text = display_string
+    span.text = markdown.util.AtomicString(display_string)
     return span
 
 def make_realm_emoji(src: str, display_string: str) -> Element:

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -249,6 +249,12 @@
       "text_content": "foo"
     },
     {
+      "name": "star_emoji",
+      "input": "**:smile:**",
+      "expected_output": "<p><strong><span aria-label=\"smile\" class=\"emoji emoji-263a\" role=\"img\" title=\"smile\">:smile:</span></strong></p>",
+      "text_content": "\u263A"
+    },
+    {
       "name": "star_strong_em",
       "input": "***foo***",
       "expected_output": "<p><strong><em>foo</em></strong></p>",


### PR DESCRIPTION
When an emoji is nested inside another inline tag, like em or strong
it was getting double processed because of the way the inlinePattern
TreeProcessor runs (it runs recursively). With this fix, we set the
inner text of the emoji span as an AtomicString, preventing us from
double processing the emoji's text.

Fixes #11621

Test Plan: Added test case for **:smile:**, verify it passes. Go into
local dev server and send "**:smile:**" to self and verify the DOM
does not have double <span> tags for the emoji.