### PR TITLE
Add open graph metadata to some portico pages.

### DIFF
--- a/templates/zerver/features.html
+++ b/templates/zerver/features.html
@@ -1,5 +1,8 @@
 {% extends "zerver/portico.html" %}
 
+{% set OPEN_GRAPH_TITLE = 'Zulip Features' %}
+{% set OPEN_GRAPH_DESCRIPTION = 'First class threading on top of everything you could want from real-time chat.' %}
+
 {% block customhead %}
 {{ render_bundle('landing-page') }}
 {% endblock %}

--- a/templates/zerver/for-open-source.html
+++ b/templates/zerver/for-open-source.html
@@ -1,5 +1,8 @@
 {% extends "zerver/portico.html" %}
 
+{% set OPEN_GRAPH_TITLE = 'Modern chat for open source' %}
+{% set OPEN_GRAPH_DESCRIPTION = 'No message limits, rich moderation features, markdown support, and a conversation model that scales to thousands of users.' %}
+
 {% block title %}
 <title>Zulip: the best group chat for open source projects</title>
 {% endblock %}

--- a/templates/zerver/why-zulip.html
+++ b/templates/zerver/why-zulip.html
@@ -1,5 +1,8 @@
 {% extends "zerver/portico.html" %}
 
+{% set OPEN_GRAPH_TITLE = 'Team chat with first-class threading' %}
+{% set OPEN_GRAPH_DESCRIPTION = 'Most team chats are overwhelming to keep up with. Zulip takes a different approach.' %}
+
 {% block title %}
 <title>The best group chat</title>
 {% endblock %}

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -155,6 +155,21 @@ class DocPageTest(ZulipTestCase):
         result = self.client_get('/static/favicon.ico')
         self.assertEqual(result.status_code, 200)
 
+    def test_portico_pages_open_graph_metadata(self) -> None:
+        # Why Zulip
+        url = '/why-zulip/'
+        title = '<meta property="og:title" content="Team chat with first-class threading">'
+        description = '<meta property="og:description" content="Most team chats are overwhelming'
+        self._test(url, title, doc_html_str=True)
+        self._test(url, description, doc_html_str=True)
+
+        # Features
+        url = '/features/'
+        title = '<meta property="og:title" content="Zulip Features">'
+        description = '<meta property="og:description" content="First class threading'
+        self._test(url, title, doc_html_str=True)
+        self._test(url, description, doc_html_str=True)
+
     @slow("Tests dozens of endpoints, including all our integrations docs")
     def test_integration_doc_endpoints(self) -> None:
         self._test('/integrations/',

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -184,6 +184,13 @@ class DocPageTest(ZulipTestCase):
         self._test(url, title, doc_html_str=True)
         self._test(url, description, doc_html_str=True)
 
+        # Test integrations page
+        url = '/integrations/'
+        title = '<meta property="og:title" content="Connect the tools you use to Zulip">'
+        description = '<meta property="og:description" content="Zulip comes with over'
+        self._test(url, title, doc_html_str=True)
+        self._test(url, description, doc_html_str=True)
+
     def test_email_integration(self) -> None:
         self._test('/integrations/doc-html/email',
                    'support+abcdefg@testserver', doc_html_str=True)

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -162,6 +162,10 @@ def add_integrations_open_graph_context(context: Dict[str, Any], request: HttpRe
         context['OPEN_GRAPH_TITLE'] = 'Connect your {category} tools to Zulip'.format(category=category)
         context['OPEN_GRAPH_DESCRIPTION'] = description
 
+    elif path_name == 'integrations':
+        context['OPEN_GRAPH_TITLE'] = 'Connect the tools you use to Zulip'
+        context['OPEN_GRAPH_DESCRIPTION'] = description
+
 class IntegrationView(ApiURLView):
     template_name = 'zerver/integrations/index.html'
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Draft PR for #12580 

Pages like /features are rendering templates directly as views. 

One idea to customize the open graph description for them was to put the open graph tags in a custom block and override them in the template files. But it looks like extending templates [cannot override included blocks](https://github.com/pallets/jinja/commit/59713a3acfa0afeac2ee572d213680bbb295280b) in jinja. 

The other solution is to just set `OPEN_GRAPH_TITLE` and `OPEN_GRAPH_DESCRIPTION` in the templates where we wish to customize the open graph metadata. I've included an example of this, in the draft PR. 

@rishig If we have a list of pages and the open graph titles, and descriptions to add to them, I can update this PR with those changes. 