### PR TITLE
Refactor and deduplicate stream notification settings.

### DIFF
--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -54,6 +54,12 @@ const denmark_stream = {
 // We often use IIFEs (immediately invoked function expressions)
 // to make our tests more self-containted.
 
+// Some quick housekeeping:  Let's clear page_params, which is a data
+// structure that the server sends down to us when the app starts.  We
+// prefer to test with a clean slate.
+
+set_global('page_params', {});
+
 zrequire('stream_data');
 set_global('i18n', global.stub_i18n);
 zrequire('settings_display');
@@ -143,13 +149,6 @@ run_test('unread', () => {
 // sender, by PM recipient, by search keywords, etc.  We will discuss
 // narrows more broadly, but first let's test out a core piece of
 // code that makes things work.
-
-
-// Some quick housekeeping:  Let's clear page_params, which is a data
-// structure that the server sends down to us when the app starts.  We
-// prefer to test with a clean slate.
-
-set_global('page_params', {});
 
 // We use the second argument of zrequire to find the location of the
 // Filter class.

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -605,30 +605,30 @@ run_test('notifications', () => {
     stream_data.clear_subscriptions();
     stream_data.add_sub('India', india);
 
-    assert(!stream_data.receives_desktop_notifications('Indiana'));
-    assert(!stream_data.receives_audible_notifications('Indiana'));
+    assert(!stream_data.receives_notifications('Indiana', "desktop_notifications"));
+    assert(!stream_data.receives_notifications('Indiana', "audible_notifications"));
 
     page_params.enable_stream_desktop_notifications = true;
     page_params.enable_stream_audible_notifications = true;
-    assert(stream_data.receives_desktop_notifications('India'));
-    assert(stream_data.receives_audible_notifications('India'));
+    assert(stream_data.receives_notifications('India', "desktop_notifications"));
+    assert(stream_data.receives_notifications('India', "audible_notifications"));
 
     page_params.enable_stream_desktop_notifications = false;
     page_params.enable_stream_audible_notifications = false;
-    assert(!stream_data.receives_desktop_notifications('India'));
-    assert(!stream_data.receives_audible_notifications('India'));
+    assert(!stream_data.receives_notifications('India', "desktop_notifications"));
+    assert(!stream_data.receives_notifications('India', "audible_notifications"));
 
     india.desktop_notifications = true;
     india.audible_notifications = true;
-    assert(stream_data.receives_desktop_notifications('India'));
-    assert(stream_data.receives_audible_notifications('India'));
+    assert(stream_data.receives_notifications('India', "desktop_notifications"));
+    assert(stream_data.receives_notifications('India', "audible_notifications"));
 
     india.desktop_notifications = false;
     india.audible_notifications = false;
     page_params.enable_stream_desktop_notifications = true;
     page_params.enable_stream_audible_notifications = true;
-    assert(!stream_data.receives_desktop_notifications('India'));
-    assert(!stream_data.receives_audible_notifications('India'));
+    assert(!stream_data.receives_notifications('India', "desktop_notifications"));
+    assert(!stream_data.receives_notifications('India', "audible_notifications"));
 });
 
 run_test('is_muted', () => {

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -124,7 +124,7 @@ run_test('update_property', () => {
     with_overrides(function (override) {
         override('stream_list.refresh_pinned_or_unpinned_stream', noop);
         stream_events.update_property(1, 'pin_to_top', true);
-        checkbox = $('#pinstream-1');
+        checkbox = $(".subscription_settings[data-stream-id='1'] #sub_pin_to_top_setting .sub_setting_control");
         assert.equal(checkbox.prop('checked'), true);
     });
 

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -73,25 +73,25 @@ run_test('update_property', () => {
     // Test desktop notifications
     stream_events.update_property(1, 'desktop_notifications', true);
     assert.equal(frontend.desktop_notifications, true);
-    var checkbox = $(".subscription_settings[data-stream-id='1'] #sub_desktop_notifications_setting .sub_setting_control");
+    var checkbox = $("#desktop_notifications_1");
     assert.equal(checkbox.prop('checked'), true);
 
     // Tests audible notifications
     stream_events.update_property(1, 'audible_notifications', true);
     assert.equal(frontend.audible_notifications, true);
-    checkbox = $(".subscription_settings[data-stream-id='1'] #sub_audible_notifications_setting .sub_setting_control");
+    checkbox = $("#audible_notifications_1");
     assert.equal(checkbox.prop('checked'), true);
 
     // Tests push notifications
     stream_events.update_property(1, 'push_notifications', true);
     assert.equal(frontend.push_notifications, true);
-    checkbox = $(".subscription_settings[data-stream-id='1'] #sub_push_notifications_setting .sub_setting_control");
+    checkbox = $("#push_notifications_1");
     assert.equal(checkbox.prop('checked'), true);
 
     // Tests email notifications
     stream_events.update_property(1, 'email_notifications', true);
     assert.equal(frontend.email_notifications, true);
-    checkbox = $(".subscription_settings[data-stream-id='1'] #sub_email_notifications_setting .sub_setting_control");
+    checkbox = $("#email_notifications_1");
     assert.equal(checkbox.prop('checked'), true);
 
     // Test name change
@@ -124,7 +124,7 @@ run_test('update_property', () => {
     with_overrides(function (override) {
         override('stream_list.refresh_pinned_or_unpinned_stream', noop);
         stream_events.update_property(1, 'pin_to_top', true);
-        checkbox = $(".subscription_settings[data-stream-id='1'] #sub_pin_to_top_setting .sub_setting_control");
+        checkbox = $("#pin_to_top_1");
         assert.equal(checkbox.prop('checked'), true);
     });
 

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -19,6 +19,10 @@ zrequire('stream_list');
 zrequire('topic_zoom');
 zrequire('ui');
 set_global('i18n', global.stub_i18n);
+set_global('page_params', {
+    is_admin: false,
+    realm_users: [],
+});
 zrequire('settings_display');
 
 stream_color.initialize();
@@ -33,11 +37,6 @@ set_global('popovers', {});
 
 set_global('keydown_util', {
     handle: noop,
-});
-
-set_global('page_params', {
-    is_admin: false,
-    realm_users: [],
 });
 
 run_test('create_sidebar_row', () => {

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -3,6 +3,7 @@ zrequire('templates');
 zrequire('settings_notifications');
 
 set_global('i18n', global.stub_i18n);
+set_global('page_params', {});
 zrequire('stream_edit');
 
 const { JSDOM } = require("jsdom");
@@ -1268,9 +1269,15 @@ run_test('subscription_settings', () => {
     };
 
     var html = '';
+    page_params.realm_push_notifications_enabled = false;
+    var check_realm_setting = {
+        push_notifications: !page_params.realm_push_notifications_enabled,
+    };
+
     html += render('subscription_settings', {
         sub: sub,
         settings: stream_edit.stream_settings(sub),
+        realm_settings: check_realm_setting,
     });
 
     var div = $(html).find(".subscription-type");

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -3,6 +3,7 @@ zrequire('templates');
 zrequire('settings_notifications');
 
 set_global('i18n', global.stub_i18n);
+zrequire('stream_edit');
 
 const { JSDOM } = require("jsdom");
 const { window } = new JSDOM();
@@ -1267,7 +1268,10 @@ run_test('subscription_settings', () => {
     };
 
     var html = '';
-    html += render('subscription_settings', sub);
+    html += render('subscription_settings', {
+        sub: sub,
+        settings: stream_edit.stream_settings(sub),
+    });
 
     var div = $(html).find(".subscription-type");
     assert(div.text().indexOf('private stream') > 0);

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -453,7 +453,7 @@ function should_send_desktop_notification(message) {
     // For streams, send if desktop notifications are enabled for this
     // stream.
     if (message.type === "stream" &&
-        stream_data.receives_desktop_notifications(message.stream)) {
+        stream_data.receives_notifications(message.stream, "desktop_notifications")) {
         return true;
     }
 
@@ -482,7 +482,7 @@ function should_send_desktop_notification(message) {
 function should_send_audible_notification(message) {
     // For streams, ding if sounds are enabled for this stream.
     if (message.type === "stream" &&
-        stream_data.receives_audible_notifications(message.stream)) {
+        stream_data.receives_notifications(message.stream, "audible_notifications")) {
         return true;
     }
 

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -135,6 +135,7 @@ exports.build_page = function () {
         notification_settings: settings_notifications.all_notifications.settings,
         push_notification_tooltip:
             settings_notifications.all_notifications.push_notification_tooltip,
+        display_settings: settings_display.all_display_settings,
     });
 
     $(".settings-box").html(rendered_settings_tab);

--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -43,6 +43,23 @@ exports.demote_inactive_streams_values = {
     },
 };
 
+exports.all_display_settings = {
+    settings: {
+        user_display_settings: [
+            "dense_mode",
+            "night_mode",
+            "high_contrast_mode",
+            "left_side_userlist",
+            "starred_message_counts",
+            "fluid_layout_width",
+        ],
+    },
+    render_only: {
+        high_contrast_mode: page_params.development_environment,
+        dense_mode: page_params.development_environment,
+    },
+};
+
 exports.set_up = function () {
     meta.loaded = true;
     $("#display-settings-status").hide();

--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -22,12 +22,6 @@ function change_display_setting(data, status_element, success_msg, sticky) {
     settings_ui.do_settings_change(channel.patch, '/json/settings/display', data, status_element, opts);
 }
 
-exports.set_night_mode = function (bool) {
-    var night_mode = bool;
-    var data = {night_mode: JSON.stringify(night_mode)};
-    change_display_setting(data, '#display-settings-status');
-};
-
 exports.demote_inactive_streams_values = {
     automatic: {
         code: 1,
@@ -74,6 +68,22 @@ exports.set_up = function () {
         overlays.close_modal('default_language_modal');
     });
 
+    _.each(exports.all_display_settings.settings.user_display_settings, function (setting) {
+        $("#" + setting).change(function () {
+            var data = {};
+            data[setting] = JSON.stringify($(this).prop('checked'));
+
+            if (["left_side_userlist"].indexOf(setting) > -1) {
+                change_display_setting(
+                    data,
+                    "#display-settings-status",
+                    i18n.t("Saved. Please <a class='reload_link'>reload</a> for the change to take effect."), true);
+            } else {
+                change_display_setting(data, "#display-settings-status");
+            }
+        });
+    });
+
     $("#default_language_modal .language").click(function (e) {
         e.preventDefault();
         e.stopPropagation();
@@ -97,43 +107,13 @@ exports.set_up = function () {
         overlays.open_modal('default_language_modal');
     });
 
-    $("#high_contrast_mode").change(function () {
-        var data = {high_contrast_mode: JSON.stringify(this.checked)};
-        change_display_setting(data, '#display-settings-status');
-    });
-
-    $("#dense_mode").change(function () {
-        var data = {dense_mode: JSON.stringify(this.checked)};
-        change_display_setting(data, '#display-settings-status');
-    });
-
-    $('#starred_message_counts').change(function () {
-        var data = {starred_message_counts: JSON.stringify(this.checked)};
-        change_display_setting(data, '#display-settings-status');
-    });
-
-    $('#fluid_layout_width').change(function () {
-        var data = {fluid_layout_width: JSON.stringify(this.checked)};
-        change_display_setting(data, '#display-settings-status');
-    });
-
     $('#demote_inactive_streams').change(function () {
         var data = {demote_inactive_streams: this.value};
         change_display_setting(data, '#display-settings-status');
     });
 
-    $("#night_mode").change(function () {
-        exports.set_night_mode(this.checked);
-    });
-
     $('body').on('click', '.reload_link', function () {
         window.location.reload();
-    });
-
-    $("#left_side_userlist").change(function () {
-        var data = {left_side_userlist: JSON.stringify(this.checked)};
-        change_display_setting(data, '#display-settings-status',
-                               i18n.t("Saved. Please <a class='reload_link'>reload</a> for the change to take effect."), true);
     });
 
     $("#twenty_four_hour_time").change(function () {

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -289,6 +289,17 @@ exports.update_stream_privacy = function (sub, values) {
     sub.history_public_to_subscribers = values.history_public_to_subscribers;
 };
 
+exports.receives_notifications = function (stream_name, notification_name) {
+    var sub = exports.get_sub(stream_name);
+    if (sub === undefined) {
+        return false;
+    }
+    if (sub[notification_name] !== null) {
+        return sub[notification_name];
+    }
+    return page_params["enable_stream_" + notification_name];
+};
+
 exports.update_calculated_fields = function (sub) {
     sub.is_admin = page_params.is_admin;
     // Admin can change any stream's name & description either stream is public or
@@ -620,28 +631,6 @@ exports.create_sub_from_server_data = function (stream_name, attrs) {
     exports.add_sub(stream_name, sub);
 
     return sub;
-};
-
-exports.receives_desktop_notifications = function (stream_name) {
-    var sub = exports.get_sub(stream_name);
-    if (sub === undefined) {
-        return false;
-    }
-    if (sub.desktop_notifications !== null) {
-        return sub.desktop_notifications;
-    }
-    return page_params.enable_stream_desktop_notifications;
-};
-
-exports.receives_audible_notifications = function (stream_name) {
-    var sub = exports.get_sub(stream_name);
-    if (sub === undefined) {
-        return false;
-    }
-    if (sub.audible_notifications !== null) {
-        return sub.audible_notifications;
-    }
-    return page_params.enable_stream_audible_notifications;
 };
 
 exports.get_streams_for_settings_page = function () {

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -300,6 +300,13 @@ exports.receives_notifications = function (stream_name, notification_name) {
     return page_params["enable_stream_" + notification_name];
 };
 
+var stream_notification_settings = [
+    "desktop_notifications",
+    "audible_notifications",
+    "push_notifications",
+    "email_notifications",
+];
+
 exports.update_calculated_fields = function (sub) {
     sub.is_admin = page_params.is_admin;
     // Admin can change any stream's name & description either stream is public or
@@ -326,26 +333,9 @@ exports.update_calculated_fields = function (sub) {
     exports.update_subscribers_count(sub);
 
     // Apply the defaults for our notification settings for rendering.
-    if (sub.email_notifications === null) {
-        sub.email_notifications_display = page_params.enable_stream_email_notifications;
-    } else {
-        sub.email_notifications_display = sub.email_notifications;
-    }
-    if (sub.push_notifications === null) {
-        sub.push_notifications_display = page_params.enable_stream_push_notifications;
-    } else {
-        sub.push_notifications_display = sub.push_notifications;
-    }
-    if (sub.desktop_notifications === null) {
-        sub.desktop_notifications_display = page_params.enable_stream_desktop_notifications;
-    } else {
-        sub.desktop_notifications_display = sub.desktop_notifications;
-    }
-    if (sub.audible_notifications === null) {
-        sub.audible_notifications_display = page_params.enable_stream_audible_notifications;
-    } else {
-        sub.audible_notifications_display = sub.audible_notifications;
-    }
+    _.each(stream_notification_settings, function (setting) {
+        sub[setting + "_display"] = exports.receives_notifications(sub.name, setting);
+    });
 };
 
 exports.all_subscribed_streams_are_in_home_view = function () {

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -311,6 +311,9 @@ function stream_setting_clicked(e) {
         blueslip.error('undefined sub in stream_setting_clicked()');
         return;
     }
+    if (checkbox.prop('disabled')) {
+        return false;
+    }
     if (exports.is_notification_setting(setting) && sub[setting] === null) {
         sub[setting] = page_params["enable_stream_" + setting];
     }

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -238,6 +238,10 @@ var settings_labels = {
     pin_to_top: i18n.t("Pin stream to top of left sidebar"),
 };
 
+var check_realm_setting = {
+    push_notifications: !page_params.realm_push_notifications_enabled,
+};
+
 exports.stream_settings = function (sub) {
     var settings = [];
     _.each(Object.keys(settings_labels), function (setting) {
@@ -267,6 +271,7 @@ exports.show_settings_for = function (node) {
     var html = templates.render('subscription_settings', {
         sub: sub,
         settings: exports.stream_settings(sub),
+        realm_settings: check_realm_setting,
     });
     ui.get_content_element($('.subscriptions .right .settings')).html(html);
 

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -489,7 +489,7 @@ exports.initialize = function () {
         e.stopPropagation();
     });
 
-    $("#subscriptions_table").on("click", "#sub_setting_is_muted",
+    $("#subscriptions_table").on("click", "#sub_is_muted_setting",
                                  stream_is_muted_clicked);
     $("#subscriptions_table").on("click", "#sub_desktop_notifications_setting",
                                  stream_desktop_notifications_clicked);
@@ -499,7 +499,7 @@ exports.initialize = function () {
                                  stream_push_notifications_clicked);
     $("#subscriptions_table").on("click", "#sub_email_notifications_setting",
                                  stream_email_notifications_clicked);
-    $("#subscriptions_table").on("click", "#sub_pin_setting",
+    $("#subscriptions_table").on("click", "#sub_pin_to_top_setting",
                                  stream_pin_clicked);
 
     $("#subscriptions_table").on("submit", ".subscriber_list_add form", function (e) {

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -222,12 +222,52 @@ function show_subscription_settings(sub_row) {
     });
 }
 
+exports.is_notification_setting = function (setting_label) {
+    if (setting_label.indexOf("_notifications") > -1) {
+        return true;
+    }
+    return false;
+};
+
+var settings_labels = {
+    is_muted: i18n.t("Mute stream"),
+    desktop_notifications: i18n.t("Visual desktop notifications"),
+    audible_notifications: i18n.t("Audible desktop notifications"),
+    push_notifications: i18n.t("Mobile notifications"),
+    email_notifications: i18n.t("Email notifications"),
+    pin_to_top: i18n.t("Pin stream to top of left sidebar"),
+};
+
+exports.stream_settings = function (sub) {
+    var settings = [];
+    _.each(Object.keys(settings_labels), function (setting) {
+        if (exports.is_notification_setting(setting)) {
+            settings.push({
+                name: setting,
+                label: settings_labels[setting],
+                value: sub[setting + "_display"],
+                is_notification_setting: true,
+            });
+        } else {
+            settings.push({
+                name: setting,
+                label: settings_labels[setting],
+                value: sub[setting],
+            });
+        }
+    });
+    return settings;
+};
+
 exports.show_settings_for = function (node) {
     var stream_id = get_stream_id(node);
     var sub = stream_data.get_sub_by_id(stream_id);
 
     stream_data.update_calculated_fields(sub);
-    var html = templates.render('subscription_settings', sub);
+    var html = templates.render('subscription_settings', {
+        sub: sub,
+        settings: exports.stream_settings(sub),
+    });
     ui.get_content_element($('.subscriptions .right .settings')).html(html);
 
     var sub_settings = exports.settings_for_sub(sub);

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -31,7 +31,7 @@ function update_stream_email_notifications(sub, value) {
 }
 
 function update_stream_pin(sub, value) {
-    var pin_checkbox = $('#pinstream-' + sub.stream_id);
+    var pin_checkbox = $(".subscription_settings[data-stream-id='" + sub.stream_id + "'] #sub_pin_to_top_setting .sub_setting_control");
     pin_checkbox.prop('checked', value);
     sub.pin_to_top = value;
 }

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -6,34 +6,10 @@ var exports = {};
 // defaults, however, they are only called after a manual override, so
 // doing so is unnecessary with the current code.  Ideally, we'd do a
 // refactor to address that, however.
-function update_stream_desktop_notifications(sub, value) {
-    var desktop_notifications_checkbox = $(".subscription_settings[data-stream-id='" + sub.stream_id + "'] #sub_desktop_notifications_setting .sub_setting_control");
-    desktop_notifications_checkbox.prop('checked', value);
-    sub.desktop_notifications = value;
-}
-
-function update_stream_audible_notifications(sub, value) {
-    var audible_notifications_checkbox = $(".subscription_settings[data-stream-id='" + sub.stream_id + "'] #sub_audible_notifications_setting .sub_setting_control");
-    audible_notifications_checkbox.prop('checked', value);
-    sub.audible_notifications = value;
-}
-
-function update_stream_push_notifications(sub, value) {
-    var push_notifications_checkbox = $(".subscription_settings[data-stream-id='" + sub.stream_id + "'] #sub_push_notifications_setting .sub_setting_control");
-    push_notifications_checkbox.prop('checked', value);
-    sub.push_notifications = value;
-}
-
-function update_stream_email_notifications(sub, value) {
-    var email_notifications_checkbox = $(".subscription_settings[data-stream-id='" + sub.stream_id + "'] #sub_email_notifications_setting .sub_setting_control");
-    email_notifications_checkbox.prop('checked', value);
-    sub.email_notifications = value;
-}
-
-function update_stream_pin(sub, value) {
-    var pin_checkbox = $(".subscription_settings[data-stream-id='" + sub.stream_id + "'] #sub_pin_to_top_setting .sub_setting_control");
-    pin_checkbox.prop('checked', value);
-    sub.pin_to_top = value;
+function update_stream_setting(sub, value, setting) {
+    var setting_checkbox = $("#" + setting + "_" + sub.stream_id);
+    setting_checkbox.prop("checked", value);
+    sub[setting] = value;
 }
 
 exports.update_property = function (stream_id, property, value, other_values) {
@@ -54,16 +30,10 @@ exports.update_property = function (stream_id, property, value, other_values) {
         stream_muting.update_is_muted(sub, !value);
         break;
     case 'desktop_notifications':
-        update_stream_desktop_notifications(sub, value);
-        break;
     case 'audible_notifications':
-        update_stream_audible_notifications(sub, value);
-        break;
     case 'push_notifications':
-        update_stream_push_notifications(sub, value);
-        break;
     case 'email_notifications':
-        update_stream_email_notifications(sub, value);
+        update_stream_setting(sub, value, property);
         break;
     case 'name':
         subs.update_stream_name(sub, value);
@@ -75,7 +45,7 @@ exports.update_property = function (stream_id, property, value, other_values) {
         sub.email_address = value;
         break;
     case 'pin_to_top':
-        update_stream_pin(sub, value);
+        update_stream_setting(sub, value, property);
         stream_list.refresh_pinned_or_unpinned_stream(sub);
         break;
     case 'invite_only':

--- a/static/js/stream_muting.js
+++ b/static/js/stream_muting.js
@@ -48,7 +48,7 @@ exports.update_is_muted = function (sub, value) {
 
     stream_list.set_in_home_view(sub.stream_id, !sub.is_muted);
 
-    var is_muted_checkbox = $(".subscription_settings[data-stream-id='" + sub.stream_id + "'] #sub_setting_is_muted .sub_setting_control");
+    var is_muted_checkbox = $(".subscription_settings[data-stream-id='" + sub.stream_id + "'] #sub_is_muted_setting .sub_setting_control");
     is_muted_checkbox.prop('checked', value);
 };
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -841,15 +841,6 @@ exports.initialize = function () {
         $(".subscriptions-header").removeClass("slide-left");
     });
 
-    $("#subscriptions_table").on("click", ".sub_setting_checkbox", function (e) {
-        var control = $(e.target).closest('.sub_setting_checkbox').find('.sub_setting_control');
-        // A hack.  Don't change the state of the checkbox if we
-        // clicked on the checkbox itself.
-        if (control[0] !== e.target) {
-            control.prop("checked", !control.prop("checked"));
-        }
-    });
-
     (function defocus_sub_settings() {
         var sel = ".search-container, .streams-list, .subscriptions-header";
 

--- a/static/js/templates.js
+++ b/static/js/templates.js
@@ -75,6 +75,15 @@ Handlebars.registerHelper('unless_a_not_b', function () {
     return options.fn(this);
 });
 
+Handlebars.registerHelper('if_equal', function () {
+    // Execute conditional code if both values are equal
+    var options = arguments[arguments.length - 1];
+    if (arguments[0] === arguments[1]) {
+        return options.fn(this);
+    }
+    return options.inverse(this);
+});
+
 Handlebars.registerHelper('if_not_a_or_b_and_not_c', function () {
     var options = arguments[arguments.length - 1];
     if (arguments[0] === false || arguments[1] === true && arguments[2] === false) {

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -148,6 +148,11 @@
     color: hsl(0, 0%, 64%);
 }
 
+.sub_setting_checkbox .muted-sub label,
+.sub_setting_checkbox .control-label-disabled label {
+    cursor: not-allowed;
+}
+
 .mute-note {
     font-size: 90%;
     opacity: 0.5;

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -144,7 +144,8 @@
     white-space: normal;
 }
 
-.muted-sub {
+.muted-sub,
+.control-label-disabled {
     color: hsl(0, 0%, 64%);
 }
 

--- a/static/templates/settings/display-settings.handlebars
+++ b/static/templates/settings/display-settings.handlebars
@@ -23,39 +23,13 @@
             <h3 class="inline-block">{{t "Display settings" }}</h3>
             <div class="alert-notification" id="display-settings-status"></div>
 
-            {{#if page_params.development_environment}}
+            {{#each display_settings.settings.user_display_settings}}
             {{partial "settings_checkbox"
-              "setting_name" "dense_mode"
-              "is_checked" page_params.dense_mode
-              "label" settings_label.dense_mode}}
-            {{/if}}
-
-            {{partial "settings_checkbox"
-              "setting_name" "night_mode"
-              "is_checked" page_params.night_mode
-              "label" settings_label.night_mode}}
-
-            {{#if page_params.development_environment}}
-            {{partial "settings_checkbox"
-              "setting_name" "high_contrast_mode"
-              "is_checked" page_params.high_contrast_mode
-              "label" settings_label.high_contrast_mode}}
-            {{/if}}
-
-            {{partial "settings_checkbox"
-              "setting_name" "left_side_userlist"
-              "is_checked" page_params.left_side_userlist
-              "label" settings_label.left_side_userlist}}
-
-            {{partial "settings_checkbox"
-              "setting_name" "starred_message_counts"
-              "is_checked" page_params.starred_message_counts
-              "label" settings_label.starred_message_counts}}
-
-            {{partial "settings_checkbox"
-              "setting_name" "fluid_layout_width"
-              "is_checked" page_params.fluid_layout_width
-              "label" settings_label.fluid_layout_width}}
+              "setting_name" this
+              "is_checked" (lookup ../page_params this)
+              "label" (lookup ../settings_label this)
+              "render_only" (lookup ../display_settings.render_only this)}}
+            {{/each}}
 
             <div class="input-group">
                 <label for="demote_inactive_streams" class="dropdown-title">{{t "Demote inactive streams" }}

--- a/static/templates/settings/settings_checkbox.handlebars
+++ b/static/templates/settings/settings_checkbox.handlebars
@@ -1,3 +1,5 @@
+{{#is_false render_only}}
+{{else}}
 <div class="input-group {{#if is_nested}}disableable{{/if}} {{#if_not_a_or_b_and_not_c is_parent_setting_enabled push_notifications_tooltip realm_push_notifications_enabled}}control-label-disabled{{/if_not_a_or_b_and_not_c}}">
     <label class="checkbox">
         <input type="checkbox" class="inline-block setting-widget prop-element" name="{{setting_name}}" data-setting-widget-type="bool"
@@ -18,3 +20,4 @@
       title="{{t 'Mobile push notifications are not configured on this server.' }}"></i>
     {{/if}}
 </div>
+{{/is_false}}

--- a/static/templates/stream-settings-checkbox.handlebars
+++ b/static/templates/stream-settings-checkbox.handlebars
@@ -1,7 +1,13 @@
-<div id="{{prefix}}{{setting_name}}{{suffix}}" class="sub_setting_checkbox {{#if notification_setting}}sub_notification_setting {{#if is_muted}}muted-sub{{/if}}{{/if}}">
-    <input id="{{setting_name}}_{{stream_id}}" name="{{setting_name}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if is_checked}}checked{{/if}} {{#if_and is_muted notification_setting}}disabled="disabled"{{/if_and}}/>
+{{!-- If setting is disabled on realm level, then render setting as control-label-disabled and do not set setting value. Setting status should not change on any click handler, as it is disabled at realm level. --}}
+<div id="{{prefix}}{{setting_name}}{{suffix}}" class="sub_setting_checkbox {{#unless realm_setting_disabled}}{{#if notification_setting}}sub_notification_setting {{#if is_muted}}muted-sub{{/if}}{{/if}}{{else}}control-label-disabled{{/unless}}">
+    <input id="{{setting_name}}_{{stream_id}}" name="{{setting_name}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#unless realm_setting_disabled}}{{#if is_checked}}checked{{/if}}{{#if_and is_muted notification_setting}}disabled="disabled"{{/if_and}}{{else}}disabled="disabled"{{/unless}} />
     <label class="subscription-control-label">{{label}}</label>
+
+    {{!-- Tooltips for settings --}}
     {{#if_equal setting_name "is_muted"}}
     <p class="mute-note {{#unless is_muted}}hide-mute-note{{/unless}}">{{t "Muted streams don't show up in \"All messages\" or generate notifications unless you are mentioned." }}</p>
+    {{/if_equal}}
+    {{#if_equal setting_name "push_notifications"}}
+    <i class="fa fa-question-circle settings-info-icon {{#unless realm_setting_disabled}}hide{{/unless}}" data-toggle="tooltip" title="{{t 'Mobile push notifications are not configured on this server.' }}"></i>
     {{/if_equal}}
 </div>

--- a/static/templates/stream-settings-checkbox.handlebars
+++ b/static/templates/stream-settings-checkbox.handlebars
@@ -1,0 +1,7 @@
+<div id="{{prefix}}{{setting_name}}{{suffix}}" class="sub_setting_checkbox {{#if notification_setting}}sub_notification_setting {{#if is_muted}}muted-sub{{/if}}{{/if}}">
+    <input id="{{setting_name}}_{{stream_id}}" name="{{setting_name}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if is_checked}}checked{{/if}} {{#if_and is_muted notification_setting}}disabled="disabled"{{/if_and}}/>
+    <label class="subscription-control-label">{{label}}</label>
+    {{#if_equal setting_name "is_muted"}}
+    <p class="mute-note {{#unless is_muted}}hide-mute-note{{/unless}}">{{t "Muted streams don't show up in \"All messages\" or generate notifications unless you are mentioned." }}</p>
+    {{/if_equal}}
+</div>

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -59,6 +59,7 @@
                           "is_muted" (lookup ../sub "is_muted")
                           "stream_id" (lookup ../sub "stream_id")
                           "notification_setting" is_notification_setting
+                          "realm_setting_disabled" (lookup ../realm_settings name)
                           "label" label}}
                     </li>
                     {{/each}}

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -49,7 +49,7 @@
             <div class="subscription-config">
                 <ul class="grey-box">
                     <li>
-                        <div id="sub_setting_is_muted" class="sub_setting_checkbox sub-mute-setting">
+                        <div id="sub_is_muted_setting" class="sub_setting_checkbox sub-mute-setting">
                             <input id="mutestream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if is_muted}}checked{{/if}} />
                             <label class="subscription-control-label">{{t "Mute stream" }}</label>
                             <p class="mute-note {{#unless is_muted}}hide-mute-note{{/unless}}">{{t "Muted streams don't show up in \"All messages\" or generate notifications unless you are mentioned." }}</p>
@@ -84,7 +84,7 @@
                         </div>
                     </li>
                     <li>
-                        <div id="sub_pin_setting" class="sub_setting_checkbox">
+                        <div id="sub_pin_to_top_setting" class="sub_setting_checkbox">
                             <input id="pinstream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if pin_to_top}}checked{{/if}} />
                             <label class="subscription-control-label">{{t "Pin stream to top of left sidebar" }}</label>
                         </div>

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -1,7 +1,7 @@
-{{#with this}}
-<div class="subscription_settings" data-stream-id="{{stream_id}}">
+<div class="subscription_settings" data-stream-id="{{sub.stream_id}}">
     <div class="inner-box">
         <div class="alert stream_change_property_info"></div>
+        {{#with sub}}
         <div class="stream-header">
             {{#if invite_only}}
             <div class="large-icon lock" style="color: {{color}}">
@@ -45,68 +45,42 @@
             </div>
             <a class="change-stream-privacy" {{#unless can_change_stream_permissions}}style="display: none;"{{/unless}}>[{{t "Change" }}]</a>
         </div>
-        <div class="regular_subscription_settings collapse {{#subscribed}}in{{/subscribed}}">
+        {{/with}}
+        <div class="regular_subscription_settings collapse {{#sub.subscribed}}in{{/sub.subscribed}}">
             <div class="subscription-config">
                 <ul class="grey-box">
+                    {{#each settings}}
                     <li>
-                        <div id="sub_is_muted_setting" class="sub_setting_checkbox sub-mute-setting">
-                            <input id="is_muted_{{stream_id}}" name="is_muted" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if is_muted}}checked{{/if}} />
-                            <label class="subscription-control-label">{{t "Mute stream" }}</label>
-                            <p class="mute-note {{#unless is_muted}}hide-mute-note{{/unless}}">{{t "Muted streams don't show up in \"All messages\" or generate notifications unless you are mentioned." }}</p>
-                        </div>
+                        {{partial "stream-settings-checkbox"
+                          "setting_name" name
+                          "prefix" "sub_"
+                          "suffix" "_setting"
+                          "is_checked" value
+                          "is_muted" (lookup ../sub "is_muted")
+                          "stream_id" (lookup ../sub "stream_id")
+                          "notification_setting" is_notification_setting
+                          "label" label}}
                     </li>
-                    <li>
-                        <div id="sub_desktop_notifications_setting"
-                          class="sub_setting_checkbox sub_notification_setting {{#if is_muted}}muted-sub{{/if}}">
-                            <input id="desktop_notifications_{{stream_id}}" name="desktop_notifications" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if desktop_notifications_display}}checked{{/if}} {{#if is_muted}}disabled="disabled"{{/if}}/>
-                            <label class="subscription-control-label">{{t "Visual desktop notifications" }}</label>
-                        </div>
-                    </li>
-                    <li>
-                        <div id="sub_audible_notifications_setting"
-                          class="sub_setting_checkbox sub_notification_setting {{#if is_muted}}muted-sub{{/if}}">
-                            <input id="audible_notifications_{{stream_id}}" name="audible_notifications" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if audible_notifications_display}}checked{{/if}} {{#if is_muted}}disabled="disabled"{{/if}}/>
-                            <label class="subscription-control-label">{{t "Audible desktop notifications" }}</label>
-                        </div>
-                    </li>
-                    <li>
-                        <div id="sub_push_notifications_setting"
-                          class="sub_setting_checkbox sub_notification_setting {{#if is_muted}}muted-sub{{/if}}">
-                            <input id="push_notifications_{{stream_id}}" name="push_notifications" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if push_notifications_display}}checked{{/if}} {{#if is_muted}}disabled="disabled"{{/if}}/>
-                            <label class="subscription-control-label">{{t "Mobile notifications" }}</label>
-                        </div>
-                    </li>
-                    <li>
-                        <div id="sub_email_notifications_setting"
-                          class="sub_setting_checkbox sub_notification_setting {{#if is_muted}}muted-sub{{/if}}">
-                            <input id="email_notifications_{{stream_id}}" name="email_notifications" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if email_notifications_display}}checked{{/if}} {{#if is_muted}}disabled="disabled"{{/if}}/>
-                            <label class="subscription-control-label">{{t "Email notifications" }}</label>
-                        </div>
-                    </li>
-                    <li>
-                        <div id="sub_pin_to_top_setting" class="sub_setting_checkbox">
-                            <input id="pin_to_top_{{stream_id}}" name="pin_to_top" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if pin_to_top}}checked{{/if}} />
-                            <label class="subscription-control-label">{{t "Pin stream to top of left sidebar" }}</label>
-                        </div>
-                    </li>
+                    {{/each}}
                     <li>
                         <label for="streamcolor" class="subscription-control-label">{{t "Stream color" }}</label>
                         <span class="sub_setting_control">
-                            <input stream_id="{{stream_id}}" class="colorpicker" id="streamcolor" type="text" value="{{color}}" tabindex="-1" />
+                            <input stream_id="{{sub.stream_id}}" class="colorpicker" id="streamcolor" type="text" value="{{sub.color}}" tabindex="-1" />
                         </span>
                     </li>
                 </ul>
             </div>
-            <div class="stream-email-box" {{#unless email_address}}style="display: none;"{{/unless}}>
+            <div class="stream-email-box" {{#unless sub.email_address}}style="display: none;"{{/unless}}>
                 <div class="sub_settings_title">{{t "Email address" }} <i class="fa fa-question-circle stream-email-hint" aria-hidden="true"></i></div>
                 <div class="stream-email">
-                    <span class="email-address">{{email_address}}</span>
+                    <span class="email-address">{{sub.email_address}}</span>
                 </div>
             </div>
         </div>
+        {{#with sub}}
         <div class="subscription-members-setting">
             {{partial "subscription_members"}}
         </div>
+        {{/with}}
     </div>
 </div>
-{{/with}}

--- a/static/templates/subscription_settings.handlebars
+++ b/static/templates/subscription_settings.handlebars
@@ -50,7 +50,7 @@
                 <ul class="grey-box">
                     <li>
                         <div id="sub_is_muted_setting" class="sub_setting_checkbox sub-mute-setting">
-                            <input id="mutestream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if is_muted}}checked{{/if}} />
+                            <input id="is_muted_{{stream_id}}" name="is_muted" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if is_muted}}checked{{/if}} />
                             <label class="subscription-control-label">{{t "Mute stream" }}</label>
                             <p class="mute-note {{#unless is_muted}}hide-mute-note{{/unless}}">{{t "Muted streams don't show up in \"All messages\" or generate notifications unless you are mentioned." }}</p>
                         </div>
@@ -58,34 +58,34 @@
                     <li>
                         <div id="sub_desktop_notifications_setting"
                           class="sub_setting_checkbox sub_notification_setting {{#if is_muted}}muted-sub{{/if}}">
-                            <input id="desktop-notifystream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if desktop_notifications_display}}checked{{/if}} {{#if is_muted}}disabled="disabled"{{/if}}/>
+                            <input id="desktop_notifications_{{stream_id}}" name="desktop_notifications" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if desktop_notifications_display}}checked{{/if}} {{#if is_muted}}disabled="disabled"{{/if}}/>
                             <label class="subscription-control-label">{{t "Visual desktop notifications" }}</label>
                         </div>
                     </li>
                     <li>
                         <div id="sub_audible_notifications_setting"
                           class="sub_setting_checkbox sub_notification_setting {{#if is_muted}}muted-sub{{/if}}">
-                            <input id="audible-notifystream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if audible_notifications_display}}checked{{/if}} {{#if is_muted}}disabled="disabled"{{/if}}/>
+                            <input id="audible_notifications_{{stream_id}}" name="audible_notifications" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if audible_notifications_display}}checked{{/if}} {{#if is_muted}}disabled="disabled"{{/if}}/>
                             <label class="subscription-control-label">{{t "Audible desktop notifications" }}</label>
                         </div>
                     </li>
                     <li>
                         <div id="sub_push_notifications_setting"
                           class="sub_setting_checkbox sub_notification_setting {{#if is_muted}}muted-sub{{/if}}">
-                            <input id="push-notifystream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if push_notifications_display}}checked{{/if}} {{#if is_muted}}disabled="disabled"{{/if}}/>
+                            <input id="push_notifications_{{stream_id}}" name="push_notifications" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if push_notifications_display}}checked{{/if}} {{#if is_muted}}disabled="disabled"{{/if}}/>
                             <label class="subscription-control-label">{{t "Mobile notifications" }}</label>
                         </div>
                     </li>
                     <li>
                         <div id="sub_email_notifications_setting"
                           class="sub_setting_checkbox sub_notification_setting {{#if is_muted}}muted-sub{{/if}}">
-                            <input id="email-notifystream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if email_notifications_display}}checked{{/if}} {{#if is_muted}}disabled="disabled"{{/if}}/>
+                            <input id="email_notifications_{{stream_id}}" name="email_notifications" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if email_notifications_display}}checked{{/if}} {{#if is_muted}}disabled="disabled"{{/if}}/>
                             <label class="subscription-control-label">{{t "Email notifications" }}</label>
                         </div>
                     </li>
                     <li>
                         <div id="sub_pin_to_top_setting" class="sub_setting_checkbox">
-                            <input id="pinstream-{{stream_id}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if pin_to_top}}checked{{/if}} />
+                            <input id="pin_to_top_{{stream_id}}" name="pin_to_top" class="sub_setting_control" type="checkbox" tabindex="-1" {{#if pin_to_top}}checked{{/if}} />
                             <label class="subscription-control-label">{{t "Pin stream to top of left sidebar" }}</label>
                         </div>
                     </li>

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -70,9 +70,7 @@ enforce_fully_covered = {
     # 'static/js/settings_ui.js',
     'static/js/settings_muting.js',
     'static/js/settings_user_groups.js',
-    # Removed because of an intermediate state of the subscription
-    # notifications migration.
-    # 'static/js/stream_data.js',
+    'static/js/stream_data.js',
     'static/js/stream_events.js',
     'static/js/stream_sort.js',
     'static/js/top_left_corner.js',


### PR DESCRIPTION
* Rename notification property `enable_stream_sounds` to
`enable_stream_audible_notifications` to match with other
notification property patterns.

Fixes part of #12304

Tested manually with stream notification settings.