### PR TITLE
webpack: Enable code splitting and deduplication

### DIFF
--- a/docs/subsystems/html-css.md
+++ b/docs/subsystems/html-css.md
@@ -164,7 +164,7 @@ webpack build, JS minification and a host of other steps for getting the assets
 ready for deployment.
 
 You can trace which source files are included in which HTML templates
-by comparing the `render_bundle` calls in the HTML templates under
+by comparing the `render_entrypoint` calls in the HTML templates under
 `templates/` with the bundles declared in `tools/webpack.assets.json`.
 
 ### Adding static files

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "font-awesome": "^4.7.0",
     "handlebars": "^4.1.2",
     "handlebars-loader": "^1.7.1",
+    "html-webpack-plugin": "^4.0.0-beta.8",
     "i18next": "^17.0.16",
     "imports-loader": "^0.8.0",
     "jquery": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
     "underscore": "^1.9.1",
     "webfonts-loader": "^5.0.0",
     "webpack": "^4.33.0",
-    "webpack-bundle-tracker": "^0.4.2-beta",
     "webpack-cli": "^3.3.2",
+    "webpack4-bundle-tracker": "^0.0.1-beta",
     "winchan": "^0.2.1",
     "xdate": "^0.8.2",
     "zxcvbn": "^4.4.2"

--- a/puppet/zulip/files/nginx/zulip-include-frontend/app
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/app
@@ -8,7 +8,7 @@ add_header Strict-Transport-Security max-age=15768000 always;
 add_header X-Frame-Options DENY always;
 
 # Serve a custom error page when the app is down
