### PR TITLE
dependencies: Upgrade simplebar to 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "sass-loader": "7.1.0",
     "script-loader": "0.7.2",
     "shebang-loader": "^0.0.1",
-    "simplebar": "^4.0.0",
+    "simplebar": "^4.1.0",
     "sortablejs": "1.9.0",
     "sorttable": "1.0.2",
     "source-sans-pro": "2.45.0",

--- a/version.py
+++ b/version.py
@@ -21,4 +21,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '37.7'
+PROVISION_VERSION = '37.8'

--- a/yarn.lock
+++ b/yarn.lock
@@ -9183,11 +9183,6 @@ script-loader@0.7.2:
   dependencies:
     raw-loader "~0.5.1"
 
-scrollbarwidth@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/scrollbarwidth/-/scrollbarwidth-0.1.3.tgz#1b0de64e288c38c427f4a01fe00a462a04b94fdf"
-  integrity sha1-Gw3mTiiMOMQn9KAf4ApGKgS5T98=
-
 scss-tokenizer@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz#8eb06db9a9723333824d3f5530641149847ce5d1"
@@ -9403,10 +9398,10 @@ signum@^1.0.0:
   resolved "https://registry.yarnpkg.com/signum/-/signum-1.0.0.tgz#74a7d2bf2a20b40eba16a92b152124f1d559fa77"
   integrity sha1-dKfSvyogtA66FqkrFSEk8dVZ+nc=
 
-simplebar@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/simplebar/-/simplebar-4.0.0.tgz#7f1b9e735ec94a58f887d4803f6b15abf401b6b5"
-  integrity sha512-td6vJVhqIXfa3JgNZR5OgETPLfmHNSSpt+OXIbk6WH/nOrUtX3Qcyio30+5rdxxAV/61+F5eJ4jJV4Ek7/KJYQ==
+simplebar@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/simplebar/-/simplebar-4.1.0.tgz#c4b78b278dd0ce41ed70a71473bfad8132a6260f"
+  integrity sha512-kX+CsWbWLeufIsqJl8xg5J4WbYMyq5NONR/aTaehN8XLQxOthSgRT/uAXsqX9Yrw3iiGxD9PPwM1PmEJfWAdcg==
   dependencies:
     can-use-dom "^0.1.0"
     core-js "^3.0.1"
@@ -9414,7 +9409,6 @@ simplebar@^4.0.0:
     lodash.memoize "^4.1.2"
     lodash.throttle "^4.1.1"
     resize-observer-polyfill "^1.5.1"
-    scrollbarwidth "^0.1.3"
 
 simplicial-complex-boundary@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This should fix the [1px white gap](https://chat.zulip.org/#narrow/stream/9-issues/topic/scrollbar.20border.20in.20night.20mode) that sometimes shows up in night mode depending on zoom level (Grsmto/simplebar#325).