### PR TITLE
Responsive integrations/docs header

### DIFF
--- a/static/js/portico/integrations.js
+++ b/static/js/portico/integrations.js
@@ -162,7 +162,7 @@ function hide_catalog_show_integration() {
         });
         $('#integration-instructions-group').css({
             opacity: 0,
-            display: 'block',
+            display: 'flex',
         });
         $('.integration-instructions').css('display', 'none');
         $('#' + state.integration + '.integration-instructions .help-content').html(doc);

--- a/static/styles/integrations.scss
+++ b/static/styles/integrations.scss
@@ -1,0 +1,603 @@
+.portico-landing.integrations {
+    color: hsl(0, 0%, 27%);
+    font-weight: normal;
+}
+
+.portico-landing.integrations .main {
+    width: calc(100% - 100px);
+    max-width: 1170px;
+    margin: 0 auto;
+
+    background-color: hsl(0, 0%, 100%);
+    box-shadow: 0px 0px 80px hsla(0, 0%, 0%, 0.12);
+
+    visibility: hidden;
+}
+
+.portico-landing.integrations .padded-content {
+    padding: 50px 0;
+}
+
+.portico-landing.integrations .padded-content .inner-content {
+    transition: all 0.3s ease;
+    min-height: 870px;
+}
+
+.portico-landing.integrations .padded-content .inner-content.show {
+    opacity: 1;
+    pointer-events: all;
+}
+
+.portico-landing.integrations ol li {
+    list-style: none;
+}
+
+.portico-landing.integrations ul li {
+    list-style: circle;
+}
+
+.portico-landing code {
+    display: inline-block;
+    vertical-align: middle;
+    max-width: 100%;
+    overflow: auto;
+
+    font-family: Monaco, Menlo, Consolas, "Courier New", Courier, monospace;
+    font-size: 0.85em;
+}
+
+.portico-landing.integrations #integration-main-text {
+    padding: 0 15px;
+}
+
+.portico-landing.integrations .portico-page-heading {
+    font-size: 2.5em;
+    font-weight: 300;
+    line-height: 1.2;
+    text-align: center;
+}
+
+.portico-landing.integrations .portico-page-heading a {
+    color: inherit;
+}
+
+.portico-landing.integrations .portico-page-subheading {
+    font-weight: 400;
+    font-size: 1.1em;
+    color: hsl(0, 0%, 67%);
+    line-height: 1.2;
+    text-align: center;
+}
+
+.portico-landing #integration-search {
+    margin-bottom: 30px;
+}
+
+.portico-landing.integrations .searchbar {
+    width: -moz-calc(100% - 40px);
+    width: -webkit-calc(100% - 40px);
+    width: -o-calc(100% - 40px);
+    width: calc(100% - 40px);
+    display: flex;
+    justify-content: center;
+    margin: 30px auto 0;
+}
+
+.portico-landing.integrations .searchbar .searchbar-reset {
+    position: relative;
+}
+
+.portico-landing.integrations .searchbar input {
+    -webkit-box-shadow: 0px 0px 7px 2px rgba(0, 0, 0, 0.03);
+    -moz-box-shadow: 0px 0px 7px 2px rgba(0, 0, 0, 0.03);
+    box-shadow: 0px 0px 7px 2px rgba(0, 0, 0, 0.03);
+
+    font-size: 1em;
+    font-family: inherit;
+
+    width: 500px;
+    height: 45px;
+    padding: 0px 20px 0px 50px;
+    border-radius: 40px;
+    border: 1px solid hsl(208, 46%, 93%);
+    display: block;
+}
+
+.portico-landing.integrations .searchbar input:focus {
+    border: 1px solid hsl(170, 47%, 53%);
+}
+
+.portico-landing.integrations .searchbar i.fa-search {
+    position: absolute;
+    left: 20px;
+    top: 13px;
+    font-size: 19px;
+    color: hsl(170, 47%, 53%);
+}
+
+.portico-landing.integrations .catalog {
+    margin-top: 20px;
+    padding: 0 30px;
+    min-height: 500px;
+}
+
+.portico-landing.integrations .integration-categories-sidebar {
+    float: left;
+    width: 200px;
+    padding: 0 30px 0 0px;
+    margin: 0;
+}
+
+.portico-landing.integrations .integration-categories-sidebar.sticky {
+    position: sticky;
+    top: 40px;
+    margin: auto;
+    height: 490px;
+    z-index: 10;
+}
+
+.portico-landing.integrations .integration-categories-sidebar h3 {
+    font-weight: 400;
+    font-size: 1.1em;
+    margin: 0px;
+}
+
+.portico-landing.integrations .integration-categories-sidebar h4 {
+    font-weight: 400;
+    font-size: .95em;
+    padding: 6px 10px 3px;
+    margin: 3px 0;
+    border-radius: 5px;
+    transition: all 0.3s ease;
+    color: hsl(219, 23%, 33%);
+}
+
+.portico-landing.integrations .integration-categories-sidebar h4.selected,
+.portico-landing.integrations .integration-categories-sidebar h4:hover {
+    background-color: hsl(170, 65%, 85%);
+    color: hsl(170, 72%, 32%);
+    cursor: pointer;
+}
+
+.portico-landing.integrations .integration-categories-dropdown {
+    margin: 30px auto;
+    display: none;
+    .heading {
+        font-weight: 600;
+    }
+}
+
+.portico-landing.integrations .integration-lozenges {
+    overflow: hidden;
+    text-align: left;
+}
+
+.portico-landing.integrations .integration-lozenge {
+    display: inline-block;
+    vertical-align: top;
+    width: 153px;
+    height: 200px;
+    padding: 0 4px;
+    margin: 7px 5px;
+    border-radius: 5px;
+    border: 1px solid hsl(208, 46%, 93%);
+    color: hsl(219, 23%, 33%);
+    text-align: center;
+    transition: all 0.3s ease;
+}
+
+.portico-landing.integrations .integration-lozenge.legacy {
+    display: none !important;
+}
+
+.portico-landing.integrations .integration-lozenge.without-category {
+    height: 180px;
+}
+
+.portico-landing.integrations .integration-lozenge:hover {
+    border: 1px solid hsl(170, 47%, 53%);
+}
+
+.portico-landing.integrations .integration-lozenge .integration-logo {
+    margin: 34px auto 20px;
+    height: 60px;
+}
+
+.portico-landing.integrations .integration-lozenge .fa-plus {
+    font-size: 59px;
+}
+
+.portico-landing.integrations .integration-lozenge .integration-name {
+    font-size: 1.2em;
+    font-weight: 400;
+    margin: 10px 4px 0 4px;
+}
+
+.portico-landing.integrations .integration-lozenge .integration-name.create-your-own {
+    margin-top: 27px;
+    font-size: 1.1em !important;
+}
+
+.portico-landing.integrations .integration-lozenge .integration-name.with-secondary {
+    font-size: 1.1em;
+    margin-top: 4px;
+}
+
+.portico-landing.integrations .integration-lozenge .integration-secondary-line-text {
+    margin: 0;
+    line-height: 10px;
+    font-size: .65em;
+    font-weight: 400;
+}
+
+.portico-landing.integrations .integration-lozenge .integration-category {
+    font-size: .85em;
+    margin-top: 5px;
+    font-weight: 400;
+    color: hsla(216, 23%, 13%, 0.5);
+}
+
+/* -- integration instructions -- */
+
+.portico-landing.integrations #integration-instructions-group {
+    padding: 0 50px;
+    display: none;
+}
+
+.portico-landing.integrations .integration-instruction-block .integration-lozenge {
+    width: 125px;
+    height: 170px;
+    margin: 0 21px;
+}
+
+.portico-landing.integrations .integration-instruction-block .integration-lozenge .integration-category {
+    display: none;
+}
+
+.portico-landing.integrations .integration-instruction-block .name {
+    display: none;
+    font-size: 1.4em;
+    font-weight: 400;
+    margin: 0;
+    padding-bottom: 35px;
+}
+
+.portico-landing.integrations .integration-instruction-block .categories {
+    position: absolute;
+    top: 230px;
+}
+
+.portico-landing.integrations .integration-instruction-block .categories .integration-category {
+    font-size: 0.90em;
+    font-weight: 400;
+    padding: 6px 10px 6px 3px;
+    margin: 3px 0;
+    width: 165px;
+    text-align: center;
+    border-radius: 5px;
+    transition: all 0.3s ease;
+    color: hsl(219, 23%, 33%);
+}
+
+.portico-landing.integrations .integration-instruction-block .categories .integration-category:hover {
+    background-color: hsl(170, 65%, 85%);
+    color: hsl(170, 72%, 32%);
+}
+
+.integration-instruction-block .integration-lozenge {
+    float: left;
+    margin-top: 5px;
+}
+
+.integration-lozenge .square-wrapper {
+    height: 80px;
+}
+
+.integration-lozenge-static:hover {
+    box-shadow: none;
+    background-color: hsl(0, 0%, 93%);
+}
+
+.integration-lozenge .integration-link:hover {
+    text-decoration: none;
+}
+
+.integration-lozenge .integration-label {
+    display: block;
+    text-align: center;
+    padding-bottom: 18px;
+    padding-top: 10px;
+}
+
+.integration-instruction-block {
+    position: relative;
+}
+
+#integration-list-link {
+    position: absolute;
+    text-align: center;
+    display: none;
+    margin-left: 5px;
+}
+
+#integration-list-link span {
+    display: inline-block;
+    margin-left: 5px;
+}
+
+/* -- media queries -- */
+@media (min-width: 768px) {
+    .integration-instructions {
+        width: calc(100% - 200px);
+    }
+
+    #integration-list-link {
+        top: 200px;
+        left: 30px;
+    }
+}
+
+@media (max-width: 906px) {
+    .portico-landing.integrations .integration-categories-sidebar {
+        display: none;
+    }
+
+    .portico-landing.integrations .integration-categories-dropdown {
+        display: block;
+        width: 670px;
+    }
+
+    .portico-landing.integrations .integration-categories-dropdown h3,
+    .portico-landing.integrations .integration-categories-dropdown h4 {
+        font-weight: 400;
+        margin: 0;
+        padding: 12px 20px;
+    }
+
+    .portico-landing.integrations .integration-categories-dropdown .dropdown-toggle {
+        cursor: pointer;
+        display: flex;
+        position: relative;
+        padding: 0;
+        align-items: center;
+        justify-content: space-between;
+        margin-left: 25px;
+        margin-right: 25px;
+        border: 1px solid hsl(208, 46%, 93%);
+    }
+
+    .portico-landing.integrations .integration-categories-dropdown i {
+        margin-right: 10px;
+        font-size: 24px;
+    }
+
+    .portico-landing.integrations .integration-categories-dropdown .dropdown-list {
+        display: none;
+        cursor: pointer;
+        padding: 0;
+        margin-left: 25px;
+        margin-right: 25px;
+    }
+
+    .portico-landing.integrations .integration-categories-dropdown h3 {
+        font-size: 1em;
+        text-align: left;
+    }
+
+    .portico-landing.integrations .integration-categories-dropdown h4 {
+        border-left: 1px solid hsl(208, 46%, 93%);
+        border-right: 1px solid hsl(208, 46%, 93%);
+        border-bottom: 1px solid hsl(208, 46%, 93%);
+        transition: all 0.3s ease;
+        font-size: .9em;
+    }
+
+    .portico-landing.integrations .integration-categories-dropdown h4.selected,
+    .portico-landing.integrations .integration-categories-dropdown h4:hover {
+        background-color: hsl(170, 65%, 85%);
+        color: hsl(170, 72%, 32%);
+    }
+
+    .portico-landing.integrations .integration-lozenges {
+        text-align: center;
+    }
+}
+
+@media (max-width: 830px) {
+    .portico-landing.integrations .integration-lozenge {
+        width: 134px;
+        height: 180px;
+    }
+
+    .portico-landing.integrations .integration-lozenge.without-category {
+        height: 160px;
+    }
+
+    .portico-landing.integrations .integration-lozenge .integration-logo {
+        margin: 34px auto 15px;
+        height: 45px;
+    }
+
+    .portico-landing.integrations .integration-lozenge .fa-plus {
+        font-size: 45px;
+    }
+
+    .portico-landing.integrations .integration-lozenge .integration-name {
+        font-size: 1em;
+    }
+
+    .portico-landing.integrations .integration-lozenge .integration-name.create-your-own {
+        font-size: 0.95em !important;
+    }
+
+    .portico-landing.integrations .integration-lozenge .integration-category {
+        font-size: .8em;
+    }
+
+    .portico-landing.integrations .integration-categories-dropdown {
+        width: 666px;
+    }
+}
+
+@media (max-width: 786px) {
+    .portico-landing.integrations .integration-categories-dropdown {
+        width: 509px;
+    }
+}
+
+@media (max-width: 768px) {
+    .portico-landing.integrations .main {
+        width: auto;
+    }
+
+    #integration-instruction-block {
+        display: flex !important;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 20px;
+        padding-bottom: 20px;
+        border-bottom: 1px solid hsl(206, 44%, 93%);
+    }
+
+    .portico-landing.integrations #integration-instructions-group {
+        flex-direction: column;
+    }
+
+    #integration-instruction-block .integration-lozenge {
+        order: 1;
+        border: none;
+
+        display: flex !important;
+        justify-content: space-between;
+        height: auto;
+        width: auto;
+        margin: unset;
+        padding: unset;
+    }
+
+    #integration-instruction-block .integration-lozenge .integration-logo {
+        margin: 0;
+    }
+
+    #integration-instruction-block .integration-lozenge .integration-name {
+        font-size: 1.2em !important;
+        margin-left: 20px;
+    }
+
+    #integration-list-link {
+        top: 33px;
+        left: -7px;
+    }
+
+    .integration-instructions {
+        margin-left: 0px;
+    }
+
+    .portico-landing.integrations .searchbar-reset {
+        width: 445px;
+    }
+
+    .portico-landing.integrations .searchbar input {
+        width: 375px;
+        margin: 0 auto;
+    }
+
+    .portico-landing.integrations .integration-instruction-block .name {
+        display: block;
+    }
+
+    .portico-landing.integrations .integration-instruction-block .categories {
+        display: none;
+    }
+
+    .portico-landing.integrations .integration-categories-dropdown {
+        width: 666px;
+    }
+
+    #integration-list-link {
+        order: 2;
+        position: unset;
+        font-size: 22px;
+    }
+
+    #integration-list-link span {
+        display: none;
+    }
+}
+
+@media (max-width: 686px) {
+    .portico-landing.integrations .main {
+        width: calc(100% - 50px);
+        margin: 0 auto;
+    }
+    .portico-landing.integrations .integration-categories-dropdown {
+        width: 509px;
+    }
+}
+
+@media (max-width: 578px) {
+    .portico-landing.integrations .integration-categories-dropdown {
+        width: 351px;
+    }
+}
+
+@media (max-width: 550px) {
+    .portico-landing.integrations .searchbar-reset {
+        width: 100%;
+    }
+
+    .portico-landing.integrations .searchbar input {
+        width: -moz-calc(100% - 80px);
+        width: -webkit-calc(100% - 80px);
+        width: -o-calc(100% - 80px);
+        width: calc(100% - 80px);
+    }
+}
+
+@media (max-width: 450px) {
+    .portico-landing.integrations .main {
+        width: 100%;
+    }
+
+    .portico-landing.integrations .main .padded-content {
+        padding: 40px 0;
+    }
+
+    .portico-landing.integrations #integration-instructions-group {
+        padding: 0 25px;
+    }
+}
+
+@media (max-width: 375px) {
+    .portico-landing.integrations .integration-lozenge {
+        width: 120px;
+    }
+}
+
+@media (max-width: 357px) {
+    .portico-landing.integrations .integration-lozenge {
+        width: 108px;
+        height: 160px;
+    }
+
+    .portico-landing.integrations .integration-lozenge.without-category {
+        height: 140px;
+    }
+
+    .portico-landing.integrations .integration-lozenge .integration-logo {
+        margin: 28px auto 10px;
+        height: 45px;
+    }
+
+    .portico-landing.integrations .integration-lozenge .integration-name {
+        font-size: .9em;
+    }
+
+    .portico-landing.integrations .integration-lozenge .integration-category {
+        font-size: .77em;
+    }
+
+    .portico-landing.integrations .integration-categories-dropdown {
+        width: 299px;
+    }
+}

