### PR TITLE
test_queue_worker: Remove timing from test_slow_queries_worker.

### DIFF
--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -2,6 +2,7 @@ import os
 import time
 import ujson
 import smtplib
+import re
 
 from django.conf import settings
 from django.test import override_settings
@@ -105,8 +106,10 @@ class WorkerTest(ZulipTestCase):
         self.assertEqual(args[2], "stream")
         self.assertEqual(args[3], "errors")
         self.assertEqual(args[4], "testserver: slow queries")
-        self.assertEqual(args[5], '    127.0.0.1       GET     200 -1000ms (db: 1ms/13q)'
-                                  ' /test/ (test@zulip.com via website) (test@zulip.com)\n')
+        # Testing for specific query times can lead to test discrepancies.
+        logging_info = re.sub(r'\(db: [0-9]+ms/13q\)', '', args[5])
+        self.assertEqual(logging_info, '    127.0.0.1       GET     200 -1000ms '
+                                       ' /test/ (test@zulip.com via website) (test@zulip.com)\n')
 
     def test_missed_message_worker(self) -> None:
         cordelia = self.example_user('cordelia')


### PR DESCRIPTION
Testing a specific query time was causing spurious failures
in CI.
