### PR TITLE
Gap handled between streams for continuous hover effect

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -94,7 +94,7 @@ li.show-more-topics a {
 }
 
 .narrows_panel li {
-    margin: 1px 0px;
+    margin: 0px 0px;
 }
 
 .narrows_panel li a:hover {
@@ -102,7 +102,7 @@ li.show-more-topics a {
 }
 
 #stream_filters li {
-    padding: 1px 0px;
+    padding: 0.3px 0px;
 }
 
 #stream_filters li ul {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #12508 
Hover effect not abrupt on going through different streams.

**Testing Plan:** <!-- How have you tested? -->
Chrome dev tools, works on browser.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Slight change in padding value, but not noticeable.
![gap](https://user-images.githubusercontent.com/49382298/63075144-3dff3300-bf4e-11e9-8d87-e3b24c9d4d97.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
