### PR TITLE
Remove static/node_modules symlink.

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -312,7 +312,7 @@ exports.set_up = function () {
             if (page_params.development_environment) {
                 // Usually the Django templates handle this path stuff
                 // for us, but in this case we need to hardcode it.
-                zxcvbn_path = '/static/node_modules/zxcvbn/dist/zxcvbn.js';
+                zxcvbn_path = '/webpack/zxcvbn.js';
             }
             $.getScript(zxcvbn_path, function () {
                 $('#pw_strength .bar').removeClass("fade");

--- a/static/node_modules
+++ b/static/node_modules
@@ -1,1 +1,0 @@
-../node_modules/

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -934,7 +934,7 @@ JS_SPECS = {
     # for bundling KaTeX.
     'katex': {
         'source_filenames': [
-            'node_modules/katex/dist/katex.js',
+            '../node_modules/katex/dist/katex.js',
         ],
         'output_filename': 'min/katex.js',
     },
@@ -943,7 +943,7 @@ JS_SPECS = {
     # good way to look up the path to the file).
     'zxcvbn': {
         'source_filenames': [
-            'node_modules/zxcvbn/dist/zxcvbn.js',
+            '../node_modules/zxcvbn/dist/zxcvbn.js',
         ],
         'output_filename': 'min/zxcvbn.js'
     },


### PR DESCRIPTION
It appears not to have been useful and makes it marginally harder to reason about how module resolution works.  Paths to static content in `node_modules` should be resolved through Webpack instead.

**Testing Plan:** Opened the password change dialog in the development environment, observed that http://localhost:9991/webpack/zxcvbn.js?_=1561595968220 was successfully loaded and the strength meter works.