### PR TITLE
design: Fixes poor line wrapping of long stream names.

### DIFF
--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -847,7 +847,6 @@ form#add_new_subscription {
         margin-top: -5px;
         margin-right: 5px;
         text-decoration: none;
-        line-height: 16px;
     }
 
     .editable-section {

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -794,11 +794,15 @@ form#add_new_subscription {
 
         .stream-name {
             display: inline-block;
+            position: relative;
             font-size: 1.5em;
             font-weight: 600;
             margin-left: -3px;
-            white-space: normal;
-            word-break: break-all;
+            padding-bottom: 5px;
+            white-space: nowrap;
+            width: 270px;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
 
         .deactivate,
@@ -844,7 +848,6 @@ form#add_new_subscription {
         margin-right: 5px;
         text-decoration: none;
         line-height: 16px;
-        vertical-align: middle;
     }
 
     .editable-section {

--- a/static/templates/subscription_settings.hbs
+++ b/static/templates/subscription_settings.hbs
@@ -15,7 +15,7 @@
             <div class="large-icon hash" style="color: {{color}}"></div>
             {{/if}}
             <div class="stream-name">
-                <span class="stream-name-editable editable-section">{{name}}</span>
+                <span title="{{name}}" class="stream-name-editable editable-section" >{{name}}</span>
                 {{#if can_change_name_description}}
                 <span class="editable" data-make-editable=".stream-name-editable"></span>
                 <span class="checkmark" data-finish-editing=".stream-name-editable">✓</span>


### PR DESCRIPTION
Earlier, on narrowing the window to some particular sizes,
long stream names used to overlap with the subscribe and view stream
buttons.
The longe names are now cut short and ellipses are added at the end. The full name of the stream was assigned as the title of the div and can hence be easily seen by hovering over it.
Also, the height of the view stream button was fixed.

Fixes: #13139

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


<!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
BEFORE--->
![before](https://user-images.githubusercontent.com/47082523/66155316-fb4c0400-e63c-11e9-8355-86df07ac9b62.png)

AFTER--->
![image](https://user-images.githubusercontent.com/47082523/68374170-6328c980-016a-11ea-94ca-bd333def6baa.png)




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
