### PR TITLE
settings_panel_menu: Fix the switching behavior for hidden section pa…

### DIFF
--- a/static/js/settings_panel_menu.js
+++ b/static/js/settings_panel_menu.js
@@ -43,12 +43,12 @@ exports.make_menu = function (opts) {
     };
 
     self.prev = function () {
-        curr_li.prev().focus().click();
+        curr_li.prevAll(":visible:first").focus().click();
         return true;
     };
 
     self.next = function () {
-        curr_li.next().focus().click();
+        curr_li.nextAll(":visible:first").focus().click();
         return true;
     };
 


### PR DESCRIPTION
…nels.

For organization settings page there are few sections' panels which are not
visible (unless you click on 'show more') but when we use up-down arrows to
navigate between sections, sections of hidden panels also get visible which
leads to confusion.

Fixes: #13008 

@shubhamdhama @timabbott FYI.