### PR TITLE
docs: In the api docs for get messages, avoid using \" in curl examples.

### DIFF
--- a/templates/zerver/api/get-messages.md
+++ b/templates/zerver/api/get-messages.md
@@ -70,7 +70,7 @@ curl -X GET {{ api_url }}/v1/messages \
     -d "use_first_unread_anchor=false" \
     -d "num_before=3" \
     -d "num_after=14" \
-    -d "narrow=[{\"operator\":\"stream\", \"operand\":\"party\"}]" \
+    -d 'narrow=[{"operator":"stream", "operand":"party"}]' \
 
 ```
 


### PR DESCRIPTION
closes #12196.

NOTE: The get messages documentation seems to be the only place where this issue of \" seems to be in the API documentation.