### PR TITLE
styles: Remove most vendor-prefixed CSS attributes

### DIFF
--- a/static/assets/icons/template.hbs
+++ b/static/assets/icons/template.hbs
@@ -17,7 +17,6 @@ i{{baseSelector}} {
     line-height: 100%;
 
     text-decoration: inherit;
-    text-rendering: auto;
     display: inline-block;
     speak: none;
 }

--- a/static/styles/app_components.scss
+++ b/static/styles/app_components.scss
@@ -172,7 +172,6 @@
 
         &[disabled="disabled"] {
             cursor: not-allowed;
-            -moz-filter: saturate(0);
             filter: saturate(0);
             background-color: hsl(0, 0%, 93%);
             color: hsl(0, 3%, 52%);
@@ -333,8 +332,6 @@
         text-shadow: none;
         outline: none !important;
         box-shadow: none;
-        -webkit-box-shadow: none;
-        -moz-box-shadow: none;
         z-index: 5;
 
         .user_status_overlay & {
@@ -375,8 +372,6 @@
         right: -30%;
         width: 50%;
         height: 50%;
-        -webkit-transform: rotate(45deg);
-        -moz-transform: rotate(45deg);
         transform: rotate(45deg);
     }
 }

--- a/static/styles/components.scss
+++ b/static/styles/components.scss
@@ -30,7 +30,7 @@
                 border: 1px solid hsla(0, 0%, 0%, 0.6);
 
                 border-radius: 4px;
-                -webkit-filter: brightness(0.80);
+                filter: brightness(0.80);
 
                 cursor: pointer;
             }

--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -327,13 +327,11 @@ textarea.new_message_textarea,
 .compose_table .recipient_box {
     border: 1px solid hsla(0, 0%, 0%, 0.2);
     box-shadow: none;
-    -webkit-box-shadow: none;
     transition: border 0.2s ease;
 
     &:focus {
         border: 1px solid hsl(0, 0%, 67%);
         box-shadow: none;
-        -webkit-box-shadow: none;
     }
 }
 

--- a/static/styles/hotspots.scss
+++ b/static/styles/hotspots.scss
@@ -31,8 +31,6 @@
     }
 
     .bounce {
-        -moz-animation: bounce 0.75s infinite;
-        -webkit-animation: bounce 0.75s infinite;
         animation: bounce 0.75s infinite;
 
         .bounce-icon {
@@ -49,12 +47,12 @@
 
 @keyframes pulsate {
     0% {
-        -webkit-transform: scale(1.0, 1.0);
+        transform: scale(1.0, 1.0);
         opacity: 0.8;
     }
 
     100% {
-        -webkit-transform: scale(2.2, 2.2);
+        transform: scale(2.2, 2.2);
         opacity: 0.0;
     }
 }
@@ -62,11 +60,11 @@
 @keyframes bounce {
     0%,
     100% {
-        -webkit-transform: translateY(0px);
+        transform: translateY(0px);
     }
 
     50% {
-        -webkit-transform: translateY(4px);
+        transform: translateY(4px);
     }
 }
 

--- a/static/styles/informational-overlays.scss
+++ b/static/styles/informational-overlays.scss
@@ -93,11 +93,6 @@
         padding: 0.1em 0.4em;
         text-shadow: 0 1px 0 hsl(0, 0%, 100%);
         /* Prevent selection */
-        -webkit-touch-callout: none;
-        -webkit-user-select: none;
-        -khtml-user-select: none;
-        -moz-user-select: none;
-        -ms-user-select: none;
         user-select: none;
     }
 

--- a/static/styles/lightbox.scss
+++ b/static/styles/lightbox.scss
@@ -20,19 +20,12 @@
 
             background-color: hsl(0, 0%, 100%);
             background-image:
-                -moz-linear-gradient(45deg, hsl(0, 0%, 80%) 25%, transparent 25%),
-                -moz-linear-gradient(-45deg, hsl(0, 0%, 80%) 25%, transparent 25%),
-                -moz-linear-gradient(45deg, transparent 75%, hsl(0, 0%, 0%) 75%),
-                -moz-linear-gradient(-45deg, transparent 75%, hsl(0, 0%, 0%) 75%);
-            background-image:
-                -webkit-gradient(linear, 0 100%, 100% 0, color-stop(.25, hsl(0, 0%, 80%)), color-stop(.25, transparent)),
-                -webkit-gradient(linear, 0 0, 100% 100%, color-stop(.25, hsl(0, 0%, 80%)), color-stop(.25, transparent)),
-                -webkit-gradient(linear, 0 100%, 100% 0, color-stop(.75, transparent), color-stop(.75, hsl(0, 0%, 80%))),
-                -webkit-gradient(linear, 0 0, 100% 100%, color-stop(.75, transparent), color-stop(.75, hsl(0, 0%, 80%)));
+                linear-gradient(45deg, hsl(0, 0%, 80%) 25%, transparent 25%),
+                linear-gradient(135deg, hsl(0, 0%, 80%) 25%, transparent 25%),
+                linear-gradient(45deg, transparent 75%, hsl(0, 0%, 80%) 75%),
+                linear-gradient(135deg, transparent 75%, hsl(0, 0%, 80%) 75%);
 
-            -moz-background-size: 20px 20px;
             background-size: 20px 20px;
-            -webkit-background-size: 20px 20px;
 
             background-position: 0 0, 50px 0, 50px -50px, 0px 50px;
         }

