### PR TITLE
echo: Consistently send local_id as string, convert it back to number.

### DIFF
--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -106,7 +106,7 @@ function insert_local_message(message_request, local_id) {
 
     local_message.insert_message(message);
 
-    return message.local_id;
+    return message.local_id.toString();
 }
 
 exports.is_slash_command = function (content) {
@@ -184,7 +184,7 @@ exports.reify_message_id = function reify_message_id(local_id, server_id) {
     message.id = server_id;
     message.locally_echoed = false;
 
-    var opts = {old_id: local_id, new_id: server_id};
+    var opts = {old_id: parseFloat(local_id), new_id: server_id};
 
     message_store.reify_message_id(opts);
     notifications.reify_message_id(opts);


### PR DESCRIPTION
Fixes: #2734.

`local_id` was being transmitted to the server as a string by the AJAX transmission path, and as a number by by the WebSocket transmission path.  Then, one of the two racing success callback paths would use the original number, while the other would use the type returned by the server.  Depending on which transmission path was used and which callback path won the race, `reify_message_id` would sometimes be passed a string that would fail to compare equal to the numerical selection id.  If the locally echoed message was selected, this would cause the selection to disappear.

**Testing Plan:** Inserted `time.sleep(3)` in `do_send_messages`.