### PR TITLE
Upgrade pip-tools to 3.8.0; downgrade pip to 19.1.1

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -49,13 +49,13 @@ python-gcm==0.4
 # Needed for the email mirror
 html2text==2018.1.9
 httplib2==0.13.0
--e git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
+git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
 
 # Needed for hipchat import
 hypchat==0.21
 
 # For doing highly usable Python profiling
--e git+https://github.com/zulip/line_profiler.git#egg=line_profiler==2.1.2.zulip1
+git+https://github.com/zulip/line_profiler.git#egg=line_profiler==2.1.2.zulip1
 
 # Needed for inlining the CSS in emails
 premailer==3.5.0
@@ -104,7 +104,7 @@ sourcemap==0.2.1
 tornado==4.5.3
 
 # Fast JSON parser
--e git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
+git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
 
 # Django extension for serving webpack modules
 django-webpack-loader==0.6.0
@@ -132,8 +132,8 @@ python-magic==0.4.15
 # these tightly, including fetching content not included in the normal
 # release tarballs (which is a bug).  So we need to pin it makes sense
 # to pin a version from Git rather than a release.
--e "git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca60acf650da#egg=zulip==0.6.1_git&subdirectory=zulip"
--e "git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca60acf650da#egg=zulip_bots==0.6.1+git&subdirectory=zulip_bots"
+git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca60acf650da#egg=zulip==0.6.1_git&subdirectory=zulip
+git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca60acf650da#egg=zulip_bots==0.6.1+git&subdirectory=zulip_bots
 
 # Used for Hesiod lookups, etc.
 py3dns==3.2.0
@@ -169,7 +169,7 @@ yamole==2.1.6
 
 # Needed for signing thumbnail requests so that they can be authenticated on the
 # other end.  Using a fork to eliminate a really slow pkgresources import.
--e "git+https://github.com/zulip/libthumbor.git@60ed2431c07686a12f2770b2d852c5650f3ccfc6#egg=libthumbor==1.3.2zulip"
+git+https://github.com/zulip/libthumbor.git@60ed2431c07686a12f2770b2d852c5650f3ccfc6#egg=libthumbor==1.3.2zulip
 
 # Needed for string matching in AlertWordProcessor
 pyahocorasick==1.4.0

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -53,6 +53,6 @@ python-digitalocean==1.14.0
 pip-tools==3.8.0
 
 # zulip's linting framework - zulint
--e git+https://github.com/zulip/zulint@aaed679f1ad38b230090eadd3870b7682500f60c#egg=zulint==0.0.1
+git+https://github.com/zulip/zulint@aaed679f1ad38b230090eadd3870b7682500f60c#egg=zulint==0.0.1
 
 -r mypy.in

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -50,7 +50,7 @@ transifex-client==0.12.5
 python-digitalocean==1.14.0
 
 # Needed for updating the locked pip dependencies
-pip-tools==2.0.2
+pip-tools==3.8.0
 
 # zulip's linting framework - zulint
 -e git+https://github.com/zulip/zulint@aaed679f1ad38b230090eadd3870b7682500f60c#egg=zulint==0.0.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -63,6 +63,7 @@ docker==4.0.2             # via moto
 docutils==0.14            # via botocore, recommonmark, sphinx
 ecdsa==0.13.2             # via python-jose, sshpubkeys
 fakeldap==0.6.1
+# future==0.17.1            # via commonmark, python-jose, python-twitter
 gitlint==0.12.0
 h2==2.6.2                 # via hyper
 hpack==3.0.0              # via h2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -63,7 +63,6 @@ docker==4.0.2             # via moto
 docutils==0.14            # via botocore, recommonmark, sphinx
 ecdsa==0.13.2             # via python-jose, sshpubkeys
 fakeldap==0.6.1
-first==2.0.2              # via pip-tools
 gitlint==0.12.0
 h2==2.6.2                 # via hyper
 hpack==3.0.0              # via h2
@@ -107,7 +106,7 @@ phonenumberslite==8.10.15
 pickleshare==0.7.5        # via ipython
 pika==0.13.0
 pillow==6.1.0
-pip-tools==2.0.2
+pip-tools==3.8.0
 polib==1.1.0
 premailer==3.5.0
 prompt-toolkit==1.0.16    # via ipython
