### PR TITLE
org settings: Update organization logo section.

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -127,6 +127,9 @@ label {
     vertical-align: top;
 
     border-radius: 4px;
+}
+
+.user-avatar-section .inline-block {
     box-shadow: 0px 0px 10px hsla(0, 0%, 0%, 0.1);
 }
 

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -492,7 +492,6 @@ input[type=checkbox] + .inline-block {
 }
 
 .realm-logo-section {
-    margin-top: 10px;
     margin-bottom: 20px;
 }
 
@@ -1121,12 +1120,11 @@ input[type=checkbox].inline-block {
 
 #realm-settings-logo,
 #realm-settings-night-logo {
-    border-radius: 5px;
     box-shadow: 0px 0px 10px hsla(0, 0%, 0%, 0.2);
     /* We allow actual images up to 800x100 in the main display, but the
-       settings UI looks bad beyond ~730px, so we limit the width here */
-    height: 100px;
-    max-width: 720px;
+       settings UI looks bad beyond ~500px, so we limit the width here */
+    height: 55px;
+    max-width: 500px;
 }
 
 #realm-settings-night-logo {
@@ -1702,14 +1700,6 @@ input[type=text]#settings_search {
     padding: 2px 6px;
     border-radius: 4px;
     margin: 0 0 0 5px;
-}
-
-@media (max-width: 1023px) {
-    #realm-settings-logo,
-    #realm-settings-night-logo {
-        max-width: 600px;
-        height: 75px;
-    }
 }
 
 @media (max-width: 953px) {

--- a/static/templates/settings/organization-profile-admin.handlebars
+++ b/static/templates/settings/organization-profile-admin.handlebars
@@ -46,16 +46,22 @@
             </div>
         </div>
 
-        <h3>{{t "Organization logo" }}</h3>
-        <p>{{t "A wide image, replacing the Zulip logo in the upper left corner of the Zulip apps." }}</p>
+        <div class="subsection-header">
+            <h3>{{t "Organization logo" }}
+                <a href="/help/create-your-organization-profile#add-a-wide-logo" target="_blank">
+                    <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+                </a>
+            </h3>
+        </div>
 
+        <p>{{t "A wide image for the upper left corner of the app." }}</p>
         <div class="realm-logo-section">
-            <div class="block realm-logo-block">
+            <div class="inline-block realm-logo-block">
                 <img id="realm-settings-logo" src="{{ realm_logo_url }}"/>
                 <input type="file" name="realm_logo_file_input" class="notvisible"
                   id="realm_logo_file_input" value="{{t 'Upload logo' }}"/>
             </div>
-            <div class="block avatar-controls">
+            <div class="inline-block avatar-controls">
                 <div id="realm_logo_file_input_error" class="alert text-error"></div>
                 <button class="button rounded sea-green w-200 block input-size"
                   id="realm_logo_upload_button">
@@ -67,16 +73,14 @@
             </div>
         </div>
 
-        <h3>{{t "Organization logo for night mode" }}</h3>
-        <p>{{t "Like Organization logo, but for the night theme." }}</p>
-
+        <p>{{t "A wide logo for night mode. Logo will be shown against a dark background." }}</p>
         <div class="realm-logo-section realm-night-logo-section">
-            <div class="block realm-logo-block">
+            <div class="inline-block realm-logo-block">
                 <img id="realm-settings-night-logo" src="{{ realm_night_logo_url }}">
                 <input type="file" name="realm_night_logo_file_input" class="notvisible"
                   id="realm_night_logo_file_input" value="{{t 'Upload logo' }}"/>
             </div>
-            <div class="block avatar-controls">
+            <div class="inline-block avatar-controls">
                 <div id="realm_night_logo_file_input_error" class="alert text-error"></div>
                 <button class="button rounded sea-green w-200 block input-size"
                   id="realm_night_logo_upload_button">


### PR DESCRIPTION
New: 
![image](https://user-images.githubusercontent.com/890911/57798323-55d1db80-7701-11e9-8d09-e9f4bfb14ad4.png)

With error:
![image](https://user-images.githubusercontent.com/890911/57798332-5d918000-7701-11e9-83de-5439d36fe4f4.png)

Responsive:
![image](https://user-images.githubusercontent.com/890911/57798373-6eda8c80-7701-11e9-9467-b0251b9a9f9f.png)

Responsive with error:
![image](https://user-images.githubusercontent.com/890911/57798605-fa541d80-7701-11e9-99be-b008971033d7.png)

With uploaded logo:
![image](https://user-images.githubusercontent.com/890911/57798680-266f9e80-7702-11e9-91d2-12fbbb35d5c3.png)

Some of the spacing is not amazing, but hopefully we're not far from being able to get rid of the buttons?

Followups:
* Make it so that people don't click upload if they are not on a paid plan (removing the likelihood of seeing errors)
* Once the buttons are gone, the text in this section should be in `<div>`s rather than `<p>`s, like other labels in settings. Right now we can't make that change since it ends up messing other things up.