### PR TITLE
Fix test-backend to not double-create test databases

### DIFF
--- a/tools/lib/test_server.py
+++ b/tools/lib/test_server.py
@@ -62,7 +62,7 @@ def test_server_running(force: bool=False, external_host: str='testserver',
     set_up_django(external_host)
 
     if use_db:
-        update_test_databases_if_required()
+        update_test_databases_if_required(rebuild_test_database=True)
 
     # Run this not through the shell, so that we have the actual PID.
     run_dev_server_command = ['tools/run-dev.py', '--test']

--- a/tools/lib/test_server.py
+++ b/tools/lib/test_server.py
@@ -19,7 +19,7 @@ TOOLS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if TOOLS_DIR not in sys.path:
     sys.path.insert(0, os.path.dirname(TOOLS_DIR))
 
-from zerver.lib.test_fixtures import run_generate_fixtures_if_required
+from zerver.lib.test_fixtures import update_test_databases_if_required
 
 def set_up_django(external_host):
     # type: (str) -> None
@@ -62,7 +62,7 @@ def test_server_running(force: bool=False, external_host: str='testserver',
     set_up_django(external_host)
 
     if use_db:
-        run_generate_fixtures_if_required()
+        update_test_databases_if_required()
 
     # Run this not through the shell, so that we have the actual PID.
     run_dev_server_command = ['tools/run-dev.py', '--test']

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -193,7 +193,7 @@ def main() -> None:
     os.environ["http_proxy"] = ""
     os.environ["https_proxy"] = ""
 
-    from zerver.lib.test_fixtures import run_generate_fixtures_if_required
+    from zerver.lib.test_fixtures import update_test_databases_if_required
 
     from tools.lib.test_script import (
         get_provisioning_status,
@@ -376,7 +376,7 @@ def main() -> None:
     # files, since part of setup is importing the models for all applications in INSTALLED_APPS.
     django.setup()
 
-    run_generate_fixtures_if_required(options.generate_fixtures)
+    update_test_databases_if_required(options.generate_fixtures)
 
     subprocess.check_call(['tools/webpack', '--test'])
 

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -384,9 +384,9 @@ def main() -> None:
 
     if parallel > 1:
         print("-- Running tests in parallel mode with {} "
-              "processes.".format(parallel))
+              "processes.".format(parallel), flush=True)
     else:
-        print("-- Running tests in serial mode.")
+        print("-- Running tests in serial mode.", flush=True)
 
     test_runner = TestRunner(failfast=options.fatal_errors, verbosity=2,
                              parallel=parallel, reverse=options.reverse,

--- a/zerver/lib/test_fixtures.py
+++ b/zerver/lib/test_fixtures.py
@@ -44,7 +44,17 @@ def run_db_migrations(platform: str) -> None:
          './manage.py', 'get_migration_status',
          '--output=%s' % (migration_status_file,)])
 
-def run_generate_fixtures_if_required(use_force: bool=False) -> None:
+def update_test_databases_if_required(use_force: bool=False) -> None:
+    """Checks whether the zulip_test_template database template, is
+    consistent with our database migrations; if not, it updates them
+    in the fastest way possible:
+
+    * If all we need to do is add some migrations, just runs those
+      migrations.
+    * Otherwise, we rebuild the test database from scratch.
+
+    If use_force is specified, it will always do a full rebuild.
+    """
     generate_fixtures_command = ['tools/setup/generate-fixtures']
     test_template_db_status = template_database_status()
     if use_force or test_template_db_status == 'needs_rebuild':


### PR DESCRIPTION
See the individual commits for details, but this PR fixes some issues that caused `test-backend <single trivial test>` to take about 40% longer than it should, because we were creating 2 test databases from the template, only one of which we were going to end up using.  On my system, it goes from ~4s to ~2.5s.