--- a/static/styles/media.scss
+++ b/static/styles/media.scss
@@ -71,8 +71,6 @@
 
     .nav .dropdown-menu {
         min-width: 180px;
-        -webkit-box-shadow: 0px 0px 5px hsla(0, 0%, 0%, 0.2);
-        -moz-box-shadow: 0px 0px 5px hsla(0, 0%, 0%, 0.2);
         box-shadow: 0px 0px 5px hsla(0, 0%, 0%, 0.2);
     }
 

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -374,7 +374,6 @@ on a dark background, and don't change the dark labels dark either. */
     }
 
     .modal-footer {
-        -webkit-box-shadow: inset 0 1px 0 hsla(0, 0%, 0%, 0.2);
         box-shadow: inset 0 1px 0 hsla(0, 0%, 0%, 0.2);
     }
 
@@ -420,10 +419,6 @@ on a dark background, and don't change the dark labels dark either. */
 
     .rendered_markdown .user-mention,
     .rendered_markdown .user-group-mention {
-        background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, hsla(0, 0%, 0%, 0.1)), color-stop(100%, hsla(0, 0%, 0%, 0.0)));
-        background: -webkit-linear-gradient(top, hsla(0, 0%, 0%, 0.2) 0%, hsla(0, 0%, 0%, 0.1) 100%);
-        background: -o-linear-gradient(top, hsla(0, 0%, 0%, 0.2) 0%, hsla(0, 0%, 0%, 0.1) 100%);
-        background: -ms-linear-gradient(top, hsla(0, 0%, 0%, 0.2) 0%, hsla(0, 0%, 0%, 0.1) 100%);
         background: linear-gradient(to bottom, hsla(0, 0%, 0%, 0.2) 0%, hsla(0, 0%, 0%, 0.1) 100%);
         box-shadow: 0px 0px 0px 1px hsla(0, 0%, 0%, 0.4);
     }
@@ -597,7 +592,6 @@ on a dark background, and don't change the dark labels dark either. */
     }
 
     .searching-for-more-topics img {
-        -webkit-filter: invert(100%);
         filter: invert(100%);
     }
 

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -69,9 +69,7 @@
             }
 
             input {
-                -webkit-box-sizing: initial;
-                -moz-box-sizing: inherit;
-                -ms-box-sizing: inherit;
+                box-sizing: inherit;  /* IE */
                 box-sizing: initial;
 
                 width: calc(100% - 13px);

--- a/static/styles/portico/activity.scss
+++ b/static/styles/portico/activity.scss
@@ -54,8 +54,6 @@ tr.admin td:first-child {
     padding-left: 15px;
     padding-top: 14px;
     border-radius: 7px;
-    -webkit-box-shadow: 0 10px 7px -6px hsl(0, 2%, 45%);
-    -moz-box-shadow: 0 10px 7px -6px hsl(0, 2%, 45%);
     box-shadow: 0 10px 7px -6px hsl(0, 2%, 45%);
 }
 

--- a/static/styles/portico/billing.scss
+++ b/static/styles/portico/billing.scss
@@ -128,7 +128,6 @@
         span {
             background: 0;
             box-shadow: none;
-            -webkit-box-shadow: none;
             font-family: 'Source Sans Pro', Helvetica, Arial;
             font-size: 1.4em;
             line-height: 20px;
@@ -146,7 +145,6 @@
         span {
             background: 0;
             box-shadow: none;
-            -webkit-box-shadow: none;
         }
     }
 
@@ -243,8 +241,6 @@
         left: -50%;
         top: -41px;
         z-index: 1;
-        -webkit-border-radius: 6px;
-        -moz-border-radius: 6px;
         border-radius: 6px;
     }
 

