### PR TITLE
test-backend: Add steps to deal with potential database leaks.

### DIFF
--- a/tools/do-destroy-leaked-templates
+++ b/tools/do-destroy-leaked-templates
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+export DJANGO_SETTINGS_MODULE=zproject.test_settings
+
+commands=""
+for template in "$@"
+do
+    commands+="DROP DATABASE IF EXISTS ${template};"
+done
+
+psql -q -v ON_ERROR_STOP=1 -h localhost postgres zulip_test <<< "$commands"

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -526,7 +526,8 @@ def main(options):
         import django
         django.setup()
 
-        from zerver.lib.test_fixtures import template_database_status, run_db_migrations
+        from zerver.lib.test_fixtures import template_database_status, run_db_migrations, \
+            destroy_leaked_test_templates
 
         try:
             from zerver.lib.queue import SimpleQueueClient
@@ -573,6 +574,13 @@ def main(options):
             run(["./manage.py", "compilemessages"])
         else:
             print("No need to run `manage.py compilemessages`.")
+
+        print("Checking for stale database test templates...")
+        destroyed = destroy_leaked_test_templates()
+        if destroyed:
+            print("All stale templates have been dropped!")
+        else:
+            print("No stale templates were found!")
 
     run(["scripts/lib/clean-unused-caches"])
 

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -194,6 +194,7 @@ def main() -> None:
     os.environ["https_proxy"] = ""
 
     from zerver.lib.test_fixtures import update_test_databases_if_required
+    from zerver.lib.test_fixtures import destroy_leaked_test_templates
 
     from tools.lib.test_script import (
         get_provisioning_status,
@@ -460,6 +461,9 @@ def main() -> None:
         # We do this even with failures, since slowness can be
         # an important clue as to why tests fail.
         report_slow_tests()
+
+    # Check for any leaked test database templates
+    destroy_leaked_test_templates()
 
     # We'll have printed whether tests passed or failed above
     sys.exit(bool(failures))

--- a/version.py
+++ b/version.py
@@ -11,4 +11,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '34.2'
+PROVISION_VERSION = '34.3'

--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -31,6 +31,8 @@ import unittest
 
 from multiprocessing.sharedctypes import Synchronized
 
+from scripts.lib.zulip_tools import get_dev_uuid_var_path
+
 # We need to pick an ID for this test-backend invocation, and store it
 # in this global so it can be used in init_worker; this is used to
 # ensure the database IDs we select are unique for each `test-backend`
@@ -407,6 +409,20 @@ class Runner(DiscoverRunner):
         settings.DATABASES['default']['NAME'] = settings.BACKEND_DATABASE_TEMPLATE
         # We create/destroy the test databases in run_tests to avoid
         # duplicate work when running in parallel mode.
+
+        # Write the template ids to a file for reference during clean up
+        os.makedirs(get_dev_uuid_var_path() + '/zulip_test_template', exist_ok=True)
+        filepath = "{root}{dir}{filename}".format(
+            root=get_dev_uuid_var_path(),
+            dir='/zulip_test_template/',
+            filename=str(random.randint(1000000, 9999999))
+        )
+        with open(filepath, "w") as f:
+            if self.parallel > 1:
+                for index in range(self.parallel):
+                    f.write(str(random_id_range_start + (index + 1)) + "\n")
+            else:
+                f.write(str(random_id_range_start) + "\n")
         return super().setup_test_environment(*args, **kwargs)
 
     def teardown_test_environment(self, *args: Any, **kwargs: Any) -> Any:


### PR DESCRIPTION
When `test-backend` starts up, the database ids that will be used for
each particular run of the test suite are written to a unique file.
A function was written in `test_fixtures.py` to drop a test database
template if the corresponding database id doesn't belong to a file.
Alongside this fact, every file that is written is removed after 60
minutes.  Meaning any potential database template can never exist
longer than one hour.

This follow-up work was added to deal with the potential race conditions
when running `test-backend`.  Ensuring that all templates are properly
dealt with.

Tested this by creating fake templates and running both `test-backend` and `provision`