### PR TITLE
narrow: Fix incorrect method of querying for operands.

### DIFF
--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -849,7 +849,7 @@ function pick_empty_narrow_banner() {
         }
 
         // For empty stream searches within other narrows, we display the stop words
-        if (current_filter.operators("search")) {
+        if (current_filter.operands("search").length > 0) {
             show_search_query();
             return $("#empty_search_narrow_message");
         }


### PR DESCRIPTION
Commit 02413f9a1be8554744141138f3629c197cd88e91 introduced a bug
where any code reaching `if(operators('search')` would be executed,
which caused inputs where we didn't have the search operator to
throw an error when we do not find a search operan later.

At least one affected cases was narrowing to an empty topic.

**Testing Plan:** <!-- How have you tested? -->

Manual testing.