### PR TITLE
markdown: Fix {start_tabs}...{end_tabs} producing broken html.

### DIFF
--- a/zerver/lib/bugdown/raw_html_postprocessor.py
+++ b/zerver/lib/bugdown/raw_html_postprocessor.py
@@ -1,0 +1,20 @@
+from markdown.extensions import Extension
+from typing import Any
+import markdown
+import zerver.lib.bugdown.tabbed_sections
+
+class RawHtmlPostprocessor(markdown.postprocessors.RawHtmlPostprocessor):
+    def run(self, text: str) -> str:
+        processed_text = super().run(text)
+        return self.remove_redundant_html(processed_text)
+
+    def remove_redundant_html(self, text: str) -> str:
+        text = zerver.lib.bugdown.tabbed_sections.remove_redundant_html(text)
+        return text
+
+class RawHtmlPostprocessorExtension(Extension):
+    def extendMarkdown(self, md: markdown) -> None:
+        md.postprocessors.register(RawHtmlPostprocessor(md), 'raw_html', 30)
+
+def makeExtension(**kwargs: Any) -> RawHtmlPostprocessorExtension:  # pragma: no cover
+    return RawHtmlPostprocessorExtension(**kwargs)

--- a/zerver/lib/bugdown/tabbed_sections.py
+++ b/zerver/lib/bugdown/tabbed_sections.py
@@ -10,12 +10,12 @@ END_TABBED_SECTION_REGEX = re.compile(r'^\{end_tabs\}$')
 TAB_CONTENT_REGEX = re.compile(r'^\{tab\|\s*(.+?)\s*\}$')
 
 CODE_SECTION_TEMPLATE = """
-<div class="code-section {tab_class}" markdown="1">
+<!--remove_tag_before--><div class="code-section {tab_class}" markdown="1">
 {nav_bar}
 <div class="blocks">
 {blocks}
 </div>
-</div>
+</div><!--remove_tag_after-->
 """.strip()
 
 NAV_BAR_TEMPLATE = """
@@ -29,9 +29,9 @@ NAV_LIST_ITEM_TEMPLATE = """
 """.strip()
 
 DIV_TAB_CONTENT_TEMPLATE = """
-<div data-language="{data_language}" markdown="1">
+<div data-language="{data_language}" markdown="1"><!--remove_tag_after-->
 {content}
-</div>
+<!--remove_tag_before--></div>
 """.strip()
 
 # If adding new entries here, also check if you need to update
@@ -156,6 +156,16 @@ class TabbedSectionsPreprocessor(Preprocessor):
                 block['end_tabs_index'] = index
                 break
         return block
+
+def remove_redundant_html(text: str) -> str:
+    # This function runs in the postprocessor after substituting the
+    # placeholders for the actual html in the content. Here, we remove
+    # the extra <p> tags added by the paragraph block processor that
+    # are needed for properly parsing this content in the tree processor.
+    # text.
+    text = text.replace('<p><!--remove_tag_before-->', '')
+    text = text.replace('<!--remove_tag_after--></p>', '')
+    return text
 
 def makeExtension(*args: Any, **kwargs: str) -> TabbedSectionsGenerator:
     return TabbedSectionsGenerator(**kwargs)

--- a/zerver/templatetags/app_filters.py
+++ b/zerver/templatetags/app_filters.py
@@ -19,6 +19,7 @@ import zerver.lib.bugdown.help_settings_links
 import zerver.lib.bugdown.help_relative_links
 import zerver.lib.bugdown.help_emoticon_translations_table
 import zerver.lib.bugdown.include
+import zerver.lib.bugdown.raw_html_postprocessor
 from zerver.lib.cache import ignore_unhashable_lru_cache, dict_to_items_tuple, items_tuple_to_dict
 
 register = Library()
@@ -114,6 +115,7 @@ def render_markdown_path(markdown_file_path: str,
             zerver.lib.bugdown.help_settings_links.makeExtension(),
             zerver.lib.bugdown.help_relative_links.makeExtension(),
             zerver.lib.bugdown.help_emoticon_translations_table.makeExtension(),
+            zerver.lib.bugdown.raw_html_postprocessor.makeExtension(),
         ]
     if md_macro_extension is None:
         md_macro_extension = zerver.lib.bugdown.include.makeExtension(

--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -229,65 +229,52 @@ class TemplateTestCase(ZulipTestCase):
         }
         content = template.render(context)
         content_sans_whitespace = content.replace(" ", "").replace('\n', '')
-
-        # Note that the expected HTML has a lot of stray <p> tags. This is a
-        # consequence of how the Markdown renderer converts newlines to HTML
-        # and how elements are delimited by newlines and so forth. However,
-        # stray <p> tags are usually matched with closing tags by HTML renderers
-        # so this doesn't affect the final rendered UI in any visible way.
         expected_html = """
 header
 
 <h1 id="heading">Heading</h1>
