### PR TITLE
Re-introduce removed event queues validation

### DIFF
--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -366,6 +366,11 @@ class EventQueueTest(ZulipTestCase):
         new_client = ClientDescriptor.from_dict(client_dict)
         self.assertEqual(client.to_dict(), new_client.to_dict())
 
+        client_dict = client.to_dict()
+        del client_dict['event_queue']['newest_pruned_id']
+        new_client = ClientDescriptor.from_dict(client_dict)
+        self.assertEqual(client.to_dict(), new_client.to_dict())
+
     def test_one_event(self) -> None:
         client = self.get_client_descriptor()
         queue = client.event_queue

--- a/zerver/tests/test_tornado.py
+++ b/zerver/tests/test_tornado.py
@@ -117,7 +117,7 @@ class EventsTestCase(TornadoWebTestCase):
         event_queue_id = self.create_queue()
         data = {
             'queue_id': event_queue_id,
-            'last_event_id': 0,
+            'last_event_id': -1,
         }
 
         path = '/json/events?{}'.format(urllib.parse.urlencode(data))

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -240,6 +240,7 @@ class EventQueue:
     def __init__(self, id: str) -> None:
         self.queue = deque()  # type: ignore # Should be Deque[Dict[str, Any]], but Deque isn't available in Python 3.4
         self.next_event_id = 0  # type: int
+        self.newest_pruned_id = -1  # type: int
         self.id = id  # type: str
         self.virtual_events = {}  # type: Dict[str, Dict[str, Any]]
 
@@ -295,6 +296,7 @@ class EventQueue:
     # See the comment on pop; that applies here as well
     def prune(self, through_id: int) -> None:
         while len(self.queue) != 0 and self.queue[0]['id'] <= through_id:
+            self.newest_pruned_id = self.queue[0]['id']
             self.pop()
 
     def contents(self) -> List[Dict[str, Any]]:
@@ -522,7 +524,11 @@ def fetch_events(query: Mapping[str, Any]) -> Dict[str, Any]:
                 raise BadEventQueueIdError(queue_id)
             if user_profile_id != client.user_profile_id:
                 raise JsonableError(_("You are not authorized to get events from this queue"))
+            if last_event_id < client.event_queue.newest_pruned_id:
+                raise JsonableError(_("An event newer than %s has already been pruned!") % (last_event_id,))
             client.event_queue.prune(last_event_id)
+            if last_event_id != client.event_queue.newest_pruned_id:
+                raise JsonableError(_("Event %s was not in this queue") % (last_event_id,))
             was_connected = client.finish_current_handler()
 
         if not client.event_queue.empty() or dont_block:


### PR DESCRIPTION
This has a test that would need to pass for the `newest_pruned_id` logic we had to be correct.  

I think probably what we need to do is either (1) have special logic for the webapp to reload after seeing this error like we had before to deal with incorrectly migrated queues or (2) to have a special state for a migrated queue where `newest_pruned_event_id` is `None` or something and not compared.

@andersk FYI.