--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -2485,293 +2485,6 @@ nav ul li.active::after {
     border-color: hsl(0, 0%, 13%);
 }
 
-/* -- integrations page css -- */
-.portico-landing.integrations {
-    color: hsl(0, 0%, 27%);
-    font-weight: normal;
-}
-
-.portico-landing.integrations .main {
-    width: calc(100% - 100px);
-    max-width: 1170px;
-    margin: 0 auto;
-
-    background-color: hsl(0, 0%, 100%);
-    box-shadow: 0px 0px 80px hsla(0, 0%, 0%, 0.12);
-
-    visibility: hidden;
-}
-
-.portico-landing.integrations .padded-content {
-    padding: 50px 0;
-}
-
-.portico-landing.integrations .padded-content .inner-content {
-    transition: all 0.3s ease;
-    min-height: 870px;
-}
-
-.portico-landing.integrations .padded-content .inner-content.show {
-    opacity: 1;
-    pointer-events: all;
-}
-
-.portico-landing.integrations ol li {
-    list-style: none;
-}
-
-.portico-landing.integrations ul li {
-    list-style: circle;
-}
-
-.portico-landing code {
-    display: inline-block;
-    vertical-align: middle;
-    max-width: 100%;
-    overflow: auto;
-
-    font-family: Monaco, Menlo, Consolas, "Courier New", Courier, monospace;
-    font-size: 0.85em;
-}
-
-.portico-landing.integrations #integration-main-text {
-    padding: 0 15px;
-}
-
-.portico-landing.integrations .portico-page-heading {
-    font-size: 2.5em;
-    font-weight: 300;
-    line-height: 1.2;
-    text-align: center;
-}
-
-.portico-landing.integrations .portico-page-heading a {
-    color: inherit;
-}
-
-.portico-landing.integrations .portico-page-subheading {
-    font-weight: 400;
-    font-size: 1.1em;
-    color: hsl(0, 0%, 67%);
-    line-height: 1.2;
-    text-align: center;
-}
-
-.portico-landing #integration-search {
-    margin-bottom: 30px;
-}
-
-.portico-landing.integrations .searchbar {
-    width: -moz-calc(100% - 40px);
-    width: -webkit-calc(100% - 40px);
-    width: -o-calc(100% - 40px);
-    width: calc(100% - 40px);
-    display: flex;
-    justify-content: center;
-    margin: 30px auto 0;
-}
-
-.portico-landing.integrations .searchbar .searchbar-reset {
-    position: relative;
-}
-
-.portico-landing.integrations .searchbar input {
-    -webkit-box-shadow: 0px 0px 7px 2px rgba(0, 0, 0, 0.03);
-    -moz-box-shadow: 0px 0px 7px 2px rgba(0, 0, 0, 0.03);
-    box-shadow: 0px 0px 7px 2px rgba(0, 0, 0, 0.03);
-
-    font-size: 1em;
-    font-family: inherit;
-
-    width: 500px;
-    height: 45px;
-    padding: 0px 20px 0px 50px;
-    border-radius: 40px;
-    border: 1px solid hsl(208, 46%, 93%);
-    display: block;
-}
-
-.portico-landing.integrations .searchbar input:focus {
-    border: 1px solid hsl(170, 47%, 53%);
-}
-
-.portico-landing.integrations .searchbar i.fa-search {
-    position: absolute;
-    left: 20px;
-    top: 13px;
-    font-size: 19px;
-    color: hsl(170, 47%, 53%);
-}
-
-.portico-landing.integrations .catalog {
-    margin-top: 20px;
-    padding: 0 30px;
-    min-height: 500px;
-}
-
-.portico-landing.integrations .integration-categories-sidebar {
-    float: left;
-    width: 200px;
-    padding: 0 30px 0 0px;
-    margin: 0;
-}
-
-.portico-landing.integrations .integration-categories-sidebar.sticky {
-    position: sticky;
-    top: 40px;
-    margin: auto;
-    height: 490px;
-    z-index: 10;
-}
-
-.portico-landing.integrations .integration-categories-sidebar h3 {
-    font-weight: 400;
-    font-size: 1.1em;
-    margin: 0px;
-}
-
-.portico-landing.integrations .integration-categories-sidebar h4 {
-    font-weight: 400;
-    font-size: .95em;
-    padding: 6px 10px 3px;
-    margin: 3px 0;
-    border-radius: 5px;
-    transition: all 0.3s ease;
-    color: hsl(219, 23%, 33%);
-}
-
-.portico-landing.integrations .integration-categories-sidebar h4.selected,
-.portico-landing.integrations .integration-categories-sidebar h4:hover {
-    background-color: hsl(170, 65%, 85%);
-    color: hsl(170, 72%, 32%);
-    cursor: pointer;
-}
-
-.portico-landing.integrations .integration-categories-dropdown {
-    margin: 30px auto;
-    display: none;
-    .heading {
-        font-weight: 600;
-    }
-}
-
-.portico-landing.integrations .integration-lozenges {
-    overflow: hidden;
-    text-align: left;
-}
-
-.portico-landing.integrations .integration-lozenge {
-    display: inline-block;
-    vertical-align: top;
-    width: 153px;
-    height: 200px;
-    padding: 0 4px;
-    margin: 7px 5px;
-    border-radius: 5px;
-    border: 1px solid hsl(208, 46%, 93%);
-    color: hsl(219, 23%, 33%);
-    text-align: center;
-    transition: all 0.3s ease;
-}
-
-.portico-landing.integrations .integration-lozenge.legacy {
-    display: none !important;
-}
-
-.portico-landing.integrations .integration-lozenge.without-category {
-    height: 180px;
-}
-
-.portico-landing.integrations .integration-lozenge:hover {
-    border: 1px solid hsl(170, 47%, 53%);
-}
-
-.portico-landing.integrations .integration-lozenge .integration-logo {
-    margin: 34px auto 20px;
-    height: 60px;
-}
-
-.portico-landing.integrations .integration-lozenge .fa-plus {
-    font-size: 59px;
-}
-
-.portico-landing.integrations .integration-lozenge .integration-name {
-    font-size: 1.2em;
-    font-weight: 400;
-    margin: 10px 4px 0 4px;
-}
-
-.portico-landing.integrations .integration-lozenge .integration-name.create-your-own {
-    margin-top: 27px;
-    font-size: 1.1em !important;
-}
-
-.portico-landing.integrations .integration-lozenge .integration-name.with-secondary {
-    font-size: 1.1em;
-    margin-top: 4px;
-}
-
-.portico-landing.integrations .integration-lozenge .integration-secondary-line-text {
-    margin: 0;
-    line-height: 10px;
-    font-size: .65em;
-    font-weight: 400;
-}
-
-.portico-landing.integrations .integration-lozenge .integration-category {
-    font-size: .85em;
-    margin-top: 5px;
-    font-weight: 400;
-    color: hsla(216, 23%, 13%, 0.5);
-}
-
-/* -- integration instructions -- */
-
-.portico-landing.integrations #integration-instructions-group {
-    padding: 0 50px;
-    display: none;
-}
-
-.portico-landing.integrations .integration-instruction-block .integration-lozenge {
-    width: 125px;
-    height: 170px;
-    margin: 0 21px;
-}
-
-.portico-landing.integrations .integration-instruction-block .integration-lozenge .integration-category {
-    display: none;
-}
-
-.portico-landing.integrations .integration-instruction-block .name {
-    display: none;
-    font-size: 1.4em;
-    font-weight: 400;
-    margin: 0;
-    padding-bottom: 35px;
-}
-
-.portico-landing.integrations .integration-instruction-block .categories {
-    position: absolute;
-    top: 230px;
-}
-
-.portico-landing.integrations .integration-instruction-block .categories .integration-category {
-    font-size: 0.90em;
-    font-weight: 400;
-    padding: 6px 10px 6px 3px;
-    margin: 3px 0;
-    width: 165px;
-    text-align: center;
-    border-radius: 5px;
-    transition: all 0.3s ease;
-    color: hsl(219, 23%, 33%);
-}
-
-.portico-landing.integrations .integration-instruction-block .categories .integration-category:hover {
-    background-color: hsl(170, 65%, 85%);
-    color: hsl(170, 72%, 32%);
-}
-
 /* -- gradients -- */
 .gradients {
     width: 100%;
@@ -3206,12 +2919,6 @@ nav ul li.active::after {
     }
 }
 
