### PR TITLE
ui.get_scroll_element: Set up SimpleBar if it’s expected but missing

### DIFF
--- a/frontend_tests/node_tests/buddy_list.js
+++ b/frontend_tests/node_tests/buddy_list.js
@@ -16,6 +16,7 @@ function init_simulated_scrolling() {
     });
 
     var elem = {
+        dataset: {},
         scrollTop: 0,
         scrollHeight: 0,
     };

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -340,6 +340,9 @@ run_test('zoom_in_and_zoom_out', () => {
         f.call(elem(stream_li1));
         f.call(elem(stream_li2));
     };
+    $('#stream-filters-container')[0] = {
+        dataset: {},
+    };
     stream_list.set_event_handlers();
 
     stream_list.zoom_in_topics({stream_id: 42});

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1,6 +1,6 @@
 var ui = (function () {
 
-require("simplebar");
+var SimpleBar = require("simplebar").default;
 
 var exports = {};
 
@@ -27,6 +27,10 @@ exports.get_scroll_element = function (element_selector) {
     var element = element_selector.expectOne()[0];
     if (element.SimpleBar) {
         return $(element.SimpleBar.getScrollElement());
+    } else if ('simplebar' in element.dataset) {
+        // The SimpleBar mutation observer hasn’t processed this element yet.
+        // Create the SimpleBar early in case we need to add event listeners.
+        return $(new SimpleBar(element).getScrollElement());
     }
     return element_selector;
 };


### PR DESCRIPTION
Although SimpleBar automatically sets itself up on elements with a `data-simplebar` attribute, sometimes we try to set event listeners before that happens.  Create the SimpleBar early in that case.

**Testing Plan:** Verified scroll-triggered tab switching on emoji picker.