### PR TITLE
Use separate realm for system bots in development, rename the realm to "zulipinternal" in production.

### DIFF
--- a/corporate/tests/stripe_fixtures/attach_discount_to_realm--Customer.create.1.json
+++ b/corporate/tests/stripe_fixtures/attach_discount_to_realm--Customer.create.1.json
@@ -15,7 +15,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/attach_discount_to_realm--Customer.retrieve.1.json
+++ b/corporate/tests/stripe_fixtures/attach_discount_to_realm--Customer.retrieve.1.json
@@ -39,7 +39,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/attach_discount_to_realm--Customer.save.1.json
+++ b/corporate/tests/stripe_fixtures/attach_discount_to_realm--Customer.save.1.json
@@ -15,7 +15,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/billing_page_permissions--Customer.create.1.json
+++ b/corporate/tests/stripe_fixtures/billing_page_permissions--Customer.create.1.json
@@ -15,7 +15,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/billing_page_permissions--Customer.retrieve.1.json
+++ b/corporate/tests/stripe_fixtures/billing_page_permissions--Customer.retrieve.1.json
@@ -39,7 +39,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/billing_page_permissions--Customer.retrieve.2.json
+++ b/corporate/tests/stripe_fixtures/billing_page_permissions--Customer.retrieve.2.json
@@ -39,7 +39,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/fixed_price_plans--Customer.create.1.json
+++ b/corporate/tests/stripe_fixtures/fixed_price_plans--Customer.create.1.json
@@ -15,7 +15,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/invoice_plan--Customer.create.1.json
+++ b/corporate/tests/stripe_fixtures/invoice_plan--Customer.create.1.json
@@ -15,7 +15,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/renewal--Customer.create.1.json
+++ b/corporate/tests/stripe_fixtures/renewal--Customer.create.1.json
@@ -15,7 +15,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/replace_payment_source--Customer.create.1.json
+++ b/corporate/tests/stripe_fixtures/replace_payment_source--Customer.create.1.json
@@ -15,7 +15,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/replace_payment_source--Customer.retrieve.1.json
+++ b/corporate/tests/stripe_fixtures/replace_payment_source--Customer.retrieve.1.json
@@ -39,7 +39,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/replace_payment_source--Customer.retrieve.2.json
+++ b/corporate/tests/stripe_fixtures/replace_payment_source--Customer.retrieve.2.json
@@ -39,7 +39,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/replace_payment_source--Customer.retrieve.3.json
+++ b/corporate/tests/stripe_fixtures/replace_payment_source--Customer.retrieve.3.json
@@ -39,7 +39,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/replace_payment_source--Customer.retrieve.4.json
+++ b/corporate/tests/stripe_fixtures/replace_payment_source--Customer.retrieve.4.json
@@ -39,7 +39,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/replace_payment_source--Customer.retrieve.5.json
+++ b/corporate/tests/stripe_fixtures/replace_payment_source--Customer.retrieve.5.json
@@ -39,7 +39,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/replace_payment_source--Customer.retrieve.6.json
+++ b/corporate/tests/stripe_fixtures/replace_payment_source--Customer.retrieve.6.json
@@ -39,7 +39,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/replace_payment_source--Customer.save.2.json
+++ b/corporate/tests/stripe_fixtures/replace_payment_source--Customer.save.2.json
@@ -15,7 +15,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/replace_payment_source--Customer.save.3.json
+++ b/corporate/tests/stripe_fixtures/replace_payment_source--Customer.save.3.json
@@ -15,7 +15,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/upgrade_by_card--Customer.create.1.json
+++ b/corporate/tests/stripe_fixtures/upgrade_by_card--Customer.create.1.json
@@ -15,7 +15,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/upgrade_by_card--Customer.retrieve.1.json
+++ b/corporate/tests/stripe_fixtures/upgrade_by_card--Customer.retrieve.1.json
@@ -39,7 +39,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/upgrade_by_card--Customer.retrieve.2.json
+++ b/corporate/tests/stripe_fixtures/upgrade_by_card--Customer.retrieve.2.json
@@ -39,7 +39,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/upgrade_by_card_with_outdated_seat_count--Customer.create.1.json
+++ b/corporate/tests/stripe_fixtures/upgrade_by_card_with_outdated_seat_count--Customer.create.1.json
@@ -15,7 +15,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/upgrade_by_invoice--Customer.create.1.json
+++ b/corporate/tests/stripe_fixtures/upgrade_by_invoice--Customer.create.1.json
@@ -15,7 +15,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/upgrade_by_invoice--Customer.retrieve.1.json
+++ b/corporate/tests/stripe_fixtures/upgrade_by_invoice--Customer.retrieve.1.json
@@ -15,7 +15,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/upgrade_by_invoice--Customer.retrieve.2.json
+++ b/corporate/tests/stripe_fixtures/upgrade_by_invoice--Customer.retrieve.2.json
@@ -15,7 +15,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/upgrade_where_first_card_fails--Customer.create.1.json
+++ b/corporate/tests/stripe_fixtures/upgrade_where_first_card_fails--Customer.create.1.json
@@ -15,7 +15,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/upgrade_where_first_card_fails--Customer.retrieve.1.json
+++ b/corporate/tests/stripe_fixtures/upgrade_where_first_card_fails--Customer.retrieve.1.json
@@ -39,7 +39,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/upgrade_where_first_card_fails--Customer.retrieve.2.json
+++ b/corporate/tests/stripe_fixtures/upgrade_where_first_card_fails--Customer.retrieve.2.json
@@ -39,7 +39,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/corporate/tests/stripe_fixtures/upgrade_where_first_card_fails--Customer.save.1.json
+++ b/corporate/tests/stripe_fixtures/upgrade_where_first_card_fails--Customer.save.1.json
@@ -15,7 +15,7 @@
   },
   "livemode": false,
   "metadata": {
-    "realm_id": "1",
+    "realm_id": "2",
     "realm_str": "zulip"
   },
   "object": "customer",

