### PR TITLE
dev-vagrant-docker: Use real systemd?

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -116,7 +116,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       d.build_args += ["--build-arg", "UBUNTU_MIRROR=#{ubuntu_mirror}"]
     end
     d.has_ssh = true
-    d.create_args = ["--ulimit", "nofile=1024:65536"]
+    d.create_args = [
+      "--stop-signal", "SIGRTMIN+3",
+      "--tmpfs", "/run",
+      "--tmpfs", "/run/lock",
+      "--tmpfs", "/var/log/journal",
+      "--volume", "/sys/fs/cgroup:/sys/fs/cgroup:ro",
+      "--ulimit", "nofile=1024:65536",
+    ]
   end
 
   config.vm.provider "virtualbox" do |vb, override|

--- a/tools/setup/dev-vagrant-docker/Dockerfile
+++ b/tools/setup/dev-vagrant-docker/Dockerfile
@@ -45,7 +45,7 @@ RUN \
     && dpkg-divert --add --rename /etc/default/redis-server \
     && printf 'ULIMIT=65536\nDAEMON_ARGS="/etc/redis/redis.conf --bind 127.0.0.1"\n' > /etc/default/redis-server \
     && mkdir /etc/systemd/system/redis-server.service.d \
-    && printf '[Service]\nExecStart=/usr/bin/redis-server /etc/redis/redis.conf --bind 127.0.0.1\n' > /etc/systemd/system/redis-server.service.d/override.conf \
+    && printf '[Service]\nExecStart=\nExecStart=/usr/bin/redis-server /etc/redis/redis.conf --bind 127.0.0.1\n' > /etc/systemd/system/redis-server.service.d/override.conf \
     # Set up the vagrant user and its SSH key (globally public)
     && useradd -ms /bin/bash -u "$VAGRANT_UID" vagrant \
     && mkdir -m 700 ~vagrant/.ssh \

--- a/tools/setup/dev-vagrant-docker/Dockerfile
+++ b/tools/setup/dev-vagrant-docker/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 ARG UBUNTU_MIRROR
 
-# Basic packages and dependencies of docker-systemctl-replacement
+# Basic packages and things we need to get Vagrant to connect to us
 RUN echo locales locales/default_environment_locale select en_US.UTF-8 | debconf-set-selections \
     && echo locales locales/locales_to_be_generated select "en_US.UTF-8 UTF-8" | debconf-set-selections \
     && { [ ! "$UBUNTU_MIRROR" ] || sed -i "s|http://\(\w*\.\)*archive\.ubuntu\.com/ubuntu/\? |$UBUNTU_MIRROR |" /etc/apt/sources.list; } \
@@ -19,6 +19,7 @@ RUN echo locales locales/default_environment_locale select en_US.UTF-8 | debconf
            locales \
            lsb-release \
            openssh-server \
+           # python3 is redundant but left for now to avoid invalidating a Docker layer.
            python3 \
            sudo \
            systemd \
@@ -27,23 +28,9 @@ RUN echo locales locales/default_environment_locale select en_US.UTF-8 | debconf
 ARG VAGRANT_UID
 
 RUN \
-    # We use https://github.com/gdraheim/docker-systemctl-replacement
-    # to make services we install like postgres, redis, etc. normally
-    # managed by systemd start within Docker, which breaks normal
-    # operation of systemd.
-    dpkg-divert --add --rename /bin/systemctl \
-    && curl -so /bin/systemctl 'https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/b0588e003562f9a8eb76c98512c6d61146a81980/files/docker/systemctl3.py' \
-    && chmod +x /bin/systemctl \
-    && ln -nsf /bin/true /usr/sbin/policy-rc.d \
-    && mkdir -p /run/sshd \
-    # docker-systemctl-replacement doesn’t work with template units yet:
-    # https://github.com/gdraheim/docker-systemctl-replacement/issues/62
-    && ln -ns /lib/systemd/system/postgresql@.service /etc/systemd/system/postgresql@10-main.service \
-    && ln -s /etc/systemd/system/postgresql@10-main.service /etc/systemd/system/multi-user.target.wants/ \
+    ln -nsf /bin/true /usr/sbin/policy-rc.d \
     # redis fails to start with the default configuration if IPv6 is disabled:
     # https://github.com/antirez/redis/pull/5598
-    && dpkg-divert --add --rename /etc/default/redis-server \
-    && printf 'ULIMIT=65536\nDAEMON_ARGS="/etc/redis/redis.conf --bind 127.0.0.1"\n' > /etc/default/redis-server \
     && mkdir /etc/systemd/system/redis-server.service.d \
     && printf '[Service]\nExecStart=\nExecStart=/usr/bin/redis-server /etc/redis/redis.conf --bind 127.0.0.1\n' > /etc/systemd/system/redis-server.service.d/override.conf \
     # Set up the vagrant user and its SSH key (globally public)
@@ -53,7 +40,7 @@ RUN \
     && chown -R vagrant: ~vagrant/.ssh \
     && echo 'vagrant ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/vagrant
 
-CMD ["/bin/systemctl"]
+CMD ["/lib/systemd/systemd"]
 
 EXPOSE 22
 EXPOSE 9991


### PR DESCRIPTION
It possibly can’t be this easy…can it? But it seems to work for me.

Known caveats: see the SELinux note [here](https://developers.redhat.com/blog/2019/04/24/how-to-run-systemd-in-a-container/) and the `/sys/fs/cgroup` security note [here](https://developers.redhat.com/blog/2016/09/13/running-systemd-in-a-non-privileged-container/). Unknown caveats: ???.

**Testing Plan:** `vagrant reload`