@@ -189,3 +188,7 @@ wrapt==1.11.2             # via aws-xray-sdk
 xmltodict==0.12.0         # via moto
 yamole==2.1.6
 zope.interface==4.6.0     # via datetime, twisted
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip==19.2.2
+# setuptools==41.2.0        # via cfn-lint, ipython, jsonschema, markdown, pyhamcrest, sphinx, zope.interface

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,13 +9,6 @@
 #
 --no-binary psycopg2
 
-git+https://github.com/zulip/libthumbor.git@60ed2431c07686a12f2770b2d852c5650f3ccfc6#egg=libthumbor==1.3.2zulip
-git+https://github.com/zulip/line_profiler.git#egg=line_profiler==2.1.2.zulip1
-git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
-git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
-git+https://github.com/zulip/zulint@aaed679f1ad38b230090eadd3870b7682500f60c#egg=zulint==0.0.1
-git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca60acf650da#egg=zulip==0.6.1_git&subdirectory=zulip
-git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca60acf650da#egg=zulip_bots==0.6.1+git&subdirectory=zulip_bots
 alabaster==0.7.12         # via sphinx
 apns2==0.5.0
 argon2-cffi==19.1.0
@@ -89,6 +82,8 @@ jsonpatch==1.23           # via cfn-lint
 jsonpickle==1.2           # via aws-xray-sdk, python-digitalocean
 jsonpointer==2.0          # via jsonpatch
 jsonschema==3.0.1         # via aws-sam-translator, cfn-lint
+git+https://github.com/zulip/libthumbor.git@60ed2431c07686a12f2770b2d852c5650f3ccfc6#egg=libthumbor==1.3.2zulip
+git+https://github.com/zulip/line_profiler.git#egg=line_profiler==2.1.2.zulip1
 lxml==4.3.4
 markdown-include==0.5.1
 markdown==3.1.1
@@ -171,6 +166,7 @@ sqlalchemy==1.3.6
 sshpubkeys==3.1.0         # via moto
 statsd==3.3.0             # via django-statsd-mozilla
 stripe==2.35.0
+git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
 tblib==1.4.0
 tornado==4.5.3
 traitlets==4.3.2          # via ipython
@@ -179,6 +175,7 @@ twilio==6.29.2
 twisted==19.2.1
 typed-ast==1.4.0          # via mypy
 typing-extensions==3.7.4
+git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
 urllib3==1.25.3           # via botocore, requests, transifex-client
 virtualenv-clone==0.5.3
 w3lib==1.20.0             # via parsel, scrapy
@@ -189,6 +186,9 @@ wrapt==1.11.2             # via aws-xray-sdk
 xmltodict==0.12.0         # via moto
 yamole==2.1.6
 zope.interface==4.6.0     # via datetime, twisted
+git+https://github.com/zulip/zulint@aaed679f1ad38b230090eadd3870b7682500f60c#egg=zulint==0.0.1
+git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca60acf650da#egg=zulip==0.6.1_git&subdirectory=zulip
+git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca60acf650da#egg=zulip_bots==0.6.1+git&subdirectory=zulip_bots
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip==19.2.2

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -29,3 +29,6 @@ sphinx-rtd-theme==0.4.3
 sphinx==1.8.4
 sphinxcontrib-websupport==1.1.2  # via sphinx
 urllib3==1.25.3           # via requests
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools==41.2.0        # via sphinx

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -13,6 +13,7 @@ certifi==2019.6.16        # via requests
 chardet==3.0.4            # via requests
 commonmark==0.9.0
 docutils==0.14            # via recommonmark, sphinx
+# future==0.17.1            # via commonmark
 idna==2.8                 # via requests
 imagesize==1.1.0          # via sphinx
 jinja2==2.10.1            # via sphinx

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,4 +1,4 @@
 # Dependencies for setting up pip to install our requirements.txt file.
-pip==19.2.1
+pip==19.1.1
 setuptools==41.0.1
 wheel==0.33.4

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -9,12 +9,6 @@
 #
 --no-binary psycopg2
 
-git+https://github.com/zulip/libthumbor.git@60ed2431c07686a12f2770b2d852c5650f3ccfc6#egg=libthumbor==1.3.2zulip
-git+https://github.com/zulip/line_profiler.git#egg=line_profiler==2.1.2.zulip1
-git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
-git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
-git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca60acf650da#egg=zulip==0.6.1_git&subdirectory=zulip
-git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca60acf650da#egg=zulip_bots==0.6.1+git&subdirectory=zulip_bots
 apns2==0.5.0
 argon2-cffi==19.1.0
 asn1crypto==0.24.0        # via cryptography
