### PR TITLE
narrow: Fix to show last message in narrow when narrow allows.

### DIFF
--- a/frontend_tests/node_tests/narrow_local.js
+++ b/frontend_tests/node_tests/narrow_local.js
@@ -325,7 +325,7 @@ run_test('search', () => {
         },
         expected_id_info: {
             target_id: undefined,
-            final_select_id: undefined,
+            final_select_id: 10000000000000000,
             local_select_id: undefined,
         },
         expected_msg_ids: [],
@@ -379,6 +379,32 @@ run_test('stream, no unread, not in all_messages', () => {
         expected_id_info: {
             target_id: 450,
             final_select_id: 450,
+            local_select_id: undefined,
+        },
+        expected_msg_ids: [],
+    };
+
+    test_with(fixture);
+});
+
+run_test('search, stream, not in all_messages', () => {
+    const fixture = {
+        filter_terms: [
+            {operator: 'search', operand: 'foo'},
+            {operator: 'stream', operand: 'whatever'},
+        ],
+        unread_info: {
+            flavor: 'cannot_compute',
+        },
+        has_found_newest: true,
+        empty: false,
+        all_messages: [
+            {id: 400},
+            {id: 500},
+        ],
+        expected_id_info: {
+            target_id: undefined,
+            final_select_id: 10000000000000000,
             local_select_id: undefined,
         },
         expected_msg_ids: [],


### PR DESCRIPTION
Fixes commit id 648a60baf63f9afade83148bd9ae1fc480510178. When
allow_use_first_unread_when_narrowing() is false last message of
narrow is shown in view.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Tested it manually by first setting all messages unread.
``python manage.py mark_all_messages_unread``
Then searched for a term.
Ensured that the anchor is at last message.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Jul-21-2019 19-43-40](https://user-images.githubusercontent.com/23462580/61592358-eb9d5180-abef-11e9-9fbf-40a8249a791d.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
