### PR TITLE
migrate, create_large_indexes: Use CREATE INDEX IF NOT EXISTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,25 +82,6 @@ aliases:
          || echo "Error in uploading coverage reports to codecov.io."
 
 jobs:
-  "trusty-backend-python3.4":
-    docker:
-      # This is built from tools/circleci/images/trusty/Dockerfile .
-      # Trusty ships with Python 3.4.
-      - image: gregprice/circleci:trusty-python-5.test
-
-    working_directory: ~/zulip
-
-    steps:
-      - checkout
-
-      - *create_cache_directories
-      - *restore_cache_package_json
-      - *restore_cache_requirements
-      - *install_dependencies
-      - *save_cache_package_json
-      - *save_cache_requirements
-      - *run_backend_tests
-
   "xenial-backend-frontend-python3.5":
     docker:
       # This is built from tools/circleci/images/xenial/Dockerfile .
@@ -160,6 +141,5 @@ workflows:
   version: 2
   build:
     jobs:
-      - "trusty-backend-python3.4"
       - "xenial-backend-frontend-python3.5"
       - "bionic-backend-python3.6"

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You might be interested in:
 
 * **Running a Zulip server**. Setting up a server takes just a couple
   of minutes. Zulip runs on Ubuntu 18.04 Bionic, Ubuntu 16.04 Xenial,
