### PR TITLE
test_templates: Add a verbose error messages for rendering failures.

### DIFF
--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -9,6 +9,8 @@ from django.test import override_settings
 from django.template.loader import get_template
 from django.test.client import RequestFactory
 
+from jinja2.exceptions import UndefinedError
+
 from zerver.lib.exceptions import InvalidMarkdownIncludeStatement
 from zerver.lib.test_helpers import get_all_templates
 from zerver.lib.test_classes import (
@@ -117,6 +119,11 @@ class TemplateTestCase(ZulipTestCase):
             template = get_template(template_name)
             try:
                 template.render(context)
+            except UndefinedError as e:  # nocoverage # ideally, this block shouldn't have to execute
+                raise UndefinedError(e.message + """\n
+This test is designed to confirm that every template renders. If you're seeing
+this message it probably means that you forget to add a variable to the context
+dictionary in zerver.tests.test_templates.TemplateTestCase.get_context.""")
             except Exception:  # nocoverage # nicer error handler
                 logging.error("Exception while rendering '{}'".format(template.template.name))
                 raise


### PR DESCRIPTION
If a template fails to render in test_templates because of a missing
context variable, we should better explain the reason for the failure.

Example:
```
======================================================================
ERROR: test_templates (zerver.tests.test_templates.TemplateTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/zulip/zerver/tests/test_templates.py", line 121, in render_templates
    template.render(context)
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/django/template/backends/jinja2.py", line 81, in render
    return self.template.render(context)
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/jinja2/asyncsupport.py", line 76, in render
    return original_render(self, *args, **kwargs)
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "/srv/zulip/templates/zerver/accounts_accept_terms.html", line 1, in top-level template code
    {% extends "zerver/portico_signup.html" %}
  File "/srv/zulip/templates/zerver/portico_signup.html", line 1, in top-level template code
    {% extends "zerver/portico.html" %}
  File "/srv/zulip/templates/zerver/portico.html", line 1, in top-level template code
    {% extends "zerver/base.html" %}
  File "/srv/zulip/templates/zerver/base.html", line 46, in top-level template code
    {% block content %}
  File "/srv/zulip/templates/zerver/portico.html", line 20, in block "content"
    {% block portico_content %}
  File "/srv/zulip/templates/zerver/accounts_accept_terms.html", line 41, in block "portico_content"
    {% if form.terms.value() %}checked="checked"{% endif %} />
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/jinja2/environment.py", line 430, in getattr
    return getattr(obj, attribute)
jinja2.exceptions.UndefinedError: 'form' is undefined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/srv/zulip-py3-venv/lib/python3.6/site-packages/django/test/utils.py", line 384, in inner
    return func(*args, **kwargs)
  File "/srv/zulip/zerver/tests/test_templates.py", line 111, in test_templates
    self.render_templates(templates, self.get_context())
  File "/srv/zulip/zerver/tests/test_templates.py", line 126, in render_templates
    dictionary in zerver.tests.test_templates.TemplateTestCase.get_context.""")
jinja2.exceptions.UndefinedError: 'form' is undefined

This test is designed to confirm that every template renders. If you're seeing
this message it probably means that you forget to add a variable to the context
dictionary in zerver.tests.test_templates.TemplateTestCase.get_context.

----------------------------------------------------------------------
Ran 10 tests in 0.606s

FAILED (errors=1)
```