### PR TITLE
requirements: Upgrade redis from 2.10.6 to 3.2.1.

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -89,7 +89,7 @@ python-dateutil==2.8.0
 pytz==2019.1
 
 # Needed for redis
-redis==2.10.6
+redis==3.2.1
 
 # Needed for Python 2+3 compatibility
 six==1.12.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -146,7 +146,7 @@ pyyaml==5.1.1             # via cfn-lint, moto, yamole
 qrcode==6.1               # via django-two-factor-auth
 queuelib==1.5.0           # via scrapy
 recommonmark==0.4.0
-redis==2.10.6
+redis==3.2.1
 regex==2019.6.8
 requests-oauthlib==1.0.0  # via python-twitter, social-auth-core
 requests[security]==2.22.0  # via aws-xray-sdk, cfn-lint, docker, hypchat, matrix-client, moto, premailer, pyoembed, python-digitalocean, python-gcm, python-twitter, requests-oauthlib, responses, social-auth-core, sphinx, stripe, twilio

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -97,7 +97,7 @@ python3-openid==3.1.0     # via social-auth-core
 pytz==2019.1
 pyyaml==5.1.1             # via yamole
 qrcode==6.1               # via django-two-factor-auth
-redis==2.10.6
+redis==3.2.1
 regex==2019.6.8
 requests-oauthlib==1.0.0  # via python-twitter, social-auth-core
 requests[security]==2.22.0  # via hypchat, matrix-client, premailer, pyoembed, python-gcm, python-twitter, requests-oauthlib, social-auth-core, stripe, twilio

--- a/zerver/lib/rate_limiter.py
+++ b/zerver/lib/rate_limiter.py
@@ -224,7 +224,7 @@ def incr_ratelimit(entity: RateLimitedObject) -> None:
                 # Add our new value to the sorted set that we keep
                 # We need to put the score and val both as timestamp,
                 # as we sort by score but remove by value
-                pipe.zadd(set_key, now, now)
+                pipe.zadd(set_key, {str(now): now})
 
                 # Remove the trimmed value from our sorted set, if there was one
                 if last_val is not None:


### PR DESCRIPTION
Fixes #11209

This requires changing how zadd is used in rate_limiter.py:
In redis-py >= 3.0 the pairs to ZADD need to be passed as a dictionary,
not as *args or **kwargs, as described at
https://pypi.org/project/redis/3.2.1/ in the section
"Upgrading from redis-py 2.X to 3.0".

The rate_limiter change has to be in one commit with the redis upgrade,
because the dict format is not supported before redis-py 3.0.

@hackerkid Does this look alright?