### PR TITLE
bots: Bots can post to announcement-only streams if their owner can.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2162,7 +2162,12 @@ def validate_sender_can_write_to_stream(sender: UserProfile,
     # matches the realm of the sender.
 
     if stream.is_announcement_only:
-        if not (sender.is_realm_admin or is_cross_realm_bot_email(sender.email)):
+        if sender.is_realm_admin or is_cross_realm_bot_email(sender.email):
+            pass
+        elif sender.is_bot and (sender.bot_owner is not None and
+                                sender.bot_owner.is_realm_admin):
+            pass
+        else:
             raise JsonableError(_("Only organization administrators can send to this stream."))
 
     if not (stream.invite_only or sender.is_guest):

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -1444,11 +1444,11 @@ class MessagePOSTTest(ZulipTestCase):
         # Cross realm bots should be allowed.
         notification_bot = get_system_bot("notification-bot@zulip.com")
         result = self.api_post(notification_bot.email,
-                               "/json/messages", {"type": "stream",
-                                                  "to": stream_name,
-                                                  "client": "test suite",
-                                                  "content": "Test message",
-                                                  "topic": "Test topic"})
+                               "/api/v1/messages", {"type": "stream",
+                                                    "to": stream_name,
+                                                    "client": "test suite",
+                                                    "content": "Test message",
+                                                    "topic": "Test topic"})
         self.assert_json_success(result)
 
     def test_message_fail_to_announce(self) -> None:


### PR DESCRIPTION
Bot owned by a non-admin gets blocked, and one owned by an admin
can post to announcement-only stream.

Fixes: #12310.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#12310

**Testing Plan:** <!-- How have you tested? -->
Wrote automated unit tests

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
Note: While writing tests for this issue I discovered few buggy tests (see: https://chat.zulip.org/#narrow/stream/49-development-help/topic/.2Fapi.2Fv1.2Fmessages.20vs.20.2Fjson.2Fmessages.20endpoint for context). I will be fixing them in another PR. 