### PR TITLE
puppet: Use built-in memorysize_mb fact

### DIFF
--- a/puppet/zulip/manifests/base.pp
+++ b/puppet/zulip/manifests/base.pp
@@ -88,10 +88,10 @@ class zulip::base {
     'user_presence',
   ]
 
-  # We can't use the built-in $memorysize fact because it's a string with human-readable units
-  # Meanwhile $memorysize_mb is a string, and can't be compared with integers in puppet 4.
-  $total_memory = regsubst(file('/proc/meminfo'), '^.*MemTotal:\s*(\d+) kB.*$', '\1', 'M') * 1024
-  $total_memory_mb = $total_memory / 1024 / 1024
+  # $::memorysize_mb is a string in Facter < 3.0 and a double in Facter ≥ 3.0.
+  # Either way, convert it to an integer.
+  $total_memory_mb_array = scanf("${::memorysize_mb}", "%i")
+  $total_memory_mb = $total_memory_mb_array[0]
 
   group { 'zulip':
     ensure     => present,

--- a/puppet/zulip/manifests/postgres_appdb_tuned.pp
+++ b/puppet/zulip/manifests/postgres_appdb_tuned.pp
@@ -12,9 +12,6 @@ class zulip::postgres_appdb_tuned {
     'redhat' => "systemctl restart postgresql-${zulip::base::postgres_version}",
   }
 
-  $half_memory = $zulip::base::total_memory / 2
-  $half_memory_pages = $half_memory / 4096
-
   $work_mem = $zulip::base::total_memory_mb / 512
   $shared_buffers = $zulip::base::total_memory_mb / 8
   $effective_cache_size = $zulip::base::total_memory_mb * 10 / 32


### PR DESCRIPTION
Fixes this warning on bionic:

    Warning: The string '8167976' was automatically coerced to the numerical value 8167976 (file: /root/zulip/puppet/zulip/manifests/base.pp, line: 93, column: 19)

**Testing Plan:** Ran docker-zulip bionic install, xenial test-install, bionic test-install (#12967).