### PR TITLE
test-backend: Add --replicate option for debugging.

### DIFF
--- a/docs/testing/testing-with-django.md
+++ b/docs/testing/testing-with-django.md
@@ -51,6 +51,14 @@ iterative development, but you can override this behavior with the
 the `--rerun` option, which will rerun just the tests that failed in
 the last test run.
 
+Additionally, we have a `--replicate` option that can prove useful for
+debugging a non-deterministic test failure.  Such test failures may
+arise when running `test-backend` with high levels of parallelism, in
+which case we may wish to rerun only the tests which were part of the
+failed process.  This option gives us a free reproduction of the failure,
+while writing the list of tests to `var/failed_thread_tests.json` in a
+pretty-printed format for quick hand-editing.
+
 **Webhook integrations**.  For performance, `test-backend` with no
 arguments will not run webhook integration tests (`zerver/webhooks/`),
 which would otherwise account for about 25% of the total runtime.

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -4,7 +4,7 @@
 from lib import sanity_check
 sanity_check.check_venv(__file__)
 
-from typing import List, Iterator
+from typing import List, Iterator, Optional
 import glob
 import argparse
 import contextlib
@@ -139,6 +139,7 @@ not_yet_fully_covered = {path for target in [
 enforce_fully_covered = sorted(target_fully_covered - not_yet_fully_covered)
 
 FAILED_TEST_PATH = 'var/last_test_failure.json'
+FAILED_THREAD_PATH = 'var/failed_thread_tests.json'
 
 def get_failed_tests() -> List[str]:
     try:
@@ -148,10 +149,22 @@ def get_failed_tests() -> List[str]:
         print("var/last_test_failure.json doesn't exist; running all tests.")
         return []
 
+def get_failed_thread_tests() -> Optional[List[str]]:
+    try:
+        with open(FAILED_THREAD_PATH, 'r') as f:
+            return ujson.load(f)
+    except IOError:
+        print("var/failed_thread_tests.json doesn't exist; running all tests.")
+        return None
+
 def write_failed_tests(failed_tests: List[str]) -> None:
     if failed_tests:
         with open(FAILED_TEST_PATH, 'w') as f:
             ujson.dump(failed_tests, f)
+
+def write_failed_thread_tests(failed_thread_tests: List[str]) -> None:
+    with open(FAILED_THREAD_PATH, 'w') as f:
+        ujson.dump(failed_thread_tests, f, indent=2)
 
 @contextlib.contextmanager
 def block_internet() -> Iterator[None]:
@@ -207,6 +220,7 @@ def main() -> None:
 
     parser = argparse.ArgumentParser(description=usage,
                                      formatter_class=argparse.RawTextHelpFormatter)
+    group = parser.add_mutually_exclusive_group()
 
     parser.add_argument('--nonfatal-errors', action="store_false", default=True,
                         dest="fatal_errors", help="Continue past test failures to run all tests")
@@ -246,11 +260,11 @@ def main() -> None:
                         action="store_true",
                         default=False,
                         help="Run tests in reverse order.")
-    parser.add_argument('--rerun', dest="rerun",
-                        action="store_true",
-                        default=False,
-                        help=("Run the tests which failed the last time "
-                              "test-backend was run.  Implies --nonfatal-errors."))
+    group.add_argument('--rerun', dest="rerun",
+                       action="store_true",
+                       default=False,
+                       help=("Run the tests which failed the last time "
+                             "test-backend was run.  Implies --nonfatal-errors."))
     parser.add_argument('--include-webhooks', dest="include_webhooks",
                         action="store_true",
                         default=False,
@@ -259,6 +273,11 @@ def main() -> None:
                         action="store_true",
                         default=False,
                         help=("Generate Stripe test fixtures by making requests to Stripe test network"))
+    group.add_argument('--replicate', dest='replicate',
+                       action="store_true",
+                       default=False,
+                       help=("Run the set of tests leading up to a failure. "
+                             "The set is specific to the worker that failed."))
     parser.add_argument('args', nargs='*')
 
     options = parser.parse_args()
@@ -283,6 +302,15 @@ def main() -> None:
         failed_tests = get_failed_tests()
         if failed_tests:
             args = failed_tests
+
+    # Similarly to --rerun, when running --replicate, we read in
+    # `var/failed_thread_tests.json` to get the list of tests which
+    # ran in the failed process on the last run.
+    if options.replicate:
+        failed_thread_tests = get_failed_thread_tests()
+        if failed_thread_tests:
+            args = failed_thread_tests
+
     if len(args) > 0:
         # If we passed a specific set of tests, run in serial mode.
         parallel = 1
@@ -390,9 +418,11 @@ def main() -> None:
         test_runner = TestRunner(failfast=options.fatal_errors, verbosity=2,
                                  parallel=parallel, reverse=options.reverse,
                                  keepdb=True)
-        failures, failed_tests = test_runner.run_tests(suites, full_suite=full_suite,
-                                                       include_webhooks=include_webhooks)
+        failures, failed_tests, failed_thread_tests = test_runner.run_tests(suites, full_suite=full_suite,
+                                                                            include_webhooks=include_webhooks)
     write_failed_tests(failed_tests)
+    if failed_thread_tests:
+        write_failed_thread_tests(failed_thread_tests)
 
     templates_not_rendered = test_runner.get_shallow_tested_templates()
     # We only check the templates if all the tests ran and passed


### PR DESCRIPTION
A multiprocessing Array is used to map subsuite indices to their
corresponding pids.  When a test failure occurs in a thread, we
search through the test subsuites for the failed test.  The subsuite
index is then used with the shared memory Array to determine the pid of
the process who ran the failure.

The tests from each subsuite who ran in the failed thread are aggregated
into a list, representing the set of all tests ran in the failed worker.

**How was this tested:**
Tested by comparing the contents of the generated files, and running the command
against constructed test failures.