### PR TITLE
dependencies: Upgrade markdown from 3.0.1 -> 3.1.1.

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -12,7 +12,7 @@ mypy_extensions==0.4.1
 Jinja2==2.10.1
 
 # Needed for markdown processing
-Markdown==3.0.1
+Markdown==3.1.1
 MarkupSafe==1.1.1
 Pygments==2.3.1
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -93,7 +93,7 @@ jsondiff==1.1.1           # via moto
 jsonpickle==1.1           # via aws-xray-sdk, python-digitalocean
 lxml==4.3.3
 markdown-include==0.5.1
-markdown==3.0.1
+markdown==3.1.1
 markupsafe==1.1.1
 matrix-client==0.3.2
 mock==2.0.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -67,7 +67,7 @@ jedi==0.13.3              # via ipython
 jinja2==2.10.1
 lxml==4.3.3
 markdown-include==0.5.1
-markdown==3.0.1
+markdown==3.1.1
 markupsafe==1.1.1
 matrix-client==0.3.2
 mock==2.0.0

--- a/version.py
+++ b/version.py
@@ -21,4 +21,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '36.1'
+PROVISION_VERSION = '37.0'


### PR DESCRIPTION
Fixes #12192.

Automated tests and basic message sending tests on the dev server.
