### PR TITLE
[WIP] Retention - restore from archive

### DIFF
--- a/zerver/lib/retention.py
+++ b/zerver/lib/retention.py
@@ -191,9 +191,10 @@ def move_expired_personal_and_huddle_messages_to_archive(realm: Realm,
         chunk_size=chunk_size,
     )
 
-    # Archive cross-realm personal messages to users in the realm:
-    # Note: Cross-realm huddle message aren't handled yet, they remain an issue
-    # that should be addressed.
+    # Archive cross-realm personal messages to users in the realm.
+    # We don't archive cross-realm huddle messages via retention policy,
+    # as they're essentially non-existant and the query to deal with them
+    # would be unnecessary complexity and waste of database time.
     query = SQL("""
     INSERT INTO zerver_archivedmessage ({dst_fields}, archive_transaction_id)
         SELECT {src_fields}, {archive_transaction_id}


### PR DESCRIPTION
WIP PR for adding functions for restoring data.

When archiving, each batch of objects (messages+related) is tied to an ArchiveTransaction row, which also stores some metadata about the batch (timestamp and "type" - was stuff in this transaction archived  automatically by the retention policies and from which realm does it come? or was it archived manualy through move_messages_to_archive?).

We restore data in chunks - by ArchiveTransaction rows.

What still needs to be done:
1. Some logging when restoring data.
2. Probably more tests, to check for hidden bugs.