### PR TITLE
notifications: Disable default permission pop up.

### DIFF
--- a/frontend_tests/node_tests/notifications.js
+++ b/frontend_tests/node_tests/notifications.js
@@ -12,6 +12,10 @@ set_global('page_params', {
     is_admin: false,
     realm_users: [],
 });
+const _navigator = {
+    userAgent: 'Mozilla/5.0 AppleWebKit/537.36 Chrome/64.0.3282.167 Safari/537.36',
+};
+set_global('navigator', _navigator);
 
 zrequire('muting');
 zrequire('stream_data');
@@ -208,7 +212,7 @@ run_test('basic_notifications', () => {
     };
 
     // Send notification.
-    notifications.process_notification({message: message_1, webkit_notify: true});
+    notifications.process_notification({message: message_1, desktop_notify: true});
     n = notifications.get_notifications();
     assert.equal('Jesse Pinkman to general > whatever' in n, true);
     assert.equal(Object.keys(n).length, 1);
@@ -223,7 +227,7 @@ run_test('basic_notifications', () => {
 
     // Send notification.
     message_1.id = 1001;
-    notifications.process_notification({message: message_1, webkit_notify: true});
+    notifications.process_notification({message: message_1, desktop_notify: true});
     n = notifications.get_notifications();
     assert.equal('Jesse Pinkman to general > whatever' in n, true);
     assert.equal(Object.keys(n).length, 1);
@@ -231,14 +235,14 @@ run_test('basic_notifications', () => {
 
     // Process same message again. Notification count shouldn't increase.
     message_1.id = 1002;
-    notifications.process_notification({message: message_1, webkit_notify: true});
+    notifications.process_notification({message: message_1, desktop_notify: true});
     n = notifications.get_notifications();
     assert.equal('Jesse Pinkman to general > whatever' in n, true);
     assert.equal(Object.keys(n).length, 1);
     assert.equal(last_shown_message_id, message_1.id);
 
     // Send another message. Notification count should increase.
-    notifications.process_notification({message: message_2, webkit_notify: true});
+    notifications.process_notification({message: message_2, desktop_notify: true});
     n = notifications.get_notifications();
     assert.equal('Gus Fring to general > lunch' in n, true);
     assert.equal('Jesse Pinkman to general > whatever' in n, true);


### PR DESCRIPTION
The issue here was that if the user has not allowed desktop
notifications, the browser would give its own pop up requesting for
permission, this would happen concurrently with zulip's custom green bar
that requests for permission, we would prefer that users interact with
our green bar and so this commit disables the pop up.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This fixes #11504 by removing the cause of the problem.

**Testing Plan:** <!-- How have you tested? -->
Open firefox, navigate to local env, log in as user 1.
Open chrome, navigate to local env, log in as user 2.
click "i" icon and reset notification permissions to default (ask), allow a reload, confirm that green bar is present. [on chrome]
send message to user 2 from user 1. [from firefox to chrome]
* prior to this, you would see a browser pop up
* after this, that pop up no longer triggers.

repeat in opposite order and confirm everything to be same.

The gifs bellow show manual testing:
chrome-notification-working
![chrome-notification-working](https://user-images.githubusercontent.com/33805964/59106855-00ca6380-8955-11e9-85c9-7997667bc2eb.gif)
chrome-notification-blocked
![chrome-notification-blocked](https://user-images.githubusercontent.com/33805964/59106861-06c04480-8955-11e9-8679-798f917c25f8.gif)

firefox-notifcations-working
![firefox-notifcations-working](https://user-images.githubusercontent.com/33805964/59106879-1049ac80-8955-11e9-8c05-6d98e94e885f.gif)
firefox-notification-blocked
![firefox-notification-blocked](https://user-images.githubusercontent.com/33805964/59106888-150e6080-8955-11e9-9744-9b5d42c02196.gif)

some extra testing:
chrome-notification-ask-later
![chrome-notification-ask-later](https://user-images.githubusercontent.com/33805964/59106917-29525d80-8955-11e9-8110-08aff6fee49c.gif)
chrome-notification-never-ask-later
![chrome-notification-never-ask-later](https://user-images.githubusercontent.com/33805964/59106921-2bb4b780-8955-11e9-95b4-5147aa73dbd4.gif)

firefox-notifcations-ask-later
![firefox-notifcations-ask-later](https://user-images.githubusercontent.com/33805964/59106930-32432f00-8955-11e9-93be-08008a1a7366.gif)
firefox-notification-never-ask-later
![firefox-notification-never-ask-later](https://user-images.githubusercontent.com/33805964/59106933-34a58900-8955-11e9-9c69-c98a1df366cf.gif)

**node tests:**
I've just restored our previous test cases, but we could possibly increase coverage here by writing more tests, but maybe that would be a good follow up?


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
