### PR TITLE
notifications: Add 'none' to unread count options.

### DIFF
--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -50,6 +50,11 @@ function test_notifiable_count(home_unread_messages, expected_notifiable_count) 
     });
     notifiable_counts = unread.get_notifiable_count();
     assert.deepEqual(notifiable_counts, expected_notifiable_count);
+    set_global('page_params', {
+        desktop_icon_count_display: 3,
+    });
+    notifiable_counts = unread.get_notifiable_count();
+    assert.deepEqual(notifiable_counts, 0);
 }
 
 run_test('empty_counts_while_narrowed', () => {

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -73,6 +73,10 @@ exports.desktop_icon_count_display_values = {
         code: 2,
         description: i18n.t("Private messages and mentions"),
     },
+    none: {
+        code: 3,
+        description: i18n.t("None"),
+    },
 };
 
 function change_notification_setting(setting, setting_data, status_element) {

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -552,9 +552,14 @@ exports.calculate_notifiable_count = function (res) {
 
     var only_show_notifiable = page_params.desktop_icon_count_display ===
         settings_notifications.desktop_icon_count_display_values.notifiable.code;
+    var no_notifications = page_params.desktop_icon_count_display ===
+        settings_notifications.desktop_icon_count_display_values.none.code;
     if (only_show_notifiable) {
         // DESKTOP_ICON_COUNT_DISPLAY_NOTIFIABLE
         new_message_count = res.mentioned_message_count + res.private_message_count;
+    } else if (no_notifications) {
+        // DESKTOP_ICON_COUNT_DISPLAY_NONE
+        new_message_count = 0;
     } else {
         // DESKTOP_ICON_COUNT_DISPLAY_MESSAGES
         new_message_count = res.home_unread_messages;

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -835,6 +835,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
 
     DESKTOP_ICON_COUNT_DISPLAY_MESSAGES = 1
     DESKTOP_ICON_COUNT_DISPLAY_NOTIFIABLE = 2
+    DESKTOP_ICON_COUNT_DISPLAY_NONE = 3
     desktop_icon_count_display = models.PositiveSmallIntegerField(
         default=DESKTOP_ICON_COUNT_DISPLAY_MESSAGES)  # type: int
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

Adds a 'none' setting to unread count summary for completely muting an org. Most useful for desktop and mobile clients. 


**Testing Plan:** <!-- How have you tested? -->

Haven't added any tests. Didn't think they were needed (I'm not a regular contributor to this side of Zulip, though, so let me know if more work is required). 


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![server](https://user-images.githubusercontent.com/24617297/63436719-cb5aef80-c446-11e9-8274-232db2e8e7de.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
