### PR TITLE
tests: Clean up and extend topic links tests in test_messages.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2046,9 +2046,9 @@ def extract_emails(emails: Iterable[str]) -> List[str]:
     return recipients
 
 def check_send_stream_message(sender: UserProfile, client: Client, stream_name: str,
-                              topic: str, body: str) -> int:
+                              topic: str, body: str, realm: Optional[Realm]=None) -> int:
     addressee = Addressee.for_stream_name(stream_name, topic)
-    message = check_message(sender, client, addressee, body)
+    message = check_message(sender, client, addressee, body, realm)
 
     return do_send_messages([message])[0]
 

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -463,7 +463,8 @@ class ZulipTestCase(TestCase):
         )
 
     def send_stream_message(self, sender_email: str, stream_name: str, content: str="test content",
-                            topic_name: str="test", sender_realm: str="zulip") -> int:
+                            topic_name: str="test", sender_realm: str="zulip",
+                            recipient_realm: Optional[Realm]=None) -> int:
         sender = get_user(sender_email, get_realm(sender_realm))
 
         (sending_client, _) = Client.objects.get_or_create(name="test suite")
@@ -474,6 +475,7 @@ class ZulipTestCase(TestCase):
             stream_name=stream_name,
             topic=topic_name,
             body=content,
+            realm=recipient_realm,
         )
 
     def get_messages_response(self, anchor: int=1, num_before: int=100, num_after: int=100,


### PR DESCRIPTION
This is a follow-up to b69213808ad5a2de1f0416fa832a8efde64b7389.
We now actually send messages from the notification_bot, which
is the real usecase for this code.
 
Also, this cleans up the code and removes needless asserts like
`assertNotEqual(zulip_realm, lear_realm)` making the test easier
to read.

Concerns #13225.


**Edit**: Tests failing due to link failure: https://zulip.readthedocs.io/en/stable/production