### PR TITLE
Vagrantfile: Remove VMmare Fusion provider.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -159,12 +159,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.cpus = vm_num_cpus
   end
 
-  config.vm.provider "vmware_fusion" do |vb, override|
-    override.vm.box = "puphpet/ubuntu1404-x64"
-    vb.vmx["memsize"] = vm_memory
-    vb.vmx["numvcpus"] = vm_num_cpus
-  end
-
   config.vm.provider "docker" do |d, override|
     override.vm.box = nil
     d.build_dir = File.join(__dir__, "tools", "setup", "dev-vagrant-docker")


### PR DESCRIPTION
Ubuntu 14.04 is EOL. Mac users can use the VirtualBox provider (and now maybe the Docker provider?). We can add back the VMware Fusion provider later if someone cares enough to get it working with Ubuntu 18.04.