### PR TITLE
css: Use SCSS nesting in popovers.scss.

### DIFF
--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -64,19 +64,19 @@
 }
 
 .streams_popover {
-    .sp-container {
-        background-color: hsl(0, 0%, 100%);
-        cursor: pointer;
-        border: none;
-
-        .sp-palette-container {
-            border-right: none;
-        }
-    }
-
     .colorpicker-container {
         display: inline-block;
         margin-right: 10px;
+
+        .sp-container {
+            background-color: hsl(0, 0%, 100%);
+            cursor: pointer;
+            border: none;
+
+            .sp-palette-container {
+                border-right: none;
+            }
+        }
     }
 
     .popover_sub_unsub_button {

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -146,10 +146,7 @@ ul {
 .popover_user_presence {
     width: 8px;
     height: 8px;
-    margin-top: 0px;
-    margin-bottom: 0px;
-    margin-left: 5px;
-    margin-right: 5px;
+    margin: 0px 5px;
 }
 
 .bot-owner-name {

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -143,8 +143,7 @@ ul {
     text-align: center;
 }
 
-.popover_user_presence,
-.group-info-popover .member-list .user_circle {
+.popover_user_presence {
     width: 8px;
     height: 8px;
     margin-top: 0px;

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -119,8 +119,11 @@ ul {
 }
 
 .group-info-popover {
-    .group-info,
     .manage-group a {
+        text-align: center;
+    }
+
+    .group-info {
         text-align: center;
     }
 

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -125,10 +125,10 @@ ul {
 
     .group-info {
         text-align: center;
-    }
 
-    .group-info .group-name {
-        font-weight: bold;
+        .group-name {
+            font-weight: bold;
+        }
     }
 
     .member-list {

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -118,29 +118,31 @@ ul {
     }
 }
 
-.group-info-popover .group-info,
-.group-info-popover .manage-group a {
-    text-align: center;
-}
+.group-info-popover {
+    .group-info,
+    .manage-group a {
+        text-align: center;
+    }
 
-.group-info-popover .group-info .group-name {
-    font-weight: bold;
-}
+    .group-info .group-name {
+        font-weight: bold;
+    }
 
-.group-info-popover .member-list {
-    position: relative;
-    max-height: 300px;
-    overflow-y: auto;
-    list-style: none;
-    margin-left: 0;
-}
+    .member-list {
+        position: relative;
+        max-height: 300px;
+        overflow-y: auto;
+        list-style: none;
+        margin-left: 0;
 
-.group-info-popover .member-list .bot {
-    color: hsl(180, 5%, 74%);
-    vertical-align: top;
-    width: 20px;
-    padding-top: 3.5px;
-    text-align: center;
+        .bot {
+            color: hsl(180, 5%, 74%);
+            vertical-align: top;
+            width: 20px;
+            padding-top: 3.5px;
+            text-align: center;
+        }
+    }
 }
 
 .popover_user_presence {

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -68,10 +68,10 @@
         background-color: hsl(0, 0%, 100%);
         cursor: pointer;
         border: none;
-    }
 
-    .sp-palette-container {
-        border-right: none;
+        .sp-palette-container {
+            border-right: none;
+        }
     }
 
     .colorpicker-container {

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -44,15 +44,6 @@
     z-index: 100;
 }
 
-.colorpicker-container .sp-container input {
-    -webkit-box-sizing: initial;
-    -moz-box-sizing: inherit;
-    -ms-box-sizing: inherit;
-    box-sizing: initial;
-
-    width: calc(100% - 13px);
-}
-
 .mobile-message-buttons-popover {
     position: absolute;
     top: auto !important;
@@ -75,6 +66,15 @@
 
             .sp-palette-container {
                 border-right: none;
+            }
+
+            input {
+                -webkit-box-sizing: initial;
+                -moz-box-sizing: inherit;
+                -ms-box-sizing: inherit;
+                box-sizing: initial;
+
+                width: calc(100% - 13px);
             }
         }
     }

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -147,6 +147,10 @@ ul {
     width: 8px;
     height: 8px;
     margin: 0px 5px;
+    display: inline-block;
+    float: initial;
+    position: relative;
+    top: 1px;
 }
 
 .bot-owner-name {
@@ -339,13 +343,6 @@ ul {
         position: static;
         margin-right: 0;
     }
-}
-
-.popover_user_presence {
-    display: inline-block;
-    float: initial;
-    position: relative;
-    top: 1px;
 }
 
 .user_info_status_text {


### PR DESCRIPTION
**Testing Plan**:

Most of the changes were straight forward since the reordering did not conflict with other rules.
*Tested manually.*

@timabbott I think there still might be more scope of nesting but it was hard to figure out whether or not to proceed with it since sometimes the CSS rules in other files conflicted (for e.g. nesting `.popover-content` in `.popover` conflicted with the `.popover-content` in `reactions.scss`) OR it was simply not feasable (e.g. the user popup in message box and in the right sidebar, both have different parent classes). Do we want to do more cleanup here? If yes then how should I proceed?