### PR TITLE
streams:public and streams:subscribed to search entire history of organisation

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -111,6 +111,23 @@ run_test('basics', () => {
     filter = new Filter(operators);
     assert(filter.has_operator('has'));
     assert(!filter.can_apply_locally());
+
+    operators = [
+        {operator: 'streams', operand: 'public', negated: true},
+    ];
+    filter = new Filter(operators);
+    assert(!filter.has_operator('streams'));
+    assert(filter.has_negated_operand('streams', 'public'));
+    assert(!filter.can_apply_locally());
+
+    operators = [
+        {operator: 'streams', operand: 'public'},
+    ];
+    filter = new Filter(operators);
+    assert(filter.has_operator('streams'));
+    assert(!filter.has_negated_operand('streams', 'public'));
+    assert(!filter.can_apply_locally());
+
 });
 run_test('show_first_unread', () => {
     var operators = [
@@ -284,6 +301,9 @@ run_test('predicate_basics', () => {
     assert(predicate({type: 'private'}));
     assert(!predicate({type: 'stream'}));
 
+    predicate = get_predicate([['streams', 'public']]);
+    assert(predicate({}));
+
     predicate = get_predicate([['is', 'starred']]);
     assert(predicate({starred: true}));
     assert(!predicate({starred: false}));
@@ -395,6 +415,13 @@ run_test('negated_predicates', () => {
     predicate = new Filter(narrow).predicate();
     assert(predicate({type: 'stream', stream_id: 999999}));
     assert(!predicate({type: 'stream', stream_id: social_stream_id}));
+
+    narrow = [
+        {operator: 'streams', operand: 'public', negated: true},
+    ];
+    predicate = new Filter(narrow).predicate();
+    assert(predicate({}));
+
 });
 
 run_test('mit_exceptions', () => {
@@ -534,6 +561,25 @@ run_test('parse', () => {
     ];
     _test();
 
+    string = 'text streams:public more text';
+    operators = [
+        {operator: 'streams', operand: 'public'},
+        {operator: 'search', operand: 'text more text'},
+    ];
+    _test();
+
+    string = 'streams:public';
+    operators = [
+        {operator: 'streams', operand: 'public'},
+    ];
+    _test();
+
+    string = '-streams:public';
+    operators = [
+        {operator: 'streams', operand: 'public', negated: true},
+    ];
+    _test();
+
     string = 'stream:foo :emoji: are cool';
     operators = [
         {operator: 'stream', operand: 'foo'},
@@ -580,6 +626,26 @@ run_test('unparse', () => {
     assert.deepEqual(Filter.unparse(operators), string);
 
     operators = [
+        {operator: 'streams', operand: 'public'},
+        {operator: 'search', operand: 'text'},
+    ];
+
+    string = 'streams:public text';
+    assert.deepEqual(Filter.unparse(operators), string);
+
+    operators = [
+        {operator: 'streams', operand: 'public'},
+    ];
+    string = 'streams:public';
+    assert.deepEqual(Filter.unparse(operators), string);
+
+    operators = [
+        {operator: 'streams', operand: 'public', negated: true},
+    ];
+    string = '-streams:public';
+    assert.deepEqual(Filter.unparse(operators), string);
+
+    operators = [
         {operator: 'id', operand: 50},
     ];
     string = 'id:50';
@@ -601,6 +667,18 @@ run_test('unparse', () => {
 run_test('describe', () => {
     var narrow;
     var string;
+
+    narrow = [
+        {operator: 'streams', operand: 'public'},
+    ];
+    string = 'streams public';
+    assert.equal(Filter.describe(narrow), string);
+
+    narrow = [
+        {operator: 'streams', operand: 'public', negated: true},
+    ];
+    string = 'exclude streams public';
+    assert.equal(Filter.describe(narrow), string);
 
     narrow = [
         {operator: 'stream', operand: 'devel'},
@@ -815,6 +893,7 @@ run_test('term_type', () => {
         };
     }
 
+    assert_term_type(term('streams', 'public'), 'streams');
     assert_term_type(term('stream', 'whatever'), 'stream');
     assert_term_type(term('pm-with', 'whomever'), 'pm-with');
     assert_term_type(term('pm-with', 'whomever', true), 'not-pm-with');

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -448,6 +448,7 @@ run_test('empty_query_suggestions', () => {
 
     var expected = [
         "",
+        "streams:public",
         "is:private",
         "is:starred",
         "is:mentioned",
@@ -613,6 +614,7 @@ run_test('check_is_suggestions', () => {
     suggestions = search.get_suggestions('', query);
     expected = [
         '',
+        'streams:public',
         'is:private',
         'is:starred',
         'is:mentioned',
@@ -673,6 +675,7 @@ run_test('check_is_suggestions', () => {
     suggestions = search.get_suggestions('', query);
     expected = [
         'st',
+        'streams:public',
         'is:starred',
         'stream:',
     ];
@@ -1092,6 +1095,7 @@ run_test('operator_suggestions', () => {
     suggestions = search.get_suggestions('', query);
     expected = [
         'st',
+        'streams:public',
         'is:starred',
         'stream:',
     ];
@@ -1109,6 +1113,7 @@ run_test('operator_suggestions', () => {
     suggestions = search.get_suggestions('', query);
     expected = [
         '-s',
+        '-streams:public',
         '-sender:bob@zulip.com',
         '-stream:',
         '-sender:',

--- a/frontend_tests/node_tests/search_suggestion_legacy.js
+++ b/frontend_tests/node_tests/search_suggestion_legacy.js
@@ -454,6 +454,7 @@ run_test('empty_query_suggestions', () => {
 
     var expected = [
         "",
+        "streams:public",
         "is:private",
         "is:starred",
         "is:mentioned",
@@ -647,6 +648,7 @@ run_test('check_is_suggestions', () => {
     suggestions = search.get_suggestions_legacy(query);
     expected = [
         'st',
+        'streams:public',
         'is:starred',
         'stream:',
     ];
@@ -1046,6 +1048,7 @@ run_test('operator_suggestions', () => {
     suggestions = search.get_suggestions_legacy(query);
     expected = [
         'st',
+        'streams:public',
         'is:starred',
         'stream:',
     ];
@@ -1063,6 +1066,7 @@ run_test('operator_suggestions', () => {
     suggestions = search.get_suggestions_legacy(query);
     expected = [
         '-s',
+        '-streams:public',
         '-sender:bob@zulip.com',
         '-stream:',
         '-sender:',

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -356,6 +356,12 @@ Filter.prototype = {
             .value();
     },
 
+    has_negated_operand: function (operator, operand) {
+        return _.any(this._operators, function (elem) {
+            return elem.negated && (elem.operator === operator && elem.operand === operand);
+        });
+    },
+
     has_operand: function (operator, operand) {
         return _.any(this._operators, function (elem) {
             return !elem.negated && (elem.operator === operator && elem.operand === operand);
@@ -394,6 +400,11 @@ Filter.prototype = {
             // See #6186 to see why we currently punt on 'has:foo'
             // queries.  This can be fixed, there are just some random
             // complications that make it non-trivial.
+            return false;
+        }
+
+        if (this.has_operator('streams') ||
+            this.has_negated_operand('streams', 'public')) {
             return false;
         }
 
@@ -554,6 +565,7 @@ Filter.term_type = function (term) {
 
 Filter.sorted_term_types = function (term_types) {
     var levels = [
+        'streams',
         'stream', 'topic',
         'pm-with', 'group-pm-with', 'sender',
         'near', 'id',
@@ -596,7 +608,8 @@ Filter.operator_to_prefix = function (operator, negated) {
     switch (operator) {
     case 'stream':
         return verb + 'stream';
-
+    case 'streams':
+        return verb + 'streams';
     case 'near':
         return verb + 'messages around';
 

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -78,6 +78,7 @@ function get_stream_suggestions(last, operators) {
     var valid = ['stream', 'search', ''];
     var invalid = [
         {operator: 'stream'},
+        {operator: 'streams'},
         {operator: 'is', operand: 'private'},
         {operator: 'pm-with'},
     ];
@@ -395,6 +396,24 @@ function get_special_filter_suggestions(last, operators, suggestions) {
     return suggestions;
 }
 
+function get_streams_filter_suggestions(last, operators) {
+    var suggestions = [
+        {
+            search_string: 'streams:public',
+            description: 'Public streams with all history',
+            invalid: [
+                {operator: 'is', operand: 'private'},
+                {operator: 'stream'},
+                {operator: 'group-pm-with'},
+                {operator: 'pm-with'},
+                {operator: 'in'},
+                {operator: 'streams'},
+            ],
+
+        },
+    ];
+    return get_special_filter_suggestions(last, operators, suggestions);
+}
 function get_is_filter_suggestions(last, operators) {
     var suggestions = [
         {
@@ -621,6 +640,9 @@ exports.get_suggestions = function (base_query, query) {
 
     // Get all individual suggestions, and then attach_suggestions
     // mutates the list 'result' to add a properly-formatted suggestion
+    suggestions = get_streams_filter_suggestions(last, base_operators);
+    attach_suggestions(result, base, suggestions);
+
     suggestions = get_is_filter_suggestions(last, base_operators);
     attach_suggestions(result, base, suggestions);
 
@@ -741,6 +763,9 @@ exports.get_suggestions_legacy = function (query) {
 
     // Get all individual suggestions, and then attach_suggestions
     // mutates the list 'result' to add a properly-formatted suggestion
+    suggestions = get_streams_filter_suggestions(last, base_operators);
+    attach_suggestions(result, base, suggestions);
+
     suggestions = get_is_filter_suggestions(last, base_operators);
     attach_suggestions(result, base, suggestions);
 

--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -83,6 +83,8 @@ function make_tab_data() {
 
         } else if (filter.has_operand("is", "starred")) {
             tabs.push(make_tab("Starred", hashed));
+        } else if (filter.has_operand("streams", "public")) {
+            tabs.push(make_tab("Public Streams", hashed));
         } else if (filter.has_operator("near")) {
             tabs.push(make_tab("Near " + filter.operands("near")[0], hashed));
         } else if (filter.has_operator("id")) {

--- a/templates/zerver/app/search_operators.html
+++ b/templates/zerver/app/search_operators.html
@@ -9,6 +9,10 @@
                 </tr>
             </thead>
             <tr>
+                <td class="operator">streams:public</td>
+                <td class="definition">{{ _('Narrow to all historical messages in all public streams, both subscribed and unsubscribed.') }}</td>
+            </tr>
+            <tr>
                 <td class="operator">stream:<span class="operator_value">stream</span></td>
                 <td class="definition">{{ _('Narrow to messages on stream') }} <span class="operator_value">stream</span></td>
             </tr>

--- a/templates/zerver/help/search-for-messages.md
+++ b/templates/zerver/help/search-for-messages.md
@@ -25,6 +25,10 @@ Here is the **full list of search operators**.
 
 * `stream:design`: Search within the stream `#design`.
 * `stream:design topic:emoji+picker`: Search within the topic `emoji picker`.
+* `streams:public`: Any `stream` or `streams` restriction searches all history,
+  otherwise it just searches received messages" and "you're only allowed one `stream`
+  or `streams` operator at a time. Search within all `public` streams
+  (both subscibed and unsubscribed).
 * `is:private`: Search all your private messages.
 * `pm-with:ada@zulip.com`: Search 1-on-1 messages with Ada.
 * `group-pm-with:ada@zulip.com`: Search group private messages that

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5233,7 +5233,7 @@ def get_web_public_streams(realm: Realm) -> List[Dict[str, Any]]:
 def do_get_streams(
         user_profile: UserProfile, include_public: bool=True,
         include_subscribed: bool=True, include_all_active: bool=False,
-        include_default: bool=False, include_owner_subscribed: bool=False
+        include_default: bool=False, include_owner_subscribed: bool=False,
 ) -> List[Dict[str, Any]]:
     if include_all_active and not user_profile.is_api_super_user:
         raise JsonableError(_("User not authorized for this query"))

--- a/zerver/lib/narrow.py
+++ b/zerver/lib/narrow.py
@@ -30,7 +30,7 @@ def is_web_public_compatible(narrow: Iterable[Dict[str, str]]) -> bool:
         operator = element['operator']
         if 'operand' not in element:
             return False
-        if operator not in ["stream", "topic", "sender", "has", "search", "near", "id"]:
+        if operator not in ["streams", "stream", "topic", "sender", "has", "search", "near", "id"]:
             return False
     return True
 

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -8,6 +8,8 @@ from zerver.models import UserProfile, Stream, Subscription, \
     Realm, Recipient, bulk_get_recipients, get_stream_recipient, get_stream, \
     bulk_get_streams, get_realm_stream, DefaultStreamGroup, get_stream_by_id_in_realm
 
+from django.db.models.query import QuerySet
+
 def check_for_exactly_one_stream_arg(stream_id: Optional[int], stream: Optional[str]) -> None:
     if stream_id is None and stream is None:
         raise JsonableError(_("Please supply 'stream'."))
@@ -89,6 +91,9 @@ def access_stream_by_id(user_profile: UserProfile,
                                             require_active=require_active,
                                             allow_realm_admin=allow_realm_admin)
     return (stream, recipient, sub)
+
+def access_stream_by_invite_only(realm: Realm, invite_only: bool) -> 'QuerySet[Stream]':
+    return Stream.objects.filter(realm=realm, invite_only=invite_only)
 
 def get_stream_by_id(stream_id: int) -> Stream:
     error = _("Invalid stream id")


### PR DESCRIPTION
Add ability to search entire message history of all public streams at
once. It includes all subscibed, non subscribed public streams messages
and even historical public stream messages sent before user had joined
an organization or stream.

Fixes: #8859.

**Testing Plan:** <!-- How have you tested? -->
1. Created two public streams. Sent some messages to it. Add a new user to stream after sending messages.
2. Created private stream. Added same user that was added in step 1.
3. Logged in to newly added user. Searched for : `is:public-stream` Ensured typeahead was working and message list contained only messages (including history) of public streams and not private streams or private messages. Also tried to search for keyword and it was also working properly.
4. Searched for: `-is:public-stream` Ensured typeahead was working and message list contained only messages of private streams and private messages. Also tried to search for keyword and it was also working properly.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

**Note: ** -is:public-stream doesn't allow to include history on private messages (not applicable anyway) and private streams (possible on some but current implementation of negation of public stream doesn't support it.)

@timabbott 
Me and @YagoGG are curious how current sql queries approach you mentioned in https://github.com/zulip/zulip/issues/8859#issuecomment-377266113 and implemented in this PR will perform for large organisation with large messages ?