### PR TITLE
mypy: Remove typing ignores

### DIFF
--- a/scripts/lib/email-mirror-postfix
+++ b/scripts/lib/email-mirror-postfix
@@ -85,7 +85,7 @@ def process_response_error(e):
         response_content = e.read()
         response_data = json.loads(response_content.decode('utf8'))
         print(response_data['msg'])
-        exit(posix.EX_NOUSER)  # type: ignore # There are no stubs for posix in python 3
+        exit(posix.EX_NOUSER)
     else:
         print("4.4.2 Connection dropped: Internal server error.")
         exit(1)
@@ -95,12 +95,12 @@ def send_email_mirror(rcpt_to, shared_secret, host, url, test, verify_ssl):
     # type: (str, str, str, str, bool, bool) -> None
     if not rcpt_to:
         print("5.1.1 Bad destination mailbox address: No missed message email address.")
-        exit(posix.EX_NOUSER)  # type: ignore # There are no stubs for posix in python 3
+        exit(posix.EX_NOUSER)
     msg_text = sys.stdin.read(MAX_ALLOWED_PAYLOAD + 1)
     if len(msg_text) > MAX_ALLOWED_PAYLOAD:
         # We're not at EOF, reject large mail.
         print("5.3.4 Message too big for system: Max size is 25MiB")
-        exit(posix.EX_DATAERR)  # type: ignore # There are no stubs for posix in python 3
+        exit(posix.EX_DATAERR)
 
     secrets_file = RawConfigParser()
     secrets_file.read("/etc/zulip/zulip-secrets.conf")

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1945,9 +1945,13 @@ def extract_recipients(
 ) -> Union[List[str], List[int]]:
     # We try to accept multiple incoming formats for recipients.
     # See test_extract_recipients() for examples of what we allow.
-    try:
-        data = ujson.loads(s)  # type: ignore # This function has a super weird union argument.
-    except (ValueError, TypeError):
+
+    if isinstance(s, str):
+        try:
+            data = ujson.loads(s)
+        except (ValueError, TypeError):
+            data = s
+    else:
         data = s
 
     if isinstance(data, str):

--- a/zerver/lib/bot_config.py
+++ b/zerver/lib/bot_config.py
@@ -66,7 +66,7 @@ def load_bot_config_template(bot: str) -> Dict[str, str]:
     if os.path.isfile(config_path):
         config = configparser.ConfigParser()
         with open(config_path) as conf:
-            config.readfp(conf)  # type: ignore # readfp->read_file in python 3, so not in stubs
+            config.readfp(conf)
         return dict(config.items(bot))
     else:
         return dict()

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -1,4 +1,5 @@
 from typing import TypeVar, Callable, Optional, List, Dict, Union, Tuple, Any, Iterable
+from typing_extensions import TypedDict
 from django.http import HttpResponse
 
 ViewFuncT = TypeVar('ViewFuncT', bound=Callable[..., HttpResponse])
