### PR TITLE
popovers: Fix broken user popover behavior.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -855,13 +855,17 @@ exports.register_click_handlers = function () {
 
         if (String(current_user_sidebar_user_id) === user_id) {
             // If the popover is already shown, clicking again should toggle it.
-            popovers.hide_all();
+            // We don't want to hide the sidebars on smaller browser windows.
+            popovers.hide_all_except_sidebars();
             return;
         }
         popovers.hide_all();
 
         if (userlist_placement === "right") {
             popovers.show_userlist_sidebar();
+        } else {
+            // Maintain the same behavior when displaying with the streamlist.
+            stream_popover.show_streamlist_sidebar();
         }
 
         var user = people.get_person_from_user_id(user_id);


### PR DESCRIPTION
If we call `popovers.hide_all` with a smaller browser
window, this breaks the functionality that the
conditional is attempting to handle.  We instead use
`hide_all_except_sidebars` to prevent the user list
from being closed.

If the display setting to show the user list in the
left sidebar is enabled, the behavior is even worse.
We add a conditional to maintain the streamlist
sidebar when clicking the chevron to show and hide
the popover here as well.

### Current Behavior:
![broken-popover](https://user-images.githubusercontent.com/39782863/63228677-ff59ba80-c191-11e9-8145-90bcb84d699d.gif)

### Left sidebar setting:
![left-sidebar](https://user-images.githubusercontent.com/39782863/63228681-0c76a980-c192-11e9-9bbe-8d7856c78061.gif)


### Right sidebar:
![right-sidebar](https://user-images.githubusercontent.com/39782863/63228684-13052100-c192-11e9-832a-b11111f0109b.gif)


