### PR TITLE
12591 fix linkifier settings page example

### DIFF
--- a/static/templates/settings/linkifier-settings-admin.handlebars
+++ b/static/templates/settings/linkifier-settings-admin.handlebars
@@ -31,7 +31,7 @@
             <li>
                 <code>(?P&lt;org&gt;[a-zA-Z0-9_-]+)/(?P&lt;repo&gt;[a-zA-Z0-9_-]+)#(?P&lt;id&gt;[0-9]+)</code>
                 {{t "and" }}
-                <code>https://github.com/%(org)s/%(repo)s/commit/%(id)s</code>
+                <code>https://github.com/%(org)s/%(repo)s/issues/%(id)s</code>
             </li>
         </ul>
         <p>


### PR DESCRIPTION
Linkifier settings page example crosses wires with GitHub commit hashes / issues IDs

Fixes #12591

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
