### PR TITLE
Refactor the tests to use the method assert_logged_in_user_id to test if the user is logged in

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -22,6 +22,7 @@ from two_factor.models import PhoneDevice
 from zerver.lib.initial_password import initial_password
 from zerver.lib.utils import is_remote_server
 from zerver.lib.users import get_api_key
+from zerver.lib.sessions import get_session_dict_user
 
 from zerver.lib.actions import (
     check_send_message, create_stream_if_needed, bulk_add_subscriptions,
@@ -558,6 +559,13 @@ class ZulipTestCase(TestCase):
         decoded = response.content.decode('utf-8')
         for substring in substrings:
             self.assertNotIn(substring, decoded)
+
+    def assert_logged_in_user_id(self, user_id: Optional[int]) -> None:
+        """
+        Verifies the user currently logged in for the test client has the provided user_id.
+        Pass None to verify no user is logged in.
+        """
+        self.assertEqual(get_session_dict_user(self.client.session), user_id)
 
     def webhook_fixture_data(self, type: str, action: str, file_type: str='json') -> str:
         fn = os.path.join(

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -7,7 +7,6 @@ from mock import patch
 from typing import Any, Dict
 
 from zerver.lib.initial_password import initial_password
-from zerver.lib.sessions import get_session_dict_user
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import MockLDAP, get_test_image_file
 from zerver.lib.users import get_all_api_keys
@@ -78,7 +77,7 @@ class ChangeSettingsTest(ZulipTestCase):
         self.logout()
         self.login(self.example_email("hamlet"), "foobar1")
         user_profile = self.example_user('hamlet')
-        self.assertEqual(get_session_dict_user(self.client.session), user_profile.id)
+        self.assert_logged_in_user_id(user_profile.id)
 
     def test_illegal_name_changes(self) -> None:
         user = self.example_user('hamlet')


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Added a method named assert_logged_in_user_id to ZulipTestCase class which checks if the user is logged in. This is done to improve readability. Discussed [here](https://github.com/zulip/zulip/pull/11893#issuecomment-494577093)

@timabbott I know its not something of priority so can you have a look at it whenever you get the chance