### PR TITLE
requirements: Include packages that pip-tools considers unsafe.

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -191,5 +191,5 @@ git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca
 git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca60acf650da#egg=zulip_bots==0.6.1+git&subdirectory=zulip_bots
 
 # The following packages are considered to be unsafe in a requirements file:
-# pip==19.2.3
-# setuptools==41.2.0        # via cfn-lint, ipython, jsonschema, markdown, pyhamcrest, sphinx, zope.interface
+pip==19.1.1
+setuptools==41.0.1        # via cfn-lint, ipython, jsonschema, markdown, pyhamcrest, sphinx, zope.interface

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -32,4 +32,4 @@ sphinxcontrib-websupport==1.1.2  # via sphinx
 urllib3==1.25.3           # via requests
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.2.0        # via sphinx
+setuptools==41.0.1        # via sphinx

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -122,5 +122,5 @@ git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca
 git+https://github.com/zulip/python-zulip-api.git@804501610b6a205334e71b4e441fca60acf650da#egg=zulip_bots==0.6.1+git&subdirectory=zulip_bots
 
 # The following packages are considered to be unsafe in a requirements file:
-# pip==19.2.3
-# setuptools==41.2.0        # via ipython, markdown
+pip==19.1.1
+setuptools==41.0.1        # via ipython, markdown

--- a/tools/update-locked-requirements
+++ b/tools/update-locked-requirements
@@ -12,7 +12,7 @@ compile_requirements () {
     output="$2"
     python_version="$3"
 
-    pip-compile --quiet --no-header --output-file "$output" "$source"
+    pip-compile --quiet --allow-unsafe --no-header --output-file "$output" "$source"
 
     if [ "$python_version" != "py2" ]; then
         # Remove an unnecessary future requirement declared by commonmark,


### PR DESCRIPTION
It’s unclear why pip-tools considers these packages unsafe (pypa/pip#6459), and excluding them from being pinned has resulted in nondeterministic output that makes our test suite unhappy.