--- a/static/styles/portico/integrations.scss
+++ b/static/styles/portico/integrations.scss
@@ -118,9 +118,6 @@ $category-text: hsl(219, 23%, 33%);
 
 
         .searchbar {
-            width: -moz-calc(100% - 40px);
-            width: -webkit-calc(100% - 40px);
-            width: -o-calc(100% - 40px);
             width: calc(100% - 40px);
             display: flex;
             justify-content: center;
@@ -130,8 +127,6 @@ $category-text: hsl(219, 23%, 33%);
                 position: relative;
 
                 input {
-                    -webkit-box-shadow: 0px 0px 7px 2px hsla(0, 0%, 0%, 0.03);
-                    -moz-box-shadow: 0px 0px 7px 2px hsla(0, 0%, 0%, 0.03);
                     box-shadow: 0px 0px 7px 2px hsla(0, 0%, 0%, 0.03);
 
                     font-size: 1em;
@@ -154,9 +149,6 @@ $category-text: hsl(219, 23%, 33%);
                     }
 
                     @media (max-width: 550px) {
-                        width: -moz-calc(100% - 80px);
-                        width: -webkit-calc(100% - 80px);
-                        width: -o-calc(100% - 80px);
                         width: calc(100% - 80px);
                     }
                 }

--- a/static/styles/portico/landing-page.scss
+++ b/static/styles/portico/landing-page.scss
@@ -301,9 +301,6 @@ nav ul {
 
 nav ul .exit {
     display: none;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
     user-select: none;
 }
 
@@ -1168,8 +1165,6 @@ nav ul li.active::after {
 
 .portico-landing.hello .screen.hero-screen .main-page {
     transform: translateY(-12px) translateX(3px);
-    -webkit-transform: translateY(-12px) translateX(3px);
-    -moz-transform: translateY(-12px) translateX(3px);
     border: 5px solid hsl(0, 0%, 0%);
 }
 
@@ -1834,7 +1829,6 @@ nav ul li.active::after {
     margin-top: -50px;
 
     background-color: hsl(177, 52%, 55%);
-    background: -webkit-linear-gradient(145deg, hsl(169, 65%, 42%), hsl(191, 55%, 54%));
     background: linear-gradient(145deg, hsl(191, 56%, 55%), hsl(169, 65%, 42%));
 
     color: hsl(0, 0%, 100%);
@@ -1908,8 +1902,6 @@ nav ul li.active::after {
 }
 
 .portico-landing.hello .apps .arrow::after {
-    -webkit-filter: brightness(4) saturate(0);
-    -moz-filter: brightness(4) saturate(0);
     filter: brightness(4) saturate(0);
 }
 
@@ -2005,8 +1997,6 @@ nav ul li.active::after {
     background-image: url(/static/images/landing-page/zulip-octopus.png);
     background-size: cover;
 
-    -webkit-filter: invert(0.9);
-    -moz-filter: invert(0.9);
     filter: invert(0.9);
 }
 
@@ -2379,7 +2369,7 @@ nav ul li.active::after {
     padding: 30px 0px;
     border-radius: 20px;
 
-    -webkit-transform: translateY(50px);
+    transform: translateY(50px);
 
     background-color: hsl(0, 0%, 100%);
 }
@@ -2390,7 +2380,7 @@ nav ul li.active::after {
     padding: 10px 0px 30px 0px;
     border-radius: 20px;
 
-    -webkit-transform: translateY(-110px);
+    transform: translateY(-110px);
 
     background: linear-gradient(90deg, hsl(0, 0%, 27%) 0%, hsl(0, 0%, 33%) 8%, hsl(0, 0%, 33%) 92%, hsl(0, 0%, 27%) 100%);
 }
@@ -2595,7 +2585,7 @@ nav ul li.active::after {
     background-position: center;
     background-repeat: no-repeat;
 
-    -webkit-filter: invert(0.3);
+    filter: invert(0.3);
 }
 
 .pricing-model .pricing-container .bottom {

--- a/static/styles/portico/landing-page.scss
+++ b/static/styles/portico/landing-page.scss
@@ -4,8 +4,6 @@ html {
 }
 
 body {
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
     margin: 0;
     background-color: hsl(0, 0%, 100%);
     color: hsl(0, 0%, 27%);

--- a/static/styles/portico/markdown.scss
+++ b/static/styles/portico/markdown.scss
@@ -64,9 +64,6 @@
     h2,
     h3 {
         font-weight: 700;
-        -webkit-user-select: none;
-        -moz-user-select: none;
-        -ms-user-select: none;
         user-select: none;
 
         &:hover {

--- a/static/styles/portico/markdown.scss
+++ b/static/styles/portico/markdown.scss
@@ -3,7 +3,6 @@
     font-size: 1rem;
     line-height: 1.5;
     overflow: auto;
-    -webkit-font-smoothing: antialiased;
 
 
 
@@ -72,9 +71,6 @@
             &::after {
                 display: inline-block;
                 font: normal normal normal 16px/1 FontAwesome;
-                text-rendering: auto;
-                -webkit-font-smoothing: antialiased;
-                -moz-osx-font-smoothing: grayscale;
 
                 cursor: pointer;
                 content: "\f0c1";

--- a/static/styles/portico/portico-signin.scss
+++ b/static/styles/portico/portico-signin.scss
@@ -226,7 +226,6 @@ html {
 }
 
 .new-style {
-    -webkit-font-smoothing: antialiased;
 }
 
 .register-form.new-style {

--- a/static/styles/portico/portico.scss
+++ b/static/styles/portico/portico.scss
@@ -40,8 +40,6 @@ body {
 
 .navbar-inner {
     border-radius: 0px;
-    -webkit-border-radius: 0px;
-    -moz-border-radius: 0px;
 }
 
 .header {
@@ -637,7 +635,7 @@ input.text-error {
 
     line-height: 0;
 
-    -webkit-transform: scale(1.8, 1);
+    transform: scale(1.8, 1);
 }
 
 .portico-header .dropdown ul li {
@@ -1417,7 +1415,7 @@ input.new-organization-button {
     }
 
     .app.help .sidebar.show ~ .markdown {
-        -webkit-filter: brightness(0.7);
+        filter: brightness(0.7);
     }
 
     .app-main,
@@ -1466,10 +1464,6 @@ input.new-organization-button {
 
     .postal-envelope {
         transform: none;
-        -webkit-transform: none;
-        -moz-transform: none;
-        -o-transform: none;
-        -ms-transform: none;
     }
 
     .letter-form {
@@ -1658,14 +1652,10 @@ input.new-organization-button {
 
 /* -- button states -- */
 .button-new:hover {
-    -webkit-filter: brightness(1.1);
-    -moz-filter: brightness(1.1);
     filter: brightness(1.1);
 }
 
 .button-new:active {
-    -webkit-filter: brightness(0.9);
-    -moz-filter: brightness(0.9);
     filter: brightness(0.9);
 }
 

--- a/static/styles/portico/portico.scss
+++ b/static/styles/portico/portico.scss
@@ -81,8 +81,6 @@ body {
     height: 100%;
     font-weight: 300;
     font-size: 17px;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
 }
 
 /* The API tabbed content tends to have a lot of code blocks,
@@ -192,7 +190,6 @@ body {
     display: block;
     font: normal normal normal 14px/1 FontAwesome;
     font-size: inherit;
-    text-rendering: auto;
 
     content: "\f107";
     margin-right: 5px;
@@ -210,7 +207,6 @@ body {
     display: inline-block;
     font: normal normal normal 14px/1 FontAwesome;
     font-size: inherit;
-    text-rendering: auto;
 
     content: "\f0d9";
     margin-right: 10px;

--- a/static/styles/portico/stats.scss
+++ b/static/styles/portico/stats.scss
@@ -42,9 +42,6 @@ hr {
 }
 
 .rangeslider-container {
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
     user-select: none;
 }
 

--- a/static/styles/pygments.scss
+++ b/static/styles/pygments.scss
@@ -1,6 +1,5 @@
 .codehilite pre {
     background-color: hsl(0, 0%, 100%);
-    -webkit-font-smoothing: auto;
 }
 .codehilite .hll {
     background-color: hsl(60, 100%, 90%);

--- a/static/styles/reactions.scss
+++ b/static/styles/reactions.scss
@@ -2,9 +2,6 @@
     padding-left: 46px;
     overflow: hidden;
 
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
     user-select: none;
 
     .message_reaction {

--- a/static/styles/rendered_markdown.scss
+++ b/static/styles/rendered_markdown.scss
@@ -119,11 +119,6 @@
         margin-right: 2px;
         margin-left: 2px;
         white-space: nowrap;
-        background: -moz-linear-gradient(top, hsla(0, 0%, 0%, 0.1) 0%, hsla(0, 0%, 0%, 0.0) 100%);
-        background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, hsla(0, 0%, 0%, 0.1)), color-stop(100%, hsla(0, 0%, 0%, 0.0)));
-        background: -webkit-linear-gradient(top, hsla(0, 0%, 0%, 0.1) 0%, hsla(0, 0%, 0%, 0.0) 100%);
-        background: -o-linear-gradient(top, hsla(0, 0%, 0%, 0.1) 0%, hsla(0, 0%, 0%, 0.0) 100%);
-        background: -ms-linear-gradient(top, hsla(0, 0%, 0%, 0.1) 0%, hsla(0, 0%, 0%, 0.0) 100%);
         background: linear-gradient(to bottom, hsla(0, 0%, 0%, 0.1) 0%, hsla(0, 0%, 0%, 0.0) 100%);
         display: inline-block;
         margin-bottom: 1px;

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -150,10 +150,6 @@ label {
 .wrapped-table {
     word-break: break-word;
     word-wrap: break-word;
-    white-space: -moz-pre-wrap !important;
-    white-space: -webkit-pre-wrap;
-    white-space: -pre-wrap;
-    white-space: -o-pre-wrap;
     white-space: pre-wrap;
     white-space: normal;
 }
@@ -921,9 +917,6 @@ input[type=checkbox].inline-block {
 .bots_list .api_key .api-key-value-and-button {
     display: block;
     margin-left: 0px;
-    white-space: -moz-pre-wrap !important;
-    white-space: -pre-wrap;
-    white-space: -o-pre-wrap;
     white-space: pre-wrap;
     word-wrap: break-word;
     word-break: break-all;
@@ -1049,9 +1042,6 @@ input[type=checkbox].inline-block {
 
 #alert_words_list .alert_word_listing .value {
     display: block;
-    white-space: -moz-pre-wrap !important;
-    white-space: -pre-wrap;
-    white-space: -o-pre-wrap;
     white-space: pre-wrap;
     word-wrap: break-word;
     word-break: break-all;
@@ -1901,8 +1891,6 @@ input[type=text]#settings_search {
     outline: 0;
     outline: 1px dotted \9;
 
-    -webkit-box-shadow: inset 0 1px 1px hsla(0, 0%, 0%, 0.075), 0 0 8px hsla(206, 80%, 62%, 0.6);
-    -moz-box-shadow: inset 0 1px 1px hsla(0, 0%, 0%, 0.075), 0 0 8px hsla(206, 80%, 62%, 0.6);
     box-shadow: inset 0 1px 1px hsla(0, 0%, 0%, 0.075), 0 0 8px hsla(206, 80%, 62%, 0.6);
 }
 

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -278,7 +278,6 @@ td .button {
                 display: inline-block;
                 font: normal normal normal 12px/1 FontAwesome;
                 font-size: inherit;
-                text-rendering: auto;
             }
 
             &.active {

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -135,9 +135,6 @@
 .stream-email .email-address {
     display: block;
     margin: auto;
-    white-space: -moz-pre-wrap !important;
-    white-space: -pre-wrap;
-    white-space: -o-pre-wrap;
     white-space: pre-wrap;
     word-wrap: break-word;
     word-break: break-all;

--- a/static/styles/user_circles.scss
+++ b/static/styles/user_circles.scss
@@ -22,14 +22,7 @@
 .user_circle_orange {
     border-color: hsl(29, 84%, 51%);
     background-color: hsl(29, 84%, 51%);
-
-    background: -moz-linear-gradient(top, hsla(0, 0%, 100%, 0.0) 50%, hsla(29, 84%, 51%, 1.0) 50%); /* FF3.6+ */
-    background: -webkit-gradient(linear, left top, left bottom, color-stop(50%, hsla(0, 0%, 100%, 0.0)), color-stop(50%, hsla(29, 84%, 51%, 1.0))); /* Chrome,Safari4+ */
-    background: -webkit-linear-gradient(top, hsla(0, 0%, 100%, 0.0) 50%, hsla(29, 84%, 51%, 1.0) 50%); /* Chrome10+,Safari5.1+ */
-    background: -o-linear-gradient(top, hsla(0, 0%, 100%, 0.0) 50%, hsla(29, 84%, 51%, 1.0) 50%); /* Opera 11.10+ */
-    background: -ms-linear-gradient(top, hsla(0, 0%, 100%, 0.0) 50%, hsla(29, 84%, 51%, 1.0) 50%); /* IE10+ */
-    background: linear-gradient(to bottom, hsla(0, 0%, 100%, 0.0) 50%, hsla(29, 84%, 51%, 1.0) 50%); /* W3C */
-    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#ec7e18', GradientType=0 ); /* IE6-9; filters only work with hex colors */
+    background: linear-gradient(to bottom, hsla(0, 0%, 100%, 0.0) 50%, hsla(29, 84%, 51%, 1.0) 50%);
 }
 
 .user_circle_empty {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -448,8 +448,6 @@ strong {
 .sp-input {
     width: calc(100% - 14px);
     box-sizing: initial !important;
-    -webkit-box-sizing: initial !important;
-    -moz-box-sizing: initial !important;
 }
 
 .logout {
@@ -659,10 +657,6 @@ td.pointer {
         .rotating {
             display: inline-block;
 
-            -webkit-animation: rotate 1s infinite linear;
-            -moz-animation: rotate 1s infinite linear;
-            -ms-animation: rotate 1s infinite linear;
-            -o-animation: rotate 1s infinite linear;
             animation: rotate 1s infinite linear;
         }
     }
@@ -769,7 +763,7 @@ td.pointer {
     border-width: 11px 0 11px 5px;
     border-color: inherit;
     z-index: 2;
-    -moz-transform: scale(.9999);
+    transform: scale(.9999);
 }
 
 .stream_label::before {
@@ -785,7 +779,7 @@ td.pointer {
     border-width: 14px 0 14px 6px;
     border-color: hsla(0, 0%, 0%, 0.0) hsla(0, 0%, 0%, 0.0) hsla(0, 0%, 0%, 0.0) transparent;
     z-index: 1;
-    -moz-transform: scale(.9999);
+    transform: scale(.9999);
 }
 
 .stream_topic {
@@ -870,46 +864,6 @@ td.pointer {
     display: none;
 }
 
-@-webkit-keyframes rotate {
-    from {
-        -webkit-transform: rotate(0deg);
-    }
-
-    to {
-        -webkit-transform: rotate(359deg);
-    }
-}
-
-@-moz-keyframes rotate {
-    from {
-        -moz-transform: rotate(0deg);
-    }
-
-    to {
-        -moz-transform: rotate(359deg);
-    }
-}
-
-@-ms-keyframes rotate {
-    from {
-        -ms-transform: rotate(0deg);
-    }
-
-    to {
-        -ms-transform: rotate(359deg);
-    }
-}
-
-@-moz-keyframes rotate {
-    from {
-        -o-transform: rotate(0deg);
-    }
-
-    to {
-        -o-transform: rotate(359deg);
-    }
-}
-
 @keyframes rotate {
     from {
         transform: rotate(0deg);
@@ -920,26 +874,6 @@ td.pointer {
     }
 }
 
-@-webkit-keyframes fadeInMessage {
-    0% {
-        opacity: 0;
-    }
-
-    100% {
-        opacity: 1;
-    }
-}
-
-@-moz-keyframes fadeInMessage {
-    0% {
-        opacity: 0;
-    }
-
-    100% {
-        opacity: 1;
-    }
-}
-
 @keyframes fadeInMessage {
     0% {
         opacity: 0;
@@ -947,26 +881,6 @@ td.pointer {
 
     100% {
         opacity: 1;
-    }
-}
-
-@-webkit-keyframes fadeInEditNotice {
-    0% {
-        transform: translateX(-10px);
-    }
-
-    100% {
-        transform: translateX(0px);
-    }
-}
-
-@-moz-keyframes fadeInEditNotice {
-    0% {
-        transform: translateX(-10px);
-    }
-
-    100% {
-        transform: translateX(0px);
     }
 }
 
@@ -1526,7 +1440,7 @@ div.focused_table {
                 position: absolute;
                 pointer-events: none;
                 z-index: 1;
-                -moz-transform: scale(.9999);
+                transform: scale(.9999);
             }
         }
 
@@ -1603,8 +1517,6 @@ div.focused_table {
     right: 0px;
     top: 30px;
     min-width: 180px;
-    -webkit-box-shadow: 0px 0px 5px hsla(0, 0%, 0%, 0.2);
-    -moz-box-shadow: 0px 0px 5px hsla(0, 0%, 0%, 0.2);
     box-shadow: 0px 0px 5px hsla(0, 0%, 0%, 0.2);
 }
 
@@ -1670,8 +1582,6 @@ div.focused_table {
         padding-left: 0px !important;
         background-color: inherit;
         box-shadow: inherit;
-        -webkit-box-shadow: inherit;
-        -moz-box-shadow: inherit;
         display: block;
         position: absolute;
         right: 0px;
@@ -1775,8 +1685,6 @@ nav a .no-style {
         color: hsl(0, 0%, 80%);
         font-size: 18px;
         box-shadow: none;
-        -webkit-box-shadow: none;
-        -moz-box-shadow: none;
         text-shadow: none;
         z-index: 5;
         float: right;
@@ -1893,8 +1801,6 @@ nav a .no-style {
         color: hsl(0, 0%, 80%);
         font-size: 18px;
         box-shadow: none;
-        -webkit-box-shadow: none;
-        -moz-box-shadow: none;
         text-shadow: none;
         z-index: 5;
     }
@@ -2057,8 +1963,6 @@ div.floating_recipient {
     left: -50%;
     top: -43px;
     z-index: 1;
-    -webkit-border-radius: 6px;
-    -moz-border-radius: 6px;
     border-radius: 6px;
 }
 
@@ -2076,8 +1980,6 @@ div.floating_recipient {
     left: -50%;
     top: -43px;
     z-index: 1;
-    -webkit-border-radius: 6px;
-    -moz-border-radius: 6px;
     border-radius: 6px;
 }
 
@@ -2427,8 +2329,6 @@ div.topic_edit_spinner .loading_indicator_spinner {
 #message_edit_form textarea {
     width: 100%;
     min-width: 206px;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
     box-sizing: border-box;
 }
 
@@ -2483,10 +2383,6 @@ div.topic_edit_spinner .loading_indicator_spinner {
 .no-drag {
     user-drag: none;
     user-select: none;
-    -moz-user-select: none;
-    -webkit-user-drag: none;
-    -webkit-user-select: none;
-    -ms-user-select: none;
 }
 
 .user_popover_email {

--- a/tools/inline-email-css
+++ b/tools/inline-email-css
@@ -23,7 +23,6 @@ if __name__ == "__main__":
     properties[Profiles.CSS_LEVEL_2]['mso-table-lspace'] = r'0|{num}(pt)'
     properties[Profiles.CSS_LEVEL_2]['mso-table-rspace'] = r'0|{num}(pt)'
     properties[Profiles.CSS_LEVEL_2]['-webkit-text-size-adjust'] = r'none|auto|{percentage}'
-    properties[Profiles.CSS_LEVEL_2]['-webkit-font-smoothing'] = r'none|antialiased|subpixel-antialiased'
     properties[Profiles.CSS_LEVEL_2]['mso-hide'] = 'all'
     properties[Profiles.CSS_LEVEL_2]['pointer-events'] = (r'auto|none|visiblePainted|'
                                                           r'visibleFill|visibleStroke|'


### PR DESCRIPTION
Many of them are now automatically generated by autoprefixer, while others are unnecessary based on `.browserslistrc`, and some were just wrong (the linear-gradient based checkerboard pattern in `lightbox` has been broken in Firefox for a while).

**Testing Plan:** Read the output diff; cursory `run-dev` testing.