### PR TITLE
templates: Make the Loading… message more robust

### DIFF
--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -231,3 +231,6 @@ import "../../styles/hotspots.scss";
 import "../../styles/night_mode.scss";
 import "../../styles/user_status.scss";
 import "../../styles/widgets.scss";
+
+// This should be last.
+import "../ready.js";

--- a/static/js/page_params.js
+++ b/static/js/page_params.js
@@ -1,1 +1,4 @@
 window.page_params = $("#page-params").remove().data("params");
+if (!window.page_params) {
+    throw new Error("Missing page-params");
+}

--- a/static/js/ready.js
+++ b/static/js/ready.js
@@ -1,0 +1,1 @@
+$("#app-loading").addClass("loaded");

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -8,7 +8,7 @@ html {
     touch-action: manipulation;
 }
 
-#css-loading {
+#app-loading.loaded {
     display: none !important; /* We are now loaded, by definition. */
 }
 

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -16,7 +16,7 @@
 <link href="/static/images/logo/apple-touch-icon-precomposed.png" rel="apple-touch-icon-precomposed">
 <link id="emoji-spritesheet" href="/static/generated/emoji/{{ emojiset }}-sprite.css" rel="stylesheet" type="text/css">
 <style>
-    #css-loading {
+    #app-loading {
     background-color: hsl(0, 0%, 100%);
     position: fixed;
     height: 100%;
@@ -24,6 +24,7 @@
     padding: 10px;
     top: 0px;
     left: 0px;
+    z-index: 9001;
     }
 
 </style>
@@ -33,7 +34,7 @@
 <div id="feedback_container" class="new-style">
 </div>
 
-<div id="css-loading">
+<div id="app-loading">
     <h3>{{ _('Loading...') }}</h3>
     <p>{% trans %}If this message does not go away, please wait a couple seconds and <a id="reload-lnk">reload</a> the page.{% endtrans %}</p>
     <script nonce="{{ csp_nonce }}">


### PR DESCRIPTION
Don’t hide it until both CSS and JS have loaded.

**Testing Plan:** Removed `page-params` from `templates/zerver/base.html`.