### PR TITLE
.editorconfig: Fix invalid brace patterns

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 
-[*.{py}]
+[*.py]
 max_line_length = 110
 
 [*.{js,ts}]
@@ -20,6 +20,6 @@ max_line_length = 120
 indent_style = space
 indent_size = 2
 
-[*.{cfg}]
+[*.cfg]
 indent_style = space
 indent_size = 8


### PR DESCRIPTION
`editorconfig` does not support brace patterns with only one alternative.

Cc: @bojidar-bg

**Testing Plan:** Run `editorconfig $PWD/foo.py`, observe that `max_line_length=110` is no longer missing.