### PR TITLE
bots: Replace remnants of new-user-bot with default-bot@zulip.com.

### DIFF
--- a/frontend_tests/casper_tests/13-user-deactivation.js
+++ b/frontend_tests/casper_tests/13-user-deactivation.js
@@ -78,22 +78,22 @@ casper.then(function () {
 });
 
 casper.then(function () {
-    casper.waitUntilVisible('.user_row[data-email="new-user-bot@zulip.com"]', function () {
-        casper.test.assertSelectorHasText('.user_row[data-email="new-user-bot@zulip.com"]', 'Deactivate');
-        casper.click('.user_row[data-email="new-user-bot@zulip.com"] .deactivate');
+    casper.waitUntilVisible('.user_row[data-email="default-bot@zulip.com"]', function () {
+        casper.test.assertSelectorHasText('.user_row[data-email="default-bot@zulip.com"]', 'Deactivate');
+        casper.click('.user_row[data-email="default-bot@zulip.com"] .deactivate');
     });
 });
 
 casper.then(function () {
-    casper.waitUntilVisible('.user_row[data-email="new-user-bot@zulip.com"].deactivated_user', function () {
-        casper.test.assertSelectorHasText('.user_row[data-email="new-user-bot@zulip.com"]', 'Reactivate');
-        casper.click('.user_row[data-email="new-user-bot@zulip.com"] .reactivate');
+    casper.waitUntilVisible('.user_row[data-email="default-bot@zulip.com"].deactivated_user', function () {
+        casper.test.assertSelectorHasText('.user_row[data-email="default-bot@zulip.com"]', 'Reactivate');
+        casper.click('.user_row[data-email="default-bot@zulip.com"] .reactivate');
     });
 });
 
 casper.then(function () {
-    casper.waitUntilVisible('.user_row[data-email="new-user-bot@zulip.com"]:not(.deactivated_user)', function () {
-        casper.test.assertSelectorHasText('.user_row[data-email="new-user-bot@zulip.com"]', 'Deactivate');
+    casper.waitUntilVisible('.user_row[data-email="default-bot@zulip.com"]:not(.deactivated_user)', function () {
+        casper.test.assertSelectorHasText('.user_row[data-email="default-bot@zulip.com"]', 'Deactivate');
     });
 });
 

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -559,7 +559,7 @@ class HomeTest(ZulipTestCase):
         self.assertNotIn('defunct-1@zulip.com', active_emails)
 
         cross_bots = page_params['cross_realm_bots']
-        self.assertEqual(len(cross_bots), 5)
+        self.assertEqual(len(cross_bots), 4)
         cross_bots.sort(key=lambda d: d['email'])
         for cross_bot in cross_bots:
             # These are either nondeterministic or boring
@@ -572,13 +572,6 @@ class HomeTest(ZulipTestCase):
         by_email = lambda d: d['email']
 
         self.assertEqual(sorted(cross_bots, key=by_email), sorted([
-            dict(
-                user_id=get_user('new-user-bot@zulip.com', get_realm('zulip')).id,
-                is_admin=False,
-                email='new-user-bot@zulip.com',
-                full_name='Zulip New User Bot',
-                is_bot=True
-            ),
             dict(
                 user_id=get_user('emailgateway@zulip.com', get_realm('zulip')).id,
                 is_admin=False,

--- a/zerver/tests/test_presence.py
+++ b/zerver/tests/test_presence.py
@@ -361,7 +361,7 @@ class SingleUserPresenceTests(ZulipTestCase):
         result = self.client_get("/json/users/cordelia@zulip.com/presence")
         self.assert_json_error(result, "No such user")
 
-        result = self.client_get("/json/users/new-user-bot@zulip.com/presence")
+        result = self.client_get("/json/users/default-bot@zulip.com/presence")
         self.assert_json_error(result, "Presence is not supported for bot users.")
 
         self.login(self.mit_email("sipbtest"), realm=get_realm("zephyr"))

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2366,7 +2366,7 @@ class SubscriptionAPITest(ZulipTestCase):
         )
 
         self.assertNotIn(self.example_user('polonius').id, add_peer_event['users'])
-        self.assertEqual(len(add_peer_event['users']), 17)
+        self.assertEqual(len(add_peer_event['users']), 16)
         self.assertEqual(add_peer_event['event']['type'], 'subscription')
         self.assertEqual(add_peer_event['event']['op'], 'peer_add')
         self.assertEqual(add_peer_event['event']['user_id'], self.user_profile.id)
@@ -2398,7 +2398,7 @@ class SubscriptionAPITest(ZulipTestCase):
         # We don't send a peer_add event to othello
         self.assertNotIn(user_profile.id, add_peer_event['users'])
         self.assertNotIn(self.example_user('polonius').id, add_peer_event['users'])
-        self.assertEqual(len(add_peer_event['users']), 17)
+        self.assertEqual(len(add_peer_event['users']), 16)
         self.assertEqual(add_peer_event['event']['type'], 'subscription')
         self.assertEqual(add_peer_event['event']['op'], 'peer_add')
         self.assertEqual(add_peer_event['event']['user_id'], user_profile.id)

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -218,7 +218,6 @@ class Command(BaseCommand):
             all_realm_bots = [(bot['name'], bot['email_template'] % (settings.INTERNAL_BOT_DOMAIN,))
                               for bot in settings.INTERNAL_BOTS]
             zulip_realm_bots = [
-                ("Zulip New User Bot", "new-user-bot@zulip.com"),
                 ("Zulip Error Bot", "error-bot@zulip.com"),
                 ("Zulip Default Bot", "default-bot@zulip.com"),
                 ("Welcome Bot", "welcome-bot@zulip.com"),

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1397,7 +1397,6 @@ CROSS_REALM_BOT_EMAILS = {
     'feedback@zulip.com',
     'notification-bot@zulip.com',
     'welcome-bot@zulip.com',
-    'new-user-bot@zulip.com',
     'emailgateway@zulip.com',
 }
 


### PR DESCRIPTION
There existed a few locations that still referenced the now
eliminated `NEW_USER_BOT`.  We replace these with
`default-bot@zulip.com` as per the planned migration of the
cross-realm bots out of the organization.

**Testing Plan:** <!-- How have you tested? -->
`tools/test-*`

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
