### PR TITLE
version: Show number of commits and commit sha in ZULIP_VERSION.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ npm-debug.log
 /staticfiles.json
 /webpack-stats-production.json
 /yarn-error.log
+zulip-git-version
 
 # Test / analysis tools
 .coverage

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -120,6 +120,8 @@ elif args.from_git:
     subprocess.check_call(["./tools/update-prod-static", "--authors-not-required", "--prev-deploy",
                            os.path.join(DEPLOYMENTS_DIR, 'current')],
                           preexec_fn=su_to_zulip)
+    logging.info("Caching zulip git version...")
+    subprocess.check_call(["./tools/cache-zulip-git-version"], preexec_fn=su_to_zulip)
 else:
     # Since this doesn't do any actual work, it's likely safe to have
     # this run before we apply puppet changes (saving a bit of downtime).

--- a/tools/build-release-tarball
+++ b/tools/build-release-tarball
@@ -62,6 +62,11 @@ cd "$BASEDIR"
 
 # Check out a temporary full copy of the index to generate static files
 git checkout-index -f -a --prefix "$TMPDIR/$prefix/"
+
+# Add the git version information file
+./tools/cache-zulip-git-version
+mv zulip-git-version "$TMPDIR/$prefix/"
+
 cd "$TMPDIR/$prefix"
 
 # create var/log directory in the new temporary checkout
@@ -109,7 +114,7 @@ echo "$version" > version
 
 cd "$TMPDIR"
 
-tar --append -f "$TARBALL" "$prefix/prod-static" "$prefix/build_id" "$prefix/version" "$prefix/staticfiles.json" "$prefix/templates/zerver/emails/compiled" "$prefix/webpack-stats-production.json"
+tar --append -f "$TARBALL" "$prefix/prod-static" "$prefix/build_id" "$prefix/version" "$prefix/zulip-git-version" "$prefix/staticfiles.json" "$prefix/templates/zerver/emails/compiled" "$prefix/webpack-stats-production.json"
 
 rm -rf "$prefix"
 

--- a/tools/cache-zulip-git-version
+++ b/tools/cache-zulip-git-version
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+cd "$(dirname "$0")/.."
+git describe --tags > zulip-git-version

--- a/version.py
+++ b/version.py
@@ -1,4 +1,14 @@
+import os
+
 ZULIP_VERSION = "2.0.4+git"
+# Add information on number of commits and commit hash to version, if available
+zulip_git_version_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'zulip-git-version')
+if os.path.exists(zulip_git_version_file):
+    with open(zulip_git_version_file) as f:
+        version = f.read().strip()
+        if version:
+            ZULIP_VERSION = version
+
 LATEST_MAJOR_VERSION = "2.0"
 LATEST_RELEASE_VERSION = "2.0.4"
 LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-released/"


### PR DESCRIPTION
We use `git describe --tags` to get information about the number of commit since
the last major version, and the sha of the current HEAD. This is added to the
ZULIP_VERSION when a deploy is done from `git`.

Modified heavily by punchagan to:
* to use git describe instead of `git log` and `wc`
* use a separate script to run the git describe command
* write the file with version info to var/ and remove it from the repo

Fixes #4685.

