### PR TITLE
(WIP) info-overlay: Improve styling of hotkeys.

### DIFF
--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -42,8 +42,8 @@ function adjust_mac_shortcuts() {
     var keys_map = new Map([
         ['Backspace', 'Delete'],
         ['Enter', 'Return'],
-        ['Home', 'Fn + ⇽'],
-        ['End', 'Fn + ⇾'],
+        ['Home', 'Fn + ←'],
+        ['End', 'Fn + →'],
         ['PgUp', 'Fn + ↑'],
         ['PgDn', 'Fn + ↓'],
     ]);

--- a/static/styles/informational-overlays.scss
+++ b/static/styles/informational-overlays.scss
@@ -50,32 +50,6 @@
     font-size: 0.9em;
 }
 
-.informational-overlays {
-    // Hack to prevent styling from 00eaf3a effecting the markdown help overlay
-    .rendered_markdown {
-        // styles to over ride those from .rendered_markdown table
-        table {
-            padding-right: 0px;
-            margin: 0px;
-            width: 100%;
-        }
-        tr td {
-            border: 0px;
-        }
-        // Duplicate styles from bootstrap to render table correctly
-        .table th,
-        .table td {
-            border-top: 1px solid hsl(0, 0%, 87%);
-        }
-        .table-bordered td {
-            border-left: 1px solid hsl(0, 0%, 87%);
-        }
-        .table-condensed th,
-        .table-condensed td {
-            padding: 4px 5px;
-        }
-    }
-}
 
 .help-table {
     table-layout: fixed;

--- a/static/styles/informational-overlays.scss
+++ b/static/styles/informational-overlays.scss
@@ -115,7 +115,6 @@
         margin: 0 0.1em;
         padding: 0.1em 0.4em;
         text-shadow: 0 1px 0 hsl(0, 0%, 100%);
-
         /* Prevent selection */
         -webkit-touch-callout: none;
         -webkit-user-select: none;
@@ -123,6 +122,10 @@
         -moz-user-select: none;
         -ms-user-select: none;
         user-select: none;
+    }
+    .arrow-key {
+        font-size: 1.5em;
+        padding: 0.1em 0.2em;
     }
 }
 

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -30,7 +30,7 @@
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Next message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Down</kbd> or <kbd>J</kbd></span></td>
+                    <td><span class="hotkey"><kbd>↓</kbd> or <kbd>J</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Last message{% endtrans %}</td>
@@ -75,11 +75,11 @@
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Previous message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Up</kbd> or <kbd>K</kbd></span></td>
+                    <td><span class="hotkey"><kbd>↑</kbd> or <kbd>K</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Next message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Down</kbd> or <kbd>J</kbd></span></td>
+                    <td><span class="hotkey"><kbd>↓</kbd> or <kbd>J</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Scroll up{% endtrans %}</td>
@@ -194,7 +194,7 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Edit your last message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Left</kbd></span></td>
+                    <td><span class="hotkey"><kbd>⇽</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Show message sender's profile{% endtrans %}</td>
@@ -287,11 +287,11 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Scroll through streams{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Up</kbd> or <kbd>Down</kbd></span></td>
+                    <td><span class="hotkey"><kbd>↑</kbd> or <kbd>↓</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Switch between tabs{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Left</kbd> or <kbd>Right</kbd></span></td>
+                    <td><span class="hotkey"><kbd>⇽</kbd> or <kbd>⇾</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}View stream messages{% endtrans %}</td>

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -30,7 +30,7 @@
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Next message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>↓</kbd> or <kbd>J</kbd></span></td>
+                    <td><span class="hotkey"><kbd class="arrow-key">↓</kbd> or <kbd>J</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Last message{% endtrans %}</td>
@@ -75,11 +75,11 @@
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Previous message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>↑</kbd> or <kbd>K</kbd></span></td>
+                    <td><span class="hotkey"><kbd class="arrow-key">↑</kbd> or <kbd>K</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Next message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>↓</kbd> or <kbd>J</kbd></span></td>
+                    <td><span class="hotkey"><kbd class="arrow-key">↓</kbd> or <kbd>J</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Scroll up{% endtrans %}</td>
@@ -194,7 +194,7 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Edit your last message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>←</kbd></span></td>
+                    <td><span class="hotkey"><kbd class="arrow-key">←</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Show message sender's profile{% endtrans %}</td>
@@ -287,11 +287,11 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Scroll through streams{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>↑</kbd> or <kbd>↓</kbd></span></td>
+                    <td><span class="hotkey"><kbd class="arrow-key">↑</kbd> or <kbd class="arrow-key">↓</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Switch between tabs{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>←</kbd> or <kbd>→</kbd></span></td>
+                    <td><span class="hotkey"><kbd class="arrow-key">←</kbd> or <kbd class="arrow-key">→</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}View stream messages{% endtrans %}</td>

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -194,7 +194,7 @@
                 </thead>
                 <tr>
                     <td class="definition">{% trans %}Edit your last message{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>⇽</kbd></span></td>
+                    <td><span class="hotkey"><kbd>←</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Show message sender's profile{% endtrans %}</td>
@@ -291,7 +291,7 @@
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Switch between tabs{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>⇽</kbd> or <kbd>⇾</kbd></span></td>
+                    <td><span class="hotkey"><kbd>←</kbd> or <kbd>→</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}View stream messages{% endtrans %}</td>

--- a/templates/zerver/app/markdown_help.html
+++ b/templates/zerver/app/markdown_help.html
@@ -1,4 +1,4 @@
-<div class="overlay-modal hide rendered_markdown" id="message-formatting" tabindex="-1" role="dialog"
+<div class="overlay-modal hide" id="message-formatting" tabindex="-1" role="dialog"
     aria-label="{{ _('Message formatting') }}">
     <div class="modal-body" tabindex="0">
         <div id="markdown-instructions">
@@ -13,19 +13,19 @@
                 <tbody>
                     <tr>
                         <td>*italic*</td>
-                        <td><i>italic</i></td>
+                        <td class="rendered_markdown"><i>italic</i></td>
                     </tr>
                     <tr>
                         <td>**bold**</td>
-                        <td><b>bold</b></td>
+                        <td class="rendered_markdown"><b>bold</b></td>
                     </tr>
                     <tr>
                         <td>~~strikethrough~~</td>
-                        <td><del>strikethrough</del></td>
+                        <td class="rendered_markdown"><del>strikethrough</del></td>
                     </tr>
                     <tr>
                         <td>[Zulip website](https://zulip.org)</td>
-                        <td><a href="https://zulip.org" target="_blank">Zulip website</a></td>
+                        <td class="rendered_markdown"><a href="https://zulip.org" target="_blank">Zulip website</a></td>
                     </tr>
                     <tr>
                         <td>* Milk<br/>
@@ -35,7 +35,7 @@
                             &nbsp;&nbsp;* Oolong tea<br/>
                             * Coffee
                         </td>
-                        <td>
+                        <td class="rendered_markdown">
                             <ul>
                                 <li>Milk</li>
                                 <li>Tea
@@ -54,48 +54,48 @@
                             1. Tea<br/>
                             1. Coffee
                         </td>
-                        <td>1. Milk<br/>
+                        <td class="rendered_markdown">1. Milk<br/>
                             2. Tea<br/>
                             3. Coffee
                         </td>
                     </tr>
                     <tr>
                         <td>:heart: (and <a href="http://www.emoji-cheat-sheet.com/" target="_blank">many others</a>, from the <a href="https://code.google.com/p/noto/" target="_blank">Noto Project</a>)</td>
-                        <td><img alt=":heart:" class="emoji" src="/static/generated/emoji/images/emoji/heart.png" title=":heart:" /></td>
+                        <td class="rendered_markdown"><img alt=":heart:" class="emoji" src="/static/generated/emoji/images/emoji/heart.png" title=":heart:" /></td>
                     </tr>
                     <tr>
                         <td>@**Joe Smith**<br/>
                           (autocompletes from @joe)</td>
-                        <td><span class="user-mention">@Joe Smith</span> (notifies Joe Smith)</td>
+                        <td class="rendered_markdown"><span class="user-mention">@Joe Smith</span> (notifies Joe Smith)</td>
                     </tr>
                     <tr>
                         <td>@_**Joe Smith**<br/>
                           (autocompletes from @_joe)</td>
-                        <td><span class="user-mention">Joe Smith</span> (links to profile but doesn't notify Joe Smith)</td>
+                        <td class="rendered_markdown"><span class="user-mention">Joe Smith</span> (links to profile but doesn't notify Joe Smith)</td>
                     </tr>
                     <tr>
                         <td>@**all**</td>
-                        <td><span class="user-mention">@all</span> (notifies all recipients)</td>
+                        <td class="rendered_markdown"><span class="user-mention">@all</span> (notifies all recipients)</td>
                     </tr>
                     <tr>
                         <td>#**streamName**</td>
-                        <td><a>#streamName</a> (links to a stream)</td>
+                        <td class="rendered_markdown"><a>#streamName</a> (links to a stream)</td>
                     </tr>
                     <tr>
                         <td>/me is busy working<br/>
                           (send a status message as user Iago)</td>
-                        <td><span class="sender_name-in-status">Iago</span> is busy working</td>
+                        <td class="rendered_markdown"><span class="sender_name-in-status">Iago</span> is busy working</td>
                     </tr>
                     <tr>
                         <td>Some inline `code`</td>
-                        <td>Some inline <code>code</code></td>
+                        <td class="rendered_markdown">Some inline <code>code</code></td>
                     </tr>
                     <tr>
                     <td class="preserve_spaces">```
 def zulip():
     print "Zulip"
 ```</td>
-                    <td>
+                    <td class="rendered_markdown">
                         <div class="codehilite"><pre>def zulip():
     print "Zulip"</pre></div>
                     </td>
@@ -105,7 +105,7 @@ def zulip():
 def zulip():
     print "Zulip"
 ```</td>
-                    <td>
+                    <td class="rendered_markdown">
                         <div class="codehilite"><pre><span class="k">def</span> <span class="nf">zulip</span><span class="p">():</span>
     <span class="k">print</span> <span class="s">"Zulip"</span></pre></div>
                     </td>
@@ -118,18 +118,18 @@ def zulip():
                     </tr>
                     <tr>
                         <td>&gt; Quoted</td>
-                        <td><blockquote>Quoted</blockquote></td>
+                        <td class="rendered_markdown"><blockquote>Quoted</blockquote></td>
 
                     </tr>
                     <tr>
                     <td class="preserve_spaces">```quote
 Quoted block
 ```</td>
-                    <td><blockquote><p>Quoted block</p></blockquote></td>
+                    <td class="rendered_markdown"><blockquote><p>Quoted block</p></blockquote></td>
                     </tr>
                     <tr>
                         <td>Some inline math $$ e^{i \pi } + 1 = 0 $$</td>
-                        <td>
+                        <td class="rendered_markdown">
                             Some inline math <span class="katex"><span class="katex-mathml"><math><semantics><mrow><msup><mi>e</mi><mrow><mi>i</mi><mi>π</mi></mrow></msup><mo>+</mo><mn>1</mn><mo>=</mo><mn>0</mn></mrow><annotation encoding="application/x-tex">e^{i\pi} + 1 = 0</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="strut" style="height: 0.874664em;"></span><span class="strut bottom" style="height: 0.957994em; vertical-align: -0.08333em;"></span><span class="base"><span class="mord"><span class="mord mathit">e</span><span class="msupsub"><span class="vlist-t"><span class="vlist-r"><span class="vlist" style="height: 0.874664em;"><span class="" style="top: -3.113em; margin-right: 0.05em;"><span class="pstrut" style="height: 2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight"><span class="mord mathit mtight">i</span><span class="mord mathit mtight" style="margin-right: 0.03588em;">π</span></span></span></span></span></span></span></span></span><span class="mbin">+</span><span class="mord mathrm">1</span><span class="mrel">=</span><span class="mord mathrm">0</span></span></span></span>
                         </td>
                     </tr>
@@ -142,7 +142,7 @@ Quoted block
                         </td>
                     </tr>
                     <tr>
-                        <td colspan="2">{% trans %}You can also make <a target="_blank"
+                        <td class="rendered_markdown" colspan="2">{% trans %}You can also make <a target="_blank"
                             href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#wiki-tables">tables</a>
                             with this <a target="_blank"
                                           href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#wiki-tables">Markdown-ish

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -110,7 +110,7 @@ below, and add more to your repertoire as needed.
 
 ## Message actions
 
-* **Edit last message**: `⇽` — Open the last editable message in the current
+* **Edit last message**: `←` — Open the last editable message in the current
   view (if any).
 
 ### For a selected message (outlined in blue)
@@ -165,7 +165,7 @@ Keyboard navigation (e.g. arrow keys) works as expected.
         Pressing `↑` from the first stream in the list moves
         you to the **Filter streams** input.
 
-* **Switch between tabs**: `⇽` and `⇾` — Switch between the
+* **Switch between tabs**: `←` and `→` — Switch between the
 **Subscribed** and **All streams** tabs.
 
 * **Create new stream**: `n`

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -607,7 +607,7 @@ def build_custom_checkers(by_lang):
         {'pattern': r'title="[^{\:]',
          'exclude_line': set([
              ('templates/zerver/app/markdown_help.html',
-              '<td><img alt=":heart:" class="emoji" src="/static/generated/emoji/images/emoji/heart.png" title=":heart:" /></td>')
+              '<td class="rendered_markdown"><img alt=":heart:" class="emoji" src="/static/generated/emoji/images/emoji/heart.png" title=":heart:" /></td>')
          ]),
          'exclude': set(["templates/zerver/emails"]),
          'description': "`title` value should be translatable."},


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Follow up to PR https://github.com/zulip/zulip/pull/12401.

**Testing Plan:** <!-- How have you tested? -->
Tested manually to see that everything looks okay.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
First commit: Replaces all the "Up", "Down", "Left", "Right" with "↑", "↓", "←" ,"→".
![image](https://user-images.githubusercontent.com/33805964/58593646-18d12180-8289-11e9-9c2c-e8520f4db7b4.png)


Second commit: Increases size of arrow-keys. (WIP)
![image](https://user-images.githubusercontent.com/33805964/58593579-e58e9280-8288-11e9-8368-a51e8a4b2f9c.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
