### PR TITLE
GENERAL UI: fixes font-size of tooltip

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -485,6 +485,9 @@ strong {
 .tooltip .tooltip-inner {
     background-color: hsla(0, 0%, 7%, 0.8);
     padding: 3px 5px;
+    font-size: 13px;
+    width: -webkit-max-content;
+    max-width: 110px;
 }
 
 #message_edit_tooltip {


### PR DESCRIPTION
fixes #13261

The fontsize of the bootstrap tooltip has been set right here.



**GIFs or Screenshots:** 
![Screenshot from 2019-10-15 18-17-00](https://user-images.githubusercontent.com/48182195/66834161-c2842700-ef7a-11e9-9d76-bba953ae9292.png)

**above: the small font-size of emoji tootip that needs fixing.**

![Screenshot from 2019-10-15 18-16-46](https://user-images.githubusercontent.com/48182195/66834280-fa8b6a00-ef7a-11e9-8714-faa39bd645d4.png)

**above: after the bootstrap tooltip font-size has been set to the same as that of other tooltips.**




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
