### PR TITLE
[WIP]requirements: Upgrade pip-tools from 2.0.2 to 3.7.0

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -193,6 +193,13 @@ lxml==4.3.3
 
 # Needed for 2-factor authentication
 django-two-factor-auth==1.8.0
+
+# Required by django-phonenumber-field which is a dependency of django-two-factor-auth.
+# Developers can install either phonenumberslite or phonenumbers. Developers of
+# django-two-factor-auth has not specified which package to install so we are going
+# with phonenumberslite since it has less memory footprint.
+phonenumberslite==8.10.12
+
 twilio==6.26.2
 
 # Needed for processing payments (in corporate)

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -55,7 +55,7 @@ defusedxml==0.5.0
 django-auth-ldap==1.7.0
 
 # Django extension providing bitfield support
--e git+https://github.com/zulip/django-bitfield@0d2b15cdb5af5ddec88d41cac19c0f2ce1b1ad38#egg=django-bitfield==1.9.3+dev.0d2b15cdb5af5ddec88d41cac19c0f2ce1b1ad38
+git+https://github.com/zulip/django-bitfield@0d2b15cdb5af5ddec88d41cac19c0f2ce1b1ad38#egg=django-bitfield==1.9.3+dev.0d2b15cdb5af5ddec88d41cac19c0f2ce1b1ad38
 
 # Django extension for sending data to statsd
 django-statsd-mozilla==0.4.0
@@ -73,13 +73,13 @@ google-api-python-client==1.7.4
 # Needed for the email mirror
 html2text==2018.1.9
 httplib2==0.12.3
--e git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
+git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
 
 # Needed for hipchat import
 hypchat==0.21
 
 # For doing highly usable Python profiling
--e git+https://github.com/zulip/line_profiler.git#egg=line_profiler==2.1.2.zulip1
+git+https://github.com/zulip/line_profiler.git#egg=line_profiler==2.1.2.zulip1
 
 # Needed for inlining the CSS in emails
 premailer==3.4.0
@@ -146,7 +146,7 @@ tornado==4.5.3
 typing==3.6.6
 
 # Fast JSON parser
--e git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
+git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
 
 uritemplate==3.0.0
 
@@ -179,8 +179,8 @@ python-magic==0.4.15
 # these tightly, including fetching content not included in the normal
 # release tarballs (which is a bug).  So we need to pin it makes sense
 # to pin a version from Git rather than a release.
--e "git+https://github.com/zulip/python-zulip-api.git@0.6.0#egg=zulip==0.6.0_git&subdirectory=zulip"
--e "git+https://github.com/zulip/python-zulip-api.git@0.6.0#egg=zulip_bots==0.6.0+git&subdirectory=zulip_bots"
+git+https://github.com/zulip/python-zulip-api.git@0.6.0#egg=zulip==0.6.0_git&subdirectory=zulip
+git+https://github.com/zulip/python-zulip-api.git@0.6.0#egg=zulip_bots==0.6.0+git&subdirectory=zulip_bots
 
 # Used for Hesiod lookups, etc.
 py3dns==3.2.0
@@ -216,7 +216,7 @@ yamole==2.1.6
 
 # Needed for signing thumbnail requests so that they can be authenticated on the
 # other end.  Using a fork to eliminate a really slow pkgresources import.
--e "git+https://github.com/zulip/libthumbor.git@60ed2431c07686a12f2770b2d852c5650f3ccfc6#egg=libthumbor==1.3.2zulip"
+git+https://github.com/zulip/libthumbor.git@60ed2431c07686a12f2770b2d852c5650f3ccfc6#egg=libthumbor==1.3.2zulip
 
 # Needed for string matching in AlertWordProcessor
 pyahocorasick==1.4.0

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -47,6 +47,6 @@ transifex-client==0.12.5
 python-digitalocean==1.14.0
 
 # Needed for updating the locked pip dependencies
-pip-tools==2.0.2
+pip-tools==3.7.0
 
 -r mypy.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -64,7 +64,6 @@ docopt==0.6.2
 docutils==0.14
 ecdsa==0.13.2             # via python-jose
 fakeldap==0.6.1
-first==2.0.2              # via pip-tools
 gitdb==0.6.4
 gitlint==0.11.0
 google-api-python-client==1.7.4
