### PR TITLE
[WIP] droplets: Update snapshot id

### DIFF
--- a/tools/droplets/create.py
+++ b/tools/droplets/create.py
@@ -227,7 +227,7 @@ if __name__ == '__main__':
     # Broken in two to satisfy linter (line too long)
     # curl -X GET -H "Content-Type: application/json" -u <API_KEY>: "https://api.digitaloc
     # ean.com/v2/images?page=5" | grep --color=always base.zulipdev.org
-    template_id = "48106286"
+    template_id = "53247956"
 
     # get command line arguments
     args = parser.parse_args()


### PR DESCRIPTION
The new snapshot is created after upgrading the base droplet from the legacy 20$ a month plan to newer $10 a month plan. RAM is the same 2GB as in old plan but SSD capacity is 50GB instead of the 40GB.

