### PR TITLE
markdown: Process fenced code blocks in blockquotes.

### DIFF
--- a/zerver/lib/bugdown/fenced_code.py
+++ b/zerver/lib/bugdown/fenced_code.py
@@ -293,7 +293,6 @@ class FencedBlockPreprocessor(markdown.preprocessors.Preprocessor):
 
         handler = OuterHandler(processor, output, self.run_content_validators)
         self.push(handler)
-
         for line in lines:
             self.handlers[-1].handle_line(line)
 

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -95,6 +95,12 @@
       "expected_output": "<blockquote>\n<p>text</p>\n</blockquote>"
     },
     {
+      "name": "blockquote_with_fenced_code",
+      "input": "> ```\n> multilne\n> codeblock\n> ```",
+      "expected_output": "<blockquote>\n<div class=\"codehilite\"><pre><span></span>multilne\ncodeblock\n</pre></div>\n\n\n</blockquote>",
+      "marked_expected_output": "<blockquote>\n<div class=\"codehilite\"><pre>multilne\ncodeblock\n</pre></div>\n\n\n</blockquote>"
+    },
+    {
       "name": "fenced_quote_with_hashtag",
       "input": "```quote\n# line 1\n#line 2\n```",
       "expected_output": "<blockquote>\n<h1>line 1</h1>\n<p>#line 2</p>\n</blockquote>",


### PR DESCRIPTION
We handle fenced code blocks in a preprocessor, and > style blockquotes
are parsed in a blockprocessor. Pymarkdown doesn't run the preprocessors
again on any blocks that it is parsing, and is unlikely to accept our
solution upstream; they intend to convert fenced_code to a block parser.

We simply run all the preprocessors on the text again, with the exteption
of NormalizeWhitespace which removed delimiters used by HtmlStash to mark
preprocessed html code. To counter this, we subclass NormalizeWhitespace
and use our customized version for when it is called from a blockparser.

Upstream issue: https://github.com/Python-Markdown/markdown/issues/53

Fixes #12800.

**Testing Plan:** <!-- How have you tested? -->
Manual testing + automated tests.

