### PR TITLE
settings: Show message in empty linkifier and custom emoji tables.

### DIFF
--- a/static/templates/settings/emoji-settings-admin.handlebars
+++ b/static/templates/settings/emoji-settings-admin.handlebars
@@ -34,7 +34,7 @@
                 <th class="image">{{t "Author" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
-            <tbody id="admin_emoji_table"></tbody>
+            <tbody id="admin_emoji_table" class="required-text" data-empty="{{t 'No custom emoji.' }}"></tbody>
         </table>
     </div>
 </div>

--- a/static/templates/settings/linkifier-settings-admin.handlebars
+++ b/static/templates/settings/linkifier-settings-admin.handlebars
@@ -41,13 +41,14 @@
         </p>
 
         <table class="table table-condensed table-striped admin_filters_table">
-            <tbody id="admin_filters_table">
+            <thead>
                 <th>{{t "Pattern" }}</th>
                 <th>{{t "URL format string" }}</th>
                 {{#if is_admin}}
                 <th class="actions">{{t "Actions" }}</th>
                 {{/if}}
-            </tbody>
+            </thead>
+            <tbody id="admin_filters_table" {{#if is_admin}}{{else}}class="required-text" data-empty="{{t 'No linkifiers set.' }}"{{/if}}></tbody>
         </table>
     </div>
     {{#if is_admin}}


### PR DESCRIPTION
Show placeholder messages to the user if the Linkifier and Custom emoji tables are empty.
The linkifier page does not show the message to the admin as there are other UI elements in the table.

Fixes #12453.


**GIFs or Screenshots:**

Empty custom emoji page: 
![custom emoji page](https://user-images.githubusercontent.com/25329595/58754294-6ac4b200-84ea-11e9-970d-bd2806bb93ab.png)

Empty Linkifier page(non-admins):
![linkifier guest](https://user-images.githubusercontent.com/25329595/58754295-6bf5df00-84ea-11e9-8422-07b4904ce8f3.png)

Empty Linkifier page (For admins):
![linkifier admin](https://user-images.githubusercontent.com/25329595/58768223-4f72a900-85b5-11e9-8119-6b4c0e2498b1.png)
