### PR TITLE
webpack: Use cache-loader for various loaders.

### DIFF
--- a/tools/webpack-helpers.ts
+++ b/tools/webpack-helpers.ts
@@ -1,5 +1,12 @@
-import { basename } from 'path';
+import { basename, resolve } from 'path';
 import { RuleSetRule } from 'webpack';
+
+export const cacheLoader: RuleSetRule = {
+    loader: 'cache-loader',
+    options: {
+        cacheDirectory: resolve(__dirname, '../var/webpack-cache'),
+    },
+};
 
 /* Return imports-loader format to the config
     For example:
@@ -17,7 +24,7 @@ function getImportLoaders(optionsArr: ImportLoaderOptions[]): RuleSetRule[] {
     for (var loaderEntry of optionsArr) {
         importsLoaders.push({
             test: require.resolve(loaderEntry.path),
-            use: "imports-loader?" + loaderEntry.args,
+            use: [cacheLoader, "imports-loader?" + loaderEntry.args],
         });
     }
     return importsLoaders;
@@ -44,7 +51,7 @@ function getExposeLoaders(optionsArr: ExportLoaderOptions[]): RuleSetRule[] {
     for (var loaderEntry of optionsArr) {
         const path = loaderEntry.path;
         let name = "";
-        const useArr = [];
+        const useArr = [cacheLoader];
         // If no name is provided, infer it
         if (!loaderEntry.name) {
             name = basename(path, '.js');

--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -4,7 +4,7 @@ import * as webpack from 'webpack';
 // The devServer member of webpack.Configuration is managed by the
 // webpack-dev-server package. We are only importing the type here.
 import * as _webpackDevServer from 'webpack-dev-server';
-import { getExposeLoaders, getImportLoaders } from './webpack-helpers';
+import { getExposeLoaders, getImportLoaders, cacheLoader } from './webpack-helpers';
 import * as MiniCssExtractPlugin from 'mini-css-extract-plugin';
 
 const assets = require('./webpack.assets.json');
@@ -42,13 +42,14 @@ export default (env?: string): webpack.Configuration => {
                 {
                     // We dont want to match admin.js
                     test: /(\.min|min\.|zxcvbn)\.js/,
-                    use: ['script-loader'],
+                    use: [cacheLoader, 'script-loader'],
                 },
                 // regular css files
                 {
                     test: /\.css$/,
                     use: getHotCSS([
                         MiniCssExtractPlugin.loader,
+                        cacheLoader,
                         {
                             loader: 'css-loader',
                             options: {
@@ -62,6 +63,7 @@ export default (env?: string): webpack.Configuration => {
                     test: /\.(sass|scss)$/,
                     use: getHotCSS([
                         MiniCssExtractPlugin.loader,
+                        cacheLoader,
                         {
                             loader: 'css-loader',
                             options: {


### PR DESCRIPTION
We fix the bug encountered before by not putting `cache-loader` before `mini-css-extract-plugin` because that actually cached it and on subsequent runs and caused file-loader to not run so all the fonts stuff was missing which broke stuff.


**Testing Plan:** <!-- How have you tested? -->
- Run `tools/run-dev.py` and kill it when webpack compiles, then re-run the development server and make sure it works as expected.