### PR TITLE
docs: Remove references to Ubuntu 14.04 Trusty as a supported platform

### DIFF
--- a/docs/development/overview.md
+++ b/docs/development/overview.md
@@ -28,7 +28,7 @@ performs well.
 Zulip also supports a wide range of ways to install the Zulip
 development environment:
 
-* On **Ubuntu** 18.04 Bionic, 16.04 Xenial and 14.04 Trusty and **Debian** 9
+* On **Ubuntu** 18.04 Bionic and 16.04 Xenial and **Debian** 9
   Stretch, you can easily
   **[install without using Vagrant][install-direct]**.
 * On **other Linux/UNIX** distributions, you'll need to follow slightly different

--- a/docs/development/remote.md
+++ b/docs/development/remote.md
@@ -5,8 +5,8 @@ be a good alternative for those with poor network connectivity or who have
 limited storage/memory on their local machines.
 
 We recommend giving the Zulip development environment its own virtual
-machine, running Ubuntu 14.04 or
-16.04, with at least 2GB of memory. If the Zulip development
+machine, running Ubuntu 16.04 or
+18.04, with at least 2GB of memory. If the Zulip development
 environment will be the only thing running on the remote virtual
 machine, we recommend installing
 [directly][install-direct]. Otherwise, we recommend the

--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -11,7 +11,7 @@ Contents:
 If you'd like to install a Zulip development environment on a computer
 that's running one of:
 
-* Ubuntu 18.10 Cosmic, 18.04 Bionic, 16.04 Xenial, 14.04 Trusty
+* Ubuntu 18.10 Cosmic, 18.04 Bionic, 16.04 Xenial
 * Debian 9 Stretch or 10 Buster
 * Centos 7 (beta)
 * Fedora 29 (beta)

--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -48,7 +48,7 @@ a proxy to access the internet.)
 
 - **All**: 2GB available RAM, Active broadband internet connection, [GitHub account][set-up-git].
 - **macOS**: macOS (10.11 El Capitan or newer recommended)
-- **Ubuntu LTS**: 18.04, 16.04, or 14.04 64-bit
+- **Ubuntu LTS**: 18.04 or 16.04 64-bit
   - or **Debian**: 9.0 "stretch" 64-bit
 - **Windows**: Windows 64-bit (Win 10 recommended), hardware
   virtualization enabled (VT-X or AMD-V), administrator access.
@@ -260,7 +260,7 @@ $ vagrant up
 The first time you run this command it will take some time because vagrant
 does the following:
 
-- downloads the base Ubuntu 14.04 virtual machine image (for macOS and Windows)
+- downloads the base Ubuntu 18.04 virtual machine image (for macOS and Windows)
   or container (for Ubuntu)
 - configures this virtual machine/container for use with Zulip,
 - creates a shared directory mapping your clone of the Zulip code inside the

--- a/docs/production/requirements.md
+++ b/docs/production/requirements.md
@@ -5,7 +5,6 @@ To run a Zulip server, you will need:
 * A supported OS:
   * Ubuntu 18.04 Bionic
   * Ubuntu 16.04 Xenial
-  * Ubuntu 14.04 Trusty (deprecated due to [approaching end-of-life][trusty-eol])
   * Debian 9 Stretch
 * At least 2GB RAM, and 10GB disk space
   * If you expect 100+ users: 4GB RAM, and 2 CPUs
@@ -29,12 +28,12 @@ can't support you, but
 
 #### Operating System
 
-Ubuntu 18.04 Bionic, Ubuntu 16.04 Xenial, Ubuntu 14.04 Trusty and
+Ubuntu 18.04 Bionic, Ubuntu 16.04 Xenial, and
 Debian Stretch are supported for running Zulip in production.  64-bit
 is recommended.  We also recommend installing on the newest option
 you're comfortable with, to save your organization the work of
-upgrading (Ubuntu Trusty will
-[reach end of life in April 2019][trusty-eol]; Zulip 2.0 will be the
+upgrading (Ubuntu Trusty
+[reached end of life in April 2019][trusty-eol]; Zulip 2.0 was the
 last major release to support it).
 
 If you're using Ubuntu, the

--- a/docs/subsystems/release-checklist.md
+++ b/docs/subsystems/release-checklist.md
@@ -22,7 +22,7 @@ preparing a new release.
 * Download updated translation strings from Transifex and commit them.
 * Use `build-release-tarball` to generate a release tarball.
 * Test the new tarball extensively, both new install and upgrade from last
-  release, on both Trusty and Xenial.
+  release, on both Xenial and Bionic.
 * Repeat until release is ready.
 * When near finished: move the blog post draft to Ghost.  (For a draft
   in Dropbox Paper, use "··· > Download > Markdown" to get a pretty


### PR DESCRIPTION
**Testing Plan:** :eyeglasses: