### PR TITLE
curl: Add a test to ensure generated_examples are correct (status 200).

### DIFF
--- a/tools/test-api
+++ b/tools/test-api
@@ -7,7 +7,6 @@ import sys
 from lib import sanity_check
 sanity_check.check_venv(__file__)
 
-import django
 ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, ZULIP_PATH)
 os.chdir(ZULIP_PATH)
@@ -16,13 +15,6 @@ from zulip import Client
 
 from tools.lib.test_script import assert_provisioning_status_ok
 from tools.lib.test_server import test_server_running
-from zerver.openapi.python_examples import test_the_api, test_invalid_api_key
-
-os.environ['DJANGO_SETTINGS_MODULE'] = 'zproject.test_settings'
-django.setup()
-from zerver.lib.actions import do_create_user
-from zerver.lib.users import get_api_key
-from zerver.models import get_user, get_realm
 
 usage = """test-api [options]"""
 parser = argparse.ArgumentParser(usage)
@@ -34,6 +26,13 @@ options = parser.parse_args()
 assert_provisioning_status_ok(options.force)
 
 with test_server_running(force=options.force, external_host='zulipdev.com:9981'):
+    # Zerver imports should happen after `django.setup()` is run
+    # by the test_server_running decorator.
+    from zerver.openapi.python_examples import test_the_api, test_invalid_api_key
+    from zerver.lib.actions import do_create_user
+    from zerver.lib.users import get_api_key
+    from zerver.models import get_user, get_realm
+
     print("Running API tests...")
 
     # Prepare the admin client

--- a/tools/test-api
+++ b/tools/test-api
@@ -29,6 +29,7 @@ with test_server_running(force=options.force, external_host='zulipdev.com:9981')
     # Zerver imports should happen after `django.setup()` is run
     # by the test_server_running decorator.
     from zerver.openapi.python_examples import test_the_api, test_invalid_api_key
+    from zerver.openapi.test_curl_examples import test_generated_curl_examples_for_success
     from zerver.lib.actions import do_create_user
     from zerver.lib.users import get_api_key
     from zerver.models import get_user, get_realm
@@ -41,14 +42,24 @@ with test_server_running(force=options.force, external_host='zulipdev.com:9981')
     user = get_user(email, realm)
     api_key = get_api_key(user)
     site = 'http://zulip.zulipdev.com:9981'
-
     client = Client(
         email=email,
         api_key=api_key,
         site=site
     )
 
-    # Prepare the admin client
+    # Prepare a generic bot client for curl testing
+    email = 'default-bot@zulip.com'
+    realm = get_realm("zulip")
+    bot_user = get_user(email, realm)
+    api_key = get_api_key(bot_user)
+    bot_client = Client(
+        email=email,
+        api_key=api_key,
+        site=site
+    )
+
+    # Prepare the non-admin client
     email = 'guest@zulip.com'  # guest is not an admin
     guest_user = do_create_user('guest@zulip.com', 'secret',
                                 get_realm('zulip'), 'Mr. Guest', 'guest')
@@ -59,6 +70,7 @@ with test_server_running(force=options.force, external_host='zulipdev.com:9981')
         site=site
     )
 
+    test_generated_curl_examples_for_success(bot_client)
     test_the_api(client, nonadmin_client)
 
     # Test error payloads