-  Ubuntu 14.04 Trusty, and Debian 9 Stretch. The installation process is
+  and Debian 9 Stretch. The installation process is
   [documented here](https://zulip.readthedocs.io/en/stable/production/install.html).
   Commercial support is available; see <https://zulipchat.com/plans>
   for details.

--- a/docs/testing/continuous-integration.md
+++ b/docs/testing/continuous-integration.md
@@ -53,7 +53,6 @@ uses those SSH keys for authentication.
 The main CircleCI configuration file is
 [./circleci/config.yml](https://github.com/zulip/zulip/blob/master/.circleci/config.yml).
 We currently run several jobs during a CircleCI build. They are:
-* trusty-python-3.4
 * xenial-python-3.5
 * bionic-python-3.6
 

--- a/tools/circleci/images.yml
+++ b/tools/circleci/images.yml
@@ -1,7 +1,3 @@
-trusty:
-  base_image: buildpack-deps:trusty-scm
-  extra_packages: python-virtualenv postgresql-9.3
-
 xenial:
   base_image: buildpack-deps:xenial-scm
   extra_packages: virtualenv postgresql-9.5

--- a/zerver/lib/migrate.py
+++ b/zerver/lib/migrate.py
@@ -5,29 +5,6 @@ import time
 
 CursorObj = TypeVar('CursorObj', bound=cursor)
 
-def create_index_if_not_exist(index_name: str, table_name: str, column_string: str,
-                              where_clause: str) -> str:
-    #
-    # FUTURE TODO: When we no longer need to support postgres 9.3 for Trusty,
-    #              we can use "IF NOT EXISTS", which is part of postgres 9.5
-    #              (and which already is supported on Xenial systems).
-    stmt = '''
-        DO $$
-        BEGIN
-            IF NOT EXISTS (
-                SELECT 1
-                FROM pg_class
-                where relname = '%s'
-                ) THEN
-                    CREATE INDEX
-                    %s
-                    ON %s (%s)
-                    %s;
-            END IF;
-        END$$;
-        ''' % (index_name, index_name, table_name, column_string, where_clause)
-    return stmt
-
 
 def do_batch_update(cursor: CursorObj,
                     table: str,

--- a/zerver/management/commands/create_large_indexes.py
+++ b/zerver/management/commands/create_large_indexes.py
@@ -4,15 +4,7 @@ from django.db import connection
 
 from zerver.lib.management import ZulipBaseCommand
 
-def create_index_if_not_exist(index_name: str, table_name: str,
-                              column_string: str, where_clause: str) -> None:
-    #
-    #  This function is somewhat similar to
-    #  zerver.lib.migrate.create_index_if_not_exist.
-    #
-    #  The other function gets used as part of Django migrations; this function
-    #  uses SQL that is not supported by Django migrations.
-    #
+def create_indexes() -> None:
     #  Creating concurrent indexes is kind of a pain with current versions
     #  of Django/postgres, because you will get this error with seemingly
     #  reasonable code:
@@ -23,85 +15,63 @@ def create_index_if_not_exist(index_name: str, table_name: str,
     # that added this file to the repo.
 
     with connection.cursor() as cursor:
-        sql = '''
-            SELECT 1
-            FROM pg_class
-            where relname = %s
-            '''
-        cursor.execute(sql, [index_name])
-        rows = cursor.fetchall()
-        if len(rows) > 0:
-            print('Index %s already exists.' % (index_name,))
-            return
+        # copied from 0082
+        print("Creating index zerver_usermessage_starred_message_id.")
+        cursor.execute('''
+            CREATE INDEX IF NOT EXISTS zerver_usermessage_starred_message_id
+            ON zerver_usermessage (user_profile_id, message_id)
+            WHERE (flags & 2) != 0;
+        ''')
 
-        print("Creating index %s." % (index_name,))
-        sql = '''
-            CREATE INDEX CONCURRENTLY
-            %s
-            ON %s (%s)
-            %s;
-            ''' % (index_name, table_name, column_string, where_clause)
-        cursor.execute(sql)
-        print('Finished creating %s.' % (index_name,))
+        # copied from 0083
+        print("Creating index zerver_usermessage_mentioned_message_id.")
+        cursor.execute('''
+            CREATE INDEX IF NOT EXISTS zerver_usermessage_mentioned_message_id
+            ON zerver_usermessage (user_profile_id, message_id)
+            WHERE (flags & 8) != 0;
+        ''')
 
+        # copied from 0095
+        print("Creating index zerver_usermessage_unread_message_id.")
+        cursor.execute('''
+            CREATE INDEX IF NOT EXISTS zerver_usermessage_unread_message_id
+            ON zerver_usermessage (user_profile_id, message_id)
+            WHERE (flags & 1) = 0;
+        ''')
 
-def create_indexes() -> None:
+        # copied from 0098
+        print("Creating index zerver_usermessage_has_alert_word_message_id.")
+        cursor.execute('''
+            CREATE INDEX IF NOT EXISTS zerver_usermessage_has_alert_word_message_id
+            ON zerver_usermessage (user_profile_id, message_id)
+            WHERE (flags & 512) != 0;
+        ''')
 
-    # copied from 0082
-    create_index_if_not_exist(
-        index_name='zerver_usermessage_starred_message_id',
-        table_name='zerver_usermessage',
-        column_string='user_profile_id, message_id',
-        where_clause='WHERE (flags & 2) != 0',
-    )
+        # copied from 0099
+        print("Creating index zerver_usermessage_wildcard_mentioned_message_id.")
+        cursor.execute('''
+            CREATE INDEX IF NOT EXISTS zerver_usermessage_wildcard_mentioned_message_id
+            ON zerver_usermessage (user_profile_id, message_id)
+            WHERE (flags & 8) != 0 OR (flags & 16) != 0;
+        ''')
 
-    # copied from 0083
-    create_index_if_not_exist(
-        index_name='zerver_usermessage_mentioned_message_id',
-        table_name='zerver_usermessage',
-        column_string='user_profile_id, message_id',
-        where_clause='WHERE (flags & 8) != 0',
-    )
+        # copied from 0177
+        print("Creating index zerver_usermessage_is_private_message_id.")
+        cursor.execute('''
+            CREATE INDEX IF NOT EXISTS zerver_usermessage_is_private_message_id
+            ON zerver_usermessage (user_profile_id, message_id)
+            WHERE (flags & 2048) != 0;
+        ''')
 
-    # copied from 0095
-    create_index_if_not_exist(
-        index_name='zerver_usermessage_unread_message_id',
-        table_name='zerver_usermessage',
-        column_string='user_profile_id, message_id',
-        where_clause='WHERE (flags & 1) = 0',
-    )
+        # copied from 0180
+        print("Creating index zerver_usermessage_active_mobile_push_notification_id.")
+        cursor.execute('''
+            CREATE INDEX IF NOT EXISTS zerver_usermessage_active_mobile_push_notification_id
+            ON zerver_usermessage (user_profile_id, message_id)
+            WHERE (flags & 4096) != 0;
+        ''')
 
-    # copied from 0098
-    create_index_if_not_exist(
-        index_name='zerver_usermessage_has_alert_word_message_id',
-        table_name='zerver_usermessage',
-        column_string='user_profile_id, message_id',
-        where_clause='WHERE (flags & 512) != 0',
-    )
-
-    # copied from 0099
-    create_index_if_not_exist(
-        index_name='zerver_usermessage_wildcard_mentioned_message_id',
-        table_name='zerver_usermessage',
-        column_string='user_profile_id, message_id',
-        where_clause='WHERE (flags & 8) != 0 OR (flags & 16) != 0',
-    )
-
-    # copied from 0177
-    create_index_if_not_exist(
-        index_name='zerver_usermessage_is_private_message_id',
-        table_name='zerver_usermessage',
-        column_string='user_profile_id, message_id',
-        where_clause='WHERE (flags & 2048) != 0',
-    )
-
-    # copied from 0180
-    create_index_if_not_exist(
-        index_name='zerver_usermessage_active_mobile_push_notification_id',
-        table_name='zerver_usermessage',
-        column_string='user_profile_id, message_id',
-        where_clause='WHERE (flags & 4096) != 0',
-    )
+        print("Finished.")
 
 class Command(ZulipBaseCommand):
     help = """Create concurrent indexes for large tables."""

--- a/zerver/migrations/0082_index_starred_user_messages.py
+++ b/zerver/migrations/0082_index_starred_user_messages.py
@@ -2,8 +2,6 @@
 
 from django.db import migrations
 
-from zerver.lib.migrate import create_index_if_not_exist  # nolint
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -12,12 +10,11 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            create_index_if_not_exist(
-                index_name='zerver_usermessage_starred_message_id',
-                table_name='zerver_usermessage',
-                column_string='user_profile_id, message_id',
-                where_clause='WHERE (flags & 2) != 0',
-            ),
+            '''
+            CREATE INDEX IF NOT EXISTS zerver_usermessage_starred_message_id
+                ON zerver_usermessage (user_profile_id, message_id)
+                WHERE (flags & 2) != 0;
+            ''',
             reverse_sql='DROP INDEX zerver_usermessage_starred_message_id;'
         ),
     ]

--- a/zerver/migrations/0083_index_mentioned_user_messages.py
+++ b/zerver/migrations/0083_index_mentioned_user_messages.py
@@ -2,8 +2,6 @@
 
 from django.db import migrations
 
-from zerver.lib.migrate import create_index_if_not_exist  # nolint
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -12,12 +10,11 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            create_index_if_not_exist(
-                index_name='zerver_usermessage_mentioned_message_id',
-                table_name='zerver_usermessage',
-                column_string='user_profile_id, message_id',
-                where_clause='WHERE (flags & 8) != 0',
-            ),
+            '''
+            CREATE INDEX IF NOT EXISTS zerver_usermessage_mentioned_message_id
+                ON zerver_usermessage (user_profile_id, message_id)
+                WHERE (flags & 8) != 0;
+            ''',
             reverse_sql='DROP INDEX zerver_usermessage_mentioned_message_id;'
         ),
     ]

