### PR TITLE
message_view: Show edit history when EDITED notice is clicked.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -127,6 +127,10 @@ exports.initialize = function () {
             return;
         }
 
+        if ($(e.target).is(".message_edit_notice")) {
+            return;
+        }
+
         // A tricky issue here is distinguishing hasty clicks (where
         // the mouse might still move a few pixels between mouseup and
         // mousedown) from selecting-for-copy.  We handle this issue
@@ -190,6 +194,33 @@ exports.initialize = function () {
         var message_id = rows.get_message_id(this);
         reactions.process_reaction_click(message_id, local_id);
         $(".tooltip").remove();
+    });
+
+    $('body').on('mouseenter', '.message_edit_notice', function (e) {
+        if (page_params.realm_allow_edit_history) {
+            $(e.currentTarget).addClass("message_edit_notice_hover");
+        }
+    });
+
+    $('body').on('mouseleave', '.message_edit_notice', function (e) {
+        if (page_params.realm_allow_edit_history) {
+            $(e.currentTarget).removeClass("message_edit_notice_hover");
+        }
+    });
+
+    $('body').on('click', '.message_edit_notice', function (e) {
+        popovers.hide_all();
+        var msgid = rows.id($(e.currentTarget).closest(".message_row"));
+        var row = current_msg_list.get_row(msgid);
+        var message = current_msg_list.get(rows.id(row));
+        var message_history_cancel_btn = $('#message-history-cancel');
+
+        if (page_params.realm_allow_edit_history) {
+            message_edit.show_history(message);
+            message_history_cancel_btn.focus();
+        }
+        e.stopPropagation();
+        e.preventDefault();
     });
 
     // TOOLTIP FOR MESSAGE REACTIONS

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -176,6 +176,10 @@ p.n-margin {
     animation-iteration-count: 1;
 }
 
+.message_edit_notice_hover:hover {
+    opacity: 1.0;
+}
+
 #feedback_container .exit-me {
     font-size: 30pt;
     font-weight: 200;


### PR DESCRIPTION
Open the edit history of a message when a user clicks on it's EDITED notice.
Also, added on-hover darkening for the EDITED notice.

Resolves #12615 

**GIFs:** 

![edited_notice](https://user-images.githubusercontent.com/25329595/62427237-a0b22c80-b70d-11e9-9d4f-8034c80ac180.gif)
