### PR TITLE
Cleanup portico why-zulip markdown pages

### DIFF
--- a/static/styles/portico/integrations.scss
+++ b/static/styles/portico/integrations.scss
@@ -12,6 +12,10 @@
     font-size: 1.1rem;
 }
 
+.portico-landing.integrations .markdown ol > li > p {
+    max-width: calc(100% - 31px);
+}
+
 .portico-landing.integrations .main {
     width: calc(100% - 100px);
     max-width: 1170px;

--- a/static/styles/portico/integrations.scss
+++ b/static/styles/portico/integrations.scss
@@ -3,6 +3,12 @@
     font-weight: normal;
 }
 
+.portico-landing.integrations h1:hover::after,
+.portico-landing.integrations h2:hover::after,
+.portico-landing.integrations h3:hover::after {
+    content: none;
+}
+
 .portico-landing.integrations .main {
     width: calc(100% - 100px);
     max-width: 1170px;
@@ -12,6 +18,11 @@
     box-shadow: 0px 0px 80px hsla(0, 0%, 0%, 0.12);
 
     visibility: hidden;
+}
+
+.portico-landing.integrations .main img {
+    box-shadow: none;
+    border: none;
 }
 
 .portico-landing.integrations .padded-content {
@@ -55,6 +66,7 @@
     font-weight: 300;
     line-height: 1.2;
     text-align: center;
+    border-bottom: none;
 }
 
 .portico-landing.integrations .portico-page-heading a {
@@ -287,6 +299,10 @@
 .integration-instruction-block .integration-lozenge {
     float: left;
     margin-top: 5px;
+}
+
+.integration-instructions .help-content h3 {
+    margin: 20px 0;
 }
 
 .integration-lozenge .square-wrapper {
@@ -551,6 +567,12 @@
         width: -webkit-calc(100% - 80px);
         width: -o-calc(100% - 80px);
         width: calc(100% - 80px);
+    }
+}
+
+@media (max-width: 500px) {
+    .portico-landing.integrations .padded-content .inner-content {
+        height: auto;
     }
 }
 

--- a/static/styles/portico/integrations.scss
+++ b/static/styles/portico/integrations.scss
@@ -8,6 +8,9 @@
 .portico-landing.integrations h3:hover::after {
     content: none;
 }
