### PR TITLE
Remove unused Python requirements

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -13,7 +13,6 @@ Jinja2==2.10.1
 
 # Needed for markdown processing
 Markdown==3.1.1
-MarkupSafe==1.1.1
 Pygments==2.3.1
 
 # Needed for manage.py
@@ -36,17 +35,6 @@ backports.ssl-match-hostname==3.7.0.1
 
 # Needed for S3 file uploads
 boto==2.49.0
-
-certifi===2019.3.9
-
-# Used for scrapy as well as argon2
-cffi==1.12.3
-
-chardet==3.0.4
-
-# Pinned version because older versions don't compile on newer Linux.
-# Not actually a direct dependency.
-cryptography==2.6.1
 
 # Needed for integrations
 defusedxml==0.5.0
@@ -94,7 +82,6 @@ markdown-include==0.5.1
 mock==2.0.0
 
 oauth2client==4.1.3
-oauthlib==3.0.1
 
 # Enhanced HTTPS support for httplib and urllib2 using PyOpenSSL
 # Needed by requests to send https request to some sites.
@@ -107,8 +94,6 @@ pika==0.13.0
 # Needed to access our database
 psycopg2==2.8.2 --no-binary psycopg2
 
-pyasn1==0.4.5
-pyasn1-modules==0.2.5
 pycrypto==2.6.1
 
 # Needed for memcached usage
@@ -126,9 +111,6 @@ pytz==2019.1
 # Needed for redis
 redis==2.10.6
 
-requests_oauthlib==1.0.0
-rsa==4.0
-
 # Needed for Python 2+3 compatibility
 six==1.12.0
 smmap==0.9.0
@@ -142,13 +124,8 @@ sourcemap==0.2.1
 # Tornado used for server->client push system
 tornado==4.5.3
 
-# Needed for Python static typing
-typing==3.6.6
-
 # Fast JSON parser
 -e git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
-
-uritemplate==3.0.0
 
 # Django extension for static asset pipeline
 django-pipeline==1.6.14

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -27,12 +27,6 @@ SQLAlchemy==1.3.3
 # Needed for password hashing
 argon2-cffi==19.1.0
 
-# Needed for Tornado >3.2 compatibility
-backports-abc==0.5
-
-# Needed for Tornado 4 compatibility
-backports.ssl-match-hostname==3.7.0.1
-
 # Needed for S3 file uploads
 boto==2.49.0
 
@@ -48,12 +42,8 @@ django-auth-ldap==1.7.0
 # Django extension for sending data to statsd
 django-statsd-mozilla==0.4.0
 
-docopt==0.6.2
-
 # Needed for Android push notifications
 python-gcm==0.4
-
-gitdb==0.6.4
 
 # Needed for Google Apps mobile auth
 google-api-python-client==1.7.4
@@ -83,18 +73,12 @@ mock==2.0.0
 
 oauth2client==4.1.3
 
-# Enhanced HTTPS support for httplib and urllib2 using PyOpenSSL
-# Needed by requests to send https request to some sites.
-ndg-httpsclient==0.5.1
-
 # Needed to access rabbitmq
 # See #8466 for why we're not using the latest version.
 pika==0.13.0
 
 # Needed to access our database
 psycopg2==2.8.2 --no-binary psycopg2
-
-pycrypto==2.6.1
 
 # Needed for memcached usage
 pylibmc==1.6.0
@@ -113,7 +97,6 @@ redis==2.10.6
 
 # Needed for Python 2+3 compatibility
 six==1.12.0
-smmap==0.9.0
 
 # Needed for Tornado websockets support
 sockjs-tornado==1.0.6

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,7 +16,7 @@ git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#
 git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
 git+https://github.com/zulip/python-zulip-api.git@0.6.0#egg=zulip==0.6.0_git&subdirectory=zulip
 git+https://github.com/zulip/python-zulip-api.git@0.6.0#egg=zulip_bots==0.6.0+git&subdirectory=zulip_bots
-alabaster==0.7.12
+alabaster==0.7.12         # via sphinx
 apns2==0.4.1
 argon2-cffi==19.1.0
 arrow==0.10.0             # via gitlint
@@ -24,7 +24,7 @@ asn1crypto==0.24.0        # via cryptography
 attrs==19.1.0             # via automat, service-identity, twisted
 automat==0.7.0            # via twisted
 aws-xray-sdk==0.95        # via moto
