### PR TITLE
emails: Send invitation reminder email two days before expiry.

### DIFF
--- a/templates/zerver/emails/invitation.source.html
+++ b/templates/zerver/emails/invitation.source.html
@@ -8,7 +8,7 @@
 <p>{{ _("Hi there,") }}</p>
 
 <p>
-    {% trans %}{{ referrer_full_name }} (<a href="mailto:{{ referrer_email }}">{{ referrer_email }}</a>)wants you to join them on Zulip &mdash; the team communication tool designed for productivity.{% endtrans %}
+    {% trans %}{{ referrer_full_name }} (<a href="mailto:{{ referrer_email }}">{{ referrer_email }}</a>) wants you to join them on Zulip &mdash; the team communication tool designed for productivity.{% endtrans %}
 </p>
 <p>
     {{ _("To get started, click the button below.") }}

--- a/templates/zerver/emails/invitation_reminder.source.html
+++ b/templates/zerver/emails/invitation_reminder.source.html
@@ -16,6 +16,9 @@
 
 <p>
     {{ _("This is the last reminder you'll receive for this invitation.") }}
-    {% trans %}Contact us any time at <a href="mailto:{{ support_email }}">{{ support_email }}</a> if you run into trouble, have any feedback, or just want to chat!{% endtrans %}
+</p>
+
+<p>
+    {% trans %}This invitation expires in two days. If the invitation expires, you'll need to ask {{ referrer_name }} for another one.{% endtrans %}
 </p>
 {% endblock %}

--- a/templates/zerver/emails/invitation_reminder.txt
+++ b/templates/zerver/emails/invitation_reminder.txt
@@ -7,4 +7,4 @@
 
 {{ _("This is the last reminder you'll receive for this invitation.") }}
 
-{% trans %}Contact us any time at {{ support_email }} if you run into trouble, have any feedback, or just want to chat!{% endtrans %}
+{% trans %}This invitation expires in two days. If the invitation expires, you'll need to ask {{ referrer_name }} for another one.{% endtrans %}

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4826,7 +4826,7 @@ def do_send_confirmation_email(invitee: PreregistrationUser,
     Send the confirmation/welcome e-mail to an invited user.
     """
     activation_url = create_confirmation_link(invitee, referrer.realm.host, Confirmation.INVITATION)
-    context = {'referrer_full_name': referrer.full_name, 'referrer_email': referrer.email,
+    context = {'referrer_full_name': referrer.full_name, 'referrer_email': referrer.delivery_email,
                'activate_url': activation_url, 'referrer_realm_name': referrer.realm.name}
     from_name = "%s (via Zulip)" % (referrer.full_name,)
     send_email('zerver/emails/invitation', to_emails=[invitee.email], from_name=from_name,

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1229,6 +1229,17 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
             scheduled_timestamp__lte=timezone_now(), type=ScheduledEmail.INVITATION_REMINDER)
         self.assertEqual(len(email_jobs_to_deliver), 0)
 
+    def test_no_invitation_reminder_when_link_expires_quickly(self) -> None:
+        self.login(self.example_email('hamlet'))
+        # Check invitation reminder email is scheduled with 4 day link expiry
+        with self.settings(INVITATION_LINK_VALIDITY_DAYS=4):
+            self.invite('alice@zulip.com', ['Denmark'])
+        self.assertEqual(ScheduledEmail.objects.filter(type=ScheduledEmail.INVITATION_REMINDER).count(), 1)
+        # Check invitation reminder email is not scheduled with 3 day link expiry
+        with self.settings(INVITATION_LINK_VALIDITY_DAYS=3):
+            self.invite('bob@zulip.com', ['Denmark'])
+        self.assertEqual(ScheduledEmail.objects.filter(type=ScheduledEmail.INVITATION_REMINDER).count(), 1)
+
     # make sure users can't take a valid confirmation key from another
     # pathway and use it with the invitation url route
     def test_confirmation_key_of_wrong_type(self) -> None:

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -228,7 +228,7 @@ class ConfirmationEmailWorker(QueueProcessingWorker):
         context.update({
             'activate_url': link,
             'referrer_name': referrer.full_name,
-            'referrer_email': referrer.email,
+            'referrer_email': referrer.delivery_email,
             'referrer_realm_name': referrer.realm.name,
         })
         send_future_email(


### PR DESCRIPTION
Reduces some of the more expensive ktlo. (Expensive since we don't have a good way of debugging invitation link / registration issues at the moment.)

![image](https://user-images.githubusercontent.com/890911/63560715-e04d8680-c50b-11e9-9d4d-6c0298f23abe.png)
