### PR TITLE
Allow users to configure incoming webhook bots according to specific parameters (backend implementation)

### DIFF
--- a/templates/zerver/api/incoming-webhooks-walkthrough.md
+++ b/templates/zerver/api/incoming-webhooks-walkthrough.md
@@ -200,6 +200,30 @@ integrations page using `static/images/integrations/logos/helloworld.png` as its
 icon. The second positional argument defines a list of categories for the
 integration.
 
+If you'd like to allow your bot's users to be able to configure your bot
+according specific parameters (in a key-value format), then you can do
+that by specifying a "config_options" when adding a "WebhookIntegration"
+entry like so:
+
+```
+    WebhookIntegration('helloworld', ['misc'], display_name='Hello World',
+                       config_options=[('HelloWorld API Key', 'hw_api_key', check_string)])
+```
+
+`config_options` is supposed to be a list containing details of all of the
+parameters you want to allow your user to configure. Each element of this list
+is a tuple containing 3 things:
+    1. A user-facing string that should be displayed in the UI when configuring the bot.
+    2. A string representing the name of the key under which to represent the parameter.
+    3. A `Validator` which will check to see if the key follows a particular format.
+You can check out `zerver/lib/validators.py` for some ready-made validators or if you
+want an example for being able to write your own validator.
+
+In the above example, The 'helloworld' integration will take exactly one configuration
+parameter which the user will see as "HelloWorld API Key" but we will handle in the
+backend as "hw_api_key". This value must simply be a string (this validator already
+exists in `zerver/lib/validators.py`) and we place no other restrictions on it.
+
 At this point, if you're following along and/or writing your own Hello World
 webhook, you have written enough code to test your integration. There are three
 tools which you can use to test your webhook - 2 command line tools and a GUI.

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -17,7 +17,7 @@ from zerver.lib.alert_words import user_alert_words
 from zerver.lib.avatar import avatar_url, get_avatar_field
 from zerver.lib.bot_config import load_bot_config_template
 from zerver.lib.hotspots import get_next_hotspots
