### PR TITLE
overlays: Fix stream edit click-through bug.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -476,6 +476,8 @@ exports.initialize = function () {
         $("#stream_privacy_modal").remove();
         $("#subscriptions_table").append(change_privacy_modal);
         overlays.open_modal('stream_privacy_modal');
+        e.preventDefault();
+        e.stopPropagation();
     });
 
     $("#subscriptions_table").on('click', '#change-stream-privacy-button',


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes ##12369.

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![stream-edit-overlay](https://user-images.githubusercontent.com/33805964/59059046-a29d7200-88bb-11e9-84ed-df163bf4561b.gif)


side note: This was a terrible experience, it ate a lot of time. (but that is my fault for trying to find a good commit for a bisect before checking simple stuff first). That said, do our dev docs say anything about `e.stopPropagation();` and if not should we consider something?
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
