### PR TITLE
Openapi validation

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1751,7 +1751,7 @@ paths:
           your client code. For most applications, one is only interested in
           messages, so one specifies: `event_types=['message']`"
         schema:
-          type: string
+          type: array
         example: event_types=['message']
       - name: all_public_streams
         in: query
@@ -1776,7 +1776,7 @@ paths:
           `fetch_event_types` is not provided, `event_types` is used and if
           `event_types` is not provided, this argument defaults to `None`.
         schema:
-          type: string
+          type: array
         example: event_types=['message']
       - name: narrow
         in: query
@@ -1786,7 +1786,7 @@ paths:
           `narrow=['stream', 'Denmark']`. Another example is
           `narrow=['is', 'private']` for private messages.
         schema:
-          type: string
+          type: array
           default: narrow=[]
         example: narrow=['stream', 'Denmark']
       security:


### PR DESCRIPTION
This is an extension of PR #12681 and wraps up most of the work for issue #12521.
- The first commit cleans up the messiness for accounting for both `<var_name>` and `{var_name}` by standardizing on the `{var_name}` format.
- The second commit upgrades test which validates the request parameter types.
> TODO: This is lower priority than the main issue, but it'd be really cool to cross-validate the types declared in OpenAPI against the types declared in REQ (via the validator parameter). We may not be able to do this always, but 95% of the time it's check_int or check_str or check_dict, and we can certainly map those to the expected type.

However, instead of checking for the validators, I went ahead and did something even better. I analyse the function declaration itself (for more, please refer to the commit message).
