### PR TITLE
puppet: “Resolve” puppet-lint warnings

### DIFF
--- a/puppet/zulip/manifests/base.pp
+++ b/puppet/zulip/manifests/base.pp
@@ -90,7 +90,7 @@ class zulip::base {
 
   # $::memorysize_mb is a string in Facter < 3.0 and a double in Facter ≥ 3.0.
   # Either way, convert it to an integer.
-  $total_memory_mb_array = scanf("${::memorysize_mb}", "%i")
+  $total_memory_mb_array = scanf("${::memorysize_mb} ", '%i')
   $total_memory_mb = $total_memory_mb_array[0]
 
   group { 'zulip':


### PR DESCRIPTION
Introduced by #12966.

puppet/zulip/manifests/base.pp - WARNING: double quoted string containing no variables on line 93
puppet/zulip/manifests/base.pp - WARNING: string containing only a variable on line 93

`scanf` doesn’t accept a number as input, so uh, add a dummy space character.

What.  You can’t give me a bad language and then complain when I write bad programs in it.

**Testing Plan:** Ran `test-install` with xenial and bionic.