@@ -112,7 +111,7 @@ phonenumberslite==8.10.12
 pickleshare==0.7.5        # via ipython
 pika==0.13.0
 pillow==5.4.1
-pip-tools==2.0.2
+pip-tools==3.7.0
 polib==1.1.0
 premailer==3.4.0
 prompt-toolkit==1.0.16    # via ipython

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -108,7 +108,7 @@ parsel==1.5.1             # via scrapy
 parso==0.4.0              # via jedi
 pbr==5.1.3                # via mock
 pexpect==4.7.0            # via ipython
-phonenumberslite==8.10.10  # via django-phonenumber-field
+phonenumberslite==8.10.12
 pickleshare==0.7.5        # via ipython
 pika==0.13.0
 pillow==5.4.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,13 +9,6 @@
 #
 --no-binary psycopg2
 
-git+https://github.com/zulip/django-bitfield@0d2b15cdb5af5ddec88d41cac19c0f2ce1b1ad38#egg=django-bitfield==1.9.3+dev.0d2b15cdb5af5ddec88d41cac19c0f2ce1b1ad38
-git+https://github.com/zulip/libthumbor.git@60ed2431c07686a12f2770b2d852c5650f3ccfc6#egg=libthumbor==1.3.2zulip
-git+https://github.com/zulip/line_profiler.git#egg=line_profiler==2.1.2.zulip1
-git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
-git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
-git+https://github.com/zulip/python-zulip-api.git@0.6.0#egg=zulip==0.6.0_git&subdirectory=zulip
-git+https://github.com/zulip/python-zulip-api.git@0.6.0#egg=zulip_bots==0.6.0+git&subdirectory=zulip_bots
 alabaster==0.7.12
 apns2==0.4.1
 argon2-cffi==19.1.0
@@ -48,6 +41,7 @@ decorator==4.4.0          # via ipython, traitlets
 defusedxml==0.5.0
 disposable-email-domains==0.0.49
 django-auth-ldap==1.7.0
+git+https://github.com/zulip/django-bitfield@0d2b15cdb5af5ddec88d41cac19c0f2ce1b1ad38#egg=django-bitfield==1.9.3+dev.0d2b15cdb5af5ddec88d41cac19c0f2ce1b1ad38
 django-formtools==2.1     # via django-two-factor-auth
 django-otp==0.5.2         # via django-two-factor-auth
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
@@ -90,6 +84,8 @@ jinja2==2.10.1
 jmespath==0.9.4           # via boto3, botocore
 jsondiff==1.1.1           # via moto
 jsonpickle==1.1           # via aws-xray-sdk, python-digitalocean
+git+https://github.com/zulip/libthumbor.git@60ed2431c07686a12f2770b2d852c5650f3ccfc6#egg=libthumbor==1.3.2zulip
+git+https://github.com/zulip/line_profiler.git#egg=line_profiler==2.1.2.zulip1
 lxml==4.3.3
 markdown-include==0.5.1
 markdown==3.0.1
@@ -176,6 +172,7 @@ sphinxcontrib-websupport==1.1.0  # via sphinx
 sqlalchemy==1.3.3
 statsd==3.3.0             # via django-statsd-mozilla
 stripe==2.21.0
+git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
 tblib==1.3.2
 tornado==4.5.3
 traitlets==4.3.2          # via ipython
@@ -185,6 +182,7 @@ twisted==19.2.0
 typed-ast==1.3.4          # via mypy
 typing==3.6.6
 typing_extensions==3.6.6
+git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
 uritemplate==3.0.0
 urllib3==1.24.2           # via botocore, requests, transifex-client
 virtualenv-clone==0.5.3
@@ -196,3 +194,5 @@ wrapt==1.11.1             # via aws-xray-sdk
 xmltodict==0.12.0         # via moto
 yamole==2.1.6
 zope.interface==4.6.0     # via twisted
+git+https://github.com/zulip/python-zulip-api.git@0.6.0#egg=zulip==0.6.0_git&subdirectory=zulip
+git+https://github.com/zulip/python-zulip-api.git@0.6.0#egg=zulip_bots==0.6.0+git&subdirectory=zulip_bots

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -9,13 +9,6 @@
 #
 --no-binary psycopg2
 
