### PR TITLE
draft: Fix draft list not being able to scoll to bottom.

### DIFF
--- a/static/styles/drafts.scss
+++ b/static/styles/drafts.scss
@@ -9,6 +9,8 @@
     overflow: hidden;
     max-width: 1200px;
     max-height: 1000px;
+    display: flex;
+    flex-direction: column;
 }
 
 .drafts-header {
@@ -45,10 +47,8 @@
 }
 
 .drafts-list {
+    padding: 10px 0;
     overflow: auto;
-    height: calc(100% - 55px);
-    width: 100%;
-    margin-top: 15px;
 }
 
 .drafts-list .no-drafts {


### PR DESCRIPTION
Fixes #12552.

This also removes the margin between the header and the draft list

Master | PR
<img src="https://user-images.githubusercontent.com/18504232/59326061-dcd19e00-8d17-11e9-81c9-5886c46036cb.png" width="320"> <img src="https://user-images.githubusercontent.com/18504232/59326063-de02cb00-8d17-11e9-9306-f7bc1460ebe5.png" width="320">