### PR TITLE
Initial CentOS 7 port: Get things working

### DIFF
--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -5,11 +5,15 @@ class zulip::app_frontend_base {
   include zulip::nginx
   include zulip::supervisor
 
-  $web_packages = [
-    # Needed to access our database
-    "postgresql-client-${zulip::base::postgres_version}",
-  ]
-  zulip::safepackage { $web_packages: ensure => 'installed' }
+  # No need to ensure client tools on redhat, since they're shipped in
+  # postgresql*
+  if $::osfamily == 'debian' {
+    $web_packages = [
+      # Needed to access our database
+      "postgresql-client-${zulip::base::postgres_version}",
+    ]
+    zulip::safepackage { $web_packages: ensure => 'installed' }
+  }
 
   file { '/etc/nginx/zulip-include/app':
     require => Package[$zulip::common::nginx],

--- a/puppet/zulip/manifests/postgres_appdb_base.pp
+++ b/puppet/zulip/manifests/postgres_appdb_base.pp
@@ -44,16 +44,18 @@ class zulip::postgres_appdb_base {
     ensure => absent,
   }
 
-  file { "${tsearch_datadir}/en_us.dict":
-    ensure  => 'link',
-    require => Package[$postgresql],
-    target  => '/var/cache/postgresql/dicts/en_us.dict',  # TODO check cache dir on CentOS
-  }
-  file { "${tsearch_datadir}/en_us.affix":
-    ensure  => 'link',
-    require => Package[$postgresql],
-    target  => '/var/cache/postgresql/dicts/en_us.affix',  # TODO check cache dir on CentOS
+  if $::osfamily == 'debian' {
+    file { "${tsearch_datadir}/en_us.dict":
+        ensure  => 'link',
+        require => Package[$postgresql],
+        target  => '/var/cache/postgresql/dicts/en_us.dict',  # TODO check cache dir on CentOS
+    }
+    file { "${tsearch_datadir}/en_us.affix":
+        ensure  => 'link',
+        require => Package[$postgresql],
+        target  => '/var/cache/postgresql/dicts/en_us.affix',  # TODO check cache dir on CentOS
 
+    }
   }
   file { "${tsearch_datadir}/zulip_english.stop":
     ensure  => file,

--- a/puppet/zulip/manifests/postgres_appdb_tuned.pp
+++ b/puppet/zulip/manifests/postgres_appdb_tuned.pp
@@ -106,11 +106,28 @@ vm.dirty_background_ratio = 5
       group  => 'postgres',
       mode   => '0644',
     }
-    # ...and has no snake oil cert
+    # ...and has no snake oil cert...
     exec { 'make_dummy_cert':
       command =>
-        'cd /etc/ssl/certs && ./make-dummy-cert ssl-cert-snakeoil.pem && cp ssl-cert-snakeoil.pem ssl-cert-snakeoil.key',
+        'cd /etc/ssl/certs && ./make-dummy-cert ssl-cert-snakeoil.pem',
       unless  => 'test -f /etc/ssl/certs/ssl-cert-snakeoil.pem'
+    }
+    file { "/etc/ssl/private":
+      ensure => 'directory',
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0755',
+    }
+    exec { 'make_dummy_key':
+      command =>
+        'cp /etc/ssl/certs/ssl-cert-snakeoil.pem /etc/ssl/private/ssl-cert-snakeoil.key',
+      unless  => 'test -f /etc/ssl/private/ssl-cert-snakeoil.key',
+    }
+    file { "/etc/ssl/private/ssl-cert-snakeoil.key":
+      ensure => 'file',
+      owner  => 'root',
+      group  => 'postgres',
+      mode   => '0640',
     }
   }
 

--- a/puppet/zulip/manifests/postgres_appdb_tuned.pp
+++ b/puppet/zulip/manifests/postgres_appdb_tuned.pp
@@ -97,6 +97,12 @@ vm.dirty_background_ratio = 5
       group  => 'postgres',
       mode   => '0644',
     }
+    # ...and has no snake oil cert
+    exec { 'make_dummy_cert':
+      command =>
+        'cd /etc/ssl/certs && ./make-dummy-cert ssl-cert-snakeoil.pem && cp ssl-cert-snakeoil.pem ssl-cert-snakeoil.key',
+      unless  => 'test -f /etc/ssl/certs/ssl-cert-snakeoil.pem'
+    }
   }
 
   exec { $postgres_restart:

--- a/puppet/zulip/manifests/postgres_appdb_tuned.pp
+++ b/puppet/zulip/manifests/postgres_appdb_tuned.pp
@@ -15,6 +15,10 @@ $postgres_locale = $::osfamily ? {
   'debian' => "C.UTF-8",
   'redhat' => "en_US.UTF-8",
 }
+$postgres_data_dir = $::osfamily ? {
+  'debian' => "/var/lib/postgresql/${zulip::base::postgres_version}/main",
+  'redhat' => "/var/lib/pgsql/${zulip::base::postgres_version}/data/",
+}
 if $zulip::base::release_name == 'trusty' {
   # tools for database setup
   $postgres_appdb_tuned_packages = ['pgtune']

--- a/puppet/zulip/manifests/postgres_appdb_tuned.pp
+++ b/puppet/zulip/manifests/postgres_appdb_tuned.pp
@@ -89,6 +89,16 @@ vm.dirty_background_ratio = 5
     content => template("zulip/postgresql/${zulip::base::postgres_version}/postgresql.conf.template.erb"),
   }
 
+  if $::osfamily == 'redhat' {
+    # conf.d doesn't exist on redhat...
+    file { "/var/lib/pgsql/${zulip::base::postgres_version}/data/conf.d":
+      ensure => 'directory',
+      owner  => 'postgres',
+      group  => 'postgres',
+      mode   => '0644',
+    }
+  }
+
   exec { $postgres_restart:
     require     => Package[$zulip::postgres_appdb_base::postgresql],
     refreshonly => true,

--- a/puppet/zulip/manifests/postgres_appdb_tuned.pp
+++ b/puppet/zulip/manifests/postgres_appdb_tuned.pp
@@ -129,6 +129,13 @@ vm.dirty_background_ratio = 5
       group  => 'postgres',
       mode   => '0640',
     }
+    # ...and no log directory
+    file { "/var/log/postgresql/":
+      ensure => 'directory',
+      owner  => 'postgres',
+      group  => 'postgres',
+      mode   => '0644',
+    }
   }
 
   exec { $postgres_restart:

--- a/puppet/zulip/manifests/postgres_appdb_tuned.pp
+++ b/puppet/zulip/manifests/postgres_appdb_tuned.pp
@@ -3,9 +3,9 @@
 class zulip::postgres_appdb_tuned {
   include zulip::postgres_appdb_base
 
-$postgres_conf = $::osfamily ? {
-  'debian' => "/etc/postgresql/${zulip::base::postgres_version}/main/postgresql.conf",
-  'redhat' => "/var/lib/pgsql/${zulip::base::postgres_version}/data/postgresql.conf",
+$postgres_conf_dir = $::osfamily ? {
+  'debian' => "/etc/postgresql/${zulip::base::postgres_version}/main",
+  'redhat' => "/var/lib/pgsql/${zulip::base::postgres_version}/data",
 }
 $postgres_restart = $::osfamily ? {
   'debian' => "pg_ctlcluster ${zulip::base::postgres_version} main restart",
@@ -19,6 +19,7 @@ $postgres_data_dir = $::osfamily ? {
   'debian' => "/var/lib/postgresql/${zulip::base::postgres_version}/main",
   'redhat' => "/var/lib/pgsql/${zulip::base::postgres_version}/data/",
 }
+$postgres_conf = "$postgres_conf_dir/postgresql.conf"
 if $zulip::base::release_name == 'trusty' {
   # tools for database setup
   $postgres_appdb_tuned_packages = ['pgtune']
@@ -99,7 +100,7 @@ vm.dirty_background_ratio = 5
 
   if $::osfamily == 'redhat' {
     # conf.d doesn't exist on redhat...
-    file { "/var/lib/pgsql/${zulip::base::postgres_version}/data/conf.d":
+    file { "$postgres_conf_dir/conf.d":
       ensure => 'directory',
       owner  => 'postgres',
       group  => 'postgres',

--- a/puppet/zulip/manifests/postgres_appdb_tuned.pp
+++ b/puppet/zulip/manifests/postgres_appdb_tuned.pp
@@ -11,6 +11,10 @@ $postgres_restart = $::osfamily ? {
   'debian' => "pg_ctlcluster ${zulip::base::postgres_version} main restart",
   'redhat' => "systemctl restart postgresql-${zulip::base::postgres_version}",
 }
+$postgres_locale = $::osfamily ? {
+  'debian' => "C.UTF-8",
+  'redhat' => "en_US.UTF-8",
+}
 if $zulip::base::release_name == 'trusty' {
   # tools for database setup
   $postgres_appdb_tuned_packages = ['pgtune']

--- a/puppet/zulip/manifests/static_asset_compiler.pp
+++ b/puppet/zulip/manifests/static_asset_compiler.pp
@@ -17,10 +17,13 @@ class zulip::static_asset_compiler {
     }
     'redhat': {
       $static_asset_compiler_packages = [
-        # TODO CentOS doesn't have closure-compiler
         'yuicompressor',
         'gettext',
       ]
+      $setup_closure_compiler_file = "${::zulip_scripts_path}/lib/setup-closure-compiler"
+      exec{'setup_closure_compiler':
+        command => "bash -c '${setup_closure_compiler_file}'",
+      }
     }
     default: {
       fail('osfamily not supported')

--- a/puppet/zulip/manifests/supervisor.pp
+++ b/puppet/zulip/manifests/supervisor.pp
@@ -77,7 +77,7 @@ class zulip::supervisor {
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    source  => 'puppet:///modules/zulip/supervisor/supervisord.conf',
+    content => template("zulip/supervisor/supervisord.conf.erb"),
     notify  => Service[$supervisor_service],
   }
 

--- a/puppet/zulip/templates/postgresql/10/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/10/postgresql.conf.template.erb
@@ -40,9 +40,9 @@
 
 data_directory = '<%= scope["zulip::postgres_appdb_tuned::postgres_data_dir"] %>'		# use data in another directory
 					# (change requires restart)
-hba_file = '/etc/postgresql/<%= scope["zulip::base::postgres_version"] %>/main/pg_hba.conf'	# host-based authentication file
+hba_file = '<%= scope["zulip::postgres_appdb_tuned::postgres_conf_dir"] %>/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)
-ident_file = '/etc/postgresql/<%= scope["zulip::base::postgres_version"] %>/main/pg_ident.conf'	# ident configuration file
+ident_file = '<%= scope["zulip::postgres_appdb_tuned::postgres_conf_dir"] %>/pg_ident.conf'	# ident configuration file
 					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.

--- a/puppet/zulip/templates/postgresql/10/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/10/postgresql.conf.template.erb
@@ -38,7 +38,7 @@
 # The default values of these variables are driven from the -D command-line
 # option or PGDATA environment variable, represented here as ConfigDir.
 
-data_directory = '/var/lib/postgresql/<%= scope["zulip::base::postgres_version"] %>/main'		# use data in another directory
+data_directory = '<%= scope["zulip::postgres_appdb_tuned::postgres_data_dir"] %>'		# use data in another directory
 					# (change requires restart)
 hba_file = '/etc/postgresql/<%= scope["zulip::base::postgres_version"] %>/main/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)

--- a/puppet/zulip/templates/postgresql/10/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/10/postgresql.conf.template.erb
@@ -577,11 +577,11 @@ timezone = 'UTC'
 					# encoding
 
 # These settings are initialized by initdb, but they can be changed.
-lc_messages = 'C.UTF-8'			# locale for system error message
+lc_messages = '<%= scope["zulip::postgres_appdb_tuned::postgres_locale"] %>'			# locale for system error message
 					# strings
-lc_monetary = 'C.UTF-8'			# locale for monetary formatting
-lc_numeric = 'C.UTF-8'			# locale for number formatting
-lc_time = 'C.UTF-8'				# locale for time formatting
+lc_monetary = '<%= scope["zulip::postgres_appdb_tuned::postgres_locale"] %>'			# locale for monetary formatting
+lc_numeric = '<%= scope["zulip::postgres_appdb_tuned::postgres_locale"] %>'			# locale for number formatting
+lc_time = '<%= scope["zulip::postgres_appdb_tuned::postgres_locale"] %>'				# locale for time formatting
 
 # default configuration for text search
 default_text_search_config = 'pg_catalog.english'

--- a/puppet/zulip/templates/supervisor/supervisord.conf.erb
+++ b/puppet/zulip/templates/supervisor/supervisord.conf.erb
@@ -27,4 +27,4 @@ serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
 ; include files themselves.
 
 [include]
-files = /etc/supervisor/conf.d/*.conf
+files = <%= scope["zulip::common::supervisor_conf_dir"] %>/*.conf

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -102,7 +102,15 @@ elif [ -f "/etc/redhat-release" ]; then
 fi
 
 # Check for a supported OS release.
-apt-get install -y lsb-release sudo
+case $os_distro in
+    debian)
+        apt-get install -y lsb-release sudo
+        ;;
+    rhel)
+        yum -y install redhat-lsb-core sudo
+        ;;
+esac
+
 os_info="$(lsb_release --short --id --release --codename)"
 if [ "$os_distro" == "rhel" ]; then
     os_info="$(echo $os_info | sed -r 's/^(\S+)\s+(\S+)\s+\S+$/\1\n\2\n\2/')"
@@ -162,8 +170,15 @@ if [ "$mem_kb" -lt 1900000 ]; then
     exit 1
 fi
 
-# setup-apt-repo does an `apt-get update`
-"$ZULIP_PATH"/scripts/lib/setup-apt-repo
+case $os_distro in
+    debian)
+        # setup-apt-repo does an `apt-get update`
+        "$ZULIP_PATH"/scripts/lib/setup-apt-repo
+        ;;
+    rhel)
+        "$ZULIP_PATH"/scripts/lib/setup-yum-repo
+        ;;
+esac
 
 # Handle issues around upstart on Ubuntu Xenial
 "$ZULIP_PATH"/scripts/lib/check-upstart
@@ -195,13 +210,35 @@ fi
 # don't run dist-upgrade in one click apps to make the
 # installation process more seamless.
 if [ -z "$NO_DIST_UPGRADE" ]; then
-    apt-get -y dist-upgrade "${APT_OPTIONS[@]}"
+    case $os_distro in
+        debian)
+            apt-get -y dist-upgrade "${APT_OPTIONS[@]}"
+            ;;
+        *)
+            echo "OS major upgraded not supported on $os_id. Skippin"
+            ;;
+    esac
 fi
 
-if ! apt-get install -y \
-    puppet git curl wget jq \
-    python python3 python-six python3-six crudini \
-    "${ADDITIONAL_PACKAGES[@]}"; then
+pkginstall_status=0
+case $os_distro in
+    debian)
+        apt-get install -y \
+            puppet git curl wget jq \
+            python python3 python-six python3-six crudini \
+            "${ADDITIONAL_PACKAGES[@]}"
+            pkginstall_status="$?"
+        ;;
+    rhel)
+        yum -y install \
+            puppet git curl wget jq \
+            python python36 python-six python36-six crudini \
+            "${ADDITIONAL_PACKAGES[@]}"
+            pkginstall_status="$?"
+        ;;
+esac
+
+if [ "$pkginstall_status" != "0" ] ; then
     set +x
     echo -e '\033[0;31m' >&2
     echo "Installing packages failed; is network working and (on Ubuntu) the universe repository enabled?" >&2
@@ -289,7 +326,11 @@ if [ "$DEPLOYMENT_TYPE" = "dockervoyager" ]; then
 fi
 
 # These server restarting bits should be moveable into puppet-land, ideally
-apt-get -y upgrade
+case $os_distro in
+    debian)
+        apt-get -y upgrade
+        ;;
+esac
 
 if [ "$has_nginx" = 0 ]; then
     # Check nginx was configured properly now that we've installed it.

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -109,8 +109,9 @@ if [ "$os_distro" == "rhel" ]; then
 fi
 { read -r os_id; read -r os_release; read -r os_codename; } <<< "$os_info"
 
-case "$os_codename" in
-    trusty|xenial|stretch|bionic) ;;
+case "$os_id-$os_codename" in
+    Ubuntu-trusty|Ubuntu-xenial|Debian-stretch|Ubuntu-bionic) ;;
+    RHEL-7.*|CentOS-7.*) ;;
     *)
         set +x
         cat <<EOF
@@ -122,6 +123,8 @@ Zulip in production is supported only on:
  - Ubuntu 14.04 LTS "trusty" (deprecated)
  - Ubuntu 16.04 LTS "xenial"
  - Ubuntu 18.04 LTS "bionic"
+ - RedHat Enterprise Linux 7.x
+ - CentOS 7.x
 
 For more information, see:
   https://zulip.readthedocs.io/en/latest/production/requirements.html

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -311,7 +311,8 @@ EOF
 set +e
 [ -e "/etc/init.d/camo" ]; has_camo=$?
 [ -e "/etc/init.d/nginx" ]; has_nginx=$?
-[ -e "/etc/supervisor/conf.d/zulip.conf" ]; has_appserver=$?
+[ -e "/etc/supervisor/conf.d/zulip.conf" ]; has_appserver=$?    # Debian
+[ -e "/etc/supervisord.d/conf.d/zulip.conf" ]; has_appserver=$? # RHEL
 [ -e "/etc/cron.d/rabbitmq-numconsumers" ]; has_rabbit=$?
 [ -e "/etc/init.d/postgresql" ]; has_postgres=$?
 set -e

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -13,6 +13,7 @@ Other options:
   --no-init-db
   --cacert
   --no-dist-upgrade
+  --no-move-deployment
 
 The --hostname and --email options are required,
 unless --no-init-db is set and --certbot is not.
@@ -34,6 +35,7 @@ while true; do
         --email) ZULIP_ADMINISTRATOR="$2"; shift; shift;;
         --no-init-db) NO_INIT_DB=1; shift;;
         --no-dist-upgrade) NO_DIST_UPGRADE=1; shift;;
+        --no-move-deployment) NO_MOVE_DEPLOYMENT=1; shift;;
         --) shift; break;;
     esac
 done
@@ -398,8 +400,11 @@ fi
 
 if [ "$has_appserver" = 0 ]; then
     deploy_path=$("$ZULIP_PATH"/scripts/lib/zulip_tools.py make_deploy_path)
-    mv "$ZULIP_PATH" "$deploy_path"
-    ln -nsf /home/zulip/deployments/next "$ZULIP_PATH"
+    deploy_path="/home/zulip/deployments/zulip"
+    if [ -z "$NO_MOVE_DEPLOYMENT" ]; then
+        mv "$ZULIP_PATH" "$deploy_path"
+        ln -nsf /home/zulip/deployments/next "$ZULIP_PATH"
+    fi
     ln -nsf "$deploy_path" /home/zulip/deployments/next
     ln -nsf "$deploy_path" /home/zulip/deployments/current
     ln -nsf /etc/zulip/settings.py "$deploy_path"/zproject/prod_settings.py

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -93,6 +93,14 @@ export LC_ALL="en_US.UTF-8"
 export LANG="en_US.UTF-8"
 export LANGUAGE="en_US.UTF-8"
 
+# Detect OS distro
+os_distro="debian"
+if [ -f "/etc/debian_version" ]; then
+    os_distro="debian"
+elif [ -f "/etc/redhat-release" ]; then
+    os_distro="rhel"
+fi
+
 # Check for a supported OS release.
 apt-get install -y lsb-release sudo
 os_info="$(lsb_release --short --id --release --codename)"

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -310,11 +310,13 @@ EOF
 # Detect which features were selected for the below
 set +e
 [ -e "/etc/init.d/camo" ]; has_camo=$?
-[ -e "/etc/init.d/nginx" ]; has_nginx=$?
+[ -e "/etc/init.d/nginx" ]; has_nginx=$?                     # Debian
+[ -e "/usr/lib/systemd/system/nginx.service" ]; has_nginx=$? # RHEL
 [ -e "/etc/supervisor/conf.d/zulip.conf" ]; has_appserver=$?    # Debian
 [ -e "/etc/supervisord.d/conf.d/zulip.conf" ]; has_appserver=$? # RHEL
 [ -e "/etc/cron.d/rabbitmq-numconsumers" ]; has_rabbit=$?
-[ -e "/etc/init.d/postgresql" ]; has_postgres=$?
+[ -e "/etc/init.d/postgresql" ]; has_postgres=$?                        # Debian
+[ -e "/usr/lib/systemd/system/postgresql-10.service" ]; has_postgres=$? # RHEL
 set -e
 
 # Docker service setup is done in the docker config, not here

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -104,6 +104,9 @@ fi
 # Check for a supported OS release.
 apt-get install -y lsb-release sudo
 os_info="$(lsb_release --short --id --release --codename)"
+if [ "$os_distro" == "rhel" ]; then
+    os_info="$(echo $os_info | sed -r 's/^(\S+)\s+(\S+)\s+\S+$/\1\n\2\n\2/')"
+fi
 { read -r os_id; read -r os_release; read -r os_codename; } <<< "$os_info"
 
 case "$os_codename" in

--- a/scripts/lib/setup-closure-compiler
+++ b/scripts/lib/setup-closure-compiler
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
+PREFIX="/usr"
+
+# Check for closure-compiler
+if [ ! -f "$PREFIX/bin/closure-compiler" ]; then
+    zip_file="$(mktemp -u)"
+    wget "https://dl.google.com/closure-compiler/compiler-latest.zip" -O $zip_file
+
+    mkdir -p $PREFIX/share/closure-compiler
+    unzip -px $zip_file 'closure-compiler-v[0-9]*.jar' > \
+        $PREFIX/share/closure-compiler/closure-compiler.jar
+
+    cat <<EOF > $PREFIX/bin/closure-compiler
+#!/bin/sh
+
+java -jar $PREFIX/share/closure-compiler/closure-compiler.jar \$@
+EOF
+    chmod a+x $PREFIX/bin/closure-compiler
+fi

--- a/scripts/lib/setup-yum-repo
+++ b/scripts/lib/setup-yum-repo
@@ -38,26 +38,27 @@ fi
 yum update -y
 
 # "Development Tools" is the equivalent of build-essential
-yum groupinstall -y "Development Tools"
+yum groups mark install "Development Tools"
+yum update -y
 
 RHVER="$(rpm -qf --queryformat="%{VERSION}" /etc/redhat-release)"
 RHARCH="$(rpm -qf --queryformat="%{ARCH}" /etc/redhat-release)"
 PGVER=10
 if [ "$is_centos" = true ]; then
     # PostgreSQL $PGVER
-    yum localinstall -y "https://yum.postgresql.org/$PGVER/redhat/rhel-$RHVER-$RHARCH/pgdg-centos$PGVER-$PGVER-2.noarch.rpm"
+    yum reinstall -y "https://yum.postgresql.org/$PGVER/redhat/rhel-$RHVER-$RHARCH/pgdg-centos$PGVER-$PGVER-2.noarch.rpm"
 
     # PGroonga
     # https://pgroonga.github.io/install/centos.html
-    yum localinstall -y https://packages.groonga.org/centos/groonga-release-latest.noarch.rpm
+    yum reinstall -y https://packages.groonga.org/centos/groonga-release-latest.noarch.rpm
 elif [ "$is_rhel" = true ]; then
     if [ "$is_rhel_registered" = false ]; then
         echo "This machine is unregistered; installing libmemcached-devel from a CentOS mirror ..."
-        yum localinstall -y http://mirror.centos.org/centos/7/os/x86_64/Packages/libmemcached-devel-1.0.16-5.el7.x86_64.rpm
+        yum reinstall -y http://mirror.centos.org/centos/7/os/x86_64/Packages/libmemcached-devel-1.0.16-5.el7.x86_64.rpm
     fi
-    yum localinstall -y https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-latest-x86_64/pgdg-redhat10-10-2.noarch.rpm
-    yum localinstall -y https://packages.groonga.org/centos/groonga-release-latest.noarch.rpm
+    yum reinstall -y https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-latest-x86_64/pgdg-redhat10-10-2.noarch.rpm
+    yum reinstall -y https://packages.groonga.org/centos/groonga-release-latest.noarch.rpm
 else
     # TODO only fedora29 for now
-    dnf install -y "https://download.postgresql.org/pub/repos/yum/$PGVER/fedora/fedora-29-x86_64/pgdg-fedora$PGVER-$PGVER-4.noarch.rpm"
+    dnf reinstall -y "https://download.postgresql.org/pub/repos/yum/$PGVER/fedora/fedora-29-x86_64/pgdg-fedora$PGVER-$PGVER-4.noarch.rpm"
 fi

--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -58,7 +58,7 @@ COMMON_YUM_VENV_DEPENDENCIES = [
     "python-six",
     "libxml2-devel",
     "libxslt-devel",
-    "postgresql-libs",  # libpq-dev on apt
+    "postgresql10-libs",  # libpq-dev on apt
     "openssl-devel",
     "jq",
 ]


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Make Zulip installation on RHEL-family Linux distributions possible #41


**Testing Plan:** <!-- How have you tested? -->
This has been tested to produce a working Zulip environment on a clean CentOS 7 x86_64 installation.

**Notes:**
This series of patches has been made to make installing Zulip on RHEL-based systems possible, at least with a basic, common setup. More elaborate cases have not been tested (and will probably fail). This is meant as a starting point so we can expand the supported feature set later.

I've also added the option --no-move-deployment to the install script. This disables moving the Zulip repository around, which is quite convenient when working on the installer.

Please let me know there are any questions on the patch set or if something could be improved.

