### PR TITLE
Fix leaking test templates in test_runner.py

### DIFF
--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -35,7 +35,7 @@ from multiprocessing.sharedctypes import Synchronized
 # in this global so it can be used in init_worker; this is used to
 # ensure the database IDs we select are unique for each `test-backend`
 # run.  This probably should use a locking mechanism rather than the
-# below hack, which fails 1/10000000 of the itme.
+# below hack, which fails 1/10000000 of the time.
 random_id_range_start = random.randint(1, 10000000) * 100
 
 _worker_id = 0  # Used to identify the worker process.


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

N = self.parallel templates are created, and these templates were
previously named 'zulip_test_template_<1, N>'.  However, to support
running multiple instances of `test-backend`, a unique
`random_id_range_start` was created for each template database.

There was no problem prior because the templates would simply be
used again and thus did not require any clean up. Now that there are
unique database names being created, every time `test-backend` is run
these templates can accumulate on disk.  Instead, we clean up our
templates at the end of every complete run of the test suite, or upon a
SIGINT.

Fixes: #12426

**Testing Plan:** 
```
>>> tools/test-backend
>>> df -h
>>> manage.py dbshell
zulip_test=> \l
```