### PR TITLE
parse_lsb_release: Use /etc/os-release instead of /etc/lsb-release.

### DIFF
--- a/scripts/lib/create-production-venv
+++ b/scripts/lib/create-production-venv
@@ -8,7 +8,7 @@ ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__f
 if ZULIP_PATH not in sys.path:
     sys.path.append(ZULIP_PATH)
 
-from scripts.lib.zulip_tools import overwrite_symlink, run, parse_lsb_release
+from scripts.lib.zulip_tools import overwrite_symlink, run, parse_os_release
 from scripts.lib.setup_venv import (
     setup_virtualenv, VENV_DEPENDENCIES, REDHAT_VENV_DEPENDENCIES,
     FEDORA_VENV_DEPENDENCIES
@@ -19,8 +19,8 @@ parser.add_argument("deploy_path")
 args = parser.parse_args()
 
 # install dependencies for setting up the virtualenv
-distro_info = parse_lsb_release()
-vendor = distro_info['DISTRIB_ID']
+distro_info = parse_os_release()
+vendor = distro_info['ID']
 family = distro_info['DISTRIB_FAMILY']
 if family == 'debian':
     run(["apt-get", "-y", "install"] + VENV_DEPENDENCIES)
@@ -31,7 +31,7 @@ elif family == 'redhat':
         _VENV_DEPS = FEDORA_VENV_DEPENDENCIES
     run(["yum", "-y", "install"] + _VENV_DEPS)
 else:
-    print("Unsupported platform: {}".format(vendor))
+    print("Unsupported platform: {}".format(family))
     sys.exit(1)
 
 python_version = sys.version_info[0]

--- a/scripts/lib/create-thumbor-venv
+++ b/scripts/lib/create-thumbor-venv
@@ -8,7 +8,7 @@ ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__f
 if ZULIP_PATH not in sys.path:
     sys.path.append(ZULIP_PATH)
 
-from scripts.lib.zulip_tools import run, parse_lsb_release
+from scripts.lib.zulip_tools import run, parse_os_release
 from scripts.lib.setup_venv import (
     setup_virtualenv, THUMBOR_VENV_DEPENDENCIES, YUM_THUMBOR_VENV_DEPENDENCIES
 )
@@ -18,15 +18,14 @@ parser.add_argument("deploy_path")
 args = parser.parse_args()
 
 # install dependencies for setting up the virtualenv
-distro_info = parse_lsb_release()
-vendor = distro_info['DISTRIB_ID']
+distro_info = parse_os_release()
 family = distro_info['DISTRIB_FAMILY']
 if family == 'debian':
     run(["apt-get", "-y", "install"] + THUMBOR_VENV_DEPENDENCIES)
 elif family == 'redhat':
     run(["yum", "-y", "install"] + YUM_THUMBOR_VENV_DEPENDENCIES)
 else:
-    print("Unsupported platform: {}".format(vendor))
+    print("Unsupported platform: {}".format(family))
     sys.exit(1)
 
 venv_name = "zulip-thumbor-venv"

--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -337,8 +337,20 @@ def may_be_perform_purging(dirs_to_purge, dirs_to_keep, dir_type, dry_run, verbo
         if verbose:
             print("Keeping used %s: %s" % (dir_type, directory))
 
-def parse_lsb_release():
+def parse_os_release():
     # type: () -> Dict[str, str]
+    """
+    Example of the useful subset of the data:
+    {
+     'DISTRIB_FAMILY': 'debian'
+     'ID': 'ubuntu',
+     'VERSION_CODENAME': 'bionic',
+     'VERSION_ID': '18.04',
+     'NAME': 'Ubuntu',
+     'VERSION': '18.04.3 LTS (Bionic Beaver)',
+     'PRETTY_NAME': 'Ubuntu 18.04.3 LTS',
+    }
+    """
     distro_info = {}  # type: Dict[str, str]
     if os.path.exists("/etc/redhat-release"):
         with open('/etc/redhat-release', 'r') as fp:
@@ -346,44 +358,30 @@ def parse_lsb_release():
         vendor = info[0]
         if vendor == 'CentOS':
             # E.g. "CentOS Linux release 7.5.1804 (Core)"
-            codename = vendor.lower() + info[3][0]
+            os_version = vendor.lower() + info[3][0]
         elif vendor == 'Fedora':
             # E.g. "Fedora release 29 (Twenty Nine)"
-            codename = vendor.lower() + info[2]
+            os_version = vendor.lower() + info[2]
         elif vendor == 'Red':
             # E.g. "Red Hat Enterprise Linux Server release 7.6 (Maipo)"
             vendor = 'RedHat'
-            codename = 'rhel' + info[6][0]  # 7
+            os_version = 'rhel' + info[6][0]  # 7
         distro_info = dict(
-            DISTRIB_CODENAME=codename,
-            DISTRIB_ID=vendor,
+            VERSION_ID=os_version,
+            ID=vendor,
             DISTRIB_FAMILY='redhat',
         )
         return distro_info
-    try:
-        # For performance reasons, we read /etc/lsb-release directly,
-        # rather than using the lsb_release command; this saves ~50ms
-        # in several places in provisioning and the installer
-        with open('/etc/lsb-release', 'r') as fp:
-            data = [line.strip().split('=') for line in fp]
-        for k, v in data:
-            if k not in ['DISTRIB_CODENAME', 'DISTRIB_ID']:
-                # We only return to the caller the values that we get
-                # from lsb_release in the exception code path.
+    with open('/etc/os-release', 'r') as fp:
+        for line in fp:
+            line = line.strip()
+            if not line or line.startswith('#'):
+                # The line may be blank or a comment, see:
+                # https://www.freedesktop.org/software/systemd/man/os-release.html
                 continue
-            distro_info[k] = v
-        distro_info['DISTRIB_FAMILY'] = 'debian'
-    except FileNotFoundError:
-        # Unfortunately, Debian stretch doesn't yet have an
-        # /etc/lsb-release, so we instead fetch the pieces of data
-        # that we use from the `lsb_release` command directly.
-        vendor = subprocess_text_output(["lsb_release", "-is"])
-        codename = subprocess_text_output(["lsb_release", "-cs"])
-        distro_info = dict(
-            DISTRIB_CODENAME=codename,
-            DISTRIB_ID=vendor,
-            DISTRIB_FAMILY='debian',
-        )
+            k, v = line.split('=', 1)
+            [distro_info[k]] = shlex.split(v)
+    distro_info['DISTRIB_FAMILY'] = 'debian'
     return distro_info
 
 def file_or_package_hash_updated(paths, hash_name, is_force, package_versions=[]):

--- a/scripts/zulip-puppet-apply
+++ b/scripts/zulip-puppet-apply
@@ -5,7 +5,7 @@ import sys
 import subprocess
 import configparser
 import re
-from lib.zulip_tools import parse_lsb_release, assert_running_as_root
+from lib.zulip_tools import parse_os_release, assert_running_as_root
 
 assert_running_as_root()
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -21,8 +21,8 @@ config = configparser.RawConfigParser()
 config.read("/etc/zulip/zulip.conf")
 
 if not os.path.exists("/etc/puppet/hiera.yaml"):
-    codename = parse_lsb_release()['DISTRIB_CODENAME']
-    if codename in ["stretch", "xenial"]:
+    distro_info = parse_os_release()
+    if (distro_info['ID'], distro_info['VERSION_ID']) in [('debian', '9'), ('ubuntu', '16.04')]:
         # Suppress warnings in old puppet about hiera.yaml not existing.
         open("/etc/puppet/hiera.yaml", "a").close()
 

--- a/zerver/management/commands/backup.py
+++ b/zerver/management/commands/backup.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.db import connection
 from django.utils.timezone import now as timezone_now
 
-from scripts.lib.zulip_tools import parse_lsb_release, run, TIMESTAMP_FORMAT
+from scripts.lib.zulip_tools import parse_os_release, run, TIMESTAMP_FORMAT
 from version import ZULIP_VERSION
 from zerver.lib.management import ZulipBaseCommand
 from zerver.logging_handlers import try_git_describe
@@ -46,7 +46,7 @@ class Command(ZulipBaseCommand):
 
             with open(os.path.join(tmp, "zulip-backup", "os-version"), "w") as f:
                 print(
-                    "{DISTRIB_ID} {DISTRIB_CODENAME}".format(**parse_lsb_release()),
+                    "{ID} {VERSION_ID}".format(**parse_os_release()),
                     file=f,
                 )
             members.append("zulip-backup/os-version")


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
- [ ] See if this covers Debian as well.

The Ubuntu's case is covered in CI.

See also https://chat.zulip.org/#narrow/stream/3-backend/topic/.2Fetc.2Fos-release.20and.20.2Fetc.2Flsb-release and https://github.com/zulip/zulip/pull/11302#issuecomment-523689914 for context.