### PR TITLE
install, provision: Treat all nonzero exit codes as failure, not just 1.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -8,7 +8,7 @@ PAPER         =
 BUILDDIR      = _build
 
 # User-friendly check for sphinx-build
-ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
+ifneq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 0)
 $(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
 endif
 

--- a/scripts/setup/install
+++ b/scripts/setup/install
@@ -15,13 +15,13 @@ mkdir -p /var/log/zulip
 "$(dirname "$(dirname "$0")")/lib/install" "$@" 2>&1 | tee -a /var/log/zulip/install.log
 failed=${PIPESTATUS[0]}
 
-if [ "$failed" = 1 ]; then
+if [ "$failed" -ne 0 ]; then
     echo -e '\033[0;31m'
-    echo "Zulip installation failed!"
+    echo "Zulip installation failed (exit code $failed)!"
     echo
     echo -n "The install process is designed to be idempotent, so you can retry "
     echo -n "after resolving whatever issue caused the failure (there should be a traceback above). "
     echo -n "A log of this installation is available in /var/log/zulip/install.log"
     echo -e '\033[0m'
-    exit 1
+    exit "$failed"
 fi

--- a/tools/ci/setup-backend
+++ b/tools/ci/setup-backend
@@ -6,7 +6,13 @@ set -x
 # Provisioning may fail due to many issues but most of the times a network
 # connection issue is the reason. So we are going to retry entire provisioning
 # once again if that fixes our problem.
-if ! tools/provision; then
-    echo "\`provision\`: Something went wrong with the provisioning, might be a network issue, Retrying to provision..."
-    tools/provision
-fi
+tools/provision || {
+    ret=$?
+    if [ "$ret" = 1 ]; then
+        echo "\`provision\`: Something went wrong with the provisioning, might be a network issue, Retrying to provision..."
+        tools/provision
+    else
+        echo "\`provision\`: Something REALLY BAD went wrong with the provisioning, not retrying."
+        exit "$ret"
+    fi
+}

--- a/tools/ci/setup-production
+++ b/tools/ci/setup-production
@@ -29,10 +29,16 @@ sudo rm -f /etc/apt/sources.list.d/mongodb*.list
 # Provisioning may fail due to many issues but most of the times a network
 # connection issue is the reason. So we are going to retry entire provisioning
 # once again if that fixes our problem.
-if ! tools/provision --production-travis; then
-    echo "\`provision\`: Something went wrong with the provisioning, might be a network issue, Retrying to provision..."
-    tools/provision --production-travis
-fi
+tools/provision --production-travis || {
+    ret=$?
+    if [ "$ret" = 1 ]; then
+        echo "\`provision\`: Something went wrong with the provisioning, might be a network issue, Retrying to provision..."
+        tools/provision --production-travis
+    else
+        echo "\`provision\`: Something REALLY BAD went wrong with the provisioning, not retrying."
+        exit "$ret"
+    fi
+}
 
 cp -a tools/ci/success-http-headers.txt ~/
 source tools/ci/activate-venv

--- a/tools/provision
+++ b/tools/provision
@@ -28,16 +28,16 @@ export PYTHONUNBUFFERED=1
 ./lib/provision.py "$@" 2>&1 | tee -a "$LOG_PATH"
 failed=${PIPESTATUS[0]}
 
-if [ "$failed" = 1 ]; then
+if [ "$failed" -ne 0 ]; then
     echo -e "$FAIL"
-    echo "Provisioning failed!"
+    echo "Provisioning failed (exit code $failed)!"
     echo
     echo "* Look at the traceback(s) above to find more about the errors."
     echo "* Resolve the errors or get help on chat."
     echo "* If you can fix this yourself, you can re-run tools/provision at any time."
     echo "* Logs are here: zulip/var/log/provision.log"
     echo -e "$ENDC"
-    exit 1
+    exit "$failed"
 elif [ "$VIRTUAL_ENV" != "/srv/zulip-py3-venv" ] && [ -z "${TRAVIS}${SKIP_VENV_SHELL_WARNING}" ]; then
     echo -e "$WARNING"
     echo "WARNING: This shell does not have the Zulip Python 3 virtualenv activated."


### PR DESCRIPTION
I…just ran into a terrifying CI issue where `tools/lib/provision.py` segfaults in `dlopen()` while importing one of the dependencies of `zulip_bots.lib`. You might imagine how confusing this was to diagnose was when `tools/provision` swallowed this failure because exit code 139 didn’t match its preconceived idea of what failures are supposed to look like, and some later test failed because it couldn’t connect to Postgres.

(Cc: @roberthoenig)