### PR TITLE
Prepopulate stream name in compose box if possible.

### DIFF
--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -21,6 +21,7 @@ zrequire('compose');
 zrequire('util');
 zrequire('compose_state');
 zrequire('compose_actions');
+zrequire('stream_data');
 
 set_global('document', 'document-stub');
 
@@ -136,6 +137,52 @@ run_test('start', () => {
     assert.equal($('#stream_message_recipient_topic').val(), 'topic1');
     assert.equal(compose_state.get_message_type(), 'stream');
     assert(compose_state.composing());
+
+    // Autofill stream field for single subscription
+    var denmark = {
+        subscribed: true,
+        color: 'blue',
+        name: 'Denmark',
+        stream_id: 1,
+    };
+    stream_data.add_sub('Denmark', denmark);
+
+    global.narrow_state.set_compose_defaults = function () {
+        var opts = {};
+        opts.trigger = "new topic button";
+        return opts;
+    };
+
+    opts = {};
+    start('stream', opts);
+    assert.equal($('#stream_message_recipient_stream').val(), 'Denmark');
+    assert.equal($('#stream_message_recipient_topic').val(), '');
+
+    global.narrow_state.set_compose_defaults = function () {
+        var opts = {};
+        opts.trigger = "compose_hotkey";
+        return opts;
+    };
+
+    opts = {};
+    start('stream', opts);
+    assert.equal($('#stream_message_recipient_stream').val(), 'Denmark');
+    assert.equal($('#stream_message_recipient_topic').val(), '');
+
+    var social = {
+        subscribed: true,
+        color: 'red',
+        name: 'social',
+        stream_id: 2,
+    };
+    stream_data.add_sub('social', social);
+
+    // More than 1 subscription, do not autofill
+    opts = {};
+    start('stream', opts);
+    assert.equal($('#stream_message_recipient_stream').val(), '');
+    assert.equal($('#stream_message_recipient_topic').val(), '');
+    stream_data.clear_subscriptions();
 
     // Start PM
     global.narrow_state.set_compose_defaults = function () {

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -221,6 +221,11 @@ exports.start = function (msg_type, opts) {
         opts.private_message_recipient = '';
     }
 
+    var subbed_streams = stream_data.subscribed_subs();
+    if (subbed_streams.length === 1 && (opts.trigger === "new topic button" || opts.trigger === "compose_hotkey" && msg_type === "stream")) {
+        opts.stream = subbed_streams[0].name;
+    }
+
     if (compose_state.composing() && !same_recipient_as_before(msg_type, opts)) {
         // Clear the compose box if the existing message is to a different recipient
         clear_box();


### PR DESCRIPTION
When users are only subbed to a single stream, this autofills the stream
field of the compose box.
Fixes #12507.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
