### PR TITLE
custom profile field: Add tests for default external field reuse issue.

### DIFF
--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -62,7 +62,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
 
         result = self.client_post("/json/realm/profile_fields", info=data)
         self.assert_json_error(result,
-                               u'A field with that label already exists.')
+                               u'A field with {} label already exists.'.format(data['name']))
 
     def test_create_choice_field(self) -> None:
         self.login(self.example_email("iago"))
@@ -263,7 +263,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.assertEqual(field_data['url_pattern'], 'https://www.reddit.com/user/%(username)s')
 
         result = self.client_post("/json/realm/profile_fields", info=data)
-        self.assert_json_error(result, "A field with that label already exists.")
+        self.assert_json_error(result, "A field with {} label already exists.".format(custom_field.name))
 
     def test_create_field_of_type_user(self) -> None:
         self.login(self.example_email("iago"))
@@ -443,7 +443,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
             "/json/realm/profile_fields/{}".format(field_2.id),
             info={'name': 'Phone', 'field_type': CustomProfileField.SHORT_TEXT})
         self.assert_json_error(
-            result, u'A field with that label already exists.')
+            result, u'A field with {} label already exists.'.format(field_1.name))
 
     def assert_error_update_invalid_value(self, field_name: str, new_value: object, error_msg: str) -> None:
         self.login(self.example_email("iago"))

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -168,6 +168,13 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
         result = self.client_delete("/json/realm/profile_fields/{}".format(field.id))
         self.assert_json_success(result)
 
+        field = try_add_realm_custom_profile_field(realm, "Twitter",
+                                                   field_type=CustomProfileField.SHORT_TEXT)
+        result = self.client_post("/json/realm/profile_fields",
+                                  info=dict(field_type=CustomProfileField.EXTERNAL_ACCOUNT,
+                                            field_data=field_data))
+        self.assert_json_error(result, "A field with Twitter label already exists.")
+
     def test_create_external_account_field(self) -> None:
         self.login(self.example_email("iago"))
         realm = get_realm('zulip')


### PR DESCRIPTION
This commit adds test case for handling a case where realm
have non external account field with our default realm field
name.

Followup of #12913 

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
