### PR TITLE
[WIP] mypy: Use caching to speed up first dmypy check.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,13 @@ aliases:
        pip install codecov && codecov \
          || echo "Error in uploading coverage reports to codecov.io."
 
+  - &get_cache_directory
+      run:
+       name: get_cache_directory
+       command: |
+         . srv/zulip-py3-venv/bin/activate
+         echo "./var/mypy-cache-`git rev-parse HEAD`"
+
 jobs:
   "xenial-backend-frontend-python3.5":
     docker:
@@ -114,7 +121,10 @@ jobs:
           destination: test-reports
 
       - store_test_results:
-            path: ./var/xunit-test-results/casper/
+          path: ./var/xunit-test-results/casper/
+
+      - store_artifacts:
+          path: ./var/mypy-cache
 
   "bionic-backend-python3.6":
     docker:

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,7 +5,6 @@ show_traceback = True
 # See https://zulip.readthedocs.io/en/latest/testing/mypy.html#mypy-stubs-for-third-party-modules
 # for notes on how we manage mypy stubs.
 mypy_path = stubs/
-cache_dir = var/mypy-cache
 
 # Options to make the checking stricter.
 check_untyped_defs = True

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -80,7 +80,16 @@ if args.quick:
 elif args.warn_unreachable:
     extra_args.append("--warn-unreachable")
 
-mypy_args = extra_args + python_files + pyi_files
+# We name our cache directory based on the HEAD of our working branch.
+cache_commit_id = subprocess.Popen(['git', 'rev-parse', 'HEAD'],
+                                   stdout=subprocess.PIPE).stdout.read().decode()
+cache_args = ['--cache-dir=var/mypy-cache-%s' % (cache_commit_id,)]
+if args.no_daemon:
+    cache_args.append('--cache-fine-grained')
+else:
+    cache_args.append('--use-fine-grained-cache')
+
+mypy_args = extra_args + python_files + pyi_files + cache_args
 if args.no_daemon:
     rc = subprocess.call([mypy_command] + mypy_args)
 else:


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes: #12438 

If I'm looking at this right, we see a pretty high cost on the initial cache as seen in the `45s` runtime of first `run-mypy --no-daemon`, but then we see an almost ~80% reduction in restart time when running `mypy` with no args.

The docs suggest the following steps for getting this working on CI:
- [ ] A shared repository for storing mypy cache files for all landed commits.
- [ ] CI build that uploads mypy incremental cache files to the shared repository for each commit for which the CI build runs.
- [ ] A wrapper script around mypy that developers use to run mypy with remote caching enabled.

**Testing Plan:** <!-- How have you tested? -->
`tools/run-mypy`
`tools/run-mypy --no-daemon`

**These are ran sequentially with no intermittent changes**
```
(zulip-py3-venv) vagrant@ubuntu-bionic:/srv/zulip$ time ./tools/run-mypy --no-daemon

real	0m45.572s
user	0m16.652s
sys	0m2.087s

(zulip-py3-venv) vagrant@ubuntu-bionic:/srv/zulip$ time ./tools/run-mypy --no-daemon

real	0m9.294s
user	0m1.953s
sys	0m0.786s
```

**Here we test without caching, and then with caching**
```
(zulip-py3-venv) vagrant@ubuntu-bionic:/srv/zulip$ time ./tools/run-mypy
Restarting: configuration changed
Daemon stopped
Daemon started

real	0m15.478s
user	0m0.489s
sys	0m0.141s
(zulip-py3-venv) vagrant@ubuntu-bionic:/srv/zulip$ time ./tools/run-mypy
Restarting: configuration changed
Daemon stopped
Daemon started

real	0m2.625s
user	0m0.415s
sys	0m0.105s
(zulip-py3-venv) vagrant@ubuntu-bionic:/srv/zulip$
```
