### PR TITLE
url preview: Replace YouTube URLs with their titles.

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -737,6 +737,12 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
             return None
         return match.group(2)
 
+    def youtube_title(self, extracted_data: Dict[str, Any]) -> Optional[str]:
+        title = extracted_data.get("title")
+        if title is not None:
+            return "YouTube - {}".format(title)
+        return None
+
     def youtube_image(self, url: str) -> Optional[str]:
         yt_id = self.youtube_id(url)
 
@@ -1088,7 +1094,11 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
                 add_a(root, youtube, url, None, None,
                       "youtube-video message_inline_image",
                       yt_id, already_thumbnailed=True)
-                continue
+                # NOTE: We don't `continue` here, to allow replacing the URL with
+                # the title, if INLINE_URL_EMBED_PREVIEW feature is enabled.
+                # The entire preview would ideally be shown only if the feature
+                # is enabled, but URL previews are a beta feature and YouTube
+                # previews are pretty stable.
 
             db_data = self.markdown.zulip_db_data
             if db_data and db_data['sent_by_bot']:
@@ -1102,7 +1112,13 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
             except NotFoundInCache:
                 self.markdown.zulip_message.links_for_preview.add(url)
                 continue
+
             if extracted_data:
+                if youtube is not None:
+                    title = self.youtube_title(extracted_data)
+                    if title is not None:
+                        found_url.family.child.text = title
+                    continue
                 add_embed(root, url, extracted_data)
                 if self.vimeo_id(url):
                     title = self.vimeo_title(extracted_data)


### PR DESCRIPTION
The titles for the videos are fetched asynchronously after the message has been
sent via the code that fetches metadata for open graph previews. So, the URLs
are replaced with titles only if the inline embed url previews feature is
enabled.

Ideally, YouTube previews should be shown only if inline url previews are
enabled, but this feature is in beta, while YouTube previews are pretty stable.
Once this feature is out of beta, YouTube previews should be shown only if the
url previews feature is turned on.

YouTube preview image is calculated as soon as the message is sent, while the
title needs to be fetched using a network request. This means that the URL is
replaced only after the data has been fetched from the request, and happens a
couple of seconds after the message has been rendered.

Closes #7549

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
