### PR TITLE
topic_list: Limit number of unread topics shown at once.

### DIFF
--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -317,9 +317,22 @@ exports.update_dom_with_unread_counts = function (counts) {
 
     // counts.topic_count maps streams to hashes of topics to counts
     counts.topic_count.each(function (topic_hash, stream_id) {
+        // Because the topic_list data structure doesn't keep track of
+        // which topics the "more topics" unread count came from, we
+        // need to compute the correct value from scratch here.
+        let more_topics_total = 0;
         topic_hash.each(function (count, topic) {
-            topic_list.set_count(stream_id, topic, count);
+            const in_more_topics = topic_list.set_count(stream_id, topic, count);
+            if (in_more_topics === true) {
+                more_topics_total += count;
+            }
         });
+        if (topic_list.active_stream_id() === stream_id) {
+            // Update the "more topics" unread count; we communicate
+            // this to the `topic_list` library by passing `null` as
+            // the topic.
+            topic_list.set_count(stream_id, null, more_topics_total);
+        }
     });
 };
 

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -39,8 +39,10 @@ $topic_indent: calc($far_left_gutter_size + $left_col_size + 4px);
     font-size: 14px;
 }
 
-li.show-more-topics a {
-    font-size: 12px;
+li.show-more-topics {
+    a {
+        font-size: 12px;
+    }
 }
 
 #left-sidebar #user-list,
@@ -425,7 +427,6 @@ ul.expanded_private_messages {
     margin-top: 3px;
 }
 
-li.show-more-topics,
 li.topic-list-item {
     position: relative;
     padding-right: 5px;
@@ -469,6 +470,7 @@ li.expanded_private_message a {
 }
 
 .zero-pm-unreads .pm-box,
+.zero-topic-unreads .more-topics-box,
 .zero-topic-unreads .topic-box {
     margin-right: 15px;
 }
@@ -514,10 +516,6 @@ li.expanded_private_message a {
 
 .zero_count {
     visibility: hidden;
-}
-
-li.show-more-topics a {
-    margin-left: 5px;
 }
 
 .searching-for-more-topics {

--- a/static/templates/more_topics.hbs
+++ b/static/templates/more_topics.hbs
@@ -1,5 +1,10 @@
-<li class="show-more-topics bottom_left_row">
-    <a href="#">{{t "more topics" }}</a>
+<li class="topic-list-item show-more-topics bottom_left_row {{#unless more_topics_unreads}}zero-topic-unreads{{/unless}}">
+    <span class='topic-box'>
+        <a class="topic-name" href="#">{{t "more topics" }}</a>
+        <div class="topic-unread-count {{#unless more_topics_unreads}}zero_count{{/unless}}">
+            <div class="value">{{more_topics_unreads}}</div>
+        </div>
+    </span>
 </li>
 <li class="searching-for-more-topics">
     <img src="/static/images/loading-ellipsis.svg" alt="" />


### PR DESCRIPTION
This avoids a stream having potentially near-infinite height when
opened in a stream with a large number of unread topics; the benefit
is that you can easily access the next stream.

We show an unread count next to "more unread topics" to make it hard
to miss.

Needs CSS work to make the count align properly and ideally some tests.

Fixes #13087.

(Ideally, someone else would take over this PR and finish the remaining bits).