### PR TITLE
meta_tags: Remove twitter:title, twitter:description, twitter:image

### DIFF
--- a/templates/zerver/meta_tags.html
+++ b/templates/zerver/meta_tags.html
@@ -5,7 +5,7 @@
 <meta name="robots" content="noindex,nofollow">
 {% endif %}
 
-<!-- Open Graph / Facebook Meta Tags -->
+<!-- Open Graph / Facebook / Twitter Meta Tags -->
 <meta property="og:url" content="{{ OPEN_GRAPH_URL }}">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Zulip">
@@ -21,19 +21,4 @@
 {% else %}
 <meta property="og:image" content="{{ realm_uri }}/static/images/logo/zulip-icon-128x128.png">
 {% endif %}
-
-
-<!-- Twitter Meta Tags -->
 <meta name="twitter:card" content="summary">
-{% if OPEN_GRAPH_TITLE %}
-<meta property="twitter:title" content="{{ OPEN_GRAPH_TITLE }}">
-<meta name="twitter:description" content="{{ OPEN_GRAPH_DESCRIPTION }}">
-{% else %}
-<meta property="twitter:title" content="The world's most productive team chat">
-<meta name="twitter:description" content="Zulip combines the immediacy of real-time chat with an email threading model. With Zulip, you can catch up on important conversations while ignoring irrelevant ones.">
-{% endif %}
-{% if OPEN_GRAPH_IMAGE %}
-<meta name="twitter:image" content="{{ OPEN_GRAPH_IMAGE }}">
-{% else %}
-<meta name="twitter:image" content="{{ realm_uri }}/static/images/logo/zulip-icon-128x128.png">
-{% endif %}

--- a/zerver/tests/test_middleware.py
+++ b/zerver/tests/test_middleware.py
@@ -64,17 +64,12 @@ class OpenGraphTest(ZulipTestCase):
         bs = BeautifulSoup(decoded, features='lxml')
         open_graph_title = bs.select_one('meta[property="og:title"]').get('content')
         self.assertEqual(open_graph_title, title)
-        twitter_title = bs.select_one('meta[property="twitter:title"]').get('content')
-        self.assertEqual(twitter_title, title)
 
         open_graph_description = bs.select_one('meta[property="og:description"]').get('content')
-        twitter_description = bs.select_one('meta[name="twitter:description"]').get('content')
         for substring in in_description:
             self.assertIn(substring, open_graph_description)
-            self.assertIn(substring, twitter_description)
         for substring in not_in_description:
             self.assertNotIn(substring, open_graph_description)
-            self.assertNotIn(substring, twitter_description)
 
     def test_admonition_and_link(self) -> None:
         # disable-message-edit-history starts with an {!admin-only.md!}, and has a link
@@ -181,9 +176,7 @@ class OpenGraphTest(ZulipTestCase):
         decoded = response.content.decode('utf-8')
         bs = BeautifulSoup(decoded, features='lxml')
         open_graph_image = bs.select_one('meta[property="og:image"]').get('content')
-        twitter_image = bs.select_one('meta[name="twitter:image"]').get('content')
         self.assertTrue(open_graph_image.endswith(realm_icon))
-        self.assertTrue(twitter_image.endswith(realm_icon))
 
     def test_no_realm_api_page_og_url(self) -> None:
         response = self.client_get('/api/', subdomain='')


### PR DESCRIPTION
Twitter [falls back](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/markup.html) to `og:title`, `og:description`, `og:image`, which we set identically, so these are redundant.

**Testing Plan:** Examined page source, ran `test-backend`.