### PR TITLE
check-templates: Exclude static/icons/fonts/template.hbs.

### DIFF
--- a/tools/check-templates
+++ b/tools/check-templates
@@ -18,6 +18,8 @@ EXCLUDED_FILES = [
     "tools/tests/test_template_data",
     # Our parser doesn't handle the way its conditionals are layered
     'templates/zerver/emails/missed_message.source.html',
+    # Previously unchecked and our parser doesn't like its indentation
+    'static/icons/fonts/template.hbs',
 ]
 
 def check_our_files(modified_only, all_dups, targets):


### PR DESCRIPTION
This file was unchecked until the .handlebars ↦ .hbs rename, so this is the easiest way to get tests passing again.