### PR TITLE
provision: Update error output on failed `yarn install` reattempt.

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -431,7 +431,13 @@ def main(options):
         setup_node_modules(prefer_offline=True)
     except subprocess.CalledProcessError:
         print(WARNING + "`yarn install` failed; retrying..." + ENDC)
-        setup_node_modules()
+        try:
+            setup_node_modules()
+        except subprocess.CalledProcessError:
+            print(FAIL +
+                  "`yarn install` is failing, this usually indicates a problem with the network."
+                  + ENDC)
+            sys.exit(1)
 
     # Install shellcheck.
     run_as_root(["scripts/lib/install-shellcheck"])


### PR DESCRIPTION
Opening a new PR due to a caching issue in: #12678

Sample output:
```
(zulip-py3-venv) vagrant@ubuntu-bionic:/srv/zulip$ ./tools/provision
No changes to apt dependencies, so skipping apt operations.
+ sudo -H -- env http_proxy= https_proxy= no_proxy= scripts/lib/install-node
Node version 12.3.1 and yarn version 1.16.0 are already installed.
+ sudo -- mkdir -p /srv/zulip-npm-cache
+ sudo -- chown 1000:1000 /srv/zulip-npm-cache
Cached version not found! Installing node modules.
+ mkdir -p /srv/zulip-npm-cache/b95090ac86beee674b2908c804d004ee8fe734f8
+ cp package.json yarn.lock /srv/zulip-npm-cache/b95090ac86beee674b2908c804d004ee8fe734f8
+ /srv/zulip/scripts/lib/cd_exec /srv/zulip-npm-cache/b95090ac86beee674b2908c804d004ee8fe734f8 /srv/zulip-yarn/bin/yarn install --non-interactive --frozen-lockfile --prefer-offline
yarn install v1.16.0
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.4: The platform "linux" is incompatible with this module.
info "fsevents@1.2.4" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@1.2.9: The platform "linux" is incompatible with this module.
info "fsevents@1.2.9" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
error /srv/zulip-npm-cache/b95090ac86beee674b2908c804d004ee8fe734f8/node_modules/phantomjs-prebuilt: Command failed.
Exit code: 1
Command: node install.js
Arguments:
Directory: /srv/zulip-npm-cache/b95090ac86beee674b2908c804d004ee8fe734f8/node_modules/phantomjs-prebuilt
Output:
PhantomJS not found on PATH
Downloading https://github.com/Medium/phantomjs/releases/download/v2.1.1/phantomjs-2.1.1-linux-x86_64.tar.bz2
Saving to /tmp/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
Receiving...

Error making request.
Error: getaddrinfo ENOTFOUND github.com
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:60:26)

Please report this full log at https://github.com/Medium/phantomjs
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

Error running a subcommand of ./lib/provision.py: /srv/zulip/scripts/lib/cd_exec /srv/zulip-npm-cache/b95090ac86beee674b2908c804d004ee8fe734f8 /srv/zulip-yarn/bin/yarn install --non-interactive --frozen-lockfile --prefer-offline
Actual error output for the subcommand is just above this.

`yarn install` failed; retrying...
Cached version not found! Installing node modules.
+ mkdir -p /srv/zulip-npm-cache/b95090ac86beee674b2908c804d004ee8fe734f8
+ cp package.json yarn.lock /srv/zulip-npm-cache/b95090ac86beee674b2908c804d004ee8fe734f8
+ /srv/zulip/scripts/lib/cd_exec /srv/zulip-npm-cache/b95090ac86beee674b2908c804d004ee8fe734f8 /srv/zulip-yarn/bin/yarn install --non-interactive --frozen-lockfile
yarn install v1.16.0
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.4: The platform "linux" is incompatible with this module.
info "fsevents@1.2.4" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@1.2.9: The platform "linux" is incompatible with this module.
info "fsevents@1.2.9" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
error /srv/zulip-npm-cache/b95090ac86beee674b2908c804d004ee8fe734f8/node_modules/phantomjs-prebuilt: Command failed.
Exit code: 1
Command: node install.js
Arguments:
Directory: /srv/zulip-npm-cache/b95090ac86beee674b2908c804d004ee8fe734f8/node_modules/phantomjs-prebuilt
Output:
PhantomJS not found on PATH
Downloading https://github.com/Medium/phantomjs/releases/download/v2.1.1/phantomjs-2.1.1-linux-x86_64.tar.bz2
Saving to /tmp/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
Receiving...

Error making request.
Error: getaddrinfo ENOTFOUND github.com
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:60:26)

Please report this full log at https://github.com/Medium/phantomjs
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

Error running a subcommand of ./lib/provision.py: /srv/zulip/scripts/lib/cd_exec /srv/zulip-npm-cache/b95090ac86beee674b2908c804d004ee8fe734f8 /srv/zulip-yarn/bin/yarn install --non-interactive --frozen-lockfile
Actual error output for the subcommand is just above this.

`yarn install` is failing, this usually indicates a problem with the network.
Traceback (most recent call last):
  File "./lib/provision.py", line 431, in main
    setup_node_modules(prefer_offline=True)
  File "/srv/zulip/scripts/lib/node_cache.py", line 70, in setup_node_modules
    copy_modules=copy_modules)
  File "/srv/zulip/scripts/lib/node_cache.py", line 105, in do_yarn_install
    run(cmd, stdout=stdout, stderr=stderr)
  File "/srv/zulip/scripts/lib/zulip_tools.py", line 199, in run
    subprocess.check_call(args, **kwargs)
  File "/usr/lib/python3.6/subprocess.py", line 311, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/srv/zulip/scripts/lib/cd_exec', '/srv/zulip-npm-cache/b95090ac86beee674b2908c804d004ee8fe734f8', '/srv/zulip-yarn/bin/yarn', 'install', '--non-interactive', '--frozen-lockfile', '--prefer-offline']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./lib/provision.py", line 628, in <module>
    sys.exit(main(options))
  File "./lib/provision.py", line 435, in main
    setup_node_modules()
  File "/srv/zulip/scripts/lib/node_cache.py", line 70, in setup_node_modules
    copy_modules=copy_modules)
  File "/srv/zulip/scripts/lib/node_cache.py", line 105, in do_yarn_install
    run(cmd, stdout=stdout, stderr=stderr)
  File "/srv/zulip/scripts/lib/zulip_tools.py", line 199, in run
    subprocess.check_call(args, **kwargs)
  File "/usr/lib/python3.6/subprocess.py", line 311, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/srv/zulip/scripts/lib/cd_exec', '/srv/zulip-npm-cache/b95090ac86beee674b2908c804d004ee8fe734f8', '/srv/zulip-yarn/bin/yarn', 'install', '--non-interactive', '--frozen-lockfile']' returned non-zero exit status 1.

Provisioning failed!

* Look at the traceback(s) above to find more about the errors.
* Resolve the errors or get help on chat.
* If you can fix this yourself, you can re-run tools/provision at any time.
* Logs are here: zulip/var/log/provision.log
```