### PR TITLE
subs: Replace all `in_home_view` uses with `is_muted` property.

### DIFF
--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -130,14 +130,14 @@ var denmark = {
     color: 'blue',
     name: 'Denmark',
     stream_id: 1,
-    in_home_view: false,
+    is_muted: true,
 };
 var social = {
     subscribed: true,
     color: 'red',
     name: 'social',
     stream_id: 2,
-    in_home_view: true,
+    is_muted: false,
     invite_only: true,
 };
 var edgecase_stream = {
@@ -145,7 +145,7 @@ var edgecase_stream = {
     color: 'green',
     name: 'Bobby <h1>Tables</h1>',
     stream_id: 3,
-    in_home_view: true,
+    is_muted: false,
 };
 stream_data.add_sub('Denmark', denmark);
 stream_data.add_sub('social', social);

--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -55,7 +55,7 @@ var denmark = {
     color: 'blue',
     name: 'Denmark',
     stream_id: 1,
-    in_home_view: false,
+    is_muted: true,
 };
 stream_data.add_sub('Denmark', denmark);
 

--- a/frontend_tests/node_tests/notifications.js
+++ b/frontend_tests/node_tests/notifications.js
@@ -26,7 +26,7 @@ var general = {
     subscribed: true,
     name: 'general',
     stream_id: 10,
-    in_home_view: true,
+    is_muted: false,
 };
 
 // Muted streams
@@ -34,7 +34,7 @@ var muted = {
     subscribed: true,
     name: 'muted',
     stream_id: 20,
-    in_home_view: false,
+    is_muted: true,
 };
 
 stream_data.add_sub('general', general);

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -79,8 +79,8 @@ run_test('basics', () => {
     assert.equal(stream_data.get_name('denMARK'), 'Denmark');
     assert.equal(stream_data.get_name('unknown Stream'), 'unknown Stream');
 
-    assert(stream_data.in_home_view(social.stream_id));
-    assert(!stream_data.in_home_view(denmark.stream_id));
+    assert(!stream_data.is_muted(social.stream_id));
+    assert(stream_data.is_muted(denmark.stream_id));
 
     assert.equal(stream_data.maybe_get_stream_name(), undefined);
     assert.equal(stream_data.maybe_get_stream_name(social.stream_id), 'social');
@@ -600,17 +600,17 @@ run_test('is_muted', () => {
 
     stream_data.add_sub('tony', tony);
     stream_data.add_sub('jazy', jazy);
-    assert(stream_data.name_in_home_view('tony'));
-    assert(!stream_data.name_in_home_view('jazy'));
-    assert(!stream_data.name_in_home_view('EEXISTS'));
+    assert(!stream_data.is_stream_muted_by_name('tony'));
+    assert(stream_data.is_stream_muted_by_name('jazy'));
+    assert(stream_data.is_stream_muted_by_name('EEXISTS'));
 });
 
-run_test('notifications_in_home_view', () => {
+run_test('is_notifications_stream_muted', () => {
     page_params.notifications_stream = 'tony';
-    assert(stream_data.notifications_in_home_view());
+    assert(!stream_data.is_notifications_stream_muted());
 
     page_params.notifications_stream = 'jazy';
-    assert(!stream_data.notifications_in_home_view());
+    assert(stream_data.is_notifications_stream_muted());
 });
 
 run_test('remove_default_stream', () => {

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -31,14 +31,14 @@ run_test('basics', () => {
         color: 'blue',
         name: 'Denmark',
         stream_id: 1,
-        in_home_view: false,
+        is_muted: true,
     };
     var social = {
         subscribed: true,
         color: 'red',
         name: 'social',
         stream_id: 2,
-        in_home_view: true,
+        is_muted: false,
         invite_only: true,
         is_announcement_only: true,
     };
@@ -47,7 +47,7 @@ run_test('basics', () => {
         color: 'yellow',
         name: 'test',
         stream_id: 3,
-        in_home_view: false,
+        is_muted: true,
         invite_only: false,
     };
     stream_data.add_sub('Denmark', denmark);
@@ -328,7 +328,7 @@ run_test('admin_options', () => {
             color: 'blue',
             name: 'stream_to_admin',
             stream_id: 1,
-            in_home_view: false,
+            is_muted: true,
             invite_only: false,
         };
         stream_data.add_sub(sub.name, sub);
@@ -583,19 +583,19 @@ run_test('notifications', () => {
     assert(!stream_data.receives_audible_notifications('India'));
 });
 
-run_test('in_home_view', () => {
+run_test('is_muted', () => {
     var tony = {
         stream_id: 999,
         name: 'tony',
         subscribed: true,
-        in_home_view: true,
+        is_muted: false,
     };
 
     var jazy = {
         stream_id: 500,
         name: 'jazy',
         subscribed: false,
-        in_home_view: false,
+        is_muted: true,
     };
 
     stream_data.add_sub('tony', tony);
@@ -618,7 +618,7 @@ run_test('remove_default_stream', () => {
         stream_id: 674,
         name: 'remove_me',
         subscribed: false,
-        in_home_view: false,
+        is_muted: true,
     };
 
     stream_data.add_sub('remove_me', remove_me);

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -27,7 +27,7 @@ var frontend = {
     color: 'yellow',
     name: 'frontend',
     stream_id: 1,
-    in_home_view: false,
+    is_muted: true,
     invite_only: false,
 };
 
@@ -364,7 +364,7 @@ var dev_help = {
     color: 'blue',
     name: 'dev help',
     stream_id: 2,
-    in_home_view: false,
+    is_muted: true,
     invite_only: false,
 };
 stream_data.add_sub(dev_help.name, dev_help);

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -62,8 +62,8 @@ run_test('update_property', () => {
     // Test in home view
     with_overrides(function (override) {
         global.with_stub(function (stub) {
-            override('stream_muting.update_in_home_view', stub.f);
-            stream_events.update_property(1, 'in_home_view', true);
+            override('stream_muting.update_is_muted', stub.f);
+            stream_events.update_property(1, 'in_home_view', false);
             var args = stub.get_args('sub', 'val');
             assert.equal(args.sub.stream_id, 1);
             assert.equal(args.val, true);

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -639,7 +639,7 @@ run_test('rename_stream', () => {
             name: 'Development',
             id: 1000,
             uri: '#narrow/stream/1000-Development',
-            not_in_home_view: false,
+            is_muted: false,
             invite_only: undefined,
             is_web_public: undefined,
             color: payload.color,

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1207,7 +1207,7 @@ run_test('stream_sidebar_actions', () => {
         stream: {
             color: 'red',
             name: 'devel',
-            in_home_view: true,
+            is_muted: false,
             id: 55,
         },
     };
@@ -1257,7 +1257,7 @@ run_test('subscription_settings', () => {
         can_change_stream_permissions: true,
         email_address: 'xxxxxxxxxxxxxxx@zulip.com',
         stream_id: 888,
-        in_home_view: true,
+        is_muted: false,
     };
 
     var html = '';
@@ -1314,7 +1314,7 @@ run_test('subscriptions', () => {
                 invite_only: true,
                 email_address: 'xxxxxxxxxxxxxxx@zulip.com',
                 stream_id: 888,
-                in_home_view: true,
+                is_muted: false,
             },
             {
                 name: 'social',

--- a/frontend_tests/node_tests/topic_generator.js
+++ b/frontend_tests/node_tests/topic_generator.js
@@ -282,8 +282,8 @@ run_test('topics', () => {
         return stream_id_dct[stream_name];
     };
 
-    global.stream_data.name_in_home_view = function (stream_name) {
-        return stream_name !== 'muted';
+    global.stream_data.is_stream_muted_by_name = function (stream_name) {
+        return stream_name === 'muted';
     };
 
     global.unread.topic_has_any_unread = function (stream_id) {

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -26,7 +26,7 @@ var social = {
     stream_id: 200,
     name: 'social',
     subscribed: true,
-    in_home_view: true,
+    is_muted: false,
 };
 stream_data.add_sub('social', social);
 

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -303,8 +303,8 @@ run_test('home_messages', () => {
     stream_data.is_subscribed = function () {
         return true;
     };
-    stream_data.in_home_view = function () {
-        return true;
+    stream_data.is_muted = function () {
+        return false;
     };
 
     var stream_id = 401;

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -41,7 +41,8 @@ function message_in_home(message) {
         return true;
     }
 
-    return stream_data.in_home_view(message.stream_id);
+    // We don't display muted streams in 'All messages' view
+    return !stream_data.is_muted(message.stream_id);
 }
 
 function message_matches_search_term(message, operator, operand) {

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -443,7 +443,7 @@ exports.message_is_notifiable = function (message) {
     // Messages to muted streams that don't mention us specifically
     // are not notifiable.
     if (message.type === "stream" &&
-        !stream_data.in_home_view(message.stream_id)) {
+        stream_data.is_muted(message.stream_id)) {
         return false;
     }
 
@@ -576,7 +576,7 @@ exports.get_local_notify_mix_reason = function (message) {
         return i18n.t("Sent! Your message was sent to a topic you have muted.");
     }
 
-    if (message.type === "stream" && !stream_data.in_home_view(message.stream_id)) {
+    if (message.type === "stream" && stream_data.is_muted(message.stream_id)) {
         return i18n.t("Sent! Your message was sent to a stream you have muted.");
     }
 

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -330,13 +330,13 @@ exports.update_calculated_fields = function (sub) {
 
 exports.all_subscribed_streams_are_in_home_view = function () {
     return _.every(exports.subscribed_subs(), function (sub) {
-        return sub.in_home_view;
+        return !sub.is_muted;
     });
 };
 
 exports.home_view_stream_names = function () {
     var home_view_subs = _.filter(exports.subscribed_subs(), function (sub) {
-        return sub.in_home_view;
+        return !sub.is_muted;
     });
     return _.map(home_view_subs, function (sub) {
         return sub.name;
@@ -357,12 +357,12 @@ exports.get_color = function (stream_name) {
 
 exports.in_home_view = function (stream_id) {
     var sub = exports.get_sub_by_id(stream_id);
-    return sub !== undefined && sub.in_home_view;
+    return sub !== undefined && !sub.is_muted;
 };
 
 exports.name_in_home_view = function (stream_name) {
     var sub = exports.get_sub(stream_name);
-    return sub !== undefined && sub.in_home_view;
+    return sub !== undefined && !sub.is_muted;
 };
 
 exports.notifications_in_home_view = function () {
@@ -581,7 +581,7 @@ exports.create_sub_from_server_data = function (stream_name, attrs) {
         render_subscribers: !page_params.realm_is_zephyr_mirror_realm || attrs.invite_only === true,
         subscribed: true,
         newly_subscribed: false,
-        in_home_view: true,
+        is_muted: false,
         invite_only: false,
         desktop_notifications: page_params.enable_stream_desktop_notifications,
         audible_notifications: page_params.enable_stream_sounds,

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -355,19 +355,27 @@ exports.get_color = function (stream_name) {
     return sub.color;
 };
 
-exports.in_home_view = function (stream_id) {
+exports.is_muted = function (stream_id) {
     var sub = exports.get_sub_by_id(stream_id);
-    return sub !== undefined && !sub.is_muted;
+    // Return true for undefined streams
+    if (sub === undefined) {
+        return true;
+    }
+    return sub.is_muted;
 };
 
-exports.name_in_home_view = function (stream_name) {
+exports.is_stream_muted_by_name = function (stream_name) {
     var sub = exports.get_sub(stream_name);
-    return sub !== undefined && !sub.is_muted;
+    // Return true for undefined streams
+    if (sub === undefined) {
+        return true;
+    }
+    return sub.is_muted;
 };
 
-exports.notifications_in_home_view = function () {
+exports.is_notifications_stream_muted = function () {
     // TODO: add page_params.notifications_stream_id
-    return exports.name_in_home_view(page_params.notifications_stream);
+    return exports.is_stream_muted_by_name(page_params.notifications_stream);
 };
 
 exports.is_subscribed = function (stream_name) {

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -239,10 +239,10 @@ exports.show_settings_for = function (node) {
     show_subscription_settings(sub_settings);
 };
 
-function stream_home_view_clicked(e) {
+function stream_is_muted_clicked(e) {
     var sub = get_sub_for_target(e.target);
     if (!sub) {
-        blueslip.error('stream_home_view_clicked() fails');
+        blueslip.error('stream_is_muted_clicked() fails');
         return;
     }
 
@@ -487,8 +487,8 @@ exports.initialize = function () {
         e.stopPropagation();
     });
 
-    $("#subscriptions_table").on("click", "#sub_setting_not_in_home_view",
-                                 stream_home_view_clicked);
+    $("#subscriptions_table").on("click", "#sub_setting_is_muted",
+                                 stream_is_muted_clicked);
     $("#subscriptions_table").on("click", "#sub_desktop_notifications_setting",
                                  stream_desktop_notifications_clicked);
     $("#subscriptions_table").on("click", "#sub_audible_notifications_setting",

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -251,7 +251,7 @@ function stream_home_view_clicked(e) {
 
     subs.toggle_home(sub);
 
-    if (sub.in_home_view) {
+    if (!sub.is_muted) {
         sub_settings.find(".mute-note").addClass("hide-mute-note");
         notification_checkboxes.removeClass("muted-sub");
         notification_checkboxes.find("input[type='checkbox']").prop("disabled", false);

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -51,7 +51,7 @@ exports.update_property = function (stream_id, property, value, other_values) {
         stream_color.update_stream_color(sub, value, {update_historical: true});
         break;
     case 'in_home_view':
-        stream_muting.update_in_home_view(sub, value);
+        stream_muting.update_is_muted(sub, !value);
         break;
     case 'desktop_notifications':
         update_stream_desktop_notifications(sub, value);

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -215,7 +215,7 @@ function build_stream_sidebar_li(sub) {
         name: name,
         id: sub.stream_id,
         uri: hash_util.by_stream_uri(sub.stream_id),
-        is_muted: stream_data.in_home_view(sub.stream_id) === false,
+        is_muted: stream_data.is_muted(sub.stream_id) === true,
         invite_only: sub.invite_only,
         is_web_public: sub.is_web_public,
         color: stream_data.get_color(name),

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -215,7 +215,7 @@ function build_stream_sidebar_li(sub) {
         name: name,
         id: sub.stream_id,
         uri: hash_util.by_stream_uri(sub.stream_id),
-        not_in_home_view: stream_data.in_home_view(sub.stream_id) === false,
+        is_muted: stream_data.in_home_view(sub.stream_id) === false,
         invite_only: sub.invite_only,
         is_web_public: sub.is_web_public,
         color: stream_data.get_color(name),

--- a/static/js/stream_muting.js
+++ b/static/js/stream_muting.js
@@ -48,8 +48,8 @@ exports.update_is_muted = function (sub, value) {
 
     stream_list.set_in_home_view(sub.stream_id, !sub.is_muted);
 
-    var not_in_home_view_checkbox = $(".subscription_settings[data-stream-id='" + sub.stream_id + "'] #sub_setting_not_in_home_view .sub_setting_control");
-    not_in_home_view_checkbox.prop('checked', value);
+    var is_muted_checkbox = $(".subscription_settings[data-stream-id='" + sub.stream_id + "'] #sub_setting_is_muted .sub_setting_control");
+    is_muted_checkbox.prop('checked', value);
 };
 
 return exports;

--- a/static/js/stream_muting.js
+++ b/static/js/stream_muting.js
@@ -5,7 +5,7 @@ var exports = {};
 exports.update_in_home_view = function (sub, value) {
     // value is true if we are in home view
     // TODO: flip the semantics to be is_muting
-    sub.in_home_view = value;
+    sub.is_muted = !value;
 
     setTimeout(function () {
         var msg_offset;
@@ -48,7 +48,7 @@ exports.update_in_home_view = function (sub, value) {
         }
     }, 0);
 
-    stream_list.set_in_home_view(sub.stream_id, sub.in_home_view);
+    stream_list.set_in_home_view(sub.stream_id, !sub.is_muted);
 
     var not_in_home_view_checkbox = $(".subscription_settings[data-stream-id='" + sub.stream_id + "'] #sub_setting_not_in_home_view .sub_setting_control");
     not_in_home_view_checkbox.prop('checked', !value);

--- a/static/js/stream_muting.js
+++ b/static/js/stream_muting.js
@@ -2,10 +2,8 @@ var stream_muting = (function () {
 
 var exports = {};
 
-exports.update_in_home_view = function (sub, value) {
-    // value is true if we are in home view
-    // TODO: flip the semantics to be is_muting
-    sub.is_muted = !value;
+exports.update_is_muted = function (sub, value) {
+    sub.is_muted = value;
 
     setTimeout(function () {
         var msg_offset;
@@ -51,7 +49,7 @@ exports.update_in_home_view = function (sub, value) {
     stream_list.set_in_home_view(sub.stream_id, !sub.is_muted);
 
     var not_in_home_view_checkbox = $(".subscription_settings[data-stream-id='" + sub.stream_id + "'] #sub_setting_not_in_home_view .sub_setting_control");
-    not_in_home_view_checkbox.prop('checked', !value);
+    not_in_home_view_checkbox.prop('checked', value);
 };
 
 return exports;

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -96,8 +96,8 @@ exports.active_stream = function () {
 };
 
 exports.toggle_home = function (sub) {
-    stream_muting.update_in_home_view(sub, !sub.in_home_view);
-    stream_edit.set_stream_property(sub, 'in_home_view', sub.in_home_view);
+    stream_muting.update_in_home_view(sub, sub.is_muted);
+    stream_edit.set_stream_property(sub, 'is_muted', sub.is_muted);
 };
 
 exports.toggle_pin_to_top_stream = function (sub) {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -96,7 +96,7 @@ exports.active_stream = function () {
 };
 
 exports.toggle_home = function (sub) {
-    stream_muting.update_in_home_view(sub, sub.is_muted);
+    stream_muting.update_is_muted(sub, !sub.is_muted);
     stream_edit.set_stream_property(sub, 'is_muted', sub.is_muted);
 };
 

--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -25,7 +25,7 @@ function make_tab_data() {
             return true;
         }
 
-        return !stream_data.in_home_view(stream_id);
+        return stream_data.is_muted(stream_id);
     }
 
     function in_all() {

--- a/static/js/topic_generator.js
+++ b/static/js/topic_generator.js
@@ -198,7 +198,7 @@ exports.get_next_topic = function (curr_stream, curr_topic) {
     var my_streams = stream_sort.get_streams();
 
     my_streams = _.filter(my_streams, function (stream_name) {
-        if (stream_data.name_in_home_view(stream_name)) {
+        if (!stream_data.is_stream_muted_by_name(stream_name)) {
             return true;
         }
         if  (stream_name === curr_stream) {

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -305,7 +305,7 @@ exports.unread_topic_counter = (function () {
                 }
             });
             res.stream_count.set(stream_id, stream_count);
-            if (stream_data.in_home_view(stream_id)) {
+            if (!stream_data.is_muted(stream_id)) {
                 res.stream_unread_messages += stream_count;
             }
 

--- a/static/templates/stream_sidebar_actions.handlebars
+++ b/static/templates/stream_sidebar_actions.handlebars
@@ -24,12 +24,12 @@
     </li>
     <li>
         <a class="toggle_home">
-            {{#if stream.in_home_view}}
-                <i class="fa fa-eye-slash" aria-hidden="true"></i>
-                {{#tr this}}Mute the stream <b>__stream.name__</b>{{/tr}}
-            {{else}}
+            {{#if stream.is_muted}}
                 <i class="fa fa-eye" aria-hidden="true"></i>
                 {{#tr this}}Unmute the stream <b>__stream.name__</b>{{/tr}}
+            {{else}}
+                <i class="fa fa-eye-slash" aria-hidden="true"></i>
+                {{#tr this}}Mute the stream <b>__stream.name__</b>{{/tr}}
             {{/if}}
         </a>
     </li>

--- a/static/templates/stream_sidebar_row.handlebars
+++ b/static/templates/stream_sidebar_row.handlebars
@@ -1,6 +1,6 @@
 {{! Stream sidebar rows }}
 
-<li class="narrow-filter{{#if not_in_home_view}} out_of_home_view{{/if}}"
+<li class="narrow-filter{{#if is_muted}} out_of_home_view{{/if}}"
   data-stream-id="{{id}}" data-stream-name="{{name}}">
     <div class="bottom_left_row">
         <div class="subscription_block selectable_sidebar_block">

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -49,7 +49,7 @@
             <div class="subscription-config">
                 <ul class="grey-box">
                     <li>
-                        <div id="sub_setting_not_in_home_view" class="sub_setting_checkbox sub-mute-setting">
+                        <div id="sub_setting_is_muted" class="sub_setting_checkbox sub-mute-setting">
                             <input id="mutestream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if is_muted}}checked{{/if}} />
                             <label class="subscription-control-label">{{t "Mute stream" }}</label>
                             <p class="mute-note {{#unless is_muted}}hide-mute-note{{/unless}}">{{t "Muted streams don't show up in \"All messages\" or generate notifications unless you are mentioned." }}</p>

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -50,36 +50,36 @@
                 <ul class="grey-box">
                     <li>
                         <div id="sub_setting_not_in_home_view" class="sub_setting_checkbox sub-mute-setting">
-                            <input id="mutestream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#unless in_home_view}}checked{{/unless}} />
+                            <input id="mutestream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if is_muted}}checked{{/if}} />
                             <label class="subscription-control-label">{{t "Mute stream" }}</label>
-                            <p class="mute-note {{#if in_home_view}}hide-mute-note{{/if}}">{{t "Muted streams don't show up in \"All messages\" or generate notifications unless you are mentioned." }}</p>
+                            <p class="mute-note {{#unless is_muted}}hide-mute-note{{/unless}}">{{t "Muted streams don't show up in \"All messages\" or generate notifications unless you are mentioned." }}</p>
                         </div>
                     </li>
                     <li>
                         <div id="sub_desktop_notifications_setting"
-                          class="sub_setting_checkbox sub_notification_setting {{#unless in_home_view}}muted-sub{{/unless}}">
-                            <input id="desktop-notifystream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if desktop_notifications_display}}checked{{/if}} {{#unless in_home_view}}disabled="disabled"{{/unless}}/>
+                          class="sub_setting_checkbox sub_notification_setting {{#if is_muted}}muted-sub{{/if}}">
+                            <input id="desktop-notifystream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if desktop_notifications_display}}checked{{/if}} {{#if is_muted}}disabled="disabled"{{/if}}/>
                             <label class="subscription-control-label">{{t "Visual desktop notifications" }}</label>
                         </div>
                     </li>
                     <li>
                         <div id="sub_audible_notifications_setting"
-                          class="sub_setting_checkbox sub_notification_setting {{#unless in_home_view}}muted-sub{{/unless}}">
-                            <input id="audible-notifystream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if audible_notifications_display}}checked{{/if}} {{#unless in_home_view}}disabled="disabled"{{/unless}}/>
+                          class="sub_setting_checkbox sub_notification_setting {{#if is_muted}}muted-sub{{/if}}">
+                            <input id="audible-notifystream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if audible_notifications_display}}checked{{/if}} {{#if is_muted}}disabled="disabled"{{/if}}/>
                             <label class="subscription-control-label">{{t "Audible desktop notifications" }}</label>
                         </div>
                     </li>
                     <li>
                         <div id="sub_push_notifications_setting"
-                          class="sub_setting_checkbox sub_notification_setting {{#unless in_home_view}}muted-sub{{/unless}}">
-                            <input id="push-notifystream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if push_notifications_display}}checked{{/if}} {{#unless in_home_view}}disabled="disabled"{{/unless}}/>
+                          class="sub_setting_checkbox sub_notification_setting {{#if is_muted}}muted-sub{{/if}}">
+                            <input id="push-notifystream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if push_notifications_display}}checked{{/if}} {{#if is_muted}}disabled="disabled"{{/if}}/>
                             <label class="subscription-control-label">{{t "Mobile notifications" }}</label>
                         </div>
                     </li>
                     <li>
                         <div id="sub_email_notifications_setting"
-                          class="sub_setting_checkbox sub_notification_setting {{#unless in_home_view}}muted-sub{{/unless}}">
-                            <input id="email-notifystream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if email_notifications_display}}checked{{/if}} {{#unless in_home_view}}disabled="disabled"{{/unless}}/>
+                          class="sub_setting_checkbox sub_notification_setting {{#if is_muted}}muted-sub{{/if}}">
+                            <input id="email-notifystream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if email_notifications_display}}checked{{/if}} {{#if is_muted}}disabled="disabled"{{/if}}/>
                             <label class="subscription-control-label">{{t "Email notifications" }}</label>
                         </div>
                     </li>


### PR DESCRIPTION
Replace all uses of `in_home_view` subscription property
with `is_muted` property in frontend.

Fixes #12322

@thedeveloperr fyi