### PR TITLE
message_fetch: Use user IDs for supported operators.

### DIFF
--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -12,6 +12,7 @@ zrequire('Filter', 'js/filter');
 zrequire('MessageListData', 'js/message_list_data');
 zrequire('message_list');
 zrequire('util');
+zrequire('people');
 
 set_global('page_params', {
     have_initial_messages: true,
@@ -36,6 +37,13 @@ set_global('server_events', {});
 set_global('stream_list', {
     maybe_scroll_narrow_into_view: () => {},
 });
+
+var alice = {
+    email: 'alice@example.com',
+    user_id: 7,
+    full_name: 'Alice',
+};
+people.add(alice);
 
 muting.is_topic_muted = function () { return false; };
 resize.resize_bottom_whitespace = noop;
@@ -273,7 +281,7 @@ function simulate_narrow() {
 
     narrow_state.active = function () { return true; };
     narrow_state.public_operators = function () {
-        return 'operators-stub';
+        return [{ operator: 'pm-with', operand: alice.email }];
     };
 
     var msg_list = new message_list.MessageList({
@@ -321,7 +329,7 @@ run_test('loading_newer', () => {
                 anchor: '444',
                 num_before: 0,
                 num_after: 100,
-                narrow: '"operators-stub"',
+                narrow: `[{"operator":"pm-with","operand":[${alice.user_id}]}]`,
                 client_gravatar: true,
             },
             resp: {

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -853,3 +853,29 @@ run_test('initialize', () => {
     assert.equal(global.page_params.cross_realm_bots, undefined);
     assert.equal(global.page_params.realm_non_active_users, undefined);
 });
+
+run_test('emails_strings_to_user_ids_array', function () {
+    const steven = {
+        email: 'steven@example.com',
+        user_id: 7,
+        full_name: 'Steven',
+    };
+
+    const maria = {
+        email: 'maria@example.com',
+        user_id: 728,
+        full_name: 'Maria',
+    };
+
+    people.add(steven);
+    people.add(maria);
+
+    let user_ids = people.emails_strings_to_user_ids_array(`${steven.email},${maria.email}`);
+    assert.deepEqual(user_ids, [steven.user_id, maria.user_id]);
+
+    blueslip.set_test_data('warn', 'Unknown emails: dummyuser@example.com');
+    user_ids = people.emails_strings_to_user_ids_array('dummyuser@example.com');
+    assert.equal(user_ids, undefined);
+    assert.equal(blueslip.get_test_logs('warn').length, 1);
+    blueslip.clear_test_data();
+});

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -188,6 +188,16 @@ exports.user_ids_string_to_ids_array = function (user_ids_string) {
     return ids;
 };
 
+exports.emails_strings_to_user_ids_array = function (emails_string) {
+    var user_ids_string = exports.emails_strings_to_user_ids_string(emails_string);
+    if (user_ids_string === undefined) {
+        return;
+    }
+
+    var user_ids_array = exports.user_ids_string_to_ids_array(user_ids_string);
+    return user_ids_array;
+};
+
 exports.reply_to_to_user_ids_string = function (emails_string) {
     // This is basically emails_strings_to_user_ids_string
     // without blueslip warnings, since it can be called with

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -510,6 +510,10 @@ def narrow_parameter(json: str) -> Optional[List[Dict[str, Any]]]:
             return dict(operator=elem[0], operand=elem[1])
 
         if isinstance(elem, dict):
+            # Make sure to sync this list to frontend also when adding a new operator.
+            # that supports user IDs. Relevant code is located in static/js/message_fetch.js
+            # in handle_user_ids_supported_operators function where you will need to update
+            # the user_ids_supported_operator.
             user_ids_supported_operators = ['pm-with']
             if elem.get('operator', '') in user_ids_supported_operators:
                 operand_validator = check_string_or_int_list


### PR DESCRIPTION
The approach taken here is basically use user IDs in operator that
support it when sending the request for fetching the messages
(see comments in code for more details).

**Testing Plan:** <!-- How have you tested? -->
- Confirm in devtools that user IDs are sent for `pm-with` operator.
- Make sure PM, Group PM, and stream narrow work.
- Search with invalid emails for `pm-with` operator to make sure no error is thrown (in people.js code).