### PR TITLE
file_upload: Remove unusable UI elements if file uploading is disabled.

### DIFF
--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -101,6 +101,7 @@ run_test('upload_error', () => {
     var msg_3 = '"foobar.txt" was too large; the maximum file size is 25MB.';
     var msg_4 = 'Sorry, the file was too large.';
     var msg_5 = 'An unknown error occurred.';
+    var msg_6 = 'File and image uploads have been disabled for this organization.';
 
     test('BrowserNotSupported', msg_prefix + msg_1);
     test('TooManyFiles', msg_prefix + msg_2);
@@ -108,6 +109,11 @@ run_test('upload_error', () => {
     test(413, msg_prefix + msg_4);
     test(400, 'ちょっと…', {msg: 'ちょっと…'});
     test('Do-not-match-any-case', msg_prefix + msg_5);
+
+    // If uploading files has been disabled, then a different error message is
+    // displayed when a user tries to paste or drag a file onto the UI.
+    page_params.max_file_upload_size = 0;
+    test('FileTooLarge', msg_prefix + msg_6, null);
 });
 
 run_test('upload_finish', () => {

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -274,6 +274,12 @@ function edit_message(row, raw_content) {
     var editability = get_editability(message, seconds_left_buffer);
     var is_editable = editability === message_edit.editability_types.TOPIC_ONLY ||
                        editability === message_edit.editability_types.FULL;
+    var max_file_upload_size = page_params.max_file_upload_size;
+    var file_upload_enabled = false;
+
+    if (max_file_upload_size > 0) {
+        file_upload_enabled = true;
+    }
 
     var form = $(templates.render(
         'message_edit_form',
@@ -284,6 +290,7 @@ function edit_message(row, raw_content) {
          has_been_editable: editability !== editability_types.NO,
          topic: util.get_message_topic(message),
          content: raw_content,
+         file_upload_enabled: file_upload_enabled,
          minutes_to_edit: Math.floor(page_params.realm_message_content_edit_limit_seconds / 60)}));
 
     var edit_obj = {form: form, raw_content: raw_content};

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -101,12 +101,18 @@ exports.options = function (config) {
             msg = i18n.t("Unable to upload that many files at once.");
             break;
         case 'FileTooLarge':
-            // sanitization not needed as the file name is not potentially parsed as HTML, etc.
-            var context = {
-                file_name: file.name,
-                file_size: page_params.max_file_upload_size,
-            };
-            msg = i18n.t('"__file_name__" was too large; the maximum file size is __file_size__MB.', context);
+            if (page_params.max_file_upload_size > 0) {
+                // sanitization not needed as the file name is not potentially parsed as HTML, etc.
+                var context = {
+                    file_name: file.name,
+                    file_size: page_params.max_file_upload_size,
+                };
+                msg = i18n.t('"__file_name__" was too large; the maximum file size is __file_size__MB.',
+                             context);
+            } else {
+                // If uploading files has been disabled.
+                msg = i18n.t('File and image uploads have been disabled for this organization.');
+            }
             break;
         case 413: // HTTP status "Request Entity Too Large"
             msg = i18n.t("Sorry, the file was too large.");

--- a/static/templates/message_edit_form.handlebars
+++ b/static/templates/message_edit_form.handlebars
@@ -41,7 +41,9 @@
                     <input type="file" id="message_edit_file_input_{{message_id}}" class="notvisible pull-left" multiple />
                     <a class="message-control-button fa fa-smile-o" aria-hidden="true" id="emoji_map" href="#" data-message-id="{{message_id}}" title="{{t 'Add emoji' }}"></a>
                     <a class="message-control-button fa fa-font" aria-hidden="true" title="{{t 'Formatting' }}" data-overlay-trigger="message-formatting" ></a>
+                    {{#if file_upload_enabled}}
                     <a class="message-control-button fa fa-paperclip notdisplayed" aria-hidden="true" id="attach_files_{{message_id}}" href="#" title="{{t "Attach files" }}"></a>
+                    {{/if}}
                     <a class="message-control-button fa fa-video-camera video_link" aria-hidden="true" href="#" data-message-id="{{message_id}}" title="{{t "Add video call" }}"></a>
                     <a id="undo_markdown_preview_{{message_id}}" class="message-control-button fa fa-edit" aria-hidden="true" style="display:none;" title="{{t 'Write' }}"></a>
                     <a id="markdown_preview_{{message_id}}" class="message-control-button fa fa-eye" aria-hidden="true" title="{{t 'Preview' }}"></a>

--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -97,8 +97,12 @@
                                     <input type="file" id="file_input" class="notvisible pull-left" multiple />
                                     <a class="message-control-button fa fa-smile-o" aria-hidden="true" id="emoji_map" href="#" title="{{ _('Add emoji') }}"></a>
                                     <a class="message-control-button fa fa-font" aria-hidden="true" title="{{ _('Formatting') }}" data-overlay-trigger="message-formatting"></a>
-                                    <a class="message-control-button fa fa-paperclip notdisplayed" aria-hidden="true" id="attach_files" href="#" title="{{ _('Attach files') }}"></a> {% if jitsi_server_url %}
-                                    <a class="message-control-button fa fa-video-camera video_link" aria-hidden="true" href="#" title="{{ _('Add video call') }}"></a> {% endif %}
+                                    {% if max_file_upload_size > 0 %}
+                                    <a class="message-control-button fa fa-paperclip notdisplayed" aria-hidden="true" id="attach_files" href="#" title="{{ _('Attach files') }}"></a>
+                                    {% endif %}
+                                    {% if jitsi_server_url %}
+                                    <a class="message-control-button fa fa-video-camera video_link" aria-hidden="true" href="#" title="{{ _('Add video call') }}"></a>
+                                    {% endif %}
                                     <a id="undo_markdown_preview" class="message-control-button fa fa-edit" aria-hidden="true" style="display:none;" title="{{ _('Write') }}"></a>
                                     <a id="markdown_preview" class="message-control-button fa fa-eye" aria-hidden="true" title="{{ _('Preview') }}"></a>
                                     <a class="drafts-link" href="#drafts" title="{{ _('Drafts') }} (d)">{{ _('Drafts') }}</a>

--- a/templates/zerver/app/settings_overlay.html
+++ b/templates/zerver/app/settings_overlay.html
@@ -33,10 +33,12 @@
                     <i class="icon fa fa-book" aria-hidden="true"></i>
                     <div class="text">{{ _('Alert words') }}</div>
                 </li>
+                {% if max_file_upload_size > 0 %}
                 <li tabindex="0" data-section="uploaded-files">
                     <i class="icon fa fa-paperclip" aria-hidden="true"></i>
                     <div class="text">{{ _('Uploaded files') }}</div>
                 </li>
+                {% endif %}
                 <li tabindex="0" data-section="muted-topics">
                     <i class="icon fa fa-eye-slash" aria-hidden="true"></i>
                     <div class="text">{{ _('Muted topics') }}</div>

--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -205,6 +205,7 @@ class TemplateTestCase(ZulipTestCase):
             seat_count=8,
             request=RequestFactory().get("/"),
             invite_as={"MEMBER": 1},
+            max_file_upload_size = 25,
         )
 
         context.update(kwargs)

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -304,6 +304,7 @@ def home_real(request: HttpRequest) -> HttpResponse:
                                'enable_feedback': settings.ENABLE_FEEDBACK,
                                'embedded': narrow_stream is not None,
                                'invite_as': PreregistrationUser.INVITE_AS,
+                               'max_file_upload_size': settings.MAX_FILE_UPLOAD_SIZE,
                                },)
     patch_cache_control(response, no_cache=True, no_store=True, must_revalidate=True)
     return response


### PR DESCRIPTION
If MAX_FILE_UPLOAD_SIZE is set to 0, then UI elements like the upload icon in the compose and message edit UI and "Attachments" menu in "/#settings" are not displayed.

A different error message is also displayed if a user tries to drag and drop or paste a file into the compose message box.

Fixes #12152.

**GIFs or Screenshots:**

> Hiding the "upload" icon in the compose and message edit UIs

![Screenshot from 2019-05-04 23-37-42](https://user-images.githubusercontent.com/25329595/57183342-2b924980-6ec9-11e9-99db-099cba4ed97a.png)

> Hiding the "Attachments" menu in "/#settings"

![Screenshot from 2019-05-04 23-37-50](https://user-images.githubusercontent.com/25329595/57183345-32b95780-6ec9-11e9-8c2a-da8f3ddf2512.png)

> A special error message if someone tries to paste or drag a file into those widgets UIs.

(Updated to new text as Rishi suggested.)

![Screenshot from 2019-05-04 23-43-23](https://user-images.githubusercontent.com/25329595/57183349-3d73ec80-6ec9-11e9-9eb6-6377dca4cdd7.png)




