### PR TITLE
scripts: Clean up output from 'clean_unused_caches'

### DIFF
--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -74,6 +74,10 @@ def parse_cache_script_args(description):
         "--verbose", dest="verbose", action="store_true",
         help="If specified then script will print a detailed report "
         "of what is being will deleted/kept back.")
+    parser.add_argument(
+        "--no-print-headings", dest="no_headings", action="store_true",
+        help="If specified then script will not print headings for "
+        "what will be deleted/kept back.")
 
     args = parser.parse_args()
     args.verbose |= args.dry_run    # Always print a detailed report in case of dry run.
@@ -290,7 +294,7 @@ def purge_unused_caches(caches_dir, caches_in_use, cache_type, args):
     caches_to_keep = all_caches - caches_to_purge
 
     may_be_perform_purging(
-        caches_to_purge, caches_to_keep, cache_type, args.dry_run, args.verbose)
+        caches_to_purge, caches_to_keep, cache_type, args.dry_run, args.verbose, args.no_headings)
     if args.verbose:
         print("Done!")
 
@@ -321,11 +325,11 @@ def generate_sha1sum_emoji(zulip_path):
 
     return sha.hexdigest()
 
-def may_be_perform_purging(dirs_to_purge, dirs_to_keep, dir_type, dry_run, verbose):
-    # type: (Set[str], Set[str], str, bool, bool) -> None
+def may_be_perform_purging(dirs_to_purge, dirs_to_keep, dir_type, dry_run, verbose, no_headings):
+    # type: (Set[str], Set[str], str, bool, bool, bool) -> None
     if dry_run:
         print("Performing a dry run...")
-    else:
+    if not no_headings:
         print("Cleaning unused %ss..." % (dir_type,))
 
     for directory in dirs_to_purge:

--- a/scripts/purge-old-deployments
+++ b/scripts/purge-old-deployments
@@ -59,7 +59,7 @@ def main():
     deployments_to_purge = get_deployments_to_be_purged(deployments_to_keep)
 
     may_be_perform_purging(
-        deployments_to_purge, deployments_to_keep, "deployment", args.dry_run, args.verbose)
+        deployments_to_purge, deployments_to_keep, "deployment", args.dry_run, args.verbose, True)
 
     if not args.dry_run:
         print("Deployments cleaned successfully...")


### PR DESCRIPTION
The output log from running clean_unused_caches was too verbose and is only
needed when running it directly. Running it otherwise seems to imply it
anyhow. So a new flag --no-print-headers is introduced. It suppresses
the header outputs for the sub-tools.

Fixes #13214.



Tested the flag on clean-unused-caches.
