### PR TITLE
docs: move production "Backups" and "Upgrading" sections

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -5,7 +5,7 @@
     # version e.g. to say that something is likely to have changed.
     # For more info see: https://www.sphinx-doc.org/en/master/templating.html
     -->
-    {% if (pagename == "production/email-gateway" or pagename == "production/modifying-zulip") and release.endswith('+git') %}
+    {% if (pagename == "production/email-gateway" or pagename == "production/upgrade-or-modify") and release.endswith('+git') %}
     <!--
     # email-gateway.html page doesn't exist in the stable documentation yet.
     # This temporary workaround prevents CircleCI failure and should be removed after the next release.

--- a/docs/overview/changelog.md
+++ b/docs/overview/changelog.md
@@ -43,7 +43,7 @@ in bursts.
   readable style.
 - We merged significant preparatory work for supporting RHEL/CentOS in
   production.  We're now interested in beta testers for this feature.
-- Added [new documentation](../production/modifying-zulip.md) on
+- Added [new documentation](../production/upgrade-or-modify.md) on
   maintaining a fork of Zulip.
 - Added new `streams:public` search operator that searches the public
   history of all streams in the organization (even before you joined).
@@ -440,7 +440,7 @@ Zulip installations; it has minimal changes for existing servers.
   phase of the upgrade closely, we recommend
   [running them first manually](../production/expensive-migrations.md)
   and as well as the usual trick of
