### PR TITLE
mypy: In non-daemon mode, follow package imports

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -14,18 +14,9 @@ disallow_any_generics = True
 warn_no_return = True
 no_implicit_optional = True
 
-# The mypy daemon requires using local_partial_types.
-local_partial_types = True
-
 # It's useful to try this occasionally, and keep it clean; but when
 # someone fixes a type error we don't want to add a burden for them.
 #warn_unused_ignores = True
-
-# Error on importing modules that are present but not part of the
-# build.  If the module can't reasonably be made to not error, errors
-# can be suppressed with ignore_errors.
-# (The mypy daemon only supports error and skip for follow_imports)
-follow_imports = error
 
 # We use a lot of third-party libraries we don't have stubs for, as
 # well as a handful of our own modules that we haven't told mypy how
@@ -58,49 +49,6 @@ ignore_errors = True
 # zerver.tornado.autoreload is a slightly-patched piece of upstream Tornado.
 [mypy-zerver.tornado.autoreload]
 ignore_errors = True
-
-
-#
-#
-# SKIP IMPORTS
-#
-#
-
-[mypy-zulip]
-# mypy is finding this module in the virtualenv.  We should tell it
-# about it on the command line; until we do, everything imported from
-# it gets treated as Any, and we have to acknowledge it here.
-#
-# (The mypy daemon insists that everything it checks, it's told about
-# in advance, which means setting follow_imports to either `skip` or
-# `error`.  Our global setting of `error` gets us an error if there's
-# something it *could* check, because it can find the file, but we
-# haven't told it to.)
-follow_imports = skip
-
-[mypy-zulint]
-follow_imports = skip
-
-[mypy-zulint.command]
-follow_imports = skip
-
-[mypy-zulint.custom_rules]
-follow_imports = skip
-
-[mypy-zulint.linters]
-follow_imports = skip
-
-[mypy-zulint.lister]
-follow_imports = skip
-
-[mypy-zulint.printer]
-follow_imports = skip
-
-[mypy-zulip_bots.custom_exceptions]
-follow_imports = skip
-
-[mypy-zulip_bots.lib]
-follow_imports = skip
 
 
 #

--- a/mypy.ini
+++ b/mypy.ini
@@ -96,6 +96,12 @@ follow_imports = skip
 [mypy-zulint.printer]
 follow_imports = skip
 
+[mypy-zulip_bots.custom_exceptions]
+follow_imports = skip
+
+[mypy-zulip_bots.lib]
+follow_imports = skip
+
 
 #
 #

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -132,8 +132,8 @@ python-magic==0.4.15
 # these tightly, including fetching content not included in the normal
 # release tarballs (which is a bug).  So we need to pin it makes sense
 # to pin a version from Git rather than a release.
--e "git+https://github.com/zulip/python-zulip-api.git@0.6.1#egg=zulip==0.6.1_git&subdirectory=zulip"
--e "git+https://github.com/zulip/python-zulip-api.git@0.6.1#egg=zulip_bots==0.6.1+git&subdirectory=zulip_bots"
+-e "git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca60acf650da#egg=zulip==0.6.1_git&subdirectory=zulip"
+-e "git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca60acf650da#egg=zulip_bots==0.6.1+git&subdirectory=zulip_bots"
 
 # Used for Hesiod lookups, etc.
 py3dns==3.2.0

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -53,6 +53,6 @@ python-digitalocean==1.14.0
 pip-tools==2.0.2
 
 # zulip's linting framework - zulint
--e git+https://github.com/zulip/zulint@9e0da9f6c9ffc617e0782ab69617f6bcf90a4271#egg=zulint==0.0.1
+-e git+https://github.com/zulip/zulint@aaed679f1ad38b230090eadd3870b7682500f60c#egg=zulint==0.0.1
 
 -r mypy.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,8 +14,8 @@ git+https://github.com/zulip/line_profiler.git#egg=line_profiler==2.1.2.zulip1
 git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
 git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
 git+https://github.com/zulip/zulint@aaed679f1ad38b230090eadd3870b7682500f60c#egg=zulint==0.0.1
