### PR TITLE
[WIP] api: Add introspection code for logging /events data types.

### DIFF
--- a/static/styles/portico/integrations_dev_panel.css
+++ b/static/styles/portico/integrations_dev_panel.css
@@ -44,7 +44,7 @@ button {
     background-color: hsl(0, 0%, 100%);
 }
 
-#top-navbar {
+.top-navbar {
     display: grid;
     grid-template-columns: 1fr 5fr 1fr;
 }
@@ -111,4 +111,15 @@ button {
     grid-template-columns: 1fr 1fr;
     margin-left: 2%;
     margin-right: 2%;
+}
+
+.events-explore-header {
+    /* Hack to make links to anchors work with fixed header */
+    padding-top: 65px;
+    margin-top: -65px;
+}
+
+.events-explore-header a {
+    text-decoration: underline;
+    color: inherit;
 }

--- a/templates/zerver/api/events_explore.html
+++ b/templates/zerver/api/events_explore.html
@@ -1,0 +1,86 @@
+{% extends "zerver/portico.html" %}
+
+{% block customhead %}
+
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+{{ bundle('api-explore') }}
+{{ bundle('portico') }}
+
+{% endblock %}
+
+{% block content %}
+    <div class="header portico-header">
+        <div class="header-main top-navbar">
+            <div>
+                <a class="brand logo">
+                    <svg class="brand-logo" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 40" version="1.1">
+                        <g transform="translate(-297.14285,-466.64792)">
+                            <circle cx="317.14285" cy="486.64792" r="19.030317"></circle>
+                            <path d="m309.24286 477.14791 14.2 0 1.6 3.9-11.2 11.9 9.6 0 1.6 3.2-14.2 0-1.6-3.9 11.2-11.9-9.6 0z"></path>
+                        </g>
+                    </svg>
+                    <span>Zulip</span>
+                </a>
+            </div>
+
+            <div class="centerpiece">API Events Explorer</div>
+
+            <div class="top-links">
+                <a href="/">Go to Zulip</a>
+            </div>
+
+        </div>
+    </div>
+
+    <div class="pad-small"></div>
+
+    <h2>Event types</h2>
+    <ul>
+        {% for event_type in events_explore_data %}
+        <li><a href="#{{ event_type }}">{{ event_type }} events</a></li>
+        {% endfor %}
+    </ul>
+
+    <br />
+    <br />
+
+    {% for event_type, schema_checker_dicts in events_explore_data.items() %}
+        <h2 class="events-explore-header" id="{{ event_type }}">
+            <a href="#{{ event_type }}">
+                {{ event_type }} events
+            </a>
+        </h2>
+        {% for schema_checker_id, event_root in schema_checker_dicts.items() %}
+
+            <h3 class="events-explore-header" id="{{ event_type }}_schema_{{ schema_checker_id }}">
+                <a href="#{{ event_type }}_schema_{{ schema_checker_id }}">
+                    Schema {{ schema_checker_id }}
+                </a>
+            </h3>
+<pre>
+{{ dump_example(event_root['fields']) }}
+</pre>
+
+            <h4 class="events-explore-header" id="{{ event_type }}_examples_{{ schema_checker_id }}">
+                <a href="#{{ event_type }}_examples_{{ schema_checker_id }}">Examples</a>
+            </h4>
+
+            {% for example in event_root['examples'] %}
+            <h5 class="events-explore-header"
+              id="{{ event_type }}_example_{{ example['instrumented_event_id'] }}">
+                <a href="#{{ event_type }}_example_{{ example['instrumented_event_id'] }}">
+                    Example {{ example['instrumented_event_id'] }}
+                </a>
+            </h5>
+<pre>
+{{ dump_example(example) }}
+</pre>
+            {% endfor %}
+
+        {% endfor %}
+    {% endfor %}
+
+
+    <div class="pad-small"></div>
+
+{% endblock %}

--- a/templates/zerver/dev_tools.html
+++ b/templates/zerver/dev_tools.html
@@ -79,6 +79,11 @@
                     <td>Test incoming webhook integrations</td>
                 </tr>
                 <tr>
+                    <td><a href="/api/events/explore/">/api/events/explorer/</a></td>
+                    <td><code>test-backend --capture-events test_events</code></td>
+                    <td>Test incoming webhook integrations</td>
+                </tr>
+                <tr>
                     <td><a href="/devtools/register_user">/devtools/register_user</a></td>
                     <td>None needed</td>
                     <td>Creates a new user</td>

