### PR TITLE
emails: Remove preheader block from missed message emails

### DIFF
--- a/templates/zerver/emails/email_base_messages.html
+++ b/templates/zerver/emails/email_base_messages.html
@@ -4,6 +4,7 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
         <title>Zulip</title>
     </head>
+    {% if has_preheader %}
     <span style="display:none !important;
       visibility:hidden;
       color:transparent;
@@ -19,6 +20,7 @@
       overflow:hidden;">
         {% block preheader %}{% endblock %}
     </span>
+    {% endif %}
     {% block content %}{% endblock %}
     {% block manage_preferences %}{% endblock %}
 </html>

--- a/templates/zerver/emails/missed_message.source.html
+++ b/templates/zerver/emails/missed_message.source.html
@@ -1,15 +1,5 @@
 {% extends "zerver/emails/email_base_messages.html" %}
 
-{% block preheader %}
-    {% for recipient_block in messages %}
-        {% for sender_block in recipient_block.senders %}
-            {% for message_block in sender_block.content %}
-            {{ message_block.html|safe }}
-            {% endfor %}
-        {% endfor %}
-    {% endfor %}
-{% endblock %}
-
 {% block content %}
     {% if show_message_content %}
         {% for recipient_block in messages %}

--- a/version.py
+++ b/version.py
@@ -26,4 +26,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '49.0'
+PROVISION_VERSION = '49.1'


### PR DESCRIPTION
Preheader block is no longer necessary since we moved to the simplified email design. Emails clients can now just parse the actual message content for setting the email header since the body of the email starts with message content. The preheader was also resulting in duplicate content in case of messages with small content. If the the message content is small the new approach would result in showing the footer of the email in header but that should be fine for most users.

