### PR TITLE
settings: Update upgrade text.

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -105,15 +105,6 @@ label {
     margin-bottom: 10px;
 }
 
-.upgrade_realm_plan_type_suggestion {
-    font-size: 16px;
-}
-
-.upgrade_realm_plan_type_suggestion::after {
-    font-family: FontAwesome;
-    content: "\f135";
-}
-
 .user-avatar-section {
     float: right;
 }
@@ -312,6 +303,7 @@ td .button {
     margin-right: 5px;
 }
 
+.settings-section .upgrade-tip,
 .settings-section .tip {
     position: relative;
     display: block;
@@ -325,14 +317,29 @@ td .button {
     color: hsl(0, 0%, 40%);
 }
 
+.settings-section .upgrade-tip::before,
 .settings-section .tip::before {
-    content: "\f0a2";
-
     display: inline;
     margin-right: 8px;
 
     font-family: FontAwesome, "Yantramanav", Source Sans Pro;
     font-weight: 600;
+}
+
+.settings-section .upgrade-tip::before {
+    content: "\f135";
+}
+
+.settings-section .upgrade-tip:hover {
+    color: hsl(0, 0%, 20%);
+    border: 1px solid hsl(49, 20%, 60%);
+    box-shadow: 0px 0px 4px hsla(199, 79%, 56%, .2);
+
+    text-decoration: none;
+}
+
+.settings-section .tip::before {
+    content: "\f0a2";
 }
 
 .dynamic-input {

--- a/static/templates/settings/organization_profile_admin.hbs
+++ b/static/templates/settings/organization_profile_admin.hbs
@@ -58,11 +58,9 @@
             </h3>
             <div>
                 {{#unless plan_includes_wide_organization_logo}}
-                <p class="upgrade_realm_plan_type_suggestion">
-                    <a href="https://zulipchat.com/plans/" target="_blank">
-                        {{upgrade_text_for_wide_organization_logo}}
-                    </a>
-                </p>
+                <a href="/upgrade" class="upgrade-tip" target="_blank">
+                    {{upgrade_text_for_wide_organization_logo}}
+                </a>
                 {{/unless}}
             </div>
         </div>

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -270,6 +270,7 @@ class Realm(models.Model):
     COMMUNITY = 2
     org_type = models.PositiveSmallIntegerField(default=CORPORATE)  # type: int
 
+    UPGRADE_TEXT_STANDARD = _("Available on Zulip Standard. Upgrade to access.")
     # plan_type controls various features around resource/feature
     # limitations for a Zulip organization on multi-tenant servers
     # like zulipchat.com.
@@ -277,7 +278,6 @@ class Realm(models.Model):
     LIMITED = 2
     STANDARD = 3
     STANDARD_FREE = 4
-    UPGRADE_TEXT_STANDARD = _("Available on all paid plans. Upgrade ")
     plan_type = models.PositiveSmallIntegerField(default=SELF_HOSTED)  # type: int
 
     # This value is also being used in static/js/settings_bots.bot_creation_policy_values.


### PR DESCRIPTION
When we add Plus, the first sentence should change to "Available on Zulip
Standard and Plus".

I copied the styling of .tip out of expediency, but it's also possible that
long term we'll want only 1 tip-like box styling.

The hover styling is a bit random, but I tried to copy other hover styles I
found in settings.scss.

![image](https://user-images.githubusercontent.com/890911/61586766-73bc2200-ab30-11e9-91d8-5675cbc95905.png)

![Peek 2019-07-20 20-54](https://user-images.githubusercontent.com/890911/61586771-9c441c00-ab30-11e9-9c92-e366b26ed53f.gif)

Here's the before:
![image](https://user-images.githubusercontent.com/890911/61586784-e6c59880-ab30-11e9-8ecf-c90de3e2c51a.png)

