### PR TITLE
requirements: Add back future

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -284,7 +284,7 @@ ecdsa==0.13.2 \
 fakeldap==0.6.1 \
     --hash=sha256:3f7262b41def43b85be886ca6d64d1c310d2db48a434fddae86efc34a09a7a81 \
     --hash=sha256:43000061ca8e6d56fe0ce89256a1a2afc46e6443762bb96631542a1af8e70354
-# future==0.18.0 \
+future==0.18.0 \
     --hash=sha256:6142ef79e2416e432931d527452a1cab3aa4a754a0a53d25b2589f79e1106f34 \
     # via aws-xray-sdk, commonmark, python-jose, python-twitter
 gitlint==0.12.0 \

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -32,7 +32,7 @@ docutils==0.15.2 \
     --hash=sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827 \
     --hash=sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99 \
     # via recommonmark, sphinx
-# future==0.18.0 \
+future==0.18.0 \
     --hash=sha256:6142ef79e2416e432931d527452a1cab3aa4a754a0a53d25b2589f79e1106f34 \
     # via commonmark
 idna==2.8 \

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -184,7 +184,7 @@ django-webpack-loader==0.6.0 \
 django==1.11.24 \
     --hash=sha256:215c27453f775b6b1add83a185f76c2e2ab711d17786a6704bd62eabd93f89e3 \
     --hash=sha256:ffd89b89a2ee860ee521f054225044f52676825be4b61168d2842d44fcf457d3
-# future==0.18.0 \
+future==0.18.0 \
     --hash=sha256:6142ef79e2416e432931d527452a1cab3aa4a754a0a53d25b2589f79e1106f34 \
     # via python-twitter
 h2==2.6.2 \

--- a/tools/update-locked-requirements
+++ b/tools/update-locked-requirements
@@ -16,13 +16,6 @@ compile_requirements () {
         /srv/zulip-thumbor-venv/bin/pip-compile --quiet --allow-unsafe --generate-hashes --no-header --output-file "$output" "$source"
     else
         /srv/zulip-py3-venv/bin/pip-compile --quiet --allow-unsafe --generate-hashes --no-header --output-file "$output" "$source"
-
-        # Remove an unnecessary future requirement declared by commonmark,
-        # python-jose, and python-twitter.
-        # https://github.com/readthedocs/commonmark.py/pull/188
-        # https://github.com/mpdavis/python-jose/pull/134
-        # https://github.com/bear/python-twitter/pull/614
-        sed -i 's/^future==/# &/' "$output"
     fi
 
     cat - "$output" <<EOF | sponge "$output"

--- a/version.py
+++ b/version.py
@@ -26,4 +26,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '58.1'
+PROVISION_VERSION = '58.2'


### PR DESCRIPTION
It happens that `commonmark`, `python-jose`, and `python-twitter` don’t actually use `future` on Python 3, and `moto` uses `aws-xray-sdk` in such a way that it doesn’t use `future`, but this was a weird game to be playing just to remove one dependency, and it caused CI failures after new releases of `future`, so let’s just include it.