### PR TITLE
search: Explain that All Messages search only searches messages received.

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -70,6 +70,7 @@ run_test('basics', () => {
     assert(!filter.is_search());
     assert(filter.can_mark_messages_read());
     assert(filter.allow_use_first_unread_when_narrowing());
+    assert(filter.includes_full_stream_history());
     assert(filter.can_apply_locally());
 
     operators = [
@@ -111,6 +112,7 @@ run_test('basics', () => {
     filter = new Filter(operators);
     assert(filter.has_operator('has'));
     assert(!filter.can_apply_locally());
+    assert(!filter.includes_full_stream_history());
 
     operators = [
         {operator: 'streams', operand: 'public', negated: true},
@@ -127,6 +129,7 @@ run_test('basics', () => {
     assert(filter.has_operator('streams'));
     assert(!filter.has_negated_operand('streams', 'public'));
     assert(!filter.can_apply_locally());
+    assert(filter.includes_full_stream_history());
 
 });
 run_test('show_first_unread', () => {

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -384,9 +384,15 @@ Filter.prototype = {
     can_mark_messages_read: function () {
         return !this.has_operator('search');
     },
+
     allow_use_first_unread_when_narrowing: function () {
         return this.can_mark_messages_read() || this.has_operator('is');
     },
+
+    includes_full_stream_history: function () {
+        return this.has_operator("stream") || this.has_operator("streams");
+    },
+
     can_apply_locally: function () {
         if (this.is_search()) {
             // The semantics for matching keywords are implemented

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -282,6 +282,13 @@ exports.activate = function (raw_operators, opts) {
         compose.update_closed_compose_buttons_for_stream();
     }
 
+    // Toggle the notice that lets users know that not all messages were searched.
+    if (filter.is_search && !filter.includes_full_stream_history()) {
+        $(".all-messages-search-caution").show();
+    } else {
+        $(".all-messages-search-caution").hide();
+    }
+
     // Put the narrow operators in the search bar.
     $('#search_query').val(Filter.unparse(operators));
     search.update_button_visibility();
@@ -691,6 +698,7 @@ function handle_post_narrow_deactivate_processes() {
     exports.narrow_title = "home";
     notifications.redraw_title();
     notifications.hide_or_show_history_limit_message(home_msg_list);
+    $(".all-messages-search-caution").hide();
 }
 
 exports.deactivate = function () {

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -531,7 +531,8 @@ on a dark background, and don't change the dark labels dark either. */
         stroke: hsl(0, 0%, 100%);
     }
 
-    .history-limited-box {
+    .history-limited-box,
+    .all-messages-search-caution {
         background-color: hsla(0, 0%, 0%, 0.2);
     }
 

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -86,8 +86,17 @@ p.n-margin {
 .history-limited-box {
     color: hsl(16, 60%, 45%);
     border: 1px solid hsl(16, 60%, 45%);
-    border-radius: 4px;
     box-shadow: 0 0 2px hsl(16, 60%, 45%);
+}
+
+.all-messages-search-caution {
+    border: 1px solid hsla(192, 19%, 75%, 0.2);
+    box-shadow: 0 0 2px hsla(192, 19%, 75%, 0.2);
+}
+
+.history-limited-box,
+.all-messages-search-caution {
+    border-radius: 4px;
     display: none;
     height: 28x;
     font-size: 16px;

--- a/templates/zerver/app/home.html
+++ b/templates/zerver/app/home.html
@@ -18,6 +18,16 @@
             {% endtrans %}
         </p>
     </div>
+    <div class="all-messages-search-caution" hidden>
+        <p>
+            <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+            {% trans %}
+            This search may exclude some messages you have access to,
+            such as messages sent to public streams before you joined the stream.
+            <a href="/help/search-for-messages#messages-sent-before-you-joined" target="_blank">[Learn more]</a>
+            {% endtrans %}
+        </p>
+    </div>
     <div id="loading_more_messages_indicator"></div>
     <div id="page_loading_indicator"></div>
     <div id="first_run_message" class="empty_feed_notice">

--- a/templates/zerver/help/search-for-messages.md
+++ b/templates/zerver/help/search-for-messages.md
@@ -68,10 +68,12 @@ keywords are ignored, we'll return 0 search results.
 
 ## Messages sent before you joined
 
-In most cases, Zulip only searches messages that you received. In particular,
-this means Zulip will not search messages sent before you joined.
+In most cases, Zulip only searches messages that you received.  In
+particular, this means Zulip will not search messages sent before you
+joined a stream (or organization).
 
-However, if a) the search includes a `stream:` operator and b) that stream
-is either public or [private with shared history](/help/stream-permissions),
-Zulip will search the entire history of the stream, including messages
-that were sent before you joined.
+Zulip's [stream permissions](/help/stream-permissions) model allows
+full access to the history of public streams and [private streams with
+shared history](/help/stream-permissions).  Searches that include a
+`stream:` or `streams:` operator will return all messages in the
+stream(s) that you have access to.


### PR DESCRIPTION
When a user performs a search in All Messages, add a message above the first search result to let the user know that not all messages may have been searched.

Resolves #12036 

**GIFs or Screenshots:** (UPDATED)

![Screenshot_1](https://user-images.githubusercontent.com/25329595/63463678-4dfda200-c47b-11e9-8b56-af2c67b4f18e.png)

--------

![Screenshot_2](https://user-images.githubusercontent.com/25329595/63463679-4dfda200-c47b-11e9-82c6-97213b10512d.png)