+.portico-landing.integrations .markdown {
+    font-size: 1.1rem;
+}
 
 .portico-landing.integrations .main {
     width: calc(100% - 100px);

--- a/static/styles/portico/landing-page.scss
+++ b/static/styles/portico/landing-page.scss
@@ -2212,6 +2212,9 @@ nav ul li.active::after {
 
     opacity: 0.7;
 }
+.portico-landing.why-page .markdown {
+    font-size: 1.1rem;
+}
 
 .portico-landing.why-page .main blockquote {
     background-color: hsl(0, 0%, 100%);

--- a/static/styles/portico/landing-page.scss
+++ b/static/styles/portico/landing-page.scss
@@ -2213,37 +2213,6 @@ nav ul li.active::after {
     opacity: 0.7;
 }
 
-.portico-landing.why-page .main .inner-content h2 {
-    margin-top: 30px;
-    margin-bottom: 10px;
-}
-
-.portico-landing.why-page .main p {
-    font-size: 1.2em;
-    margin: 0px 0px 20px;
-    line-height: 1.4;
-}
-
-.portico-landing.why-page .main h3 {
-    margin-top: 20px;
-}
-
-.portico-landing.why-page .main li {
-    line-height: 1.6;
-    font-size: 1.2em;
-    margin-bottom: 5px;
-    p,
-    li {
-        /* Avoid double-applying the 1.2em font-size here */
-        font-size: 1em;
-    }
-}
-
-.portico-landing.why-page .main li strong {
-    font-weight: 600;
-    color: hsl(0, 0%, 20%);
-}
-
 .portico-landing.why-page .main blockquote {
     background-color: hsl(0, 0%, 100%);
     border-color: hsl(168, 24%, 51%);

--- a/static/styles/portico/markdown.scss
+++ b/static/styles/portico/markdown.scss
@@ -5,12 +5,7 @@
     overflow: auto;
     -webkit-font-smoothing: antialiased;
 
-    .code-section {
-        ol {
-            margin-left: 15px;
-            margin-top: 10px;
-        }
-    }
+
 
     h1[id],
     h2[id],
@@ -136,6 +131,10 @@
             & > p:not(:first-child) {
                 padding-left: 24px;
                 margin-left: 5px;
+            }
+
+            .codehilite {
+                background-color: hsl(0, 0%, 100%);
             }
 
             & > ul {
@@ -298,8 +297,58 @@
             background-color: hsl(106, 74%, 44%);
         }
     }
-}
 
-li div.codehilite {
-    background-color: hsl(0, 0%, 100%);
+    .code-section {
+        ol {
+            margin-left: 15px;
+            margin-top: 10px;
+        }
+        ul.nav {
+            margin: 0;
+
+            li {
+                display: inline-block;
+                padding: 5px 14px;
+                margin: 0;
+
+                cursor: pointer;
+
+                &.active {
+                    color: hsl(176, 46%, 41%);
+                    margin-bottom: -1px;
+
+                    border: 1px solid hsl(0, 0%, 87%);
+                    border-bottom: 1px solid hsl(0, 0%, 100%);
+                    border-radius: 4px 4px 0px 0px;
+                }
+            }
+        }
+
+        &.no-tabs ul.nav {
+            display: none;
+        }
+
+        .blocks {
+            padding: 10px;
+            margin-bottom: 10px;
+            border: 1px solid hsl(0, 0%, 87%);
+
+            & > div {
+                display: none;
+            }
+        }
+
+        &.has-tabs .blocks {
+            border-radius: 0px 6px 6px 6px;
+        }
+
+        &.no-tabs .blocks {
+            border-radius: 6px;
+        }
+
+        &.no-tabs .blocks > div,
+        &.has-tabs .blocks > .active {
+            display: block;
+        }
+    }
 }

--- a/static/styles/portico/markdown.scss
+++ b/static/styles/portico/markdown.scss
@@ -1,315 +1,310 @@
-.markdown .code-section ol {
-    margin-left: 15px;
-    margin-top: 10px;
-}
-
-.markdown h1[id]::before,
-.markdown h2[id]::before,
-.markdown h3[id]::before,
-.markdown h4[id]::before {
-    display: block;
-    content: " ";
-    visibility: hidden;
-}
-
-.markdown h1[id]::before {
-    margin-top: -30px;
-    height: 30px;
-}
-
-.markdown h2[id]::before,
-.markdown h3[id]::before,
-.markdown h4[id]::before {
-    margin-top: -10px;
-    height: 10px;
-}
-
-.markdown ul,
-.markdown ol {
-    margin-left: 30px;
-}
-
-.markdown li {
-    line-height: 150%;
-}
-
-.markdown ol {
-    counter-reset: item;
-    list-style: none;
-}
-
-.markdown ol > li {
-    counter-increment: item;
-    margin-bottom: 5px;
-}
-
-.markdown ol > li::before {
-    content: counter(item);
-    display: inline-block;
-    vertical-align: top;
-    padding: 3px 6.5px 3px 7.5px;
-    margin-right: 5px;
-    background-color: hsl(170, 48%, 54%);
-    color: hsl(0, 0%, 100%);
-    border-radius: 100%;
-    font-size: 0.9em;
-    line-height: 1.1;
-    text-align: center;
-}
-
-.markdown ol > li > p {
-    display: inline-block;
-    vertical-align: top;
-    max-width: calc(100% - 30px);
-    position: relative;
-    top: -2px;
-}
-
-ol > li > div.codehilite,
-.markdown ol > li > p:not(:first-child) {
-    padding-left: 24px;
-    margin-left: 5px;
-}
-
-li div.codehilite {
-    background-color: hsl(0, 0%, 100%);
-}
-
-.markdown .content ol li p:not(:first-child) {
-    display: block;
-}
-.markdown ol > li > ul {
-    padding-left: 20px;
-}
-
-.markdown ul > li::before {
-    content: none;
-}
-
 .markdown {
     font-weight: 400;
     font-size: 1rem;
     line-height: 1.5;
     overflow: auto;
     -webkit-font-smoothing: antialiased;
-}
 
-.markdown .content {
-    padding: 30px;
-    max-width: 768px;
-    background-color: hsl(0, 0%, 100%);
-}
-
-.markdown a {
-    color: hsl(176, 46%, 41%);
-    font-weight: 600;
-}
-
-.markdown strong {
-    font-weight: 600;
-}
-
-.markdown h1,
-.markdown h2,
-.markdown h3 {
-    font-weight: 700;
-}
-
-.markdown h1,
-.markdown h2,
-.markdown h3 {
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-}
-
-.markdown h1:hover,
-.markdown h2:hover,
-.markdown h3:hover {
-    cursor: pointer;
-}
-
-.markdown h1:hover::after,
-.markdown h2:hover::after,
-.markdown h3:hover::after {
-    display: inline-block;
-    font: normal normal normal 16px/1 FontAwesome;
-    text-rendering: auto;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-
-    cursor: pointer;
-    content: "\f0c1";
-    margin-left: 5px;
-    vertical-align: middle;
-}
-
-.markdown h1 {
-    border-bottom: 1px solid hsl(0, 0%, 93%);
-    padding-bottom: 10px;
-    margin-bottom: 15px;
-}
-
-.markdown h1#using-zulip,
-.markdown h1#zulip-administration {
-    font-size: 1.75em;
-    padding: 10px 0;
-    margin-bottom: 0px;
-    line-height: 100%;
-}
-
-.markdown h2 {
-    font-size: 1.5em;
-    line-height: 1.25;
-    margin: 20px 0px 5px 0px;
-}
-
-.markdown h3 {
-    font-size: 1.25em;
-    line-height: 1.25;
-    opacity: 1;
-    margin-bottom: 7px;
-}
-
-.markdown img {
-    vertical-align: top;
-    box-shadow: 0px 0px 4px hsla(0, 0%, 0%, 0.05);
-    border: 1px solid hsl(0, 0%, 87%);
-    border-radius: 4px;
-}
-
-.markdown img.inline {
-    height: 1.4em;
-    box-shadow: none;
-}
-
-.markdown img.emoji-small {
-    width: 20px;
-    box-shadow: none;
-    border: none;
-    vertical-align: sub;
-}
-
-.markdown img.emoji-big {
-    width: 25px;
-    box-shadow: none;
-    border: none;
-}
-
-.markdown .warn,
-.markdown .tip,
-.markdown .keyboard_tip {
-    position: relative;
-    display: block;
-    background-color: hsl(210, 22%, 96%);
-    border: 1px solid hsl(210, 22%, 90%);
-    border-radius: 4px;
-    padding: 10px;
-    margin: 5px 0px;
-}
-
-.markdown .tip,
-.markdown .keyboard_tip {
-    background-color: hsl(46, 63%, 95%);
-    border: 1px solid hsl(46, 63%, 84%);
-}
-
-.markdown .warn p,
-.markdown .tip p,
-.markdown .keyboard_tip p {
-    margin-bottom: 0;
-}
-
-.markdown .tip::before {
-    display: inline;
-    content: "\f0eb   Tip:  ";
-    font-family: FontAwesome, "Yantramanav", Source Sans Pro;
-    font-weight: 600;
-}
-
-.markdown .keyboard_tip::before {
-    display: inline;
-    content: "\f11c   Keyboard Shortcut:  ";
-    font-family: FontAwesome, "Yantramanav", Source Sans Pro;
-    font-weight: 600;
-}
-
-.markdown .tip p:first-of-type,
-.markdown .keyboard_tip p:first-of-type {
-    display: inline;
-}
-
-.markdown ol > li > div.keyboard_tip,
-.markdown ol > li > div.tip,
-.markdown ol > li > div.warn {
-    margin: 5px 25px 5px;
-}
-
-.markdown ol p {
-    margin: 0 0 2px;
-}
-
-.markdown .indicator {
-    position: relative;
-    display: inline-block;
-    top: 1px;
-    padding: 5px;
-    border-radius: 6px;
-}
-
-.markdown .indicator.grey {
-    border: 1px solid hsl(0, 0%, 80%);
-}
-
-.markdown .indicator.grey-line {
-    border: 1px solid hsl(0, 0%, 80%);
-    top: 2px;
-
-    &::after {
-        content: '';
-        background: hsl(0, 0%, 80%);
-        height: 1.5px;
-        width: 6px;
-        display: block;
-        margin: .5px -2px;
+    .code-section {
+        ol {
+            margin-left: 15px;
+            margin-top: 10px;
+        }
     }
-}
 
-.markdown .indicator.orange {
-    border: 1px solid hsl(29, 84%, 51%);
-    background: linear-gradient(to bottom, hsla(0, 0%, 100%, 0.0) 50%, hsla(29, 84%, 51%, 1.0) 50%);
-}
+    h1[id],
+    h2[id],
+    h3[id],
+    h4[id] {
+        &::before {
+            display: block;
+            content: " ";
+            visibility: hidden;
+        }
+    }
 
-.markdown .indicator.green {
-    border: 1px solid hsl(106, 74%, 44%);
-    background-color: hsla(106, 74%, 44%, 0.3);
-}
+    h2[id],
+    h3[id],
+    h4[id] {
+        &::before {
+            margin-top: -10px;
+            height: 10px;
+        }
+    }
 
-.markdown .indicator.green.solid {
-    background-color: hsl(106, 74%, 44%);
-}
+    h1 {
+        border-bottom: 1px solid hsl(0, 0%, 93%);
+        padding-bottom: 10px;
+        margin-bottom: 15px;
 
-.markdown ul {
-    margin: 0px 10px 15px 25px;
-}
+        &[id] {
+            &::before {
+                margin-top: -30px;
+                height: 30px;
+            }
+        }
+        &#using-zulip,
+        &#zulip-administration {
+            font-size: 1.75em;
+            padding: 10px 0;
+            margin-bottom: 0px;
+            line-height: 100%;
+        }
+    }
 
