### PR TITLE
markdown: Render ordered lists using <ol> markup.

### DIFF
--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -284,7 +284,7 @@ run_test('marked', () => {
         {input: 'Some text first\n* a\n* list \n* here\n\nand then after',
          expected: '<p>Some text first</p>\n<ul>\n<li>a</li>\n<li>list </li>\n<li>here</li>\n</ul>\n<p>and then after</p>'},
         {input: '1. an\n2. ordered \n3. list',
-         expected: '<p>1. an<br>\n2. ordered<br>\n3. list</p>'},
+         expected: '<ol>\n<li>an</li>\n<li>ordered </li>\n<li>list</li>\n</ol>'},
         {input: '\n~~~quote\nquote this for me\n~~~\nthanks\n',
          expected: '<blockquote>\n<p>quote this for me</p>\n</blockquote>\n<p>thanks</p>'},
         {input: 'This is a @**Cordelia Lear** mention',

--- a/static/styles/rendered_markdown.scss
+++ b/static/styles/rendered_markdown.scss
@@ -25,7 +25,7 @@
 
     /* Ensure ordered lists are nicely centered in 1-line messages */
     ol {
-        margin: 2px 0 5px 6px;
+        margin: 2px 0 5px 20px;
     }
 
     /* Swap the left and right margins of ordered list for Right-To-Left languages */

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -27,7 +27,7 @@ import requests
 from django.conf import settings
 from django.db.models import Q
 
-from markdown.extensions import codehilite, nl2br, tables
+from markdown.extensions import codehilite, nl2br, tables, sane_lists
 from zerver.lib.bugdown import fenced_code
 from zerver.lib.bugdown.fenced_code import FENCE_RE
 from zerver.lib.camo import get_camo_url
@@ -1421,23 +1421,23 @@ class AutoLink(CompiledPattern):
         db_data = self.markdown.zulip_db_data
         return url_to_a(db_data, url)
 
-class UListProcessor(markdown.blockprocessors.UListProcessor):
-    """ Process unordered list blocks.
-
-        Based on markdown.blockprocessors.UListProcessor, but does not accept
-        '+' or '-' as a bullet character."""
-
-    TAG = 'ul'
-    RE = re.compile('^[ ]{0,3}[*][ ]+(.*)')
-
+class OListProcessor(sane_lists.SaneOListProcessor):
     def __init__(self, parser: Any) -> None:
-
-        # HACK: Set the tab length to 2 just for the initialization of
-        # this class, so that bulleted lists (and only bulleted lists)
-        # work off 2-space indentation.
         parser.markdown.tab_length = 2
         super().__init__(parser)
         parser.markdown.tab_length = 4
+
+class UListProcessor(sane_lists.SaneUListProcessor):
+    """ Does not accept '+' or '-' as a bullet character. """
+
+    def __init__(self, parser: Any) -> None:
+        parser.markdown.tab_length = 2
+        super().__init__(parser)
+        parser.markdown.tab_length = 4
+
+        self.RE = re.compile('^[ ]{0,%d}[*][ ]+(.*)' % (self.tab_length - 1,))
+        self.CHILD_RE = re.compile(r'^[ ]{0,%d}(([*]))[ ]+(.*)' %
+                                   (self.tab_length - 1,))
 
 class ListIndentProcessor(markdown.blockprocessors.ListIndentProcessor):
     """ Process unordered list blocks.
@@ -1482,16 +1482,15 @@ class BlockQuoteProcessor(markdown.blockprocessors.BlockQuoteProcessor):
         # And then run the upstream processor's code for removing the '>'
         return super().clean(line)
 
-class BugdownUListPreprocessor(markdown.preprocessors.Preprocessor):
-    """ Allows unordered list blocks that come directly after a
-        paragraph to be rendered as an unordered list
+class BugdownListPreprocessor(markdown.preprocessors.Preprocessor):
+    """ Allows list blocks that come directly after another block
+        to be rendered as a list.
 
         Detects paragraphs that have a matching list item that comes
         directly after a line of text, and inserts a newline between
         to satisfy Markdown"""
 
-    LI_RE = re.compile('^[ ]{0,3}[*][ ]+(.*)', re.MULTILINE)
-    HANGING_ULIST_RE = re.compile('^.+\\n([ ]{0,3}[*][ ]+.*)', re.MULTILINE)
+    LI_RE = re.compile(r'^[ ]{0,3}(\*|\d\.)[ ]+(.*)', re.MULTILINE)
 
     def run(self, lines: List[str]) -> List[str]:
         """ Insert a newline between a paragraph and ulist if missing """
@@ -1509,90 +1508,16 @@ class BugdownUListPreprocessor(markdown.preprocessors.Preprocessor):
                 fence = None
 
             # If we're not in a fenced block and we detect an upcoming list
-            #  hanging off a paragraph, add a newline
-            if (not fence and lines[i] and
-                self.LI_RE.match(lines[i+1]) and
-                    not self.LI_RE.match(lines[i])):
-
-                copy.insert(i+inserts+1, '')
-                inserts += 1
+            # hanging off any block (including a list of another type), add
+            # a newline.
+            li1 = self.LI_RE.match(lines[i])
+            li2 = self.LI_RE.match(lines[i+1])
+            if not fence and lines[i]:
+                if (li2 and not li1) or (li1 and li2 and
+                                         (len(li1.group(1)) == 1) != (len(li2.group(1)) == 1)):
+                    copy.insert(i+inserts+1, '')
+                    inserts += 1
         return copy
-
-class AutoNumberOListPreprocessor(markdown.preprocessors.Preprocessor):
-    """ Finds a sequence of lines numbered by the same number"""
-    RE = re.compile(r'^([ ]*)(\d+)\.[ ]+(.*)')
-    TAB_LENGTH = 2
-
-    def run(self, lines: List[str]) -> List[str]:
-        new_lines = []  # type: List[str]
-        current_list = []  # type: List[Match[str]]
-        current_indent = 0
-
-        for line in lines:
-            m = self.RE.match(line)
-
-            # Remember if this line is a continuation of already started list
-            is_next_item = (m and current_list
-                            and current_indent == len(m.group(1)) // self.TAB_LENGTH)
-
-            is_blank_line = line.strip() == ""
-
-            if not is_next_item and not is_blank_line:
-                # This is a non-blank line that doesn't start with a
-                # bullet, so we're done with the previous numbered
-                # list and can start a new one.
-                new_lines.extend(self.renumber(current_list))
-                current_list = []
-
-            if not m:
-                # This line doesn't start with a bullet.  If it's not
-                # between bullets of a list (i.e. `current_list =
-                # []`), this is just normal content outside a bulleted
-                # list and we can append it to `new_lines`.
-                if not current_list:
-                    # Ordinary line
-                    new_lines.append(line)
-
-                # Otherwise, it's a blank line in between bullets,
-                # because if this was a bullet, `m` would be truthy,
-                # and if it wasn't blank, we could have terminated the
-                # list (see above).  We can just skip this blank line
-                # syntax, as our bulleted list CSS styling will
-                # control vertical spacing between bullets.
-            elif is_next_item:
-                # Another list item
-                current_list.append(m)
-            else:
-                # First list item
-                current_list = [m]
-                current_indent = len(m.group(1)) // self.TAB_LENGTH
-
-        new_lines.extend(self.renumber(current_list))
-
-        return new_lines
-
-    def renumber(self, mlist: List[Match[str]]) -> List[str]:
-        if not mlist:
-            return []
-
-        start_number = int(mlist[0].group(2))
-
-        # Change numbers only if every one is the same
-        change_numbers = True
-        for m in mlist:
-            if int(m.group(2)) != start_number:
-                change_numbers = False
-                break
-
-        lines = []  # type: List[str]
-        counter = start_number
-
-        for m in mlist:
-            number = str(counter) if change_numbers else m.group(2)
-            lines.append('%s%s. %s' % (m.group(1), number, m.group(3)))
-            counter += 1
-
-        return lines
 
 def prepare_realm_pattern(source: str) -> str:
     """ Augment a realm filter so it only matches after start-of-string,
@@ -1869,8 +1794,7 @@ class Bugdown(markdown.Markdown):
         # html_block - insecure
         # reference - references don't make sense in a chat context.
         preprocessors = markdown.util.Registry()
-        preprocessors.register(AutoNumberOListPreprocessor(self), 'auto_number_olist', 40)
-        preprocessors.register(BugdownUListPreprocessor(self), 'hanging_ulists', 35)
+        preprocessors.register(BugdownListPreprocessor(self), 'hanging_lists', 35)
         preprocessors.register(markdown.preprocessors.NormalizeWhitespace(self), 'normalize_whitespace', 30)
         preprocessors.register(fenced_code.FencedBlockPreprocessor(self), 'fenced_code_block', 25)
         preprocessors.register(AlertWordsNotificationProcessor(self), 'custom_text_notifications', 20)
@@ -1892,6 +1816,7 @@ class Bugdown(markdown.Markdown):
         parser.blockprocessors.register(HashHeaderProcessor(parser), 'hashheader', 78)
         # We get priority 75 from 'table' extension
         parser.blockprocessors.register(markdown.blockprocessors.HRProcessor(parser), 'hr', 70)
+        parser.blockprocessors.register(OListProcessor(parser), 'olist', 68)
         parser.blockprocessors.register(UListProcessor(parser), 'ulist', 65)
         parser.blockprocessors.register(ListIndentProcessor(parser), 'indent', 60)
         parser.blockprocessors.register(BlockQuoteProcessor(parser), 'quote', 55)

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -488,15 +488,31 @@ def get_mobile_push_content(rendered_content: str) -> str:
         quote_text += '\n'
         return quote_text
 
+    def render_olist(ol: lxml.html.HtmlElement) -> str:
+        items = []
+        counter = int(ol.get('start')) if ol.get('start') else 1
+        nested_levels = len(list(ol.iterancestors('ol')))
+        indent = ('\n' + '  ' * nested_levels) if nested_levels else ''
+
+        for li in ol:
+            items.append(indent + str(counter) + '. ' + process(li).strip())
+            counter += 1
+
+        return '\n'.join(items)
+
     def process(elem: lxml.html.HtmlElement) -> str:
-        plain_text = get_text(elem)
-        sub_text = ''
-        for child in elem:
-            sub_text += process(child)
-        if elem.tag == 'blockquote':
-            sub_text = format_as_quote(sub_text)
-        plain_text += sub_text
-        plain_text += elem.tail or ""
+        plain_text = ''
+        if elem.tag == 'ol':
+            plain_text = render_olist(elem)
+        else:
+            plain_text = get_text(elem)
+            sub_text = ''
+            for child in elem:
+                sub_text += process(child)
+            if elem.tag == 'blockquote':
+                sub_text = format_as_quote(sub_text)
+            plain_text += sub_text
+            plain_text += elem.tail or ""
         return plain_text
 
     if settings.PUSH_NOTIFICATION_REDACT_CONTENT:

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -776,6 +776,7 @@
       "name": "auto_renumbered_list_blankline",
       "input": "1. A\n\n1. B\n\n1. C\n\n1. D\nordinary paragraph\n1. AA\n\n1. BB",
       "expected_output": "<ol>\n<li>\n<p>A</p>\n</li>\n<li>\n<p>B</p>\n</li>\n<li>\n<p>C</p>\n</li>\n<li>\n<p>D<br>\nordinary paragraph</p>\n</li>\n<li>\n<p>AA</p>\n</li>\n<li>\n<p>BB</p>\n</li>\n</ol>",
+      "marked_expected_output": "<ol>\n<li><p>A</p>\n</li>\n<li><p>B</p>\n</li>\n<li><p>C</p>\n</li>\n<li><p>D<br>\nordinary paragraph</p>\n</li>\n<li><p>AA</p>\n</li>\n<li><p>BB</p>\n</li>\n</ol>",
       "text_content": "1. A\n2. B\n3. C\n4. D\nordinary paragraph\n5. AA\n6. BB"
     }
   ],

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -292,27 +292,27 @@
     },
     {
       "name": "numbered_list",
-      "input": "1. A\n 2. B",
-      "expected_output": "<p>1. A<br>\n 2. B</p>",
-      "text_content": "1. A\n 2. B"
+      "input": "1. A\n2. B\n  3. C",
+      "expected_output": "<ol>\n<li>A</li>\n<li>B<ol start=\"3\">\n<li>C</li>\n</ol>\n</li>\n</ol>",
+      "text_content": "1. A\n2. B\n  3. C"
     },
     {
       "name": "auto_renumbered_list",
-      "input": "1. A\n1. B\n 1. C\n1. D",
-      "expected_output": "<p>1. A<br>\n2. B<br>\n 3. C<br>\n4. D</p>",
-      "text_content": "1. A\n2. B\n 3. C\n4. D"
+      "input": "1. A\n1. B\n  1. C\n1. D",
+      "expected_output": "<ol>\n<li>A</li>\n<li>B<ol>\n<li>C</li>\n</ol>\n</li>\n<li>D</li>\n</ol>",
+      "text_content": "1. A\n2. B\n  1. C\n3. D"
     },
     {
       "name": "auto_renumbered_list_from",
       "input": "3. A\n3. B\n3. C\n3. D",
-      "expected_output": "<p>3. A<br>\n4. B<br>\n5. C<br>\n6. D</p>",
+      "expected_output": "<ol start=\"3\">\n<li>A</li>\n<li>B</li>\n<li>C</li>\n<li>D</li>\n</ol>",
       "text_content": "3. A\n4. B\n5. C\n6. D"
     },
     {
       "name": "not_auto_renumbered_list",
-      "input": "1. A\n3. B\n 2. C\n1. D",
-      "expected_output": "<p>1. A<br>\n3. B<br>\n 2. C<br>\n1. D</p>",
-      "text_content": "1. A\n3. B\n 2. C\n1. D"
+      "input": "1. A\n3. B\n  2. C\n1. D",
+      "expected_output": "<ol>\n<li>A</li>\n<li>B<ol start=\"2\">\n<li>C</li>\n</ol>\n</li>\n<li>D</li>\n</ol>",
+      "text_content": "1. A\n2. B\n  2. C\n3. D"
     },
     {
       "name": "linkify_interference",
@@ -775,8 +775,8 @@
     {
       "name": "auto_renumbered_list_blankline",
       "input": "1. A\n\n1. B\n\n1. C\n\n1. D\nordinary paragraph\n1. AA\n\n1. BB",
-      "expected_output": "<p>1. A<br>\n2. B<br>\n3. C<br>\n4. D<br>\nordinary paragraph<br>\n1. AA<br>\n2. BB</p>",
-      "text_content": "1. A\n2. B\n3. C\n4. D\nordinary paragraph\n1. AA\n2. BB"
+      "expected_output": "<ol>\n<li>\n<p>A</p>\n</li>\n<li>\n<p>B</p>\n</li>\n<li>\n<p>C</p>\n</li>\n<li>\n<p>D<br>\nordinary paragraph</p>\n</li>\n<li>\n<p>AA</p>\n</li>\n<li>\n<p>BB</p>\n</li>\n</ol>",
+      "text_content": "1. A\n2. B\n3. C\n4. D\nordinary paragraph\n5. AA\n6. BB"
     }
   ],
   "linkify_tests": [

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -463,7 +463,7 @@ class BugdownTest(ZulipTestCase):
         converted = render_markdown(msg, content)
         self.assertEqual(converted, expected)
 
-        content = '>- http://cdn.wallpapersafari.com/13/6/16eVjx.jpeg\n\nAwesome!'
+        content = '>* http://cdn.wallpapersafari.com/13/6/16eVjx.jpeg\n\nAwesome!'
         expected = '<blockquote>\n<ul>\n<li><a href="http://cdn.wallpapersafari.com/13/6/16eVjx.jpeg" target="_blank" title="http://cdn.wallpapersafari.com/13/6/16eVjx.jpeg">http://cdn.wallpapersafari.com/13/6/16eVjx.jpeg</a></li>\n</ul>\n</blockquote>\n<p>Awesome!</p>'
         sender_user_profile = self.example_user('othello')
         msg = Message(sender=sender_user_profile, sending_client=get_client("test"))


### PR DESCRIPTION
I couldn't quite figured out how to set the tab length in markedjs yet. It considers a block with one single space before the number a nested item.

This also make nested ordered-list work as intended.

FYI @aero31aero 

Fixes #12822 