### PR TITLE
get_realm: raise DoesNotExist instead of returning None

### DIFF
--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -280,9 +280,12 @@ class OurAuthenticationForm(AuthenticationForm):
         if username is not None and password:
             subdomain = get_subdomain(self.request)
             try:
-                realm = get_realm(subdomain)  # type: Optional[Realm]
+                realm = get_realm(subdomain)
             except Realm.DoesNotExist:
-                realm = None
+                logging.warning("User %s attempted to password login to nonexistent subdomain %s" %
+                                (username, subdomain))
+                raise ValidationError("Realm does not exist")
+
             return_data = {}  # type: Dict[str, Any]
             self.user_cache = authenticate(self.request, username=username, password=password,
                                            realm=realm, return_data=return_data)

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1121,7 +1121,7 @@ class GoogleSubdomainLoginTest(GoogleOAuthTest):
             user_profile = self.example_user('hamlet')
             with mock.patch(
                     'zerver.views.auth.authenticate_remote_user',
-                    return_value=(user_profile, {'invalid_subdomain': False})):
+                    return_value=user_profile):
                 with mock.patch('zerver.views.auth.do_login'):
                     result = self.get_log_into_subdomain(data)
             return result

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -202,7 +202,7 @@ class AuthBackendTest(ZulipTestCase):
                                              return_data=dict()),
                             bad_kwargs=dict(password=password,
                                             username=username,
-                                            realm=None,
+                                            realm=get_realm('zephyr'),
                                             return_data=dict()))
 
     def test_email_auth_backend_disabled_password_auth(self) -> None:
@@ -269,15 +269,18 @@ class AuthBackendTest(ZulipTestCase):
 
         with mock.patch('apiclient.sample_tools.client.verify_id_token', return_value=payload):
             self.verify_backend(backend,
-                                good_kwargs=dict(realm=get_realm("zulip")),
-                                bad_kwargs=dict(realm=None))
+                                good_kwargs=dict(google_oauth2_token="",
+                                                 realm=get_realm("zulip")),
+                                bad_kwargs=dict(google_oauth2_token="",
+                                                realm=get_realm("zephyr")))
 
         # Verify valid_attestation parameter is set correctly
         unverified_payload = dict(email_verified=False)
         with mock.patch('apiclient.sample_tools.client.verify_id_token',
                         return_value=unverified_payload):
             ret = dict()  # type: Dict[str, str]
-            result = backend.authenticate(realm=get_realm("zulip"), return_data=ret)
+            result = backend.authenticate(
+                google_oauth2_token="", realm=get_realm("zulip"), return_data=ret)
             self.assertIsNone(result)
             self.assertFalse(ret["valid_attestation"])
 
@@ -285,13 +288,15 @@ class AuthBackendTest(ZulipTestCase):
         with mock.patch('apiclient.sample_tools.client.verify_id_token',
                         return_value=nonexistent_user_payload):
             ret = dict()
-            result = backend.authenticate(realm=get_realm("zulip"), return_data=ret)
+            result = backend.authenticate(
+                google_oauth2_token="", realm=get_realm("zulip"), return_data=ret)
             self.assertIsNone(result)
             self.assertTrue(ret["valid_attestation"])
         with mock.patch('apiclient.sample_tools.client.verify_id_token',
                         side_effect=AppIdentityError):
             ret = dict()
-            result = backend.authenticate(realm=get_realm("zulip"), return_data=ret)
+            result = backend.authenticate(
+                google_oauth2_token="", realm=get_realm("zulip"), return_data=ret)
             self.assertIsNone(result)
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
@@ -326,7 +331,7 @@ class AuthBackendTest(ZulipTestCase):
             self.verify_backend(backend,
                                 bad_kwargs=dict(username=username,
                                                 password=password,
-                                                realm=None),
+                                                realm=get_realm('zephyr')),
                                 good_kwargs=dict(username=username,
                                                  password=password,
                                                  realm=get_realm('zulip')))
@@ -336,7 +341,7 @@ class AuthBackendTest(ZulipTestCase):
                             good_kwargs=dict(dev_auth_username=self.get_username(),
                                              realm=get_realm("zulip")),
                             bad_kwargs=dict(dev_auth_username=self.get_username(),
-                                            realm=None))
+                                            realm=get_realm("zephyr")))
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',))
     def test_remote_user_backend(self) -> None:
