### PR TITLE
coveragerc: Omit blub

### DIFF
--- a/tools/coveragerc
+++ b/tools/coveragerc
@@ -38,3 +38,5 @@ omit =
     zerver/lib/ccache.py
     # Settings.py files are hard to test
     zproject/*settings.py
+    # https://github.com/davidhalter/jedi/issues/1122
+    blub


### PR DESCRIPTION
The jedi package `exec()`s some code in the context of the fake module `blub`, causing errors when generating the coverage report.  See davidhalter/jedi#1122.

**Testing Plan:** This.