### PR TITLE
custom fields: Add separate alert-save widget for create field.

### DIFF
--- a/frontend_tests/casper_tests/10-admin.js
+++ b/frontend_tests/casper_tests/10-admin.js
@@ -276,8 +276,8 @@ casper.then(function () {
 });
 
 casper.then(function () {
-    casper.waitUntilVisible('#admin-profile-field-status img', function () {
-        casper.test.assertSelectorHasText('div#admin-profile-field-status', 'Saved');
+    casper.waitUntilVisible('#admin-add-profile-field-status img', function () {
+        casper.test.assertSelectorHasText('div#admin-add-profile-field-status', 'Saved');
     });
     casper.waitUntilVisible('.profile-field-row span.profile_field_name', function () {
         casper.test.assertSelectorHasText('.profile-field-row span.profile_field_name', 'Teams');

--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -150,7 +150,7 @@ function create_profile_field(e) {
     };
 
     settings_ui.do_settings_change(channel.post, "/json/realm/profile_fields", form_data,
-                                   $('#admin-profile-field-status').expectOne(), opts);
+                                   $('#admin-add-profile-field-status').expectOne(), opts);
     update_profile_fields_table_element();
 }
 

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -960,6 +960,10 @@ input[type=checkbox].inline-block {
     margin-right: 20px;
 }
 
+.admin-profile-field-form #custom_external_account_url_pattern input {
+    width: 70%;
+}
+
 #upload_avatar_spinner,
 #upload_logo_spinner,
 #upload_icon_spinner,

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -629,6 +629,10 @@ input[type=checkbox].inline-block {
     margin-top: -2px;
 }
 
+#profile-field-settings #admin-add-profile-field-status {
+    margin-top: 4px;
+}
+
 #notification-settings .notification-reminder {
     text-align: left;
 }

--- a/static/templates/settings/profile-field-settings-admin.handlebars
+++ b/static/templates/settings/profile-field-settings-admin.handlebars
@@ -17,7 +17,8 @@
     <form class="form-horizontal admin-profile-field-form">
         <div class="add-new-profile-field-box grey-box">
             <div class="new-profile-field-form wrapper">
-                <div class="settings-section-title new-profile-field-section-title">{{t "Add a new profile field" }}</div>
+                <div class="settings-section-title new-profile-field-section-title inline-block">{{t "Add a new profile field" }}</div>
+                <div class="alert-notification" id="admin-add-profile-field-status"></div>
                 <div class="control-group">
                     <label for="profile_field_name" class="control-label">{{t "Label" }}</label>
                     <input type="text" id="profile_field_name" name="name" autocomplete="off" maxlength="40" />


### PR DESCRIPTION
Add separate alert-notification widget for create-custom-field
in admin view.

Fixes part of #12748
Followup of #12442 

![image](https://user-images.githubusercontent.com/25907420/60999327-86886700-a378-11e9-9378-e9bab7b5f333.png)

