### PR TITLE
docs: pip upgrade recommonmark

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,9 @@ from typing import Any, Dict, List, Optional
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []  # type: List[str]
+extensions = [
+    'recommonmark',
+]  # type: List[str]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -292,16 +294,15 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
 
-from recommonmark.parser import CommonMarkParser
 from recommonmark.transform import AutoStructify
 
-source_parsers = {
-    '.md': CommonMarkParser,
+# The suffix(es) of source filenames. You can specify multiple suffix
+# as a dictionary mapping file extensions to file types
+# https://www.sphinx-doc.org/en/master/usage/markdown.html:
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown',
 }
-
-# The suffix(es) of source filenames.
-# You can specify multiple suffix as a list of string:
-source_suffix = ['.rst', '.md']
 
 # Temporary workaround to supress warnings after upgrading to recommonmark==0.5.0
 # Otherwise, sphinx build complains about all the links ending in .html

--- a/docs/development/remote.md
+++ b/docs/development/remote.md
@@ -81,8 +81,7 @@ This will start up the Zulip server on port 9991. You can then
 navigate to `http://<REMOTE_IP>:9991` and you should see something like
 this screenshot of the Zulip development environment:
 
-![Image of Zulip development
-environment](../images/zulip-dev.png)
+![Image of Zulip development environment](../images/zulip-dev.png)
 
 The `--interface=''` option makes the Zulip development environment
 accessible from any IP address (in contrast with the much more secure

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -143,7 +143,7 @@ pytz==2019.2
 pyyaml==5.1.2             # via cfn-lint, moto, yamole
 qrcode==6.1               # via django-two-factor-auth
 queuelib==1.5.0           # via scrapy
-recommonmark==0.5.0
+recommonmark==0.6.0
 redis==3.3.8
 regex==2019.8.19
 requests-oauthlib==1.2.0  # via python-twitter, social-auth-core

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -12,4 +12,4 @@ sphinx
 sphinx-rtd-theme
 
 # Needed to build markdown docs
-recommonmark==0.6.*  # https://github.com/zulip/zulip/issues/11395
+recommonmark

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -12,4 +12,4 @@ sphinx
 sphinx-rtd-theme
 
 # Needed to build markdown docs
-recommonmark==0.5.*  # https://github.com/zulip/zulip/issues/11395
+recommonmark==0.6.*  # https://github.com/zulip/zulip/issues/11395

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -22,7 +22,7 @@ packaging==19.2           # via sphinx
 pygments==2.4.2           # via sphinx
 pyparsing==2.4.2          # via packaging
 pytz==2019.2              # via babel
-recommonmark==0.5.0
+recommonmark==0.6.0
 requests==2.22.0          # via sphinx
 six==1.12.0               # via packaging
 snowballstemmer==1.9.1    # via sphinx

--- a/version.py
+++ b/version.py
@@ -26,4 +26,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '56.2'
+PROVISION_VERSION = '57.0'


### PR DESCRIPTION
- recommonmark: 0.5.0 -> 0.6.0
- Fixed build `TypeError: sequence item 1: expected str instance, NoneType found`
  caused by `recommonmark/parser.py` erroring on a newline character.

This commit is also relevant to PR #13232.

**Remarks:**
It would be useful to have `/tools/build-docs` time out or abort itself somehow so that it showed the entire error log in this type of scenario. The build error wasn't that easy to troubleshoot because `sphinx-build` would hang, which prevented useful error messages from being displayed, and the single error message shown wasn't helpful.

The solution was to temporarily remove the `SPHINXOPTS    = -j8` flag in `/docs/Makefile` to uncover the source of the problem as
```
".../recommonmark/parser.py", line 211, in visit_image
    img_node['alt'] = ''.join(content)
```
where a couple of print statements showed the issue was coming from a single newline character in the alt text of an inline-style image link in `docs/development/remote.md`. This error had prevented an earlier attempt to upgrade recommonmark to its latest version [#11395](https://github.com/zulip/zulip/issues/11395#issuecomment-521139602).

**Testing Plan:** <!-- How have you tested? -->
```
./tools/test-documentation --skip-external-links
./tools/lint --groups=backend --skip=gitlint,mypy
./tools/check-templates

```