### PR TITLE
api/streams: Support including deactivated streams.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1836,6 +1836,14 @@ paths:
           type: boolean
           default: false
         example: true
+      - name: include_all_deactivated
+        in: query
+        description: Include all deactivated streams. The user must have
+          administrative privileges to use this parameter.
+        schema:
+          type: boolean
+          default: false
+        example: true
       security:
       - basicAuth: []
       responses:

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -446,14 +446,16 @@ def get_streams_backend(
         include_subscribed: bool=REQ(validator=check_bool, default=True),
         include_all_active: bool=REQ(validator=check_bool, default=False),
         include_default: bool=REQ(validator=check_bool, default=False),
-        include_owner_subscribed: bool=REQ(validator=check_bool, default=False)
+        include_owner_subscribed: bool=REQ(validator=check_bool, default=False),
+        include_all_deactivated: bool=REQ(validator=check_bool, default=False),
 ) -> HttpResponse:
 
     streams = do_get_streams(user_profile, include_public=include_public,
                              include_subscribed=include_subscribed,
                              include_all_active=include_all_active,
                              include_default=include_default,
-                             include_owner_subscribed=include_owner_subscribed)
+                             include_owner_subscribed=include_owner_subscribed,
+                             include_all_deactivated=include_all_deactivated)
     return json_success({"streams": streams})
 
 @has_request_variables


### PR DESCRIPTION
Now the deactivated streams can be fetched from `GET /streams`
by using `include_all_deactivated=true` argument.

Closes https://github.com/zulip/zulip/issues/12308
