### PR TITLE
docs: Update desktop repo URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ needs doing:
   [backend](https://github.com/zulip/zulip), web
   [frontend](https://github.com/zulip/zulip), React Native
   [mobile app](https://github.com/zulip/zulip-mobile), or Electron
-  [desktop app](https://github.com/zulip/zulip-electron).
+  [desktop app](https://github.com/zulip/zulip-desktop).
 * Building out our
   [Python API and bots](https://github.com/zulip/python-zulip-api) framework.
 * [Writing an integration](https://zulipchat.com/api/integrations-overview).
@@ -85,7 +85,7 @@ on.
 
 * If you're interested in
   [mobile](https://github.com/zulip/zulip-mobile/issues?q=is%3Aopen+is%3Aissue),
-  [desktop](https://github.com/zulip/zulip-electron/issues?q=is%3Aopen+is%3Aissue),
+  [desktop](https://github.com/zulip/zulip-desktop/issues?q=is%3Aopen+is%3Aissue),
   or
   [bots](https://github.com/zulip/python-zulip-api/issues?q=is%3Aopen+is%3Aissue)
   development, check the respective links for open issues, or post in
@@ -318,7 +318,7 @@ list typically takes about 15 minutes.
 * Star us on GitHub. There are four main repositories:
   [server/web](https://github.com/zulip/zulip),
   [mobile](https://github.com/zulip/zulip-mobile),
-  [desktop](https://github.com/zulip/zulip-electron), and
+  [desktop](https://github.com/zulip/zulip-desktop), and
   [Python API](https://github.com/zulip/python-zulip-api).
 * [Follow us](https://twitter.com/zulip) on Twitter.
 

--- a/docs/overview/architecture-overview.md
+++ b/docs/overview/architecture-overview.md
@@ -14,7 +14,7 @@ bindings and most of our integrations with other services and applications (see
 [Zulip Mobile](https://github.com/zulip/zulip-mobile) is the official
 mobile Zulip client supporting both iOS and Android, written in
 JavaScript with React Native, and
-[Zulip Desktop](https://github.com/zulip/zulip-electron) is the
+[Zulip Desktop](https://github.com/zulip/zulip-desktop) is the
 official Zulip desktop client for macOS, Linux, and Windows.
 
 We also maintain several separate repositories for integrations and

--- a/docs/overview/changelog.md
+++ b/docs/overview/changelog.md
@@ -754,7 +754,7 @@ Zulip apps.
   Serbian, Malayalam, Korean, and Italian).
 
 [mobile-push]: ../production/mobile-push-notifications.html
-[electron-app]: https://github.com/zulip/zulip-electron/releases
+[electron-app]: https://github.com/zulip/zulip-desktop/releases
 [ios-app]: https://itunes.apple.com/us/app/zulip/id1203036395
 
 **Full feature changelog:**

--- a/docs/overview/gsoc-ideas.md
+++ b/docs/overview/gsoc-ideas.md
@@ -506,11 +506,11 @@ we have enough strong applicants.
 ### Electron Desktop app
 
 Code:
-[Our cross-platform desktop app written in JavaScript on Electron](https://github.com/zulip/zulip-electron).
+[Our cross-platform desktop app written in JavaScript on Electron](https://github.com/zulip/zulip-desktop).
 Experts: Akash Nimare, Abhighyan Khaund
 
 - Contribute to our
-  [Electron-based desktop client application](https://github.com/zulip/zulip-electron).
+  [Electron-based desktop client application](https://github.com/zulip/zulip-desktop).
   There's plenty of feature/UI work to do, but focus areas for us
   include things to (1) improve the release process for the app, using
   automated testing, typescript, etc. and (2) making it easy to

--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -1,7 +1,7 @@
 const ELECTRON_APP_VERSION = "2.3.82";
-const ELECTRON_APP_URL_LINUX = "https://github.com/zulip/zulip-electron/releases/download/v" + ELECTRON_APP_VERSION + "/Zulip-" + ELECTRON_APP_VERSION + "-x86_64.AppImage";
-const ELECTRON_APP_URL_MAC = "https://github.com/zulip/zulip-electron/releases/download/v" + ELECTRON_APP_VERSION + "/Zulip-" + ELECTRON_APP_VERSION + ".dmg";
-const ELECTRON_APP_URL_WINDOWS = "https://github.com/zulip/zulip-electron/releases/download/v" + ELECTRON_APP_VERSION + "/Zulip-Web-Setup-" + ELECTRON_APP_VERSION + ".exe";
+const ELECTRON_APP_URL_LINUX = "https://github.com/zulip/zulip-desktop/releases/download/v" + ELECTRON_APP_VERSION + "/Zulip-" + ELECTRON_APP_VERSION + "-x86_64.AppImage";
+const ELECTRON_APP_URL_MAC = "https://github.com/zulip/zulip-desktop/releases/download/v" + ELECTRON_APP_VERSION + "/Zulip-" + ELECTRON_APP_VERSION + ".dmg";
+const ELECTRON_APP_URL_WINDOWS = "https://github.com/zulip/zulip-desktop/releases/download/v" + ELECTRON_APP_VERSION + "/Zulip-Web-Setup-" + ELECTRON_APP_VERSION + ".exe";
 
 import render_tabs from './team.js';
 import {detect_user_os}  from './tabbed-instructions.js';

--- a/templates/zerver/for/open-source.md
+++ b/templates/zerver/for/open-source.md
@@ -95,7 +95,7 @@ Don’t like something? You can
 [submit a patch](https://zulip.readthedocs.io/en/latest/development/overview.html),
 [fork the project](https://github.com/zulip/zulip), or chat with us directly
 at [chat.zulip.org](https://chat.zulip.org). All code, including the
-[desktop](https://github.com/zulip/zulip-electron) and
+[desktop](https://github.com/zulip/zulip-desktop) and
 [mobile](https://github.com/zulip/zulip-mobile) apps, is under the Apache 2
 license.
 

--- a/templates/zerver/help/desktop-app-install-guide.md
+++ b/templates/zerver/help/desktop-app-install-guide.md
@@ -120,8 +120,8 @@ sudo apt update
 sudo apt install zulip
 ```
 
-[latest]: https://github.com/zulip/zulip-electron/releases/latest
-[release-list]: https://github.com/zulip/zulip-electron/releases
+[latest]: https://github.com/zulip/zulip-desktop/releases/latest
+[release-list]: https://github.com/zulip/zulip-desktop/releases
 
 ## Related articles
 

--- a/tools/update-authors-json
+++ b/tools/update-authors-json
@@ -72,7 +72,7 @@ def run_production() -> None:
     # page (e.g. if they are deprecated).
     repositories = {
         'server': 'https://api.github.com/repos/zulip/zulip/stats/contributors',
-        'desktop': 'https://api.github.com/repos/zulip/zulip-electron/stats/contributors',
+        'desktop': 'https://api.github.com/repos/zulip/zulip-desktop/stats/contributors',
         'mobile': 'https://api.github.com/repos/zulip/zulip-mobile/stats/contributors',
         'python-zulip-api': 'https://api.github.com/repos/zulip/python-zulip-api/stats/contributors',
         'zulip-js': 'https://api.github.com/repos/zulip/zulip-js/stats/contributors',


### PR DESCRIPTION
Since the desktop app's autoupdate process broke in v2.3.82, multiple channels need to be maintained on GitHub to handle future updates. The new desktop repo URL is therefore `zulip/zulip-desktop`.

This PR is meant to update all documentation still using `zulip/zulip-electron`. 