### PR TITLE
Clean test backend output

### DIFF
--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -303,7 +303,6 @@ class BugdownTest(ZulipTestCase):
                 converted = bugdown_convert(test['input'])
 
             with self.subTest(markdown_test_case=name):
-                print("Running Bugdown test %s" % (name,))
                 self.assertEqual(converted, test['expected_output'])
 
         def replaced(payload: str, url: str, phrase: str='') -> str:

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -118,7 +118,7 @@ from zerver.lib.message import (
 )
 from zerver.lib.test_helpers import POSTRequestMock, get_subscription, \
     get_test_image_file, stub_event_queue_user_events, queries_captured, \
-    create_dummy_file
+    create_dummy_file, stdout_suppressed
 from zerver.lib.test_classes import (
     ZulipTestCase,
 )
@@ -2788,9 +2788,10 @@ class EventsRegisterTest(ZulipTestCase):
 
         with mock.patch('zerver.lib.export.do_export_realm',
                         return_value=create_dummy_file('test-export.tar.gz')):
-            events = self.do_test(
-                lambda: self.client_post('/json/export/realm'),
-                state_change_expected=True, num_events=2)
+            with stdout_suppressed():
+                events = self.do_test(
+                    lambda: self.client_post('/json/export/realm'),
+                    state_change_expected=True, num_events=2)
 
         # The first event is a message from notification-bot.
         error = schema_checker('events[1]', events[1])

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -172,13 +172,11 @@ class TestCommandsCanStart(TestCase):
 
     @slow("Aggregate of runs dozens of individual --help tests")
     def test_management_commands_show_help(self) -> None:
-        with stdout_suppressed() as stdout:
+        with stdout_suppressed():
             for command in self.commands:
-                print('Testing management command: {}'.format(command),
-                      file=stdout)
-
-                with self.assertRaises(SystemExit):
-                    call_command(command, '--help')
+                with self.subTest(management_command=command):
+                    with self.assertRaises(SystemExit):
+                        call_command(command, '--help')
         # zerver/management/commands/runtornado.py sets this to True;
         # we need to reset it here.  See #3685 for details.
         settings.RUNNING_INSIDE_TORNADO = False

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1710,7 +1710,6 @@ class TestPushNotificationsContent(ZulipTestCase):
         for test in tests:
             if "text_content" in test:
                 with self.subTest(markdown_test_case=test["name"]):
-                    print("Running markdown fixture test %s" % (test["name"],))
                     output = get_mobile_push_content(test["expected_output"])
                     self.assertEqual(output, test["text_content"])
 

--- a/zerver/tests/test_realm_export.py
+++ b/zerver/tests/test_realm_export.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.test_helpers import use_s3_backend, create_s3_buckets, \
-    create_dummy_file
+    create_dummy_file, stdout_suppressed
 
 from zerver.models import RealmAuditLog
 from zerver.views.realm_export import export_realm
@@ -42,7 +42,7 @@ class RealmExportTest(ZulipTestCase):
         # Test the export logic.
         with patch('zerver.lib.export.do_export_realm',
                    return_value=tarball_path) as mock_export:
-            with self.settings(LOCAL_UPLOADS_DIR=None):
+            with self.settings(LOCAL_UPLOADS_DIR=None), stdout_suppressed():
                 result = self.client_post('/json/export/realm')
         self.assert_json_success(result)
         self.assertFalse(os.path.exists(tarball_path))
@@ -99,7 +99,8 @@ class RealmExportTest(ZulipTestCase):
         # Test the export logic.
         with patch('zerver.lib.export.do_export_realm',
                    return_value=tarball_path) as mock_export:
-            result = self.client_post('/json/export/realm')
+            with stdout_suppressed():
+                result = self.client_post('/json/export/realm')
         self.assert_json_success(result)
         self.assertFalse(os.path.exists(tarball_path))
         args = mock_export.call_args_list[0][1]

--- a/zerver/tests/test_slack_message_conversion.py
+++ b/zerver/tests/test_slack_message_conversion.py
@@ -45,8 +45,8 @@ class SlackMessageConversion(ZulipTestCase):
             channel_map = {}     # type: Dict[str, Tuple[str, int]]
             converted = convert_to_zulip_markdown(test['input'], users, channel_map, slack_user_map)
             converted_text = converted[0]
-            print("Running Slack Message Conversion test: %s" % (name,))
-            self.assertEqual(converted_text, test['conversion_output'])
+            with self.subTest(slack_message_conversion=name):
+                self.assertEqual(converted_text, test['conversion_output'])
 
     def test_mentioned_data(self) -> None:
         slack_user_map = {'U08RGD1RD': 540,


### PR DESCRIPTION
This PR deals only with the following:
* Using `self.subTest` in favor of print statements in:
  * `test_management_commands.py`
  * `test_bugdown.py`
  * `test_slack_message_conversion.py`
  * `test_push_notifications.py`

I also added `stdout_suppressed` to be used with the `realm_export` related tests to remove output in the form of:
```
Finished exporting to /tmp/zulip-export-v4vuikjj
Tarball written to /srv/zulip/var/00367a82-ac8b-4521-be16-64bd289c5b72/test-backend/run_217706400/worker_0/test-export.tar.gz
Uploading export tarball...

Uploaded to http://zulip.testserver/user_avatars/exports/2/AMgUUQw_ss0zdMDInjT0csQv/test-export.tar.gz
Successfully deleted the tarball at /srv/zulip/var/00367a82-ac8b-4521-be16-64bd289c5b72/test-backend/run_217706400/worker_0/test-export.tar.gz
```