### PR TITLE
Remove uses of ES6 syntax and builtins, and lint against them

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,9 @@
 {
     "env": {
-        "node": true,
-        "es6": true
+        "node": true
     },
     "parserOptions": {
+        "ecmaVersion": 6,
         "warnOnUnsupportedTypeScriptVersion": false,
         "sourceType": "module"
     },
@@ -412,6 +412,24 @@
         "yoda": "error"
     },
     "overrides": [
+        {
+            "files": ["static/js/**"],
+            "env": {
+                "browser": true,
+                "node": false
+            }
+        },
+        {
+            "files": ["static/js/**/*.js"],
+            "env": {
+                "commonjs": true
+            },
+            "plugins": ["es"],
+            "extends": ["plugin:es/no-2015"],
+            "rules": {
+                "es/no-modules": "off"
+            }
+        },
         {
             "files": ["**/*.ts"],
             "parser": "@typescript-eslint/parser",

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -1,4 +1,3 @@
-/*global Dict */
 zrequire('hash_util');
 zrequire('katex', 'katex/dist/katex.min.js');
 zrequire('marked', 'third/marked/lib/marked');

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "difflib": "0.2.4",
     "eslint": "^6.0.1",
     "eslint-plugin-empty-returns": "1.0.2",
+    "eslint-plugin-es": "^1.4.0",
     "jsdom": "15.1.1",
     "nyc": "14.1.1",
     "phantomjs-prebuilt": "2.1.16",

--- a/package.json
+++ b/package.json
@@ -59,11 +59,11 @@
     "zxcvbn": "4.4.2"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "1.9.0",
-    "@typescript-eslint/parser": "1.9.0",
+    "@typescript-eslint/eslint-plugin": "^1.11.0",
+    "@typescript-eslint/parser": "^1.11.0",
     "casperjs": "casperjs/casperjs",
     "difflib": "0.2.4",
-    "eslint": "5.16.0",
+    "eslint": "^6.0.1",
     "eslint-plugin-empty-returns": "1.0.2",
     "jsdom": "15.1.1",
     "nyc": "14.1.1",

--- a/static/js/billing/helpers.js
+++ b/static/js/billing/helpers.js
@@ -1,7 +1,7 @@
 var helpers = (function () {
 var exports = {};
 
-exports.create_ajax_request = function (url, form_name, stripe_token = null) {
+exports.create_ajax_request = function (url, form_name, stripe_token) {
     var form = $("#" + form_name + "-form");
     var form_loading_indicator = "#" + form_name + "_loading_indicator";
     var form_input_section = "#" + form_name + "-input-section";

--- a/static/js/billing/upgrade.js
+++ b/static/js/billing/upgrade.js
@@ -1,7 +1,7 @@
 var upgrade = (function () {
 var exports = {};
 
-exports.initialize = () => {
+exports.initialize = function () {
     helpers.set_tab("upgrade");
 
     var add_card_handler = StripeCheckout.configure({ // eslint-disable-line no-undef

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -109,15 +109,15 @@ exports.adjust_mac_shortcuts = function (key_elem_class, require_cmd_style) {
         return;
     }
 
-    var keys_map = new Map([
-        ['Backspace', 'Delete'],
-        ['Enter', 'Return'],
-        ['Home', 'Fn + ←'],
-        ['End', 'Fn + →'],
-        ['PgUp', 'Fn + ↑'],
-        ['PgDn', 'Fn + ↓'],
-        ['Ctrl', '⌘'],
-    ]);
+    var keys_map = {
+        Backspace: 'Delete',
+        Enter: 'Return',
+        Home: 'Fn + ←',
+        End: 'Fn + →',
+        PgUp: 'Fn + ↑',
+        PgDn: 'Fn + ↓',
+        Ctrl: '⌘',
+    };
 
     $(key_elem_class).each(function () {
         var key_text = $(this).text();
@@ -127,8 +127,8 @@ exports.adjust_mac_shortcuts = function (key_elem_class, require_cmd_style) {
             $(this).addClass("mac-cmd-key");
         }
         _.each(keys, function (key) {
-            if (keys_map.get(key)) {
-                key_text = key_text.replace(key, keys_map.get(key));
+            if (keys_map.hasOwnProperty(key)) {
+                key_text = key_text.replace(key, keys_map[key]);
             }
         });
         $(this).text(key_text);

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -616,12 +616,12 @@ exports.handle_keydown = function (event, textarea) {
 
     if ((isBold || isItalic || isLink) && isCmdOrCtrl) {
         var range = textarea.range();
-        function wrap_text_with_markdown(prefix, suffix) {
+        var wrap_text_with_markdown = function (prefix, suffix) {
             if (!document.execCommand('insertText', false, prefix + range.text + suffix)) {
                 textarea.range(range.start, range.end).range(prefix + range.text + suffix);
             }
             event.preventDefault();
-        }
+        };
 
         if (isBold) {
             // ctrl + b: Convert selected text to bold text

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -320,7 +320,7 @@ function fetch_group_members(member_ids) {
             return m !== undefined;
         })
         .map(function (p) {
-            return Object.assign({}, p, {
+            return _.assign({}, p, {
                 user_circle_class: buddy_data.get_user_circle_class(p.user_id),
                 is_active: people.is_active_user_for_popover(p.user_id),
                 user_last_seen_time_status: buddy_data.user_last_seen_time_status(p.user_id),

--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -3,11 +3,11 @@ import SimpleBar from 'simplebar';
 import {activate_correct_tab} from './tabbed-instructions.js';
 
 function registerCodeSection($codeSection) {
-    const $li = $codeSection.find("ul.nav li");
-    const $blocks = $codeSection.find(".blocks div");
+    var $li = $codeSection.find("ul.nav li");
+    var $blocks = $codeSection.find(".blocks div");
 
     $li.click(function () {
-        const language = this.dataset.language;
+        var language = this.dataset.language;
 
         $li.removeClass("active");
         $li.filter("[data-language=" + language + "]").addClass("active");

--- a/static/js/portico/integrations.js
+++ b/static/js/portico/integrations.js
@@ -34,7 +34,7 @@ var INITIAL_STATE = {
     query: '',
 };
 
-var state = Object.assign({}, INITIAL_STATE);
+var state = _.assign({}, INITIAL_STATE);
 
 
 function adjust_font_sizing() {
@@ -229,7 +229,7 @@ function hide_integration_show_catalog() {
 }
 
 function get_state_from_path() {
-    var result = Object.assign({}, INITIAL_STATE);
+    var result = _.assign({}, INITIAL_STATE);
     result.query = state.query;
 
     var parts = path_parts();
@@ -243,7 +243,7 @@ function get_state_from_path() {
 }
 
 function render(next_state) {
-    var previous_state = Object.assign({}, state);
+    var previous_state = _.assign({}, state);
     state = next_state;
 
     if (previous_state.integration !== next_state.integration &&
@@ -271,28 +271,28 @@ function render(next_state) {
 function dispatch(action, payload) {
     switch (action) {
     case 'CHANGE_CATEGORY':
-        render(Object.assign({}, state, {
+        render(_.assign({}, state, {
             category: payload.category,
         }));
         update_path();
         break;
 
     case 'SHOW_INTEGRATION':
-        render(Object.assign({}, state, {
+        render(_.assign({}, state, {
             integration: payload.integration,
         }));
         update_path();
         break;
 
     case 'HIDE_INTEGRATION':
-        render(Object.assign({}, state, {
+        render(_.assign({}, state, {
             integration: null,
         }));
         update_path();
         break;
 
     case 'SHOW_CATEGORY':
-        render(Object.assign({}, state, {
+        render(_.assign({}, state, {
             integration: null,
             category: payload.category,
         }));
@@ -300,7 +300,7 @@ function dispatch(action, payload) {
         break;
 
     case 'UPDATE_QUERY':
-        render(Object.assign({}, state, {
+        render(_.assign({}, state, {
             query: payload.query,
         }));
         break;

--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -1,7 +1,7 @@
-const ELECTRON_APP_VERSION = "3.0.0";
-const ELECTRON_APP_URL_LINUX = "https://github.com/zulip/zulip-desktop/releases/download/v" + ELECTRON_APP_VERSION + "/Zulip-" + ELECTRON_APP_VERSION + "-x86_64.AppImage";
-const ELECTRON_APP_URL_MAC = "https://github.com/zulip/zulip-desktop/releases/download/v" + ELECTRON_APP_VERSION + "/Zulip-" + ELECTRON_APP_VERSION + ".dmg";
-const ELECTRON_APP_URL_WINDOWS = "https://github.com/zulip/zulip-desktop/releases/download/v" + ELECTRON_APP_VERSION + "/Zulip-Web-Setup-" + ELECTRON_APP_VERSION + ".exe";
+var ELECTRON_APP_VERSION = "3.0.0";
+var ELECTRON_APP_URL_LINUX = "https://github.com/zulip/zulip-desktop/releases/download/v" + ELECTRON_APP_VERSION + "/Zulip-" + ELECTRON_APP_VERSION + "-x86_64.AppImage";
+var ELECTRON_APP_URL_MAC = "https://github.com/zulip/zulip-desktop/releases/download/v" + ELECTRON_APP_VERSION + "/Zulip-" + ELECTRON_APP_VERSION + ".dmg";
+var ELECTRON_APP_URL_WINDOWS = "https://github.com/zulip/zulip-desktop/releases/download/v" + ELECTRON_APP_VERSION + "/Zulip-Web-Setup-" + ELECTRON_APP_VERSION + ".exe";
 
 import render_tabs from './team.js';
 import {detect_user_os}  from './tabbed-instructions.js';

--- a/static/js/portico/tabbed-instructions.js
+++ b/static/js/portico/tabbed-instructions.js
@@ -20,11 +20,11 @@ export function detect_user_os() {
 export function activate_correct_tab($codeSection) {
     var user_os = detect_user_os();
     var desktop_os = ["mac", "linux", "windows"];
-    const $li = $codeSection.find("ul.nav li");
-    const $blocks = $codeSection.find(".blocks div");
+    var $li = $codeSection.find("ul.nav li");
+    var $blocks = $codeSection.find(".blocks div");
 
     $li.each(function () {
-        const language = this.dataset.language;
+        var language = this.dataset.language;
         $(this).removeClass("active");
         if (language === user_os) {
             $(this).addClass("active");
@@ -36,7 +36,7 @@ export function activate_correct_tab($codeSection) {
     });
 
     $blocks.each(function () {
-        const language = this.dataset.language;
+        var language = this.dataset.language;
         $(this).removeClass("active");
         if (language === user_os) {
             $(this).addClass("active");

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -156,7 +156,7 @@ exports.initialize_custom_user_type_fields = function (element_id, user_id, is_e
                                          field.id + '"] .pill-container').expectOne();
             var pills = user_pill.create_pills(pill_container);
 
-            function update_custom_user_field() {
+            var update_custom_user_field = function () {
                 var fields = [];
                 var user_ids = user_pill.get_user_ids(pills);
                 if (user_ids.length < 1) {
@@ -166,7 +166,7 @@ exports.initialize_custom_user_type_fields = function (element_id, user_id, is_e
                     fields.push({id: field.id, value: user_ids});
                     update_user_custom_profile_fields(fields, channel.patch);
                 }
-            }
+            };
 
             if (field_value_raw) {
                 var field_value = JSON.parse(field_value_raw);

--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -321,7 +321,7 @@ function round_to_percentages(values, total) {
             6, // this is the max precision (two #, 4 decimal points; 99.9999%).
             Math.max(
                 2, // the minimum amount of precision (40% or 6.0%).
-                Math.floor(-Math.log10(100 - unrounded)) + 3
+                Math.floor(-Math.log(100 - unrounded) / Math.log(10)) + 3
             )
         );
 

--- a/version.py
+++ b/version.py
@@ -21,4 +21,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '37.3'
+PROVISION_VERSION = '38.0'

--- a/version.py
+++ b/version.py
@@ -21,4 +21,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '38.0'
+PROVISION_VERSION = '38.1'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3299,6 +3299,14 @@ eslint-plugin-empty-returns@1.0.2:
   resolved "https://registry.yarnpkg.com/eslint-plugin-empty-returns/-/eslint-plugin-empty-returns-1.0.2.tgz#9f9d4b10215a25c719f32675f44ffe5c80963147"
   integrity sha1-n51LECFaJccZ8yZ19E/+XICWMUc=
 
+eslint-plugin-es@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-1.4.0.tgz#475f65bb20c993fc10e8c8fe77d1d60068072da6"
+  integrity sha512-XfFmgFdIUDgvaRAlaXUkxrRg5JSADoRC8IkKLc/cISeR3yHVMefFHQZpcyXXEUUPHfy5DwviBcrfqlyqEwlQVw==
+  dependencies:
+    eslint-utils "^1.3.0"
+    regexpp "^2.0.1"
+
 eslint-scope@^4.0.0, eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
@@ -3307,7 +3315,7 @@ eslint-scope@^4.0.0, eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-utils@^1.3.1:
+eslint-utils@^1.3.0, eslint-utils@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
   integrity sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,6 +239,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/eslint-visitor-keys@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
+  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -385,40 +390,39 @@
     "@types/uglify-js" "*"
     source-map "^0.6.0"
 
-"@typescript-eslint/eslint-plugin@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.9.0.tgz#29d73006811bf2563b88891ceeff1c5ea9c8d9c6"
-  integrity sha512-FOgfBorxjlBGpDIw+0LaZIXRX6GEEUfzj8LXwaQIUCp+gDOvkI+1WgugJ7SmWiISqK9Vj5r8S7NDKO/LB+6X9A==
+"@typescript-eslint/eslint-plugin@^1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.11.0.tgz#870f752c520db04db6d3668af7479026a6f2fb9a"
+  integrity sha512-mXv9ccCou89C8/4avKHuPB2WkSZyY/XcTQUXd5LFZAcLw1I3mWYVjUu6eS9Ja0QkP/ClolbcW9tb3Ov/pMdcqw==
   dependencies:
-    "@typescript-eslint/experimental-utils" "1.9.0"
-    "@typescript-eslint/parser" "1.9.0"
+    "@typescript-eslint/experimental-utils" "1.11.0"
     eslint-utils "^1.3.1"
     functional-red-black-tree "^1.0.1"
     regexpp "^2.0.1"
-    requireindex "^1.2.0"
     tsutils "^3.7.0"
 
-"@typescript-eslint/experimental-utils@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-1.9.0.tgz#a92777d0c92d7bc8627abd7cdb06cdbcaf2b39e8"
-  integrity sha512-1s2dY9XxBwtS9IlSnRIlzqILPyeMly5tz1bfAmQ84Ul687xBBve5YsH5A5EKeIcGurYYqY2w6RkHETXIwnwV0A==
+"@typescript-eslint/experimental-utils@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-1.11.0.tgz#594abe47091cbeabac1d6f9cfed06d0ad99eb7e3"
+  integrity sha512-7LbfaqF6B8oa8cp/315zxKk8FFzosRzzhF8Kn/ZRsRsnpm7Qcu25cR/9RnAQo5utZ2KIWVgaALr+ZmcbG47ruw==
   dependencies:
-    "@typescript-eslint/typescript-estree" "1.9.0"
-
-"@typescript-eslint/parser@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.9.0.tgz#5796cbfcb9a3a5757aeb671c1ac88d7a94a95962"
-  integrity sha512-CWgC1XrQ34H/+LwAU7vY5xteZDkNqeAkeidEpJnJgkKu0yqQ3ZhQ7S+dI6MX4vmmM1TKRbOrKuXc6W0fIHhdbA==
-  dependencies:
-    "@typescript-eslint/experimental-utils" "1.9.0"
-    "@typescript-eslint/typescript-estree" "1.9.0"
+    "@typescript-eslint/typescript-estree" "1.11.0"
     eslint-scope "^4.0.0"
+
+"@typescript-eslint/parser@^1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.11.0.tgz#2f6d4f7e64eeb1e7c25b422f8df14d0c9e508e36"
+  integrity sha512-5xBExyXaxVyczrZvbRKEXvaTUFFq7gIM9BynXukXZE0zF3IQP/FxF4mPmmh3gJ9egafZFqByCpPTFm3dk4SY7Q==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "1.11.0"
+    "@typescript-eslint/typescript-estree" "1.11.0"
     eslint-visitor-keys "^1.0.0"
 
-"@typescript-eslint/typescript-estree@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.9.0.tgz#5d6d49be936e96fb0f859673480f89b070a5dd9b"
-  integrity sha512-7Eg0TEQpCkTsEwsl1lIzd6i7L3pJLQFWesV08dS87bNz0NeSjbL78gNAP1xCKaCejkds4PhpLnZkaAjx9SU8OA==
+"@typescript-eslint/typescript-estree@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.11.0.tgz#b7b5782aab22e4b3b6d84633652c9f41e62d37d5"
+  integrity sha512-fquUHF5tAx1sM2OeRCC7wVxFd1iMELWMGCzOSmJ3pLzArj9+kRixdlC4d5MncuzXpjEqc6045p3KwM0o/3FuUA==
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"
@@ -726,6 +730,16 @@ ajv@^6.1.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.1"
+
+ajv@^6.10.0:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.1.tgz#ebf8d3af22552df9dd049bfbe50cc2390e823593"
+  integrity sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
 
 ajv@^6.5.5, ajv@^6.9.1:
   version "6.10.0"
@@ -3303,13 +3317,13 @@ eslint-visitor-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
   integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
 
-eslint@5.16.0:
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.16.0.tgz#a1e3ac1aae4a3fbd8296fcf8f7ab7314cbb6abea"
-  integrity sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==
+eslint@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.0.1.tgz#4a32181d72cb999d6f54151df7d337131f81cda7"
+  integrity sha512-DyQRaMmORQ+JsWShYsSg4OPTjY56u1nCjAmICrE8vLWqyLKxhFXOthwMj1SA8xwfrv0CofLNVnqbfyhwCkaO0w==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    ajv "^6.9.1"
+    ajv "^6.10.0"
     chalk "^2.1.0"
     cross-spawn "^6.0.5"
     debug "^4.0.1"
@@ -3317,18 +3331,19 @@ eslint@5.16.0:
     eslint-scope "^4.0.3"
     eslint-utils "^1.3.1"
     eslint-visitor-keys "^1.0.0"
-    espree "^5.0.1"
+    espree "^6.0.0"
     esquery "^1.0.1"
     esutils "^2.0.2"
     file-entry-cache "^5.0.1"
     functional-red-black-tree "^1.0.1"
-    glob "^7.1.2"
+    glob-parent "^3.1.0"
     globals "^11.7.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
     inquirer "^6.2.2"
-    js-yaml "^3.13.0"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
     lodash "^4.17.11"
@@ -3336,7 +3351,6 @@ eslint@5.16.0:
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
-    path-is-inside "^1.0.2"
     progress "^2.0.0"
     regexpp "^2.0.1"
     semver "^5.5.1"
@@ -3345,10 +3359,10 @@ eslint@5.16.0:
     table "^5.2.3"
     text-table "^0.2.0"
 
-espree@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
-  integrity sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==
+espree@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-6.0.0.tgz#716fc1f5a245ef5b9a7fdb1d7b0d3f02322e75f6"
+  integrity sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==
   dependencies:
     acorn "^6.0.7"
     acorn-jsx "^5.0.0"
@@ -4506,7 +4520,7 @@ glob@^6.0.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2, glob@~7.1.1, glob@~7.1.2:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@~7.1.1, glob@~7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   integrity sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==
@@ -5816,7 +5830,7 @@ js-yaml@^3.10.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^3.12.1, js-yaml@^3.13.0, js-yaml@^3.13.1:
+js-yaml@^3.12.1, js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -8864,11 +8878,6 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
-
-requireindex@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
-  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
 
 requires-port@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
We had more ES6 than we realized, especially in `portico` and other places untested by `casper_tests`.