### PR TITLE
[DO NOT MERGE] Stream > Topic Mention

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -1109,6 +1109,7 @@ run_test('begins_typeahead', () => {
         slash: true,
         stream: true,
         syntax: true,
+        topic: true,
     }}};
 
     function get_values(input, rest) {
@@ -1281,6 +1282,18 @@ run_test('begins_typeahead', () => {
     assert_typeahead_equals("~~~ f", lang_list);
     assert_typeahead_equals("test\n~~~ p", lang_list);
     assert_typeahead_equals("test\n~~~  p", lang_list);
+
+    // topic_jump
+    assert_typeahead_equals("@**a person**>", false);
+    assert_typeahead_equals("@**a person** >", false);
+    assert_typeahead_equals("#**stream**>", ['']); // this is deliberately a blank choice.
+    assert_typeahead_equals("#**stream** >", ['']);
+
+    // topic_list
+    var sweden_topics_to_show = topic_data.get_recent_names(1); //includes "more ice"
+    assert_typeahead_equals("#**Sweden>more ice", sweden_topics_to_show);
+    sweden_topics_to_show.push('totally new topic');
+    assert_typeahead_equals("#**Sweden>totally new topic", sweden_topics_to_show);
 
     // Following tests place the cursor before the second string
     assert_typeahead_equals("#test", "ing", false);

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -134,6 +134,14 @@ function query_matches_emoji(query, emoji) {
     return query_matches_source_attrs(query, emoji, ["emoji_name"], "_");
 }
 
+function query_matches_topic(query, topic) {
+    var obj = {
+        topic: topic,
+    };
+    query = query.toLowerCase();
+    return query_matches_source_attrs(query, obj, ['topic'], ' ');
+}
+
 // nextFocus is set on a keydown event to indicate where we should focus on keyup.
 // We can't focus at the time of keydown because we need to wait for typeahead.
 // And we can't compute where to focus at the time of keyup because only the keydown
@@ -347,6 +355,15 @@ exports.tokenize_compose_str = function (s) {
             } else if (/[\s(){}\[\]]/.test(s[i - 1])) {
                 return s.slice(i);
             }
+            break;
+        case '>':
+            // topic_jump
+            if (s.substring(i - 2, i) === '**' || s.substring(i - 3, i) === '** ') {
+                // return any string as long as its not ''.
+                return '>topic_jump';
+            }
+            // maybe topic_list; let's let the stream_topic_regex decide later.
+            return '>topic_list';
         }
     }
 
@@ -393,6 +410,21 @@ function filter_mention_name(current_token) {
     return current_token;
 }
 
+function should_show_custom_query(query, items) {
+    // returns true if the custom query doesn't match one of the
+    // choices in the items list.
+    if (!query) {
+        return false;
+    }
+    var matched = _.reduce(items, function (matched, elem) {
+        if (elem.toLowerCase() === query.toLowerCase()) {
+            return true;
+        }
+        return matched;
+    }, false);
+    return !matched;
+}
+
 exports.slash_commands = [
     {
         text: i18n.t("/me is excited (Display action text)"),
@@ -419,7 +451,7 @@ exports.compose_content_begins_typeahead = function (query) {
 
     // We will likely want to extend this list to be more i18n-friendly.
     var terminal_symbols = ',.;?!()[] "\'\n\t';
-    if (rest !== '' && terminal_symbols.indexOf(rest[0]) === -1) {
+    if (rest !== '' && terminal_symbols.indexOf(rest[0]) === -1 && current_token !== '>topic_list') {
         return false;
     }
 
@@ -516,6 +548,34 @@ exports.compose_content_begins_typeahead = function (query) {
         this.token = current_token;
         return stream_data.get_unsorted_subs();
     }
+
+    if (this.options.completions.topic) {
+        // Stream regex modified from marked.js
+        // Matches '#**stream name** >' at the end of a split.
+        var stream_regex =  /#\*\*([^\*]+)\*\*\s?>$/;
+        var should_jump_inside_typeahead = stream_regex.test(split[0]);
+        if (should_jump_inside_typeahead) {
+            this.completing = 'topic_jump';
+            this.token = '>';
+            return ['']; // return something so that the typeahead is shown.
+        }
+        // Matches '#**stream name>some text' at the end of a split.
+        var stream_topic_regex = /#\*\*([^\*>]+)>([^\*]*)$/;
+        var should_begin_typeahead = stream_topic_regex.test(split[0]);
+        if (should_begin_typeahead) {
+            this.completing = 'topic_list';
+            var tokens = stream_topic_regex.exec(split[0]);
+            if (tokens[1]) {
+                var stream_name = tokens[1];
+                this.token = tokens[2] || '';
+                var topic_list = exports.topics_seen_for(stream_name);
+                if (should_show_custom_query(this.token, topic_list)) {
+                    topic_list.push(this.token);
+                }
+                return topic_list;
+            }
+        }
+    }
     return false;
 };
 
@@ -532,10 +592,14 @@ exports.content_highlighter = function (item) {
         return typeahead_helper.render_stream(item);
     } else if (this.completing === 'syntax') {
         return typeahead_helper.render_typeahead_item({ primary: item });
+    } else if (this.completing === 'topic_jump') {
+        return typeahead_helper.render_typeahead_item({ primary: item });
+    } else if (this.completing === 'topic_list') {
+        return typeahead_helper.render_typeahead_item({ primary: item });
     }
 };
 
-exports.content_typeahead_selected = function (item) {
+exports.content_typeahead_selected = function (item, event) {
     var pieces = exports.split_at_cursor(this.query, this.$element);
     var beginning = pieces[0];
     var rest = pieces[1];
@@ -576,7 +640,12 @@ exports.content_typeahead_selected = function (item) {
         if (beginning.endsWith('#*')) {
             beginning = beginning.substring(0, beginning.length - 2);
         }
-        beginning += '#**' + item.name + '** ';
+        beginning += '#**' + item.name;
+        if (event && event.key === '>') {
+            beginning += '>';
+        } else {
+            beginning += '** ';
+        }
         $(document).trigger('streamname_completed.zulip', {stream: item});
     } else if (this.completing === 'syntax') {
         // Isolate the end index of the triple backticks/tildes, including
@@ -593,6 +662,15 @@ exports.content_typeahead_selected = function (item) {
             // "rest" (i.e. do not add a closing fence)
             beginning = beginning.substring(0, backticks) + item;
         }
+    } else if (this.completing === 'topic_jump') {
+        // Put the cursor at the end of the previous stream typeahead's content.
+        var index = beginning.lastIndexOf('**'); // index where the stream completion closes.
+        if (index !== -1) {
+            beginning = beginning.substring(0, index) + '>';
+        }
+    } else if (this.completing === 'topic_list') {
+        var start = beginning.length - this.token.length;
+        beginning = beginning.substring(0, start) + item + '** ';
     }
 
     // Keep the cursor after the newly inserted text, as Bootstrap will call textbox.change() to
@@ -616,6 +694,10 @@ exports.compose_content_matcher = function (item) {
         return query_matches_user_group_or_stream(this.token, item);
     } else if (this.completing === 'syntax') {
         return query_matches_language(this.token, item);
+    } else if (this.completing === 'topic_jump') {
+        return true;
+    } else if (this.completing === 'topic_list') {
+        return query_matches_topic(this.token, item);
     }
 };
 
@@ -630,7 +712,27 @@ exports.compose_matches_sorter = function (matches) {
         return typeahead_helper.sort_streams(matches, this.token);
     } else if (this.completing === 'syntax') {
         return typeahead_helper.sort_languages(matches, this.token);
+    } else if (this.completing === 'topic_jump') {
+        return matches;
+    } else if (this.completing === 'topic_list') {
+        return typeahead_helper.sorter(this.token, matches, function (x) {return x;});
     }
+};
+
+exports.compose_automated_selection = function () {
+    if (this.completing === 'topic_jump') {
+        // automatically jump inside stream mention on typing >
+        return true;
+    }
+    return false;
+};
+
+exports.compose_trigger_selection = function (event) {
+    if (this.completing === 'stream' && event.key === '>') {
+        // complete stream typeahead partially to immediately start the topic_list typeahead.
+        return true;
+    }
+    return false;
 };
 
 exports.initialize_compose_typeahead = function (selector) {
@@ -641,6 +743,7 @@ exports.initialize_compose_typeahead = function (selector) {
         slash: true,
         stream: true,
         syntax: true,
+        topic: true,
     };
 
     $(selector).typeahead({
@@ -654,6 +757,8 @@ exports.initialize_compose_typeahead = function (selector) {
         updater: exports.content_typeahead_selected,
         stopAdvance: true, // Do not advance to the next field on a tab or enter
         completions: completions,
+        automated: exports.compose_automated_selection,
+        trigger_selection: exports.compose_trigger_selection,
     });
 };
 

--- a/static/third/bootstrap-typeahead/typeahead.js
+++ b/static/third/bootstrap-typeahead/typeahead.js
@@ -17,6 +17,18 @@
  * limitations under the License.
  * ============================================================ */
 
+/* =============================================================
+ * Zulip's custom changes
+ *
+ * 1. Automated selection:
+ *
+ *   This adds support for automatically selecting a typeahead (on certain
+ *   completions or queries). If `this.automated` returns true, we do not
+ *   render the typeahead and directly trigger selection of the current
+ *   choice.
+ *
+ *   Our custom changes include all mentions of this.automated.
+ * ============================================================ */
 
 !function($){
 
@@ -38,6 +50,7 @@
     this.shown = false
     this.dropup = this.options.dropup
     this.fixed = this.options.fixed || false;
+    this.automated = this.options.automated || this.automated;
 
     if (this.fixed) {
       this.$menu.css('position', 'fixed');
@@ -68,6 +81,10 @@
   , updater: function (item) {
       return item
     }
+
+  , automated: function() {
+    return false;
+  }
 
   , show: function () {
       var pos;
@@ -136,7 +153,11 @@
       if (!items.length) {
         return this.shown ? this.hide() : this
       }
-
+      if (this.automated()) {
+        this.select();
+        this.lookup();
+        return this;
+      }
       return this.render(items.slice(0, this.options.items)).show()
     }
 

--- a/static/third/bootstrap-typeahead/typeahead.js
+++ b/static/third/bootstrap-typeahead/typeahead.js
@@ -28,6 +28,17 @@
  *   choice.
  *
  *   Our custom changes include all mentions of this.automated.
+ *
+ * 2. Custom selection triggers:
+ *
+ *   This adds support for completing a typeahead on custom keyup input. By
+ *   default, we only support Tab and Enter to complete a typeahead, but we
+ *   have usecases where we want to complete using custom characters like: >.
+ *
+ *   If `this.trigger_selection` returns true, we complete the typeahead and
+ *   pass the keyup event to the updater.
+ *
+ *   Our custom changes include all mentions of this.trigger_selection.
  * ============================================================ */
 
 !function($){
@@ -51,6 +62,7 @@
     this.dropup = this.options.dropup
     this.fixed = this.options.fixed || false;
     this.automated = this.options.automated || this.automated;
+    this.trigger_selection = this.options.trigger_selection || this.trigger_selection;
 
     if (this.fixed) {
       this.$menu.css('position', 'fixed');
@@ -83,6 +95,10 @@
     }
 
   , automated: function() {
+    return false;
+  }
+
+  , trigger_selection: function() {
     return false;
   }
 
@@ -310,6 +326,10 @@
           break
 
         default:
+          if (this.trigger_selection(e)) {
+            if (!this.shown) return;
+            this.select(e);
+          }
           this.lookup()
       }
 

--- a/templates/zerver/app/markdown_help.html
+++ b/templates/zerver/app/markdown_help.html
@@ -83,6 +83,14 @@
                         <td class="rendered_markdown"><a>#streamName</a> (links to a stream)</td>
                     </tr>
                     <tr>
+                        <td>#**streamName>topicName**</td>
+                        <td class="rendered_markdown"><a>#streamName &gt; topicName</a> (links to a topic)</td>
+                    </tr>
+                    <tr>
+                        <td colspan="2">{% trans %}To mention a topic, start mentioning a stream as usual and type '&gt;'. You
+                          can then start typing or use the autocomplete to select a topic.{% endtrans %}</td>
+                    </tr>
+                    <tr>
                         <td>/me is busy working<br/>
                           (send a status message as user Iago)</td>
                         <td class="rendered_markdown"><span class="sender_name-in-status">Iago</span> is busy working</td>

--- a/templates/zerver/help/format-your-message-using-markdown.md
+++ b/templates/zerver/help/format-your-message-using-markdown.md
@@ -66,6 +66,7 @@ patterns like `#1234` to your ticketing system.
 Auto-detected URL: zulipchat.com
 Named link: [Zulip homepage](zulipchat.com)
 Stream: #**announce**
+Stream and Topic: #**general>a topic name**
 Custom linkifier: #1234 (links to ticket 1234 in your ticketing system)
 ```
 

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -36,6 +36,7 @@
 * [Mention a user or group](/help/mention-a-user-or-group)
 * [Edit or delete a message](/help/edit-or-delete-a-message)
 * [Message a stream by email](/help/message-a-stream-by-email)
+* [Stream and topic links](/help/stream-and-topic-links)
 
 ## Reading messages
 * [Reading strategies](/help/reading-strategies)
@@ -68,6 +69,7 @@
 * [Change the topic of a message](/help/change-the-topic-of-a-message)
 * [Rename a topic](/help/rename-a-topic)
 * [Manage inactive streams](/help/manage-inactive-streams)
+* [Stream and topic links](/help/stream-and-topic-links)
 
 ## Notifications
 * [Stream notifications](/help/stream-notifications)

--- a/templates/zerver/help/mention-a-user-or-group.md
+++ b/templates/zerver/help/mention-a-user-or-group.md
@@ -50,3 +50,8 @@ notification. Silent mentions start with `@_` instead of `@`.
 
 You can mention everyone on a stream with the `@**all**` mention. Use
 sparingly! Note that this will not notify anyone who has muted the stream.
+
+## Stream and topic links
+
+You can also insert links to streams or topics in a message with a similar
+process as user mentions. Read more about them [here](/help/stream-and-topic-links).

--- a/templates/zerver/help/stream-and-topic-links.md
+++ b/templates/zerver/help/stream-and-topic-links.md
@@ -1,0 +1,53 @@
+# Stream and topic links
+
+You can easily insert links to streams and topics in your message. These are
+useful to help redirect people to correct streams or to link to other relevant
+discussions happening on Zulip.
+
+### Stream links
+
+{start_tabs}
+
+{!start-composing.md!}
+
+2. Type `#` followed by a few letters from a stream name.
+
+3. Pick the appropriate stream from the autocomplete.
+
+{end_tabs}
+
+### Topic Links
+
+To link to a topic, you need to specify both the stream and the topic. We
+have two similar methods of creating topic links:
+
+{start_tabs}
+
+{!start-composing.md!}
+
+2. Type `#` followed by a few letters from a stream name.
+
+3. Use the arrow keys to select the appropriate stream from the autocomplete.
+
+4. Press `>` instead of Enter or Tab.
+
+5. Type a few letters from a topic name.
+
+6. Pick the appropriate topic from the autocomplete.
+
+{end_tabs}
+
+Alternatively, if you have already completed a stream link, you can:
+
+{start_tabs}
+
+1. Type `>` just after a stream link ends.
+
+2. Type a few letters from a topic name.
+
+3. Pick the appropriate topic from the autocomplete.
+
+{end_tabs}
+
+**Note**: You can also create links to topics that haven't yet been created by
+simply typing the name you want that topic to have.


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

- [x] Bugdown Implementation
- [x] Marked Implementation
- [x] DOM changes in Bugdown HTML by JS.
- [x] Jump Typeahead
- [x] Topic List Typeahead
- [x] Documentation
- [ ] Disable > in Stream Names (and migration)

Re: 3th point above: we replace stream name in the $(`.stream`) to make sure that renamed streams show up correctly. We would need to do the same for the streams as part of this new syntax.

**Testing Plan:** <!-- How have you tested? -->
Added automated tests. Manually tested.

**Screenshot**

Below, we have a regular stream mention followed by a stream-topic mention.

![image](https://user-images.githubusercontent.com/8033238/59934266-cab6d480-9468-11e9-99ec-2c864ab5e1e4.png)