@@ -354,7 +359,7 @@ class AuthBackendTest(ZulipTestCase):
                             good_kwargs=dict(remote_user=username,
                                              realm=get_realm('zulip')),
                             bad_kwargs=dict(remote_user=username,
-                                            realm=None))
+                                            realm=get_realm('zephyr')))
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',))
     @override_settings(SSO_APPEND_DOMAIN='zulip.com')
@@ -2469,7 +2474,8 @@ class TestLDAP(ZulipLDAPTestCase):
                 LDAP_APPEND_DOMAIN='zulip.com',
                 AUTH_LDAP_BIND_PASSWORD='',
                 AUTH_LDAP_USER_DN_TEMPLATE='uid=%(user)s,ou=users,dc=zulip,dc=com'):
-            user = self.backend.authenticate(self.example_email("hamlet"), 'wrong')
+            user = self.backend.authenticate(self.example_email("hamlet"), 'wrong',
+                                             realm=get_realm('zulip'))
             self.assertIs(user, None)
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
@@ -2483,7 +2489,8 @@ class TestLDAP(ZulipLDAPTestCase):
                 LDAP_APPEND_DOMAIN='zulip.com',
                 AUTH_LDAP_BIND_PASSWORD='',
                 AUTH_LDAP_USER_DN_TEMPLATE='uid=%(user)s,ou=users,dc=zulip,dc=com'):
-            user = self.backend.authenticate('nonexistent@zulip.com', 'testing')
+            user = self.backend.authenticate('nonexistent@zulip.com', 'testing',
+                                             realm=get_realm('zulip'))
             self.assertIs(user, None)
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
@@ -2639,7 +2646,8 @@ class TestLDAP(ZulipLDAPTestCase):
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_login_failure_when_domain_does_not_match(self) -> None:
         with self.settings(LDAP_APPEND_DOMAIN='acme.com'):
-            user_profile = self.backend.authenticate(self.example_email("hamlet"), 'pass')
+            user_profile = self.backend.authenticate(self.example_email("hamlet"), 'pass',
+                                                     realm=get_realm('zulip'))
             self.assertIs(user_profile, None)
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
@@ -2662,21 +2670,6 @@ class TestLDAP(ZulipLDAPTestCase):
             user_profile = self.backend.authenticate(self.example_email('hamlet'), 'testing',
                                                      realm=get_realm('acme'))
             self.assertEqual(user_profile.email, self.example_email('hamlet'))
-
-    @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
-    def test_login_failure_due_to_invalid_subdomain(self) -> None:
-        self.mock_ldap.directory = {
-            'uid=hamlet,ou=users,dc=zulip,dc=com': {
-                'userPassword': ['testing', ]
-            }
-        }
-        with self.settings(
-                LDAP_APPEND_DOMAIN='zulip.com',
-                AUTH_LDAP_BIND_PASSWORD='',
-                AUTH_LDAP_USER_DN_TEMPLATE='uid=%(user)s,ou=users,dc=zulip,dc=com'):
-            user_profile = self.backend.authenticate(self.example_email("hamlet"), 'testing',
-                                                     realm=None)
-            self.assertIs(user_profile, None)
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_login_success_with_valid_subdomain(self) -> None:
@@ -2765,7 +2758,8 @@ class TestLDAP(ZulipLDAPTestCase):
 class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
     def test_authenticate(self) -> None:
         backend = ZulipLDAPUserPopulator()
