### PR TITLE
Vagrantfile: Update Docker fallback patch for installed but broken case

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,7 +39,7 @@ else
     method(:usable?).owner == singleton_class or def self.usable?(raise_error=false)
       VagrantPlugins::DockerProvider::Driver.new.execute("docker", "version")
       true
-    rescue Vagrant::Errors::CommandUnavailable
+    rescue Vagrant::Errors::CommandUnavailable, VagrantPlugins::DockerProvider::Errors::ExecuteError
       raise if raise_error
       return false
     end


### PR DESCRIPTION
The corresponding upstream PR has been updated as well.

**Testing Plan:** `vagrant up` from a user without Docker permissions.