### PR TITLE
docs: add docs/README.md to the exclude_patterns list

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ language = None  # type: Optional[str]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ['_build', 'README.md']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.


### PR DESCRIPTION
This commmit removes "WARNING: document isn't included in any toctree"
from build output.

Addresses part of #13263.