### PR TITLE
group-pms: Update list when new group pm is made.

### DIFF
--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -87,7 +87,11 @@ function insert_local_message(message_request, local_id) {
                         unknown_local_echo_user: true};
             }
             // NORMAL PATH
-            return person;
+            return {
+                id: person.user_id,
+                email: person.email,
+                full_name: person.full_name,
+            };
         });
     }
 


### PR DESCRIPTION
Fixes: #12503.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
It was a little tricky tracking this down, but I think I've got it.

I think we should also make it so deleting all the messages of a group-pm live removes that group-pm from the list instead of having to reload. I haven't looked into it that much though, I'll have to track down how to do that.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Window might look weird because I had to use responsive view to record with both user lists open.
![group-pms](https://user-images.githubusercontent.com/33805964/59980324-e8736d80-9611-11e9-8b84-996c13d11a02.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
