### PR TITLE
settings: Disable auto-hide on right pane scrollbar

### DIFF
--- a/static/templates/subscription_table_body.handlebars
+++ b/static/templates/subscription_table_body.handlebars
@@ -34,7 +34,7 @@
                     <span>{{t 'First time? Read our <a href="/help/getting-your-organization-started-with-zulip#create-streams" target="_blank">guidelines</a> for creating and naming streams.' }}</span>
                     {{/if}}
                 </div>
-                <div class="settings" data-simplebar>
+                <div class="settings" data-simplebar data-simplebar-auto-hide="false">
                     {{!-- edit stream here --}}
                 </div>
                 {{ partial "stream_creation_form" }}

--- a/templates/zerver/app/settings_overlay.html
+++ b/templates/zerver/app/settings_overlay.html
@@ -152,7 +152,7 @@
                 <span class="exit-sign">&times;</span>
             </div>
         </div>
-        <div id="settings_content" data-simplebar>
+        <div id="settings_content" data-simplebar data-simplebar-auto-hide="false">
             <div class="organization-box organization">
 
             </div>


### PR DESCRIPTION
Closes #11694. Alternative to #12364.

Personally I’m not sure I agree with this change. #11694 describes a bug where the scrollbar would fail to appear, and that bug has now been fixed by #11792. So I’m not convinced it should be necessary to make the scrollbar even more persistent.

But, if we decide this is a change we want, here it is.

(The first commit, replacing imperative `ui.set_up_scrollbar()` calls with the declarative `<div data-simplebar>` syntax, seems like a nicer way to create SimpleBars either way.)

**Testing Plan:** Ran `test-js-with-node`, `test-js-with-casper`, manual tests.