-babel==2.5.3
+babel==2.5.3              # via django-phonenumber-field, sphinx
 backcall==0.1.0           # via ipython
 backports-abc==0.5
 backports.ssl-match-hostname==3.7.0.1
@@ -34,14 +34,14 @@ boto==2.49.0
 botocore==1.12.183        # via boto3, moto, s3transfer
 cachetools==3.1.1         # via google-auth, premailer
 cchardet==2.1.4
-certifi==2019.3.9
-cffi==1.12.3
-chardet==3.0.4
+certifi==2019.3.9         # via requests
+cffi==1.12.3              # via argon2-cffi, cryptography
+chardet==3.0.4            # via requests
 click==6.7                # via gitlint, pip-tools
 commonmark==0.5.4
 constantly==15.1.0        # via twisted
 coverage==4.5.3
-cryptography==2.6.1
+cryptography==2.6.1       # via apns2, moto, pyopenssl, requests, service-identity
 cssselect==1.0.3          # via parsel, premailer, scrapy
 cssutils==1.0.2           # via premailer
 decorator==4.4.0          # via ipython, traitlets
@@ -60,7 +60,7 @@ django-webpack-loader==0.6.0
 django==1.11.22
 docker==4.0.2             # via moto
 docopt==0.6.2
-docutils==0.14
+docutils==0.14            # via botocore, recommonmark, sphinx
 ecdsa==0.13.2             # via python-jose
 fakeldap==0.6.1
 first==2.0.2              # via pip-tools
@@ -80,7 +80,7 @@ hyperframe==3.2.0         # via h2, hyper
 hyperlink==19.0.0         # via twisted
 idna==2.8                 # via hyperlink, requests
 ijson==2.3
-imagesize==1.1.0
+imagesize==1.1.0          # via sphinx
 incremental==17.5.0       # via twisted
 ipython-genutils==0.2.0   # via traitlets
 ipython==6.5.0
@@ -93,7 +93,7 @@ jsonpickle==1.2           # via aws-xray-sdk, python-digitalocean
 lxml==4.3.3
 markdown-include==0.5.1
 markdown==3.1.1
-markupsafe==1.1.1
+markupsafe==1.1.1         # via jinja2
 matrix-client==0.3.2
 mock==2.0.0
 moto==1.3.7
@@ -101,7 +101,7 @@ mypy-extensions==0.4.1
 mypy==0.670
 ndg-httpsclient==0.5.1
 oauth2client==4.1.3
-oauthlib==3.0.1
+oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
 packaging==19.0           # via sphinx
 parsel==1.5.1             # via scrapy
 parso==0.5.0              # via jedi
@@ -120,8 +120,8 @@ ptyprocess==0.6.0         # via pexpect
 py3dns==3.2.0
 pyahocorasick==1.4.0
 pyaml==19.4.1             # via moto
-pyasn1-modules==0.2.5
-pyasn1==0.4.5
+pyasn1-modules==0.2.5     # via google-auth, oauth2client, python-ldap, service-identity
+pyasn1==0.4.5             # via ndg-httpsclient, oauth2client, pyasn1-modules, python-ldap, rsa, service-identity
 pycodestyle==2.5.0
 pycparser==2.19           # via cffi
 pycrypto==2.6.1
@@ -153,10 +153,10 @@ queuelib==1.5.0           # via scrapy
 recommonmark==0.4.0
 redis==2.10.6
 regex==2019.6.8
-requests-oauthlib==1.0.0
+requests-oauthlib==1.0.0  # via python-twitter, social-auth-core
 requests[security]==2.22.0  # via aws-xray-sdk, docker, hypchat, matrix-client, moto, premailer, pyoembed, python-digitalocean, python-gcm, python-twitter, requests-oauthlib, responses, social-auth-core, sphinx, stripe, twilio
 responses==0.10.6         # via moto
-rsa==4.0
+rsa==4.0                  # via google-auth, oauth2client
 s3transfer==0.2.1         # via boto3
 scrapy==1.6.0
 service-identity==18.1.0  # via scrapy
@@ -165,7 +165,7 @@ simplegeneric==0.8.1      # via ipython
 six==1.12.0
 smmap==0.9.0
 snakeviz==2.0.0
