### PR TITLE
emails: Remove unsubscribe link from missed message emails.

### DIFF
--- a/templates/zerver/emails/missed_message.source.html
+++ b/templates/zerver/emails/missed_message.source.html
@@ -32,12 +32,14 @@
     {% elif stream_email_notify %}
     You are receiving this because you have email notifications enabled for this stream.<br>
     {% endif %}
-    <a href="{{ realm_uri }}/#settings/notifications">Manage email preferences</a> | <a href="{{ unsubscribe_link }}">Unsubscribe</a> from missed message emails.<br>
     {% if reply_to_zulip %}
-        Reply to this email directly, or <a href="{{ narrow_url }}">view it in Zulip</a><br>
+    Reply to this email directly, <a href="{{ narrow_url }}">view it in Zulip</a>, or <a href="{{ realm_uri }}/#settings/notifications">manage email preferences</a>.
     {% else %}
-        Do not reply to this message. This Zulip server is not
-    configured to accept incoming emails (<a href="https://zulip.readthedocs.io/en/latest/production/email-gateway.html">help</a>). <a href="{{ narrow_url }}">Reply in Zulip</a>.<br>
+    <a href="{{ narrow_url }}">Reply in Zulip</a>, or <a href="{{ realm_uri }}/#settings/notifications">manage email preferences</a>.<br>
+    <br>
+    Do not reply to this message. This Zulip server is not
+    configured to accept incoming emails (<a href="https://zulip.readthedocs.io/en/latest/production/email-gateway.html">help</a>).
+
     {% endif %}
 </div>
 {% endblock %}

--- a/templates/zerver/emails/missed_message.txt
+++ b/templates/zerver/emails/missed_message.txt
@@ -8,31 +8,24 @@
 {% endfor %}
 {% endif %}
 
+--
 {% if mention %}
 You are receiving this because you were mentioned.
 {% elif stream_email_notify %}
 You are receiving this because you have email notifications enabled for this stream.
 {% endif %}
 
-Manage email preferences:
-
-{{ realm_uri }}/#settings/notifications
-
-Unsubscribe from missed message emails:
-
-{{ unsubscribe_link }}
-
 {% if reply_to_zulip  %}
 Reply to this email directly, or view it in Zulip:
-
 {{ narrow_url }}
 {% else %}
+Reply in Zulip:
+{{ narrow_url }}
+
 Do not reply to this message. This Zulip server is not configured to accept
 incoming emails. Help:
-
 https://zulip.readthedocs.io/en/latest/production/email-gateway.html
-
-Reply in Zulip:
-
-{{ narrow_url }}
 {% endif %}
+
+Manage email preferences:
+{{ realm_uri }}/#settings/notifications

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -315,6 +315,8 @@ def do_send_missedmessage_events_reply_in_zulip(user_profile: UserProfile,
             (recipients,)
         )
 
