### PR TITLE
Small line spacing tweaks

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1254,7 +1254,7 @@ div.focused_table {
 }
 
 .message_content {
-    line-height: 17px;
+    line-height: 1.214;
     min-height: 17px;
     font-size: 14px;
     margin-left: 46px;

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1486,7 +1486,7 @@ a:hover code {
     /* Reduce top-margin when a paragraph is followed by an ordered or bulleted list */
     p + ul,
     p + ol {
-        margin-top: -2px;
+        margin-top: -3px;
     }
 
     /* Formatting for blockquotes */


### PR DESCRIPTION
* css: Specify message_content line-height in relative units.

  This fixes (or at least reduces) a problem with inline `code blocks` causing extra uneven vertical space below their line. The absolute line-height was being measured relative to the lower midline of the smaller font-size in the code blocks.

* css: Make paragraph-to-list spacing consistent with normal line spacing.

  The -2px list margin was almost but not exactly cancelling the 3px paragraph margin, resulting in a line spacing exactly 1px taller than the normal line spacing.

**GIFs or Screenshots:**

(Click to view at native resolution.)

Before:
![before](https://user-images.githubusercontent.com/26471/60848876-399c6900-a19d-11e9-860c-7108c1dfc3b8.png)
After:
![after](https://user-images.githubusercontent.com/26471/60848879-3b662c80-a19d-11e9-8d1f-73ce59bd945d.png)
