### PR TITLE
Email mirror - fix typos and expand integration docs

### DIFF
--- a/templates/zerver/integrations/email.md
+++ b/templates/zerver/integrations/email.md
@@ -21,3 +21,31 @@ To send an email to a Zulip stream:
 
 Please note that it may take up to one minute for the message to show
 up in Zulip.
+
+**Additional options**
+
+This integration supports additional options when sending an email into it,
+controled through the email address. The way you use them is by adding
+`.option-name` at the end of the first part of the email address.
+The options can be used in conjunction with each other.
+Example: `{{ email_gateway_example_with_options }}`
+
+* `show-sender`: Add `.show-sender` in the address (as specified above)
+  if you want `From: <Sender email address>` to be displayed at the top
+  of your message.
+* `include-footer`: By default, Zulip tries to remove the footer from the messages,
+  as they can cause unnecessary clutter. If you want the footer to be kept,
+  add `.include-footer` in the address when sending the message.
+* `include-quotes`: Just like footers, quotations of other emails are removed by default.
+  To keep them, add `.include-quotes` in the address.
+  Additional note: If the email is forwarded (this is determined by the presence of `FWD:`,
+  or similar, at the beginning of the subject), quotations are kept by default,
+  regardless of usage of this option.
+
+**Final notes**
+
+* The stream name (with the following `.`) can be omitted from the address,
+  and the email will still be properly processed as long as the alphanumeric token
+  is correct.
+* Alternatively, `+` can be used in place of the `.` separators, but this is supported
+  mainly for backward compatibility.

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -208,11 +208,11 @@ class DocPageTest(ZulipTestCase):
 
     def test_email_integration(self) -> None:
         self._test('/integrations/doc-html/email',
-                   'support+abcdefg@testserver', doc_html_str=True)
+                   'support.abcdefg@testserver', doc_html_str=True)
 
         with self.settings(EMAIL_GATEWAY_PATTERN=''):
             result = self.get_doc('integrations/doc-html/email', subdomain='zulip')
-            self.assertNotIn('support+abcdefg@testserver', str(result.content))
+            self.assertNotIn('support.abcdefg@testserver', str(result.content))
             # if EMAIL_GATEWAY_PATTERN is empty, the main /integrations page should
             # be rendered instead
             self._test('/integrations/', 'native integrations.')

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -195,6 +195,7 @@ def integration_doc(request: HttpRequest, integration_name: str=REQ(default=None
         context['hubot_docs_url'] = integration.hubot_docs_url
     if isinstance(integration, EmailIntegration):
         context['email_gateway_example'] = settings.EMAIL_GATEWAY_EXAMPLE
+        context['email_gateway_example_with_options'] = settings.EMAIL_GATEWAY_EXAMPLE_WITH_OPTIONS
 
     doc_html_str = render_markdown_path(integration.doc, context)
 

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -829,9 +829,12 @@ for bot in INTERNAL_BOTS + REALM_INTERNAL_BOTS + DISABLED_REALM_INTERNAL_BOTS:
         vars()[bot['var_name']] = bot_email
 
 if EMAIL_GATEWAY_PATTERN != "":
-    EMAIL_GATEWAY_EXAMPLE = EMAIL_GATEWAY_PATTERN % ("support+abcdefg",)
+    EMAIL_GATEWAY_EXAMPLE = EMAIL_GATEWAY_PATTERN % ("support.abcdefg",)
+    EMAIL_GATEWAY_EXAMPLE_WITH_OPTIONS = EMAIL_GATEWAY_PATTERN % (
+        "support.abcdefg.option1_name.option2_name",)
 else:
     EMAIL_GATEWAY_EXAMPLE = ""
+    EMAIL_GATEWAY_EXAMPLE_WITH_OPTIONS = ""
 
 ########################################################################
 # STATSD CONFIGURATION


### PR DESCRIPTION
Commit one just fixes some typos I noticed in the just-merged email-gateway.md ReadTheDocs docs.

Commit two is a first draft of integration documentaion of the various options and behaviors we have added to the email mirror.