### PR TITLE
data export: Fix sort regression and perma-success banner bug.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -60,6 +60,7 @@ set_global('settings_exports', {
     populate_exports_table: function (exports) {
         return exports;
     },
+    clear_success_banner: noop,
 });
 
 // page_params is highly coupled to dispatching now

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -512,6 +512,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
         break;
     case 'realm_export':
         settings_exports.populate_exports_table(event.exports);
+        settings_exports.clear_success_banner();
         break;
     }
 

--- a/static/js/settings_exports.js
+++ b/static/js/settings_exports.js
@@ -12,6 +12,18 @@ exports.reset = function () {
     meta.loaded = false;
 };
 
+exports.clear_success_banner = function () {
+    var export_status = $('#export_status');
+    if (export_status.hasClass('alert-success')) {
+        // Politely remove our success banner if the export
+        // finishes before the view is closed.
+        export_status.fadeTo(200, 0);
+        setTimeout(function () {
+            export_status.hide();
+        }, 205);
+    }
+};
+
 exports.populate_exports_table = function (exports) {
     if (!meta.loaded) {
         return;

--- a/static/js/settings_exports.js
+++ b/static/js/settings_exports.js
@@ -18,8 +18,8 @@ exports.populate_exports_table = function (exports) {
     }
 
     var exports_table = $('#admin_exports_table').expectOne();
-    var exports_list = list_render.create(exports_table, exports, {
-        name: "admin-exports-list",
+    var exports_list = list_render.create(exports_table, Object.values(exports), {
+        name: "admin_exports_list",
         modifier: function (data) {
             if (data.export_data.deleted_timestamp === undefined) {
                 return render_admin_export_list({
@@ -46,7 +46,7 @@ exports.populate_exports_table = function (exports) {
             },
         },
         parent_container: $("#data-exports").expectOne(),
-    });
+    }).init();
 
     exports_list.add_sort_function("user", function (a, b) {
         var a_name = people.get_full_name(a.acting_user_id).toLowerCase();

--- a/static/templates/settings/data_exports_admin.hbs
+++ b/static/templates/settings/data_exports_admin.hbs
@@ -28,7 +28,9 @@
         </div>
     </form>
     {{/if}}
-    <div class="admin-table-wrapper">
+    <input type="hidden" class="search" placeholder="{{t 'Filter exports' }}"
+      aria-label="{{t 'Filter exports' }}"/>
+    <div class="progressive-table-wrapper" data-simplebar data-list-render="admin_exports_list">
         <table class="table table-condensed table-striped wrapped-table admin_exports_table">
             <thead>
                 <th class="active" data-sort="user">{{t "Requesting user" }}</th>


### PR DESCRIPTION
### 1st commit
Looks like a regression was caused in 02cfb47315322c88b7b3730ba7a784fd67094121 as a result of removing the following tags (related #13049):
```html
<input type="text" class="search" placeholder="{{t 'Filter exports' }}"
  aria-label="{{t 'Filter exports' }}"/>
<div class="progressive-table-wrapper" data-simplebar data-list-render="admin_exports_list">
```
Also updated to use `Object.values(exports)` to return an array of each exports enumerable values.  As well as adding `.init()` which looks standard for implementations of this kind, but were missing here.

### 2nd commit
This Fixes #13045. I tried using `ui_report` in this situation, but nothing really seems to work for what we want.  So with this approach it fades and hides the `div`.

![hide_banner](https://user-images.githubusercontent.com/39782863/63646728-255fed00-c6b3-11e9-9b95-da0d80a5f93f.gif)
