### PR TITLE
provisioning: fix up .bash_profile creation for Docker

### DIFF
--- a/tools/lib/provision_inner.py
+++ b/tools/lib/provision_inner.py
@@ -55,8 +55,46 @@ def setup_shell_profile(shell_profile):
     if os.path.exists('/srv/zulip'):
         write_command('cd /srv/zulip')
 
+def setup_bash_profile() -> None:
+    """Select a bash profile file to add setup code to."""
+
+    BASH_PROFILES = [os.path.expanduser(p) for p in
+        ("~/.bash_profile", "~/.bash_login", "~/.profile")
+    ]
+
+    def clear_old_profile() -> None:
+        # An earlier version of this script would output a fresh .bash_profile
+        # even though a .profile existed in the image used. As a convenience to
+        # existing developers (and, perhaps, future developers git-bisecting the
+        # provisioning scripts), check for this situation, and blow away the
+        # created .bash_profile if one is found.
+        import errno
+        BASH_PROFILE = BASH_PROFILES[0]
+        DOT_PROFILE = BASH_PROFILES[2]
+        OLD_PROFILE_TEXT = "source /srv/zulip-py3-venv/bin/activate\n" + \
+            "cd /srv/zulip\n"
+
+        if os.path.exists(DOT_PROFILE):
+            try:
+                with open(BASH_PROFILE, "r") as f:
+                    profile_contents = f.read()
+                if profile_contents == OLD_PROFILE_TEXT:
+                    os.unlink(BASH_PROFILE)
+            except FileNotFoundError as e:
+                pass
+
+    clear_old_profile()
+
+    for candidate_profile in BASH_PROFILES:
+        if os.path.exists(candidate_profile):
+            setup_shell_profile(candidate_profile)
+            break
+    else:
+        # no existing bas profile found; claim .bash_profile
+        setup_shell_profile(BASH_PROFILES[0])
+
 def main(options: argparse.Namespace) -> int:
-    setup_shell_profile('~/.bash_profile')
+    setup_bash_profile()
     setup_shell_profile('~/.zprofile')
 
     # This needs to happen before anything that imports zproject.settings.


### PR DESCRIPTION
The base Docker image, as currently used on MacOS, includes no
`.bash_profile`. Creating one will prevent the existing support
scripts in `~/.profile` from loading.

Instead, if we have to create a `~/.bash_profile`, create one that
explicitly checks for and loads `~/.profile` (or `~/.bash_login`, as
the case may be, per the Bash manual page).

Existing Docker users may need to delete their `.bash_profile`, if it
was autogenerated.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Tested against a Docker image provisioned with a recent `master`, as well as one with its `.bash_profile` deleted (which seemed to be its initial state).

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
