### PR TITLE
dependencies: Downgrade typescript to v3.4.5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "to-markdown": "3.1.0",
     "ts-loader": "5.3.3",
     "ts-node": "7.0.1",
-    "typescript": "3.5.1",
+    "typescript": "3.5.0",
     "underscore": "1.9.1",
     "webfonts-generator": "0.4.0",
     "webpack": "4.32.2",

--- a/version.py
+++ b/version.py
@@ -11,4 +11,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '34.0'
+PROVISION_VERSION = '34.1'

--- a/yarn.lock
+++ b/yarn.lock
@@ -11285,10 +11285,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
-  integrity sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==
+typescript@3.5.0:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
+  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
 uglify-js@^2.6, uglify-js@^2.6.0:
   version "2.8.29"


### PR DESCRIPTION
In 537014ee4757d3b8c585650a3ee1c57b6b892897, we upgraded typescript
to v3.5.1 which causes eslint to complain that it doesn't support the
newer version yet:

```
$ tools/lint tools/webpack.config.ts
eslint    | =============
eslint    |
eslint    | WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-estree.
eslint    |
eslint    | You may find that it works just fine, or you may not.
eslint    |
eslint    | SUPPORTED TYPESCRIPT VERSIONS: >=3.2.1 <3.5.0
eslint    |
eslint    | YOUR TYPESCRIPT VERSION: 3.5.1
eslint    |
eslint    | Please only submit bug reports when using the officially supported version.
eslint    |
eslint    | =============
```

This commit upgrades to v3.4.5 instead to reverting the original commit
since newer typescript version is supported.

**Testing Plan:** <!-- How have you tested? -->
Running `tools/lint tools/webpack.config.ts` eslint stops complaning about unsupported version.
