### PR TITLE
thumbor requirements fixes

### DIFF
--- a/requirements/thumbor-dev.in
+++ b/requirements/thumbor-dev.in
@@ -1,0 +1,2 @@
+-r thumbor.in
+pip-tools==4.1.0

--- a/requirements/thumbor-dev.txt
+++ b/requirements/thumbor-dev.txt
@@ -13,7 +13,7 @@ botocore==1.12.183        # via tornado-botocore
 click==7.0                # via pip-tools
 derpconf==0.8.3           # via thumbor
 django-auth-ldap==1.7.0
-django==1.11.14
+django==1.11.23
 docutils==0.14            # via botocore
 futures==3.1.1            # via thumbor, tornado
 jmespath==0.9.4           # via botocore

--- a/requirements/thumbor-dev.txt
+++ b/requirements/thumbor-dev.txt
@@ -10,6 +10,7 @@
 argparse==1.4.0           # via thumbor
 backports-abc==0.5        # via tornado
 botocore==1.12.183        # via tornado-botocore
+click==7.0                # via pip-tools
 derpconf==0.8.3           # via thumbor
 django-auth-ldap==1.7.0
 django==1.11.14
@@ -19,6 +20,7 @@ jmespath==0.9.4           # via botocore
 libthumbor==1.3.2         # via thumbor
 piexif==1.0.13            # via thumbor
 pillow==5.1.0             # via thumbor
+pip-tools==4.1.0
 pyasn1-modules==0.2.5     # via python-ldap
 pyasn1==0.4.5             # via pyasn1-modules, python-ldap
 pycryptodome==3.8.2       # via thumbor
@@ -27,7 +29,7 @@ python-dateutil==2.8.0    # via botocore, tc-aws
 python-ldap==3.2.0        # via django-auth-ldap
 pytz==2019.1              # via django, thumbor
 singledispatch==3.4.0.3   # via tornado
-six==1.12.0               # via derpconf, libthumbor, python-dateutil, singledispatch, thumbor, webcolors
+six==1.12.0               # via derpconf, libthumbor, pip-tools, python-dateutil, singledispatch, thumbor, webcolors
 statsd==3.3.0             # via thumbor
 tc-aws==6.2.10
 thumbor==6.5.1

--- a/requirements/thumbor.in
+++ b/requirements/thumbor.in
@@ -5,14 +5,5 @@ typing==3.6.6
 django-auth-ldap==1.7.0
 Django==1.11.14
 
-# Below dependencies should ideally have been added to thumbor.txt by the
-# use of tools/update-locked-requirements but for some reason `pip-compile`
-# doesn't do so. An issue relating to this is
-# https://github.com/thumbor/thumbor/issues/1006
-backports-abc==0.5
-backports.ssl-match-hostname==3.5.0.1
-certifi==2019.6.16
-singledispatch==3.4.0.3
-
 # Needed for cloning virtual environments
 virtualenv-clone==0.5.1

--- a/requirements/thumbor.in
+++ b/requirements/thumbor.in
@@ -1,9 +1,10 @@
 tc-aws==6.2.10
 thumbor==6.5.1
-typing==3.6.6
+
 # Required for just importing settings from our main django app.
 django-auth-ldap==1.7.0
-Django==1.11.14
+Django==1.11.23
+typing==3.6.6
 
 # Needed for cloning virtual environments
 virtualenv-clone==0.5.1

--- a/requirements/thumbor.txt
+++ b/requirements/thumbor.txt
@@ -12,7 +12,7 @@ backports-abc==0.5        # via tornado
 botocore==1.12.183        # via tornado-botocore
 derpconf==0.8.3           # via thumbor
 django-auth-ldap==1.7.0
-django==1.11.14
+django==1.11.23
 docutils==0.14            # via botocore
 futures==3.1.1            # via thumbor, tornado
 jmespath==0.9.4           # via botocore

--- a/tools/setup/setup_venvs.py
+++ b/tools/setup/setup_venvs.py
@@ -13,7 +13,7 @@ from scripts.lib.zulip_tools import overwrite_symlink
 VENV_PATH = "/srv/zulip-py3-venv"
 
 DEV_REQS_FILE = os.path.join(ZULIP_PATH, "requirements", "dev.txt")
-THUMBOR_REQS_FILE = os.path.join(ZULIP_PATH, "requirements", "thumbor.txt")
+THUMBOR_REQS_FILE = os.path.join(ZULIP_PATH, "requirements", "thumbor-dev.txt")
 
 def main() -> None:
     setup_virtualenv("/srv/zulip-thumbor-venv", THUMBOR_REQS_FILE,

--- a/tools/update-locked-requirements
+++ b/tools/update-locked-requirements
@@ -2,19 +2,20 @@
 set -e
 
 # Make sure the Zulip dev virtualenv exists, and operate within it.
-if [ ! -d /srv/zulip-py3-venv ]; then
+if [ ! -d /srv/zulip-py3-venv ] || [ ! -d /srv/zulip-thumbor-venv ]; then
     ./tools/setup/setup_venvs.py
 fi
-source /srv/zulip-py3-venv/bin/activate
 
 compile_requirements () {
     source="$1"
     output="$2"
     python_version="$3"
 
-    pip-compile --quiet --allow-unsafe --no-header --output-file "$output" "$source"
+    if [ "$python_version" == "py2" ]; then
+        /srv/zulip-thumbor-venv/bin/pip-compile --quiet --allow-unsafe --no-header --output-file "$output" "$source"
+    else
+        /srv/zulip-py3-venv/bin/pip-compile --quiet --allow-unsafe --no-header --output-file "$output" "$source"
 
-    if [ "$python_version" != "py2" ]; then
         # Remove an unnecessary future requirement declared by commonmark,
         # python-jose, and python-twitter.
         # https://github.com/readthedocs/commonmark.py/pull/188
@@ -64,3 +65,4 @@ compile_requirements requirements/dev.in "$OUTPUT_BASE_DIR/dev.txt"
 compile_requirements requirements/mypy.in "$OUTPUT_BASE_DIR/mypy.txt"
 compile_requirements requirements/docs.in "$OUTPUT_BASE_DIR/docs.txt"
 compile_requirements requirements/thumbor.in "$OUTPUT_BASE_DIR/thumbor.txt" py2
+compile_requirements requirements/thumbor-dev.in "$OUTPUT_BASE_DIR/thumbor-dev.txt" py2

--- a/version.py
+++ b/version.py
@@ -26,4 +26,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '55.1'
+PROVISION_VERSION = '55.2'

--- a/version.py
+++ b/version.py
@@ -26,4 +26,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '55.0'
+PROVISION_VERSION = '55.1'


### PR DESCRIPTION
* requirements: Compile thumbor requirements with pip-tools on Python 2.

  The reason that `pip-tools` running on Python 3 didn’t detect the right requirements for `thumbor` on Python 2 is simply that some of them are conditional on the Python version.

  As for the requirements that had been manually added as a workaround: `backports-abc` and `singledispatch` are now correctly detected, while `backports.ssl-match-hostname` was vendored into `urllib3` some time ago and `certifi` is no longer necessary.

* requirements: Bump thumbor Django to match main Django.

**Testing Plan:** Sent an https image on the dev server.