### PR TITLE
search: Fix '2 enter to search' for Unicode chars

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -120,13 +120,18 @@ exports.initialize = function () {
         advanceKeyCodes: [8],
     });
 
-    searchbox_form.on('compositionend', function () {
+    searchbox_form.on('compositionend', function (e) {
         // Set `is_using_input_method` to true if enter is pressed to exit
         // the input tool popover and get the text in the search bar. Then
         // we suppress searching triggered by this enter key by checking
         // `is_using_input_method` before searching.
         // More details in the commit message that added this line.
-        exports.is_using_input_method = true;
+        // If the 'e' is truly this means an Unicode character was typed,
+        // in this case we shouldn't set 'is_using_input_method' so the
+        // search can be made
+        if (!e) {
+            exports.is_using_input_method = true;
+        }
     });
 
     searchbox_form.keydown(function (e) {


### PR DESCRIPTION
The event '[compositionend](https://developer.mozilla.org/en-US/docs/Web/API/Element/compositionend_event)' is triggered when the user uses
the enter to exit the search or when an Unicode character is
typed. Treating indistinctivily both cases creates the need
of typing two times the enter to trigger the search. This commit
solves this problem by handling each case separately.

Fixes: #13093


**Testing Plan:** 
Tested manually.


