### PR TITLE
setup_venv: Add pkg-config to VENV_DEPENDENCIES

### DIFF
--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -36,7 +36,7 @@ VENV_DEPENDENCIES = [
     "libmagic1",            # Used for install python-magic
     # Needed by python-xmlsec:
     "libxmlsec1-dev",
-    "libxmlsec1-openssl",
+    "pkg-config",
 
     # This is technically a node dependency, but we add it here
     # because we don't have another place that we install apt packages


### PR DESCRIPTION
This is needed on at least Debian 10, otherwise xmlsec fails to install: `Could not find xmlsec1 config. Are libxmlsec1-dev and pkg-config installed?`

Also remove libxmlsec1-openssl, which libxmlsec1-dev already depends.

(No changes are needed on RHEL, where libxml2-devel and xmlsec1-devel already declare a requirement on /usr/bin/pkg-config.)

**Testing Plan:** `upgrade-zulip-from-git` on Debian 10.