--- a/zerver/migrations/0095_index_unread_user_messages.py
+++ b/zerver/migrations/0095_index_unread_user_messages.py
@@ -2,8 +2,6 @@
 
 from django.db import migrations
 
-from zerver.lib.migrate import create_index_if_not_exist  # nolint
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -12,12 +10,11 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            create_index_if_not_exist(
-                index_name='zerver_usermessage_unread_message_id',
-                table_name='zerver_usermessage',
-                column_string='user_profile_id, message_id',
-                where_clause='WHERE (flags & 1) = 0',
-            ),
+            '''
+            CREATE INDEX IF NOT EXISTS zerver_usermessage_unread_message_id
+                ON zerver_usermessage (user_profile_id, message_id)
+                WHERE (flags & 1) = 0;
+            ''',
             reverse_sql='DROP INDEX zerver_usermessage_unread_message_id;'
         ),
     ]

--- a/zerver/migrations/0098_index_has_alert_word_user_messages.py
+++ b/zerver/migrations/0098_index_has_alert_word_user_messages.py
@@ -2,8 +2,6 @@
 
 from django.db import migrations
 
-from zerver.lib.migrate import create_index_if_not_exist  # nolint
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -12,12 +10,11 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            create_index_if_not_exist(
-                index_name='zerver_usermessage_has_alert_word_message_id',
-                table_name='zerver_usermessage',
-                column_string='user_profile_id, message_id',
-                where_clause='WHERE (flags & 512) != 0',
-            ),
+            '''
+            CREATE INDEX IF NOT EXISTS zerver_usermessage_has_alert_word_message_id
+                ON zerver_usermessage (user_profile_id, message_id)
+                WHERE (flags & 512) != 0;
+            ''',
             reverse_sql='DROP INDEX zerver_usermessage_has_alert_word_message_id;'
         ),
     ]

