### PR TITLE
Vagrantfile: Be nice to /etc/update-motd.d.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -176,18 +176,11 @@ set -o pipefail
 # development environment not using Vagrant.
 
 # Set the MOTD on the system to have Zulip instructions
-sudo rm -f /etc/update-motd.d/*
-sudo bash -c 'cat << EndOfMessage > /etc/motd
-Welcome to the Zulip development environment!  Popular commands:
-* tools/provision - Update the development environment
-* tools/run-dev.py - Run the development server
-* tools/lint - Run the linter (quick and catches many problems)
-* tools/test-* - Run tests (use --help to learn about options)
-
-Read https://zulip.readthedocs.io/en/latest/testing/testing.html to learn
-how to run individual test suites so that you can get a fast debug cycle.
-
-EndOfMessage'
+sudo ln -s /srv/zulip/tools/setup/dev-motd /etc/update-motd.d/99-zulip-dev
+sudo rm -f /etc/update-motd.d/10-help-text
+sudo dpkg --purge landscape-client landscape-common ubuntu-release-upgrader-core update-manager-core update-notifier-common
+sudo dpkg-divert --add --rename /etc/default/motd-news
+sudo sh -c 'echo ENABLED=0 > /etc/default/motd-news'
 
 # If the host is running SELinux remount the /sys/fs/selinux directory as read only,
 # needed for apt-get to work.

--- a/tools/setup/dev-motd
+++ b/tools/setup/dev-motd
@@ -1,0 +1,11 @@
+#!/usr/bin/tail -n+2
+
+This is the Zulip development environment.  Popular commands:
+* tools/provision - Update the development environment
+* tools/run-dev.py - Run the development server
+* tools/lint - Run the linter (quick and catches many problems)
+* tools/test-* - Run tests (use --help to learn about options)
+
+Read https://zulip.readthedocs.io/en/latest/testing/testing.html to learn
+how to run individual test suites so that you can get a fast debug cycle.
+


### PR DESCRIPTION
Some of its information is helpful (especially on a box based on a minimized image from Ubuntu cloud-images, where the motd points out the `unminimize` command—see #12357).

**Testing Plan:**

```console
$ vagrant up
[…]
$ vagrant ssh
Welcome to Ubuntu 14.04.1 LTS (GNU/Linux 5.0.0-15-lowlatency x86_64)

 * Documentation:  https://help.ubuntu.com/

Welcome to the Zulip development environment!  Popular commands:
* tools/provision - Update the development environment
* tools/run-dev.py - Run the development server
* tools/lint - Run the linter (quick and catches many problems)
* tools/test-* - Run tests (use --help to learn about options)

Read https://zulip.readthedocs.io/en/latest/testing/testing.html to learn
how to run individual test suites so that you can get a fast debug cycle.

Last login: Thu May 23 04:36:05 2019 from 10.0.3.1
vagrant@vagrant-base-trusty-amd64:~$ 
```