### PR TITLE
requirements: Upgrade django-sendfile2

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -254,8 +254,8 @@ django-phonenumber-field==1.3.0 \
 django-pylibmc==0.6.1 \
     --hash=sha256:02b591933a029eb552388cced713028f3c6cbb021639fc8de388bd1ca87981d4 \
     --hash=sha256:9cffdee703aaf9ebc029d9dbdee8abdd0723564b95e4b2ac59e4a668b8e58f93
-django-sendfile2==0.4.2 \
-    --hash=sha256:b1654d844d68da45620bc27eda3c4b89c2cbbd521146f88a05f3347375807757
+django-sendfile2==0.4.3 \
+    --hash=sha256:267cdd817a5fe7e649df9139ac3efbe8675c61ccdab43146d1e8cbd9bab70554
 django-statsd-mozilla==0.4.0 \
     --hash=sha256:0d87cb63de8107279cbb748caad9aa74c6a44e7e96ccc5dbf07b89f77285a4b8 \
     --hash=sha256:81084f3d426f5184f0a0f1dbfe035cc26b66f041d2184559d916a228d856f0d3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -170,8 +170,8 @@ django-phonenumber-field==1.3.0 \
 django-pylibmc==0.6.1 \
     --hash=sha256:02b591933a029eb552388cced713028f3c6cbb021639fc8de388bd1ca87981d4 \
     --hash=sha256:9cffdee703aaf9ebc029d9dbdee8abdd0723564b95e4b2ac59e4a668b8e58f93
-django-sendfile2==0.4.2 \
-    --hash=sha256:b1654d844d68da45620bc27eda3c4b89c2cbbd521146f88a05f3347375807757
+django-sendfile2==0.4.3 \
+    --hash=sha256:267cdd817a5fe7e649df9139ac3efbe8675c61ccdab43146d1e8cbd9bab70554
 django-statsd-mozilla==0.4.0 \
     --hash=sha256:0d87cb63de8107279cbb748caad9aa74c6a44e7e96ccc5dbf07b89f77285a4b8 \
     --hash=sha256:81084f3d426f5184f0a0f1dbfe035cc26b66f041d2184559d916a228d856f0d3

--- a/version.py
+++ b/version.py
@@ -26,4 +26,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '57.1'
+PROVISION_VERSION = '58.0'

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -706,7 +706,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
                     self.assertIn('attachment;', response['Content-disposition'])
                     self.assertIn(content_disposition, response['Content-disposition'])
                 else:
-                    self.assertEqual(response.get('Content-disposition'), None)
+                    self.assertIn('inline;', response['Content-disposition'])
                 self.assertEqual(set(response["Cache-Control"].split(", ")),
                                  {"private", "immutable"})
 


### PR DESCRIPTION
django-sendfile2 now always sends a Content-Disposition header even if it’s inline.