### PR TITLE
ldap: Do not modify self._LDAPUser.attrs in test_query_email_attr.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -3002,7 +3002,7 @@ class TestQueryLDAP(ZulipLDAPTestCase):
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_query_email_attr(self) -> None:
-        self._LDAPUser.attrs = {
+        attrs = {
             'cn': ['King Hamlet', ],
             'sn': ['Hamlet', ],
             'email_attr': ['separate_email@zulip.com', ],
@@ -3010,7 +3010,7 @@ class TestQueryLDAP(ZulipLDAPTestCase):
         with self.settings(AUTH_LDAP_USER_ATTR_MAP={'full_name': 'cn',
                                                     'short_name': 'sn'},
                            LDAP_EMAIL_ATTR='email_attr'), \
-                mock.patch('zproject.backends._LDAPUser', self._LDAPUser, create=True):
+                mock.patch('zproject.backends._LDAPUser.attrs', attrs):
             values = query_ldap(self.example_email('hamlet'))
         self.assertEqual(len(values), 3)
         self.assertIn('full_name: King Hamlet', values)


### PR DESCRIPTION
Fixes #12273.
When running the test_query_email_attr test in reverse, the test failed
because self._LDAPUser.attrs was being modified and it was being shared
with other tests.

Testing:
`./tools/test-backend --parallel=1 --reverse zerver.tests.test_auth_backends.TestQueryLDAP`