### PR TITLE
css: Add nightmode variant for fetching more messages loading indicator

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -582,6 +582,10 @@ on a dark background, and don't change the dark labels dark either. */
     .collapse-settings-btn:hover {
         color: hsl(200, 79%, 66%);
     }
+
+    #loading_more_messages_indicator path {
+        fill: rgb(255, 255, 255);
+    }
 }
 
 @-moz-document url-prefix() {


### PR DESCRIPTION
Fixes: #12522

Added white color to the loading spinner that is displayed when more messages are fetched.

The first GIF I just changed the code so that the spinner is displayed all the time so the change can be seen easier. 
![spinner2](https://user-images.githubusercontent.com/18381652/59115238-2cdfe780-8949-11e9-8be1-e3738d020f82.gif)
For the second one, I am not sure why the spinner is not displayed all the times.
![spinner](https://user-images.githubusercontent.com/18381652/59115247-2fdad800-8949-11e9-8703-581ccd5e3a56.gif)
