### PR TITLE
mattermost: Fix test flake in test_convert_channel_data

### DIFF
--- a/zerver/tests/test_mattermost_importer.py
+++ b/zerver/tests/test_mattermost_importer.py
@@ -185,9 +185,12 @@ class MatterMostImporter(ZulipTestCase):
         self.assertTrue(stream_id_mapper.has("dumbledores-army"))
 
         # TODO: Add ginny
-        self.assertEqual(subscriber_handler.get_users(stream_id_mapper.get("gryffindor-common-room")), {1, 2})
-        self.assertEqual(subscriber_handler.get_users(stream_id_mapper.get("gryffindor-quidditch-team")), {1, 2})
-        self.assertEqual(subscriber_handler.get_users(stream_id_mapper.get("dumbledores-army")), {1, 2})
+        ron_id = user_id_mapper.get("ron")
+        harry_id = user_id_mapper.get("harry")
+        self.assertEqual({ron_id, harry_id}, {1, 2})
+        self.assertEqual(subscriber_handler.get_users(stream_id_mapper.get("gryffindor-common-room")), {ron_id, harry_id})
+        self.assertEqual(subscriber_handler.get_users(stream_id_mapper.get("gryffindor-quidditch-team")), {ron_id, harry_id})
+        self.assertEqual(subscriber_handler.get_users(stream_id_mapper.get("dumbledores-army")), {ron_id, harry_id})
 
         # Converting channel data when a user's `teams` value is `null`.
         self.username_to_user["ron"].update({"teams": None})
@@ -200,9 +203,11 @@ class MatterMostImporter(ZulipTestCase):
             realm_id=3,
             team_name=team_name,
         )
-        self.assertEqual(subscriber_handler.get_users(stream_id_mapper.get("gryffindor-common-room")), {2})
-        self.assertEqual(subscriber_handler.get_users(stream_id_mapper.get("gryffindor-quidditch-team")), {2})
-        self.assertEqual(subscriber_handler.get_users(stream_id_mapper.get("dumbledores-army")), {2})
+        harry_id = user_id_mapper.get("harry")
+        self.assertIn(harry_id, {1, 2})
+        self.assertEqual(subscriber_handler.get_users(stream_id_mapper.get("gryffindor-common-room")), {harry_id})
+        self.assertEqual(subscriber_handler.get_users(stream_id_mapper.get("gryffindor-quidditch-team")), {harry_id})
+        self.assertEqual(subscriber_handler.get_users(stream_id_mapper.get("dumbledores-army")), {harry_id})
 
         team_name = "slytherin"
         zerver_stream = convert_channel_data(
@@ -215,8 +220,12 @@ class MatterMostImporter(ZulipTestCase):
             team_name=team_name,
         )
 
-        self.assertEqual(subscriber_handler.get_users(stream_id_mapper.get("slytherin-common-room")), {3, 4, 5})
-        self.assertEqual(subscriber_handler.get_users(stream_id_mapper.get("slytherin-quidditch-team")), {3, 4})
+        malfoy_id = user_id_mapper.get("malfoy")
+        pansy_id = user_id_mapper.get("pansy")
+        snape_id = user_id_mapper.get("snape")
+        self.assertEqual({malfoy_id, pansy_id, snape_id}, {3, 4, 5})
+        self.assertEqual(subscriber_handler.get_users(stream_id_mapper.get("slytherin-common-room")), {malfoy_id, pansy_id, snape_id})
+        self.assertEqual(subscriber_handler.get_users(stream_id_mapper.get("slytherin-quidditch-team")), {malfoy_id, pansy_id})
 
     def test_write_emoticon_data(self) -> None:
         output_dir = self.make_import_output_dir("mattermost")


### PR DESCRIPTION
So the reason 38f8cf612c9245c3f81ec94ae780ab78165ae186 seems to be flaking is because the value of harry id switches between 1 and 2 in Xenial while in Bionic it would be fixed at 2. The reason behind this is that Bionic ships with Python3.6 which preserves dict insert order while Python3.5 that ships with Xenial dont preserve the order. In initialize_stream_membership_dicts we iterat user_data_map dict and the order in which the iteration happens affects the ID of the users.



