### PR TITLE
test_classes.py: Add activation to default language.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -16,6 +16,7 @@ from django.db.migrations.executor import MigrationExecutor
 from django.db import connection
 from django.db.utils import IntegrityError
 from django.http import HttpRequest
+from django.utils import translation
 
 from two_factor.models import PhoneDevice
 from zerver.lib.initial_password import initial_password
@@ -100,6 +101,7 @@ class ZulipTestCase(TestCase):
         clear_client_event_queues_for_testing()
         clear_supported_auth_backends_cache()
         flush_per_request_caches()
+        translation.activate(settings.LANGUAGE_CODE)
 
     '''
     WRAPPER_COMMENT:


### PR DESCRIPTION
Running the backend tests with a high number of processes can cause
unexpected errors with language changes.  When certain tests that change
the default language, (without explicitly overriding the teardown method
to reset the default language), interleave with other tests that are
expecting the language to be in English, discrepancies arise.

(Tested with the tentative replicate option)

Fixed:
```
======================================================================
FAIL: test_addressee_for_user_ids_nonexistent_id (zerver.tests.test_messages.TestAddressee)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.4/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/lib/python3.4/unittest/case.py", line 577, in run
    testMethod()
  File "/srv/zulip/zerver/tests/test_messages.py", line 467, in test_addressee_for_user_ids_nonexistent_id
    Addressee.for_user_ids(user_ids=[779], realm=get_realm('zulip'))
  File "/usr/lib/python3.4/unittest/case.py", line 195, in __exit__
    expected_regex.pattern, str(exc_value)))
  File "/usr/lib/python3.4/unittest/case.py", line 130, in _raiseFailure
    raise self.test_case.failureException(msg)
AssertionError: "Invalid user ID " does not match "Ungültige Nutzer-ID 779"

----------------------------------------------------------------------
```