### PR TITLE
api: Legacy emoji reactions endpoint removal

### DIFF
--- a/zerver/lib/emoji.py
+++ b/zerver/lib/emoji.py
@@ -51,9 +51,6 @@ def emoji_name_to_emoji_code(realm: Realm, emoji_name: str) -> Tuple[str, str]:
         return name_to_codepoint[emoji_name], Reaction.UNICODE_EMOJI
     raise JsonableError(_("Emoji '%s' does not exist") % (emoji_name,))
 
-def check_valid_emoji(realm: Realm, emoji_name: str) -> None:
-    emoji_name_to_emoji_code(realm, emoji_name)
-
 def check_emoji_request(realm: Realm, emoji_name: str, emoji_code: str,
                         emoji_type: str) -> None:
     # For a given realm and emoji type, checks whether an emoji

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -426,10 +426,6 @@ class ZulipTestCase(TestCase):
         kwargs['HTTP_AUTHORIZATION'] = self.encode_credentials(identifier, kwargs.get('subdomain', 'zulip'))
         return self.client_patch(*args, **kwargs)
 
-    def api_put(self, identifier: str, *args: Any, **kwargs: Any) -> HttpResponse:
-        kwargs['HTTP_AUTHORIZATION'] = self.encode_credentials(identifier, kwargs.get('subdomain', 'zulip'))
-        return self.client_put(*args, **kwargs)
-
     def api_delete(self, identifier: str, *args: Any, **kwargs: Any) -> HttpResponse:
         kwargs['HTTP_AUTHORIZATION'] = self.encode_credentials(identifier, kwargs.get('subdomain', 'zulip'))
         return self.client_delete(*args, **kwargs)

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -1122,9 +1122,12 @@ class GetOldMessagesTest(ZulipTestCase):
 
         self.login(self.example_email("othello"))
         reaction_name = 'thumbs_up'
+        reaction_info = {
+            'emoji_name': reaction_name
+        }
 
-        url = '/json/messages/{}/emoji_reactions/{}'.format(message_id, reaction_name)
-        payload = self.client_put(url)
+        url = '/json/messages/{}/reactions'.format(message_id)
+        payload = self.client_post(url, reaction_info)
         self.assert_json_success(payload)
 
         self.login(self.example_email("hamlet"))

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -218,7 +218,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         '/invites/{prereg_id}/resend',
         '/invites/multiuse/{invite_id}',
         '/users/me/subscriptions/{stream_id}',
-        '/messages/{message_id}/emoji_reactions/{emoji_name}',
         '/attachments/{attachment_id}',
         '/user_groups/{user_group_id}/members',
         '/streams/{stream_id}/members',

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -213,18 +213,13 @@ v1_api_and_json_patterns = [
         {'POST': 'zerver.views.submessage.process_submessage'}),
 
     # New endpoint for handling reactions.
+    # reactions -> zerver.view.reactions
+    # POST adds a reaction to a message
+    # DELETE removes a reaction from a message
     url(r'^messages/(?P<message_id>[0-9]+)/reactions$',
         rest_dispatch,
         {'POST': 'zerver.views.reactions.add_reaction',
          'DELETE': 'zerver.views.reactions.remove_reaction'}),
-
-    # reactions -> zerver.view.reactions
-    # PUT adds a reaction to a message
-    # DELETE removes a reaction from a message
-    url(r'^messages/(?P<message_id>[0-9]+)/emoji_reactions/(?P<emoji_name>.*)$',
-        rest_dispatch,
-        {'PUT': 'zerver.views.reactions.add_reaction_legacy',
-         'DELETE': 'zerver.views.reactions.remove_reaction_legacy'}),
 
     # attachments -> zerver.views.attachments
     url(r'^attachments$', rest_dispatch,


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#12940 
Continues the process of removing legacy emoji reactions endpoint.

Not ready to be merged.  Some tests are failing in CircleCI/TravisCI

**Testing Plan:** <!-- How have you tested? --> Run  ./tools/test-backend


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
