### PR TITLE
test_retention: Quick fix for the remaining test failure.

### DIFF
--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -123,7 +123,7 @@ class TestRetentionLib(ZulipTestCase):
         sent_message_id = self._send_cross_realm_message()
         all_user_messages_qty = UserMessage.objects.count()
         self._change_messages_pub_date([sent_message_id], timezone_now() - timedelta(days=period))
-        realms = Realm.objects.filter(message_retention_days__isnull=False)
+        realms = Realm.objects.filter(message_retention_days__isnull=False).order_by("id")
         for realm_instance in realms:
             move_expired_messages_to_archive(realm_instance)
             move_expired_user_messages_to_archive(realm_instance)


### PR DESCRIPTION
test_cross_realm_messages_archiving_two_realm_expired doesn't run the
code path patched in commit 3d1aa98b2ea344fba7fbb2373a37d4cf30f53e08i,
so it can still fail. We apply the analogical change in the test as
the cited commit.