### PR TITLE
Update droplet base image

### DIFF
--- a/tools/droplets/create.py
+++ b/tools/droplets/create.py
@@ -227,7 +227,7 @@ if __name__ == '__main__':
     # Broken in two to satisfy linter (line too long)
     # curl -X GET -H "Content-Type: application/json" -u <API_KEY>: "https://api.digitaloc
     # ean.com/v2/images?page=5" | grep --color=always base.zulipdev.org
-    template_id = "36947213"
+    template_id = "48106286"
 
     # get command line arguments
     args = parser.parse_args()

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -275,7 +275,8 @@ def setup_shell_profile(shell_profile):
 
     source_activate_command = "source " + os.path.join(VENV_PATH, "bin", "activate")
     write_command(source_activate_command)
-    write_command('cd /srv/zulip')
+    if os.path.exists('/srv/zulip'):
+        write_command('cd /srv/zulip')
 
 def install_system_deps():
     # type: () -> None


### PR DESCRIPTION
I accidentally deleted our current snapshot of the remote development environment while deleting a snapshot of `DO one click app`. So I generated a new snapshot after updating the base.zulipdev.org. The base droplet now has zulip/zulip commit till ac0d60f5773ade23ad61658f0349ca6df6493d55. I have also included the custom motd from b594708915ad4c2a1975860b9dc665eb98aa7d9a in base droplet.

We should also probably delete all other base.zulipdev.org snapshots as well. They are of no use currently and costs us money every month.
```bash
~/zulip on  droplet-update-4 [$] is 📦  v0.0.0 via ⬢ v8.11.3 took 7s 
➜ ssh zulipdev@hackerkid.zulipdev.org
Welcome to Ubuntu 16.04.1 LTS (GNU/Linux 4.4.0-47-generic x86_64)


This is the Zulip development environment.  Popular commands:
* tools/provision - Update the development environment
* tools/run-dev.py - Run the development server
* tools/lint - Run the linter (quick and catches many problems)
* tools/test-* - Run tests (use --help to learn about options)

Read https://zulip.readthedocs.io/en/latest/testing/testing.html to learn
how to run individual test suites so that you can get a fast debug cycle.

Last login: Fri Jun  7 14:43:07 2019 from 103.81.182.83
-bash: cd: /srv/zulip: No such file or directory
(zulip-py3-venv) ~$ 
```