### PR TITLE
 popovers: Hide email under hidden email-address-visibility cases.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -146,6 +146,13 @@ function get_custom_profile_field_data(user, field, field_types, dateFormat) {
     return profile_field;
 }
 
+function get_visible_email(user) {
+    if (user.delivery_email) {
+        return user.delivery_email;
+    }
+    return user.email;
+}
+
 function render_user_info_popover(user, popover_element, is_sender_popover, private_msg_class,
                                   template_class, popover_placement) {
     var is_me = people.is_my_user_id(user.user_id);
@@ -174,7 +181,7 @@ function render_user_info_popover(user, popover_element, is_sender_popover, priv
         sent_by_uri: hash_util.by_sender_uri(user.email),
         show_email: settings_org.show_email(),
         show_user_profile: !(user.is_bot || page_params.custom_profile_fields.length === 0),
-        user_email: user.email,
+        user_email: get_visible_email(user),
         user_full_name: user.full_name,
         user_id: user.user_id,
         user_last_seen_time_status: buddy_data.user_last_seen_time_status(user.user_id),

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -302,7 +302,7 @@ exports.show_user_profile = function (user) {
 
     var args = {
         full_name: user.full_name,
-        email: user.email,
+        email: get_visible_email(user),
         profile_data: profile_data,
         user_avatar: "avatar/" + user.email + "/medium",
         is_me: people.is_current_user(user.email),

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -326,7 +326,8 @@ realm_user_dict_fields = [
     'id', 'full_name', 'short_name', 'email',
     'avatar_source', 'avatar_version', 'is_active',
     'is_realm_admin', 'is_bot', 'realm_id', 'timezone',
-    'date_joined', 'is_guest', 'bot_owner_id'
+    'date_joined', 'is_guest', 'bot_owner_id',
+    'delivery_email'
 ]  # type: List[str]
 
 def realm_user_dicts_cache_key(realm_id: int) -> str:

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -3513,7 +3513,7 @@ class TestEventsRegisterNarrowDefaults(ZulipTestCase):
 
 class TestGetRawUserDataSystemBotRealm(ZulipTestCase):
     def test_get_raw_user_data_on_system_bot_realm(self) -> None:
-        result = get_raw_user_data(get_realm("zulipinternal"), True)
+        result = get_raw_user_data(get_realm("zulipinternal"), self.example_user('hamlet'), True)
 
         for bot_email in settings.CROSS_REALM_BOT_EMAILS:
             bot_profile = get_system_bot(bot_email)


### PR DESCRIPTION
This completes the remaining pieces of this issue, https://github.com/zulip/zulip/issues/11455

When email address visibility is set to everyone, there is no change in
behavior, but when it is set to "admins-only", we don't show any email
in popovers for everyone but admins.