### PR TITLE
requirements: Downgrade stripe from 2.27.0 to 2.21.0.

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -196,7 +196,7 @@ django-two-factor-auth==1.8.0
 twilio==6.26.2
 
 # Needed for processing payments (in corporate)
-stripe==2.27.0
+stripe==2.21.0
 
 # Needed for serving uploaded files from nginx but perform auth checks in django.
 django-sendfile==0.3.11

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -176,7 +176,7 @@ sphinx==1.8.4
 sphinxcontrib-websupport==1.1.0  # via sphinx
 sqlalchemy==1.3.3
 statsd==3.3.0             # via django-statsd-mozilla
-stripe==2.27.0
+stripe==2.21.0
 tblib==1.3.2
 tornado==4.5.3
 traitlets==4.3.2          # via ipython

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -123,7 +123,7 @@ soupsieve==1.9.1          # via beautifulsoup4
 sourcemap==0.2.1
 sqlalchemy==1.3.3
 statsd==3.3.0             # via django-statsd-mozilla
-stripe==2.27.0
+stripe==2.21.0
 tornado==4.5.3
 traitlets==4.3.2          # via ipython
 twilio==6.26.2


### PR DESCRIPTION
Reverts c09962b and 697b4b2. The lines that break look like
stripe.Invoice.finalize_invoice(stripe_invoice).

Something like stripe_invoice.finalize_invoice() would work, but it's a big
change given how the tests in test_stripe.py currently work.

Tim: wasn't sure if this needed a provision version bump?

@hackerkid fyi. For upgrading the stripe package we need to set `GENERATE_STRIPE_FIXTURES` to True and re-run the test suite, similar to https://zulip.readthedocs.io/en/stable/subsystems/billing.html#upgrading-stripe-api-versions. 