### PR TITLE
tests: setUp overrides should call super().setUp().

### DIFF
--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -37,6 +37,7 @@ class AnalyticsTestCase(TestCase):
     TIME_LAST_HOUR = TIME_ZERO - HOUR
 
     def setUp(self) -> None:
+        super().setUp()
         self.default_realm = Realm.objects.create(
             string_id='realmtest', name='Realm Test', date_created=self.TIME_ZERO - 2*self.DAY)
         # used to generate unique names in self.create_*

--- a/analytics/tests/test_views.py
+++ b/analytics/tests/test_views.py
@@ -69,6 +69,7 @@ class TestStatsEndpoint(ZulipTestCase):
 
 class TestGetChartData(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.realm = get_realm('zulip')
         self.user = self.example_user('hamlet')
         self.login(self.user.email)

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -213,6 +213,7 @@ class Kandra(object):  # nocoverage: TODO
 
 class StripeTestCase(ZulipTestCase):
     def setUp(self, *mocks: Mock) -> None:
+        super().setUp()
         # This test suite is not robust to users being added in populate_db. The following
         # hack ensures get_seat_count is fixed, even as populate_db changes.
         realm = get_realm('zulip')
@@ -963,6 +964,7 @@ class StripeTest(StripeTestCase):
 
 class RequiresBillingAccessTest(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         hamlet = self.example_user("hamlet")
         hamlet.is_billing_admin = True
         hamlet.save(update_fields=["is_billing_admin"])

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -797,6 +797,7 @@ class WebhookTestCase(ZulipTestCase):
         return get_user(self.TEST_USER_EMAIL, get_realm("zulip"))
 
     def setUp(self) -> None:
+        super().setUp()
         self.url = self.build_webhook_url()
 
     def api_stream_message(self, email: str, *args: Any, **kwargs: Any) -> HttpResponse:

--- a/zerver/tests/test_attachments.py
+++ b/zerver/tests/test_attachments.py
@@ -11,6 +11,7 @@ from zerver.models import Attachment
 
 class AttachmentsTests(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         user_profile = self.example_user('cordelia')
         self.attachment = Attachment.objects.create(
             file_name='test.txt', path_id='foo/bar/test.txt', owner=user_profile)

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -475,6 +475,7 @@ class SocialAuthBase(ZulipTestCase):
     __unittest_skip__ = True
 
     def setUp(self) -> None:
+        super().setUp()
         self.user_profile = self.example_user('hamlet')
         self.email = self.user_profile.email
         self.name = self.user_profile.full_name
@@ -1647,6 +1648,7 @@ class GoogleAuthBackendTest(SocialAuthBase):
 
 class JSONFetchAPIKeyTest(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.user_profile = self.example_user('hamlet')
         self.email = self.user_profile.email
 
@@ -1673,6 +1675,7 @@ class JSONFetchAPIKeyTest(ZulipTestCase):
 
 class FetchAPIKeyTest(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.user_profile = self.example_user('hamlet')
         self.email = self.user_profile.email
 
@@ -1726,6 +1729,7 @@ class FetchAPIKeyTest(ZulipTestCase):
 
 class DevFetchAPIKeyTest(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.user_profile = self.example_user('hamlet')
         self.email = self.user_profile.email
 

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -250,6 +250,7 @@ class BugdownMiscTest(ZulipTestCase):
 
 class BugdownTest(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         bugdown.clear_state_for_testing()
 
     def assertEqual(self, first: Any, second: Any, msg: str = "") -> None:

--- a/zerver/tests/test_create_video_call.py
+++ b/zerver/tests/test_create_video_call.py
@@ -5,6 +5,7 @@ from typing import Dict
 
 class TestFeedbackBot(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         user_profile = self.example_user('hamlet')
         self.login(user_profile.email, realm=user_profile.realm)
 

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -16,6 +16,7 @@ import mock
 
 class CustomProfileFieldTestCase(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.realm = get_realm("zulip")
         self.original_count = len(custom_profile_fields_for_realm(self.realm.id))
 

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1264,6 +1264,7 @@ class InactiveUserTest(ZulipTestCase):
 
 class TestIncomingWebhookBot(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         zulip_realm = get_realm('zulip')
         self.webhook_bot = get_user('webhook-bot@zulip.com', zulip_realm)
 
@@ -1281,6 +1282,7 @@ class TestIncomingWebhookBot(ZulipTestCase):
 
 class TestValidateApiKey(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         zulip_realm = get_realm('zulip')
         self.webhook_bot = get_user('webhook-bot@zulip.com', zulip_realm)
         self.default_bot = get_user('default-bot@zulip.com', zulip_realm)

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -333,6 +333,7 @@ class AboutPageTest(ZulipTestCase):
         would not have the `static/generated/github-contributors.json` fixture
         file.
         """
+        super().setUp()
         # This block has unreliable test coverage due to the implicit
         # caching here, so we exclude it from coverage.
         if not os.path.exists(static_path('generated/github-contributors.json')):

--- a/zerver/tests/test_embedded_bot_system.py
+++ b/zerver/tests/test_embedded_bot_system.py
@@ -13,6 +13,7 @@ import ujson
 
 class TestEmbeddedBotMessaging(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.user_profile = self.example_user("othello")
         self.bot_profile = self.create_test_bot('embedded', self.user_profile,
                                                 full_name='Embedded bot',

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -3512,6 +3512,7 @@ class FetchQueriesTest(ZulipTestCase):
 
 class TestEventsRegisterAllPublicStreamsDefaults(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.user_profile = self.example_user('hamlet')
         self.email = self.user_profile.email
 
@@ -3553,6 +3554,7 @@ class TestEventsRegisterAllPublicStreamsDefaults(ZulipTestCase):
 
 class TestEventsRegisterNarrowDefaults(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.user_profile = self.example_user('hamlet')
         self.email = self.user_profile.email
         self.stream = get_stream('Verona', self.user_profile.realm)

--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -48,6 +48,7 @@ class MITNameTest(ZulipTestCase):
 class RateLimitTests(ZulipTestCase):
 
     def setUp(self) -> None:
+        super().setUp()
         settings.RATE_LIMITING = True
         add_ratelimit_rule(1, 5)
 

--- a/zerver/tests/test_hotspots.py
+++ b/zerver/tests/test_hotspots.py
@@ -11,6 +11,7 @@ import ujson
 # complicated hotspots logic.
 class TestGetNextHotspots(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.user = do_create_user(
             'user@zulip.com', 'password', get_realm('zulip'), 'user', 'user')
 

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -220,6 +220,7 @@ class QueryUtilTest(ZulipTestCase):
 class ImportExportTest(ZulipTestCase):
 
     def setUp(self) -> None:
+        super().setUp()
         self.rm_tree(settings.LOCAL_UPLOADS_DIR)
 
     def _make_output_dir(self) -> str:

--- a/zerver/tests/test_logging_handlers.py
+++ b/zerver/tests/test_logging_handlers.py
@@ -39,6 +39,7 @@ class AdminNotifyHandlerTest(ZulipTestCase):
     logger = logging.getLogger('django')
 
     def setUp(self) -> None:
+        super().setUp()
         self.handler = AdminNotifyHandler()
         # Prevent the exceptions we're going to raise from being printed
         # You may want to disable this when debugging tests

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -39,6 +39,7 @@ class TestCheckConfig(ZulipTestCase):
 
 class TestZulipBaseCommand(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.zulip_realm = get_realm("zulip")
         self.command = ZulipBaseCommand()
 
@@ -162,6 +163,7 @@ class TestZulipBaseCommand(ZulipTestCase):
 class TestCommandsCanStart(TestCase):
 
     def setUp(self) -> None:
+        super().setUp()
         self.commands = filter(
             lambda filename: filename != '__init__',
             map(
@@ -185,6 +187,7 @@ class TestSendWebhookFixtureMessage(TestCase):
     COMMAND_NAME = 'send_webhook_fixture_message'
 
     def setUp(self) -> None:
+        super().setUp()
         self.fixture_path = os.path.join('some', 'fake', 'path.json')
         self.url = '/some/url/with/hook'
 

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -85,6 +85,7 @@ def first_visible_id_as(message_id: int) -> Any:
 
 class NarrowBuilderTest(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.realm = get_realm('zulip')
         self.user_profile = self.example_user('hamlet')
         self.builder = NarrowBuilder(self.user_profile, column('id'))

--- a/zerver/tests/test_new_users.py
+++ b/zerver/tests/test_new_users.py
@@ -111,6 +111,7 @@ class SendLoginEmailTest(ZulipTestCase):
 class TestBrowserAndOsUserAgentStrings(ZulipTestCase):
 
     def setUp(self) -> None:
+        super().setUp()
         self.user_agents = [
             ('mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) ' +
                 'Chrome/54.0.2840.59 Safari/537.36', 'Chrome', 'Linux',),

--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -16,6 +16,7 @@ from zerver.models import get_realm, get_user, SLACK_INTERFACE
 class TestGenericOutgoingWebhookService(ZulipTestCase):
 
     def setUp(self) -> None:
+        super().setUp()
         self.event = {
             u'command': '@**test**',
             u'message': {
@@ -98,6 +99,7 @@ class TestGenericOutgoingWebhookService(ZulipTestCase):
 class TestSlackOutgoingWebhookService(ZulipTestCase):
 
     def setUp(self) -> None:
+        super().setUp()
         self.stream_message_event = {
             u'command': '@**test**',
             u'user_profile_id': 12,

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -38,6 +38,7 @@ service_handler = GenericOutgoingWebhookService(None, None, None)
 
 class DoRestCallTests(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         realm = get_realm("zulip")
         user_profile = get_user("outgoing-webhook@zulip.com", realm)
         self.mock_event = {
@@ -139,6 +140,7 @@ I'm a generic exception :(
 
 class TestOutgoingWebhookMessaging(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.user_profile = self.example_user("othello")
         self.bot_profile = self.create_test_bot('outgoing-webhook', self.user_profile,
                                                 full_name='Outgoing Webhook bot',

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1720,6 +1720,7 @@ class TestClearOnRead(ZulipTestCase):
 
 class TestReceivesNotificationsFunctions(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.user = self.example_user('cordelia')
 
     def test_receivers_online_notifications_when_user_is_a_bot(self) -> None:

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -383,6 +383,7 @@ class EmojiReactionBase(ZulipTestCase):
 
 class DefaultEmojiReactionTests(EmojiReactionBase):
     def setUp(self) -> None:
+        super().setUp()
         self.reaction_type = 'unicode_emoji'
         reaction_info = {
             'emoji_name': 'hamburger',
@@ -620,6 +621,7 @@ class ZulipExtraEmojiReactionTest(EmojiReactionBase):
 
 class RealmEmojiReactionTests(EmojiReactionBase):
     def setUp(self) -> None:
+        super().setUp()
         green_tick_emoji = RealmEmoji.objects.get(name="green_tick")
         self.default_reaction_info = {
             'emoji_name': 'green_tick',

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -542,6 +542,7 @@ class RealmTest(ZulipTestCase):
 class RealmAPITest(ZulipTestCase):
 
     def setUp(self) -> None:
+        super().setUp()
         user_profile = self.example_user('cordelia')
         email = user_profile.email
         self.login(email)

--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -72,6 +72,7 @@ class RetentionTestingBase(ZulipTestCase):
 
 class ArchiveMessagesTestingBase(RetentionTestingBase):
     def setUp(self) -> None:
+        super().setUp()
         self.zulip_realm = get_realm('zulip')
         self.mit_realm = get_realm('zephyr')
         self._set_realm_message_retention_value(self.zulip_realm, ZULIP_REALM_DAYS)
@@ -471,6 +472,7 @@ class TestArchivingReactions(ArchiveMessagesTestingBase, EmojiReactionBase):
 
 class MoveMessageToArchiveBase(RetentionTestingBase):
     def setUp(self) -> None:
+        super().setUp()
         self.sender = 'hamlet@zulip.com'
         self.recipient = 'cordelia@zulip.com'
 

--- a/zerver/tests/test_service_bot_system.py
+++ b/zerver/tests/test_service_bot_system.py
@@ -170,6 +170,7 @@ class TestServiceBotBasics(ZulipTestCase):
 
 class TestServiceBotStateHandler(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.user_profile = self.example_user("othello")
         self.bot_profile = do_create_user(email="embedded-bot-1@zulip.com",
                                           password="test",
@@ -350,6 +351,7 @@ class TestServiceBotStateHandler(ZulipTestCase):
 
 class TestServiceBotConfigHandler(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.user_profile = self.example_user("othello")
         self.bot_profile = self.create_test_bot('embedded', self.user_profile,
                                                 full_name='Embedded bot',
@@ -406,6 +408,7 @@ class TestServiceBotConfigHandler(ZulipTestCase):
 class TestServiceBotEventTriggers(ZulipTestCase):
 
     def setUp(self) -> None:
+        super().setUp()
         self.user_profile = self.example_user("othello")
         self.bot_profile = do_create_user(email="foo-bot@zulip.com",
                                           password="test",

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1451,6 +1451,7 @@ class InvitationsTestCase(InviteUserBase):
 
 class InviteeEmailsParserTests(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.email1 = "email1@zulip.com"
         self.email2 = "email2@zulip.com"
         self.email3 = "email3@zulip.com"
@@ -1477,6 +1478,7 @@ class InviteeEmailsParserTests(TestCase):
 
 class MultiuseInviteTest(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.realm = get_realm('zulip')
         self.realm.invite_required = True
         self.realm.save()

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1985,6 +1985,7 @@ class SubscriptionAPITest(ZulipTestCase):
         All tests will be logged in as hamlet. Also save various useful values
         as attributes that tests can access.
         """
+        super().setUp()
         self.user_profile = self.example_user('hamlet')
         self.test_email = self.user_profile.email
         self.test_user = self.user_profile
@@ -3298,6 +3299,7 @@ class GetPublicStreamsTest(ZulipTestCase):
 
 class StreamIdTest(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.user_profile = self.example_user('hamlet')
         self.email = self.user_profile.email
         self.login(self.email)
@@ -3406,6 +3408,7 @@ class InviteOnlyStreamTest(ZulipTestCase):
 class GetSubscribersTest(ZulipTestCase):
 
     def setUp(self) -> None:
+        super().setUp()
         self.user_profile = self.example_user('hamlet')
         self.email = self.user_profile.email
         self.login(self.email)

--- a/zerver/tests/test_tutorial.py
+++ b/zerver/tests/test_tutorial.py
@@ -10,6 +10,7 @@ import ujson
 
 class TutorialTests(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         # This emulates the welcome message sent by the welcome bot to hamlet@zulip.com
         # This is only a quick fix - ideally, we would have this message sent by the initialization
         # code in populate_db.py

--- a/zerver/tests/test_unread.py
+++ b/zerver/tests/test_unread.py
@@ -205,6 +205,7 @@ class PointerTest(ZulipTestCase):
 
 class UnreadCountTests(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         with mock.patch('zerver.lib.push_notifications.push_notifications_enabled',
                         return_value = True) as mock_push_notifications_enabled:
             self.unread_msg_ids = [

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -1809,6 +1809,7 @@ class SanitizeNameTests(TestCase):
 
 class UploadSpaceTests(UploadSerializeMixin, ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.realm = get_realm("zulip")
         self.user_profile = self.example_user('hamlet')
 
@@ -1878,6 +1879,7 @@ class ExifRotateTests(TestCase):
 
 class DecompressionBombTests(ZulipTestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.test_urls = {
             "/json/users/me/avatar": "Image size exceeds limit.",
             "/json/realm/logo": "Image size exceeds limit.",

--- a/zerver/webhooks/taiga/tests.py
+++ b/zerver/webhooks/taiga/tests.py
@@ -8,6 +8,7 @@ class TaigaHookTests(WebhookTestCase):
     FIXTURE_DIR_NAME = 'taiga'
 
     def setUp(self) -> None:
+        super().setUp()
         self.url = self.build_webhook_url(topic=self.TOPIC)
 
     def test_taiga_userstory_deleted(self) -> None:


### PR DESCRIPTION
Requested follow-up to https://github.com/zulip/zulip/pull/13300

MigrationsTestCase is intentionally omitted from this, since migrations
tests are different in their nature and so whatever setUp()
ZulipTestCase may do in the future, MigrationsTestCase may not
necessarily want to replicate.
