### PR TITLE
Stream > Topic Mention 2

### DIFF
--- a/templates/zerver/app/markdown_help.html
+++ b/templates/zerver/app/markdown_help.html
@@ -83,6 +83,14 @@
                         <td class="rendered_markdown"><a>#streamName</a> (links to a stream)</td>
                     </tr>
                     <tr>
+                        <td>#**streamName>topicName**</td>
+                        <td class="rendered_markdown"><a>#streamName &gt; topicName</a> (links to a topic)</td>
+                    </tr>
+                    <tr>
+                        <td colspan="2">{% trans %}To mention a topic, start mentioning a stream as usual and type '&gt;'. You
+                          can then start typing or use the autocomplete to select a topic.{% endtrans %}</td>
+                    </tr>
+                    <tr>
                         <td>/me is busy working<br/>
                           (send a status message as user Iago)</td>
                         <td class="rendered_markdown"><span class="sender_name-in-status">Iago</span> is busy working</td>

--- a/templates/zerver/help/format-your-message-using-markdown.md
+++ b/templates/zerver/help/format-your-message-using-markdown.md
@@ -66,6 +66,7 @@ patterns like `#1234` to your ticketing system.
 Auto-detected URL: zulipchat.com
 Named link: [Zulip homepage](zulipchat.com)
 Stream: #**announce**
+Stream and Topic: #**general>a topic name**
 Custom linkifier: #1234 (links to ticket 1234 in your ticketing system)
 ```
 


### PR DESCRIPTION
A variation on #12623.

See 840b24a953d6805cb966a1e8a3fb96b7eff8aefc as the main difference.

I thought of squashing the changes to each individual commit independently but this feels like a better commit structure:

1. Make custom changes to third/typeahead.
2. Add typeaheads. (These 3 commits could be squashed but the resulting diff would be large)
3. Add basic usage docs and 'fix' the issue. 