### PR TITLE
requirements: Use PyPI fork of line_profiler supporting Python 3.7

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -54,9 +54,6 @@ git+https://github.com/zulip/talon.git@7d8bdc4dbcfcc5a73298747293b99fe53da55315#
 # Needed for hipchat import
 hypchat==0.21
 
-# For doing highly usable Python profiling
-git+https://github.com/zulip/line_profiler.git#egg=line_profiler==2.1.2.zulip1
-
 # Needed for inlining the CSS in emails
 premailer==3.5.0
 

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -25,6 +25,10 @@ httpretty==0.9.6
 # For sorting imports
 isort==4.3.21
 
+# For doing highly usable Python profiling (temporary fork of
+# line_profiler: https://github.com/rkern/line_profiler/issues/127)
+lp37==2.1.1
+
 # for pep8 linter
 pycodestyle==2.5.0
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -83,7 +83,7 @@ jsonpickle==1.2           # via aws-xray-sdk, python-digitalocean
 jsonpointer==2.0          # via jsonpatch
 jsonschema==3.0.1         # via aws-sam-translator, cfn-lint
 git+https://github.com/zulip/libthumbor.git@60ed2431c07686a12f2770b2d852c5650f3ccfc6#egg=libthumbor==1.3.2zulip
-git+https://github.com/zulip/line_profiler.git#egg=line_profiler==2.1.2.zulip1
+lp37==2.1.1
 lxml==4.3.4
 markdown-include==0.5.1
 markdown==3.1.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -54,7 +54,6 @@ ipython==6.5.0
 jedi==0.14.0              # via ipython
 jinja2==2.10.1
 git+https://github.com/zulip/libthumbor.git@60ed2431c07686a12f2770b2d852c5650f3ccfc6#egg=libthumbor==1.3.2zulip
-git+https://github.com/zulip/line_profiler.git#egg=line_profiler==2.1.2.zulip1
 lxml==4.3.4
 markdown-include==0.5.1
 markdown==3.1.1

--- a/version.py
+++ b/version.py
@@ -26,4 +26,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '54.3'
+PROVISION_VERSION = '54.4'


### PR DESCRIPTION
Also move it to dev.in.

Other notes for posterity: this should have been installed with a pinned commit hash, and could have been installed directly from the upstream Git repository, even on Python 3.7, as long as Cython was installed as well.