### PR TITLE
remove gaps between left sidebar list items

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -102,7 +102,7 @@ li.show-more-topics a {
 }
 
 #stream_filters li {
-    padding: 1px 0px;
+    padding: 0px 0px;
 }
 
 #stream_filters li ul {

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -93,16 +93,16 @@ li.show-more-topics a {
     margin-bottom: 4px;
 }
 
-.narrows_panel li {
-    margin: 1px 0px;
+.narrows_panel li a {
+    margin-top: 1px;
 }
 
 .narrows_panel li a:hover {
     text-decoration: none;
 }
 
-#stream_filters li {
-    padding: 0px 0px;
+#stream_filters li a {
+    padding: 1px 0px;
 }
 
 #stream_filters li ul {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
closes #12508 

<!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![ok1 (1)](https://user-images.githubusercontent.com/40122794/64012767-f24aad00-cb3b-11e9-826f-3f8f1d9406ba.png)  ![ok2 (1)](https://user-images.githubusercontent.com/40122794/64012776-f7a7f780-cb3b-11e9-9b96-bfed0222401d.png)

shown with highlighted element and hover:
![after2](https://user-images.githubusercontent.com/40122794/63960232-a51efa80-caab-11e9-9984-5969b2ce06d9.png)

the positions of all elements of the left sidebar remain same, except the list items

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->