### PR TITLE
Hotkeys: changing keyboard shortcuts for creating streams and toggling stream subscriptions.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -180,7 +180,7 @@ run_test('basic_chars', () => {
     // Unmapped keys should immediately return false, without
     // calling any functions outside of hotkey.js.
     assert_unmapped('abfhlmotyz');
-    assert_unmapped('BEFHILNOQTUWXYZ');
+    assert_unmapped('BEFHILNOQUWXYZ');
 
     // We have to skip some checks due to the way the code is
     // currently organized for mapped keys.
@@ -236,7 +236,7 @@ run_test('basic_chars', () => {
 
     overlays.streams_open = return_true;
     overlays.is_active = return_true;
-    assert_mapping('S', 'subs.keyboard_sub');
+    assert_mapping('T', 'subs.keyboard_sub');
     assert_mapping('V', 'subs.view_stream');
     overlays.streams_open = return_false;
     test_normal_typing();
@@ -289,7 +289,7 @@ run_test('basic_chars', () => {
     assert_mapping('k', 'navigate.up');
     assert_mapping('K', 'navigate.page_up');
     assert_mapping('s', 'narrow.by_recipient');
-    assert_mapping('S', 'narrow.by_topic');
+    assert_mapping('T', 'narrow.by_topic');
     assert_mapping('u', 'popovers.show_sender_info');
     assert_mapping('i', 'popovers.open_message_menu');
     assert_mapping(':', 'reactions.open_reactions_popover', true);

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -107,6 +107,7 @@ run_test('mappings', () => {
     assert.equal(map_down(75, false, true).name, 'search_with_k'); // ctrl + k
     assert.equal(map_down(83, false, true).name, 'star_message'); // ctrl + s
     assert.equal(map_down(190, false, true).name, 'narrow_to_compose_target'); // ctrl + .
+    assert.equal(map_down(83, true, true).name, 'create_stream'); // ctrl + shift + s
 
     // More negative tests.
     assert.equal(map_down(47), undefined);
@@ -128,7 +129,6 @@ run_test('mappings', () => {
     assert.equal(map_down(75, false, false, true), undefined); // cmd + k
     assert.equal(map_down(83, false, false, true), undefined); // cmd + s
     assert.equal(map_down(75, true, true), undefined); // shift + ctrl + k
-    assert.equal(map_down(83, true, true), undefined); // shift + ctrl + s
     assert.equal(map_down(219, true, true, false), undefined); // shift + ctrl + [
 
     // CMD tests for MacOS
@@ -143,6 +143,8 @@ run_test('mappings', () => {
     assert.equal(map_down(83, false, true, false), undefined); // ctrl + s
     assert.equal(map_down(190, false, false, true).name, 'narrow_to_compose_target'); // cmd + .
     assert.equal(map_down(190, false, true, false), undefined); // ctrl + .
+    assert.equal(map_down(83, true, true, false).name, 'create_stream'); // ctrl + shift + s
+    assert.equal(map_down(83, true, false, true), undefined); // cmd + shift + s
     // Reset platform
     global.navigator.platform = '';
 });
@@ -232,14 +234,10 @@ run_test('basic_chars', () => {
     overlays.lightbox_open = return_false;
     overlays.drafts_open = return_false;
 
-    page_params.can_create_streams = true;
     overlays.streams_open = return_true;
     overlays.is_active = return_true;
     assert_mapping('S', 'subs.keyboard_sub');
     assert_mapping('V', 'subs.view_stream');
-    assert_mapping('n', 'subs.open_create_stream');
-    page_params.can_create_streams = false;
-    assert_unmapped('n');
     overlays.streams_open = return_false;
     test_normal_typing();
     overlays.is_active = return_false;
@@ -335,6 +333,7 @@ run_test('motion_keys', () => {
         spacebar: 32,
         up_arrow: 38,
         '+': 187,
+        create_stream: 83,
     };
 
     function process(name, shiftKey, ctrlKey) {
@@ -364,6 +363,18 @@ run_test('motion_keys', () => {
             assert(process(key_name, shiftKey, ctrlKey));
         });
     }
+
+    page_params.can_create_streams = false;
+    assert_unmapped('create_stream');
+    page_params.can_create_streams = true;
+    overlays.streams_open = return_true;
+    overlays.is_active = return_true;
+    assert_mapping('create_stream', 'subs.open_create_stream', true, true);
+    page_params.can_create_streams = false;
+    assert_unmapped('create_stream');
+    overlays.streams_open = return_false;
+    overlays.is_active = return_false;
+
 
     list_util.inside_list = return_false;
     global.current_msg_list.empty = return_true;

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -59,6 +59,10 @@ var keydown_cmd_or_ctrl_mappings = {
     190: {name: 'narrow_to_compose_target', message_view_only: true}, // '.'
 };
 
+var keydown_ctrl_and_shift_mappings = {
+    83: {name: 'create_stream', message_view_only: false}, // 's'
+};
+
 var keydown_either_mappings = {
     // these can be triggered by key or shift + key
     // Note that codes for letters are still case sensitive!
@@ -128,7 +132,15 @@ exports.get_keydown_hotkey = function (e) {
         }
     }
 
+    if (e.ctrlKey && e.shiftKey) {
+        hotkey = keydown_ctrl_and_shift_mappings[e.which];
+        if (hotkey) {
+            return hotkey;
+        }
+    }
+
     var isCmdOrCtrl = common.has_mac_keyboard() ? e.metaKey : e.ctrlKey;
+
     if (isCmdOrCtrl && !e.shiftKey) {
         hotkey = keydown_cmd_or_ctrl_mappings[e.which];
         if (hotkey) {
@@ -620,6 +632,18 @@ exports.process_hotkey = function (e, hotkey) {
         }
     }
 
+    // Create a new stream
+    if (event_name === 'create_stream' && page_params.can_create_streams) {
+        if (overlays.is_active() && overlays.streams_open()) {
+            subs.open_create_stream();
+            return true;
+        }
+        subs.launch();
+        subs.open_create_stream();
+        return true;
+
+    }
+
     // Prevent navigation in the background when the overlays are active.
     if (overlays.is_active()) {
         if (event_name === 'view_selected_stream' && overlays.streams_open()) {
@@ -627,7 +651,7 @@ exports.process_hotkey = function (e, hotkey) {
             return true;
         }
         if (event_name === 'n_key' && overlays.streams_open() && page_params.can_create_streams) {
-            subs.open_create_stream();
+            ui.maybe_show_deprecation_notice('n');
             return true;
         }
         return false;

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -98,7 +98,7 @@ var keypress_mappings = {
     77: {name: 'toggle_mute', message_view_only: true}, // 'M'
     80: {name: 'narrow_private', message_view_only: true}, // 'P'
     82: {name: 'respond_to_author', message_view_only: true}, // 'R'
-    83: {name: 'narrow_by_topic', message_view_only: true}, //'S'
+    84: {name: 'narrow_by_topic', message_view_only: true}, //'T'
     86: {name: 'view_selected_stream', message_view_only: false}, //'V'
     99: {name: 'compose', message_view_only: true}, // 'c'
     100: {name: 'open_drafts', message_view_only: true}, // 'd'

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -144,6 +144,8 @@ exports.maybe_show_deprecation_notice = function (key) {
         message = exports.get_hotkey_deprecation_notice('C', 'x');
     } else if (key === '*') {
         message = exports.get_hotkey_deprecation_notice("*", isCmdOrCtrl + " + s");
+    } else if (key === 'n') {
+        message = exports.get_hotkey_deprecation_notice("n", "Ctrl" + " + shift" + " + s");
     } else {
         blueslip.error("Unexpected deprecation notice for hotkey:", key);
         return;

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -303,7 +303,7 @@
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Create new stream{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>N</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>S</kbd></span></td>
                 </tr>
             </table>
         </div>

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -299,7 +299,7 @@
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Subscribe to/unsubscribe from selected stream{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>S</kbd></span></td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>T</kbd></span></td>
                 </tr>
                 <tr>
                     <td class="definition">{% trans %}Create new stream{% endtrans %}</td>

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -178,4 +178,4 @@ Keyboard navigation (e.g. arrow keys) works as expected.
 
 * **View stream messages**: `V`
 
-* **Toggle subscription**: `S`
+* **Toggle subscription**: `T`

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -172,7 +172,7 @@ Keyboard navigation (e.g. arrow keys) works as expected.
 * **Switch between tabs**: `←` and `→` — Switch between the
 **Subscribed** and **All streams** tabs.
 
-* **Create new stream**: `n`
+* **Create new stream**: `Ctrl + shift + s`
 
 ### For a selected stream
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


<!--**Testing Plan:** --><!-- How have you tested? -->



 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  --> 
fixes #9614 
**1.** The create_stream shortcut has been changed from 'n' to 'ctrl + shift + s'.
Earlier the shortcut could only be triggered from the stream settings modal.This has been fixed.
Now streams can be created without  having to go to the stream settings modal.

**2.** Also,The toggle subscription hotkey has been changed from 'shift + s ' / ('S') to 'shift + t' / ('T'). 

**GIFs or Screenshots:**
![create](https://user-images.githubusercontent.com/48182195/65644958-5ebdac80-e013-11e9-85de-4eafbd8d41ff.gif)
shortcut can now be triggered from main message view also.
