### PR TITLE
tests: tearDown overrides should call super().tearDown().

### DIFF
--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -55,6 +55,8 @@ class RateLimitTests(ZulipTestCase):
         settings.RATE_LIMITING = False
         remove_ratelimit_rule(1, 5)
 
+        super().tearDown()
+
     def send_api_message(self, email: str, content: str) -> HttpResponse:
         return self.api_post(email, "/api/v1/messages", {"type": "stream",
                                                          "to": "Verona",

--- a/zerver/tests/test_i18n.py
+++ b/zerver/tests/test_i18n.py
@@ -62,6 +62,7 @@ class TranslationTestCase(ZulipTestCase):
 
     def tearDown(self) -> None:
         translation.activate(settings.LANGUAGE_CODE)
+        super().tearDown()
 
     # e.g. self.client_post(url) if method is "post"
     def fetch(self, method: str, url: str, expected_status: int, **kwargs: Any) -> HttpResponse:
@@ -113,6 +114,7 @@ class TranslationTestCase(ZulipTestCase):
 class JsonTranslationTestCase(ZulipTestCase):
     def tearDown(self) -> None:
         translation.activate(settings.LANGUAGE_CODE)
+        super().tearDown()
 
     @mock.patch('zerver.lib.request._')
     def test_json_error(self, mock_gettext: Any) -> None:

--- a/zerver/tests/test_logging_handlers.py
+++ b/zerver/tests/test_logging_handlers.py
@@ -51,6 +51,7 @@ class AdminNotifyHandlerTest(ZulipTestCase):
 
     def tearDown(self) -> None:
         settings.LOGGING_ENABLED = True
+        super().tearDown()
 
     def get_admin_zulip_handler(self) -> AdminNotifyHandler:
         return [

--- a/zerver/tests/test_queue.py
+++ b/zerver/tests/test_queue.py
@@ -110,3 +110,4 @@ class TestQueueImplementation(ZulipTestCase):
     def tearDown(self) -> None:
         queue_client = get_queue_client()
         queue_client.drain_queue("test_suite")
+        super().tearDown()

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -721,6 +721,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
 
     def tearDown(self) -> None:
         destroy_uploads()
+        super().tearDown()
 
 
 class AvatarTest(UploadSerializeMixin, ZulipTestCase):
@@ -1073,6 +1074,7 @@ class AvatarTest(UploadSerializeMixin, ZulipTestCase):
 
     def tearDown(self) -> None:
         destroy_uploads()
+        super().tearDown()
 
 class EmojiTest(UploadSerializeMixin, ZulipTestCase):
     # While testing GIF resizing, we can't test if the final GIF has the same
@@ -1113,6 +1115,7 @@ class EmojiTest(UploadSerializeMixin, ZulipTestCase):
 
     def tearDown(self) -> None:
         destroy_uploads()
+        super().tearDown()
 
 class RealmIconTest(UploadSerializeMixin, ZulipTestCase):
 
@@ -1244,6 +1247,7 @@ class RealmIconTest(UploadSerializeMixin, ZulipTestCase):
 
     def tearDown(self) -> None:
         destroy_uploads()
+        super().tearDown()
 
 class RealmLogoTest(UploadSerializeMixin, ZulipTestCase):
     night = False
@@ -1386,6 +1390,7 @@ class RealmLogoTest(UploadSerializeMixin, ZulipTestCase):
 
     def tearDown(self) -> None:
         destroy_uploads()
+        super().tearDown()
 
 class RealmNightLogoTest(RealmLogoTest):
     # Run the same tests as for RealmLogoTest, just with night mode enabled
@@ -1480,6 +1485,7 @@ class LocalStorageTest(UploadSerializeMixin, ZulipTestCase):
 
     def tearDown(self) -> None:
         destroy_uploads()
+        super().tearDown()
 
 
 class S3Test(ZulipTestCase):


### PR DESCRIPTION
ZulipTestCase subclasses that override tearDown() should call the parent
class tearDown() too, as it does some clean up of its own.

Now, about setUp() - ZulipTestCase (and parents) don't do any setUp() and in almost all our ZulipTestCase subclasses we don't do ``super().setUp()`` (it wouldn't do anything anyway). Should we eliminate super().setUp() from those few cases where it is called and does absolutely nothing? For consistency and not to mislead people who look at it into thinking there is something happening in that call. 