### PR TITLE
typing: Do time math with numbers, not Date objects.

### DIFF
--- a/static/js/typing.js
+++ b/static/js/typing.js
@@ -59,7 +59,7 @@ function is_valid_conversation(user_ids_string) {
 }
 
 function get_current_time() {
-    return new Date();
+    return new Date().getTime();
 }
 
 function notify_server_start(user_ids_string) {


### PR DESCRIPTION
When `typing_status` adds 10000 to this value, it would previously
obtain wacky strings like

    "Fri Oct 04 2019 16:45:59 GMT-0700 (Pacific Daylight Time)10000"

**Testing Plan:** Dev server.