### PR TITLE
docs: Treat sphinx-build warnings as errors

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -j8
+SPHINXOPTS    = -j8 -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build


### PR DESCRIPTION


Follow-up to issue [#13263](https://github.com/zulip/zulip/issues/13263#issuecomment-539272626).