### PR TITLE
ldap: Fix attempting to sync data for deactivated users.

### DIFF
--- a/zerver/management/commands/sync_ldap_user_data.py
+++ b/zerver/management/commands/sync_ldap_user_data.py
@@ -22,12 +22,7 @@ def sync_ldap_user_data(user_profiles: List[UserProfile]) -> None:
         # This will save the user if relevant, and will do nothing if the user
         # does not exist.
         try:
-            if sync_user_from_ldap(u):
-                logger.info("Updated %s." % (u.email,))
-            else:
-                logger.warning("Did not find %s in LDAP." % (u.email,))
-                if settings.LDAP_DEACTIVATE_NON_MATCHING_USERS:
-                    logger.info("Deactivated non-matching user: %s" % (u.email,))
+            sync_user_from_ldap(u, logger)
         except ZulipLDAPException as e:
             logger.error("Error attempting to update user %s:" % (u.email,))
             logger.error(e)

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -2558,7 +2558,7 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
                 LDAP_APPEND_DOMAIN='zulip.com',
                 AUTH_LDAP_BIND_PASSWORD='',
                 AUTH_LDAP_USER_DN_TEMPLATE='uid=%(user)s,ou=users,dc=zulip,dc=com'):
-            result = sync_user_from_ldap(user_profile)
+            result = sync_user_from_ldap(user_profile, mock.Mock())
             self.assertTrue(result)
 
     def test_update_full_name(self) -> None:
@@ -2725,9 +2725,9 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
                            AUTH_LDAP_BIND_PASSWORD='',
                            AUTH_LDAP_USER_DN_TEMPLATE='uid=%(user)s,ou=users,dc=zulip,dc=com',
                            LDAP_DEACTIVATE_NON_MATCHING_USERS=True):
-            result = sync_user_from_ldap(self.example_user('hamlet'))
+            result = sync_user_from_ldap(self.example_user('hamlet'), mock.Mock())
 
-            self.assertFalse(result)
+            self.assertTrue(result)
             hamlet = self.example_user('hamlet')
             self.assertFalse(hamlet.is_active)
 


### PR DESCRIPTION
The order of operations for our LDAP synchronization code wasn't
correct: We would run the code to sync avatars (etc.) even for
deactivated users.

Thanks to niels for the report.
