### PR TITLE
LDAP fixes based on search-by-email.

### DIFF
--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -182,6 +182,14 @@ In either configuration, you will need to do the following:
       To do this, set `AUTH_LDAP_USER_SEARCH` to query by LDAP
       username, and `LDAP_EMAIL_ATTR = "email"`.
 
+5. If you're using configuration (A) or (C) you should set
+   `AUTH_LDAP_REVERSE_EMAIL_SEARCH` to query for email address in the attribute
+   that holds email addresses. In most cases it is going to be the username
+   attribute from `AUTH_LDAP_USER_SEARCH` in case of configuration (A)
+   or `LDAP_EMAIL_ATTR` in configuration (C).
+   Finally, set `AUTH_LDAP_USERNAME_ATTR` to the name of the attribute that
+   holds usernames.
+
 You can quickly test whether your configuration works by running:
 
 ```

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -259,6 +259,13 @@ class ZulipTestCase(TestCase):
         me='me@zulip.com',
     )
 
+    example_user_ldap_username_map = dict(
+        hamlet='hamlet',
+        cordelia='cordelia',
+        # aaron's uid in our test directory is "letham".
+        aaron='letham',
+    )
+
     def nonreg_user(self, name: str) -> UserProfile:
         email = self.nonreg_user_map[name]
         return get_user(email, get_realm("zulip"))
@@ -778,6 +785,18 @@ class ZulipTestCase(TestCase):
             data = attr_value
 
         self.mock_ldap.directory[dn][attr_name] = [data, ]
+
+    def ldap_username(self, username: str) -> str:
+        """
+        Maps zulip username to the name of the corresponding ldap user
+        in our test directory at zerver/tests/fixtures/ldap/directory.json,
+        if the ldap user exists.
+        """
+        return self.example_user_ldap_username_map[username]
+
+    def ldap_password(self) -> str:
+        # Currently all ldap users have password "testing"
+        return "testing"
 
 class WebhookTestCase(ZulipTestCase):
     """

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.core import mail
 from django.http import HttpResponse
 from django.test import override_settings
-from django_auth_ldap.backend import LDAPBackend, LDAPSearch, _LDAPUser
+from django_auth_ldap.backend import LDAPSearch, _LDAPUser
 from django.test.client import RequestFactory
 from django.utils.timezone import now as timezone_now
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
@@ -2988,17 +2988,6 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
         self.assertEqual(actual_value, expected_value)
 
 class TestQueryLDAP(ZulipLDAPTestCase):
-    class _LDAPUser:
-        attrs = {
-            'cn': ['King Hamlet', ],
-            'sn': ['Hamlet', ],
-            'thumbnailPhoto': [open(static_path("images/team/tim.png"), "rb").read()],
-            'birthDate': ['1990-01-01', ],
-            'twitter': ['@handle', ],
-        }
-
-        def __init__(self, backend: LDAPBackend, username: str) -> None:
-            super().__init__()
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.EmailAuthBackend',))
     def test_ldap_not_configured(self) -> None:
@@ -3015,36 +3004,30 @@ class TestQueryLDAP(ZulipLDAPTestCase):
     def test_normal_query(self) -> None:
         with self.settings(AUTH_LDAP_USER_ATTR_MAP={'full_name': 'cn',
                                                     'short_name': 'sn',
-                                                    'avatar': 'thumbnailPhoto',
+                                                    'avatar': 'jpegPhoto',
                                                     'custom_profile_field__birthday': 'birthDate',
-                                                    'custom_profile_field__phone_number': 'phoneNumber',
-                                                    'custom_profile_field__twitter': 'twitter'}), \
-                mock.patch('zproject.backends._LDAPUser', self._LDAPUser, create=True):
+                                                    'custom_profile_field__phone_number': 'nonExistentAttr'
+                                                    }):
             values = query_ldap(self.example_email('hamlet'))
-        self.assertEqual(len(values), 6)
+        self.assertEqual(len(values), 5)
         self.assertIn('full_name: King Hamlet', values)
         self.assertIn('short_name: Hamlet', values)
         self.assertIn('avatar: (An avatar image file)', values)
-        self.assertIn('custom_profile_field__birthday: 1990-01-01', values)
+        self.assertIn('custom_profile_field__birthday: 1900-09-08', values)
         self.assertIn('custom_profile_field__phone_number: LDAP field not present', values)
-        self.assertIn('custom_profile_field__twitter: @handle', values)
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_query_email_attr(self) -> None:
-        attrs = {
-            'cn': ['King Hamlet', ],
-            'sn': ['Hamlet', ],
-            'email_attr': ['separate_email@zulip.com', ],
-        }
         with self.settings(AUTH_LDAP_USER_ATTR_MAP={'full_name': 'cn',
                                                     'short_name': 'sn'},
-                           LDAP_EMAIL_ATTR='email_attr'), \
-                mock.patch('zproject.backends._LDAPUser.attrs', attrs):
+                           LDAP_EMAIL_ATTR='mail'):
+            # This will look up the user by email in our test dictionary,
+            # should successfully find hamlet's ldap entry.
             values = query_ldap(self.example_email('hamlet'))
         self.assertEqual(len(values), 3)
         self.assertIn('full_name: King Hamlet', values)
         self.assertIn('short_name: Hamlet', values)
-        self.assertIn('email: separate_email@zulip.com', values)
+        self.assertIn('email: hamlet@zulip.com', values)
 
 class TestZulipAuthMixin(ZulipTestCase):
     def test_get_user(self) -> None:

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.core import mail
 from django.http import HttpResponse
 from django.test import override_settings
-from django_auth_ldap.backend import LDAPBackend, LDAPSearch
+from django_auth_ldap.backend import LDAPBackend, LDAPSearch, _LDAPUser
 from django.test.client import RequestFactory
 from django.utils.timezone import now as timezone_now
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
@@ -2542,10 +2542,11 @@ class TestLDAP(ZulipLDAPTestCase):
             backend.django_to_ldap_username('"hamlet@test"@test.com')
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
-    def test_ldap_to_django_username(self) -> None:
+    def test_user_email_from_ldapuser_with_append_domain(self) -> None:
         backend = self.backend
         with self.settings(LDAP_APPEND_DOMAIN='zulip.com'):
-            username = backend.ldap_to_django_username('"hamlet@test"')
+            username = backend.user_email_from_ldapuser('this_argument_is_ignored',
+                                                        _LDAPUser(self.backend, username='"hamlet@test"'))
             self.assertEqual(username, '"hamlet@test"@zulip.com')
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -271,7 +271,7 @@ class AuthBackendTest(ZulipTestCase):
         self.init_default_ldap_database()
         user_profile = self.example_user('hamlet')
         email = user_profile.email
-        password = "testing"
+        password = self.ldap_password()
         self.setup_subdomain(user_profile)
 
         username = self.get_username()
@@ -1701,7 +1701,7 @@ class FetchAPIKeyTest(ZulipTestCase):
         with self.settings(LDAP_APPEND_DOMAIN='zulip.com'):
             result = self.client_post("/api/v1/fetch_api_key",
                                       dict(username=self.example_email('hamlet'),
-                                           password="testing"))
+                                           password=self.ldap_password()))
         self.assert_json_success(result)
 
     def test_inactive_user(self) -> None:
@@ -1918,7 +1918,7 @@ class TestTwoFactor(ZulipTestCase):
         # type: (mock.MagicMock) -> None
         token = 123456
         email = self.example_email('hamlet')
-        password = 'testing'
+        password = self.ldap_password()
 
         user_profile = self.example_user('hamlet')
         user_profile.set_password(password)
@@ -2433,7 +2433,7 @@ class TestLDAP(ZulipLDAPTestCase):
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_login_success(self) -> None:
         with self.settings(LDAP_APPEND_DOMAIN='zulip.com'):
-            user_profile = self.backend.authenticate(username=self.example_email("hamlet"), password='testing',
+            user_profile = self.backend.authenticate(username=self.example_email("hamlet"), password=self.ldap_password(),
                                                      realm=get_realm('zulip'))
 
             assert(user_profile is not None)
@@ -2442,7 +2442,7 @@ class TestLDAP(ZulipLDAPTestCase):
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_login_success_with_username(self) -> None:
         with self.settings(LDAP_APPEND_DOMAIN='zulip.com'):
-            user_profile = self.backend.authenticate(username="hamlet", password='testing',
+            user_profile = self.backend.authenticate(username="hamlet", password=self.ldap_password(),
                                                      realm=get_realm('zulip'))
 
             assert(user_profile is not None)
@@ -2451,8 +2451,8 @@ class TestLDAP(ZulipLDAPTestCase):
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_login_success_with_email_attr(self) -> None:
         with self.settings(LDAP_EMAIL_ATTR='mail'):
-            # aaron has uid "letham" in the test directory:
-            user_profile = self.backend.authenticate(username="letham", password='testing',
+            user_profile = self.backend.authenticate(username=self.ldap_username("aaron"),
+                                                     password=self.ldap_password(),
                                                      realm=get_realm('zulip'))
 
             assert (user_profile is not None)
@@ -2470,8 +2470,8 @@ class TestLDAP(ZulipLDAPTestCase):
         ):
             realm = get_realm('zulip')
             self.assertEqual(email_belongs_to_ldap(realm, self.example_email("aaron")), True)
-            # aaron's uid in our test directory is "letham".
-            user_profile = ZulipLDAPAuthBackend().authenticate(username="letham", password='testing',
+            user_profile = ZulipLDAPAuthBackend().authenticate(username=self.ldap_username("aaron"),
+                                                               password=self.ldap_password(),
                                                                realm=realm)
             self.assertEqual(user_profile, self.example_user("aaron"))
 
@@ -2506,7 +2506,7 @@ class TestLDAP(ZulipLDAPTestCase):
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_login_failure_due_to_nonexistent_user(self) -> None:
         with self.settings(LDAP_APPEND_DOMAIN='zulip.com'):
-            user = self.backend.authenticate(username='nonexistent@zulip.com', password='testing',
+            user = self.backend.authenticate(username='nonexistent@zulip.com', password=self.ldap_password(),
                                              realm=get_realm('zulip'))
             self.assertIs(user, None)
 
@@ -2664,7 +2664,8 @@ class TestLDAP(ZulipLDAPTestCase):
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_login_failure_when_domain_does_not_match(self) -> None:
         with self.settings(LDAP_APPEND_DOMAIN='acme.com'):
-            user_profile = self.backend.authenticate(username=self.example_email("hamlet"), password='testing',
+            user_profile = self.backend.authenticate(username=self.example_email("hamlet"),
+                                                     password=self.ldap_password(),
                                                      realm=get_realm('zulip'))
             self.assertIs(user_profile, None)
 
@@ -2676,14 +2677,16 @@ class TestLDAP(ZulipLDAPTestCase):
         with self.settings(
                 LDAP_APPEND_DOMAIN='zulip.com',
                 AUTH_LDAP_USER_ATTR_MAP=ldap_user_attr_map):
-            user_profile = self.backend.authenticate(username=self.example_email('hamlet'), password='testing',
+            user_profile = self.backend.authenticate(username=self.example_email('hamlet'),
+                                                     password=self.ldap_password(),
                                                      realm=get_realm('acme'))
             self.assertEqual(user_profile.email, self.example_email('hamlet'))
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_login_success_with_valid_subdomain(self) -> None:
         with self.settings(LDAP_APPEND_DOMAIN='zulip.com'):
-            user_profile = self.backend.authenticate(username=self.example_email("hamlet"), password='testing',
+            user_profile = self.backend.authenticate(username=self.example_email("hamlet"),
+                                                     password=self.ldap_password(),
                                                      realm=get_realm('zulip'))
             assert(user_profile is not None)
             self.assertEqual(user_profile.email, self.example_email("hamlet"))
@@ -2693,7 +2696,8 @@ class TestLDAP(ZulipLDAPTestCase):
         user_profile = self.example_user("hamlet")
         do_deactivate_user(user_profile)
         with self.settings(LDAP_APPEND_DOMAIN='zulip.com'):
-            user_profile = self.backend.authenticate(username=self.example_email("hamlet"), password='testing',
+            user_profile = self.backend.authenticate(username=self.example_email("hamlet"),
+                                                     password=self.ldap_password(),
                                                      realm=get_realm('zulip'))
             self.assertIs(user_profile, None)
 
@@ -2705,7 +2709,8 @@ class TestLDAP(ZulipLDAPTestCase):
     def test_login_success_when_user_does_not_exist_with_valid_subdomain(self) -> None:
         RealmDomain.objects.create(realm=self.backend._realm, domain='acme.com')
         with self.settings(LDAP_APPEND_DOMAIN='acme.com'):
-            user_profile = self.backend.authenticate(username='newuser@acme.com', password='testing',
+            user_profile = self.backend.authenticate(username='newuser@acme.com',
+                                                     password=self.ldap_password(),
                                                      realm=get_realm('zulip'))
             assert(user_profile is not None)
             self.assertEqual(user_profile.email, 'newuser@acme.com')
@@ -2722,7 +2727,8 @@ class TestLDAP(ZulipLDAPTestCase):
         with self.settings(
                 LDAP_APPEND_DOMAIN='zulip.com',
                 AUTH_LDAP_USER_ATTR_MAP={'first_name': 'sn', 'last_name': 'cn'}):
-            user_profile = self.backend.authenticate(username='newuser_splitname@zulip.com', password='testing',
+            user_profile = self.backend.authenticate(username='newuser_splitname@zulip.com',
+                                                     password=self.ldap_password(),
                                                      realm=get_realm('zulip'))
             assert(user_profile is not None)
             self.assertEqual(user_profile.email, 'newuser_splitname@zulip.com')
@@ -2732,7 +2738,7 @@ class TestLDAP(ZulipLDAPTestCase):
 class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
     def test_authenticate(self) -> None:
         backend = ZulipLDAPUserPopulator()
-        result = backend.authenticate(username=self.example_email("hamlet"), password='testing',
+        result = backend.authenticate(username=self.example_email("hamlet"), password=self.ldap_password(),
                                       realm=get_realm('zulip'))
         self.assertIs(result, None)
 

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.core import mail
 from django.http import HttpResponse
 from django.test import override_settings
-from django_auth_ldap.backend import LDAPBackend, _LDAPUser
+from django_auth_ldap.backend import LDAPBackend, LDAPSearch, _LDAPUser
 from django.test.client import RequestFactory
 from django.utils.timezone import now as timezone_now
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
@@ -12,6 +12,7 @@ from django.urls import reverse
 
 import httpretty
 
+import ldap
 import jwt
 import mock
 import re
@@ -56,7 +57,7 @@ from zproject.backends import ZulipDummyBackend, EmailAuthBackend, \
     require_email_format_usernames, AUTH_BACKEND_NAME_MAP, \
     ZulipLDAPConfigurationError, ZulipLDAPExceptionOutsideDomain, \
     ZulipLDAPException, query_ldap, sync_user_from_ldap, SocialAuthMixin, \
-    PopulateUserLDAPError, SAMLAuthBackend, saml_auth_enabled
+    PopulateUserLDAPError, SAMLAuthBackend, saml_auth_enabled, email_belongs_to_ldap
 
 from zerver.views.auth import (maybe_send_to_registration,
                                _subdomain_token_salt)
@@ -2463,6 +2464,44 @@ class TestLDAP(ZulipLDAPTestCase):
 
             assert (user_profile is not None)
             self.assertEqual(user_profile, self.example_user("aaron"))
+
+    @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.EmailAuthBackend',
+                                                'zproject.backends.ZulipLDAPAuthBackend',))
+    def test_email_and_ldap_backends_together(self) -> None:
+        with self.settings(
+            LDAP_EMAIL_ATTR='mail',
+            AUTH_LDAP_REVERSE_EMAIL_SEARCH = LDAPSearch("ou=users,dc=zulip,dc=com",
+                                                        ldap.SCOPE_ONELEVEL,
+                                                        "(mail=%(email)s)"),
+            AUTH_LDAP_USERNAME_ATTR = "uid"
+        ):
+            realm = get_realm('zulip')
+            self.assertEqual(email_belongs_to_ldap(realm, self.example_email("aaron")), True)
+            # aaron's uid in our test directory is "letham".
+            user_profile = ZulipLDAPAuthBackend().authenticate(username="letham", password='testing',
+                                                               realm=realm)
+            self.assertEqual(user_profile, self.example_user("aaron"))
+
+            othello = self.example_user('othello')
+            password = "testpassword"
+            othello.set_password(password)
+            othello.save()
+
+            self.assertEqual(email_belongs_to_ldap(realm, othello.email), False)
+            user_profile = EmailAuthBackend().authenticate(username=othello.email, password=password,
+                                                           realm=realm)
+            self.assertEqual(user_profile, othello)
+
+    @override_settings(AUTH_LDAP_REVERSE_EMAIL_SEARCH=None, LDAP_APPEND_DOMAIN=None,
+                       AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
+    def test_no_append_domain_and_email_search_not_configured(self) -> None:
+        with mock.patch("zproject.backends.logging.warning") as mock_warning:
+            result = email_belongs_to_ldap(get_realm("zulip"), "nonexistant@email.com")
+            self.assertEqual(result, True)
+            mock_warning.assert_called_with(
+                "LDAP_APPEND_DOMAIN isn't used, but searching by email "
+                "is not configured. email_belongs_to_ldap will always return True."
+            )
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_login_failure_due_to_wrong_password(self) -> None:

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -59,7 +59,7 @@ class TestFollowupEmails(ZulipTestCase):
         ldap_user_attr_map = {'full_name': 'cn', 'short_name': 'sn'}
 
         with self.settings(AUTH_LDAP_USER_ATTR_MAP=ldap_user_attr_map):
-            self.login_with_return("newuser_email_as_uid@zulip.com", "testing")
+            self.login_with_return("newuser_email_as_uid@zulip.com", self.ldap_password())
             user = UserProfile.objects.get(email="newuser_email_as_uid@zulip.com")
             scheduled_emails = ScheduledEmail.objects.filter(users=user)
 
@@ -78,7 +78,7 @@ class TestFollowupEmails(ZulipTestCase):
                 LDAP_APPEND_DOMAIN='zulip.com',
                 AUTH_LDAP_USER_ATTR_MAP=ldap_user_attr_map,
         ):
-            self.login_with_return("newuser@zulip.com", "testing")
+            self.login_with_return("newuser@zulip.com", self.ldap_password())
 
             user = UserProfile.objects.get(email="newuser@zulip.com")
             scheduled_emails = ScheduledEmail.objects.filter(users=user)
@@ -98,7 +98,7 @@ class TestFollowupEmails(ZulipTestCase):
                 LDAP_EMAIL_ATTR='mail',
                 AUTH_LDAP_USER_ATTR_MAP=ldap_user_attr_map,
         ):
-            self.login_with_return("newuser_with_email", "testing")
+            self.login_with_return("newuser_with_email", self.ldap_password())
             user = UserProfile.objects.get(email="newuser_email@zulip.com")
             scheduled_emails = ScheduledEmail.objects.filter(users=user)
 

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -1,3 +1,4 @@
+import ldap
 import random
 import re
 import ujson
@@ -5,6 +6,7 @@ import ujson
 from django.conf import settings
 from django.core import mail
 from django.test import override_settings
+from django_auth_ldap.config import LDAPSearch
 from email.utils import formataddr
 from mock import patch, MagicMock
 from typing import List, Optional
@@ -47,7 +49,11 @@ class TestFollowupEmails(ZulipTestCase):
     # See https://zulip.readthedocs.io/en/latest/production/authentication-methods.html#ldap-including-active-directory
     # for case details.
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',
-                                                'zproject.backends.ZulipDummyBackend'))
+                                                'zproject.backends.ZulipDummyBackend'),
+                       # configure email search for email address in the uid attribute:
+                       AUTH_LDAP_REVERSE_EMAIL_SEARCH=LDAPSearch("ou=users,dc=zulip,dc=com",
+                                                                 ldap.SCOPE_ONELEVEL,
+                                                                 "(uid=%(email)s)"))
     def test_day1_email_ldap_case_a_login_credentials(self) -> None:
         self.init_default_ldap_database()
         ldap_user_attr_map = {'full_name': 'cn', 'short_name': 'sn'}

--- a/zerver/tests/test_ldap.py
+++ b/zerver/tests/test_ldap.py
@@ -4,7 +4,7 @@ from django.test.utils import override_settings
 
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.models import get_realm
-from zproject.backends import ZulipLDAPAuthBackend, ZulipLDAPExceptionOutsideDomain
+from zproject.backends import ZulipLDAPAuthBackend, ZulipLDAPExceptionOutsideDomain, sync_user_from_ldap
 
 from django_auth_ldap.config import LDAPSearch
 
@@ -89,3 +89,23 @@ class DjangoToLDAPUsernameTests(ZulipTestCase):
             # Ldap password works now:
             self.assertEqual(authenticate(username=user_profile.email, password="testing", realm=realm),
                              user_profile)
+
+    @override_settings(LDAP_EMAIL_ATTR='mail', LDAP_DEACTIVATE_NON_MATCHING_USERS=True)
+    def test_sync_user_from_ldap_with_email_attr(self) -> None:
+        """
+        In LDAP configurations with LDAP_EMAIL_ATTR and LDAP_DEACTIVATE_NON_MATCHING_USERS,
+        sync_user_from_ldap used to
+        deactivate all ldap users, because of the inability to translate
+        email to ldap username. This tests that this is fixed.
+        """
+
+        user_profile = self.example_user("hamlet")
+        with self.settings():
+            sync_user_from_ldap(user_profile, mock.Mock())
+            # Syncing didn't deactivate the user:
+            self.assertTrue(user_profile.is_active)
+
+        with self.settings(AUTH_LDAP_REVERSE_EMAIL_SEARCH=None):
+            # Without email search, the user will get deactivated.
+            sync_user_from_ldap(user_profile, mock.Mock())
+            self.assertFalse(user_profile.is_active)

--- a/zerver/tests/test_ldap.py
+++ b/zerver/tests/test_ldap.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+from django.contrib.auth import authenticate
+from django.test.utils import override_settings
+
+from zerver.lib.test_classes import ZulipTestCase
+from zerver.models import get_realm
+from zproject.backends import ZulipLDAPAuthBackend, ZulipLDAPExceptionOutsideDomain
+
+from django_auth_ldap.config import LDAPSearch
+
+import ldap
+import mock
+
+"""
+This is a file for additional LDAP tests, that don't belong
+anywhere else.
+"""
+
+class DjangoToLDAPUsernameTests(ZulipTestCase):
+    def setUp(self) -> None:
+        self.init_default_ldap_database()
+        self.backend = ZulipLDAPAuthBackend()
+
+    def test_django_to_ldap_username_with_append_domain(self) -> None:
+        with self.settings(LDAP_APPEND_DOMAIN="zulip.com"):
+            self.assertEqual(self.backend.django_to_ldap_username("hamlet"), "hamlet")
+            self.assertEqual(self.backend.django_to_ldap_username("hamlet@zulip.com"), "hamlet")
+            with self.assertRaises(ZulipLDAPExceptionOutsideDomain):
+                self.backend.django_to_ldap_username("hamlet@example.com")
+
+    def test_django_to_ldap_username_without_email_search(self) -> None:
+        with self.settings(AUTH_LDAP_REVERSE_EMAIL_SEARCH=None):
+            self.assertEqual(self.backend.django_to_ldap_username("hamlet"), "hamlet")
+            self.assertEqual(self.backend.django_to_ldap_username("hamlet@zulip.com"), "hamlet@zulip.com")
+            self.assertEqual(self.backend.django_to_ldap_username("hamlet@example.com"), "hamlet@example.com")
+
+    def test_django_to_ldap_username_with_email_search(self) -> None:
+        with self.settings():
+            self.assertEqual(self.backend.django_to_ldap_username("hamlet"), "hamlet")
+            self.assertEqual(self.backend.django_to_ldap_username("hamlet@zulip.com"), "hamlet")
+            # If there are no matches through the email search, return the email unchanged:
+            self.assertEqual(self.backend.django_to_ldap_username("no_such_email@example.com"),
+                             "no_such_email@example.com")
+            # aaron has uid=letham in our test directory:
+            self.assertEqual(self.backend.django_to_ldap_username("aaron@zulip.com"), "letham")
+
+            with mock.patch("zproject.backends.logging.warning") as mock_warn:
+                self.assertEqual(
+                    self.backend.django_to_ldap_username("shared_email@zulip.com"),
+                    "shared_email@zulip.com"
+                )
+                mock_warn.assert_called_with("Multiple users with email shared_email@zulip.com found in LDAP.")
+
+        # Configure email search for emails in the uid attribute:
+        with self.settings(AUTH_LDAP_REVERSE_EMAIL_SEARCH=LDAPSearch("ou=users,dc=zulip,dc=com",
+                                                                     ldap.SCOPE_ONELEVEL,
+                                                                     "(uid=%(email)s)")):
+            self.assertEqual(self.backend.django_to_ldap_username("newuser_email_as_uid@zulip.com"),
+                             "newuser_email_as_uid@zulip.com")
+
+    @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.EmailAuthBackend',
+                                                'zproject.backends.ZulipLDAPAuthBackend',))
+    def test_authenticate_to_ldap_via_email(self) -> None:
+        """
+        With AUTH_LDAP_REVERSE_EMAIL_SEARCH configured, django_to_ldap_username
+        should be able to translate an email to ldap username,
+        and thus it should be possible to authenticate through user_profile.email.
+        """
+        realm = get_realm("zulip")
+        user_profile = self.example_user("hamlet")
+        password = "testpassword"
+        user_profile.set_password(password)
+        user_profile.save()
+
+        # Without email search, can't login via ldap:
+        with self.settings(AUTH_LDAP_REVERSE_EMAIL_SEARCH=None, LDAP_EMAIL_ATTR='mail'):
+            # Using hamlet's ldap password fails without email search:
+            self.assertEqual(authenticate(username=user_profile.email, password="testing", realm=realm),
+                             None)
+            # Need hamlet's zulip password to login (via email backend)
+            self.assertEqual(authenticate(username=user_profile.email, password="testpassword", realm=realm),
+                             user_profile)
+            # To login via ldap, username needs to be the ldap username, not email:
+            self.assertEqual(authenticate(username="hamlet", password="testing", realm=realm),
+                             user_profile)
+
+        # With email search:
+        with self.settings(LDAP_EMAIL_ATTR='mail'):
+            # Ldap password works now:
+            self.assertEqual(authenticate(username=user_profile.email, password="testing", realm=realm),
+                             user_profile)

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -204,7 +204,7 @@ class ChangeSettingsTest(ZulipTestCase):
             result = self.client_patch(
                 "/json/settings",
                 dict(
-                    old_password='testing',  # hamlet's password in ldap
+                    old_password=self.ldap_password(),  # hamlet's password in ldap
                     new_password="ignored",
                 ))
             self.assert_json_error(result, "Your Zulip password is managed in LDAP")

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -2489,7 +2489,7 @@ class UserSignUpTest(InviteUserBase):
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',
                                                 'zproject.backends.ZulipDummyBackend'))
     def test_ldap_registration_from_confirmation(self) -> None:
-        password = "testing"
+        password = self.ldap_password()
         email = "newuser@zulip.com"
         subdomain = "zulip"
         self.init_default_ldap_database()
@@ -2557,7 +2557,7 @@ class UserSignUpTest(InviteUserBase):
                                                 'zproject.backends.ZulipLDAPUserPopulator',
                                                 'zproject.backends.ZulipDummyBackend'))
     def test_ldap_populate_only_registration_from_confirmation(self) -> None:
-        password = "testing"
+        password = self.ldap_password()
         email = "newuser@zulip.com"
         subdomain = "zulip"
         self.init_default_ldap_database()
@@ -2618,7 +2618,7 @@ class UserSignUpTest(InviteUserBase):
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',
                                                 'zproject.backends.ZulipDummyBackend'))
     def test_ldap_registration_end_to_end(self) -> None:
-        password = "testing"
+        password = self.ldap_password()
         email = "newuser@zulip.com"
         subdomain = "zulip"
 
@@ -2686,7 +2686,7 @@ class UserSignUpTest(InviteUserBase):
 
         subdomain = 'zulip'
         email = 'newuser_splitname@zulip.com'
-        password = 'testing'
+        password = self.ldap_password()
         with patch('zerver.views.registration.get_subdomain', return_value=subdomain):
             result = self.client_post('/register/', {'email': email})
 
@@ -2732,7 +2732,7 @@ class UserSignUpTest(InviteUserBase):
 
         This test verifies that flow.
         """
-        password = "testing"
+        password = self.ldap_password()
         email = "newuser@zulip.com"
         subdomain = "zulip"
 
@@ -2765,7 +2765,7 @@ class UserSignUpTest(InviteUserBase):
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_ldap_registration_multiple_realms(self) -> None:
-        password = "testing"
+        password = self.ldap_password()
         email = "newuser@zulip.com"
 
         self.init_default_ldap_database()
@@ -2799,7 +2799,7 @@ class UserSignUpTest(InviteUserBase):
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',
                                                 'zproject.backends.ZulipDummyBackend'))
     def test_ldap_registration_when_names_changes_are_disabled(self) -> None:
-        password = "testing"
+        password = self.ldap_password()
         email = "newuser@zulip.com"
         subdomain = "zulip"
 
@@ -2919,7 +2919,7 @@ class UserSignUpTest(InviteUserBase):
 
         subdomain = 'zulip'
         email = 'newuser@zulip.com'
-        password = 'testing'
+        password = self.ldap_password()
 
         with self.settings(
                 POPULATE_PROFILE_VIA_LDAP=True,
@@ -2985,7 +2985,7 @@ class UserSignUpTest(InviteUserBase):
         """
         Test `name_changes_disabled` when we are not running under LDAP.
         """
-        password = "testing"
+        password = self.ldap_password()
         email = "newuser@zulip.com"
         subdomain = "zulip"
 
@@ -3009,7 +3009,7 @@ class UserSignUpTest(InviteUserBase):
             self.assertEqual(user_profile.full_name, 'New Name')
 
     def test_realm_creation_through_ldap(self) -> None:
-        password = "testing"
+        password = self.ldap_password()
         email = "newuser@zulip.com"
         subdomain = "zulip"
         realm_name = "Zulip"
@@ -3424,7 +3424,7 @@ class TwoFactorAuthTest(ZulipTestCase):
         # type: (MagicMock) -> None
         token = 123456
         email = self.example_email('hamlet')
-        password = 'testing'
+        password = self.ldap_password()
 
         user_profile = self.example_user('hamlet')
         user_profile.set_password(password)

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -346,9 +346,35 @@ class ZulipLDAPAuthBackendBase(ZulipAuthMixin, LDAPBackend):
 
         return username
 
-    def ldap_to_django_username(self, username: str) -> str:
+    def user_email_from_ldapuser(self, username: str, ldap_user: _LDAPUser) -> str:
+        if hasattr(ldap_user, '_username'):
+            # In tests, we sometimes pass a simplified _LDAPUser without _username attr,
+            # and with the intended username in the username argument.
+            username = ldap_user._username
+
         if settings.LDAP_APPEND_DOMAIN:
             return "@".join((username, settings.LDAP_APPEND_DOMAIN))
+
+        if settings.LDAP_EMAIL_ATTR is not None:
+            # Get email from ldap attributes.
+            if settings.LDAP_EMAIL_ATTR not in ldap_user.attrs:
+                raise ZulipLDAPException("LDAP user doesn't have the needed %s attribute" % (
+                    settings.LDAP_EMAIL_ATTR,))
+            else:
+                return ldap_user.attrs[settings.LDAP_EMAIL_ATTR][0]
+
+        return username
+
+    def ldap_to_django_username(self, username: str) -> str:
+        """
+        This is called inside django_auth_ldap with only one role:
+        to convert _LDAPUser._username to django username (so in Zulip, the email)
+        and pass that as "username" argument to get_or_build_user(username, ldapuser).
+        In many cases, the email is stored in the _LDAPUser's attributes, so it can't be
+        constructed just from the username. We choose to do nothing in this function,
+        and our overrides of get_or_build_user() obtain that username from the _LDAPUser
+        object on their own, through our user_email_from_ldapuser function.
+        """
         return username
 
     def sync_avatar_from_ldap(self, user: UserProfile, ldap_user: _LDAPUser) -> None:
@@ -476,7 +502,13 @@ class ZulipLDAPAuthBackendBase(ZulipAuthMixin, LDAPBackend):
              ./manage.py sync_ldap_user_data
            In authentication contexts, this is overriden in ZulipLDAPAuthBackend.
         """
+        # Obtain the django username from the ldap_user object:
+        username = self.user_email_from_ldapuser(username, ldap_user)
+
+        # Call the library get_or_build_user for building the UserProfile
+        # with the username we obtained:
         (user, built) = super().get_or_build_user(username, ldap_user)
+        # Synchronise the UserProfile with its LDAP attributes:
         if 'userAccountControl' in settings.AUTH_LDAP_USER_ATTR_MAP:
             user_disabled_in_ldap = self.is_account_control_disabled_user(ldap_user)
             if user_disabled_in_ldap:
@@ -545,14 +577,7 @@ class ZulipLDAPAuthBackend(ZulipLDAPAuthBackendBase):
         """
         return_data = {}  # type: Dict[str, Any]
 
-        if settings.LDAP_EMAIL_ATTR is not None:
-            # Get email from ldap attributes.
-            if settings.LDAP_EMAIL_ATTR not in ldap_user.attrs:
-                return_data["ldap_missing_attribute"] = settings.LDAP_EMAIL_ATTR
-                raise ZulipLDAPException("LDAP user doesn't have the needed %s attribute" % (
-                    settings.LDAP_EMAIL_ATTR,))
-
-            username = ldap_user.attrs[settings.LDAP_EMAIL_ATTR][0]
+        username = self.user_email_from_ldapuser(username, ldap_user)
 
         if 'userAccountControl' in settings.AUTH_LDAP_USER_ATTR_MAP:  # nocoverage
             ldap_disabled = self.is_account_control_disabled_user(ldap_user)

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -328,6 +328,22 @@ class ZulipLDAPAuthBackendBase(ZulipAuthMixin, LDAPBackend):
                     raise ZulipLDAPExceptionOutsideDomain("Email %s does not match LDAP domain %s." % (
                         username, settings.LDAP_APPEND_DOMAIN))
                 return email_to_username(username)
+            else:
+                return username
+
+        if settings.AUTH_LDAP_USERNAME_ATTR and settings.AUTH_LDAP_REVERSE_EMAIL_SEARCH:
+            # We can use find_ldap_users_by_email
+            if is_valid_email(username):
+                result = find_ldap_users_by_email(username)
+                if result:
+                    if len(result) == 1:
+                        return result[0]._username
+                    if len(result) > 1:
+                        # This is possible, but strange, so worth logging a warning about.
+                        # We can't translate the email to a unique username,
+                        # so we don't do anything else here.
+                        logging.warning("Multiple users with email {} found in LDAP.".format(username))
+
         return username
 
     def ldap_to_django_username(self, username: str) -> str:
@@ -492,6 +508,10 @@ class ZulipLDAPAuthBackend(ZulipLDAPAuthBackendBase):
             return None
 
         try:
+            # If searching for email in LDAP is configured,
+            # django_to_ldap_username can translate email to user's LDAP username,
+            # so that this authenticate() can successfully be called with
+            # user_profile.email .
             username = self.django_to_ldap_username(username)
         except ZulipLDAPExceptionOutsideDomain:
             if return_data is not None:

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -493,6 +493,19 @@ AUTH_LDAP_USER_SEARCH = LDAPSearch("ou=users,dc=example,dc=com",
 # leave as None and see LDAP_EMAIL_ATTR.
 LDAP_APPEND_DOMAIN = None  # type: Optional[str]
 
+# If you're not using LDAP_APPEND_DOMAIN, for things to work well, you will need to
+# configure the email search settings below.
+# AUTH_LDAP_REVERSE_EMAIL_SEARCH you should configure like you did AUTH_LDAP_USER_SEARCH,
+# but this search query is meant for finding if there are users in LDAP with the
+# specified email address.
+# AUTH_LDAP_USERNAME_ATTR should be set to the attribute that is the username. This should
+# most likely match the attribute by which you're looking up users in AUTH_LDAP_USER_SEARCH.
+#
+# AUTH_LDAP_REVERSE_EMAIL_SEARCH = LDAPSearch("ou=users,dc=example,dc=com",
+#                                             ldap.SCOPE_SUBTREE, "(email=%(email)s)")
+#
+# AUTH_LDAP_USERNAME_ATTR = "uid"
+
 # LDAP attribute to find a user's email address.
 #
 # Leave as None if users log in with their email addresses,

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -147,6 +147,8 @@ DEFAULT_SETTINGS = {
     # LDAP auth
     'AUTH_LDAP_SERVER_URI': "",
     'LDAP_EMAIL_ATTR': None,
+    'AUTH_LDAP_USERNAME_ATTR': None,
+    'AUTH_LDAP_REVERSE_EMAIL_SEARCH': None,
     # AUTH_LDAP_CONNECTION_OPTIONS: we set ldap.OPT_REFERRALS below if unset.
     'AUTH_LDAP_CONNECTION_OPTIONS': {},
     # Disable django-auth-ldap caching, to prevent problems with OU changes.

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -71,6 +71,10 @@ GOOGLE_OAUTH2_CLIENT_ID = "test_client_id"
 AUTH_LDAP_ALWAYS_UPDATE_USER = False
 AUTH_LDAP_USER_SEARCH = LDAPSearch("ou=users,dc=zulip,dc=com",
                                    ldap.SCOPE_ONELEVEL, "(uid=%(user)s)")
+AUTH_LDAP_USERNAME_ATTR = "uid"
+AUTH_LDAP_REVERSE_EMAIL_SEARCH = LDAPSearch("ou=users,dc=zulip,dc=com",
+                                            ldap.SCOPE_ONELEVEL,
+                                            "(mail=%(email)s)")
 
 TEST_SUITE = True
 RATE_LIMITING = False


### PR DESCRIPTION
This should fix the following issues:
https://github.com/zulip/zulip/issues/11878
https://github.com/zulip/zulip/issues/11715
https://github.com/zulip/zulip/issues/9277
possibly some other related ones :thinking: 

1. We swtich to our fork of django-auth-ldap, where I implemented searching in LDAP by email.
2. . A rather unpleasant migration of tests to slapdtest. This is where most of the large number of line changes of PR comes from. This is necessary, because as explained the main migration commit:
> the fakeldap setup we used, with mocking of django_auth_ldap.config.ldap.initialize, would permanently affect the internal state of the ldap modules for all other tests

so having any fakeldap-based tests broke slapdtest (the ldap modules would keep trying to connect to fakeldap instead of slapd.). Plus switching to slapdtest has various other benefits, so I think we're definitely better off relying on that everywhere.

3. We fix email_belongs_to_ldap, to search for emails in the directory rather than blindly returning True.

4. Use email search in django_to_ldap_username, which allows fixing the flows of things like getting api keys and sync_user_from_ldap, which use user_profile.email as the identifier, by allowing them to translate that email into the proper ldap username.
