### PR TITLE
nginx: Remove invalid extra headers for OPTIONS /api/v1/events.

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-frontend/app
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/app
@@ -30,8 +30,6 @@ location /api/v1/events {
     include /etc/nginx/zulip-include/api_headers;
 
     if ($request_method = 'OPTIONS') {
-        add_header 'Content-Type' 'text/plain charset=UTF-8';
-        add_header 'Content-Length' 0;
         return 204;
     }
 


### PR DESCRIPTION
Since 204 responses don’t contain a payload body, `Content-Type` is neither required nor encouraged (RFC 7231 §3.1.1.5), and ours was missing a semicolon to boot; `Content-Length` is expressly forbidden (RFC 7230 §3.3.2).

Furthermore, these `add_header` directives were silencing the CORS headers set in `api_headers`, because `add_header` inheritance doesn’t work the way you think it does, as was known before commit 5614d51afcaf09dca6f22dfc36303b8275610608.

Fixes: #12902.