### PR TITLE
bugdown: Force absolute urls in topic links.

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -14,6 +14,7 @@ Jinja2==2.10.1
 # Needed for markdown processing
 Markdown==3.1.1
 Pygments==2.3.1
+hyperlink==19.0.0
 
 # Needed for manage.py
 ipython==6.5.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -73,7 +73,7 @@ httpretty==0.9.6
 hypchat==0.21
 hyper==0.7.0              # via apns2
 hyperframe==3.2.0         # via h2, hyper
-hyperlink==19.0.0         # via twisted
+hyperlink==19.0.0
 idna==2.8                 # via hyperlink, requests
 ijson==2.3
 imagesize==1.1.0          # via sphinx

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -55,7 +55,8 @@ httplib2==0.12.3
 hypchat==0.21
 hyper==0.7.0              # via apns2
 hyperframe==3.2.0         # via h2, hyper
-idna==2.8                 # via requests
+hyperlink==19.0.0
+idna==2.8                 # via hyperlink, requests
 ijson==2.3
 ipython-genutils==0.2.0   # via traitlets
 ipython==6.5.0

--- a/version.py
+++ b/version.py
@@ -21,4 +21,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 # Typically, adding a dependency only requires a minor version bump, and
 # removing a dependency requires a major version bump.
 
-PROVISION_VERSION = '37.6'
+PROVISION_VERSION = '37.7'

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -18,6 +18,7 @@ import ujson
 import xml.etree.cElementTree as etree
 from xml.etree.cElementTree import Element
 import ahocorasick
+from hyperlink import parse
 
 from collections import deque, defaultdict
 
@@ -2074,7 +2075,11 @@ def topic_links(realm_filters_key: int, topic_name: str) -> List[str]:
     for sub_string in basic_link_splitter.split(topic_name):
         link_match = re.match(get_web_link_regex(), sub_string)
         if link_match:
-            matches.append(link_match.group('url'))
+            url = link_match.group('url')
+            url_object = parse(url)
+            if not url_object.scheme:
+                url = url_object.replace(scheme='https').to_text()
+            matches.append(url)
 
     return matches
 

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -832,6 +832,14 @@ class BugdownTest(ZulipTestCase):
         converted_topic = bugdown.topic_links(realm.id, msg.topic_name())
         self.assertEqual(converted_topic, [u'https://google.com/hello-world'])
 
+        msg.set_topic_name("Without scheme google.com/hello-world")
+        converted_topic = bugdown.topic_links(realm.id, msg.topic_name())
+        self.assertEqual(converted_topic, [u'https://google.com/hello-world'])
+
+        msg.set_topic_name("Without scheme random.words/hello-world")
+        converted_topic = bugdown.topic_links(realm.id, msg.topic_name())
+        self.assertEqual(converted_topic, [])
+
         msg.set_topic_name("Try out http://ftp.debian.org, https://google.com/ and https://google.in/.")
         converted_topic = bugdown.topic_links(realm.id, msg.topic_name())
         self.assertEqual(converted_topic, [u'http://ftp.debian.org', 'https://google.com/', 'https://google.in/'])


### PR DESCRIPTION
If a url doesn't have a scheme, browsers would treat it as a relative
url and open something like: https://chat.zulip.org/google.com instead.

This PR fixes the issue on the backend; the frontend implementation
remains out of sync and the user sending the message wouldn't see
any linkification for urls without a scheme.

Fixes #12791.

---

Also, I believe some part of this would be relevant to the discussion with Mateusz on topic links. I'll be doing my tests on that assuming this PR is merged.

