### PR TITLE
css: Fix weird checkbox scrolling bug in Chrome

### DIFF
--- a/static/styles/components.scss
+++ b/static/styles/components.scss
@@ -5,6 +5,7 @@
     label.checkbox {
         padding: 0px;
         display: inline-block;
+        position: relative;
         vertical-align: top;
 
         input[type=checkbox] {


### PR DESCRIPTION
This fixes a problem in Chrome where checking our styled checkboxes in the stream creation form sometimes caused parts of the page to scroll in weird ways or disappear.

The issue was that the hidden `position: absolute` checkboxes weren’t scrolling with the `#stream-creation` scrollbar, which is `overflow: auto`, not SimpleBar.  When you focused them, Chrome tried to scroll them into view by whatever means necessary.  In this case, the necessary means were to scroll the `.subscriptions-container`, which is `overflow: hidden`.

**Testing Plan:** Dev server in Chrome and Firefox.