### PR TITLE
docs: Use systemctl instead of service

### DIFF
--- a/docs/production/maintain-secure-upgrade.md
+++ b/docs/production/maintain-secure-upgrade.md
@@ -334,7 +334,7 @@ match the new OS version:
     pg_dropcluster 9.5 main
     apt remove postgresql-9.5
     systemctl start postgresql
-    service memcached restart
+    systemctl restart memcached
     ```
 
 4. At this point, you are now running the version of postgres that


### PR DESCRIPTION
Because memcached package on Ubuntu 18.04 supports systemd.

**Testing Plan:** <!-- How have you tested? -->

We can test this by creating Ubuntu 18.04 machine, installing `memcached` package and run `sudo systemctl restart memcached`.
