### PR TITLE
webhooks/jira: Update webhook to support improved comment events.

### DIFF
--- a/zerver/webhooks/jira/doc.md
+++ b/zerver/webhooks/jira/doc.md
@@ -14,16 +14,13 @@ These instructions apply to Atlassian Cloud's hosted JIRA, and JIRA Server versi
 1. Set **Name** to a name of your choice, such as `Zulip`. Set **Status** to
    **Enabled**, and set **URL** to the URL constructed above. Select the events
    you'd like to be notified about, and click **Create**. We
-   only support the following **Issue** events:
+   support the following **Issue** and **Comment** events:
     * when an issue is created
     * when an issue is deleted
     * when an issue is updated
-
-    !!! tip ""
-        If you'd like to be notified of issue comments, you should enable **Issue**
-        updates; Zulip ignores Jira's webhook **Comment** events as
-        they are redundant with the Issue events and do not have
-        complete information in some versions of Jira.
+    * when a comment is added
+    * when a comment is updated
+    * when a comment is deleted
 
 {!congrats.md!}
 

--- a/zerver/webhooks/jira/fixtures/comment_created.json
+++ b/zerver/webhooks/jira/fixtures/comment_created.json
@@ -1,0 +1,113 @@
+{
+  "timestamp": 1565964017153,
+  "webhookEvent": "comment_created",
+  "comment": {
+    "self": "https://f20171170.atlassian.net/rest/api/2/issue/10000/comment/10000",
+    "id": "10000",
+    "author": {
+      "self": "https://f20171170.atlassian.net/rest/api/2/user?accountId=5c76b994e1bcdf6294d0eb0f",
+      "name": "admin",
+      "key": "admin",
+      "accountId": "5c76b994e1bcdf6294d0eb0f",
+      "avatarUrls": {
+        "48x48": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=48&s=48",
+        "24x24": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=24&s=24",
+        "16x16": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=16&s=16",
+        "32x32": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=32&s=32"
+      },
+      "displayName": "Hemanth V. Alluri",
+      "active": true,
+      "timeZone": "Asia/Calcutta",
+      "accountType": "atlassian"
+    },
+    "body": "Sounds like it’s pretty important. I’ll get this fixed ASAP\\!",
+    "updateAuthor": {
+      "self": "https://f20171170.atlassian.net/rest/api/2/user?accountId=5c76b994e1bcdf6294d0eb0f",
+      "name": "admin",
+      "key": "admin",
+      "accountId": "5c76b994e1bcdf6294d0eb0f",
+      "avatarUrls": {
+        "48x48": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=48&s=48",
+        "24x24": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=24&s=24",
+        "16x16": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=16&s=16",
+        "32x32": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=32&s=32"
+      },
+      "displayName": "Hemanth V. Alluri",
+      "active": true,
+      "timeZone": "Asia/Calcutta",
+      "accountType": "atlassian"
+    },
+    "created": "2019-08-16T19:30:17.153+0530",
+    "updated": "2019-08-16T19:30:17.153+0530",
+    "jsdPublic": true
+  },
+  "issue": {
+    "id": "10000",
+    "self": "https://f20171170.atlassian.net/rest/api/2/issue/10000",
+    "key": "SP-1",
+    "fields": {
+      "summary": "Add support for newer format Jira issue comment events",
+      "issuetype": {
+        "self": "https://f20171170.atlassian.net/rest/api/2/issuetype/10100",
+        "id": "10100",
+        "description": "A task that needs to be done.",
+        "iconUrl": "https://f20171170.atlassian.net/secure/viewavatar?size=medium&avatarId=10318&avatarType=issuetype",
+        "name": "Task",
+        "subtask": false,
+        "avatarId": 10318,
+        "entityId": "7781fe72-66c8-43f7-b4cb-ef2482548605"
+      },
+      "project": {
+        "self": "https://f20171170.atlassian.net/rest/api/2/project/10000",
+        "id": "10000",
+        "key": "SP",
+        "name": "Sample Project",
+        "projectTypeKey": "software",
+        "simplified": true,
+        "avatarUrls": {
+          "48x48": "https://f20171170.atlassian.net/secure/projectavatar?pid=10000&avatarId=10410",
+          "24x24": "https://f20171170.atlassian.net/secure/projectavatar?size=small&s=small&pid=10000&avatarId=10410",
+          "16x16": "https://f20171170.atlassian.net/secure/projectavatar?size=xsmall&s=xsmall&pid=10000&avatarId=10410",
+          "32x32": "https://f20171170.atlassian.net/secure/projectavatar?size=medium&s=medium&pid=10000&avatarId=10410"
+        }
+      },
+      "assignee": {
+        "self": "https://f20171170.atlassian.net/rest/api/2/user?accountId=5c76b994e1bcdf6294d0eb0f",
+        "name": "admin",
+        "key": "admin",
+        "accountId": "5c76b994e1bcdf6294d0eb0f",
+        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+        "avatarUrls": {
+          "48x48": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=48&s=48",
+          "24x24": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=24&s=24",
+          "16x16": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=16&s=16",
+          "32x32": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=32&s=32"
+        },
+        "displayName": "Hemanth V. Alluri",
+        "active": true,
+        "timeZone": "Asia/Calcutta",
+        "accountType": "atlassian"
+      },
+      "priority": {
+        "self": "https://f20171170.atlassian.net/rest/api/2/priority/3",
+        "iconUrl": "https://f20171170.atlassian.net/images/icons/priorities/medium.svg",
+        "name": "Medium",
+        "id": "3"
+      },
+      "status": {
+        "self": "https://f20171170.atlassian.net/rest/api/2/status/10000",
+        "description": "",
+        "iconUrl": "https://f20171170.atlassian.net/",
+        "name": "To Do",
+        "id": "10000",
+        "statusCategory": {
+          "self": "https://f20171170.atlassian.net/rest/api/2/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "To Do"
+        }
+      }
+    }
+  }
+}

