### PR TITLE
Add note on ZULIP_ADMINISTRATOR in email.md

### DIFF
--- a/docs/production/email.md
+++ b/docs/production/email.md
@@ -12,7 +12,9 @@ email addresses and send notifications.
 2. Fill out the section of `/etc/zulip/settings.py` headed "Outgoing
    email (SMTP) settings".  This includes the hostname and typically
    the port to reach your SMTP provider, and the username to log into
-   it as.
+   it as. Ensure that your SMTP server allows emails originating from
+   the email address listed as `ZULIP_ADMINISTRATOR` in
+   `/etc/zulip/settings.py`.
 
 3. Put the password for the SMTP user account in
    `/etc/zulip/zulip-secrets.conf` by setting `email_password`. For


### PR DESCRIPTION
Outgoing email documentation should mention that the SMTP server needs to allow emails originating from ZULIP_ADMINISTRATOR.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
