### PR TITLE
[wip] Split reply button into reply + drop down menu

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -504,6 +504,29 @@ exports.initialize = function () {
         compose_actions.respond_to_message({trigger: 'reply button'});
     });
 
+    $('.button.dropdown').click(function () {
+        var menu = $(this).find(".menu");
+        var dropdown_button = $(this);
+
+        var close_menu = function () {
+            menu.slideUp('fast');
+            dropdown_button.removeClass("menu-open");
+            $("body").off("click", close_menu);
+        };
+
+        var open_menu = function () {
+            menu.slideDown('fast');
+            dropdown_button.addClass("menu-open");
+            $("body").on("click", close_menu)
+        }
+
+        if (dropdown_button.hasClass("menu-open")) {
+            close_menu();
+        } else {
+            open_menu();
+        }
+    });
+
     $('.empty_feed_compose_stream').click(function (e) {
         compose_actions.start('stream', {trigger: 'empty feed message'});
         e.preventDefault();

--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -48,11 +48,52 @@
         font-weight: 400;
         line-height: 1em;
     }
-}
 
-#compose_buttons .button.small {
-    font-size: 1em;
-    padding: 3px 10px;
+    .button.small {
+        font-size: 1em;
+        padding: 3px 10px;
+    }
+
+    .button.rounded.has-dropdown {
+        border-radius: 4px 0px 0px 4px;
+        border-right: none;
+    }
+
+    .button.dropdown {
+        border-radius: 0px 4px 4px 0px;
+        padding: 3px 3px;
+        position: relative;
+
+        .menu-open {
+            background-color: hsl(0, 0%, 30%);
+        }
+
+        .menu {
+            display: none;
+            position: absolute;
+            bottom: 0px;
+            right: 0px;
+            padding: 3px 0px;
+            margin-bottom: 24px;
+            background-color: hsl(0, 0%, 100%);
+            min-width: 15em;
+            box-shadow: 0px 1px 2px hsl(0, 0%, 33%);
+
+            .menu-item {
+                text-align: left;
+                padding: 3px 14px;
+
+                &:hover {
+                    background-color: hsl(156, 30%, 50%);
+                    color: white;
+                }
+
+                .shortcut {
+                    float: right;
+                }
+            }
+        }
+    }
 }
 
 .message_header_colorblock {
@@ -491,13 +532,6 @@ a#undo_markdown_preview {
 .compose_mobile_stream_button i,
 .compose_mobile_private_button i {
     margin-right: 4px;
-}
-
-@media (max-width: 550px) {
-    #compose_buttons .compose_stream_button,
-    #compose_buttons .compose_private_button {
-        display: none;
-    }
 }
 
 @media (min-width: 551px) {

--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -22,26 +22,23 @@
                     </button>
                 </span>
                 <span class="new_message_button">
-                    <button type="button" class="button small rounded compose_stream_button"
-                      id="left_bar_compose_stream_button_big"
-                      title="{{ _('New topic') }} (c)">
-                        <span class="compose_stream_button_label">{{ _('New topic') }}</span>
-                    </button>
-                </span>
-                {% if not embedded %}
-                <span class="new_message_button">
-                    <button type="button" class="button small rounded compose_private_button"
-                      id="left_bar_compose_private_button_big"
-                      title="{{ _('New private message') }} (x)">
-                        <span class="compose_private_button_label">{{ _('New private message') }}</span>
-                    </button>
-                </span>
-                {% endif %}
-                <span class="new_message_button">
-                    <button type="button" class="button small rounded compose_reply_button"
+                    <button type="button" class="button small rounded has-dropdown compose_reply_button"
                       id="left_bar_compose_reply_button_big"
                       title="{{ _('Reply') }} (r)">
                         <span class="compose_reply_button_label">{{ _('Reply') }}</span>
+                    </button><!-- we can't have a space character between these divs or they'll have a gap between
+                 --><button type="button" class="button small dropdown compose_dropdown_button">
+                        ▾
+                        <div class="menu button">
+                            <div class="menu-item compose_private_button" id="left_bar_compose_private_button_big" title="{{ _('New private message') }} (x)">
+                                <span class="compose_private_button_label">{{ _('New private message') }}</span>
+                                <div class="shortcut">x</div>
+                            </div>
+                            <div class="menu-item compose_stream_button" id="left_bar_compose_stream_button_big" title="{{ _('New topic') }} (c)">
+                                <span class="compose_stream_button_label">{{ _('New topic') }}</span>
+                                <div class="shortcut">c</div>
+                            </div>
+                        </div>
                     </button>
                 </span>
             </div>


### PR DESCRIPTION
This puts [new private message] and [new topic] buttons into a dropdown menu, attached to the reply button.

<img width="919" alt="Screen Shot 2019-05-15 at 8 38 50 PM" src="https://user-images.githubusercontent.com/223277/57831660-79247700-7751-11e9-9091-b7b46c895864.png">

1) This is implemented in a somewhat re-usable way, though could be vastly improved on this front, if dropdown buttons like this are a UX idiom we could re-use elsewhere.
2) I discovered popovers by discovering the mobile (+) button while starting mobile testing for this, and didn't have time to go back and re-work this to use popovers, though I think it has advantages over the existing popover code in some small dovetaily ways.
3) Handles clicking in the <body> anywhere to close the menu.
4) Not fully adapted to mobile yet, seems like it could potentially replace or be merged with the existing mobile [+] button? I did remove the conditional CSS hiding of the popup menu items in CSS. Need to consider whether to remove the existing mobile popup button?

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
1) Make sure reply, private, and topic buttons still work
2) Make sure clicking menu items closes the menu
3) Make sure clicking elsewhere closes the menu
4) Make sure keyboard shortcuts still work

**GIFs or Screenshots:**
![wholescreen](https://user-images.githubusercontent.com/223277/57831820-df10fe80-7751-11e9-8922-5bfbc651b4a6.gif)
![splitreply](https://user-images.githubusercontent.com/223277/57831824-e20bef00-7751-11e9-9588-c96f3337acff.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