@@ -59,6 +53,8 @@ ipython-genutils==0.2.0   # via traitlets
 ipython==6.5.0
 jedi==0.14.0              # via ipython
 jinja2==2.10.1
+git+https://github.com/zulip/libthumbor.git@60ed2431c07686a12f2770b2d852c5650f3ccfc6#egg=libthumbor==1.3.2zulip
+git+https://github.com/zulip/line_profiler.git#egg=line_profiler==2.1.2.zulip1
 lxml==4.3.4
 markdown-include==0.5.1
 markdown==3.1.1
@@ -111,15 +107,19 @@ sourcemap==0.2.1
 sqlalchemy==1.3.6
 statsd==3.3.0             # via django-statsd-mozilla
 stripe==2.35.0
+git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#egg=talon==1.2.10.zulip1
 tornado==4.5.3
 traitlets==4.3.2          # via ipython
 twilio==6.29.2
 typing_extensions==3.7.4
+git+https://github.com/zulip/ultrajson@70ac02bec#egg=ujson==1.35+git
 urllib3==1.25.3           # via requests
 uwsgi==2.0.17.1
 virtualenv-clone==0.5.3
 wcwidth==0.1.7            # via prompt-toolkit
 yamole==2.1.6
+git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca60acf650da#egg=zulip==0.6.1_git&subdirectory=zulip
+git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca60acf650da#egg=zulip_bots==0.6.1+git&subdirectory=zulip_bots
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip==19.2.2

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -119,3 +119,7 @@ uwsgi==2.0.17.1
 virtualenv-clone==0.5.3
 wcwidth==0.1.7            # via prompt-toolkit
 yamole==2.1.6
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip==19.2.2
+# setuptools==41.2.0        # via ipython, markdown

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -44,6 +44,7 @@ django-statsd-mozilla==0.4.0
 django-two-factor-auth==1.9.1
 django-webpack-loader==0.6.0
 django==1.11.23
+# future==0.17.1            # via python-twitter
 h2==2.6.2                 # via hyper
 hpack==3.0.0              # via h2
 html2text==2018.1.9

--- a/requirements/unupgradable.json
+++ b/requirements/unupgradable.json
@@ -14,8 +14,11 @@
     "transifex-client": {
         "issue": "https://github.com/zulip/zulip/issues/8914"
     },
+    "pip": {
+        "issue": "https://github.com/zulip/zulip/issues/13067"
+    },
     "pip-tools": {
-        "issue": "https://github.com/zulip/zulip/issues/10802"
+        "issue": "https://github.com/zulip/zulip/issues/13067"
     },
     "defusedxml": {
         "issue": "https://github.com/zulip/zulip/issues/12191"

--- a/tools/test-locked-requirements
+++ b/tools/test-locked-requirements
@@ -31,8 +31,7 @@ def print_diff(path_file1, path_file2):
                 fromfile=path_file1,
                 tofile=path_file2,
             )
-    for line in diff:
-        print(line)
+    sys.stdout.writelines(diff)
 
 def test_locked_requirements(tmp_dir):
     # type: (str) -> bool
@@ -44,8 +43,7 @@ def test_locked_requirements(tmp_dir):
         locked_file = os.path.join(REQS_DIR, fn)
         test_locked_file = os.path.join(tmp_dir, fn)
         shutil.copyfile(locked_file, test_locked_file)
