### PR TITLE
Couple of URL preview improvements

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -25,7 +25,7 @@ body.night-mode {
     }
 
     .message_embed .data-container::after {
-        background: linear-gradient(0deg, hsl(212, 28%, 18%), transparent 10%);
+        background: linear-gradient(0deg, hsl(212, 28%, 18%), transparent 100%);
     }
 
     .column-left .left-sidebar,

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1626,10 +1626,10 @@ a:hover code {
             content: " ";
             position: absolute;
             width: 100%;
-            height: 100%;
-            top: 0;
+            height: 10%;
+            bottom: 0;
 
-            background: linear-gradient(0deg, hsl(0, 0%, 100%), transparent 10%);
+            background: linear-gradient(0deg, hsl(0, 0%, 100%), transparent 100%);
         }
     }
 

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -395,22 +395,25 @@ def add_embed(root: Element, link: str, extracted_data: Dict[str, Any]) -> None:
     if oembed and add_oembed_data(root, link, extracted_data):
         return
 
+    img_link = extracted_data.get('image')
+    if not img_link:
+        # Don't add an embed if an image is not found
+        return
+
     container = markdown.util.etree.SubElement(root, "div")
     container.set("class", "message_embed")
 
-    img_link = extracted_data.get('image')
-    if img_link:
-        parsed_img_link = urllib.parse.urlparse(img_link)
-        # Append domain where relative img_link url is given
-        if not parsed_img_link.netloc:
-            parsed_url = urllib.parse.urlparse(link)
-            domain = '{url.scheme}://{url.netloc}/'.format(url=parsed_url)
-            img_link = urllib.parse.urljoin(domain, img_link)
-        img = markdown.util.etree.SubElement(container, "a")
-        img.set("style", "background-image: url(" + img_link + ")")
-        img.set("href", link)
-        img.set("target", "_blank")
-        img.set("class", "message_embed_image")
+    parsed_img_link = urllib.parse.urlparse(img_link)
+    # Append domain where relative img_link url is given
+    if not parsed_img_link.netloc:
+        parsed_url = urllib.parse.urlparse(link)
+        domain = '{url.scheme}://{url.netloc}/'.format(url=parsed_url)
+        img_link = urllib.parse.urljoin(domain, img_link)
+    img = markdown.util.etree.SubElement(container, "a")
+    img.set("style", "background-image: url(" + img_link + ")")
+    img.set("href", link)
+    img.set("target", "_blank")
+    img.set("class", "message_embed_image")
 
     data_container = markdown.util.etree.SubElement(container, "div")
     data_container.set("class", "data-container")


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
1. Don't display the URL preview embed if no image was found for the URL. 
2. Make the title of the URL clickable (again). 

**Testing Plan:** <!-- How have you tested? -->
Tested 1 using https://zulip.readthedocs.io/en/latest/ and other such links. 

2 can be tested with https://zulipchat.com/ 