### PR TITLE
fixed #11662 : Message collapse/condense bugs

### DIFF
--- a/static/js/condense.js
+++ b/static/js/condense.js
@@ -40,9 +40,8 @@ exports.uncollapse = function (row) {
         content.removeClass("collapsed");
 
         if (message.condensed === true) {
-            // This message was condensed by the user, so re-show the
-            // [More] link.
-            condense_row(row);
+            // hide the [More..] link
+            row.find(".message_expander").hide();
         } else if (message.condensed === false) {
             // This message was un-condensed by the user, so re-show the
             // [Condense] link.


### PR DESCRIPTION
Fixed #11662

Tested on short, moderate and long messages.

Short messages now cycle from collapsed-normal (normal also meaning uncondensed).
Long messages now cycle as collapsed-condensed-normal.

![smolexp](https://user-images.githubusercontent.com/41019632/59787012-24db5c80-92e6-11e9-92e0-f0275954c599.png)

short message cycle and long message cycle (1)
![smolminandlargeexp](https://user-images.githubusercontent.com/41019632/59787022-2a38a700-92e6-11e9-92e6-e0eccf75296c.png)

long message cycle (2)
![largealarge](https://user-images.githubusercontent.com/41019632/59787027-2efd5b00-92e6-11e9-88f0-37fc19079437.png)
edit: Last PR got messed up so I made a new one
Here are GIFs demonstrating the changes.
Before:
![zulipbefore](https://user-images.githubusercontent.com/41019632/60029717-4ca03b00-96bf-11e9-9d54-aceae251ff84.gif)
After:
![zulip#11662demo](https://user-images.githubusercontent.com/41019632/60029393-b10eca80-96be-11e9-878f-08ffab3788c3.gif)
