### PR TITLE
messages: Render topic links in context of stream realm.

### DIFF
--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -331,7 +331,13 @@ class MessageDict:
         obj[TOPIC_NAME] = topic_name
         obj['sender_realm_id'] = sender_realm_id
 
-        obj[TOPIC_LINKS] = bugdown.topic_links(sender_realm_id, topic_name)
+        # Render topic_links with the stream's realm instead of the user's realm.
+        rendering_realm_id = sender_realm_id
+        if message and recipient_type == Recipient.STREAM:
+            stream = Stream.objects.select_related("realm").get(id=recipient_type_id)
+            rendering_realm_id = stream.realm.id
+
+        obj[TOPIC_LINKS] = bugdown.topic_links(rendering_realm_id, topic_name)
 
         if last_edit_time is not None:
             obj['last_edit_timestamp'] = datetime_to_timestamp(last_edit_time)

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1529,7 +1529,6 @@ def get_stream_recipients(stream_ids: List[int]) -> List[Recipient]:
 class AbstractMessage(models.Model):
     sender = models.ForeignKey(UserProfile, on_delete=CASCADE)  # type: UserProfile
     recipient = models.ForeignKey(Recipient, on_delete=CASCADE)  # type: Recipient
-
     # The message's topic.
     #
     # Early versions of Zulip called this concept a "subject", as in an email

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3167,7 +3167,7 @@ class SubscriptionAPITest(ZulipTestCase):
                     principals=ujson.dumps([user1.email, user2.email])
                 )
             )
-        self.assert_length(queries, 53)
+        self.assert_length(queries, 54)
 
 class GetBotOwnerStreamsTest(ZulipTestCase):
     def test_streams_api_for_bot_owners(self) -> None:


### PR DESCRIPTION
Priviously, we rendered the topic links using the msg.sender.realm.
This resulted in issues with Zulip's internal bots not having access
to the realm_filters of the destination stream's realm. For example,
sending a message via the email gateway would not linkify any realm
filters that a user would expect them to.

The solution here is to call bugdown.topic_links with the stream's
realm's id, however, when we create a message's json dict, we only
have access to the message object. Thus, we add a new field to the
AbstractMessage: rendering_realm.

**Testing Plan:** <!-- How have you tested? -->
Manual testing by running the following and derivatives on `./manage.py shell` and checking the results on the webapp:

```python
stream = Stream.objects.filter(name__contains="design")[0]
gateway = UserProfile.objects.get(full_name__contains="Gateway")
iago = UserProfile.objects.get(email__contains="iago")
internal_send_stream_message(stream.realm, iago, stream, '#123', 'Hello #456.')
internal_send_stream_message(stream.realm, gateway, stream, '#321', 'Hello #456.')
```