-git+https://github.com/zulip/python-zulip-api.git@0.6.1#egg=zulip==0.6.1_git&subdirectory=zulip
-git+https://github.com/zulip/python-zulip-api.git@0.6.1#egg=zulip_bots==0.6.1+git&subdirectory=zulip_bots
+git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca60acf650da#egg=zulip==0.6.1_git&subdirectory=zulip
+git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca60acf650da#egg=zulip_bots==0.6.1+git&subdirectory=zulip_bots
 alabaster==0.7.12         # via sphinx
 apns2==0.5.0
 argon2-cffi==19.1.0
@@ -179,7 +179,6 @@ twilio==6.29.2
 twisted==19.2.1
 typed-ast==1.4.0          # via mypy
 typing-extensions==3.7.4
-typing==3.6.6
 urllib3==1.25.3           # via botocore, requests, transifex-client
 virtualenv-clone==0.5.3
 w3lib==1.20.0             # via parsel, scrapy

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,7 +13,7 @@ git+https://github.com/zulip/libthumbor.git@60ed2431c07686a12f2770b2d852c5650f3c
 git+https://github.com/zulip/line_profiler.git#egg=line_profiler==2.1.2.zulip1
 git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
 git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
-git+https://github.com/zulip/zulint@9e0da9f6c9ffc617e0782ab69617f6bcf90a4271#egg=zulint==0.0.1
+git+https://github.com/zulip/zulint@aaed679f1ad38b230090eadd3870b7682500f60c#egg=zulint==0.0.1
 git+https://github.com/zulip/python-zulip-api.git@0.6.1#egg=zulip==0.6.1_git&subdirectory=zulip
 git+https://github.com/zulip/python-zulip-api.git@0.6.1#egg=zulip_bots==0.6.1+git&subdirectory=zulip_bots
 alabaster==0.7.12         # via sphinx

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -13,8 +13,8 @@ git+https://github.com/zulip/libthumbor.git@60ed2431c07686a12f2770b2d852c5650f3c
 git+https://github.com/zulip/line_profiler.git#egg=line_profiler==2.1.2.zulip1
 git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
 git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
-git+https://github.com/zulip/python-zulip-api.git@0.6.1#egg=zulip==0.6.1_git&subdirectory=zulip
-git+https://github.com/zulip/python-zulip-api.git@0.6.1#egg=zulip_bots==0.6.1+git&subdirectory=zulip_bots
+git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca60acf650da#egg=zulip==0.6.1_git&subdirectory=zulip
+git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca60acf650da#egg=zulip_bots==0.6.1+git&subdirectory=zulip_bots
 apns2==0.5.0
 argon2-cffi==19.1.0
 asn1crypto==0.24.0        # via cryptography
@@ -113,7 +113,6 @@ stripe==2.21.0
 tornado==4.5.3
 traitlets==4.3.2          # via ipython
 twilio==6.29.2
-typing==3.6.6
 typing_extensions==3.7.4
 urllib3==1.25.3           # via requests
 uwsgi==2.0.17.1

--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -2,7 +2,6 @@ import logging
 import os
 import shutil
 import subprocess
-import sys
 from scripts.lib.zulip_tools import run, run_as_root, ENDC, WARNING
 from scripts.lib.hash_reqs import expand_reqs
 
@@ -343,15 +342,5 @@ def do_setup_virtualenv(venv_path, requirements_file, virtualenv_args):
         # Might be a failure due to network connection issues. Retrying...
         print(WARNING + "`pip install` failed; retrying..." + ENDC)
         install_venv_deps(pip, requirements_file)
