### PR TITLE
provision: Sort system dependencies deterministically

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -281,7 +281,7 @@ def install_system_deps():
     # type: () -> None
 
     # By doing list -> set -> list conversion, we remove duplicates.
-    deps_to_install = list(set(SYSTEM_DEPENDENCIES))
+    deps_to_install = sorted(set(SYSTEM_DEPENDENCIES))
 
     if family == 'redhat':
         install_yum_deps(deps_to_install)


### PR DESCRIPTION
`set` iteration order is randomized in Python ≥ 3.3. That might or might not have had the potential for causing rare probabilistic bugs, but if nothing else, it made build logs harder to compare.