### PR TITLE
css: Add bottom margin to titles in the register pages

### DIFF
--- a/static/styles/portico/portico-signin.scss
+++ b/static/styles/portico/portico-signin.scss
@@ -449,6 +449,7 @@ html {
     font-size: 2.5rem;
     text-align: center;
     color: hsl(0, 0%, 40%);
+    margin-bottom: 20px;
 }
 
 .new-style button {


### PR DESCRIPTION
This change was suggested by @synicalsyntax while I was working for the GitHub auth login page.

**GIFs or Screenshots:** 
I hope I found all the pages related to this task.
![Screen Shot 2019-08-16 at 21 07 25 (2)](https://user-images.githubusercontent.com/18381652/63188972-84967f80-c06b-11e9-8039-2a23ff5a2443.png)
![Screen Shot 2019-08-16 at 21 07 18 (2)](https://user-images.githubusercontent.com/18381652/63188973-852f1600-c06b-11e9-9789-8a0f40fbfef8.png)
![Screen Shot 2019-08-16 at 21 07 10 (2)](https://user-images.githubusercontent.com/18381652/63188974-852f1600-c06b-11e9-91c2-31d221a0f371.png)
![Screen Shot 2019-08-16 at 21 06 54 (2)](https://user-images.githubusercontent.com/18381652/63188975-852f1600-c06b-11e9-9114-f2bd9c663e91.png)
![Screen Shot 2019-08-16 at 21 06 38 (2)](https://user-images.githubusercontent.com/18381652/63188976-852f1600-c06b-11e9-862b-2828bd4f2ec4.png)
![Screen Shot 2019-08-16 at 21 05 12 (2)](https://user-images.githubusercontent.com/18381652/63188977-852f1600-c06b-11e9-9c3d-f6e71eb44aeb.png)
![Screen Shot 2019-08-16 at 21 04 56 (2)](https://user-images.githubusercontent.com/18381652/63189374-86147780-c06c-11e9-8ed5-4a8e17c48125.png)
