### PR TITLE
Revert "gitattributes: Mark yarn.lock as "binary", i.e. suppress diffs."

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,4 +11,3 @@
 *.otf binary
 *.tif binary
 *.ogg binary
-yarn.lock binary


### PR DESCRIPTION
This reverts commit a717ac6d85c4992d19725139ddda3f699bf41b4e.

.gitattributes affects the behavior of many Git operations like rebase and merge and mergetool, not just the output of show and diff.  Treating yarn.lock as binary was making it too hard to deal with yarn.lock diffs when we actually needed them.  Also, the GitHub website ignores this setting and suppresses large parts of diffs regardless.