### PR TITLE
email_mirror: Handle case of unspecified charset in Content-Type header.

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -217,6 +217,11 @@ def get_message_part_by_type(message: message.Message, content_type: str) -> Opt
             assert isinstance(content, bytes)
             if charsets[idx]:
                 return content.decode(charsets[idx], errors="ignore")
+            # If no charset has been specified in the header, assume us-ascii,
+            # by RFC6657: https://tools.ietf.org/html/rfc6657
+            else:
+                return content.decode("us-ascii", errors="ignore")
+
     return None
 
 talon_initialized = False


### PR DESCRIPTION
See: https://chat.zulip.org/#narrow/stream/9-issues/topic/sending.20message.20by.20email.20does.20not.20work

If the text part of an email message didn't specify the charset in the
Content-Type header, the text content wouldn't be found. We fix this, by
assuming us-ascii charset in those cases, as specified by RFC6657:
https://tools.ietf.org/html/rfc6657

