### PR TITLE
requirements: Use maintained fork django-sendfile2 of django-sendfile

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -159,7 +159,7 @@ twilio==6.29.2
 stripe==2.21.0
 
 # Needed for serving uploaded files from nginx but perform auth checks in django.
-django-sendfile==0.3.11
+django-sendfile2==0.4.2
 
 # For checking whether email of the user is from a disposable email provider.
 disposable-email-domains==0.0.52

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -54,7 +54,7 @@ django-formtools==2.1     # via django-two-factor-auth
 django-otp==0.6.0         # via django-two-factor-auth
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-pylibmc==0.6.1
-django-sendfile==0.3.11
+django-sendfile2==0.4.2
 django-statsd-mozilla==0.4.0
 django-two-factor-auth==1.9.1
 django-webpack-loader==0.6.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -39,7 +39,7 @@ django-formtools==2.1     # via django-two-factor-auth
 django-otp==0.6.0         # via django-two-factor-auth
 django-phonenumber-field==1.3.0  # via django-two-factor-auth
 django-pylibmc==0.6.1
-django-sendfile==0.3.11
+django-sendfile2==0.4.2
 django-statsd-mozilla==0.4.0
 django-two-factor-auth==1.9.1
 django-webpack-loader==0.6.0

--- a/version.py
+++ b/version.py
@@ -26,4 +26,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '47.0'
+PROVISION_VERSION = '48.0'

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -708,14 +708,14 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
                 else:
                     self.assertEqual(response.get('Content-disposition'), None)
 
-        check_xsend_links('zulip.txt', 'zulip.txt', "filename*=UTF-8''zulip.txt")
+        check_xsend_links('zulip.txt', 'zulip.txt', 'filename="zulip.txt"')
         check_xsend_links('áéБД.txt', '%C3%A1%C3%A9%D0%91%D0%94.txt',
                           "filename*=UTF-8''%C3%A1%C3%A9%D0%91%D0%94.txt")
-        check_xsend_links('zulip.html', 'zulip.html', "filename*=UTF-8''zulip.html")
-        check_xsend_links('zulip.sh', 'zulip.sh', "filename*=UTF-8''zulip.sh")
+        check_xsend_links('zulip.html', 'zulip.html', 'filename="zulip.html"')
+        check_xsend_links('zulip.sh', 'zulip.sh', 'filename="zulip.sh"')
         check_xsend_links('zulip.jpeg', 'zulip.jpeg')
         check_xsend_links('áéБД.pdf', '%C3%A1%C3%A9%D0%91%D0%94.pdf')
-        check_xsend_links('zulip', 'zulip', "filename*=UTF-8''zulip")
+        check_xsend_links('zulip', 'zulip', 'filename="zulip"')
 
     def tearDown(self) -> None:
         destroy_uploads()

--- a/zerver/views/upload.py
+++ b/zerver/views/upload.py
@@ -24,11 +24,12 @@ def serve_local(request: HttpRequest, path_id: str) -> HttpResponse:
     # an attachment (and thus clicking a link to it should download)
     # or like a link (and thus clicking a link to it should display it
     # in a browser tab).  This is controlled by the
-    # Content-Disposition header; `django-sendfile` sends the
+    # Content-Disposition header; `django-sendfile2` sends the
     # attachment-style version of that header if and only if the
     # attachment argument is passed to it.  For attachments,
-    # django-sendfile sets the response['Content-disposition'] like
-    # this: `attachment; filename="b'zulip.txt'"; filename*=UTF-8''zulip.txt`.
+    # django-sendfile2 sets the response['Content-disposition'] like
+    # this: `attachment; filename="zulip.txt"; filename*=UTF-8''zulip.txt`.
+    # The filename* parameter is omitted for ASCII filenames like this one.
     #
     # The "filename" field (used to name the file when downloaded) is
     # unreliable because it doesn't have a well-defined encoding; the


### PR DESCRIPTION
The original seems to be unmaintained (johnsensible/django-sendfile#65).  Notably, this fixes a bug in the `filename` parameter, which perviously showed the Python 3 `repr` of a byte string (johnsensible/django-sendfile#49).

**Testing Plan:** Downloaded attachment from dev server and production (https://andersk.zulipdev.org).