### PR TITLE
docs: Update desktop app version to 3.0.0.

### DIFF
--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -1,4 +1,4 @@
-const ELECTRON_APP_VERSION = "2.3.82";
+const ELECTRON_APP_VERSION = "3.0.0";
 const ELECTRON_APP_URL_LINUX = "https://github.com/zulip/zulip-desktop/releases/download/v" + ELECTRON_APP_VERSION + "/Zulip-" + ELECTRON_APP_VERSION + "-x86_64.AppImage";
 const ELECTRON_APP_URL_MAC = "https://github.com/zulip/zulip-desktop/releases/download/v" + ELECTRON_APP_VERSION + "/Zulip-" + ELECTRON_APP_VERSION + ".dmg";
 const ELECTRON_APP_URL_WINDOWS = "https://github.com/zulip/zulip-desktop/releases/download/v" + ELECTRON_APP_VERSION + "/Zulip-Web-Setup-" + ELECTRON_APP_VERSION + ".exe";


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

Pretty simple PR, updates the landing page to show v3 of the Electron app. 