### PR TITLE
user settings: Fix bugs related to disabling name changes.

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -871,21 +871,25 @@ run_test('misc', () => {
     page_params.server_name_changes_disabled = false;
     settings_account.update_name_change_display();
     assert.equal($('#full_name').attr('disabled'), false);
+    assert.equal($('.change_name_tooltip').is(':visible'), false);
 
     page_params.realm_name_changes_disabled = true;
     page_params.server_name_changes_disabled = false;
     settings_account.update_name_change_display();
     assert.equal($('#full_name').attr('disabled'), 'disabled');
+    assert($('.change_name_tooltip').is(':visible'));
 
     page_params.realm_name_changes_disabled = true;
     page_params.server_name_changes_disabled = true;
     settings_account.update_name_change_display();
     assert.equal($('#full_name').attr('disabled'), 'disabled');
+    assert($('.change_name_tooltip').is(':visible'));
 
     page_params.realm_name_changes_disabled = false;
     page_params.server_name_changes_disabled = true;
     settings_account.update_name_change_display();
     assert.equal($('#full_name').attr('disabled'), 'disabled');
+    assert($('.change_name_tooltip').is(':visible'));
 
     page_params.realm_email_changes_disabled = false;
     settings_account.update_email_change_display();
@@ -923,6 +927,7 @@ run_test('misc', () => {
     page_params.is_admin = true;
     settings_account.update_name_change_display();
     assert.equal($('#full_name').attr('disabled'), false);
+    assert.equal($('.change_name_tooltip').is(':visible'), false);
 
     settings_account.update_email_change_display();
     assert.equal($("#change_email .button").attr('disabled'), false);

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -442,7 +442,7 @@ run_test('settings/admin_auth_methods_list', () => {
 
     var method = $(html).find('tr.method_row').first().find('span.method');
     assert.equal(method.text(), 'Email');
-    assert.equal(method.is("checked"), false);
+    assert.equal(method.is(":checked"), false);
 });
 
 run_test('bookend', () => {

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -140,6 +140,7 @@ exports.build_page = function () {
         push_notification_tooltip:
             settings_notifications.all_notifications.push_notification_tooltip,
         display_settings: settings_display.all_display_settings,
+        user_can_change_name: settings_account.user_can_change_name(),
     });
 
     $(".settings-box").html(rendered_settings_tab);

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -28,9 +28,18 @@ exports.update_full_name = function (new_full_name) {
     }
 };
 
+exports.user_can_change_name = function () {
+    if (page_params.is_admin) {
+        return true;
+    }
+    if (page_params.realm_name_changes_disabled || page_params.server_name_changes_disabled) {
+        return false;
+    }
+    return true;
+};
+
 exports.update_name_change_display = function () {
-    if ((page_params.realm_name_changes_disabled || page_params.server_name_changes_disabled)
-        && !page_params.is_admin) {
+    if (!exports.user_can_change_name()) {
         $('#full_name').attr('disabled', 'disabled');
         $(".change_name_tooltip").show();
     } else {
@@ -295,8 +304,7 @@ exports.set_up = function () {
     $("#change_full_name").on('click', function (e) {
         e.preventDefault();
         e.stopPropagation();
-        if (!page_params.realm_name_changes_disabled && !page_params.server_name_changes_disabled
-        || page_params.is_admin) {
+        if (exports.user_can_change_name()) {
             $('#change_full_name_modal').find("input[name='full_name']").val(page_params.full_name);
             overlays.open_modal('change_full_name_modal');
         }

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -58,7 +58,7 @@
                             </button>
                         </a>
                         <i class="fa fa-question-circle change_name_tooltip settings-info-icon" data-toggle="tooltip"
-                          {{#unless page_params.is_admin}}{{#if page_params.realm_name_changes_disabled}}{{else}}{{#unless page_params.server_name_changes_disabled}}style="display:none"{{/unless}}{{/if}}{{/unless}}
+                          {{#if (or page_params.is_admin (not (or page_params.realm_name_changes_disabled page_params.server_name_changes_disabled)))}}style="display:none"{{/if}}
                           title="{{t 'Name changes are disabled in this organization. Contact an administrator to change your name.' }}"/>
                     </div>
                     <div id="change_full_name_modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog"

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -53,8 +53,10 @@
                           {{#unless page_params.is_admin}}{{#if page_params.realm_name_changes_disabled}}{{else}}{{#unless page_params.server_name_changes_disabled}}href="#change_email"{{/unless}}{{/if}}{{/unless}}>
                             <button type="button" class="button small white rounded inline-block" id="full_name"
                               {{#unless page_params.is_admin}}{{#if page_params.realm_name_changes_disabled}}disabled="disabled"{{else}}{{#if page_params.server_name_changes_disabled}}disabled="disabled"{{/if}}{{/if}}{{/unless}}>
+                                {{~#if true~}}
                                 <span id="full_name_value">{{page_params.full_name}}</span>
                                 <i class="fa fa-pencil"></i>
+                                {{~/if~}}
                             </button>
                         </a>
                         <i class="fa fa-question-circle change_name_tooltip settings-info-icon" data-toggle="tooltip"

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -49,10 +49,9 @@
                 <div class="input-group inline-block grid user-name-parent">
                     <div class="user-name-section inline-block">
                         <label for="full_name" class="inline-block title">{{t "Full name" }}</label>
-                        <a id="change_full_name"
-                          {{#unless page_params.is_admin}}{{#if page_params.realm_name_changes_disabled}}{{else}}{{#unless page_params.server_name_changes_disabled}}href="#change_email"{{/unless}}{{/if}}{{/unless}}>
+                        <a id="change_full_name" {{#if user_can_change_name}}href="#change_email"{{/if}}>
                             <button type="button" class="button small white rounded inline-block" id="full_name"
-                              {{#unless page_params.is_admin}}{{#if page_params.realm_name_changes_disabled}}disabled="disabled"{{else}}{{#if page_params.server_name_changes_disabled}}disabled="disabled"{{/if}}{{/if}}{{/unless}}>
+                              {{#unless user_can_change_name}}disabled="disabled"{{/unless}}>
                                 {{~#if true~}}
                                 <span id="full_name_value">{{page_params.full_name}}</span>
                                 <i class="fa fa-pencil"></i>
@@ -60,7 +59,7 @@
                             </button>
                         </a>
                         <i class="fa fa-question-circle change_name_tooltip settings-info-icon" data-toggle="tooltip"
-                          {{#if (or page_params.is_admin (not (or page_params.realm_name_changes_disabled page_params.server_name_changes_disabled)))}}style="display:none"{{/if}}
+                          {{#if user_can_change_name}}style="display:none"{{/if}}
                           title="{{t 'Name changes are disabled in this organization. Contact an administrator to change your name.' }}"/>
                     </div>
                     <div id="change_full_name_modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog"


### PR DESCRIPTION
1. Previously, if a user were an admin (they're always supposed to be able to change their names no matter the realm or server setting), they would see an info icon next to the name change button no matter the server setting. Fix Handlebars logic related to displaying them and add Node tests verifying the display status to sovle this issue.

2. Hovering over the Change name field when the disabled info icon is showing displays linkified trailing whitespace due to the nature of links with the inline-block property. Use Handlebars whitespace trim syntax to remove the trailing whitespace for this issue.

Before (logged in as an admin):
![image](https://user-images.githubusercontent.com/15116870/61097041-4adec180-a48c-11e9-9f17-5a543719ab8a.png)

After (logged in as an admin + regular user with server changes disabled):
![image](https://user-images.githubusercontent.com/15116870/61097083-7366bb80-a48c-11e9-82a2-4a404f39150d.png)
![image](https://user-images.githubusercontent.com/15116870/61097131-9d1fe280-a48c-11e9-8ef4-1e4255f5a988.png)
