### PR TITLE
puppet: Reload postfix on /etc/postfix/virtual changes

### DIFF
--- a/puppet/zulip/files/postfix/virtual
+++ b/puppet/zulip/files/postfix/virtual
@@ -1,3 +1,3 @@
-/.*\+.*@.*/ zulip@localhost
-/.*\..*@.*/ zulip@localhost
-/^mm.*/ zulip@localhost
+/\+.*@/ zulip@localhost
+/\..*@/ zulip@localhost
+/^mm/ zulip@localhost

--- a/puppet/zulip/manifests/postfix_localmail.pp
+++ b/puppet/zulip/manifests/postfix_localmail.pp
@@ -47,14 +47,7 @@ class zulip::postfix_localmail {
     group   => root,
     source  => 'puppet:///modules/zulip/postfix/virtual',
     require => Package[postfix],
-  }
-  exec {'postmap /etc/postfix/virtual':
-    subscribe   => File['/etc/postfix/virtual'],
-    refreshonly => true,
-    require     => [
-      File['/etc/postfix/main.cf'],
-      Package[postfix],
-    ],
+    notify  => Service['postfix'],
   }
 
   file {'/etc/postfix/transport':


### PR DESCRIPTION
`/etc/postfix/virtual` is of `regexp:` type, not `hash:` type, so running `postmap` on it has no effect; we need to reload Postfix when it changes.

http://www.postfix.org/DATABASE_README.html#detect

In the interest of forcing a reload now, optimize the regexes by eliding the unanchored `.*`s at the beginnings and ends.

**Testing Plan:** Not tested yet; CZO would be a good test case, as it reportedly hasn’t picked up 2eb855b302e37b52e6b8f1685391e90b7f0398db.