### PR TITLE
Preparatory commits from ES6 module conversion

### DIFF
--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -284,11 +284,11 @@ run_test("bulk_data_hacks", () => {
 });
 
 run_test("level", () => {
-    assert.equal(buddy_data.my_user_status(me.user_id), "translated: (you)");
+    assert.equal(buddy_data.get_my_user_status(me.user_id), "translated: (you)");
     user_status.set_away(me.user_id);
-    assert.equal(buddy_data.my_user_status(me.user_id), "translated: (unavailable)");
+    assert.equal(buddy_data.get_my_user_status(me.user_id), "translated: (unavailable)");
     user_status.revoke_away(me.user_id);
-    assert.equal(buddy_data.my_user_status(me.user_id), "translated: (you)");
+    assert.equal(buddy_data.get_my_user_status(me.user_id), "translated: (you)");
 });
 
 run_test("level", () => {

--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -521,7 +521,7 @@ run_test("unread_ops", () => {
         unread.process_loaded_messages(test_messages);
 
         // Make our window appear visible.
-        notifications.window_has_focus = () => true;
+        notifications.is_window_focused = () => true;
 
         // Make our "test" message appear visible.
         message_viewport.bottom_message_visible = () => true;

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -15,8 +15,6 @@
 
 const emoji_codes = zrequire("emoji_codes", "generated/emoji/emoji_codes.json");
 
-set_global("activity", {});
-
 set_global("navigator", {
     platform: "",
 });
@@ -36,6 +34,7 @@ emoji.initialize({
     emoji_codes,
 });
 
+zrequire("activity");
 const hotkey = zrequire("hotkey");
 zrequire("common");
 

--- a/frontend_tests/node_tests/narrow_state.js
+++ b/frontend_tests/node_tests/narrow_state.js
@@ -32,7 +32,7 @@ run_test("stream", () => {
     assert(narrow_state.active());
 
     assert.equal(narrow_state.stream(), "Test");
-    assert.equal(narrow_state.stream_id(), test_stream.stream_id);
+    assert.equal(narrow_state.stream_sub().stream_id, test_stream.stream_id);
     assert.equal(narrow_state.topic(), "Bar");
     assert(narrow_state.is_for_stream_id(test_stream.stream_id));
 
@@ -56,7 +56,7 @@ run_test("narrowed", () => {
     assert(!narrow_state.narrowed_to_search());
     assert(!narrow_state.narrowed_to_topic());
     assert(!narrow_state.narrowed_by_stream_reply());
-    assert.equal(narrow_state.stream_id(), undefined);
+    assert.equal(narrow_state.stream_sub(), undefined);
     assert(!narrow_state.narrowed_to_starred());
 
     set_filter([["stream", "Foo"]]);
@@ -246,7 +246,7 @@ run_test("topic", () => {
 run_test("stream", () => {
     set_filter([]);
     assert.equal(narrow_state.stream(), undefined);
-    assert.equal(narrow_state.stream_id(), undefined);
+    assert.equal(narrow_state.stream_sub(), undefined);
 
     set_filter([
         ["stream", "Foo"],
@@ -254,11 +254,9 @@ run_test("stream", () => {
     ]);
     assert.equal(narrow_state.stream(), "Foo");
     assert.equal(narrow_state.stream_sub(), undefined);
-    assert.equal(narrow_state.stream_id(), undefined);
 
     const sub = {name: "Foo", stream_id: 55};
     stream_data.add_sub(sub);
-    assert.equal(narrow_state.stream_id(), 55);
     assert.deepEqual(narrow_state.stream_sub(), sub);
 
     set_filter([

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "style-loader": "^1.0.0",
     "terser-webpack-plugin": "^4.1.0",
     "turndown": "^6.0.0",
-    "unorm": "^1.6.0",
     "webfonts-loader": "^6.0.2",
     "webpack": "^4.33.0",
     "webpack-cli": "^3.3.2",

--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -29,6 +29,9 @@ exports.client_is_active = document.hasFocus && document.hasFocus();
 // if this was a server-initiated-reload to avoid counting a
 // server-initiated reload as user activity.
 exports.new_user_input = true;
+exports.set_new_user_input = function (value) {
+    exports.new_user_input = value;
+};
 
 function update_pm_count_in_dom(count_span, value_span, count) {
     const li = count_span.parents("li");

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -140,7 +140,7 @@ function get_num_unread(user_id) {
     return unread.num_unread_for_person(user_id.toString());
 }
 
-exports.my_user_status = function (user_id) {
+exports.get_my_user_status = function (user_id) {
     if (!people.is_my_user_id(user_id)) {
         return;
     }
@@ -179,7 +179,7 @@ exports.user_last_seen_time_status = function (user_id) {
 exports.info_for = function (user_id) {
     const user_circle_class = exports.get_user_circle_class(user_id);
     const person = people.get_by_user_id(user_id);
-    const my_user_status = exports.my_user_status(user_id);
+    const my_user_status = exports.get_my_user_status(user_id);
     const user_circle_status = exports.status_description(user_id);
 
     return {

--- a/static/js/compose_pm_pill.js
+++ b/static/js/compose_pm_pill.js
@@ -10,8 +10,6 @@ exports.initialize_pill = function () {
         container,
         create_item_from_text: user_pill.create_item_from_email,
         get_text_from_item: user_pill.get_email_from_item,
-        onPillCreate: input_pill.onPillCreate,
-        onPillRemove: input_pill.onPillRemove,
     });
 
     return pill;

--- a/static/js/dropdown_list_widget.js
+++ b/static/js/dropdown_list_widget.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const render_dropdown_list = require("../templates/settings/dropdown_list.hbs");
+
 const DropdownListWidget = function (opts) {
     const init = () => {
         // Run basic sanity checks on opts, and set up sane defaults.
@@ -19,8 +21,6 @@ const DropdownListWidget = function (opts) {
         }
     };
     init();
-
-    const render_dropdown_list = require("../templates/settings/dropdown_list.hbs");
 
     const render = (value) => {
         $(`#${opts.container_id} #${opts.value_id}`).data("value", value);

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -583,7 +583,7 @@ function register_popover_events(popover) {
     });
 }
 
-exports.render_emoji_popover = function (elt, id) {
+exports.build_emoji_popover = function (elt, id) {
     const template_args = {
         class: "emoji-info-popover",
     };
@@ -649,7 +649,7 @@ exports.toggle_emoji_popover = function (element, id) {
     if (elt.data("popover") === undefined) {
         // Keep the element over which the popover is based off visible.
         elt.addClass("reaction_button_visible");
-        exports.render_emoji_popover(elt, id);
+        exports.build_emoji_popover(elt, id);
     }
     reset_emoji_showcase();
 };

--- a/static/js/floating_recipient_bar.js
+++ b/static/js/floating_recipient_bar.js
@@ -16,7 +16,7 @@ exports.first_visible_message = function (bar) {
     // overlaps the floating recipient bar's space (since you ).
 
     const messages = bar.children(".message_row");
-    const frb_bottom = exports.frb_bottom();
+    const frb_bottom = exports.get_frb_bottom();
     const frb_top = frb_bottom - 25;
     let result;
 
@@ -103,7 +103,7 @@ exports.get_date = function (elem) {
     return rendered_date;
 };
 
-exports.frb_bottom = function () {
+exports.get_frb_bottom = function () {
     const bar = $("#floating_recipient_bar");
     const bar_top = top_offset(bar);
     const bar_bottom = bar_top + bar.safeOuterHeight();

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -860,7 +860,7 @@ exports.process_hotkey = function (e, hotkey) {
    instead just let keypress go for it. */
 
 exports.process_keydown = function (e) {
-    activity.new_user_input = true;
+    activity.set_new_user_input(true);
     const hotkey = exports.get_keydown_hotkey(e);
     if (!hotkey) {
         return false;

--- a/static/js/message_scroll.js
+++ b/static/js/message_scroll.js
@@ -110,7 +110,7 @@ exports.hide_top_of_narrow_notices = function () {
     exports.hide_history_limit_notice();
 };
 
-exports.actively_scrolling = function () {
+exports.is_actively_scrolling = function () {
     return actively_scrolling;
 };
 

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -787,7 +787,7 @@ exports.deactivate = function () {
     unnarrow_times = {start_time: new Date()};
     blueslip.debug("Unnarrowed");
 
-    if (message_scroll.actively_scrolling()) {
+    if (message_scroll.is_actively_scrolling()) {
         // There is no way to intercept in-flight scroll events, and they will
         // cause you to end up in the wrong place if you are actively scrolling
         // on an unnarrow. Wait a bit and try again once the scrolling is over.

--- a/static/js/narrow_state.js
+++ b/static/js/narrow_state.js
@@ -124,16 +124,6 @@ exports.stream_sub = function () {
     return sub;
 };
 
-exports.stream_id = function () {
-    const sub = exports.stream_sub();
-
-    if (!sub) {
-        return;
-    }
-
-    return sub.stream_id;
-};
-
 exports.topic = function () {
     if (current_filter === undefined) {
         return;
@@ -223,25 +213,25 @@ exports._possible_unread_message_ids = function () {
         return;
     }
 
-    let stream_id;
+    let sub;
     let topic_name;
     let current_filter_pm_string;
 
     if (current_filter.can_bucket_by("stream", "topic")) {
-        stream_id = exports.stream_id();
-        if (stream_id === undefined) {
+        sub = exports.stream_sub();
+        if (sub === undefined) {
             return [];
         }
         topic_name = exports.topic();
-        return unread.get_msg_ids_for_topic(stream_id, topic_name);
+        return unread.get_msg_ids_for_topic(sub.stream_id, topic_name);
     }
 
     if (current_filter.can_bucket_by("stream")) {
-        stream_id = exports.stream_id();
-        if (stream_id === undefined) {
+        sub = exports.stream_sub();
+        if (sub === undefined) {
             return [];
         }
-        return unread.get_msg_ids_for_stream(stream_id);
+        return unread.get_msg_ids_for_stream(sub.stream_id);
     }
 
     if (current_filter.can_bucket_by("pm-with")) {
@@ -349,13 +339,13 @@ exports.is_for_stream_id = function (stream_id) {
     // This is not perfect, since we still track narrows by
     // name, not id, but at least the interface is good going
     // forward.
-    const narrow_stream_id = exports.stream_id();
+    const narrow_sub = exports.stream_sub();
 
-    if (narrow_stream_id === undefined) {
+    if (narrow_sub === undefined) {
         return false;
     }
 
-    return stream_id === narrow_stream_id;
+    return stream_id === narrow_sub.stream_id;
 };
 
 window.narrow_state = exports;

--- a/static/js/narrow_state.js
+++ b/static/js/narrow_state.js
@@ -225,7 +225,7 @@ exports._possible_unread_message_ids = function () {
 
     let stream_id;
     let topic_name;
-    let pm_string;
+    let current_filter_pm_string;
 
     if (current_filter.can_bucket_by("stream", "topic")) {
         stream_id = exports.stream_id();
@@ -245,11 +245,11 @@ exports._possible_unread_message_ids = function () {
     }
 
     if (current_filter.can_bucket_by("pm-with")) {
-        pm_string = exports.pm_string();
-        if (pm_string === undefined) {
+        current_filter_pm_string = exports.pm_string();
+        if (current_filter_pm_string === undefined) {
             return [];
         }
-        return unread.get_msg_ids_for_person(pm_string);
+        return unread.get_msg_ids_for_person(current_filter_pm_string);
     }
 
     if (current_filter.can_bucket_by("is-private")) {

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -10,9 +10,9 @@ const settings_config = require("./settings_config");
 
 const notice_memory = new Map();
 
-// When you start Zulip, window_has_focus should be true, but it might not be the
+// When you start Zulip, window_focused should be true, but it might not be the
 // case after a server-initiated reload.
-let window_has_focus = document.hasFocus && document.hasFocus();
+let window_focused = document.hasFocus && document.hasFocus();
 
 let supports_sound;
 
@@ -71,7 +71,7 @@ function get_audio_file_path(audio_element, audio_file_without_extension) {
 exports.initialize = function () {
     $(window)
         .on("focus", () => {
-            window_has_focus = true;
+            window_focused = true;
 
             for (const notice_mem_entry of notice_memory.values()) {
                 notice_mem_entry.obj.close();
@@ -83,7 +83,7 @@ exports.initialize = function () {
             unread_ops.process_visible();
         })
         .on("blur", () => {
-            window_has_focus = false;
+            window_focused = false;
         });
 
     const audio = $("<audio>");
@@ -212,8 +212,8 @@ exports.update_pm_count = function () {
     }
 };
 
-exports.window_has_focus = function () {
-    return window_has_focus;
+exports.is_window_focused = function () {
+    return window_focused;
 };
 
 function in_browser_notify(message, title, content, raw_operators, opts) {

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -1,7 +1,6 @@
 import md5 from "blueimp-md5";
 import _ from "lodash";
 import moment from "moment-timezone";
-import "unorm"; // String.prototype.normalize polyfill for IE11
 
 import * as typeahead from "../shared/js/typeahead";
 

--- a/static/js/portico/integrations.js
+++ b/static/js/portico/integrations.js
@@ -1,6 +1,6 @@
 import _ from "lodash";
 
-import blueslip from "../blueslip";
+import * as blueslip from "../blueslip";
 
 import * as google_analytics from "./google-analytics";
 import {path_parts} from "./landing-page";

--- a/static/js/reload.js
+++ b/static/js/reload.js
@@ -167,7 +167,7 @@ exports.initialize = function () {
         page_params.initial_narrow_offset = narrow_offset;
     }
 
-    activity.new_user_input = false;
+    activity.set_new_user_input(false);
     hashchange.changehash(vars.oldhash);
 };
 

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -448,14 +448,14 @@ exports.set_up = function () {
             }
         }
 
-        setup.password_change_in_progress = true;
+        setup.set_password_change_in_progress(true);
         const opts = {
             success_continuation() {
-                setup.password_change_in_progress = false;
+                setup.set_password_change_in_progress(false);
                 overlays.close_modal("#change_password_modal");
             },
             error_continuation() {
-                setup.password_change_in_progress = false;
+                setup.set_password_change_in_progress(false);
             },
             error_msg_element: change_password_error,
         };

--- a/static/js/setup.js
+++ b/static/js/setup.js
@@ -4,6 +4,11 @@ const util = require("./util");
 
 // Miscellaneous early setup.
 exports.password_change_in_progress = false;
+
+exports.set_password_change_in_progress = function (value) {
+    exports.password_change_in_progress = value;
+};
+
 $(() => {
     if (util.is_mobile()) {
         // Disable the tutorial; it's ugly on mobile.

--- a/static/js/starred_messages.js
+++ b/static/js/starred_messages.js
@@ -1,12 +1,12 @@
 "use strict";
 
-exports.ids = new Set();
+exports.starred_ids = new Set();
 
 exports.initialize = function () {
-    exports.ids.clear();
+    exports.starred_ids.clear();
 
     for (const id of page_params.starred_messages) {
-        exports.ids.add(id);
+        exports.starred_ids.add(id);
     }
 
     exports.rerender_ui();
@@ -14,7 +14,7 @@ exports.initialize = function () {
 
 exports.add = function (ids) {
     for (const id of ids) {
-        exports.ids.add(id);
+        exports.starred_ids.add(id);
     }
 
     exports.rerender_ui();
@@ -22,18 +22,18 @@ exports.add = function (ids) {
 
 exports.remove = function (ids) {
     for (const id of ids) {
-        exports.ids.delete(id);
+        exports.starred_ids.delete(id);
     }
 
     exports.rerender_ui();
 };
 
 exports.count = function () {
-    return exports.ids.size;
+    return exports.starred_ids.size;
 };
 
 exports.get_starred_msg_ids = function () {
-    return Array.from(exports.ids);
+    return Array.from(exports.starred_ids);
 };
 
 exports.rerender_ui = function () {

--- a/static/js/starred_messages.js
+++ b/static/js/starred_messages.js
@@ -28,7 +28,7 @@ exports.remove = function (ids) {
     exports.rerender_ui();
 };
 
-exports.count = function () {
+exports.get_count = function () {
     return exports.starred_ids.size;
 };
 
@@ -37,7 +37,7 @@ exports.get_starred_msg_ids = function () {
 };
 
 exports.rerender_ui = function () {
-    let count = exports.count();
+    let count = exports.get_count();
 
     if (!page_params.starred_message_counts) {
         // This essentially hides the count

--- a/static/js/unread_ops.js
+++ b/static/js/unread_ops.js
@@ -94,7 +94,7 @@ exports.notify_server_message_read = function (message, options) {
 // If we ever materially change the algorithm for this function, we
 // may need to update notifications.received_messages as well.
 exports.process_visible = function () {
-    if (overlays.is_active() || !notifications.window_has_focus()) {
+    if (overlays.is_active() || !notifications.is_window_focused()) {
         return;
     }
 

--- a/version.py
+++ b/version.py
@@ -44,4 +44,4 @@ API_FEATURE_LEVEL = 33
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '107.2'
+PROVISION_VERSION = '108.0'

--- a/yarn.lock
+++ b/yarn.lock
@@ -12299,11 +12299,6 @@ unist-util-visit@^2.0.0:
     unist-util-is "^4.0.0"
     unist-util-visit-parents "^3.0.0"
 
-unorm@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/unorm/-/unorm-1.6.0.tgz#029b289661fba714f1a9af439eb51d9b16c205af"
-  integrity sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==
-
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"


### PR DESCRIPTION
These are the manual preparatory commits from #10118 “WIP: Automatically convert most CommonJS modules to ES6 modules”. They should be mergeable independently from the rest of that branch and from each other. Some form of these changes will probably be needed whether we’re going to ES6 modules or TypeScript or ES6 modules on the path to TypeScript.

Feel free to bikeshed the new variable and function names—I mostly just picked the first nonconflicting ones I could think of.