### PR TITLE
left_sidebar: Add "+ Add streams" to bottom of streams list.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -551,7 +551,7 @@ exports.initialize = function () {
 
     $("#streams_inline_cog").click(function (e) {
         e.stopPropagation();
-        hashchange.go_to_location('streams/all');
+        hashchange.go_to_location('streams/subscribed');
     });
 
     $("#streams_filter_icon").click(function (e) {

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -84,7 +84,7 @@ li.show-more-topics a {
     overflow: visible;
     /* The -1px here prevents the scrollbar from going above the top of the container */
     margin-top: -1px;
-    margin-bottom: 18px;
+    margin-bottom: 10px;
     padding: 0;
     font-weight: normal;
 }
@@ -138,6 +138,15 @@ li.show-more-topics a {
 
 #stream_filters li.active-sub-filter:hover {
     background-color: hsl(120, 11%, 82%);
+}
+
+#add-stream-link {
+    text-decoration: none;
+    margin-left: 10px;
+}
+
+#add-stream-link i {
+    margin-right: 5px;
 }
 
 ul.filters {

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -71,6 +71,9 @@
             </div>
             <div id="stream-filters-container" class="scrolling_list">
                 <ul id="stream_filters" class="filters"></ul>
+                {% if show_add_streams %}
+                <a id="add-stream-link" href="#streams/all"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{ _('Add streams') }}</a>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -249,12 +249,14 @@ def home_real(request: HttpRequest) -> HttpResponse:
 
     statsd.incr('views.home')
     show_invites = True
+    show_add_streams = True
 
     # Some realms only allow admins to invite users
     if user_profile.realm.invite_by_admins_only and not user_profile.is_realm_admin:
         show_invites = False
     if user_profile.is_guest:
         show_invites = False
+        show_add_streams = False
 
     show_billing = False
     show_plans = False
@@ -295,6 +297,7 @@ def home_real(request: HttpRequest) -> HttpResponse:
                                'pipeline': settings.PIPELINE_ENABLED,
                                'search_pills_enabled': settings.SEARCH_PILLS_ENABLED,
                                'show_invites': show_invites,
+                               'show_add_streams': show_add_streams,
                                'show_billing': show_billing,
                                'show_plans': show_plans,
                                'is_admin': user_profile.is_realm_admin,


### PR DESCRIPTION
This PR fixes #11642. 

**GIFs or Screenshots:**

This is what the button looks like:

![add stream normal user](https://user-images.githubusercontent.com/25329595/57573387-a2d55980-7444-11e9-9baf-18e3a266e01a.gif)

This is what it looks like to a Guest user:

![Screenshot from 2019-05-11 23-27-47](https://user-images.githubusercontent.com/25329595/57573398-bd0f3780-7444-11e9-9af3-9176bf28744b.png)

Additionally, behavior of the gear on top is also changed:

![gear to subscribed](https://user-images.githubusercontent.com/25329595/57573412-d31cf800-7444-11e9-9122-88ef8a0a9b94.gif)


