### PR TITLE
messagebox: Add title-text for user profile on sender name and avatar.

### DIFF
--- a/static/templates/me_message.hbs
+++ b/static/templates/me_message.hbs
@@ -1,10 +1,16 @@
 <span class="message_sender no-select">
     <span class="sender_info_hover">
-        {{> message_avatar}}
+        <span title="{{t 'User profile' }} (u)">
+            {{> message_avatar}}
+        </span>
     </span>
 
     <span class="sender-status">
-        <span class="sender_info_hover sender_name-in-status auto-select" role="button" tabindex="0">{{msg/sender_full_name}}</span>
+        <span class="sender_info_hover sender_name-in-status auto-select" role="button" tabindex="0">
+            <span title="{{t 'User profile' }} (u)">
+                {{msg/sender_full_name}}
+            </span>
+        </span>
         {{#if sender_is_bot}}
         <i class="zulip-icon bot" aria-label="{{t 'Bot' }}"></i>
         {{/if}}

--- a/static/templates/message_body.hbs
+++ b/static/templates/message_body.hbs
@@ -2,14 +2,14 @@
     {{#unless status_message}}
     <span class="message_sender sender_info_hover no-select">
         {{#if include_sender}}
-
+        <span title="{{t 'User profile' }} (u)">
             {{> message_avatar}}
 
             <span class="sender_name auto-select" role="button" tabindex="0">{{msg/sender_full_name}}</span>
             {{#if sender_is_bot}}
             <i class="zulip-icon bot" aria-label="{{t 'Bot' }}"></i>
             {{/if}}
-
+        </span>
         {{/if}}
     </span>
     {{/unless}}


### PR DESCRIPTION
A separate element with the title text has been added since the
default popover takes the `title` as the popover title, if provided.
To change this behaviour we will need to make changes in the third
party library (here bootstrap).

Fixes #12769 
