### PR TITLE
Autolink (Custom protocols + Link Anywhere)

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1430,11 +1430,19 @@ class CompiledPattern(markdown.inlinepatterns.Pattern):
         self.compiled_re = compiled_re
         self.md = md
 
-class AutoLink(CompiledPattern):
-    def handleMatch(self, match: Match[str]) -> ElementStringNone:
+class CompiledInlineProcessor(markdown.inlinepatterns.InlineProcessor):
+    def __init__(self, compiled_re: Pattern, md: markdown.Markdown) -> None:
+        # This is similar to the superclass's small __init__ function,
+        # but we skip the compilation step and let the caller give us
+        # a compiled regex.
+        self.compiled_re = compiled_re
+        self.md = md
+
+class AutoLink(CompiledInlineProcessor):
+    def handleMatch(self, match: Match[str], data: str) -> Tuple[ElementStringNone, int, int]:
         url = match.group('url')
         db_data = self.markdown.zulip_db_data
-        return url_to_a(db_data, url)
+        return url_to_a(db_data, url), match.start('url'), match.end('url')
 
 class OListProcessor(sane_lists.SaneOListProcessor):
     def __init__(self, parser: Any) -> None:

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -163,7 +163,7 @@ def get_web_link_regex() -> str:
         nested_paren_chunk = nested_paren_chunk % (paren_group,)
     nested_paren_chunk = nested_paren_chunk % (inner_paren_contents,)
 
