### PR TITLE
portico: /hello fixes

### DIFF
--- a/static/styles/portico/landing-page.scss
+++ b/static/styles/portico/landing-page.scss
@@ -1848,7 +1848,7 @@ nav ul li.active::after {
     height: 0;
     border-style: solid;
     border-width: 150px 100vw 0 0;
-    border-color: hsl(0, 0%, 100%) transparent transparent transparent;
+    border-color: hsl(0, 0%, 98%) transparent transparent transparent;
 }
 
 .portico-landing.hello .apps .arrow {

--- a/static/styles/portico/landing-page.scss
+++ b/static/styles/portico/landing-page.scss
@@ -1357,7 +1357,7 @@ nav ul li.active::after {
     color: hsl(0, 0%, 100%);
     background-color: hsl(185, 38%, 55%);
     background: linear-gradient(145deg, hsl(191, 56%, 55%), hsl(169, 65%, 42%));
-    box-shadow: 0px 3px 10px hsla(0, 0%, 0%, 0.3);
+    box-shadow: 0px 3px 10px hsla(0, 0%, 0%, 0.2);
     border: 0;
     position: absolute;
     left: 50%;

--- a/static/styles/portico/landing-page.scss
+++ b/static/styles/portico/landing-page.scss
@@ -1905,6 +1905,11 @@ nav ul li.active::after {
     width: 80px;
 
     font-size: 3.5em;
+    opacity: 0.8;
+}
+
+.portico-landing.hello .apps .left-side .platform-icons .group i:hover {
+    opacity: 1;
 }
 
 .portico-landing.hello .apps .arrow::after {

--- a/static/styles/portico/landing-page.scss
+++ b/static/styles/portico/landing-page.scss
@@ -2001,6 +2001,7 @@ nav ul li.active::after {
     margin-top: 60px;
     text-align: center;
     font-size: 1.3rem;
+    font-weight: 300;
 }
 
 .portico-landing.hello .call-to-action-bottom .zulip-octopus {

--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -542,10 +542,10 @@
             {{ _('Sign up now') }}
         </a>
         {% endif %}
-        <div class="atlassian-migration">
+        <p class="atlassian-migration">
             Migrating from HipChat or Stride?
             Check out our <a href="/atlassian">Atlassian migration guide</a>.
-        </div>
+        </p>
         <div class="zulip-octopus"></div>
     </div>
 </div>


### PR DESCRIPTION
Fixes: #12853 

I didn't add any behavior on hover for the big card because I think none of: changing the cursor to pointer or changing the luminosity of the picture/container is suited there. I find it a bit confusing that you can click on the entire picture but you can go only forward. I think it would be better to remove the ability to click on the entire picture and leave only the button and arrow clickable as a fast fix. 

But this PR can be merged like this and I will make the changes afterwards.

**GIFs or Screenshots:** 
![take-the-tour](https://user-images.githubusercontent.com/18381652/63381109-b0ce3b00-c3a0-11e9-9e95-9e3a3f4f4583.gif)
<img width="1440" alt="Screen Shot 2019-08-20 at 23 11 11" src="https://user-images.githubusercontent.com/18381652/63381124-b62b8580-c3a0-11e9-8cc5-c74f0bf0bd3a.png">
![app-icons](https://user-images.githubusercontent.com/18381652/63381122-b592ef00-c3a0-11e9-8f17-3be4c09b18bd.gif)
![atlassian-link](https://user-images.githubusercontent.com/18381652/63381121-b592ef00-c3a0-11e9-8604-165890937fbd.gif)



