### PR TITLE
retention: Split migration deleting and altering ArchivedMessage.

### DIFF
--- a/zerver/migrations/0232_make_archive_transaction_field_not_nullable.py
+++ b/zerver/migrations/0232_make_archive_transaction_field_not_nullable.py
@@ -4,21 +4,30 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 import django.db.models.deletion
 
-
 class Migration(migrations.Migration):
+    """
+    Tables cannot have data deleted from them and be altered in a single transaction,
+    but we need the DELETEs to be atomic together. So we set atomic=False for the migration
+    in general, and run the DELETEs in one transaction, and AlterField in another.
+    """
+    atomic = False
 
     dependencies = [
         ('zerver', '0231_add_archive_transaction_model'),
     ]
 
     operations = [
-        migrations.RunSQL("DELETE FROM zerver_archivedusermessage"),
-        migrations.RunSQL("DELETE FROM zerver_archivedreaction"),
-        migrations.RunSQL("DELETE FROM zerver_archivedsubmessage"),
-        migrations.RunSQL("DELETE FROM zerver_archivedattachment"),
-        migrations.RunSQL("DELETE FROM zerver_archivedattachment_messages"),
-        migrations.RunSQL("DELETE FROM zerver_archivedmessage"),
-        migrations.RunSQL("DELETE FROM zerver_archivetransaction"),
+        migrations.RunSQL("""
+        BEGIN;
+        DELETE FROM zerver_archivedusermessage;
+        DELETE FROM zerver_archivedreaction;
+        DELETE FROM zerver_archivedsubmessage;
+        DELETE FROM zerver_archivedattachment_messages;
+        DELETE FROM zerver_archivedattachment;
+        DELETE FROM zerver_archivedmessage;
+        DELETE FROM zerver_archivetransaction;
+        COMMIT;
+        """),
         migrations.AlterField(
             model_name='archivedmessage',
             name='archive_transaction',


### PR DESCRIPTION
IMPORTANT NOTE: I'm not sure if we do "retroactive" editing of migrations like this, or if it breaks something in the "upgrade from git" scripts or such, but I wasn't sure how else to do this.
EDIT: Okay, I think I figured it out now - see last comment

Addresses the problem at https://chat.zulip.org/#narrow/stream/3-backend/topic/Update.20fails/near/763497

Django runs each migration in a transaction. Postgres doesn't allow
DELETing from a table and ALTERing it in a single transaction - so we
need to split the migration.
