### PR TITLE
styles: Fix left sidebar indentation for PostCSS migration

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -6,7 +6,7 @@ $far_left_gutter_size: 10px;
 $left_col_size: 19px;
 /* The full topic indentation includes 4px of indent in addition to
    the above (and another 5px of padding not measured here) */
-$topic_indent: $far_left_gutter_size + $left_col_size + 4px;
+$topic_indent: calc($far_left_gutter_size + $left_col_size + 4px);
 
 #left-sidebar #group-pm-list {
     display: none;


### PR DESCRIPTION
`cssnano` reduces this to a constant in a production build. (We could add `postcss-calc` if we wanted this reduced in development.)

**Testing Plan:** `run-dev`, `tools/webpack`, https://andersk.zulipdev.org