### PR TITLE
typeahead: Prioritize language names subset of another for sorting.

### DIFF
--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -14,6 +14,7 @@ zrequire('stream_data');
 zrequire('narrow');
 zrequire('hash_util');
 zrequire('marked', 'third/marked/lib/marked');
+zrequire('actual_pygments_data', 'generated/pygments_data');
 zrequire('settings_org');
 var th = zrequire('typeahead_helper');
 
@@ -104,6 +105,27 @@ run_test('sort_languages', () => {
     test_langs = th.sort_languages(test_langs, "p");
 
     assert.deepEqual(test_langs, ["php", "python", "pascal", "perl", "javascript"]);
+
+    // Some final tests on the actual pygments data to check ordering.
+    // We may later decide we want to change this behavior to e.g.
+    // prioritize `j` mapping to JavaScript as the first option rather
+    // than J or Java (while still having `java` have Java as the first option).
+    //
+    // We may eventually want to use human-readable names like
+    // "JavaScript" with several machine-readable aliases for what the
+    // user typed, which might help provide a better user experience.
+    global.pygments_data = global.actual_pygments_data;
+    test_langs = ["j", "java", "javascript", "js"];
+
+    // Sort acccording to priority only.
+    test_langs = th.sort_languages(test_langs, "jav");
+    assert.deepEqual(test_langs, ["javascript", "java", "js", "j"]);
+
+    // Push exact matches to top, regardless of priority
+    test_langs = th.sort_languages(test_langs, "java");
+    assert.deepEqual(test_langs, ["java", "javascript", "js", "j"]);
+    test_langs = th.sort_languages(test_langs, "j");
+    assert.deepEqual(test_langs, ["j", "javascript", "java", "js"]);
 });
 
 var matches = [

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -302,6 +302,14 @@ exports.sort_languages = function (matches, query) {
 
     // Languages that start with the query
     results.matches = results.matches.sort(exports.compare_by_popularity);
+
+    // Push exact matches to top.
+    const match_index = results.matches.indexOf(query);
+    if (match_index > -1) {
+        results.matches.splice(match_index, 1);
+        results.matches.unshift(query);
+    }
+
     // Languages that have the query somewhere in their name
     results.rest = results.rest.sort(exports.compare_by_popularity);
     return results.matches.concat(results.rest);


### PR DESCRIPTION
This ensures that typing '```java' and pressing enter would result in
getting dropped into a java codeblock instead of javascript codeblock.

We implement this by modifying the popularity score of languages that we
have deemed popular in lang.json. All other languages still have score of 0
so we still have cases for languages like `j` => `java, javascript, j`.

Fixes #13109.

**Testing Plan:** <!-- How have you tested? -->
Manual testing.