### PR TITLE
provision: Remove some unnecessary execs

### DIFF
--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -148,7 +148,7 @@ If you want to do it manually, here are the steps:
 
 ```
 sudo virtualenv /srv/zulip-py3-venv -p python3 # Create a python3 virtualenv
-sudo chown -R `whoami`:`whoami` /srv/zulip-py3-venv
+sudo chown -R `whoami`: /srv/zulip-py3-venv
 source /srv/zulip-py3-venv/bin/activate # Activate python3 virtualenv
 pip install --upgrade pip # upgrade pip itself because older versions have known issues
 pip install --no-deps -r requirements/dev.txt # install python packages required for development
@@ -160,7 +160,7 @@ Now run these commands:
 sudo ./scripts/lib/install-node
 yarn install
 sudo mkdir /srv/zulip-emoji-cache
-sudo chown -R `whoami`:`whoami` /srv/zulip-emoji-cache
+sudo chown -R `whoami`: /srv/zulip-emoji-cache
 ./tools/setup/emoji/build_emoji
 ./tools/inline-email-css
 ./tools/setup/build_pygments_data

--- a/scripts/lib/cd_exec
+++ b/scripts/lib/cd_exec
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-# cd into $1 and then exec the rest of the args
-
-cd "$1"
-shift
-exec "$@"

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -247,8 +247,6 @@ REPO_STOPWORDS_PATH = os.path.join(
     "zulip_english.stop",
 )
 
-user_id = os.getuid()
-
 def install_system_deps():
     # type: () -> None
 
@@ -393,7 +391,7 @@ def main(options):
 
     if not os.access(NODE_MODULES_CACHE_PATH, os.W_OK):
         run_as_root(["mkdir", "-p", NODE_MODULES_CACHE_PATH])
-        run_as_root(["chown", "%s:%s" % (user_id, user_id), NODE_MODULES_CACHE_PATH])
+        run_as_root(["chown", "%s:%s" % (os.getuid(), os.getgid()), NODE_MODULES_CACHE_PATH])
 
     # This is a wrapper around `yarn`, which we run last since
     # it can often fail due to network issues beyond our control.

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -391,15 +391,13 @@ def main(options):
     ]
     run_as_root(proxy_env + ["scripts/lib/install-node"], sudo_args = ['-H'])
 
+    if not os.access(NODE_MODULES_CACHE_PATH, os.W_OK):
+        run_as_root(["mkdir", "-p", NODE_MODULES_CACHE_PATH])
+        run_as_root(["chown", "%s:%s" % (user_id, user_id), NODE_MODULES_CACHE_PATH])
+
     # This is a wrapper around `yarn`, which we run last since
     # it can often fail due to network issues beyond our control.
     try:
-        # Hack: We remove `node_modules` as root to work around an
-        # issue with the symlinks being improperly owned by root.
-        if os.path.islink("node_modules"):
-            run_as_root(["rm", "-f", "node_modules"])
-        run_as_root(["mkdir", "-p", NODE_MODULES_CACHE_PATH])
-        run_as_root(["chown", "%s:%s" % (user_id, user_id), NODE_MODULES_CACHE_PATH])
         setup_node_modules(prefer_offline=True)
     except subprocess.CalledProcessError:
         print(WARNING + "`yarn install` failed; retrying..." + ENDC)

--- a/tools/lib/provision_inner.py
+++ b/tools/lib/provision_inner.py
@@ -80,9 +80,9 @@ def main(options: argparse.Namespace) -> int:
     # The `build_emoji` script requires `emoji-datasource` package
     # which we install via npm; thus this step is after installing npm
     # packages.
-    if not os.path.isdir(EMOJI_CACHE_PATH):
-        run_as_root(["mkdir", EMOJI_CACHE_PATH])
-    run_as_root(["chown", "%s:%s" % (user_id, user_id), EMOJI_CACHE_PATH])
+    if not os.access(EMOJI_CACHE_PATH, os.W_OK):
+        run_as_root(["mkdir", "-p", EMOJI_CACHE_PATH])
+        run_as_root(["chown", "%s:%s" % (user_id, user_id), EMOJI_CACHE_PATH])
     run(["tools/setup/emoji/build_emoji"])
 
     # copy over static files from the zulip_bots package

--- a/tools/lib/provision_inner.py
+++ b/tools/lib/provision_inner.py
@@ -34,8 +34,6 @@ if is_travis:
 
 UUID_VAR_PATH = get_dev_uuid_var_path()
 
-user_id = os.getuid()
-
 def setup_shell_profile(shell_profile):
     # type: (str) -> None
     shell_profile_path = os.path.expanduser(shell_profile)
@@ -82,7 +80,7 @@ def main(options: argparse.Namespace) -> int:
     # packages.
     if not os.access(EMOJI_CACHE_PATH, os.W_OK):
         run_as_root(["mkdir", "-p", EMOJI_CACHE_PATH])
-        run_as_root(["chown", "%s:%s" % (user_id, user_id), EMOJI_CACHE_PATH])
+        run_as_root(["chown", "%s:%s" % (os.getuid(), os.getgid()), EMOJI_CACHE_PATH])
     run(["tools/setup/emoji/build_emoji"])
 
     # copy over static files from the zulip_bots package


### PR DESCRIPTION
* provision: Skip some rm, mkdir, chown commands if possible.
* node_cache: Remove unused copy_modules parameter.
* node_cache: Avoid shelling out for rm, ln, mkdir, cp, cd, touch.

**Testing Plan:** Ran `provision` (with no `node_modules`, old `node_modules`, and current `node_modules`).