### PR TITLE
buddy_list: Do not fade current user in PMs.

### DIFF
--- a/static/js/compose_fade.js
+++ b/static/js/compose_fade.js
@@ -130,7 +130,7 @@ function update_user_row_when_fading(li, conf) {
     var email = people.get_person_from_user_id(user_id).email;
     var would_receive = exports.would_receive_message(email);
 
-    if (would_receive) {
+    if (would_receive || people.is_my_user_id(user_id)) {
         conf.unfade(li);
     } else {
         conf.fade(li);


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes an issue where we would fade out own name because it wasn't in the list of recipients for a pm.

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
