### PR TITLE
check-templates: Add fix option to tools/check_templates.

### DIFF
--- a/tools/check-templates
+++ b/tools/check-templates
@@ -22,8 +22,8 @@ EXCLUDED_FILES = [
     'static/icons/fonts/template.hbs',
 ]
 
-def check_our_files(modified_only, all_dups, targets):
-    # type: (bool, bool, List[str]) -> None
+def check_our_files(modified_only, all_dups, fix, targets):
+    # type: (bool, bool, bool, List[str]) -> None
     by_lang = cast(
         Dict[str, List[str]],
         lister.list_files(
@@ -32,11 +32,11 @@ def check_our_files(modified_only, all_dups, targets):
             ftypes=['hbs', 'html'],
             group_by_ftype=True, exclude=EXCLUDED_FILES))
 
-    check_handlebar_templates(by_lang['hbs'])
-    check_html_templates(by_lang['html'], args.all_dups)
+    check_handlebar_templates(by_lang['hbs'], args.fix)
+    check_html_templates(by_lang['html'], args.all_dups, args.fix)
 
-def check_html_templates(templates, all_dups):
-    # type: (Iterable[str], bool) -> None
+def check_html_templates(templates, all_dups, fix):
+    # type: (Iterable[str], bool, bool) -> None
     # Our files with .html extensions are usually for Django, but we also
     # have a few static .html files.
     #
@@ -141,11 +141,11 @@ def check_html_templates(templates, all_dups):
     # TODO: Clean these files
     for fn in templates:
         if fn not in IGNORE_FILES:
-            if not validate_indent_html(fn):
+            if not validate_indent_html(fn, fix):
                 sys.exit(1)
 
-def check_handlebar_templates(templates):
-    # type: (Iterable[str]) -> None
+def check_handlebar_templates(templates, fix):
+    # type: (Iterable[str], bool) -> None
     # Check all our handlebars templates.
     templates = [fn for fn in templates if fn.endswith('.hbs')]
 
@@ -162,7 +162,7 @@ def check_handlebar_templates(templates):
     for fn in templates:
         if fn in IGNORE_FILES:
             continue
-        if not validate_indent_html(fn):
+        if not validate_indent_html(fn, fix):
             sys.exit(1)
 
 if __name__ == '__main__':
@@ -173,6 +173,9 @@ if __name__ == '__main__':
     parser.add_argument('--all-dups',
                         action="store_true", default=False,
                         help='Run lint tool to detect duplicate ids on ignored files as well')
+    parser.add_argument('--fix',
+                        action='store_true', default=False,
+                        help='Automatically fix indentation problems.')
     parser.add_argument('targets', nargs=argparse.REMAINDER)
     args = parser.parse_args()
-    check_our_files(args.modified, args.all_dups, args.targets)
+    check_our_files(args.modified, args.all_dups, args.fix, args.targets)

--- a/tools/lib/pretty_print.py
+++ b/tools/lib/pretty_print.py
@@ -5,6 +5,9 @@ from .template_parser import (
     tokenize,
     is_django_block_tag,
 )
+
+from zulint.printer import GREEN, ENDC
+
 import subprocess
 
 def pretty_print_html(html, num_spaces=4):
@@ -189,13 +192,18 @@ def pretty_print_html(html, num_spaces=4):
     return '\n'.join(formatted_lines)
 
 
-def validate_indent_html(fn):
-    # type: (str) -> int
+def validate_indent_html(fn, fix):
+    # type: (str, bool) -> int
     file = open(fn)
     html = file.read()
     phtml = pretty_print_html(html)
     file.close()
     if not html.split('\n') == phtml.split('\n'):
+        if fix:
+            print(GREEN + "Automatically fixing problems..." + ENDC)
+            with open(fn, 'w') as f:
+                f.write(phtml)
+            return 1
         print('Invalid Indentation detected in file: '
               '%s\nDiff for the file against expected indented file:' % (fn,), flush=True)
         with subprocess.Popen(
@@ -204,5 +212,7 @@ def validate_indent_html(fn):
                 stderr=subprocess.STDOUT,
                 universal_newlines=True) as p:
             p.communicate(phtml)
+        print()
+        print("This problem can be fixed with the `--fix` option.")
         return 0
     return 1

--- a/tools/lint
+++ b/tools/lint
@@ -72,7 +72,8 @@ def run():
                                   "(config: tools/linter_lib/exclude.py)")
     linter_config.external_linter('templates', ['tools/check-templates'], ['hbs', 'html'],
                                   description="Custom linter checks whitespace formatting"
-                                  "of HTML templates.")
+                                  "of HTML templates.",
+                                  fix_arg='--fix')
     linter_config.external_linter('swagger', ['node', 'tools/check-swagger'], ['yaml'],
                                   description="Validates our OpenAPI/Swagger API documentation"
                                   "(zerver/openapi/zulip.yaml) ")


### PR DESCRIPTION
Add support to fix indentation problems with our HTML linters.

fixes: #12641

**Testing Plan:** <!-- How have you tested? -->
$ `tools/lint`
$ `tools/lint --fix`
$`tools/lint`

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<img width="883" alt="Screen Shot 2019-07-17 at 2 41 08 PM" src="https://user-images.githubusercontent.com/39782863/61421433-cf717b80-a8a2-11e9-9dce-f752e75630ad.png">
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
