### PR TITLE
typeahead: Add header text to show info about current completion.

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -754,6 +754,23 @@ exports.compose_trigger_selection = function (event) {
     return false;
 };
 
+function get_header_text() {
+    var tip_text = '';
+    switch (this.completing) {
+    case 'stream':
+    case 'topic_list':
+        tip_text = i18n.t('Press > to mention topic');
+        break;
+    case 'mention':
+    case 'silent_mention':
+        tip_text = i18n.t('@_ for silent mention');
+        break;
+    default:
+        return false;
+    }
+    return '<em>' + tip_text + '</em>';
+}
+
 exports.initialize_compose_typeahead = function (selector) {
     var completions = {
         mention: true,
@@ -778,6 +795,7 @@ exports.initialize_compose_typeahead = function (selector) {
         completions: completions,
         automated: exports.compose_automated_selection,
         trigger_selection: exports.compose_trigger_selection,
+        header: get_header_text,
     });
 };
 

--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -495,7 +495,7 @@ a#undo_markdown_preview {
     padding-left: 20px;
     padding-bottom: 5px;
     padding-right: 20px;
-    border-bottom: 1px solid hsla(0, 0%, 0%, 0.2);
+    border-top: 1px solid hsla(0, 0%, 0%, 0.2);
     display: flex;
     align-items: center;
 }

--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -490,6 +490,24 @@ a#undo_markdown_preview {
     background: hsl(0, 0%, 100%);
 }
 
+.dropdown-menu .typeahead-header {
+    margin: 0;
+    padding-left: 20px;
+    padding-bottom: 5px;
+    padding-right: 20px;
+    border-bottom: 1px solid hsla(0, 0%, 0%, 0.2);
+    display: flex;
+    align-items: center;
+}
+
+.dropdown-menu #typeahead-header-text {
+    font-size: 12px;
+}
+
+.dropdown-menu.typeahead {
+    background: hsl(0, 0%, 100%);
+}
+
 .compose_mobile_stream_button i,
 .compose_mobile_private_button i {
     margin-right: 4px;

--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -484,6 +484,12 @@ a#undo_markdown_preview {
     margin: auto;
 }
 
+.dropdown-menu ul {
+    list-style: none;
+    margin: 0;
+    background: hsl(0, 0%, 100%);
+}
+
 .compose_mobile_stream_button i,
 .compose_mobile_private_button i {
     margin-right: 4px;

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -229,11 +229,13 @@ on a dark background, and don't change the dark labels dark either. */
     }
 
     .overlay .flex.overlay-content > div,
+    .dropdown-menu.typeahead,
     #settings_page,
     .informational-overlays .overlay-content {
         box-shadow: 0px 0px 30px hsl(212, 32%, 7%);
     }
 
+    .dropdown-menu ul,
     .dropdown .dropdown-menu,
     .popover,
     .popover-title,

--- a/static/third/bootstrap-typeahead/typeahead.js
+++ b/static/third/bootstrap-typeahead/typeahead.js
@@ -67,8 +67,8 @@
     this.highlighter = this.options.highlighter || this.highlighter
     this.updater = this.options.updater || this.updater
     this.$container = $(this.options.container).appendTo('body')
-    this.$header = $(this.options.header_html).appendTo(this.$container)
     this.$menu = $(this.options.menu).appendTo(this.$container)
+    this.$header = $(this.options.header_html).appendTo(this.$container)
     this.source = this.options.source
     this.shown = false
     this.dropup = this.options.dropup

--- a/static/third/bootstrap-typeahead/typeahead.js
+++ b/static/third/bootstrap-typeahead/typeahead.js
@@ -39,6 +39,16 @@
  *   pass the keyup event to the updater.
  *
  *   Our custom changes include all mentions of this.trigger_selection.
