### PR TITLE
 settings_org: Make save widgets fadeout quick if setting toggled back.

### DIFF
--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -543,7 +543,7 @@ exports.change_save_button_state = function ($element, state) {
     }
 
     if (state === "discarded") {
-        show_hide_element($element, false);
+        show_hide_element($element, false, 0);
         return;
     }
 
@@ -673,7 +673,7 @@ exports.build_page = function () {
         });
 
         var save_btn_controls = subsection.find('.subsection-header .save-button-controls');
-        var button_state = show_change_process_button ? "unsaved" : "saved";
+        var button_state = show_change_process_button ? "unsaved" : "discarded";
         exports.change_save_button_state(save_btn_controls, button_state);
     });
 


### PR DESCRIPTION
In "discarded" state, "Save/discard" widgets start disappearing without the
lag of 800ms as in "saved" state. Furthermore, when all settings are restored to
the original state (i.e. there is no net change in the state of input elements),
"discard" state is more intuitive.

While doing this I have fixed a very minor bug that we haven't sent
fadeout_delay argument as 0, but having its value as undefined still
defaults to 0 so there will no impact of this change.

Fixes: #12258.