### PR TITLE
Added integration for Facebook Oauth2 login

### DIFF
--- a/docs/overview/changelog.md
+++ b/docs/overview/changelog.md
@@ -7,6 +7,8 @@ All notable changes to the Zulip server are documented in this file.
 This section lists notable unreleased changes; it is generally updated
 in bursts.
 
+- Added Facebook Oauth2 integration.
+
 ### 2.0.3 -- 2019-04-23
 
 - Added documentation for upgrading the underlying OS version.

--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -29,6 +29,7 @@ authentication providers:
 * Google accounts, with `GoogleMobileOauth2Backend`
 * GitHub accounts, with `GitHubAuthBackend`
 * Microsoft Azure Active Directory, with `AzureADAuthBackend`
+* Facebook accouts, with `FacebookAuthBackend`
 
 Each of these requires one to a handful of lines of configuration in
 `settings.py`, as well as a secret in `zulip-secrets.conf`.  Details

--- a/static/styles/portico-signin.scss
+++ b/static/styles/portico-signin.scss
@@ -645,6 +645,14 @@ button.login-google-button {
     transform: translateX(15px) translateY(13px);
 }
 
+.facebook-wrapper::before {
+    content:"\F230";
+    position:absolute;
+    font-family:"FontAwesome";
+    font-size:2rem;color:#3b5998;
+    transform: translateX(15px) translateY(13px);
+}
+
 .login-page-container .right-side .actions,
 .forgot-password-container .actions {
     margin: 20px 0px 0px;

--- a/zerver/migrations/0197_azure_active_directory_auth.py
+++ b/zerver/migrations/0197_azure_active_directory_auth.py
@@ -16,6 +16,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='realm',
             name='authentication_methods',
-            field=bitfield.models.BitField(['Google', 'Email', 'GitHub', 'LDAP', 'Dev', 'RemoteUser', 'AzureAD'], default=2147483647),
+            field=bitfield.models.BitField(['Google', 'Email', 'GitHub', 'LDAP', 'Dev', 'RemoteUser', 'AzureAD', 'Facebook'], default=2147483647),
         ),
     ]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -156,7 +156,7 @@ class Realm(models.Model):
     MAX_GOOGLE_HANGOUTS_DOMAIN_LENGTH = 255  # This is just the maximum domain length by RFC
     INVITES_STANDARD_REALM_DAILY_MAX = 3000
     MESSAGE_VISIBILITY_LIMITED = 10000
-    AUTHENTICATION_FLAGS = [u'Google', u'Email', u'GitHub', u'LDAP', u'Dev', u'RemoteUser', u'AzureAD']
+    AUTHENTICATION_FLAGS = [u'Google', u'Email', u'GitHub', u'LDAP', u'Dev', u'RemoteUser', u'AzureAD', u'Facebook']
     SUBDOMAIN_FOR_ROOT_DOMAIN = ''
 
     # User-visible display name and description used on e.g. the organization homepage

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -377,7 +377,7 @@ def start_social_login(request: HttpRequest, backend: str) -> HttpResponse:
     if (backend == "github") and not (settings.SOCIAL_AUTH_GITHUB_KEY and
                                       settings.SOCIAL_AUTH_GITHUB_SECRET):
         return redirect_to_config_error("github")
-    # TODO: Add a similar block of AzureAD.
+    # TODO: Add a similar block of AzureAD and Facebook.
 
     return oauth_redirect_to_root(request, backend_url, 'social')
 

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -27,6 +27,7 @@ from requests import HTTPError
 from social_core.backends.github import GithubOAuth2, GithubOrganizationOAuth2, \
     GithubTeamOAuth2
 from social_core.backends.azuread import AzureADOAuth2
+from social_core.backends.facebook import FacebookOAuth2
 from social_core.backends.base import BaseAuth
 from social_core.backends.oauth import BaseOAuth2
 from social_core.exceptions import AuthFailed, SocialAuthBaseException
@@ -916,6 +917,10 @@ class GitHubAuthBackend(SocialAuthMixin, GithubOAuth2):
                 return dict(auth_failed_reason="GitHub user is not member of required organization")
 
         raise AssertionError("Invalid configuration")
