### PR TITLE
mypy: Remove daemon mode

### DIFF
--- a/docs/testing/mypy.md
+++ b/docs/testing/mypy.md
@@ -48,14 +48,6 @@ To run mypy on Zulip's python code, you can run the command:
 
     tools/run-mypy
 
-This will take a while to start running, since it runs mypy as a
-long-running daemon (server) process and send type-checking requests
-to the server; this makes checking mypy about 100x faster.  But if
-you're debugging or for whatever reason don't want the daemon, you can
-use:
-
-    tools/run-mypy --no-daemon
-
 Mypy outputs errors in the same style as a compiler would.  For
 example, if your code has a type error like this:
 
@@ -117,10 +109,6 @@ For any third-party modules that don't have stubs, `mypy` treats
 everything in the third-party module as an `Any`, which is the right
 model (one certainly wouldn't want to need stubs for everything just
 to use `mypy`!), but means the code can't be fully type-checked.
-
-**Note**: When editing stubs, we recommend using
-`tools/run-mypy --no-daemon`, because the mypy daemon's caching
-system has some bugs around editing stubs that can be confusing.
 
 ## `type_debug.py`
 

--- a/stubs/stripe/__init__.pyi
+++ b/stubs/stripe/__init__.pyi
@@ -1,6 +1,3 @@
-# NOTE: When editing stubs, we recommend using `tools/run-mypy --no-daemon`,
-# because the mypy daemon's caching system has some bugs around editing stubs
-#
 # See https://zulip.readthedocs.io/en/latest/testing/mypy.html#mypy-stubs-for-third-party-modules
 # for notes on how we manage mypy stubs.
 

--- a/tools/ci/backend
+++ b/tools/ci/backend
@@ -17,10 +17,7 @@ set -x
 # We run mypy after the backend tests so we get output from the
 # backend tests, which tend to uncover more serious problems, first.
 ./tools/run-mypy --version
-# We run mypy without daemon mode, since that's faster given that
-# we're only going to run it once, and catches more errors since
-# daemon mode doesn't follow package imports.
-./tools/run-mypy --no-daemon
+./tools/run-mypy
 
 ./tools/test-migrations
 ./tools/setup/optimize-svg

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -23,8 +23,6 @@ parser.add_argument('targets', nargs='*',
                     help="files and directories to check (default: .)")
 parser.add_argument('--version', action='store_true',
                     help="show mypy version information and exit")
-parser.add_argument('--quick', action='store_true',
-                    help="pass --quick to mypy")
 parser.add_argument('-m', '--modified', action='store_true',
                     help="check only modified files")
 parser.add_argument('--scripts-only', action='store_true',
@@ -68,11 +66,7 @@ if not python_files and not pyi_files:
     print("There are no files to run mypy on.")
     sys.exit(0)
 
-extra_args = []
-if args.quick:
-    extra_args.append("--quick")
-
-mypy_args = extra_args + python_files + pyi_files
+mypy_args = python_files + pyi_files
 rc = subprocess.call([mypy_command] + mypy_args)
 
 if rc != 0:

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -27,8 +27,6 @@ parser.add_argument('--quick', action='store_true',
                     help="pass --quick to mypy")
 parser.add_argument('-m', '--modified', action='store_true',
                     help="check only modified files")
-parser.add_argument('--no-daemon', action='store_true',
-                    help="Start and run the mypy fine-grained incremental daemon")
 parser.add_argument('--scripts-only', action='store_true',
                     help="only check extensionless python scripts")
 parser.add_argument('-a', '--all', action='store_true',
@@ -39,7 +37,7 @@ args = parser.parse_args()
 
 assert_provisioning_status_ok(args.force)
 
-command_name = "mypy" if (args.no_daemon or args.version) else "dmypy"
+command_name = "mypy"
 
 # Use zulip-py3-venv's mypy if it's available.
 VENV_DIR = "/srv/zulip-py3-venv"
@@ -75,15 +73,7 @@ if args.quick:
     extra_args.append("--quick")
 
 mypy_args = extra_args + python_files + pyi_files
-if args.no_daemon:
-    rc = subprocess.call([mypy_command] + mypy_args)
-else:
-    mypy_args += ["--follow-imports=skip"]
-    rc = subprocess.call([mypy_command, "status"], stdout=subprocess.PIPE)
-    if rc != 0:
-        print("Starting mypy daemon, this will take a minute...")
-        sys.stdout.flush()
-    rc = subprocess.call([mypy_command, 'run', '--'] + mypy_args)
+rc = subprocess.call([mypy_command] + mypy_args)
 
 if rc != 0:
     print("")


### PR DESCRIPTION
mypy in daemon mode takes some 400 MiB of memory, and cannot follow imports of type-annotated third-party packages; meanwhile, non-daemon mode is no longer nearly as slow as it once was.

Alternative to #13026.

**Testing Plan:** Ran `run-mypy`.