### PR TITLE
Ratelimitfilter

### DIFF
--- a/zerver/lib/logging_util.py
+++ b/zerver/lib/logging_util.py
@@ -10,6 +10,7 @@ import traceback
 from typing import Optional
 from datetime import datetime, timedelta
 from django.conf import settings
+from django.core.cache import cache
 from logging import Logger
 
 # Adapted http://djangosnippets.org/snippets/2242/ by user s29 (October 25, 2010)
@@ -18,9 +19,6 @@ class _RateLimitFilter:
     last_error = datetime.min.replace(tzinfo=timezone_utc)
 
     def filter(self, record: logging.LogRecord) -> bool:
-        from django.conf import settings
-        from django.core.cache import cache
-
         # Track duplicate errors
         duplicate = False
         rate = getattr(settings, '%s_LIMIT' % (self.__class__.__name__.upper(),),


### PR DESCRIPTION
EDIT: Oops, I didn't set the PR title properly and now can't edit it :see_no_evil: 

Fixes https://github.com/zulip/zulip/issues/12595.

I tried to more-or-less implement the idea for fixing this outlined there. The way I did this is pretty ugly, so I'll be happy to change it up if it can be made nicer. The comments in the code explain what's going on.

Seems to work in the sense of passing the unit test added in commit 1 and with manual testing - I can kill ``memcached`` in development environment, do ``tools/run-dev.py`` and open the page in my browser - it leads to ``Fatal Python error: Cannot recover from stack overflow.`` before the changes, and normal handling with the changes.

I'm not sure how to test whether this works correctly in terms of threading - if the thread-local variable acts like it should and each thread has its own version of it. It should be the case, as long as I didn't misread the documentation, but this seems like something that should get tested somehow before feeling happy with this fix :thinking: 

As for the logging.error generated, nothing unusal about them I think and they can be rate limited just fine. Here's an example output (by making _RateLimitFilter print out info about the received logging record at the start of the function). It duplicates the errors printed, because it's printed one time by the _RateLimitFilter and once by Django's logging.error calls, but you can see the generated cache keys for the same error are the same each time:
https://pastebin.com/u783LAbr