### PR TITLE
events: Workaround badly behaving browser caching.

### DIFF
--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -236,6 +236,21 @@ function get_events(options) {
                                      save_narrow: true,
                                      save_compose: true});
                 }
+                // If this browser window were incorrectly
+                // re-initialized from a browser cache, it will have a
+                // stale `last_event_id` in page_params, which will
+                // result in the REQUEST_PRUNED_EVENTS error from the server.
+                //
+                // In this case, we should destroy our event queue and
+                // reload the browser window.
+                if (xhr.status === 400 &&
+                    JSON.parse(xhr.responseText).code === 'REQUESTED_PRUNED_EVENTS') {
+                    exports.cleanup_event_queue();
+                    reload.initiate({immediate: true,
+                                     save_pointer: false,
+                                     save_narrow: true,
+                                     save_compose: true});
+                }
 
                 if (error_type === 'abort') {
                     // Don't restart if we explicitly aborted

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -45,6 +45,7 @@ class ErrorCode(AbstractEnum):
     INVALID_MARKDOWN_INCLUDE_STATEMENT = ()
     REQUEST_CONFUSING_VAR = ()
     INVALID_API_KEY = ()
+    REQUESTED_PRUNED_EVENTS = ()
 
 class JsonableError(Exception):
     '''A standardized error format we can turn into a nice JSON HTTP response.

--- a/zerver/tests/test_tornado.py
+++ b/zerver/tests/test_tornado.py
@@ -117,7 +117,7 @@ class EventsTestCase(TornadoWebTestCase):
         event_queue_id = self.create_queue()
         data = {
             'queue_id': event_queue_id,
-            'last_event_id': 0,
+            'last_event_id': -1,
         }
 
         path = '/json/events?{}'.format(urllib.parse.urlencode(data))

--- a/zerver/tornado/exceptions.py
+++ b/zerver/tornado/exceptions.py
@@ -13,3 +13,14 @@ class BadEventQueueIdError(JsonableError):
     @staticmethod
     def msg_format() -> str:
         return _("Bad event queue id: {queue_id}")
+
+class RequestedPrunedEventsError(JsonableError):
+    code = ErrorCode.REQUESTED_PRUNED_EVENTS
+    data_fields = ['last_event_id']
+
+    def __init__(self, last_event_id: int) -> None:
+        self.last_event_id = last_event_id  # type: int
+
+    @staticmethod
+    def msg_format() -> str:
+        return _("Events older than %(last_event_id)s have already been pruned!")


### PR DESCRIPTION
The code comments explain this issue in some detail.

In theory, the cache control headers that Zulip specifies via
patch_cache_control should prevent this situation from happening, but
we've had a number of reports of users seeing an invalid state clearly
caused by the browser using a stale version of the webapp's HTML and
thus page_params, resulting in it feeling like the Zulip window
travelled back in time a few hours (I've had it happen to me myself).

We can fix this by adding error checking that is reasonable to do in
any case (and could, in theory, catch other bugs): Rejecting requests
to fetch events from an events queue that have already been pruned /
garbage collected.

Fixes #12876.
