### PR TITLE
message view: Show edit history for a message when a user clicks on i…

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -126,6 +126,9 @@ exports.initialize = function () {
             // stopPropagation prevents them from being called.
             return;
         }
+        if ($(e.target).is(".message_edit_notice")) {
+            return;
+        }
 
         // A tricky issue here is distinguishing hasty clicks (where
         // the mouse might still move a few pixels between mouseup and
@@ -229,6 +232,18 @@ exports.initialize = function () {
         message_edit.start(row);
         e.stopPropagation();
         popovers.hide_all();
+    });
+    $('body').on('click', '.message_edit_notice', function (e) {
+        var row = current_msg_list.get_row(rows.id($(this).closest(".message_row")));
+        current_msg_list.select_id(rows.id(row));
+        var message = current_msg_list.get(rows.id(row));
+        var message_history_cancel_btn = $('#message-history-cancel');
+
+        popovers.hide_actions_popover();
+        message_edit.show_history(message);
+        message_history_cancel_btn.focus();
+        e.stopPropagation();
+        e.preventDefault();
     });
     $('body').on('click', '.always_visible_topic_edit,.on_hover_topic_edit', function (e) {
         var recipient_row = $(this).closest(".recipient_row");

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -566,6 +566,11 @@ td.pointer {
     @include prefixed-user-select(none);
 }
 
+.message_edit_notice:hover {
+    opacity: 1.0;
+}
+
+
 .include-sender .message_time {
     top: -4px;
 }


### PR DESCRIPTION
#Fixes12615

**GIFs or Screenshots:**
![ezgif com-crop](https://user-images.githubusercontent.com/45951376/60651209-5d8d4100-9e63-11e9-8f9b-84aeb6093269.gif)

Clicking on EDITED tag now open a popover that shows the history of the edited message.
On-hover EDITED tag darkens.
