### PR TITLE
[waiting for czo migration] Remove Ubuntu 14.04 (trusty) from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,25 +82,6 @@ aliases:
          || echo "Error in uploading coverage reports to codecov.io."
 
 jobs:
-  "trusty-backend-python3.4":
-    docker:
-      # This is built from tools/circleci/images/trusty/Dockerfile .
-      # Trusty ships with Python 3.4.
-      - image: gregprice/circleci:trusty-python-5.test
-
-    working_directory: ~/zulip
-
-    steps:
-      - checkout
-
-      - *create_cache_directories
-      - *restore_cache_package_json
-      - *restore_cache_requirements
-      - *install_dependencies
-      - *save_cache_package_json
-      - *save_cache_requirements
-      - *run_backend_tests
-
   "xenial-backend-frontend-python3.5":
     docker:
       # This is built from tools/circleci/images/xenial/Dockerfile .
@@ -160,6 +141,5 @@ workflows:
   version: 2
   build:
     jobs:
-      - "trusty-backend-python3.4"
       - "xenial-backend-frontend-python3.5"
       - "bionic-backend-python3.6"

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You might be interested in:
 
 * **Running a Zulip server**. Setting up a server takes just a couple
   of minutes. Zulip runs on Ubuntu 18.04 Bionic, Ubuntu 16.04 Xenial,
-  Ubuntu 14.04 Trusty, and Debian 9 Stretch. The installation process is
+  and Debian 9 Stretch. The installation process is
   [documented here](https://zulip.readthedocs.io/en/stable/production/install.html).
   Commercial support is available; see <https://zulipchat.com/plans>
   for details.

--- a/docs/testing/continuous-integration.md
+++ b/docs/testing/continuous-integration.md
@@ -53,7 +53,6 @@ uses those SSH keys for authentication.
 The main CircleCI configuration file is
 [./circleci/config.yml](https://github.com/zulip/zulip/blob/master/.circleci/config.yml).
 We currently run several jobs during a CircleCI build. They are:
-* trusty-python-3.4
 * xenial-python-3.5
 * bionic-python-3.6
 

--- a/tools/circleci/images.yml
+++ b/tools/circleci/images.yml
@@ -1,7 +1,3 @@
-trusty:
-  base_image: buildpack-deps:trusty-scm
-  extra_packages: python-virtualenv postgresql-9.3
-
 xenial:
   base_image: buildpack-deps:xenial-scm
   extra_packages: virtualenv postgresql-9.5


### PR DESCRIPTION
Split from #12396.

**Testing Plan:** You’re looking at it.