### PR TITLE
github webhook: For release events show actions and tag name.

### DIFF
--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -205,7 +205,7 @@ class GithubWebhookTest(WebhookTestCase):
         self.send_and_test_stream_message('team_add', self.EXPECTED_TOPIC_REPO_EVENTS, expected_message)
 
     def test_release_msg(self) -> None:
-        expected_message = u"baxterthehacker published [the release](https://github.com/baxterthehacker/public-repo/releases/tag/0.0.1)."
+        expected_message = u"baxterthehacker published [release for tag 0.0.1](https://github.com/baxterthehacker/public-repo/releases/tag/0.0.1)."
         self.send_and_test_stream_message('release', self.EXPECTED_TOPIC_REPO_EVENTS, expected_message)
 
     def test_page_build_msg(self) -> None:

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -236,8 +236,10 @@ def get_add_team_body(payload: Dict[str, Any]) -> str:
     )
 
 def get_release_body(payload: Dict[str, Any]) -> str:
-    return u"{} published [the release]({}).".format(
+    return u"{} {} [release for tag {}]({}).".format(
         get_sender_name(payload),
+        payload['action'],
+        payload['release']['tag_name'],
         payload['release']['html_url'],
     )
 
@@ -502,7 +504,7 @@ def get_event(request: HttpRequest, payload: Dict[str, Any], branches: str) -> O
         # Unsupported pull_request events
         if action in ('labeled', 'unlabeled', 'review_request_removed'):
             return None
-    if event == 'push':
+    elif event == 'push':
         if is_commit_push_event(payload):
             if branches is not None:
                 branch = get_branch_name_from_ref(payload['ref'])


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
The github webhook release event comes in several [defined actions ](https://developer.github.com/v3/activity/events/types/#releaseevent)(e.g. created or deleted). The current webhook always says `published` even if the event got deleted. The new implementation takes the action and puts it 1:1 into the message (as it fits gramatically).
Furthermore instead of `the release` it now says `release for tag xyz`. (I am rather showing tag names than release names, as release names are often null).

**Testing Plan:** <!-- How have you tested? -->
The existing test got updated. I could also add payload of all action types, but that seems unnecessary overhead as it is passed 1:1.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
No UI change.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
