### PR TITLE
docs: replace duplicated `mentioned` in update-message-flags.md

### DIFF
--- a/templates/zerver/api/update-message-flags.md
+++ b/templates/zerver/api/update-message-flags.md
@@ -103,7 +103,7 @@ curl -X POST {{ api_url }}/v1/messages/flags \
                 </td>
             </tr>
             <tr>
-                <td>`mentioned`</td>
+                <td>`has_alert_word`</td>
                 <td>
                      Whether the message contains any of the current
                      user's [configured alert


### PR DESCRIPTION
The second instance of `mentioned` is actually supposed to be `has_alert_word`.
https://chat.zulip.org/#narrow/stream/3-backend/topic/api.20docs/near/762115