-@media (min-width: 768px) {
-    .integration-instructions {
-        width: calc(100% - 200px);
-    }
-}
-
 @media (max-width: 1295px) {
     .portico-landing.hello .apps .right-side {
         display: none;
@@ -3448,70 +3155,6 @@ nav ul li.active::after {
 }
 
 @media (max-width: 906px) {
-    .portico-landing.integrations .integration-categories-sidebar {
-        display: none;
-    }
-
-    .portico-landing.integrations .integration-categories-dropdown {
-        display: block;
-        width: 670px;
-    }
-
-    .portico-landing.integrations .integration-categories-dropdown h3,
-    .portico-landing.integrations .integration-categories-dropdown h4 {
-        font-weight: 400;
-        margin: 0;
-        padding: 12px 20px;
-    }
-
-    .portico-landing.integrations .integration-categories-dropdown .dropdown-toggle {
-        cursor: pointer;
-        display: flex;
-        position: relative;
-        padding: 0;
-        align-items: center;
-        justify-content: space-between;
-        margin-left: 25px;
-        margin-right: 25px;
-        border: 1px solid hsl(208, 46%, 93%);
-    }
-
-    .portico-landing.integrations .integration-categories-dropdown i {
-        margin-right: 10px;
-        font-size: 24px;
-    }
-
-    .portico-landing.integrations .integration-categories-dropdown .dropdown-list {
-        display: none;
-        cursor: pointer;
-        padding: 0;
-        margin-left: 25px;
-        margin-right: 25px;
-    }
-
-    .portico-landing.integrations .integration-categories-dropdown h3 {
-        font-size: 1em;
-        text-align: left;
-    }
-
-    .portico-landing.integrations .integration-categories-dropdown h4 {
-        border-left: 1px solid hsl(208, 46%, 93%);
-        border-right: 1px solid hsl(208, 46%, 93%);
-        border-bottom: 1px solid hsl(208, 46%, 93%);
-        transition: all 0.3s ease;
-        font-size: .9em;
-    }
-
-    .portico-landing.integrations .integration-categories-dropdown h4.selected,
-    .portico-landing.integrations .integration-categories-dropdown h4:hover {
-        background-color: hsl(170, 65%, 85%);
-        color: hsl(170, 72%, 32%);
-    }
-
-    .portico-landing.integrations .integration-lozenges {
-        text-align: center;
-    }
-
     .portico-landing.why-page .hero p br {
         display: none;
     }
@@ -3535,36 +3178,6 @@ nav ul li.active::after {
 }
 
 @media (max-width: 830px) {
-    .portico-landing.integrations .integration-lozenge {
-        width: 134px;
-        height: 180px;
-    }
-
-    .portico-landing.integrations .integration-lozenge.without-category {
-        height: 160px;
-    }
-
-    .portico-landing.integrations .integration-lozenge .integration-logo {
-        margin: 34px auto 15px;
-        height: 45px;
-    }
-
-    .portico-landing.integrations .integration-lozenge .fa-plus {
-        font-size: 45px;
-    }
-
-    .portico-landing.integrations .integration-lozenge .integration-name {
-        font-size: 1em;
-    }
-
-    .portico-landing.integrations .integration-lozenge .integration-name.create-your-own {
-        font-size: 0.95em !important;
-    }
-
-    .portico-landing.integrations .integration-lozenge .integration-category {
-        font-size: .8em;
-    }
-
     .portico-landing.features-app section .headliner {
         display: inline-flex;
 
@@ -3617,16 +3230,6 @@ nav ul li.active::after {
     .tour .carousel-inner .tour-item-header {
         font-size: 1.1em;
     }
-
-    .portico-landing.integrations .integration-categories-dropdown {
-        width: 666px;
-    }
-}
-
-@media (max-width: 786px) {
-    .portico-landing.integrations .integration-categories-dropdown {
-        width: 509px;
-    }
 }
 
 @media (max-width: 768px) {
@@ -3658,7 +3261,6 @@ nav ul li.active::after {
         width: 75%;
     }
 
-    .portico-landing.integrations .main,
     .main {
         width: auto;
     }
@@ -3699,70 +3301,6 @@ nav ul li.active::after {
         font-size: 1em;
     }
 
-    #integration-instruction-block {
-        display: flex !important;
-        justify-content: space-between;
-        align-items: center;
-        margin-bottom: 20px;
-        padding-bottom: 20px;
-        border-bottom: 1px solid hsl(206, 44%, 93%);
-    }
-
-    .portico-landing.integrations #integration-instructions-group {
-        flex-direction: column;
-    }
-
-    #integration-instruction-block .integration-lozenge {
-        order: 1;
-        border: none;
-
-        display: flex !important;
-        justify-content: space-between;
-        height: auto;
-        width: auto;
-        margin: unset;
-        padding: unset;
-    }
-
-    #integration-instruction-block .integration-lozenge .integration-logo {
-        margin: 0;
-    }
-
-    #integration-instruction-block .integration-lozenge .integration-name {
-        font-size: 1.2em !important;
-        margin-left: 20px;
-    }
-
-    #integration-list-link {
-        top: 33px;
-        left: -7px;
-    }
-
-    .integration-instructions {
-        margin-left: 0px;
-    }
-
-    .portico-landing.integrations .portico-page-header {
-        padding-top: 20px;
-    }
-
-    .portico-landing.integrations .searchbar-reset {
-        width: 445px;
-    }
-
-    .portico-landing.integrations .searchbar input {
-        width: 375px;
-        margin: 0 auto;
-    }
-
-    .portico-landing.integrations .integration-instruction-block .name {
-        display: block;
-    }
-
-    .portico-landing.integrations .integration-instruction-block .categories {
-        display: none;
-    }
-
     .platform.image {
         display: none !important;
     }
