### PR TITLE
docs: Suggest installing vagrant-vbguest plugin

### DIFF
--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -274,6 +274,7 @@ development environment with `vagrant up`:
 ```
 # On Windows or macOS:
 cd zulip
+vagrant plugin install vagrant-vbguest
 vagrant up --provider=virtualbox
 
 # On Linux:


### PR DESCRIPTION
This plugin updates the VirtualBox Guest Additions in the guest, which makes shared folders work more reliably.

**Testing Plan:** Tested with VirtualBox on Linux.