### PR TITLE
templates: Improve bot creation menu

### DIFF
--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -248,7 +248,7 @@ exports.set_up = function () {
             exports.hide_errors();
         },
         submitHandler: function () {
-            const bot_type = $('#create_bot_type :selected').val();
+            const bot_type = $('input[name="bot_type"]:checked').val();
             const full_name = $('#create_bot_name').val();
             const short_name = $('#create_bot_short_name').val() || $('#create_bot_short_name').text();
             const payload_url = $('#create_payload_url').val();
@@ -294,7 +294,7 @@ exports.set_up = function () {
                     $("[name*='" + service_name + "'] input").each(function () {
                         $(this).val('');
                     });
-                    $('#create_bot_type').val(GENERIC_BOT_TYPE);
+                    $('input[name="bot_type"]:checked').val(GENERIC_BOT_TYPE);
                     $('#select_service_name').val('converter'); // TODO: Later we can change this to hello bot or similar
                     $('#service_name_list').hide();
                     $('#create_bot_button').show();
@@ -313,8 +313,8 @@ exports.set_up = function () {
         },
     });
 
-    $("#create_bot_type").on("change", function () {
-        const bot_type = $('#create_bot_type :selected').val();
+    $(".create_bot_type").on("change", function () {
+        const bot_type = $('input[name="bot_type"]:checked').val();
         // For "generic bot" or "incoming webhook" both these fields need not be displayed.
         $('#service_name_list').hide();
         $('#select_service_name').removeClass('required');

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -988,6 +988,23 @@ input[type=checkbox].inline-block {
     white-space: pre;
 }
 
+.new-bot-form {
+    .title {
+        font-size: 1.3em;
+        margin-bottom: 0.2em;
+    }
+    .grey-box {
+        li {
+            border-bottom: 1px solid hsl(0, 0%, 87%);
+            padding: 5px 0px;
+
+            &:last-of-type {
+                border-bottom: none;
+            }
+        }
+    }
+}
+
 #create_bot_form .control-label,
 #create_alert_word_form .control-label,
 .admin-emoji-form .control-label,

--- a/static/templates/settings/bot_settings.hbs
+++ b/static/templates/settings/bot_settings.hbs
@@ -33,21 +33,22 @@
               class="form-horizontal no-padding {{#unless can_create_new_bots}}hide{{/unless}}">
                 <div class="new-bot-form">
                     <div class="input-group">
-                        <label for="bot_type">
+                        <label for="bot_type" class="title">
                             {{t "Bot type" }}
-                            <i class="fa fa-question-circle settings-info-icon bot_type_tooltip" aria-hidden="true" data-toggle="tooltip"
-                              title='{{t "Incoming webhooks can only send messages." }}'></i>
                         </label>
-                        <select name="bot_type" id="create_bot_type">
+                        <ul class="grey-box">
                             {{#each page_params.bot_types}}
-                                {{#if this.allowed}}
-                                <option value="{{this.type_id}}">{{this.name}}</option>
-                                {{/if}}
+                            <li>
+                                <label class="radio">
+                                    <input type="radio" name="bot_type" class="create_bot_type" value="{{this.type_id}}">
+                                    <b>{{t this.name}}:</b> {{t this.description}}
+                                </label>
+                            </li>
                             {{/each}}
-                        </select>
+                        </ul>
                     </div>
                     <div class="input-group" id="service_name_list">
-                        <label for="select_service_name">{{t "Bot"}}</label>
+                        <label for="select_service_name" class="title">{{t "Bot"}}</label>
                         <select name="service_name" id="select_service_name">
                             {{#each page_params.realm_embedded_bots}}
                             <option value="{{this.name}}">{{this.name}}</option>
@@ -55,13 +56,13 @@
                         </select>
                     </div>
                     <div class="input-group">
-                        <label for="create_bot_name">{{t "Full name" }}</label>
+                        <label for="create_bot_name" class="title">{{t "Full name" }}</label>
                         <input type="text" name="bot_name" id="create_bot_name" class="required"
                           maxlength=100 placeholder="{{t 'Cookie Bot' }}" value="" />
                         <div><label for="create_bot_name" generated="true" class="text-error"></label></div>
                     </div>
                     <div class="input-group">
-                        <label for="bot_short_name">{{t "Bot email (a-z, 0-9, and dashes only)" }}</label>
+                        <label for="bot_short_name" class="title">{{t "Bot email (a-z, 0-9, and dashes only)" }}</label>
                         <input type="text" name="bot_short_name" id="create_bot_short_name" class="required bot_local_part"
                           placeholder="{{t 'cookie' }}" value="" />
                         -bot@{{ page_params.realm_bot_domain }}
@@ -71,13 +72,13 @@
                     </div>
                     <div id="payload_url_inputbox">
                         <div class="input-group">
-                            <label for="create_payload_url">{{t "Endpoint URL" }}</label>
+                            <label for="create_payload_url" class="title">{{t "Endpoint URL" }}</label>
                             <input type="text" name="payload_url" id="create_payload_url"
                               maxlength=2083 placeholder="https://hostname.example.com" value="" />
                             <div><label for="create_payload_url" generated="true" class="text-error"></label></div>
                         </div>
                         <div class="input-group">
-                            <label for="interface_type">{{t "Outgoing webhook message format" }}</label>
+                            <label for="interface_type" class="title">{{t "Outgoing webhook message format" }}</label>
                             <select name="interface_type" id="create_interface_type">
                                 <option value="1">Zulip</option>
                                 <option value="2">{{t "Slack compatible" }}</option>

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -62,12 +62,19 @@ def sent_time_in_epoch_seconds(user_message: Optional[UserMessage]) -> Optional[
     return calendar.timegm(user_message.message.date_sent.utctimetuple())
 
 def get_bot_types(user_profile: UserProfile) -> List[Dict[str, object]]:
+    bot_descriptions = {
+        1: "Default Sunt sed officia ex sint exercitation ullamco in dolore in eu.",
+        2: "Incoming Sit labore elit et eu nisi ad anim nostrud enim reprehenderit ut.",
+        3: "Outgoing Dolor excepteur in cupidatat excepteur duis sunt nulla excepteur ut.",
+        4: "Embedded Quis in quis ex ullamco occaecat ut dolor aliqua ut non elit sit."
+    }
     bot_types = []
     for type_id, name in UserProfile.BOT_TYPES.items():
         bot_types.append({
             'type_id': type_id,
             'name': name,
-            'allowed': type_id in user_profile.allowed_bot_types
+            'allowed': type_id in user_profile.allowed_bot_types,
+            'description': bot_descriptions.get(type_id, None)
         })
     return bot_types
 


### PR DESCRIPTION
This changes the bot type list from a drop-down to radio buttons.
The tooltip was expanded to describe each bot type.
Added "POST" to ignored phrases when checking proper capitalization.

Fixes #5273