### PR TITLE
dev-vagrant-docker: Clear redis-server ExecStart before overriding it

### DIFF
--- a/tools/setup/dev-vagrant-docker/Dockerfile
+++ b/tools/setup/dev-vagrant-docker/Dockerfile
@@ -45,7 +45,7 @@ RUN \
     && dpkg-divert --add --rename /etc/default/redis-server \
     && printf 'ULIMIT=65536\nDAEMON_ARGS="/etc/redis/redis.conf --bind 127.0.0.1"\n' > /etc/default/redis-server \
     && mkdir /etc/systemd/system/redis-server.service.d \
-    && printf '[Service]\nExecStart=/usr/bin/redis-server /etc/redis/redis.conf --bind 127.0.0.1\n' > /etc/systemd/system/redis-server.service.d/override.conf \
+    && printf '[Service]\nExecStart=\nExecStart=/usr/bin/redis-server /etc/redis/redis.conf --bind 127.0.0.1\n' > /etc/systemd/system/redis-server.service.d/override.conf \
     # Set up the vagrant user and its SSH key (globally public)
     && useradd -ms /bin/bash -u "$VAGRANT_UID" vagrant \
     && mkdir -m 700 ~vagrant/.ssh \


### PR DESCRIPTION
Real systemd requires this. docker-systemctl-replacement currently doesn’t but maybe it will later.

**Testing Plan:** Did `vagrant reload`, checked that `redis-server` is running before and after `vagrant halt; vagrant up`.