### PR TITLE
Styling of topic save and cancel buttons 

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -591,6 +591,27 @@ on a dark background, and don't change the dark labels dark either. */
     #loading_more_messages_indicator path {
         fill: hsl(0, 0%, 100%);
     }
+
+    .small_square_button {
+        &.small_square_check {
+            background-color: hsl(166, 35%, 52%);
+            color: hsl(0, 0%, 90%);
+
+            &:hover {
+                background-color: hsl(156, 30%, 45%);
+                color: hsl(0, 0%, 95%);
+            }
+        }
+
+        &.small_square_x {
+            background-color: hsl(0, 0%, 95%);
+            color: hsl(0, 0%, 42%);
+
+            &:hover {
+                color: hsl(0, 0%, 18%);
+            }
+        }
+    }
 }
 
 @-moz-document url-prefix() {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2538,29 +2538,36 @@ li .message_inline_image img {
     text-align: center;
 }
 
-button.primary {
-    background-color: hsl(207, 21%, 62%);
-    padding: 2px;
-    color: hsl(0, 0%, 100%);
+.small_square_button {
+    background-color: hsl(156, 30%, 50%);
+    padding: 0;
+    color: hsl(0, 0%, 95%);
     border: none;
-    border-radius: 0px;
-}
-
-button.primary:hover {
-    background-color: hsl(207, 25%, 65%);
-}
-
-button.primary:focus {
-    outline: none;
-}
-
-button.topic_edit_save,
-button.topic_edit_cancel {
     font-size: 12px;
     width: 18px;
     height: 18px;
-    vertical-align: baseline;
     border-radius: 4px;
+    margin-bottom: 3px;
+}
+
+.small_square_button:hover {
+    color: hsl(0, 0%, 100%);
+    box-shadow: 0 10px 41px 0 hsl(166, 35%, 48%);
+}
+
+.small_square_button:focus {
+    outline: none;
+}
+
+.small_square_x {
+    background-color: white;
+    color: hsl(0, 0%, 47%);
+}
+
+.small_square_x:hover {
+    background-color: hsl(0, 0%, 100%);
+    color: hsl(0, 0%, 18%);
+    box-shadow: 0 10px 41px 0 hsl(0, 0%, 48%);
 }
 
 div.topic_edit_spinner {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2546,29 +2546,29 @@ li .message_inline_image img {
     height: 18px;
     border-radius: 4px;
     margin-bottom: 3px;
-}
 
-.small_square_button:focus {
-    outline: none;
-}
+    &:focus {
+        outline: none;
+    }
 
-.small_square_button.small_square_check {
-    background-color: hsl(166, 35%, 57%);
-    color: hsl(0, 0%, 95%);
-}
+    &.small_square_check {
+        background-color: hsl(166, 35%, 57%);
+        color: hsl(0, 0%, 95%);
 
-.small_square_button.small_square_check:hover {
-    background-color: hsl(156, 30%, 50%);
-    color: hsl(0, 0%, 100%);
-}
+        &:hover {
+            background-color: hsl(156, 30%, 50%);
+            color: hsl(0, 0%, 100%);
+        }
+    }
 
-.small_square_button.small_square_x {
-    background-color: hsl(0, 0%, 100%);
-    color: hsl(0, 0%, 47%);
-}
+    &.small_square_x {
+        background-color: hsl(0, 0%, 100%);
+        color: hsl(0, 0%, 47%);
 
-.small_square_button.small_square_x:hover {
-    color: hsl(0, 0%, 18%);
+        &:hover {
+            color: hsl(0, 0%, 18%);
+        }
+    }
 }
 
 div.topic_edit_spinner {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2539,9 +2539,7 @@ li .message_inline_image img {
 }
 
 .small_square_button {
-    background-color: hsl(156, 30%, 50%);
     padding: 0;
-    color: hsl(0, 0%, 95%);
     border: none;
     font-size: 12px;
     width: 18px;
@@ -2550,24 +2548,27 @@ li .message_inline_image img {
     margin-bottom: 3px;
 }
 
-.small_square_button:hover {
-    color: hsl(0, 0%, 100%);
-    box-shadow: 0 10px 41px 0 hsl(166, 35%, 48%);
-}
-
 .small_square_button:focus {
     outline: none;
 }
 
-.small_square_x {
-    background-color: white;
+.small_square_button.small_square_check {
+    background-color: hsl(166, 35%, 57%);
+    color: hsl(0, 0%, 95%);
+}
+
+.small_square_button.small_square_check:hover {
+    background-color: hsl(156, 30%, 50%);
+    color: hsl(0, 0%, 100%);
+}
+
+.small_square_button.small_square_x {
+    background-color: hsl(0, 0%, 100%);
     color: hsl(0, 0%, 47%);
 }
 
-.small_square_x:hover {
-    background-color: hsl(0, 0%, 100%);
+.small_square_button.small_square_x:hover {
     color: hsl(0, 0%, 18%);
-    box-shadow: 0 10px 41px 0 hsl(0, 0%, 48%);
 }
 
 div.topic_edit_spinner {

--- a/static/templates/topic_edit_form.hbs
+++ b/static/templates/topic_edit_form.hbs
@@ -3,8 +3,8 @@
 <form id="topic_edit_form" class="form-horizontal">
     <input type="text" value="" class="inline_topic_edit header-v" id="inline_topic_edit"
       autocomplete="off" />
-    <button type="button" class="topic_edit_save primary"><i class="fa fa-check" aria-hidden="true"></i></button>
-    <button type="button" class="topic_edit_cancel primary"><i class="fa fa-remove" aria-hidden="true"></i></button>
+    <button type="button" class="topic_edit_save small_square_button small_square_check"><i class="fa fa-check" aria-hidden="true"></i></button>
+    <button type="button" class="topic_edit_cancel small_square_button small_square_x"><i class="fa fa-remove" aria-hidden="true"></i></button>
     <div class="topic_edit_spinner"></div>
     <div class="alert alert-error edit_error hide"></div>
 </form>


### PR DESCRIPTION
Related to https://github.com/zulip/zulip/pull/11233
The first commit from this PR is the one @architkshk made in the PR above.

**GIFs:** 
This is how it looks like:
![light](https://user-images.githubusercontent.com/18381652/61409394-d58b4a80-a8ea-11e9-9273-a86d0a932fa2.gif)

![night-mode](https://user-images.githubusercontent.com/18381652/61409439-e9cf4780-a8ea-11e9-95c5-b9452b968198.gif)

I also thought of another version for the night mode:
![Jul-17-2019 23-24-30](https://user-images.githubusercontent.com/18381652/61409475-fc498100-a8ea-11e9-9958-d4c8221fb487.gif)

@synicalsyntax 