### PR TITLE
test_mattermost_importer: Add test coverage (rebase).

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -123,7 +123,6 @@ not_yet_fully_covered = {path for target in [
     'zerver/tornado/websocket_client.py',
     # Data import files; relatively low priority
     'zerver/data_import/hipchat*.py',
-    'zerver/data_import/mattermost.py',
     'zerver/data_import/sequencer.py',
     'zerver/data_import/slack.py',
     'zerver/data_import/gitter.py',


### PR DESCRIPTION
We were seeing non-deterministic test failures in the from of [this](https://github.com/zulip/zulip/pull/13041#discussion_r315947177).   Which was likely due to using an incorrect `realm_id` as the actual parameter.  However, it seems such an error should cause the assertion to fail unconditionally (?).
