### PR TITLE
docs: Add a comment explaining the fancy conditional-include syntax.

### DIFF
--- a/docs/production/install.md
+++ b/docs/production/install.md
@@ -30,6 +30,12 @@ using code from our [repository on GitHub](https://github.com/zulip/zulip/).
 
 ## Step 2: Install Zulip
 
+<!---
+  The `.. only:: unreleased` syntax invokes an rST "directive"
+  called `only`, defined by Sphinx:
+    https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#including-content-based-on-tags
+  It's controlled by `docs/conf.py` through the `tags` object.
+-->
 ```eval_rst
 .. only:: unreleased
 


### PR DESCRIPTION
We only use it in this one place, so a comment right here seems the
most discoverable place to put it.  If we started using it more...
probably the section in docs/documentation/overview.md about the
dev/sysadmin docs system should split off into a new file, and this
info would become a subsection there.