--- a/templates/zerver/integrations/development/dev_panel.html
+++ b/templates/zerver/integrations/development/dev_panel.html
@@ -9,7 +9,7 @@
 
 {% block content %}
 <div class="header portico-header">
-    <div class="header-main" id="top-navbar">
+    <div class="header-main top-navbar">
         <div>
             <a class="brand logo">
                 <svg class="brand-logo" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 40" version="1.1">

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -246,6 +246,10 @@ def main() -> None:
                         action="store_true",
                         default=False,
                         help="Show detailed output")
+    parser.add_argument('--capture-events', dest='capture_events',
+                        action="store_true",
+                        default=False,
+                        help="Capture API test fixtures from /events")
     parser.add_argument('--generate-fixtures', action="store_true", default=False,
                         dest="generate_fixtures",
                         help=("Force a call to generate-fixtures."))
@@ -455,6 +459,16 @@ def main() -> None:
         # We do this even with failures, since slowness can be
         # an important clue as to why tests fail.
         report_slow_tests()
+
+    # TODO: This logic should really be conditional on running in a
+    # special mode that sets settings.LOG_EVENT_TYPES, tests just
+    # `test_events.py`, and is otherwise more controlled; it's
+    # unmergable until we fix that.
+    if options.capture_events:
+        from zerver.tests.test_events import events_schema_checkers
+        import json
+        with open("static/generated/events_schema_checkers.json", "w") as f:
+            f.write(json.dumps(events_schema_checkers, indent=2, sort_keys=True))
 
     # Ideally, we'd check for any leaked test databases here;
     # but that needs some hackery with database names.

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -106,6 +106,9 @@
         "./static/styles/portico/integrations_dev_panel.css",
         "./static/js/channel.js"
     ],