@@ -3796,10 +3334,6 @@ nav ul li.active::after {
 
     .portico-landing.features-app section {
         padding: 0px 20px;
-    }
-
-    .portico-landing.integrations .integration-categories-dropdown {
-        width: 666px;
     }
 
     .billing-upgrade-page {
@@ -3871,7 +3405,6 @@ nav ul li.active::after {
         width: 100%;
     }
 
-    .portico-landing.integrations .main,
     .main {
         width: calc(100% - 50px);
         margin: 0 auto;
@@ -4048,21 +3581,11 @@ nav ul li.active::after {
     .tour .carousel-inner button.call-to-action {
         margin: 40px auto;
     }
-
-    .portico-landing.integrations .integration-categories-dropdown {
-        width: 509px;
-    }
 }
 
 @media (max-width: 640px) {
     .portico-landing.hello .integrations .integration-icons .group {
         margin: 10px 16px 0 16px;
-    }
-}
-
-@media (max-width: 578px) {
-    .portico-landing.integrations .integration-categories-dropdown {
-        width: 351px;
     }
 }
 
@@ -4081,17 +3604,6 @@ nav ul li.active::after {
 
     .portico-landing.features-app section.messages .features .feature-block {
         margin: 20px 0px;
-    }
-
-    .portico-landing.integrations .searchbar-reset {
-        width: 100%;
-    }
-
-    .portico-landing.integrations .searchbar input {
-        width: -moz-calc(100% - 80px);
-        width: -webkit-calc(100% - 80px);
-        width: -o-calc(100% - 80px);
-        width: calc(100% - 80px);
     }
 
     .portico-landing .tour {
@@ -4182,21 +3694,8 @@ nav ul li.active::after {
         margin: 4px 2px;
     }
 
-    .main,
-    .portico-landing.integrations .main {
+    .main {
         width: 100%;
-    }
-
-    .portico-landing.integrations .main .portico-page-header {
-        padding-top: 10px;
-    }
-
-    .portico-landing.integrations .main .padded-content {
-        padding: 40px 0;
-    }
-
-    .portico-landing.integrations #integration-instructions-group {
-        padding: 0 25px;
     }
 
     .portico-landing.plans .compare .padded-content {
@@ -4253,44 +3752,12 @@ nav ul li.active::after {
         width: 60px;
     }
 
-    .portico-landing.integrations .integration-lozenge {
-        width: 120px;
-    }
-
     .portico-landing.features-app section.keyboard-shortcuts::after {
         left: 0;
     }
 
     .portico-landing.integrations .integration-categories-dropdown {
         width: 323px;
-    }
-}
-
-@media (max-width: 357px) {
-    .portico-landing.integrations .integration-lozenge {
-        width: 108px;
-        height: 160px;
-    }
-
-    .portico-landing.integrations .integration-lozenge.without-category {
-        height: 140px;
-    }
-
-    .portico-landing.integrations .integration-lozenge .integration-logo {
-        margin: 28px auto 10px;
-        height: 45px;
-    }
-
-    .portico-landing.integrations .integration-lozenge .integration-name {
-        font-size: .9em;
-    }
-
-    .portico-landing.integrations .integration-lozenge .integration-category {
-        font-size: .77em;
-    }
-
-    .portico-landing.integrations .integration-categories-dropdown {
-        width: 299px;
     }
 }
 

--- a/static/styles/landing-page.scss
+++ b/static/styles/landing-page.scss
@@ -3206,6 +3206,12 @@ nav ul li.active::after {
     }
 }
 
+@media (min-width: 768px) {
+    .integration-instructions {
+        width: calc(100% - 200px);
+    }
+}
+
 @media (max-width: 1295px) {
     .portico-landing.hello .apps .right-side {
         display: none;
@@ -3273,10 +3279,6 @@ nav ul li.active::after {
 @media (max-width: 1024px) {
     .portico-landing.hello .gradients .gradient {
         height: 1400px;
-    }
-
-    nav {
-        padding-bottom: 110px;
     }
 
     nav.white {
@@ -3697,8 +3699,38 @@ nav ul li.active::after {
         font-size: 1em;
     }
 
+    #integration-instruction-block {
+        display: flex !important;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 20px;
+        padding-bottom: 20px;
+        border-bottom: 1px solid hsl(206, 44%, 93%);
+    }
+
+    .portico-landing.integrations #integration-instructions-group {
+        flex-direction: column;
+    }
+
     #integration-instruction-block .integration-lozenge {
-        display: none !important;
+        order: 1;
+        border: none;
+
+        display: flex !important;
+        justify-content: space-between;
+        height: auto;
+        width: auto;
+        margin: unset;
+        padding: unset;
+    }
+
+    #integration-instruction-block .integration-lozenge .integration-logo {
+        margin: 0;
+    }
+
+    #integration-instruction-block .integration-lozenge .integration-name {
+        font-size: 1.2em !important;
+        margin-left: 20px;
     }
 
     #integration-list-link {
@@ -4132,10 +4164,6 @@ nav ul li.active::after {
     .pricing-model .pricing-container .bottom {
         position: static;
         height: auto;
-    }
-
-    nav {
-        padding-bottom: 105px;
     }
 
     .portico-landing.hello .hero {

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -1135,15 +1135,12 @@ input#terminal:checked ~ #tab-terminal {
 }
 
 @media (min-width: 768px) {
-    .integration-instructions {
-        margin-left: 220px;
-    }
-
     #integration-list-link {
         top: 200px;
         left: 30px;
     }
 }
+
 .api-page-header,
 .authors-page-header,
 .integrations-page-header,
@@ -1223,6 +1220,18 @@ input#terminal:checked ~ #tab-terminal {
 #integration-list-link span {
     display: inline-block;
     margin-left: 5px;
+}
+
+@media (max-width: 768px) {
+    #integration-list-link {
+        order: 2;
+        position: unset;
+        font-size: 22px;
+    }
+
+    #integration-list-link span {
+        display: none;
+    }
 }
 
 .integrations-page-header .integrations-icon {

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -1090,38 +1090,6 @@ input#terminal:checked ~ #tab-terminal {
     pointer-events: none;
 }
 
-.integration-instruction-block .integration-lozenge {
-    float: left;
-    margin-top: 5px;
-}
-
-.integration-lozenge .square-wrapper {
-    height: 80px;
-}
-
-.integration-lozenge-static:hover {
-    box-shadow: none;
-    background-color: hsl(0, 0%, 93%);
-}
-
-.integration-lozenge .integration-link:hover {
-    text-decoration: none;
-}
-
-.integration-lozenge .integration-label {
-    display: block;
-    text-align: center;
-    padding-bottom: 18px;
-    padding-top: 10px;
-}
-
-@media (min-width: 768px) {
-    #integration-list-link {
-        top: 200px;
-        left: 30px;
-    }
-}
-
 .login-page-header {
     width: 100%;
 }
