### PR TITLE
Improve error messaging when yarn install fails.

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -430,7 +430,9 @@ def main(options):
         run_as_root(["chown", "%s:%s" % (user_id, user_id), NODE_MODULES_CACHE_PATH])
         setup_node_modules(prefer_offline=True)
     except subprocess.CalledProcessError:
-        print(WARNING + "`yarn install` failed; retrying..." + ENDC)
+        print(WARNING +
+              "`yarn install` failed, this is usually indicative of a network issue; retrying..." +
+              ENDC)
         setup_node_modules()
 
     # Install shellcheck.


### PR DESCRIPTION
See the discussion at https://chat.zulip.org/#narrow/stream/21-provision-help/topic/provision.20failing.20at.20yarn.20install for more details.