### PR TITLE
settings page: Align permission "Discard" option.

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -478,12 +478,12 @@ input[type=checkbox] + .inline-block {
 #settings_page .icon-button .icon-button-icon {
     vertical-align: bottom;
     margin-right: 3px;
-    font-size: 24px;
-    font-weight: 600;
+    margin-bottom: 1px;
+    font-size: 15px;
+    font-weight: 500;
 }
 
 #settings_page .icon-button.primary .icon-button-icon {
-    font-size: 15px;
     font-weight: lighter;
     color: hsl(0, 0%, 100%);
 }

--- a/static/templates/settings/settings_save_discard_widget.hbs
+++ b/static/templates/settings/settings_save_discard_widget.hbs
@@ -11,7 +11,7 @@
     </div>
     <div class="inline-block subsection-changes-discard">
         <div class="icon-button button discard-button" type="button" id="org-discard-{{section_name}}">
-            <span class="icon-button-icon">×</span>
+            <span class="fa fa-times icon-button-icon"></span>
             <span class="icon-button-text">
                 {{t 'Discard' }}
             </span>


### PR DESCRIPTION
In 50545a3 we made an incomplete revert of some style changes from
7b8da9b, this commit reverts the "x" to "fa fa-times" and also fixes an
alignment issue for the "Discard" box in chrome.
Fixes #13233.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
firefox:
![image](https://user-images.githubusercontent.com/33805964/66324107-8598ae80-e942-11e9-85be-a60e1c4b639e.png)

chrome:
![image](https://user-images.githubusercontent.com/33805964/66324180-9d703280-e942-11e9-9765-2bce00122eba.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
