### PR TITLE
settings: User account settings refactor and cleanup

### DIFF
--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -106,6 +106,7 @@ exports.open_modal = function (name) {
     $('.overlay.show').attr("style", "pointer-events: none");
     // Remove previous alert messsages from modal, if exists.
     $("#" + name).find(".alert").hide();
+    $("#" + name).find(".alert-notification").html("");
 };
 
 exports.close_overlay = function (name) {

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -426,6 +426,8 @@ exports.set_up = function () {
                 overlays.close_modal('change_email_modal');
             },
             error_msg_element: change_email_error,
+            success_msg: i18n.t('Check your email (%s) to confirm the new address.').replace(
+                "%s", data.email),
         };
         settings_ui.do_settings_change(channel.patch, '/json/settings', data,
                                        $('#account-settings-status').expectOne(), opts);

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -74,14 +74,28 @@ function settings_change_error(message, xhr) {
     ui_report.error(message, xhr, $('#account-settings-status').expectOne());
 }
 
+function update_custom_profile_field(field, method) {
+    var field_id;
+    if (method === channel.del) {
+        field_id = field;
+    } else {
+        field_id = field.id;
+    }
+
+    var spinner = $('.custom_user_field[data-field-id="' + field_id +
+        '"] .custom-field-status').expectOne();
+    loading.make_indicator(spinner, {text: 'Saving ...'});
+    settings_ui.do_settings_change(method, "/json/users/me/profile_data",
+                                   {data: JSON.stringify([field])}, spinner);
+}
+
 function update_user_custom_profile_fields(fields, method) {
     if (method === undefined) {
         blueslip.error("Undefined method in update_user_custom_profile_fields");
     }
-    var spinner = $("#custom-field-status").expectOne();
-    loading.make_indicator(spinner, {text: 'Saving ...'});
-    settings_ui.do_settings_change(method, "/json/users/me/profile_data",
-                                   {data: JSON.stringify(fields)}, spinner);
+    _.each(fields, function (field) {
+        update_custom_profile_field(field, method);
+    });
 }
 
 exports.append_custom_profile_fields = function (element_id, user_id) {

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -133,9 +133,12 @@ label {
     box-shadow: 0px 0px 10px hsla(0, 0%, 0%, 0.1);
 }
 
-#change_email_modal,
-#change_full_name_modal {
+#change_email_modal {
     width: 460px;
+}
+
+#change_full_name_modal {
+    width: 480px;
 }
 
 .admin-realm-description {
@@ -1558,10 +1561,7 @@ body:not(.night-mode) #account-settings .custom_user_field .datepicker {
     min-width: 206px;
 }
 
-#settings_page #change_full_name_modal .change_full_name_info {
-    margin-bottom: 0px;
-}
-
+#settings_page #change_full_name_modal .change_full_name_info,
 #settings_page #change_email_modal .change_email_info,
 #settings_page #change_password_modal .change_password_info {
     margin-top: 3px;

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1564,7 +1564,7 @@ body:not(.night-mode) #account-settings .custom_user_field .datepicker {
 }
 
 #settings_page #change_password_modal .change_password_info {
-    margin: 10px;
+    margin-top: 3px;
 }
 
 #confirm_dialog_modal,

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -651,6 +651,16 @@ input[type=checkbox].inline-block {
     text-align: left;
 }
 
+#account-settings .custom-profile-fields-form .custom_user_field label {
+    min-width: fit-content;
+}
+
+#account-settings .alert-notification.custom-field-status {
+    margin-top: 0px;
+    font-size: 14px;
+    margin-bottom: 4px;
+}
+
 #realm_notifications_stream_label > button,
 #realm_signup_notifications_stream_label > button {
     margin: 0px 5px;

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1558,11 +1558,11 @@ body:not(.night-mode) #account-settings .custom_user_field .datepicker {
     min-width: 206px;
 }
 
-#settings_page #change_email_modal .change_email_info,
 #settings_page #change_full_name_modal .change_full_name_info {
     margin-bottom: 0px;
 }
 
