### PR TITLE
mypy: Migrate from mypy_extensions to typing_extensions

### DIFF
--- a/puppet/zulip/files/nagios_plugins/zulip_nagios_server/check_postgres_replication_lag
+++ b/puppet/zulip/files/nagios_plugins/zulip_nagios_server/check_postgres_replication_lag
@@ -8,7 +8,7 @@ secondary Postgres servers' xlog location.
 import subprocess
 import re
 
-from mypy_extensions import NoReturn
+from typing_extensions import NoReturn
 
 states = {
     "OK": 0,

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -5,8 +5,8 @@
 # Django itself
 Django==1.11.22
 
-# needed for mypy TypedDict
-mypy_extensions==0.4.1
+# needed for Deque (in Python < 3.5.4) and TypedDict
+typing_extensions==3.7.4
 
 # Needed for rendering backend templates
 Jinja2==2.10.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -96,7 +96,7 @@ markupsafe==1.1.1         # via jinja2
 matrix-client==0.3.2
 mock==3.0.5
 moto==1.3.13
-mypy-extensions==0.4.1
+mypy-extensions==0.4.1    # via mypy
 mypy==0.720
 oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
 packaging==19.0           # via sphinx
@@ -178,7 +178,7 @@ transifex-client==0.12.5
 twilio==6.29.2
 twisted==19.2.1
 typed-ast==1.4.0          # via mypy
-typing-extensions==3.7.4  # via mypy
+typing-extensions==3.7.4
 typing==3.6.6
 urllib3==1.25.3           # via botocore, requests, transifex-client
 virtualenv-clone==0.5.3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -64,7 +64,6 @@ markdown==3.1.1
 markupsafe==1.1.1         # via jinja2
 matrix-client==0.3.2
 mock==3.0.5
-mypy_extensions==0.4.1
 oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
 parso==0.5.0              # via jedi
 pexpect==4.7.0            # via ipython
@@ -115,6 +114,7 @@ tornado==4.5.3
 traitlets==4.3.2          # via ipython
 twilio==6.29.2
 typing==3.6.6
+typing_extensions==3.7.4
 urllib3==1.25.3           # via requests
 uwsgi==2.0.17.1
 virtualenv-clone==0.5.3

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -26,8 +26,8 @@ from tools.setup import setup_venvs
 
 from typing import List, TYPE_CHECKING
 if TYPE_CHECKING:
-    # mypy_extensions might not be installed yet
-    from mypy_extensions import NoReturn
+    # typing_extensions might not be installed yet
+    from typing_extensions import NoReturn
 
 SUPPORTED_PLATFORMS = {
     "Ubuntu": [

--- a/tools/update-authors-json
+++ b/tools/update-authors-json
@@ -9,7 +9,7 @@ from lib import sanity_check
 sanity_check.check_venv(__file__)
 
 from typing import Any, Dict, List, Optional, Union, cast
-from mypy_extensions import TypedDict
+from typing_extensions import TypedDict
 
 import os
 import shutil

--- a/tools/webpack
+++ b/tools/webpack
@@ -4,7 +4,7 @@ import argparse
 import os
 import json
 import subprocess
-from mypy_extensions import NoReturn
+from typing_extensions import NoReturn
 
 os.chdir(os.path.join(os.path.dirname(__file__), '..'))
 STATIC_PATH = 'static/'

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2,7 +2,7 @@ from typing import (
     AbstractSet, Any, Callable, Dict, Iterable, List, Mapping, MutableMapping,
     Optional, Sequence, Set, Tuple, Union, cast
 )
-from mypy_extensions import TypedDict
+from typing_extensions import TypedDict
 
 import django.db.utils
 from django.db.models import Count

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -2,8 +2,8 @@
 # detailed documentation on our markdown syntax.
 from typing import (Any, Callable, Dict, Iterable, List, NamedTuple,
                     Optional, Set, Tuple, TypeVar, Union)
-from mypy_extensions import TypedDict
 from typing.re import Match, Pattern
+from typing_extensions import TypedDict
 
 import markdown
 import logging
@@ -310,7 +310,7 @@ def walk_tree_with_family(root: Element,
         currElementPair = queue.popleft()
         for child in currElementPair.value.getchildren():
             if child.getchildren():
-                queue.append(ElementPair(parent=currElementPair, value=child))  # type: ignore  # Lack of Deque support in typing module for Python <=3.5.3
+                queue.append(ElementPair(parent=currElementPair, value=child))
             result = processor(child)
             if result is not None:
                 if currElementPair.parent is not None:

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from typing import Any, Dict, List, Type, Optional
-from mypy_extensions import NoReturn
+from typing_extensions import NoReturn
 
 from django.core.exceptions import PermissionDenied
 from django.utils.translation import ugettext as _

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -52,7 +52,7 @@ from zerver.models import (
 )
 
 from typing import Any, Dict, List, Optional, Set, Tuple, Union, Sequence
-from mypy_extensions import TypedDict
+from typing_extensions import TypedDict
 
 RealmAlertWords = Dict[int, List[str]]
 

--- a/zerver/lib/stream_subscription.py
+++ b/zerver/lib/stream_subscription.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict, List, Tuple
-from mypy_extensions import TypedDict
+from typing_extensions import TypedDict
 
 from django.db.models.query import QuerySet
 from zerver.models import (

--- a/zerver/tests/test_logging_handlers.py
+++ b/zerver/tests/test_logging_handlers.py
@@ -10,9 +10,9 @@ from django.test import TestCase
 from django.utils.log import AdminEmailHandler
 from functools import wraps
 from mock import MagicMock, patch
-from mypy_extensions import NoReturn
-from typing import Any, Callable, Dict, Iterator, Optional, Tuple, Type
 from types import TracebackType
+from typing import Any, Callable, Dict, Iterator, Optional, Tuple, Type
+from typing_extensions import NoReturn
 
 from zerver.lib.types import ViewFuncT
 from zerver.lib.test_classes import ZulipTestCase

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -2,7 +2,7 @@
 # high-level documentation on how this system works.
 from typing import cast, AbstractSet, Any, Callable, Dict, List, \
     Mapping, MutableMapping, Optional, Iterable, Sequence, Set, Union
-from mypy_extensions import TypedDict
+from typing_extensions import Deque, TypedDict
 
 from django.utils.translation import ugettext as _
 from django.conf import settings
@@ -238,7 +238,7 @@ def compute_full_event_type(event: Mapping[str, Any]) -> str:
 
 class EventQueue:
     def __init__(self, id: str) -> None:
-        self.queue = deque()  # type: ignore # Should be Deque[Dict[str, Any]], but Deque isn't available in Python 3.4
+        self.queue = deque()  # type: Deque[Dict[str, Any]]
         self.next_event_id = 0  # type: int
         self.id = id  # type: str
         self.virtual_events = {}  # type: Dict[str, Dict[str, Any]]


### PR DESCRIPTION
This gives us access to `typing_extensions.Deque`, which was not added to `typing` until 3.5.4.

(`PROVISION_VERSION` is not bumped because the transitive dependency set in `dev.txt` hasn’t changed.)