### PR TITLE
Fix popover arrow shifting to the left in message actions popover

### DIFF
--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -27,6 +27,8 @@ set_global('rows', {});
 
 set_global('message_viewport', {
     height: () => 500,
+    width: () => 800,
+    is_narrow: () => false,
 });
 
 set_global('emoji_picker', {

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -432,6 +432,18 @@ exports.toggle_actions_popover = function (element, id) {
             editability_menu_item = i18n.t("View source");
         }
         const topic = message.topic;
+        let topic_string_mute;
+        let topic_string_unmute;
+
+        if (message_viewport.is_narrow()) {
+            topic_string_mute = i18n.t("Mute this topic");
+            topic_string_unmute = i18n.t("Unmute this topic");
+        } else {
+            topic_string_mute = i18n.t("Mute the topic <strong>__topic__</strong>",
+                                       {topic: topic});
+            topic_string_unmute = i18n.t("Unmute the topic <strong>__topic__</strong>",
+                                         {topic: topic});
+        }
         const can_mute_topic =
                 message.stream &&
                 topic &&
@@ -475,6 +487,8 @@ exports.toggle_actions_popover = function (element, id) {
             topic: topic,
             use_edit_icon: use_edit_icon,
             editability_menu_item: editability_menu_item,
+            topic_string_mute: topic_string_mute,
+            topic_string_unmute: topic_string_unmute,
             can_mute_topic: can_mute_topic,
             can_unmute_topic: can_unmute_topic,
             should_display_collapse: should_display_collapse,
@@ -498,6 +512,9 @@ exports.toggle_actions_popover = function (element, id) {
             html: true,
             trigger: "manual",
         });
+        if (message_viewport.width() <= 320) {
+            elt.data('popover').options.template = render_no_arrow_popover({class: "message-info-popover"});
+        }
         elt.popover("show");
         current_actions_popover_elem = elt;
     }

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -99,6 +99,16 @@ ul {
     }
 }
 
+@media (max-width: 1165px) {
+    .message_top_line {
+        margin-right: 14px;
+    }
+
+    .message_time {
+        margin-right: -14px;
+    }
+}
+
 .user_popover {
     width: 240px;
 

--- a/static/templates/actions_popover_content.hbs
+++ b/static/templates/actions_popover_content.hbs
@@ -63,7 +63,7 @@
     <li>
         <a href="#" class="popover_mute_topic" data-msg-stream-id="{{stream_id}}" data-msg-topic="{{topic}}">
             <i class="fa fa-eye-slash" aria-hidden="true"></i>
-            {{#tr this}}Mute the topic <b>__topic__</b>{{/tr}} <span class="hotkey-hint">(M)</span>
+            {{{topic_string_mute}}} <span class="hotkey-hint">(M)</span>
         </a>
     </li>
     {{/if}}
@@ -72,7 +72,7 @@
     <li>
         <a href="#" class="popover_unmute_topic" data-msg-stream-id="{{stream_id}}" data-msg-topic="{{topic}}">
             <i class="fa fa-eye" aria-hidden="true"></i>
-            {{#tr this}}Unmute the topic <b>__topic__</b>{{/tr}}
+            {{{topic_string_unmute}}}
         </a>
     </li>
     {{/if}}


### PR DESCRIPTION
When the message actions popover was invoked, the popover arrow seemed to be going left
which was because the topic length had no wrapper.
This commit removes the topic name altogether, from the list-item 'Mute the topic (topic)',
effectively making it 'Mute this topic' which solves the problem.

Fixes [#4145](https://github.com/zulip/zulip/issues/4145).
![popover11](https://user-images.githubusercontent.com/41019632/61877341-717d0d80-af0c-11e9-92e4-a71298ec5960.png)
![popover12](https://user-images.githubusercontent.com/41019632/61877347-7346d100-af0c-11e9-89ea-9859378265f5.png)






