### PR TITLE
Removed duplicate line

### DIFF
--- a/docs/contributing/version-control.md
+++ b/docs/contributing/version-control.md
@@ -112,8 +112,6 @@ Compare "*gather_subscriptions: Fix exception handling bad input.*" with:
   tell from the summary what part of the code is affected
 * "*gather_subscriptions: Fixing exception when given bad input.*",
   not in the imperative
-* "*gather_subscriptions: Fixed exception when given bad input.*",
-  not in the imperative
 
 The summary is followed by a blank line, and then the body of the
 commit message.


### PR DESCRIPTION
Removed a duplicate line under the header 'Good summaries'.
This is a documentation fix.
I felt that raising an issue is not important since this is a very minor fix and there is no logical reason to keep a duplicate line there.

