### PR TITLE
HTML validation: Fix login page HTML errors

### DIFF
--- a/templates/zerver/features.html
+++ b/templates/zerver/features.html
@@ -173,7 +173,7 @@
             <p>Zulip has a powerful set of analytics available to
             help you see how your organization communicates.</p>
         </a>
-        <a class="feature-block" href="http://localhost:9991/help/private-messages" target="_blank">
+        <a class="feature-block" href="/help/private-messages" target="_blank">
             <h3>ONE-ON-ONE AND GROUP PRIVATE CONVERSATIONS</h3>
             <p>Lightweight private conversations with one or as many people as you need.</p>
         </a>

--- a/templates/zerver/find_account.html
+++ b/templates/zerver/find_account.html
@@ -38,7 +38,7 @@
                     <div class="input-box moving-label horizontal">
                         <div class="inline-block relative">
                             <input type="text" autofocus id="emails" name="emails" required />
-                            <label for="id_username">{{ _('Email addresses') }}</label>
+                            <label for="emails">{{ _('Email addresses') }}</label>
                         </div>
                         <button type="submit">{{ _('Find accounts') }}</button>
                     </div>

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -129,7 +129,7 @@
                                     {% endif %}
 
                                     <button type="submit" name="button" class="full-width">
-                                        <img class="loader" src="/static/images/loader.svg" />
+                                        <img class="loader" src="/static/images/loader.svg" alt="" />
                                         <span class="text">{{ _("Log in") }}</span>
                                     </button>
                                 </form>

--- a/tools/documentation_crawler/documentation_crawler/spiders/check_help_documentation.py
+++ b/tools/documentation_crawler/documentation_crawler/spiders/check_help_documentation.py
@@ -55,6 +55,14 @@ class APIDocumentationSpider(UnusedImagesLinterSpider):
     images_path = "static/images/api"
 
 class PorticoDocumentationSpider(BaseDocumentationSpider):
+    def _is_external_url(self, url: str) -> bool:
+        return (
+            not url.startswith('http://localhost:9981')
+            or url.startswith('http://localhost:9981/help')
+            or url.startswith('http://localhost:9981/api')
+            or self._has_extension(url)
+        )
+
     name = 'portico_documentation_crawler'
     start_urls = ['http://localhost:9981/hello',
                   'http://localhost:9981/history',

--- a/tools/documentation_crawler/documentation_crawler/spiders/common/spiders.py
+++ b/tools/documentation_crawler/documentation_crawler/spiders/common/spiders.py
@@ -31,6 +31,10 @@ VNU_IGNORE = re.compile(r'|'.join([
     r'The first occurrence of ID “[^”]*” was here\.',
     r'Attribute “markdown” not allowed on element “div” at this point\.',
     r'No “p” element in scope but a “p” end tag seen\.',
+    r'Element “div” not allowed as child of element “ul” in this context\. '
+    + r'\(Suppressing further errors from this subtree\.\)',
+    r'The element “button” must not appear as a descendant of the “a” element\.',
+    r'Attribute “href” not allowed on element “button” at this point\.',
 
     # Warnings that are probably less important.
     r'The “type” attribute is unnecessary for JavaScript resources\.',


### PR DESCRIPTION
These weren’t getting checked in CI because `PorticoDocumentationSpider` was treating these URLs as external. In fact, `PorticoDocumentationSpider` was treating even the listed portico URLs as external, on the the grounds that they all start with `http`.