### PR TITLE
css: Restore keyboard accessibility to styled checkboxes

### DIFF
--- a/static/styles/components.scss
+++ b/static/styles/components.scss
@@ -8,7 +8,8 @@
         vertical-align: top;
 
         input[type=checkbox] {
-            display: none;
+            position: absolute;
+            clip: rect(0, 0, 0, 0);
 
             ~ span {
                 display: inline-block;
@@ -26,7 +27,6 @@
                 font-size: 1.3rem;
                 text-align: center;
                 border: 1px solid hsla(0, 0%, 0%, 0.6);
-                color: hsl(0, 0%, 80%);
 
                 border-radius: 4px;
                 -webkit-filter: brightness(0.80);
@@ -35,12 +35,15 @@
             }
 
             &:checked ~ span {
-                color: transparent;
-
                 background-image: url(/static/images/checkbox.svg);
                 background-size: 85%;
                 background-position: 50% 50%;
                 background-repeat: no-repeat;
+            }
+
+            &:focus ~ span {
+                outline: 1px dotted;
+                outline: -webkit-focus-ring-color auto 5px;
             }
 
             &:disabled ~ span {


### PR DESCRIPTION
Hiding a checkbox with `display: none` has the side effect of removing it from the tab order and preventing it from attaining or retaining focus.  Use clip instead.  Also emulate the native focus ring so the user can see which checkbox is selected during keyboard navigation.

**GIFs or Screenshots:**
Chrome:

![chrome-day](https://user-images.githubusercontent.com/26471/59641937-058ed480-9118-11e9-9302-e444bbbf0129.png)
![chrome-night](https://user-images.githubusercontent.com/26471/59641938-07589800-9118-11e9-831e-70f311536c93.png)

Firefox:

![firefox-day](https://user-images.githubusercontent.com/26471/59641945-0aec1f00-9118-11e9-8cbb-087e63ca955c.png)
![firefox-night](https://user-images.githubusercontent.com/26471/59641948-0c1d4c00-9118-11e9-9aa1-c4c395e70cd7.png)

(The difference matches the difference in native focus rings.)