### PR TITLE
Restore last draft

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -249,9 +249,6 @@ run_test('basic_chars', () => {
     assert_mapping('w', 'activity.initiate_search');
     assert_mapping('q', 'stream_list.initiate_search');
 
-    assert_mapping('A', 'narrow.stream_cycle_backward');
-    assert_mapping('D', 'narrow.stream_cycle_forward');
-
     assert_mapping('c', 'compose_actions.start');
     assert_mapping('x', 'compose_actions.start');
     assert_mapping('P', 'narrow.by');

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -172,7 +172,9 @@ exports.restore_draft = function (draft_id) {
         }
     }
 
-    overlays.close_overlay("drafts");
+    if (overlays.drafts_open()) {
+        overlays.close_overlay("drafts");
+    }
     compose_fade.clear_compose();
     compose.clear_preview_area();
 
@@ -182,6 +184,15 @@ exports.restore_draft = function (draft_id) {
     compose_actions.start(compose_args.type, compose_args);
     compose_ui.autosize_textarea();
     $("#compose-textarea").data("draft-id", draft_id);
+};
+
+exports.restore_last_draft = function () {
+    const draft_arrow = draft_model.get();
+    const draft_id_arrow = Object.getOwnPropertyNames(draft_arrow);
+    if (draft_id_arrow.length) {
+        const first_draft = draft_id_arrow[draft_id_arrow.length - 1];
+        exports.restore_draft(first_draft);
+    }
 };
 
 const DRAFT_LIFETIME = 30;

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -81,9 +81,8 @@ const keypress_mappings = {
     62: {name: 'compose_quote_reply', message_view_only: true}, // '>'
     63: {name: 'show_shortcuts', message_view_only: false}, // '?'
     64: {name: 'compose_reply_with_mention', message_view_only: true}, // '@'
-    65: {name: 'stream_cycle_backward', message_view_only: true}, // 'A'
+    65: {name: 'A_deprecated', message_view_only: true}, // 'A'
     67: {name: 'C_deprecated', message_view_only: true}, // 'C'
-    68: {name: 'stream_cycle_forward', message_view_only: true}, // 'D'
     71: {name: 'G_end', message_view_only: true}, // 'G'
     74: {name: 'vim_page_down', message_view_only: true}, // 'J'
     75: {name: 'vim_page_up', message_view_only: true}, // 'K'
@@ -658,12 +657,6 @@ exports.process_hotkey = function (e, hotkey) {
     case 'show_shortcuts': // Show keyboard shortcuts page
         info_overlay.maybe_show_keyboard_shortcuts();
         return true;
-    case 'stream_cycle_backward':
-        narrow.stream_cycle_backward();
-        return true;
-    case 'stream_cycle_forward':
-        narrow.stream_cycle_forward();
-        return true;
     case 'n_key':
         narrow.narrow_to_next_topic();
         return true;
@@ -677,6 +670,9 @@ exports.process_hotkey = function (e, hotkey) {
         // Note that you can "enter" to respond to messages as well,
         // but that is handled in process_enter_key().
         compose_actions.respond_to_message({trigger: 'hotkey'});
+        return true;
+    case 'A_deprecated':
+        ui.maybe_show_deprecation_notice('A');
         return true;
     case 'C_deprecated':
         ui.maybe_show_deprecation_notice('C');

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -83,6 +83,7 @@ const keypress_mappings = {
     64: {name: 'compose_reply_with_mention', message_view_only: true}, // '@'
     65: {name: 'A_deprecated', message_view_only: true}, // 'A'
     67: {name: 'C_deprecated', message_view_only: true}, // 'C'
+    68: {name: 'open_last_draft', message_view_only: true}, //'D'
     71: {name: 'G_end', message_view_only: true}, // 'G'
     74: {name: 'vim_page_down', message_view_only: true}, // 'J'
     75: {name: 'vim_page_up', message_view_only: true}, // 'K'
@@ -636,6 +637,9 @@ exports.process_hotkey = function (e, hotkey) {
         return true;
     case 'compose_private_message':
         compose_actions.start('private', {trigger: "compose_hotkey"});
+        return true;
+    case 'open_last_draft':
+        drafts.restore_last_draft();
         return true;
     case 'narrow_private':
         return do_narrow_action(function (target, opts) {

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -145,6 +145,8 @@ exports.maybe_show_deprecation_notice = function (key) {
     const isCmdOrCtrl = common.has_mac_keyboard() ? "Cmd" : "Ctrl";
     if (key === 'C') {
         message = exports.get_hotkey_deprecation_notice('C', 'x');
+    } else if (key === 'A') {
+        message = i18n.t('Hotkey \'A\' has been withdrawn from use.');
     } else if (key === '*') {
         message = exports.get_hotkey_deprecation_notice("*", isCmdOrCtrl + " + s");
     } else {

--- a/static/styles/drafts.scss
+++ b/static/styles/drafts.scss
@@ -52,6 +52,15 @@
         }
     }
 
+    .drafts-footer {
+        position: relative;
+        bottom: 0;
+        width: 100%;
+        padding-top: 5px;
+        padding-bottom: 10px;
+        border-top: 1px solid hsl(0, 0%, 87%);
+        text-align: center;
+    }
     .drafts-list {
         padding: 10px 0;
         overflow: auto;

--- a/static/templates/draft_table_body.hbs
+++ b/static/templates/draft_table_body.hbs
@@ -22,6 +22,11 @@
                 {{> draft}}
                 {{/each}}
             </div>
+            <div class="drafts-footer">
+                <div class="edit_last_draft">
+                    {{#tr this}} Type <strong>shift + d</strong> from the main message feed to restore the last draft. {{/tr}}
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -172,10 +172,6 @@
                     <td><span class="hotkey"><kbd>P</kbd></span></td>
                 </tr>
                 <tr>
-                    <td class="definition">{% trans %}Cycle between stream narrows{% endtrans %}</td>
-                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>A</kbd> or <kbd>Shift</kbd> + <kbd>D</kbd></span></td>
-                </tr>
-                <tr>
                     <td class="definition">{% trans %}Narrow to all unmuted messages{% endtrans %}</td>
                     <td><span class="hotkey"><kbd>Esc</kbd> or <kbd>Ctrl</kbd> + <kbd>[</kbd></span></td>
                 </tr>

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -240,6 +240,10 @@
                     <td><span class="hotkey"><kbd>D</kbd></span></td>
                 </tr>
                 <tr>
+                    <td class="definition">{% trans %}Edit last draft{% endtrans %}</td>
+                    <td><span class="hotkey"><kbd>Shift</kbd> + <kbd>D</kbd></span></td>
+                </tr>
+                <tr>
                     <td class="definition">{% trans %}Edit selected draft{% endtrans %}</td>
                     <td><span class="hotkey"><kbd>Enter</kbd></span></td>
                 </tr>

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -74,8 +74,6 @@ below, and add more to your repertoire as needed.
 
 * **Narrow to all private messages**: `P`
 
-* **Cycle between stream narrows**: `A` (previous) and `D` (next)
-
 * **Narrow to all messages**: `Esc` or `Ctrl` + `[` — Shows all unmuted messages.
 
 * **Narrow to current compose box recipient**: `Ctrl` + `.`

--- a/templates/zerver/help/keyboard-shortcuts.md
+++ b/templates/zerver/help/keyboard-shortcuts.md
@@ -138,6 +138,7 @@ title="thumbs up"/>**: `+`
 ## Drafts
 
 * **Toggle drafts view**: `d`
+* **Edit last draft**: `D`
 
 ### Within the drafts view
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
The 'A' and 'D' hotkeys were used to cycle up and down through streams.
This functionality has been removed.
A Deprecation notice for hotkey 'A' has been added.
The 'D' hotkey can now be used for opening the last draft for edit.
The tests for these keys have been modified accordingly.
A note telling the same has been added to the bottom of the drafts modal.  

Fixes #9612 .

**GIFs or Screenshots:** 
![a](https://user-images.githubusercontent.com/48182195/66713450-bce6df80-edc8-11e9-8ad5-4a9359578b11.gif)

above : The deprecation notice for hotkey A


![Screenshot from 2019-10-13 14-54-41](https://user-images.githubusercontent.com/48182195/66713543-b5740600-edc9-11e9-88fe-3c7a2fbe412d.png)


above: The note that has been added at the bottom of the drafts modal.



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
