### PR TITLE
devtools: Order the fixtures dropdown menu alphabetically in the IDP.

### DIFF
--- a/static/js/portico/integrations_dev_panel.js
+++ b/static/js/portico/integrations_dev_panel.js
@@ -127,7 +127,7 @@ function load_fixture_options(integration_name) {
     the fixture options for the fixture_names dropdown and also set
     the fixture body to the first fixture by default. */
     var fixtures_options_dropdown = $("#fixture_name")[0];
-    var fixtures_names = Object.keys(loaded_fixtures[integration_name]);
+    var fixtures_names = Object.keys(loaded_fixtures[integration_name]).sort();
 
     fixtures_names.forEach(function (fixture_name) {
         var new_dropdown_option = document.createElement("option");


### PR DESCRIPTION
This is a simple and small commit which will alphabetically order the
entries of the fixtures dropdown menu in the "integrations developer
panel" devtool. Nothing fancy.