### PR TITLE
api_docs: Detect missing arguments in curl examples.

### DIFF
--- a/templates/zerver/api/add-linkifiers.md
+++ b/templates/zerver/api/add-linkifiers.md
@@ -15,7 +15,7 @@ appear in messages and topics.
 
 {tab|curl}
 
-```
+``` curl
 curl -X POST {{ api_url }}/v1/realm/filters \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     -d "pattern=#(?P<id>[0-9]+)" \

--- a/templates/zerver/api/add-subscriptions.md
+++ b/templates/zerver/api/add-subscriptions.md
@@ -52,8 +52,8 @@ zulip(config).then((client) => {
 
 {tab|curl}
 
-```
-curl {{ api_url }}/v1/users/me/subscriptions \
+``` curl
+curl -X POST {{ api_url }}/v1/users/me/subscriptions \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     -d 'subscriptions=[{"name": "Verona"}]'
 ```
@@ -61,8 +61,8 @@ curl {{ api_url }}/v1/users/me/subscriptions \
 To subscribe another user to a stream, you may pass in
 the `principals` argument, like so:
 
-```
-curl {{ api_url }}/v1/users/me/subscriptions \
+``` curl
+curl -X POST {{ api_url }}/v1/users/me/subscriptions \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     -d 'subscriptions=[{"name": "Verona"}]' \
     -d 'principals=["ZOE@zulip.com"]'

--- a/templates/zerver/api/create-user.md
+++ b/templates/zerver/api/create-user.md
@@ -38,8 +38,8 @@ zulip(config).then((client) => {
 
 {tab|curl}
 
-```
-curl {{ api_url }}/v1/users \
+``` curl
+curl -X POST {{ api_url }}/v1/users \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     -d "email=newbie@zulip.com" \
     -d "full_name=New User" \

--- a/templates/zerver/api/delete-message.md
+++ b/templates/zerver/api/delete-message.md
@@ -19,7 +19,7 @@ the Zulip Help Center.
 
 {tab|curl}
 
-```
+``` curl
 curl -X DELETE {{ api_url }}/v1/messages/{message_id} \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
 ```

--- a/templates/zerver/api/delete-queue.md
+++ b/templates/zerver/api/delete-queue.md
@@ -41,7 +41,7 @@ zulip(config).then((client) => {
 
 {tab|curl}
 
-```
+``` curl
 curl -X "DELETE" {{ api_url }}/v1/events \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
     -d 'queue_id=1515096410:1'

--- a/templates/zerver/api/dev-fetch-api-key.md
+++ b/templates/zerver/api/dev-fetch-api-key.md
@@ -17,8 +17,8 @@ in a Zulip production server.
 {start_tabs}
 {tab|curl}
 
-```
-curl {{ api_url }}/v1/dev_fetch_api_key \
+``` curl
+curl -X POST {{ api_url }}/v1/dev_fetch_api_key \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     -d "username=iago@zulip.com"
 ```

--- a/templates/zerver/api/get-all-streams.md
+++ b/templates/zerver/api/get-all-streams.md
@@ -31,14 +31,14 @@ zulip(config).then((client) => {
 
 {tab|curl}
 
-```
+``` curl
 curl -X GET {{ api_url }}/v1/streams -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```
 
 You may pass in one or more of the parameters mentioned above
 as URL query parameters, like so:
 
-```
+``` curl
 curl -X GET {{ api_url }}/v1/streams?include_public=false \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```

--- a/templates/zerver/api/get-all-users.md
+++ b/templates/zerver/api/get-all-users.md
@@ -33,13 +33,13 @@ zulip(config).then((client) => {
 
 {tab|curl}
 
-```
+``` curl
 curl -X GET {{ api_url }}/v1/users -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```
 
 You may pass the `client_gravatar` query parameter as follows:
 
-```
+``` curl
 curl -X GET {{ api_url }}/v1/users?client_gravatar=true \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```

--- a/templates/zerver/api/get-events-from-queue.md
+++ b/templates/zerver/api/get-events-from-queue.md
@@ -62,8 +62,8 @@ zulip(config).then((client) => {
 
 {tab|curl}
 
-```
-curl -G {{ api_url }}/v1/events \
+``` curl
+curl -X GET {{ api_url }}/v1/events \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
     -d "queue_id=1375801870:2942" \
     -d "last_event_id=-1"

--- a/templates/zerver/api/get-message-history.md
+++ b/templates/zerver/api/get-message-history.md
@@ -18,7 +18,7 @@ Note that edit history may be disabled in some organizations; see the
 
 {tab|curl}
 
-```
+``` curl
 curl -X GET {{ api_url }}/v1/messages/<message_id>/history \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```

--- a/templates/zerver/api/get-messages.md
+++ b/templates/zerver/api/get-messages.md
@@ -63,7 +63,7 @@ zulip(config).then((client) => {
 
 {tab|curl}
 
-```
+``` curl
 curl -X GET {{ api_url }}/v1/messages \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     -d "anchor=42" \

--- a/templates/zerver/api/get-org-emoji.md
+++ b/templates/zerver/api/get-org-emoji.md
@@ -29,7 +29,7 @@ zulip(config).then((client) => {
 
 {tab|curl}
 
-```
+``` curl
 curl -X GET {{ api_url }}/v1/realm/emoji \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```

--- a/templates/zerver/api/get-presence.md
+++ b/templates/zerver/api/get-presence.md
@@ -23,7 +23,7 @@ for details on the data model for presence in Zulip.
 
 {tab|curl}
 
-```
+``` curl
 curl -X GET {{ api_url }}/v1/users/<email>/presence \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```

--- a/templates/zerver/api/get-profile.md
+++ b/templates/zerver/api/get-profile.md
@@ -31,7 +31,7 @@ zulip(config).then((client) => {
 
 {tab|curl}
 
-```
+``` curl
 curl -X GET {{ api_url }}/v1/users/me \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```

--- a/templates/zerver/api/get-raw-message.md
+++ b/templates/zerver/api/get-raw-message.md
@@ -18,7 +18,7 @@ UI).
 
 {tab|curl}
 
-```
+``` curl
 curl -X GET {{ api_url }}/v1/messages/<msg_id> \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
 ```

--- a/templates/zerver/api/get-stream-id.md
+++ b/templates/zerver/api/get-stream-id.md
@@ -30,8 +30,8 @@ zulip(config).then((client) => {
 
 {tab|curl}
 
-```
-curl X GET {{ api_url }}/v1/get_stream_id?stream=Denmark \
+``` curl
+curl -X GET {{ api_url }}/v1/get_stream_id?stream=Denmark \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```
 

--- a/templates/zerver/api/get-stream-topics.md
+++ b/templates/zerver/api/get-stream-topics.md
@@ -31,7 +31,7 @@ zulip(config).then((client) => {
 
 {tab|curl}
 
-```
+``` curl
 curl -X GET {{ api_url }}/v1/users/me/<stream_id>/topics \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```

--- a/templates/zerver/api/get-subscribed-streams.md
+++ b/templates/zerver/api/get-subscribed-streams.md
@@ -32,7 +32,7 @@ zulip(config).then((client) => {
 
 {tab|curl}
 
-```
+``` curl
 curl -X GET {{ api_url }}/v1/users/me/subscriptions \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```

--- a/templates/zerver/api/get-user-groups.md
+++ b/templates/zerver/api/get-user-groups.md
@@ -15,7 +15,7 @@ Fetches all of the user groups in the organization.
 
 <div data-language="curl" markdown="1">
 
-```
+``` curl
 curl -X GET {{ api_url }}/v1/user_groups \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```

--- a/templates/zerver/api/list-linkifiers.md
+++ b/templates/zerver/api/list-linkifiers.md
@@ -16,8 +16,8 @@ in messages and topics.
 
 {tab|curl}
 
-```
-curl {{ api_url }}/v1/realm/filters \
+``` curl
+curl -X GET {{ api_url }}/v1/realm/filters \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
 ```
 

--- a/templates/zerver/api/mark-as-read-bulk.md
+++ b/templates/zerver/api/mark-as-read-bulk.md
@@ -13,7 +13,7 @@ Marks all of the current user's unread messages as read.
 
 {tab|curl}
 
-```
+``` curl
 curl -X POST {{ api_url }}/v1/mark_all_as_read \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```
@@ -48,7 +48,7 @@ Mark all the unread messages in a stream as read.
 
 {tab|curl}
 
-```
+``` curl
 curl -X POST {{ api_url }}/v1/mark_stream_as_read \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     -d "stream_id=42"
@@ -84,7 +84,7 @@ Mark all the unread messages in a topic as read.
 
 {tab|curl}
 
-```
+``` curl
 curl -X POST {{ api_url }}/v1/mark_topic_as_read \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     -d "stream_id=42" \

--- a/templates/zerver/api/mute-topics.md
+++ b/templates/zerver/api/mute-topics.md
@@ -15,7 +15,7 @@ UI, and are not included in the user's unread count totals.
 
 {tab|curl}
 
-```
+``` curl
 curl -X PATCH {{ api_url }}/v1/users/me/subscriptions/muted_topics \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     -d "stream=Verona"

--- a/templates/zerver/api/register-queue.md
+++ b/templates/zerver/api/register-queue.md
@@ -75,8 +75,8 @@ zulip(config).then((client) => {
 
 {tab|curl}
 
-```
-curl {{ api_url }}/v1/register \
+``` curl
+curl -X POST {{ api_url }}/v1/register \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
     -d 'event_types=["message"]'
 ```

--- a/templates/zerver/api/remove-linkifiers.md
+++ b/templates/zerver/api/remove-linkifiers.md
@@ -15,7 +15,7 @@ in messages and topics.
 
 {tab|curl}
 
-```
+``` curl
 curl -X DELETE {{ api_url }}/v1/realm/filters/<filter_id> \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```

--- a/templates/zerver/api/remove-subscriptions.md
+++ b/templates/zerver/api/remove-subscriptions.md
@@ -40,7 +40,7 @@ zulip(config).then((client) => {
 
 {tab|curl}
 
-```
+``` curl
 curl -X "DELETE" {{ api_url }}/v1/users/me/subscriptions \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     -d 'subscriptions=["Denmark"]'
@@ -48,7 +48,7 @@ curl -X "DELETE" {{ api_url }}/v1/users/me/subscriptions \
 
 You may specify the `principals` argument like so:
 
-```
+``` curl
 curl -X "DELETE" {{ api_url }}/v1/users/me/subscriptions \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     -d 'subscriptions=["Denmark"]' \

--- a/templates/zerver/api/render-message.md
+++ b/templates/zerver/api/render-message.md
@@ -34,8 +34,8 @@ zulip(config).then((client) => {
 
 {tab|curl}
 
-```
-curl {{ api_url }}/v1/messages/render \
+``` curl
+curl -X POST {{ api_url }}/v1/messages/render \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     -d $"content=**foo**"
 

--- a/templates/zerver/api/send-message.md
+++ b/templates/zerver/api/send-message.md
@@ -51,7 +51,7 @@ zulip(config).then((client) => {
 
 {tab|curl}
 
-```
+``` curl
 # For stream messages
 curl -X POST {{ api_url }}/v1/messages \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \

--- a/templates/zerver/api/server-settings.md
+++ b/templates/zerver/api/server-settings.md
@@ -21,8 +21,8 @@ Fetch global settings for a Zulip server.
 
 {tab|curl}
 
-```
-curl {{ api_url }}/v1/server_settings \
+``` curl
+curl -X GET {{ api_url }}/v1/server_settings \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```
 

--- a/templates/zerver/api/typing.md
+++ b/templates/zerver/api/typing.md
@@ -38,7 +38,7 @@ zulip(config).then((client) => {
 
 {tab|curl}
 
-```
+``` curl
 curl -X POST {{ api_url }}/v1/typing \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     -d "op=start" \

--- a/templates/zerver/api/update-message-flags.md
+++ b/templates/zerver/api/update-message-flags.md
@@ -44,7 +44,7 @@ zulip(config).then((client) => {
 
 {tab|curl}
 
-```
+``` curl
 curl -X POST {{ api_url }}/v1/messages/flags \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     -d "messages=[4,8,15]" \

--- a/templates/zerver/api/update-message.md
+++ b/templates/zerver/api/update-message.md
@@ -38,7 +38,7 @@ zulip(config).then((client) => {
 
 {tab|curl}
 
-```
+``` curl
 curl -X "PATCH" {{ api_url }}/v1/messages/<msg_id> \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     -d $"content=New content"

--- a/templates/zerver/api/update-subscription-properties.md
+++ b/templates/zerver/api/update-subscription-properties.md
@@ -15,7 +15,7 @@ per-stream notification settings.
 
 {tab|curl}
 
-```
+``` curl
 curl -X POST {{ api_url }}/v1/users/me/subscriptions/properties \
      -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
      -d 'subscription_data=[{"stream_id": 1, \

--- a/templates/zerver/api/upload-custom-emoji.md
+++ b/templates/zerver/api/upload-custom-emoji.md
@@ -16,8 +16,8 @@ organization.  Access to this endpoint depends on the
 
 {tab|curl}
 
-```
-curl {{ api_url }}/v1/realm/emoji/<emoji_name> \
+``` curl
+curl -X POST {{ api_url }}/v1/realm/emoji/<emoji_name> \
     -F "data=@/path/to/img.png" \
     -u USER_EMAIL:API_KEY
 ```

--- a/zerver/templatetags/app_filters.py
+++ b/zerver/templatetags/app_filters.py
@@ -103,7 +103,9 @@ def render_markdown_path(markdown_file_path: str,
                 linenums=False,
                 guess_lang=False
             ),
-            zerver.lib.bugdown.fenced_code.makeExtension(),
+            zerver.lib.bugdown.fenced_code.makeExtension(
+                run_content_validators=context.get('run_content_validators', False)
+            ),
             zerver.lib.bugdown.api_arguments_table_generator.makeExtension(
                 base_path='templates/zerver/api/'),
             zerver.lib.bugdown.api_code_examples.makeExtension(),

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -89,6 +89,22 @@ class DocPageTest(ZulipTestCase):
             if not doc_html_str:
                 self.assert_in_success_response(['<meta name="robots" content="noindex,nofollow">'], result)
 
+    @slow("Tests dozens of endpoints")
+    def test_api_doc_endpoints(self) -> None:
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        api_docs_dir = os.path.join(current_dir, '..', '..', 'templates/zerver/api/')
+        files = os.listdir(api_docs_dir)
+
+        def _filter_func(fp: str) -> bool:
+            ignored_files = ['sidebar_index.md', 'index.md', 'missing.md']
+            return fp.endswith('.md') and fp not in ignored_files
+
+        files = list(filter(_filter_func, files))
+
+        for f in files:
+            endpoint = '/api/{}'.format(os.path.splitext(f)[0])
+            self._test(endpoint, '', doc_html_str=True)
+
     @slow("Tests dozens of endpoints, including generating lots of emails")
     def test_doc_endpoints(self) -> None:
         self._test('/api/', 'The Zulip API')

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -124,6 +124,7 @@ class MarkdownDirectoryView(ApiURLView):
         # An "article" might require the api_uri_context to be rendered
         api_uri_context = {}  # type: Dict[str, Any]
         add_api_uri_context(api_uri_context, self.request)
+        api_uri_context["run_content_validators"] = True
         context["api_uri_context"] = api_uri_context
         return context
 


### PR DESCRIPTION
This commit adds automated tests that make sure that every curl
example command in our API docs has the '-X (POST|GET)' argument.

Fixes: #11927

@timabbott: FYI! :)