### PR TITLE
Set the layout width even if the sbwidth is 0

### DIFF
--- a/static/js/scroll_bar.js
+++ b/static/js/scroll_bar.js
@@ -61,9 +61,8 @@ exports.initialize = function () {
         $("head").append("<style> @media (max-width: 1165px) { .compose-content, .header-main .column-middle { margin-right: " + (7 + sbWidth) + "px !important; } } " +
                          "@media (max-width: 775px) { .fixed-app .column-middle { margin-left: " + (7 + sbWidth) + "px !important; } } " +
                          "</style>");
-
-        exports.set_layout_width();
     }
+    exports.set_layout_width();
 };
 
 exports.set_layout_width = function () {


### PR DESCRIPTION
If sbWidth is 0, then the fluid layout width is never applied.

Testing Plan:
Initially tested by running locally and verifying on reload that the
setting stayed applied.

I looked for tests relating to the ui initialization but only found
ui_init.js, which I don't really understand how to implement a test in.
Manually tested instead

Manually tested with Cordelia, Hamlet, and Iago