@@ -15,7 +16,16 @@ ExtractRecipients = Callable[[Union[str, Iterable[str], Iterable[int]]], Union[L
 ExtendedValidator = Callable[[str, str, object], Optional[str]]
 RealmUserValidator = Callable[[int, List[int], bool], Optional[str]]
 
-ProfileDataElement = Dict[str, Union[int, float, Optional[str]]]
+ProfileDataElement = TypedDict('ProfileDataElement', {
+    'id': int,
+    'name': str,
+    'type': int,
+    'hint': Optional[str],
+    'field_data': Optional[str],
+    'order': int,
+    'value': str,
+    'rendered_value': Optional[str],
+}, total=False)  # TODO: Can we remove this requirement?
 ProfileData = List[ProfileDataElement]
 
 FieldElement = Tuple[int, str, Validator, Callable[[Any], Any], str]

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -281,7 +281,7 @@ def upload_image_to_s3(
     else:
         headers = None
 
-    key.set_contents_from_string(contents, headers=headers)  # type: ignore # https://github.com/python/typeshed/issues/1552
+    key.set_contents_from_string(contents, headers=headers)
 
 def check_upload_within_quota(realm: Realm, uploaded_file_size: int) -> None:
     upload_quota = realm.upload_quota_bytes()
@@ -430,10 +430,10 @@ class S3UploadBackend(ZulipUploadBackend):
         s3_target_file_name = user_avatar_path(target_profile)
 
         key = self.get_avatar_key(s3_source_file_name + ".original")
-        image_data = key.get_contents_as_string()  # type: ignore # https://github.com/python/typeshed/issues/1552
+        image_data = key.get_contents_as_string()
         content_type = key.content_type
 
-        self.write_avatar_images(s3_target_file_name, target_profile, image_data, content_type)  # type: ignore # image_data is `bytes`, boto subs are wrong
+        self.write_avatar_images(s3_target_file_name, target_profile, image_data, content_type)
 
     def get_avatar_url(self, hash_key: str, medium: bool=False) -> str:
         bucket = settings.S3_AVATAR_BUCKET
@@ -520,7 +520,7 @@ class S3UploadBackend(ZulipUploadBackend):
         key = bucket.get_key(file_path + ".original")
         image_data = key.get_contents_as_string()
 
-        resized_medium = resize_avatar(image_data, MEDIUM_AVATAR_SIZE)  # type: ignore # image_data is `bytes`, boto subs are wrong
+        resized_medium = resize_avatar(image_data, MEDIUM_AVATAR_SIZE)
         upload_image_to_s3(
             bucket_name,
             s3_file_name + "-medium.png",
@@ -541,7 +541,7 @@ class S3UploadBackend(ZulipUploadBackend):
         key = bucket.get_key(file_path + ".original")
         image_data = key.get_contents_as_string()
 
-        resized_avatar = resize_avatar(image_data)  # type: ignore # image_data is `bytes`, boto subs are wrong
+        resized_avatar = resize_avatar(image_data)
         upload_image_to_s3(
             bucket_name,
             s3_file_name,

--- a/zerver/management/commands/email_mirror.py
+++ b/zerver/management/commands/email_mirror.py
@@ -51,7 +51,7 @@ def get_imap_messages() -> Generator[Message, None, None]:
     try:
         mbox.select(settings.EMAIL_GATEWAY_IMAP_FOLDER)
         try:
-            status, num_ids_data = mbox.search(None, 'ALL')  # type: ignore # https://github.com/python/typeshed/pull/1762
+            status, num_ids_data = mbox.search(None, 'ALL')
             for msgid in num_ids_data[0].split():
                 status, msg_data = mbox.fetch(msgid, '(RFC822)')
                 msg_as_bytes = msg_data[0][1]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1010,9 +1010,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
                 converter = field.FIELD_CONVERTERS[field_type]
                 value = converter(value)
 
-            field_data = {}  # type: ProfileDataElement
-            for k, v in field.as_dict().items():
-                field_data[k] = v
+            field_data = field.as_dict()
             field_data['value'] = value
             field_data['rendered_value'] = rendered_value
             data.append(field_data)

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -556,9 +556,9 @@ class CustomProfileFieldTest(ZulipTestCase):
         result = self.client_patch("/json/users/me/profile_data",
                                    {'data': ujson.dumps(data)})
         self.assert_json_success(result)
-        for f in iago.profile_data:
-            if f['id'] == field.id:
-                self.assertEqual(f['value'], 'foobar')
+        for field_dict in iago.profile_data:
+            if field_dict['id'] == field.id:
+                self.assertEqual(field_dict['value'], 'foobar')
 
     def test_update_invalid_choice_field(self) -> None:
         field_name = "Favorite editor"

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -304,7 +304,7 @@ class MissedMessageWorker(QueueProcessingWorker):
         self.timer_event.start()
 
     def stop_timer(self) -> None:
-        if self.timer_event and self.timer_event.is_alive():  # type: ignore # Report mypy bug.
+        if self.timer_event and self.timer_event.is_alive():
             self.timer_event.cancel()
             self.timer_event = None
 

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -398,7 +398,7 @@ class ZulipLDAPAuthBackendBase(ZulipAuthMixin, LDAPBackend):
 
         existing_values = {}
         for data in user_profile.profile_data:
-            var_name = '_'.join(data['name'].lower().split(' '))    # type: ignore # data field values can also be int
+            var_name = '_'.join(data['name'].lower().split(' '))
             existing_values[var_name] = data['value']
 
         profile_data = []   # type: List[Dict[str, Union[int, str, List[int]]]]


### PR DESCRIPTION
This PR removes some type ignores for mypy that appear to be not necessary now, or can be removed after refactoring slightly.

The first 4 commits should be pretty straightforward;
* the penultimate commit defines `ProfileDataElement` using a `TypedDict` to avoid an ignore (should be fine)
* the last commit (actions.py) refactors some code slightly to avoid a type ignore (less clear)

This passes all tests for me locally.