### PR TITLE
dependencies: Update yarn.lock for simplebar@4.0.0-alpha.9 upgrade

### DIFF
--- a/scripts/lib/node_cache.py
+++ b/scripts/lib/node_cache.py
@@ -97,7 +97,7 @@ def do_yarn_install(target_path, yarn_args, success_stamp, stdout=None, stderr=N
         cd_exec = os.path.join(ZULIP_PATH, "scripts/lib/cd_exec")
         if os.environ.get('CUSTOM_CA_CERTIFICATES'):
             cmds.append([YARN_BIN, "config", "set", "cafile", os.environ['CUSTOM_CA_CERTIFICATES']])
-        cmds.append([cd_exec, target_path, YARN_BIN, "install", "--non-interactive"] +
+        cmds.append([cd_exec, target_path, YARN_BIN, "install", "--non-interactive", "--frozen-lockfile"] +
                     yarn_args)
     cmds.append(['touch', success_stamp])
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10687,10 +10687,10 @@ signum@^1.0.0:
   resolved "https://registry.yarnpkg.com/signum/-/signum-1.0.0.tgz#74a7d2bf2a20b40eba16a92b152124f1d559fa77"
   integrity sha1-dKfSvyogtA66FqkrFSEk8dVZ+nc=
 
-simplebar@^4.0.0-alpha.6:
-  version "4.0.0-alpha.6"
-  resolved "https://registry.yarnpkg.com/simplebar/-/simplebar-4.0.0-alpha.6.tgz#69b2822486b8950f2d7121773d0c52361b3a3b30"
-  integrity sha512-OWU0lrx1hI/o7WddOz1TNlvQQiNMTv6I6p06HQwC1NjYORxutNOWM56Z/au9tVAz551x+IZn6UAuQGjkCgDnNQ==
+simplebar@^4.0.0-alpha.9:
+  version "4.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/simplebar/-/simplebar-4.0.0-alpha.9.tgz#e6cf24a2e613abbef952e962680ed2429d421617"
+  integrity sha512-WGscL/Lsrfk0uTuG1Pyl/jV6ZkZh0A70atCxcVfvS81aGZdnRjQfHntQPT/nSr+8jxv6YSib5F+FnPCGVw9raw==
   dependencies:
     can-use-dom "^0.1.0"
     core-js "^3.0.1"


### PR DESCRIPTION
This somehow got dropped from commit 491589579ad737a3a5a7959b275ee473a5971fd1. We were ~~installing the right package anyway~~ (not anymore, now that simplebar@4.0.0 is released) but `yarn` wasn’t happy.