### PR TITLE
node_cache: Preserve symlinks when copying an old node_modules tree

### DIFF
--- a/scripts/lib/node_cache.py
+++ b/scripts/lib/node_cache.py
@@ -83,7 +83,7 @@ def do_yarn_install(target_path, yarn_args, success_stamp, stdout=None, stderr=N
 
     # Copy the existing node_modules to speed up install
     if os.path.exists("node_modules"):
-        shutil.copytree("node_modules/", cached_node_modules)
+        shutil.copytree("node_modules/", cached_node_modules, symlinks=True)
     if os.environ.get('CUSTOM_CA_CERTIFICATES'):
         run([YARN_BIN, "config", "set", "cafile", os.environ['CUSTOM_CA_CERTIFICATES']],
             stdout=stdout, stderr=stderr)


### PR DESCRIPTION
**Testing Plan:** Dev server.