### PR TITLE
provision: Use pre-built pgroonga on Debian 10

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -171,7 +171,7 @@ COMMON_YUM_DEPENDENCIES = COMMON_DEPENDENCIES + [
 ] + YUM_THUMBOR_VENV_DEPENDENCIES
 
 BUILD_PGROONGA_FROM_SOURCE = False
-if vendor == 'debian' and os_version == "10":
+if vendor == 'debian' and os_version in []:
     # For platforms without a pgroonga release, we need to build it
     # from source.
     BUILD_PGROONGA_FROM_SOURCE = True


### PR DESCRIPTION
Followup from #13002, #13092.

**Testing Plan:** Enabled pgroonga on https://andersk.zulipdev.org.