### PR TITLE
Read password file in `create_user` script only if param is specified

### DIFF
--- a/zerver/management/commands/create_user.py
+++ b/zerver/management/commands/create_user.py
@@ -85,7 +85,7 @@ parameters, or specify no parameters for interactive user creation.""")
                 user_initial_password = initial_password(email)
                 if user_initial_password is None:
                     raise CommandError("Password is unusable.")
-                pw = user_initial_password.encode()
+                pw = user_initial_password
             do_create_user(email, pw, realm, full_name, email_to_username(email))
         except IntegrityError:
             raise CommandError("User already exists.")

--- a/zerver/management/commands/create_user.py
+++ b/zerver/management/commands/create_user.py
@@ -1,4 +1,3 @@
-
 import argparse
 import sys
 from typing import Any
@@ -77,10 +76,10 @@ parameters, or specify no parameters for interactive user creation.""")
                 full_name = input("Full name: ")
 
         try:
-            if 'password' in options:
-                pw = options['password']
-            if 'password_file' in options:
+            if options['password_file']:
                 pw = open(options['password_file'], 'r').read()
+            elif options['password']:
+                pw = options['password']
             else:
                 user_initial_password = initial_password(email)
                 if user_initial_password is None:


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes a problem with the password file being read even if the option hasn't been given by the user.  
