### PR TITLE
restore-backup: Run zulip-puppet-apply before pg_restore.

### DIFF
--- a/scripts/setup/restore-backup
+++ b/scripts/setup/restore-backup
@@ -94,22 +94,22 @@ def restore_backup(tarball_file):
         as_postgres = ["su", "-s", "/usr/bin/env", "-", "--", POSTGRES_USER]
         run(as_postgres + ["dropdb", "--if-exists", "--", db_name])
         run(as_postgres + ["createdb", "-O", "zulip", "-T", "template0", "--", db_name])
-        run(as_postgres + ["pg_restore", "-d", db_name, "--", db_dir])
-        run(["chown", "-R", str(uid), "--", tmp])
-        os.setresuid(uid, uid, 0)
 
         # In production, we also need to do a `zulip-puppet-apply` in
         # order to adjust any configuration from /etc/zulip/zulip.conf
         # to this system.
         if settings.PRODUCTION:
-            os.setresuid(0, 0, 0)
             run(
                 [
                     os.path.join(settings.DEPLOY_ROOT, "scripts", "zulip-puppet-apply"),
                     "-f",
                 ]
             )
-            os.setresuid(uid, uid, 0)
+        run(as_postgres + ["pg_restore", "-d", db_name, "--", db_dir])
+        run(["chown", "-R", str(uid), "--", tmp])
+        os.setresuid(uid, uid, 0)
+
+        if settings.PRODUCTION:
             run(["supervisorctl", "restart", "all"])
 
         run([os.path.join(settings.DEPLOY_ROOT, "scripts", "setup", "flush-memcached")])


### PR DESCRIPTION
This should ensure that we apply any special configuration for the
database system (e.g. installing `pgroonga`) before we try to restore
the database contents from the archive.

For pgroonga in particular, this is important so that we can preserve
the configuration of the extension in the `pg_restore` process.

Fixes #12345.