-    subprocess.check_call([os.path.join(TOOLS_DIR, 'update-locked-requirements'), '--output-dir', tmp_dir],
-                          stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    subprocess.check_call([os.path.join(TOOLS_DIR, 'update-locked-requirements'), '--output-dir', tmp_dir])
 
     same = True
     for fn in LOCKED_REQS_FILE_NAMES:
@@ -114,7 +112,7 @@ def main():
         for fn in LOCKED_REQS_FILE_NAMES:
             locked_file = os.path.join(REQS_DIR, fn)
             test_locked_file = os.path.join(tmp_dir, fn)
-            print_diff(test_locked_file, locked_file)
+            print_diff(locked_file, test_locked_file)
         # Flush the output to ensure we print the error at the end.
         sys.stdout.flush()
         raise Exception("It looks like you have updated some python dependencies but haven't "

--- a/tools/update-locked-requirements
+++ b/tools/update-locked-requirements
@@ -14,12 +14,6 @@ compile_requirements () {
 
     pip-compile --quiet --output-file "$output" "$source"
 
-    # Remove the editable flag.  It's there because pip-compile can't
-    # yet do without it (see
-    # https://github.com/jazzband/pip-tools/issues/272 upstream), but
-    # in the output of pip-compile it's no longer needed.
-    sed -i 's/-e //' "$output"
-
     if [ "$python_version" != "py2" ]; then
         # Remove an unnecessary future requirement declared by commonmark,
         # python-jose, and python-twitter.

--- a/tools/update-locked-requirements
+++ b/tools/update-locked-requirements
@@ -21,9 +21,12 @@ compile_requirements () {
     sed -i 's/-e //' "$output"
 
     if [ "$python_version" != "py2" ]; then
-        # pip-tools bug; future, futures are obsolete in python3
-        sed -i '/futures==/d' "$output"
-        sed -i '/future==/d' "$output"
+        # Remove an unnecessary future requirement declared by commonmark,
+        # python-jose, and python-twitter.
+        # https://github.com/readthedocs/commonmark.py/pull/188
+        # https://github.com/mpdavis/python-jose/pull/134
+        # https://github.com/bear/python-twitter/pull/614
+        sed -i 's/^future==/# &/' "$output"
     fi
 
     (

--- a/tools/update-locked-requirements
+++ b/tools/update-locked-requirements
@@ -41,6 +41,9 @@ EOF
         # This perl invocation strips the existing block of header comments.
         perl -0pe 's/\A(^#.*\n)*//m' "$output"
     ) | sponge "$output"
+
+    # Work around https://github.com/jazzband/pip-tools/issues/268
+    chmod a+r "$output"
 }
 
 OUTPUT_BASE_DIR='requirements'

--- a/tools/update-locked-requirements
+++ b/tools/update-locked-requirements
@@ -12,7 +12,7 @@ compile_requirements () {
     output="$2"
     python_version="$3"
 
-    pip-compile --quiet --output-file "$output" "$source"
+    pip-compile --quiet --no-header --output-file "$output" "$source"
 
     if [ "$python_version" != "py2" ]; then
         # Remove an unnecessary future requirement declared by commonmark,
@@ -23,8 +23,7 @@ compile_requirements () {
         sed -i 's/^future==/# &/' "$output"
     fi
 
-    (
-        cat <<EOF
+    cat - "$output" <<EOF | sponge "$output"
 #
 # This file is GENERATED.  Don't edit directly.
 #
@@ -35,9 +34,6 @@ compile_requirements () {
 # For details, see requirements/README.md .
 #
 EOF
-        # This perl invocation strips the existing block of header comments.
-        perl -0pe 's/\A(^#.*\n)*//m' "$output"
-    ) | sponge "$output"
 
     # Work around https://github.com/jazzband/pip-tools/issues/268
     chmod a+r "$output"

--- a/tools/update-locked-requirements
+++ b/tools/update-locked-requirements
@@ -12,7 +12,7 @@ compile_requirements () {
     output="$2"
     python_version="$3"
 
-    pip-compile --output-file "$output" "$source"
+    pip-compile --quiet --output-file "$output" "$source"
 
     # Remove the editable flag.  It's there because pip-compile can't
     # yet do without it (see

--- a/version.py
+++ b/version.py
@@ -26,4 +26,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '49.1'
+PROVISION_VERSION = '49.2'


### PR DESCRIPTION
These are not the latest versions, but pip-tools 3.9.0 or 4.0.0 fails to resolve dependencies from Git URLs (jazzband/pip-tools#851):

`pip._internal.exceptions.DistributionNotFound: No matching distribution found for zulip==0.6.1_git (from -r requirements/common.in (line 135))`

while pip 19.2 breaks pip-tools 3.8.0 (jazzband/pip-tools#853):

`TypeError: __init__() got an unexpected keyword argument 'find_links'`

Fixes #10802, and enables some other cleanup:

* Run `pip-compile` with `--quiet`, so we don’t have to silence its stderr in `test-locked-requirements`. While there, I made some fixes to the diff output.
* Remove the editable flag from `*.in`, and the code in `update-locked-requirements` that deletes it from `*.txt` (fixes #12374). While there, I improved the `futures`/`future` situation a bit.

Somehow this avoids the setuptools problem that #12399 ran into. Cc: @hackerkid.