### PR TITLE
pm_list: Bot availability status in pm

### DIFF
--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -93,6 +93,12 @@ exports._build_private_messages_list = function (active_conversation) {
         if (is_group) {
             user_circle_class = 'user_circle_fraction';
             fraction_present = buddy_data.huddle_fraction_present(user_ids_string);
+        } else {
+            var recipient_user_obj = people.get_person_from_user_id(user_ids_string);
+
+            if (recipient_user_obj.is_bot) {
+                user_circle_class = 'user_circle_green';
+            }
         }
 
         var display_message = {


### PR DESCRIPTION
Changes the bot availability circle to bot icon on
left side bar, pm listing.

Fixes #13149

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
**Testing Plan:** <!-- How have you tested? -->
Manual testing

**GIFs or Screenshots:** 
![Captura de tela de 2019-09-16 18-13-47](https://user-images.githubusercontent.com/15564640/64996772-416f3c80-d8b5-11e9-9d37-f7bcf7c6aad6.png)

On the discussion of this issue, it was said that if the recipient of the message is a bot, it shouldn't have an availability circle at all. But for me personally, it was kinda odd seeing no icon at all besides the name of the bot, and also I think it would be less confusing if it had some indication that that user is a bot. So, I put a bot icon, but I'm not sure if it is nice or ok. What do you think @timabbott and @rishig ? 


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
