### PR TITLE
 org settings: Remove old method of success status for notification streams.

### DIFF
--- a/frontend_tests/casper_tests/10-admin.js
+++ b/frontend_tests/casper_tests/10-admin.js
@@ -33,19 +33,15 @@ casper.then(function () {
         casper.click("#id_realm_notifications_stream .dropdown-list-body li.stream_name");
     });
 
-    casper.waitUntilVisible('#admin-realm-notifications-stream-status', function () {
-        casper.test.assertSelectorHasText('#admin-realm-notifications-stream-status',
-                                          'Notifications stream changed!');
-        casper.test.assertSelectorHasText('#realm_notifications_stream_name', '#Verona');
+    casper.waitUntilVisible('#org-submit-notifications[data-status="saved"]', function () {
+        casper.test.assertSelectorHasText('#org-submit-notifications', 'Saved');
     });
 });
 
 casper.then(function () {
     casper.click(".notifications-stream-disable");
-    casper.waitUntilVisible('#admin-realm-notifications-stream-status', function () {
-        casper.test.assertSelectorHasText('#admin-realm-notifications-stream-status',
-                                          'Notifications stream disabled!');
-        casper.test.assertSelectorHasText('#realm_notifications_stream_name', 'Disabled');
+    casper.waitUntilVisible('#org-submit-notifications[data-status="saved"]', function () {
+        casper.test.assertSelectorHasText('#org-submit-notifications', 'Saved');
     });
 });
 
@@ -59,19 +55,15 @@ casper.then(function () {
         casper.click("#id_realm_signup_notifications_stream .dropdown-list-body li.stream_name");
     });
 
-    casper.waitUntilVisible('#admin-realm-signup-notifications-stream-status', function () {
-        casper.test.assertSelectorHasText('#admin-realm-signup-notifications-stream-status',
-                                          'Signup notifications stream changed!');
-        casper.test.assertSelectorHasText('#realm_signup_notifications_stream_name', '#Verona');
+    casper.waitUntilVisible('#org-submit-notifications[data-status="saved"]', function () {
+        casper.test.assertSelectorHasText('#org-submit-notifications', 'Saved');
     });
 });
 
 casper.then(function () {
     casper.click(".signup-notifications-stream-disable");
-    casper.waitUntilVisible('#admin-realm-signup-notifications-stream-status', function () {
-        casper.test.assertSelectorHasText('#admin-realm-signup-notifications-stream-status',
-                                          'Signup notifications stream disabled!');
-        casper.test.assertSelectorHasText('#realm_signup_notifications_stream_name', 'Disabled');
+    casper.waitUntilVisible('#org-submit-notifications[data-status="saved"]', function () {
+        casper.test.assertSelectorHasText('#org-submit-notifications', 'Saved');
     });
 });
 

--- a/frontend_tests/casper_tests/10-admin.js
+++ b/frontend_tests/casper_tests/10-admin.js
@@ -23,6 +23,15 @@ casper.then(function () {
     casper.click("li[data-section='organization-settings']");
 });
 
+function submit_notifications_stream_settings() {
+    casper.waitUntilVisible('#org-submit-notifications[data-status="unsaved"]', function () {
+        casper.test.assertSelectorHasText('#org-submit-notifications', 'Save');
+    });
+    casper.then(function () {
+        casper.click('#org-submit-notifications');
+    });
+}
+
 // Test changing notifications stream
 casper.then(function () {
     casper.test.info('Changing notifications stream to Verona by filtering with "verona"');
@@ -33,6 +42,8 @@ casper.then(function () {
         casper.click("#id_realm_notifications_stream .dropdown-list-body li.stream_name");
     });
 
+    submit_notifications_stream_settings();
+
     casper.waitUntilVisible('#org-submit-notifications[data-status="saved"]', function () {
         casper.test.assertSelectorHasText('#org-submit-notifications', 'Saved');
     });
@@ -40,6 +51,9 @@ casper.then(function () {
 
 casper.then(function () {
     casper.click("#notifications_stream_disable");
+
+    submit_notifications_stream_settings();
+
     casper.waitUntilVisible('#org-submit-notifications[data-status="saved"]', function () {
         casper.test.assertSelectorHasText('#org-submit-notifications', 'Saved');
     });
@@ -55,6 +69,8 @@ casper.then(function () {
         casper.click("#id_realm_signup_notifications_stream .dropdown-list-body li.stream_name");
     });
 
+    submit_notifications_stream_settings();
+
     casper.waitUntilVisible('#org-submit-notifications[data-status="saved"]', function () {
         casper.test.assertSelectorHasText('#org-submit-notifications', 'Saved');
     });
@@ -62,6 +78,9 @@ casper.then(function () {
 
 casper.then(function () {
     casper.click("#signup_notifications_stream_disable");
+
+    submit_notifications_stream_settings();
+
     casper.waitUntilVisible('#org-submit-notifications[data-status="saved"]', function () {
         casper.test.assertSelectorHasText('#org-submit-notifications', 'Saved');
     });

--- a/frontend_tests/casper_tests/10-admin.js
+++ b/frontend_tests/casper_tests/10-admin.js
@@ -39,7 +39,7 @@ casper.then(function () {
 });
 
 casper.then(function () {
-    casper.click(".notifications-stream-disable");
+    casper.click("#notifications_stream_disable");
     casper.waitUntilVisible('#org-submit-notifications[data-status="saved"]', function () {
         casper.test.assertSelectorHasText('#org-submit-notifications', 'Saved');
     });
@@ -61,7 +61,7 @@ casper.then(function () {
 });
 
 casper.then(function () {
-    casper.click(".signup-notifications-stream-disable");
+    casper.click("#signup_notifications_stream_disable");
     casper.waitUntilVisible('#org-submit-notifications[data-status="saved"]', function () {
         casper.test.assertSelectorHasText('#org-submit-notifications', 'Saved');
     });

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -890,12 +890,12 @@ run_test('misc', () => {
         assert.equal(stream_id, 42);
         return { name: 'some_stream' };
     };
-    settings_org.render_notifications_stream_ui(42, elem);
+    settings_org.render_notifications_stream_ui(42, "notifications");
     assert.equal(elem.text(), '#some_stream');
     assert(!elem.hasClass('text-warning'));
 
     stream_data.get_sub_by_id = noop;
-    settings_org.render_notifications_stream_ui(undefined, elem);
+    settings_org.render_notifications_stream_ui(undefined, "notifications");
     assert.equal(elem.text(), 'translated: Disabled');
     assert(elem.hasClass('text-warning'));
 
@@ -907,12 +907,12 @@ run_test('misc', () => {
         assert.equal(stream_id, 75);
         return { name: 'some_stream' };
     };
-    settings_org.render_notifications_stream_ui(75, elem);
+    settings_org.render_notifications_stream_ui(75, "signup_notifications");
     assert.equal(elem.text(), '#some_stream');
     assert(!elem.hasClass('text-warning'));
 
     stream_data.get_sub_by_id = noop;
-    settings_org.render_notifications_stream_ui(undefined, elem);
+    settings_org.render_notifications_stream_ui(undefined, "signup_notifications");
     assert.equal(elem.text(), 'translated: Disabled');
     assert(elem.hasClass('text-warning'));
 

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -382,56 +382,6 @@ function test_upload_realm_icon(upload_realm_icon) {
     assert(posted);
 }
 
-function test_disable_notifications_stream(disable_notifications_stream) {
-    let success_callback;
-    let error_callback;
-    channel.patch = function (req) {
-        assert.equal(req.url, '/json/realm');
-        assert.equal(req.data.notifications_stream_id, '-1');
-        success_callback = req.success;
-        error_callback = req.error;
-    };
-
-    disable_notifications_stream();
-
-    const response_data = {
-        notifications_stream_id: -1,
-    };
-
-    success_callback(response_data);
-    assert.equal($('#admin-realm-notifications-stream-status').val(),
-                 'translated: Notifications stream disabled!');
-
-    error_callback({});
-    assert.equal($('#admin-realm-notifications-stream-status').val(),
-                 'translated: Failed to change notifications stream!');
-}
-
-function test_disable_signup_notifications_stream(disable_signup_notifications_stream) {
-    let success_callback;
-    let error_callback;
-    channel.patch = function (req) {
-        assert.equal(req.url, '/json/realm');
-        assert.equal(req.data.signup_notifications_stream_id, '-1');
-        success_callback = req.success;
-        error_callback = req.error;
-    };
-
-    disable_signup_notifications_stream();
-
-    const response_data = {
-        signup_notifications_stream_id: -1,
-    };
-
-    success_callback(response_data);
-    assert.equal($('#admin-realm-signup-notifications-stream-status').val(),
-                 'translated: Signup notifications stream disabled!');
-
-    error_callback({});
-    assert.equal($('#admin-realm-signup-notifications-stream-status').val(),
-                 'translated: Failed to change signup notifications stream!');
-}
-
 function test_change_allow_subdomains(change_allow_subdomains) {
     const ev = {
         stopPropagation: noop,
@@ -793,8 +743,6 @@ run_test('set_up', () => {
     $('#id_realm_video_chat_provider').change = set_callback('realm_video_chat_provider');
     $("#id_realm_org_join_restrictions").change = set_callback('change_org_join_restrictions');
     $('#submit-add-realm-domain').click = set_callback('add_realm_domain');
-    $('.notifications-stream-disable').click = set_callback('disable_notifications_stream');
-    $('.signup-notifications-stream-disable').click = set_callback('disable_signup_notifications_stream');
 
     let submit_settings_form;
     let discard_changes;
@@ -852,8 +800,6 @@ run_test('set_up', () => {
     test_realms_domain_modal(callbacks.add_realm_domain);
     test_submit_settings_form(submit_settings_form);
     test_upload_realm_icon(upload_realm_icon);
-    test_disable_notifications_stream(callbacks.disable_notifications_stream);
-    test_disable_signup_notifications_stream(callbacks.disable_signup_notifications_stream);
     test_change_allow_subdomains(change_allow_subdomains);
     test_extract_property_name();
     test_change_save_button_state();

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -5,6 +5,8 @@ const admin_settings_label = {
     realm_allow_community_topic_editing: i18n.t("Users can edit the topic of any message"),
     realm_allow_edit_history: i18n.t("Enable message edit history"),
     realm_mandatory_topics: i18n.t("Require topics in stream messages"),
+    realm_notifications_stream: i18n.t("New stream notifications:"),
+    realm_signup_notifications_stream: i18n.t("New user notifications:"),
     realm_inline_image_preview: i18n.t("Show previews of uploaded and linked images"),
     realm_inline_url_embed_preview: i18n.t("Show previews of linked websites"),
     realm_default_twenty_four_hour_time: i18n.t("Time format"),

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -142,12 +142,10 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
                 }
             } else if (event.property === 'notifications_stream_id') {
                 settings_org.render_notifications_stream_ui(
-                    page_params.realm_notifications_stream_id,
-                    $('#realm_notifications_stream_name'));
+                    page_params.realm_notifications_stream_id, 'notifications');
             } else if (event.property === 'signup_notifications_stream_id') {
                 settings_org.render_notifications_stream_ui(
-                    page_params.realm_signup_notifications_stream_id,
-                    $('#realm_signup_notifications_stream_name'));
+                    page_params.realm_signup_notifications_stream_id, 'signup_notifications');
             }
 
             if (event.property === 'name' && window.electron_bridge !== undefined) {
@@ -293,14 +291,12 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
                 if (page_params.realm_notifications_stream_id === stream.stream_id) {
                     page_params.realm_notifications_stream_id = -1;
                     settings_org.render_notifications_stream_ui(
-                        page_params.realm_notifications_stream_id,
-                        $('#realm_notifications_stream_name'));
+                        page_params.realm_notifications_stream_id, 'notifications');
                 }
                 if (page_params.realm_signup_notifications_stream_id === stream.stream_id) {
                     page_params.realm_signup_notifications_stream_id = -1;
                     settings_org.render_notifications_stream_ui(
-                        page_params.realm_signup_notifications_stream_id,
-                        $('#realm_signup_notifications_stream_name'));
+                        page_params.realm_signup_notifications_stream_id, 'signup_notifications');
                 }
             });
         }

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -518,13 +518,12 @@ function discard_property_element_changes(elem) {
     const property_name = exports.extract_property_name(elem);
     const property_value = get_property_value(property_name);
 
-    if (typeof property_value === 'boolean') {
+    if (property_name === 'realm_authentication_methods') {
+        exports.populate_auth_methods(property_value);
+    } else if (typeof property_value === 'boolean') {
         elem.prop('checked', property_value);
     } else if (typeof property_value === 'string' || typeof property_value === 'number') {
         elem.val(property_value);
-    } else if (typeof property_value === 'object' &&
-              property_name === 'realm_authentication_methods') {
-        exports.populate_auth_methods(property_value);
     } else {
         blueslip.error('Element refers to unknown property ' + property_name);
     }
@@ -670,19 +669,19 @@ exports.build_page = function () {
         const property_name = exports.extract_property_name(elem);
         let changed_val;
         let current_val = get_property_value(property_name);
-        if (typeof current_val === 'boolean') {
+
+        if (property_name === 'realm_authentication_methods') {
+            current_val = sort_object_by_key(current_val);
+            current_val = JSON.stringify(current_val);
+            changed_val = get_auth_method_table_data();
+            changed_val = JSON.stringify(changed_val);
+        } else if (typeof current_val === 'boolean') {
             changed_val = elem.prop('checked');
         } else if (typeof current_val === 'string') {
             changed_val = elem.val().trim();
         } else if (typeof current_val === 'number') {
             current_val = current_val.toString();
             changed_val = elem.val().trim();
-        } else if (typeof current_val === 'object') {
-            // Currently we only deal with realm_authentication_methods object
-            current_val = sort_object_by_key(current_val);
-            current_val = JSON.stringify(current_val);
-            changed_val = get_auth_method_table_data();
-            changed_val = JSON.stringify(changed_val);
         } else {
             blueslip.error('Element refers to unknown property ' + property_name);
         }

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -192,6 +192,14 @@ function get_property_value(property_name) {
         return JSON.stringify(page_params[property_name]);
     }
 
+    if (property_name === 'realm_notifications_stream') {
+        return page_params.realm_notifications_stream_id;
+    }
+
+    if (property_name === 'realm_signup_notifications_stream') {
+        return page_params.realm_signup_notifications_stream_id;
+    }
+
     return page_params[property_name];
 }
 
@@ -520,6 +528,10 @@ function discard_property_element_changes(elem) {
 
     if (property_name === 'realm_authentication_methods') {
         exports.populate_auth_methods(property_value);
+    } else if (property_name === 'realm_notifications_stream') {
+        exports.render_notifications_stream_ui(property_value, "notifications");
+    } else if (property_name === 'realm_signup_notifications_stream') {
+        exports.render_notifications_stream_ui(property_value, "signup_notifications");
     } else if (typeof property_value === 'boolean') {
         elem.prop('checked', property_value);
     } else if (typeof property_value === 'string' || typeof property_value === 'number') {
@@ -675,6 +687,10 @@ exports.build_page = function () {
             current_val = JSON.stringify(current_val);
             changed_val = get_auth_method_table_data();
             changed_val = JSON.stringify(changed_val);
+        } else if (property_name === 'realm_notifications_stream') {
+            changed_val = parseInt($("#id_realm_notifications_stream").data('stream-id'), 10);
+        } else if (property_name === 'realm_signup_notifications_stream') {
+            changed_val = parseInt($("#id_realm_signup_notifications_stream").data('stream-id'), 10);
         } else if (typeof current_val === 'boolean') {
             changed_val = elem.prop('checked');
         } else if (typeof current_val === 'string') {
@@ -685,7 +701,6 @@ exports.build_page = function () {
         } else {
             blueslip.error('Element refers to unknown property ' + property_name);
         }
-
         return current_val !== changed_val;
     }
 
@@ -786,6 +801,11 @@ exports.build_page = function () {
                 data.message_content_delete_limit_seconds =
                     exports.msg_delete_limit_dropdown_values[delete_limit_setting_value].seconds;
             }
+        } else if (subsection === 'notifications') {
+            data.notifications_stream_id = JSON.stringify(
+                parseInt($('#id_realm_notifications_stream').data('stream-id'), 10));
+            data.signup_notifications_stream_id = JSON.stringify(
+                parseInt($('#id_realm_signup_notifications_stream').data('stream-id'), 10));
         } else if (subsection === 'other_settings') {
             let new_message_retention_days = $("#id_realm_message_retention_days").val();
 
@@ -1074,10 +1094,7 @@ exports.build_page = function () {
 
     function notification_stream_update(stream_id, notification_type) {
         exports.render_notifications_stream_ui(stream_id, notification_type);
-        exports.save_organization_settings({
-            [`${notification_type}_stream_id`]: JSON.stringify(parseInt(stream_id, 10)),
-        }, $("#org-submit-notifications"));
-
+        save_discard_widget_status_handler($('#org-notifications'));
     }
 
     $(".notifications-stream-setting .dropdown-list-body").on("click keypress", ".stream_name", function (e) {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -1096,7 +1096,7 @@ exports.build_page = function () {
         update_notifications_stream(stream_id);
     });
 
-    $(".notifications-stream-disable").click(function () {
+    $("#notifications_stream_disable").click(function () {
         update_notifications_stream(-1);
     });
 
@@ -1122,7 +1122,7 @@ exports.build_page = function () {
         update_signup_notifications_stream(stream_id);
     });
 
-    $(".signup-notifications-stream-disable").click(function () {
+    $("#signup_notifications_stream_disable").click(function () {
         update_signup_notifications_stream(-1);
     });
 

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -1083,11 +1083,10 @@ exports.build_page = function () {
         });
     }
 
-    let dropdown_menu = $("#id_realm_notifications_stream .dropdown-menu");
     $("#id_realm_notifications_stream .dropdown-list-body").on("click keypress", ".stream_name", function (e) {
         if (e.type === "keypress") {
             if (e.which === 13) {
-                dropdown_menu.dropdown("toggle");
+                $("#id_realm_notifications_stream .dropdown-menu").dropdown("toggle");
             } else {
                 return;
             }
@@ -1110,11 +1109,10 @@ exports.build_page = function () {
         });
     }
 
-    dropdown_menu = $("#id_realm_signup_notifications_stream .dropdown-menu");
     $("#id_realm_signup_notifications_stream .dropdown-list-body").on("click keypress", ".stream_name", function (e) {
         if (e.type === "keypress") {
             if (e.which === 13) {
-                dropdown_menu.dropdown("toggle");
+                $("#id_realm_signup_notifications_stream .dropdown-menu").dropdown("toggle");
             } else {
                 return;
             }

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -689,6 +689,22 @@ exports.build_page = function () {
         return current_val !== changed_val;
     }
 
+    function save_discard_widget_status_handler(subsection) {
+        subsection.find('.subsection-failed-status p').hide();
+        subsection.find('.save-button').show();
+        const properties_elements = get_subsection_property_elements(subsection);
+        let show_change_process_button = false;
+        _.each(properties_elements, function (elem) {
+            if (check_property_changed(elem)) {
+                show_change_process_button = true;
+            }
+        });
+
+        const save_btn_controls = subsection.find('.subsection-header .save-button-controls');
+        const button_state = show_change_process_button ? "unsaved" : "discarded";
+        exports.change_save_button_state(save_btn_controls, button_state);
+    }
+
     $('.admin-realm-form').on('change input', 'input, select, textarea', function (e) {
         e.preventDefault();
         e.stopPropagation();
@@ -708,19 +724,7 @@ exports.build_page = function () {
         }
 
         const subsection = $(e.target).closest('.org-subsection-parent');
-        subsection.find('.subsection-failed-status p').hide();
-        subsection.find('.save-button').show();
-        const properties_elements = get_subsection_property_elements(subsection);
-        let show_change_process_button = false;
-        _.each(properties_elements, function (elem) {
-            if (check_property_changed(elem)) {
-                show_change_process_button = true;
-            }
-        });
-
-        const save_btn_controls = subsection.find('.subsection-header .save-button-controls');
-        const button_state = show_change_process_button ? "unsaved" : "discarded";
-        exports.change_save_button_state(save_btn_controls, button_state);
+        save_discard_widget_status_handler(subsection);
     });
 
     $('.organization').on('click', '.subsection-header .subsection-changes-discard .button', function (e) {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -407,9 +407,12 @@ function insert_tip_box() {
         .prepend(tip_box);
 }
 
-exports.render_notifications_stream_ui = function (stream_id, elem) {
-
+exports.render_notifications_stream_ui = function (stream_id, notification_type) {
     const name = stream_data.maybe_get_stream_name(stream_id);
+
+    $(`#id_realm_${notification_type}_stream`).data("stream-id", stream_id);
+
+    const elem = $(`#realm_${notification_type}_stream_name`);
 
     if (!name) {
         elem.text(i18n.t("Disabled"));
@@ -628,10 +631,8 @@ exports.build_page = function () {
         exports.populate_notifications_stream_dropdown(streams);
         exports.populate_signup_notifications_stream_dropdown(streams);
     }
-    exports.render_notifications_stream_ui(page_params.realm_notifications_stream_id,
-                                           $('#realm_notifications_stream_name'));
-    exports.render_notifications_stream_ui(page_params.realm_signup_notifications_stream_id,
-                                           $('#realm_signup_notifications_stream_name'));
+    exports.render_notifications_stream_ui(page_params.realm_notifications_stream_id, 'notifications');
+    exports.render_notifications_stream_ui(page_params.realm_signup_notifications_stream_id, 'signup_notifications');
 
     // Populate realm domains
     exports.populate_realm_domains(page_params.realm_domains);
@@ -1069,8 +1070,7 @@ exports.build_page = function () {
     });
 
     function notification_stream_update(stream_id, notification_type) {
-        exports.render_notifications_stream_ui(stream_id,
-                                               $(`#realm_${notification_type}_stream_name`));
+        exports.render_notifications_stream_ui(stream_id, notification_type);
         exports.save_organization_settings({
             [`${notification_type}_stream_id`]: JSON.stringify(parseInt(stream_id, 10)),
         }, $("#org-submit-notifications"));

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -1068,62 +1068,30 @@ exports.build_page = function () {
         });
     });
 
-    function notification_stream_update(data) {
-        _.each(get_subsection_property_elements($("#org-discard-notifications")),
-               discard_property_element_changes);
-        const nearest_save_button = $("#org-submit-notifications");
-        exports.save_organization_settings(data, nearest_save_button);
+    function notification_stream_update(stream_id, notification_type) {
+        exports.render_notifications_stream_ui(stream_id,
+                                               $(`#realm_${notification_type}_stream_name`));
+        exports.save_organization_settings({
+            [`${notification_type}_stream_id`]: JSON.stringify(parseInt(stream_id, 10)),
+        }, $("#org-submit-notifications"));
+
     }
 
-    function update_notifications_stream(new_notifications_stream_id) {
-        exports.render_notifications_stream_ui(new_notifications_stream_id,
-                                               $('#realm_notifications_stream_name'));
-        notification_stream_update({
-            notifications_stream_id: JSON.stringify(parseInt(new_notifications_stream_id, 10)),
-        });
-    }
-
-    $("#id_realm_notifications_stream .dropdown-list-body").on("click keypress", ".stream_name", function (e) {
+    $(".notifications-stream-setting .dropdown-list-body").on("click keypress", ".stream_name", function (e) {
+        const notifications_stream_setting_elem = $(this).closest(".notifications-stream-setting");
         if (e.type === "keypress") {
             if (e.which === 13) {
-                $("#id_realm_notifications_stream .dropdown-menu").dropdown("toggle");
+                notifications_stream_setting_elem.find(".dropdown-menu").dropdown("toggle");
             } else {
                 return;
             }
         }
-
         const stream_id = parseInt($(this).attr('data-stream-id'), 10);
-        update_notifications_stream(stream_id);
+        notification_stream_update(stream_id, notifications_stream_setting_elem.data("notifications-type"));
     });
 
-    $("#notifications_stream_disable").click(function () {
-        update_notifications_stream(-1);
-    });
-
-    function update_signup_notifications_stream(new_signup_notifications_stream_id) {
-        exports.render_notifications_stream_ui(new_signup_notifications_stream_id,
-                                               $('#realm_signup_notifications_stream_name'));
-        notification_stream_update({
-            signup_notifications_stream_id: JSON.stringify(
-                parseInt(new_signup_notifications_stream_id, 10)),
-        });
-    }
-
-    $("#id_realm_signup_notifications_stream .dropdown-list-body").on("click keypress", ".stream_name", function (e) {
-        if (e.type === "keypress") {
-            if (e.which === 13) {
-                $("#id_realm_signup_notifications_stream .dropdown-menu").dropdown("toggle");
-            } else {
-                return;
-            }
-        }
-
-        const stream_id = parseInt($(this).attr('data-stream-id'), 10);
-        update_signup_notifications_stream(stream_id);
-    });
-
-    $("#signup_notifications_stream_disable").click(function () {
-        update_signup_notifications_stream(-1);
+    $(".notification-disable").click(function (e) {
+        notification_stream_update(-1, e.target.id.replace("_stream_disable", ""));
     });
 
     function upload_realm_icon(file_input) {

--- a/static/templates/settings/notifications_stream_settings_widget.hbs
+++ b/static/templates/settings/notifications_stream_settings_widget.hbs
@@ -1,0 +1,21 @@
+<div class="input-group">
+    <label for="realm_{{ notifications_type }}_stream" id="realm_{{ notifications_type }}_stream_label" class="inline-block">
+        {{ label }}
+        <span class="dropup actual-dropdown-menu" id="id_realm_{{ notifications_type }}_stream"
+          name="realm_{{ notifications_type }}_stream" aria-labelledby="realm_{{ notifications_type }}_stream_label">
+            <button class="button small rounded dropdown-toggle" data-toggle="dropdown">
+                <span id="realm_{{ notifications_type }}_stream_name"></span>
+                <i class="fa fa-pencil"></i>
+            </button>
+            <ul class="dropdown-menu modal-bg" role="menu">
+                <li class="dropdown-search" role="presentation">
+                    <input class="no-input-change-detection" type="text" role="menuitem" placeholder="{{t 'Filter streams' }}" autofocus/>
+                </li>
+                <span class="dropdown-list-body" data-simplebar></span>
+            </ul>
+        </span>
+    </label>
+    {{#if is_admin }}
+    <a class="notification-disable" id="{{ notifications_type }}_stream_disable">{{t "[Disable]" }}</a>
+    {{/if}}
+</div>

--- a/static/templates/settings/notifications_stream_settings_widget.hbs
+++ b/static/templates/settings/notifications_stream_settings_widget.hbs
@@ -1,7 +1,7 @@
 <div class="input-group">
     <label for="realm_{{ notifications_type }}_stream" id="realm_{{ notifications_type }}_stream_label" class="inline-block">
         {{ label }}
-        <span class="notifications-stream-setting dropup actual-dropdown-menu" id="id_realm_{{ notifications_type }}_stream"
+        <span class="notifications-stream-setting dropup actual-dropdown-menu prop-element" id="id_realm_{{ notifications_type }}_stream"
           name="realm_{{ notifications_type }}_stream" aria-labelledby="realm_{{ notifications_type }}_stream_label"
           data-notifications-type="{{ notifications_type }}">
             <button class="button small rounded dropdown-toggle" data-toggle="dropdown">

--- a/static/templates/settings/notifications_stream_settings_widget.hbs
+++ b/static/templates/settings/notifications_stream_settings_widget.hbs
@@ -1,8 +1,9 @@
 <div class="input-group">
     <label for="realm_{{ notifications_type }}_stream" id="realm_{{ notifications_type }}_stream_label" class="inline-block">
         {{ label }}
-        <span class="dropup actual-dropdown-menu" id="id_realm_{{ notifications_type }}_stream"
-          name="realm_{{ notifications_type }}_stream" aria-labelledby="realm_{{ notifications_type }}_stream_label">
+        <span class="notifications-stream-setting dropup actual-dropdown-menu" id="id_realm_{{ notifications_type }}_stream"
+          name="realm_{{ notifications_type }}_stream" aria-labelledby="realm_{{ notifications_type }}_stream_label"
+          data-notifications-type="{{ notifications_type }}">
             <button class="button small rounded dropdown-toggle" data-toggle="dropdown">
                 <span id="realm_{{ notifications_type }}_stream_name"></span>
                 <i class="fa fa-pencil"></i>

--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -102,49 +102,13 @@
                 </div>
             </div>
 
-            <div class="input-group">
-                <label for="realm_notifications_stream" id="realm_notifications_stream_label" class="inline-block">
-                    {{t "New stream notifications:" }}
-                    <span class="dropup actual-dropdown-menu" id="id_realm_notifications_stream"
-                      name="realm_notifications_stream" aria-labelledby="realm_notifications_stream_label">
-                        <button class="button small rounded dropdown-toggle" data-toggle="dropdown">
-                            <span id="realm_notifications_stream_name"></span>
-                            <i class="fa fa-pencil"></i>
-                        </button>
-                        <ul class="dropdown-menu modal-bg" role="menu">
-                            <li class="dropdown-search" role="presentation">
-                                <input class="no-input-change-detection" type="text" role="menuitem" placeholder="{{t 'Filter streams' }}" autofocus/>
-                            </li>
-                            <span class="dropdown-list-body" data-simplebar></span>
-                        </ul>
-                    </span>
-                </label>
-                {{#if is_admin }}
-                <a class="notification-disable" id="notifications_stream_disable">{{t "[Disable]" }}</a>
-                {{/if}}
-            </div>
+            {{> notifications_stream_settings_widget
+              notifications_type="notifications"
+              label=admin_settings_label.realm_notifications_stream }}
 
-            <div class="input-group">
-                <label for="realm_signup_notifications_stream" id="realm_signup_notifications_stream_label" class="inline-block">
-                    {{t "New user notifications:" }}
-                    <span class="dropup actual-dropdown-menu" id="id_realm_signup_notifications_stream"
-                      name="realm_signup_notifications_stream" aria-labelledby="realm_signup_notifications_stream_label">
-                        <button class="button small rounded dropdown-toggle" data-toggle="dropdown">
-                            <span id="realm_signup_notifications_stream_name"></span>
-                            <i class="fa fa-pencil"></i>
-                        </button>
-                        <ul class="dropdown-menu modal-bg" role="menu">
-                            <li class="dropdown-search" role="presentation">
-                                <input class="no-input-change-detection" type="text" role="menuitem" placeholder="{{t 'Filter streams' }}" autofocus/>
-                            </li>
-                            <span class="dropdown-list-body" data-simplebar></span>
-                        </ul>
-                    </span>
-                </label>
-                {{#if is_admin }}
-                <a class="notification-disable" id="signup_notifications_stream_disable">{{t "[Disable]" }}</a>
-                {{/if}}
-            </div>
+            {{> notifications_stream_settings_widget
+              notifications_type="signup_notifications"
+              label=admin_settings_label.realm_signup_notifications_stream }}
         </div>
 
         <div id="org-user-defaults" class="org-subsection-parent">

--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -1,7 +1,5 @@
 <div id="organization-settings" data-name="organization-settings" class="settings-section">
     <form class="form-horizontal admin-realm-form org-settings-form">
-        <div class="alert" id="admin-realm-notifications-stream-status"></div>
-        <div class="alert" id="admin-realm-signup-notifications-stream-status"></div>
 
         <div id="org-msg-editing" class="org-subsection-parent">
             <div class="subsection-header">
@@ -115,7 +113,7 @@
                         </button>
                         <ul class="dropdown-menu modal-bg" role="menu">
                             <li class="dropdown-search" role="presentation">
-                                <input type="text" role="menuitem" placeholder="{{t 'Filter streams' }}" autofocus/>
+                                <input class="no-input-change-detection" type="text" role="menuitem" placeholder="{{t 'Filter streams' }}" autofocus/>
                             </li>
                             <span class="dropdown-list-body" data-simplebar></span>
                         </ul>
@@ -137,7 +135,7 @@
                         </button>
                         <ul class="dropdown-menu modal-bg" role="menu">
                             <li class="dropdown-search" role="presentation">
-                                <input type="text" role="menuitem" placeholder="{{t 'Filter streams' }}" autofocus/>
+                                <input class="no-input-change-detection" type="text" role="menuitem" placeholder="{{t 'Filter streams' }}" autofocus/>
                             </li>
                             <span class="dropdown-list-body" data-simplebar></span>
                         </ul>

--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -120,7 +120,7 @@
                     </span>
                 </label>
                 {{#if is_admin }}
-                <a class="notifications-stream-disable notification-disable">{{t "[Disable]" }}</a>
+                <a class="notification-disable" id="notifications_stream_disable">{{t "[Disable]" }}</a>
                 {{/if}}
             </div>
 
@@ -142,7 +142,7 @@
                     </span>
                 </label>
                 {{#if is_admin }}
-                <a class="signup-notifications-stream-disable notification-disable">{{t "[Disable]" }}</a>
+                <a class="notification-disable" id="signup_notifications_stream_disable">{{t "[Disable]" }}</a>
                 {{/if}}
             </div>
         </div>


### PR DESCRIPTION
This is in reference to https://github.com/zulip/zulip/pull/12017#issuecomment-505672192.

I've maintained the current behavior of dropdowns, i.e. if we select any streams from dropdown it directly saves without showing "Save" or "Discard" widget, if we want that too, please let me know I'll add its commits too on top of current commits.

GIF:
![Aug-08-2019 18-25-13](https://user-images.githubusercontent.com/40331304/62704960-300b5880-ba0a-11e9-8dc1-079f4f4cfa78.gif)
