### PR TITLE
messages: Use user ID for sender and group-pm-with operators.

### DIFF
--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -110,6 +110,7 @@ function get_messages_success(data, opts) {
 // because doing so breaks the app in various modules that expect emails string.
 function handle_user_ids_supported_operators(data) {
     var user_ids_supported_operators = ['pm-with'];
+    var user_id_supported_operators = ['sender', 'group-pm-with'];
 
     if (data.narrow === undefined) {
         return data;
@@ -119,6 +120,13 @@ function handle_user_ids_supported_operators(data) {
     data.narrow = _.map(data.narrow, function (filter) {
         if (user_ids_supported_operators.indexOf(filter.operator) !== -1) {
             filter.operand = people.emails_strings_to_user_ids_array(filter.operand);
+        }
+
+        if (user_id_supported_operators.indexOf(filter.operator) !== -1) {
+            var person = people.get_by_email(filter.operand);
+            if (person !== undefined) {
+                filter.operand = person.user_id;
+            }
         }
 
         return filter;

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -337,3 +337,9 @@ def check_string_or_int_list(var_name: str, val: object) -> Optional[str]:
         return _('%s is not a string or an integer list') % (var_name,)
 
     return check_list(check_int)(var_name, val)
+
+def check_string_or_int(var_name: str, val: object) -> Optional[str]:
+    if isinstance(val, str) or isinstance(val, int):
+        return None
+
+    return _('%s is not a string or integer') % (var_name,)

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -44,7 +44,7 @@ from zerver.lib.validator import (
     check_string, check_dict, check_dict_only, check_bool, check_float, check_int, check_list, Validator,
     check_variable_type, equals, check_none_or, check_url, check_short_string,
     check_string_fixed_length, check_capped_string, check_color, to_non_negative_int,
-    check_string_or_int_list
+    check_string_or_int_list, check_string_or_int
 )
 from zerver.models import \
     get_realm, get_user, UserProfile, Realm
@@ -918,6 +918,16 @@ class ValidatorTestCase(TestCase):
 
         x = [1, 2, '3']
         self.assertEqual(check_string_or_int_list('x', x), 'x[2] is not an integer')
+
+    def test_check_string_or_int(self) -> None:
+        x = "string"  # type: Any
+        self.assertEqual(check_string_or_int('x', x), None)
+
+        x = 1
+        self.assertEqual(check_string_or_int('x', x), None)
+
+        x = None
+        self.assertEqual(check_string_or_int('x', x), 'x is not a string or integer')
 
 
 class DeactivatedRealmTest(ZulipTestCase):

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -1183,11 +1183,13 @@ class GetOldMessagesTest(ZulipTestCase):
         )
 
         self.login(me)
-        narrow = [dict(operator='group-pm-with', operand=self.example_email("cordelia"))]
-        result = self.get_and_check_messages(dict(narrow=ujson.dumps(narrow)))
-        for message in result["messages"]:
-            self.assertIn(message["id"], matching_message_ids)
-            self.assertNotIn(message["id"], non_matching_message_ids)
+        test_operands = [self.example_email("cordelia"), self.example_user("cordelia").id]
+        for operand in test_operands:
+            narrow = [dict(operator='group-pm-with', operand=operand)]
+            result = self.get_and_check_messages(dict(narrow=ujson.dumps(narrow)))
+            for message in result["messages"]:
+                self.assertIn(message["id"], matching_message_ids)
+                self.assertNotIn(message["id"], non_matching_message_ids)
 
     def test_get_visible_messages_with_narrow_group_pm_with(self) -> None:
         me = self.example_email('hamlet')

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -1426,11 +1426,13 @@ class GetOldMessagesTest(ZulipTestCase):
         self.send_personal_message(self.example_email("othello"), self.example_email("hamlet"))
         self.send_stream_message(self.example_email("iago"), "Scotland")
 
-        narrow = [dict(operator='sender', operand=self.example_email("othello"))]
-        result = self.get_and_check_messages(dict(narrow=ujson.dumps(narrow)))
+        test_operands = [self.example_email("othello"), self.example_user("othello").id]
+        for operand in test_operands:
+            narrow = [dict(operator='sender', operand=operand)]
+            result = self.get_and_check_messages(dict(narrow=ujson.dumps(narrow)))
 
-        for message in result["messages"]:
-            self.assertEqual(message["sender_email"], self.example_email("othello"))
+            for message in result["messages"]:
+                self.assertEqual(message["sender_email"], self.example_email("othello"))
 
     def _update_tsvector_index(self) -> None:
         # We use brute force here and update our text search index

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -365,10 +365,13 @@ class NarrowBuilder:
                     column("recipient_id") == recipient.id)
         return query.where(maybe_negate(cond))
 
-    def by_group_pm_with(self, query: Query, operand: str,
+    def by_group_pm_with(self, query: Query, operand: Union[str, int],
                          maybe_negate: ConditionTransform) -> Query:
         try:
-            narrow_profile = get_user_including_cross_realm(operand, self.user_realm)
+            if isinstance(operand, str):
+                narrow_profile = get_user_including_cross_realm(operand, self.user_realm)
+            else:
+                narrow_profile = get_user_by_id_in_realm_including_cross_realm(operand, self.user_realm)
         except UserProfile.DoesNotExist:
             raise BadNarrowOperator('unknown user ' + str(operand))
 
@@ -518,7 +521,7 @@ def narrow_parameter(json: str) -> Optional[List[Dict[str, Any]]]:
             # that supports user IDs. Relevant code is located in static/js/message_fetch.js
             # in handle_user_ids_supported_operators function where you will need to update
             # user_id_supported_operator, or user_ids_supported_operator array.
-            user_id_supported_operator = ['sender']
+            user_id_supported_operator = ['sender', 'group-pm-with']
             user_ids_supported_operators = ['pm-with']
 
             operator = elem.get('operator', '')


### PR DESCRIPTION
Both frontend and backend migration is done. The only thing left is `stream:`; I was done with it but ran into a issue where for some reason `get_cache_with_key` isn't happy for reason. It throws error saying `AttributeError: 'int' object has no attribute 'strip'`.

Once we get done with `stream:` we can provide a better example in the docs which we have been meaning to do. 

**Testing Plan:** <!-- How have you tested? -->
- Check that user ID is sent for `group-pm-with` and `sender` operators. Also check for `sender:me` case.
- Try out incorrect emails just to make sure no error is thrown.
- Unit Tests

