### PR TITLE
Oauth/Social backends - very minor cleanup

### DIFF
--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -68,7 +68,7 @@ page can be easily identified in it's respective JavaScript file -->
                                 <button class="full-width" type="submit">{{ _('Sign up') }}</button>
                             </form>
 
-                            {% if any_oauth_backend_enabled %}
+                            {% if any_social_backend_enabled %}
                             <div class="or"><span>{{ _('OR') }}</span></div>
                             {% endif %}
                         {% endif %}

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -124,7 +124,7 @@ page can be easily identified in it's respective JavaScript file. -->
                                 </button>
                             </form>
 
-                            {% if any_oauth_backend_enabled %}
+                            {% if any_social_backend_enabled %}
                             <div class="or"><span>{{ _('OR') }}</span></div>
                             {% endif %}
 

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 
 from zerver.models import UserProfile, get_realm, Realm
 from zproject.backends import (
-    any_oauth_backend_enabled,
+    any_social_backend_enabled,
     password_auth_enabled,
     require_email_format_usernames,
     auth_enabled_helper,
@@ -158,7 +158,7 @@ def login_context(request: HttpRequest) -> Dict[str, Any]:
         'realm_description': realm_description,
         'require_email_format_usernames': require_email_format_usernames(realm),
         'password_auth_enabled': password_auth_enabled(realm),
-        'any_oauth_backend_enabled': any_oauth_backend_enabled(realm),
+        'any_social_backend_enabled': any_social_backend_enabled(realm),
         'two_factor_authentication_enabled': settings.TWO_FACTOR_AUTHENTICATION_ENABLED,
     }  # type: Dict[str, Any]
 

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -99,7 +99,9 @@ def github_auth_enabled(realm: Optional[Realm]=None) -> bool:
 def any_oauth_backend_enabled(realm: Optional[Realm]=None) -> bool:
     """Used by the login page process to determine whether to show the
     'OR' for login with Google"""
-    return auth_enabled_helper(OAUTH_BACKEND_NAMES, realm)
+    social_backend_names = [social_auth_subclass.auth_backend_name
+                            for social_auth_subclass in SOCIAL_AUTH_BACKENDS]
+    return auth_enabled_helper(social_backend_names, realm)
 
 def require_email_format_usernames(realm: Optional[Realm]=None) -> bool:
     if ldap_auth_enabled(realm):
@@ -983,15 +985,12 @@ AUTH_BACKEND_NAME_MAP = {
     'LDAP': ZulipLDAPAuthBackend,
     'RemoteUser': ZulipRemoteUserBackend,
 }  # type: Dict[str, Any]
-OAUTH_BACKEND_NAMES = []  # type: List[str]
 SOCIAL_AUTH_BACKENDS = []  # type: List[BaseOAuth2]
 
 # Authomatically add all of our social auth backends to relevant data structures.
 for social_auth_subclass in SocialAuthMixin.__subclasses__():
     AUTH_BACKEND_NAME_MAP[social_auth_subclass.auth_backend_name] = social_auth_subclass
-    if issubclass(social_auth_subclass, BaseOAuth2):
-        OAUTH_BACKEND_NAMES.append(social_auth_subclass.auth_backend_name)
-        SOCIAL_AUTH_BACKENDS.append(social_auth_subclass)
+    SOCIAL_AUTH_BACKENDS.append(social_auth_subclass)
 
 # Provide this alternative name for backwards compatibility with
 # installations that had the old backend enabled.

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -96,7 +96,7 @@ def google_auth_enabled(realm: Optional[Realm]=None) -> bool:
 def github_auth_enabled(realm: Optional[Realm]=None) -> bool:
     return auth_enabled_helper(['GitHub'], realm)
 
-def any_oauth_backend_enabled(realm: Optional[Realm]=None) -> bool:
+def any_social_backend_enabled(realm: Optional[Realm]=None) -> bool:
     """Used by the login page process to determine whether to show the
     'OR' for login with Google"""
     social_backend_names = [social_auth_subclass.auth_backend_name


### PR DESCRIPTION
As explained in the commits, there is a bit of a weird juggling of "social backend" / "oauth backend" concepts in the code, where we're better served just thinking of "social backends".

Otherwise, when we add SAML, we would have to add some additional logic dealing with the fact that it's a "social" backend, but not an oauth backend and things would just get more confusing, for no benefit.