-
-    # The typing module has been included in stdlib since 3.5.
-    # Installing a pypi version of it has been harmless until a bug
-    # "AttributeError: type object 'Callable' has no attribute
-    # '_abc_registry'" happens in 3.7. And so just to be safe, it is
-    # disabled from now on for all >= 3.5 versions.
-    # Remove this once 3.4 is no longer supported.
-    at_least_35 = (sys.version_info.major == 3) and (sys.version_info.minor >= 5)
-    if at_least_35 and ('python2.7' not in virtualenv_args):
-        run([pip, "uninstall", "-y", "typing"])
 
     run_as_root(["chmod", "-R", "a+rX", venv_path])

--- a/tools/ci/backend
+++ b/tools/ci/backend
@@ -18,7 +18,8 @@ set -x
 # backend tests, which tend to uncover more serious problems, first.
 ./tools/run-mypy --version
 # We run mypy without daemon mode, since that's faster given that
-# we're only going to run it once.
+# we're only going to run it once, and catches more errors since
+# daemon mode doesn't follow package imports.
 ./tools/run-mypy --no-daemon
 
 ./tools/test-migrations

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -78,6 +78,7 @@ mypy_args = extra_args + python_files + pyi_files
 if args.no_daemon:
     rc = subprocess.call([mypy_command] + mypy_args)
 else:
+    mypy_args += ["--follow-imports=skip"]
     rc = subprocess.call([mypy_command, "status"], stdout=subprocess.PIPE)
     if rc != 0:
         print("Starting mypy daemon, this will take a minute...")

--- a/version.py
+++ b/version.py
@@ -26,4 +26,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '48.1'
+PROVISION_VERSION = '49.0'

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -605,7 +605,7 @@ def send_message(client):
 def add_reaction(client, message_id):
     # type: (Client, int) -> None
     request = {
-        'message_id': message_id,
+        'message_id': str(message_id),
         'emoji_name': 'joy',
         'emoji_code': '1f602',
         'emoji_type': 'unicode_emoji'
@@ -618,7 +618,7 @@ def add_reaction(client, message_id):
 def remove_reaction(client, message_id):
     # type: (Client, int) -> None
     request = {
-        'message_id': message_id,
+        'message_id': str(message_id),
         'emoji_name': 'joy',
         'emoji_code': '1f602',
         'reaction_type': 'unicode_emoji'

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -44,7 +44,7 @@ from zerver.lib.redis_utils import get_redis_client
 from zerver.context_processors import common_context
 from zerver.lib.outgoing_webhook import do_rest_call, get_outgoing_webhook_service_handler
 from zerver.models import get_bot_services, RealmAuditLog
-from zulip_bots.lib import extract_query_without_mention
+from zulip_bots.lib import ExternalBotHandler, extract_query_without_mention
 from zerver.lib.bot_lib import EmbeddedBotHandler, get_bot_handler, EmbeddedBotQuitException
 from zerver.lib.exceptions import RateLimited
 from zerver.lib.export import export_realm_wrapper
@@ -586,7 +586,7 @@ class EmbeddedBotWorker(QueueProcessingWorker):
                 if event['trigger'] == 'mention':
                     message['content'] = extract_query_without_mention(
                         message=message,
-                        client=self.get_bot_api_client(user_profile),
+                        client=cast(ExternalBotHandler, self.get_bot_api_client(user_profile)),
                     )
                     assert message['content'] is not None
                 bot_handler.handle_message(


### PR DESCRIPTION
We have been missing a bunch of mypy errors in our usage of the `zulint` and `zulip` packages because mypy cannot follow package imports in daemon mode. Fix these errors, and configure mypy to be able to find them when running in non-daemon mode.

This is perhaps a minimally disruptive solution, but it means that non-daemon mode will find errors that daemon mode won’t. We should consider removing daemon mode entirely, since non-daemon mode is no longer nearly as slow as it once was.

Depends: ~~zulip/zulint#4 (which is blocked on #12946)~~, ~~zulip/python-zulip-api#520~~, ~~zulip/python-zulip-api#521~~.