### PR TITLE
help and docs: Cleaning out a few todos.

### DIFF
--- a/docs/contributing/gsod-ideas.md
+++ b/docs/contributing/gsod-ideas.md
@@ -49,6 +49,15 @@ project today).
 
 ### Expectations for technical writers
 
+At minimum, you'll need native or near-native written fluency in English,
+and some public-facing writing you can show us.
+
+We also recommend reviewing
+[the official GSoD guide](https://developers.google.com/season-of-docs/docs/tech-writer-guide),
+and keeping your eye on
+[the GSoD timeline](https://developers.google.com/season-of-docs/docs/timeline). The
+application deadline is June 28, 2019.
+
 [Our guide for having a great summer with Zulip](../contributing/summer-with-zulip.html)
 is focused on what one should know once doing a GSoC project with
 Zulip; while it is written for the GSoC student audience, it should give
@@ -57,13 +66,6 @@ you a feel for how we interact with and mentor committed contributors.
 [What makes a great Zulip contributor](../overview/contributing.html#what-makes-a-great-zulip-contributor)
 also has some helpful information on what we look for during the application
 process.
-
-We also recommend reviewing
-[the official GSoD guide](https://developers.google.com/season-of-docs/docs/tech-writer-guide).
-
-Finally, keep your eye on
-[the GSoD timeline](https://developers.google.com/season-of-docs/docs/timeline). The
-application deadline is June 28, 2019.
 
 ## Getting started
 
@@ -105,8 +107,7 @@ abilities during the application process, through some combination of
 looking at your past work and collaborating with you on small
 preparatory projects for your summer.  For example, for working on our
 REST API docs, we'd love to see you contribute documentation for at
-least one endpoint as well as some thoughtful feedback or discussions
-on how we can improve the system.
+least one endpoint.
 
 Getting started earlier is better, so you have more time to learn
 about the organization, make contributions, and make a good proposal.
@@ -129,7 +130,7 @@ Your application should include the following:
   chat.zulip.org talking about Zulip's documentation are considered
   valuable contributions worth mentioning here.
 
-We expect applicants to be fluent in (technical) English writing.  For
+We expect applicants to have near-native fluency in English writing.  For
 some projects, a technical background is a plus,
 but not essential as long as we're confident you
 can learn.  General programming and/or sysadmin
@@ -141,11 +142,6 @@ We also expect applicants to be able to edit their work effectively,
 and communicate clearly about the reasoning behind their ideas (as
 well as which parts of their work they have concerns about and would
 appreciate extra attention on).
-
-While only one contribution is required to be considered for the
-program, we find that the strongest applicants make multiple
-contributions throughout the application process, including after the
-application deadline.
 
 We are more interested in candidates if we see them submitting good
 bug reports, helping other people on GitHub and on

--- a/templates/zerver/help/delete-a-topic.md
+++ b/templates/zerver/help/delete-a-topic.md
@@ -15,6 +15,9 @@ In most other cases, [renaming a topic](/help/rename-a-topic) is often a
 better idea, or just leaving the topic as is. Deleting a topic can confuse
 users who come to the topic later via an email notification.
 
+Note that deleting a topic also deletes every message with that topic,
+whereas [deleting a stream](/help/delete-a-stream) does not.
+
 ### Delete a topic
 
 {start_tabs}
@@ -28,3 +31,6 @@ users who come to the topic later via an email notification.
 1. Click **Delete messages**.
 
 {end_tabs}
+
+Note that deleting the last message with a particular topic also deletes
+that topic.

--- a/templates/zerver/help/enable-full-width-display.md
+++ b/templates/zerver/help/enable-full-width-display.md
@@ -1,0 +1,15 @@
+# Enable full width display
+
+By default, Zulip limits how wide the center message pane can be. You can
+remove this restriction, and allow Zulip to use the full width of your
+screen.
+
+### Enable full width display
+
+{start_tabs}
+
+{settings_tab|display-settings}
+
+2. Under **Display settings**, select **Use full width on wide screens**.
+
+{end_tabs}

--- a/templates/zerver/help/export-your-organization.md
+++ b/templates/zerver/help/export-your-organization.md
@@ -51,12 +51,11 @@ Such an export will include all the messages received by any user in
 the organization that consented to the data export.  In particular, it
 will include all public stream content and any private stream or
 private message content where at least one of the participants gave
-consent.  Users who do not consent to export their private data will
-still be able to see public message history sent before the export,
-but will not have access to any private message history, including the
-history of which messages they personally received (which will result
-in their experience for All Messages and our full-text search being
-like that of a new user who joined after the data export).
+consent.
+
+Users who do not provide consent will have their settings and stream
+subscriptions exported, but will otherwise be treated as new users after
+import.
 
 For **full export without member consent**, we will additionally need
 evidence that you have authority to read members' private

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -88,6 +88,7 @@
 * [Enable emoticon translations](/help/enable-emoticon-translations)
 * [Manage your uploaded files](/help/manage-your-uploaded-files)
 * [View emoji as text](/help/view-emoji-as-text)
+* [Enable full width display](/help/enable-full-width-display)
 * [Change your timezone](/help/change-your-timezone)
 * [Display the buddy list on narrow screens](/help/move-the-users-list-to-the-left-sidebar)
 * [View organization statistics](/help/analytics)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/890911/57818511-04454300-7739-11e9-8311-e8ca2d426fac.png)

The export caveat thing is a bit vague and doesn't hold up to careful thought, but I think that's fine for this doc. In general I think user expectations are going to be pretty low here, and we likely surpass them. (Also I expect most people not exporting are people that are long gone, or people with message content they know they want to keep private, rather than people whose decision will be affected by the details of the policy.)