### PR TITLE
compose: Use new ID-based api for sending messages.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -607,13 +607,14 @@ run_test('send_message', () => {
                 queue_id: undefined,
                 stream: '',
                 topic: '',
-                to: '["alice@example.com"]',
+                to: `[${alice.user_id}]`,
                 reply_to: 'alice@example.com',
                 private_message_recipient: 'alice@example.com',
                 to_user_ids: '31',
                 local_id: 1,
                 locally_echoed: true,
             };
+
             assert.deepEqual(payload, single_msg);
             payload.id = stub_state.local_id_counter;
             success(payload);
@@ -1672,14 +1673,19 @@ run_test('create_message_object', () => {
         return 'private';
     };
     compose_state.recipient = function () {
-        return 'alice@example.com,    bob@example.com';
+        return 'alice@example.com, bob@example.com';
     };
 
     message = compose.create_message_object();
-    assert.deepEqual(message.to, ['alice@example.com', 'bob@example.com']);
+    assert.deepEqual(message.to, [alice.user_id, bob.user_id]);
     assert.equal(message.to_user_ids, '31,32');
     assert.equal(message.content, 'burrito');
 
+    var { email_list_to_user_ids_string } = people;
+    people.email_list_to_user_ids_string = () => undefined;
+    message = compose.create_message_object();
+    assert.deepEqual(message.to, [alice.email, bob.email]);
+    people.email_list_to_user_ids_string = email_list_to_user_ids_string;
 });
 
 run_test('nonexistent_stream_reply_error', () => {

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -179,6 +179,15 @@ function create_message_object() {
         message.reply_to = recipient;
         message.private_message_recipient = recipient;
         message.to_user_ids = people.email_list_to_user_ids_string(emails);
+
+        if (message.to_user_ids !== undefined) {
+            // split the user_ids into array i.e. "1,2" -> ["1", "2"]
+            // then turn them into number
+            message.to = _.map(message.to_user_ids.split(','), function (id) {
+                return Number(id);
+            });
+        }
+
     } else {
         var stream_name = compose_state.stream_name();
         message.to = stream_name;


### PR DESCRIPTION
This only happens if the realm is not a zephyr realm.
Finishes part of #9474.

**Testing Plan:** <!-- How have you tested? -->
- Added tests
- Manually verified that sending messages works. Sent private, group and stream messages.
- Also verified that ids are passed by setting `page_params.use_websockets` to `false` and checking it in networks panel. 