+    "api-explore": [
+        "./static/styles/portico/integrations_dev_panel.css"
+    ],
     "email-log": [
         "./static/js/bundles/common.js",
         "./static/js/portico/email_log.js",

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -307,7 +307,8 @@ def notify_invites_changed(user_profile: UserProfile) -> None:
     event = dict(type="invites_changed")
     admin_ids = [user.id for user in
                  user_profile.realm.get_admin_users_and_bots()]
-    send_event(user_profile.realm, event, admin_ids)
+    send_event(user_profile.realm, event, admin_ids,
+               description="For realm administrators when invitations are sent")
 
 def notify_new_user(user_profile: UserProfile, internal: bool=False) -> None:
     send_signup_message(settings.NOTIFICATION_BOT, "signups", user_profile, internal)

--- a/zerver/templatetags/app_filters.py
+++ b/zerver/templatetags/app_filters.py
@@ -156,3 +156,12 @@ def render_markdown_path(markdown_file_path: str,
     rendered_html = jinja.from_string(html).render(context)
 
     return mark_safe(rendered_html)
+
+import json
+import copy
+def dump_example(data: Dict[str, Any]) -> str:
+    newdata = copy.deepcopy(data)
+    if 'event_description' in data:
+        del newdata['event_description']
+        del newdata['instrumented_event_id']
+    return json.dumps(newdata, sort_keys=True, indent=4)

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -146,6 +146,8 @@ class DocPageTest(ZulipTestCase):
         self._test('/errors/404/', 'Page not found')
         self._test('/errors/5xx/', 'Internal server error')
         self._test('/emails/', 'manually generate most of the emails by clicking')
+        # The integrations docs page
+        self._test('/api/events/explore/', 'API Events Explorer')
 
         result = self.client_get('/integrations/doc-html/nonexistent_integration', follow=True,
                                  HTTP_X_REQUESTED_WITH='XMLHttpRequest')

--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -188,6 +188,7 @@ of syntax errors.  There are two common causes for this test failing:
                          "login_time": "9:33am NewYork, NewYork",
                          },
             api_uri_context={},
+            events_explore_data={},
             realm_plan_type=Realm.LIMITED,
             cloud_annual_price=80,
             seat_count=8,

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -874,6 +874,8 @@ def process_message_event(event_template: Mapping[str, Any], users: Iterable[Map
         user_event = dict(type='message', message=message_dict, flags=flags)  # type: Dict[str, Any]
         if extra_data is not None:
             user_event.update(extra_data)
+        if 'instrumented_event_id' in event_template:
+            user_event['instrumented_event_id'] = event_template['instrumented_event_id']
 
         if is_sender:
             local_message_id = event_template.get('local_id', None)
@@ -1039,11 +1041,23 @@ def send_notification_http(realm: Realm, data: Mapping[str, Any]) -> None:
     else:
         process_notification(data)
 
-def send_event(realm: Realm, event: Mapping[str, Any],
-               users: Union[Iterable[int], Iterable[Mapping[str, Any]]]) -> None:
+captured_events = {}  # type: Dict[int, Any]
+instrumented_event_counter = 0
+def send_event(realm: Realm, event: Dict[str, Any],
+               users: Union[Iterable[int], Iterable[Mapping[str, Any]]],
+               description: Optional[str]=None) -> None:
     """`users` is a list of user IDs, or in the case of `message` type
     events, a list of dicts describing the users and metadata about
     the user/message pair."""
+    if settings.INSTRUMENT_SEND_EVENT:
+        global instrumented_event_counter
+        instrumented_event_id = instrumented_event_counter
+        instrumented_event_counter += 1
+        event['instrumented_event_id'] = instrumented_event_id
+
+        copied_event = copy.deepcopy(event)  # type: Dict[str, Any]
+        copied_event['event_description'] = description
+        captured_events[instrumented_event_id] = copied_event
     port = get_tornado_port(realm)
     queue_json_publish(notify_tornado_queue_name(port),
                        dict(event=event, users=users),

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -346,6 +346,12 @@ CUSTOM_LOGO_URL = None  # type: Optional[str]
 # development.
 INITIAL_PASSWORD_SALT = None  # type: Optional[str]
 
+# These two settings are used to determine whether we're running
+# the `test_events.py` test suite for the purpose of some special
+# logging.
+LOG_EVENT_TYPES = False
+INSTRUMENT_SEND_EVENT = False
+
 # Used to control whether certain management commands are run on
 # the server.
 # TODO: Replace this with a smarter "run on only one server" system.

--- a/zproject/jinja2/__init__.py
+++ b/zproject/jinja2/__init__.py
@@ -7,7 +7,7 @@ from django.utils.timesince import timesince
 from jinja2 import Environment
 from two_factor.templatetags.two_factor import device_action
 
-from zerver.templatetags.app_filters import display_list, render_markdown_path
+from zerver.templatetags.app_filters import display_list, render_markdown_path, dump_example
 
 
 def environment(**options: Any) -> Environment:
@@ -15,6 +15,7 @@ def environment(**options: Any) -> Environment:
     env.globals.update({
         'url': reverse,
         'render_markdown_path': render_markdown_path,
+        'dump_example': dump_example,
     })
 
     env.install_gettext_translations(translation, True)

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -132,6 +132,10 @@ if not CASPER_TESTS:
     set_loglevel('zerver.worker.queue_processors', 'WARNING')
     set_loglevel('stripe', 'WARNING')
 
+    # An internal piece of logic to control whether the test_events.py
+    # test suite is responsible for collecting example events.
+    LOG_EVENT_TYPES = True
+
 # Enable file:/// hyperlink support by default in tests
 ENABLE_FILE_LINKS = True
 

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -542,6 +542,7 @@ i18n_urls = [
         name="zerver.views.documentation.integration_doc"),
     url(r'^integrations/(.*)$', IntegrationView.as_view()),
     url(r'^team/$', zerver.views.users.team_view),
+    url(r'^api/events/explore/$', zerver.views.documentation.api_events_docs),
     url(r'^history/$', TemplateView.as_view(template_name='zerver/history.html')),
     url(r'^apps/(.*)$', zerver.views.home.apps_view, name='zerver.views.home.apps_view'),
     url(r'^plans/$', zerver.views.home.plans_view, name='plans'),


### PR DESCRIPTION
api: Add introspection code for logging /events data types.

This is part of a larger project to provide nice API documentation for
the events that the Zulip webapp sends to clients.  It's available at
/api/events/explore/, and currently only works reliably in the
development environment, since one needs to run `test-backend
--capture-events test_events` in order to set it up.  Documentation on
/devtools/.

There are definitely things I'd like to see improved:

* It's generally pretty hacky; the validator.py logic in particular is
  pretty messy.

* While we suppress directly duplicate events from the examples, we
  don't suppress near-duplicate events or duplicate schemas, so
  examples have a ton of semi-duplicates.  May be fixable through a
  semi-manual process of passing a new `suppress_from_docs=True`
  argument to check_events_dict generated schema checkers.  Also, some
  of the schema checkers are identical; we should fix that with
  deduplication or otherwise.

See https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/events.20API.20docs/near/787813 for a screenshot and some discussion.