### PR TITLE
Update setup-advanced.md

### DIFF
--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -158,7 +158,7 @@ sudo chown -R `whoami`: /srv/zulip-emoji-cache
 ./tools/setup/emoji/build_emoji
 ./tools/inline-email-css
 ./tools/setup/build_pygments_data
-./tools/setup/generate_zulip_bots_static_files.py
+./tools/setup/generate_zulip_bots_static_files
 ./scripts/setup/generate_secrets.py --development
 if [ $(uname) = "OpenBSD" ]; then
     sudo cp ./puppet/zulip/files/postgresql/zulip_english.stop /var/postgresql/tsearch_data/


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
The file mentioned in the instructions "generate_zulip_bots_static_files.py" does not exist.
"generate_zulip_bots_static_files" does.

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