--- a/zerver/webhooks/jira/fixtures/comment_deleted.json
+++ b/zerver/webhooks/jira/fixtures/comment_deleted.json
@@ -1,0 +1,113 @@
+{
+  "timestamp": 1565964144825,
+  "webhookEvent": "comment_deleted",
+  "comment": {
+    "self": "https://f20171170.atlassian.net/rest/api/2/issue/10000/comment/10000",
+    "id": "10000",
+    "author": {
+      "self": "https://f20171170.atlassian.net/rest/api/2/user?accountId=5c76b994e1bcdf6294d0eb0f",
+      "name": "admin",
+      "key": "admin",
+      "accountId": "5c76b994e1bcdf6294d0eb0f",
+      "avatarUrls": {
+        "48x48": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=48&s=48",
+        "24x24": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=24&s=24",
+        "16x16": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=16&s=16",
+        "32x32": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=32&s=32"
+      },
+      "displayName": "Hemanth V. Alluri",
+      "active": true,
+      "timeZone": "Asia/Calcutta",
+      "accountType": "atlassian"
+    },
+    "body": "This is a very important issue\\! I’m on it\\!",
+    "updateAuthor": {
+      "self": "https://f20171170.atlassian.net/rest/api/2/user?accountId=5c76b994e1bcdf6294d0eb0f",
+      "name": "admin",
+      "key": "admin",
+      "accountId": "5c76b994e1bcdf6294d0eb0f",
+      "avatarUrls": {
+        "48x48": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=48&s=48",
+        "24x24": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=24&s=24",
+        "16x16": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=16&s=16",
+        "32x32": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=32&s=32"
+      },
+      "displayName": "Hemanth V. Alluri",
+      "active": true,
+      "timeZone": "Asia/Calcutta",
+      "accountType": "atlassian"
+    },
+    "created": "2019-08-16T19:30:17.153+0530",
+    "updated": "2019-08-16T19:31:43.489+0530",
+    "jsdPublic": true
+  },
+  "issue": {
+    "id": "10000",
+    "self": "https://f20171170.atlassian.net/rest/api/2/issue/10000",
+    "key": "SP-1",
+    "fields": {
+      "summary": "Add support for newer format Jira issue comment events",
+      "issuetype": {
+        "self": "https://f20171170.atlassian.net/rest/api/2/issuetype/10100",
+        "id": "10100",
+        "description": "A task that needs to be done.",
+        "iconUrl": "https://f20171170.atlassian.net/secure/viewavatar?size=medium&avatarId=10318&avatarType=issuetype",
+        "name": "Task",
+        "subtask": false,
+        "avatarId": 10318,
+        "entityId": "7781fe72-66c8-43f7-b4cb-ef2482548605"
+      },
+      "project": {
+        "self": "https://f20171170.atlassian.net/rest/api/2/project/10000",
+        "id": "10000",
+        "key": "SP",
+        "name": "Sample Project",
+        "projectTypeKey": "software",
+        "simplified": true,
+        "avatarUrls": {
+          "48x48": "https://f20171170.atlassian.net/secure/projectavatar?pid=10000&avatarId=10410",
+          "24x24": "https://f20171170.atlassian.net/secure/projectavatar?size=small&s=small&pid=10000&avatarId=10410",
+          "16x16": "https://f20171170.atlassian.net/secure/projectavatar?size=xsmall&s=xsmall&pid=10000&avatarId=10410",
+          "32x32": "https://f20171170.atlassian.net/secure/projectavatar?size=medium&s=medium&pid=10000&avatarId=10410"
+        }
+      },
+      "assignee": {
+        "self": "https://f20171170.atlassian.net/rest/api/2/user?accountId=5c76b994e1bcdf6294d0eb0f",
+        "name": "admin",
+        "key": "admin",
+        "accountId": "5c76b994e1bcdf6294d0eb0f",
+        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+        "avatarUrls": {
+          "48x48": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=48&s=48",
+          "24x24": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=24&s=24",
+          "16x16": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=16&s=16",
+          "32x32": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=32&s=32"
+        },
+        "displayName": "Hemanth V. Alluri",
+        "active": true,
+        "timeZone": "Asia/Calcutta",
+        "accountType": "atlassian"
+      },
+      "priority": {
+        "self": "https://f20171170.atlassian.net/rest/api/2/priority/3",
+        "iconUrl": "https://f20171170.atlassian.net/images/icons/priorities/medium.svg",
+        "name": "Medium",
+        "id": "3"
+      },
+      "status": {
+        "self": "https://f20171170.atlassian.net/rest/api/2/status/10000",
+        "description": "",
+        "iconUrl": "https://f20171170.atlassian.net/",
+        "name": "To Do",
+        "id": "10000",
+        "statusCategory": {
+          "self": "https://f20171170.atlassian.net/rest/api/2/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "To Do"
+        }
+      }
+    }
+  }
+}

