### PR TITLE
circleci/config: Store casper, and zulip-test-event-log artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,10 +105,13 @@ jobs:
       # runs the frontend tests.
       - *upload_coverage_report
 
-      # - store_artifacts:  # TODO
-      #     path: var/casper/
-      #     # also /tmp/zulip-test-event-log/
-      #     destination: test-reports
+      - store_artifacts:
+          path: ./var/casper/
+          destination: casper
+
+      - store_artifacts:    
+          path: ../../../tmp/zulip-test-event-log/
+          destination: test-reports
 
   "bionic-backend-python3.6":
     docker:


### PR DESCRIPTION
We upload the output from a failed `Casper` test as an artifact, along with the output from `zulip-test-event-log`.  The example below demonstrates this by testing it out on a manufactured failure:

Example: https://circleci.com/gh/whoodes/zulip/737#artifacts/containers/0