### PR TITLE
Don't try to desktop_notify until permission is granted

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -531,7 +531,7 @@ exports.received_messages = function (messages) {
         if (should_send_desktop_notification(message)) {
             process_notification({
                 message: message,
-                desktop_notify: exports.granted_desktop_notifications_permission()
+                desktop_notify: exports.granted_desktop_notifications_permission(),
             });
         }
         if (should_send_audible_notification(message) && supports_sound) {

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -44,15 +44,6 @@ if (window.webkitNotifications) {
     };
 }
 
-
-function browser_desktop_notifications_on() {
-    return notifications_api &&
-            // Firefox on Ubuntu claims to do webkitNotifications but its notifications are terrible
-            /webkit/i.test(navigator.userAgent) &&
-            // 0 is PERMISSION_ALLOWED
-            notifications_api.checkPermission() === 0;
-}
-
 function cancel_notification_object(notification_object) {
     // We must remove the .onclose so that it does not trigger on .cancel
     notification_object.onclose = function () {};
@@ -364,7 +355,8 @@ function process_notification(notification) {
         ];
     }
 
-    if (notification.webkit_notify === true) {
+    // Firefox on Ubuntu claims to do webkitNotifications but its notifications are terrible
+    if (notification.desktop_notify && /webkit/i.test(navigator.userAgent)) {
         var icon_url = people.small_avatar_url(message);
         notice_memory[key] = {
             obj: notifications_api.createNotification(icon_url, title, content, message.id),
@@ -383,7 +375,7 @@ function process_notification(notification) {
             delete notice_memory[key];
         };
         notification_object.show();
-    } else if (notification.webkit_notify === false && typeof Notification !== "undefined" && /mozilla/i.test(navigator.userAgent) === true) {
+    } else if (notification.desktop_notify && typeof Notification !== "undefined" && /mozilla/i.test(navigator.userAgent)) {
         Notification.requestPermission(function (perm) {
             if (perm === 'granted') {
                 notification_object = new Notification(title, {
@@ -403,7 +395,7 @@ function process_notification(notification) {
                 in_browser_notify(message, title, content, raw_operators, opts);
             }
         });
-    } else if (notification.webkit_notify === false) {
+    } else {
         in_browser_notify(message, title, content, raw_operators, opts);
     }
 }
@@ -537,11 +529,10 @@ exports.received_messages = function (messages) {
         message.notification_sent = true;
 
         if (should_send_desktop_notification(message)) {
-            if (browser_desktop_notifications_on()) {
-                process_notification({message: message, webkit_notify: true});
-            } else {
-                process_notification({message: message, webkit_notify: false});
-            }
+            process_notification({
+                message: message,
+                desktop_notify: exports.granted_desktop_notifications_permission()
+            });
         }
         if (should_send_audible_notification(message) && supports_sound) {
             $("#notifications-area").find("audio")[0].play();


### PR DESCRIPTION
This fixes #11504 , following Tim's suggestion to approach it by avoiding notification in notification.js prior to permission being granted.

Prior to this PR, we'd put up the green "Enable desktop notifications" bar AND the first time a desktop notification worthy message was received, it would attempt to notify, triggering a browser permission popup (the same one as clicking the green bar results in).

Now notifications are not attempted until the green bar is clicked, additionally Firefox and Webkit browser-specific checks are made more uniform and done at the same point.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Tested on both Firefox and Chrome (since the code paths are different between webkit and not webkit).

1) Open an ingcognito/private window without notifications granted
2) Verify green notification nag bar appears
3) Send a PM from another browser window
4) Verify that the browser permission dialog does NOT appear
5) Click the green desktop notification nag bar and grant permission to notify
6) Send another PM and verify that it DOES notify


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
