### PR TITLE
Revert "vagrant: Add NFS backend for file synchronization for OSX."

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,13 +60,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   ubuntu_mirror = ""
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
-  if (/darwin/ =~ RUBY_PLATFORM) != nil
-    config.vm.synced_folder ".", "/srv/zulip", type: "nfs",
-        linux__nfs_options: ['rw']
-    config.vm.network "private_network", type: "dhcp"
-  else
-    config.vm.synced_folder ".", "/srv/zulip"
-  end
+  config.vm.synced_folder ".", "/srv/zulip"
 
   vagrant_config_file = ENV['HOME'] + "/.zulip-vagrant-config"
   if File.file?(vagrant_config_file)


### PR DESCRIPTION
Reportedly the NFS synced folder type doesn’t work on macOS with the Docker provider, while the default type does.  And it seems likely that four years of Ubuntu updates will have resolved the guest crashes that motivated the prior switch to NFS.

https://chat.zulip.org/#narrow/stream/21-provision-help/topic/experimental.20docker.20setup

This reverts commit 9e8ae68dfb7a82caccaf93ac932766004f72490d (#7520).

**Testing Plan:** We probably want someone to test this on macOS with the VirtualBox provider.