### PR TITLE
[WIP] Collect all dev virtualenv requirements into 1 executable xar file.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,12 @@ aliases:
       name: run backend tests
       command: |
         . /srv/zulip-py3-venv/bin/activate
+        sudo apt-get install squashfs-tools
+        pip install pex xar
+        pex -r requirements/dev.txt -o pak.pex
+        make_xar --python pak.pex --output pak.xar
+        deactivate
+        ./pak.xar
         mispipe ./tools/ci/backend ts
 
   - &run_frontend_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,10 +66,13 @@ aliases:
         . /srv/zulip-py3-venv/bin/activate
         sudo apt-get install squashfs-tools
         pip install pex xar
-        pex -r requirements/dev.txt -o pak.pex
-        make_xar --python pak.pex --output pak.xar
+        #pex -r requirements/dev.txt -o pak.pex
+        #make_xar --python pak.pex --output pak.xar
+        python setup.py bdist_xar
         deactivate
-        ./pak.xar
+        #./pak.xar
+        ls
+        ./zulip.xar
         mispipe ./tools/ci/backend ts
 
   - &run_frontend_tests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,7 +7,6 @@
 #
 # For details, see requirements/README.md .
 #
---no-binary psycopg2
 
 git+https://github.com/zulip/django-bitfield@0d2b15cdb5af5ddec88d41cac19c0f2ce1b1ad38#egg=django-bitfield==1.9.3+dev.0d2b15cdb5af5ddec88d41cac19c0f2ce1b1ad38
 git+https://github.com/zulip/libthumbor.git@60ed2431c07686a12f2770b2d852c5650f3ccfc6#egg=libthumbor==1.3.2zulip

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup, find_packages
+
+with open('requirements/dev.txt') as rfp:
+    reqs = [i for i in rfp.read().split('\n') if not (i.startswith('#') or len(i) == 0)]
+setup(
+    name='zulip',
+    version='2.0.0',
+    url='https://github.com/zulip/zulip',
+    author='zulip',
+    packages=find_packages(),
+    install_requires=reqs,
+)


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

This addresses #10992.
This is a roundabout way that doesn't require `setup.py`: serialize a virtualenv session into a .pex file, which makes `bin/activate` to be the entrypoint. The .pex file is then converted to .xar.

**Testing Plan:** <!-- How have you tested? -->

Will check how long it takes to finish the backend test from circleci.