### PR TITLE
night-mode: Fix invite_user_form overlap bug.

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -359,6 +359,11 @@ on a dark background, and don't change the dark labels dark either. */
         box-shadow: inset 0 1px 0 hsla(0, 0%, 0%, 0.2);
     }
 
+    #invite_user_form .modal-footer {
+        // no transperancy prevents overlap issues
+        background-color: hsl(211, 28%, 14%);
+    }
+
     .subscriptions-container .right .display-type,
     .stream-row,
     .subscriptions-container .left .search-container,


### PR DESCRIPTION
Adding the element for the invite link would cause the modal footer to
shift upwards, in nightmode this caused the stream list to appear
beneath the footer as the footer background was transparent. This commit
replaces that styling with a solid equivalent color.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

Follow up to https://github.com/zulip/zulip/pull/11471.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/33805964/59128629-3fc5dc80-8988-11e9-8562-d18764950087.png)

side note: (the hsl replacement gives `#1a232e` instead of `#1a242f`)
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
