### PR TITLE
webpack: Use cache-loader for various loaders.

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "xmlhttprequest": "1.8.0"
   },
   "scripts": {
+    "postinstall": "rm -rf ./var/webpack-cache",
     "lint": "eslint --quiet --cache",
     "lint-fix": "eslint --quiet --fix",
     "lint-loud": "eslint static/js frontend_tests --cache"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@types/webpack": "4.4.32",
     "@types/webpack-dev-server": "3.1.6",
     "blueimp-md5": "2.10.0",
+    "cache-loader": "3.0.1",
     "clipboard": "2.0.4",
     "css-hot-loader": "1.3.9",
     "css-loader": "0.28.11",

--- a/tools/webpack-helpers.ts
+++ b/tools/webpack-helpers.ts
@@ -1,9 +1,5 @@
 import { basename } from 'path';
-
-interface Loader {
-    test: string;
-    use: string;
-}
+import { RuleSetRule } from 'webpack';
 
 /* Return imports-loader format to the config
     For example:
@@ -16,7 +12,7 @@ interface ImportLoaderOptions {
     path: string;
     args: string;
 }
-function getImportLoaders(optionsArr: ImportLoaderOptions[]): Loader[] {
+function getImportLoaders(optionsArr: ImportLoaderOptions[]): RuleSetRule[] {
     const importsLoaders = [];
     for (var loaderEntry of optionsArr) {
         importsLoaders.push({
@@ -43,7 +39,7 @@ interface ExportLoaderOptions {
     path: string;
     name?: string | string[];
 }
-function getExposeLoaders(optionsArr: ExportLoaderOptions[]): Loader[] {
+function getExposeLoaders(optionsArr: ExportLoaderOptions[]): RuleSetRule[] {
     const exposeLoaders = [];
     for (var loaderEntry of optionsArr) {
         const path = loaderEntry.path;

--- a/tools/webpack-helpers.ts
+++ b/tools/webpack-helpers.ts
@@ -1,5 +1,12 @@
-import { basename } from 'path';
+import { basename, resolve } from 'path';
 import { RuleSetRule } from 'webpack';
+
+export const cacheLoader: RuleSetRule = {
+    loader: 'cache-loader',
+    options: {
+        cacheDirectory: resolve(__dirname, '../var/webpack-cache'),
+    },
+};
 
 /* Return imports-loader format to the config
     For example:
@@ -17,7 +24,7 @@ function getImportLoaders(optionsArr: ImportLoaderOptions[]): RuleSetRule[] {
     for (var loaderEntry of optionsArr) {
         importsLoaders.push({
             test: require.resolve(loaderEntry.path),
-            use: "imports-loader?" + loaderEntry.args,
+            use: [cacheLoader, "imports-loader?" + loaderEntry.args],
         });
     }
     return importsLoaders;
@@ -44,7 +51,7 @@ function getExposeLoaders(optionsArr: ExportLoaderOptions[]): RuleSetRule[] {
     for (var loaderEntry of optionsArr) {
         const path = loaderEntry.path;
         let name = "";
-        const useArr = [];
+        const useArr = [cacheLoader];
         // If no name is provided, infer it
         if (!loaderEntry.name) {
             name = basename(path, '.js');

--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -4,7 +4,7 @@ import * as webpack from 'webpack';
 // The devServer member of webpack.Configuration is managed by the
 // webpack-dev-server package. We are only importing the type here.
 import * as _webpackDevServer from 'webpack-dev-server';
-import { getExposeLoaders, getImportLoaders } from './webpack-helpers';
+import { getExposeLoaders, getImportLoaders, cacheLoader } from './webpack-helpers';
 import * as MiniCssExtractPlugin from 'mini-css-extract-plugin';
 
 const assets = require('./webpack.assets.json');
@@ -42,12 +42,13 @@ export default (env?: string): webpack.Configuration => {
                 {
                     // We dont want to match admin.js
                     test: /(\.min|min\.|zxcvbn)\.js/,
-                    use: ['script-loader'],
+                    use: [cacheLoader, 'script-loader'],
                 },
                 // regular css files
                 {
                     test: /\.css$/,
                     use: getHotCSS([
+                        cacheLoader,
                         MiniCssExtractPlugin.loader,
                         {
                             loader: 'css-loader',
@@ -61,6 +62,7 @@ export default (env?: string): webpack.Configuration => {
                 {
                     test: /\.(sass|scss)$/,
                     use: getHotCSS([
+                        cacheLoader,
                         MiniCssExtractPlugin.loader,
                         {
                             loader: 'css-loader',

--- a/version.py
+++ b/version.py
@@ -11,4 +11,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '34.0'
+PROVISION_VERSION = '34.1'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1389,6 +1389,11 @@ buffer-indexof@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-1.1.1.tgz#52fabcc6a606d1a00302802648ef68f639da268c"
   integrity sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==
 
+buffer-json@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-json/-/buffer-json-2.0.0.tgz#f73e13b1e42f196fe2fd67d001c7d7107edd7c23"
+  integrity sha512-+jjPFVqyfF1esi9fvfUs3NqM0pH1ziZ36VP4hmA/y/Ssfo/5w5xHKfTw9BwQjoJ1w/oVtpLomqwUHKdefGyuHw==
+
 buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
@@ -1464,6 +1469,18 @@ cache-base@^1.0.1:
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"
+
+cache-loader@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/cache-loader/-/cache-loader-3.0.1.tgz#cee6cf4b3cdc7c610905b26bad6c2fc439c821af"
+  integrity sha512-HzJIvGiGqYsFUrMjAJNDbVZoG7qQA+vy9AIoKs7s9DscNfki0I589mf2w6/tW+kkFH3zyiknoWV5Jdynu6b/zw==
+  dependencies:
+    buffer-json "^2.0.0"
+    find-cache-dir "^2.1.0"
+    loader-utils "^1.2.3"
+    mkdirp "^0.5.1"
+    neo-async "^2.6.1"
+    schema-utils "^1.0.0"
 
 caching-transform@^1.0.0:
   version "1.0.1"
@@ -3868,7 +3885,7 @@ find-cache-dir@^0.1.1:
     mkdirp "^0.5.1"
     pkg-dir "^1.0.0"
 
-find-cache-dir@^2.0.0:
+find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
   integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
@@ -7207,7 +7224,7 @@ neo-async@^2.5.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.5.1.tgz#acb909e327b1e87ec9ef15f41b8a269512ad41ee"
   integrity sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA==
 
-neo-async@^2.6.0:
+neo-async@^2.6.0, neo-async@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==


### PR DESCRIPTION
Profiling shows that using cache-loader saves ~6-7 seconds of time take
by webpack-dev-server on subsequent runs. The overhaul this adds when
nothing is cached (when running first time) is around 1-2 seconds. We don't
use cache loader for ts-loader since webpack docs says it will slow it down
and file-loader since it just copies files over and caching it would just
was disk space.

Profiling data:

<details>
<summary>Master</summary>
<pre>
~/zulip (master) $ tools/webpack --watch | ts -s '%.S' # master
03.995825 ℹ ｢wds｣: Project is running at http://127.0.0.1:9994
03.996161 ℹ ｢wds｣: webpack output is served from /webpack/
03.996289 ℹ ｢wds｣: Content not from webpack is served from ...
19.284477 ℹ ｢wdm｣:
19.285371 ℹ ｢wdm｣: Compiled successfully.
</pre>
</details>

<details>
<summary>cache-loader</summary>
<pre>
~/zulip (cache-loader)$ tools/webpack --watch | ts -s '%.S'
04.107913 ℹ ｢wds｣: Project is running at http://127.0.0.1:9994
04.108646 ℹ ｢wds｣: webpack output is served from /webpack/
04.109068 ℹ ｢wds｣: Content not from webpack is served from ...
12.633782 ℹ ｢wdm｣:
12.634083 ℹ ｢wdm｣: Compiled successfully.
<pre>
</details>

**Testing Plan:** <!-- How have you tested? -->
* `tools/run-dev.py` to check everything work fine in development server.
