### PR TITLE
compose: Do not trigger topic mention if already completed.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -1288,6 +1288,7 @@ run_test('begins_typeahead', () => {
     assert_typeahead_equals("@**a person** >", false);
     assert_typeahead_equals("#**stream**>", ['']); // this is deliberately a blank choice.
     assert_typeahead_equals("#**stream** >", ['']);
+    assert_typeahead_equals("#**Sweden>some topic** >", false); // Already completed a topic.
 
     // topic_list
     var sweden_topics_to_show = topic_data.get_recent_names(1); //includes "more ice"

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -559,7 +559,7 @@ exports.compose_content_begins_typeahead = function (query) {
     if (this.options.completions.topic) {
         // Stream regex modified from marked.js
         // Matches '#**stream name** >' at the end of a split.
-        var stream_regex =  /#\*\*([^\*]+)\*\*\s?>$/;
+        var stream_regex =  /#\*\*([^\*>]+)\*\*\s?>$/;
         var should_jump_inside_typeahead = stream_regex.test(split[0]);
         if (should_jump_inside_typeahead) {
             this.completing = 'topic_jump';


### PR DESCRIPTION
This fixes a minor bug I noticed where we reopen the typeahead and add an extra '>' even if we'd already completed a topic-mention. This assumes that there wouldn't be any streams with '>' in them, which should be discussed and addressed soon.
