### PR TITLE
Left sidebar add streams

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -150,7 +150,12 @@ li.show-more-topics a {
 }
 
 #add-stream-link i {
-    margin-right: 5px;
+    min-width: 19px;
+    text-align: center;
+}
+
+#add-stream-link i::before {
+    padding-right: 3px;
 }
 
 ul.filters {

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -125,6 +125,10 @@ li.show-more-topics a {
     width: 100%;
 }
 
+#stream-filters-container .simplebar-content {
+    margin-bottom: 18px;
+}
+
 #private-container {
     max-height: 200px;
 }


### PR DESCRIPTION
- **First commit** fixes: #12519. I added the `margin-bottom` on the container of streams and the add stream button so that, if another element is added there, this problem will not occur again.
- **Second commit** centers the `+` icon of the `Add streams` button and aligns the text with the stream names. I used the same styles as for the `#`s.

**Screenshots:**
Bottom margin: 
<img src="https://user-images.githubusercontent.com/18381652/59362871-832b9c80-8d34-11e9-9e08-0422e0424676.png" width="250px"><img src="https://user-images.githubusercontent.com/18381652/59362866-8161d900-8d34-11e9-810e-68fc34c8c162.png" width="250px">

Centering:
Before changes:![Screen Shot 2019-06-12 at 16 45 29](https://user-images.githubusercontent.com/18381652/59362477-cc2f2100-8d33-11e9-9772-4976f7395520.png)
After changes:![Screen Shot 2019-06-12 at 16 45 52](https://user-images.githubusercontent.com/18381652/59362471-c89b9a00-8d33-11e9-8b06-d605a2e63277.png)