-.markdown ul li {
-    margin: 5px 0px;
-}
+    h2 {
+        font-size: 1.5em;
+        line-height: 1.25;
+        margin: 20px 0px 5px 0px;
+    }
 
-@media (max-width: 500px) {
+    h3 {
+        font-size: 1.25em;
+        line-height: 1.25;
+        opacity: 1;
+        margin-bottom: 7px;
+    }
 
-    .markdown {
+    h1,
+    h2,
+    h3 {
+        font-weight: 700;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+
+        &:hover {
+            cursor: pointer;
+
+            &::after {
+                display: inline-block;
+                font: normal normal normal 16px/1 FontAwesome;
+                text-rendering: auto;
+                -webkit-font-smoothing: antialiased;
+                -moz-osx-font-smoothing: grayscale;
+
+                cursor: pointer;
+                content: "\f0c1";
+                margin-left: 5px;
+                vertical-align: middle;
+            }
+        }
+    }
+
+
+    ul,
+    ol {
+        margin-left: 30px;
+    }
+
+    li {
+        line-height: 150%;
+    }
+
+    ol {
+        counter-reset: item;
+        list-style: none;
+
+        & > li {
+            counter-increment: item;
+            margin-bottom: 5px;
+
+            &::before {
+                content: counter(item);
+                display: inline-block;
+                vertical-align: top;
+                padding: 3px 6.5px 3px 7.5px;
+                margin-right: 5px;
+                background-color: hsl(170, 48%, 54%);
+                color: hsl(0, 0%, 100%);
+                border-radius: 100%;
+                font-size: 0.9em;
+                line-height: 1.1;
+                text-align: center;
+            }
+
+            & > p {
+                display: inline-block;
+                vertical-align: top;
+                max-width: calc(100% - 30px);
+                position: relative;
+                top: -2px;
+            }
+
+            & > .codehilite,
+            & > p:not(:first-child) {
+                padding-left: 24px;
+                margin-left: 5px;
+            }
+
+            & > ul {
+                padding-left: 20px;
+            }
+
+            .warn,
+            .tip,
+            .keyboard_tip {
+                margin: 5px 25px 5px;
+            }
+        }
+
+        p {
+            margin: 0 0 2px;
+        }
+
+        @media (max-width: 500px) {
+            margin-left: 0px;
+        }
+    }
+
+    ul {
+        margin: 0px 10px 15px 25px;
+
+        & > li {
+            margin: 5px 0px;
+
+            ::before {
+                content: none;
+            }
+        }
+    }
+
+    .content {
+        padding: 30px;
+        max-width: 768px;
+        background-color: hsl(0, 0%, 100%);
+
+        ol li p:not(:first-child) {
+            display: block;
+        }
+
+        @media (max-width: 500px) {
+            padding: 10px;
+        }
+    }
+
+    a {
+        color: hsl(176, 46%, 41%);
+        font-weight: 600;
+    }
+
+    strong {
+        font-weight: 600;
+    }
+
+    img {
+        vertical-align: top;
+        box-shadow: 0px 0px 4px hsla(0, 0%, 0%, 0.05);
+        border: 1px solid hsl(0, 0%, 87%);
+        border-radius: 4px;
+
+        &.inline {
+            height: 1.4em;
+            box-shadow: none;
+        }
+
+
+        &.emoji-small {
+            width: 20px;
+            box-shadow: none;
+            border: none;
+            vertical-align: sub;
+        }
+
+        &.emoji-big {
+            width: 25px;
+            box-shadow: none;
+            border: none;
+        }
+    }
+
+    .warn,
+    .tip,
+    .keyboard_tip {
+        position: relative;
+        display: block;
+        background-color: hsl(210, 22%, 96%);
+        border: 1px solid hsl(210, 22%, 90%);
+        border-radius: 4px;
+        padding: 10px;
+        margin: 5px 0px;
+
+        p {
+            margin-bottom: 0;
+        }
+    }
+
+    .tip,
+    .keyboard_tip {
+        background-color: hsl(46, 63%, 95%);
+        border: 1px solid hsl(46, 63%, 84%);
+
+        p:first-of-type {
+            display: inline;
+        }
+    }
+
+    .tip::before {
+        display: inline;
+        content: "\f0eb   Tip:  ";
+        font-family: FontAwesome, "Yantramanav", Source Sans Pro;
+        font-weight: 600;
+    }
+
+    .keyboard_tip::before {
+        display: inline;
+        content: "\f11c   Keyboard Shortcut:  ";
+        font-family: FontAwesome, "Yantramanav", Source Sans Pro;
+        font-weight: 600;
+    }
+
+    .indicator {
+        position: relative;
+        display: inline-block;
+        top: 1px;
+        padding: 5px;
+        border-radius: 6px;
+
+        &.grey {
+            border: 1px solid hsl(0, 0%, 80%);
+        }
+
+        &.grey-line {
+            border: 1px solid hsl(0, 0%, 80%);
+            top: 2px;
+
+            &::after {
+                content: '';
+                background: hsl(0, 0%, 80%);
+                height: 1.5px;
+                width: 6px;
+                display: block;
+                margin: .5px -2px;
+            }
+        }
+
+        &.orange {
+            border: 1px solid hsl(29, 84%, 51%);
+            background: linear-gradient(to bottom, hsla(0, 0%, 100%, 0.0) 50%, hsla(29, 84%, 51%, 1.0) 50%);
+        }
+
+        &.green {
+            border: 1px solid hsl(106, 74%, 44%);
+            background-color: hsla(106, 74%, 44%, 0.3);
+        }
+
+        &.green.solid {
+            background-color: hsl(106, 74%, 44%);
+        }
+    }
+
+    @media (max-width: 500px) {
         height: calc(100vh - 39px);
         width: 100%;
     }
+}
 
-    .markdown .content {
-        padding: 10px;
-    }
-
-    .markdown ol {
-        margin-left: 0px;
-    }
+li div.codehilite {
+    background-color: hsl(0, 0%, 100%);
 }

--- a/static/styles/portico/markdown.scss
+++ b/static/styles/portico/markdown.scss
@@ -1,0 +1,315 @@
+.markdown .code-section ol {
+    margin-left: 15px;
+    margin-top: 10px;
+}
+
+.markdown h1[id]::before,
+.markdown h2[id]::before,
+.markdown h3[id]::before,
+.markdown h4[id]::before {
+    display: block;
+    content: " ";
+    visibility: hidden;
+}
+
+.markdown h1[id]::before {
+    margin-top: -30px;
+    height: 30px;
+}
+
+.markdown h2[id]::before,
+.markdown h3[id]::before,
+.markdown h4[id]::before {
+    margin-top: -10px;
+    height: 10px;
+}
+
+.markdown ul,
+.markdown ol {
+    margin-left: 30px;
+}
+
+.markdown li {
+    line-height: 150%;
+}
+
+.markdown ol {
+    counter-reset: item;
+    list-style: none;
+}
+
+.markdown ol > li {
+    counter-increment: item;
+    margin-bottom: 5px;
+}
+
+.markdown ol > li::before {
+    content: counter(item);
+    display: inline-block;
+    vertical-align: top;
+    padding: 3px 6.5px 3px 7.5px;
+    margin-right: 5px;
+    background-color: hsl(170, 48%, 54%);
+    color: hsl(0, 0%, 100%);
+    border-radius: 100%;
+    font-size: 0.9em;
+    line-height: 1.1;
+    text-align: center;
+}
+
+.markdown ol > li > p {
+    display: inline-block;
+    vertical-align: top;
+    max-width: calc(100% - 30px);
+    position: relative;
+    top: -2px;
+}
+
+ol > li > div.codehilite,
+.markdown ol > li > p:not(:first-child) {
+    padding-left: 24px;
+    margin-left: 5px;
+}
+
+li div.codehilite {
+    background-color: hsl(0, 0%, 100%);
+}
+
+.markdown .content ol li p:not(:first-child) {
+    display: block;
+}
+.markdown ol > li > ul {
+    padding-left: 20px;
+}
+
+.markdown ul > li::before {
+    content: none;
+}
+
+.markdown {
+    font-weight: 400;
+    font-size: 1rem;
+    line-height: 1.5;
+    overflow: auto;
+    -webkit-font-smoothing: antialiased;
+}
+
+.markdown .content {
+    padding: 30px;
+    max-width: 768px;
+    background-color: hsl(0, 0%, 100%);
+}
+
+.markdown a {
+    color: hsl(176, 46%, 41%);
+    font-weight: 600;
+}
+
+.markdown strong {
+    font-weight: 600;
+}
+
+.markdown h1,
+.markdown h2,
+.markdown h3 {
+    font-weight: 700;
+}
+
+.markdown h1,
+.markdown h2,
+.markdown h3 {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+.markdown h1:hover,
+.markdown h2:hover,
+.markdown h3:hover {
+    cursor: pointer;
+}
+
+.markdown h1:hover::after,
+.markdown h2:hover::after,
+.markdown h3:hover::after {
+    display: inline-block;
+    font: normal normal normal 16px/1 FontAwesome;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+
+    cursor: pointer;
+    content: "\f0c1";
+    margin-left: 5px;
+    vertical-align: middle;
+}
+
+.markdown h1 {
+    border-bottom: 1px solid hsl(0, 0%, 93%);
+    padding-bottom: 10px;
+    margin-bottom: 15px;
+}
+
+.markdown h1#using-zulip,
+.markdown h1#zulip-administration {
+    font-size: 1.75em;
+    padding: 10px 0;
+    margin-bottom: 0px;
+    line-height: 100%;
+}
+
+.markdown h2 {
+    font-size: 1.5em;
+    line-height: 1.25;
+    margin: 20px 0px 5px 0px;
+}
+
+.markdown h3 {
+    font-size: 1.25em;
+    line-height: 1.25;
+    opacity: 1;
+    margin-bottom: 7px;
+}
+
+.markdown img {
+    vertical-align: top;
+    box-shadow: 0px 0px 4px hsla(0, 0%, 0%, 0.05);
+    border: 1px solid hsl(0, 0%, 87%);
+    border-radius: 4px;
+}
+
+.markdown img.inline {
+    height: 1.4em;
+    box-shadow: none;
+}
+
+.markdown img.emoji-small {
+    width: 20px;
+    box-shadow: none;
+    border: none;
+    vertical-align: sub;
+}
+
+.markdown img.emoji-big {
+    width: 25px;
+    box-shadow: none;
+    border: none;
+}
+
+.markdown .warn,
+.markdown .tip,
+.markdown .keyboard_tip {
+    position: relative;
+    display: block;
+    background-color: hsl(210, 22%, 96%);
+    border: 1px solid hsl(210, 22%, 90%);
+    border-radius: 4px;
+    padding: 10px;
+    margin: 5px 0px;
+}
+
+.markdown .tip,
+.markdown .keyboard_tip {
+    background-color: hsl(46, 63%, 95%);
+    border: 1px solid hsl(46, 63%, 84%);
+}
+
+.markdown .warn p,
+.markdown .tip p,
+.markdown .keyboard_tip p {
+    margin-bottom: 0;
+}
+
+.markdown .tip::before {
+    display: inline;
+    content: "\f0eb   Tip:  ";
+    font-family: FontAwesome, "Yantramanav", Source Sans Pro;
+    font-weight: 600;
+}
+
+.markdown .keyboard_tip::before {
+    display: inline;
+    content: "\f11c   Keyboard Shortcut:  ";
+    font-family: FontAwesome, "Yantramanav", Source Sans Pro;
+    font-weight: 600;
+}
+
+.markdown .tip p:first-of-type,
+.markdown .keyboard_tip p:first-of-type {
+    display: inline;
+}
+
+.markdown ol > li > div.keyboard_tip,
+.markdown ol > li > div.tip,
+.markdown ol > li > div.warn {
+    margin: 5px 25px 5px;
+}
+
+.markdown ol p {
+    margin: 0 0 2px;
+}
+
+.markdown .indicator {
+    position: relative;
+    display: inline-block;
+    top: 1px;
+    padding: 5px;
+    border-radius: 6px;
+}
+
+.markdown .indicator.grey {
+    border: 1px solid hsl(0, 0%, 80%);
+}
+
+.markdown .indicator.grey-line {
+    border: 1px solid hsl(0, 0%, 80%);
+    top: 2px;
+
+    &::after {
+        content: '';
+        background: hsl(0, 0%, 80%);
+        height: 1.5px;
+        width: 6px;
+        display: block;
+        margin: .5px -2px;
+    }
+}
+
+.markdown .indicator.orange {
+    border: 1px solid hsl(29, 84%, 51%);
+    background: linear-gradient(to bottom, hsla(0, 0%, 100%, 0.0) 50%, hsla(29, 84%, 51%, 1.0) 50%);
+}
+
+.markdown .indicator.green {
+    border: 1px solid hsl(106, 74%, 44%);
+    background-color: hsla(106, 74%, 44%, 0.3);
+}
+
+.markdown .indicator.green.solid {
+    background-color: hsl(106, 74%, 44%);
+}
+
+.markdown ul {
+    margin: 0px 10px 15px 25px;
+}
+
+.markdown ul li {
+    margin: 5px 0px;
+}
+
+@media (max-width: 500px) {
+
+    .markdown {
+        height: calc(100vh - 39px);
+        width: 100%;
+    }
+
+    .markdown .content {
+        padding: 10px;
+    }
+
+    .markdown ol {
+        margin-left: 0px;
+    }
+}

--- a/static/styles/portico/markdown.scss
+++ b/static/styles/portico/markdown.scss
@@ -298,11 +298,6 @@
             background-color: hsl(106, 74%, 44%);
         }
     }
