### PR TITLE
Fix warn unreachable errors

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -35,6 +35,8 @@ follow_imports = error
 # This doesn't get in the way of using the stubs we *do* have.
 ignore_missing_imports = True
 
+# Warn of unreachable or redundant code.
+warn_unreachable = True
 
 #
 #

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -36,10 +36,6 @@ parser.add_argument('-a', '--all', action='store_true',
                     help="check all files, bypassing the default exclude list")
 parser.add_argument('--force', action="store_true",
                     help="run tests despite possible provisioning problems")
-parser.add_argument('--warn-unreachable',
-                    action='store_false',
-                    default=True,
-                    help="warn of unreachable or redundant code; defaults to true")
 args = parser.parse_args()
 
 assert_provisioning_status_ok(args.force)
@@ -77,8 +73,6 @@ if not python_files and not pyi_files:
 extra_args = []
 if args.quick:
     extra_args.append("--quick")
-elif args.warn_unreachable:
-    extra_args.append("--warn-unreachable")
 
 mypy_args = extra_args + python_files + pyi_files
 if args.no_daemon:


### PR DESCRIPTION
In favor of #12871 (I realize now I could have just re-opened this...), as a result of splitting up the mypy upgrade, and the fixes regarding the `--warn-unreachable` blob.

This PR is tracking the progress of the fixes related to the errors found via the new `--warn-unreachable` feature that shipped with mypy 0.720.

~I imagine we'll probably want to squash all the `migrate to normal import statement` commits, but I'm keeping those separated for now.~

### `--warn-unreachable` related errors
- [x] zerver/lib/openapi.py:55: error: Statement is unreachable
- [x] ~tools/zulint/printer.py:8: error: Statement is unreachable~
- [x] ~tools/zulint/linters.py:8: error: Statement is unreachable~
- [x] scripts/nagios/cron_file_helper.py:5: error: Statement is unreachable
- [x] scripts/nagios/check-rabbitmq-consumers:13: error: Statement is unreachable
- [x] scripts/lib/hash_reqs.py:9: error: Statement is unreachable
- [x] puppet/zulip_ops/files/nagios_plugins/zulip_zephyr_mirror/check_zephyr_mirror:14: error: Statement is unreachable
- [x] puppet/zulip_ops/files/nagios_plugins/zulip_zephyr_mirror/check_personal_zephyr_mirrors:13: error: Statement is unreachable
- [x] puppet/zulip/files/nagios_plugins/zulip_app_frontend/check_cron_file:10: error: Statement is unreachable
- [x] zerver/lib/logging_util.py:136: error: Statement is unreachable
- [x] zerver/lib/domains.py:7: error: Left operand of 'or' is always false
- [x] ~tools/zulint/custom_rules.py:12: error: Statement is unreachable~
- [x] ~tools/zulint/custom_rules.py:146: error: Statement is unreachable~
- [x] ~tools/zulint/command.py:14: error: Statement is unreachable~
- [x] tools/webpack:9: error: Statement is unreachable
- [x] scripts/setup/generate_secrets.py:8: error: Statement is unreachable
- [x] scripts/lib/zulip_tools.py:21: error: Statement is unreachable
- [x] puppet/zulip/files/nagios_plugins/zulip_nagios_server/check_postgres_replication_lag:9: error: Statement is unreachable
- [x] zerver/lib/api_test_helpers.py:10: error: Statement is unreachable
- [x] scripts/purge-old-deployments:9: error: Statement is unreachable
- [x] scripts/lib/setup_venv.py:19: error: Statement is unreachable
- [x] scripts/lib/node_cache.py:8: error: Statement is unreachable
- [x] scripts/lib/clean_venv_cache.py:8: error: Statement is unreachable
- [x] scripts/lib/clean_node_cache.py:9: error: Statement is unreachable
- [x] scripts/lib/clean_emoji_cache.py:8: error: Statement is unreachable
- [x] puppet/zulip/files/postgresql/pg_backup_and_purge:14: error: Statement is unreachable
- [x] scripts/setup/restore-backup:11: error: Statement is unreachable
- [x] tools/lib/provision.py:29: error: Statement is unreachable
- [x] ~tools/zulint/lister.py:15: error: Statement is unreachable~
- [x] zerver/migrations/0077_add_file_name_field_to_realm_emoji.py:26: error: Statement is unreachable
- [x] zerver/migrations/0064_sync_uploads_filesize_with_db.py:43: error: Statement is unreachable
- [x] zerver/lib/cache.py:25: error: Statement is unreachable
- [x] zerver/lib/upload.py:320: error: Statement is unreachable
- [x] zerver/lib/upload.py:334: error: Statement is unreachable
- [x] zerver/lib/bugdown/__init__.py:1496: error: Left operand of 'and' is always true
- [x] zerver/middleware.py:342: error: Statement is unreachable
- [x] zerver/tornado/descriptors.py:4: error: Statement is unreachable
- [x] zerver/lib/actions.py:5251: error: Statement is unreachable
- [x] zerver/views/auth.py:369: error: Statement is unreachable
- [x] zerver/webhooks/pivotal/view.py:177: error: Left operand of 'or' is always false
- [x] zerver/webhooks/jira/view.py:281: error: Left operand of 'or' is always false
- [x] zerver/webhooks/clubhouse/view.py:529: error: Statement is unreachable
- [x] zerver/views/zephyr.py:29: error: Statement is unreachable
- [x] zerver/views/archive.py:59: error: Right operand of 'or' is never evaluated
- [x] zerver/migrations/0060_move_avatars_to_be_uid_based.py:31: error: Statement is unreachable
- [x] zerver/management/commands/add_users_to_mailing_list.py:34: error: Statement is unreachable
- [x] zerver/management/commands/add_users_to_mailing_list.py:43: error: Statement is unreachable
- [x] tools/diagnose:11: error: Statement is unreachable
- [x] puppet/zulip_ops/files/nagios_plugins/zulip_zephyr_mirror/check_user_zephyr_mirror_liveness:29: error: Statement is unreachable
- [x] corporate/views.py:54: error: Left operand of 'or' is always false
- [x] corporate/views.py:63: error: Statement is unreachable
- [x] zerver/views/messages.py:514: error: Right operand of 'and' is never evaluated
- [x] zerver/views/messages.py:755: error: Right operand of 'and' is never evaluated
- [x] zerver/views/messages.py:756: error: Statement is unreachable
- [x] zerver/management/commands/send_webhook_fixture_message.py:64: error: Left operand of 'or' is always false
- [x] zerver/management/commands/send_webhook_fixture_message.py:65: error: Statement is unreachable
- [x] zerver/management/commands/send_to_email_mirror.py:59: error: Statement is unreachable
- [x] zerver/management/commands/send_to_email_mirror.py:63: error: Statement is unreachable
- [x] zerver/management/commands/fill_memcached_caches.py:19: error: Statement is unreachable
- [x] puppet/zulip_ops/files/zulip-ec2-configure-interfaces:55: error: Statement is unreachable
- [x] analytics/views.py:246: error: Left operand of 'or' is always false
- [x] analytics/management/commands/client_activity.py:62: error: Statement is unreachable
- [x] zerver/lib/test_helpers.py:43: error: Statement is unreachable
- [x] zerver/lib/test_runner.py:570: error: Statement is unreachable
