### PR TITLE
provision: Move apt-get update from retry handler to setup-apt-repo

### DIFF
--- a/scripts/lib/setup-apt-repo
+++ b/scripts/lib/setup-apt-repo
@@ -27,7 +27,11 @@ touch "$SOURCES_FILE"
 # Hash it to check if the sources file is changed by the script later.
 zulip_source_hash=$(sha1sum "$SOURCES_FILE")
 
-apt-get install -y lsb-release apt-transport-https gnupg
+pre_setup_deps=(lsb-release apt-transport-https gnupg)
+if ! apt-get -s install "${pre_setup_deps[@]}" > /dev/null 2>&1; then
+    apt-get update
+fi
+apt-get -y install "${pre_setup_deps[@]}"
 
 SCRIPTS_PATH="$(dirname "$(dirname "$0")")"
 


### PR DESCRIPTION
This avoids unnecessarily alarming error messages if the apt-cache is missing.

**Testing Plan:** Ran `vagrant up --provider=docker`.