-from zerver.lib.integrations import EMBEDDED_BOTS
+from zerver.lib.integrations import EMBEDDED_BOTS, WEBHOOK_INTEGRATIONS
 from zerver.lib.message import (
     aggregate_unread_data,
     apply_unread_message_event,
@@ -289,6 +289,17 @@ def fetch_initial_state_data(user_profile: UserProfile,
             realm_embedded_bots.append({'name': bot.name,
                                         'config': load_bot_config_template(bot.name)})
         state['realm_embedded_bots'] = realm_embedded_bots
+
+    # This does not have an apply_events counterpart either since
+    # this data is mostly static.
+    if want('realm_incoming_webhook_bots'):
+        realm_incoming_webhook_bots = []
+        for integration in WEBHOOK_INTEGRATIONS:
+            realm_incoming_webhook_bots.append({
+                'name': integration.name,
+                'config': {c[1]: c[2] for c in integration.config_options}
+            })
+        state['realm_incoming_webhook_bots'] = realm_incoming_webhook_bots
 
     if want('recent_private_conversations'):
         # A data structure containing records of this form:

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -47,19 +47,21 @@ def check_short_name(short_name_raw: str) -> str:
         raise JsonableError(_("Bad name or username"))
     return short_name
 
-def check_valid_bot_config(service_name: str, config_data: Dict[str, str]) -> None:
-    try:
-        from zerver.lib.bot_lib import get_bot_handler
-        bot_handler = get_bot_handler(service_name)
-        if hasattr(bot_handler, 'validate_config'):
-            bot_handler.validate_config(config_data)
-    except ConfigValidationError:
-        # The exception provides a specific error message, but that
-        # message is not tagged translatable, because it is
-        # triggered in the external zulip_bots package.
-        # TODO: Think of some clever way to provide a more specific
-        # error message.
-        raise JsonableError(_("Invalid configuration data!"))
+def check_valid_bot_config(bot_type: int, service_name: str,
+                           config_data: Dict[str, str]) -> None:
+    if bot_type == UserProfile.EMBEDDED_BOT:
+        try:
+            from zerver.lib.bot_lib import get_bot_handler
+            bot_handler = get_bot_handler(service_name)
+            if hasattr(bot_handler, 'validate_config'):
+                bot_handler.validate_config(config_data)
+        except ConfigValidationError:
+            # The exception provides a specific error message, but that
+            # message is not tagged translatable, because it is
+            # triggered in the external zulip_bots package.
+            # TODO: Think of some clever way to provide a more specific
+            # error message.
+            raise JsonableError(_("Invalid configuration data!"))
 
 # Adds an outgoing webhook or embedded bot service.
 def add_service(name: str, user_profile: UserProfile, base_url: Optional[str]=None,

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -4,10 +4,10 @@ import ujson
 
 from django.core import mail
 from mock import patch, MagicMock
-from typing import Any, Dict, List, Mapping
+from typing import Any, Dict, List, Mapping, Optional
 
 from zerver.lib.actions import do_change_stream_invite_only, do_deactivate_user
-from zerver.lib.bot_config import get_bot_config
+from zerver.lib.bot_config import get_bot_config, ConfigError
 from zerver.models import get_realm, get_stream, \
     Realm, UserProfile, get_user, get_bot_services, Service, \
     is_cross_realm_bot_email
@@ -18,10 +18,21 @@ from zerver.lib.test_helpers import (
     queries_captured,
     tornado_redirected_to_list,
 )
-from zerver.lib.integrations import EMBEDDED_BOTS
+from zerver.lib.integrations import EMBEDDED_BOTS, WebhookIntegration
 from zerver.lib.bot_lib import get_bot_handler
-
 from zulip_bots.custom_exceptions import ConfigValidationError
+
+
+# A test validator
+def _check_string(var_name: str, val: object) -> Optional[str]:
+    if str(val).startswith("_"):
+        return ('%s starts with a "_" and is hence invalid.') % (var_name,)
+    return None
+
+stripe_sample_config_options = [
+    WebhookIntegration('stripe', ['financial'], display_name='Stripe',
+                       config_options=[("Stripe API Key", "stripe_api_key", _check_string)])
+]
 
 class BotTest(ZulipTestCase, UploadSerializeMixin):
     def get_bot_user(self, email: str) -> UserProfile:
@@ -1441,3 +1452,82 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         with self.settings(CROSS_REALM_BOT_EMAILS={"random-bot@zulip.com"}):
             self.assertTrue(is_cross_realm_bot_email("random-bot@zulip.com"))
             self.assertFalse(is_cross_realm_bot_email("notification-bot@zulip.com"))
+
+    @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", stripe_sample_config_options)
+    def test_create_incoming_webhook_bot_with_service_name_and_with_keys(self) -> None:
+        self.login(self.example_email('hamlet'))
+        bot_metadata = {
+            "full_name": "My Stripe Bot",
+            "short_name": "my-stripe",
+            "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
+            "service_name": "stripe",
+            "config_data": ujson.dumps({"stripe_api_key": "sample-api-key"})
+        }
+        self.create_bot(**bot_metadata)
+        new_bot = UserProfile.objects.get(full_name="My Stripe Bot")
+        config_data = get_bot_config(new_bot)
+        self.assertEqual(config_data, {"integration_id": "stripe",
+                                       "stripe_api_key": "sample-api-key"})
+
+    @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", stripe_sample_config_options)
+    def test_create_incoming_webhook_bot_with_service_name_incorrect_keys(self) -> None:
+        self.login(self.example_email('hamlet'))
+        bot_metadata = {
+            "full_name": "My Stripe Bot",
+            "short_name": "my-stripe",
+            "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
+            "service_name": "stripe",
+            "config_data": ujson.dumps({"stripe_api_key": "_invalid_key"})
+        }
+        response = self.client_post("/json/bots", bot_metadata)
+        self.assertEqual(response.status_code, 400)
+        expected_error_message = '_invalid_key is an invalid input for stripe_api_key (stripe_api_key starts with a "_" and is hence invalid.)'
+        self.assertEqual(ujson.loads(response.content.decode('utf-8'))["msg"], expected_error_message)
+        with self.assertRaises(UserProfile.DoesNotExist):
+            UserProfile.objects.get(full_name="My Stripe Bot")
+
+    @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", stripe_sample_config_options)
+    def test_create_incoming_webhook_bot_with_service_name_without_keys(self) -> None:
+        self.login(self.example_email('hamlet'))
+        bot_metadata = {
+            "full_name": "My Stripe Bot",
+            "short_name": "my-stripe",
+            "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
+            "service_name": "stripe",
+        }
+        response = self.client_post("/json/bots", bot_metadata)
+        self.assertEqual(response.status_code, 400)
+        expected_error_message = "The following keys are missing and are required to be able \
+to set up an integration with stripe: {\'stripe_api_key\'}"
+        self.assertEqual(ujson.loads(response.content.decode('utf-8'))["msg"], expected_error_message)
+        with self.assertRaises(UserProfile.DoesNotExist):
+            UserProfile.objects.get(full_name="My Stripe Bot")
+
+    @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", stripe_sample_config_options)
+    def test_create_incoming_webhook_bot_without_service_name(self) -> None:
+        self.login(self.example_email('hamlet'))
+        bot_metadata = {
+            "full_name": "My Stripe Bot",
+            "short_name": "my-stripe",
+            "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
+        }
+        self.create_bot(**bot_metadata)
+        new_bot = UserProfile.objects.get(full_name="My Stripe Bot")
+        with self.assertRaises(ConfigError):
+            get_bot_config(new_bot)
+
+    @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", stripe_sample_config_options)
+    def test_create_incoming_webhook_bot_with_incorrect_service_name(self) -> None:
+        self.login(self.example_email('hamlet'))
+        bot_metadata = {
+            "full_name": "My Stripe Bot",
+            "short_name": "my-stripe",
+            "bot_type": UserProfile.INCOMING_WEBHOOK_BOT,
+            "service_name": "stripes",
+        }
+        response = self.client_post("/json/bots", bot_metadata)
+        self.assertEqual(response.status_code, 400)
+        expected_error_message = "\"stripes\" is not an integration that's supported by Zulip."
+        self.assertEqual(ujson.loads(response.content.decode('utf-8'))["msg"], expected_error_message)
+        with self.assertRaises(UserProfile.DoesNotExist):
+            UserProfile.objects.get(full_name="My Stripe Bot")

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -3399,6 +3399,7 @@ class FetchQueriesTest(ZulipTestCase):
             realm_bot=1,
             realm_domains=1,
             realm_embedded_bots=0,
+            realm_incoming_webhook_bots=0,
             realm_emoji=1,
             realm_filters=1,
             realm_user=3,

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -151,6 +151,7 @@ class HomeTest(ZulipTestCase):
             "realm_google_hangouts_domain",
             "realm_icon_source",
             "realm_icon_url",
+            "realm_incoming_webhook_bots",
             "realm_inline_image_preview",
             "realm_inline_url_embed_preview",
             "realm_invite_by_admins_only",

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -321,7 +321,7 @@ def add_bot_backend(
             user_profile, default_events_register_stream_name)
 
     if bot_type == UserProfile.EMBEDDED_BOT:
-        check_valid_bot_config(service_name, config_data)
+        check_valid_bot_config(bot_type, service_name, config_data)
 
     bot_profile = do_create_user(email=email, password='',
                                  realm=user_profile.realm, full_name=full_name,


### PR DESCRIPTION
### Commit 1: Specify config options for an incoming webhook integration.
Basically just update the necessary classes to allow a "bot_config" parameter.

    In integrations.py we have a class called Integration which we then usually
    subclass and then use to define the meta-data for all of our integrations.
    Now, we want to allow all of our bots, specifically incoming webhook bots,
    to be configured (i.e. we should let the user provide BotConfigData).
    
    For this we create a new instance member of the Integration class called
    config_options which will be a list of tuples containing the displayable
    integration name, the configuration key form of the integration name and
    the validator that it's value is supposed to adhere to.

### Commit 2 (prep commit): Have check_valid_bot_config also take the bot_type.
With this the logical flow of code in the view function can be the same for incoming webhook bot as with embedded bots.

    This is a prep commit to allow us to validate user provided bot
    config data using the same function for incoming webhook type
    bots alongside embedded bots (as opposed to creating a new
    function just for incoming webhook bots).

### Commit 3: Allow incoming webhook bots to be configured via. /bots endpoint.
Use the bot_config parameter to now allow the backend to receive configuration preferences from users and then do checking before creating the bot or configuration objects.

    Without disturbing the flow of the existing code for configuring
    embedded bots too much, we now use the config_options feature to
    allow incoming webhook type bot to be configured via. the "/bots"
    endpoint of the API.

@timabbott can you please review this? After this gets merged, I'll apply it to #10907.