### PR TITLE
upgrade-zulip-from-git: Fix handling of errors in git clone.

### DIFF
--- a/scripts/lib/upgrade-zulip-from-git
+++ b/scripts/lib/upgrade-zulip-from-git
@@ -48,6 +48,7 @@ try:
         logging.info("Cloning the repository")
         subprocess.check_call(["git", "clone", "-q", remote_url, "--mirror", LOCAL_GIT_CACHE_DIR],
                               stdout=open('/dev/null', 'w'))
+    if os.stat(LOCAL_GIT_CACHE_DIR).st_uid == 0:
         subprocess.check_call(["chown", "-R", "zulip:zulip", LOCAL_GIT_CACHE_DIR])
 
     logging.info("Fetching the latest commits")


### PR DESCRIPTION
Apparently, the `chown -R` wasn't running if the original clone had
networking errors.
