### PR TITLE
setup-apt-repo: Try to download pre-setup deps before skipping update

### DIFF
--- a/scripts/lib/setup-apt-repo
+++ b/scripts/lib/setup-apt-repo
@@ -28,7 +28,7 @@ touch "$SOURCES_FILE"
 zulip_source_hash=$(sha1sum "$SOURCES_FILE")
 
 pre_setup_deps=(lsb-release apt-transport-https gnupg)
-if ! apt-get -s install "${pre_setup_deps[@]}" > /dev/null 2>&1; then
+if ! apt-get -dy install "${pre_setup_deps[@]}"; then
     apt-get update
 fi
 apt-get -y install "${pre_setup_deps[@]}"


### PR DESCRIPTION
Simulate isn’t enough in some cases.  The error message when this fails looks sufficiently non-alarming.

LXC:

    default: + apt-get -dy install lsb-release apt-transport-https gnupg
    default: Reading package lists...
    default: Building dependency tree...
    default:
    default: Reading state information...
    default: lsb-release is already the newest version.
    default: gnupg is already the newest version.
    default: The following NEW packages will be installed:
    default:   apt-transport-https
    default: 0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
    default: Need to get 25.1 kB of archives.
    default: After this operation, 238 kB of additional disk space will be used.
    default: Err http://archive.ubuntu.com/ubuntu/ trusty-updates/main apt-transport-https amd64 1.0.1ubuntu2.3
    default:   404  Not Found [IP: 91.189.88.161 80]
    default: Err http://security.ubuntu.com/ubuntu/ trusty-security/main apt-transport-https amd64 1.0.1ubuntu2.3
    default:   404  Not Found [IP: 91.189.88.161 80]
    default: E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/a/apt/apt-transport-https_1.0.1ubuntu2.3_amd64.deb  404  Not Found [IP: 91.189.88.161 80]
    default:
    default: E: Some files failed to download
    default: + apt-get update
    […]
    default: Fetched 4,504 kB in 7s (611 kB/s)
    default: Reading package lists...
    default: + apt-get -y install lsb-release apt-transport-https gnupg
    default: Reading package lists...

Docker:

    default: + apt-get -dy install lsb-release apt-transport-https gnupg
    default: Reading package lists...
    default: Building dependency tree...
    default:
    default: Reading state information...
    default: Package gnupg is not available, but is referred to by another package.
    default: This may mean that the package is missing, has been obsoleted, or
    default: is only available from another source
    default: E: Package 'gnupg' has no installation candidate
    default: + apt-get update
    […]
    default: Fetched 16.2 MB in 5s (3,326 kB/s)
    default: Reading package lists...
    default: + apt-get -y install lsb-release apt-transport-https gnupg
    default: Reading package lists...

(All in green.)

**Testing Plan:** Tested `vagrant up` with LXC and Docker providers.