### PR TITLE
[WIP] bots: Allow users to configure incoming webhook bots

### DIFF
--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -237,6 +237,7 @@ exports.set_up = function () {
 
     var create_avatar_widget = avatar.build_bot_create_widget();
     var OUTGOING_WEBHOOK_BOT_TYPE = '3';
+    var INCOMING_WEBHOOK_BOT_TYPE = '2';
     var GENERIC_BOT_TYPE = '1';
     var EMBEDDED_BOT_TYPE = '4';
 
@@ -409,6 +410,41 @@ exports.set_up = function () {
             $("#service_data").append(templates.render("edit-embedded-bot-service",
                                                        {service: service}));
         }
+        if (bot.bot_type.toString() === INCOMING_WEBHOOK_BOT_TYPE) {
+            var config_data = {};
+            if (service !== undefined) {
+                config_data = service.config_data;
+            }
+            $("#service_data").append(templates.render("edit-bot-config-data",
+                                                       {config_data: config_data}));
+
+            $("#add_new_bot_config_element").click(function () {
+                var new_key = $("#new_key").val();
+                var new_val = $("#new_value").val();
+                if (new_key === "") {
+                    return;
+                }
+
+                // Perform a check to see if the user is trying to duplicate a key. If so just
+                // update the new value instead of inserting a new row.
+                var existing_config_elements = $(".bot_config_element").toArray();
+                for (var i = 0; i < existing_config_elements.length; i += 1) {
+                    var key = existing_config_elements[i].children[0].children[0].value;
+                    if (key === new_key) {
+                        existing_config_elements[i].children[1].children[0].value = new_val;
+                        return;
+                    }
+                }
+
+                // This is a new key. So add a new row.
+                var new_index = $(".bot_config_element").toArray().length;
+                var new_row = $("#bot_config_table_tbody")[0].insertRow(new_index);
+                new_row.className = "bot_config_element";
+                var new_row_content = "<td><input type=\"text\" value=\"" + new_key + "\" /></td>";
+                new_row_content += "<td><input type=\"text\" value=\"" + new_val + "\" /></td>";
+                new_row.innerHTML = new_row_content;
+            });
+        }
 
         avatar_widget.clear();
 
@@ -443,6 +479,15 @@ exports.set_up = function () {
                         config_data[$(this).attr('name')] = $(this).val();
                     });
                     formData.append('config_data', JSON.stringify(config_data));
+                } else if (type === INCOMING_WEBHOOK_BOT_TYPE) {
+                    var conf_data = {};
+                    var config_elements = $(".bot_config_element").toArray();
+                    config_elements.forEach(function (config_element) {
+                        var key = config_element.children[0].children[0].value;
+                        var value = config_element.children[1].children[0].value;
+                        conf_data[key] = value;
+                    });
+                    formData.append('config_data', JSON.stringify(conf_data));
                 }
                 jQuery.each(file_input[0].files, function (i, file) {
                     formData.append('file-' + i, file);

--- a/static/templates/settings/edit-bot-config-data.handlebars
+++ b/static/templates/settings/edit-bot-config-data.handlebars
@@ -1,0 +1,47 @@
+<br />
+
+<style>
+    #bot_config_table {
+    border: 1px solid #ddd;
+    width: 100%;
+    }
+    #bot_config_table > thead {
+    border-bottom: 1px solid #ddd;
+    }
+    #bot_config_table_container {
+    overflow-x:auto;
+    }
+    th {
+    border: 1px solid #ddd;
+    }
+    td {
+    width: 45%;
+    padding-left: 10px;
+    padding-right: 10px;
+    }
+</style>
+
+<div id="bot_config_table_container">
+    <label for="bot_config_table">{{t "Edit bot configuration data" }}</label>
+    <table id="bot_config_table">
+        <thead>
+            <th> Key </th>
+            <th> Value </th>
+        </thead>
+        <tbody id="bot_config_table_tbody">
+            {{#each config_data as |value key|}}
+            <tr class="bot_config_element" data-row="{{@index}}">
+                <td> <input type="text" value="{{key}}" /> </td>
+                <td> <input type="text" value="{{value}}" /> </td>
+            </tr>
+            {{/each}}
+            <tr>
+                <td> <input type="text" value="{{key}}" id="new_key"/> </td>
+                <td> <input type="text" value="{{value}}" id="new_value"/> </td>
+                <td> <a class="btn" id="add_new_bot_config_element"> <i class="fa fa-plus-circle" aria-hidden="true"></i> </a> </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<br />

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -301,7 +301,7 @@ class HomeTest(ZulipTestCase):
                 result = self._get_home_page()
                 self.assertEqual(result.status_code, 200)
                 self.assert_length(cache_mock.call_args_list, 6)
-            self.assert_length(queries, 42)
+            self.assert_length(queries, 43)
 
     @slow("Creates and subscribes 10 users in a loop.  Should use bulk queries.")
     def test_num_queries_with_streams(self) -> None:


### PR DESCRIPTION
Going forwards, Zulip will need to let it's users configure their bots' BotConfigData (for example see the discussion under issue #10907). For embedded bots and outgoing webhook bots, the keys that can be configured are predetermined and users can already modify them from **settings** > **your bots** > **active bots**. Now for Incoming webhook type bots there are no predetermined keys as we do not strongly associate a bot with an integration (e.g. multiple integrations might use the same incoming webhook bot - e.g. A GitHub + GitLab notification bot) - so letting users set these keys-value pairs freely seems like a flexible approach.

This PR introduces 2 commits:
1. Changes the backend to send config data for incoming webhook type bots in the initial state as well as for update events. Patching the config data is already possible for all kinds of bots and this did not require any changes (it was just not used up until now).

2. [WIP] Modify the UI to allow users to modify their bot config data - add new keys or edit existing ones. Pending work for this commit:
- remove key option
- polish UI - the table currently looks ugly.
- polish code a bit - just some minor refactoring
- move the CSS (**_but to which file?_**)

@timabbott and @eeshangarg I'd appreciate a code review as well as any general opinions you guys have about this.

Getting this completed and merged would make it possible to begin work on developing a framework for how to allow our incoming webhook type bots to contact an API (as a callback), as @eeshangarg suggested.