### PR TITLE
templates: Move page_params to a <div> at the bottom of <body>

### DIFF
--- a/static/js/page_params.js
+++ b/static/js/page_params.js
@@ -1,2 +1,1 @@
-window.page_params = $(document.body).data("params");
-$(document.body).removeAttr("data-params");
+window.page_params = $("#page-params").remove().data("params");

--- a/templates/zerver/base.html
+++ b/templates/zerver/base.html
@@ -41,11 +41,11 @@
         {% endblock %}
     </head>
 
-    <body {% if night_mode %}class="night-mode"{% endif %}
-      data-params='{{ page_params|default({"debug_mode": false})|tojson }}'
-      >
+    <body {% if night_mode %}class="night-mode"{% endif %}>
         {% block content %}
         {% endblock %}
+
+        <div hidden id="page-params" data-params='{{ page_params|default({"debug_mode": false})|tojson }}'></div>
     </body>
 
 </html>

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -354,7 +354,8 @@ class HomeTest(ZulipTestCase):
 
     def _get_page_params(self, result: HttpResponse) -> Dict[str, Any]:
         doc = lxml.html.document_fromstring(result.content)
-        page_params_json = doc.find("body").get("data-params")
+        [div] = doc.xpath("//div[@id='page-params']")
+        page_params_json = div.get("data-params")
         page_params = ujson.loads(page_params_json)
         return page_params
 


### PR DESCRIPTION
In a gigantic realm where we send several MB of `page_params`, it’s slightly better to have the rest of the `<body>` available to the browser earlier, so it can show the “Loading…” spinner and start fetching subresources.

**Testing Plan:** Dev server, prod at https://andersk.zulipdev.org