### PR TITLE
events: Check last_event_id for validity, take 2

### DIFF
--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -366,6 +366,11 @@ class EventQueueTest(ZulipTestCase):
         new_client = ClientDescriptor.from_dict(client_dict)
         self.assertEqual(client.to_dict(), new_client.to_dict())
 
+        client_dict = client.to_dict()
+        del client_dict['event_queue']['newest_pruned_id']
+        new_client = ClientDescriptor.from_dict(client_dict)
+        self.assertEqual(client_dict, new_client.to_dict())
+
     def test_one_event(self) -> None:
         client = self.get_client_descriptor()
         queue = client.event_queue

--- a/zerver/tests/test_tornado.py
+++ b/zerver/tests/test_tornado.py
@@ -117,7 +117,7 @@ class EventsTestCase(TornadoWebTestCase):
         event_queue_id = self.create_queue()
         data = {
             'queue_id': event_queue_id,
-            'last_event_id': 0,
+            'last_event_id': -1,
         }
 
         path = '/json/events?{}'.format(urllib.parse.urlencode(data))


### PR DESCRIPTION
This verifies that the client passed a `last_event_id` that actually came from the queue instead of making up an ID from the future.  It turns out one of our tests was making up such an ID, but legitimate clients are expected not to do so.

The previous version of this commit (commit e00d4be6d57ca8282a668f9aec2c835d367c6f69, #12888) had to be reverted (commit b86c5cc4903e737bb95aafa240ca3706d090c453) because it was missing the `to_dict`/`from_dict` migration code.