### PR TITLE
webpack: Restart webpack-dev-server on config file changes.

### DIFF
--- a/tools/webpack
+++ b/tools/webpack
@@ -4,6 +4,8 @@ import argparse
 import os
 import sys
 import json
+import subprocess
+import pyinotify
 
 if False:
     from typing import NoReturn
@@ -33,7 +35,7 @@ def build_for_prod_or_casper(quiet):
     os.execvp(webpack_args[0], webpack_args)
 
 def build_for_dev_server(host, port, minify, disable_host_check):
-    # type: (str, str, bool, bool) -> NoReturn
+    # type: (str, str, bool, bool) -> None
     """watches and rebuilds on changes, serving files from memory via webpack-dev-server"""
 
     # This is our most dynamic configuration, which we use for our
@@ -55,7 +57,28 @@ def build_for_dev_server(host, port, minify, disable_host_check):
         webpack_args.append('--optimize-minimize')
     if disable_host_check:
         webpack_args.append('--disable-host-check')
-    os.execvp(webpack_args[0], webpack_args)
+
+    try:
+        webpack_process = subprocess.Popen(webpack_args)
+
+        class WebpackConfigFileChangeHandler(pyinotify.ProcessEvent):
+            def process_default(self, event):
+                # type: (pyinotify.Event) -> None
+                nonlocal webpack_process
+                print('Restarting webpack-dev-server due to config changes...')
+                webpack_process.terminate()
+                webpack_process.wait()
+                webpack_process = subprocess.Popen(webpack_args)
+
+        watch_manager = pyinotify.WatchManager()
+        event_notifier = pyinotify.Notifier(watch_manager, WebpackConfigFileChangeHandler())
+        for file in ['webpack.config.ts', 'webpack-helpers.ts', 'webpack.assets.json']:
+            filepath = os.path.join(os.path.dirname(__file__), file)
+            watch_manager.add_watch(filepath, pyinotify.IN_MODIFY)
+        event_notifier.loop()
+    finally:
+        webpack_process.terminate()
+        webpack_process.wait()
 
 def build_for_most_tests():
     # type: () -> None


### PR DESCRIPTION
Using `pyinotify` library automatically restarts webpack process if webpack config files are modified.
Also we are still using python 2 mypy annotations for `tools/webpack`, is this for a reason for this or it just not migrated.

**Testing Plan:** <!-- How have you tested? -->
Run `tools/run-dev.py` then edit any of the webpack config file (`webpack.config.ts`, `webpack-helpers.ts`, `webpack.assets.json`); webpack process should restart.

