### PR TITLE
docs: Fix newly broken link

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -13,7 +13,7 @@
     <div class="admonition warning">
         <p class="first admonition-title">Warning</p>
         <p class="last">You are reading a <strong>development version</strong> of the Zulip documentation. These instructions may not correspond to the latest Zulip Server release.
-        See <a class="reference external" href="https://zulip.readthedocs.io/en/stable/production">documentation for the latest stable release</a>.</p>
+        See <a class="reference external" href="https://zulip.readthedocs.io/en/stable/production/">documentation for the latest stable release</a>.</p>
     </div>
     {% elif pagename.split("/")[0] == "production" and release.endswith('+git') %}
     <div class="admonition warning">


### PR DESCRIPTION
It seems https://zulip.readthedocs.io/en/stable/production is now a broken link instead of redirecting to https://zulip.readthedocs.io/en/stable/production/, which angered `test-documentation`.