### PR TITLE
Eliminate some unnecessarily hard-coded user ids from tests, to allow populate_db changes.

### DIFF
--- a/frontend_tests/casper_tests/04-compose.js
+++ b/frontend_tests/casper_tests/04-compose.js
@@ -143,7 +143,7 @@ casper.then(function () {
 casper.then(function () {
     casper.click('*[title="Narrow to your private messages with Cordelia Lear"]');
 });
-casper.waitUntilVisible('li[data-user-ids-string="3"].expanded_private_message.active-sub-filter', function () {
+casper.waitUntilVisible('li[data-user-ids-string="9"].expanded_private_message.active-sub-filter', function () {
     casper.page.sendEvent('keypress', 'c');
 });
 

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -959,13 +959,13 @@ def remove_alert_words(client):
 @openapi_test_function("/user_groups/create:post")
 def create_user_group(client):
     # type: (Client) -> None
-    ensure_users([1, 2, 3, 4], ['aaron', 'zoe', 'cordelia', 'hamlet'])
+    ensure_users([7, 8, 9, 10], ['aaron', 'zoe', 'cordelia', 'hamlet'])
 
     # {code_example|start}
     request = {
         'name': 'marketing',
         'description': 'The marketing team.',
-        'members': [1, 2, 3, 4],
+        'members': [7, 8, 9, 10],
     }
 
     result = client.create_user_group(request)
@@ -1001,12 +1001,12 @@ def remove_user_group(client, group_id):
 @openapi_test_function("/user_groups/{group_id}/members:post")
 def update_user_group_members(client, group_id):
     # type: (Client, int) -> None
-    ensure_users([3, 4, 5], ['cordelia', 'hamlet', 'iago'])
+    ensure_users([9, 10, 11], ['cordelia', 'hamlet', 'iago'])
 
     request = {
         'group_id': group_id,
-        'delete': [3, 4],
-        'add': [5]
+        'delete': [9, 10],
+        'add': [11]
     }
 
     result = client.update_user_group_members(request)

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -213,7 +213,7 @@ class EmailChangeTestCase(ZulipTestCase):
                                         response)
         user_profile = get_user_profile_by_id(user_profile.id)
         self.assertEqual(user_profile.delivery_email, new_email)
-        self.assertEqual(user_profile.email, "user4@zulip.testserver")
+        self.assertEqual(user_profile.email, "user{}@zulip.testserver".format(user_profile.id))
         obj.refresh_from_db()
         self.assertEqual(obj.status, 1)
         with self.assertRaises(UserProfile.DoesNotExist):

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2360,7 +2360,8 @@ class EventsRegisterTest(ZulipTestCase):
         stream = self.make_stream('old_name')
         new_name = u'stream with a brand new name'
         self.subscribe(self.user_profile, stream.name)
-        notification = '<p><span class="user-mention silent" data-user-id="4">King Hamlet</span> renamed stream <strong>old_name</strong> to <strong>stream with a brand new name</strong>.</p>'
+        notification = '<p><span class="user-mention silent" data-user-id="{user_id}">King Hamlet</span> renamed stream <strong>old_name</strong> to <strong>stream with a brand new name</strong>.</p>'
+        notification = notification.format(user_id=self.user_profile.id)
         action = lambda: do_rename_stream(stream, new_name, self.user_profile)
         events = self.do_test(action, num_events=3)
         schema_checker = self.check_events_dict([

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -972,8 +972,8 @@ class TestGetAPNsPayload(PushNotificationTest):
     def test_get_message_payload_apns_personal_message(self) -> None:
         user_profile = self.example_user("othello")
         message_id = self.send_personal_message(
-            self.example_email('hamlet'),
-            self.example_email('othello'),
+            self.sender.email,
+            user_profile.email,
             'Content of personal message',
         )
         message = Message.objects.get(id=message_id)
@@ -991,11 +991,11 @@ class TestGetAPNsPayload(PushNotificationTest):
                 'zulip': {
                     'message_ids': [message.id],
                     'recipient_type': 'private',
-                    'sender_email': 'hamlet@zulip.com',
-                    'sender_id': 4,
+                    'sender_email': self.sender.email,
+                    'sender_id': self.sender.id,
                     'server': settings.EXTERNAL_HOST,
-                    'realm_id': message.sender.realm.id,
-                    'realm_uri': message.sender.realm.uri,
+                    'realm_id': self.sender.realm.id,
+                    'realm_uri': self.sender.realm.uri,
                     "user_id": user_profile.id,
                 }
             }
@@ -1027,11 +1027,11 @@ class TestGetAPNsPayload(PushNotificationTest):
                         str(s.user_profile_id)
                         for s in Subscription.objects.filter(
                             recipient=message.recipient)),
-                    'sender_email': 'hamlet@zulip.com',
-                    'sender_id': 4,
+                    'sender_email': self.sender.email,
+                    'sender_id': self.sender.id,
                     'server': settings.EXTERNAL_HOST,
-                    'realm_id': message.sender.realm.id,
-                    'realm_uri': message.sender.realm.uri,
+                    'realm_id': self.sender.realm.id,
+                    'realm_uri': self.sender.realm.uri,
                     "user_id": user_profile.id,
                 }
             }
@@ -1059,13 +1059,13 @@ class TestGetAPNsPayload(PushNotificationTest):
                 'zulip': {
                     'message_ids': [message.id],
                     'recipient_type': 'stream',
-                    'sender_email': 'hamlet@zulip.com',
-                    'sender_id': 4,
+                    'sender_email': self.sender.email,
+                    'sender_id': self.sender.id,
                     "stream": get_display_recipient(message.recipient),
                     "topic": message.topic_name(),
                     'server': settings.EXTERNAL_HOST,
-                    'realm_id': message.sender.realm.id,
-                    'realm_uri': message.sender.realm.uri,
+                    'realm_id': self.sender.realm.id,
+                    'realm_uri': self.sender.realm.uri,
                     "user_id": user_profile.id,
                 }
             }
