### PR TITLE
Rename `not_subscribed key` to `not_removed` in users/me/subscriptions.

### DIFF
--- a/templates/zerver/api/remove-subscriptions.md
+++ b/templates/zerver/api/remove-subscriptions.md
@@ -69,7 +69,7 @@ administrative privileges.
 * `removed`: A list of the names of streams which were unsubscribed from as
   a result of the query.
 
-* `not_subscribed`: A list of the names of streams that the user is already
+* `not_removed`: A list of the names of streams that the user is already
   unsubscribed from, and hence doesn't need to be unsubscribed.
 
 #### Example response

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1629,7 +1629,7 @@ paths:
                 allOf:
                 - $ref: '#/components/schemas/JsonSuccess'
                 - properties:
-                    not_subscribed:
+                    not_removed:
                       type: array
                       items:
                         type: string
@@ -1645,7 +1645,7 @@ paths:
                 - example:
                     {
                         "msg": "",
-                        "not_subscribed": [],
+                        "not_removed": [],
                         "removed": [
                             "new stream"
                         ],

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -126,7 +126,7 @@ class DocPageTest(ZulipTestCase):
         self._test('/api/get-profile', 'takes no arguments')
         self._test('/api/add-subscriptions', 'authorization_errors_fatal')
         self._test('/api/create-user', 'zuliprc-admin')
-        self._test('/api/remove-subscriptions', 'not_subscribed')
+        self._test('/api/remove-subscriptions', 'not_removed')
         self._test('/team/', 'industry veterans')
         self._test('/history/', 'Cambridge, Massachusetts')
         # Test the i18n version of one of these pages.

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -991,7 +991,7 @@ class StreamAdminTest(ZulipTestCase):
             other_user_subbed=True)
         json = self.assert_json_success(result)
         self.assertEqual(len(json["removed"]), 1)
-        self.assertEqual(len(json["not_subscribed"]), 0)
+        self.assertEqual(len(json["not_removed"]), 0)
 
     def test_admin_remove_others_from_subbed_private_stream(self) -> None:
         """
@@ -1003,7 +1003,7 @@ class StreamAdminTest(ZulipTestCase):
             other_user_subbed=True)
         json = self.assert_json_success(result)
         self.assertEqual(len(json["removed"]), 1)
-        self.assertEqual(len(json["not_subscribed"]), 0)
+        self.assertEqual(len(json["not_removed"]), 0)
 
     def test_admin_remove_others_from_unsubbed_private_stream(self) -> None:
         """
@@ -1015,7 +1015,7 @@ class StreamAdminTest(ZulipTestCase):
             other_user_subbed=True, other_sub_users=[self.example_user("othello")])
         json = self.assert_json_success(result)
         self.assertEqual(len(json["removed"]), 1)
-        self.assertEqual(len(json["not_subscribed"]), 0)
+        self.assertEqual(len(json["not_removed"]), 0)
 
     def test_create_stream_policy_setting(self) -> None:
         """
@@ -1155,7 +1155,7 @@ class StreamAdminTest(ZulipTestCase):
             other_user_subbed=False)
         json = self.assert_json_success(result)
         self.assertEqual(len(json["removed"]), 0)
-        self.assertEqual(len(json["not_subscribed"]), 1)
+        self.assertEqual(len(json["not_removed"]), 1)
 
     def test_remove_invalid_user(self) -> None:
         """
@@ -2839,7 +2839,7 @@ class SubscriptionAPITest(ZulipTestCase):
 
         {"msg": "",
          "removed": ["Denmark", "Scotland", "Verona"],
-         "not_subscribed": ["Rome"], "result": "success"}
+         "not_removed": ["Rome"], "result": "success"}
         """
         result = self.client_delete("/json/users/me/subscriptions",
                                     {"subscriptions": ujson.dumps(subscriptions)})
@@ -2868,7 +2868,7 @@ class SubscriptionAPITest(ZulipTestCase):
         try_to_remove = not_subbed[:3]  # attempt to remove up to 3 streams not already subbed to
         streams_to_remove.extend(try_to_remove)
         self.helper_check_subs_before_and_after_remove(streams_to_remove,
-                                                       {"removed": self.streams[1:], "not_subscribed": try_to_remove},
+                                                       {"removed": self.streams[1:], "not_removed": try_to_remove},
                                                        self.test_email, [self.streams[0]], self.test_realm)
 
     def test_subscriptions_remove_fake_stream(self) -> None:

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -257,7 +257,7 @@ def remove_subscriptions_backend(
     else:
         people_to_unsub = set([user_profile])
 
-    result = dict(removed=[], not_subscribed=[])  # type: Dict[str, List[str]]
+    result = dict(removed=[], not_removed=[])  # type: Dict[str, List[str]]
     (removed, not_subscribed) = bulk_remove_subscriptions(people_to_unsub, streams,
                                                           request.client,
                                                           acting_user=user_profile)
@@ -265,7 +265,7 @@ def remove_subscriptions_backend(
     for (subscriber, removed_stream) in removed:
         result["removed"].append(removed_stream.name)
     for (subscriber, not_subscribed_stream) in not_subscribed:
-        result["not_subscribed"].append(not_subscribed_stream.name)
+        result["not_removed"].append(not_subscribed_stream.name)
 
     return json_success(result)
 


### PR DESCRIPTION
Rename `not_subscibed_key` to `not_removed` in
`users/me/subscriptions` DELETE response.

Fixes #13277.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
By running `tools/test-all`

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
