### PR TITLE
Separate "waiting period threshold" into own setting.

### DIFF
--- a/frontend_tests/casper_tests/10-admin.js
+++ b/frontend_tests/casper_tests/10-admin.js
@@ -85,9 +85,9 @@ function submit_permissions_change() {
     casper.click('#org-submit-other-permissions');
 }
 
-// Test setting limiting stream creation to administrators
+// Test setting create streams policy to 'admins only'.
 casper.then(function () {
-    casper.test.info("Test setting limiting stream creation to administrators");
+    casper.test.info("Test setting create streams policy to 'admins only'.");
     casper.waitUntilVisible("#id_realm_create_stream_policy", function () {
         casper.evaluate(function () {
             $("#id_realm_create_stream_policy").val("by_admins_only").change();
@@ -97,50 +97,137 @@ casper.then(function () {
 });
 
 casper.then(function () {
-    // Test setting was activated
+    // Test that save worked.
     casper.waitUntilVisible('#org-submit-other-permissions[data-status="saved"]', function () {
-        casper.test.assertSelectorHasText('#org-submit-other-permissions',
-                                          'Saved');
+        casper.test.assertSelectorHasText('#org-submit-other-permissions', 'Saved');
     });
 });
 
+// Test setting create streams policy to 'members and admins'.
 casper.then(function () {
+    casper.test.info("Test setting create streams policy to 'members and admins'.");
     casper.waitUntilVisible("#id_realm_create_stream_policy", function () {
         casper.evaluate(function () {
-            $("#id_realm_create_stream_policy").val("by_admin_user_with_custom_time").change();
-            $("#id_realm_waiting_period_threshold").val('6');
+            $("#id_realm_create_stream_policy").val("by_members").change();
         });
         submit_permissions_change();
     });
 });
 
 casper.then(function () {
-    // Test setting was activated
+    // Test that save worked.
     casper.waitUntilVisible('#org-submit-other-permissions[data-status="saved"]', function () {
-        casper.test.assertSelectorHasText('#org-submit-other-permissions',
-                                          'Saved');
+        casper.test.assertSelectorHasText('#org-submit-other-permissions', 'Saved');
     });
 });
 
-casper.waitUntilVisible('#id_realm_create_stream_policy', function () {
-    // Test setting was saved
-    casper.test.assertEval(function () {
-        return $('input[type="text"][id="id_realm_waiting_period_threshold"]').val() === '6';
-    }, 'Waiting period threshold set to 6 days');
-
-
-    // Deactivate setting
-    casper.evaluate(function () {
-        $("#id_realm_create_stream_policy").val("by_admins_only").change();
+// Test setting create streams policy to 'full members'.
+casper.then(function () {
+    casper.test.info("Test setting create streams policy to 'waiting period.");
+    casper.waitUntilVisible("#id_realm_create_stream_policy", function () {
+        casper.evaluate(function () {
+            $("#id_realm_create_stream_policy").val("by_full_members").change();
+        });
+        submit_permissions_change();
     });
-    submit_permissions_change();
 });
 
 casper.then(function () {
-    // Test setting was activated
+    // Test that save worked.
     casper.waitUntilVisible('#org-submit-other-permissions[data-status="saved"]', function () {
-        casper.test.assertSelectorHasText('#org-submit-other-permissions',
-                                          'Saved');
+        casper.test.assertSelectorHasText('#org-submit-other-permissions', 'Saved');
+    });
+});
+
+// Test setting invite to streams policy to 'admins only'.
+casper.then(function () {
+    casper.test.info("Test setting invite to streams policy to 'admins only'.");
+    casper.waitUntilVisible("#id_realm_invite_to_stream_policy", function () {
+        casper.evaluate(function () {
+            $("#id_realm_invite_to_stream_policy").val("by_admins_only").change();
+        });
+        submit_permissions_change();
+    });
+});
+
+casper.then(function () {
+    // Test that save worked.
+    casper.waitUntilVisible('#org-submit-other-permissions[data-status="saved"]', function () {
+        casper.test.assertSelectorHasText('#org-submit-other-permissions', 'Saved');
+    });
+});
+
+// Test setting invite to streams policy to 'members and admins'.
+casper.then(function () {
+    casper.test.info("Test setting invite to streams policy to 'members and admins'.");
+    casper.waitUntilVisible("#id_realm_invite_to_stream_policy", function () {
+        casper.evaluate(function () {
+            $("#id_realm_invite_to_stream_policy").val("by_members").change();
+        });
+        submit_permissions_change();
+    });
+});
+
+casper.then(function () {
+    // Test that save worked.
+    casper.waitUntilVisible('#org-submit-other-permissions[data-status="saved"]', function () {
+        casper.test.assertSelectorHasText('#org-submit-other-permissions', 'Saved');
+    });
+});
+
+// Test setting invite to streams policy to 'full members'.
+casper.then(function () {
+    casper.test.info("Test setting invite to streams policy to 'waiting period'.");
+    casper.waitUntilVisible("#id_realm_invite_to_stream_policy", function () {
+        casper.evaluate(function () {
+            $("#id_realm_invite_to_stream_policy").val("by_full_members").change();
+        });
+        submit_permissions_change();
+    });
+});
+
+casper.then(function () {
+    // Test that save worked.
+    casper.waitUntilVisible('#org-submit-other-permissions[data-status="saved"]', function () {
+        casper.test.assertSelectorHasText('#org-submit-other-permissions', 'Saved');
+    });
+});
+
+// Test setting new user threshold to three days.
+casper.then(function () {
+    casper.test.info("Test setting new user threshold to three days.");
+    casper.waitUntilVisible("#id_realm_waiting_period_setting", function () {
+        casper.evaluate(function () {
+            $("#id_realm_waiting_period_setting").val("three_days").change();
+        });
+        submit_permissions_change();
+    });
+});
+
+casper.then(function () {
+    // Test that save worked.
+    casper.waitUntilVisible('#org-submit-other-permissions[data-status="saved"]', function () {
+        casper.test.assertSelectorHasText('#org-submit-other-permissions', 'Saved');
+        casper.test.assertNotVisible('#id_realm_waiting_period_threshold');
+    });
+});
+
+// Test setting new user threshold to N days.
+casper.then(function () {
+    casper.test.info("Test setting new user threshold to N days.");
+    casper.waitUntilVisible("#id_realm_waiting_period_setting", function () {
+        casper.evaluate(function () {
+            $("#id_realm_waiting_period_setting").val("custom_days").change();
+        });
+        submit_permissions_change();
+    });
+});
+
+casper.then(function () {
+    // Test that save worked.
+    casper.waitUntilVisible('#org-submit-other-permissions[data-status="saved"]', function () {
+        casper.test.assertSelectorHasText('#org-submit-other-permissions', 'Saved');
+        casper.test.assertVisible('#id_realm_waiting_period_threshold');
     });
 });
 

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -33,7 +33,7 @@ exports.build_page = function () {
         server_inline_url_embed_preview: page_params.server_inline_url_embed_preview,
         realm_authentication_methods: page_params.realm_authentication_methods,
         realm_create_stream_policy: page_params.realm_create_stream_policy,
-        realm_invite_to_stream_by_admins_only: page_params.realm_invite_to_stream_by_admins_only,
+        realm_invite_to_stream_policy: page_params.realm_invite_to_stream_policy,
         realm_name_changes_disabled: page_params.realm_name_changes_disabled,
         realm_email_changes_disabled: page_params.realm_email_changes_disabled,
         realm_avatar_changes_disabled: page_params.realm_avatar_changes_disabled,

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -70,18 +70,26 @@ function get_property_value(property_name) {
         return exports.get_realm_time_limits_in_minutes('realm_message_content_delete_limit_seconds');
     }
 
+    if (property_name === 'realm_waiting_period_setting') {
+        if (page_params.realm_waiting_period_threshold === 0) {
+            return "none";
+        }
+        if (page_params.realm_waiting_period_threshold === 3) {
+            return "three_days";
+        }
+        return "custom_days";
+    }
+
     if (property_name === 'realm_create_stream_policy') {
         if (page_params.realm_create_stream_policy === 2) {
             return "by_admins_only";
         }
         if (page_params.realm_create_stream_policy === 1) {
-            return "by_anyone";
+            return "by_members";
         }
-        if (page_params.realm_create_stream_policy === 3 &&
-            page_params.realm_waiting_period_threshold === 3) {
-            return "by_admin_user_with_three_days_old";
+        if (page_params.realm_create_stream_policy === 3) {
+            return "by_full_members";
         }
-        return "by_admin_user_with_custom_time";
     }
 
     if (property_name === 'realm_invite_to_stream_policy') {
@@ -156,14 +164,19 @@ exports.extract_property_name = function (elem) {
     return elem.attr('id').split('-').join('_').replace("id_", "");
 };
 
-function set_create_stream_policy_dropdown() {
-    var value = get_property_value("realm_create_stream_policy");
-    $("#id_realm_create_stream_policy").val(value);
-    if (value === "by_admin_user_with_custom_time") {
+function set_realm_waiting_period_dropdown() {
+    var value = get_property_value("realm_waiting_period_setting");
+    $("#id_realm_waiting_period_setting").val(value);
+    if (value === "custom_days") {
         $("#id_realm_waiting_period_threshold").parent().show();
     } else {
         $("#id_realm_waiting_period_threshold").parent().hide();
     }
+}
+
+function set_create_stream_policy_dropdown() {
+    var value = get_property_value("realm_create_stream_policy");
+    $("#id_realm_create_stream_policy").val(value);
 }
 
 function set_invite_to_stream_policy_dropdown() {
@@ -410,7 +423,9 @@ exports.populate_signup_notifications_stream_dropdown = function (stream_list) {
 };
 
 function update_dependent_subsettings(property_name) {
-    if (property_name === 'realm_create_stream_policy' || property_name === 'realm_waiting_period_threshold') {
+    if (property_name === 'realm_waiting_period_threshold') {
+        set_realm_waiting_period_dropdown();
+    } else if (property_name === 'realm_create_stream_policy') {
         set_create_stream_policy_dropdown();
     } else if (property_name === 'realm_invite_to_stream_policy') {
         set_invite_to_stream_policy_dropdown();
@@ -586,6 +601,7 @@ exports.build_page = function () {
         return data;
     }
 
+    set_realm_waiting_period_dropdown();
     set_create_stream_policy_dropdown();
     set_invite_to_stream_policy_dropdown();
     set_add_emoji_permission_dropdown();
@@ -713,6 +729,7 @@ exports.build_page = function () {
             data.message_retention_days = new_message_retention_days !== "" ?
                 JSON.stringify(parseInt(new_message_retention_days, 10)) : null;
         } else if (subsection === 'other_permissions') {
+            var waiting_period_threshold = $("#id_realm_waiting_period_setting").val();
             var create_stream_policy = $("#id_realm_create_stream_policy").val();
             var invite_to_stream_policy = $("#id_realm_invite_to_stream_policy").val();
             var add_emoji_permission = $("#id_realm_add_emoji_by_admins_only").val();
@@ -725,15 +742,10 @@ exports.build_page = function () {
 
             if (create_stream_policy === "by_admins_only") {
                 data.create_stream_policy = 2;
-            } else if (create_stream_policy === "by_admin_user_with_three_days_old") {
-                data.create_stream_policy = 3;
-                data.waiting_period_threshold = 3;
-            } else if (create_stream_policy === "by_admin_user_with_custom_time") {
-                data.create_stream_policy = 3;
-                data.waiting_period_threshold = $("#id_realm_waiting_period_threshold").val();
-            } else if (create_stream_policy === "by_anyone") {
+            } else if (create_stream_policy === "by_members") {
                 data.create_stream_policy = 1;
-                data.waiting_period_threshold = 0;
+            } else if (create_stream_policy === "by_full_members") {
+                data.create_stream_policy = 3;
             }
 
             if (invite_to_stream_policy === "by_admins_only") {
@@ -742,6 +754,14 @@ exports.build_page = function () {
                 data.invite_to_stream_policy = 1;
             } else if (invite_to_stream_policy === "by_full_members") {
                 data.invite_to_stream_policy = 3;
+            }
+
+            if (waiting_period_threshold === "none") {
+                data.waiting_period_threshold = 0;
+            } else if (waiting_period_threshold === "three_days") {
+                data.waiting_period_threshold = 3;
+            } else if (waiting_period_threshold === "custom_days") {
+                data.waiting_period_threshold = $("#id_realm_waiting_period_threshold").val();
             }
         } else if (subsection === 'org_join') {
             var org_join_restrictions = $('#id_realm_org_join_restrictions').val();
@@ -811,10 +831,10 @@ exports.build_page = function () {
         }
     });
 
-    $("#id_realm_create_stream_policy").change(function () {
-        var create_stream_policy = this.value;
+    $("#id_realm_waiting_period_setting").change(function () {
+        var waiting_period_threshold = this.value;
         var node = $("#id_realm_waiting_period_threshold").parent();
-        if (create_stream_policy === 'by_admin_user_with_custom_time') {
+        if (waiting_period_threshold === 'custom_days') {
             node.show();
         } else {
             node.hide();

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -92,7 +92,7 @@ function get_property_value(property_name) {
             return "by_admins_only";
         }
         if (page_params.realm_invite_to_stream_policy === 3) {
-            return "by_members_with_waiting_period";
+            return "by_full_members";
         }
     }
 
@@ -740,7 +740,7 @@ exports.build_page = function () {
                 data.invite_to_stream_policy = 2;
             } else if (invite_to_stream_policy === "by_members") {
                 data.invite_to_stream_policy = 1;
-            } else if (invite_to_stream_policy === "by_members_with_waiting_period") {
+            } else if (invite_to_stream_policy === "by_full_members") {
                 data.invite_to_stream_policy = 3;
             }
         } else if (subsection === 'org_join') {

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1545,6 +1545,7 @@ body:not(.night-mode) #account-settings .custom_user_field .datepicker {
     pointer-events: all;
 }
 
+#id_realm_waiting_period_setting,
 #id_realm_create_stream_policy,
 #id_realm_invite_to_stream_policy,
 #id_realm_org_join_restrictions,

--- a/static/templates/settings/organization-permissions-admin.handlebars
+++ b/static/templates/settings/organization-permissions-admin.handlebars
@@ -66,16 +66,18 @@
             </div>
             <div class="m-10 inline-block organization-permissions-parent">
                 <div class="input-group">
-                    <label for="realm_create_stream_policy" class="dropdown-title">{{t "Who can create streams" }}</label>
-                    <select name="realm_create_stream_policy" id="id_realm_create_stream_policy" class="prop-element">
-                        <option value="by_anyone">{{t "Members and admins" }}</option>
-                        <option value="by_admins_only">{{t "Admins only" }}</option>
-                        <option value="by_admin_user_with_three_days_old">{{t "All admins, and members with accounts at least 3 days old" }}</option>
-                        <option value="by_admin_user_with_custom_time">{{t "All admins, and members with accounts at least N days old" }}</option>
+                    <label for="realm_waiting_period_setting" class="dropdown-title">
+                        {{t "Waiting period before new members turn into full members" }}
+                    </label>
+                    <select name="realm_waiting_period_setting" id="id_realm_waiting_period_setting" class="prop-element">
+                        <option value="none">{{t "None" }}</option>
+                        <option value="three_days">{{t "3 days" }}</option>
+                        <option value="custom_days">{{t "Custom" }}</option>
                     </select>
                 </div>
+                {{!-- This setting is hidden unless `custom_days` --}}
                 <div class="dependent-block">
-                    <label for="aitin" class="inline-block">{{t "Minimum account age (N)" }}:</label>
+                    <label for="aitin" class="inline-block">{{t "Waiting period (days)" }}:</label>
                     <input type="text" id="id_realm_waiting_period_threshold"
                       name="realm_waiting_period_threshold"
                       class="admin-realm-time-limit-input prop-element"
@@ -83,11 +85,20 @@
                 </div>
 
                 <div class="input-group">
+                    <label for="realm_create_stream_policy" class="dropdown-title">{{t "Who can create streams" }}</label>
+                    <select name="realm_create_stream_policy" id="id_realm_create_stream_policy" class="prop-element">
+                        <option value="by_members">{{t "Members and admins" }}</option>
+                        <option value="by_admins_only">{{t "Admins only" }}</option>
+                        <option value="by_full_members">{{t "Admins and full members" }}</option>
+                    </select>
+                </div>
+
+                <div class="input-group">
                     <label for="realm_invite_to_stream_policy" class="dropdown-title">{{t "Who can add users to streams" }}</label>
                     <select name="realm_invite_to_stream_policy" id="id_realm_invite_to_stream_policy" class="prop-element">
                         <option value="by_members">{{t "Members and admins" }}</option>
                         <option value="by_admins_only">{{t "Admins only" }}</option>
-                        <option value="by_full_members">{{t "All admins and members who can create streams" }}</option>
+                        <option value="by_full_members">{{t "Admins and full members" }}</option>
                     </select>
                 </div>
 

--- a/static/templates/settings/organization-permissions-admin.handlebars
+++ b/static/templates/settings/organization-permissions-admin.handlebars
@@ -87,7 +87,7 @@
                     <select name="realm_invite_to_stream_policy" id="id_realm_invite_to_stream_policy" class="prop-element">
                         <option value="by_members">{{t "Members and admins" }}</option>
                         <option value="by_admins_only">{{t "Admins only" }}</option>
-                        <option value="by_members">{{t "All admins and members who can create streams" }}</option>
+                        <option value="by_full_members">{{t "All admins and members who can create streams" }}</option>
                     </select>
                 </div>
 

--- a/static/templates/settings/organization-permissions-admin.handlebars
+++ b/static/templates/settings/organization-permissions-admin.handlebars
@@ -68,6 +68,7 @@
                 <div class="input-group">
                     <label for="realm_waiting_period_setting" class="dropdown-title">
                         {{t "Waiting period before new members turn into full members" }}
+                        <a href="/help/configure-waiting-period-for-full-members">(?)</a>
                     </label>
                     <select name="realm_waiting_period_setting" id="id_realm_waiting_period_setting" class="prop-element">
                         <option value="none">{{t "None" }}</option>

--- a/templates/zerver/help/configure-waiting-period-for-full-members.md
+++ b/templates/zerver/help/configure-waiting-period-for-full-members.md
@@ -1,0 +1,35 @@
+# Waiting period for full members
+
+{!admin-only.md!}
+
+Some organization settings allow permissions to be limited to all members or just full members.
+Full members are members whose accounts are older than the configured waiting period which can be
+configured as:
+
+* **No waiting period**
+* **Members with accounts less than 3 days old**
+* **Members with accounts less than N days old**, for some `N`.
+
+This functionality can be useful to limit what "disruptive features" a new user has access to
+until they are familiar with Zulip and the rules of your organization.
+
+For large Zulips where anyone can join, we recommend setting the waiting period
+to at least a few days old (we suggest starting with `N = 3`), to make it easier to cope with
+spammers and confused users.
+
+Currently, the following permissions support limiting access to only full members:
+
+- [**Configure who can create streams**](/help/configure-who-can-create-streams)
+- [**Configure who can invite to streams**](/help/configure-who-can-invite-to-streams)
+
+### Manage the waiting period
+
+{start_tabs}
+
+{settings_tab|organization-permissions}
+
+2. Under **Other permissions**, configure **Waiting period before new members turn into full members**.
+
+{!save-changes.md!}
+
+{end_tabs}

--- a/templates/zerver/help/configure-who-can-create-streams.md
+++ b/templates/zerver/help/configure-who-can-create-streams.md
@@ -5,17 +5,13 @@
 By default, anyone other than guests can create new streams. However, you can restrict stream
 creation to:
 
-* **Organization administrators and members**
 * **Organization administrators**
-* **Organization administrators, and members with accounts at least `N` days old**, for some `N`.
+* **Organization administrators and all members**
+* **Organization administrators and full members**
 
 For corporations and other entities with controlled access, we highly
 recommend keeping stream creation open. A typical Zulip organization with
 heavy use has as many streams as users.
-
-For large Zulips where anyone can join, we recommend restricting stream
-creation to those with accounts at least a few days old (we suggest starting
-with `N = 3`), to make it easier to cope with spammers and confused users.
 
 ### Manage who can create streams
 

--- a/templates/zerver/help/configure-who-can-create-streams.md
+++ b/templates/zerver/help/configure-who-can-create-streams.md
@@ -2,11 +2,12 @@
 
 {!admin-only.md!}
 
-By default, anyone other than guests can create new streams. However, you can restrict stream creation to
+By default, anyone other than guests can create new streams. However, you can restrict stream
+creation to:
 
-* **Organization administrators**, or
-* **Organization administrators, and members with accounts at least `N` days old**,
-  for any `N`.
+* **Organization administrators and members**
+* **Organization administrators**
+* **Organization administrators, and members with accounts at least `N` days old**, for some `N`.
 
 For corporations and other entities with controlled access, we highly
 recommend keeping stream creation open. A typical Zulip organization with
@@ -22,7 +23,7 @@ with `N = 3`), to make it easier to cope with spammers and confused users.
 
 {settings_tab|organization-permissions}
 
-2. Under **Other permissions**, configure **Who can create streams**.
+2. Under **New user permissions**, configure **Who can create streams**.
 
 {!save-changes.md!}
 

--- a/templates/zerver/help/configure-who-can-invite-to-streams.md
+++ b/templates/zerver/help/configure-who-can-invite-to-streams.md
@@ -5,15 +5,13 @@
 By default, anyone other than guests can invite others to streams. However, you can restrict stream
 invitation to:
 
-* **Organization administrators and members**
 * **Organization administrators**
-* **Organization administrators, and members with accounts at least `N` days old**, for some `N`.
+* **Organization administrators and all members**
+* **Organization administrators and full members**
 
 For corporations and other entities with controlled access, we highly
-recommend keeping stream invitation open.
-
-For entities with lots of streams with confidential contents, it may be desirable
-to limit invitations.
+recommend keeping stream invitation open. For entities with lots of streams with confidential
+contents, it may be desirable to limit invitations.
 
 ### Manage who can create streams
 

--- a/templates/zerver/help/configure-who-can-invite-to-streams.md
+++ b/templates/zerver/help/configure-who-can-invite-to-streams.md
@@ -3,11 +3,11 @@
 {!admin-only.md!}
 
 By default, anyone other than guests can invite others to streams. However, you can restrict stream
-invitation to
+invitation to:
 
-* **Members and organization administrators**, or
-* **Organization administrators**, or
-* **Organization administrators, and members with accounts older than the new user waiting period**
+* **Organization administrators and members**
+* **Organization administrators**
+* **Organization administrators, and members with accounts at least `N` days old**, for some `N`.
 
 For corporations and other entities with controlled access, we highly
 recommend keeping stream invitation open.

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -115,6 +115,7 @@
 * [GDPR Compliance](/help/gdpr-compliance)
 
 ## Organization settings
+* [Waiting period for full members](/help/configure-waiting-period-for-full-members)
 * [Restrict stream creation](/help/configure-who-can-create-streams)
 * [Restrict stream invitation](/help/configure-who-can-invite-to-streams)
 * [Change who can add custom emoji](/help/only-allow-admins-to-add-emoji)

--- a/templates/zerver/security.md
+++ b/templates/zerver/security.md
@@ -48,13 +48,17 @@ priority.
   projects), to requiring an invitation to join, to having an email from a
   list of domains, to being a member of a specific organization in
   LDAP/Active Directory.
+- Zulip can limit the features that new users have access to until their
+  accounts are older than a [configurable waiting period][waiting_period].
 - Zulip also supports customizing whether non-admins can
   [create streams](/help/configure-who-can-create-streams),
+  [invite to streams](/help/configure-who-can-invite-to-streams),
   [add custom emoji](/help/only-allow-admins-to-add-emoji),
   [add integrations and bots](/help/restrict-bot-creation),
   [edit or delete messages](/help/configure-message-editing-and-deletion),
   and more.
 
+[waiting_period]: /help/configure-waiting-period-for-full-members
 [ldap-name]: https://zulip.readthedocs.io/en/latest/production/authentication-methods.html#ldap-including-active-directory
 
 ## Authentication


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR follows-up on #12276 to separate the "waiting period threshold" based on [discussion in Zulip](https://chat.zulip.org/#narrow/stream/137-feedback/topic/too.20new.20to.20add.20subscriber.20to.20stream/near/740683).

Quoting from the first commit:
 > This commit separates the `waiting_period_threshold` setting from
    the `create_stream_policy` setting, adding a new setting that the user
    can use to select a waiting period threshold.
>
> Both the invite to stream policy and create stream policy now have three
    options: admins only, members and admins, or members after waiting
    period/admins.

cc @rishig @timabbott 

**Testing Plan:** <!-- How have you tested? -->
I've updated the frontend tests (both node and casper) and tested manually.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/1295100/57480922-e3906f80-7298-11e9-90a0-3b1dc69884e7.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