@@ -1144,34 +1112,6 @@ input#terminal:checked ~ #tab-terminal {
     margin: auto;
     text-align: center;
     margin-bottom: 30px;
-}
-
-.integration-instruction-block {
-    position: relative;
-}
-
-#integration-list-link {
-    position: absolute;
-    text-align: center;
-    display: none;
-    margin-left: 5px;
-}
-
-#integration-list-link span {
-    display: inline-block;
-    margin-left: 5px;
-}
-
-@media (max-width: 768px) {
-    #integration-list-link {
-        order: 2;
-        position: unset;
-        font-size: 22px;
-    }
-
-    #integration-list-link span {
-        display: none;
-    }
 }
 
 .apps-instructions-header {

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -916,25 +916,6 @@ a.bottom-signup-button {
     font-size: 16px;
 }
 
-.portico-page-header {
-    font-weight: 300;
-    font-size: 35px;
-    display: block;
-    padding-top: 40px;
-    margin-bottom: 20px;
-}
-
-.portico-page-header .portico-page-header-icon {
-    margin-right: 12px;
-}
-
-.portico-page-header a,
-.portico-page-header a:hover {
-    color: hsl(0, 0%, 0%);
-    text-decoration: none;
-    display: inline-block;
-}
-
 .portico-large-text {
     font-size: 16px;
     line-height: 20px;
@@ -1141,23 +1122,6 @@ input#terminal:checked ~ #tab-terminal {
     }
 }
 
