### PR TITLE
Vagrantfile: Add customization to remove log file.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -148,6 +148,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider "virtualbox" do |vb, override|
     override.vm.box = "ubuntu/trusty64"
+    # An unnecessary log file gets generated when running vagrant up for the
+    # first time with the Ubuntu Bionic box. This looks like it is being
+    # caused upstream by the base box containing a Vagrantfile with a similar
+    # line to the one below.
+    # see https://github.com/hashicorp/vagrant/issues/9425
+    vb.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ]
     # It's possible we can get away with just 1.5GB; more testing needed
     vb.memory = vm_memory
     vb.cpus = vm_num_cpus


### PR DESCRIPTION
An unnecessary log file gets generated when running vagrant up for the
first time with the Ubuntu Bionic box.  This looks like it is being
caused upstream by the base box containing a Vagrantfile with a line
that looks something like:

```
vb.customize [ ..., ..., ..., ..., \
File.join(Dir.pwd, "ubuntu-bionic-18.04-cloudimg-console.log") ]
```
The line added here negates this.

A relevant discussion can be found here: https://github.com/hashicorp/vagrant/issues/9425