### PR TITLE
stream settings: Remove text suggesting members can post to public st…

### DIFF
--- a/static/templates/subscription_type.handlebars
+++ b/static/templates/subscription_type.handlebars
@@ -9,11 +9,7 @@
     {{t 'This is a <i class="hash" aria-hidden="true"></i> <b>public stream</b>. Any member of the organization can join without an invitation.' }}
 {{/if}}
 {{#if is_announcement_only}}
-    {{t 'Only organization administrators can post.'}}
+{{t 'Only organization administrators can post.'}}
 {{else}}
-    {{#if invite_only}}
-    {{t 'Only stream subscribers can post.'}}
-    {{else}}
-    {{t 'Organization members, administrators, and subscribed guests can post.'}}
-    {{/if}}
+{{t 'All stream members can post.'}}
 {{/if}}


### PR DESCRIPTION
…reams.

The UI does not allow you to send a message to a stream you're not
subscribed to, even if the API does.

