### PR TITLE
email_mirror.send_to_missed_message_address: Check if the user isn't deactivated

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -26,6 +26,8 @@ from zerver.models import Stream, Recipient, \
     get_user_profile_by_id, get_display_recipient, get_personal_recipient, \
     Message, Realm, UserProfile, get_system_bot, get_user, get_stream_by_id_in_realm
 
+from zproject.backends import is_user_active
+
 logger = logging.getLogger(__name__)
 
 def redact_email_address(error_message: str) -> str:
@@ -180,6 +182,9 @@ def send_to_missed_message_address(address: str, message: message.Message) -> No
     user_profile_id, recipient_id, subject_b = result  # type: (bytes, bytes, bytes)
 
     user_profile = get_user_profile_by_id(user_profile_id)
+    if not is_user_active(user_profile):
+        logger.warning("Sending user is not active. Ignoring this missed message email.")
+        return
     recipient = Recipient.objects.get(id=recipient_id)
 
     body = construct_zulip_body(message, user_profile.realm)

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -546,7 +546,7 @@ class TestMissedMessageEmailMessageTokenMissingData(ZulipTestCase):
 
             self.assertEqual(exception_message, 'Missing missed message address data')
 
-class TestMissedPersonalMessageEmailMessages(ZulipTestCase):
+class TestMissedMessageEmailMessages(ZulipTestCase):
     def test_receive_missed_personal_message_email_messages(self) -> None:
 
         # build dummy messages for missed messages email reply
@@ -586,7 +586,6 @@ class TestMissedPersonalMessageEmailMessages(ZulipTestCase):
         self.assertEqual(message.recipient.id, user_profile.id)
         self.assertEqual(message.recipient.type, Recipient.PERSONAL)
 
-class TestMissedHuddleMessageEmailMessages(ZulipTestCase):
     def test_receive_missed_huddle_message_email_messages(self) -> None:
 
         # build dummy messages for missed messages email reply
@@ -633,7 +632,6 @@ class TestMissedHuddleMessageEmailMessages(ZulipTestCase):
         self.assertEqual(message.sender, self.example_user('cordelia'))
         self.assertEqual(message.recipient.type, Recipient.HUDDLE)
 
-class TestMissedStreamMessageEmailMessages(ZulipTestCase):
     def test_receive_missed_stream_message_email_messages(self) -> None:
         # build dummy messages for missed messages email reply
         # have Hamlet send a message to stream Denmark, that Othello

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -109,6 +109,21 @@ def require_email_format_usernames(realm: Optional[Realm]=None) -> bool:
             return False
     return True
 
+def is_user_active(user_profile: UserProfile, return_data: Optional[Dict[str, Any]]=None) -> bool:
+    if not user_profile.is_active:
+        if return_data is not None:
+            if user_profile.is_mirror_dummy:
+                # Record whether it's a mirror dummy account
+                return_data['is_mirror_dummy'] = True
+            return_data['inactive_user'] = True
+        return False
+    if user_profile.realm.deactivated:
+        if return_data is not None:
+            return_data['inactive_realm'] = True
+        return False
+
+    return True
+
 def common_get_active_user(email: str, realm: Realm,
                            return_data: Optional[Dict[str, Any]]=None) -> Optional[UserProfile]:
     """This is the core common function used by essentially all
@@ -128,17 +143,9 @@ def common_get_active_user(email: str, realm: Realm,
         if return_data is not None:
             return_data['invalid_subdomain'] = True
         return None
-    if not user_profile.is_active:
-        if return_data is not None:
-            if user_profile.is_mirror_dummy:
-                # Record whether it's a mirror dummy account
-                return_data['is_mirror_dummy'] = True
-            return_data['inactive_user'] = True
+    if not is_user_active(user_profile, return_data):
         return None
-    if user_profile.realm.deactivated:
-        if return_data is not None:
-            return_data['inactive_realm'] = True
-        return None
+
     return user_profile
 
 class ZulipAuthMixin:


### PR DESCRIPTION
Quick PR for a bug mentioned in a chat:
>  send_to_missed_message_address doesn't check if the user's account or realm has been deactivated

This adds a simple check for these things.
As a followup, should we perhaps check for the same in these:
```
def receives_offline_push_notifications(user_profile: UserProfile) -> bool:
    return (user_profile.enable_offline_push_notifications and
            not user_profile.is_bot)

def receives_offline_email_notifications(user_profile: UserProfile) -> bool:
    return (user_profile.enable_offline_email_notifications and
            not user_profile.is_bot)

def receives_online_notifications(user_profile: UserProfile) -> bool:
    return (user_profile.enable_online_push_notifications and
            not user_profile.is_bot)

def receives_stream_notifications(user_profile: UserProfile) -> bool:
    return (user_profile.enable_stream_push_notifications and
            not user_profile.is_bot)
```

Since deactivated users (or users of deactivated realms) probably shouldn't be getting missed message emails/push notifications? And btw ``receives_stream_notifications`` seems to not be used anywhere in our code?