### PR TITLE
info-overlay: Improve styling of hotkeys.

### DIFF
--- a/static/styles/informational-overlays.scss
+++ b/static/styles/informational-overlays.scss
@@ -72,6 +72,7 @@
 
     .small_hotkey {
         font-size: 0.9em !important;
+        line-height: 12px;
         kbd {
             font-size: 0.9em;
         }

--- a/static/styles/informational-overlays.scss
+++ b/static/styles/informational-overlays.scss
@@ -50,6 +50,32 @@
     font-size: 0.9em;
 }
 
+.informational-overlays {
+    // Hack to prevent styling from 00eaf3a effecting the markdown help overlay
+    .rendered_markdown {
+        // styles to over ride those from .rendered_markdown table
+        table {
+            padding-right: 0px;
+            margin: 0px;
+            width: 100%;
+        }
+        tr td {
+            border: 0px;
+        }
+        // Duplicate styles from bootstrap to render table correctly
+        .table th,
+        .table td {
+            border-top: 1px solid hsl(0, 0%, 87%);
+        }
+        .table-bordered td {
+            border-left: 1px solid hsl(0, 0%, 87%);
+        }
+        .table-condensed th,
+        .table-condensed td {
+            padding: 4px 5px;
+        }
+    }
+}
 
 .help-table {
     table-layout: fixed;

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -10,15 +10,15 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Reply to message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Enter</kbd> or  <kbd>r</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Enter</kbd> or <kbd>R</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}New stream message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>c</kbd></span></td>
+                    <td><span class="hotkey"><kbd>C</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}New private message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>x</kbd></span></td>
+                    <td><span class="hotkey"><kbd>X</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Cancel compose{% endtrans %}</td>
@@ -26,27 +26,27 @@
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}View drafts{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>d</kbd></span></td>
+                    <td><span class="hotkey"><kbd>D</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Next message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Down</kbd> or <kbd>j</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Down</kbd> or <kbd>J</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Last message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>End</kbd> or <kbd>Shift</kbd> + <kbd>g</kbd></span></td>
+                    <td><span class="hotkey"><kbd>End</kbd> or <kbd>Shift</kbd> + <kbd>G</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Next unread topic{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>n</kbd></span></td>
+                    <td><span class="hotkey"><kbd>N</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Next unread private message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>p</kbd></span></td>
+                    <td><span class="hotkey"><kbd>P</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Initiate a search{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>k</kbd> or <kbd>/</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>K</kbd> or <kbd>/</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Show keyboard shortcuts{% endtrans %}</td>
@@ -63,35 +63,35 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Initiate a search{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>k</kbd> or <kbd>/</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>K</kbd> or <kbd>/</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Search streams{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>q</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Q</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Search people{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>w</kbd></span></td>
+                    <td><span class="hotkey"><kbd>W</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Previous message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Up</kbd> or <kbd>k</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Up</kbd> or <kbd>K</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Next message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Down</kbd> or <kbd>j</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Down</kbd> or <kbd>J</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Scroll up{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>PgUp</kbd> or <kbd>Shift</kbd> + <kbd>k</kbd></span></td>
+                    <td><span class="hotkey"><kbd>PgUp</kbd> or <kbd>Shift</kbd> + <kbd>K</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Scroll down{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>PgDn</kbd> or <kbd>Shift</kbd> + <kbd>j</kbd> or <kbd>Space</kbd></span></td>
+                    <td><span class="hotkey"><kbd>PgDn</kbd> or <kbd>Shift</kbd> + <kbd>J</kbd> or <kbd>Space</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Last message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>End</kbd> or <kbd>Shift</kbd> + <kbd>g</kbd></span></td>
+                    <td><span class="hotkey"><kbd>End</kbd> or <kbd>Shift</kbd> + <kbd>G</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}First message{% endtrans %}</td>
@@ -108,11 +108,11 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Reply to message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Enter</kbd> or <kbd>r</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Enter</kbd> or <kbd>R</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Reply to author{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>r</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>R</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Quote and reply to message{% endtrans %}</td>
@@ -120,11 +120,11 @@
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}New stream message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>c</kbd></span></td>
+                    <td><span class="hotkey"><kbd>C</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}New private message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>x</kbd></span></td>
+                    <td><span class="hotkey"><kbd>X</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Compose a reply @-mentioning author{% endtrans %}</td>
@@ -153,27 +153,27 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Narrow to stream{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>s</kbd></span></td>
+                    <td><span class="hotkey"><kbd>S</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Narrow to topic or PM conversation{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>s</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>S</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Narrow to all private messages{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>p</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>P</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Narrow to next unread topic{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>n</kbd></span></td>
+                    <td><span class="hotkey"><kbd>N</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Narrow to next unread private message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>p</kbd></span></td>
+                    <td><span class="hotkey"><kbd>P</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Cycle between stream narrows{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>a</kbd> or <kbd>Shift</kbd> + <kbd>d</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>A</kbd> or <kbd>Shift</kbd> + <kbd>D</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Narrow to all unmuted messages{% endtrans %}</td>
@@ -198,19 +198,19 @@
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Show message sender's profile{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>u</kbd></span></td>
+                    <td><span class="hotkey"><kbd>U</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Show images in thread{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>v</kbd></span></td>
+                    <td><span class="hotkey"><kbd>V</kbd></span></td>
                 </tr>
                 <tr id="edit-message-hotkey-help">
                     <td class="definition">{% trans %}Edit selected message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>e</kbd></span></td>
+                    <td><span class="hotkey"><kbd>E</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Star selected message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>s</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>S</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">
@@ -228,7 +228,7 @@
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Toggle topic mute{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>m</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>M</kbd></span></td>
                 </tr>
             </table>
         </div>
@@ -241,7 +241,7 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}View drafts{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>d</kbd></span></td>
+                    <td><span class="hotkey"><kbd>D</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Edit selected draft{% endtrans %}</td>
@@ -262,11 +262,11 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Toggle the gear menu{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>g</kbd></span></td>
+                    <td><span class="hotkey"><kbd>G</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Open message menu{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>i</kbd></span></td>
+                    <td><span class="hotkey"><kbd>I</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Open reactions menu{% endtrans %}</td>
@@ -295,15 +295,15 @@
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}View stream messages{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>v</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>V</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Subscribe to/unsubscribe from selected stream{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>s</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>S</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Create new stream{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>n</kbd></span></td>
+                    <td><span class="hotkey"><kbd>N</kbd></span></td>
                 </tr>
             </table>
         </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Follow up to PR https://github.com/zulip/zulip/pull/11952.

**Testing Plan:** <!-- How have you tested? -->
Tested manually to see that everything looks okay.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
First commit: Tries to make text within bubble within "small_hotkey" seem better vertically aligned.
![image](https://user-images.githubusercontent.com/33805964/58345166-5989fe80-7e75-11e9-92cd-41fe16b5d170.png)

Second commit: Raises all single key hotkeys to upper case.
![image](https://user-images.githubusercontent.com/33805964/58364434-e2368800-7ed1-11e9-95fd-0ba94a3566ca.png)

Third commit makes a fix on the "message formatting" or "markdown help" tab.
![image](https://user-images.githubusercontent.com/33805964/58364358-ef06ac00-7ed0-11e9-85e1-b7fc4786092a.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