@@ -1092,13 +1092,13 @@ class TestGetAPNsPayload(PushNotificationTest):
                 'zulip': {
                     'message_ids': [message.id],
                     'recipient_type': 'stream',
-                    'sender_email': 'hamlet@zulip.com',
-                    'sender_id': 4,
+                    'sender_email': self.sender.email,
+                    'sender_id': self.sender.id,
                     "stream": get_display_recipient(message.recipient),
                     "topic": message.topic_name(),
                     'server': settings.EXTERNAL_HOST,
-                    'realm_id': message.sender.realm.id,
-                    'realm_uri': message.sender.realm.uri,
+                    'realm_id': self.sender.realm.id,
+                    'realm_uri': self.sender.realm.uri,
                     "user_id": user_profile.id,
                 }
             }
@@ -1130,11 +1130,11 @@ class TestGetAPNsPayload(PushNotificationTest):
                         str(s.user_profile_id)
                         for s in Subscription.objects.filter(
                             recipient=message.recipient)),
-                    'sender_email': self.example_email("hamlet"),
-                    'sender_id': 4,
+                    'sender_email': self.sender.email,
+                    'sender_id': self.sender.id,
                     'server': settings.EXTERNAL_HOST,
-                    'realm_id': message.sender.realm.id,
-                    'realm_uri': message.sender.realm.uri,
+                    'realm_id': self.sender.realm.id,
+                    'realm_uri': self.sender.realm.uri,
                     "user_id": user_profile.id,
                 }
             }

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -313,7 +313,7 @@ class UserGroupAPITestCase(ZulipTestCase):
         # Test adding a member already there.
         result = self.client_post('/json/user_groups/{}/members'.format(user_group.id),
                                   info=params)
-        self.assert_json_error(result, "User 6 is already a member of this group")
+        self.assert_json_error(result, "User {} is already a member of this group".format(othello.id))
         self.assertEqual(UserGroupMembership.objects.count(), 4)
         members = get_memberships_of_users(user_group, [hamlet, othello])
         self.assertEqual(len(members), 2)
@@ -359,7 +359,7 @@ class UserGroupAPITestCase(ZulipTestCase):
         params = {'delete': ujson.dumps([othello.id])}
         result = self.client_post('/json/user_groups/{}/members'.format(user_group.id),
                                   info=params)
-        self.assert_json_error(result, "There is no member '6' in this user group")
+        self.assert_json_error(result, "There is no member '{}' in this user group".format(othello.id))
         self.assertEqual(UserGroupMembership.objects.count(), 4)
         members = get_memberships_of_users(user_group, [hamlet, othello, aaron])
         self.assertEqual(len(members), 2)

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -21,7 +21,7 @@ from zerver.models import UserProfile, Recipient, Realm, \
     ScheduledEmail, check_valid_user_ids, \
     get_user_by_id_in_realm_including_cross_realm, CustomProfileField
 
-from zerver.lib.avatar import avatar_url
+from zerver.lib.avatar import avatar_url, get_gravatar_url
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.send_email import send_future_email, clear_scheduled_emails, \
     deliver_email
@@ -192,7 +192,7 @@ class PermissionTest(ZulipTestCase):
         members = result.json()['members']
         hamlet = find_dict(members, 'user_id', user.id)
         self.assertEqual(hamlet['email'], "user%s@zulip.testserver" % (user.id,))
