### PR TITLE
signup, settings: Update password strength meter on input events

### DIFF
--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -13,7 +13,7 @@ $(function () {
         // was just reloaded due to a validation failure on the backend.
         common.password_quality(password_field.val(), $('#pw_strength .bar'), password_field);
 
-        password_field.on('change keyup', function () {
+        password_field.on('input', function () {
             // Update the password strength bar even if we aren't validating
             // the field yet.
             common.password_quality($(this).val(), $('#pw_strength .bar'), $(this));

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -372,7 +372,7 @@ exports.set_up = function () {
         });
     });
 
-    $('#new_password').on('change keyup', function () {
+    $('#new_password').on('input', function () {
         var field = $('#new_password');
         common.password_quality(field.val(), $('#pw_strength .bar'), field);
     });


### PR DESCRIPTION
Pasting a generated password into the password box triggers neither a `change` event (until the password box is unfocused) nor a `keyup` event.

**Testing Plan:** Pasted a password into the password change dialog.