### PR TITLE
production-helper: Clarify log output on check_rabbitmq_consumers failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,11 +45,11 @@ aliases:
         rm -f /home/circleci/.gitconfig
 
         # This is the main setup job for the test suite
-        mispipe "tools/ci/setup-backend" ts
+        mispipe "tools/ci/setup-backend 2>&1" ts
 
         # Cleaning caches is mostly unnecessary in Circle, because
         # most builds don't get to write to the cache.
-        # mispipe "scripts/lib/clean-unused-caches --verbose --threshold 0" ts
+        # mispipe "scripts/lib/clean-unused-caches --verbose --threshold 0 2>&1" ts
 
   - &save_cache_package_json
     save_cache:
@@ -82,14 +82,14 @@ aliases:
       name: run backend tests
       command: |
         . /srv/zulip-py3-venv/bin/activate
-        mispipe ./tools/ci/backend ts
+        mispipe "./tools/ci/backend 2>&1" ts
 
   - &run_frontend_tests
     run:
       name: run frontend tests
       command: |
         . /srv/zulip-py3-venv/bin/activate
-        mispipe ./tools/ci/frontend ts
+        mispipe "./tools/ci/frontend 2>&1" ts
 
   - &upload_coverage_report
     run:
@@ -119,7 +119,7 @@ aliases:
         # Install moreutils so we can use `ts` and `mispipe` in the following.
         sudo apt-get install -y moreutils
 
-        mispipe ./tools/ci/production-build ts
+        mispipe "./tools/ci/production-build 2>&1" ts
 
   - &production_extract_tarball
     run:
@@ -129,14 +129,14 @@ aliases:
       # Install moreutils so we can use `ts` and `mispipe` in the following.
       sudo apt-get install -y moreutils
 
-      mispipe /tmp/production-extract-tarball ts
+      mispipe "/tmp/production-extract-tarball 2>&1" ts
 
   - &install_production
     run:
      name: install production
      command: |
       sudo service rabbitmq-server restart
-      sudo mispipe /tmp/production-install ts
+      sudo mispipe "/tmp/production-install 2>&1" ts
 
   - &check_xenial_provision_error
     run:
@@ -192,7 +192,7 @@ jobs:
           name: test locked requirements
           command: |
             . /srv/zulip-py3-venv/bin/activate
-            mispipe ./tools/test-locked-requirements ts
+            mispipe "./tools/test-locked-requirements 2>&1" ts
 
       - *run_frontend_tests
         # We only need to upload coverage reports on whichever platform

--- a/scripts/nagios/cron_file_helper.py
+++ b/scripts/nagios/cron_file_helper.py
@@ -11,25 +11,31 @@ def nagios_from_file(results_file: str) -> Tuple[int, str]:
     This file is created by various nagios checking cron jobs such as
     check-rabbitmq-queues and check-rabbitmq-consumers"""
 
-    with open(results_file) as f:
-        data = f.read().strip()
-    pieces = data.split('|')
-
-    if not len(pieces) == 4:
+    try:
+        with open(results_file) as f:
+            data = f.read().strip()
+    except FileNotFoundError:
         state = 'UNKNOWN'
         ret = 3
-        data = "Results file malformed"
+        data = "Results file is missing"
     else:
-        timestamp = int(pieces[0])
+        pieces = data.split('|')
 
-        time_diff = time.time() - timestamp
-        if time_diff > 60 * 2:
-            ret = 3
+        if not len(pieces) == 4:
             state = 'UNKNOWN'
-            data = "Results file is stale"
+            ret = 3
+            data = "Results file malformed"
         else:
-            ret = int(pieces[1])
-            state = pieces[2]
-            data = pieces[3]
+            timestamp = int(pieces[0])
+
+            time_diff = time.time() - timestamp
+            if time_diff > 60 * 2:
+                ret = 3
+                state = 'UNKNOWN'
+                data = "Results file is stale"
+            else:
+                ret = int(pieces[1])
+                state = pieces[2]
+                data = pieces[3]
 
     return (ret, f"{state}: {data}")

--- a/tools/ci/production-install
+++ b/tools/ci/production-install
@@ -100,12 +100,10 @@ for consumer in $consumer_list; do
         set +x
         echo
         echo "FAILURE: Missing Nagios consumer for $consumer; displaying full consumer output:"
+        set -x
         rabbitmqctl list_consumers
         supervisorctl status
-        echo "EVENTS LOGS"
-        echo
-        cat /var/log/zulip/events*.log
-        echo
+        tail -n +1 /var/log/zulip/events*.log
         exit 1
     fi
 done


### PR DESCRIPTION
(This is a PR against the `chat.zulip.org` branch, mostly to help debug why I keep getting emails about that branch failing Travis. Maybe this will be useful for `master` at some point.)