-        self.assertEqual(hamlet['avatar_url'], "https://secure.gravatar.com/avatar/5106fb7f928d89e2f2ddb3c4c42d6949?d=identicon&version=1")
+        self.assertEqual(hamlet['avatar_url'], get_gravatar_url(hamlet['email'], 1))
         self.assertNotIn('delivery_email', hamlet)
 
         # Also verify the /events code path.  This is a bit hacky, but
@@ -217,7 +217,7 @@ class PermissionTest(ZulipTestCase):
         members = result.json()['members']
         hamlet = find_dict(members, 'user_id', user.id)
         self.assertEqual(hamlet['email'], "user%s@zulip.testserver" % (user.id,))
-        self.assertEqual(hamlet['avatar_url'], "https://secure.gravatar.com/avatar/5106fb7f928d89e2f2ddb3c4c42d6949?d=identicon&version=1")
+        self.assertEqual(hamlet['avatar_url'], get_gravatar_url(hamlet['email'], 1))
         self.assertEqual(hamlet['delivery_email'], self.example_email("hamlet"))
 
     def test_user_cannot_promote_to_admin(self) -> None:

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -180,7 +180,7 @@ class Command(BaseCommand):
             # Create our three default realms
             # Could in theory be done via zerver.lib.actions.do_create_realm, but
             # welcome-bot (needed for do_create_realm) hasn't been created yet
-            internal_realm = Realm.objects.create(string_id=settings.SYSTEM_BOT_REALM)
+            create_internal_realm()
             zulip_realm = Realm.objects.create(
                 string_id="zulip", name="Zulip Dev", emails_restricted_to_domains=True,
                 description="The Zulip development environment default organization."
@@ -224,11 +224,6 @@ class Command(BaseCommand):
 
             # These bots are directly referenced from code and thus
             # are needed for the test suite.
-            internal_realm_bots = [(bot['name'], bot['email_template'] % (settings.INTERNAL_BOT_DOMAIN,))
-                                   for bot in settings.INTERNAL_BOTS]
-            internal_realm_bots += [
-                ("Zulip Feedback Bot", "feedback@zulip.com"),
-            ]
             zulip_realm_bots = [
                 ("Zulip Error Bot", "error-bot@zulip.com"),
                 ("Zulip Default Bot", "default-bot@zulip.com"),
@@ -236,12 +231,7 @@ class Command(BaseCommand):
             for i in range(options["extra_bots"]):
                 zulip_realm_bots.append(('Extra Bot %d' % (i,), 'extrabot%d@zulip.com' % (i,)))
 
-            create_users(internal_realm, internal_realm_bots, bot_type=UserProfile.DEFAULT_BOT)
             create_users(zulip_realm, zulip_realm_bots, bot_type=UserProfile.DEFAULT_BOT)
-
-            # Initialize the email gateway bot as an API Super User
-            email_gateway_bot = get_system_bot(settings.EMAIL_GATEWAY_BOT)
-            do_change_is_admin(email_gateway_bot, True, permission="api_super_user")
 
             zoe = get_user("zoe@zulip.com", zulip_realm)
             zulip_webhook_bots = [
@@ -558,6 +548,20 @@ class Command(BaseCommand):
                 # development purpose only
                 call_command('populate_analytics_db')
             self.stdout.write("Successfully populated test database.\n")
+
+def create_internal_realm() -> None:
+    internal_realm = Realm.objects.create(string_id=settings.SYSTEM_BOT_REALM)
+
+    internal_realm_bots = [(bot['name'], bot['email_template'] % (settings.INTERNAL_BOT_DOMAIN,))
+                           for bot in settings.INTERNAL_BOTS]
+    internal_realm_bots += [
+        ("Zulip Feedback Bot", "feedback@zulip.com"),
+    ]
+    create_users(internal_realm, internal_realm_bots, bot_type=UserProfile.DEFAULT_BOT)
+
+    # Initialize the email gateway bot as an API Super User
+    email_gateway_bot = get_system_bot(settings.EMAIL_GATEWAY_BOT)
+    do_change_is_admin(email_gateway_bot, True, permission="api_super_user")
 
 recipient_hash = {}  # type: Dict[int, Recipient]
 def get_recipient_by_id(rid: int) -> Recipient:


### PR DESCRIPTION
This PR is a part of a more proper (but unfinished) follow-up on the recent populate_db changes (mainly https://github.com/zulip/zulip/pull/12823). I'm submitting this finished part, seeing as this is likely to be the last, or almost last, PR I  submit until the GSoC deadline on Monday 26th August - as I shift my focus to the more urgent migration of the id column in ``UserMessage`` to big int.

The point of these changes is mainly to just elimiate some unnecessary hard-coded user ids in tests and change things up to make it possible to actually change things in the populate_db process.

The last commit is a small refactoring in populate_db, but it's not particularly useful on its own, so I'm not sure if it should be merged.