--- a/docs/production/maintain-secure-upgrade.md
+++ b/docs/production/maintain-secure-upgrade.md
@@ -727,7 +727,7 @@ id    string_id                                name
 2                                              Zulip Community
 ```
 
-(Note that every Zulip server has a special `zulip` realm containing
+(Note that every Zulip server has a special `zulipinternal` realm containing
 system-internal bots like `welcome-bot`; you are unlikely to need to
 interact with that realm.)
 

--- a/docs/production/multiple-organizations.md
+++ b/docs/production/multiple-organizations.md
@@ -116,7 +116,7 @@ avoid confusion as to why there's an extra realm when inspecting the
 Zulip database.
 
 Every Zulip server comes with 1 realm that isn't created by users: the
-`zulip` realm.  By default, this realm only contains the Zulip "system
+`zulipinternal` realm.  By default, this realm only contains the Zulip "system
 bots".  You can get a list of these on your system via
 `./scripts/get-django-setting INTERNAL_BOTS`, but this is where bots
 like "Notification Bot", "Welcome Bot", etc. exist.  In the future,

--- a/frontend_tests/casper_tests/10-admin.js
+++ b/frontend_tests/casper_tests/10-admin.js
@@ -432,7 +432,7 @@ casper.then(function () {
         }, false);
         casper.click("#realm_icon_upload_button");
         casper.waitWhileVisible("#upload_icon_spinner .loading_indicator_spinner", function () {
-            casper.test.assertExists('img#realm-settings-icon[src^="/user_avatars/1/realm/icon.png?version=2"]');
+            casper.test.assertExists('img#realm-settings-icon[src^="/user_avatars/2/realm/icon.png?version=2"]');
             casper.test.assertEqual(casper.visible('#realm_icon_delete_button'), true);
         });
     });

--- a/zerver/management/commands/initialize_voyager_db.py
+++ b/zerver/management/commands/initialize_voyager_db.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
         if Realm.objects.count() > 0:
             print("Database already initialized; doing nothing.")
             return
-        realm = Realm.objects.create(string_id=settings.INTERNAL_BOT_DOMAIN.split('.')[0])
+        realm = Realm.objects.create(string_id=settings.SYSTEM_BOT_REALM)
 
         names = [(settings.FEEDBACK_BOT_NAME, settings.FEEDBACK_BOT)]
         create_users(realm, names, bot_type=UserProfile.DEFAULT_BOT)

--- a/zerver/migrations/0237_rename_zulip_realm_to_zulipinternal.py
+++ b/zerver/migrations/0237_rename_zulip_realm_to_zulipinternal.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from django.conf import settings
+from django.db import migrations
+from django.db.backends.postgresql_psycopg2.schema import DatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+def rename_zulip_realm_to_zulipinternal(apps: StateApps, schema_editor: DatabaseSchemaEditor) -> None:
+    if not settings.PRODUCTION:
+        return
+
+    Realm = apps.get_model('zerver', 'Realm')
+    UserProfile = apps.get_model('zerver', 'UserProfile')
+
+    if Realm.objects.count() == 0:
+        # Database not yet populated, do nothing:
+        return
+
+    if Realm.objects.filter(string_id="zulipinternal").exists():
+        return
+
+    internal_realm = Realm.objects.get(string_id="zulip")
+
+    # For safety, as a sanity check, verify that "internal_realm" is indeed the realm for system bots:
+    welcome_bot = UserProfile.objects.get(email="welcome-bot@zulip.com")
+    assert welcome_bot.realm.id == internal_realm.id
+
+    internal_realm.string_id = "zulipinternal"
+    internal_realm.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0236_remove_illegal_characters_email_full'),
+    ]
+
+    operations = [
+        migrations.RunPython(rename_zulip_realm_to_zulipinternal)
+    ]

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -336,8 +336,8 @@ class ImportExportTest(ZulipTestCase):
         self.assertEqual('1.png', os.listdir(fn)[0])
         records = full_data['emoji_dir_records']
         self.assertEqual(records[0]['file_name'], '1.png')
-        self.assertEqual(records[0]['path'], '1/emoji/images/1.png')
-        self.assertEqual(records[0]['s3_path'], '1/emoji/images/1.png')
+        self.assertEqual(records[0]['path'], '2/emoji/images/1.png')
+        self.assertEqual(records[0]['s3_path'], '2/emoji/images/1.png')
 
         # Test avatars
         fn = os.path.join(full_data['avatar_dir'], original_avatar_path_id)
@@ -386,8 +386,8 @@ class ImportExportTest(ZulipTestCase):
         records = full_data['emoji_dir_records']
         self.assertEqual(records[0]['file_name'], '1.png')
         self.assertTrue('last_modified' in records[0])
-        self.assertEqual(records[0]['path'], '1/emoji/images/1.png')
-        self.assertEqual(records[0]['s3_path'], '1/emoji/images/1.png')
+        self.assertEqual(records[0]['path'], '2/emoji/images/1.png')
+        self.assertEqual(records[0]['s3_path'], '2/emoji/images/1.png')
         check_variable_type(records[0]['user_profile_id'], records[0]['realm_id'])
 
         # Test avatars
@@ -415,13 +415,12 @@ class ImportExportTest(ZulipTestCase):
         realm_emoji.save()
 
         data = full_data['realm']
-        self.assertEqual(len(data['zerver_userprofile_crossrealm']), 0)
+        self.assertEqual(len(data['zerver_userprofile_crossrealm']), 3)
         self.assertEqual(len(data['zerver_userprofile_mirrordummy']), 0)
 
         exported_user_emails = self.get_set(data['zerver_userprofile'], 'email')
         self.assertIn(self.example_email('cordelia'), exported_user_emails)
         self.assertIn('default-bot@zulip.com', exported_user_emails)
-        self.assertIn('emailgateway@zulip.com', exported_user_emails)
 
         exported_streams = self.get_set(data['zerver_stream'], 'name')
         self.assertEqual(
@@ -472,7 +471,6 @@ class ImportExportTest(ZulipTestCase):
         self.assertIn(self.example_email('cordelia'), dummy_user_emails)
         self.assertIn(self.example_email('othello'), dummy_user_emails)
         self.assertIn('default-bot@zulip.com', dummy_user_emails)
-        self.assertIn('emailgateway@zulip.com', dummy_user_emails)
         self.assertNotIn(self.example_email('iago'), dummy_user_emails)
         self.assertNotIn(self.example_email('hamlet'), dummy_user_emails)
 
@@ -541,7 +539,7 @@ class ImportExportTest(ZulipTestCase):
 
         data = full_data['realm']
 
-        self.assertEqual(len(data['zerver_userprofile_crossrealm']), 0)
+        self.assertEqual(len(data['zerver_userprofile_crossrealm']), 3)
         self.assertEqual(len(data['zerver_userprofile_mirrordummy']), 0)
 
         exported_user_emails = self.get_set(data['zerver_userprofile'], 'email')
@@ -550,7 +548,6 @@ class ImportExportTest(ZulipTestCase):
         self.assertIn(self.example_email('iago'), exported_user_emails)
         self.assertIn(self.example_email('othello'), exported_user_emails)
         self.assertIn('default-bot@zulip.com', exported_user_emails)
-        self.assertIn('emailgateway@zulip.com', exported_user_emails)
 
         exported_streams = self.get_set(data['zerver_stream'], 'name')
         self.assertEqual(

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -454,7 +454,7 @@ class LoginTest(ZulipTestCase):
         with queries_captured() as queries:
             self.register(self.nonreg_email('test'), "test")
         # Ensure the number of queries we make is not O(streams)
-        self.assert_length(queries, 77)
+        self.assertEqual(len(queries), 78)
         user_profile = self.nonreg_user('test')
         self.assert_logged_in_user_id(user_profile.id)
         self.assertFalse(user_profile.enable_stream_desktop_notifications)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2326,7 +2326,7 @@ class SubscriptionAPITest(ZulipTestCase):
                     streams_to_sub,
                     dict(principals=ujson.dumps([user1.email, user2.email])),
                 )
-        self.assert_length(queries, 44)
+        self.assert_length(queries, 45)
 
         self.assert_length(events, 7)
         for ev in [x for x in events if x['event']['type'] not in ('message', 'stream')]:
@@ -2367,7 +2367,7 @@ class SubscriptionAPITest(ZulipTestCase):
         )
 
         self.assertNotIn(self.example_user('polonius').id, add_peer_event['users'])
-        self.assertEqual(len(add_peer_event['users']), 16)
+        self.assertEqual(len(add_peer_event['users']), 10)
         self.assertEqual(add_peer_event['event']['type'], 'subscription')
         self.assertEqual(add_peer_event['event']['op'], 'peer_add')
         self.assertEqual(add_peer_event['event']['user_id'], self.user_profile.id)
@@ -2399,7 +2399,7 @@ class SubscriptionAPITest(ZulipTestCase):
         # We don't send a peer_add event to othello
         self.assertNotIn(user_profile.id, add_peer_event['users'])
         self.assertNotIn(self.example_user('polonius').id, add_peer_event['users'])
-        self.assertEqual(len(add_peer_event['users']), 16)
+        self.assertEqual(len(add_peer_event['users']), 10)
         self.assertEqual(add_peer_event['event']['type'], 'subscription')
         self.assertEqual(add_peer_event['event']['op'], 'peer_add')
         self.assertEqual(add_peer_event['event']['user_id'], user_profile.id)
@@ -3066,7 +3066,7 @@ class SubscriptionAPITest(ZulipTestCase):
                 [new_streams[0]],
                 dict(principals=ujson.dumps([user1.email, user2.email])),
             )
-        self.assert_length(queries, 44)
+        self.assert_length(queries, 45)
 
         # Test creating private stream.
         with queries_captured() as queries:
@@ -3076,7 +3076,7 @@ class SubscriptionAPITest(ZulipTestCase):
                 dict(principals=ujson.dumps([user1.email, user2.email])),
                 invite_only=True,
             )
-        self.assert_length(queries, 39)
+        self.assert_length(queries, 40)
 
         # Test creating a public stream with announce when realm has a notification stream.
         notifications_stream = get_stream(self.streams[0], self.test_realm)
@@ -3091,7 +3091,7 @@ class SubscriptionAPITest(ZulipTestCase):
                     principals=ujson.dumps([user1.email, user2.email])
                 )
             )
-        self.assert_length(queries, 52)
+        self.assert_length(queries, 53)
 
 class GetBotOwnerStreamsTest(ZulipTestCase):
     def test_streams_api_for_bot_owners(self) -> None:

--- a/zerver/webhooks/stripe/fixtures/customer_updated__account_balance.json
+++ b/zerver/webhooks/stripe/fixtures/customer_updated__account_balance.json
@@ -18,7 +18,7 @@
             "invoice_prefix": "6E2831C",
             "livemode": false,
             "metadata": {
-                "realm_id": "1",
+                "realm_id": "2",
                 "realm_str": "zulip"
             },
             "shipping": null,

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -283,7 +283,7 @@ DEFAULT_SETTINGS.update({
     # SYSTEM_BOT_REALM would be a constant always set to 'zulip',
     # except that it isn't that on zulipchat.com.  We will likely do a
     # migration and eliminate this parameter in the future.
-    'SYSTEM_BOT_REALM': 'zulip',
+    'SYSTEM_BOT_REALM': 'zulipinternal',
 
     # Structurally, we will probably eventually merge
     # analytics into part of the main server, rather


### PR DESCRIPTION
PR for points 2 and 4 of https://github.com/zulip/zulip/issues/11015 .

Perhaps some of these commits should be squashed, but I went with this spammy approach since it allows merging some of the initial commits selectively and seems easier to review in chunks.

First we have a spam of boring commits adjusting tests in a way that they'll work on both the old and the new structure of realms in development (replacing hard-coded realm ids with `` get_realm("zulip").id ``, using a normal bot where appropriate instead of a cross-realm bot, etc.).

Then we have 3 commits that need to be merged together (or squashed?):
1. Change populate_db to have the separate system bot realm, named according to settings.SYSTEM_BOT_REALM - which we set to "zulipinternal".
2. Change production - `` initialize_voyager_db.py  `` will name the internal realm according to settings.SYSTEM_BOT_REALM too (so "zulipinternal"). In addition we write a migration to rename it for already deployed zulip instances, and fix up a bit of documentation where it was refering to the "zulip" internal realm - the name needs to be adjusted to "zulipinternal" now.
3. Fix remaining tests that were broken by these changes, but couldn't be "prepared" for them in advance, like we did in the first chunk of commits.

