### PR TITLE
echo: Update topic_links when we get messages back from server.

### DIFF
--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -1,4 +1,5 @@
 zrequire('echo');
+zrequire('util');
 
 let disparities = [];
 let messages_to_rerender = [];
@@ -52,6 +53,7 @@ run_test('process_from_server for differently rendered messages', () => {
             timestamp: old_value,
             is_me_message: old_value,
             submessages: old_value,
+            subject_links: old_value,
         },
     };
     const server_messages = [
@@ -61,6 +63,7 @@ run_test('process_from_server for differently rendered messages', () => {
             timestamp: new_value,
             is_me_message: new_value,
             submessages: new_value,
+            subject_links: new_value,
         },
     ];
     echo._patch_waiting_for_awk(waiting_for_ack);
@@ -74,5 +77,6 @@ run_test('process_from_server for differently rendered messages', () => {
         timestamp: new_value,
         is_me_message: new_value,
         submessages: new_value,
+        subject_links: new_value,
     }]);
 });

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -228,6 +228,7 @@ exports.process_from_server = function process_from_server(messages) {
         // the backend.
         client_message.timestamp = message.timestamp;
 
+        util.set_topic_links(client_message, util.get_topic_links(message));
         client_message.is_me_message = message.is_me_message;
         client_message.submessages = message.submessages;
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

This fixes the issues with inconsistencies between marked and bugdown implementations for topic_links.

**Testing Plan:** <!-- How have you tested? -->

Manual Testing.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
