### PR TITLE
linter: Do not lint scripts parsed with tail (like tools/setup/dev-motd).

### DIFF
--- a/tools/zulint/lister.py
+++ b/tools/zulint/lister.py
@@ -33,6 +33,8 @@ def get_ftype(fpath, use_shebang):
                 return 'js'
             elif re.search(r'^#!.*\bruby', first_line):
                 return 'rb'
+            elif re.search(r'^#!.*\btail', first_line):
+                return ''  # do not lint these scripts.
             elif re.search(r'^#!', first_line):
                 print('Error: Unknown shebang in file "%s":\n%s' % (fpath, first_line), file=sys.stderr)
                 return ''


### PR DESCRIPTION
This throws an error in the console when running `tools/lint` as:

```
$ tools/lint
Error: Unknown shebang in file "tools/setup/dev-motd":
#!/usr/bin/tail -n+2

mypy      | Error: Unknown shebang in file "tools/setup/dev-motd":
mypy      | #!/usr/bin/tail -n+2
mypy      |
```