### PR TITLE
lightbox: Set URL in payload instead of computing from video IDs.

### DIFF
--- a/frontend_tests/node_tests/lightbox.js
+++ b/frontend_tests/node_tests/lightbox.js
@@ -13,29 +13,45 @@ set_global('overlays', {
 set_global('popovers', {
     hide_all: () => {},
 });
-set_global('$', function () {
-    return {
-        hasClass: () => false,
-        closest: () => [],
-        attr: (attr) => attr,
-        parent: () => ({
-            closest: () => ({
-                attr: (attr) => attr,
-            }),
-            attr: (attr) => attr,
-        }),
-        html: () => ({
-            show: () => {},
-        }),
-        hide: () => {},
-        show: () => {},
-        text: () => '',
-    };
-});
+
+set_global('$', global.make_zjquery());
 
 run_test('pan_and_zoom', () => {
-    lightbox.open('<img src="./image.png" data-src-fullsize="./original.png">');
+    $.clear_all_elements();
+
+    var img = '<img src="./image.png" data-src-fullsize="./original.png">';
+    var link = '<a href="https://zulip.com"></a>';
+    var msg = '<div [zid]></div>';
+    $(img).set_parent($(link));
+    $(link).set_parent($(msg));
+
+    // Used by render_lightbox_list_images
+    $.stub_selector('.focused_table .message_inline_image img', []);
+
+    lightbox.open(img);
     assert.equal(blueslip.get_test_logs('error').length, 0);
     lightbox.open('<img src="./image.png">');
+    assert.equal(blueslip.get_test_logs('error').length, 0);
+});
+
+run_test('open_url', () => {
+    $.clear_all_elements();
+
+    var url = 'https://youtube.com/1234';
+    var img = '<img></img>';
+    $(img).attr('src', "https://youtube.com/image.png");
+    var link = '<a></a>';
+    $(link).attr('href', url);
+    var div = '<div class="youtube-video"></div>';
+    var msg = '<div [zid]></div>';
+    $(img).set_parent($(link));
+    $(link).set_parent($(div));
+    $(div).set_parent($(msg));
+
+    // Used by render_lightbox_list_images
+    $.stub_selector('.focused_table .message_inline_image img', []);
+
+    lightbox.open(img);
+    assert.equal($('.image-actions .open').attr('href'), url);
     assert.equal(blueslip.get_test_logs('error').length, 0);
 });

--- a/frontend_tests/node_tests/zjquery.js
+++ b/frontend_tests/node_tests/zjquery.js
@@ -210,3 +210,31 @@ run_test('extensions', () => {
     // But we also have area available from general extension.
     assert.equal(rect.area(), 35);
 });
+
+run_test('closest', () => {
+    var widget = $('#my-widget');
+    var parent;
+    var parentSelector;
+
+    parentSelector = '#my-parent';
+    parent = $(parentSelector);
+    widget.set_parent(parent);
+    assert.equal(widget.closest('#my-parent').selector, parentSelector);
+
+    parentSelector = '<div id="my-parent"></div>';
+    parent = $(parentSelector);
+    widget.set_parent(parent);
+    assert.equal(widget.closest('#my-parent').selector, parentSelector);
+
+    parentSelector = '<div class="parent-class"></div>';
+    parent = $(parentSelector);
+    widget.set_parent(parent);
+    assert.equal(widget.closest('.parent-class').selector, parentSelector);
+
+    parentSelector = '#my-parent';
+    parent = $(parentSelector);
+    widget.set_parents_result(parentSelector, parent);
+    assert.equal(widget.closest('#my-parent').selector, parentSelector);
+
+    assert.equal(widget.closest('#bogus-parent').selector, undefined);
+});

--- a/frontend_tests/node_tests/zjquery.js
+++ b/frontend_tests/node_tests/zjquery.js
@@ -215,26 +215,38 @@ run_test('closest', () => {
     var widget = $('#my-widget');
     var parent;
     var parentSelector;
+    var closest;
 
     parentSelector = '#my-parent';
     parent = $(parentSelector);
     widget.set_parent(parent);
-    assert.equal(widget.closest('#my-parent').selector, parentSelector);
+    closest = widget.closest('#my-parent');
+    assert.equal(closest.selector, parentSelector);
+    assert.equal(closest.length, 1);
 
     parentSelector = '<div id="my-parent"></div>';
     parent = $(parentSelector);
     widget.set_parent(parent);
-    assert.equal(widget.closest('#my-parent').selector, parentSelector);
+    closest = widget.closest('#my-parent');
+    assert.equal(closest.selector, parentSelector);
+    assert.equal(closest.length, 1);
 
     parentSelector = '<div class="parent-class"></div>';
     parent = $(parentSelector);
     widget.set_parent(parent);
-    assert.equal(widget.closest('.parent-class').selector, parentSelector);
+    closest = widget.closest('.parent-class');
+    assert.equal(closest.selector, parentSelector);
+    assert.equal(closest.length, 1);
 
     parentSelector = '#my-parent';
     parent = $(parentSelector);
     widget.set_parents_result(parentSelector, parent);
-    assert.equal(widget.closest('#my-parent').selector, parentSelector);
+    closest = widget.closest('#my-parent');
+    assert.equal(closest.selector, parentSelector);
+    assert.equal(closest.length, 1);
 
-    assert.equal(widget.closest('#bogus-parent').selector, undefined);
+    closest = widget.closest('#bogus-parent-class');
+    assert.equal(closest.selector, undefined);
+    assert.equal(closest.length, 0);
+
 });

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -163,6 +163,18 @@ exports.make_new_elem = function (selector, opts) {
             event_store.generic_event('click', arg);
             return self;
         },
+        closest: function (selector) {
+            var elem = self;
+            var search = selector.startsWith('.') || selector.startsWith('#') ? selector.substring(1) : selector;
+            if (elem.selector.indexOf(search) > -1) {
+                return elem;
+            } else if (parents_result.get(selector)) {
+                return parents_result.get(selector);
+            } else if (!elem.parent()) {
+                return [];
+            }
+            return elem.parent().closest(selector);
+        },
         data: noop,
         delay: function () {
             return self;

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -367,6 +367,8 @@ exports.make_new_elem = function (selector, opts) {
 
     self.selector = selector;
 
+    self.length = 1;
+
     return self;
 };
 

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -71,9 +71,7 @@ function display_video(payload) {
     iframe.attr("allowfullscreen", true);
 
     $("#lightbox_overlay .player-container").html(iframe).show();
-
-    var url = (payload.type === "youtube-video" ? "https://youtu.be/" : "https://vimeo.com/") + payload.source;
-    $(".image-actions .open").attr("href", url);
+    $(".image-actions .open").attr("href", payload.url);
 }
 
 // the image param is optional, but required on the first preview of an image.
@@ -107,6 +105,7 @@ exports.open = function (image, options) {
         var $parent = $image.parent();
         var $type;
         var $source;
+        var $url = $parent.attr("href");
         if (is_youtube_video) {
             $type = "youtube-video";
             $source = $parent.attr("data-id");
@@ -139,6 +138,7 @@ exports.open = function (image, options) {
             type: $type,
             preview: $image.attr("src"),
             source: $source,
+            url: $url,
         };
 
         asset_map[$source] = payload;


### PR DESCRIPTION
Lightbox previews for youtube playlists use the "current" video in the playlist
for the preview. The open link for such previews is incorrectly set to the first
video alone, and not the playlist. This commit fixes the bug by linking to the
original URL for lightbox preview is being shown, instead of computing the URL.

This change is also a preparatory refactor to allow for video embeds from sites other than YouTube and Vimeo. 

**Testing Plan:** <!-- How have you tested? -->
Verified that youtube video URLs, playlist URLs and vimeo URLs work correctly. 