-snowballstemmer==1.2.1
+snowballstemmer==1.2.1    # via sphinx
 social-auth-app-django==3.1.0
 social-auth-core==3.2.0   # via social-auth-app-django
 sockjs-tornado==1.0.6
@@ -186,7 +186,7 @@ twisted==19.2.1
 typed-ast==1.3.5          # via mypy
 typing==3.6.6
 typing_extensions==3.6.6
-uritemplate==3.0.0
+uritemplate==3.0.0        # via google-api-python-client
 urllib3==1.25.3           # via botocore, requests, transifex-client
 virtualenv-clone==0.5.3
 w3lib==1.20.0             # via parsel, scrapy

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -26,8 +26,6 @@ automat==0.7.0            # via twisted
 aws-xray-sdk==0.95        # via moto
 babel==2.5.3              # via django-phonenumber-field, sphinx
 backcall==0.1.0           # via ipython
-backports-abc==0.5
-backports.ssl-match-hostname==3.7.0.1
 beautifulsoup4==4.7.1
 boto3==1.9.183            # via moto
 boto==2.49.0
@@ -59,12 +57,10 @@ django-two-factor-auth==1.8.0
 django-webpack-loader==0.6.0
 django==1.11.22
 docker==4.0.2             # via moto
-docopt==0.6.2
 docutils==0.14            # via botocore, recommonmark, sphinx
 ecdsa==0.13.2             # via python-jose
 fakeldap==0.6.1
 first==2.0.2              # via pip-tools
-gitdb==0.6.4
 gitlint==0.11.0
 google-api-python-client==1.7.4
 google-auth-httplib2==0.0.3  # via google-api-python-client
@@ -99,7 +95,6 @@ mock==2.0.0
 moto==1.3.7
 mypy-extensions==0.4.1
 mypy==0.670
-ndg-httpsclient==0.5.1
 oauth2client==4.1.3
 oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
 packaging==19.0           # via sphinx
@@ -121,10 +116,9 @@ py3dns==3.2.0
 pyahocorasick==1.4.0
 pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.5     # via google-auth, oauth2client, python-ldap, service-identity
-pyasn1==0.4.5             # via ndg-httpsclient, oauth2client, pyasn1-modules, python-ldap, rsa, service-identity
+pyasn1==0.4.5             # via oauth2client, pyasn1-modules, python-ldap, rsa, service-identity
 pycodestyle==2.5.0
 pycparser==2.19           # via cffi
-pycrypto==2.6.1
 pycryptodome==3.8.2       # via python-jose
 pydispatcher==2.0.5       # via scrapy
 pyflakes==2.1.1
@@ -135,7 +129,7 @@ pyjwt==1.7.1
 pyldap==3.0.0.post1       # via fakeldap
 pylibmc==1.6.0
 pyoembed==0.1.2
-pyopenssl==19.0.0         # via ndg-httpsclient, requests, scrapy
+pyopenssl==19.0.0         # via requests, scrapy
 pyparsing==2.4.0          # via packaging
 pysocks==1.7.0            # via twilio
 python-dateutil==2.8.0
@@ -163,7 +157,6 @@ service-identity==18.1.0  # via scrapy
 sh==1.12.14               # via gitlint
 simplegeneric==0.8.1      # via ipython
 six==1.12.0
-smmap==0.9.0
 snakeviz==2.0.0
 snowballstemmer==1.2.1    # via sphinx
 social-auth-app-django==3.1.0
@@ -185,7 +178,6 @@ twilio==6.26.2
 twisted==19.2.1
 typed-ast==1.3.5          # via mypy
 typing==3.6.6
-typing_extensions==3.6.6
 uritemplate==3.0.0        # via google-api-python-client
 urllib3==1.25.3           # via botocore, requests, transifex-client
 virtualenv-clone==0.5.3

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -18,6 +18,3 @@ recommonmark==0.4.0
 # compatibility with recommonmark.  See
 # https://github.com/rtfd/recommonmark/issues/24
 CommonMark==0.5.4
-
-# Include typing explicitly, since it's needed on Python 3.4
-typing==3.6.6

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -14,16 +14,10 @@ sphinx-rtd-theme==0.4.3
 # Needed to build markdown docs
 recommonmark==0.4.0
 
