### PR TITLE
docs: Fix typos in git cheat sheet documentation.

### DIFF
--- a/docs/git/cheat-sheet.md
+++ b/docs/git/cheat-sheet.md
@@ -24,14 +24,14 @@ See also [fixing commits][fix-commit]
     - `git fetch origin`
     - `git fetch upstream`
 - grep
-    - `git grep update_unread_counts
+    - `git grep update_unread_counts`
 - log
     - `git log`
 - pull
     - `git pull --rebase`: **Use this**. Zulip uses a [rebase oriented workflow][git-overview].
     - `git pull` (with no options): Will either create a merge commit
       (which you don't want) or do the same thing as `git pull --rebase`,
-      depending on [whether you're configured Git properly][git-clone-config]
+      depending on [whether you've configured Git properly][git-config-clone]
 - push
     - `git push origin +branch-name`
 - rebase
@@ -87,7 +87,7 @@ See also [fixing commits][fix-commit]
     - `git pull --rebase`: rebase your changes on top of master.
     - `git pull` (with no options): Will either create a merge commit
       (which you don't want) or do the same thing as `git pull --rebase`,
-      depending on [whether you're configured Git properly][git-clone-config]
+      depending on [whether you've configured Git properly][git-config-clone]
 - push
     - `git push origin branch-name`: push you commits to the origin repository *only if* there are no conflicts.
       Use this when collaborating with others to prevent overwriting their work.


### PR DESCRIPTION
* Missing a closing back-tick (`).
* Fixed a couple broken links.