### PR TITLE
restart-server: Warn if the shell’s PWD goes through an updated symlink

### DIFF
--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -7,9 +7,10 @@ import pwd
 import subprocess
 import logging
 import time
+import shlex
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-from scripts.lib.zulip_tools import ENDC, OKGREEN, DEPLOYMENTS_DIR, overwrite_symlink
+from scripts.lib.zulip_tools import ENDC, OKGREEN, WARNING, DEPLOYMENTS_DIR, overwrite_symlink
 
 logging.Formatter.converter = time.gmtime
 logging.basicConfig(format="%(asctime)s restart-server: %(message)s",
@@ -40,7 +41,8 @@ if os.path.exists("/etc/supervisor/conf.d/thumbor.conf"):
 
 current_symlink = os.path.join(DEPLOYMENTS_DIR, "current")
 last_symlink = os.path.join(DEPLOYMENTS_DIR, "last")
-if os.readlink(current_symlink) != deploy_path:
+change_symlink = os.readlink(current_symlink) != deploy_path
+if change_symlink:
     overwrite_symlink(os.readlink(current_symlink), last_symlink)
     overwrite_symlink(deploy_path, current_symlink)
 
@@ -83,3 +85,18 @@ if os.path.exists("/etc/supervisor/conf.d/zulip_db.conf"):
 
 logging.info("Done!")
 print(OKGREEN + "Application restarted successfully!" + ENDC)
+
+if change_symlink and "PWD" in os.environ:
+    for symlink in [last_symlink, current_symlink]:
+        if os.path.commonprefix([os.environ["PWD"], symlink]) == symlink:
+            print(
+                """
+%sYour shell entered its current directory through a symlink:
+  %s
+which has now changed. Your shell will not see this change until you run:
+  cd %s
+to traverse the symlink again.%s
+"""
+                % (WARNING, symlink, shlex.quote(os.environ["PWD"]), ENDC),
+                file=sys.stderr,
+            )


### PR DESCRIPTION
**Testing Plan:**

```console
root@zulip-buster:/home/zulip/deployments/current# scripts/upgrade-zulip-from-git pwd
…
2019-09-20 01:18:44,187 upgrade-zulip-stage-2: Restarting Zulip...
2019-09-20 01:18:47,140 restart-server: Filling memcached caches
2019-09-20 01:18:49.688 INFO [] Successfully populated user cache!  Consumed 1 remote cache queries (0.0 time)
2019-09-20 01:18:49.691 INFO [] Successfully populated client cache!  Consumed 1 remote cache queries (0.0 time)
2019-09-20 01:18:49.697 INFO [] Successfully populated recipient cache!  Consumed 1 remote cache queries (0.0 time)
2019-09-20 01:18:49.704 INFO [] Successfully populated stream cache!  Consumed 1 remote cache queries (0.0 time)
2019-09-20 01:18:49.706 INFO [] Successfully populated huddle cache!  Consumed 1 remote cache queries (0.0 time)
2019-09-20 01:18:49.709 INFO [] Successfully populated session cache!  Consumed 1 remote cache queries (0.0 time)
2019-09-20 01:18:51,256 restart-server: Stopping workers
2019-09-20 01:18:51,519 restart-server: Stopping server core
2019-09-20 01:18:51,786 restart-server: Starting server core
2019-09-20 01:18:56,586 restart-server: Starting workers
2019-09-20 01:19:04,334 restart-server: Done!

Your shell entered its current directory through a symlink:
  /home/zulip/deployments/current
which has now changed. Your shell will not see this change until you run:
  cd /home/zulip/deployments/current
to traverse the symlink again.

2019-09-20 01:19:04,364 upgrade-zulip-stage-2: Upgrade complete!
2019-09-20 01:19:04,364 upgrade-zulip-stage-2: Purging old deployments...
Cleaning unused deployments...
Deployments cleaned successfully...
Cleaning orphaned/unused caches...
Cleaning unused venv caches...
Cleaning unused node modules caches...
Cleaning unused emoji caches...
Done!
root@zulip-buster:/home/zulip/deployments/current#
```
