### PR TITLE
docs: Add trailing slash to readthedocs link.

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -13,7 +13,7 @@
     <div class="admonition warning">
         <p class="first admonition-title">Warning</p>
         <p class="last">You are reading a <strong>development version</strong> of the Zulip documentation. These instructions may not correspond to the latest Zulip Server release.
-        See <a class="reference external" href="https://zulip.readthedocs.io/en/stable/production">documentation for the latest stable release</a>.</p>
+        See <a class="reference external" href="https://zulip.readthedocs.io/en/stable/production/">documentation for the latest stable release</a>.</p>
     </div>
     {% elif pagename.split("/")[0] == "production" and release.endswith('+git') %}
     <div class="admonition warning">

--- a/docs/contributing/code-reviewing.md
+++ b/docs/contributing/code-reviewing.md
@@ -187,7 +187,7 @@ the maintainer time and get the PR merged quicker.
 
 We also strongly recommend reviewers to go through the following resources.
 
-* [The Gentle Art of Patch Review](http://sarah.thesharps.us/2014/09/01/the-gentle-art-of-patch-review/)
+* [The Gentle Art of Patch Review](http://sage.thesharps.us/2014/09/01/the-gentle-art-of-patch-review/)
   article by Sarah Sharp
 * [Zulip & Good Code Review](https://www.harihareswara.net/sumana/2016/05/17/0)
   article by Sumana Harihareswara


### PR DESCRIPTION
This is likely a regression in upstream readthedocs issue
https://github.com/readthedocs/readthedocs.org/issues/93
that is causing our automated link tests to fail.

```
$ curl -I https://zulip.readthedocs.io/en/stable/production
HTTP/1.1 404 Not Found

$ curl -I https://zulip.readthedocs.io/en/stable/production/
HTTP/1.1 200 OK
```

See https://app.circleci.com/jobs/github/aero31aero/zulip/1058 for CI failure.