### PR TITLE
email_gateway: Use html2text directly.

### DIFF
--- a/zerver/webhooks/freshdesk/tests.py
+++ b/zerver/webhooks/freshdesk/tests.py
@@ -114,7 +114,7 @@ Requester Bob <requester-bob@example.com> added a {} note to \
         """
         expected_topic = u"#12: Not enough ☃ guinea pigs"
         expected_message = """
-Requester \u2603 Bob <requester-bob@example.com> created [ticket #12](http://test1234zzz.freshdesk.com/helpdesk/tickets/12):\n\n``` quote\nThere are too many cat pictures on the internet \u2603. We need more guinea pigs. Exhibit 1:\n\n  \n\n\n[guinea_pig.png](http://cdn.freshdesk.com/data/helpdesk/attachments/production/12744808/original/guinea_pig.png)\n```\n\n* **Type**: Problem\n* **Priority**: Urgent\n* **Status**: Open
+Requester \u2603 Bob <requester-bob@example.com> created [ticket #12](http://test1234zzz.freshdesk.com/helpdesk/tickets/12):\n\n``` quote\nThere are too many cat pictures on the internet \u2603. We need more guinea pigs.\nExhibit 1:\n\n  \n\n[guinea_pig.png](http://cdn.freshdesk.com/data/helpdesk/attachments/production/12744808/original/guinea_pig.png)\n```\n\n* **Type**: Problem\n* **Priority**: Urgent\n* **Status**: Open
 """.strip()
         self.api_stream_message(self.TEST_USER_EMAIL, "inline_images", expected_topic, expected_message,
                                 content_type="application/x-www-form-urlencoded")


### PR DESCRIPTION
In the rare case that Zulip receives an email with only an HTML
format, we originally (code dating to 2013) shelled out to
html2markdown/python-html2text in order to convert the HTML into
markdown.

We long since added html2text as a reasonably managed Python
dependency of Zulip; we should just use it here.

@mateuszmandera this is primarily an email gateway piece of code; can you review?

@andersk FYI as well.

One thing I'm a little suspicious of is that the output for 

`test-backend zerver.tests.test_email_mirror.TestReplyExtraction.test_reply_is_extracted_from_html`

seems to differ between the old code (`apt install python3-html2text`) and the new code, in terms of blank lines.  We should figure out whether this is a difference in options used by `html2text` by default on the command line vs. being invoked directly, and if so, fix it.

May also be related to the freshdesk webhook test failure, which is for this code path.