### PR TITLE
settings_account: Fix birthday input bg color, hover and reset.

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -140,8 +140,20 @@ exports.initialize_custom_date_type_fields = function (element_id) {
     $(element_id).find(".custom_user_field .datepicker").flatpickr({
         altInput: true,
         altFormat: "F j, Y"});
-};
 
+    $(element_id).find(".custom_user_field ").on("mouseenter", function () {
+        if ($(element_id).find(".custom_user_field .datepicker").val() !== '') {
+            $(element_id).find(".remove_date").show();
+        } else {
+            $(element_id).find(".remove_date").hide();
+        }
+
+    });
+
+    $(element_id).find(".remove_date").on("click", function () {
+        $(element_id).find(".custom_user_field .datepicker").val('');
+    });
+};
 exports.initialize_custom_user_type_fields = function (element_id, user_id, is_editable,
                                                        set_handler_on_update) {
     var field_types = page_params.custom_profile_field_types;

--- a/static/third/bootstrap/css/bootstrap.css
+++ b/static/third/bootstrap/css/bootstrap.css
@@ -1470,7 +1470,7 @@ input[readonly],
 select[readonly],
 textarea[readonly] {
   cursor: not-allowed;
-  background-color: #eeeeee;
+  background-color: #ffffff;
 }
 
 input[type="radio"][disabled],


### PR DESCRIPTION
This changes the background color of the birthday input field from
grey to white. The X on the right side of the box no longer shows
when the box is empty. If the box is not empty, clicking on the X
clears back the input field.

After fixing the issues:
![check](https://user-images.githubusercontent.com/48182195/61979879-b9865800-b012-11e9-9501-29e64b24f794.gif)
