### PR TITLE
Populate_db fixes

### DIFF
--- a/zerver/tests/test_populate_db.py
+++ b/zerver/tests/test_populate_db.py
@@ -1,0 +1,20 @@
+from zilencer.management.commands.populate_db import choose_pub_date
+from zerver.lib.test_classes import ZulipTestCase
+
+from django.utils.timezone import timedelta as timezone_timedelta
+
+class TestChoosePubDate(ZulipTestCase):
+    def test_choose_pub_date_large_tot_messages(self) -> None:
+        """
+        Test for a bug that was present, where specifying a large amount of messages to generate
+        would cause each message to have pub_date set to timezone_now(), instead of the pub_dates
+        being distributed across the span of several days.
+        """
+        tot_messages = 1000000
+        datetimes_list = [
+            choose_pub_date(i, tot_messages, 1) for i in range(1, tot_messages, tot_messages // 100)
+        ]
+
+        # Verify there is a meaningful difference between elements.
+        for i in range(1, len(datetimes_list)):
+            self.assertTrue(datetimes_list[i] - datetimes_list[i-1] > timezone_timedelta(minutes=5))

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -455,7 +455,7 @@ class Command(BaseCommand):
             jobs.append((count, personals_pairs, options, self.stdout.write, random.randint(0, 10**10)))
 
         for job in jobs:
-            send_messages(job)
+            generate_and_send_messages(job)
 
         if options["delete"]:
             # Create the "website" and "API" clients; if we don't, the
@@ -573,8 +573,8 @@ def get_recipient_by_id(rid: int) -> Recipient:
 # - multiple personals converastions
 # - multiple messages per subject
 # - both single and multi-line content
-def send_messages(data: Tuple[int, Sequence[Sequence[int]], Mapping[str, Any],
-                              Callable[[str], Any], int]) -> int:
+def generate_and_send_messages(data: Tuple[int, Sequence[Sequence[int]], Mapping[str, Any],
+                                           Callable[[str], Any], int]) -> int:
     (tot_messages, personals_pairs, options, output, random_seed) = data
     random.seed(random_seed)
 
@@ -651,23 +651,27 @@ def send_messages(data: Tuple[int, Sequence[Sequence[int]], Mapping[str, Any],
         recipients[num_messages] = (message_type, message.recipient.id, saved_data)
         num_messages += 1
 
-        if (num_messages % message_batch_size) == 0 or (num_messages == tot_messages):
-            # Send the batch:
+        if (num_messages % message_batch_size) == 0:
+            # Send the batch and empty the list:
+            send_messages(messages)
+            messages = []
 
-            # We disable USING_RABBITMQ here, so that deferred work is
-            # executed in do_send_message_messages, rather than being
-            # queued.  This is important, because otherwise, if run-dev.py
-            # wasn't running when populate_db was run, a developer can end
-            # up with queued events that reference objects from a previous
-            # life of the database, which naturally throws exceptions.
-            settings.USING_RABBITMQ = False
-            do_send_messages([{'message': message} for message in messages])
-            settings.USING_RABBITMQ = True
-
-            # Empty the list:
-            messages.clear()
+    if len(messages):
+        # If there are unsent messages after exiting the loop, send them:
+        send_messages(messages)
 
     return tot_messages
+
+def send_messages(messages: List[Message]) -> None:
+    # We disable USING_RABBITMQ here, so that deferred work is
+    # executed in do_send_message_messages, rather than being
+    # queued.  This is important, because otherwise, if run-dev.py
+    # wasn't running when populate_db was run, a developer can end
+    # up with queued events that reference objects from a previous
+    # life of the database, which naturally throws exceptions.
+    settings.USING_RABBITMQ = False
+    do_send_messages([{'message': message} for message in messages])
+    settings.USING_RABBITMQ = True
 
 def choose_pub_date(num_messages: int, tot_messages: int, threads: int) -> datetime:
     # Spoofing time not supported with threading


### PR DESCRIPTION
Commit one fixes a bug where specifying too large a number of messages to generate, the code distributing the pub_dates didn't work as intended, and set them all to timezone_now().

Commit makes it send all the messages in one `` do_send_messages `` call, which offer a performance improvement. Some measurements here:
```
(zulip-py3-venv) vagrant@32de60bf2049:/srv/zulip$ ./measure.sh 
Trying command: ./manage.py populate_db -n100
With patch:
time:6.87
Without patch:
time:7.73
Trying command: ./manage.py populate_db -n1000
With patch:
time:22.24
Without patch:
time:28.09
Trying command: ./manage.py populate_db -n10000
With patch:
time:219.82
Without patch:
time:238.34
Trying command: ./manage.py populate_db -n10000 --extra-users=120
With patch:
time:248.82
Without patch:
time:330.19
Trying command: ./manage.py populate_db -n100000 --extra-users=120
With patch:
time:2744.65
Without patch:
time:3302.74
```
Another run, without the  longest one (100k messages one):
```
$ ./measure.sh 
Trying command: ./manage.py populate_db -n100
With patch:
time:7.58
Without patch:
time:7.44
Trying command: ./manage.py populate_db -n1000
With patch:
time:23.12
Without patch:
time:29.79
Trying command: ./manage.py populate_db -n10000
With patch:
time:203.44
Without patch:
time:258.67
```
Now, this can of course eat a lot of memory, so for those who need to generate more messages than their machine can handle at once, an option to split the process into smaller chunks is needed - commit 3 takes care of that.