### PR TITLE
left_sidebar: Click target includes whole row for all links.

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -554,3 +554,10 @@ li.show-more-topics a {
 .show-all-streams .fa-chevron-left {
     text-decoration: none;
 }
+
+li.top_left_all_messages a,
+li.top_left_private_messages a,
+li.top_left_mentions a,
+li.top_left_starred_messages a {
+    display: block;
+}


### PR DESCRIPTION
Extended the click targets for the top four links (All messages, Private messages, Mentions and Starred messages).
The click target now covers the whole row and the mouse pointer also changes as expected.

Fixes #12449.

**GIFs:**

![left sidebar links](https://user-images.githubusercontent.com/25329595/58753835-ed497380-84e2-11e9-8b99-0e84138538c5.gif)
