### PR TITLE
Vagrantfile: Support Vagrant Docker provider

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -169,8 +169,9 @@ set -o pipefail
 # development environment not using Vagrant.
 
 # Set the MOTD on the system to have Zulip instructions
-sudo rm -f /etc/update-motd.d/*
-sudo bash -c 'cat << EndOfMessage > /etc/motd
+sudo sh -c 'cat > /etc/update-motd.d/99-zulip-dev' <<EndOfMessage
+#!/usr/bin/tail -n+2
+
 Welcome to the Zulip development environment!  Popular commands:
 * tools/provision - Update the development environment
 * tools/run-dev.py - Run the development server
@@ -180,7 +181,11 @@ Welcome to the Zulip development environment!  Popular commands:
 Read https://zulip.readthedocs.io/en/latest/testing/testing.html to learn
 how to run individual test suites so that you can get a fast debug cycle.
 
-EndOfMessage'
+EndOfMessage
+sudo chmod +x /etc/update-motd.d/99-zulip-dev
+sudo dpkg --purge landscape-client landscape-common ubuntu-release-upgrader-core update-manager-core update-notifier-common
+sudo dpkg-divert --add --rename /etc/default/motd-news
+sudo sh -c 'echo ENABLED=0 > /etc/default/motd-news'
 
 # If the host is running SELinux remount the /sys/fs/selinux directory as read only,
 # needed for apt-get to work.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -159,6 +159,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.vmx["numvcpus"] = vm_num_cpus
   end
 
+  config.vm.provider "docker" do |d, override|
+    override.vm.box = nil
+    d.build_dir = File.join(__dir__, "tools", "dev-vagrant-docker")
+    d.has_ssh = true
+    d.create_args = ["--ulimit", "nofile=1024:65536"]
+  end
+
 $provision_script = <<SCRIPT
 set -x
 set -e

--- a/tools/dev-vagrant-docker/Dockerfile
+++ b/tools/dev-vagrant-docker/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:18.04
+
+RUN echo locales locales/default_environment_locale select en_US.UTF-8 | debconf-set-selections \
+    && echo locales locales/locales_to_be_generated select "en_US.UTF-8 UTF-8" | debconf-set-selections \
+    && apt-get update \
+    && apt-get install --no-install-recommends -y \
+           ca-certificates \
+           curl \
+           locales \
+           lsb-release \
+           openssh-server \
+           python3 \
+           sudo \
+           systemd \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN dpkg-divert --add --rename /bin/systemctl \
+    && curl -so /bin/systemctl 'https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/b0588e003562f9a8eb76c98512c6d61146a81980/files/docker/systemctl3.py' \
+    && chmod +x /bin/systemctl \
+    && ln -nsf /bin/true /usr/sbin/policy-rc.d \
+    && mkdir -p /run/sshd \
+    # docker-systemctl-replacement doesn’t work with template units yet:
+    # https://github.com/gdraheim/docker-systemctl-replacement/issues/62
+    && ln -ns /lib/systemd/system/postgresql@.service /etc/systemd/system/postgresql@10-main.service \
+    && ln -s /etc/systemd/system/postgresql@10-main.service /etc/systemd/system/multi-user.target.wants/ \
+    # redis fails to start with the default configuration if IPv6 is disabled:
+    # https://github.com/antirez/redis/pull/5598
+    && dpkg-divert --add --rename /etc/default/redis-server \
+    && printf 'ULIMIT=65536\nDAEMON_ARGS="/etc/redis/redis.conf --bind 127.0.0.1"\n' > /etc/default/redis-server \
+    && mkdir /etc/systemd/system/redis-server.service.d \
+    && printf '[Service]\nExecStart=/usr/bin/redis-server /etc/redis/redis.conf --bind 127.0.0.1\n' > /etc/systemd/system/redis-server.service.d/override.conf \
+    && useradd -ms /bin/bash vagrant \
+    && mkdir -m 700 ~vagrant/.ssh \
+    && curl -so ~vagrant/.ssh/authorized_keys 'https://raw.githubusercontent.com/hashicorp/vagrant/be7876d83644aa6bdf7f951592fdc681506bcbe6/keys/vagrant.pub' \
+    && chown -R vagrant: ~vagrant/.ssh \
+    && echo 'vagrant ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/vagrant
+
+CMD ["/bin/systemctl"]
+
+EXPOSE 22
+EXPOSE 9991

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -310,7 +310,13 @@ def install_apt_deps(deps_to_install, retry=False):
 
     # setup-apt-repo does an `apt-get update`
     run_as_root(["./scripts/lib/setup-apt-repo"])
-    run_as_root(["apt-get", "-y", "install", "--no-install-recommends"] + deps_to_install)
+    run_as_root(
+        [
+            "env", "DEBIAN_FRONTEND=noninteractive",
+            "apt-get", "-y", "install", "--no-install-recommends",
+        ]
+        + deps_to_install
+    )
 
 def install_yum_deps(deps_to_install, retry=False):
     # type: (List[str], bool) -> None


### PR DESCRIPTION
The Vagrant LXC provider seems to be dying a slow death upstream (fgrehm/vagrant-lxc#375), so this is an experiment to see if we could easily replace it with the Vagrant Docker provider. Because we want to run lots of services and systemd and Docker [hate each other](https://developers.redhat.com/blog/2019/04/24/how-to-run-systemd-in-a-container/), I overwrote `systemctl` with [docker-systemctl-replacement](https://github.com/gdraheim/docker-systemctl-replacement). This went better than I was expecting: I got all the way through `provision`, but Postgres wouldn’t start because docker-systemctl-replacement doesn’t support template units yet (gdraheim/docker-systemctl-replacement#62). Upstream seems active, so maybe it’ll work soon.

Maybe we could run a separate Postgres container with the `zulip-postgresql` image from [docker-zulip](https://github.com/zulip/docker-zulip). That would make this less of a drop-in replacement, though.