### PR TITLE
notifications: Provide desktop app inline notification reply data.

### DIFF
--- a/frontend_tests/zjsunit/namespace.js
+++ b/frontend_tests/zjsunit/namespace.js
@@ -41,6 +41,7 @@ exports.restore = function () {
         delete require.cache[require.resolve(fn)];
     });
     dependencies = [];
+    delete global.window.electron_bridge;
     _.extend(global, old_builtins);
     old_builtins = {};
 };

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -277,6 +277,46 @@ exports.notify_above_composebox = function (note, link_class, link_msg_id, link_
     $('#out-of-view-notification').show();
 };
 
+if (window.electron_bridge !== undefined) {
+    // The code below is for sending a message received from notification reply which
+    // is often refered to as inline reply feature. This is done so desktop app doesn't
+    // have to depend on channel.post for setting crsf_token and narrow.by_topic
+    // to narrow to the message being sent.
+    window.electron_bridge.send_notification_reply_message_supported = true;
+    window.electron_bridge.on_event('send_notification_reply_message', function (message_id, reply) {
+        var message = message_store.get(message_id);
+        var data = {
+            type: message.type,
+            content: reply,
+            to: message.type === 'private' ? message.reply_to : message.stream,
+            topic: util.get_message_topic(message),
+        };
+
+        function success() {
+            if (message.type === 'stream') {
+                narrow.by_topic(message_id, {trigger: 'desktop_notification_reply'});
+            } else {
+                narrow.by_recipient(message_id, {trigger: 'desktop_notification_reply'});
+            }
+        }
+
+        function error(error) {
+            window.electron_bridge.send_event('send_notification_reply_message_failed', {
+                data: data,
+                message_id: message_id,
+                error: error,
+            });
+        }
+
+        channel.post({
+            url: '/json/messages',
+            data: data,
+            success: success,
+            error: error,
+        });
+    });
+}
+
 function process_notification(notification) {
     var i;
     var notification_object;


### PR DESCRIPTION
**Testing Plan:** <!-- How have you tested? -->
I pasted the script below into desktop app, more specifically Devtools of Active Tab when the development server running this PR's code is focused:
```javascript
class TestNotification extends Notification {
  constructor(title, opts) {
      super(title, opts);

      const message_id = data.tag;
      const reply = '** *Reply for testing desktop app notification reply!* **';
      electron_bridge.send_event('send_notification_reply_message', message_id, reply);
  }
}

window.Notification = TestNotification;
```
Then in browser tab send Private and Group PM along with Stream message mentioning the user logged in to desktop app. It should send back `Reply from desktop app inline notification reply` and in the desktop app should narrow to the message.