### PR TITLE
install: Include no-dist-upgrade in args list

### DIFF
--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -12,6 +12,7 @@ Other options:
   --self-signed-cert
   --no-init-db
   --cacert
+  --no-dist-upgrade
 
 The --hostname and --email options are required,
 unless --no-init-db is set and --certbot is not.
@@ -21,7 +22,7 @@ EOF
 
 # Shell option parsing.  Over time, we'll want to move some of the
 # environment variables below into this self-documenting system.
-args="$(getopt -o '' --long help,no-init-db,self-signed-cert,certbot,hostname:,email:,cacert: -n "$0" -- "$@")"
+args="$(getopt -o '' --long help,no-init-db,no-dist-upgrade,self-signed-cert,certbot,hostname:,email:,cacert: -n "$0" -- "$@")"
 eval "set -- $args"
 while true; do
     case "$1" in


### PR DESCRIPTION
This was missed out in 2e51ac8c49850149d3c47c9aa5ef35c3c870917e. Without `no-dist-upgrade` in args list the install command wont execute if `--no-dist-upgrade` is passed.

I have included this fix in Fabric via this commit

https://github.com/hackerkid/marketplace-partners/commit/32973a2f6c62be30900308953cd03e0ef58f5415

The gist file is the same `scripts/lib/install` file in the latest release except it has `no-dist-upgrade` in args list. So when Fabric is doing the build process it replaces the `install` file without `no-dist-upgrade` in args list with  the correct `install` file just after it extracts the tar. I have also generated the image for the one click app. More details on front.

Sorry for missing this out in original PR. I was a bit overconfident that the original PR did the right thing.