### PR TITLE
custom profile field: Fix styling regression in admin settings.

### DIFF
--- a/static/templates/admin_profile_field_list.handlebars
+++ b/static/templates/admin_profile_field_list.handlebars
@@ -24,7 +24,7 @@
     </td>
     {{/if}}
 </tr>
-<tr class="profile-field-form display-none" data-profile-field-id="{{id}}">
+<tr class="profile-field-form" data-profile-field-id="{{id}}" style="display: none;">
     <td colspan="3">
         <form class="form-horizontal name-setting">
             <div class="input-group name_change_container">


### PR DESCRIPTION
The css of `display-none` class was override by
`.rendered_markdown tr` class's css.
This commit fix this regression by applying style
to html element instead of class.

[Link](https://chat.zulip.org/#narrow/stream/9-issues/topic/Save.20changes.20does.20not.20work/near/739493) to issue discussion  


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![image](https://user-images.githubusercontent.com/25907420/57282505-d02fa980-70ca-11e9-953e-cb6f487e8cf8.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