--- a/zerver/webhooks/jira/fixtures/comment_updated.json
+++ b/zerver/webhooks/jira/fixtures/comment_updated.json
@@ -1,0 +1,113 @@
+{
+  "timestamp": 1565964103489,
+  "webhookEvent": "comment_updated",
+  "comment": {
+    "self": "https://f20171170.atlassian.net/rest/api/2/issue/10000/comment/10000",
+    "id": "10000",
+    "author": {
+      "self": "https://f20171170.atlassian.net/rest/api/2/user?accountId=5c76b994e1bcdf6294d0eb0f",
+      "name": "admin",
+      "key": "admin",
+      "accountId": "5c76b994e1bcdf6294d0eb0f",
+      "avatarUrls": {
+        "48x48": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=48&s=48",
+        "24x24": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=24&s=24",
+        "16x16": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=16&s=16",
+        "32x32": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=32&s=32"
+      },
+      "displayName": "Hemanth V. Alluri",
+      "active": true,
+      "timeZone": "Asia/Calcutta",
+      "accountType": "atlassian"
+    },
+    "body": "This is a very important issue\\! I’m on it\\!",
+    "updateAuthor": {
+      "self": "https://f20171170.atlassian.net/rest/api/2/user?accountId=5c76b994e1bcdf6294d0eb0f",
+      "name": "admin",
+      "key": "admin",
+      "accountId": "5c76b994e1bcdf6294d0eb0f",
+      "avatarUrls": {
+        "48x48": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=48&s=48",
+        "24x24": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=24&s=24",
+        "16x16": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=16&s=16",
+        "32x32": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=32&s=32"
+      },
+      "displayName": "Hemanth V. Alluri",
+      "active": true,
+      "timeZone": "Asia/Calcutta",
+      "accountType": "atlassian"
+    },
+    "created": "2019-08-16T19:30:17.153+0530",
+    "updated": "2019-08-16T19:31:43.489+0530",
+    "jsdPublic": true
+  },
+  "issue": {
+    "id": "10000",
+    "self": "https://f20171170.atlassian.net/rest/api/2/issue/10000",
+    "key": "SP-1",
+    "fields": {
+      "summary": "Add support for newer format Jira issue comment events",
+      "issuetype": {
+        "self": "https://f20171170.atlassian.net/rest/api/2/issuetype/10100",
+        "id": "10100",
+        "description": "A task that needs to be done.",
+        "iconUrl": "https://f20171170.atlassian.net/secure/viewavatar?size=medium&avatarId=10318&avatarType=issuetype",
+        "name": "Task",
+        "subtask": false,
+        "avatarId": 10318,
+        "entityId": "7781fe72-66c8-43f7-b4cb-ef2482548605"
+      },
+      "project": {
+        "self": "https://f20171170.atlassian.net/rest/api/2/project/10000",
+        "id": "10000",
+        "key": "SP",
+        "name": "Sample Project",
+        "projectTypeKey": "software",
+        "simplified": true,
+        "avatarUrls": {
+          "48x48": "https://f20171170.atlassian.net/secure/projectavatar?pid=10000&avatarId=10410",
+          "24x24": "https://f20171170.atlassian.net/secure/projectavatar?size=small&s=small&pid=10000&avatarId=10410",
+          "16x16": "https://f20171170.atlassian.net/secure/projectavatar?size=xsmall&s=xsmall&pid=10000&avatarId=10410",
+          "32x32": "https://f20171170.atlassian.net/secure/projectavatar?size=medium&s=medium&pid=10000&avatarId=10410"
+        }
+      },
+      "assignee": {
+        "self": "https://f20171170.atlassian.net/rest/api/2/user?accountId=5c76b994e1bcdf6294d0eb0f",
+        "name": "admin",
+        "key": "admin",
+        "accountId": "5c76b994e1bcdf6294d0eb0f",
+        "emailAddress": "f20171170@pilani.bits-pilani.ac.in",
+        "avatarUrls": {
+          "48x48": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=48&s=48",
+          "24x24": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=24&s=24",
+          "16x16": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=16&s=16",
+          "32x32": "https://secure.gravatar.com/avatar/bc3f74559ceceb488f4189b7e7bdfec2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FHA-1.png&size=32&s=32"
+        },
+        "displayName": "Hemanth V. Alluri",
+        "active": true,
+        "timeZone": "Asia/Calcutta",
+        "accountType": "atlassian"
+      },
+      "priority": {
+        "self": "https://f20171170.atlassian.net/rest/api/2/priority/3",
+        "iconUrl": "https://f20171170.atlassian.net/images/icons/priorities/medium.svg",
+        "name": "Medium",
+        "id": "3"
+      },
+      "status": {
+        "self": "https://f20171170.atlassian.net/rest/api/2/status/10000",
+        "description": "",
+        "iconUrl": "https://f20171170.atlassian.net/",
+        "name": "To Do",
+        "id": "10000",
+        "statusCategory": {
+          "self": "https://f20171170.atlassian.net/rest/api/2/statuscategory/2",
+          "id": 2,
+          "key": "new",
+          "colorName": "blue-gray",
+          "name": "To Do"
+        }
+      }
+    }
+  }
+}

