### PR TITLE
rest_dispatch: Remove invalid Content-Length: 0 from 204 responses.

### DIFF
--- a/zerver/lib/rest.py
+++ b/zerver/lib/rest.py
@@ -71,7 +71,6 @@ def rest_dispatch(request: HttpRequest, **kwargs: Any) -> HttpResponse:
     if request.method == 'OPTIONS':
         response = HttpResponse(status=204)  # No content
         response['Allow'] = ', '.join(sorted(supported_methods.keys()))
-        response['Content-Length'] = "0"
         return response
 
     # Override requested method if magic method=??? parameter exists


### PR DESCRIPTION
There’s an apparent contradiction between [RFC 7230 §3.3.2 `Content-Length`](https://tools.ietf.org/html/rfc7230#section-3.3.2):

“A server MUST NOT send a `Content-Length` header field in any response with a status code of 1xx (Informational) or 204 (No Content).”

and [RFC 7231 §4.3.7 `OPTIONS`](https://tools.ietf.org/html/rfc7231#section-4.3.7):

“A server MUST generate a `Content-Length` field with a value of "0" if no payload body is to be sent in the response.”

The only resolution within the existing language would be to disallow all 204 responses to `OPTIONS` requests.  However, I don’t think that was the intention, so I submitted this erratum report:

https://www.rfc-editor.org/errata/eid5806

and updated the code accordingly.

These `Content-Length` headers seem to get filtered out at some other layer anyway, so there may be no visible effect.