### PR TITLE
GitHub auth email selection page styling

### DIFF
--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -214,4 +214,9 @@ $(function () {
         clearTimeout(timer);
         timer = setTimeout(check_subdomain_avilable, 250, $('#id_team_subdomain').val());
     });
+
+    // GitHub auth
+    $("body").on("click", "#choose_email .choose-email-box", function () {
+        this.parentNode.submit();
+    });
 });

--- a/static/styles/portico/portico-signin.scss
+++ b/static/styles/portico/portico-signin.scss
@@ -1076,14 +1076,6 @@ button.login-social-button:active {
         font-size: 0.9em;
     }
 
-    #create-organization-section {
-        text-align: center;
-        margin-top: 20px;
-        font-weight: 500;
-        margin-left: -28px;
-        font-size: 0.9em;
-    }
-
     .find-account-link {
         color: hsl(165, 100.0%, 14.7%);
     }

--- a/static/styles/portico/portico-signin.scss
+++ b/static/styles/portico/portico-signin.scss
@@ -31,6 +31,15 @@ html {
     margin-top: 20px;
     font-weight: 500;
     font-size: 0.9em;
+
+    a {
+        color: hsl(164, 100%, 23%);
+
+        &:hover {
+            text-decoration: none;
+            color: hsl(156, 62%, 61%);
+        }
+    }
 }
 
 .grey {
@@ -1088,26 +1097,62 @@ button.login-social-button:active {
 #choose_email {
     flex-direction: column;
 
+    .white-box {
+        min-width: 450px;
+        padding: 30px 0 50px 0;
+    }
+
     form {
         padding: 0;
         margin: 0;
+
+        &.form-horizontal:hover {
+            background-color: hsl(202, 56%, 91%);
+            cursor: pointer;
+
+            i.fa {
+                color: hsl(203, 63%, 76%);
+            }
+        }
     }
 
-    button {
-        color: hsl(0, 0%, 0%);
-        background-color: hsl(0, 0%, 100%);
-        width: 100%;
-        margin-top: 15px;
-        border: 1px solid hsl(0, 0%, 80%);
-        border-radius: 4px;
-    }
+    .choose-email-box {
+        padding: 13px 0;
+        margin: 0 30px;
+        border-bottom: 1px solid hsl(0, 0%, 95%);
+        display: flex;
+        align-items: center;
 
-    button:hover {
-        border-color: hsl(0, 0%, 0%);
-    }
+        p {
+            margin: 0;
+            font-size: 0.8em;
 
-    button:active {
-        border-color: hsl(0, 0%, 60%);
-        background-color: hsl(0, 0%, 95%);
+            &:last-child {
+                line-height: 1.2em;
+            }
+        }
+
+        .email {
+            font-size: 0.95em;
+            font-weight: 500;
+        }
+
+        img,
+        i {
+            width: 35px;
+            height: 35px;
+            margin-right: 10px;
+            border-radius: 3px;
+        }
+
+        i.fa {
+            color: hsl(0, 0%, 67%);
+            text-align: center;
+            line-height: 38px;
+
+            &::before {
+                font-size: 30px;
+            }
+        }
     }
 }

--- a/static/styles/portico/portico-signin.scss
+++ b/static/styles/portico/portico-signin.scss
@@ -26,6 +26,13 @@ html {
     border-radius: 4px;
 }
 
+.bottom-text {
+    text-align: center;
+    margin-top: 20px;
+    font-weight: 500;
+    font-size: 0.9em;
+}
+
 .grey {
     color: hsl(0, 0%, 67%);
 }

--- a/static/styles/portico/portico-signin.scss
+++ b/static/styles/portico/portico-signin.scss
@@ -326,11 +326,6 @@ html {
     margin-top: 25px;
 }
 
-.register-page .register-form .bottom-text {
-    font-size: 1.2rem;
-    margin-top: 40px;
-}
-
 .new-style .alert:not(.alert-info) {
     padding: 0;
     margin-bottom: 0;

--- a/templates/zerver/create_realm.html
+++ b/templates/zerver/create_realm.html
@@ -15,19 +15,21 @@ page can be easily identified in it's respective JavaScript file -->
             <div class="lead">
                 <h1 class="get-started">{{ _("Create a new Zulip organization") }}</h1>
             </div>
-            <form class="form-inline" id="send_confirm" name="email_form"
-              action="{{ current_url() }}" method="post">
-                {{ csrf_input }}
-                <div class="input-box horizontal">
-                    <div class="inline-block relative">
-                        <input type="text" class="email required" placeholder="{{ _("Enter your email address") }}"
-                          id="email" name="email" required />
-                        <label for="email">{{ _('Email') }}</label>
-                    </div>
+            <div class="white-box">
+                <form class="form-inline" id="send_confirm" name="email_form"
+                  action="{{ current_url() }}" method="post">
+                    {{ csrf_input }}
+                    <div class="input-box horizontal">
+                        <div class="inline-block relative">
+                            <input type="text" class="email required" placeholder="{{ _("Enter your email address") }}"
+                              id="email" name="email" required />
+                            <label for="email">{{ _('Email') }}</label>
+                        </div>
 
-                    <button type="submit" class="new-organization-button register-button">{{ _("Create organization") }}</button>
-                </div>
-            </form>
+                        <button type="submit" class="new-organization-button register-button">{{ _("Create organization") }}</button>
+                    </div>
+                </form>
+            </div>
             <div class="alert alert-error email-frontend-error"></div>
             {% if form.email.errors %}
                 {% for error in form.email.errors %}

--- a/templates/zerver/realm_redirect.html
+++ b/templates/zerver/realm_redirect.html
@@ -30,17 +30,17 @@
                             {% endif %}
                         </div>
                         <button id="enter-realm-button" type="submit">{{ _('Next') }}</button>
-                        <p id="find-account-section">
+                        <p class="bottom-text">
                             {{ _("Don't know your organization URL?") }}
-                            <a target="_blank" class="find-account-link" href="/accounts/find/">{{ _("Find your organization.") }}</a>
+                            <a target="_blank" href="/accounts/find/">{{ _("Find your organization.") }}</a>
                         </p>
                     </div>
                 </form>
             </div>
         </div>
 
-        <div id="create-organization-section">
-            {{ _("Need to get your group started on Zulip?") }} <a target="_blank" class="find-account-link" href="/new/">{{ _("Create a new organization.") }}</a>
+        <div class="bottom-text">
+            {{ _("Need to get your group started on Zulip?") }} <a target="_blank" href="/new/">{{ _("Create a new organization.") }}</a>
         </div>
     </div>
 

--- a/templates/zerver/social_auth_select_email.html
+++ b/templates/zerver/social_auth_select_email.html
@@ -2,10 +2,9 @@
 
 {% block portico_content %}
 <div class="register-account flex full-page new-style" id="choose_email">
-
-    <div class="pitch">
+    <div class="lead">
         {% trans %}
-        <h1>Select email</h1>
+        <h1 class="get-started">Select account</h1>
         {% endtrans %}
     </div>
 
@@ -28,6 +27,9 @@
             </div>
         </form>
         {% endfor %}
+    </div>
+    <div class="bottom-text">
+        Only verified GitHub email addresses are listed.
     </div>
 </div>
 {% endblock %}

--- a/templates/zerver/social_auth_select_email.html
+++ b/templates/zerver/social_auth_select_email.html
@@ -8,28 +8,57 @@
         {% endtrans %}
     </div>
 
-    <div>
+    <div class="white-box">
         <form method="post" class="form-horizontal" action="/complete/{{ backend }}/">
-            <div class='choose-email-box'>
+            <div class="choose-email-box">
                 <input type="hidden" name="email" value="{{ primary_email }}" />
-                <button type="submit" >
-                    {{ primary_email }}
-                </button>
+                {% if avatar_urls[primary_email] %}
+                <img src="{{ avatar_urls[primary_email] }}" alt=""/>
+                {% else %}
+                <i class="fa fa-plus" aria-hidden="true"></i>
+                {% endif %}
+                <div>
+                    <p class="email">
+                        {{ primary_email }}
+                    </p>
+                    <p>
+                        GitHub primary
+                        {% if avatar_urls[primary_email] %}
+                        - Log in
+                        {% else %}
+                        - Create new account
+                        {% endif %}
+                    </p>
+                </div>
             </div>
         </form>
         {% for email in verified_non_primary_emails %}
         <form method="post" class="form-horizontal" action="/complete/{{ backend }}/">
-            <div class='choose-email-box'>
+            <div class="choose-email-box">
                 <input type="hidden" name="email" value="{{ email }}" />
-                <button type="submit" >
-                    {{ email }}
-                </button>
+                {% if avatar_urls[email] %}
+                <img src="{{ avatar_urls[email] }}" alt="" class="no-drag"/>
+                {% else %}
+                <i class="fa fa-plus" aria-hidden="true"></i>
+                {% endif %}
+                <div>
+                    <p class="email">
+                        {{ email }}
+                    </p>
+                    <p>
+                        {% if avatar_urls[email] %}
+                        Log in
+                        {% else %}
+                        Create new account
+                        {% endif %}
+                    </p>
+                </div>
             </div>
         </form>
         {% endfor %}
     </div>
-    <div class="bottom-text">
+    <p class="bottom-text">
         Only verified GitHub email addresses are listed.
-    </div>
+    </p>
 </div>
 {% endblock %}

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1113,7 +1113,7 @@ class GitHubAuthBackendTest(SocialAuthBase):
         # As emails ending with `noreply.github.com` are excluded from
         # verified_emails, choosing it as an email should raise a `email
         # not associated` warning.
-        account_data_dict = dict(email="hamlet@noreply.github.com", name=self.name)
+        account_data_dict = dict(email="hamlet@users.noreply.github.com", name=self.name)
         email_data = [
             dict(email="notprimary@zulip.com",
                  verified=True),

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -570,7 +570,7 @@ class SocialAuthBase(ZulipTestCase):
             # TODO: Generalize this testing code for use with other
             # authentication backends; for now, we just assert that
             # it's definitely the GitHub authentication backend.
-            self.assert_in_success_response(["Select email"], result)
+            self.assert_in_success_response(["Select account"], result)
             assert self.AUTH_FINISH_URL == "/complete/github/"
 
             # Testing hack: When the pipeline goes to the partial

--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -181,6 +181,7 @@ class TemplateTestCase(ZulipTestCase):
             request=RequestFactory().get("/"),
             invite_as={"MEMBER": 1},
             max_file_upload_size = 25,
+            avatar_urls={"john@gmail.com": "www.zulip.com"},
         )
 
         context.update(kwargs)

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -887,15 +887,16 @@ class GitHubAuthBackend(SocialAuthMixin, GithubOAuth2):
         return verified_emails
 
     def filter_usable_emails(self, emails: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        # We only let users login using email addresses that are verified
-        # by GitHub, because the whole point is for the user to
-        # demonstrate that they control the target email address.  We also
-        # disallow the @noreply.github.com email addresses, because
-        # structurally, we only want to allow email addresses that can
-        # receive emails, and those cannot.
+        # We only let users login using email addresses that are
+        # verified by GitHub, because the whole point is for the user
+        # to demonstrate that they control the target email address.
+        # We also disallow the
+        # @noreply.github.com/@users.noreply.github.com email
+        # addresses, because structurally, we only want to allow email
+        # addresses that can receive emails, and those cannot.
         return [
             email for email in emails
-            if email.get('verified') and not email["email"].endswith("@noreply.github.com")
+            if email.get('verified') and not email["email"].endswith("noreply.github.com")
         ]
 
     def user_data(self, access_token: str, *args: Any, **kwargs: Any) -> Dict[str, str]:


### PR DESCRIPTION
Related to: PR https://github.com/zulip/zulip/pull/9977 and https://github.com/zulip/zulip/issues/12638

**Testing Plan:** <!-- How have you tested? -->
I tested the styling and the login with the primary email address on Chrome, Firefox and Safari.

**GIFs or Screenshots:**
For the users that have an account in Zulip with a GitHub email, the avatar of the account is displayed. If the email does not have an associated account, then the `Create new account` text is displayed. 

The white box has a minimum height so that it doesn't look wired if there is only one verified email address.
![github_auth](https://user-images.githubusercontent.com/18381652/62414855-7e42e500-b621-11e9-8dfa-450a1859cba7.gif)

Without any account in Zulip:
![Screen Shot 2019-08-03 at 15 55 29](https://user-images.githubusercontent.com/18381652/62414934-6455d200-b622-11e9-8a88-8fc330f3e49e.png)

*First commit:* ee04a639
   * Changed the title from `Select email` to `Select account` and the class of the container so it is the same as `/accounts/go`, '/login' etc
   * Added the text under the list and styling for it
   * Changed the test related to the `<h1>Select email</h1>`

*Second commit:* 9cde2c0e
   * Changed the text of the header in translations 

*Third commit:* 63dbf96
   * Added the backend logic to display the avatars. 

*Fourth commit* 57f2a97
   * Added the `white-box` to the page
   * Changed from buttons to divs and added the `onclick` handler to submit the form
   * Added styling 

*Fifth commit* 193463d
   * https://zulipchat.com/new/ looks wired without the white box and it is not consistent with the other pages from signup/login. Therefore I added the white box to the page
   * Changed the class on the bottom text to be the same as the one for the GitHub auth
   * Added styling for the `a`s that is the color from `/accounts/go/` and on hover the color from the links on `/login`
Before changes:
<img width="668" alt="Screen Shot 2019-08-03 at 19 24 48" src="https://user-images.githubusercontent.com/18381652/62415070-69b41c00-b624-11e9-8288-d96d601025eb.png">

After changes:

![:new](https://user-images.githubusercontent.com/18381652/62415103-d4655780-b624-11e9-8c6a-00eece7dd79e.gif)

*Sixth commit* eaff75f
   * Removed the unused css, that became unused with the previous commit
 
*Seventh commit* 6260570
   * Change the class of the bottom text from `/accounts/go/` to use the same class as the ones above and remove unused css.
![accounts:go](https://user-images.githubusercontent.com/18381652/62415686-1cd54300-b62e-11e9-9eda-64a330a99129.gif)
