### PR TITLE
WIP: Full UI based web public archive branch

### DIFF
--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -298,6 +298,9 @@ function send_presence_to_server(want_redraw) {
         blueslip.log("Skipping querying presence because reload in progress");
         return;
     }
+    if (page_params.is_web_public_guest) {
+        return;
+    }
 
     channel.post({
         url: '/json/users/me/presence',

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -169,6 +169,9 @@ function get_events(options) {
     if (reload_state.is_in_progress()) {
         return;
     }
+    if (page_params.is_web_public_guest) {
+        return;
+    }
 
     get_events_params.dont_block = options.dont_block || get_events_failures > 0;
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -306,6 +306,14 @@ paths:
           type: boolean
           default: false
         example: true
+      - name: is_web_public_query
+        in: query
+        description: If `true`, this is an unauthenticated request from a web public user.
+          If `false`, this is an authenticated request or the instance is not web public.
+        schema:
+          type: boolean
+          default: false
+        example: true
       - name: num_before
         in: query
         description: The number of messages with IDs less than the anchor to retrieve.

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -1157,6 +1157,47 @@ class GetOldMessagesTest(ZulipTestCase):
 
         self.get_and_check_messages(dict(narrow=ujson.dumps([dict(operator='pm-with', operand=self.example_email("othello"))])))
 
+    def test_unauthenticated_get_messages_without_web_public(self) -> None:
+        """
+        A unauthenticated call to GET /json/messages with valid parameters
+        returns a 401.
+        """
+        post_params = {
+            "anchor": 1,
+            "num_before": 1,
+            "num_after": 1
+        }  # type: Dict[str, Union[str, int]]
+        result = self.client_get("/json/messages", dict(post_params))
+        self.assert_json_error(result, 'Not logged in: API authentication or user session required',
+                               status_code=401)
+
+    def test_unauthenticated_get_messages_with_web_public(self) -> None:
+        """
+        A unauthenticated call to GET /json/messages with valid parameters
+        including `is_web_public_query` returns a list of messages.
+        """
+        post_params = {
+            "anchor": 1,
+            "num_before": 1,
+            "num_after": 1,
+            "is_web_public_query": 'true',
+        }  # type: Dict[str, Union[str, int]]
+        result = self.client_get("/json/messages", dict(post_params))
+        # TODO: Change this to success once the feature is done.
+        self.assert_json_error(result, "Not implemented",
+                               status_code=401)
+
+        post_params = {
+            "anchor": 1,
+            "num_before": 1,
+            "num_after": 1,
+            "narrow": ujson.dumps([dict(operator='is', operand="private")]),
+            "is_web_public_query": 'true',
+        }
+        result = self.client_get("/json/messages", dict(post_params))
+        self.assert_json_error(result, "Not logged in: API authentication or user session required",
+                               status_code=401)
+
     def test_client_avatar(self) -> None:
         """
         The client_gravatar flag determines whether we send avatar_url.

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -845,7 +845,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
             self.curl_example("/endpoint", "BREW")  # see: HTCPCP
 
     def test_generate_and_render_curl_with_array_example(self) -> None:
-        generated_curl_example = self.curl_example("/messages", "GET")
+        generated_curl_example = self.curl_example("/messages", "GET", exclude=["is_web_public_query"])
         expected_curl_example = [
             '```curl',
             'curl -sSX GET -G http://localhost:9991/api/v1/messages \\',
@@ -913,7 +913,9 @@ class TestCurlExampleGeneration(ZulipTestCase):
 
     def test_generate_and_render_curl_example_with_excludes(self) -> None:
         generated_curl_example = self.curl_example("/messages", "GET",
-                                                   exclude=["client_gravatar", "apply_markdown"])
+                                                   exclude=["client_gravatar",
+                                                            "apply_markdown",
+                                                            "is_web_public_query"])
         expected_curl_example = [
             '```curl',
             'curl -sSX GET -G http://localhost:9991/api/v1/messages \\',

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -28,7 +28,8 @@ from zerver.lib.message import (
     render_markdown,
     get_first_visible_message_id,
 )
-from zerver.lib.response import json_success, json_error
+from zerver.lib.narrow import is_web_public_compatible
+from zerver.lib.response import json_success, json_error, json_unauthorized
 from zerver.lib.sqlalchemy_utils import get_sqlalchemy_connection
 from zerver.lib.streams import access_stream_by_id, get_public_streams_queryset, \
     can_access_stream_history_by_name, can_access_stream_history_by_id, \
@@ -810,19 +811,41 @@ def get_messages_backend(request: HttpRequest, user_profile: UserProfile,
                          use_first_unread_anchor_val: bool=REQ('use_first_unread_anchor',
                                                                validator=check_bool, default=False),
                          client_gravatar: bool=REQ(validator=check_bool, default=False),
+                         is_web_public_query: bool=REQ(validator=check_bool, default=False),
                          apply_markdown: bool=REQ(validator=check_bool, default=True)) -> HttpResponse:
     anchor = parse_anchor_value(anchor_val, use_first_unread_anchor_val)
     if num_before + num_after > MAX_MESSAGES_PER_FETCH:
         return json_error(_("Too many messages requested (maximum %s).")
                           % (MAX_MESSAGES_PER_FETCH,))
 
-    if user_profile.realm.email_address_visibility == Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS:
+    if is_web_public_query:
+        # Web public queries are only allowed for limited types of narrows.
+        if narrow is not None and not is_web_public_compatible(narrow):
+            return json_unauthorized()
+
+        # TODO: Ensure that the base query limits us to messages on
+        # streams with is_web_public set as the replacement for the
+        # usual limitation to messages in the target user's's personal
+        # history.
+        print("HERE")
+        return json_unauthorized("Not implemented")
+    else:
+        if not request.user.is_authenticated:
+            return json_unauthorized()
+
+    if is_web_public_query or \
+            user_profile.realm.email_address_visibility == Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS:
         # If email addresses are only available to administrators,
         # clients cannot compute gravatars, so we force-set it to false.
         client_gravatar = False
 
     include_history = ok_to_include_history(narrow, user_profile)
-    if include_history:
+    if is_web_public_query:
+        # Web public queries don't have an authenticated user, so we
+        # will never join with UserMesage.
+        need_message = True
+        need_user_message = False
+    elif include_history:
         # The initial query in this case doesn't use `zerver_usermessage`,
         # and isn't yet limited to messages the user is entitled to see!
         #
@@ -884,7 +907,10 @@ def get_messages_backend(request: HttpRequest, user_profile: UserProfile,
     if anchored_to_right:
         num_after = 0
 
-    first_visible_message_id = get_first_visible_message_id(user_profile.realm)
+    first_visible_message_id = 0
+    if not is_web_public_query:
+        first_visible_message_id = get_first_visible_message_id(user_profile.realm)
+
     query = limit_query_to_range(
         query=query,
         num_before=num_before,
@@ -934,6 +960,11 @@ def get_messages_backend(request: HttpRequest, user_profile: UserProfile,
         for message_id in message_ids:
             if message_id not in user_message_flags:
                 user_message_flags[message_id] = ["read", "historical"]
+    elif is_web_public_query:
+        for row in rows:
+            message_id = row[0]
+            message_ids.append(message_id)
+            user_message_flags[message_id] = []
     else:
         for row in rows:
             message_id = row[0]
@@ -956,13 +987,17 @@ def get_messages_backend(request: HttpRequest, user_profile: UserProfile,
                 # debugged the case that makes it happen.
                 raise Exception(str(err), message_id, narrow)
 
+    allow_edit_history = False
+    if not is_web_public_query:
+        allow_edit_history = user_profile.realm.allow_edit_history
+
     message_list = messages_for_ids(
         message_ids=message_ids,
         user_message_flags=user_message_flags,
         search_fields=search_fields,
         apply_markdown=apply_markdown,
         client_gravatar=client_gravatar,
-        allow_edit_history=user_profile.realm.allow_edit_history,
+        allow_edit_history=allow_edit_history,
     )
 
     statsd.incr('loaded_old_messages', len(message_list))

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -187,7 +187,8 @@ v1_api_and_json_patterns = [
     # messages -> zerver.views.messages
     # GET returns messages, possibly filtered, POST sends a message
     url(r'^messages$', rest_dispatch,
-        {'GET': 'zerver.views.messages.get_messages_backend',
+        {'GET': ('zerver.views.messages.get_messages_backend',
+                 {'allow_anonymous_user_web'}),
          'POST': ('zerver.views.messages.send_message_backend',
                   {'allow_incoming_webhooks'})}),
     url(r'^messages/(?P<message_id>[0-9]+)$', rest_dispatch,


### PR DESCRIPTION
This PR is a checkpoint of the work done so far in the direction of a full Zulip UI public archive / demo user experience.  The advantage of this approach is that it'll naturally support instant update and all of Zulip features (including, e.g., full-text search, message deleting doing the right thing, etc.) and not require a ton of maintenance.  Basically, the design is:

* We patch how `page_params` is generated, both in `zerver/lib/events.py` and `zerver/views/home.py`, so that "public archive" users get a special user experience.
* We patch the `get_messages` endpoint to just include web_public messages for this AnonymousUser access.
* We modify the webapp user experience to disable/hide a ton of menus/buttons/etc. that won't be available to public archive users.

Probably the `get_messages` element of this we'll want for just about any version of how the "public archive" might work as a native Zulip feature.

This PR implements a reasonably correct version of the first two bullets and a tiny bit of the third that I wrote about a year ago as a prototype of the concept.  It definitely does not work.  If we wanted to move towards merging it, some good steps would be:
* [ ] Making the `get_messages` commit cleaned up with tests and merged.  I think this roughly entails making `get_messages_backend` use the `allow_unauthenticated` flag, move `is_web_public_query` to be a REQ option, and have it reject unauthenticated users unless `is_web_public_query` is set, and then add JS code to set that flag in the `get_messages` requests if `page_params.is_web_public_user` (or however we're planning on encoding that).
* [ ] Refactoring `home_real` to move a lot of the logic that would be copied unmodified in the later commits (e.g. which Django settings to pass through) into a reusable function, possibly one we put in `zerver/lib/events.py` to have the things in `page_params` more consistently live in one place.


 

