### PR TITLE
circleci: Fix redis on Bionic.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ jobs:
           command: |
               # Temporary hack till `sudo service redis-server start` gets fixes in Bionic. See
               # https://chat.zulip.org/#narrow/stream/3-backend/topic/Ubuntu.20bionic.20CircleCI
-              redis-server --daemonize yes
+              sudo sed -i '/^bind/s/bind.*/bind 0.0.0.0/' /etc/redis/redis.conf
 
       - *restore_cache_package_json
       - *restore_cache_requirements


### PR DESCRIPTION
I posted a more detailed explanation/report in https://chat.zulip.org/#narrow/stream/3-backend/topic/Ubuntu.20bionic.20CircleCI/near/738875

A summary, from the commit message:

Because of "service redis-server start" not working properly, in "do Bionic hack" another instance of the server was being started. However, once in a while this would fail for unknown reasons causing flakes in tests involving redis. The cause of the service not starting was the error:
`` ::1:6379: bind: Cannot assign requested address ``
(see https://github.com/antirez/redis/issues/3241)
This is fixed by editing /etc/redis/redis.conf to not attempt binding on IPv6. We change "do Bionic hack" to a simple sed command, changing the appropriate line in the file. By default, the line is  `` bind 127.0.0.1 ::1 ``. We change it to `` bind 0.0.0.0 ``.