-
-    @media (max-width: 500px) {
-        height: calc(100vh - 39px);
-        width: 100%;
-    }
 }
 
 li div.codehilite {

--- a/static/styles/portico/portico-styles.scss
+++ b/static/styles/portico/portico-styles.scss
@@ -1,3 +1,4 @@
 @import "../components";
 @import "portico";
 @import "portico-signin";
+@import "markdown";

--- a/static/styles/portico/portico.scss
+++ b/static/styles/portico/portico.scss
@@ -1570,6 +1570,10 @@ input.new-organization-button {
         top: 50px;
     }
 
+    .help .markdown {
+        height: calc(100vh - 39px);
+    }
+
     .error_page .lead {
         font-size: 1.5em;
         margin-bottom: 10px;

--- a/static/styles/portico/portico.scss
+++ b/static/styles/portico/portico.scss
@@ -34,12 +34,6 @@ body {
     font-weight: normal;
 }
 
-.why-page h3.normal {
-    font-size: 1.2em;
-    margin-top: 20px;
-    margin-bottom: 5px;
-}
-
 .navbar {
     margin-bottom: 0px;
 }
@@ -1498,10 +1492,7 @@ input.new-organization-button {
 
 .markdown h1,
 .markdown h2,
-.markdown h3,
-.why-page h1,
-.why-page h2,
-.why-page h3 {
+.markdown h3 {
     font-weight: 700;
 }
 
@@ -1535,8 +1526,7 @@ input.new-organization-button {
     vertical-align: middle;
 }
 
-.markdown h1,
-.why-page .main h1 {
+.markdown h1 {
     border-bottom: 1px solid hsl(0, 0%, 93%);
     padding-bottom: 10px;
     margin-bottom: 15px;
@@ -1550,15 +1540,13 @@ input.new-organization-button {
     line-height: 100%;
 }
 
-.markdown h2,
-.why-page h2 {
+.markdown h2 {
     font-size: 1.5em;
     line-height: 1.25;
     margin: 20px 0px 5px 0px;
 }
 
-.markdown h3,
-.why-page h3 {
+.markdown h3 {
     font-size: 1.25em;
     line-height: 1.25;
     opacity: 1;

--- a/static/styles/portico/portico.scss
+++ b/static/styles/portico/portico.scss
@@ -355,14 +355,12 @@ body {
     list-style: none;
 }
 
-.markdown ol > li,
-.portico-landing.integrations ol > li {
+.markdown ol > li {
     counter-increment: item;
     margin-bottom: 5px;
 }
 
-.markdown ol > li::before,
-.portico-landing.integrations ol > li::before {
+.markdown ol > li::before {
     content: counter(item);
     display: inline-block;
     vertical-align: top;
@@ -376,19 +374,12 @@ body {
     text-align: center;
 }
 
-.markdown ol > li > p,
-.portico-landing.integrations ol > li > p {
+.markdown ol > li > p {
     display: inline-block;
     vertical-align: top;
     max-width: calc(100% - 30px);
     position: relative;
     top: -2px;
-}
-
-/* TODO: Clean up this override */
-.portico-landing.integrations ol > li > p {
-    max-width: calc(100% - 33px) !important;
-    margin-top: 0px !important;
 }
 
 .help-center ol,
@@ -397,24 +388,17 @@ body {
 }
 
 ol > li > div.codehilite,
-.markdown ol > li > p:not(:first-child),
-.portico-landing.integrations ol > li > p:not(:first-child) {
+.markdown ol > li > p:not(:first-child) {
     padding-left: 24px;
     margin-left: 5px;
 }
 
-.markdown .content ol li p:not(:first-child),
-.integration-instructions .help-content ol li p:not(:first-child) {
+.markdown .content ol li p:not(:first-child) {
     display: block;
 }
 
 li div.codehilite {
     background-color: hsl(0, 0%, 100%);
-}
-
-.portico-landing.integrations ol ul {
-    padding-left: 40px;
-    margin-left: 5px;
 }
 
 .markdown ol > li > ul {
@@ -423,10 +407,6 @@ li div.codehilite {
 
 .markdown ul > li::before {
     content: none;
-}
-
-#hubot-integrations {
-    margin-top: 30px;
 }
 
 .title {
@@ -1578,7 +1558,6 @@ input.new-organization-button {
     border: none;
 }
 
-.integration-instructions .tip,
 .markdown .warn,
 .markdown .tip,
 .markdown .keyboard_tip {
@@ -1591,7 +1570,6 @@ input.new-organization-button {
     margin: 5px 0px;
 }
 
-.integration-instructions .tip,
 .markdown .tip,
 .markdown .keyboard_tip {
     background-color: hsl(46, 63%, 95%);
@@ -1604,7 +1582,6 @@ input.new-organization-button {
     margin-bottom: 0;
 }
 
-.integration-instructions .tip::before,
 .markdown .tip::before {
     display: inline;
     content: "\f0eb   Tip:  ";
@@ -1619,14 +1596,9 @@ input.new-organization-button {
     font-weight: 600;
 }
 
-.integration-instructions .tip p:first-of-type,
 .markdown .tip p:first-of-type,
 .markdown .keyboard_tip p:first-of-type {
     display: inline;
-}
-
-.integration-instructions .help-content h3 {
-    margin: 20px 0;
 }
 
 .markdown ol > li > div.keyboard_tip,

--- a/static/styles/portico/portico.scss
+++ b/static/styles/portico/portico.scss
@@ -152,11 +152,6 @@ body {
     display: block;
 }
 
-.markdown .code-section ol {
-    margin-left: 15px;
-    margin-top: 10px;
-}
-
 .digest-container {
     padding-top: 100px;
 }
@@ -320,93 +315,9 @@ body {
     display: none;
 }
 
-.markdown h1[id]::before,
-.markdown h2[id]::before,
-.markdown h3[id]::before,
-.markdown h4[id]::before {
-    display: block;
-    content: " ";
-    visibility: hidden;
-}
-
-.markdown h1[id]::before {
-    margin-top: -30px;
-    height: 30px;
-}
-
-.markdown h2[id]::before,
-.markdown h3[id]::before,
-.markdown h4[id]::before {
-    margin-top: -10px;
-    height: 10px;
-}
-
-.markdown ul,
-.markdown ol {
-    margin-left: 30px;
-}
-
-.markdown li {
-    line-height: 150%;
-}
-
-.markdown ol {
-    counter-reset: item;
-    list-style: none;
-}
-
-.markdown ol > li {
-    counter-increment: item;
-    margin-bottom: 5px;
-}
-
-.markdown ol > li::before {
-    content: counter(item);
-    display: inline-block;
-    vertical-align: top;
-    padding: 3px 6.5px 3px 7.5px;
-    margin-right: 5px;
-    background-color: hsl(170, 48%, 54%);
-    color: hsl(0, 0%, 100%);
-    border-radius: 100%;
-    font-size: 0.9em;
-    line-height: 1.1;
-    text-align: center;
-}
-
-.markdown ol > li > p {
-    display: inline-block;
-    vertical-align: top;
-    max-width: calc(100% - 30px);
-    position: relative;
-    top: -2px;
-}
-
 .help-center ol,
 .portico-landing.integrations ol {
     margin-left: 0;
-}
-
-ol > li > div.codehilite,
-.markdown ol > li > p:not(:first-child) {
-    padding-left: 24px;
-    margin-left: 5px;
-}
-
-.markdown .content ol li p:not(:first-child) {
-    display: block;
-}
-
-li div.codehilite {
-    background-color: hsl(0, 0%, 100%);
-}
-
-.markdown ol > li > ul {
-    padding-left: 20px;
-}
-
-.markdown ul > li::before {
-    content: none;
 }
 
 .title {
@@ -1440,223 +1351,10 @@ input.new-organization-button {
     font-weight: 300;
 }
 
-/* -- markdown styling -- */
-.markdown {
-    font-weight: 400;
-    font-size: 1rem;
-    line-height: 1.5;
-    overflow: auto;
-    -webkit-font-smoothing: antialiased;
-}
-
 .help .markdown {
     background-color: hsl(0, 0%, 100%);
     width: calc(100vw - 300px);
     height: calc(100vh - 59px);
-}
-
-.markdown .content {
-    padding: 30px;
-    max-width: 768px;
-    background-color: hsl(0, 0%, 100%);
-}
-
-.markdown a {
-    color: hsl(176, 46%, 41%);
-    font-weight: 600;
-}
-
-.markdown strong {
-    font-weight: 600;
-}
-
-.markdown h1,
-.markdown h2,
-.markdown h3 {
-    font-weight: 700;
-}
-
-.markdown h1,
-.markdown h2,
-.markdown h3 {
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-}
-
-.markdown h1:hover,
-.markdown h2:hover,
-.markdown h3:hover {
-    cursor: pointer;
-}
-
-.markdown h1:hover::after,
-.markdown h2:hover::after,
-.markdown h3:hover::after {
-    display: inline-block;
-    font: normal normal normal 16px/1 FontAwesome;
-    text-rendering: auto;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-
-    cursor: pointer;
-    content: "\f0c1";
-    margin-left: 5px;
-    vertical-align: middle;
-}
-
-.markdown h1 {
-    border-bottom: 1px solid hsl(0, 0%, 93%);
-    padding-bottom: 10px;
-    margin-bottom: 15px;
-}
-
-.markdown h1#using-zulip,
-.markdown h1#zulip-administration {
-    font-size: 1.75em;
-    padding: 10px 0;
-    margin-bottom: 0px;
-    line-height: 100%;
-}
-
-.markdown h2 {
-    font-size: 1.5em;
-    line-height: 1.25;
-    margin: 20px 0px 5px 0px;
-}
-
-.markdown h3 {
-    font-size: 1.25em;
-    line-height: 1.25;
-    opacity: 1;
-    margin-bottom: 7px;
-}
-
-.markdown img {
-    vertical-align: top;
-    box-shadow: 0px 0px 4px hsla(0, 0%, 0%, 0.05);
-    border: 1px solid hsl(0, 0%, 87%);
-    border-radius: 4px;
-}
-
-.markdown img.inline {
-    height: 1.4em;
-    box-shadow: none;
-}
-
-.markdown img.emoji-small {
-    width: 20px;
-    box-shadow: none;
-    border: none;
-    vertical-align: sub;
-}
-
-.markdown img.emoji-big {
-    width: 25px;
-    box-shadow: none;
-    border: none;
-}
-
-.markdown .warn,
-.markdown .tip,
-.markdown .keyboard_tip {
-    position: relative;
-    display: block;
-    background-color: hsl(210, 22%, 96%);
-    border: 1px solid hsl(210, 22%, 90%);
-    border-radius: 4px;
-    padding: 10px;
-    margin: 5px 0px;
-}
-
-.markdown .tip,
-.markdown .keyboard_tip {
-    background-color: hsl(46, 63%, 95%);
-    border: 1px solid hsl(46, 63%, 84%);
-}
-
-.markdown .warn p,
-.markdown .tip p,
-.markdown .keyboard_tip p {
-    margin-bottom: 0;
-}
-
-.markdown .tip::before {
-    display: inline;
-    content: "\f0eb   Tip:  ";
-    font-family: FontAwesome, "Yantramanav", Source Sans Pro;
-    font-weight: 600;
-}
-
-.markdown .keyboard_tip::before {
-    display: inline;
-    content: "\f11c   Keyboard Shortcut:  ";
-    font-family: FontAwesome, "Yantramanav", Source Sans Pro;
-    font-weight: 600;
-}
-
-.markdown .tip p:first-of-type,
-.markdown .keyboard_tip p:first-of-type {
-    display: inline;
-}
-
-.markdown ol > li > div.keyboard_tip,
-.markdown ol > li > div.tip,
-.markdown ol > li > div.warn {
-    margin: 5px 25px 5px;
-}
-
-.markdown ol p {
-    margin: 0 0 2px;
-}
-
-.markdown .indicator {
-    position: relative;
-    display: inline-block;
-    top: 1px;
-    padding: 5px;
-    border-radius: 6px;
-}
-
-.markdown .indicator.grey {
-    border: 1px solid hsl(0, 0%, 80%);
-}
-
-.markdown .indicator.grey-line {
-    border: 1px solid hsl(0, 0%, 80%);
-    top: 2px;
-
-    &::after {
-        content: '';
-        background: hsl(0, 0%, 80%);
-        height: 1.5px;
-        width: 6px;
-        display: block;
-        margin: .5px -2px;
-    }
-}
-
-.markdown .indicator.orange {
-    border: 1px solid hsl(29, 84%, 51%);
-    background: linear-gradient(to bottom, hsla(0, 0%, 100%, 0.0) 50%, hsla(29, 84%, 51%, 1.0) 50%);
-}
-
-.markdown .indicator.green {
-    border: 1px solid hsl(106, 74%, 44%);
-    background-color: hsla(106, 74%, 44%, 0.3);
-}
-
-.markdown .indicator.green.solid {
-    background-color: hsl(106, 74%, 44%);
-}
-
-.markdown ul {
-    margin: 0px 10px 15px 25px;
-}
-
-.markdown ul li {
-    margin: 5px 0px;
 }
 
 .error_page {
@@ -1877,15 +1575,6 @@ input.new-organization-button {
         margin-bottom: 10px;
     }
 
-    .markdown {
-        height: calc(100vh - 39px);
-        width: 100%;
-    }
-
-    .markdown .content {
-        padding: 10px;
-    }
-
     .brand.logo .light {
         display: none;
     }
@@ -1901,10 +1590,6 @@ input.new-organization-button {
     .header-main {
         max-width: 100vw;
         padding: 0 10px;
-    }
-
-    .markdown ol {
-        margin-left: 0px;
     }
 
     .main-headline-text .tagline {

--- a/static/styles/portico/portico.scss
+++ b/static/styles/portico/portico.scss
@@ -87,45 +87,6 @@ body {
     -moz-osx-font-smoothing: grayscale;
 }
 
-.code-section ul.nav {
-    margin: 0;
-}
-
-.code-section ul.nav li {
-    display: inline-block;
-    padding: 5px 14px;
-    margin: 0;
-
-    cursor: pointer;
-}
-
-.code-section ul.nav li.active {
-    color: hsl(176, 46%, 41%);
-    margin-bottom: -1px;
-
-    border: 1px solid hsl(0, 0%, 87%);
-    border-bottom: 1px solid hsl(0, 0%, 100%);
-    border-radius: 4px 4px 0px 0px;
-}
-
-.code-section.no-tabs ul.nav {
-    display: none;
-}
-
-.code-section .blocks {
-    padding: 10px;
-    margin-bottom: 10px;
-    border: 1px solid hsl(0, 0%, 87%);
-}
-
-.code-section.has-tabs .blocks {
-    border-radius: 0px 6px 6px 6px;
-}
-
-.code-section.no-tabs .blocks {
-    border-radius: 6px;
-}
-
 /* The API tabbed content tends to have a lot of code blocks,
    which look nicer against a different background */
 .api-center .code-section .blocks {
@@ -141,15 +102,6 @@ body {
    We also want the Help Center tabbed content to pop more. */
 .help-center .code-section .blocks {
     max-width: 500px;
-}
-
-.code-section .blocks > div {
-    display: none;
-}
-
-.code-section.no-tabs .blocks > div,
-.code-section.has-tabs .blocks > .active {
-    display: block;
 }
 
 .digest-container {

--- a/templates/corporate/jobs.html
+++ b/templates/corporate/jobs.html
@@ -24,7 +24,7 @@
 
     <div class="open-positions-top">
         <div class="main">
-            <div class="padded-content">
+            <div class="padded-content markdown">
                 <h1>Open positions</h1>
                 <p>
                     <ul>
@@ -38,7 +38,7 @@
 
     <div class="how-we-work">
         <div class="main">
-            <div class="padded-content">
+            <div class="padded-content markdown">
                 <h1>How we work</h1>
                 <p>
                     <strong>Open source.</strong>  The Zulip software is 100% free and
@@ -80,7 +80,7 @@
 
     <div class="what-were-building">
         <div class="main">
-            <div class="padded-content">
+            <div class="padded-content markdown">
                 <h1>What we're building</h1>
                 <p>
                     People working together need to communicate with their teammates, and they
@@ -105,7 +105,7 @@
 
     <div class="open-positions">
         <div class="main">
-            <div class="padded-content">
+            <div class="padded-content markdown">
                 <h1>Open positions</h1>
 
                 <h2 id="mobile">Senior Mobile Engineer</h2>

--- a/templates/corporate/zephyr.html
+++ b/templates/corporate/zephyr.html
@@ -18,7 +18,7 @@
     </div>
     <div class="main">
         <div class="padded-content">
-            <div class="inner-content">
+            <div class="inner-content markdown">
                 <p>If you have an MIT Athena account, you can start using Zulip for Zephyr in a couple of minutes.</p>
 
                 <h2>First time setup</h2>

--- a/templates/zerver/atlassian.html
+++ b/templates/zerver/atlassian.html
@@ -25,7 +25,7 @@
 
     <div class="main">
         <div class="padded-content">
-            <div class="inner-content">
+            <div class="inner-content markdown">
                 {{ render_markdown_path('zerver/atlassian.md') }}
             </div>
         </div>

--- a/templates/zerver/for-companies.html
+++ b/templates/zerver/for-companies.html
@@ -21,7 +21,7 @@
     </div>
     <div class="main">
         <div class="padded-content">
-            <div class="inner-content">
+            <div class="inner-content markdown">
                 {{ render_markdown_path('zerver/for/companies.md') }}
             </div>
         </div>

--- a/templates/zerver/for-mystery-hunt.html
+++ b/templates/zerver/for-mystery-hunt.html
@@ -25,7 +25,7 @@
 
     <div class="main">
         <div class="padded-content">
-            <div class="inner-content">
+            <div class="inner-content markdown">
                 {{ render_markdown_path('zerver/for/mystery-hunt.md') }}
             </div>
         </div>

--- a/templates/zerver/for-open-source.html
+++ b/templates/zerver/for-open-source.html
@@ -23,7 +23,7 @@
     </div>
     <div class="main">
         <div class="padded-content">
-            <div class="inner-content">
+            <div class="inner-content markdown">
                 {{ render_markdown_path('zerver/for/open-source.md') }}
             </div>
         </div>

--- a/templates/zerver/for-working-groups-and-communities.html
+++ b/templates/zerver/for-working-groups-and-communities.html
@@ -21,7 +21,7 @@
     </div>
     <div class="main">
         <div class="padded-content">
-            <div class="inner-content">
+            <div class="inner-content markdown">
                 {{ render_markdown_path('zerver/for/working-groups-and-communities.md') }}
             </div>
         </div>

--- a/templates/zerver/history.html
+++ b/templates/zerver/history.html
@@ -23,7 +23,7 @@
     </div>
     <div class="main">
         <div class="padded-content">
-            <div class="inner-content history">
+            <div class="inner-content history markdown">
                 <div class="photo-description">
                     Zulip at the PyCon Sprints in Portland, Oregon.
                     Over seventy-five people sprinted during the four day event.

--- a/templates/zerver/history.html
+++ b/templates/zerver/history.html
@@ -23,12 +23,11 @@
     </div>
     <div class="main">
         <div class="padded-content">
+            <div class="photo-description">
+                Zulip at the PyCon Sprints in Portland, Oregon.
+                Over seventy-five people sprinted during the four day event.
+            </div>
             <div class="inner-content history markdown">
-                <div class="photo-description">
-                    Zulip at the PyCon Sprints in Portland, Oregon.
-                    Over seventy-five people sprinted during the four day event.
-                </div>
-
                 <h1>Early history</h1>
 
                 <p>

--- a/templates/zerver/integrations/index.html
+++ b/templates/zerver/integrations/index.html
@@ -15,7 +15,7 @@
 <div class="portico-landing integrations">
     <div class="main">
         <div class="padded-content">
-            <div class="inner-content">
+            <div class="inner-content markdown">
 
                 <div id="integration-main-text">
                     <header>

--- a/templates/zerver/privacy.html
+++ b/templates/zerver/privacy.html
@@ -19,7 +19,7 @@
     </div>
     <div class="main">
         <div class="padded-content">
-            <div class="inner-content">
+            <div class="inner-content markdown">
                 {% if privacy_policy %}
                     {{ render_markdown_path(privacy_policy, pure_markdown=True) }}
                 {% else %}

--- a/templates/zerver/security.html
+++ b/templates/zerver/security.html
@@ -25,7 +25,7 @@
 
     <div class="main">
         <div class="padded-content">
-            <div class="inner-content">
+            <div class="inner-content markdown">
                 {{ render_markdown_path('zerver/security.md') }}
             </div>
         </div>

--- a/templates/zerver/team.html
+++ b/templates/zerver/team.html
@@ -26,7 +26,7 @@
     </div>
 
     <div class="main">
-        <div class="padded-content">
+        <div class="padded-content markdown">
             <div class="team">
                 <p>
                     Over 500 people have contributed to the Zulip

--- a/templates/zerver/terms.html
+++ b/templates/zerver/terms.html
@@ -18,7 +18,7 @@
     </div>
     <div class="main">
         <div class="padded-content">
-            <div class="inner-content">
+            <div class="inner-content markdown">
                 {% if terms_of_service %}
                     {{ render_markdown_path(terms_of_service, pure_markdown=True) }}
                 {% else %}

--- a/templates/zerver/why-zulip.html
+++ b/templates/zerver/why-zulip.html
@@ -28,7 +28,7 @@
 
     <div class="main">
         <div class="padded-content">
-            <div class="inner-content">
+            <div class="inner-content markdown">
                 {{ render_markdown_path('zerver/why-zulip.md') }}
             </div>
         </div>


### PR DESCRIPTION
Fixes part of: https://github.com/zulip/zulip/issues/12566
* added the `.markdown` class to the pages from `why-zulip` cluster
* removed the border and box-shadow from the `img` that were added by the `.markdown` class
* removed duplicated `why-page` selectors

* added the `.markdown` class to the `integrations` page so I can deduplicate this kind of selectors: 

```
.markdown ol > li::before,
.portico-landing.integrations ol > li::before { 
```
* removed duplicated `integrations` selectors and fixed styling that was broken when I added the `markdown` class

* moved the markdown CSS to a separate file
* refactored `markdown.scss` to use SCSS nesting
* removed selectors from `why-page` that were overwritten by markdown styling
* changed the `font-size` of the markdown text 
  * here I think it looks good with `1.1rem`; it is a little bigger for `/help` and a little smaller for `why Zulip` than the current version.

**TO DO**
* move CSS of `why-page`s in a separate file (`why-pages.scss`?)
* refactor `why-pages.scss` to use SCSS nesting
* refactor `integrations.scss` to use SCSS nesting ?

**Note:**
I still have some work to do here and some testing. 