-.api-page-header,
-.authors-page-header,
-.integrations-page-header,
-.register-page-header {
-    font-weight: 300;
-    font-size: 40px;
-    display: block;
-    margin: auto;
-    width: 360px;
-    text-align: center;
-    margin-bottom: 50px;
-}
-
-.register-page-header {
-    text-align: left;
-}
-
 .login-page-header {
     width: 100%;
 }
@@ -1173,20 +1137,6 @@ input#terminal:checked ~ #tab-terminal {
     margin-bottom: 50px;
 }
 
-.api-page-header,
-.authors-page-header,
-.integrations-page-header {
-    padding-top: 56px;
-}
-
-.integrations-page-header,
-.register-page-header,
-.api-page-header {
-    line-height: 42px;
-    width: auto;
-    margin-bottom: 10px;
-}
-
 .apps-muted {
     font-weight: 300;
     font-size: 20px;
@@ -1194,16 +1144,6 @@ input#terminal:checked ~ #tab-terminal {
     margin: auto;
     text-align: center;
     margin-bottom: 30px;
-}
-
-.integrations-page-header,
-.api-page-header {
-    text-align: left;
-}
-
-.integrations-page-header {
-    font-size: 25px;
-    padding-top: 20px;
 }
 
 .integration-instruction-block {
@@ -1232,11 +1172,6 @@ input#terminal:checked ~ #tab-terminal {
     #integration-list-link span {
         display: none;
     }
