### PR TITLE
actions: Keep last 80 messages unread onboarding.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -310,6 +310,12 @@ def add_new_user_history(user_profile: UserProfile, streams: Iterable[Stream]) -
     if len(message_ids_to_use) == 0:
         return
 
+    # flag last n messages as unread
+    # last_n_messages = 80  # currently set to 80
+    # mark_last_n_messages_as_unread = message_ids_to_use[-last_n_messages:]
+    UserMessage.objects.filter(user_profile=user_profile).update(
+        flags=F('flags').bitand(~UserMessage.flags.read))
+
     # Handle the race condition where a message arrives between
     # bulk_add_subscriptions above and the Message query just above
     already_ids = set(UserMessage.objects.filter(message_id__in=message_ids_to_use,

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -141,6 +141,11 @@ class AddNewUserHistoryTest(ZulipTestCase):
         self.send_stream_message(self.example_email('hamlet'), streams[0].name, "test")
         add_new_user_history(user_profile, streams)
 
+        # last_n_messages = 80
+        unreadmsgs = UserMessage.objects.filter(user_profile=user_profile)
+        for msg in unreadmsgs:
+            self.assertFalse(msg.flags.read.is_set)
+
 class InitialPasswordTest(ZulipTestCase):
     def test_none_initial_password_salt(self) -> None:
         with self.settings(INITIAL_PASSWORD_SALT=None):


### PR DESCRIPTION
This commit flags last n messages unread for a new user that joins
the realm.

Fixes part of #6512.