-# Dependencies of Sphinx
-alabaster==0.7.12
-babel==2.5.3
 # Upgrading to the latest version of CommonMark breaks the
 # compatibility with recommonmark.  See
 # https://github.com/rtfd/recommonmark/issues/24
 CommonMark==0.5.4
-docutils==0.14
-imagesize==1.1.0
-snowballstemmer==1.2.1
 
 # Include typing explicitly, since it's needed on Python 3.4
 typing==3.6.6

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -28,5 +28,4 @@ snowballstemmer==1.2.1    # via sphinx
 sphinx-rtd-theme==0.4.3
 sphinx==1.8.4
 sphinxcontrib-websupport==1.1.2  # via sphinx
-typing==3.6.6
 urllib3==1.25.3           # via requests

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -7,14 +7,14 @@
 #
 # For details, see requirements/README.md .
 #
-alabaster==0.7.12
-babel==2.5.3
+alabaster==0.7.12         # via sphinx
+babel==2.5.3              # via sphinx
 certifi==2019.6.16        # via requests
 chardet==3.0.4            # via requests
 commonmark==0.5.4
-docutils==0.14
+docutils==0.14            # via recommonmark, sphinx
 idna==2.8                 # via requests
-imagesize==1.1.0
+imagesize==1.1.0          # via sphinx
 jinja2==2.10.1            # via sphinx
 markupsafe==1.1.1         # via jinja2
 packaging==19.0           # via sphinx
@@ -24,7 +24,7 @@ pytz==2019.1              # via babel
 recommonmark==0.4.0
 requests==2.22.0          # via sphinx
 six==1.12.0               # via packaging, sphinx
-snowballstemmer==1.2.1
+snowballstemmer==1.2.1    # via sphinx
 sphinx-rtd-theme==0.4.3
 sphinx==1.8.4
 sphinxcontrib-websupport==1.1.2  # via sphinx

--- a/requirements/mypy.in
+++ b/requirements/mypy.in
@@ -3,6 +3,3 @@
 # and requirements/mypy.txt.
 # See requirements/README.md for more detail.
 mypy==0.670
-# Include typing explicitly, since it's needed on Python 3.4
-typing==3.6.6
-typing_extensions==3.6.6

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -10,5 +10,3 @@
 mypy-extensions==0.4.1    # via mypy
 mypy==0.670
 typed-ast==1.3.1          # via mypy
-typing==3.6.6
-typing_extensions==3.6.6

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -27,10 +27,10 @@ beautifulsoup4==4.7.1
 boto==2.49.0
 cachetools==3.1.1         # via google-auth, premailer
 cchardet==2.1.4
-certifi==2019.3.9
-cffi==1.12.3
-chardet==3.0.4
-cryptography==2.6.1
+certifi==2019.3.9         # via requests
+cffi==1.12.3              # via argon2-cffi, cryptography
+chardet==3.0.4            # via requests
+cryptography==2.6.1       # via apns2, pyopenssl, requests
 cssselect==1.0.3          # via premailer
 cssutils==1.0.2           # via premailer
 decorator==4.4.0          # via ipython, traitlets
@@ -68,13 +68,13 @@ jinja2==2.10.1
 lxml==4.3.3
 markdown-include==0.5.1
 markdown==3.1.1
-markupsafe==1.1.1
+markupsafe==1.1.1         # via jinja2
 matrix-client==0.3.2
 mock==2.0.0
 mypy_extensions==0.4.1
 ndg-httpsclient==0.5.1
 oauth2client==4.1.3
-oauthlib==3.0.1
+oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
 parso==0.5.0              # via jedi
 pbr==5.3.1                # via mock
 pexpect==4.7.0            # via ipython
@@ -89,8 +89,8 @@ psycopg2==2.8.2
 ptyprocess==0.6.0         # via pexpect
 py3dns==3.2.0
 pyahocorasick==1.4.0
-pyasn1-modules==0.2.5
-pyasn1==0.4.5
+pyasn1-modules==0.2.5     # via google-auth, oauth2client, python-ldap
+pyasn1==0.4.5             # via ndg-httpsclient, oauth2client, pyasn1-modules, python-ldap, rsa
 pycparser==2.19           # via cffi
 pycrypto==2.6.1
 pygments==2.3.1
