### PR TITLE
[WIP] api: Remove use of legacy emoji reaction endpoint

### DIFF
--- a/zerver/lib/onboarding.py
+++ b/zerver/lib/onboarding.py
@@ -3,7 +3,8 @@ from django.conf import settings
 from zerver.lib.actions import \
     internal_prep_stream_message_by_name, internal_send_private_message, \
     do_send_messages, \
-    do_add_reaction_legacy, create_users, missing_any_realm_internal_bots
+    do_add_reaction, create_users, missing_any_realm_internal_bots
+from zerver.lib.emoji import emoji_name_to_emoji_code
 from zerver.models import Message, Realm, UserProfile, get_system_bot
 
 from typing import Dict, List
@@ -101,4 +102,5 @@ def send_initial_realm_messages(realm: Realm) -> None:
     turtle_message = Message.objects.get(
         id__in=message_ids,
         content__icontains='cute/turtle.png')
-    do_add_reaction_legacy(welcome_bot, turtle_message, 'turtle')
+    (emoji_code, reaction_type) = emoji_name_to_emoji_code(realm, 'turtle')
+    do_add_reaction(welcome_bot, turtle_message, 'turtle', emoji_code, reaction_type)

--- a/zilencer/management/commands/add_mock_conversation.py
+++ b/zilencer/management/commands/add_mock_conversation.py
@@ -5,8 +5,9 @@ from typing import Any, Dict, List
 from django.core.management.base import BaseCommand
 
 from zerver.lib.actions import bulk_add_subscriptions, \
-    ensure_stream, do_add_reaction_legacy, do_change_avatar_fields, \
+    ensure_stream, do_add_reaction, do_change_avatar_fields, \
     do_create_user, do_send_messages, internal_prep_stream_message
+from zerver.lib.emoji import emoji_name_to_emoji_code
 from zerver.lib.upload import upload_avatar_image
 from zerver.models import Message, UserProfile, get_realm
 
@@ -85,7 +86,8 @@ From image editing program:
         message_ids = do_send_messages(messages)
 
         preview_message = Message.objects.get(id__in=message_ids, content__icontains='image previews')
-        do_add_reaction_legacy(starr, preview_message, 'whale')
+        (emoji_code, reaction_type) = emoji_name_to_emoji_code(realm, 'whale')
+        do_add_reaction(starr, preview_message, 'whale', emoji_code, reaction_type)
 
         twitter_message = Message.objects.get(id__in=message_ids, content__icontains='gvanrossum')
         # Setting up a twitter integration in dev is a decent amount of work. If you need
@@ -103,7 +105,8 @@ From image editing program:
 
         # Put a short pause between the whale reaction and this, so that the
         # thumbs_up shows up second
-        do_add_reaction_legacy(starr, preview_message, 'thumbs_up')
+        (emoji_code, reaction_type) = emoji_name_to_emoji_code(realm, 'thumbs_up')
+        do_add_reaction(starr, preview_message, 'thumbs_up', emoji_code, reaction_type)
 
     def handle(self, *args: Any, **options: str) -> None:
         self.add_message_formatting_conversation()


### PR DESCRIPTION
Updates zulip modules to remove use of the legacy API endpoint for adding and removing emoji reactions.

1st commit replaces the legacy endpoint with the current one.





Fixes #12940 
