### PR TITLE
management: Don't prepend "HTTP_" to certian headers in parse_headers.

### DIFF
--- a/zerver/management/commands/send_webhook_fixture_message.py
+++ b/zerver/management/commands/send_webhook_fixture_message.py
@@ -20,7 +20,10 @@ def parse_headers(custom_headers: Union[None, str]) -> Union[None, Dict[str, str
     for header in custom_headers_dict:
         if len(header.split(" ")) > 1:
             raise ValueError("custom header '%s' contains a space." % (header,))
-        headers["HTTP_" + header.upper().replace("-", "_")] = str(custom_headers_dict[header])
+        new_header = header.upper().replace("-", "_")
+        if new_header not in ["CONTENT_TYPE", "CONTENT_LENGTH"]:
+            new_header = "HTTP_" + new_header
+        headers[new_header] = str(custom_headers_dict[header])
     return headers
 
 class Command(ZulipBaseCommand):

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -236,7 +236,8 @@ class TestSendWebhookFixtureMessage(TestCase):
     def test_parse_headers_method(self) -> None:
         command = Command()
         self.assertEqual(command.parse_headers(None), None)
-        self.assertEqual(command.parse_headers('{"X-Custom-Header": "value"}'), {"HTTP_X_CUSTOM_HEADER": "value"})
+        self.assertEqual(command.parse_headers('{"Content-Type": "text/plain", "X-Custom-Header": "value"}'),
+                         {"CONTENT_TYPE": "text/plain", "HTTP_X_CUSTOM_HEADER": "value"})
         with self.assertRaises(CommandError):
             command.parse_headers('{"X-Custom - Headers": "some_val"}')
 


### PR DESCRIPTION
Django does not prepend "HTTP_" to "Content-Type" or "Content-Length" headers. So parse_headers should not do that either This was just a small bug I noticed while working on something else.