### PR TITLE
Email mirror - display address using '.' as the separator.

### DIFF
--- a/zerver/lib/email_mirror_helpers.py
+++ b/zerver/lib/email_mirror_helpers.py
@@ -58,11 +58,10 @@ def decode_email_address(email: str) -> Tuple[str, Dict[str, bool]]:
     # Perform the reverse of encode_email_address. Returns a tuple of
     # (email_token, options)
     msg_string = get_email_gateway_message_string_from_address(email)
-    # Workaround for Google Groups and other programs that don't accept emails
-    # that have + signs in them (see Trac #2102)
-    splitting_char = '.' if '.' in msg_string else '+'
+    # Support both + and . as separators:
+    msg_string = msg_string.replace('.', '+')
 
-    parts = msg_string.split(splitting_char)
+    parts = msg_string.split('+')
     options = {}  # type: Dict[str, bool]
     for part in parts:
         if part in optional_address_tokens:

--- a/zerver/lib/email_mirror_helpers.py
+++ b/zerver/lib/email_mirror_helpers.py
@@ -7,7 +7,7 @@ from zerver.models import Stream
 
 from typing import Dict, Tuple
 
-optional_address_tokens = ["show-sender", "include-footer", "include-quotations"]
+optional_address_tokens = ["show-sender", "include-footer", "include-quotes"]
 
 class ZulipEmailForwardError(Exception):
     pass

--- a/zerver/lib/email_mirror_helpers.py
+++ b/zerver/lib/email_mirror_helpers.py
@@ -48,7 +48,7 @@ def encode_email_address_helper(name: str, email_token: str) -> str:
 
     # If encoded_name ends up empty, we just skip this part of the address:
     if encoded_name:
-        encoded_token = "%s+%s" % (encoded_name, email_token)
+        encoded_token = "%s.%s" % (encoded_name, email_token)
     else:
         encoded_token = email_token
 

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -125,7 +125,7 @@ class TestEncodeDecode(ZulipTestCase):
         asciiable_stream_name = "ąężć"
         stream = ensure_stream(realm, asciiable_stream_name)
         email_address = encode_email_address(stream)
-        self.assertTrue(email_address.startswith("aezc+"))
+        self.assertTrue(email_address.startswith("aezc."))
 
     def test_decode_ignores_stream_name(self) -> None:
         stream = get_stream("Denmark", get_realm("zulip"))

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -76,19 +76,10 @@ class TestEncodeDecode(ZulipTestCase):
         self.assertEqual(token, stream.email_token)
 
         parts = email_address.split('@')
-        parts[0] += "+include-footer+show-sender+include-quotations"
+        # Use a mix of + and . as separators, to test that it works:
+        parts[0] += "+include-footer.show-sender+include-quotations"
         email_address_all_options = '@'.join(parts)
         token, options = decode_email_address(email_address_all_options)
-        self._assert_options(options, show_sender=True, include_footer=True, include_quotations=True)
-        self.assertEqual(token, stream.email_token)
-
-        email_address_dots = email_address.replace('+', '.')
-        token, options = decode_email_address(email_address_dots)
-        self._assert_options(options)
-        self.assertEqual(token, stream.email_token)
-
-        email_address_dots_all_options = email_address_all_options.replace('+', '.')
-        token, options = decode_email_address(email_address_dots_all_options)
         self._assert_options(options, show_sender=True, include_footer=True, include_quotations=True)
         self.assertEqual(token, stream.email_token)
 

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -59,10 +59,10 @@ from typing import Any, Callable, Dict, Mapping, Union, Optional
 
 class TestEncodeDecode(ZulipTestCase):
     def _assert_options(self, options: Dict[str, bool], show_sender: bool=False,
-                        include_footer: bool=False, include_quotations: bool=False) -> None:
+                        include_footer: bool=False, include_quotes: bool=False) -> None:
         self.assertEqual(show_sender, ('show_sender' in options) and options['show_sender'])
         self.assertEqual(include_footer, ('include_footer' in options) and options['include_footer'])
-        self.assertEqual(include_quotations, ('include_quotations' in options) and options['include_quotations'])
+        self.assertEqual(include_quotes, ('include_quotes' in options) and options['include_quotes'])
 
     def test_encode_decode(self) -> None:
         realm = get_realm('zulip')
@@ -77,10 +77,10 @@ class TestEncodeDecode(ZulipTestCase):
 
         parts = email_address.split('@')
         # Use a mix of + and . as separators, to test that it works:
-        parts[0] += "+include-footer.show-sender+include-quotations"
+        parts[0] += "+include-footer.show-sender+include-quotes"
         email_address_all_options = '@'.join(parts)
         token, options = decode_email_address(email_address_all_options)
-        self._assert_options(options, show_sender=True, include_footer=True, include_quotations=True)
+        self._assert_options(options, show_sender=True, include_footer=True, include_quotes=True)
         self.assertEqual(token, stream.email_token)
 
         email_address = email_address.replace('@testserver', '@zulip.org')
@@ -97,7 +97,7 @@ class TestEncodeDecode(ZulipTestCase):
             self.assertEqual(token, stream.email_token)
 
             token, options = decode_email_address(email_address_all_options)
-            self._assert_options(options, show_sender=True, include_footer=True, include_quotations=True)
+            self._assert_options(options, show_sender=True, include_footer=True, include_quotes=True)
             self.assertEqual(token, stream.email_token)
 
         with self.assertRaises(ZulipEmailForwardError):
@@ -335,7 +335,7 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
         self.assertEqual(get_display_recipient(message.recipient), stream.name)
         self.assertEqual(message.topic_name(), incoming_valid_message['Subject'])
 
-    def test_receive_stream_email_include_quotations_success(self) -> None:
+    def test_receive_stream_email_include_quotes_success(self) -> None:
         user_profile = self.example_user('hamlet')
         self.login(user_profile.email)
         self.subscribe(user_profile, "Denmark")
@@ -343,7 +343,7 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
 
         stream_to_address = encode_email_address(stream)
         parts = stream_to_address.split('@')
-        parts[0] += "+include-quotations"
+        parts[0] += "+include-quotes"
         stream_to_address = '@'.join(parts)
 
         text = """Reply


### PR DESCRIPTION
PR for changes discussed in https://github.com/zulip/zulip/pull/12758.

I'm not sure if this is indeed the best of doing things, but while doing this I figured it might be good to handle mixes of + and . being used as separators, since we'll already have a mix in the address in IMAP setup - `` username+stream.token@example.com ``. Users might get confused when adding options like `` show-sender `` and do `` username+stream.token+show-sender@example.com `` instead of `` username+stream.token.show-sender@example.com ``, so it seems good to handle everything.

The last commit does the renaming requested in https://github.com/zulip/zulip/pull/12758#issuecomment-510297324

I wanted to do the change to replace the box with the huge, ugly email address with a "Copy to clipboard" button instead, but realized I'm not familiar enough with our frontend to know in which .js file would the appropriate place to put the jquery code defining "copy to clipboard" for the button.