### PR TITLE
webhooks/buildbot: Add missing "skipped" build result code.

### DIFF
--- a/zerver/webhooks/buildbot/fixtures/finished_cancelled.json
+++ b/zerver/webhooks/buildbot/fixtures/finished_cancelled.json
@@ -1,0 +1,9 @@
+{
+    "timestamp":1558960446,
+    "buildid":10434,
+    "project":"zulip\/zulip-zapier",
+    "results":6,
+    "url":"https:\/\/ci.example.org\/#builders\/79\/builds\/307",
+    "event":"finished",
+    "buildername":"AMD64 Ubuntu 18.04 Python 3"
+}

--- a/zerver/webhooks/buildbot/tests.py
+++ b/zerver/webhooks/buildbot/tests.py
@@ -19,3 +19,8 @@ class BuildbotHookTests(WebhookTestCase):
         expected_topic = "general"  # project key is empty
         expected_message = "Build [#34](http://exampleurl.com/#builders/1/builds/34) (result: failure) for **runtests** finished."
         self.send_and_test_stream_message("finished_failure", expected_topic, expected_message)
+
+    def test_build_cancelled(self) -> None:
+        expected_topic = "zulip/zulip-zapier"
+        expected_message = "Build [#10434](https://ci.example.org/#builders/79/builds/307) (result: cancelled) for **AMD64 Ubuntu 18.04 Python 3** finished."
+        self.send_and_test_stream_message("finished_cancelled", expected_topic, expected_message)

--- a/zerver/webhooks/buildbot/view.py
+++ b/zerver/webhooks/buildbot/view.py
@@ -21,7 +21,9 @@ def api_buildbot_webhook(request: HttpRequest, user_profile: UserProfile,
 
 def get_message(payload: Dict[str, Any]) -> str:
     if "results" in payload:
-        results = ("success", "warning", "failure", "exception", "retry", "cancelled")
+        # See http://docs.buildbot.net/latest/developer/results.html
+        results = ("success", "warnings", "failure", "skipped",
+                   "exception", "retry", "cancelled")
         status = results[payload["results"]]
 
     if payload["event"] == "new":


### PR DESCRIPTION
The payload for when a build is cancelled was causing an error
because the build result code mapping was missing one of the
codes. This commit also fixes a minor typo in the result codes.

@timabbott: FYI :)