--- a/zerver/webhooks/jira/tests.py
+++ b/zerver/webhooks/jira/tests.py
@@ -190,3 +190,18 @@ Adding a comment. Oh, what a comment it is!
 
     def get_body(self, fixture_name: str) -> str:
         return self.webhook_fixture_data('jira', fixture_name)
+
+    def test_comment_event_comment_created(self) -> None:
+        expected_topic = "SP-1: Add support for newer format Jira issue comment events"
+        expected_message = """Hemanth V. Alluri commented on issue: *"Add support for newer format Jira issue comment events"*\n``` quote\nSounds like it’s pretty important. I’ll get this fixed ASAP!\n```"""
+        self.send_and_test_stream_message("comment_created", expected_topic, expected_message)
+
+    def test_comment_event_comment_edited(self) -> None:
+        expected_topic = "SP-1: Add support for newer format Jira issue comment events"
+        expected_message = """Hemanth V. Alluri updated their comment on issue: *"Add support for newer format Jira issue comment events"*\n``` quote\nThis is a very important issue! I’m on it!\n```"""
+        self.send_and_test_stream_message("comment_updated", expected_topic, expected_message)
+
+    def test_comment_event_comment_deleted(self) -> None:
+        expected_topic = "SP-1: Add support for newer format Jira issue comment events"
+        expected_message = """Hemanth V. Alluri deleted their comment on issue: *"Add support for newer format Jira issue comment events"*\n``` quote\n~~This is a very important issue! I’m on it!~~\n```"""
+        self.send_and_test_stream_message("comment_deleted", expected_topic, expected_message)


### PR DESCRIPTION
Atlassian announced that it will no longer provide information about
comments along with their "issue" type event payloads for Jira. So
we must now update the Jira integration to appropriately respond to
"comment" type events (the reason why we didn't do this before was
that initially, the "comment" type event payloads didn't contain
sufficient information about their issues, but this payload has
since been improved).

Note: This commit does *not* remove support for the older "issue"
type event payloads where information about comments was included.
This way we can maintain compatibility with old self-hosted versions
of self hosted Jira (2016 and before).

Fixes #13012