### PR TITLE
styles: Remove overrides for KaTeX line-height and white-space

### DIFF
--- a/static/styles/rendered_markdown.scss
+++ b/static/styles/rendered_markdown.scss
@@ -149,15 +149,6 @@
     }
 
     /* LaTeX styling */
-    .katex-html {
-        line-height: initial;
-        white-space: initial;
-    }
-
-    .katex-display .katex-html {
-        line-height: 3em;
-    }
-
     .katex-display {
         margin: 0em 0;
     }


### PR DESCRIPTION
Commit ba66dfe977f3f4d2d532095bc5e125585960c222 incorrectly inflated the specificity level of these rules by moving them inside `.rendered_markdown` “entirely for readability”. KaTeX has its own rules that work better, so just delete ours.

**Testing Plan:** Dev server with [these test cases](https://github.com/zulip/zulip/issues/7620#issuecomment-529997957) and others.