### PR TITLE
dependencies: Upgrade simplebar to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "plotly.js": "1.37.1",
     "sass-loader": "7.0.1",
     "script-loader": "0.7.2",
-    "simplebar": "^4.0.0-alpha.9",
+    "simplebar": "^4.0.0",
     "sortablejs": "^1.7.0",
     "sorttable": "1.0.2",
     "source-map-loader": "0.2.3",

--- a/version.py
+++ b/version.py
@@ -11,4 +11,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '32.0'
+PROVISION_VERSION = '32.1'

--- a/yarn.lock
+++ b/yarn.lock
@@ -10687,10 +10687,10 @@ signum@^1.0.0:
   resolved "https://registry.yarnpkg.com/signum/-/signum-1.0.0.tgz#74a7d2bf2a20b40eba16a92b152124f1d559fa77"
   integrity sha1-dKfSvyogtA66FqkrFSEk8dVZ+nc=
 
-simplebar@^4.0.0-alpha.9:
-  version "4.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/simplebar/-/simplebar-4.0.0-alpha.9.tgz#e6cf24a2e613abbef952e962680ed2429d421617"
-  integrity sha512-WGscL/Lsrfk0uTuG1Pyl/jV6ZkZh0A70atCxcVfvS81aGZdnRjQfHntQPT/nSr+8jxv6YSib5F+FnPCGVw9raw==
+simplebar@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/simplebar/-/simplebar-4.0.0.tgz#7f1b9e735ec94a58f887d4803f6b15abf401b6b5"
+  integrity sha512-td6vJVhqIXfa3JgNZR5OgETPLfmHNSSpt+OXIbk6WH/nOrUtX3Qcyio30+5rdxxAV/61+F5eJ4jJV4Ek7/KJYQ==
   dependencies:
     can-use-dom "^0.1.0"
     core-js "^3.0.1"


### PR DESCRIPTION
Fixes #12347.

**Testing Plan:** Dragged the settings scrollbar, releasing the mouse outside the modal; observed that the modal doesn’t spuriously close.