### PR TITLE
messages: Support passing stream ID for stream operator.

### DIFF
--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -108,7 +108,7 @@ function get_messages_success(data, opts) {
 // instead of emails string if it is supported. We currently don't set
 // or convert the emails string to user IDs directly into the Filter code
 // because doing so breaks the app in various modules that expect emails string.
-function handle_user_ids_supported_operators(data) {
+function handle_operators_supporting_id_based_api(data) {
     var operators_supporting_ids = ['pm-with'];
     var operators_supporting_id = ['sender', 'group-pm-with'];
 
@@ -170,7 +170,7 @@ exports.load_messages = function (opts) {
     }
 
     data.client_gravatar = true;
-    data = handle_user_ids_supported_operators(data);
+    data = handle_operators_supporting_id_based_api(data);
 
     channel.get({
         url: '/json/messages',

--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -110,7 +110,7 @@ function get_messages_success(data, opts) {
 // because doing so breaks the app in various modules that expect emails string.
 function handle_operators_supporting_id_based_api(data) {
     var operators_supporting_ids = ['pm-with'];
-    var operators_supporting_id = ['sender', 'group-pm-with'];
+    var operators_supporting_id = ['sender', 'group-pm-with', 'stream'];
 
     if (data.narrow === undefined) {
         return data;
@@ -123,6 +123,15 @@ function handle_operators_supporting_id_based_api(data) {
         }
 
         if (operators_supporting_id.indexOf(filter.operator) !== -1) {
+            if (filter.operator === 'stream') {
+                const stream_id = stream_data.get_stream_id(filter.operand);
+                if (stream_id !== undefined) {
+                    filter.operand = stream_id;
+                }
+
+                return filter;
+            }
+
             var person = people.get_by_email(filter.operand);
             if (person !== undefined) {
                 filter.operand = person.user_id;

--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -109,8 +109,8 @@ function get_messages_success(data, opts) {
 // or convert the emails string to user IDs directly into the Filter code
 // because doing so breaks the app in various modules that expect emails string.
 function handle_user_ids_supported_operators(data) {
-    var user_ids_supported_operators = ['pm-with'];
-    var user_id_supported_operators = ['sender', 'group-pm-with'];
+    var operators_supporting_ids = ['pm-with'];
+    var operators_supporting_id = ['sender', 'group-pm-with'];
 
     if (data.narrow === undefined) {
         return data;
@@ -118,11 +118,11 @@ function handle_user_ids_supported_operators(data) {
 
     data.narrow = JSON.parse(data.narrow);
     data.narrow = _.map(data.narrow, function (filter) {
-        if (user_ids_supported_operators.indexOf(filter.operator) !== -1) {
+        if (operators_supporting_ids.indexOf(filter.operator) !== -1) {
             filter.operand = people.emails_strings_to_user_ids_array(filter.operand);
         }
 
-        if (user_id_supported_operators.indexOf(filter.operator) !== -1) {
+        if (operators_supporting_id.indexOf(filter.operator) !== -1) {
             var person = people.get_by_email(filter.operand);
             if (person !== undefined) {
                 filter.operand = person.user_id;

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -395,10 +395,6 @@ python_rules = RuleList(
              # how most instances are written, but better to exclude something than nothing
              ('zerver/lib/actions.py', 'stream = get_stream(stream_name, realm)'),
              ('zerver/lib/actions.py', 'get_stream(admin_realm_signup_notifications_stream, admin_realm)'),
-             # Here we need get_stream to access streams you've since unsubscribed from.
-             ('zerver/views/messages.py', 'stream = get_stream(operand, self.user_profile.realm)'),
-             # Use stream_id to exclude mutes.
-             ('zerver/views/messages.py', 'stream_id = get_stream(stream_name, user_profile.realm).id'),
          ]),
          'description': 'Please use access_stream_by_*() to fetch Stream objects',
          },

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -150,7 +150,7 @@ def access_stream_for_unmute_topic_by_id(user_profile: UserProfile,
         raise JsonableError(error)
     return stream
 
-def can_access_stream_history_by_name(user_profile: UserProfile, stream_name: str) -> bool:
+def can_access_stream_history(user_profile: UserProfile, stream: Stream) -> bool:
     """Determine whether the provided user is allowed to access the
     history of the target stream.  The stream is specified by name.
 
@@ -166,23 +166,25 @@ def can_access_stream_history_by_name(user_profile: UserProfile, stream_name: st
     access_stream is being called elsewhere to confirm that the user
     can actually see this stream.
     """
-    try:
-        stream = get_stream(stream_name, user_profile.realm)
-    except Stream.DoesNotExist:
-        return False
-
     if stream.is_history_realm_public() and not user_profile.is_guest:
         return True
 
     if stream.is_history_public_to_subscribers():
         # In this case, we check if the user is subscribed.
-        error = _("Invalid stream name '%s'") % (stream_name,)
+        error = _("Invalid stream name '%s'") % (stream.name,)
         try:
             (recipient, sub) = access_stream_common(user_profile, stream, error)
         except JsonableError:
             return False
         return True
     return False
+
+def can_access_stream_history_by_name(user_profile: UserProfile, stream_name: str) -> bool:
+    try:
+        stream = get_stream(stream_name, user_profile.realm)
+    except Stream.DoesNotExist:
+        return False
+    return can_access_stream_history(user_profile, stream)
 
 def filter_stream_authorization(user_profile: UserProfile,
                                 streams: Iterable[Stream]) -> Tuple[List[Stream], List[Stream]]:

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -186,6 +186,13 @@ def can_access_stream_history_by_name(user_profile: UserProfile, stream_name: st
         return False
     return can_access_stream_history(user_profile, stream)
 
+def can_access_stream_history_by_id(user_profile: UserProfile, stream_id: int) -> bool:
+    try:
+        stream = get_stream_by_id_in_realm(stream_id, user_profile.realm)
+    except Stream.DoesNotExist:
+        return False
+    return can_access_stream_history(user_profile, stream)
+
 def filter_stream_authorization(user_profile: UserProfile,
                                 streams: Iterable[Stream]) -> Tuple[List[Stream], List[Stream]]:
     streams_subscribed = set()  # type: Set[int]

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -520,14 +520,14 @@ def narrow_parameter(json: str) -> OptionalNarrowListT:
             # Make sure to sync this list to frontend also when adding a new operator.
             # that supports user IDs. Relevant code is located in static/js/message_fetch.js
             # in handle_user_ids_supported_operators function where you will need to update
-            # user_id_supported_operator, or user_ids_supported_operator array.
-            user_id_supported_operator = ['sender', 'group-pm-with']
-            user_ids_supported_operators = ['pm-with']
+            # operators_supporting_id, or operators_supporting_ids array.
+            operators_supporting_id = ['sender', 'group-pm-with']
+            operators_supporting_ids = ['pm-with']
 
             operator = elem.get('operator', '')
-            if operator in user_id_supported_operator:
+            if operator in operators_supporting_id:
                 operand_validator = check_string_or_int
-            elif operator in user_ids_supported_operators:
+            elif operator in operators_supporting_ids:
                 operand_validator = check_string_or_int_list
             else:
                 operand_validator = check_string

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -519,7 +519,7 @@ def narrow_parameter(json: str) -> OptionalNarrowListT:
         if isinstance(elem, dict):
             # Make sure to sync this list to frontend also when adding a new operator.
             # that supports user IDs. Relevant code is located in static/js/message_fetch.js
-            # in handle_user_ids_supported_operators function where you will need to update
+            # in handle_operators_supporting_id_based_api function where you will need to update
             # operators_supporting_id, or operators_supporting_ids array.
             operators_supporting_id = ['sender', 'group-pm-with']
             operators_supporting_ids = ['pm-with']

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -31,7 +31,7 @@ from zerver.lib.message import (
 from zerver.lib.response import json_success, json_error
 from zerver.lib.sqlalchemy_utils import get_sqlalchemy_connection
 from zerver.lib.streams import access_stream_by_id, can_access_stream_history_by_name, \
-    get_stream_by_narrow_operand_access_unchecked
+    can_access_stream_history_by_id, get_stream_by_narrow_operand_access_unchecked
 from zerver.lib.timestamp import datetime_to_timestamp, convert_to_UTC
 from zerver.lib.timezone import get_timezone
 from zerver.lib.topic import (
@@ -204,14 +204,14 @@ class NarrowBuilder:
                     s[i] = '\\' + c
         return ''.join(s)
 
-    def by_stream(self, query: Query, operand: str, maybe_negate: ConditionTransform) -> Query:
+    def by_stream(self, query: Query, operand: Union[str, int], maybe_negate: ConditionTransform) -> Query:
         try:
             # Because you can see your own message history for
             # private streams you are no longer subscribed to, we
             # need get_stream_by_narrow_operand_access_unchecked here.
             stream = get_stream_by_narrow_operand_access_unchecked(operand, self.user_profile.realm)
         except Stream.DoesNotExist:
-            raise BadNarrowOperator('unknown stream ' + operand)
+            raise BadNarrowOperator('unknown stream ' + str(operand))
 
         if self.user_profile.realm.is_zephyr_mirror_realm:
             # MIT users expect narrowing to "social" to also show messages to
@@ -522,7 +522,7 @@ def narrow_parameter(json: str) -> OptionalNarrowListT:
             # that supports user IDs. Relevant code is located in static/js/message_fetch.js
             # in handle_operators_supporting_id_based_api function where you will need to update
             # operators_supporting_id, or operators_supporting_ids array.
-            operators_supporting_id = ['sender', 'group-pm-with']
+            operators_supporting_id = ['sender', 'group-pm-with', 'stream']
             operators_supporting_ids = ['pm-with']
 
             operator = elem.get('operator', '')
@@ -568,8 +568,13 @@ def ok_to_include_history(narrow: OptionalNarrowListT, user_profile: UserProfile
     if narrow is not None:
         for term in narrow:
             if term['operator'] == "stream" and not term.get('negated', False):
-                if can_access_stream_history_by_name(user_profile, term['operand']):
-                    include_history = True
+                operand = term['operand']  # type: Union[str, int]
+                if isinstance(operand, str):
+                    if can_access_stream_history_by_name(user_profile, operand):
+                        include_history = True
+                else:
+                    if can_access_stream_history_by_id(user_profile, operand):
+                        include_history = True
         # Disable historical messages if the user is narrowing on anything
         # that's a property on the UserMessage table.  There cannot be
         # historical messages in these cases anyway.


### PR DESCRIPTION
Both backend and frontend migrations are done. Next thing left is to update the docs and then I think we can close issue #9474.

**Testing Plan:**
  - Unit Tests
  - Make sure stream ID is sent using devtools.

**(Potential) Followups**:
  - Docs 
  - Node tests for the frontend `handle_user_ids_supported_operators`
  - Add mypy types for narrow i.e. which operator should have which types since currently I think we type annotate it as `Dict[str, Any]` where maybe we could type annotate it in a way mypy knows that if operand is say `stream` it should be `str` or `int`.