### PR TITLE
Added correct server restart command

### DIFF
--- a/docs/production/email.md
+++ b/docs/production/email.md
@@ -39,7 +39,7 @@ email addresses and send notifications.
    configuration is working.
 
 1. Once your configuration is working, restart the Zulip server with
-   `/home/zulip/deployments/current/scripts/restart`.
+   `su zulip -c '/home/zulip/deployments/current/scripts/restart-server'`.
 
 ## Email services
 


### PR DESCRIPTION
The Restart Zulip command on email.md doesn't work 

**Testing Plan:** 
Tried running /home/zulip/deployments/current/scripts/restart with sudo zulip
didnt work.

```
root@socialZulip:~# root@socialZulip:~# su zulip /etc/zulip/deployments/current/scripts/restart
root@socialZulip:~#: command not found
su zulip -c "/etc/zulip/deployments/current/scripts/restart"
root@socialZulip:~#: command not found

```
The command that does work is
`su zulip -c '/home/zulip/deployments/current/scripts/restart-server'`