-git+https://github.com/zulip/django-bitfield@0d2b15cdb5af5ddec88d41cac19c0f2ce1b1ad38#egg=django-bitfield==1.9.3+dev.0d2b15cdb5af5ddec88d41cac19c0f2ce1b1ad38
-git+https://github.com/zulip/libthumbor.git@60ed2431c07686a12f2770b2d852c5650f3ccfc6#egg=libthumbor==1.3.2zulip
-git+https://github.com/zulip/line_profiler.git#egg=line_profiler==2.1.2.zulip1
-git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
-git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
-git+https://github.com/zulip/python-zulip-api.git@0.6.0#egg=zulip==0.6.0_git&subdirectory=zulip
-git+https://github.com/zulip/python-zulip-api.git@0.6.0#egg=zulip_bots==0.6.0+git&subdirectory=zulip_bots
 apns2==0.4.1
 argon2-cffi==19.1.0
 asn1crypto==0.24.0        # via cryptography
@@ -37,6 +30,7 @@ decorator==4.4.0          # via ipython, traitlets
 defusedxml==0.5.0
 disposable-email-domains==0.0.49
 django-auth-ldap==1.7.0
+git+https://github.com/zulip/django-bitfield@0d2b15cdb5af5ddec88d41cac19c0f2ce1b1ad38#egg=django-bitfield==1.9.3+dev.0d2b15cdb5af5ddec88d41cac19c0f2ce1b1ad38
 django-formtools==2.1     # via django-two-factor-auth
 django-otp==0.5.2         # via django-two-factor-auth
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
@@ -65,6 +59,8 @@ ipython-genutils==0.2.0   # via traitlets
 ipython==6.5.0
 jedi==0.13.3              # via ipython
 jinja2==2.10.1
+git+https://github.com/zulip/libthumbor.git@60ed2431c07686a12f2770b2d852c5650f3ccfc6#egg=libthumbor==1.3.2zulip
+git+https://github.com/zulip/line_profiler.git#egg=line_profiler==2.1.2.zulip1
 lxml==4.3.3
 markdown-include==0.5.1
 markdown==3.0.1
@@ -124,13 +120,17 @@ sourcemap==0.2.1
 sqlalchemy==1.3.3
 statsd==3.3.0             # via django-statsd-mozilla
 stripe==2.21.0
+git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
 tornado==4.5.3
 traitlets==4.3.2          # via ipython
 twilio==6.26.2
 typing==3.6.6
+git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
 uritemplate==3.0.0
 urllib3==1.24.2           # via requests
 uwsgi==2.0.17.1
 virtualenv-clone==0.5.3
 wcwidth==0.1.7            # via prompt-toolkit
 yamole==2.1.6
+git+https://github.com/zulip/python-zulip-api.git@0.6.0#egg=zulip==0.6.0_git&subdirectory=zulip
+git+https://github.com/zulip/python-zulip-api.git@0.6.0#egg=zulip_bots==0.6.0+git&subdirectory=zulip_bots

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -78,7 +78,7 @@ oauthlib==3.0.1
 parso==0.4.0              # via jedi
 pbr==5.1.3                # via mock
 pexpect==4.7.0            # via ipython
-phonenumberslite==8.10.10  # via django-phonenumber-field
+phonenumberslite==8.10.12
 pickleshare==0.7.5        # via ipython
 pika==0.13.0
 pillow==5.4.1

--- a/tools/update-locked-requirements
+++ b/tools/update-locked-requirements
@@ -14,12 +14,6 @@ compile_requirements () {
 
     pip-compile --output-file "$output" "$source"
 
-    # Remove the editable flag.  It's there because pip-compile can't
-    # yet do without it (see
-    # https://github.com/jazzband/pip-tools/issues/272 upstream), but
-    # in the output of pip-compile it's no longer needed.
-    sed -i 's/-e //' "$output"
-
     if [ "$python_version" != "py2" ]; then
         # pip-tools bug; future, futures are obsolete in python3
         sed -i '/futures==/d' "$output"

--- a/version.py
+++ b/version.py
@@ -11,4 +11,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '32.1'
+PROVISION_VERSION = '32.2'


### PR DESCRIPTION
We can get rid of our semantically incorrect usage of -e in our requirements files with this upgrade.

Fixes #12374
Fixes #10802