-  [doing an apt upgrade first](../production/maintain-secure-upgrade.html#applying-system-updates).
+  [doing an apt upgrade first](../production/upgrade-or-modify.html#applying-system-updates).
 
 **Full feature changelog:**
 - Added an organization setting for message deletion time limits.
@@ -818,7 +818,7 @@ Backend and scaling
   phase of the upgrade closely, we recommend
   [running them first manually](../production/expensive-migrations.md) and as well
   as the usual trick of
-  [doing an apt upgrade first](../production/maintain-secure-upgrade.html#applying-system-updates).
+  [doing an apt upgrade first](../production/upgrade-or-modify.html#applying-system-updates).
 
 * We've removed support for an uncommon legacy deployment model where
   a Zulip server served multiple organizations on the same domain.

--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -19,7 +19,7 @@ git clone https://github.com/zulip/zulip.git zulip-server-git
 
 and then
 [continue the normal installation instructions](../production/install.html#step-2-install-zulip).
-You can also [upgrade Zulip from Git](../production/maintain-secure-upgrade.html#upgrading-from-a-git-repository).
+You can also [upgrade Zulip from Git](../production/upgrade-or-modify.html#upgrading-from-a-git-repository).
 
 ## Zulip in Docker
 

--- a/docs/production/export-and-import.md
+++ b/docs/production/export-and-import.md
@@ -338,7 +338,7 @@ cd /home/zulip/deployments/current
 This could take several minutes to run depending on how much data you're
 importing.
 
-[upgrade-zulip-from-git]: ../production/maintain-secure-upgrade.html#upgrading-from-a-git-repository
+[upgrade-zulip-from-git]: ../production/upgrade-or-modify.html#upgrading-from-a-git-repository
 
 #### Import options
 

--- a/docs/production/index.rst
+++ b/docs/production/index.rst
@@ -11,6 +11,7 @@ Zulip in Production
    settings
    mobile-push-notifications
    maintain-secure-upgrade
+   upgrade-or-modify
    security-model
    authentication-methods
    export-and-import
@@ -20,4 +21,3 @@ Zulip in Production
    email
    deployment
    email-gateway
-   modifying-zulip

--- a/docs/production/install.md
+++ b/docs/production/install.md
@@ -109,7 +109,8 @@ for server administrators.  This extremely low-traffic list is for
 important announcements, including new releases and security issues.
 * Follow [Zulip on Twitter](https://twitter.com/zulip).
 * Learn how to [configure your Zulip server settings](settings.md).
-* Learn about [maintaining a production Zulip server](maintain-secure-upgrade.md).
+* Learn about [maintaining](../production/maintain-secure-upgrade.md) and
+[upgrading](../production/upgrade-or-modify.html#upgrading) a production Zulip server.
 
 [realm-admin-docs]: https://zulipchat.com/help/getting-your-organization-started-with-zulip
 

--- a/docs/production/maintain-secure-upgrade.md
+++ b/docs/production/maintain-secure-upgrade.md
@@ -1,11 +1,8 @@
-# Secure, maintain, and upgrade
+# Maintain, secure, and upgrade
 
 This page covers topics that will help you maintain a healthy, up-to-date, and
 secure Zulip installation, including:
 
-- [Upgrading](#upgrading)
-- [Upgrading from a git repository](#upgrading-from-a-git-repository)
-- [Upgrading the operating system](#upgrading-the-operating-system)
 - [Monitoring](#monitoring)
 - [Scalability](#scalability)
 - [Management commands](#management-commands)
@@ -13,360 +10,7 @@ secure Zulip installation, including:
 You may also want to read this related content:
 
 - [Security Model](../production/security-model.md)
-
-## Upgrading
-
-**We recommend reading this entire section before doing your first
-upgrade.**
-
-To upgrade to a new version of the zulip server, download the appropriate
-release tarball from <https://www.zulip.org/dist/releases/>.
-
-You also have the option of creating your own release tarballs from a
-copy of the [zulip.git repository](https://github.com/zulip/zulip)
-using `tools/build-release-tarball` or upgrade Zulip
-[to a version in a Git repository directly](#upgrading-from-a-git-repository).
-
-Next, run as root:
-
-```
-/home/zulip/deployments/current/scripts/upgrade-zulip zulip-server-VERSION.tar.gz
-```
-
-The upgrade process will shut down the Zulip service and then run `apt-get upgrade`, a
-puppet apply, any database migrations, and then bring the Zulip service back
-up. Upgrading will result in some brief downtime for the service, which should be
-under 30 seconds unless there is an expensive transition involved. Unless you
-have tested the upgrade in advance, we recommend doing upgrades at off hours.
-
-(Note that there are
-[separate instructions for upgrading Zulip if you're using Docker][docker-upgrade].)
-
-[docker-upgrade]: https://github.com/zulip/docker-zulip#upgrading-the-zulip-container
-
-### Preserving local changes to configuration files
-
-**Warning**: If you have modified configuration files installed by
-Zulip (e.g. the nginx configuration), the Zulip upgrade process will
-overwrite your configuration when it does the `puppet apply`.
-
-You can test whether this will happen assuming no upstream changes to
-the configuration using `scripts/zulip-puppet-apply` (without the
-`-f` option), which will do a test puppet run and output and changes
-it would make. Using this list, you can save a copy of any files
-that you've modified, do the upgrade, and then restore your
-configuration.
-
-That said, Zulip's configuration files are designed to be flexible
-enough for a wide range of installations, from a small self-hosted
-system to Zulip Cloud.  Before making local changes to a configuration
-file, first check whether there's an option supported by
-`/etc/zulip/zulip.conf` for the customization you need.  And if you
-need to make local modifications, please report the issue so that we
-can make the Zulip puppet configuration flexible enough to handle your
-setup.
-
-#### nginx configuration changes
-
-If you need to modify Zulip's `nginx` configuration, we recommend
-first attempting to add configuration to `/etc/nginx/conf.d` or
-`/etc/nginx/zulip-include/app.d`; those directories are designed for
-custom configuration.
-
-### Troubleshooting with the upgrade log
-
-The Zulip upgrade script automatically logs output to
-`/var/log/zulip/upgrade.log`. Please use those logs to include output
-that shows all errors in any bug reports.
-
-After the upgrade, we recommend checking `/var/log/zulip/errors.log`
-to confirm that your users are not experiencing errors after the
-upgrade.
-
-### Rolling back to a prior version
-
-The Zulip upgrade process works by creating a new deployment under
-`/home/zulip/deployments/` containing a complete copy of the Zulip server code,
-and then moving the symlinks at `/home/zulip/deployments/{current,last,next}`
-as part of the upgrade process.
-
-This means that if the new version isn't working,
-you can quickly downgrade to the old version by running
-`/home/zulip/deployments/last/scripts/restart-server`, or to an
-earlier previous version by running
-`/home/zulip/deployments/DATE/scripts/restart-server`.  The
-`restart-server` script stops any running Zulip server, and starts
-the version corresponding to the `restart-server` path you call.
-
-### Updating settings
-
-If required, you can update your settings by editing `/etc/zulip/settings.py`
-and then run `/home/zulip/deployments/current/scripts/restart-server` to
-restart the server.
-
-### Applying system updates
-
-The Zulip upgrade script will automatically run `apt-get update` and
-then `apt-get upgrade`, to make sure you have any new versions of
-dependencies (this will also update system packages).  We assume that
-you will install security updates from `apt` regularly, according to
-your usual security practices for a production server.
-
-If you'd like to minimize downtime when installing a Zulip server
-upgrade, you may want to do an `apt-get upgrade` (and then restart the
-server and check everything is working) before running the Zulip
-upgrade script.
-
-There's one `apt` package to be careful about: upgrading `postgresql`
-while the server is running may result in an outage (basically,
-`postgresql` might stop accepting new queries but refuse to shut down
-while waiting for connections from the Zulip server to shut down).
-While this only happens sometimes, it can be hard to fix for someone
-who isn't comfortable managing a `postgresql` database [1].  You can
-avoid that possibility with the following procedure (run as root):
-
-```
-apt-get update
-supervisorctl stop all
-apt-get upgrade -y
-supervisorctl start all
-```
-
-[1] If this happens to you, just stop the Zulip server, restart
-postgres, and then start the Zulip server again, and you'll be back in
-business.
-
-#### Disabling unattended upgrades
-
-**Important**: We recommend that you
-[disable Ubuntu's unattended-upgrades][disable-unattended-upgrades],
-and instead install apt upgrades manually.  With unattended upgrades
-enabled, the moment a new Postgres release is published, your Zulip
-server will have its postgres server upgraded (and thus restarted).
-
-When one of the services Zulip depends on (postgres, memcached, redis,
-rabbitmq) is restarted, that services will disconnect everything using
-them (like the Zulip server), and every operation that Zulip does
-which uses that service will throw an exception (and send you an error
-report email).  These apparently "random errors" can be confusing and
-might cause you to worry incorrectly about the stability of the Zulip
-software, which in fact the problem is that Ubuntu automatically
-upgraded and then restarted key Zulip dependencies.
-
-Instead, we recommend installing updates for these services manually,
-and then restarting the Zulip server with
-`/home/zulip/deployments/current/scripts/restart-server` afterwards.
-
-[disable-unattended-upgrades]: https://linoxide.com/ubuntu-how-to/enable-disable-unattended-upgrades-ubuntu-16-04/
-
-### API and your Zulip URL
-
-To use the Zulip API with your Zulip server, you will need to use the
-API endpoint of e.g. `https://zulip.example.com/api`.  Our Python
-API example scripts support this via the
-`--site=https://zulip.example.com` argument.  The API bindings
-support it via putting `site=https://zulip.example.com` in your
-.zuliprc.
-
-Every Zulip integration supports this sort of argument (or e.g. a
-`ZULIP_SITE` variable in a zuliprc file or the environment), but this
-is not yet documented for some of the integrations (the included
-integration documentation on `/integrations` will properly document
-how to do this for most integrations).  We welcome pull requests for
-integrations that don't discuss this!
-
-Similarly, you will need to instruct your users to specify the URL
-for your Zulip server when using the Zulip desktop and mobile apps.
-
-### Memory leak mitigation
-
-As a measure to mitigate the impact of potential memory leaks in one
-of the Zulip daemons, the service automatically restarts itself
-every Sunday early morning.  See `/etc/cron.d/restart-zulip` for the
-precise configuration.
-
-## Upgrading from a git repository
-
-Zulip supports upgrading a production installation to any commit in
-Git, which is great for running pre-release versions or maintaining a
-small fork.  If you're using Zulip 1.7 or newer, you can just run the
-command:
-
-```
-# Upgrade to a tagged release
-/home/zulip/deployments/current/scripts/upgrade-zulip-from-git 1.8.1
-# Upgrade to a branch or other Git ref
-/home/zulip/deployments/current/scripts/upgrade-zulip-from-git master
-```
-
-and Zulip will automatically fetch the relevant Git commit and upgrade
-to that version of Zulip.
-
-By default, this uses the main upstream Zulip server repository
-(example below), but you can configure any other Git repository by
-adding a section like this to `/etc/zulip/zulip.conf`:
-
-```
-[deployment]
-git_repo_url = https://github.com/zulip/zulip.git
-```
-
-See also our documentation on [modifying
-Zulip](../production/modifying-zulip.md) and [upgrading
-docker-zulip](https://github.com/zulip/docker-zulip#upgrading-from-a-git-repository).
-
-**Systems with limited RAM**: If you are running a minimal Zulip
-  server with 2GB of RAM or less, the upgrade can fail due to the
-  system running out of RAM running both the Zulip server and Zulip's
-  static asset build process (`tools/webpack`
-  is usually the step that fails).  If you encounter this,
-  you can run `supervisorctl stop all` to shut down the Zulip server
-  while you run the upgrade (this will, of course, add some downtime,
-  which is part of we already recommend more RAM for organizations of
-  more than a few people).
-
-### Upgrading using Git from Zulip 1.6 and older
-
-If you're are upgrading from a Git repository, and you currently have
-Zulip 1.6 or older installed, you will need to install the
-dependencies for building Zulip's static assets.  To do this, add
-`zulip::static_asset_compiler` to your `/etc/zulip/zulip.conf` file's
-`puppet_classes` entry, like this:
-
-```
-puppet_classes = zulip::voyager, zulip::static_asset_compiler
-```
-
-and run `scripts/zulip-puppet-apply`.  After approving the changes,
-you'll be able to use `upgrade-zulip-from-git`.
-
-After you've upgraded to Zulip 1.7 or above, you can safely remove
-`zulip::static_asset_compiler` from `puppet_classes`; in Zulip 1.7 and
-above, it is a dependency of `zulip::voyager` and thus these
-dependencies are installed by default.
-
-## Upgrading the operating system
-
-When you upgrade the operating system on which Zulip is installed
-(E.g. Ubuntu 14.04 Trusty to Ubuntu 16.04 Xenial), you need to take
-some additional steps to update your Zulip installation, documented
-below.
-
-The steps are largely the same for the various OS upgrades aside from
-the versions of postgres, so you should be able to adapt these
-instructions for other supported platforms.
-
-### Upgrading from Ubuntu 14.04 Trusty to 16.04 Xenial
-
-1. First, as the Zulip user, stop the Zulip server and run the following
-to back up the system:
-
-    ```
-    supervisorctl stop all
-    /home/zulip/deployments/current/manage.py backup --output=/home/zulip/release-upgrade.backup.tar.gz
-    ```
-
-2. Switch to the root user and upgrade the operating system using the
-OS's standard tooling.  E.g. for Ubuntu, this means running
-`do-release-upgrade` and following the prompts until it completes
-successfully:
-
-    ```
-    sudo -i # Or otherwise get a root shell
-    do-release-upgrade
-    ```
-
-    When `do-release-upgrade` asks you how to upgrade configuration
-    files for services that Zulip manages like `redis`, `postgres`,
-    `nginx`, and `memcached`, the best choice is `N` to keep the
-    currently installed version.  But it's not important; the next
-    step will re-install Zulip's configuration in any case.
-
-3. As root, upgrade the database installation and OS configuration to
-match the new OS version:
-
-    ```
-    apt remove upstart -y
-    /home/zulip/deployments/current/scripts/zulip-puppet-apply -f
-    pg_dropcluster 9.5 main --stop
-    systemctl stop postgresql
-    pg_upgradecluster -m upgrade 9.3 main
-    pg_dropcluster 9.3 main
-    apt remove postgresql-9.3
-    systemctl start postgresql
-    service memcached restart
-    ```
-
-4. At this point, you are now running the version of postgres that
-comes with the new Ubuntu version.  Finally, we need to reinstall the
-current version of Zulip, which among other things will recompile
-Zulip's Python module dependencies for your new version of Python:
-
-    ```
-    rm -rf /srv/zulip-venv-cache/*
-    /home/zulip/deployments/current/scripts/lib/upgrade-zulip-stage-2 \
-        /home/zulip/deployments/current/ --ignore-static-assets
-    ```
-
-That last command will finish by restarting your Zulip server; you
-should now be able to navigate to its URL and confirm everything is
-working correctly.
-
-### Upgrading from Ubuntu 16.04 Xenial to 18.04 Bionic
-
-1. First, as the Zulip user, stop the Zulip server and run the following
-to back up the system:
-
-    ```
-    supervisorctl stop all
-    /home/zulip/deployments/current/manage.py backup --output=/home/zulip/release-upgrade.backup.tar.gz
-    ```
-
-2. Switch to the root user and upgrade the operating system using the
-OS's standard tooling.  E.g. for Ubuntu, this means running
-`do-release-upgrade` and following the prompts until it completes
-successfully:
-
-    ```
-    sudo -i # Or otherwise get a root shell
-    do-release-upgrade
-    ```
-
-    When `do-release-upgrade` asks you how to upgrade configuration
-    files for services that Zulip manages like `redis`, `postgres`,
-    `nginx`, and `memcached`, the best choice is `N` to keep the
-    currently installed version.  But it's not important; the next
-    step will re-install Zulip's configuration in any case.
-
-3. As root, upgrade the database installation and OS configuration to
-match the new OS version:
-
-    ```
-    touch /usr/share/postgresql/10/pgroonga_setup.sql.applied
-    /home/zulip/deployments/current/scripts/zulip-puppet-apply -f
-    pg_dropcluster 10 main --stop
-    systemctl stop postgresql
-    pg_upgradecluster 9.5 main
-    pg_dropcluster 9.5 main
-    apt remove postgresql-9.5
-    systemctl start postgresql
-    systemctl restart memcached
-    ```
-
-4. At this point, you are now running the version of postgres that
-comes with the new Ubuntu version.  Finally, we need to reinstall the
-current version of Zulip, which among other things will recompile
-Zulip's Python module dependencies for your new version of Python:
-
-    ```
-    rm -rf /srv/zulip-venv-cache/*
-    /home/zulip/deployments/current/scripts/lib/upgrade-zulip-stage-2 \
-        /home/zulip/deployments/current/ --ignore-static-assets
-    ```
-
-That last command will finish by restarting your Zulip server; you
-should now be able to navigate to its URL and confirm everything is
-working correctly.
+- [Backups, export and import](../production/export-and-import.md)
 
 ## Monitoring
 
@@ -500,6 +144,32 @@ welcome!  This is an area we are hoping to improve.
 
 Zulip's security model is discussed in
 [a separate document](../production/security-model.md).
+
+### API and your Zulip URL
+
+To use the Zulip API with your Zulip server, you will need to use the
+API endpoint of e.g. `https://zulip.example.com/api`.  Our Python
+API example scripts support this via the
+`--site=https://zulip.example.com` argument.  The API bindings
+support it via putting `site=https://zulip.example.com` in your
+.zuliprc.
+
+Every Zulip integration supports this sort of argument (or e.g. a
+`ZULIP_SITE` variable in a zuliprc file or the environment), but this
+is not yet documented for some of the integrations (the included
+integration documentation on `/integrations` will properly document
+how to do this for most integrations).  We welcome pull requests for
+integrations that don't discuss this!
+
+Similarly, you will need to instruct your users to specify the URL
+for your Zulip server when using the Zulip desktop and mobile apps.
+
+### Memory leak mitigation
+
+As a measure to mitigate the impact of potential memory leaks in one
+of the Zulip daemons, the service automatically restarts itself
+every Sunday early morning.  See `/etc/cron.d/restart-zulip` for the
+precise configuration.
 
 ## Management commands
 

--- a/docs/production/mobile-push-notifications.md
+++ b/docs/production/mobile-push-notifications.md
@@ -21,7 +21,7 @@ follows:
 1. Uncomment the `PUSH_NOTIFICATION_BOUNCER_URL =
    'https://push.zulipchat.com'` line in your `/etc/zulip/settings.py`
    file (i.e. remove the `#` at the start of the line), and
-   [restart your Zulip server](../production/maintain-secure-upgrade.html#updating-settings).
+   [restart your Zulip server](../production/upgrade-or-modify.html#updating-settings).
    If you installed your Zulip server with a version older than 1.6,
    you'll need to add the line (it won't be there to uncomment).
 

--- a/docs/production/settings.md
+++ b/docs/production/settings.md
@@ -116,5 +116,5 @@ request; we love even small contributions, and we'd love to make the
 Zulip documentation cover everything anyone might want to know about
 running Zulip in production.
 
-Next: [Maintaining and upgrading Zulip in
-production](../production/maintain-secure-upgrade.md).
+Next: [Maintaining](../production/maintain-secure-upgrade.md) and
+[upgrading](../production/upgrade-or-modify.html#upgrading) Zulip in production.

--- a/templates/zerver/help/import-from-gitter.md
+++ b/templates/zerver/help/import-from-gitter.md
@@ -97,4 +97,4 @@ to mark the appropriate users as administrators.
   [issue mentions](https://gitter.zendesk.com/hc/en-us/articles/200176692-Issue-and-Pull-Request-mentions)
   aren't translated into anything yet.
 
-[upgrade-zulip-from-git]: https://zulip.readthedocs.io/en/latest/production/maintain-secure-upgrade.html#upgrading-from-a-git-repository
+[upgrade-zulip-from-git]: https://zulip.readthedocs.io/en/latest/production/upgrade-or-modify.html#upgrading-from-a-git-repository

--- a/templates/zerver/help/import-from-hipchat.md
+++ b/templates/zerver/help/import-from-hipchat.md
@@ -130,7 +130,7 @@ root domain. Replace the last line above with the following, after replacing
 
 {!import-login.md!}
 
-[upgrade-zulip-from-git]: https://zulip.readthedocs.io/en/latest/production/maintain-secure-upgrade.html#upgrading-from-a-git-repository
+[upgrade-zulip-from-git]: https://zulip.readthedocs.io/en/latest/production/upgrade-or-modify.html#upgrading-from-a-git-repository
 
 ## Caveats
 
@@ -152,5 +152,5 @@ rooms.  You can pick one of the following options for handling this:
   access token via `--token=abcd1234` in `manage.py convert_hipchat_data`
   (or include it in your request, if importing into Zulip Cloud).
 
-[upgrade-zulip-from-git]: https://zulip.readthedocs.io/en/latest/production/maintain-secure-upgrade.html#upgrading-from-a-git-repository
+[upgrade-zulip-from-git]: https://zulip.readthedocs.io/en/latest/production/upgrade-or-modify.html#upgrading-from-a-git-repository
 [hipchat-api-tokens]: https://developer.atlassian.com/server/hipchat/hipchat-rest-api-access-tokens/

--- a/templates/zerver/help/import-from-mattermost.md
+++ b/templates/zerver/help/import-from-mattermost.md
@@ -170,7 +170,7 @@ root domain. Replace the last line above with the following, after replacing
 
 {!import-login.md!}
 
-[upgrade-zulip-from-git]: https://zulip.readthedocs.io/en/latest/production/maintain-secure-upgrade.html#upgrading-from-a-git-repository
+[upgrade-zulip-from-git]: https://zulip.readthedocs.io/en/latest/production/upgrade-or-modify.html#upgrading-from-a-git-repository
 
 ## Caveats
 
@@ -188,4 +188,4 @@ messages with a specific Mattermost team.  For that reason, the import
 tool will only import private messages for data export archives
 containing a single Mattermost team.
 
-[upgrade-zulip-from-git]: https://zulip.readthedocs.io/en/latest/production/maintain-secure-upgrade.html#upgrading-from-a-git-repository
+[upgrade-zulip-from-git]: https://zulip.readthedocs.io/en/latest/production/upgrade-or-modify.html#upgrading-from-a-git-repository

--- a/templates/zerver/help/import-from-slack.md
+++ b/templates/zerver/help/import-from-slack.md
@@ -97,4 +97,4 @@ root domain. Replace the last line above with the following, after replacing
 
 - The "joined #channel_name" messages are not imported.
 
-[upgrade-zulip-from-git]: https://zulip.readthedocs.io/en/latest/production/maintain-secure-upgrade.html#upgrading-from-a-git-repository
+[upgrade-zulip-from-git]: https://zulip.readthedocs.io/en/latest/production/upgrade-or-modify.html#upgrading-from-a-git-repository


### PR DESCRIPTION
Moves the production "Backups" and "Upgrading" sections from `maintain-secure-upgrade.md` to `export-and-import.md` and `modifying-zulip.md`.

Fixes #13184.

**Testing Plan:**
`./tools/test-documentation --skip-external-links`
`./tools/lint --groups=backend --skip=gitlint,mypy`

**GIFs or Screenshots:**
![image](https://user-images.githubusercontent.com/2343554/65559235-b44c6900-deee-11e9-9c27-d7b26b08c323.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zulip/zulip/13222)
<!-- Reviewable:end -->