-        result = backend.authenticate(self.example_email("hamlet"), 'testing')  # type: ignore # complains that the function does not return any value!
+        result = backend.authenticate(self.example_email("hamlet"), 'testing',
+                                      realm=get_realm('zulip'))
         self.assertIs(result, None)
 
     def perform_ldap_sync(self, user_profile: UserProfile) -> None:

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -261,12 +261,11 @@ def remote_user_sso(request: HttpRequest,
 
     subdomain = get_subdomain(request)
     try:
-        realm = get_realm(subdomain)  # type: Optional[Realm]
+        realm = get_realm(subdomain)
     except Realm.DoesNotExist:
-        realm = None
-    # Since RemoteUserBackend will return None if Realm is None, we
-    # don't need to check whether `realm` is None.
-    user_profile = authenticate(remote_user=remote_user, realm=realm)
+        user_profile = None
+    else:
+        user_profile = authenticate(remote_user=remote_user, realm=realm)
 
     redirect_to = request.GET.get('next', '')
 

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -154,7 +154,7 @@ class ZulipDummyBackend(ZulipAuthMixin):
     when explicitly requested by including the use_dummy_backend kwarg.
     """
 
-    def authenticate(self, username: str, realm: Realm,
+    def authenticate(self, *, username: str, realm: Realm,
                      use_dummy_backend: bool=False,
                      return_data: Optional[Dict[str, Any]]=None) -> Optional[UserProfile]:
         if use_dummy_backend:
@@ -168,7 +168,7 @@ class EmailAuthBackend(ZulipAuthMixin):
     Allows a user to sign in using an email/password pair.
     """
 
-    def authenticate(self, username: str, password: str,
+    def authenticate(self, *, username: str, password: str,
                      realm: Realm,
                      return_data: Optional[Dict[str, Any]]=None) -> Optional[UserProfile]:
         """ Authenticate a user based on email address as the user name. """
@@ -201,7 +201,7 @@ class GoogleMobileOauth2Backend(ZulipAuthMixin):
         https://developers.google.com/accounts/docs/CrossClientAuth#offlineAccess
     """
 
-    def authenticate(self, google_oauth2_token: str, realm: Realm,
+    def authenticate(self, *, google_oauth2_token: str, realm: Realm,
                      return_data: Optional[Dict[str, Any]]=None) -> Optional[UserProfile]:
         # We lazily import apiclient as part of optimizing the base
         # import time for a Zulip management command, since it's only
@@ -238,7 +238,7 @@ class ZulipRemoteUserBackend(RemoteUserBackend):
     """
     create_unknown_user = False
 
-    def authenticate(self, remote_user: str, realm: Realm,
+    def authenticate(self, *, remote_user: str, realm: Realm,
                      return_data: Optional[Dict[str, Any]]=None) -> Optional[UserProfile]:
         if not auth_enabled_helper(["RemoteUser"], realm):
             return None
@@ -456,7 +456,7 @@ class ZulipLDAPAuthBackendBase(ZulipAuthMixin, LDAPBackend):
 class ZulipLDAPAuthBackend(ZulipLDAPAuthBackendBase):
     REALM_IS_NONE_ERROR = 1
 
-    def authenticate(self, username: str, password: str, realm: Realm,
+    def authenticate(self, *, username: str, password: str, realm: Realm,
                      prereg_user: Optional[PreregistrationUser]=None,
                      return_data: Optional[Dict[str, Any]]=None) -> Optional[UserProfile]:
         self._realm = realm
@@ -574,7 +574,7 @@ class ZulipLDAPUserPopulator(ZulipLDAPAuthBackendBase):
     registration for organizations that use a different SSO solution
     for managing login (often via RemoteUserBackend).
     """
-    def authenticate(self, username: str, password: str, realm: Realm,
+    def authenticate(self, *, username: str, password: str, realm: Realm,
                      return_data: Optional[Dict[str, Any]]=None) -> Optional[UserProfile]:
         return None
 
@@ -611,7 +611,7 @@ def query_ldap(email: str) -> List[str]:
 class DevAuthBackend(ZulipAuthMixin):
     """Allow logging in as any user without a password.  This is used for
     convenience when developing Zulip, and is disabled in production."""
-    def authenticate(self, dev_auth_username: str, realm: Realm,
+    def authenticate(self, *, dev_auth_username: str, realm: Realm,
                      return_data: Optional[Dict[str, Any]]=None) -> Optional[UserProfile]:
         if not dev_auth_enabled(realm):
             return None

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -753,7 +753,6 @@ def social_auth_finish(backend: Any,
     inactive_user = return_data.get('inactive_user')
     inactive_realm = return_data.get('inactive_realm')
     invalid_realm = return_data.get('invalid_realm')
-    invalid_subdomain = return_data.get('invalid_subdomain')
     invalid_email = return_data.get('invalid_email')
     auth_failed_reason = return_data.get("social_auth_failed_reason")
 
@@ -812,7 +811,6 @@ def social_auth_finish(backend: Any,
         # in the web login flow (below).
         return login_or_register_remote_user(strategy.request, email_address,
                                              user_profile, full_name,
-                                             invalid_subdomain=bool(invalid_subdomain),
                                              mobile_flow_otp=mobile_flow_otp,
                                              is_signup=is_signup,
                                              redirect_to=redirect_to)


### PR DESCRIPTION
This makes the implementation of `get_realm` consistent with its declared return type of `Realm` rather than `Optional[Realm]`.

Fixes #12263.

**Testing Plan:** Passed `test-backend` and `lint`.