+
+class FacebookAuthBackend(SocialAuthMixin, FacebookOAuth2):
+    auth_backend_name = "Facebook"
+    REDIRECT_STATE = False
 
 class AzureADAuthBackend(SocialAuthMixin, AzureADOAuth2):
     sort_order = 50

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -46,6 +46,7 @@ AUTHENTICATION_BACKENDS = (
     'zproject.backends.GitHubAuthBackend',
     'zproject.backends.GoogleMobileOauth2Backend',
     # 'zproject.backends.AzureADAuthBackend',
+	# 'zproject.backends.FacebookAuthBackend',
 )
 
 EXTERNAL_URI_SCHEME = "http://"

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -115,6 +115,7 @@ AUTHENTICATION_BACKENDS = (
     # 'zproject.backends.GoogleMobileOauth2Backend',  # Google Apps, setup below
     # 'zproject.backends.GitHubAuthBackend',  # GitHub auth, setup below
     # 'zproject.backends.AzureADAuthBackend',  # Microsoft Azure Active Directory auth, setup below
+	# 'zproject.backends.FacebookAuthBackend', # Facebook auth, setup below
     # 'zproject.backends.ZulipLDAPAuthBackend',  # LDAP, setup below
     # 'zproject.backends.ZulipRemoteUserBackend',  # Local SSO, setup docs on readthedocs
 )
@@ -196,6 +197,24 @@ AUTHENTICATION_BACKENDS = (
 # (2) Enter the application ID for the app as SOCIAL_AUTH_AZUREAD_OAUTH2_KEY here
 # (3) Put the application password in zulip-secrets.conf as 'azure_oauth2_secret'.
 #SOCIAL_AUTH_AZUREAD_OAUTH2_KEY = ''
+
+###########
+# Facebook Active Directory OAuth.
+#
+# To set up Facebook, you'll need to do the following:
+#
+# (1) Register an OAuth2 application with Facebook at:
+# https://developers.facebook.com/
+# Generate a new key under Application Secrets
+# For the login application, supply authentic information about firm.
+# For Redirect URL, enter:
+#   https://zulip.example.com/complete/facebook/
+# (2) Publish Application.
+# (3) Enter the application ID for the app as SOCIAL_AUTH_FACEBOOK_OAUTH2_KEY here
+# (4) Put the application password in zulip-secrets.conf as 'facebook_secret'.
+# 
+# Uncomment from here if you wish to enable facebook auth:
+#SOCIAL_AUTH_FACEBOOK_OAUTH2_KEY = ''
 
 ########
 # SSO via REMOTE_USER.

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -159,6 +159,7 @@ DEFAULT_SETTINGS = {
     'SOCIAL_AUTH_GITHUB_TEAM_ID': None,
     'SOCIAL_AUTH_SUBDOMAIN': None,
     'SOCIAL_AUTH_AZUREAD_OAUTH2_SECRET': get_secret('azure_oauth2_secret'),
+	'SOCIAL_AUTH_FACEBOOK_SECRET': get_secret('facebook_secret'),
 
     # Other auth
     'SSO_APPEND_DOMAIN': None,
@@ -1434,3 +1435,15 @@ CROSS_REALM_BOT_EMAILS = {
 CONTRIBUTORS_DATA = os.path.join(STATIC_ROOT, 'generated/github-contributors.json')
 
 THUMBOR_KEY = get_secret('thumbor_key')
+
+########################################################################
+#
+# Facebook OAuth Settings, for developers
+# who would like specific API version/define scope
+#
+########################################################################
+
+SOCIAL_AUTH_FACEBOOK_API_VERSION = '3.2'
+SOCIAL_AUTH_FACEBOOK_APP_NAMESPACE = ''
+SOCIAL_AUTH_FACEBOOK_SCOPE = ['email']
+SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS = {'fields': 'id,name,email', }


### PR DESCRIPTION
#Facebook Oauth2 login for zulip

**Testing Plan:**
None, unfortunately. I have no idea how it's done when facebook explicitly wants a proper url(no localhost), as well as SSL secured website, so as to keep their users safe.