-error_page 502 503 504 /static/html/5xx.html;
+error_page 502 503 504 /static/webpack-bundles/5xx.html;
 
 # Serve static files directly
 location /static/ {

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -106,7 +106,7 @@ tornado==4.*  # https://github.com/zulip/zulip/issues/8913
 https://github.com/zulip/ultrajson/archive/70ac02becc3e11174cd5072650f885b30daab8a8.zip#egg=ujson==1.35+git
 
 # Django extension for serving webpack modules
-django-webpack-loader
+django-webpack4-loader
 
 # Needed for iOS push notifications
 apns2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -262,9 +262,9 @@ django-statsd-mozilla==0.4.0 \
 django-two-factor-auth==1.9.1 \
     --hash=sha256:464c33bcbd2f43470adc5f9b1c1957c8afad7bbada08a92c95031d26e7a8dd73 \
     --hash=sha256:df45c2aafce5174c2c0ccc15740f6bb3bb78402b6bd27223d87cb3ba3ee52626
-django-webpack-loader==0.6.0 \
-    --hash=sha256:60bab6b9a037a5346fad12d2a70a6bc046afb33154cf75ed640b93d3ebd5f520 \
-    --hash=sha256:970b968c2a8975fb7eff56a3bab5d0d90d396740852d1e0c50c5cfe2b824199a
+django-webpack4-loader==0.0.5 \
+    --hash=sha256:baa043c4601ed763d161490e2888cf6aa93a2fd9b60681e6b19e35dc7fcb155d \
+    --hash=sha256:be90257041170f39c025ff674c9064569c9303b464536488b6a6cedd8e3d28be
 django==1.11.24 \
     --hash=sha256:215c27453f775b6b1add83a185f76c2e2ab711d17786a6704bd62eabd93f89e3 \
     --hash=sha256:ffd89b89a2ee860ee521f054225044f52676825be4b61168d2842d44fcf457d3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -178,9 +178,9 @@ django-statsd-mozilla==0.4.0 \
 django-two-factor-auth==1.9.1 \
     --hash=sha256:464c33bcbd2f43470adc5f9b1c1957c8afad7bbada08a92c95031d26e7a8dd73 \
     --hash=sha256:df45c2aafce5174c2c0ccc15740f6bb3bb78402b6bd27223d87cb3ba3ee52626
-django-webpack-loader==0.6.0 \
-    --hash=sha256:60bab6b9a037a5346fad12d2a70a6bc046afb33154cf75ed640b93d3ebd5f520 \
-    --hash=sha256:970b968c2a8975fb7eff56a3bab5d0d90d396740852d1e0c50c5cfe2b824199a
+django-webpack4-loader==0.0.5 \
+    --hash=sha256:baa043c4601ed763d161490e2888cf6aa93a2fd9b60681e6b19e35dc7fcb155d \
+    --hash=sha256:be90257041170f39c025ff674c9064569c9303b464536488b6a6cedd8e3d28be
 django==1.11.24 \
     --hash=sha256:215c27453f775b6b1add83a185f76c2e2ab711d17786a6704bd62eabd93f89e3 \
     --hash=sha256:ffd89b89a2ee860ee521f054225044f52676825be4b61168d2842d44fcf457d3

--- a/static/html/5xx.html
+++ b/static/html/5xx.html
@@ -3,11 +3,6 @@
     <head>
         <meta charset="UTF-8">
         <title>Zulip - 500 internal server error</title>
-        <link href="/static/third/bootstrap/css/bootstrap.css" rel="stylesheet">
-        <link href="/static/third/bootstrap/css/bootstrap-responsive.css" rel="stylesheet">
-        <!-- This requires a hardcoded path because this error page is
-        for when Django is down -->
-        <link href="/static/webpack-bundles/error-styles.css" rel="stylesheet">
 
         <meta http-equiv="refresh" content="60;URL='/'">
 

--- a/static/js/bundles/portico.js
+++ b/static/js/bundles/portico.js
@@ -1,0 +1,4 @@
+import "./common.js";
+import "../translations.js";
+import "../portico/header.js";
+import "../../styles/portico/portico-styles.scss";

--- a/templates/analytics/activity.html
+++ b/templates/analytics/activity.html
@@ -1,4 +1,5 @@
 {% extends "zerver/base.html" %}
+{% set entrypoint = "activity" %}
 
 {# User Activity. #}
 
@@ -6,11 +7,6 @@
 <title>{{ title }}</title>
 {% endblock %}
 
-
-{% block customhead %}
-{{ super() }}
-{{ bundle('activity') }}
-{% endblock %}
 
 {% block content %}
 

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -1,14 +1,8 @@
 {% extends "zerver/base.html" %}
-
-{% block customhead %}
-{{ bundle('portico') }}
-{% endblock %}
+{% set entrypoint = "stats" %}
 
 {% block content %}
 <div class="app portico-page">
-
-    {{ bundle('translations') }}
-    {{ bundle('stats') }}
 
     <div class="page-content">
         <div id="id_stats_errors" class="alert alert-error"></div>

--- a/templates/analytics/support.html
+++ b/templates/analytics/support.html
@@ -1,4 +1,5 @@
 {% extends "zerver/base.html" %}
+{% set entrypoint = "support" %}
 
 {# User Activity. #}
 
@@ -6,12 +7,6 @@
 <title>Info</title>
 {% endblock %}
 
-
-{% block customhead %}
-{{ super() }}
-{{ bundle('activity') }}
-{{ bundle('support') }}
-{% endblock %}
 
 {% block content %}
 <div class="container">

--- a/templates/confirmation/confirm_preregistrationuser.html
+++ b/templates/confirmation/confirm_preregistrationuser.html
@@ -1,9 +1,5 @@
 {% extends "zerver/base.html" %}
-
-{% block customhead %}
-{{ super() }}
-{{ bundle('confirm-preregistrationuser') }}
-{% endblock %}
+{% set entrypoint = "confirm-preregistrationuser" %}
 
 {% block content %}
 

--- a/templates/corporate/billing.html
+++ b/templates/corporate/billing.html
@@ -1,9 +1,8 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "billing" %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-{{ bundle('landing-page') }}
-{{ bundle('billing') }}
 <script src="https://checkout.stripe.com/checkout.js"></script>
 {% endblock %}
 
@@ -13,7 +12,6 @@
 
     {% include 'zerver/billing_nav.html' %}
 
-    {{ bundle('translations') }}
     <div class="portico-landing billing-upgrade-page">
         <div class="hero small-hero"></div>
 

--- a/templates/corporate/jobs.html
+++ b/templates/corporate/jobs.html
@@ -1,4 +1,5 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
 
 {% block title %}
 <title>Zulip jobs</title>
@@ -6,7 +7,6 @@
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-{{ bundle('landing-page') }}
 {% endblock %}
 
 {% block portico_content %}

--- a/templates/corporate/upgrade.html
+++ b/templates/corporate/upgrade.html
@@ -1,9 +1,8 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "upgrade" %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-{{ bundle('landing-page') }}
-{{ bundle('upgrade') }}
 <script src="https://checkout.stripe.com/checkout.js"></script>
 {% endblock %}
 
@@ -12,8 +11,6 @@
 <div class="app portico-page">
 
     {% include 'zerver/billing_nav.html' %}
-
-    {{ bundle('translations') }}
 
     <div class="portico-landing billing-upgrade-page">
         <div class="hero small-hero"></div>

--- a/templates/corporate/zephyr.html
+++ b/templates/corporate/zephyr.html
@@ -1,4 +1,5 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
 
 {% block title %}
 <title>Zulip zephyr</title>
@@ -6,7 +7,6 @@
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-{{ bundle('landing-page') }}
 {% endblock %}
 
 {% block portico_content %}

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -1,14 +1,10 @@
 {% extends "zerver/base.html" %}
+{% set entrypoint = "app" %}
 {# The app itself. #}
 {# Includes some other templates as tabs. #}
 
 {% block meta_viewport %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-{% endblock %}
-
-{% block commonjs %}
-{{ bundle('app') }}
-{{ bundle('katex') }}
 {% endblock %}
 
 {% block customhead %}

--- a/templates/zerver/apps.html
+++ b/templates/zerver/apps.html
@@ -1,11 +1,11 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <style media="screen">
     .app.portico-page { padding-bottom: 0px; }
 </style>
-{{ bundle('landing-page') }}
 {% endblock %}
 
 {% block portico_content %}

--- a/templates/zerver/archive/index.html
+++ b/templates/zerver/archive/index.html
@@ -1,4 +1,5 @@
 {% extends "zerver/base.html" %}
+{% set entrypoint = "archive" %}
 
 {% block customhead %}
     <link id="emoji-spritesheet" href="/static/generated/emoji/google-sprite.css" rel="stylesheet" type="text/css">
@@ -10,13 +11,6 @@
         width: auto;
         }
     </style>
-
-    {{ bundle('translations') }}
-    {{ bundle('katex') }}
-    {{ bundle('portico') }}
-    {{ bundle('archive') }}
-    {{ bundle('archive-styles') }}
-
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/atlassian.html
+++ b/templates/zerver/atlassian.html
@@ -1,4 +1,5 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
 
 {% block title %}
 <title>Migrating from HipChat and Stride</title>
@@ -6,8 +7,6 @@
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-{{ bundle('landing-page') }}
-
 {% endblock %}
 
 {% block portico_content %}

--- a/templates/zerver/base.html
+++ b/templates/zerver/base.html
@@ -21,8 +21,8 @@
         {% endif %}
 
         {% macro bundle(name) %}
-        {{ render_bundle(name, 'css', attrs='nonce="%s"' % (csp_nonce,) if csp_nonce else '') }}
-        {{ render_bundle(name, 'js', attrs='defer nonce="%s"' % (csp_nonce,) if csp_nonce else 'defer') }}
+        {{ render_entrypoint(name, 'css', attrs='nonce="%s"' % (csp_nonce,) if csp_nonce else '') }}
+        {{ render_entrypoint(name, 'js', attrs='defer nonce="%s"' % (csp_nonce,) if csp_nonce else 'defer') }}
         {% endmacro %}
 
         <!-- This is a temporary block to enable webpack transition

--- a/templates/zerver/base.html
+++ b/templates/zerver/base.html
@@ -20,24 +20,12 @@
         {% include 'zerver/meta_tags.html' %}
         {% endif %}
 
-        {% macro bundle(name) %}
-        {{ render_entrypoint(name, 'css', attrs='nonce="%s"' % (csp_nonce,) if csp_nonce else '') }}
-        {{ render_entrypoint(name, 'js', attrs='defer nonce="%s"' % (csp_nonce,) if csp_nonce else 'defer') }}
-        {% endmacro %}
-
-        <!-- This is a temporary block to enable webpack transition
-        This allows pages requiring common files via webpack to override
-        this block -->
-        {% block commonjs %}
-        {{ bundle('common') }}
+        {% block webpack %}
+        {{ render_entrypoint(entrypoint, 'css', attrs='nonce="%s"' % (csp_nonce,) if csp_nonce else '') }}
+        {{ render_entrypoint(entrypoint, 'js', attrs='defer nonce="%s"' % (csp_nonce,) if csp_nonce else 'defer') }}
         {% endblock %}
+
         {% block customhead %}
-        {% endblock %}
-
-        {# this is required because we want to put a custom head in
-        `zerver/portico.html` that isn't overwritten like the
-        `customhead` #}
-        {% block porticocustomhead %}
         {% endblock %}
     </head>
 
@@ -49,3 +37,5 @@
     </body>
 
 </html>
+
+{% set entrypoint = entrypoint|default("common") %}

--- a/templates/zerver/dev_login.html
+++ b/templates/zerver/dev_login.html
@@ -1,8 +1,8 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "dev-login" %}
 
 {# Login page. #}
 {% block portico_content %}
-{{ bundle('dev-login') }}
 <!-- The following empty tag has unique data-page-id so that this
 page can be easily identified in it's respective JavaScript file -->
 <div data-page-id="dev-login"></div>

--- a/templates/zerver/dev_tools.html
+++ b/templates/zerver/dev_tools.html
@@ -54,7 +54,7 @@
                     <td>View the /stats page with some pre-populated data</td>
                 </tr>
                 <tr>
-                    <td><a href="/static/html/5xx.html">/static/html/5xx.html</a></td>
+                    <td><a href="/webpack/5xx.html">/webpack/5xx.html</a></td>
                     <td><code>./manage.py collectstatic --noinput</code></td>
                     <td>Error 5xx page served by nginx (used when Django is totally broken)</td>
                 </tr>

--- a/templates/zerver/digest_base.html
+++ b/templates/zerver/digest_base.html
@@ -1,8 +1,5 @@
 {% extends "zerver/base.html" %}
-
-{% block porticocustomhead %}
-{{ bundle('portico') }}
-{% endblock %}
+{% set entrypoint = "digest" %}
 
 {% block content %}
 <body>

--- a/templates/zerver/documentation_main.html
+++ b/templates/zerver/documentation_main.html
@@ -1,4 +1,5 @@
 {% extends "zerver/portico-help.html" %}
+{% set entrypoint = "help" %}
 
 {# Zulip User and API Documentation. #}
 
@@ -27,6 +28,4 @@
         </div>
     </div>
 </div>
-
-{{ bundle("help") }}
 {% endblock %}

--- a/templates/zerver/email_log.html
+++ b/templates/zerver/email_log.html
@@ -1,6 +1,6 @@
 {% extends "zerver/base.html" %}
+{% set entrypoint = "email-log" %}
 {% block content %}
-{{ bundle('email-log') }}
 <div class="container">
     <div style="position: fixed">
         <div class="alert">

--- a/templates/zerver/features.html
+++ b/templates/zerver/features.html
@@ -1,11 +1,8 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
 
 {% set OPEN_GRAPH_TITLE = 'Zulip Features' %}
 {% set OPEN_GRAPH_DESCRIPTION = 'First class threading on top of everything you could want from real-time chat.' %}
-
-{% block customhead %}
-{{ bundle('landing-page') }}
-{% endblock %}
 
 {% block portico_content %}
 

--- a/templates/zerver/for-companies.html
+++ b/templates/zerver/for-companies.html
@@ -1,4 +1,5 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
 
 {% block title %}
 <title>Zulip: the best group chat for companies</title>
@@ -6,8 +7,6 @@
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-{{ bundle('landing-page') }}
-
 {% endblock %}
 
 {% block portico_content %}

--- a/templates/zerver/for-mystery-hunt.html
+++ b/templates/zerver/for-mystery-hunt.html
@@ -1,4 +1,5 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
 
 {% block title %}
 <title>Zephyr reloaded</title>
@@ -6,8 +7,6 @@
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-{{ bundle('landing-page') }}
-
 {% endblock %}
 
 {% block portico_content %}

--- a/templates/zerver/for-open-source.html
+++ b/templates/zerver/for-open-source.html
@@ -1,4 +1,5 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
 
 {% set OPEN_GRAPH_TITLE = 'Modern chat for open source' %}
 {% set OPEN_GRAPH_DESCRIPTION = 'No message limits, rich moderation features, markdown support, and a conversation model that scales to thousands of users.' %}
@@ -9,7 +10,6 @@
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-{{ bundle('landing-page') }}
 {% endblock %}
 
 {% block portico_content %}

--- a/templates/zerver/for-working-groups-and-communities.html
+++ b/templates/zerver/for-working-groups-and-communities.html
@@ -1,4 +1,5 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
 
 {% block title %}
 <title>Zulip: the best group chat for working groups and communities</title>
@@ -6,8 +7,6 @@
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-{{ bundle('landing-page') }}
-
 {% endblock %}
 
 {% block portico_content %}

--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -1,11 +1,11 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <!-- Bootstrap 2.3.2-->
 <script src="https://stackpath.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js" defer></script>
 
-{{ bundle('landing-page') }}
 <style>
     .portico-page {
     padding-bottom: 0px;

--- a/templates/zerver/history.html
+++ b/templates/zerver/history.html
@@ -1,4 +1,5 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
 
 {% block title %}
 <title>Zulip history</title>
@@ -6,8 +7,6 @@
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-{{ bundle('landing-page') }}
-
 {% endblock %}
 
 {% block portico_content %}

--- a/templates/zerver/integrations/development/dev_panel.html
+++ b/templates/zerver/integrations/development/dev_panel.html
@@ -1,11 +1,9 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "integrations-dev-panel" %}
 
 {% block customhead %}
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-{{ bundle('integrations-dev-panel') }}
-{{ bundle('portico') }}
-
 {% endblock %}
 
 

--- a/templates/zerver/integrations/index.html
+++ b/templates/zerver/integrations/index.html
@@ -1,8 +1,8 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "integrations" %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-{{ bundle('integrations') }}
 {% endblock %}
 
 {% block hello_page_container %} hello-main{% endblock %}

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -1,10 +1,6 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "signup" %}
 {# Login page. #}
-
-{% block customhead %}
-{{ super() }}
-{{ bundle('signup') }}
-{% endblock %}
 
 {% block portico_content %}
 

--- a/templates/zerver/plans.html
+++ b/templates/zerver/plans.html
@@ -1,8 +1,8 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-{{ bundle('landing-page') }}
 {% endblock %}
 
 {% block portico_content %}

--- a/templates/zerver/portico.html
+++ b/templates/zerver/portico.html
@@ -1,15 +1,11 @@
 {% extends "zerver/base.html" %}
+{% set entrypoint = entrypoint|default("portico") %}
 
 {# A base template for stuff like login, register, etc.
 
     Not inside the app itself, but covered by the same structure,
     hence the name.
 #}
-
-{% block porticocustomhead %}
-{{ bundle('translations') }}
-{{ bundle('portico') }}
-{% endblock %}
 
 {% block content %}
 <div class="portico-container" data-platform="{{ platform }}">

--- a/templates/zerver/portico_signup.html
+++ b/templates/zerver/portico_signup.html
@@ -1,8 +1,4 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = entrypoint|default("signup") %}
 
 {# Portico page with signup code #}
-
-{% block customhead %}
-{{ super() }}
-{{ bundle('signup') }}
-{% endblock %}

--- a/templates/zerver/privacy.html
+++ b/templates/zerver/privacy.html
@@ -1,4 +1,5 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
 
 {% block title %}
 <title>Zulip: the best group chat for open source projects</title>
@@ -6,7 +7,6 @@
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-{{ bundle('landing-page') }}
 {% endblock %}
 
 {% block portico_content %}

--- a/templates/zerver/realm_creation_failed.html
+++ b/templates/zerver/realm_creation_failed.html
@@ -1,9 +1,8 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-{{ bundle('landing-page') }}
-
 {% endblock %}
 
 {% block portico_content %}

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -1,16 +1,11 @@
 {% extends "zerver/portico_signup.html" %}
+{% set entrypoint = "register" %}
 {#
 Gather other user information, after having confirmed
 their email address.
 
 Form is validated both client-side using jquery-validate (see signup.js) and server-side.
 #}
-
-{% block customhead %}
-{{ super() }}
-{{ bundle('zxcvbn') }}
-{{ bundle('translations') }}
-{% endblock %}
 
 {% block portico_content %}
 <div class="register-account flex full-page">

--- a/templates/zerver/reset_confirm.html
+++ b/templates/zerver/reset_confirm.html
@@ -1,8 +1,5 @@
 {% extends "zerver/portico_signup.html" %}
-{% block customhead %}
-{{ super() }}
-{{ bundle('zxcvbn') }}
-{% endblock %}
+{% set entrypoint = "register" %}
 
 {% block portico_content %}
 

--- a/templates/zerver/security.html
+++ b/templates/zerver/security.html
@@ -1,4 +1,5 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
 
 {% block title %}
 <title>Zulip Security</title>
@@ -6,8 +7,6 @@
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-{{ bundle('landing-page') }}
-
 {% endblock %}
 
 {% block portico_content %}

--- a/templates/zerver/team.html
+++ b/templates/zerver/team.html
@@ -1,11 +1,8 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
 
 {% block title %}
 <title>Zulip: the best group chat for open source projects</title>
-{% endblock %}
-
-{% block customhead %}
-{{ bundle('landing-page') }}
 {% endblock %}
 
 {% block portico_content %}

--- a/templates/zerver/terms.html
+++ b/templates/zerver/terms.html
@@ -1,11 +1,10 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
 
 {# Terms of Service. #}
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-{{ bundle('landing-page') }}
-
 {% endblock %}
 
 {% block portico_content %}

--- a/templates/zerver/why-zulip.html
+++ b/templates/zerver/why-zulip.html
@@ -1,4 +1,5 @@
 {% extends "zerver/portico.html" %}
+{% set entrypoint = "landing-page" %}
 
 {% set OPEN_GRAPH_TITLE = 'Team chat with first-class threading' %}
 {% set OPEN_GRAPH_DESCRIPTION = 'Most team chats are overwhelming to keep up with. Zulip takes a different approach.' %}
@@ -9,8 +10,6 @@
 
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-{{ bundle('landing-page') }}
-
 {% endblock %}
 
 {% block portico_content %}

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -620,7 +620,7 @@ html_rules = whitespace_rules + prose_style_rules + [
      'description': "Don't directly load dependencies from CDNs.  See docs/subsystems/html-css.md",
      'exclude': set(["templates/corporate/billing.html", "templates/zerver/hello.html",
                      "templates/corporate/upgrade.html"]),
-     'good_lines': ["{{ render_bundle('landing-page') }}"],
+     'good_lines': ["{{ render_entrypoint('landing-page') }}"],
      'bad_lines': ['<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>']},
     {'pattern': "title='[^{]",
      'description': "`title` value should be translatable.",

--- a/tools/update-prod-static
+++ b/tools/update-prod-static
@@ -61,7 +61,7 @@ run(authors_cmd, stdout=fp, stderr=fp)
 
 # Collect the files that we're going to serve; this creates prod-static/serve.
 run(['./manage.py', 'collectstatic', '--no-default-ignore',
-     '--noinput', '-i', 'assets', '-i', 'js', '-i', 'styles', '-i', 'templates'],
+     '--noinput', '-i', 'assets', '-i', 'html', '-i', 'js', '-i', 'styles', '-i', 'templates'],
     stdout=fp, stderr=fp)
 
 # Compile translation strings to generate `.mo` files.

--- a/tools/webpack
+++ b/tools/webpack
@@ -108,7 +108,8 @@ def build_for_most_tests():
             }]
     stat_data = {
         "status": "done",
-        "chunks": entries
+        "chunks": entries,
+        "entryPoints": {name: [chunk] for name, chunk in entries.items()},
     }
     directory = 'var'
     if not os.path.exists(directory):

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -6,11 +6,8 @@
         "./static/styles/portico/activity.scss"
     ],
     "archive": [
-        "./static/js/bundles/common.js",
-        "./static/js/translations.js",
+        "./static/js/bundles/portico.js",
         "katex/dist/katex.min.js",
-        "./static/js/portico/header.js",
-        "./static/styles/portico/portico-styles.scss",
         "xdate/src/xdate.js",
         "handlebars/dist/cjs/handlebars.runtime.js",
         "./static/js/archive.js",
@@ -26,10 +23,7 @@
         "./static/styles/portico/archive.scss"
     ],
     "billing": [
-        "./static/js/bundles/common.js",
-        "./static/js/translations.js",
-        "./static/js/portico/header.js",
-        "./static/styles/portico/portico-styles.scss",
+        "./static/js/bundles/portico.js",
         "./static/js/portico/landing-page.js",
         "./static/styles/portico/landing-page.scss",
         "./static/js/billing/helpers.js",
@@ -40,10 +34,7 @@
         "./static/styles/portico/billing.scss"
     ],
     "upgrade": [
-        "./static/js/bundles/common.js",
-        "./static/js/translations.js",
-        "./static/js/portico/header.js",
-        "./static/styles/portico/portico-styles.scss",
+        "./static/js/bundles/portico.js",
         "./static/js/portico/landing-page.js",
         "./static/styles/portico/landing-page.scss",
         "./static/js/billing/helpers.js",
@@ -54,10 +45,7 @@
         "./static/styles/portico/billing.scss"
     ],
     "portico": [
-        "./static/js/bundles/common.js",
-        "./static/js/translations.js",
-        "./static/js/portico/header.js",
-        "./static/styles/portico/portico-styles.scss"
+        "./static/js/bundles/portico.js"
     ],
     "error-styles": [
         "./static/third/bootstrap/css/bootstrap.css",
@@ -68,45 +56,30 @@
         "./static/js/bundles/common.js"
     ],
     "help": [
-        "./static/js/bundles/common.js",
-        "./static/js/translations.js",
-        "./static/js/portico/header.js",
-        "./static/styles/portico/portico-styles.scss",
+        "./static/js/bundles/portico.js",
         "simplebar/dist/simplebar.css",
         "simplebar/dist/simplebar.js",
         "./static/js/portico/help.js",
         "./static/js/portico/tabbed-instructions.js"
     ],
     "landing-page": [
-        "./static/js/bundles/common.js",
-        "./static/js/translations.js",
-        "./static/js/portico/header.js",
-        "./static/styles/portico/portico-styles.scss",
+        "./static/js/bundles/portico.js",
         "./static/js/portico/landing-page.js",
         "./static/styles/portico/landing-page.scss"
     ],
     "integrations": [
-        "./static/js/bundles/common.js",
-        "./static/js/translations.js",
-        "./static/js/portico/header.js",
-        "./static/styles/portico/portico-styles.scss",
+        "./static/js/bundles/portico.js",
         "./static/js/portico/integrations.js",
         "./static/styles/portico/landing-page.scss",
         "./static/styles/portico/integrations.scss"
     ],
     "signup": [
-        "./static/js/bundles/common.js",
-        "./static/js/translations.js",
-        "./static/js/portico/header.js",
-        "./static/styles/portico/portico-styles.scss",
+        "./static/js/bundles/portico.js",
         "jquery-validation/dist/jquery.validate.min.js",
         "./static/js/portico/signup.js"
     ],
     "register": [
-        "./static/js/bundles/common.js",
-        "./static/js/translations.js",
-        "./static/js/portico/header.js",
-        "./static/styles/portico/portico-styles.scss",
+        "./static/js/bundles/portico.js",
         "jquery-validation/dist/jquery.validate.min.js",
         "./static/js/portico/signup.js",
         "zxcvbn/dist/zxcvbn.js"
@@ -124,17 +97,11 @@
         "./static/styles/app_components.scss"
     ],
     "dev-login": [
-        "./static/js/bundles/common.js",
-        "./static/js/translations.js",
-        "./static/js/portico/header.js",
-        "./static/styles/portico/portico-styles.scss",
+        "./static/js/bundles/portico.js",
         "./static/js/portico/dev-login.js"
     ],
     "integrations-dev-panel": [
-        "./static/js/bundles/common.js",
-        "./static/js/translations.js",
-        "./static/js/portico/header.js",
-        "./static/styles/portico/portico-styles.scss",
+        "./static/js/bundles/portico.js",
         "./static/js/portico/integrations_dev_panel.js",
         "./static/styles/portico/integrations_dev_panel.css",
         "./static/js/channel.js"
@@ -145,10 +112,7 @@
         "./static/js/channel.js"
     ],
     "stats": [
-        "./static/js/bundles/common.js",
-        "./static/js/portico/header.js",
-        "./static/styles/portico/portico-styles.scss",
-        "./static/js/translations.js",
+        "./static/js/bundles/portico.js",
         "./static/styles/portico/stats.scss",
         "./static/js/stats/stats.js",
         "plotly.js/dist/plotly-basic.min.js"
@@ -158,8 +122,6 @@
         "katex/dist/katex.min.js"
     ],
     "digest": [
-        "./static/js/bundles/common.js",
-        "./static/js/portico/header.js",
-        "./static/styles/portico/portico-styles.scss"
+        "./static/js/bundles/portico.js"
     ]
 }

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -1,10 +1,16 @@
 {
     "activity": [
+        "./static/js/bundles/common.js",
         "sorttable/sorttable.js",
         "./static/js/analytics/activity.js",
         "./static/styles/portico/activity.scss"
     ],
     "archive": [
+        "./static/js/bundles/common.js",
+        "./static/js/translations.js",
+        "katex/dist/katex.min.js",
+        "./static/js/portico/header.js",
+        "./static/styles/portico/portico-styles.scss",
         "xdate/src/xdate.js",
         "handlebars/dist/cjs/handlebars.runtime.js",
         "./static/js/archive.js",
@@ -13,9 +19,19 @@
         "./static/js/timerender.js",
         "./static/js/templates.js",
         "./static/js/stream_color.js",
-        "./static/js/scroll_bar.js"
+        "./static/js/scroll_bar.js",
+        "katex/dist/katex.css",
+        "./static/styles/rendered_markdown.scss",
+        "./static/styles/zulip.scss",
+        "./static/styles/portico/archive.scss"
     ],
     "billing": [
+        "./static/js/bundles/common.js",
+        "./static/js/translations.js",
+        "./static/js/portico/header.js",
+        "./static/styles/portico/portico-styles.scss",
+        "./static/js/portico/landing-page.js",
+        "./static/styles/portico/landing-page.scss",
         "./static/js/billing/helpers.js",
         "./static/js/billing/billing.js",
         "handlebars/dist/cjs/handlebars.runtime.js",
@@ -24,6 +40,12 @@
         "./static/styles/portico/billing.scss"
     ],
     "upgrade": [
+        "./static/js/bundles/common.js",
+        "./static/js/translations.js",
+        "./static/js/portico/header.js",
+        "./static/styles/portico/portico-styles.scss",
+        "./static/js/portico/landing-page.js",
+        "./static/styles/portico/landing-page.scss",
         "./static/js/billing/helpers.js",
         "./static/js/billing/upgrade.js",
         "handlebars/dist/cjs/handlebars.runtime.js",
@@ -32,6 +54,8 @@
         "./static/styles/portico/billing.scss"
     ],
     "portico": [
+        "./static/js/bundles/common.js",
+        "./static/js/translations.js",
         "./static/js/portico/header.js",
         "./static/styles/portico/portico-styles.scss"
     ],
@@ -44,54 +68,98 @@
         "./static/js/bundles/common.js"
     ],
     "help": [
+        "./static/js/bundles/common.js",
+        "./static/js/translations.js",
+        "./static/js/portico/header.js",
+        "./static/styles/portico/portico-styles.scss",
         "simplebar/dist/simplebar.css",
         "simplebar/dist/simplebar.js",
         "./static/js/portico/help.js",
         "./static/js/portico/tabbed-instructions.js"
     ],
-    "katex": "katex/dist/katex.min.js",
     "landing-page": [
+        "./static/js/bundles/common.js",
+        "./static/js/translations.js",
+        "./static/js/portico/header.js",
+        "./static/styles/portico/portico-styles.scss",
         "./static/js/portico/landing-page.js",
         "./static/styles/portico/landing-page.scss"
     ],
     "integrations": [
+        "./static/js/bundles/common.js",
+        "./static/js/translations.js",
+        "./static/js/portico/header.js",
+        "./static/styles/portico/portico-styles.scss",
         "./static/js/portico/integrations.js",
         "./static/styles/portico/landing-page.scss",
         "./static/styles/portico/integrations.scss"
     ],
     "signup": [
+        "./static/js/bundles/common.js",
+        "./static/js/translations.js",
+        "./static/js/portico/header.js",
+        "./static/styles/portico/portico-styles.scss",
         "jquery-validation/dist/jquery.validate.min.js",
         "./static/js/portico/signup.js"
     ],
+    "register": [
+        "./static/js/bundles/common.js",
+        "./static/js/translations.js",
+        "./static/js/portico/header.js",
+        "./static/styles/portico/portico-styles.scss",
+        "jquery-validation/dist/jquery.validate.min.js",
+        "./static/js/portico/signup.js",
+        "zxcvbn/dist/zxcvbn.js"
+    ],
     "confirm-preregistrationuser": [
+        "./static/js/bundles/common.js",
         "./static/js/portico/confirm-preregistrationuser.js"
     ],
     "support": [
+        "./static/js/bundles/common.js",
+        "sorttable/sorttable.js",
+        "./static/js/analytics/activity.js",
+        "./static/styles/portico/activity.scss",
         "./static/js/analytics/support.js",
         "./static/styles/app_components.scss"
     ],
-    "dev-login": "./static/js/portico/dev-login.js",
+    "dev-login": [
+        "./static/js/bundles/common.js",
+        "./static/js/translations.js",
+        "./static/js/portico/header.js",
+        "./static/styles/portico/portico-styles.scss",
+        "./static/js/portico/dev-login.js"
+    ],
     "integrations-dev-panel": [
+        "./static/js/bundles/common.js",
+        "./static/js/translations.js",
+        "./static/js/portico/header.js",
+        "./static/styles/portico/portico-styles.scss",
         "./static/js/portico/integrations_dev_panel.js",
         "./static/styles/portico/integrations_dev_panel.css",
         "./static/js/channel.js"
     ],
     "email-log": [
+        "./static/js/bundles/common.js",
         "./static/js/portico/email_log.js",
         "./static/js/channel.js"
     ],
     "stats": [
+        "./static/js/bundles/common.js",
+        "./static/js/portico/header.js",
+        "./static/styles/portico/portico-styles.scss",
+        "./static/js/translations.js",
         "./static/styles/portico/stats.scss",
         "./static/js/stats/stats.js",
         "plotly.js/dist/plotly-basic.min.js"
     ],
-    "translations": "./static/js/translations.js",
-    "zxcvbn": "zxcvbn/dist/zxcvbn.js",
-    "app": "./static/js/bundles/app.js",
-    "archive-styles": [
-        "katex/dist/katex.css",
-        "./static/styles/rendered_markdown.scss",
-        "./static/styles/zulip.scss",
-        "./static/styles/portico/archive.scss"
+    "app": [
+        "./static/js/bundles/app.js",
+        "katex/dist/katex.min.js"
+    ],
+    "digest": [
+        "./static/js/bundles/common.js",
+        "./static/js/portico/header.js",
+        "./static/styles/portico/portico-styles.scss"
     ]
 }

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -36,6 +36,8 @@
         "./static/styles/portico/portico-styles.scss"
     ],
     "error-styles": [
+        "./static/third/bootstrap/css/bootstrap.css",
+        "./static/third/bootstrap/css/bootstrap-responsive.css",
         "./static/styles/portico/portico-styles.scss"
     ],
     "common": [

--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -238,7 +238,9 @@ export default (env?: string): webpack.Configuration[] => {
 
     if (!production) {
         // Out JS debugging tools
-        config.entry['common'].push('./static/js/debug.js');  // eslint-disable-line dot-notation
+        for (const name of Object.keys(config.entry)) {
+            config.entry[name].push('./static/js/debug.js');
+        }
         config.devServer = {
             clientLogLevel: "error",
             stats: "errors-only",

--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -130,7 +130,8 @@ export default (env?: string): webpack.Configuration[] => {
         output: {
             path: resolve(__dirname, '../static/webpack-bundles'),
             publicPath,
-            filename: production ? '[name].[chunkhash].js' : '[name].js',
+            filename: production ? '[name].[contenthash].js' : '[name].js',
+            chunkFilename: production ? '[contenthash].js' : '[id].js',
         },
         resolve: {
             extensions: [".ts", ".js"],
@@ -178,6 +179,12 @@ export default (env?: string): webpack.Configuration[] => {
                     sourceMap: true,
                 }),
             ],
+            splitChunks: {
+                chunks: "all",
+                // webpack/examples/many-pages suggests 20 requests for HTTP/2
+                maxAsyncRequests: 20,
+                maxInitialRequests: 20,
+            },
         },
         plugins: [
             new BundleTracker({
@@ -196,7 +203,7 @@ export default (env?: string): webpack.Configuration[] => {
             // Extract CSS from files
             new MiniCssExtractPlugin({
                 filename: production ? "[name].[contenthash].css" : "[name].css",
-                chunkFilename: "[chunkhash].css",
+                chunkFilename: production ? "[contenthash].css" : "[id].css",
             }),
             new HtmlWebpackPlugin({
                 filename: "5xx.html",

--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -9,6 +9,7 @@ import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import OptimizeCssAssetsPlugin from 'optimize-css-assets-webpack-plugin';
 import CleanCss from 'clean-css';
 import TerserPlugin from 'terser-webpack-plugin';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
 
 const assets = require('./webpack.assets.json');
 
@@ -194,18 +195,13 @@ export default (env?: string): webpack.Configuration[] => {
                 ],
             // Extract CSS from files
             new MiniCssExtractPlugin({
-                filename: production
-                    ? (data) => {
-                        // This is a special case in order to produce
-                        // a static CSS file to be consumed by
-                        // static/html/5xx.html
-                        if (data.chunk.name === 'error-styles') {
-                            return 'error-styles.css';
-                        }
-                        return '[name].[contenthash].css';
-                    }
-                    : "[name].css",
+                filename: production ? "[name].[contenthash].css" : "[name].css",
                 chunkFilename: "[chunkhash].css",
+            }),
+            new HtmlWebpackPlugin({
+                filename: "5xx.html",
+                template: "static/html/5xx.html",
+                chunks: ["error-styles"],
             }),
         ],
     };

--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -1,5 +1,5 @@
 import { basename, resolve } from 'path';
-import BundleTracker from 'webpack-bundle-tracker';
+import BundleTracker from 'webpack4-bundle-tracker';
 import webpack from 'webpack';
 // The devServer member of webpack.Configuration is managed by the
 // webpack-dev-server package. We are only importing the type here.

--- a/version.py
+++ b/version.py
@@ -26,4 +26,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '59.1'
+PROVISION_VERSION = '59.2'

--- a/version.py
+++ b/version.py
@@ -26,4 +26,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '59.2'
+PROVISION_VERSION = '60.0'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2573,7 +2573,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2, commander@2.x.x, commander@^2.10.0, commander@^2.12.2, commander@^2.15.1, commander@^2.19.0, commander@^2.20.0, commander@^2.7.1, commander@~2.20.0, commander@~2.20.3:
+commander@2, commander@2.x.x, commander@^2.10.0, commander@^2.12.2, commander@^2.15.1, commander@^2.19.0, commander@^2.20.0, commander@^2.7.1, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -12036,15 +12036,6 @@ webidl-conversions@^4.0.0, webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
-webpack-bundle-tracker@^0.4.2-beta:
-  version "0.4.2-beta"
-  resolved "https://registry.yarnpkg.com/webpack-bundle-tracker/-/webpack-bundle-tracker-0.4.2-beta.tgz#263c3a3db8722aaab0083763154e5f025e47825d"
-  integrity sha512-CCyJbCQnRtjR1sk97u/H5DtJibrIcJ79MnntMyjOpc9HCmfIQYgt7ze7i/Z+DStBZ4NC4HxqGDsB///2Na1DTA==
-  dependencies:
-    deep-extend "^0.6.0"
-    mkdirp "^0.5.1"
-    strip-ansi "^2.0.1"
-
 webpack-cli@^3.3.2:
   version "3.3.9"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.9.tgz#79c27e71f94b7fe324d594ab64a8e396b9daa91a"
@@ -12127,6 +12118,15 @@ webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
+
+webpack4-bundle-tracker@^0.0.1-beta:
+  version "0.0.1-beta"
+  resolved "https://registry.yarnpkg.com/webpack4-bundle-tracker/-/webpack4-bundle-tracker-0.0.1-beta.tgz#f576821ffbce584206e8dd41ba10cf9a7738731a"
+  integrity sha512-UcCqw8LT2IqqZhZDKPw9FAtWvHarS5iGYmw/aaWupSI1q55qdj7fjGsbiK/O/PxOuaAjfVxMVLq2CBvCbdp+XA==
+  dependencies:
+    deep-extend "^0.6.0"
+    mkdirp "^0.5.1"
+    strip-ansi "^2.0.1"
 
 webpack@^4.33.0:
   version "4.40.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2161,6 +2161,14 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+camel-case@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
+  integrity sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=
+  dependencies:
+    no-case "^2.2.0"
+    upper-case "^1.1.1"
+
 camelcase-keys@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-4.2.0.tgz#a2aa5fb1af688758259c32c141426d78923b9b77"
@@ -2565,10 +2573,10 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2, commander@2.x.x, commander@^2.10.0, commander@^2.12.2, commander@^2.15.1, commander@^2.19.0, commander@^2.20.0, commander@^2.7.1, commander@~2.20.0:
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
-  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
+commander@2, commander@2.x.x, commander@^2.10.0, commander@^2.12.2, commander@^2.15.1, commander@^2.19.0, commander@^2.20.0, commander@^2.7.1, commander@~2.20.0, commander@~2.20.3:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -2934,6 +2942,16 @@ css-select-base-adapter@^0.1.1:
   resolved "https://registry.yarnpkg.com/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz#3b2ff4972cc362ab88561507a95408a1432135d7"
   integrity sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==
 
+css-select@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
+  integrity sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=
+  dependencies:
+    boolbase "~1.0.0"
+    css-what "2.1"
+    domutils "1.5.1"
+    nth-check "~1.0.1"
+
 css-select@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-2.0.2.tgz#ab4386cec9e1f668855564b17c3733b43b2a5ede"
@@ -2970,7 +2988,7 @@ css-unit-converter@^1.1.1:
   resolved "https://registry.yarnpkg.com/css-unit-converter/-/css-unit-converter-1.1.1.tgz#d9b9281adcfd8ced935bdbaba83786897f64e996"
   integrity sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=
 
-css-what@^2.1.2:
+css-what@2.1, css-what@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
@@ -3468,6 +3486,13 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-converter@^0.2:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.2.0.tgz#6721a9daee2e293682955b6afe416771627bb768"
+  integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
+  dependencies:
+    utila "~0.4"
+
 dom-serializer@0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.1.tgz#13650c850daffea35d8b626a4cfc4d3a17643fdb"
@@ -3503,6 +3528,14 @@ domhandler@^2.3.0:
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
   integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
   dependencies:
+    domelementtype "1"
+
+domutils@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  integrity sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=
+  dependencies:
+    dom-serializer "0"
     domelementtype "1"
 
 domutils@^1.5.1, domutils@^1.7.0:
@@ -5423,6 +5456,11 @@ hasha@^3.0.0:
   dependencies:
     is-stream "^1.0.1"
 
+he@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 "heap@>= 0.2.0":
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.6.tgz#087e1f10b046932fc8594dd9e6d378afc9d1e5ac"
@@ -5496,12 +5534,37 @@ html-entities@^1.2.1:
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
   integrity sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=
 
+html-minifier@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-4.0.0.tgz#cca9aad8bce1175e02e17a8c33e46d8988889f56"
+  integrity sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==
+  dependencies:
+    camel-case "^3.0.0"
+    clean-css "^4.2.1"
+    commander "^2.19.0"
+    he "^1.2.0"
+    param-case "^2.1.1"
+    relateurl "^0.2.7"
+    uglify-js "^3.5.1"
+
 html-tags@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.1.0.tgz#7b5e6f7e665e9fb41f30007ed9e0d41e97fb2140"
   integrity sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==
 
-htmlparser2@^3.10.0:
+html-webpack-plugin@^4.0.0-beta.8:
+  version "4.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.8.tgz#d9a8d4322d8cf310f1568f6f4f585a80df0ad378"
+  integrity sha512-n5S2hJi3/vioRvEDswZP2WFgZU8TUqFoYIrkg5dt+xDC4TigQEhIcl4Y81Qs2La/EqKWuJZP8+ikbHGVmzQ4Mg==
+  dependencies:
+    html-minifier "^4.0.0"
+    loader-utils "^1.2.3"
+    lodash "^4.17.11"
+    pretty-error "^2.1.1"
+    tapable "^1.1.3"
+    util.promisify "1.0.0"
+
+htmlparser2@^3.10.0, htmlparser2@^3.3.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
   integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
@@ -6718,6 +6781,11 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
+lower-case@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
+  integrity sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
+
 lru-cache@^4.0.1:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
@@ -7426,6 +7494,13 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+no-case@^2.2.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
+  integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
+  dependencies:
+    lower-case "^1.1.1"
+
 node-forge@0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.8.2.tgz#b4bcc59fb12ce77a8825fc6a783dfe3182499c5a"
@@ -7614,7 +7689,7 @@ npm-run-path@^2.0.0:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-nth-check@^1.0.2:
+nth-check@^1.0.2, nth-check@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
   integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
@@ -8029,6 +8104,13 @@ parallel-transform@^1.1.0:
     cyclist "^1.0.1"
     inherits "^2.0.3"
     readable-stream "^2.1.5"
+
+param-case@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/param-case/-/param-case-2.1.1.tgz#df94fd8cf6531ecf75e6bef9a0858fbc72be2247"
+  integrity sha1-35T9jPZTHs915r75oIWPvHK+Ikc=
+  dependencies:
+    no-case "^2.2.0"
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -8901,6 +8983,14 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+pretty-error@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"
+  integrity sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=
+  dependencies:
+    renderkid "^2.0.1"
+    utila "~0.4"
+
 private@^0.1.6:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -9411,6 +9501,11 @@ regl@^1.3.11:
   resolved "https://registry.yarnpkg.com/regl/-/regl-1.3.13.tgz#c376bfa6477995a9be9cd21495a0c9beb9b2f3af"
   integrity sha512-TTiCabJbbUykCL4otjqOvKqDFJhvJOT7xB51JxcDeSHGrEJl1zz4RthPcoOogqfuR3ECN4Te790DfHCXzli5WQ==
 
+relateurl@^0.2.7:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
+  integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
+
 release-zalgo@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/release-zalgo/-/release-zalgo-1.0.0.tgz#09700b7e5074329739330e535c5a90fb67851730"
@@ -9472,6 +9567,17 @@ remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
   integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
+
+renderkid@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-2.0.3.tgz#380179c2ff5ae1365c522bf2fcfcff01c5b74149"
+  integrity sha512-z8CLQp7EZBPCwCnncgf9C4XAi3WR0dv+uWu/PjIyhhAb5d6IJ/QZqlHFprHeKT+59//V6BNUsLbvN8+2LarxGA==
+  dependencies:
+    css-select "^1.1.0"
+    dom-converter "^0.2"
+    htmlparser2 "^3.3.0"
+    strip-ansi "^3.0.0"
+    utila "^0.4.0"
 
 repeat-element@^1.1.2:
   version "1.1.3"
@@ -11380,12 +11486,12 @@ uglify-js@^2.6.0:
   optionalDependencies:
     uglify-to-browserify "~1.0.0"
 
-uglify-js@^3.1.4:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.0.tgz#704681345c53a8b2079fb6cec294b05ead242ff5"
-  integrity sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==
+uglify-js@^3.1.4, uglify-js@^3.5.1:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.3.tgz#1351533bbe22cc698f012589ed6bd4cbd971bff8"
+  integrity sha512-KfQUgOqTkLp2aZxrMbCuKCDGW9slFYu2A23A36Gs7sGzTLcRBDORdOi5E21KWHFIfkY8kzgi/Pr1cXCh0yIp5g==
   dependencies:
-    commander "~2.20.0"
+    commander "~2.20.3"
     source-map "~0.6.1"
 
 uglify-to-browserify@~1.0.0:
@@ -11553,6 +11659,11 @@ update-diff@^1.1.0:
   resolved "https://registry.yarnpkg.com/update-diff/-/update-diff-1.1.0.tgz#f510182d81ee819fb82c3a6b22b62bbdeda7808f"
   integrity sha1-9RAYLYHugZ+4LDprIrYrve2ngI8=
 
+upper-case@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
+  integrity sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=
+
 uri-js@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
@@ -11596,7 +11707,7 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-util.promisify@~1.0.0:
+util.promisify@1.0.0, util.promisify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"
   integrity sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==
@@ -11617,6 +11728,11 @@ util@^0.11.0:
   integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
   dependencies:
     inherits "2.0.3"
+
+utila@^0.4.0, utila@~0.4:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
+  integrity sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=
 
 utils-copy-error@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This sets up webpack [code splitting](https://webpack.js.org/guides/code-splitting/) using [SplitChunksPlugin](https://webpack.js.org/plugins/split-chunks-plugin/). We can now share sections of our code between different entry points—no more duplication between the `app` entry and the `common` entry, for example. Each page now uses a single webpack entry, split into multiple chunks—no more duplication between multiple entries included on one page. Best of all, webpack computes the split automatically, so we can go forward with modularization work without having to worry about this nonsense. The release tarball magically shrinks by 1.3 MB compressed, 4.9 MB uncompressed.

There is one caveat, hence the draft marker: code splitting necessarily entails giving up some control over the inclusion order of CSS files, which it turns out we were incorrectly relying on. Some of these bugs are known and not yet fixed here, mostly due to `media.scss`, whose rules must be included after the rules they override. There will probably be others that can only realistically be uncovered through QA.

**Testing Plan:** Dev server, production (https://andersk.zulipdev.org)