### PR TITLE
webhooks/jira: Fix markup conversion of full links

### DIFF
--- a/zerver/webhooks/jira/fixtures/commented_v2_with_two_full_links.json
+++ b/zerver/webhooks/jira/fixtures/commented_v2_with_two_full_links.json
@@ -1,0 +1,190 @@
+{
+  "webhookEvent": "jira:issue_updated",
+  "issue_event_type_name":"issue_commented",
+  "timestamp": 1364403934253,
+  "user": {
+    "self": "http://lfranchi.com:8080/rest/api/2/user?username=lfranchi",
+    "name": "lfranchi",
+    "emailAddress": "othello@zulip.com",
+    "avatarUrls": {
+      "16x16": "http://lfranchi.com:8080/secure/useravatar?size=small&avatarId=10122",
+      "48x48": "http://lfranchi.com:8080/secure/useravatar?avatarId=10122"
+    },
+    "displayName": "Leo Franchi",
+    "active": true
+  },
+  "issue": {
+    "id": "10400",
+    "self": "http://lfranchi.com:8080/rest/api/2/issue/10400",
+    "key": "BUG-15",
+    "fields": {
+      "summary": "New bug with hook",
+      "progress": {
+        "progress": 0,
+        "total": 0
+      },
+      "timetracking": {},
+      "issuetype": {
+        "self": "http://lfranchi.com:8080/rest/api/2/issuetype/1",
+        "id": "1",
+        "description": "A problem which impairs or prevents the functions of the product.",
+        "iconUrl": "http://lfranchi.com:8080/images/icons/bug.gif",
+        "name": "Bug",
+        "subtask": false
+      },
+      "votes": {
+        "self": "http://lfranchi.com:8080/rest/api/2/issue/BUG-15/votes",
+        "votes": 0,
+        "hasVoted": false
+      },
+      "resolution": null,
+      "fixVersions": [],
+      "resolutiondate": null,
+      "timespent": null,
+      "reporter": {
+        "self": "http://lfranchi.com:8080/rest/api/2/user?username=lfranchi",
+        "name": "lfranchi",
+        "emailAddress": "othello@zulip.com",
+        "avatarUrls": {
+          "16x16": "http://lfranchi.com:8080/secure/useravatar?size=small&avatarId=10122",
+          "48x48": "http://lfranchi.com:8080/secure/useravatar?avatarId=10122"
+        },
+        "displayName": "Leo Franchi",
+        "active": true
+      },
+      "aggregatetimeoriginalestimate": null,
+      "created": "2013-03-27T16:53:58.301+0000",
+      "updated": "2013-03-27T16:57:45.287+0000",
+      "description": "Fix me please",
+      "priority": {
+        "self": "http://lfranchi.com:8080/rest/api/2/priority/3",
+        "iconUrl": "http://lfranchi.com:8080/images/icons/priority_major.gif",
+        "name": "Major",
+        "id": "3"
+      },
+      "duedate": null,
+      "issuelinks": [],
+      "watches": {
+        "self": "http://lfranchi.com:8080/rest/api/2/issue/BUG-15/watchers",
+        "watchCount": 1,
+        "isWatching": true
+      },
+      "worklog": {
+        "startAt": 0,
+        "maxResults": 0,
+        "total": 0,
+        "worklogs": []
+      },
+      "customfield_10000": null,
+      "subtasks": [],
+      "status": {
+        "self": "http://lfranchi.com:8080/rest/api/2/status/1",
+        "description": "The issue is open and ready for the assignee to start work on it.",
+        "iconUrl": "http://lfranchi.com:8080/images/icons/status_open.gif",
+        "name": "Open",
+        "id": "1"
+      },
+      "labels": [],
+      "workratio": -1,
+      "assignee": {
+        "self": "http://lfranchi.com:8080/rest/api/2/user?username=lfranchi",
+        "name": "lfranchi",
+        "emailAddress": "othello@zulip.com",
+        "avatarUrls": {
+          "16x16": "http://lfranchi.com:8080/secure/useravatar?size=small&avatarId=10122",
+          "48x48": "http://lfranchi.com:8080/secure/useravatar?avatarId=10122"
+        },
+        "displayName": "Leo Franchi",
+        "active": true
+      },
+      "attachment": [],
+      "aggregatetimeestimate": null,
+      "project": {
+        "self": "http://lfranchi.com:8080/rest/api/2/project/BUG",
+        "id": "10000",
+        "key": "BUG",
+        "name": "buggery-test",
+        "avatarUrls": {
+          "16x16": "http://lfranchi.com:8080/secure/projectavatar?size=small&pid=10000&avatarId=10011",
+          "48x48": "http://lfranchi.com:8080/secure/projectavatar?pid=10000&avatarId=10011"
+        }
+      },
+      "versions": [],
+      "environment": null,
+      "timeestimate": null,
+      "aggregateprogress": {
+        "progress": 0,
+        "total": 0
+      },
+      "lastViewed": "2013-03-27T16:57:45.258+0000",
+      "components": [],
+      "comment": {
+        "startAt": 0,
+        "maxResults": 1,
+        "total": 1,
+        "comments": [
+          {
+            "self": "http://lfranchi.com:8080/rest/api/2/issue/10400/comment/10400",
+            "id": "10400",
+            "author": {
+              "self": "http://lfranchi.com:8080/rest/api/2/user?username=lfranchi",
+              "name": "lfranchi",
+              "emailAddress": "othello@zulip.com",
+              "avatarUrls": {
+                "16x16": "http://lfranchi.com:8080/secure/useravatar?size=small&avatarId=10122",
+                "48x48": "http://lfranchi.com:8080/secure/useravatar?avatarId=10122"
+              },
+              "displayName": "Leo Franchi",
+              "active": true
+            },
+            "body": "This is the [first link|https://google.com] and this is the [second link|https://google.com] and this is the end.",
+            "updateAuthor": {
+              "self": "http://lfranchi.com:8080/rest/api/2/user?username=lfranchi",
+              "name": "lfranchi",
+              "emailAddress": "othello@zulip.com",
+              "avatarUrls": {
+                "16x16": "http://lfranchi.com:8080/secure/useravatar?size=small&avatarId=10122",
+                "48x48": "http://lfranchi.com:8080/secure/useravatar?avatarId=10122"
+              },
+              "displayName": "Leo Franchi",
+              "active": true
+            },
+            "created": "2013-03-27T17:05:34.250+0000",
+            "updated": "2013-03-27T17:05:34.250+0000"
+          }
+        ]
+      },
+      "timeoriginalestimate": null,
+      "aggregatetimespent": null
+    }
+  },
+  "comment": {
+    "self": "http://lfranchi.com:8080/rest/api/2/issue/10400/comment/10400",
+    "id": "10400",
+    "author": {
+      "self": "http://lfranchi.com:8080/rest/api/2/user?username=lfranchi",
+      "name": "lfranchi",
+      "emailAddress": "othello@zulip.com",
+      "avatarUrls": {
+        "16x16": "http://lfranchi.com:8080/secure/useravatar?size=small&avatarId=10122",
+        "48x48": "http://lfranchi.com:8080/secure/useravatar?avatarId=10122"
+      },
+      "displayName": "Leo Franchi",
+      "active": true
+    },
+    "body": "This is the [first link|https://google.com] and this is the [second link|https://google.com] and this is the end.",
+    "updateAuthor": {
+      "self": "http://lfranchi.com:8080/rest/api/2/user?username=lfranchi",
+      "name": "lfranchi",
+      "emailAddress": "othello@zulip.com",
+      "avatarUrls": {
+        "16x16": "http://lfranchi.com:8080/secure/useravatar?size=small&avatarId=10122",
+        "48x48": "http://lfranchi.com:8080/secure/useravatar?avatarId=10122"
+      },
+      "displayName": "Leo Franchi",
+      "active": true
+    },
+    "created": "2013-03-27T17:05:34.250+0000",
+    "updated": "2013-03-27T17:05:34.250+0000"
+  }
+}