-    file_links = r"| (?:file://(/[^/ ]*)+/?)" if settings.ENABLE_FILE_LINKS else r""
+    file_links = r"| (?:file://(/[^/ ]*)+/?)"
     REGEX = r"""
         (?<![^\s'"\(,:<])    # Start after whitespace or specified chars
                              # (Double-negative lookbehind to allow start-of-string)
@@ -179,7 +179,7 @@ def get_web_link_regex() -> str:
                 %s           # zero-to-6 sets of paired parens
             )?)              # Path is optional
             | (?:[\w.-]+\@[\w.-]+\.[\w]+) # Email is separate, since it can't have a path
-            %s               # File path start with file:///, enable by setting ENABLE_FILE_LINKS=True
+            %s               # File path start with file:///
             | (?:bitcoin:[13][a-km-zA-HJ-NP-Z1-9]{25,34})  # Bitcoin address pattern, see https://mokagio.github.io/tech-journal/2014/11/21/regex-bitcoin.html
         )
         (?=                            # URL must be followed by (not included in group)
@@ -192,8 +192,8 @@ def get_web_link_regex() -> str:
 
 def clear_state_for_testing() -> None:
     # The link regex never changes in production, but our tests
-    # try out both sides of ENABLE_FILE_LINKS, so we need
-    # a way to clear it.
+    # try out multiple forms of the link regex, so we need a way
+    # to clear it.
     global LINK_REGEX
     LINK_REGEX = None
 

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -1188,6 +1188,76 @@
       "quora http://generate.quora.net/render?width=700&from=-4hours&until=now&height=400&bgcolor=black&lineMode=connected&title=arb%20hint%20status&target=alias(ans.hintland.hand.arb.enhint_rate%2C%22enhint%20rate%22)&target=alias(ans.hintland.hand.arb.unhint_rate%2C%22unhint%20rate%22)&target=alias(ans.hintland.hand.arb.size%2C%22hint%20size%22)&target=alias(scale(ans.vagabond.dingarb_cube_count%2C10000)%2C%22cube%20count%20x%2010K%22)&target=alias(scale(hnumbers.time.ding.gegevens.query.count%2C10)%2C%22ding%20gegevens%20query%20count%20x%2010%22)&fgcolor=white&uniq=0.44046106841415167",
       "<p>quora %s</p>",
       "http://generate.quora.net/render?width=700&amp;from=-4hours&amp;until=now&amp;height=400&amp;bgcolor=black&amp;lineMode=connected&amp;title=arb%20hint%20status&amp;target=alias(ans.hintland.hand.arb.enhint_rate%2C%22enhint%20rate%22)&amp;target=alias(ans.hintland.hand.arb.unhint_rate%2C%22unhint%20rate%22)&amp;target=alias(ans.hintland.hand.arb.size%2C%22hint%20size%22)&amp;target=alias(scale(ans.vagabond.dingarb_cube_count%2C10000)%2C%22cube%20count%20x%2010K%22)&amp;target=alias(scale(hnumbers.time.ding.gegevens.query.count%2C10)%2C%22ding%20gegevens%20query%20count%20x%2010%22)&amp;fgcolor=white&amp;uniq=0.44046106841415167"
+    ],
+    [
+      "do not autolink custom schemes outside angle brackets: : custom://www.google.com.",
+      "<p>do not autolink custom schemes outside angle brackets: : custom://www.google.com.</p>",
+      ""
+    ],
+    [
+      "===================== TESTS FOR BRACKETED LINKS =====================",
+      "<p>===================== TESTS FOR BRACKETED LINKS =====================</p>",
+      ""
+    ],
+    [
+      "simple http link: <http://www.google.com>.",
+      "<p>simple http link: &lt;%s&gt;.</p>",
+      "http://www.google.com"
+    ],
+    [
+      "custom scheme: <irc://www.google.com>.",
+      "<p>custom scheme: &lt;%s&gt;.</p>",
+      "irc://www.google.com"
+    ],
+    [
+      "custom scheme: <random-but+totally.valid://any-text-here>.",
+      "<p>custom scheme: &lt;%s&gt;.</p>",
+      "random-but+totally.valid://any-text-here"
+    ],
+    [
+      "file urls: <file://any-text-here>.",
+      "<p>file urls: &lt;%s&gt;.</p>",
+      "file://any-text-here"
+    ],
+    [
+      "file urls: <file:///any-text-here>.",
+      "<p>file urls: &lt;%s&gt;.</p>",
+      "file:///any-text-here"
+    ],
+    [
+      "blocked custom scheme: <javascript://www.google.com>.",
+      "<p>blocked custom scheme: &lt;javascript://www.google.com&gt;.</p>",
+      ""
+    ],
+    [
+      "blocked custom scheme: <JaVaScRiPt://www.google.com>.",
+      "<p>blocked custom scheme: &lt;JaVaScRiPt://www.google.com&gt;.</p>",
+      ""
+    ],
+    [
+      "blocked custom scheme: <vbscript://www.google.com>.",
+      "<p>blocked custom scheme: &lt;vbscript://www.google.com&gt;.</p>",
+      ""
+    ],
+    [
+      "blocked custom scheme: <data:something://www.google.com>.",
+      "<p>blocked custom scheme: &lt;data:something://www.google.com&gt;.</p>",
+      ""
+    ],
+    [
+      "deviating from commonmark by rendering urls without scheme: <google.com>.",
+      "<p>deviating from commonmark by rendering urls without scheme: &lt;%s&gt;.</p>",
+      "google.com"
+    ],
+    [
+      "but scheme-less url with invalid tlds are ignored: <google.definitelynotatld>.",
+      "<p>but scheme-less url with invalid tlds are ignored: &lt;google.definitelynotatld&gt;.</p>",
+      ""
+    ],
+    [
+      "no data links: <data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==>.",
+      "<p>no data links: &lt;data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==&gt;.</p>",
+      ""
     ]
   ]
 }

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -429,14 +429,8 @@ class BugdownTest(ZulipTestCase):
     def test_inline_file(self) -> None:
         msg = 'Check out this file file:///Volumes/myserver/Users/Shared/pi.py'
         converted = bugdown_convert(msg)
-        self.assertEqual(converted, '<p>Check out this file <a href="file:///Volumes/myserver/Users/Shared/pi.py">file:///Volumes/myserver/Users/Shared/pi.py</a></p>')
-
-        bugdown.clear_state_for_testing()
-        with self.settings(ENABLE_FILE_LINKS=False):
-            realm = Realm.objects.create(string_id='file_links_test')
-            bugdown.maybe_update_markdown_engines(realm.id, False)
-            converted = bugdown.convert(msg, message_realm=realm)
-            self.assertEqual(converted, '<p>Check out this file file:///Volumes/myserver/Users/Shared/pi.py</p>')
+        expected = '<p>Check out this file <a href="file:///Volumes/myserver/Users/Shared/pi.py">file:///Volumes/myserver/Users/Shared/pi.py</a></p>'
+        self.assertEqual(converted, expected)
 
     def test_inline_bitcoin(self) -> None:
         msg = 'To bitcoin:1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa or not to bitcoin'

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -48,6 +48,7 @@ import mock
 import os
 import ujson
 import re
+import urllib
 
 from typing import cast, Any, Dict, List, Optional, Set, Tuple
 
@@ -408,7 +409,8 @@ class BugdownTest(ZulipTestCase):
                 self.assertEqual(converted, test['expected_output'])
 
         def replaced(payload: str, url: str, phrase: str='') -> str:
-            if url[:4] == 'http':
+            scheme, netloc, path, params, query, fragment = urllib.parse.urlparse(url)
+            if scheme:
                 href = url
             elif '@' in url:
                 href = 'mailto:' + url
@@ -424,7 +426,7 @@ class BugdownTest(ZulipTestCase):
                 except TypeError:
                     match = reference
                 converted = bugdown_convert(inline_url)
-                self.assertEqual(match, converted)
+                self.assertEqual(match, converted, "Original messsage: {}".format(inline_url))
 
     def test_inline_file(self) -> None:
         msg = 'Check out this file file:///Volumes/myserver/Users/Shared/pi.py'

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -126,7 +126,6 @@ PRIVACY_POLICY: Optional[str] = None
 TERMS_OF_SERVICE: Optional[str] = None
 
 # Security
-ENABLE_FILE_LINKS = False
 ENABLE_GRAVATAR = True
 INLINE_IMAGE_PREVIEW = True
 INLINE_URL_EMBED_PREVIEW = True

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -367,10 +367,6 @@ SESSION_COOKIE_AGE = 60 * 60 * 24 * 7 * 2  # 2 weeks
 # can also be disabled in a realm's organization settings.
 #INLINE_URL_EMBED_PREVIEW = True
 
-# Controls whether or not Zulip will parse links starting with
-# "file:///" as a hyperlink (useful if you have e.g. an NFS share).
-ENABLE_FILE_LINKS = False
-
 # By default, files uploaded by users and profile pictures are stored
 # directly on the Zulip server.  You can configure files being instead
 # stored in Amazon S3 or another scalable data store here.  See docs at:

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -138,9 +138,6 @@ if not CASPER_TESTS:
     set_loglevel('zerver.worker.queue_processors', 'WARNING')
     set_loglevel('stripe', 'WARNING')
 
-# Enable file:/// hyperlink support by default in tests
-ENABLE_FILE_LINKS = True
-
 # These settings are set dynamically in `zerver/lib/test_runner.py`:
 TEST_WORKER_DIR = ''
 # Allow setting LOCAL_UPLOADS_DIR in the environment so that the


### PR DESCRIPTION
Concerns #10797 and #10450.

Current plan:

- [x] Add a liberal link regex that allows linking to any url scheme.
- [x] Allow regular autolink regex to match http and https links anywhere in the text.

@timabbott please take a look at the test cases I've had to change so far. I'm not sure if autolinking any random scheme is a good idea after all.

We could do something simple like providing a server level setting in `settings.py` to where people can list custom protocols that want to enable for links, and keep the existing links regex with minor changes to `sanitize_url` to allow the specified protocols.

**Testing Plan:**

Automated tests for bugdown and marked.