### PR TITLE
Add support for exporting Casper results as XUnit XML file in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,9 @@ jobs:
           path: ../../../tmp/zulip-test-event-log/
           destination: test-reports
 
+      - store_test_results:
+            path: ./var/xunit-test-results/casper/
+
   "bionic-backend-python3.6":
     docker:
       # This is built from tools/circleci/images/bionic/Dockerfile .

--- a/frontend_tests/run-casper
+++ b/frontend_tests/run-casper
@@ -43,6 +43,9 @@ parser.add_argument('--remote-debug',
                     help='Whether or not to enable remote debugging on port 7777',
                     action="store_true",
                     default=False)
+parser.add_argument('--xunit-export', dest='xunit_export',
+                    action="store_true",
+                    default=False, help='Export the results of the test suite to an XUnit XML file,')
 parser.add_argument('tests', nargs=argparse.REMAINDER,
                     help='Specific tests to run; by default, runs all tests')
 options = parser.parse_args()
@@ -94,6 +97,10 @@ def run_tests(files: Iterable[str], external_host: str) -> None:
     if options.verbose:
         verbose = ["--verbose", "--log-level=debug"]
 
+    xunit_export = []  # type: List[str]
+    if options.xunit_export:
+        xunit_export = ["--xunit=var/xunit-test-results/casper/result.xml"]
+
     with test_server_running(options.force, external_host):
         # Important: do this next call inside the `with` block, when Django
         #            will be pointing at the test database.
@@ -102,7 +109,7 @@ def run_tests(files: Iterable[str], external_host: str) -> None:
         ret = 1
         for test_file in test_files:
             test_name = os.path.basename(test_file)
-            cmd = ["node_modules/.bin/casperjs"] + remote_debug + verbose + ["test", test_file]
+            cmd = ["node_modules/.bin/casperjs"] + remote_debug + verbose + xunit_export + ["test", test_file]
             print("\n\n===================== %s\nRunning %s\n\n" % (test_name, " ".join(map(shlex.quote, cmd))))
             ret = subprocess.call(cmd)
             if ret != 0:

--- a/tools/ci/frontend
+++ b/tools/ci/frontend
@@ -16,7 +16,7 @@ PYTHONWARNINGS=ignore ./tools/check-capitalization --no-generate
 PYTHONWARNINGS=ignore ./tools/check-frontend-i18n --no-generate
 
 # Run the slower Casper tests last
-./tools/test-js-with-casper
+./tools/test-js-with-casper --xunit-export
 
 # NB: Everything here should be in `tools/test-all`.  If there's a
 # reason not to run it there, it should be there as a comment

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -59,6 +59,7 @@ UPLOAD_DIR_PATH = os.path.join(VAR_DIR_PATH, 'uploads')
 TEST_UPLOAD_DIR_PATH = os.path.join(VAR_DIR_PATH, 'test_uploads')
 COVERAGE_DIR_PATH = os.path.join(VAR_DIR_PATH, 'coverage')
 NODE_TEST_COVERAGE_DIR_PATH = os.path.join(VAR_DIR_PATH, 'node-coverage')
+XUNIT_XML_TEST_RESULTS_DIR_PATH = os.path.join(VAR_DIR_PATH, 'xunit-test-results')
 
 is_travis = 'TRAVIS' in os.environ
 is_circleci = 'CIRCLECI' in os.environ
@@ -465,6 +466,8 @@ def main(options):
     os.makedirs(COVERAGE_DIR_PATH, exist_ok=True)
     # create linecoverage directory `var/node-coverage`
     os.makedirs(NODE_TEST_COVERAGE_DIR_PATH, exist_ok=True)
+    # create XUnit XML test results directory`var/xunit-test-results`
+    os.makedirs(XUNIT_XML_TEST_RESULTS_DIR_PATH, exist_ok=True)
 
     # The `build_emoji` script requires `emoji-datasource` package
     # which we install via npm; thus this step is after installing npm

--- a/version.py
+++ b/version.py
@@ -21,4 +21,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '37.1'
+PROVISION_VERSION = '37.2'


### PR DESCRIPTION
A rebase of #8627 ([WIP]Add support for exporting results as XUnit XML file), addressing issue #8593

Tested via https://circleci.com/build-insights/gh/whoodes/zulip/xunit-results.

Relevant backend-test discussion can be found [here](https://chat.zulip.org/#narrow/stream/49-development-help/topic/Structured.20test.20result.20data/near/764665).