### PR TITLE
i18n: Attempt to translate search suggestions.

### DIFF
--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -2,6 +2,7 @@ set_global('page_params', {
     search_pills_enabled: true,
 });
 zrequire('util');
+set_global('i18n', global.stub_i18n);
 zrequire('typeahead_helper');
 set_global('Handlebars', global.make_handlebars());
 zrequire('Filter', 'js/filter');
@@ -467,15 +468,15 @@ run_test('empty_query_suggestions', () => {
     function describe(q) {
         return suggestions.lookup_table[q].description;
     }
-    assert.equal(describe('is:private'), 'Private messages');
-    assert.equal(describe('is:starred'), 'Starred messages');
-    assert.equal(describe('is:mentioned'), '@-mentions');
-    assert.equal(describe('is:alerted'), 'Alerted messages');
-    assert.equal(describe('is:unread'), 'Unread messages');
-    assert.equal(describe('sender:bob@zulip.com'), 'Sent by me');
-    assert.equal(describe('has:link'), 'Messages with one or more link');
-    assert.equal(describe('has:image'), 'Messages with one or more image');
-    assert.equal(describe('has:attachment'), 'Messages with one or more attachment');
+    assert.equal(describe('is:private'), 'Translated: private messages');
+    assert.equal(describe('is:starred'), 'Translated: starred messages');
+    assert.equal(describe('is:mentioned'), 'Translated: @-mentions');
+    assert.equal(describe('is:alerted'), 'Translated: alerted messages');
+    assert.equal(describe('is:unread'), 'Translated: unread messages');
+    assert.equal(describe('sender:bob@zulip.com'), 'Translated: sent by me');
+    assert.equal(describe('has:link'), 'Translated: messages with one or more link');
+    assert.equal(describe('has:image'), 'Translated: messages with one or more image');
+    assert.equal(describe('has:attachment'), 'Translated: messages with one or more attachment');
 });
 
 run_test('has_suggestions', () => {
@@ -502,9 +503,9 @@ run_test('has_suggestions', () => {
         return suggestions.lookup_table[q].description;
     }
 
-    assert.equal(describe('has:link'), 'Messages with one or more link');
-    assert.equal(describe('has:image'), 'Messages with one or more image');
-    assert.equal(describe('has:attachment'), 'Messages with one or more attachment');
+    assert.equal(describe('has:link'), 'Translated: messages with one or more link');
+    assert.equal(describe('has:image'), 'Translated: messages with one or more image');
+    assert.equal(describe('has:attachment'), 'Translated: messages with one or more attachment');
 
     query = '-h';
     suggestions = search.get_suggestions('', query);
@@ -515,9 +516,9 @@ run_test('has_suggestions', () => {
         '-has:attachment',
     ];
     assert.deepEqual(suggestions.strings, expected);
-    assert.equal(describe('-has:link'), 'Exclude messages with one or more link');
-    assert.equal(describe('-has:image'), 'Exclude messages with one or more image');
-    assert.equal(describe('-has:attachment'), 'Exclude messages with one or more attachment');
+    assert.equal(describe('-has:link'), 'Translated: exclude messages with one or more link');
+    assert.equal(describe('-has:image'), 'Translated: exclude messages with one or more image');
+    assert.equal(describe('-has:attachment'), 'Translated: exclude messages with one or more attachment');
 
     // operand suggestions follow.
 

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -365,7 +365,8 @@ function get_special_filter_suggestions(last, operators, suggestions) {
         suggestions = _.map(suggestions, function (suggestion) {
             return {
                 search_string: '-' + suggestion.search_string,
-                description: 'exclude ' + suggestion.description,
+                description: i18n.t('exclude __description__',
+                                    {description: suggestion.description}),
                 invalid: suggestion.invalid,
             };
         });
@@ -391,7 +392,7 @@ function get_special_filter_suggestions(last, operators, suggestions) {
 
     // Only show home if there's an empty bar
     if (operators.length === 0 && last_string === '') {
-        suggestions.unshift({search_string: '', description: 'All messages'});
+        suggestions.unshift({search_string: '', description: i18n.t('All messages')});
     }
     return suggestions;
 }
@@ -400,7 +401,7 @@ function get_streams_filter_suggestions(last, operators) {
     var suggestions = [
         {
             search_string: 'streams:public',
-            description: 'All public streams in organization',
+            description: i18n.t('All public streams in organization'),
             invalid: [
                 {operator: 'is', operand: 'private'},
                 {operator: 'stream'},
@@ -418,7 +419,7 @@ function get_is_filter_suggestions(last, operators) {
     var suggestions = [
         {
             search_string: 'is:private',
-            description: 'private messages',
+            description: i18n.t('private messages'),
             invalid: [
                 {operator: 'is', operand: 'private'},
                 {operator: 'stream'},
@@ -429,28 +430,28 @@ function get_is_filter_suggestions(last, operators) {
         },
         {
             search_string: 'is:starred',
-            description: 'starred messages',
+            description: i18n.t('starred messages'),
             invalid: [
                 {operator: 'is', operand: 'starred'},
             ],
         },
         {
             search_string: 'is:mentioned',
-            description: '@-mentions',
+            description: i18n.t('@-mentions'),
             invalid: [
                 {operator: 'is', operand: 'mentioned'},
             ],
         },
         {
             search_string: 'is:alerted',
-            description: 'alerted messages',
+            description: i18n.t('alerted messages'),
             invalid: [
                 {operator: 'is', operand: 'alerted'},
             ],
         },
         {
             search_string: 'is:unread',
-            description: 'unread messages',
+            description: i18n.t('unread messages'),
             invalid: [
                 {operator: 'is', operand: 'unread'},
             ],
@@ -463,21 +464,23 @@ function get_has_filter_suggestions(last, operators) {
     var suggestions = [
         {
             search_string: 'has:link',
-            description: 'messages with one or more link',
+            description: i18n.t('messages with one or more link'),
+            // Probably a better way to handle negation is to just have a
+            // translated version here for it.
             invalid: [
                 {operator: 'has', operand: 'link'},
             ],
         },
         {
             search_string: 'has:image',
-            description: 'messages with one or more image',
+            description: i18n.t('messages with one or more image'),
             invalid: [
                 {operator: 'has', operand: 'image'},
             ],
         },
         {
             search_string: 'has:attachment',
-            description: 'messages with one or more attachment',
+            description: i18n.t('messages with one or more attachment'),
             invalid: [
                 {operator: 'has', operand: 'attachment'},
             ],
@@ -491,14 +494,18 @@ function get_sent_by_me_suggestions(last, operators) {
     var last_string = Filter.unparse([last]).toLowerCase();
     var negated = last.negated || last.operator === 'search' && last.operand[0] === '-';
     var negated_symbol = negated ? '-' : '';
-    var verb = negated ? 'exclude ' : '';
 
     var sender_query = negated_symbol + 'sender:' + people.my_current_email();
     var from_query = negated_symbol + 'from:' + people.my_current_email();
     var sender_me_query = negated_symbol + 'sender:me';
     var from_me_query = negated_symbol + 'from:me';
     var sent_string = negated_symbol + 'sent';
-    var description = verb + 'sent by me';
+    var description;
+    if (negated) {
+        description = i18n.t('exclude sent by me');
+    } else {
+        description = i18n.t('sent by me');
+    }
 
     var invalid = [
         {operator: 'sender'},


### PR DESCRIPTION
This is unfinished work on making our search suggestions code use proper i18n.

I'd love for someone else to pick this up and finish it.

The main outstanding work needed is we need a good way to handle the "exclude" piece, and it's probably best done by moving that out of code and just having a `negated_description` field.   And then updating tests.