--- a/zerver/webhooks/jira/tests.py
+++ b/zerver/webhooks/jira/tests.py
@@ -124,6 +124,17 @@ Adding a comment. Oh, what a comment it is!
         self.send_and_test_stream_message('commented_v1', expected_topic, expected_message)
         self.send_and_test_stream_message('commented_v2', expected_topic, expected_message)
 
+    def test_commented_with_two_full_links(self) -> None:
+        expected_topic = "BUG-15: New bug with hook"
+        expected_message = """
+Leo Franchi commented on [BUG-15: New bug with hook](http://lfranchi.com:8080/browse/BUG-15) (assigned to **Othello, the Moor of Venice**):
+
+``` quote
+This is the [first link](https://google.com) and this is the [second link](https://google.com) and this is the end.
+```
+""".strip()
+        self.send_and_test_stream_message('commented_v2_with_two_full_links', expected_topic, expected_message)
+
     def test_comment_edited(self) -> None:
         expected_topic = "BUG-15: New bug with hook"
         expected_message = """

--- a/zerver/webhooks/jira/view.py
+++ b/zerver/webhooks/jira/view.py
@@ -74,7 +74,7 @@ def convert_jira_markup(content: str, realm: Realm) -> str:
     content = re.sub(r'\[([^\|~]+?)\]', r'[\1](\1)', content)
 
     # Full links which have a | are converted into a better markdown link
-    full_link_re = re.compile(r'\[(?:(?P<title>[^|~]+)\|)(?P<url>.*)\]')
+    full_link_re = re.compile(r'\[(?:(?P<title>[^|~]+)\|)(?P<url>[^\]]*)\]')
     content = re.sub(full_link_re, r'[\g<title>](\g<url>)', content)
 
     # Try to convert a JIRA user mention of format [~username] into a


### PR DESCRIPTION
This PR modifies the regex used when parsing JIRA's full links of
the form `[text|link]` so that if you have two in a message, Zulip
markup conversion doesn't think that the first link extends to the
closing `]` of the second link.

**Testing Plan:** <!-- How have you tested? -->
I've added a new test that would have been incorrect before this change.

**GIFs or Screenshots:**
Before this fix, the following comment sent in JIRA:

```
This is the [first link|https://google.com] and this is the [second link|https://google.com] and this is the end.
```

Would result in the two full links being converted incorrectly, as shown below:

![image](https://user-images.githubusercontent.com/1295100/58237016-15dfa980-7d3c-11e9-8e21-d6477fc9c209.png)

```markdown
This is the [first link](https://google.com] and this is the [second link|https://google.com) and this is the end.
```

After this fix, they are converted correctly:

![image](https://user-images.githubusercontent.com/1295100/58236983-06f8f700-7d3c-11e9-8333-2f54fea981ff.png)

```markdown
This is the [first link](https://google.com) and this is the [second link](https://google.com) and this is the end.
```

