### PR TITLE
message_view: Add unread divider in message list.

### DIFF
--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -8,6 +8,7 @@ zrequire('FetchStatus', 'js/fetch_status');
 zrequire('MessageListData', 'js/message_list_data');
 zrequire('MessageListView', 'js/message_list_view');
 zrequire('message_list');
+zrequire('stream_data');
 
 const noop = function () {};
 
@@ -160,6 +161,18 @@ run_test('merge_message_groups', () => {
         list.list = {
             unsubscribed_bookend_content: function () {},
             subscribed_bookend_content: function () {},
+            data: new MessageListData({filter: new Filter([
+                {
+                    negated: false,
+                    operator: 'stream',
+                    operand: 'Test Stream 1',
+                },
+                {
+                    negated: false,
+                    operator: 'topic',
+                    operand: 'Test Subject 1',
+                },
+            ])}),
         };
         return list;
     }

--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -27,6 +27,12 @@ set_global('timerender', {
         }
         return [{outerHTML: String(time1.getTime()) + ' - ' + String(time2.getTime())}];
     },
+    render_now: function (time) {
+        // The render_now function actually takes two parameters
+        // But for the sake of this test, one's enough since the
+        // other parameter is just the refernce date (mostly "today")
+        return {time_str: time};
+    },
     stringify_time: function (time) {
         if (page_params.twenty_four_hour_time) {
             return time.toString('HH:mm');
@@ -318,7 +324,7 @@ run_test('merge_message_groups', () => {
         assert.deepEqual(result.rerender_groups, []);
         assert.deepEqual(result.append_messages, [message2]);
         assert.deepEqual(result.rerender_messages_next_same_sender, [message1]);
-        assert(list._message_groups[0].message_containers[1].want_date_divider);
+        assert(list._message_groups[0].message_containers[1].want_divider);
     }());
 
     (function test_append_message_historical() {
@@ -471,9 +477,14 @@ run_test('merge_message_groups', () => {
         const result = list.merge_message_groups([message_group2], 'top');
 
         // We should have a group date divider within the single recipient block.
-        assert.equal(
-            message_group2.message_containers[1].date_divider_html,
-            '900000000 - 1000000');
+        assert.deepEqual(
+            message_group2.message_containers[1].divider_properties,
+            {
+                unread_marker: false,
+                time_above: new XDate(1000000),
+                time_below: new XDate(900000000),
+            }
+        );
         assert_message_groups_list_equal(
             list._message_groups,
             [message_group2]);

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -191,6 +191,17 @@ function update_unread_messages_divider(opts) {
     clear_unread_messages_divider(curr_msg_container);
 }
 
+function clear_message_divider(msg) {
+    clear_message_date_divider(msg);
+    clear_unread_messages_divider(msg);
+}
+
+function update_message_divider(opts) {
+    update_message_date_divider(opts);
+    // Unread messages divider should be updated once the date divider has been updated
+    update_unread_messages_divider(opts);
+}
+
 function set_timestr(message_container) {
     const time = new XDate(message_container.msg.timestamp * 1000);
     message_container.timestr = timerender.stringify_time(time);
@@ -353,11 +364,7 @@ MessageListView.prototype = {
             if (same_recipient(prev, message_container) && self.collapse_messages &&
                 prev.msg.historical === message_container.msg.historical) {
                 add_message_container_to_group(message_container);
-                update_message_date_divider({
-                    prev_msg_container: prev,
-                    curr_msg_container: message_container,
-                });
-                update_unread_messages_divider({
+                update_message_divider({
                     list: self.list,
                     prev_msg_container: prev,
                     curr_msg_container: message_container,
@@ -368,7 +375,7 @@ MessageListView.prototype = {
                 add_message_container_to_group(message_container);
 
                 update_group_date_divider(current_group, message_container, prev);
-                clear_message_date_divider(message_container);
+                clear_message_divider(message_container);
 
                 message_container.include_recipient = true;
                 message_container.subscribed = false;
@@ -507,18 +514,13 @@ MessageListView.prototype = {
 
         const was_joined = this.join_message_groups(first_group, second_group);
         if (was_joined) {
-            update_message_date_divider({
-                prev_msg_container: prev_msg_container,
-                curr_msg_container: curr_msg_container,
-            });
-            update_unread_messages_divider({
+            update_message_divider({
                 prev_msg_container: prev_msg_container,
                 curr_msg_container: curr_msg_container,
                 list: self.list,
             });
         } else {
-            clear_message_date_divider(curr_msg_container);
-            clear_unread_messages_divider(curr_msg_container);
+            clear_message_divider(curr_msg_container);
         }
 
         if (where === 'top') {

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -597,6 +597,17 @@ on a dark background, and don't change the dark labels dark either. */
         opacity: 0.2;
     }
 
+    .date_row.unread_divider span {
+        $UNREAD_DIVIDER_COLOR: hsl(0, 64%, 59%);
+
+        &::after,
+        &::before {
+            opacity: 1;
+            border-top-color: $UNREAD_DIVIDER_COLOR;
+            border-bottom-color: transparent;
+        }
+    }
+
     .star:not(.empty-star),
     .empty-star:hover {
         color: hsla(126, 66%, 72%, 0.75);

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -968,6 +968,10 @@ td.pointer {
     z-index: 1;
     bottom: 1px;
     transition: all 0.3s ease-out;
+
+    &.with_divider {
+        top: 28px;
+    }
 }
 
 .unread-marker-fill {
@@ -2316,6 +2320,25 @@ div.topic_edit_spinner .loading_indicator_spinner {
 .date_row span::after {
     left: 0.5em;
     margin-right: -50%;
+}
+
+.date_row.unread_divider {
+    $UNREAD_DIVIDER_COLOR: hsl(0, 64%, 59%);
+
+    span {
+        opacity: 1;
+        color: $UNREAD_DIVIDER_COLOR;
+
+        &::after,
+        &::before {
+            border-top-color: $UNREAD_DIVIDER_COLOR;
+        }
+
+        .date-line {
+            width: 20%;
+            border-top-color: $UNREAD_DIVIDER_COLOR;
+        }
+    }
 }
 
 .include-sender .message_edit {

--- a/static/templates/message_divider.hbs
+++ b/static/templates/message_divider.hbs
@@ -1,0 +1,19 @@
+<div class="date_row no-select{{#if divider_properties.unread_marker}} unread_divider{{/if}}" {{#if msg/is_stream}}style="box-shadow: inset 2px 0px 0px 0px {{background_color}}, -1px 0px 0px 0px {{background_color}};"{{/if}}>
+    <span>
+        {{#if divider_properties.time_above}}
+        <i class="date-direction fa fa-caret-up"></i>
+        {{{divider_properties.time_above}}}
+        <hr class="date-line">
+        {{/if}}
+        {{#if divider_properties.unread_marker}}
+            NEW MESSAGES
+            {{#if divider_properties.time_below}}
+            <hr class="date-line">
+            {{/if}}
+        {{/if}}
+        {{#if divider_properties.time_below}}
+        <i class="date-direction fa fa-caret-down"></i>
+        {{{divider_properties.time_below}}}
+        {{/if}}
+    </span>
+</div>

--- a/static/templates/single_message.hbs
+++ b/static/templates/single_message.hbs
@@ -1,11 +1,9 @@
 <div zid="{{msg/id}}" id="{{table_name}}{{msg/id}}"
   class="message_row{{^msg/is_stream}} private-message{{/msg/is_stream}}{{#include_sender}} include-sender{{/include_sender}}{{#contains_mention}} mention{{/contains_mention}}{{#include_footer}} last_message{{/include_footer}}{{#msg.unread}} unread{{/msg.unread}} {{#if msg.locally_echoed}}local{{/if}} selectable_row"
   role="listitem">
-    <div class="unread_marker{{#if want_unread_divider}} with_divider{{/if}}"><div class="unread-marker-fill"></div></div>
-    {{#if want_unread_divider}}
-    <div class="unread_divider date_row no-select" {{#if msg/is_stream}}style="box-shadow: inset 2px 0px 0px 0px {{background_color}}, -1px 0px 0px 0px {{background_color}};"{{/if}}>{{{unread_divider_html}}}</div>
-    {{else if want_date_divider}}
-    <div class="date_row no-select" {{#if msg/is_stream}}style="box-shadow: inset 2px 0px 0px 0px {{background_color}}, -1px 0px 0px 0px {{background_color}};"{{/if}}>{{{date_divider_html}}}</div>
+    <div class="unread_marker{{#if divider_properties.unread_marker}} with_divider{{/if}}"><div class="unread-marker-fill"></div></div>
+    {{#if want_divider}}
+    {{> "message_divider"}}
     {{/if}}
     <div class="messagebox {{#if next_is_same_sender}}next_is_same_sender{{/if}}"
       {{#if msg/is_stream}}style="box-shadow: inset 2px 0px 0px 0px {{background_color}}, -1px 0px 0px 0px {{background_color}};"{{/if}}>

--- a/static/templates/single_message.hbs
+++ b/static/templates/single_message.hbs
@@ -1,8 +1,10 @@
 <div zid="{{msg/id}}" id="{{table_name}}{{msg/id}}"
   class="message_row{{^msg/is_stream}} private-message{{/msg/is_stream}}{{#include_sender}} include-sender{{/include_sender}}{{#contains_mention}} mention{{/contains_mention}}{{#include_footer}} last_message{{/include_footer}}{{#msg.unread}} unread{{/msg.unread}} {{#if msg.locally_echoed}}local{{/if}} selectable_row"
   role="listitem">
-    <div class="unread_marker"><div class="unread-marker-fill"></div></div>
-    {{#if want_date_divider}}
+    <div class="unread_marker{{#if want_unread_divider}} with_divider{{/if}}"><div class="unread-marker-fill"></div></div>
+    {{#if want_unread_divider}}
+    <div class="unread_divider date_row no-select" {{#if msg/is_stream}}style="box-shadow: inset 2px 0px 0px 0px {{background_color}}, -1px 0px 0px 0px {{background_color}};"{{/if}}>{{{unread_divider_html}}}</div>
+    {{else if want_date_divider}}
     <div class="date_row no-select" {{#if msg/is_stream}}style="box-shadow: inset 2px 0px 0px 0px {{background_color}}, -1px 0px 0px 0px {{background_color}};"{{/if}}>{{{date_divider_html}}}</div>
     {{/if}}
     <div class="messagebox {{#if next_is_same_sender}}next_is_same_sender{{/if}}"

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -666,6 +666,7 @@ html_rules = whitespace_rules + prose_style_rules + [
          'static/templates/draft.hbs',
          'static/templates/subscription.hbs',
          'static/templates/single_message.hbs',
+         'static/templates/message_divider.hbs',
 
          # Old-style email templates need to use inline style
          # attributes; it should be possible to clean these up


### PR DESCRIPTION
This adds a divider for the first unread message of the narrow. It
appears only when the narrow is a topic or pm with a person/group.
If the message includes this divider it also includes the sender;
If the message has a date divider, it replaces it with a custom
version of the date divider which include the new messages text with
the dates above and below, else the divider just has the new messages
text. The divider does not appear when the message is first in it's
group.

Fixes #12518 

**GIFs or Screenshots:**

**With date divider**
![Screenshot 2019-06-18 at 12 51 22 AM](https://user-images.githubusercontent.com/33068691/59633560-5c24fe80-916a-11e9-937c-4407db251d2b.png)

**Without date divider**
![Screenshot 2019-06-18 at 12 51 42 AM](https://user-images.githubusercontent.com/33068691/59633568-60e9b280-916a-11e9-91bb-2b921c7e4054.png)

**Night mode**
![Screenshot 2019-06-18 at 12 52 07 AM](https://user-images.githubusercontent.com/33068691/59633591-75c64600-916a-11e9-96fe-929d21c0cf33.png)
