### PR TITLE
docs: In api.md add the tools/ part before test-backend.

### DIFF
--- a/docs/documentation/api.md
+++ b/docs/documentation/api.md
@@ -194,7 +194,7 @@ above.
 
    You can check your formatting using two helpful tools.
    * `tools/check-openapi` will verify the syntax of `zerver/openapi/zulip.yaml`.
-   * `test-backend zerver/tests/test_openapi.py`; this test compares
+   * `tools/test-backend zerver/tests/test_openapi.py`; this test compares
       your documentation against the code and can find many common
       mistakes in how arguments are declared.
 


### PR DESCRIPTION
In this section of the docs, two tools for testing openapi documentation are mentioned. But for the second one, we forgot to mention that the tool also resides in the tools/ folder (like the first one which explicitly mentions it). This commit fixes that.