### PR TITLE
Muted @all mention

### DIFF
--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -166,6 +166,11 @@ run_test('update_booleans', () => {
     assert.equal(message.mentioned_me_directly, true);
     assert.equal(message.alerted, true);
 
+    flags = ['wildcard_mentioned', 'unread'];
+    message_store.update_booleans(message, flags);
+    assert.equal(message.mentioned, true);
+    assert.equal(message.mentioned_me_directly, false);
+
     flags = ['read'];
     message_store.update_booleans(message, flags);
     assert.equal(message.mentioned, false);

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -114,6 +114,45 @@ run_test('add_message_metadata', () => {
     assert.equal(message.alerted, false);
 });
 
+run_test('message_booleans_parity', () => {
+    // We have two code paths that update/set message booleans.
+    // This test asserts that both have identical behavior for the
+    // flags common between them.
+    const assert_bool_match = (flags, expected_message) => {
+        const set_message = {topic: 'set_message_booleans', flags: flags};
+        const update_message = {topic: 'update_booleans'};
+        message_store.set_message_booleans(set_message);
+        message_store.update_booleans(update_message, flags);
+        Object.keys(expected_message).forEach((key) => {
+            assert.equal(set_message[key], expected_message[key], `'${key}' != ${expected_message[key]}`);
+            assert.equal(update_message[key], expected_message[key]);
+        });
+        assert.equal(set_message.topic, 'set_message_booleans');
+        assert.equal(update_message.topic, 'update_booleans');
+    };
+
+    assert_bool_match(['wildcard_mentioned'],
+                      {
+                          mentioned: true,
+                          mentioned_me_directly: false,
+                          alerted: false,
+                      });
+
+    assert_bool_match(['mentioned'],
+                      {
+                          mentioned: true,
+                          mentioned_me_directly: true,
+                          alerted: false,
+                      });
+
+    assert_bool_match(['has_alert_word'],
+                      {
+                          mentioned: false,
+                          mentioned_me_directly: false,
+                          alerted: true,
+                      });
+});
+
 run_test('errors', () => {
     // Test a user that doesn't exist
     var message = {

--- a/frontend_tests/node_tests/narrow_unread.js
+++ b/frontend_tests/node_tests/narrow_unread.js
@@ -54,6 +54,7 @@ run_test('get_unread_ids', () => {
         topic: 'my topic',
         unread: true,
         mentioned: true,
+        mentioned_me_directly: true,
     };
 
     const private_msg = {

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -495,7 +495,10 @@ exports.process_loaded_messages = function (messages) {
             );
         }
 
-        if (message.mentioned) {
+        const is_unmuted_mention = message.type === 'stream' && message.mentioned &&
+                                   !muting.is_topic_muted(message.stream_id,
+                                                          util.get_message_topic(message));
+        if (message.mentioned_me_directly || is_unmuted_mention) {
             exports.unread_mentions_counter.add(message.id);
         }
     });


### PR DESCRIPTION
This addresses the first part of #13073.

For the second part (what to do with the `is:mentioned` narrow, I don't understand the exact idea behind it. Why would we want to hide all `@all` mentions in muted streams but show the `@all`s of unmuted streams? There certainly would be usecases where people do not want to miss important messages in streams they've muted (if they are that unconcerned with a stream, they'd unsubscribe to them ideally?).

**Testing Plan:** <!-- How have you tested? -->
Manual testing, added automated tests.
