### PR TITLE
Followups to #12772 

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1077,6 +1077,7 @@ input[type=checkbox].inline-block {
 
     #user_avatar_delete_button {
         cursor: pointer;
+        color: hsl(236, 33%, 90%);
         opacity: 0;
         font-size: 3rem;
         position: absolute;

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1082,6 +1082,7 @@ input[type=checkbox].inline-block {
         position: absolute;
         top: 67px; // 31.5px + 5px + 30px
         right: 30px;
+        z-index: 99;
     }
 
     #user-avatar-source {
@@ -1104,8 +1105,14 @@ input[type=checkbox].inline-block {
     }
 
     &:hover {
-        #user-avatar-block {
-            -webkit-filter: brightness(0.4);
+        #user-avatar-block::after {
+            content: '';
+            background-color: hsl(0, 0%, 0%);
+            height: 200px;
+            width: 200px;
+            opacity: 0.6;
+            z-index: 99;
+            position: absolute;
         }
 
         #user_avatar_delete_button {


### PR DESCRIPTION
![](https://i.imgur.com/DjCJ1CD.gif)

Solves 2 followups noted by @timabbott in #12722
1. For non-square profile pictures (like transparent circles), darken the area outside that's still considered part of the avatar
2. Improves visibility of the new x icon to delete a profile pic in light mode by changing the color of the icon

@YJDave Feel free to fix the other followups that Tim noted :)