-}
-
-.integrations-page-header .integrations-icon {
-    font-size: 22px;
-    margin-right: 10px;
 }
 
 .apps-instructions-header {

--- a/static/styles/portico.scss
+++ b/static/styles/portico.scss
@@ -1721,7 +1721,6 @@ input.new-organization-button {
     border: 1px solid hsl(46, 63%, 84%);
 }
 
-.integration-instructions .tip,
 .markdown .warn p,
 .markdown .tip p,
 .markdown .keyboard_tip p {

--- a/templates/zerver/integrations/errbot.md
+++ b/templates/zerver/integrations/errbot.md
@@ -1,4 +1,4 @@
-# Run your favorite chatbot in Zulip!
+Run your favorite chatbot in Zulip!
 
 0. [Install errbot](http://errbot.io/en/latest/user_guide/setup.html)
    and follow to instructions to setup a `config.py`.
@@ -43,7 +43,6 @@
 
 ![](/static/images/integrations/errbot/000.png)
 
-Tips
-----
+### Tips
 
 * Rooms in ErrBot are streams in Zulip.

--- a/templates/zerver/integrations/index.html
+++ b/templates/zerver/integrations/index.html
@@ -139,7 +139,6 @@
                 <div id="integration-instructions-group">
                     <div id="integration-instruction-block" class="integration-instruction-block">
                         <a href="/integrations" id="integration-list-link" class="no-underline"><i class="fa fa-arrow-circle-left" aria-hidden="true"></i><span>Back to list</span></a>
-                        <h3 class="name">Name</h3>
                         <div class="categories"></div>
                     </div>
 

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -75,7 +75,8 @@
     ],
     "integrations": [
         "./static/js/portico/integrations.js",
-        "./static/styles/landing-page.scss"
+        "./static/styles/landing-page.scss",
+        "./static/styles/integrations.scss"
     ],
     "signup": [
         "./node_modules/jquery-validation/dist/jquery.validate.min.js",


### PR DESCRIPTION
- **First commit** removes the title from `errbot` integration documentation so that all documentations have the same style. Also, removes the `margin: 0` from the instruction tip because where the tip is followed by a list, there is no space between the two; this change doesn't mess up the other places where the tip is used. There are two other docs changed in the `python-zulip-api` repo through this PR: https://github.com/zulip/python-zulip-api/pull/515
- **Second commit** resolves #12365.
   - I added display `flex` on some elements so I can change the positioning of the logo and the title of the integration. As a consequence of adding flex, I could remove the 
`@media (min-width: 768px) {
    .integration-instructions {
        margin-left: 220px;  }}`.
   -  I removed the `padding-bottom` from the `nav` because after I changed the header, the back arrow was too high and the padding of the nav was overlapping it, therefore you couldn't click on the back button. I tested this on all the pages from the menu and it doesn't break anything.

- **Third commit** removes unused css from `portico.scss`. I searched in the entire project in `html` and `js` files and those classes are not used anywhere.
- **The forth commit** moves the css for the integrations page into a new `integrations.scss` in order to have it in one place only. 
   - I didn't move this into the new file: [L363-L417](https://github.com/alexandraciobica/zulip/blob/1af4f8fe202fcd759a3d17273ca85cb60eba60d8/static/styles/portico.scss#L363-L417) because I am not sure if it should be moved. 

**Testing Plan:** 
I tested the header on all the screen sizes, Chrome and Mozilla.
For the moving of the css I tried to test step by step while I moved the css.


**GIFs or Screenshots:** 
This is how the header looks like now:
<img width="500" alt="Screen Shot 2019-06-10 at 15 15 43" src="https://user-images.githubusercontent.com/18381652/59197866-af0f1c80-8b92-11e9-897b-ca10d506f684.png">


The page is full-width for `686px < screen width < 768px` and for `screen width < 450px`. For `max-width: 686px` the integration description page looks like this: 
<img width="717" alt="Screen Shot 2019-06-10 at 15 09 09" src="https://user-images.githubusercontent.com/18381652/59197636-0fea2500-8b92-11e9-98e6-3305a0933355.png">
I'm not sure if this has a reason, but if it doesn't, I think I should change the `686px` to full width also.

@synicalsyntax 