### PR TITLE
docs: Fix upgrade process for Ubuntu 16.04 -> 18.04

### DIFF
--- a/docs/production/maintain-secure-upgrade.md
+++ b/docs/production/maintain-secure-upgrade.md
@@ -327,10 +327,11 @@ successfully:
 match the new OS version:
 
     ```
+    touch /usr/share/postgresql/10/pgroonga_setup.sql.applied
     /home/zulip/deployments/current/scripts/zulip-puppet-apply -f
     pg_dropcluster 10 main --stop
     systemctl stop postgresql
-    pg_upgradecluster -m upgrade 9.5 main
+    pg_upgradecluster 9.5 main
     pg_dropcluster 9.5 main
     apt remove postgresql-9.5
     systemctl start postgresql


### PR DESCRIPTION
We need to disable "CREATE EXTENSION pgroonga" in zulip-puppet-apply
by creating /usr/share/postgresql/10/pgroonga_setup.sql.applied.
Because PostgreSQL 10 isn't running in this case. If PostgreSQL 10
isn't running, we can't run "CREATE EXTENSION pgroonga".

We can't use pg_upgrade with PGroonga. PGroonga's install SQL
https://github.com/pgroonga/pgroonga/blob/master/data/pgroonga.sql has
conditions to support multiple PostgreSQL versions. So it's not safe
to use pg_upgrade. pg_upgrade copies metadata for PostgreSQL 9.5 to
PostgreSQL 10. We need to use pg_dump and pg_restore to upgrade
PGroonga correctly for PostgreSQL 10.

**Testing Plan:** <!-- How have you tested? -->

We can test this by creating Ubuntu 16.04 with PGroonga environment and then upgrading to 18.04.
