### PR TITLE
compose: Update placeholder text depending on the narrow.

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -1074,6 +1074,16 @@ exports.initialize = function () {
         })
     );
 
+    $("#compose-textarea").focus(function () {
+        var opts = {
+            message_type: compose_state.get_message_type(),
+            stream: $('#stream_message_recipient_stream').val(),
+            topic: $('#stream_message_recipient_topic').val(),
+            private_message_recipient: compose_pm_pill.get_emails(),
+        };
+        compose_actions.update_placeholder_text(opts);
+    });
+
     if (page_params.narrow !== undefined) {
         if (page_params.narrow_topic !== undefined) {
             compose_actions.start("stream", {topic: page_params.narrow_topic});

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -131,6 +131,7 @@ exports.complete_starting_tasks = function (msg_type, opts) {
     exports.decorate_stream_bar(opts.stream);
     $(document).trigger($.Event('compose_started.zulip', opts));
     resize.resize_bottom_whitespace();
+    exports.update_placeholder_text(opts);
 };
 
 // In an attempt to decrease mixing, make the composebox's
@@ -195,6 +196,11 @@ function same_recipient_as_before(msg_type, opts) {
              msg_type === "private" &&
               opts.private_message_recipient === compose_state.recipient());
 }
+
+exports.update_placeholder_text = function (opts) {
+    var placeholder_text = compose_ui.compute_placeholder_text(opts);
+    $('#compose-textarea').attr('placeholder', placeholder_text);
+};
 
 exports.start = function (msg_type, opts) {
     exports.autosize_message_content();

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -76,6 +76,60 @@ exports.replace_syntax = function (old_syntax, new_syntax, textarea) {
     }));
 };
 
+exports.compute_placeholder_text = function (opts) {
+    if (opts.message_type === 'stream') {
+        if (opts.topic) {
+            return i18n.t("Message #__stream_name__ > __topic_name__",
+                          {stream_name: opts.stream,
+                           topic_name: opts.topic});
+        } else if (opts.stream) {
+            return i18n.t("Message #__stream_name__", {stream_name: opts.stream});
+        }
+    }
+
+    // For Private Messages
+    if (opts.private_message_recipient) {
+        var recipient_list = opts.private_message_recipient.split(",");
+
+        if (recipient_list.length > 1) {
+            var recipient_names = [];
+            var num_users = 0;
+            var recipients = '';
+
+            recipient_list.forEach(recipient => {
+                var user = people.get_by_email(recipient);
+                recipient_names[num_users] = user.full_name;
+                num_users = num_users + 1;
+            });
+
+            recipient_names.forEach(recipient_name => {
+                num_users = num_users - 1;
+                if (num_users > 0) {
+                    recipients += recipient_name + ", ";
+                } else {
+                    recipients += recipient_name;
+                }
+            });
+            return i18n.t("Message __recipient__",
+                          {recipient: recipients});
+        }
+
+        // Individual PMs
+        var user = people.get_by_email(recipient_list[0]);
+        var recipient_name = user.full_name;
+        var status = user_status.get_status_text(user.user_id);
+
+        if (status) {
+            return i18n.t("Message __recipient_name__ (__recipient_status__)",
+                          {recipient_name: recipient_name,
+                           recipient_status: status});
+        }
+        return i18n.t("Message __recipient_name__",
+                      {recipient_name: recipient_name});
+    }
+    return i18n.t("Compose your message here");
+};
+
 return exports;
 
 }());


### PR DESCRIPTION
Change the `compose-textarea` placeholder text depending on the stream/topic or PM recipients that the message will be sent to.

Resolves #12834.

**GIFs or Screenshots:**
Stream:
![Stream](https://user-images.githubusercontent.com/25329595/61736786-80e14700-ada4-11e9-992a-84bc6f689a50.png)

Individual PM:
![pm_individual](https://user-images.githubusercontent.com/25329595/61736799-85a5fb00-ada4-11e9-94b2-c2669e6faabf.png)

Group PM:
![PM_group](https://user-images.githubusercontent.com/25329595/61736793-8474ce00-ada4-11e9-9e09-28194651ef1c.png)

----------------------------------------------------------------
New topic button:
![New_topic_button_text](https://user-images.githubusercontent.com/25329595/61736860-a79f7d80-ada4-11e9-99b8-72b1f62a1b01.gif)

New private message button:
![New_pm_text](https://user-images.githubusercontent.com/25329595/61736867-aa9a6e00-ada4-11e9-86b1-240e1ff9455f.gif)

