### PR TITLE
templates: Fix wrong path to edit-embedded-bot-service template.

### DIFF
--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -406,7 +406,7 @@ exports.set_up = function () {
             $("#edit_service_interface").val(service.interface);
         }
         if (bot.bot_type.toString() === EMBEDDED_BOT_TYPE) {
-            $("#service_data").append(templates.render("edit-embedded-bot-service",
+            $("#service_data").append(templates.render("settings/edit-embedded-bot-service",
                                                        {service: service}));
         }
 


### PR DESCRIPTION
This bug is introduced in #12667 (use handlebars-loader). Discovered via https://circleci.com/gh/tommyip/zulip/115?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
