### PR TITLE
 settings_users: Refactor logic for "last active" column in users table.

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -105,6 +105,20 @@ function failed_listing_users(xhr) {
     ui_report.error(i18n.t("Error listing users or bots"), xhr, status);
 }
 
+var LAST_ACTIVE_NEVER = -1;
+var LAST_ACTIVE_UNKNOWN = -2;
+
+function get_last_active(user) {
+    var presence_info = presence.presence_info[user.user_id];
+    if (!presence_info) {
+        return LAST_ACTIVE_UNKNOWN;
+    }
+    if (!isNaN(presence_info.last_active)) {
+        return presence_info.last_active;
+    }
+    return LAST_ACTIVE_NEVER;
+}
+
 function populate_users(realm_people_data) {
     var active_users = [];
     var deactivated_users = [];
@@ -116,6 +130,7 @@ function populate_users(realm_people_data) {
             user.bot_type = settings_bots.type_id_to_string(user.bot_type);
             bots.push(user);
         } else if (user.is_active) {
+            user.last_active = get_last_active(user);
             active_users.push(user);
         } else {
             deactivated_users.push(user);

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -170,29 +170,29 @@ function populate_users(realm_people_data) {
         },
     }).init();
 
+    function get_rendered_last_activity(item) {
+        var today = new XDate();
+        if (item.last_active === LAST_ACTIVE_UNKNOWN) {
+            return $("<span></span>").text(i18n.t("Unknown"));
+        }
+        if (item.last_active === LAST_ACTIVE_NEVER) {
+            return $("<span></span>").text(i18n.t("Never"));
+        }
+        return timerender.render_date(
+            new XDate(item.last_active * 1000), undefined, today);
+    }
+
     var $users_table = $("#admin_users_table");
     list_render.create($users_table, active_users, {
         name: "users_table_list",
         modifier: function (item) {
-            var activity_rendered;
-            var today = new XDate();
-            if (item.last_active === LAST_ACTIVE_UNKNOWN) {
-                activity_rendered = $("<span></span>").text(i18n.t("Unknown"));
-            } else if (item.last_active === LAST_ACTIVE_NEVER) {
-                activity_rendered = $("<span></span>").text(i18n.t("Never"));
-            } else {
-                activity_rendered = timerender.render_date(
-                    new XDate(item.last_active * 1000), undefined, today);
-            }
-
             var $row = $(render_admin_user_list({
                 can_modify: page_params.is_admin,
                 is_current_user: people.is_my_user_id(item.user_id),
                 show_email: settings_org.show_email(),
                 user: item,
             }));
-            $row.find(".last_active").append(activity_rendered);
-
+            $row.find(".last_active").append(get_rendered_last_activity(item));
             return $row;
         },
         filter: {

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -176,18 +176,13 @@ function populate_users(realm_people_data) {
         modifier: function (item) {
             var activity_rendered;
             var today = new XDate();
-            if (presence.presence_info[item.user_id]) {
-                // XDate takes number of milliseconds since UTC epoch.
-                var last_active = presence.presence_info[item.user_id].last_active * 1000;
-
-                if (!isNaN(last_active)) {
-                    var last_active_date = new XDate(last_active);
-                    activity_rendered = timerender.render_date(last_active_date, undefined, today);
-                } else {
-                    activity_rendered = $("<span></span>").text(i18n.t("Never"));
-                }
-            } else {
+            if (item.last_active === LAST_ACTIVE_UNKNOWN) {
                 activity_rendered = $("<span></span>").text(i18n.t("Unknown"));
+            } else if (item.last_active === LAST_ACTIVE_NEVER) {
+                activity_rendered = $("<span></span>").text(i18n.t("Never"));
+            } else {
+                activity_rendered = timerender.render_date(
+                    new XDate(item.last_active * 1000), undefined, today);
             }
 
             var $row = $(render_admin_user_list({

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -161,9 +161,7 @@ function populate_users(realm_people_data) {
         modifier: function (item) {
             var activity_rendered;
             var today = new XDate();
-            if (people.is_current_user(item.email)) {
-                activity_rendered = timerender.render_date(today, undefined, today);
-            } else if (presence.presence_info[item.user_id]) {
+            if (presence.presence_info[item.user_id]) {
                 // XDate takes number of milliseconds since UTC epoch.
                 var last_active = presence.presence_info[item.user_id].last_active * 1000;
 


### PR DESCRIPTION
I continued to work on https://github.com/zulip/zulip/pull/12692, while I was doing that I found this refactor useful and also added `last_active` attribute to user object for sorting purpose.

@timabbott @shubhamdhama it would be really great if this can be merged asap!! Thankyou!!