### PR TITLE
emoji_picker: Change state of emoji tab to active on click.

### DIFF
--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -736,6 +736,9 @@ exports.register_click_handlers = function () {
         if (offset) {
             ui.get_scroll_element($(".emoji-popover-emoji-map")).scrollTop(offset.position_y);
         }
+
+        $('.emoji-popover-tab-item.active').removeClass('active');
+        $(this).addClass('active');
     });
 
     $("body").on("click", ".emoji-popover-filter", function () {


### PR DESCRIPTION
When an emoji tab is clicked, the popover content is scrolled but
the tab style doesn't change. This fixes the issue by adding
`.active` class to the tab clicked.