### PR TITLE
Follow-up to #13017 / settings modal enhancements

### DIFF
--- a/frontend_tests/node_tests/list_render.js
+++ b/frontend_tests/node_tests/list_render.js
@@ -182,10 +182,8 @@ function sort_button(opts) {
 
     const $button = {
         data: data,
-        parents: lookup('table', {
-            next: lookup('.progressive-table-wrapper', {
-                data: lookup('list-render', opts.list_name),
-            }),
+        closest: lookup('.progressive-table-wrapper', {
+            data: lookup('list-render', opts.list_name),
         }),
         hasClass: lookup('active', opts.active),
         siblings: lookup('.active', {

--- a/static/js/list_render.js
+++ b/static/js/list_render.js
@@ -179,6 +179,12 @@ var list_render = (function () {
                 return this;
             },
 
+            reverse: function () {
+                meta.filtered_list.reverse();
+                prototype.init();
+                return this;
+            },
+
             // the sorting function is either the function or string that calls the
             // function to sort the list by. The prop is used for generic functions
             // that can be called to sort with a particular prop.
@@ -188,7 +194,7 @@ var list_render = (function () {
 
             // `do_not_display` will signal to not update the DOM, likely because in
             // the next function it will be updated in the DOM.
-            sort: function (sorting_function, prop, map, do_not_display, reverse) {
+            sort: function (sorting_function, prop, do_not_display) {
                 meta.prop = prop;
 
                 if (typeof sorting_function === "function") {
@@ -206,11 +212,6 @@ var list_render = (function () {
                 // by calling with no sorting_function
                 if (meta.sorting_function) {
                     meta.filtered_list = meta.filtered_list.sort(meta.sorting_function);
-                }
-
-                if (reverse) {
-                    // simple mutable array reversal.
-                    meta.filtered_list.reverse();
                 }
 
                 if (!do_not_display) {
@@ -274,7 +275,7 @@ var list_render = (function () {
                         // it will then also not run an update in the DOM (because we
                         // pass `true`), because it will update regardless below at
                         // `prototype.init()`.
-                        prototype.sort(undefined, meta.prop, undefined, true);
+                        prototype.sort(undefined, meta.prop, true);
                         meta.filter_list(value, opts.filter.callback);
 
                         // clear and re-initialize the list with the newly filtered subset
@@ -376,7 +377,7 @@ var list_render = (function () {
                 $this.removeClass("descend");
             }
 
-            list.sort(undefined, undefined, undefined, undefined, true);
+            list.reverse();
             // Table has already been sorted by this property; do not re-sort.
             return;
         }

--- a/static/js/list_render.js
+++ b/static/js/list_render.js
@@ -347,14 +347,12 @@ var list_render = (function () {
 
         you MUST specify the `data-list-render` in the `.progressive-table-wrapper`
 
-        <table>
-            <tr>
-                <td data-sort="alphabetic" data-sort-prop="name">
-                <td data-sort="numeric" data-sort-prop="age">
-            </tr>
-        </table>
         <div class="progressive-table-wrapper" data-list-render="some-list">
             <table>
+                <thead>
+                    <th data-sort="alphabetic" data-sort-prop="name"></th>
+                    <th data-sort="numeric" data-sort-prop="age"></th>
+                </thead>
                 <tbody></tbody>
             </table>
         </div>
@@ -362,7 +360,7 @@ var list_render = (function () {
         var $this = $(this);
         var sort_type = $this.data("sort");
         var prop_name = $this.data("sort-prop");
-        var list_name = $this.parents("table").next(".progressive-table-wrapper").data("list-render");
+        var list_name = $this.closest(".progressive-table-wrapper").data("list-render");
 
         var list = list_render.get(list_name);
 

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -3,29 +3,6 @@ var render_settings_tab = require('../templates/settings_tab.hbs');
 var settings = (function () {
 
 var exports = {};
-var header_map = {
-    "your-account": i18n.t("Your account"),
-    "display-settings": i18n.t("Display settings"),
-    notifications: i18n.t("Notifications"),
-    "your-bots": i18n.t("Your bots"),
-    "alert-words": i18n.t("Alert words"),
-    "uploaded-files": i18n.t("Uploaded files"),
-    "muted-topics": i18n.t("Muted topics"),
-    "organization-profile": i18n.t("Organization profile"),
-    "organization-settings": i18n.t("Organization settings"),
-    "organization-permissions": i18n.t("Organization permissions"),
-    "emoji-settings": i18n.t("Emoji settings"),
-    "auth-methods": i18n.t("Authorization methods"),
-    "user-list-admin": i18n.t("Active users"),
-    "deactivated-users-admin": i18n.t("Deactivated users"),
-    "bot-list-admin": i18n.t("Bot list"),
-    "default-streams-list": i18n.t("Default streams"),
-    "filter-settings": i18n.t("Linkifiers"),
-    "invites-list-admin": i18n.t("Invitations"),
-    "user-groups-admin": i18n.t("User groups"),
-    "profile-field-settings": i18n.t("Profile field settings"),
-    "data-exports-admin": i18n.t("Data exports"),
-};
 
 $("body").ready(function () {
     var $sidebar = $(".form-sidebar");
@@ -158,11 +135,12 @@ exports.launch = function (section) {
 };
 
 exports.set_settings_header = function (key) {
-    if (header_map[key]) {
-        $(".settings-header h1 .section").text(" / " + header_map[key]);
+    var header_text = $(`#settings_page .sidebar-list [data-section='${key}'] .text`).text();
+    if (header_text) {
+        $(".settings-header h1 .section").text(" / " + header_text);
     } else {
         blueslip.warn("Error: the key '" + key + "' does not exist in the settings" +
-            " header mapping file. Please add it.");
+            " sidebar list. Please add it.");
     }
 };
 

--- a/static/js/settings_exports.js
+++ b/static/js/settings_exports.js
@@ -24,7 +24,7 @@ exports.populate_exports_table = function (exports) {
             exports_table.append(render_admin_export_list({
                 realm_export: {
                     id: data.id,
-                    acting_user: people.my_full_name(data.acting_user_id),
+                    acting_user: people.get_full_name(data.acting_user_id),
                     // Convert seconds -> milliseconds
                     event_time: timerender.last_seen_status_from_date(
                         new XDate(data.export_time * 1000)

--- a/static/js/settings_exports.js
+++ b/static/js/settings_exports.js
@@ -18,22 +18,48 @@ exports.populate_exports_table = function (exports) {
     }
 
     var exports_table = $('#admin_exports_table').expectOne();
-    exports_table.find('tr.export_row').remove();
-    _.each(exports, function (data) {
-        if (data.export_data.deleted_timestamp === undefined) {
-            exports_table.append(render_admin_export_list({
-                realm_export: {
-                    id: data.id,
-                    acting_user: people.get_full_name(data.acting_user_id),
-                    // Convert seconds -> milliseconds
-                    event_time: timerender.last_seen_status_from_date(
-                        new XDate(data.export_time * 1000)
-                    ),
-                    path: data.export_data.export_path,
-                },
-            }));
-        }
+    var exports_list = list_render.create(exports_table, exports, {
+        name: "admin-exports-list",
+        modifier: function (data) {
+            if (data.export_data.deleted_timestamp === undefined) {
+                return render_admin_export_list({
+                    realm_export: {
+                        id: data.id,
+                        acting_user: people.get_full_name(data.acting_user_id),
+                        // Convert seconds -> milliseconds
+                        event_time: timerender.last_seen_status_from_date(
+                            new XDate(data.export_time * 1000)
+                        ),
+                        path: data.export_data.export_path,
+                    },
+                });
+            }
+            return "";
+        },
+        filter: {
+            element: exports_table.closest(".settings-section").find(".search"),
+            callback: function (item, value) {
+                return people.get_full_name(item.acting_user_id).toLowerCase().indexOf(value) >= 0;
+            },
+            onupdate: function () {
+                ui.reset_scrollbar(exports_table);
+            },
+        },
+        parent_container: $("#data-exports").expectOne(),
     });
+
+    exports_list.add_sort_function("user", function (a, b) {
+        var a_name = people.get_full_name(a.acting_user_id).toLowerCase();
+        var b_name = people.get_full_name(b.acting_user_id).toLowerCase();
+        if (a_name > b_name) {
+            return 1;
+        } else if (a_name === b_name) {
+            return 0;
+        }
+        return -1;
+    });
+
+    exports_list.sort("user");
 };
 
 exports.set_up = function () {

--- a/static/js/settings_invites.js
+++ b/static/js/settings_invites.js
@@ -59,7 +59,7 @@ function populate_invites(invites_data) {
         admin_invites_list.set_container(invites_table);
         admin_invites_list.render();
     } else {
-        list_render.create(invites_table, invites_data.invites, {
+        var invites_list = list_render.create(invites_table, invites_data.invites, {
             name: "admin_invites_list",
             modifier: function (item) {
                 item.invited_absolute_time = timerender.absolute_time(item.invited * 1000);
@@ -76,7 +76,10 @@ function populate_invites(invites_data) {
                     return referrer_email_matched || invitee_email_matched;
                 },
             },
+            parent_container: $("#admin-invites-list").expectOne(),
         }).init();
+
+        invites_list.sort("alphabetic", "email");
     }
 
     loading.destroy_indicator($('#admin_page_invites_loading_indicator'));

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -148,7 +148,6 @@ label {
 }
 
 .wrapped-table {
-    table-layout: fixed;
     word-break: break-word;
     word-wrap: break-word;
     white-space: -moz-pre-wrap !important;
@@ -157,10 +156,6 @@ label {
     white-space: -o-pre-wrap;
     white-space: pre-wrap;
     white-space: normal;
-}
-
-.wrapped-cell {
-    width: 20%;
 }
 
 .table tbody {
@@ -173,13 +168,6 @@ label {
 
 #settings_content table + .progressive-table-wrapper table tr.user_row td:first-of-type {
     width: 20%;
-}
-
-#uploaded_files_table > tr > td:nth-of-type(4),
-#uploaded_files_table > tr > td:nth-of-type(5),
-.upload-size,
-.upload-actions {
-    width: 15%;
 }
 
 #uploaded_files_table > tr > td:nth-of-type(1),
@@ -275,6 +263,8 @@ td .button {
     }
 
     .table-striped {
+        table-layout: auto;
+
         tbody {
             border-bottom: none;
         }
@@ -313,6 +303,12 @@ td .button {
                     opacity: 0.3;
                 }
             }
+        }
+
+        // Force the actions column to use the minimum space necessary
+        .actions {
+            width: 1%;
+            white-space: nowrap;
         }
     }
 
@@ -732,10 +728,6 @@ input[type=checkbox].inline-block {
     margin-bottom: 20px;
 }
 
-.admin_emoji_table {
-    margin: 20px auto;
-}
-
 .emoji_image {
     width: 20px;
     display: block;
@@ -822,6 +814,7 @@ input[type=checkbox].inline-block {
     position: relative;
     max-height: calc(95vh - 220px);
     overflow: auto;
+    width: 100%;
 }
 
 #admin-default-streams-list .progressive-table-wrapper {
@@ -1820,10 +1813,6 @@ input[type=text]#settings_search {
 
 #admin-user-list .last_active {
     width: 100px;
-}
-
-thead .actions {
-    min-width: 230px;
 }
 
 #settings_page .display-settings-form select {

--- a/static/templates/admin_default_streams_list.hbs
+++ b/static/templates/admin_default_streams_list.hbs
@@ -5,7 +5,7 @@
         <span class="default_stream_name">{{name}}</span>
     </td>
     {{#if ../can_modify}}
-    <td>
+    <td class="actions">
         <button class="button rounded remove-default-stream btn-danger">
             {{t "Remove from default" }}
         </button>

--- a/static/templates/admin_export_list.hbs
+++ b/static/templates/admin_export_list.hbs
@@ -13,7 +13,7 @@
         <span class="export_url">{{t 'The export URL is not yet available... Check back soon.' }}</span>
         {{/if}}
     </td>
-    <td>
+    <td class="actions">
         <button class="button rounded small delete btn-danger" data-export-id="{{id}}">
             <i class="fa fa-trash-o" aria-hidden="true"></i>
         </button>

--- a/static/templates/admin_filter_list.hbs
+++ b/static/templates/admin_filter_list.hbs
@@ -7,7 +7,7 @@
         <span class="filter_url_format_string">{{url_format_string}}</span>
     </td>
     {{#if ../can_modify}}
-    <td class="no-select">
+    <td class="no-select actions">
         <button class="button small delete btn-danger" data-filter-id="{{id}}">
             <i class="fa fa-trash-o" aria-hidden="true"></i>
         </button>

--- a/static/templates/admin_invites_list.hbs
+++ b/static/templates/admin_invites_list.hbs
@@ -16,7 +16,7 @@
     <td>
         <span>{{invited_as_text}}</span>
     </td>
-    <td>
+    <td class="actions">
         <button class="button rounded small revoke btn-danger" data-invite-id="{{id}}" data-is-multiuse="{{is_multiuse}}">
             {{t "Revoke" }}
         </button>

--- a/static/templates/admin_user_list.hbs
+++ b/static/templates/admin_user_list.hbs
@@ -42,7 +42,7 @@
     </td>
     {{/if}}
     {{#if ../can_modify}}
-    <td>
+    <td class="actions">
         <span class="user-status-settings">
             {{#if is_active}}
             <button class="button rounded small deactivate btn-danger" {{#if ../is_current_user}}disabled="disabled"{{/if}}>

--- a/static/templates/settings/attachments_settings.hbs
+++ b/static/templates/settings/attachments_settings.hbs
@@ -3,19 +3,17 @@
     <input id="upload_file_search" class="search" type="text" placeholder="{{t 'Search uploads...' }}" aria-label="{{t 'Search uploads...' }}"/>
     <div class="clear-float"></div>
     <div class="alert" id="delete-upload-status"></div>
-    <table class="table table-condensed table-striped wrapped-table">
-        <thead>
-            <th data-sort="alphabetic" data-sort-prop="name" class="upload-file-name">{{t "File" }}</th>
-            <th class="active" data-sort="numeric" data-sort-prop="create_time">{{t "Date uploaded" }}</th>
-            <th data-sort="mentioned-in">{{t "Mentioned in" }}</th>
-            <th class="upload-size" data-sort="numeric" data-sort-prop="size">{{t "Size" }}</th>
-            <th class="upload-actions">{{t "Actions" }}</th>
-        </thead>
-    </table>
     <div class="progressive-table-wrapper" data-simplebar data-list-render="uploaded-files-list">
         <table class="table table-condensed table-striped wrapped-table">
+            <thead>
+                <th data-sort="alphabetic" data-sort-prop="name" class="upload-file-name">{{t "File" }}</th>
+                <th class="active" data-sort="numeric" data-sort-prop="create_time">{{t "Date uploaded" }}</th>
+                <th data-sort="mentioned-in">{{t "Mentioned in" }}</th>
+                <th class="upload-size" data-sort="numeric" data-sort-prop="size">{{t "Size" }}</th>
+                <th class="upload-actions">{{t "Actions" }}</th>
+            </thead>
             <tbody class="required-text" data-empty="{{t 'You have not uploaded any files.' }}"
-              id="uploaded_files_table" ></tbody>
+              id="uploaded_files_table"></tbody>
         </table>
     </div>
     <div id="attachments_loading_indicator"></div>

--- a/static/templates/settings/attachments_settings.hbs
+++ b/static/templates/settings/attachments_settings.hbs
@@ -10,7 +10,7 @@
                 <th class="active" data-sort="numeric" data-sort-prop="create_time">{{t "Date uploaded" }}</th>
                 <th data-sort="mentioned-in">{{t "Mentioned in" }}</th>
                 <th class="upload-size" data-sort="numeric" data-sort-prop="size">{{t "Size" }}</th>
-                <th class="upload-actions">{{t "Actions" }}</th>
+                <th class="upload-actions actions">{{t "Actions" }}</th>
             </thead>
             <tbody class="required-text" data-empty="{{t 'You have not uploaded any files.' }}"
               id="uploaded_files_table"></tbody>

--- a/static/templates/settings/bot_list_admin.hbs
+++ b/static/templates/settings/bot_list_admin.hbs
@@ -7,7 +7,7 @@
     <div class="progressive-table-wrapper" data-simplebar data-list-render="admin_bot_list">
         <table class="table table-condensed table-striped wrapped-table">
             <thead>
-                <th class="wrapped-cell active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
+                <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
                 <th data-sort="alphabetic" data-sort-prop="email">{{t "Email" }}</th>
                 <th data-sort="bot_owner">{{t "Owner" }}</th>
                 <th data-sort="alphabetic" data-sort-prop="bot_type">{{t "Bot type" }}</th>

--- a/static/templates/settings/bot_list_admin.hbs
+++ b/static/templates/settings/bot_list_admin.hbs
@@ -4,19 +4,17 @@
     <input type="text" class="search" placeholder="{{t 'Filter bots' }}" aria-label="{{t 'Filter bots' }}"/>
     <div class="alert-notification" id="bot-field-status"></div>
     <div class="clear-float"></div>
-    <table class="table table-condensed table-striped wrapped-table">
-        <thead>
-            <th class="wrapped-cell active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
-            <th data-sort="alphabetic" data-sort-prop="email">{{t "Email" }}</th>
-            <th data-sort="bot_owner">{{t "Owner" }}</th>
-            <th data-sort="alphabetic" data-sort-prop="bot_type">{{t "Bot type" }}</th>
-            {{#if is_admin}}
-            <th class="actions">{{t "Actions" }}</th>
-            {{/if}}
-        </thead>
-    </table>
     <div class="progressive-table-wrapper" data-simplebar data-list-render="admin_bot_list">
         <table class="table table-condensed table-striped wrapped-table">
+            <thead>
+                <th class="wrapped-cell active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
+                <th data-sort="alphabetic" data-sort-prop="email">{{t "Email" }}</th>
+                <th data-sort="bot_owner">{{t "Owner" }}</th>
+                <th data-sort="alphabetic" data-sort-prop="bot_type">{{t "Bot type" }}</th>
+                {{#if is_admin}}
+                <th class="actions">{{t "Actions" }}</th>
+                {{/if}}
+            </thead>
             <tbody id="admin_bots_table" class="admin_bot_table required-text thick"
               data-empty="{{t 'No bots match your current filter.' }}"></tbody>
         </table>

--- a/static/templates/settings/data_exports_admin.hbs
+++ b/static/templates/settings/data_exports_admin.hbs
@@ -22,13 +22,16 @@
     </form>
     {{/if}}
     <p class="alert-word-settings-note">{{#tr this}}Any member with administrative access can conduct an export.  Please note that individual organizations are limited to five exports per week.{{/tr}}</p>
-    <div class="admin-table-wrapper">
+
+    <input type="text" class="search" placeholder="{{t 'Filter exports' }}"
+      aria-label="{{t 'Filter exports' }}"/>
+    <div class="progressive-table-wrapper admin-table-wrapper" data-simplebar data-list-render="admin-exports-list">
         <table class="table table-condensed table-striped wrapped-table admin_exports_table">
             <thead>
-                <th>{{t "Requesting user" }}</th>
-                <th>{{t "Time" }}</th>
+                <th class="active" data-sort="user">{{t "Requesting user" }}</th>
+                <th data-sort="numeric" data-sort-prop="export_time">{{t "Time" }}</th>
                 <th>{{t "File" }}</th>
-                <th>{{t "Actions" }}</th>
+                <th class="actions">{{t "Actions" }}</th>
             </thead>
             <tbody id="admin_exports_table" class="required-text" data-empty="{{t 'No exports.' }}"></tbody>
         </table>

--- a/static/templates/settings/deactivated_users_admin.hbs
+++ b/static/templates/settings/deactivated_users_admin.hbs
@@ -11,7 +11,7 @@
     <div class="progressive-table-wrapper" data-simplebar data-list-render="deactivated_users_table_list">
         <table class="table table-condensed table-striped wrapped-table">
             <thead>
-                <th class="wrapped-cell active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
+                <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
                 {{#if show_email}}
                 <th data-sort="alphabetic" data-sort-prop="email">{{t "Email" }}</th>
                 {{/if}}

--- a/static/templates/settings/deactivated_users_admin.hbs
+++ b/static/templates/settings/deactivated_users_admin.hbs
@@ -8,20 +8,18 @@
     <div class="alert-notification" id="deactivated-user-field-status"></div>
     <div class="clear-float"></div>
 
-    <table class="table table-condensed table-striped wrapped-table">
-        <thead>
-            <th class="wrapped-cell active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
-            {{#if show_email}}
-            <th data-sort="alphabetic" data-sort-prop="email">{{t "Email" }}</th>
-            {{/if}}
-            <th class="user_role" data-sort="role">{{t "Role" }}</th>
-            {{#if is_admin}}
-            <th class="actions">{{t "Actions" }}</th>
-            {{/if}}
-        </thead>
-    </table>
     <div class="progressive-table-wrapper" data-simplebar data-list-render="deactivated_users_table_list">
         <table class="table table-condensed table-striped wrapped-table">
+            <thead>
+                <th class="wrapped-cell active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
+                {{#if show_email}}
+                <th data-sort="alphabetic" data-sort-prop="email">{{t "Email" }}</th>
+                {{/if}}
+                <th class="user_role" data-sort="role">{{t "Role" }}</th>
+                {{#if is_admin}}
+                <th class="actions">{{t "Actions" }}</th>
+                {{/if}}
+            </thead>
             <tbody id="admin_deactivated_users_table" class="required-text thick admin_user_table"
               data-empty="{{t 'No users match your current filter.' }}"></tbody>
         </table>

--- a/static/templates/settings/default_streams_list_admin.hbs
+++ b/static/templates/settings/default_streams_list_admin.hbs
@@ -24,16 +24,14 @@
     <input type="text" class="search" placeholder="{{t 'Filter streams' }}" aria-label="{{t 'Filter streams' }}"/>
     <div class="clear-float"></div>
 
-    <table class="table table-condensed table-striped wrapped-table">
-        <thead>
-            <th class="active" data-sort="alphabetic" data-sort-prop="name">{{t "Name" }}</th>
-            {{#if is_admin}}
-            <th class="actions">{{t "Actions" }}</th>
-            {{/if}}
-        </thead>
-    </table>
     <div class="progressive-table-wrapper" data-simplebar data-list-render="default_streams_list">
         <table class="table table-condensed table-striped wrapped-table">
+            <thead>
+                <th class="active" data-sort="alphabetic" data-sort-prop="name">{{t "Name" }}</th>
+                {{#if is_admin}}
+                <th class="actions">{{t "Actions" }}</th>
+                {{/if}}
+            </thead>
             <tbody class="required-text" data-empty="{{t 'No default streams match you current filter.' }}"
               id="admin_default_streams_table" class="admin_default_stream_table"></tbody>
         </table>

--- a/static/templates/settings/emoji_settings_admin.hbs
+++ b/static/templates/settings/emoji_settings_admin.hbs
@@ -29,16 +29,14 @@
 
     <input type="text" class="search" placeholder="{{t 'Filter emojis' }}"
       aria-label="{{t 'Filter linkifiers' }}"/>
-    <table class="table table-condensed table-striped wrapped-table admin_emoji_table">
-        <thead>
-            <th class="active" data-sort="alphabetic" data-sort-prop="name">{{t "Name" }}</th>
-            <th class="image">{{t "Image" }}</th>
-            <th class="image" data-sort="author_full_name">{{t "Author" }}</th>
-            <th class="actions">{{t "Actions" }}</th>
-        </thead>
-    </table>
     <div class="progressive-table-wrapper" data-simplebar data-list-render="emoji_list">
         <table class="table table-condensed table-striped wrapped-table admin_emoji_table">
+            <thead>
+                <th class="active" data-sort="alphabetic" data-sort-prop="name">{{t "Name" }}</th>
+                <th class="image">{{t "Image" }}</th>
+                <th class="image" data-sort="author_full_name">{{t "Author" }}</th>
+                <th class="actions">{{t "Actions" }}</th>
+            </thead>
             <tbody id="admin_emoji_table" class="required-text" data-empty="{{t 'No custom emoji.' }}"></tbody>
         </table>
     </div>

--- a/static/templates/settings/invites_list_admin.hbs
+++ b/static/templates/settings/invites_list_admin.hbs
@@ -7,14 +7,14 @@
     </div>
     <div class="clear-float"></div>
 
-    <div class="progressive-table-wrapper">
+    <div class="progressive-table-wrapper" data-simplebar data-list-render="admin_invites_list">
         <table class="table table-condensed table-striped">
             <thead>
-                <th>{{t "Email" }}</th>
-                <th>{{t "Invited by" }}</th>
-                <th>{{t "Invited at" }}</th>
-                <th>{{t "Invited as" }}</th>
-                <th>{{t "Actions" }}</th>
+                <th class="active" data-sort="alphabetic" data-sort-prop="email">{{t "Email" }}</th>
+                <th data-sort="alphabetic" data-sort-prop="ref">{{t "Invited by" }}</th>
+                <th data-sort="numeric" data-sort-prop="invited">{{t "Invited at" }}</th>
+                <th data-sort="numeric" data-sort-prop="invited_as">{{t "Invited as" }}</th>
+                <th class="actions">{{t "Actions" }}</th>
             </thead>
             <tbody id="admin_invites_table" class="required-text thick admin_invites_table" data-empty="{{t 'No invites match your current filter.' }}"></tbody>
         </table>

--- a/static/templates/settings/linkifier_settings_admin.hbs
+++ b/static/templates/settings/linkifier_settings_admin.hbs
@@ -65,17 +65,15 @@
         {{/if}}
 
         <input type="text" class="search" placeholder="{{t 'Filter linkifiers' }}" aria-label="{{t 'Filter linkifiers' }}"/>
-        <table class="table table-condensed table-striped wrapped-table admin_filters_table">
-            <thead>
-                <th class="active" data-sort="pattern">{{t "Pattern" }}</th>
-                <th data-sort="url">{{t "URL format string" }}</th>
-                {{#if is_admin}}
-                <th class="actions">{{t "Actions" }}</th>
-                {{/if}}
-            </thead>
-        </table>
         <div class="progressive-table-wrapper" data-simplebar data-list-render="linkifiers_list">
             <table class="table table-condensed table-striped wrapped-table admin_filters_table">
+                <thead>
+                    <th class="active" data-sort="pattern">{{t "Pattern" }}</th>
+                    <th data-sort="url">{{t "URL format string" }}</th>
+                    {{#if is_admin}}
+                    <th class="actions">{{t "Actions" }}</th>
+                    {{/if}}
+                </thead>
                 <tbody id="admin_filters_table" {{#unless is_admin}}class="required-text" data-empty="{{t 'No linkifiers set.' }}"{{/unless}}></tbody>
             </table>
         </div>

--- a/static/templates/settings/user_list_admin.hbs
+++ b/static/templates/settings/user_list_admin.hbs
@@ -5,21 +5,19 @@
     <div class="alert-notification" id="user-field-status"></div>
     <div class="clear-float"></div>
 
-    <table class="table table-condensed table-striped wrapped-table">
-        <thead>
-            <th class="wrapped-cell active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
-            {{#if show_email}}
-            <th data-sort="alphabetic" data-sort-prop="email">{{t "Email" }}</th>
-            {{/if}}
-            <th class="user_role" data-sort="role">{{t "Role" }}</th>
-            <th class="last_active" data-sort="last_active">{{t "Last active" }}</th>
-            {{#if is_admin}}
-            <th class="actions">{{t "Actions" }}</th>
-            {{/if}}
-        </thead>
-    </table>
     <div class="progressive-table-wrapper" data-simplebar data-list-render="users_table_list">
         <table class="table table-condensed table-striped wrapped-table">
+            <thead>
+                <th class="wrapped-cell active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
+                {{#if show_email}}
+                <th data-sort="alphabetic" data-sort-prop="email">{{t "Email" }}</th>
+                {{/if}}
+                <th class="user_role" data-sort="role">{{t "Role" }}</th>
+                <th class="last_active" data-sort="last_active">{{t "Last active" }}</th>
+                {{#if is_admin}}
+                <th class="actions">{{t "Actions" }}</th>
+                {{/if}}
+            </thead>
             <tbody id="admin_users_table" class="admin_user_table required-text thick"
               data-empty="{{t 'No users match your current filter.' }}"></tbody>
         </table>

--- a/static/templates/settings/user_list_admin.hbs
+++ b/static/templates/settings/user_list_admin.hbs
@@ -8,7 +8,7 @@
     <div class="progressive-table-wrapper" data-simplebar data-list-render="users_table_list">
         <table class="table table-condensed table-striped wrapped-table">
             <thead>
-                <th class="wrapped-cell active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
+                <th class="active" data-sort="alphabetic" data-sort-prop="full_name">{{t "Name" }}</th>
                 {{#if show_email}}
                 <th data-sort="alphabetic" data-sort-prop="email">{{t "Email" }}</th>
                 {{/if}}

--- a/static/templates/uploaded_files_list.hbs
+++ b/static/templates/uploaded_files_list.hbs
@@ -18,7 +18,7 @@
         {{/if}}
     </td>
     <td>{{ size_str }}</td>
-    <td>
+    <td class="actions">
         <span class="edit-attachment-buttons">
             <button type="submit"
               class="button small no-style remove-attachment"


### PR DESCRIPTION
* Set the column width of "Actions" to be the smallest necessary.
![image](https://user-images.githubusercontent.com/18504232/63511075-c3688180-c512-11e9-935c-2edec7371022.png)
![image](https://user-images.githubusercontent.com/18504232/63511100-d5e2bb00-c512-11e9-80da-424517b53fc6.png)
* Fix the problem where clicking a table header (to sort) twice causes the list to stop reversing.
* Added the sorting feature to "Invitations" and "Data exports".
* Fixed #13046 (Fix mismatching labels for "organization settings" tabs).
![image](https://user-images.githubusercontent.com/18504232/63511582-260e4d00-c514-11e9-83db-df61eb0b37e5.png)
