### PR TITLE
codecov: Change threshold to use % syntax.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,6 +5,8 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 0.50
+        # Codecov has the tendency to report a lot of false negatives,
+        # so we basically suppress comments completely.
+        threshold: 50%
         base: auto
     patch: off


### PR DESCRIPTION
As seen here:
https://community.codecov.io/t/threshold-confusion/88/2

~~Having the threshold set to `0.50` translates to 50%, when we
really mean 0.5%.~~

Update the syntax to avoid ambiguity and add a comment.
