### PR TITLE
portico: Add links from /features to /help.

### DIFF
--- a/static/styles/portico/landing-page.scss
+++ b/static/styles/portico/landing-page.scss
@@ -664,8 +664,17 @@ nav ul li.active::after {
 }
 
 .portico-landing.features-app section > .feature-block {
-    margin: 10px 20px;
+    padding: 10px 20px;
     flex: 1 1 320px;
+    color: inherit;
+}
+
+.portico-landing.features-app section a.feature-block:hover {
+    box-shadow: 0px 3px 10px hsl(0, 0%, 75%);
+}
+
+.portico-landing.features-app section a.feature-block:active {
+    box-shadow: 0px 3px 10px hsl(0, 0%, 50%);
 }
 
 .portico-landing.features-app .feature-block h3 {

--- a/templates/zerver/features.html
+++ b/templates/zerver/features.html
@@ -94,7 +94,7 @@
             <p>Communicate as efficiently as you use your favorite
                 text editor.  Anything you can do with a mouse, you
                 can do even faster from the keyboard.
-                <a class="cta" href="/help/keyboard-shortcuts">
+                <a class="cta" href="/help/keyboard-shortcuts" target="_blank">
                 Learn more about keyboard shortcuts.</a>
             </p>
         </div>
@@ -104,32 +104,32 @@
     <section>
         <h2>Apps, Integrations, and API</h2>
 
-        <div class="feature-block">
+        <a class="feature-block" href="/integrations" target="_blank">
             <h3>INTEGRATIONS</h3>
             <p>
                 Get alerts and updates from your favorite services with
                 off-the-shelf integrations for Trac, Nagios, GitHub,
                 Jenkins, and more.
             </p>
-        </div>
-        <div class="feature-block">
+        </a>
+        <a class="feature-block" href="/api" target="_blank">
             <h3>API</h3>
             <p>
                 Want to roll your own notifications? We've got a
                 dead-simple RESTful API and Python bindings that will make
                 integrations—both sending and receiving—a snap!
             </p>
-        </div>
-        <div class="feature-block">
+        </a>
+        <a class="feature-block" href="/apps" target="_blank">
             <h3>MOBILE APPS</h3>
             <p>Keep up while on the go with our native quality iOS and
             Android apps.</p>
-        </div>
-        <div class="feature-block">
+        </a>
+        <a class="feature-block" href="/apps" target="_blank">
             <h3>DESKTOP APPS</h3>
             <p>Prefer Zulip in its own window and rich, OS-level
             notifications? Enjoy Zulip on your desktop.</p>
-        </div>
+        </a>
         <!--Hack: These two pseudo elements are here to ensure the flex
         arrangment uses the proper cell size with 4 elements in 2 rows.-->
         <div class="feature-block"></div>
@@ -139,69 +139,69 @@
     <section>
         <h2>And everything else you need...</h2>
 
-        <div class="feature-block">
+        <a class="feature-block" href="/security" target="_blank">
             <h3>ENTERPRISE-GRADE SECURITY</h3>
             <p>
                 Zulip is used by some of the most security-conscious
                 organizations in the world.
             </p>
-        </div>
-        <div class="feature-block">
+        </a>
+        <a class="feature-block" href="/help/search-for-messages" target="_blank">
             <h3>FULL-TEXT FULL-HISTORY SEARCH</h3>
             <p>
                 Search is both snappy and smart, helping you look for
                 text, people, and threads of conversation, with advanced
                 search operators for fine-grained control.
             </p>
-        </div>
-        <div class="feature-block">
+        </a>
+        <a class="feature-block" href="/help/stream-permissions" target="_blank">
             <h3>HISTORY</h3>
             <p>Join a stream and see its history, so even new team
             members are never out of the loop.</p>
-        </div>
-        <div class="feature-block">
+        </a>
+        <a class="feature-block" href="/help/star-a-message" target="_blank">
             <h3>STARRED MESSAGES</h3>
             <p>Keep a todo list of messages to come back to, or keep
             track of interesting conversations.</p>
-        </div>
+        </a>
 
-        <div class="feature-block">
+        <a class="feature-block" href="/help/analytics" target="_blank">
             <h3>STATISTICS</h3>
             <p>Zulip has a powerful set of analytics available to
             help you see how your organization communicates.</p>
-        </div>
-        <div class="feature-block">
+        </a>
+        <a class="feature-block" href="http://localhost:9991/help/private-messages" target="_blank">
             <h3>ONE-ON-ONE AND GROUP PRIVATE CONVERSATIONS</h3>
             <p>Lightweight private conversations with one or as many people as you need.</p>
-        </div>
-        <div class="feature-block">
+        </a>
+        <a class="feature-block" href="/help/status-and-availability" target="_blank">
             <h3>TEAM AVAILABILITY</h3>
             <p>See who is currently online at a glance.</p>
-        </div>
-        <div class="feature-block">
+        </a>
+        <a class="feature-block" href="/help/stream-permissions" target="_blank">
             <h3>PRIVATE STREAMS</h3>
             <p>Enjoy the benefits of threaded conversations while
             controlling your audience and privacy.</p>
-        </div>
+        </a>
         <div class="feature-block">
             <h3>PERSISTENCE</h3>
             <p>We're always receiving messages for you, even when
             you're logged out or away from your computer.</p>
         </div>
-        <div class="feature-block">
+        <a class="feature-block" href="/help/edit-or-delete-a-message" target="_blank">
             <h3>MESSAGE EDITING</h3>
             <p>Don't worry, you can always fix that typo, either in
             the body of message or its topic.</p>
-        </div>
+        </a>
         <div class="feature-block">
             <h3>TYPING NOTIFICATIONS</h3>
             <p>Know when other users are composing messages to you.</p>
         </div>
-        <div class="feature-block">
+        <a class="feature-block" href="/help/view-and-edit-your-message-drafts" target="_blank">
             <h3>SAVED DRAFTS</h3>
             <p>Zulip's drafts make it easy to write longer messages
             without worrying about losing your work.</p>
-        </div>
+        </a>
         <div class="feature-block">
             <h3>ACCESSIBILITY</h3>
             <p>
@@ -210,82 +210,82 @@
                 tools.
             </p>
         </div>
-        <div class="feature-block">
+        <a class="feature-block" href="/help/about-streams-and-topics" target="_blank">
             <h3>CONVERSATIONS THREADED BY TOPIC</h3>
             <p>Participate in several conversations with the same
             group at once, without getting lost or overwhelmed.</p>
-        </div>
-        <div class="feature-block">
+        </a>
+        <a class="feature-block" href="/help/reading-strategies" target="_blank">
             <h3>CATCH UP IN NO TIME</h3>
             <p>With topics, hotkeys and snappy performance, usefully
             reviewing hundreds of messages takes just minutes.</p>
-        </div>
-        <div class="feature-block">
+        </a>
+        <a class="feature-block" href="/help/change-your-language" target="_blank">
             <h3>FULLY INTERNATIONALIZED</h3>
             <p>The Zulip UI is fully internationalized and has been
             translated into over a dozen languages.</p>
-        </div>
-        <div class="feature-block">
+        </a>
+        <a class="feature-block" href="/help/configure-authentication-methods" target="_blank">
             <h3>CUSTOMIZABLE LOGIN AND REGISTRATION</h3>
             <p>
                 Customize the available authentication methods and
                 customize the login and registration pages for your
                 organization using Markdown.
             </p>
-        </div>
-        <div class="feature-block">
+        </a>
+        <a class="feature-block" href="/help/start-a-call" target="_blank">
             <h3>VIDEO CALLS</h3>
             <p>
                 Create and join video calls with a single click. Powered
                 by your choice of Zoom, Jitsi Meet, or Google Hangouts.
             </p>
-        </div>
-        <div class="feature-block">
+        </a>
+        <a class="feature-block" href="/help/import-from-slack" target="_blank">
             <h3>DATA IMPORT</h3>
             <p>
                 Import an existing Slack, Mattermost, HipChat, Stride,
                 or Gitter workspace into Zulip.
             </p>
-        </div>
-        <div class="feature-block">
+        </a>
+        <a class="feature-block" href="/help/add-custom-profile-fields" target="_blank">
             <h3>CUSTOM PROFILE FIELDS</h3>
             <p>
                 Use Zulip to store directory information, links to social
                 media profiles, food preferences, or anything else.
             </p>
-        </div>
-        <div class="feature-block">
+        </a>
+        <a class="feature-block" href="/help/roles-and-permissions" target="_blank">
             <h3>GUESTS</h3>
             <p>
                 Guests cannot see or join streams unless they are explicitly
                 added. Perfect for partners, vendors, and temporary
                 contractors.
             </p>
-        </div>
-        <div class="feature-block">
+        </a>
+        <a class="feature-block" href="/help/create-your-organization-profile" target="_blank">
             <h3>CUSTOM BRANDING</h3>
             <p>
                 Use your logo instead of Zulip's in the desktop and webapp.
             </p>
-        </div>
-        <div class="feature-block">
+        </a>
+        <a class="feature-block" href="/integrations/communication" target="_blank">
             <h3>INTEGRATE WITH IRC, MATRIX, OR SLACK</h3>
             <p>
                 Two way integrations with IRC and Matrix, and one way
                 integration with Slack.
             </p>
-        </div>
-        <div class="feature-block">
+        </a>
+        <a class="feature-block" href="/help/moderating-open-organizations" target="_blank">
             <h3>MODERATION</h3>
             <p>
                 A full suite of tools for moderating open communities.
             </p>
-        </div>
-        <div class="feature-block">
+        </a>
+        <a class="feature-block" href="https://github.com/zulip/zulip/" target="_blank">
             <h3>YOUR FEATURE HERE</h3>
             <p>Zulip is open source, so if something important for
             your use case is missing, you can make it happen!</p>
-        </div>
+        </a>
         <!--Hack: These two pseudo elements are here to ensure the flex
         arrangment uses the proper cell size with 4 elements in 2 rows.-->
         <div class="feature-block"></div>


### PR DESCRIPTION
I left out the top section ("Beautiful messaging") because the styling would
have to be different.

![Peek 2019-07-10 15-12](https://user-images.githubusercontent.com/890911/61008718-3633e980-a325-11e9-9c23-f6bae4235ef4.gif)
