### PR TITLE
test_server: Set LOCAL_UPLOADS_DIR in set_up_django.

### DIFF
--- a/tools/lib/test_server.py
+++ b/tools/lib/test_server.py
@@ -20,11 +20,14 @@ if TOOLS_DIR not in sys.path:
     sys.path.insert(0, os.path.dirname(TOOLS_DIR))
 
 from zerver.lib.test_fixtures import update_test_databases_if_required
+from scripts.lib.zulip_tools import get_or_create_dev_uuid_var_path
 
 def set_up_django(external_host):
     # type: (str) -> None
     os.environ['EXTERNAL_HOST'] = external_host
     os.environ["TORNADO_SERVER"] = "http://127.0.0.1:9983"
+    os.environ["LOCAL_UPLOADS_DIR"] = get_or_create_dev_uuid_var_path(
+        'test-backend/test_uploads')
     os.environ['DJANGO_SETTINGS_MODULE'] = 'zproject.test_settings'
     django.setup()
     os.environ['PYTHONUNBUFFERED'] = 'y'

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -126,7 +126,11 @@ ENABLE_FILE_LINKS = True
 
 # These settings are set dynamically in `zerver/lib/test_runner.py`:
 TEST_WORKER_DIR = ''
-LOCAL_UPLOADS_DIR = ''
+# Don't unintentionally override a set value.
+if "LOCAL_UPLOADS_DIR" in os.environ:
+    LOCAL_UPLOADS_DIR = os.getenv("LOCAL_UPLOADS_DIR")
+else:
+    LOCAL_UPLOADS_DIR = ''
 
 S3_KEY = 'test-key'
 S3_SECRET_KEY = 'test-secret-key'


### PR DESCRIPTION
We map 'LOCAL_UPLOADS_DIR' to the value `1` to negate
an overwrite.  This is accomplished by configuring the
`LOCAL_UPLOADS_DIR` attribute to the empty string only
if the mapped value is not found in the environment.


**Testing Plan:** <!-- How have you tested? -->
`tools/test-*`