+    # This link is no longer a part of the email, but keeping the code in case
+    # we find a clean way to add it back in the future
     unsubscribe_link = one_click_unsubscribe_link(user_profile, "missed_messages")
     context = common_context(user_profile)
     context.update({

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -241,7 +241,7 @@ class TestMissedMessages(ZulipTestCase):
             '@**King Hamlet**')
 
         if show_message_content:
-            body = ("Othello, the Moor of Venice: 1 2 3 4 5 6 7 8 9 10 @**King Hamlet** "
+            body = ("Othello, the Moor of Venice: 1 2 3 4 5 6 7 8 9 10 @**King Hamlet** -- "
                     "You are receiving this because you were mentioned")
             email_subject = '#Denmark > test'
             verify_body_does_not_include = []  # type: List[str]
@@ -271,7 +271,7 @@ class TestMissedMessages(ZulipTestCase):
         msg_id = self.send_stream_message(
             self.example_email('othello'), "denmark",
             '12')
-        body = ("Othello, the Moor of Venice: 1 2 3 4 5 6 7 8 9 10 12 "
+        body = ("Othello, the Moor of Venice: 1 2 3 4 5 6 7 8 9 10 12 -- "
                 "You are receiving this because you have email notifications enabled for this stream.")
         email_subject = '#Denmark > test'
         self._test_cases(tokens, msg_id, body, email_subject, send_as_user, trigger='stream_email_notify')
@@ -287,7 +287,7 @@ class TestMissedMessages(ZulipTestCase):
         msg_id = self.send_stream_message(
             self.example_email('othello'), "Denmark",
             '@**King Hamlet**')
-        body = ("Cordelia Lear: 0 1 2 Othello, the Moor of Venice: @**King Hamlet** "
+        body = ("Cordelia Lear: 0 1 2 Othello, the Moor of Venice: @**King Hamlet** -- "
                 "You are receiving this because you were mentioned")
         email_subject = '#Denmark > test'
         self._test_cases(tokens, msg_id, body, email_subject, send_as_user, trigger='mentioned')
@@ -365,7 +365,7 @@ class TestMissedMessages(ZulipTestCase):
         )
 
         if show_message_content:
-            body = 'Othello, the Moor of Venice: Group personal message! Manage email preferences:'
+            body = 'Othello, the Moor of Venice: Group personal message! -- Reply'
             email_subject = 'Group PMs with Iago and Othello, the Moor of Venice'
             verify_body_does_not_include = []  # type: List[str]
         else:
@@ -394,7 +394,7 @@ class TestMissedMessages(ZulipTestCase):
             'Group personal message!',
         )
 
-        body = 'Othello, the Moor of Venice: Group personal message! Manage email preferences'
+        body = 'Othello, the Moor of Venice: Group personal message! -- Reply'
         email_subject = 'Group PMs with Cordelia Lear, Iago, and Othello, the Moor of Venice'
         self._test_cases(tokens, msg_id, body, email_subject, send_as_user)
 
@@ -411,7 +411,7 @@ class TestMissedMessages(ZulipTestCase):
                                            self.example_email('prospero')],
                                           'Group personal message!')
 
-        body = 'Othello, the Moor of Venice: Group personal message! Manage email preferences'
+        body = 'Othello, the Moor of Venice: Group personal message! -- Reply'
         email_subject = 'Group PMs with Cordelia Lear, Iago, and 2 others'
         self._test_cases(tokens, msg_id, body, email_subject, send_as_user)
 
@@ -679,16 +679,16 @@ class TestMissedMessages(ZulipTestCase):
             {'message_id': msg_id_3},
         ])
 
-        self.assertIn('Iago: @**King Hamlet**\n\nYou are', mail.outbox[0].body)
+        self.assertIn('Iago: @**King Hamlet**\n\n--\nYou are', mail.outbox[0].body)
         # If message content starts with <p> tag the sender name is appended inside the <p> tag.
         self.assertIn('<p><b>Iago</b>: <span class="user-mention"', mail.outbox[0].alternatives[0][0])
 
-        self.assertIn('Iago: * 1\n *2\n\nYou are receiving', mail.outbox[1].body)
+        self.assertIn('Iago: * 1\n *2\n\n--\nYou are receiving', mail.outbox[1].body)
         # If message content does not starts with <p> tag sender name is appended before the <p> tag
         self.assertIn('       <b>Iago</b>: <ul>\n<li>1<br/>\n *2</li>\n</ul>\n',
                       mail.outbox[1].alternatives[0][0])
 
-        self.assertEqual('Hello\n\n\nManage email preferences:', mail.outbox[2].body[:33])
+        self.assertEqual('Hello\n\n--\n\nReply', mail.outbox[2].body[:16])
         # Sender name is not appended to message for PM missed messages
         self.assertIn('>\n                    \n                        <p>Hello</p>\n',
                       mail.outbox[2].alternatives[0][0])


### PR DESCRIPTION
Leaving the code for the unsubscribe link in place, since it is a useful feature, and not totally confident we should remove it. E.g. we might decide to more aggressively send notifications for "topics I follow" in the future, in which case having a "stop all notifications" would be nice. 

html, with email configured:
![image](https://user-images.githubusercontent.com/890911/61571589-4e081d80-aa49-11e9-9a51-511aed8e70c9.png)

html, email not configured
![image](https://user-images.githubusercontent.com/890911/61571594-54969500-aa49-11e9-9605-f1115aa8de3a.png)

Text only versions. Not perfect, but didn't try to optimize:
![image](https://user-images.githubusercontent.com/890911/61571579-392b8a00-aa49-11e9-9ad3-04f520c76582.png)

![image](https://user-images.githubusercontent.com/890911/61571583-40529800-aa49-11e9-9531-77bb4bac5000.png)
