### PR TITLE
settings: Move API key form into its own modal.

### DIFF
--- a/frontend_tests/casper_tests/06-settings.js
+++ b/frontend_tests/casper_tests/06-settings.js
@@ -68,13 +68,13 @@ casper.then(function () {
 
 casper.then(function () {
     casper.waitUntilVisible('#get_api_key_button', function () {
-        casper.fill('#get_api_key_form', {password: test_credentials.default_user.password});
+        casper.fill('#api_key_form', {password: test_credentials.default_user.password});
         casper.click('#get_api_key_button');
     });
 });
 
 casper.then(function () {
-    casper.waitUntilVisible('#show_api_key_box', function () {
+    casper.waitUntilVisible('#show_api_key', function () {
         casper.test.assertMatch(casper.fetchText('#api_key_value'), /[a-zA-Z0-9]{32}/, "Looks like an API key");
 
         /*
@@ -90,7 +90,7 @@ casper.then(function () {
 });
 
 casper.then(function () {
-    casper.waitUntilVisible('#show_api_key_box', function () {
+    casper.waitUntilVisible('#show_api_key', function () {
         casper.test.assertExists('#download_zuliprc', '~/.zuliprc button exists');
         casper.click('#download_zuliprc');
     });
@@ -106,6 +106,8 @@ casper.then(function () {
 });
 
 casper.then(function () {
+    casper.click('#api_key_modal .close');
+
     // casper.waitUntilVisible('#account-settings-status', function () {
     casper.click('[data-section="your-bots"]');
     // });

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -280,7 +280,6 @@ exports.set_up = function () {
         data.password = $("#get_api_key_password").val();
         channel.post({
             url: '/json/fetch_api_key',
-            dataType: 'json',
             data: data,
             success: function (data) {
                 var settings_status = $('#account-settings-status').expectOne();

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1565,7 +1565,8 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 
 #settings_page #change_full_name_modal .change_full_name_info,
 #settings_page #change_email_modal .change_email_info,
-#settings_page #change_password_modal .change_password_info {
+#settings_page #change_password_modal .change_password_info,
+#settings_page #api_key_modal #api_key_status {
     margin-top: 3px;
 }
 
@@ -1812,10 +1813,6 @@ input[type=text]#settings_search {
         width: 250px;
         height: 100%;
     }
-}
-
-#show_api_key_box {
-    padding-bottom: 20px;
 }
 
 #muted_topics_table {

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -213,31 +213,7 @@
                 <button class="button rounded" id="api_key_button">{{t "Show/change your API key" }}</button>
             </div>
         </div>
-        <div id="get_api_key_box">
-            <p>{{t "Please re-enter your password to confirm your identity." }}
-              <a href="/accounts/password/reset/" target="_blank">{{t "Never had one? Forgotten it?" }}</a></p>
-            <form cslass="form-horizontal" id="get_api_key_form">
-                <div class="control-group">
-                    <label for="password" class="control-label">{{t "Current password" }}</label>
-                    <input type="password" autocomplete="off"
-                      name="password" id="get_api_key_password" value="" />
-                    <button type="submit" name="view_api_key" id="get_api_key_button"
-                      class="button sea-green">{{t 'Get API key' }}</button>
-                </div>
-            </form>
-        </div>
-        <div id="show_api_key_box">
-            <p>{{t "Your API key:" }}</p>
-            <p><b><span id="api_key_value"></span></b></p>
-            <div id="api_key_buttons">
-                <button type="submit" class="button white rounded regenerate_api_key">
-                    {{t "Generate new API key" }}
-                </button>
-                <a id="download_zuliprc" download="{{zuliprc}}" class="button sea-green">
-                    {{t "Download .zuliprc" }}
-                </a>
-            </div>
-            <div id="user_api_key_error" class="text-error"></div>
-        </div>
+        <!-- Render /settings/api_key_modal.hbs after #api_key_button is clicked
+        to avoid password being inserted by password manager too aggressively. -->
     </div>
 </div>

--- a/static/templates/settings/api_key_modal.hbs
+++ b/static/templates/settings/api_key_modal.hbs
@@ -1,0 +1,38 @@
+<div id="api_key_modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog"
+  aria-labelledby="api_key_modal_label" aria-hidden="true">
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}">
+            <span aria-hidden="true">&times;</span>
+        </button>
+        <h3 class="inline-block" id="api_key_modal_label">{{t "Show API key" }}</h3>
+        <span class="alert-notification" id="api_key_status"></span>
+    </div>
+    <div class="modal-body">
+        <div id="password_confirmation">
+            <form id="api_key_form">
+                <p>{{t "Please re-enter your password to confirm your identity." }}
+                    <a href="/accounts/password/reset/" target="_blank">{{t "Never had one? Forgotten it?" }}</a></p>
+                <div class="control-group">
+                    <label for="password" class="control-label">{{t "Current password" }}</label>
+                    <input type="password" autocomplete="off" name="password" id="get_api_key_password" value="" />
+                </div>
+                <button type="submit" name="view_api_key" id="get_api_key_button" class="button sea-green">
+                    {{t 'Get API key' }}
+                </button>
+            </form>
+        </div>
+        <div id="show_api_key">
+            <p>{{t "Your API key:" }}</p>
+            <p><b><span id="api_key_value"></span></b></p>
+            <div id="api_key_buttons">
+                <button type="submit" class="button white rounded regenerate_api_key">
+                    {{t "Generate new API key" }}
+                </button>
+                <a id="download_zuliprc" download="{{zuliprc}}" class="button sea-green">
+                    {{t "Download .zuliprc" }}
+                </a>
+            </div>
+            <div id="user_api_key_error" class="text-error"></div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
The modal is rendered dynamically to avoid password managers inserting password into the input field too aggressively.

Fixes #12523.

![image](https://user-images.githubusercontent.com/18504232/62876523-b5b73d00-bd57-11e9-9c6b-ec9ea62de3b9.png)
(The green key icon is my password manager)
![image](https://user-images.githubusercontent.com/18504232/62876538-bd76e180-bd57-11e9-85ae-3ea0cf5e94e5.png)
