### PR TITLE
Fix searching and viewing Group PM and refactor of by_pm_with

### DIFF
--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -323,7 +323,8 @@ class NarrowBuilder:
             recipient = recipient_for_user_profiles(user_profiles=user_profiles,
                                                     forwarded_mirror_message=False,
                                                     forwarder_user_profile=None,
-                                                    sender=self.user_profile)
+                                                    sender=self.user_profile,
+                                                    allow_deactivated=True)
         except (JsonableError, ValidationError):
             raise BadNarrowOperator('unknown user in ' + str(operand))
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR is a fix for two separate bugs (one frontend and one backend)
defined in this message: https://chat.zulip.org/#narrow/stream/9-issues/topic/.2312593.20DMs.20with.20deactivated.20users/near/758272

**Testing Plan:** <!-- How have you tested? -->
Searching group DM before caused error. Saw that search operand was not being sent properly from frontend to backend.
After fixing searched group DMs again. Now the search ooperand is being properly handled and sent to backend.
**Frontend issue:** Ready to be merged.
**Before** : The frontend didn't handle searching a group DM properly (inactive and active members alike)
![image](https://user-images.githubusercontent.com/23462580/60288347-a314b000-9931-11e9-8007-296f56ddc36c.png)

**After**
<img width="1113" alt="image" src="https://user-images.githubusercontent.com/23462580/60288584-259d6f80-9932-11e9-8c2f-d2e33fbd6f78.png">

**WIP** : Backend issue of showing and searching group DMs containing inactive users





<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->