### PR TITLE
User status code cleanup

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -209,6 +209,7 @@ exports.initialize = function () {
         e.stopPropagation();
         var user_status_value = $(e.currentTarget).attr("data-user-status-value");
         $("input.user_status").val(user_status_value);
+        user_status_ui.toggle_clear_message_button();
         user_status_ui.update_button();
     });
 

--- a/static/js/user_status_ui.js
+++ b/static/js/user_status_ui.js
@@ -24,6 +24,7 @@ exports.open_overlay = function () {
     field.val(old_status_text);
     field.select();
     field.focus();
+    exports.toggle_clear_message_button();
 
     var button = exports.submit_button();
     button.attr('disabled', true);
@@ -66,12 +67,32 @@ exports.update_button = function () {
     }
 };
 
+exports.toggle_clear_message_button = function () {
+    if (exports.input_field().val() !== '') {
+        $('#clear_status_message_button').prop('disabled', false);
+    } else {
+        $('#clear_status_message_button').prop('disabled', true);
+    }
+};
+
+exports.clear_message = function () {
+    var field = exports.input_field();
+    field.val('');
+    $('#clear_status_message_button').prop('disabled', true);
+};
+
 exports.initialize = function () {
     $('body').on('click', '.user_status_overlay .set_user_status', function () {
         exports.submit_new_status();
     });
 
     $('body').on('keyup', '.user_status_overlay input.user_status', function () {
+        exports.update_button();
+        exports.toggle_clear_message_button();
+    });
+
+    $('#clear_status_message_button').on('click', function () {
+        exports.clear_message();
         exports.update_button();
     });
 };

--- a/static/styles/app_components.scss
+++ b/static/styles/app_components.scss
@@ -327,6 +327,12 @@
     -webkit-box-shadow: none;
     -moz-box-shadow: none;
     z-index: 5;
+
+    .user_status_overlay & {
+        margin-left: -26px;
+        right: 0;
+        padding-top: 6px;
+    }
 }
 
 .grey-box {

--- a/static/styles/user_status.scss
+++ b/static/styles/user_status.scss
@@ -48,14 +48,17 @@
     }
 
     .user-status-options {
-        padding: 20px;
-        padding-top: 0;
-        padding-bottom: 3px;
-        line-height: 1.0em;
-    }
+        padding: 0 20px 3px;
 
-    .user-status-options p:hover {
-        cursor: pointer;
-        color: hsl(200, 100%, 40%);
+        button.user-status-value:hover {
+            color: hsl(200, 100%, 40%);
+        }
+
+        .user-status-value {
+            width: 100%;
+            text-align: left;
+            margin-bottom: 10px;
+            line-height: 1.1em;
+        }
     }
 }

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -163,11 +163,11 @@
                 <input type="text" class="user_status" maxlength="60" />
             </div>
             <div class="user-status-options">
-                <p class="user-status-value" data-user-status-value="In a meeting">In a meeting</p>
-                <p class="user-status-value" data-user-status-value="Commuting">Commuting</p>
-                <p class="user-status-value" data-user-status-value="Out sick">Out sick</p>
-                <p class="user-status-value" data-user-status-value="Vacationing">Vacationing</p>
-                <p class="user-status-value" data-user-status-value="Working remotely">Working remotely</p>
+                <button type="button" class="button no-style user-status-value" data-user-status-value="In a meeting">In a meeting</button>
+                <button type="button" class="button no-style user-status-value" data-user-status-value="Commuting">Commuting</button>
+                <button type="button" class="button no-style user-status-value" data-user-status-value="Out sick">Out sick</button>
+                <button type="button" class="button no-style user-status-value" data-user-status-value="Vacationing">Vacationing</button>
+                <button type="button" class="button no-style user-status-value" data-user-status-value="Working remotely">Working remotely</button>
             </div>
             <div class="modal-footer">
                 <button class="button exit small rounded">Cancel</button>

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -161,6 +161,9 @@
             <div class="modal-body">
                 <label for="user_status">Status message</label>
                 <input type="text" class="user_status" maxlength="60" />
+                <button type="button" class="btn clear_search_button" id="clear_status_message_button" disabled="disabled">
+                    <i class="fa fa-remove" aria-hidden="true"></i>
+                </button>
             </div>
             <div class="user-status-options">
                 <button type="button" class="button no-style user-status-value" data-user-status-value="In a meeting">In a meeting</button>


### PR DESCRIPTION
This is a followup to this PR: https://github.com/zulip/zulip/pull/12179

1. I changed the `<p>`s from user status into buttons, and changed the css accordingly. I also increased the line height because on Safari the letter `g` was not visible entirely.

2. I added the `x` icon that allows users to clear the text if they need it. I think sometimes it is annoying when you do not have it. I did it in a separate commit, therefore if it is not wanted is easily removable. I carefully added the `x` without changing the behavior of the `Save` button

![userStatus](https://user-images.githubusercontent.com/18381652/57042790-ffc35980-6c65-11e9-81e3-a7096f571fe0.gif)

