### PR TITLE
Follow ups to introducing a system to store HTTP headers with fixtures for integrations

### DIFF
--- a/static/js/portico/integrations_dev_panel.js
+++ b/static/js/portico/integrations_dev_panel.js
@@ -283,12 +283,10 @@ function send_all_fixture_messages() {
         return;
     }
 
-    var custom_headers = get_custom_http_headers();
-
     var csrftoken = $("#csrftoken").val();
     channel.post({
         url: "/devtools/integrations/send_all_webhook_fixture_messages",
-        data: {url: url, custom_headers: custom_headers, integration_name: integration},
+        data: {url: url, integration_name: integration},
         beforeSend: function (xhr) {xhr.setRequestHeader('X-CSRFToken', csrftoken);},
         success: function (response) {set_results(response);},
         error: handle_unsuccessful_response,

--- a/templates/zerver/api/incoming-webhooks-walkthrough.md
+++ b/templates/zerver/api/incoming-webhooks-walkthrough.md
@@ -52,16 +52,18 @@ put key details like the event type in a separate HTTP header
 test Zulip's handling of that integration, you will need to record
 which HTTP headers are used with each fixture you capture.
 
-Since this integration-dependent, Zulip offers a simple API for doing
-this, which is probably best explained by looking at the example for
-GitHub: `zerver/webhooks/github/headers.py`; basically, as part of
-writing your integration, you'll write a special function at that path
-that maps the filename of the fixture to the set of HTTP headers to
-use. Most such functions will use the same strategy as the GitHub
-integration: encoding the third party variable header data (usually
-just an event type) in the fixture filename, in such a case, you
-won't need to explicitly write such a special function and can instead
-just use the same helper method that the GitHub integration uses.
+Since this is integration-dependent, Zulip offers a simple API for
+doing this, which is probably best explained by looking at the example
+for GitHub: `zerver/webhooks/github/view.py`; basically, as part of
+writing your integration, you'll write a special function in your
+view.py file that maps the filename of the fixture to the set of HTTP
+headers to use. This function must be named "fixture_to_headers". Most
+integrations will use the same strategy as the GitHub integration:
+encoding the third party variable header data (usually just an event
+type) in the fixture filename, in such a case, you won't need to
+explicitly write the logic for such a special function again,
+instead you can just use the same helper method that the GitHub
+integration uses.
 
 ## Step 1: Initialize your webhook python package
 

--- a/templates/zerver/api/incoming-webhooks-walkthrough.md
+++ b/templates/zerver/api/incoming-webhooks-walkthrough.md
@@ -57,9 +57,11 @@ this, which is probably best explained by looking at the example for
 GitHub: `zerver/webhooks/github/headers.py`; basically, as part of
 writing your integration, you'll write a special function at that path
 that maps the filename of the fixture to the set of HTTP headers to
-use.  Most such functions will use the same strategy as the GitHub
+use. Most such functions will use the same strategy as the GitHub
 integration: encoding the third party variable header data (usually
-just an event type) in the fixture filename.
+just an event type) in the fixture filename, in such a case, you
+won't need to explicitly write such a special function and can instead
+just use the same helper method that the GitHub integration uses.
 
 ## Step 1: Initialize your webhook python package
 

--- a/zerver/lib/webhooks/common.py
+++ b/zerver/lib/webhooks/common.py
@@ -146,26 +146,16 @@ def get_fixture_http_headers(integration_name: str,
     function from the target integration module to determine what set
     of HTTP headers goes with the given test fixture.
     """
-
-    headers_module_name = "zerver.webhooks.{integration_name}.headers".format(
-        integration_name=integration_name)
+    view_module_name = "zerver.webhooks.{integration_name}.view".format(
+        integration_name=integration_name
+    )
     try:
-        # Try to import the headers.py file. If it does not exist,
-        # then that means that the integration does not have any
-        # special http headers registered.
-        #
         # TODO: We may want to migrate to a more explicit registration
         # strategy for this behavior rather than a try/except import.
-        headers_module = importlib.import_module(headers_module_name)
-    except ImportError:
+        view_module = importlib.import_module(view_module_name)
+        fixture_to_headers = view_module.fixture_to_headers  # type: ignore # we do extra exception handling in case it does not exist below.
+    except (ImportError, AttributeError):
         return {}
-    try:
-        fixture_to_headers = headers_module.fixture_to_headers  # type: ignore # we do extra exception handling in case it does not exist below.
-    except AttributeError as e:
-        msg = ". The {module_name} module must contain a fixture_to_headers method.".format(
-            module_name=headers_module_name
-        )
-        raise AttributeError(str(e) + msg)
     return fixture_to_headers(fixture_name)
 
 

--- a/zerver/lib/webhooks/common.py
+++ b/zerver/lib/webhooks/common.py
@@ -3,7 +3,7 @@ from urllib.parse import unquote
 
 from django.http import HttpRequest
 from django.utils.translation import ugettext as _
-from typing import Optional, Dict, Union, Any
+from typing import Optional, Dict, Union, Any, Callable
 
 from zerver.lib.actions import check_send_stream_message, \
     check_send_private_message, send_rate_limited_pm_notification_to_bot_owner
@@ -167,3 +167,17 @@ def get_fixture_http_headers(integration_name: str,
         )
         raise AttributeError(str(e) + msg)
     return fixture_to_headers(fixture_name)
+
+
+def get_http_headers_from_filename(http_header_key: str) -> Callable[[str], Dict[str, str]]:
+    """If an integration requires an event type kind of HTTP header which can
+    be easily (statically) determined, then name the fixtures in the format
+    of "header_value__other_details" or even "header_value" and the use this
+    method in the headers.py file for the integration."""
+    def fixture_to_headers(filename: str) -> Dict[str, str]:
+        if '__' in filename:
+            event_type = filename.split("__")[0]
+        else:
+            event_type = filename
+        return {http_header_key: event_type}
+    return fixture_to_headers

--- a/zerver/tests/test_webhooks_common.py
+++ b/zerver/tests/test_webhooks_common.py
@@ -109,12 +109,18 @@ class WebhooksCommonTestCase(ZulipTestCase):
         self.assertEqual(headers, {})
 
     @patch("zerver.lib.webhooks.common.importlib.import_module")
-    def test_get_fixture_http_headers_for_error_handling(self, import_module_mock: MagicMock) -> None:
+    def test_get_fixture_http_headers_with_no_fixtures_to_headers_function(
+        self,
+        import_module_mock: MagicMock
+    ) -> None:
+
         fake_module = SimpleNamespace()
         import_module_mock.return_value = fake_module
 
-        with self.assertRaises(AttributeError):
-            get_fixture_http_headers("some_integration", "simple_fixture")
+        self.assertEqual(
+            get_fixture_http_headers("some_integration", "simple_fixture"),
+            {}
+        )
 
     def test_standardize_headers(self) -> None:
         self.assertEqual(standardize_headers({}), {})

--- a/zerver/webhooks/github/headers.py
+++ b/zerver/webhooks/github/headers.py
@@ -1,8 +1,4 @@
-from typing import Dict
+from zerver.lib.webhooks.common import get_http_headers_from_filename
 
-def fixture_to_headers(filename: str) -> Dict[str, str]:
-    if '__' in filename:
-        event_type = filename.split("__")[0]
-    else:
-        event_type = filename
-    return {"HTTP_X_GITHUB_EVENT": event_type}
+key = "HTTP_X_GITHUB_EVENT"
+fixture_to_headers = get_http_headers_from_filename(key)

--- a/zerver/webhooks/github/headers.py
+++ b/zerver/webhooks/github/headers.py
@@ -1,4 +1,0 @@
-from zerver.lib.webhooks.common import get_http_headers_from_filename
-
-key = "HTTP_X_GITHUB_EVENT"
-fixture_to_headers = get_http_headers_from_filename(key)

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -16,6 +16,8 @@ from zerver.lib.webhooks.git import CONTENT_MESSAGE_TEMPLATE, \
     get_pull_request_event_message, get_push_commits_event_message, \
     get_push_tag_event_message, get_setup_webhook_message
 from zerver.models import UserProfile
+from zerver.lib.webhooks.common import \
+    get_http_headers_from_filename
 
 class UnknownEventType(Exception):
     pass
@@ -511,3 +513,7 @@ def get_event(request: HttpRequest, payload: Dict[str, Any], branches: str) -> O
 
 def get_body_function_based_on_type(type: str) -> Any:
     return EVENT_FUNCTION_MAPPER.get(type)
+
+fixture_to_headers = get_http_headers_from_filename(
+    "HTTP_X_GITHUB_EVENT"
+)


### PR DESCRIPTION
Follow up to PR #12515. So far I've extracted the header parsing logic for GitHub-like integrations into a common and easy to use method (thanks to @timabbott for the good idea/suggestion) and merged the 3 parse_header logic instances (in management commands, webhooks lib, and IDP) into a single one.

I'm waiting on eliminating the headers file and just sticking everything in views file until we have decided for sure that that's the best idea (See the prior PR as linked above for discussion).