### PR TITLE
Retention - handle reactions and submessages

### DIFF
--- a/zerver/lib/retention.py
+++ b/zerver/lib/retention.py
@@ -4,7 +4,8 @@ from datetime import timedelta
 from django.db import connection, transaction
 from django.utils.timezone import now as timezone_now
 from zerver.models import (Message, UserMessage, ArchivedMessage, ArchivedUserMessage, Realm,
-                           Attachment, ArchivedAttachment, Reaction, ArchivedReaction)
+                           Attachment, ArchivedAttachment, Reaction, ArchivedReaction,
+                           SubMessage, ArchivedSubMessage)
 
 from typing import Any, Dict, List
 
@@ -14,6 +15,12 @@ models_with_message_key = [
         'archive_class': ArchivedReaction,
         'table_name': 'zerver_reaction',
         'archive_table_name': 'zerver_archivedreaction'
+    },
+    {
+        'class': SubMessage,
+        'archive_class': ArchivedSubMessage,
+        'table_name': 'zerver_submessage',
+        'archive_table_name': 'zerver_archivedsubmessage'
     },
 ]  # type: List[Dict[str, Any]]
 

--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -20,7 +20,7 @@ from zerver.lib.retention import (
 ZULIP_REALM_DAYS = 30
 MIT_REALM_DAYS = 100
 
-class TestRetentionLib(ZulipTestCase):
+class RetentionTestingBase(ZulipTestCase):
     """
         Test receiving expired messages retention tool.
     """
@@ -113,6 +113,7 @@ class TestRetentionLib(ZulipTestCase):
         return {'expired_message_id': expired_message_id, 'actual_message_id': actual_message_id,
                 'other_user_message_id': other_message_id}
 
+class TestArchivingGeneral(RetentionTestingBase):
     def test_no_expired_messages(self) -> None:
         move_expired_to_archive()
 


### PR DESCRIPTION
Commits 1-2: Small cleanup to prepare for the following commits.
Commits 3-4: Add tests to see Reactions/SubMessages get properly deleted when their parent Message gets archived, as requested in https://github.com/zulip/zulip/pull/12431#issuecomment-497144920
Commit 5: Implement a general way of archiving all models with a message key(like Reactions and SubMessages). Apply it to Reactions and expand the tests from commit 3 accordingly.
Commit 6: Apply the above to SubMessages.

With this, Reactions and SubMessages should be getting properly archived by the retention system.

One awkward thing is that I'm importing `` from zerver.tests.test_reactions import EmojiReactionBase `` in tests, to inherit from this class - it's useful for the Reactions tests, but I haven't seen tests importing stuff from other tests in the codebase, so maybe this isn't appropriate.