### PR TITLE
Revert "provision: Give concrete NFS error message on older OSX versions."

### DIFF
--- a/tools/setup/generate_zulip_bots_static_files.py
+++ b/tools/setup/generate_zulip_bots_static_files.py
@@ -16,13 +16,7 @@ def generate_zulip_bots_static_files() -> None:
     bots_dir = 'static/generated/bots'
     if os.path.isdir(bots_dir):
         # delete old static files, they could be outdated
-        try:
-            shutil.rmtree(bots_dir)
-        except OSError:
-            print("There was a permission error with Vagrant's NFS file      sharing on old versions of " +
-                  "OSX. You can fix this by upgrading to the latest OSX High Sierra, or work around it " +
-                  "by giving read/write permissions to your /zulip folder to everyone.")
-            sys.exit(1)
+        shutil.rmtree(bots_dir)
 
     os.makedirs(bots_dir, exist_ok=True)
 


### PR DESCRIPTION
This reverts commit 073ecaac66f277b7eef74f0b5610352d55e4d5a9 (#9365).

This exception handler was overly broad in catching all `OSError`s, and it made debugging harder by hiding the actual exception. Furthermore, we no longer use NFS (#12963), and we’re now getting reports of Windows users running into this message.