### PR TITLE
Retention: batching + logging + delete objects in one query with their archiving

### DIFF
--- a/zerver/lib/retention.py
+++ b/zerver/lib/retention.py
@@ -146,17 +146,22 @@ def move_expired_personal_and_huddle_messages_to_archive(realm: Realm,
                                        realm_id=realm.id, recipient_types=recipient_types,
                                        check_date=check_date.isoformat(), chunk_size=chunk_size)
 
-def move_models_with_message_key_to_archive(msg_ids: List[int]) -> None:
+def move_to_archive_and_delete_models_with_message_key(msg_ids: List[int]) -> None:
     assert len(msg_ids) > 0
 
     for model in models_with_message_key:
         query = """
-        INSERT INTO {archive_table_name} ({dst_fields}, archive_timestamp)
-        SELECT {src_fields}, '{archive_timestamp}'
-        FROM {table_name}
-        LEFT JOIN {archive_table_name} ON {archive_table_name}.id = {table_name}.id
-        WHERE {table_name}.message_id IN {message_ids}
-            AND {archive_table_name}.id IS NULL
+        WITH archived_data AS (
+            INSERT INTO {archive_table_name} ({dst_fields}, archive_timestamp)
+            SELECT {src_fields}, '{archive_timestamp}'
+            FROM {table_name}
+            LEFT JOIN {archive_table_name} ON {archive_table_name}.id = {table_name}.id
+            WHERE {table_name}.message_id IN {message_ids}
+                AND {archive_table_name}.id IS NULL
+            RETURNING id
+        )
+        DELETE FROM {table_name}
+        WHERE id IN (SELECT id FROM archived_data)
         """
         move_rows(model['class'], query, table_name=model['table_name'],
                   archive_table_name=model['archive_table_name'],
@@ -183,14 +188,19 @@ def move_attachment_messages_to_archive(msg_ids: List[int]) -> None:
     assert len(msg_ids) > 0
 
     query = """
-       INSERT INTO zerver_archivedattachment_messages (id, archivedattachment_id, archivedmessage_id)
-       SELECT zerver_attachment_messages.id, zerver_attachment_messages.attachment_id,
-           zerver_attachment_messages.message_id
-       FROM zerver_attachment_messages
-       LEFT JOIN zerver_archivedattachment_messages
-           ON zerver_archivedattachment_messages.id = zerver_attachment_messages.id
-       WHERE  zerver_attachment_messages.message_id IN {message_ids}
-            AND  zerver_archivedattachment_messages.id IS NULL
+        WITH archived_data AS (
+            INSERT INTO zerver_archivedattachment_messages (id, archivedattachment_id, archivedmessage_id)
+            SELECT zerver_attachment_messages.id, zerver_attachment_messages.attachment_id,
+                zerver_attachment_messages.message_id
+            FROM zerver_attachment_messages
+            LEFT JOIN zerver_archivedattachment_messages
+                ON zerver_archivedattachment_messages.id = zerver_attachment_messages.id
+            WHERE  zerver_attachment_messages.message_id IN {message_ids}
+                    AND  zerver_archivedattachment_messages.id IS NULL
+            RETURNING id
+        )
+        DELETE FROM zerver_attachment_messages
+        WHERE id IN (SELECT id FROM archived_data)
     """
     with connection.cursor() as cursor:
         cursor.execute(query.format(message_ids=ids_list_to_sql_query_format(msg_ids)))
@@ -211,7 +221,7 @@ def delete_expired_attachments(realm: Realm) -> None:
     ).delete()
 
 def move_related_objects_to_archive(msg_ids: List[int]) -> None:
-    move_models_with_message_key_to_archive(msg_ids)
+    move_to_archive_and_delete_models_with_message_key(msg_ids)
     move_attachments_to_archive(msg_ids)
     move_attachment_messages_to_archive(msg_ids)
 

--- a/zerver/lib/retention.py
+++ b/zerver/lib/retention.py
@@ -12,7 +12,7 @@ from zerver.models import (Message, UserMessage, ArchivedMessage, ArchivedUserMe
                            SubMessage, ArchivedSubMessage, Recipient, Stream,
                            get_stream_recipients, get_user_including_cross_realm)
 
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterator, List
 
 import logging
 
@@ -75,25 +75,27 @@ def ids_list_to_sql_query_format(ids: List[int]) -> str:
     return ids_string
 
 def run_message_batch_query(query: str, chunk_size: int=MESSAGE_BATCH_SIZE,
-                            **kwargs: Any) -> List[List[int]]:
-    id_chunks = []  # type: List[List[int]]
+                            **kwargs: Any) -> Iterator[List[int]]:
     while True:
         new_chunk = move_rows(Message, query, chunk_size=chunk_size, **kwargs)
         if new_chunk:
-            id_chunks.append(new_chunk)
+            yield new_chunk
 
         # We run the loop, until the query returns fewer results than chunk_size, which means we are done:
         if len(new_chunk) < chunk_size:
-            return id_chunks
+            break
 
 # Note about batching these Message archiving queries:
 # We can simply use LIMIT without worrying about OFFSETs and ordering
 # while executing batches, because any Message already archived (in the previous batch)
 # will not show up in the "SELECT ... FROM zerver_message ..." query for the next batches.
 
