### PR TITLE
dev-vagrant-docker: Copy the host user’s uid for the vagrant user

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -162,6 +162,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "docker" do |d, override|
     override.vm.box = nil
     d.build_dir = File.join(__dir__, "tools", "setup", "dev-vagrant-docker")
+    d.build_args = ["--build-arg", "VAGRANT_UID=#{Process.uid}"]
     d.has_ssh = true
     d.create_args = ["--ulimit", "nofile=1024:65536"]
   end

--- a/tools/setup/dev-vagrant-docker/Dockerfile
+++ b/tools/setup/dev-vagrant-docker/Dockerfile
@@ -21,6 +21,8 @@ RUN echo locales locales/default_environment_locale select en_US.UTF-8 | debconf
            systemd \
     && rm -rf /var/lib/apt/lists/*
 
+ARG VAGRANT_UID
+
 RUN \
     # We use https://github.com/gdraheim/docker-systemctl-replacement
     # to make services we install like postgres, redis, etc. normally
@@ -42,7 +44,7 @@ RUN \
     && mkdir /etc/systemd/system/redis-server.service.d \
     && printf '[Service]\nExecStart=/usr/bin/redis-server /etc/redis/redis.conf --bind 127.0.0.1\n' > /etc/systemd/system/redis-server.service.d/override.conf \
     # Set up the vagrant user and its SSH key (globally public)
-    && useradd -ms /bin/bash vagrant \
+    && useradd -ms /bin/bash -u "$VAGRANT_UID" vagrant \
     && mkdir -m 700 ~vagrant/.ssh \
     && curl -so ~vagrant/.ssh/authorized_keys 'https://raw.githubusercontent.com/hashicorp/vagrant/be7876d83644aa6bdf7f951592fdc681506bcbe6/keys/vagrant.pub' \
     && chown -R vagrant: ~vagrant/.ssh \


### PR DESCRIPTION
This allows `/srv/zulip` to be writable from the guest even if the host user’s uid is not 1000.

**Testing Plan:** Ran `vagrant up --provider=docker` with uid 1001.