### PR TITLE
styles: Add overflow: hidden on .message_content

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1171,6 +1171,7 @@ div.focused_table {
     margin-left: 46px;
     display: block;
     position: relative;
+    overflow: hidden;
 }
 
 .rtl {


### PR DESCRIPTION
This has two purposes:

1. Prevent stupid stacks of diacritical marks from overflowing into other messages.  Fixes #7843.

2. Prevent Chrome from collapsing the inside bottom margin with the .messagebox outside (in a way that Firefox doesn’t).

**Testing Plan:** Dev server.