### PR TITLE
Email mirror -  option tokens in address (including +include-footers)

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -153,11 +153,13 @@ def mark_missed_message_address_as_used(address: str) -> None:
         raise ZulipEmailForwardError('Missed message address has already been used')
 
 def construct_zulip_body(message: message.Message, realm: Realm, show_sender: bool=False,
-                         remove_quotations: bool=True) -> str:
+                         remove_quotations: bool=True, include_footers: bool=False) -> str:
     body = extract_body(message, remove_quotations)
     # Remove null characters, since Zulip will reject
     body = body.replace("\x00", "")
-    body = filter_footer(body)
+    if not include_footers:
+        body = filter_footer(body)
+
     body += extract_and_upload_attachments(message, realm)
     body = body.strip()
     if not body:

--- a/zerver/lib/email_mirror_helpers.py
+++ b/zerver/lib/email_mirror_helpers.py
@@ -7,7 +7,7 @@ from zerver.models import Stream
 
 from typing import Dict, Tuple
 
-optional_address_tokens = ["show-sender", "include-footers"]
+optional_address_tokens = ["show-sender", "include-footers", "include-quotations"]
 
 class ZulipEmailForwardError(Exception):
     pass

--- a/zerver/lib/email_mirror_helpers.py
+++ b/zerver/lib/email_mirror_helpers.py
@@ -7,7 +7,7 @@ from zerver.models import Stream
 
 from typing import Dict, Tuple
 
-optional_address_tokens = ["show-sender"]
+optional_address_tokens = ["show-sender", "include-footers"]
 
 class ZulipEmailForwardError(Exception):
     pass
@@ -58,7 +58,6 @@ def decode_email_address(email: str) -> Tuple[str, Dict[str, bool]]:
     # Perform the reverse of encode_email_address. Returns a tuple of
     # (email_token, options)
     msg_string = get_email_gateway_message_string_from_address(email)
-
     # Workaround for Google Groups and other programs that don't accept emails
     # that have + signs in them (see Trac #2102)
     splitting_char = '.' if '.' in msg_string else '+'

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -58,8 +58,10 @@ from django.conf import settings
 from typing import Any, Callable, Dict, Mapping, Union, Optional
 
 class TestEncodeDecode(ZulipTestCase):
-    def _assert_options(self, options: Dict[str, bool], show_sender: bool=False) -> None:
+    def _assert_options(self, options: Dict[str, bool], show_sender: bool=False,
+                        include_footers: bool=False) -> None:
         self.assertEqual(show_sender, ('show_sender' in options) and options['show_sender'])
+        self.assertEqual(include_footers, ('include_footers' in options) and options['include_footers'])
 
     def test_encode_decode(self) -> None:
         realm = get_realm('zulip')
@@ -69,41 +71,41 @@ class TestEncodeDecode(ZulipTestCase):
         self.assertTrue(email_address.startswith('dev-help'))
         self.assertTrue(email_address.endswith('@testserver'))
         token, options = decode_email_address(email_address)
-        self._assert_options(options, show_sender=False)
+        self._assert_options(options)
         self.assertEqual(token, stream.email_token)
 
         parts = email_address.split('@')
-        parts[0] += "+show-sender"
-        email_address_show = '@'.join(parts)
-        token, options = decode_email_address(email_address_show)
-        self._assert_options(options, show_sender=True)
+        parts[0] += "+include-footers+show-sender"
+        email_address_all_options = '@'.join(parts)
+        token, options = decode_email_address(email_address_all_options)
+        self._assert_options(options, show_sender=True, include_footers=True)
         self.assertEqual(token, stream.email_token)
 
         email_address_dots = email_address.replace('+', '.')
         token, options = decode_email_address(email_address_dots)
-        self._assert_options(options, show_sender=False)
+        self._assert_options(options)
         self.assertEqual(token, stream.email_token)
 
-        email_address_dots_show = email_address_show.replace('+', '.')
-        token, options = decode_email_address(email_address_dots_show)
-        self._assert_options(options, show_sender=True)
+        email_address_dots_all_options = email_address_all_options.replace('+', '.')
+        token, options = decode_email_address(email_address_dots_all_options)
+        self._assert_options(options, show_sender=True, include_footers=True)
         self.assertEqual(token, stream.email_token)
 
         email_address = email_address.replace('@testserver', '@zulip.org')
-        email_address_show = email_address_show.replace('@testserver', '@zulip.org')
+        email_address_all_options = email_address_all_options.replace('@testserver', '@zulip.org')
         with self.assertRaises(ZulipEmailForwardError):
             decode_email_address(email_address)
 
         with self.assertRaises(ZulipEmailForwardError):
-            decode_email_address(email_address_show)
+            decode_email_address(email_address_all_options)
 
         with self.settings(EMAIL_GATEWAY_EXTRA_PATTERN_HACK='@zulip.org'):
             token, options = decode_email_address(email_address)
-            self._assert_options(options, show_sender=False)
+            self._assert_options(options)
             self.assertEqual(token, stream.email_token)
 
-            token, options = decode_email_address(email_address_show)
-            self._assert_options(options, show_sender=True)
+            token, options = decode_email_address(email_address_all_options)
+            self._assert_options(options, show_sender=True, include_footers=True)
             self.assertEqual(token, stream.email_token)
 
         with self.assertRaises(ZulipEmailForwardError):
@@ -310,6 +312,34 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
 
         self.assertEqual(message.content, "From: %s\n%s" % (self.example_email('hamlet'),
                                                             "TestStreamEmailMessages Body"))
+        self.assertEqual(get_display_recipient(message.recipient), stream.name)
+        self.assertEqual(message.topic_name(), incoming_valid_message['Subject'])
+
+    def test_receive_stream_email_include_footers_success(self) -> None:
+        user_profile = self.example_user('hamlet')
+        self.login(user_profile.email)
+        self.subscribe(user_profile, "Denmark")
+        stream = get_stream("Denmark", user_profile.realm)
+
+        stream_to_address = encode_email_address(stream)
+        parts = stream_to_address.split('@')
+        parts[0] += "+include-footers"
+        stream_to_address = '@'.join(parts)
+
+        text = """Test message
+        --
+        Footer"""
+
+        incoming_valid_message = MIMEText(text)
+        incoming_valid_message['Subject'] = 'TestStreamEmailMessages Subject'
+        incoming_valid_message['From'] = self.example_email('hamlet')
+        incoming_valid_message['To'] = stream_to_address
+        incoming_valid_message['Reply-to'] = self.example_email('othello')
+
+        process_message(incoming_valid_message)
+        message = most_recent_message(user_profile)
+
+        self.assertEqual(message.content, text)
         self.assertEqual(get_display_recipient(message.recipient), stream.name)
         self.assertEqual(message.topic_name(), incoming_valid_message['Subject'])
 


### PR DESCRIPTION
The main objective of this PR is to, as requested in https://github.com/zulip/zulip/issues/12071 , add an option to include "+include-footers" in the stream email address to disable the stripping of the footer from the message.

What we do exactly is:
1. In the first commit, we establish a general way to support such additional tokens in the email address - +show-sender being the only one available at that point.
2. In the second commit, using this new framework, we easily implement the +include-footers option.
3. In the third commit, since this is now so easy, we implement +include-quotations, which will cause quotations (such as marked by "-----Original Message-----") to be kept. If this is not useful, then this commit can be skipped as it's not needed for anything.