### PR TITLE
navbar: Fix stream + topic jump at 500px.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1756,7 +1756,6 @@ a:hover code {
             margin: 0px;
             padding: 0px;
             text-overflow: ellipsis;
-            height: 40px;
             padding: 0 5px;
         }
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes a bug on the mobile web app caused by the refactor for navbar css.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

before:
![image](https://user-images.githubusercontent.com/33805964/57845904-99efd980-77f0-11e9-94d5-5512d6fc3a6d.png)

after:
![image](https://user-images.githubusercontent.com/33805964/57844690-35337f80-77ee-11e9-831e-aed6989264ba.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
