### PR TITLE
webpack: Chill. Out. When watching for changes.

### DIFF
--- a/tools/webpack
+++ b/tools/webpack
@@ -33,6 +33,9 @@ def build_for_dev_server(host, port, minify, disable_host_check):
     webpack_args += [
         '--config',
         'tools/webpack.config.ts',
+        # webpack-cli has a bug where it ignores --watch-poll with
+        # multi-config, and we don't need the katex-cli part anyway.
+        '--config-name', 'frontend',
         '--allowed-hosts', ','.join([host, '.zulipdev.com', '.zulipdev.org']),
         '--host', host,
         '--port', port,
@@ -46,6 +49,20 @@ def build_for_dev_server(host, port, minify, disable_host_check):
     if disable_host_check:
         webpack_args.append('--disable-host-check')
 
+    # Tell webpack-dev-server to fall back to periodic polling on
+    # filesystems where inotify is known to be broken.
+    cwd = os.getcwd()
+    inotify_broken = False
+    with open('/proc/self/mounts') as mounts:
+        for line in mounts:
+            fields = line.split()
+            if fields[1] == cwd:
+                inotify_broken = fields[2] in ["nfs", "vboxsf"]
+    if inotify_broken:
+        webpack_args.append('--watch-poll=1000')
+
+    # TODO: This process should also fall back to periodic polling if
+    # inotify_broken.
     import pyinotify
     try:
         webpack_process = subprocess.Popen(webpack_args)

--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -13,6 +13,7 @@ export default (env?: string): webpack.Configuration[] => {
     const production: boolean = env === "production";
     const publicPath = production ? '/static/webpack-bundles/' : '/webpack/';
     const config: webpack.Configuration = {
+        name: "frontend",
         mode: production ? "production" : "development",
         context: resolve(__dirname, "../"),
         entry: assets,
@@ -192,9 +193,6 @@ export default (env?: string): webpack.Configuration[] => {
         config.devServer = {
             clientLogLevel: "error",
             stats: "errors-only",
-            watchOptions: {
-                poll: 100,
-            },
         };
     }
 


### PR DESCRIPTION
Polling for changes every 100 milliseconds was burning enough CPU to set mid-2015 MacBooks on fire.  Use the default inotify watching, except on filesystems where that’s known not to work (nfs, vboxsf), in which case polling once per second is more than enough for even the fastest typers.

**Testing Plan:** Tested watching on Linux with both VirtualBox and Docker.