### PR TITLE
Reenable mobile zooming on non-app pages

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -2,6 +2,10 @@
 {# The app itself. #}
 {# Includes some other templates as tabs. #}
 
+{% block meta_viewport %}
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+{% endblock %}
+
 {% block page_params %}
 {# Insert parameters, which have been encoded with JSONEncoderForHTML. #}
 <script nonce="{{ csp_nonce }}">

--- a/templates/zerver/base.html
+++ b/templates/zerver/base.html
@@ -13,7 +13,9 @@
             {% endif %}
         {% endblock %}
         <link href="/static/favicon.ico?v=2" rel="shortcut icon">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+        {% block meta_viewport %}
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        {% endblock %}
         {% if not user_profile %}
         {% include 'zerver/meta_tags.html' %}
         {% endif %}


### PR DESCRIPTION
Commit db45d220a82a941a68e88011dbd561513f05326e (#3996) disabled mobile zooming on all pages, with the reasoning that focusing an input may automatically zoom the page and break content.  I’m not sure whether that was a good reason, but at most it only applies to the app page.  Reenable zooming on all other pages like the portico and documentation to improve their accessibility.

(Note: the other common reason to disable zooming, which was that mobile browsers once added a 300ms tap delay to recognize double-tap zoom gestures, has been [obsolete since 2014](
https://developers.google.com/web/updates/2013/12/300ms-tap-delay-gone-away).)

**Testing Plan:** Checked page source.