### PR TITLE
Remove anchor links with nested button tags and improve styling of buttons

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -2,7 +2,6 @@ body.night-mode {
     background-color: hsl(212, 28%, 18%);
     color: hsl(236, 33%, 90%);
 
-    .new-style .button.btn-link:hover,
     a:hover {
         color: hsl(200, 79%, 66%);
     }
@@ -95,7 +94,16 @@ on a dark background, and don't change the dark labels dark either. */
 
     .new-style .button {
         background-color: hsla(0, 0%, 0%, 0.2);
-        border-color: unset;
+
+        &:not(.sea-green):not(.btn-danger):not(.btn-warning):not(.btn-link) {
+            border-color: hsla(0, 0%, 0%, 0.6);
+            color: inherit;
+        }
+
+        &.btn-link {
+            border-color: hsla(0, 0%, 0%, 0.6);
+            color: hsl(200, 79%, 66%);
+        }
 
         &:hover,
         &:focus,

--- a/static/styles/portico/landing-page.scss
+++ b/static/styles/portico/landing-page.scss
@@ -147,6 +147,7 @@ ol a:hover {
 }
 
 /* -- component styling -- */
+.button,
 button {
     padding: 5px 12px;
 
@@ -155,26 +156,27 @@ button {
     background-color: hsl(0, 0%, 100%);
     color: hsl(0, 0%, 27%);
 
+    line-height: 20px;
     border-radius: 4px;
     border: 1px solid hsl(0, 0%, 80%);
     outline: none;
 
+    &:active {
+        background-color: hsl(0, 0%, 98%);
+        border-color: hsl(0, 0%, 73%);
+    }
+
     &.green {
         color: hsl(0, 0%, 100%);
         background-color: hsl(170, 47%, 53%);
-
-        border: 1px solid hsl(169, 45%, 43%);
+        border-color: hsl(169, 45%, 43%);
 
         &:hover {
-            -webkit-filter: brightness(1.05);
-            -moz-filter: brightness(1.05);
-            filter: brightness(1.05);
+            background-color: hsl(170, 47%, 58%);
         }
 
         &:active {
-            -webkit-filter: brightness(0.95);
-            -moz-filter: brightness(0.95);
-            filter: brightness(0.95);
+            background-color: hsl(170, 47%, 48%);
         }
     }
 
@@ -182,12 +184,7 @@ button {
         cursor: default;
         color: hsl(0, 0%, 20%);
         background-color: transparent;
-        border: 1px solid hsl(0, 0%, 53%);
-    }
-
-    &:active {
-        background-color: hsl(0, 0%, 98%);
-        border: 1px solid hsl(0, 0%, 73%);
+        border-color: hsl(0, 0%, 53%);
     }
 }
 
@@ -1970,8 +1967,8 @@ nav ul li.active::after {
     margin-top: 0px;
 }
 
-.portico-landing.hello .call-to-action-bottom button {
-    display: block;
+.portico-landing.hello .call-to-action-bottom .button {
+    display: table;
     margin: 20px auto 0 auto;
     padding: 11px 25px 11px 25px;
 
@@ -1984,7 +1981,7 @@ nav ul li.active::after {
     transition: all 0.2s ease;
 }
 
-.portico-landing.hello .call-to-action-bottom button:hover {
+.portico-landing.hello .call-to-action-bottom .button:hover {
     color: hsl(219, 23%, 33%);
     border: 1px solid hsl(220, 15%, 20%);
 }
@@ -2111,7 +2108,8 @@ nav ul li.active::after {
     width: 90%;
 }
 
-.portico-landing.apps .hero .info button {
+.portico-landing.apps .hero .info .button {
+    display: inline-block;
     padding: 10px 20px;
 
     font-size: 1em;
@@ -2668,9 +2666,10 @@ nav ul li.active::after {
     text-align: left;
 }
 
-.pricing-model .pricing-container .bottom button {
+.pricing-model .pricing-container .bottom .button {
     margin-top: 20px;
-    width: 100%;
+    display: block;
+    text-align: center;
 
     font-size: 0.9em;
 
@@ -2681,7 +2680,7 @@ nav ul li.active::after {
     outline: none;
 }
 
-.pricing-model .pricing-container .price-box:focus button {
+.pricing-model .pricing-container .price-box:focus .button {
     box-shadow: 0px 0px 25px hsl(169, 48%, 60%);
     animation: box-shadow-pulse 2s infinite;
 }

--- a/templates/zerver/apps.html
+++ b/templates/zerver/apps.html
@@ -23,9 +23,7 @@
                         <h1>Zulip for <span class="platform"></span></h1>
                         <p class="description"></p>
                         <p class="download-instructions">For download instructions, go to the <a class="silver bold" href="/help/desktop-app-install-guide" target="_blank">desktop app install guide</a>.</p>
-                        <a class="link no-action" href="">
-                            <button type="button" name="button" class="green">Download Zulip for <span class="platform"></span></button>
-                        </a>
+                        <a class="link no-action" href=""><span class="button green">Download Zulip for <span class="platform"></span></span></a>
                         <span id="download-android-apk"><a href="https://github.com/zulip/zulip-mobile/releases/latest">or manually download APK</a></span>
                     </div>
                 </div>

--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -529,19 +529,18 @@
     <div class="padded-content call-to-action-bottom">
         <h1>Experience Zulip today!</h1>
         {% if root_domain_landing_page %}
-        <a href="{{ url('plans') }}">
-            <button href="" class="download-button" type="button"
-              name="button">{{ _('See plans and pricing') }}</button>
+        <a href="{{ url('plans') }}" class="download-button button">
+            {{ _('See plans and pricing') }}
         </a>
         {% endif %}
         {% if register_link_disabled %}
         {% elif only_sso %}
-        <a href="{{ url('login-sso') }}">
-            <button href="" type="button" name="button">{{ _('Log in now') }}</button>
+        <a href="{{ url('login-sso') }}" class="button">
+            {{ _('Log in now') }}
         </a>
         {% else %}
-        <a href="{{ url('register') }}">
-            <button href="" type="button" name="button">{{ _('Sign up now') }}</button>
+        <a href="{{ url('register') }}" class="button">
+            {{ _('Sign up now') }}
         </a>
         {% endif %}
         <div class="atlassian-migration">

--- a/templates/zerver/plans.html
+++ b/templates/zerver/plans.html
@@ -42,10 +42,8 @@
                                     <div class="pricing-details">
                                         Free
                                     </div>
-                                    <a href="/new/">
-                                        <button class="green" type="button">
-                                            Sign up now
-                                        </button>
+                                    <a href="/new/" class="button green">
+                                        Sign up now
                                     </a>
                                     {% elif realm_plan_type == 2 %}
                                     <div class="pricing-details"></div>
@@ -88,16 +86,12 @@
                                         Current plan
                                     </button>
                                     {% elif realm_plan_type == 2 %}
-                                    <a href="/upgrade">
-                                        <button class="green" type="button">
-                                            Buy Standard
-                                        </button>
+                                    <a href="/upgrade" class="button green">
+                                        Buy Standard
                                     </a>
                                     {% else %}
-                                    <a href="/upgrade">
-                                        <button class="green" type="button">
-                                            Buy Standard
-                                        </button>
+                                    <a href="/upgrade" class="button green">
+                                        Buy Standard
                                     </a>
                                     {% endif %}
                                 </div>
@@ -129,10 +123,8 @@
                                     <div class="pricing-details">
                                         Free and open source forever
                                     </div>
-                                    <a href="https://zulip.readthedocs.io/en/stable/production/install.html">
-                                        <button class="green" type="button">
-                                            Install a Zulip server
-                                        </button>
+                                    <a href="https://zulip.readthedocs.io/en/stable/production/install.html" class="button green">
+                                        Install a Zulip server
                                     </a>
                                 </div>
                             </div>
@@ -158,8 +150,8 @@
                                     <div class="pricing-details">
                                         Pricing varies with support required
                                     </div>
-                                    <a href="mailto:sales@zulipchat.com" target="_blank" class="no-action">
-                                        <button class="green" type="button" name="button">Contact sales</button>
+                                    <a href="mailto:sales@zulipchat.com" target="_blank" class="no-action button green">
+                                        Contact sales
                                     </a>
                                 </div>
                             </div>


### PR DESCRIPTION
As a followup to #12770 where @andersk pointed out that the root reason behind the linkified whitespace for the Change name button was that it was improperly nested inside an anchor link (invalid HTML), this PR includes a series of commits to fix #6126.

First, remove anchor links with nested buttons from user settings Handlebars templates (fb7dd5f)
  - Replace link styling with .sea-green class (a40bad7)

Now that the user settings buttons are no longer anchor links but buttons, improve their styling (along with other buttons in the codebase)
- Disabled buttons should not react on hover/focus/other user action for proper UX (7047c94)
- Improve coloring of buttons in night mode (border/text color for classes like sea-green and btn-warning was previously lost) (92ccc5a)

Refactor SCSS of portico buttons in preparation for transitioning anchor links with nested buttons to anchor links with just button styling (f8015d1 and 35b11aa)

Transition anchor links needing button styling to use the new `.button` class that inherits button styling (28043b3)

Remove unused CSS along the way (5f8b0e8 and 8df3662)

