### PR TITLE
compose: Rename New conversation button to New private message.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1710,7 +1710,7 @@ run_test('narrow_button_titles', () => {
 
     compose.update_closed_compose_buttons_for_private();
     assert.equal($("#left_bar_compose_stream_button_big").text(), i18n.t("New stream message"));
-    assert.equal($("#left_bar_compose_private_button_big").text(), i18n.t("New conversation"));
+    assert.equal($("#left_bar_compose_private_button_big").text(), i18n.t("New private message"));
 
     compose.update_closed_compose_buttons_for_stream();
     assert.equal($("#left_bar_compose_stream_button_big").text(), i18n.t("New topic"));

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -114,7 +114,7 @@ function update_conversation_button(btn_text, title) {
 exports.update_closed_compose_buttons_for_private = function () {
     var text_stream = i18n.t("New stream message");
     var title_stream = text_stream + " (c)";
-    var text_conversation = i18n.t("New conversation");
+    var text_conversation = i18n.t("New private message");
     var title_conversation = text_conversation + " (x)";
     update_stream_button(text_stream, title_stream);
     update_conversation_button(text_conversation, title_conversation);

--- a/static/templates/mobile_message_buttons_popover_content.handlebars
+++ b/static/templates/mobile_message_buttons_popover_content.handlebars
@@ -13,7 +13,7 @@
         <a class="compose_mobile_private_button">
             <i class="fa fa-envelope" aria-hidden="true"></i>
             {{#if is_in_private_narrow }}
-            {{t "New conversation" }}
+            {{t "New private message" }}
             {{else}}
             {{t "New private message" }}
             {{/if}}


### PR DESCRIPTION
Right now we have buttons for "New conversation" and "New private message"
in different views, but both buttons do the same thing.

The current state is confusing for new users, since there is already a lot
of terminology one needs to learn in order to understand the Zulip
conversation model. It's very plausible a user would think a "conversation"
is something different from a "private message" or a "topic".

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
