### PR TITLE
markdown: Add `.rendered_markdown` to elements in with MD content.

### DIFF
--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -247,7 +247,6 @@ ul.remind_me_popover .remind_icon {
             }
 
             &[data-type="2"] .value {
-                white-space: pre-line;
                 overflow-wrap: break-word;
             }
         }

--- a/static/templates/subscription.handlebars
+++ b/static/templates/subscription.handlebars
@@ -16,7 +16,7 @@
             </div>
         </div>
         <div class="bottom-bar">
-            <div class="description" data-no-description="{{t 'No description.'}}">{{{rendered_description}}}</div>
+            <div class="description rendered_markdown" data-no-description="{{t 'No description.'}}">{{{rendered_description}}}</div>
             {{#if is_old_stream}}
             <div class="stream-message-count" data-toggle="tooltip" title="{{t 'Estimated messages per week' }}">
                 <i class="fa fa-bar-chart"></i>

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -33,7 +33,7 @@
             </div>
         </div>
         <div class="stream-description">
-            <span class="stream-description-editable editable-section description" data-no-description="{{t 'No description.' }}">{{{rendered_description}}}</span>
+            <span class="stream-description-editable editable-section description rendered_markdown" data-no-description="{{t 'No description.' }}">{{{rendered_description}}}</span>
             {{#if can_change_name_description}}
             <span class="editable" data-make-editable=".stream-description-editable"></span>
             <span class="checkmark" data-finish-editing=".stream-description-editable">✓</span>

--- a/static/templates/user_profile_modal.handlebars
+++ b/static/templates/user_profile_modal.handlebars
@@ -53,7 +53,7 @@
                     <a href={{this.value}} target="_blank" class="value">{{this.value}}</a>
                 {{else}}
                     {{#if this.rendered_value}}
-                    <div class="value">{{{this.rendered_value}}}</div>
+                    <div class="value rendered_markdown">{{{this.rendered_value}}}</div>
                     {{else}}
                     <div class="value">{{this.value}}</div>
                     {{/if}}

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -374,7 +374,10 @@ class Command(BaseCommand):
             ])
             do_update_user_custom_profile_data(hamlet, [
                 {"id": phone_number.id, "value": "+0-11-23-456-7890"},
-                {"id": biography.id, "value": "Prince of Denmark, and other things!"},
+                {
+                    "id": biography.id,
+                    "value": "I am:\n* The prince of Denmark\n* Nephew to the usurping Claudius",
+                },
                 {"id": favorite_food.id, "value": "Dark chocolate"},
                 {"id": favorite_editor.id, "value": "vim"},
                 {"id": birthday.id, "value": "1900-1-1"},
@@ -470,12 +473,12 @@ class Command(BaseCommand):
 
                 zulip_stream_dict = {
                     "devel": {"description": "For developing"},
-                    "all": {"description": "For everything"},
+                    "all": {"description": "For **everything**"},
                     "announce": {"description": "For announcements", 'is_announcement_only': True},
                     "design": {"description": "For design"},
                     "support": {"description": "For support"},
                     "social": {"description": "For socializing"},
-                    "test": {"description": "For testing"},
+                    "test": {"description": "For testing `code`"},
                     "errors": {"description": "For errors"},
                     "sales": {"description": "For sales discussion"}
                 }  # type: Dict[str, Dict[str, Any]]


### PR DESCRIPTION
These elements include:
* Stream description in the subscription overlay
  * sidebar and
  * stream settings
* Custom profile fields with rendered MD content

I did not include the portico because basic MD styling for light mode elements are applied without the `.rendered_markdown` nesting. (This was done because we needed the light-mode styling while copying the text). Since portico is only in light-mode, current styling works fine.