### PR TITLE
css: Improve SimpleBar scrollbar contrast

### DIFF
--- a/static/styles/components.scss
+++ b/static/styles/components.scss
@@ -67,7 +67,8 @@ a.no-underline:hover {
 }
 
 .simplebar-track .simplebar-scrollbar::before {
-    background-color: rgb(136, 136, 136);
+    background-color: rgb(0, 0, 0);
+    box-shadow: 0px 0px 0px 1px rgba(255, 255, 255, 0.33);
 }
 
 .simplebar-track.simplebar-vertical {

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -573,6 +573,11 @@ on a dark background, and don't change the dark labels dark either. */
         -webkit-filter: invert(100%);
         filter: invert(100%);
     }
+
+    .simplebar-track .simplebar-scrollbar::before {
+        background-color: rgb(255, 255, 255);
+        box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.33);
+    }
 }
 
 @-moz-document url-prefix() {


### PR DESCRIPTION
Show black scrollbars with a thin light border in day mode, or white scrollbars with a thin dark border in night mode (both at 50% opacity). This matches the native scrollbars on macOS pretty closely.

Cc: @rishig

![day](https://user-images.githubusercontent.com/26471/58069076-c1c0a380-7b48-11e9-9c49-d04b48b6e68d.png)
![night](https://user-images.githubusercontent.com/26471/58069080-c38a6700-7b48-11e9-8b39-b42c6b24c066.png)
