### PR TITLE
ldap: Turn off the AUTH_LDAP_ALWAYS_UPDATE_USER setting.

### DIFF
--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -134,11 +134,10 @@ management command:
 ```
 
 This will sync the fields declared in `AUTH_LDAP_USER_ATTR_MAP` for
-all of your users; in the default configuration, it will just
-synchronize users' `full_name`.
+all of your users.
 
 We recommend running this command in a **regular cron job**, to pick
-up name changes made on your LDAP server.
+up changes made on your LDAP server.
 
 All of these data synchronization options have the same model:
 * New users will be populated automatically with the

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -146,6 +146,8 @@ DEFAULT_SETTINGS = {
     'AUTH_LDAP_CONNECTION_OPTIONS': {},
     # Disable django-auth-ldap caching, to prevent problems with OU changes.
     'AUTH_LDAP_CACHE_TIMEOUT': 0,
+    # Disable syncing user on each login; Using sync_ldap_user_data cron is recommended.
+    'AUTH_LDAP_ALWAYS_UPDATE_USER': False,
     # Development-only settings for fake LDAP authentication; used to
     # support local development of LDAP auth without an LDAP server.
     # Detailed docs in zproject/dev_settings.py.


### PR DESCRIPTION
The `AUTH_LDAP_ALWAYS_UPDATE_USER` is `True` by default, and this would sync the
attributes defined in the `AUTH_LDAP_USER_ATTR_MAP` to the user profile. But,
the default code in `django-auth-ldap` would work correctly only for `full_name`
field. This commit disables the setting by default, in favour of using the
`sync_ldap_user_data` script as a cron job.
