### PR TITLE
[minor] portico: Cleanups.

### DIFF
--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -154,27 +154,6 @@ var apps_events = function () {
 var events = function () {
     ScrollTo();
 
-    $("a").click(function (e) {
-        // if a user is holding the CMD/CTRL key while clicking a link, they
-        // want to open the link in another browser tab which means that we
-        // should preserve the state of this one. Return out, and don't fade
-        // the page.
-        if (e.metaKey || e.ctrlKey) {
-            return;
-        }
-
-        // if the pathname is different than what we are already on, run the
-        // custom transition function.
-        if (window.location.pathname !== this.pathname && !this.hasAttribute("download") &&
-            !/no-action/.test(this.className)) {
-            e.preventDefault();
-
-            setTimeout(function () {
-                window.location.href = $(this).attr("href");
-            }.bind(this), 500);
-        }
-    });
-
     // get the location url like `zulipchat.com/features/`, cut off the trailing
     // `/` and then split by `/` to get ["zulipchat.com", "features"], then
     // pop the last element to get the current section (eg. `features`).

--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -6,24 +6,6 @@ const ELECTRON_APP_URL_WINDOWS = "https://github.com/zulip/zulip-desktop/release
 import render_tabs from './team.js';
 import {detect_user_os}  from './tabbed-instructions.js';
 
-// this will either smooth scroll to an anchor where the `name`
-// is the same as the `scroll-to` reference, or to a px height
-// (as specified like `scroll-to='0px'`).
-var ScrollTo = function () {
-    $("[scroll-to]").click(function () {
-        var sel = $(this).attr("scroll-to");
-
-        // if the `scroll-to` is a parse-able pixel value like `50px`,
-        // then use that as the scrollTop, else assume it is a selector name
-        // and find the `offsetTop`.
-        var top = /\dpx/.test(sel) ?
-            parseInt(sel, 10) :
-            $("[name='" + sel + "']").offset().top;
-
-        $("body").animate({ scrollTop: top + "px" }, 300);
-    });
-};
-
 export function path_parts() {
     return window.location.pathname.split('/').filter(function (chunk) {
         return chunk !== '';
@@ -152,8 +134,6 @@ var apps_events = function () {
 };
 
 var events = function () {
-    ScrollTo();
-
     // get the location url like `zulipchat.com/features/`, cut off the trailing
     // `/` and then split by `/` to get ["zulipchat.com", "features"], then
     // pop the last element to get the current section (eg. `features`).


### PR DESCRIPTION
We added custom event handlers on anchor tags to show transitions
when switching between pages, a behaviour we have since removes in
commit a0dacea81193600983e55c60fe8265ed061abb04.

Our approach didn't respect the target attribute for links and other
defaults that browsers offer with links.

We can now safelhy remove the event handler and restore the default
behavior of anchor tags.

**Also removed scroll-to attribute support**.
