### PR TITLE
digest: Always render digest options since js toggle visibility.

### DIFF
--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -37,6 +37,14 @@ function change_notification_setting(setting, setting_data, status_element) {
     settings_ui.do_settings_change(channel.patch, '/json/settings/notifications', data, status_element);
 }
 
+exports.set_enable_digest_emails_visibility = function () {
+    if (page_params.realm_digest_emails_enabled) {
+        $('#enable_digest_emails_label').parent().show();
+    } else {
+        $('#enable_digest_emails_label').parent().hide();
+    }
+};
+
 exports.set_up = function () {
     _.each(pm_mention_notification_settings, function (setting) {
         $("#" + setting).change(function () {
@@ -85,6 +93,7 @@ exports.set_up = function () {
             notification_sound_dropdown.parent().addClass("control-label-disabled");
         }
     });
+    exports.set_enable_digest_emails_visibility();
 };
 
 exports.update_page = function () {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -274,14 +274,6 @@ function set_message_content_in_email_notifications_visiblity() {
     }
 }
 
-function set_enable_digest_emails_visibility() {
-    if (page_params.realm_digest_emails_enabled) {
-        $('#enable_digest_emails_label').parent().show();
-    } else {
-        $('#enable_digest_emails_label').parent().hide();
-    }
-}
-
 function set_digest_emails_weekday_visibility() {
     if (page_params.realm_digest_emails_enabled) {
         $('#id_realm_digest_weekday').parent().show();
@@ -437,7 +429,7 @@ function update_dependent_subsettings(property_name) {
     } else if (property_name === 'realm_message_content_allowed_in_email_notifications') {
         set_message_content_in_email_notifications_visiblity();
     } else if (property_name === 'realm_digest_emails_enabled') {
-        set_enable_digest_emails_visibility();
+        settings_notifications.set_enable_digest_emails_visibility();
         set_digest_emails_weekday_visibility();
     }
 }
@@ -601,7 +593,6 @@ exports.build_page = function () {
     set_org_join_restrictions_dropdown();
     set_user_invite_restriction_dropdown();
     set_message_content_in_email_notifications_visiblity();
-    set_enable_digest_emails_visibility();
     set_digest_emails_weekday_visibility();
 
     function check_property_changed(elem) {

--- a/static/templates/settings/notification-settings.handlebars
+++ b/static/templates/settings/notification-settings.handlebars
@@ -103,12 +103,10 @@
 
             <h5>{{t "Email" }}</h5>
 
-            {{#if page_params.realm_digest_emails_enabled}}
             {{partial "settings_checkbox"
               "setting_name" "enable_digest_emails"
               "is_checked" page_params.enable_digest_emails
               "label" settings_label.enable_digest_emails}}
-            {{/if}}
 
             {{partial "settings_checkbox"
               "setting_name" "enable_login_emails"

--- a/static/templates/settings/organization-settings-admin.handlebars
+++ b/static/templates/settings/organization-settings-admin.handlebars
@@ -83,7 +83,6 @@
                   "is_checked" realm_digest_emails_enabled
                   "label" admin_settings_label.realm_digest_emails_enabled}}
                 {{/if}}
-                {{#if realm_digest_emails_enabled}}
                 <div class="input-group">
                     <label for="realm_digest_weekday" class="dropdown-title">{{t "Day of the week to send digests" }}</label>
                     <select name="realm_digest_weekday"
@@ -99,7 +98,6 @@
                         <option value="6">{{t "Sunday" }}</option>
                     </select>
                 </div>
-                {{/if}}
             </div>
 
             <div class="input-group">


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

Fixes incorrect display of digest notifications and digest weekday dropdown options

**Testing Plan:** <!-- How have you tested? -->

Test for digest notification options
- Open a tab as Iago
- Open "notification settings", note digest email option not there.
- Go to "organization settings", enable option
- Go back to settings, don't see option.

Test for digest weekday options
- Open a tab as Iago
- Open "organisation settings", turn off digest emails
- Re-open "organisation settings", turn on digest emails
- Verify that the weekday options dropdown shows up
- Toggling digest emails should toggle visibility of weekday options dropdown