### PR TITLE
emoji: Change size for emoji in rendered markdown to 19px.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1643,6 +1643,11 @@ a:hover code {
         padding: 5px;
         border: none;
     }
+
+    .emoji {
+        height: 19px;
+        width: 19px;
+    }
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
I went from 18px to 19px. Just makes the emoji even easier to decipher.