### PR TITLE
bulk_get_subscriber_user_ids: Sort each user list by ID

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2627,7 +2627,8 @@ def bulk_get_subscriber_user_ids(stream_dicts: Iterable[Mapping[str, Any]],
             zerver_subscription.active AND
             zerver_userprofile.is_active
         ORDER BY
-            zerver_subscription.recipient_id
+            zerver_subscription.recipient_id,
+            zerver_subscription.user_profile_id
         ''' % (id_list,)
 
     cursor = connection.cursor()


### PR DESCRIPTION
This simple backwards-compatible change saves approximately 12% in the compressed size of the chat.zulip.org `page_params`.  We can do much, much better by changing the format, but this seems like a good intermediate step.

**Testing Plan:** Dev server.