--- a/zerver/migrations/0099_index_wildcard_mentioned_user_messages.py
+++ b/zerver/migrations/0099_index_wildcard_mentioned_user_messages.py
@@ -2,8 +2,6 @@
 
 from django.db import migrations
 
-from zerver.lib.migrate import create_index_if_not_exist  # nolint
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -12,12 +10,11 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            create_index_if_not_exist(
-                index_name='zerver_usermessage_wildcard_mentioned_message_id',
-                table_name='zerver_usermessage',
-                column_string='user_profile_id, message_id',
-                where_clause='WHERE (flags & 8) != 0 OR (flags & 16) != 0',
-            ),
+            '''
+            CREATE INDEX IF NOT EXISTS zerver_usermessage_wildcard_mentioned_message_id
+                ON zerver_usermessage (user_profile_id, message_id)
+                WHERE (flags & 8) != 0 OR (flags & 16) != 0;
+            ''',
             reverse_sql='DROP INDEX zerver_usermessage_wilcard_mentioned_message_id;'
         ),
     ]

--- a/zerver/migrations/0177_user_message_add_and_index_is_private_flag.py
+++ b/zerver/migrations/0177_user_message_add_and_index_is_private_flag.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 import sys
 import bitfield.models
 from django.db import migrations
-from zerver.lib.migrate import create_index_if_not_exist  # nolint
 from django.db.backends.postgresql_psycopg2.schema import DatabaseSchemaEditor
 from django.db.migrations.state import StateApps
 from django.db.models import F
@@ -65,12 +64,11 @@ class Migration(migrations.Migration):
             field=bitfield.models.BitField(['read', 'starred', 'collapsed', 'mentioned', 'wildcard_mentioned', 'summarize_in_home', 'summarize_in_stream', 'force_expand', 'force_collapse', 'has_alert_word', 'historical', 'is_private'], default=0),
         ),
         migrations.RunSQL(
-            create_index_if_not_exist(
-                index_name='zerver_usermessage_is_private_message_id',
-                table_name='zerver_usermessage',
-                column_string='user_profile_id, message_id',
-                where_clause='WHERE (flags & 2048) != 0',
-            ),
+            '''
+            CREATE INDEX IF NOT EXISTS zerver_usermessage_is_private_message_id
+                ON zerver_usermessage (user_profile_id, message_id)
+                WHERE (flags & 2048) != 0;
+            ''',
             reverse_sql='DROP INDEX zerver_usermessage_is_private_message_id;'
         ),
         migrations.RunPython(reset_is_private_flag,

--- a/zerver/migrations/0180_usermessage_add_active_mobile_push_notification.py
+++ b/zerver/migrations/0180_usermessage_add_active_mobile_push_notification.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 import bitfield.models
 from django.db import migrations
-from zerver.lib.migrate import create_index_if_not_exist  # nolint
 
 
 class Migration(migrations.Migration):
@@ -25,12 +24,11 @@ class Migration(migrations.Migration):
             field=bitfield.models.BitField(['read', 'starred', 'collapsed', 'mentioned', 'wildcard_mentioned', 'summarize_in_home', 'summarize_in_stream', 'force_expand', 'force_collapse', 'has_alert_word', 'historical', 'is_private', 'active_mobile_push_notification'], default=0),
         ),
         migrations.RunSQL(
-            create_index_if_not_exist(
-                index_name='zerver_usermessage_active_mobile_push_notification_id',
-                table_name='zerver_usermessage',
-                column_string='user_profile_id, message_id',
-                where_clause='WHERE (flags & 4096) != 0',
-            ),
+            '''
+            CREATE INDEX IF NOT EXISTS zerver_usermessage_active_mobile_push_notification_id
+                ON zerver_usermessage (user_profile_id, message_id)
+                WHERE (flags & 4096) != 0;
+            ''',
             reverse_sql='DROP INDEX zerver_usermessage_active_mobile_push_notification_id;'
         ),
     ]


### PR DESCRIPTION
We no longer support Postgres versions missing this syntax.

**Testing Plan:** Ran `manage.py create_large_indexes` (it was a no-op, but at least that means the syntax is okay).