### PR TITLE
blueslip: Ignore error events with null error

### DIFF
--- a/static/js/blueslip.js
+++ b/static/js/blueslip.js
@@ -219,7 +219,7 @@ exports.exception_msg = function blueslip_exception_msg(ex) {
 
 $(window).on('error', function (event) {
     var ex = event.originalEvent.error;
-    if (ex instanceof BlueslipError) {
+    if (!ex || ex instanceof BlueslipError) {
         return;
     }
     var message = exports.exception_msg(ex);


### PR DESCRIPTION
Chrome generates these to report things like “ResizeObserver loop limit exceeded” (which is harmless).

**Testing Plan:** Watch the browser console while opening the hamburger menu in a narrow Chrome window.