### PR TITLE
narrow: Window title shows user's name, in private message narrows.

### DIFF
--- a/frontend_tests/casper_tests/03-narrow.js
+++ b/frontend_tests/casper_tests/03-narrow.js
@@ -300,7 +300,7 @@ casper.thenClick('.top_left_private_messages a');
 
 expect_all_pm();
 
-casper.then(check_narrow_title('private - Zulip Dev - Zulip'));
+casper.then(check_narrow_title('Private messages - Zulip Dev - Zulip'));
 
 un_narrow();
 

--- a/frontend_tests/casper_tests/03-narrow.js
+++ b/frontend_tests/casper_tests/03-narrow.js
@@ -245,7 +245,7 @@ casper.then(function () {
 
 expect_huddle();
 
-casper.then(check_narrow_title('private - Zulip Dev - Zulip'));
+casper.then(check_narrow_title('Cordelia Lear, King Hamlet - Zulip Dev - Zulip'));
 
 casper.then(function () {
     // Un-narrow by clicking "Zulip"
@@ -261,7 +261,7 @@ search_and_check('Verona', 'Stream', expect_stream,
                  'Verona - Zulip Dev - Zulip');
 
 search_and_check('Cordelia', 'Private', expect_1on1,
-                 'private - Zulip Dev - Zulip');
+                 'Cordelia Lear - Zulip Dev - Zulip');
 
 // Test operators
 search_and_check('stream:Verona', '', expect_stream,

--- a/frontend_tests/casper_tests/14-drafts.js
+++ b/frontend_tests/casper_tests/14-drafts.js
@@ -148,7 +148,7 @@ casper.then(function () {
             content: 'Test Private Message',
         }, "Private message box filled with draft content");
         common.pm_recipient.expect('cordelia@zulip.com,hamlet@zulip.com');
-        casper.test.assertSelectorHasText('title', 'private - Zulip Dev - Zulip', 'Narrowed to huddle');
+        casper.test.assertSelectorHasText('title', 'Cordelia Lear, King Hamlet - Zulip Dev - Zulip', 'Narrowed to huddle');
     });
 });
 

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -89,10 +89,14 @@ exports.activate = function (raw_operators, opts) {
         }
     } else if (filter.has_operator("is")) {
         exports.narrow_title = filter.operands("is")[0];
-    } else if (filter.has_operator("pm-with")) {
-        exports.narrow_title = "private";
-    } else if (filter.has_operator("group-pm-with")) {
-        exports.narrow_title = "private group";
+    } else if (filter.has_operator("pm-with") || filter.has_operator("group-pm-with")) {
+        var emails = filter.public_operators()[0].operand;
+        var names = people.get_recipients(people.emails_strings_to_user_ids_string(emails));
+        if (filter.has_operator("pm-with")) {
+            exports.narrow_title = names;
+        } else {
+            exports.narrow_title = names + " and others";
+        }
     }
 
     notifications.redraw_title();

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -88,7 +88,9 @@ exports.activate = function (raw_operators, opts) {
             exports.narrow_title = filter.operands("stream")[0];
         }
     } else if (filter.has_operator("is")) {
-        exports.narrow_title = filter.operands("is")[0];
+        var title = filter.operands("is")[0];
+        title = title.charAt(0).toUpperCase() + title.slice(1) + " messages";
+        exports.narrow_title = title;
     } else if (filter.has_operator("pm-with") || filter.has_operator("group-pm-with")) {
         var emails = filter.public_operators()[0].operand;
         var names = people.get_recipients(people.emails_strings_to_user_ids_string(emails));


### PR DESCRIPTION
Modified by punchagan to correctly handle narrowing to huddles, and to fix a
couple of tests.

Closes #5876

Supersedes #8532