### PR TITLE
left sidebar: Avoid unnecessary scrollbar.

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -125,10 +125,6 @@ li.show-more-topics a {
     width: 100%;
 }
 
-#stream-filters-container .simplebar-content {
-    margin-bottom: 18px;
-}
-
 #private-container {
     max-height: 200px;
 }
@@ -147,6 +143,7 @@ li.show-more-topics a {
 #add-stream-link {
     text-decoration: none;
     margin-left: 10px;
+    margin-bottom: 18px;
 }
 
 #add-stream-link i {

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -74,7 +74,9 @@
             <div id="stream-filters-container" class="scrolling_list" data-simplebar>
                 <ul id="stream_filters" class="filters"></ul>
                 {% if show_add_streams %}
-                <a id="add-stream-link" href="#streams/all"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{ _('Add streams') }}</a>
+                <div id="add-stream-link">
+                    <a href="#streams/all"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{ _('Add streams') }}</a>
+                </div>
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This pull request replaces the `margin-bottom` styling on the left stream sidebar with an empty element with the same height. This preserves the intended behaviour of the commit which introduced the margin, to fix #12519 while removing an unnecessary scrollbar which could hide the top-most stream in the stream list, which resolves #13050.

**Testing Plan:** <!-- How have you tested? -->
Visually confirmed the desired result while preserving the previous behaviour.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
With sufficient vertical space, there is no scrollbar:
![image](https://user-images.githubusercontent.com/1295100/66849133-4c79c300-ef6e-11e9-91bc-769bea1750c9.png)

When there is a scrollbar, there is margin at the bottom which stops the browser's currently-hovered-over url from obscuring the button:
![image](https://user-images.githubusercontent.com/1295100/66849204-6adfbe80-ef6e-11e9-8f25-4473bd653285.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
