### PR TITLE
css: Remove `display-none` class css entirely.

### DIFF
--- a/static/styles/app_components.scss
+++ b/static/styles/app_components.scss
@@ -17,10 +17,6 @@
     font-weight: 300;
 }
 
-.display-none {
-    display: none;
-}
-
 .inline-block {
     display: inline-block;
 }

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -466,10 +466,6 @@ li div.codehilite {
     background-color: hsl(0, 0%, 98%);
 }
 
-.display-none {
-    display: none;
-}
-
 .help-box .blob {
     margin-top: 0px;
 }
@@ -2181,10 +2177,6 @@ input.new-organization-button {
 .input-group label.inline-block {
     /* eyeballing off-centered aesth. */
     margin-top: 1px;
-}
-
-.display-none {
-    display: none;
 }
 
 .inline-block {

--- a/static/templates/admin_user_list.handlebars
+++ b/static/templates/admin_user_list.handlebars
@@ -43,7 +43,7 @@
             </button>
             {{/if}}
         </span>
-        <button class="button rounded small btn-warning open-user-form{{#unless is_active}} display-none{{/unless}}" title="{{t 'Edit user' }}" data-user-id="{{user_id}}">
+        <button class="button rounded small btn-warning open-user-form" {{#unless is_active}}style="display: none;"{{/unless}} title="{{t 'Edit user' }}" data-user-id="{{user_id}}">
             <i class="fa fa-pencil" aria-hidden="true"></i>
         </button>
     </td>

--- a/static/templates/edit_bot.handlebars
+++ b/static/templates/edit_bot.handlebars
@@ -24,7 +24,7 @@
             <input type="file" name="bot_avatar_file_input" class="notvisible edit_bot_avatar_file_input" value="{{t 'Upload profile picture' }}" />
             <div class="edit_bot_avatar_file"></div>
             <button type="button" class="btn btn-default edit_bot_avatar_upload_button">{{t "Choose avatar" }}</button>
-            <button type="button" class="btn btn-default edit_bot_avatar_clear_button display-none">{{t "Clear profile picture" }}</button>
+            <button type="button" class="btn btn-default edit_bot_avatar_clear_button" style="display: none;">{{t "Clear profile picture" }}</button>
             <div><label for="edit_bot_avatar_file" generated="true" class="edit_bot_avatar_error text-error"></label></div>
         </div>
         <div class="buttons">

--- a/static/templates/settings/bot-settings.handlebars
+++ b/static/templates/settings/bot-settings.handlebars
@@ -95,7 +95,7 @@
                     <div class="input-group">
                         <div id="bot_avatar_file"></div>
                         <input type="file" name="bot_avatar_file_input" class="notvisible" id="bot_avatar_file_input" value="{{t 'Upload profile picture' }}" />
-                        <button class="button white rounded small btn-danger display-none" id="bot_avatar_clear_button">{{t "Clear profile picture" }}</button>
+                        <button class="button white rounded small btn-danger" style="display: none;" id="bot_avatar_clear_button">{{t "Clear profile picture" }}</button>
                         <button class="button white rounded" id="bot_avatar_upload_button">{{t "Customize profile picture" }}</button> ({{t "Optional" }})
                     </div>
                     <p>

--- a/static/templates/settings/emoji-settings-admin.handlebars
+++ b/static/templates/settings/emoji-settings-admin.handlebars
@@ -15,7 +15,7 @@
                     <span id="emoji-file-name"></span>
                     <input type="file" name="emoji_file_input" class="notvisible"
                       id="emoji_file_input" value="{{t 'Upload image or GIF' }}"/>
-                    <button class="button white rounded display-none" id="emoji_image_clear_button">{{t "Clear emoji image" }}</button>
+                    <button class="button white rounded" style="display: none;" id="emoji_image_clear_button">{{t "Clear emoji image" }}</button>
                     <button class="button rounded" id="emoji_upload_button">{{t "Upload image or GIF" }}</button>
                 </div>
                 <button id="admin_emoji_submit" type="submit" class="button rounded sea-green">


### PR DESCRIPTION
All the elements to which `display-none` class
is applied, are handled with `.show()`/`.hide()`
functions instead of `.addClass('display-none')`
and `.removeClass('display-none')`.
Therefore, we should use apply `display: none;`
to elements with `style` attribute.

This commits removes all usage of `display-none`.

Followup of #12288 
I tested every element which is changed and it worked as expected.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
