### PR TITLE
provision: Improve error messaging when attempting to use Ubuntu Trusty.

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -128,6 +128,12 @@ codename = distro_info['DISTRIB_CODENAME']
 family = distro_info['DISTRIB_FAMILY']
 if not (vendor in SUPPORTED_PLATFORMS and codename in SUPPORTED_PLATFORMS[vendor]):
     logging.critical("Unsupported platform: {} {}".format(vendor, codename))
+    if codename == 'trusty':
+        print()
+        print("Ubuntu Trusty reached end-of-life upstream and is no longer a supported platform for Zulip")
+        if os.path.exists('/home/vagrant'):
+            print("It's recommended to run `vagrant destroy`, and rebuild the VM.\n")
+            print("See: https://zulip.readthedocs.io/en/latest/development/setup-vagrant.html")
     sys.exit(1)
 
 POSTGRES_VERSION_MAP = {


### PR DESCRIPTION
As part of dropping support, we add appropriate error messaging when a
user attempts to provision while using trusty.  If the user is running
in Vagrant we append information on how to proceed.


**Testing Plan:** <!-- How have you tested? -->
With `bionic` in place of `trusty`.

Sample output:
```
(zulip-py3-venv) vagrant@ubuntu-bionic:~/zulip$ ./tools/provision
CRITICAL:root:Unsupported platform: Ubuntu bionic

Ubuntu Trusty reached end-of-life upstream and is no longer a supported platform for Zulip
It's recommended to run `vagrant destroy`, and rebuild the VM.

See: https://zulip.readthedocs.io/en/latest/development/setup-vagrant.html

Provisioning failed!

* Look at the traceback(s) above to find more about the errors.
* Resolve the errors or get help on chat.
* If you can fix this yourself, you can re-run tools/provision at any time.
* Logs are here: zulip/var/log/provision.log
```