+#settings_page #change_email_modal .change_email_info,
 #settings_page #change_password_modal .change_password_info {
     margin-top: 3px;
 }

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -60,14 +60,14 @@
                       aria-labelledby="change_full_name_modal_label" aria-hidden="true">
                         <div class="modal-header">
                             <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
-                            <h3 id="change_full_name_modal_label">{{t "Change full name" }}</h3>
+                            <h3 class="inline-block" id="change_full_name_modal_label">{{t "Change full name" }}</h3>
+                            <div class="alert-notification change_full_name_info"></div>
                         </div>
                         <div class="modal-body">
                             <div class="input-group full_name_change_container">
                                 <label for="email">{{t "New full name" }}</label>
                                 <input type="text" name="full_name" value="{{ page_params.full_name }}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
                             </div>
-                            <div class="alert change_full_name_info"></div>
                         </div>
                         <div class="modal-footer">
                             <button class="button white rounded" type="button" data-dismiss="modal">{{t "Cancel" }}</button>

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -20,14 +20,14 @@
                   aria-labelledby="change_email_modal_label" aria-hidden="true">
                     <div class="modal-header">
                         <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
-                        <h3 id="change_email_modal_label">{{t "Change email" }}</h3>
+                        <h3 class="inline-block" id="change_email_modal_label">{{t "Change email" }}</h3>
+                        <div class="alert-notification change_email_info"></div>
                     </div>
                     <div class="modal-body">
                         <div class="input-group email_change_container">
                             <label for="email">{{t "New email" }}</label>
                             <input type="text" name="email" value="{{ page_params.delivery_email }}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
                         </div>
-                        <div class="alert change_email_info"></div>
                     </div>
                     <div class="modal-footer">
                         <button class="button white rounded" type="button" data-dismiss="modal">{{t "Cancel" }}</button>

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -8,11 +8,11 @@
                 <div class="input-group user-name-section">
                     <label class="inline-block title">{{t "Email" }}</label>
                     <button id='change_email' type="button" class="button btn-link small rounded inline-block" id='email_value'
