### PR TITLE
eslint: Turn off warning from eslint about using unsupported typescript.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,7 @@
         "es6": true
     },
     "parserOptions": {
+        "warnOnUnsupportedTypeScriptVersion": false,
         "sourceType": "module"
     },
     "globals": {


### PR DESCRIPTION
We are mostly fine using newer versions of typescript since they
work fine; eslint just warns since it doesn't test against it.

**Testing Plan:** <!-- How have you tested? -->
`tools/lint webpack.config.ts` shouldn't warn about using unsupported tslint version.