--- a/zerver/lib/bugdown/api_code_examples.py
+++ b/zerver/lib/bugdown/api_code_examples.py
@@ -105,16 +105,17 @@ def render_python_code_example(function: str, admin_config: Optional[bool]=False
 
 def curl_method_arguments(endpoint: str, method: str,
                           api_url: str) -> List[str]:
+    # We also include the -sS verbosity arguments here.
     method = method.upper()
     url = "{}/v1{}".format(api_url, endpoint)
     valid_methods = ["GET", "POST", "DELETE", "PUT", "PATCH", "OPTIONS"]
-    if method == valid_methods[0]:
+    if method == "GET":
         # Then we need to make sure that each -d option translates to becoming
         # a GET parameter (in the URL) and not a POST parameter (in the body).
         # TODO: remove the -X part by updating the linting rule. It's redundant.
-        return ["-X", "GET", "-G", url]
+        return ["-sSX", "GET", "-G", url]
     elif method in valid_methods:
-        return ["-X", method, url]
+        return ["-sSX", method, url]
     else:
         msg = "The request method {} is not one of {}".format(method,
                                                               valid_methods)

--- a/zerver/lib/bugdown/fenced_code.py
+++ b/zerver/lib/bugdown/fenced_code.py
@@ -116,7 +116,7 @@ Missing required -X argument in curl command:
 """.strip()
 
     for line in lines:
-        regex = r'curl [-]X "?(GET|DELETE|PATCH|POST)"?'
+        regex = r'curl [-](sS)?X "?(GET|DELETE|PATCH|POST)"?'
         if line.startswith('curl'):
             if re.search(regex, line) is None:
                 raise BugdownRenderingException(error_msg.format(command=line.strip()))

--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -1,0 +1,84 @@
+import glob
+import json
+import shlex
+import subprocess
+import markdown
+
+from zulip import Client
+from zerver.lib.bugdown import api_code_examples
+from zerver.models import get_realm
+
+# whitelisted_files is a list of endpoints which have been
+# migrated to the example generation system and can thus be
+# tested.
+whitelisted_files = [
+    "get-messages.md",
+]
+
+def test_generated_curl_examples_for_success(client: Client) -> None:
+    authentication_line = "{}:{}".format(client.email, client.api_key)
+    # A limited markdown engine that just processes the code example syntax.
+    realm = get_realm("zulip")
+    md_engine = markdown.Markdown(extensions=[api_code_examples.makeExtension(
+        api_url=realm.uri + "/api")])
+
+    for file_name in glob.glob("templates/zerver/api/*.md"):
+        documentation_lines = open(file_name, "r").readlines()
+        for line in documentation_lines:
+            # A typical example from the markdown source looks like this:
+            #     {generate_code_example(curl, ...}
+            if not line.startswith("{generate_code_example(curl"):
+                continue
+
+            # To do an end-to-end test on the documentation examples
+            # that will be actually shown to users, we use the
+            # markdown rendering pipeline to compute the user-facing
+            # example, and then run that to test it.
+            curl_command_html = md_engine.convert(line.strip())
+            curl_command_text = curl_command_html[len("<p><code>curl\n"):-len("</code></p>")]
+
+            curl_command_text = curl_command_text.replace(
+                "BOT_EMAIL_ADDRESS:BOT_API_KEY", authentication_line)
+
+            print("Testing %s ..." % (curl_command_text.split("\n")[0],))
+
+            # Turn the text into an arguments list.
+            generated_curl_command = [
+                x for x in shlex.split(curl_command_text) if x != "\n"]
+
+            response = None
+            try:
+                # We split this across two lines so if curl fails and
+                # returns non-JSON output, we'll still print it.
+                response = subprocess.check_output(generated_curl_command).decode('utf-8')
+                response = json.loads(response)
+                assert(response["result"] == "success")
+            except (AssertionError, Exception):
+                error_template = """
+Error verifying the success of the API documentation curl example.
+
+File: {file_name}
+Line: {line}
+Curl Command:
+{curl_command}
+Response:
+{response}
+
+This test is designed to check each generate_code_example(curl) instance in the
+API documentation for success. If this fails then it means that the curl example
+that was generated was faulty and when tried, it resulted in an unsuccessful
+response.
+
+Common reasons for why this could occur:
+    1. One or more example values in zerver/openapi/zulip.yaml for this endpoint
+       do not line up with the values in the test database.
+    2. One or more mandatory parameters were included in the "exclude" list.
+
+To learn more about the test itself, see zerver/openapi/test_curl_examples.py.
+"""
+                print(error_template.format(
+                    file_name=file_name,
+                    line=line,
+                    curl_command=generated_curl_command,
+                    response=json.dumps(response, indent=4)))
+                raise

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -695,11 +695,15 @@ class TestCurlExampleGeneration(ZulipTestCase):
         }
     }
 
+    def curl_example(self, endpoint: str, method: str, *args: Any, **kwargs: Any) -> List[str]:
+        return generate_curl_example(endpoint, method,
+                                     "http://localhost:9991/api", *args, **kwargs)
+
     def test_generate_and_render_curl_example(self) -> None:
-        generated_curl_example = generate_curl_example("/get_stream_id", "GET")
+        generated_curl_example = self.curl_example("/get_stream_id", "GET")
         expected_curl_example = [
             "```curl",
-            "curl -X GET -G localhost:9991/api/v1/get_stream_id \\",
+            "curl -X GET -G http://localhost:9991/api/v1/get_stream_id \\",
             "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
             "    -d 'stream=Denmark'",
             "```"
@@ -708,15 +712,15 @@ class TestCurlExampleGeneration(ZulipTestCase):
 
     def test_generate_and_render_curl_example_with_nonexistant_endpoints(self) -> None:
         with self.assertRaises(KeyError):
-            generate_curl_example("/mark_this_stream_as_read", "POST")
+            self.curl_example("/mark_this_stream_as_read", "POST")
         with self.assertRaises(KeyError):
-            generate_curl_example("/mark_stream_as_read", "GET")
+            self.curl_example("/mark_stream_as_read", "GET")
 
     def test_generate_and_render_curl_without_auth(self) -> None:
-        generated_curl_example = generate_curl_example("/dev_fetch_api_key", "POST")
+        generated_curl_example = self.curl_example("/dev_fetch_api_key", "POST")
         expected_curl_example = [
             "```curl",
-            "curl -X POST localhost:9991/api/v1/dev_fetch_api_key \\",
+            "curl -X POST http://localhost:9991/api/v1/dev_fetch_api_key \\",
             "    -d 'username=iago@zulip.com'",
             "```"
         ]
@@ -725,10 +729,10 @@ class TestCurlExampleGeneration(ZulipTestCase):
     @patch("zerver.lib.openapi.OpenAPISpec.spec")
     def test_generate_and_render_curl_with_default_examples(self, spec_mock: MagicMock) -> None:
         spec_mock.return_value = self.spec_mock_without_examples
-        generated_curl_example = generate_curl_example("/mark_stream_as_read", "POST")
+        generated_curl_example = self.curl_example("/mark_stream_as_read", "POST")
         expected_curl_example = [
             "```curl",
-            "curl -X POST localhost:9991/api/v1/mark_stream_as_read \\",
+            "curl -X POST http://localhost:9991/api/v1/mark_stream_as_read \\",
             "    -d 'stream_id=1' \\",
             "    -d 'bool_param=false'",
             "```"
@@ -739,13 +743,13 @@ class TestCurlExampleGeneration(ZulipTestCase):
     def test_generate_and_render_curl_with_invalid_method(self, spec_mock: MagicMock) -> None:
         spec_mock.return_value = self.spec_mock_with_invalid_method
         with self.assertRaises(ValueError):
-            generate_curl_example("/endpoint", "BREW")  # see: HTCPCP
+            self.curl_example("/endpoint", "BREW")  # see: HTCPCP
 
     def test_generate_and_render_curl_with_array_example(self) -> None:
-        generated_curl_example = generate_curl_example("/messages", "GET")
+        generated_curl_example = self.curl_example("/messages", "GET")
         expected_curl_example = [
             '```curl',
-            'curl -X GET -G localhost:9991/api/v1/messages \\',
+            'curl -X GET -G http://localhost:9991/api/v1/messages \\',
             '    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\',
             "    -d 'anchor=42' \\",
             "    -d 'use_first_unread_anchor=true' \\",
@@ -761,10 +765,10 @@ class TestCurlExampleGeneration(ZulipTestCase):
     @patch("zerver.lib.openapi.OpenAPISpec.spec")
     def test_generate_and_render_curl_with_object(self, spec_mock: MagicMock) -> None:
         spec_mock.return_value = self.spec_mock_using_object
-        generated_curl_example = generate_curl_example("/endpoint", "GET")
+        generated_curl_example = self.curl_example("/endpoint", "GET")
         expected_curl_example = [
             '```curl',
-            'curl -X GET -G localhost:9991/api/v1/endpoint \\',
+            'curl -X GET -G http://localhost:9991/api/v1/endpoint \\',
             '    --data-urlencode param1=\'{"key": "value"}\'',
             '```'
         ]
@@ -774,19 +778,20 @@ class TestCurlExampleGeneration(ZulipTestCase):
     def test_generate_and_render_curl_with_object_without_example(self, spec_mock: MagicMock) -> None:
         spec_mock.return_value = self.spec_mock_using_object_without_example
         with self.assertRaises(ValueError):
-            generate_curl_example("/endpoint", "GET")
+            self.curl_example("/endpoint", "GET")
 
     @patch("zerver.lib.openapi.OpenAPISpec.spec")
     def test_generate_and_render_curl_with_array_without_example(self, spec_mock: MagicMock) -> None:
         spec_mock.return_value = self.spec_mock_using_array_without_example
         with self.assertRaises(ValueError):
-            generate_curl_example("/endpoint", "GET")
+            self.curl_example("/endpoint", "GET")
 
     def test_generate_and_render_curl_wrapper(self) -> None:
-        generated_curl_example = render_curl_example("/get_stream_id:GET:email:key:chat.zulip.org/api")
+        generated_curl_example = render_curl_example("/get_stream_id:GET:email:key",
+                                                     api_url="https://zulip.example.com/api")
         expected_curl_example = [
             "```curl",
-            "curl -X GET -G chat.zulip.org/api/v1/get_stream_id \\",
+            "curl -X GET -G https://zulip.example.com/api/v1/get_stream_id \\",
             "    -u email:key \\",
             "    -d 'stream=Denmark'",
             "```"
@@ -794,10 +799,11 @@ class TestCurlExampleGeneration(ZulipTestCase):
         self.assertEqual(generated_curl_example, expected_curl_example)
 
     def test_generate_and_render_curl_example_with_excludes(self) -> None:
-        generated_curl_example = generate_curl_example("/messages", "GET", exclude=["client_gravatar", "apply_markdown"])
+        generated_curl_example = self.curl_example("/messages", "GET",
+                                                   exclude=["client_gravatar", "apply_markdown"])
         expected_curl_example = [
             '```curl',
-            'curl -X GET -G localhost:9991/api/v1/messages \\',
+            'curl -X GET -G http://localhost:9991/api/v1/messages \\',
             '    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\',
             "    -d 'anchor=42' \\",
             "    -d 'use_first_unread_anchor=true' \\",

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -703,7 +703,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
         generated_curl_example = self.curl_example("/get_stream_id", "GET")
         expected_curl_example = [
             "```curl",
-            "curl -X GET -G http://localhost:9991/api/v1/get_stream_id \\",
+            "curl -sSX GET -G http://localhost:9991/api/v1/get_stream_id \\",
             "    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\",
             "    -d 'stream=Denmark'",
             "```"
@@ -720,7 +720,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
         generated_curl_example = self.curl_example("/dev_fetch_api_key", "POST")
         expected_curl_example = [
             "```curl",
-            "curl -X POST http://localhost:9991/api/v1/dev_fetch_api_key \\",
+            "curl -sSX POST http://localhost:9991/api/v1/dev_fetch_api_key \\",
             "    -d 'username=iago@zulip.com'",
             "```"
         ]
@@ -732,7 +732,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
         generated_curl_example = self.curl_example("/mark_stream_as_read", "POST")
         expected_curl_example = [
             "```curl",
-            "curl -X POST http://localhost:9991/api/v1/mark_stream_as_read \\",
+            "curl -sSX POST http://localhost:9991/api/v1/mark_stream_as_read \\",
             "    -d 'stream_id=1' \\",
             "    -d 'bool_param=false'",
             "```"
@@ -749,7 +749,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
         generated_curl_example = self.curl_example("/messages", "GET")
         expected_curl_example = [
             '```curl',
-            'curl -X GET -G http://localhost:9991/api/v1/messages \\',
+            'curl -sSX GET -G http://localhost:9991/api/v1/messages \\',
             '    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\',
             "    -d 'anchor=42' \\",
             "    -d 'use_first_unread_anchor=true' \\",
@@ -768,7 +768,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
         generated_curl_example = self.curl_example("/endpoint", "GET")
         expected_curl_example = [
             '```curl',
-            'curl -X GET -G http://localhost:9991/api/v1/endpoint \\',
+            'curl -sSX GET -G http://localhost:9991/api/v1/endpoint \\',
             '    --data-urlencode param1=\'{"key": "value"}\'',
             '```'
         ]
@@ -791,7 +791,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
                                                      api_url="https://zulip.example.com/api")
         expected_curl_example = [
             "```curl",
-            "curl -X GET -G https://zulip.example.com/api/v1/get_stream_id \\",
+            "curl -sSX GET -G https://zulip.example.com/api/v1/get_stream_id \\",
             "    -u email:key \\",
             "    -d 'stream=Denmark'",
             "```"
@@ -803,7 +803,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
                                                    exclude=["client_gravatar", "apply_markdown"])
         expected_curl_example = [
             '```curl',
-            'curl -X GET -G http://localhost:9991/api/v1/messages \\',
+            'curl -sSX GET -G http://localhost:9991/api/v1/messages \\',
             '    -u BOT_EMAIL_ADDRESS:BOT_API_KEY \\',
             "    -d 'anchor=42' \\",
             "    -d 'use_first_unread_anchor=true' \\",


### PR DESCRIPTION
This PR aims to use/test the new curl example generating code and make sure that every example generated would return a successful response (status 200) against our test data. As of opening this PR, the test is incomplete (hence WIP) since I'm facing a few issues with getting the right API key. @timabbott could you please help?