### PR TITLE
topic_edit: Add typeahead to inline topic edit.

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -790,6 +790,30 @@ exports.initialize_compose_typeahead = function (selector) {
     });
 };
 
+exports.add_topic_edit_typeahead = function (inline_edit_selector) {
+    inline_edit_selector.typeahead({
+        source: function () {
+            const parent_selector = inline_edit_selector.parents(".message-header-contents");
+            const href = parent_selector.children()[0].href;
+            const slug = href.split("/")[5];
+            const stream_name = stream_data.slug_to_name(slug);
+            return composebox_typeahead.topics_seen_for(stream_name);
+        },
+        items: 3,
+        fixed: true,
+        highlighter: function (item) {
+            return typeahead_helper.render_typeahead_item({ primary: item });
+        },
+        sorter: function (items) {
+            const sorted = typeahead_helper.sorter(this.query, items, function (x) {return x;});
+            if (sorted.length > 0 && sorted.indexOf(this.query) === -1) {
+                sorted.unshift(this.query);
+            }
+            return sorted;
+        },
+    });
+};
+
 exports.initialize = function () {
     exports.update_emoji_data();
     select_on_focus("stream_message_recipient_stream");

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -418,7 +418,9 @@ exports.start_topic_edit = function (recipient_row) {
     if (topic === compose.empty_topic_placeholder()) {
         topic = '';
     }
-    form.find(".inline_topic_edit").val(topic).select().focus();
+    const inline_topic_edit = form.find(".inline_topic_edit");
+    inline_topic_edit.val(topic).select().focus();
+    composebox_typeahead.add_topic_edit_typeahead(inline_topic_edit);
 };
 
 exports.is_editing = function (id) {

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -329,6 +329,7 @@ exports.MessageList.prototype = {
         recipient_row.find(".stream_topic").show();
         recipient_row.find('.fa-pencil').show();
         recipient_row.find(".topic_edit").hide();
+        recipient_row.find(".topic_edit_form").empty();
     },
 
     show_message_as_read: function (message, options) {

--- a/static/templates/topic_edit_form.hbs
+++ b/static/templates/topic_edit_form.hbs
@@ -1,7 +1,7 @@
 {{! Client-side Mustache template for rendering the topic edit form. }}
 
 <form id="topic_edit_form" class="form-horizontal">
-    <input type="text" value="" class="inline_topic_edit header-v" id="inline_topic_edit"
+    <input type="text" value="" class="inline_topic_edit header-v typeahead" id="inline_topic_edit"
       autocomplete="off" />
     <button type="button" class="topic_edit_save small_square_button small_square_check"><i class="fa fa-check" aria-hidden="true"></i></button>
     <button type="button" class="topic_edit_cancel small_square_button small_square_x"><i class="fa fa-remove" aria-hidden="true"></i></button>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#12493 
This adds a typeahead to the topic edit box that appears when we click the small pencil icon.
Todo: Add a typeahead to the message edit box when we're editing the whole message.

not directly related to this, but something in this area:
Todo: Add "Esc" hotkey handler to close inline topic edit.
<!-- **Testing Plan:**  How have you tested? -->


<!-- **GIFs or Screenshots:** If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
