### PR TITLE
css: Fix .message_top_line stealing mouse events from .message_edit_form

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2837,6 +2837,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
     display: none;
     margin-top: 5px;
     margin-left: 47px;
+    position: relative;
 }
 
 /* Reduce some of the heavy padding from Bootstrap. */


### PR DESCRIPTION
This is a replacement for the workaround removed by commit 22736084778d1d00a382681c178b634e19cc05aa.