### PR TITLE
restore-backup: Fix error on systems using S3 upload backend.

### DIFF
--- a/scripts/setup/restore-backup
+++ b/scripts/setup/restore-backup
@@ -51,8 +51,11 @@ def restore_backup(tarball_file):
         ("settings", "/etc/zulip"),
         # zproject will only be present for development environment backups.
         ("zproject", os.path.join(settings.DEPLOY_ROOT, "zproject")),
-        ("uploads", os.path.join(settings.DEPLOY_ROOT, settings.LOCAL_UPLOADS_DIR)),
     ]
+    if settings.LOCAL_UPLOADS_DIR is not None:
+        # We only need to restore LOCAL_UPLOADS_DIR if the system is
+        # configured to locally host uploads.
+        paths.append(("uploads", os.path.join(settings.DEPLOY_ROOT, settings.LOCAL_UPLOADS_DIR)))
 
     with tempfile.TemporaryDirectory(prefix="zulip-restore-backup-") as tmp:
         uid = os.getuid()


### PR DESCRIPTION
With the S3 file upload backend, we don't store uploads locally, so
the `uploads` directory in the backup will be empty, and more
importantly, LOCAL_UPLOADS_DIR will be None, which the previous code
crashed on.
