### PR TITLE
provision: Fix avatars spam when running provision with force.

### DIFF
--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -42,6 +42,8 @@ settings.TORNADO_SERVER = None
 settings.CACHES['default'] = {
     'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'
 }
+# Set the appropriate path to avoid spamming the project directory.
+settings.LOCAL_UPLOADS_DIR = 'var/uploads'
 
 # Suppress spammy output from the push notifications logger
 push_notifications_logger.disabled = True


### PR DESCRIPTION
~~When running `tools/provision --force`, from what looks like
running migrations, we see `avatars` directory spam in the
project's root.  This is similar to what was happening with
running Casper/API tests, so we take the same approach here.~~

This was coming from `populate_db` when running the `do-destroy-rebuild-database` script in provision.

**Tested with:**
`tools/provision --force`