### PR TITLE
upgrade-zulip-from-git: Fetch tags to make version info more useful.

### DIFF
--- a/scripts/lib/upgrade-zulip-from-git
+++ b/scripts/lib/upgrade-zulip-from-git
@@ -54,7 +54,7 @@ try:
     logging.info("Fetching the latest commits")
     os.chdir(LOCAL_GIT_CACHE_DIR)
     subprocess.check_call(["git", "remote", "set-url", "origin", remote_url], preexec_fn=su_to_zulip)
-    subprocess.check_call(["git", "fetch", "-q"], preexec_fn=su_to_zulip)
+    subprocess.check_call(["git", "fetch", "-q", "--tags"], preexec_fn=su_to_zulip)
 
     subprocess.check_call(["git", "clone", "-q", "-b", refname, LOCAL_GIT_CACHE_DIR, deploy_path],
                           stdout=open('/dev/null', 'w'),


### PR DESCRIPTION
To be able to show more detailed git information in ZULIP_VERSION, we need
to fetch tags when running `upgrade-zulip-from-git`.

