### PR TITLE
reactions_button: Remove title from reaction button in controls.

### DIFF
--- a/static/templates/message_controls.hbs
+++ b/static/templates/message_controls.hbs
@@ -5,7 +5,7 @@
 
     {{#unless msg/sent_by_me}}
     <div class="reaction_button">
-        <i class="fa fa-smile-o" title="{{#tr this}}Add emoji reaction{{/tr}} (:)" aria-label="{{#tr this}}Add emoji reaction{{/tr}} (:)" role="button" aria-haspopup="true" tabindex="0"></i>
+        <i class="fa fa-smile-o" aria-label="{{#tr this}}Add emoji reaction{{/tr}} (:)" role="button" aria-haspopup="true" tabindex="0"></i>
     </div>
     {{/unless}}
 


### PR DESCRIPTION
Since the button already has a tooltip, we can remove the title.