### PR TITLE
templates: Fix wrong path to edit-outgoing-webhook-service template

### DIFF
--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -401,7 +401,7 @@ exports.set_up = function () {
         $("#settings_page .edit_bot .edit-bot-owner select").val(bot.owner);
         var service = bot_data.get_services(bot_id)[0];
         if (bot.bot_type.toString() === OUTGOING_WEBHOOK_BOT_TYPE) {
-            $("#service_data").append(templates.render("edit-outgoing-webhook-service",
+            $("#service_data").append(templates.render("settings/edit-outgoing-webhook-service",
                                                        {service: service}));
             $("#edit_service_interface").val(service.interface);
         }


### PR DESCRIPTION
Found by running the Casper tests with #12737.