+ *
+ * 3. Header text:
+ *
+ *   This adds support for showing a custom header text like: "You are now
+ *   completing a user mention". Provide the function `this.header` that
+ *   returns a string containing the header text, or false.
+ *
+ *   Our custom changes include all mentions of this.header, some CSS changes
+ *   in compose.scss and splitting $container out of $menu so we can insert
+ *   additional HTML before $menu.
  * ============================================================ */
 
 !function($){
@@ -57,6 +67,7 @@
     this.highlighter = this.options.highlighter || this.highlighter
     this.updater = this.options.updater || this.updater
     this.$container = $(this.options.container).appendTo('body')
+    this.$header = $(this.options.header_html).appendTo(this.$container)
     this.$menu = $(this.options.menu).appendTo(this.$container)
     this.source = this.options.source
     this.shown = false
@@ -64,6 +75,7 @@
     this.fixed = this.options.fixed || false;
     this.automated = this.options.automated || this.automated;
     this.trigger_selection = this.options.trigger_selection || this.trigger_selection;
+    this.header = this.options.header || this.header;
 
     if (this.fixed) {
       this.$container.css('position', 'fixed');
@@ -103,6 +115,11 @@
     return false;
   }
 
+  , header: function() {
+    // return a string to show in typeahead header or false.
+    return false;
+  }
+
   , show: function () {
       var pos;
 
@@ -129,6 +146,14 @@
         top: top_pos
        , left: pos.left
       })
+
+      var header_text = this.header();
+      if (header_text) {
+        this.$header.find('span#typeahead-header-text').html(header_text);
+        this.$header.show();
+      } else {
+        this.$header.hide();
+      }
 
       this.$container.show()
       this.shown = true
@@ -382,6 +407,7 @@
     source: []
   , items: 8
   , container: '<div class="typeahead dropdown-menu"></div>'
+  , header_html: '<p class="typeahead-header"><span id="typeahead-header-text"></span></p>'
   , menu: '<ul class="typeahead-menu"></ul>'
   , item: '<li><a href="#"></a></li>'
   , minLength: 1

--- a/static/third/bootstrap-typeahead/typeahead.js
+++ b/static/third/bootstrap-typeahead/typeahead.js
@@ -56,7 +56,8 @@
     this.sorter = this.options.sorter || this.sorter
     this.highlighter = this.options.highlighter || this.highlighter
     this.updater = this.options.updater || this.updater
-    this.$menu = $(this.options.menu).appendTo('body')
+    this.$container = $(this.options.container).appendTo('body')
+    this.$menu = $(this.options.menu).appendTo(this.$container)
     this.source = this.options.source
     this.shown = false
     this.dropup = this.options.dropup
@@ -65,7 +66,7 @@
     this.trigger_selection = this.options.trigger_selection || this.trigger_selection;
 
     if (this.fixed) {
-      this.$menu.css('position', 'fixed');
+      this.$container.css('position', 'fixed');
     }
     // The naturalSearch option causes arrow keys to immediately
     // update the search box with the underlying values from the
@@ -121,21 +122,21 @@
 
       var top_pos = pos.top + pos.height
       if (this.dropup) {
-        top_pos = pos.top - this.$menu.outerHeight()
+        top_pos = pos.top - this.$container.outerHeight()
       }
 
-      this.$menu.css({
+      this.$container.css({
         top: top_pos
        , left: pos.left
       })
 
-      this.$menu.show()
+      this.$container.show()
       this.shown = true
       return this
     }
 
   , hide: function () {
-      this.$menu.hide()
+      this.$container.hide()
       this.shown = false
       return this
     }
@@ -344,7 +345,7 @@
   , blur: function (e) {
       var that = this
       setTimeout(function () {
-        if (!that.$menu.is(':hover')) {
+        if (!that.$container.is(':hover')) {
           that.hide();
         }
       }, 150)
@@ -380,7 +381,8 @@
   $.fn.typeahead.defaults = {
     source: []
   , items: 8
-  , menu: '<ul class="typeahead dropdown-menu"></ul>'
+  , container: '<div class="typeahead dropdown-menu"></div>'
+  , menu: '<ul class="typeahead-menu"></ul>'
   , item: '<li><a href="#"></a></li>'
   , minLength: 1
   , stopAdvance: false


### PR DESCRIPTION
Second commit would add some uses of this feature. @rishig this continues what we discussed in #12814, and I could use your inputs on what to show here.

---

We can provide a function that returns an HTML string: `this.header()` to
display a header text above the typeahead. This can be used to provide
contextual information such as hinting about the silent mentions syntax
or the topic mentions syntax.

For cleaner HTML, we have split the $menu element into two parts, ending
with the following structure:

```
$container <div>:
  $header <p>:
    info-icon
    header-text
  $menu <ul>
    list-items
```

**Testing Plan:**

Manual testing

**GIFs or Screenshots:**

![image](https://user-images.githubusercontent.com/8033238/61849617-838c8b00-aecf-11e9-811a-aef49d7da381.png)
![image](https://user-images.githubusercontent.com/8033238/61850038-d87cd100-aed0-11e9-9162-d199654b3542.png)

