### PR TITLE
org settings: Change a few references to Jitsi to Jitsi Meet.

### DIFF
--- a/templates/zerver/features.html
+++ b/templates/zerver/features.html
@@ -237,7 +237,7 @@
             <h3>VIDEO CALLS</h3>
             <p>
                 Create and join video calls with a single click. Powered
-                by your choice of Zoom, Jitsi, or Google Hangouts.
+                by your choice of Zoom, Jitsi Meet, or Google Hangouts.
             </p>
         </div>
         <div class="feature-block">

--- a/templates/zerver/help/start-a-call.md
+++ b/templates/zerver/help/start-a-call.md
@@ -58,7 +58,7 @@ accounts with their respective providers.
 
 {tab|jitsi-on-premise}
 
-If you're running both Zulip and Jitsi on-premise, just set
+If you're running both Zulip and Jitsi Meet on-premise, just set
 `JITSI_SERVER_URL` in `/etc/zulip/settings.py`.
 
 {end_tabs}

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -553,7 +553,7 @@ CAMO_URI = '/external_content/'
 # can modify the image's appearance.
 #THUMBNAIL_IMAGES = True
 
-# Controls the Jitsi video call integration.  By default, the
+# Controls the Jitsi Meet video call integration.  By default, the
 # integration uses the SaaS meet.jit.si server.  You can specify
 # your own Jitsi Meet server, or if you'd like to disable the
 # integration, set JITSI_SERVER_URL = None.

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -188,7 +188,7 @@ DEFAULT_SETTINGS = {
     'LOCAL_UPLOADS_DIR': None,
     'MAX_FILE_UPLOAD_SIZE': 25,
 
-    # JITSI video call integration; set to None to disable integration.
+    # Jitsi Meet video call integration; set to None to disable integration.
     'JITSI_SERVER_URL': 'https://meet.jit.si/',
 
     # Feedback bot settings


### PR DESCRIPTION
Jitsi Meet is the correct name for the product we integrate with. There is
one other reference to Jitsi, but it's in the db and will require a
migration.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
