### PR TITLE
Right sidebar: Keyboard shortcuts icon should disappear in medium widths.

### DIFF
--- a/static/styles/media.scss
+++ b/static/styles/media.scss
@@ -22,6 +22,10 @@
         display: none;
     }
 
+    #sidebar-keyboard-shortcuts {
+        display: none;
+    }
+
     .column-right.expanded {
         display: block;
         position: absolute;


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Fixes the issue #13122**

*here's a GIF showing the fix*
![zulip](https://user-images.githubusercontent.com/44665669/65905845-03a70380-e3df-11e9-975e-b758e9da3408.gif)




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
