### PR TITLE
vagrant docs: specify restart command

### DIFF
--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -984,8 +984,9 @@ machines than the VM host, you can manually set the host IP address in the
 HOST_IP_ADDR 0.0.0.0
 ```
 
-(and restart the Vagrant guest), your host IP would be 0.0.0.0, a special value
-for the IP address that means any IP address can connect to your development server.
+(and restart the Vagrant guest with `vagrant reload`), your host IP would be
+0.0.0.0, a special value for the IP address that means any IP address can
+connect to your development server.
 
 ### Customizing CPU and RAM allocation
 


### PR DESCRIPTION
Add a specific command to restart Vagrant to adopt the new
configuration.

(When naïvely using only `vagrant halt` + `vagrant up --provision`,
external devices remained unable to connect; per `netstat -nltp`, the
host IP of forwarded ports remained `127.0.0.1`.)

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Connecting from a phone to a Linux dev box. A trivial Python webserver on the host was reachable, but the guest's `run-dev` server was not (until the `reload` was done).

I've only tested successfully on Linux at present, but the Mac-hosted dev server was also unable to be connected to, presumably for the same reason.