### PR TITLE
css: Fix azuread-wrapper name.

### DIFF
--- a/static/styles/portico/portico-signin.scss
+++ b/static/styles/portico/portico-signin.scss
@@ -652,7 +652,7 @@ button.login-social-button:active {
     transform: translateX(15px) translateY(13px);
 }
 
-.azuread-wrapper::before {
+.azuread-oauth2-wrapper::before {
     content: "\f17a";
     position: absolute;
 


### PR DESCRIPTION
It should be azuread-oauth2-wrapper, as the name of the corresponding
backend is 'azuread-oauth2'. Without the correct name, the icon isn't
showing on the "Log in with AzureAD" button.

How to reproduce the problem and test the fix:
1. Uncomment ``zproject.backends.AzureADAuthBackend`` in AUTHENTICATION_BACKENDS in dev_settings.py
2. Go to the login page.
3. Without the fix the AzureAD icon is missing on the button. With the fix, it shows.