-                      {{#unless page_params.is_admin}}{{#if page_params.realm_email_changes_disabled}}disabled="disabled"{{/if}}{{/unless}}>
+                      {{#if (and page_params.realm_email_changes_disabled (not page_params.is_admin))}}disabled="disabled"{{/if}}>
                         {{page_params.delivery_email}}
                         <i class="fa fa-pencil"></i>
                     </button>
-                    <i class="fa fa-question-circle change_email_tooltip settings-info-icon" {{#if page_params.is_admin}}style="display:none"{{else}}{{#unless page_params.realm_email_changes_disabled}}style="display:none"{{/unless}}{{/if}}  data-toggle="tooltip"
+                    <i class="fa fa-question-circle change_email_tooltip settings-info-icon" {{#if (or (not page_params.realm_email_changes_disabled) page_params.is_admin)}}style="display: none;"{{/if}} data-toggle="tooltip"
                       title="{{t 'Email address changes are disabled in this organization.' }}"></i>
                 </div>
 
@@ -169,7 +169,7 @@
             </div>
             <div class="avatar-controls">
                 <button class="button rounded sea-green w-200 block" id="user_avatar_upload_button"
-                  {{#unless page_params.is_admin}}{{#if page_params.realm_avatar_changes_disabled}}style="display:none"{{else}}{{#if page_params.server_avatar_changes_disabled}}style="display:none"{{/if}}{{/if}}{{/unless}}>
+                  {{#if (and (not page_params.is_admin) page_params.realm_avatar_changes_disabled)}}style="display:none"{{/if}}>
                     {{t 'Upload new profile picture' }}
                 </button>
                 <div id="user_avatar_file_input_error" class="text-error"></div>

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -91,7 +91,8 @@
                   aria-labelledby="change_password_modal_label" aria-hidden="true">
                     <div class="modal-header">
                         <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
-                        <h3 id="change_password_modal_label">{{t "Change password" }}</h3>
+                        <h3 class="inline-block" id="change_password_modal_label">{{t "Change password" }}</h3>
+                        <div class="alert-notification change_password_info"></div>
                     </div>
                     <div class="flex-row normal">
                         <div class="field">
@@ -111,7 +112,6 @@
                             </div>
                         </div>
                     </div>
-                    <div class="alert change_password_info"></div>
                     <div class="modal-footer">
                         <button class="button white rounded" type="button" data-dismiss="modal">{{t "Cancel" }}</button>
                         <button id='change_password_button' class="button rounded sea-green">{{t "Change" }}</button>

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -141,7 +141,6 @@
             </form>
 
             <h3 class="inline-block" id="custom-field-header" {{#unless page_params.custom_profile_fields}}style="display: none"{{/unless}}>{{t "Profile" }}</h3>
-            <div class="alert-notification" id="custom-field-status"></div>
             <form class="form-horizontal custom-profile-fields-form grid"></form>
             <button class="button rounded sea-green w-200 block" id="show_my_user_profile_modal">
                 {{t 'Preview profile' }}

--- a/static/templates/settings/custom_user_profile_field.hbs
+++ b/static/templates/settings/custom_user_profile_field.hbs
@@ -1,24 +1,27 @@
 <div class="user-name-section custom_user_field" name="{{ field.name }}" data-field-id="{{ field.id }}">
-    <label for="{{ field.name }}" class="title">{{ field.name }}</label>
-    {{#if is_long_text_field}}
-    <textarea maxlength="500" class="custom_user_field_value">{{ field_value.value }}</textarea>
-    {{else if is_choice_field}}
-    <select class="custom_user_field_value">
-        <option value=""></option>
-        {{#each field_choices}}
-        <option value="{{ this.value }}" {{#if this.selected}}selected{{/if}}>{{ this.text }}</option>
-        {{/each}}
-    </select>
-    {{else if is_user_field }}
-    <div class="pill-container person_picker">
-        <div class="input" contenteditable="true"></div>
+    <label class="inline-block" for="{{ field.name }}" class="title">{{ field.name }}</label>
+    <div class="alert-notification custom-field-status"></div>
+    <div class="field">
+        {{#if is_long_text_field}}
+        <textarea maxlength="500" class="custom_user_field_value">{{ field_value.value }}</textarea>
+        {{else if is_choice_field}}
+        <select class="custom_user_field_value">
+            <option value=""></option>
+            {{#each field_choices}}
+            <option value="{{ this.value }}" {{#if this.selected}}selected{{/if}}>{{ this.text }}</option>
+            {{/each}}
+        </select>
+        {{else if is_user_field }}
+        <div class="pill-container person_picker">
+            <div class="input" contenteditable="true"></div>
+        </div>
+        {{else if is_date_field }}
+        <input class="custom_user_field_value datepicker" data-field-id="{{ field.id }}" type="text"
+          value="{{ field_value.value }}" />
+        <span class="remove_date"><i class="fa fa-close"></i></span>
+        {{else}}
+        <input class="custom_user_field_value" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" />
+        {{/if}}
     </div>
-    {{else if is_date_field }}
-    <input class="custom_user_field_value datepicker" data-field-id="{{ field.id }}" type="text"
-      value="{{ field_value.value }}" />
-    <span class="remove_date"><i class="fa fa-close"></i></span>
-    {{else}}
-    <input class="custom_user_field_value" type="{{ field_type }}" value="{{ field_value.value }}" maxlength="50" />
-    {{/if}}
     <div class="field_hint">{{ field.hint }}</div>
 </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
First fixed "save" don't disappear issue and fixed following bugs in account setting section that I came across. 
cc @rishig 
Here is the demo:
Account settings:

![account-password](https://user-images.githubusercontent.com/25907420/60995354-fd6d3200-a36f-11e9-947f-e6c12455383f.gif)

![account-setting](https://user-images.githubusercontent.com/25907420/60995406-17a71000-a370-11e9-8314-0cf21e30d596.gif)

