### PR TITLE
version: Fail gracefully if git describe cannot get version.

### DIFF
--- a/tools/cache-zulip-git-version
+++ b/tools/cache-zulip-git-version
@@ -2,4 +2,4 @@
 set -e
 
 cd "$(dirname "$0")/.."
-git describe --tags > zulip-git-version
+git describe --tags > zulip-git-version || true


### PR DESCRIPTION
When running the `./tools/cache-zulip-git-version` script on Travis, the script
fails because Travis gets a shallow clone of the repository, and not a full
clone. This commit changes the script to fail gracefully, if we are unable to
get the version information using `git describe`.