### PR TITLE
templates: Replace logic helpers with sensible logic helpers

### DIFF
--- a/static/js/templates.js
+++ b/static/js/templates.js
@@ -46,74 +46,35 @@ Handlebars.registerHelper('plural', function (condition, one, other) {
     return condition === 1 ? one : other;
 });
 
-Handlebars.registerHelper('if_and', function () {
-    // Execute the conditional code if all conditions are true.
-    // Example usage:
-    //     {{#if_and cond1 cond2 cond3}}
-    //         <p>All true</p>
-    //     {{/if_and}}
-    var options = arguments[arguments.length - 1];
-    var i;
-    for (i = 0; i < arguments.length - 1; i += 1) {
-        if (!arguments[i]) {
-            return options.inverse(this);
+Handlebars.registerHelper({
+    eq: function (a, b) { return a === b; },
+    and: function () {
+        // last argument is Handlebars options
+        if (arguments.length < 2) {
+            return true;
         }
-    }
-    return options.fn(this);
-});
-
-Handlebars.registerHelper('unless_a_not_b', function () {
-    // Execute the conditional code if at least one condition is false.
-    // Example usage:
-    //     {{#unless_a_not_b cond1 cond2}}
-    //         <p>a is false or b is true</p>
-    //     {{/unless_a_not_b}}
-    var options = arguments[arguments.length - 1];
-    if (arguments[0] && !arguments[1]) {
-        return options.inverse(this);
-    }
-    return options.fn(this);
-});
-
-Handlebars.registerHelper('if_equal', function () {
-    // Execute conditional code if both values are equal
-    var options = arguments[arguments.length - 1];
-    if (arguments[0] === arguments[1]) {
-        return options.fn(this);
-    }
-    return options.inverse(this);
-});
-
-Handlebars.registerHelper('if_not_a_or_b_and_not_c', function () {
-    var options = arguments[arguments.length - 1];
-    if (arguments[0] === false || arguments[1] === true && arguments[2] === false) {
-        return options.fn(this);
-    }
-    return options.inverse(this);
-});
-
-Handlebars.registerHelper('if_or', function () {
-    // Execute the conditional code if any of the conditions are true.
-    // Example usage:
-    //     {{#if_or cond1 cond2 cond3}}
-    //         <p>At least one is true</p>
-    //     {{/if_or}}
-    var options = arguments[arguments.length - 1];
-    var i;
-    for (i = 0; i < arguments.length - 1; i += 1) {
-        if (arguments[i]) {
-            return options.fn(this);
-
+        var i;
+        for (i = 0; i < arguments.length - 2; i += 1) {
+            if (!arguments[i] || Handlebars.Utils.isEmpty(arguments[i])) {
+                return arguments[i];
+            }
         }
-    }
-    return options.inverse(this);
-});
-
-Handlebars.registerHelper('is_false', function (variable, options) {
-    if (variable === false) {
-        return options.fn(this);
-    }
-    return options.inverse(this);
+        return arguments[i];
+    },
+    or: function () {
+        // last argument is Handlebars options
+        if (arguments.length < 2) {
+            return false;
+        }
+        var i;
+        for (i = 0; i < arguments.length - 2; i += 1) {
+            if (arguments[i] && !Handlebars.Utils.isEmpty(arguments[i])) {
+                return arguments[i];
+            }
+        }
+        return arguments[i];
+    },
+    not: function (a) { return !a || Handlebars.Utils.isEmpty(a); },
 });
 
 Handlebars.registerHelper('t', function (i18n_key) {

--- a/static/templates/settings/settings_checkbox.handlebars
+++ b/static/templates/settings/settings_checkbox.handlebars
@@ -1,14 +1,13 @@
-{{#is_false render_only}}
-{{else}}
-<div class="input-group {{#if is_nested}}disableable{{/if}} {{#if_not_a_or_b_and_not_c is_parent_setting_enabled push_notifications_tooltip realm_push_notifications_enabled}}control-label-disabled{{/if_not_a_or_b_and_not_c}}">
+{{#unless (eq render_only false)}}
+<div class="input-group {{#if is_nested}}disableable{{/if}} {{#if (and push_notifications_tooltip (not realm_push_notifications_enabled))}}control-label-disabled{{/if}}">
     <label class="checkbox">
         <input type="checkbox" class="inline-block setting-widget prop-element" name="{{setting_name}}" data-setting-widget-type="bool"
           id="{{prefix}}{{setting_name}}"
-          {{#if_not_a_or_b_and_not_c is_parent_setting_enabled push_notifications_tooltip realm_push_notifications_enabled}}disabled="disabled"{{/if_not_a_or_b_and_not_c}}
+          {{#if (and push_notifications_tooltip (not realm_push_notifications_enabled))}}disabled="disabled"{{/if}}
           {{#if is_checked}}
-          {{#unless_a_not_b push_notifications_tooltip realm_push_notifications_enabled}}
+          {{#unless (and push_notifications_tooltip (not realm_push_notifications_enabled))}}
           checked="checked"
-          {{/unless_a_not_b}}
+          {{/unless}}
           {{/if}} />
         <span></span>
     </label>
@@ -20,4 +19,4 @@
       title="{{t 'Mobile push notifications are not configured on this server.' }}"></i>
     {{/if}}
 </div>
-{{/is_false}}
+{{/unless}}

--- a/static/templates/stream-settings-checkbox.handlebars
+++ b/static/templates/stream-settings-checkbox.handlebars
@@ -1,13 +1,13 @@
 {{!-- If setting is disabled on realm level, then render setting as control-label-disabled and do not set setting value. Setting status should not change on any click handler, as it is disabled at realm level. --}}
 <div id="{{prefix}}{{setting_name}}{{suffix}}" class="sub_setting_checkbox {{#unless realm_setting_disabled}}{{#if notification_setting}}sub_notification_setting {{#if is_muted}}muted-sub{{/if}}{{/if}}{{else}}control-label-disabled{{/unless}}">
-    <input id="{{setting_name}}_{{stream_id}}" name="{{setting_name}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#unless realm_setting_disabled}}{{#if is_checked}}checked{{/if}}{{#if_and is_muted notification_setting}}disabled="disabled"{{/if_and}}{{else}}disabled="disabled"{{/unless}} />
+    <input id="{{setting_name}}_{{stream_id}}" name="{{setting_name}}" class="sub_setting_control" type="checkbox" tabindex="-1" {{#unless realm_setting_disabled}}{{#if is_checked}}checked{{/if}}{{#if (and is_muted notification_setting)}}disabled="disabled"{{/if}}{{else}}disabled="disabled"{{/unless}} />
     <label class="subscription-control-label">{{label}}</label>
 
     {{!-- Tooltips for settings --}}
-    {{#if_equal setting_name "is_muted"}}
+    {{#if (eq setting_name "is_muted")}}
     <p class="mute-note {{#unless is_muted}}hide-mute-note{{/unless}}">{{t "Muted streams don't show up in \"All messages\" or generate notifications unless you are mentioned." }}</p>
-    {{/if_equal}}
-    {{#if_equal setting_name "push_notifications"}}
+    {{/if}}
+    {{#if (eq setting_name "push_notifications")}}
     <i class="fa fa-question-circle settings-info-icon {{#unless realm_setting_disabled}}hide{{/unless}}" data-toggle="tooltip" title="{{t 'Mobile push notifications are not configured on this server.' }}"></i>
-    {{/if_equal}}
+    {{/if}}
 </div>


### PR DESCRIPTION
`if_not_a_or_b_and_not_c`?  Really?

**Testing Plan:** Verified that logic seems to be working using console.log; checked that stream settings checkboxes seem normal.