### PR TITLE
[WIP] docs: Doc for `/messages/{message_id}/reactions` -- just look at zulip.yaml for now

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -843,6 +843,133 @@ paths:
                         "rendered": "<p><strong>foo</strong></p>",
                         "result": "success"
                     }
+  /messages/{message_id}/reactions:
+    post:
+      description: Add an emoji reaction to a message.
+      parameters:
+      - name: message_id
+        in: path
+        description: The ID of the message that you want to add an emoji reaction to.
+        schema:
+          type: integer
+        example: 42
+        required: true
+      - name: emoji_name
+        in: query
+        description: |
+                     Name of the emoji you want to add as as a reaction.
+
+
+                     To find the an emoji's name, hover over a message to
+                     reveal three icons on the right, then click the smiley face icon.
+                     Images of available reaction emojis appear. Hover over the emoji
+                     you want, and note that emoji's text name.
+        schema:
+          type: string
+        example: '**:slight smile:**'
+        required: true
+      - name: emoji_code
+        in: query
+        description: |
+                     An encoded version of the unicode codepoint. Used only
+                     in rare corner cases to consolidate identical reactions
+                     to the same emoji name.
+        schema:
+          type: string
+        example: '**foo**'
+        required: false
+      - name: reaction_type
+        in: query
+        description: |
+                     If you are using a custom emoji,
+                     set `reaction_type` to `realm_emoji`.
+        schema:
+          type: string
+        example: '**realm_emoji**'
+        required: false
+      security:
+      - basicAuth: []
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/JsonSuccess'
+                - properties:
+                    rendered:
+                      type: string
+                      description: The rendered HTML.
+                - example:
+                    {
+                        "msg": "",
+                        "rendered": "<p><strong>foo</strong></p>",
+                        "result": "success"
+                    }
+    delete:
+      description: Delete an emoji reaction from a message.
+      parameters:
+      - name: message_id
+        in: path
+        description: The ID of the message from which you want to delete the emoji reaction.
+        schema:
+          type: integer
+        example: 42
+        required: true
+      - name: emoji_name
+        in: query
+        description: |
+                     Name of the emoji you want to delete from a reaction.
+
+
+                     To find the an emoji's name, hover over a message to
+                     reveal three icons on the right, then click the smiley face icon.
+                     Images of available reaction emojis appear. Hover over the emoji
+                     you want, and note that emoji's text name.
+        schema:
+          type: string
+        example: '**:slight smile:**'
+        required: true
+      - name: emoji_code
+        in: query
+        description: |
+                     An encoded version of the unicode codepoint. Used only
+                     in rare corner cases to consolidate identical reactions
+                     to the same emoji name.
+        schema:
+          type: string
+        example: '**foo**'
+        required: false
+      - name: reaction_type
+        in: query
+        description: |
+                     If you are using a custom emoji,
+                     set `reaction_type` to `realm_emoji`.
+        schema:
+          type: string
+        example: '**realm_emoji**'
+        required: false
+      security:
+      - basicAuth: []
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/JsonSuccess'
+                - properties:
+                    rendered:
+                      type: string
+                      description: The rendered HTML.
+                - example:
+                    {
+                        "msg": "",
+                        "rendered": "<p><strong>foo</strong></p>",
+                        "result": "success"
+                    }
   /user_uploads:
     post:
       description: Upload a single file and get the corresponding URI.

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -218,7 +218,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         '/invites/{prereg_id}/resend',
         '/invites/multiuse/{invite_id}',
         '/users/me/subscriptions/{stream_id}',
-        '/messages/{message_id}/reactions',
         '/messages/{message_id}/emoji_reactions/{emoji_name}',
         '/attachments/{attachment_id}',
         '/user_groups/{user_group_id}/members',


### PR DESCRIPTION
When complete, this PR is for creating REST API doc for the `/messages/{message_id}/reactions` endpoint. This includes doc for the POST and DELETE methods associated with this endpoint.

For now, I would like comments ONLY on the new lines I added to `zerver/openapi/zulip.yaml`. Those lines are:

Lines 846 through 849

and

Lines 910 through 952

Thanks.
