### PR TITLE
test_fixtures.py: Use hashing to optimize migrations check.

### DIFF
--- a/zerver/lib/test_fixtures.py
+++ b/zerver/lib/test_fixtures.py
@@ -8,6 +8,7 @@ import sys
 from typing import Any, List, Optional
 from importlib import import_module
 from io import StringIO
+import glob
 
 from django.db import connections, DEFAULT_DB_ALIAS
 from django.db.utils import OperationalError
@@ -17,7 +18,7 @@ from django.core.management import call_command
 from django.utils.module_loading import module_has_submodule
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
-from scripts.lib.zulip_tools import get_dev_uuid_var_path, run
+from scripts.lib.zulip_tools import get_dev_uuid_var_path, run, file_or_package_hash_updated
 
 UUID_VAR_DIR = get_dev_uuid_var_path()
 FILENAME_SPLITTER = re.compile(r'[\W\-_]')
@@ -217,6 +218,13 @@ def template_database_status(
         hash_status = files_hash_status and settings_hash_status
         if not hash_status:
             return 'needs_rebuild'
+
+        # Here we hash and compare our migration files before doing the
+        # work of seeing what to do with them.
+        paths = glob.glob('*/migrations/*.py')
+        check_migrations = file_or_package_hash_updated(paths, "migrations_hash", is_force=False)
+        if not check_migrations:
+            return 'current'
 
         migration_op = what_to_do_with_migrations(migration_status, settings=settings)
         if migration_op == 'scrap':


### PR DESCRIPTION
Instead of running `what_to_do_with_migrations` unconditionally, we
add a function to hash and compare the files located in
`zerver/migrations`. Only if the a migration file has changed (or the
hash file does not exist yet) do we call `what_to_do_with_migrations`.

It was discovered that the call to Django's `showmigrations.py` file was
causing roughly a 500ms increase in `test-backend`'s start up time.

Fixes: #12428

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