-<p>
-  <div class="code-section has-tabs" markdown="1">
-    <ul class="nav">
-      <li data-language="ios">iOS</li>
-      <li data-language="desktop-web">Desktop/Web</li>
-    </ul>
-    <div class="blocks">
-      <div data-language="ios" markdown="1"></p>
-        <p>iOS instructions</p>
-      <p></div>
-      <div data-language="desktop-web" markdown="1"></p>
-        <p>Desktop/browser instructions</p>
-      <p></div>
+<div class="code-section has-tabs" markdown="1">
+  <ul class="nav">
+    <li data-language="ios">iOS</li>
+    <li data-language="desktop-web">Desktop/Web</li>
+  </ul>
+  <div class="blocks">
+    <div data-language="ios" markdown="1">
+      <p>iOS instructions</p>
+    </div>
+    <div data-language="desktop-web" markdown="1">
+      <p>Desktop/browser instructions</p>
     </div>
   </div>
-</p>
+</div>
 
 <h2 id="heading-2">Heading 2</h2>
-<p>
-  <div class="code-section has-tabs" markdown="1">
-    <ul class="nav">
-      <li data-language="desktop-web">Desktop/Web</li>
-      <li data-language="android">Android</li>
-    </ul>
-    <div class="blocks">
-      <div data-language="desktop-web" markdown="1"></p>
-        <p>Desktop/browser instructions</p>
-      <p></div>
-      <div data-language="android" markdown="1"></p>
-        <p>Android instructions</p>
-      <p></div>
+<div class="code-section has-tabs" markdown="1">
+  <ul class="nav">
+    <li data-language="desktop-web">Desktop/Web</li>
+    <li data-language="android">Android</li>
+  </ul>
+  <div class="blocks">
+    <div data-language="desktop-web" markdown="1">
+      <p>Desktop/browser instructions</p>
+    </div>
+    <div data-language="android" markdown="1">
+      <p>Android instructions</p>
     </div>
   </div>
-</p>
+</div>
 
 <h2 id="heading-3">Heading 3</h2>
-<p>
-  <div class="code-section no-tabs" markdown="1">
-    <ul class="nav">
-      <li data-language="null_tab">None</li>
-    </ul>
-    <div class="blocks">
-      <div data-language="null_tab" markdown="1"></p>
-        <p>Instructions for all platforms</p>
-      <p></div>
+<div class="code-section no-tabs" markdown="1">
+  <ul class="nav">
+    <li data-language="null_tab">None</li>
+  </ul>
+  <div class="blocks">
+    <div data-language="null_tab" markdown="1">
+      <p>Instructions for all platforms</p>
     </div>
   </div>
-</p>
-
+</div>
 footer
 """
 


### PR DESCRIPTION
The ParagraphProcessor in python-markdown puts `<p>` tags around all
blocks that aren't lists. Here, we have two raw html blocks and one
regular block where we do not want our HTML block to be surrounded
by `<p>`.

We subclass the RawHtmlPostprocessor to run a custom function on the
final substituted HTML, in which we remove the stray p tags along
with our placeholder HTML comments to generate correct HTML.

Fixes #12186.

**Testing Plan:** <!-- How have you tested? -->
Changed 1 automated test and checked the UI visually on browser.