@@ -110,9 +110,9 @@ pyyaml==5.1.1             # via yamole
 qrcode==6.1               # via django-two-factor-auth
 redis==2.10.6
 regex==2019.6.8
-requests-oauthlib==1.0.0
+requests-oauthlib==1.0.0  # via python-twitter, social-auth-core
 requests[security]==2.22.0  # via hypchat, matrix-client, premailer, pyoembed, python-gcm, python-twitter, requests-oauthlib, social-auth-core, stripe, twilio
-rsa==4.0
+rsa==4.0                  # via google-auth, oauth2client
 simplegeneric==0.8.1      # via ipython
 six==1.12.0
 smmap==0.9.0
@@ -128,7 +128,7 @@ tornado==4.5.3
 traitlets==4.3.2          # via ipython
 twilio==6.26.2
 typing==3.6.6
-uritemplate==3.0.0
+uritemplate==3.0.0        # via google-api-python-client
 urllib3==1.25.3           # via requests
 uwsgi==2.0.17.1
 virtualenv-clone==0.5.3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -21,8 +21,6 @@ argon2-cffi==19.1.0
 asn1crypto==0.24.0        # via cryptography
 babel==2.7.0              # via django-phonenumber-field
 backcall==0.1.0           # via ipython
-backports-abc==0.5
-backports.ssl-match-hostname==3.7.0.1
 beautifulsoup4==4.7.1
 boto==2.49.0
 cachetools==3.1.1         # via google-auth, premailer
@@ -47,8 +45,6 @@ django-statsd-mozilla==0.4.0
 django-two-factor-auth==1.8.0
 django-webpack-loader==0.6.0
 django==1.11.22
-docopt==0.6.2
-gitdb==0.6.4
 google-api-python-client==1.7.4
 google-auth-httplib2==0.0.3  # via google-api-python-client
 google-auth==1.6.3        # via google-api-python-client, google-auth-httplib2
@@ -72,7 +68,6 @@ markupsafe==1.1.1         # via jinja2
 matrix-client==0.3.2
 mock==2.0.0
 mypy_extensions==0.4.1
-ndg-httpsclient==0.5.1
 oauth2client==4.1.3
 oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
 parso==0.5.0              # via jedi
@@ -90,14 +85,13 @@ ptyprocess==0.6.0         # via pexpect
 py3dns==3.2.0
 pyahocorasick==1.4.0
 pyasn1-modules==0.2.5     # via google-auth, oauth2client, python-ldap
-pyasn1==0.4.5             # via ndg-httpsclient, oauth2client, pyasn1-modules, python-ldap, rsa
+pyasn1==0.4.5             # via oauth2client, pyasn1-modules, python-ldap, rsa
 pycparser==2.19           # via cffi
-pycrypto==2.6.1
 pygments==2.3.1
 pyjwt==1.7.1
 pylibmc==1.6.0
 pyoembed==0.1.2
-pyopenssl==19.0.0         # via ndg-httpsclient, requests
+pyopenssl==19.0.0         # via requests
 pysocks==1.7.0            # via twilio
 python-dateutil==2.8.0
 python-gcm==0.4
@@ -115,7 +109,6 @@ requests[security]==2.22.0  # via hypchat, matrix-client, premailer, pyoembed, p
 rsa==4.0                  # via google-auth, oauth2client
 simplegeneric==0.8.1      # via ipython
 six==1.12.0
-smmap==0.9.0
 social-auth-app-django==3.1.0
 social-auth-core==3.2.0   # via social-auth-app-django
 sockjs-tornado==1.0.6


### PR DESCRIPTION
The first commit delists recursive dependencies from `common.in` not used directly. `*.txt` is unaffected modulo comments.

The second commit removes

* backports-abc: For old Python versions.
* backports.ssl-match-hostname: For old Python versions.
* docopt: Has never been used directly.
* gitdb: Has never been used directly.
* ndg-httpsclient: No longer used by requests ≥ 2.12.1.
* pycrypto: Has never been used directly.
* smmap: Has never been used directly.
* typing: For old Python versions.
* typing_extensions: For old Python versions.

Cc: @hackerkid in case you know something I missed.

**Testing Plan:** Ran `test-all` on Bionic (with forced reprovision) and a production docker-zulip install on Xenial.