+# Important: These two functions below are generators and you need to iterate through
+# the Iterator returned by them for the queries to actually be executed.
+
 def move_expired_messages_to_archive_by_recipient(recipient: Recipient,
                                                   message_retention_days: int,
-                                                  chunk_size: int=MESSAGE_BATCH_SIZE) -> List[List[int]]:
+                                                  chunk_size: int=MESSAGE_BATCH_SIZE) -> Iterator[List[int]]:
     query = """
     INSERT INTO zerver_archivedmessage ({dst_fields}, archive_timestamp)
         SELECT {src_fields}, '{archive_timestamp}'
@@ -107,13 +109,13 @@ def move_expired_messages_to_archive_by_recipient(recipient: Recipient,
     """
     check_date = timezone_now() - timedelta(days=message_retention_days)
 
-    return run_message_batch_query(query, returning_id=True,
-                                   recipient_id=recipient.id, check_date=check_date.isoformat(),
-                                   chunk_size=chunk_size)
+    yield from run_message_batch_query(query, returning_id=True,
+                                       recipient_id=recipient.id, check_date=check_date.isoformat(),
+                                       chunk_size=chunk_size)
 
 def move_expired_personal_and_huddle_messages_to_archive(realm: Realm,
                                                          chunk_size: int=MESSAGE_BATCH_SIZE
-                                                         ) -> List[List[int]]:
+                                                         ) -> Iterator[List[int]]:
     cross_realm_bot_ids_list = [get_user_including_cross_realm(email).id
                                 for email in settings.CROSS_REALM_BOT_EMAILS]
     cross_realm_bot_ids = str(tuple(cross_realm_bot_ids_list))
@@ -140,9 +142,9 @@ def move_expired_personal_and_huddle_messages_to_archive(realm: Realm,
     assert realm.message_retention_days is not None
     check_date = timezone_now() - timedelta(days=realm.message_retention_days)
 
-    return run_message_batch_query(query, returning_id=True, cross_realm_bot_ids=cross_realm_bot_ids,
-                                   realm_id=realm.id, recipient_types=recipient_types,
-                                   check_date=check_date.isoformat(), chunk_size=chunk_size)
+    yield from run_message_batch_query(query, returning_id=True, cross_realm_bot_ids=cross_realm_bot_ids,
+                                       realm_id=realm.id, recipient_types=recipient_types,
+                                       check_date=check_date.isoformat(), chunk_size=chunk_size)
 
 def move_models_with_message_key_to_archive(msg_ids: List[int]) -> None:
     assert len(msg_ids) > 0

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1065,6 +1065,7 @@ ZULIP_PATHS = [
     ("TRACEMALLOC_DUMP_DIR", "/var/log/zulip/tracemalloc"),
     ("SCHEDULED_MESSAGE_DELIVERER_LOG_PATH",
      "/var/log/zulip/scheduled_message_deliverer.log"),
+    ("RETENTION_LOG_PATH", "/var/log/zulip/message_retention.log"),
 ]
 
 # The Event log basically logs most significant database changes,
@@ -1282,6 +1283,10 @@ LOGGING = {
         },
         'zulip.queue': {
             'level': 'WARNING',
+        },
+        'zulip.retention': {
+            'handlers': ['file', 'errors_file'],
+            'propagate': False,
         },
         'zulip.soft_deactivation': {
             'handlers': ['file', 'errors_file'],


### PR DESCRIPTION
Addressing comments made in https://github.com/zulip/zulip/pull/12499#issuecomment-499616595 :

> I think I mentioned batching queries to BATCH_SIZE messages at a time (probably we'll want ~1000).

Implemented in the first commit

> We'll want to think about logging that we might use to debug issues with this system. We should setup a logger object for retention.py (see examples in other files; I think we also have a doc on it).

Simple version of this in the third commit. I'm not sure if we want to specify some extra settings for this system's logger in settings.py?

> Related to logging, I was thinking we might want to group the archive_stream_messages function by realm, and log the realm string_id and total number of messages archived when we're starting processing a given realm in both the PM and stream code paths. 

Implemented in commits 2-3.

> There's number of queries performance optimization we could do with archive_messages_by_recipient to have it support taking a list of up to RECIPIENT_BATCH_SIZE~20 recipient_ids with the same policy; not sure it's worth doing that refactor now, but I wanted to mention it since we now have the structural setup where doing that refactor would make sense. (I'm imagining we'd construct in Python a dict mapping retention_days_value -> [recipient_ids], and then use that).

Wouldn't this refactoring be in direct conflict with above approach of grouping things per-realm for logging purposes?

> For delete_expired_attachments, if we were to do the per-realm approach suggested above, given realm column for the Attachment with an index, would that mean we could do those as per-realm queries? I think that'd make life a lot easier for tracking down potential performance issues to do smaller per-realm queries.

I don't feel confident touching this, because I'm not sure how exactly linking to attachmens works? I assume the .realm field is set when someone uploads and posts an attachment for the first time, according to the realm where this action happens. Afterwards, other messages can use this attachment - I'm not sure if a message in another realm can do that? If it can, then that complicates things  I think.



The last commit implements deleting some objects in the same query as they're archived - we do that because these objects are guaranteed to be deleted anyway due to their CASCADE property.

