### PR TITLE
settings: Add FAKE_EMAIL_DOMAIN setting.

### DIFF
--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import UserManager
 from django.utils.timezone import now as timezone_now
-from zerver.models import UserProfile, Recipient, Subscription, Realm, Stream
+from zerver.models import UserProfile, Recipient, Subscription, Realm, Stream, \
+    get_fake_email_domain
 from zerver.lib.upload import copy_avatar
 from zerver.lib.hotspots import copy_hotpots
 from zerver.lib.utils import generate_api_key
@@ -32,8 +33,7 @@ def copy_user_settings(source_profile: UserProfile, target_profile: UserProfile)
 
 def get_display_email_address(user_profile: UserProfile, realm: Realm) -> str:
     if realm.email_address_visibility != Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE:
-        # TODO: realm.host isn't always a valid option here.
-        return "user%s@%s" % (user_profile.id, realm.host.split(':')[0])
+        return "user%s@%s" % (user_profile.id, get_fake_email_domain())
     return user_profile.delivery_email
 
 # create_user_profile is based on Django's User.objects.create_user,

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -19,7 +19,8 @@ from zerver.models import UserProfile, Recipient, Realm, \
     get_user, get_realm, get_stream, get_stream_recipient, \
     get_source_profile, get_system_bot, \
     ScheduledEmail, check_valid_user_ids, \
-    get_user_by_id_in_realm_including_cross_realm, CustomProfileField
+    get_user_by_id_in_realm_including_cross_realm, CustomProfileField, \
+    InvalidFakeEmailDomain, get_fake_email_domain
 
 from zerver.lib.avatar import avatar_url, get_gravatar_url
 from zerver.lib.exceptions import JsonableError
@@ -42,6 +43,7 @@ from zerver.lib.users import user_ids_to_users, access_user_by_id, \
     get_accounts_for_email
 
 from django.conf import settings
+from django.test import override_settings
 
 import datetime
 import mock
@@ -1272,3 +1274,9 @@ class GetProfileTest(ZulipTestCase):
                     user['avatar_url'],
                     avatar_url(user_profile),
                 )
+
+class FakeEmailDomainTest(ZulipTestCase):
+    @override_settings(FAKE_EMAIL_DOMAIN="invaliddomain")
+    def test_invalid_fake_email_domain(self) -> None:
+        with self.assertRaises(InvalidFakeEmailDomain):
+            get_fake_email_domain()

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -38,6 +38,12 @@ ZULIP_ADMINISTRATOR = 'zulip-admin@example.com'
 # EXTERNAL_HOST to e.g. zulip.example.com:1234 here.
 EXTERNAL_HOST = 'zulip.example.com'
 
+# If EXTERNAL_HOST is not a valid domain (e.g. if it's just an IP address),
+# you should set FAKE_EMAIL_DOMAIN below to something that is
+# a (potentially fake) domain. It will be used for email addresses
+# of bots and, if email visibility is disabled, for dummy emails of users.
+# FAKE_EMAIL_DOMAIN = 'fake-domain.example.com'
+
 # Alternative hostnames.  A comma-separated list of strings
 # representing the host/domain names that your users can enter in
 # their browsers to access Zulip.  This is a security measure; for

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -130,6 +130,7 @@ DEFAULT_SETTINGS = {
     'ADD_TOKENS_TO_NOREPLY_ADDRESS': True,
     'TOKENIZED_NOREPLY_EMAIL_ADDRESS': "noreply-{token}@" + EXTERNAL_HOST.split(":")[0],
     'PHYSICAL_ADDRESS': '',
+    'FAKE_EMAIL_DOMAIN': EXTERNAL_HOST.split(":")[0],
 
     # SMTP settings
     'EMAIL_HOST': None,

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -18,6 +18,8 @@ if os.getenv("EXTERNAL_HOST") is None:
     os.environ["EXTERNAL_HOST"] = "testserver"
 from .settings import *
 
+FAKE_EMAIL_DOMAIN = "zulip.testserver"
+
 # Clear out the REALM_HOSTS set in dev_settings.py
 REALM_HOSTS = {}
 


### PR DESCRIPTION
Fixes #9401.

This add a FAKE_EMAIL_DOMAIN setting, which should be used if
EXTERNAL_HOST is not a valid domain, and something else is needed to
form bot email and dummy user email (if email visibility is turned off).
It default to EXTERNAL_HOST.

get_fake_email_domain() should be used to get this value. It validates
that it's correctly set - that it can be used to form valid emails.

If it's not set correctly, an exception is raised. This is the right
approach, because it's undesirable to have the server seemingly
peacefully operating with that setting misconfigured, as that could
mask some hidden sneaky bugs due to UserProfiles with invalid emails,
which would blow up the moment some code that does validate the emails
is called.
