### PR TITLE
[WIP] Clean up filesystem access in test-backend unit tests

### DIFF
--- a/docs/testing/testing-with-django.md
+++ b/docs/testing/testing-with-django.md
@@ -51,6 +51,13 @@ iterative development, but you can override this behavior with the
 the `--rerun` option, which will rerun just the tests that failed in
 the last test run.
 
+It's important to know that some of our tests create directory trees
+within `var/<uuid>/test-backend/`.  This is the preferred path to use
+whenever a test flow requires reads or writes involving generated data.
+In this regard, we also try to ensure that our tests clean up after
+themselves.  That is, any such data should be removed, when possible,
+to reduce the accumulation of unwanted files.
+
 **Webhook integrations**.  For performance, `test-backend` with no
 arguments will not run webhook integration tests (`zerver/webhooks/`),
 which would otherwise account for about 25% of the total runtime.

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -7,6 +7,7 @@ import platform
 import subprocess
 import glob
 import hashlib
+import shutil
 
 os.environ["PYTHONUNBUFFERED"] = "y"
 
@@ -589,6 +590,19 @@ def main(options):
         # https://github.com/eslint/eslint/issues/11639 is fixed
         # upstream.
         os.remove('.eslintcache')
+
+    # Clean up the `var/` directory for the move to `var/<uuid>/test-backend`
+    print("Cleaning var/ directory files...")
+    var_paths = glob.glob('var/test*')
+    var_paths.append('var/bot_avatar')
+    for path in var_paths:
+        try:
+            if os.path.isdir(path):
+                shutil.rmtree(path)
+            else:
+                os.remove(path)
+        except FileNotFoundError:
+            pass
 
     version_file = os.path.join(UUID_VAR_PATH, 'provision_version')
     print('writing to %s\n' % (version_file,))

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -12,6 +12,7 @@ import ujson
 import httplib2
 import httpretty
 import requests
+import shutil
 
 # check for the venv
 from lib import sanity_check
@@ -465,6 +466,19 @@ def main() -> None:
     # but that needs some hackery with database names.
     #
     # destroy_leaked_test_databases()
+
+    # The majority of spam being written to var/<uuid>/test-backend/ is a result
+    # of test-mattermost-import-* and test-gitter-import-*
+    from scripts.lib.zulip_tools import get_or_create_dev_uuid_var_path
+    for path in glob.glob(os.path.join(get_or_create_dev_uuid_var_path('test-backend'),
+                                       "test-*-import-*")):
+        try:
+            if os.path.isdir(path):
+                shutil.rmtree(path)
+            else:
+                os.remove(path)
+        except FileNotFoundError:
+            pass
 
     # We'll have printed whether tests passed or failed above
     sys.exit(bool(failures))

--- a/version.py
+++ b/version.py
@@ -21,4 +21,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '34.3'
+PROVISION_VERSION = '34.4'

--- a/zerver/lib/generate_test_data.py
+++ b/zerver/lib/generate_test_data.py
@@ -2,6 +2,9 @@ import itertools
 import ujson
 import random
 from typing import List, Dict, Any
+import os
+
+from scripts.lib.zulip_tools import get_or_create_dev_uuid_var_path
 
 def load_config() -> Dict[str, Any]:
     with open("zerver/tests/fixtures/config.generate_data.json", "r") as infile:
@@ -169,7 +172,8 @@ def create_test_data() -> None:
 
     paragraphs = parse_file(config, gens, config["corpus"]["filename"])
 
-    write_file(paragraphs, "var/test_messages.json")
+    write_file(paragraphs, os.path.join(get_or_create_dev_uuid_var_path('test-backend'),
+                                        "test_messages.json"))
 
 config = load_config()  # type: Dict[str, Any]
 

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -688,8 +688,11 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
                 response = self.client_get(uri)
                 _get_sendfile.clear()
                 test_upload_dir = os.path.split(settings.LOCAL_UPLOADS_DIR)[1]
+                uuid_directory, test_backend = os.path.split(os.path.dirname(settings.LOCAL_UPLOADS_DIR))
                 self.assertEqual(response['X-Accel-Redirect'],
-                                 '/serve_uploads/../../'  + test_upload_dir +
+                                 '/serve_uploads/../../' +
+                                 os.path.join(os.path.basename(uuid_directory), test_backend) +
+                                 '/' + test_upload_dir +
                                  '/files/' + fp_path + '/' + name_str_for_test)
                 if content_disposition != '':
                     self.assertIn('attachment;', response['Content-disposition'])

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -30,6 +30,8 @@ from zerver.models import CustomProfileField, DefaultStream, Message, Realm, Rea
     email_to_username, get_client, get_huddle, get_realm, get_stream, \
     get_system_bot, get_user, get_user_profile_by_id
 
+from scripts.lib.zulip_tools import get_or_create_dev_uuid_var_path
+
 settings.TORNADO_SERVER = None
 # Disable using memcached caches to avoid 'unsupported pickle
 # protocol' errors if `populate_db` is run with a different Python
@@ -559,7 +561,8 @@ def send_messages(data: Tuple[int, Sequence[Sequence[int]], Mapping[str, Any],
     (tot_messages, personals_pairs, options, output, random_seed) = data
     random.seed(random_seed)
 
-    with open("var/test_messages.json", "r") as infile:
+    with open(os.path.join(get_or_create_dev_uuid_var_path('test-backend'),
+                           "test_messages.json"), "r") as infile:
         dialog = ujson.load(infile)
     random.shuffle(dialog)
     texts = itertools.cycle(dialog)

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -18,6 +18,8 @@ if os.getenv("EXTERNAL_HOST") is None:
     os.environ["EXTERNAL_HOST"] = "testserver"
 from .settings import *
 
+from scripts.lib.zulip_tools import get_or_create_dev_uuid_var_path
+
 # Clear out the REALM_HOSTS set in dev_settings.py
 REALM_HOSTS = {}
 
@@ -125,7 +127,7 @@ if not CASPER_TESTS:
 ENABLE_FILE_LINKS = True
 
 
-LOCAL_UPLOADS_DIR = 'var/test_uploads'
+LOCAL_UPLOADS_DIR = get_or_create_dev_uuid_var_path('test-backend/test_uploads')
 
 S3_KEY = 'test-key'
 S3_SECRET_KEY = 'test-secret-key'


### PR DESCRIPTION
This PR represents the effort to improve the `/var` directory structure: 

Quoted from the issue:

- [ ] We could put all these scribble files in paths inside var/test-backend/, specifically, so there's just a single top-level directory in var/ getting scribbled to.
- [ ] We could use the UploadSerializeMixin style approach for the import/export stuff as well (e.g. make test_import_3).
- [ ] We could make some of our standard individual test classes clean up the directory after successful completion.
- [ ] We could document these approaches in our test-backend page in ReadTheDocs.


**Testing Plan:** <!-- How have you tested? -->

`test-backend`

Closes: #12259
