### PR TITLE
emails: Add realm name to footer of missed message emails.

### DIFF
--- a/templates/zerver/emails/missed_message.source.html
+++ b/templates/zerver/emails/missed_message.source.html
@@ -18,7 +18,7 @@
 <div class="email-preferences">
     &mdash;<br>
     {% if mention %}
-    You are receiving this because you were mentioned.<br>
+    You are receiving this because you were mentioned in {{ realm_name }}.<br>
     {% elif stream_email_notify %}
     You are receiving this because you have email notifications enabled for this stream.<br>
     {% endif %}

--- a/templates/zerver/emails/missed_message.txt
+++ b/templates/zerver/emails/missed_message.txt
@@ -10,7 +10,7 @@
 
 --
 {% if mention %}
-You are receiving this because you were mentioned.
+You are receiving this because you were mentioned in {{ realm_name }}.
 {% elif stream_email_notify %}
 You are receiving this because you have email notifications enabled for this stream.
 {% endif %}

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -242,7 +242,7 @@ class TestMissedMessages(ZulipTestCase):
 
         if show_message_content:
             body = ("Othello, the Moor of Venice: 1 2 3 4 5 6 7 8 9 10 @**King Hamlet** -- "
-                    "You are receiving this because you were mentioned")
+                    "You are receiving this because you were mentioned in Zulip Dev.")
             email_subject = '#Denmark > test'
             verify_body_does_not_include = []  # type: List[str]
         else:
@@ -275,7 +275,7 @@ class TestMissedMessages(ZulipTestCase):
 
         if show_message_content:
             body = ("Othello, the Moor of Venice: 1 2 3 4 5 @**all** -- "
-                    "You are receiving this because you were mentioned")
+                    "You are receiving this because you were mentioned in Zulip Dev.")
             email_subject = '#Denmark > test'
             verify_body_does_not_include = []  # type: List[str]
         else:
@@ -321,7 +321,7 @@ class TestMissedMessages(ZulipTestCase):
             self.example_email('othello'), "Denmark",
             '@**King Hamlet**')
         body = ("Cordelia Lear: 0 1 2 Othello, the Moor of Venice: @**King Hamlet** -- "
-                "You are receiving this because you were mentioned")
+                "You are receiving this because you were mentioned in Zulip Dev.")
         email_subject = '#Denmark > test'
         self._test_cases(tokens, msg_id, body, email_subject, send_as_user, trigger='mentioned')
 


### PR DESCRIPTION
Missed message emails for mentions come from streams and possibly orgs you
don't normally get missed message emails for, so they can be hard to place.
