### PR TITLE
subscriptions: Avoid sending subscriber information when unneeded

### DIFF
--- a/templates/zerver/api/get-subscribed-streams.md
+++ b/templates/zerver/api/get-subscribed-streams.md
@@ -37,11 +37,18 @@ curl -X GET {{ api_url }}/v1/users/me/subscriptions \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY
 ```
 
+You may pass the `include_subscribers` query parameter as follows:
+
+``` curl
+curl -X GET {{ api_url }}/v1/users/me/subscriptions?include_subscribers=true \
+    -u BOT_EMAIL_ADDRESS:BOT_API_KEY
+```
+
 {end_tabs}
 
 ## Arguments
 
-This request takes no arguments.
+{generate_api_arguments_table|zulip.yaml|/users/me/subscriptions:get}
 
 ## Response
 
@@ -55,7 +62,7 @@ This request takes no arguments.
     * `invite-only`: Specifies whether a stream is private or not.
       Only people who have been invited can access a private stream.
     * `subscribers`: A list of email addresses of users who are also subscribed
-      to a given stream.
+      to a given stream. Included only if `include_subscribers` is `true`.
     * `desktop_notifications`: A boolean specifiying whether desktop notifications
       are enabled for the given stream.
     * `push_notifications`: A boolean specifiying whether push notifications

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4736,20 +4736,28 @@ def gather_subscriptions_helper(user_profile: UserProfile,
             sorted(unsubscribed, key=lambda x: x['name']),
             sorted(never_subscribed, key=lambda x: x['name']))
 
-def gather_subscriptions(user_profile: UserProfile) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
-    subscribed, unsubscribed, never_subscribed = gather_subscriptions_helper(user_profile)
-    user_ids = set()
-    for subs in [subscribed, unsubscribed, never_subscribed]:
-        for sub in subs:
-            if 'subscribers' in sub:
-                for subscriber in sub['subscribers']:
-                    user_ids.add(subscriber)
-    email_dict = get_emails_from_user_ids(list(user_ids))
+def gather_subscriptions(
+    user_profile: UserProfile,
+    include_subscribers: bool=False,
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    subscribed, unsubscribed, _ = gather_subscriptions_helper(
+        user_profile, include_subscribers=include_subscribers)
 
-    for subs in [subscribed, unsubscribed]:
-        for sub in subs:
-            if 'subscribers' in sub:
-                sub['subscribers'] = sorted([email_dict[user_id] for user_id in sub['subscribers']])
+    if include_subscribers:
+        user_ids = set()
+        for subs in [subscribed, unsubscribed]:
+            for sub in subs:
+                if 'subscribers' in sub:
+                    for subscriber in sub['subscribers']:
+                        user_ids.add(subscriber)
+        email_dict = get_emails_from_user_ids(list(user_ids))
+
+        for subs in [subscribed, unsubscribed]:
+            for sub in subs:
+                if 'subscribers' in sub:
+                    sub['subscribers'] = sorted([
+                        email_dict[user_id] for user_id in sub['subscribers']
+                    ])
 
     return (subscribed, unsubscribed)
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1210,6 +1210,16 @@ paths:
   /users/me/subscriptions:
     get:
       description: Get information on every stream the user is subscribed to.
+      parameters:
+      - name: include_subscribers
+        in: query
+        description: Set to `true` if you would like each stream's info to include a
+          list of current subscribers to that stream. (This may be significantly slower
+          in organizations with thousands of users.)
+        schema:
+          type: boolean
+          default: false
+        example: true
       security:
       - basicAuth: []
       responses:

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -180,8 +180,16 @@ def update_stream_backend(
         do_change_stream_invite_only(stream, is_private, history_public_to_subscribers)
     return json_success()
 
-def list_subscriptions_backend(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
-    return json_success({"subscriptions": gather_subscriptions(user_profile)[0]})
+@has_request_variables
+def list_subscriptions_backend(
+    request: HttpRequest,
+    user_profile: UserProfile,
+    include_subscribers: bool=REQ(validator=check_bool, default=False),
+) -> HttpResponse:
+    subscribed, _ = gather_subscriptions(
+        user_profile, include_subscribers=include_subscribers
+    )
+    return json_success({"subscriptions": subscribed})
 
 FuncKwargPair = Tuple[Callable[..., HttpResponse], Dict[str, Union[int, Iterable[Any]]]]
 


### PR DESCRIPTION
The `users/me/subscriptions` endpoint recently started returning
subscriber information for each stream. This is convenient, but
unnecessarily costly for those clients which already acquire this
information elsewhere (including the Zulip-provided clients).

This change removes that functionality from the default response.
Clients which had come to rely on it, or would like to rely on it in
future, may still access it via an additional documented API parameter.

`zulip-python-api` and `zulip-js` should be able to use this parameter, albeit awkwardly.

Fixes #12917.

**Testing Plan:** <!-- How have you tested? -->
  * Ran `tools/test-api` _et al_.
  * Queried the endpoint via `curl` several times, and confirmed that the median reported execution time with `include_subscribers=false` was less than with `include_subscribers=true` (~25ms vs. ~30ms, n=20).
