### PR TITLE
markdown: Make raw urls in topic names navigable.

### DIFF
--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -425,6 +425,18 @@ run_test('topic_links', () => {
     assert.equal(util.get_topic_links(message).length, 1);
     assert.equal(util.get_topic_links(message)[0], "https://zone_45.zulip.net/ticket/123");
 
+    message = {type: 'stream', topic: "Hello https://google.com"};
+    markdown.add_topic_links(message);
+    assert.equal(util.get_topic_links(message).length, 1);
+    assert.equal(util.get_topic_links(message)[0], "https://google.com");
+
+    message = {type: 'stream', topic: "#456 https://google.com https://github.com"};
+    markdown.add_topic_links(message);
+    assert.equal(util.get_topic_links(message).length, 3);
+    assert(util.get_topic_links(message).indexOf("https://google.com") !== -1);
+    assert(util.get_topic_links(message).indexOf("https://github.com") !== -1);
+    assert(util.get_topic_links(message).indexOf("https://trac.zulip.net/ticket/456") !== -1);
+
     message = {type: "not-stream"};
     markdown.add_topic_links(message);
     assert.equal(util.get_topic_links(message).length, 0);

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1711,3 +1711,17 @@ run_test('archive_message_group', () => {
     assert.equal(last_message_text, 'This is message two.');
 
 });
+
+run_test('recipient_row', () => {
+    // Assert HTML escaping in topic links.
+    const data = {
+        is_stream: true,
+        topic_links: [
+            'https://google.com',
+            'https://<script>alert("Hello")</script>',
+        ],
+    };
+    var html = render('recipient_row', data);
+    assert(html.indexOf('<script>alert("Hello")</script>') === -1);
+    assert(html.indexOf('&lt;script&gt;alert(&quot;Hello&quot;)&lt;/script&gt;') !== -1);
+});

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -160,6 +160,14 @@ exports.add_topic_links = function (message) {
             links.push(link_url);
         }
     });
+
+    // Also make raw urls navigable
+    var url_re = /\b(https?:\/\/[^\s<]+[^<.,:;"')\]\s])/g; // Slightly modified from third/marked.js
+    var match = topic.match(url_re);
+    if (match) {
+        links = links.concat(match);
+    }
+
     util.set_topic_links(message, links);
 };
 

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1969,6 +1969,10 @@ def build_engine(realm_filters: List[Tuple[str, str, int]],
         ])
     return engine
 
+# Split the topic name into multiple sections so that we can easily use
+# our common single link matching regex on it.
+basic_link_splitter = re.compile(r'[ !;\?\),\'\"]')
+
 # Security note: We don't do any HTML escaping in this
 # function on the URLs; they are expected to be HTML-escaped when
 # rendered by clients (just as links rendered into message bodies
@@ -1982,6 +1986,13 @@ def topic_links(realm_filters_key: int, topic_name: str) -> List[str]:
         pattern = prepare_realm_pattern(realm_filter[0])
         for m in re.finditer(pattern, topic_name):
             matches += [realm_filter[1] % m.groupdict()]
+
+    # Also make raw urls navigable.
+    for sub_string in basic_link_splitter.split(topic_name):
+        link_match = re.match(get_web_link_regex(), sub_string)
+        if link_match:
+            matches.append(link_match.group('url'))
+
     return matches
 
 def maybe_update_markdown_engines(realm_filters_key: Optional[int], email_gateway: bool) -> None:

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1969,6 +1969,10 @@ def build_engine(realm_filters: List[Tuple[str, str, int]],
         ])
     return engine
 
+# Security note: We don't do any HTML escaping in this
+# function on the URLs; they are expected to be HTML-escaped when
+# rendered by clients (just as links rendered into message bodies
+# are validated and escaped inside `url_to_a`).
 def topic_links(realm_filters_key: int, topic_name: str) -> List[str]:
     matches = []  # type: List[str]
 


### PR DESCRIPTION
We reuse the link regexes we use elsewhere inn markdown
for parsing links in topic names and add a button to open
them in new tabs similar to our behavior with linkifiers
in topic names.

Fixes #12391.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Adds automated tests.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![image](https://user-images.githubusercontent.com/8033238/58370559-a2998b80-7f25-11e9-860c-5b4292fdcf1f.png)

![image](https://user-images.githubusercontent.com/8033238/58370548-8990da80-7f25-11e9-904a-34c4d61c0528.png)
