### PR TITLE
Clean up typing-status logic

### DIFF
--- a/frontend_tests/node_tests/typing_status.js
+++ b/frontend_tests/node_tests/typing_status.js
@@ -16,7 +16,7 @@ run_test('basics', () => {
 
     // invalid conversation basically does nothing
     var worker = {};
-    typing_status.handle_text_input(worker, "alice", false);
+    typing_status.handle_text_input(worker, undefined);
 
     // Start setting up more testing state.
     typing_status.initialize_state();
@@ -53,9 +53,9 @@ run_test('basics', () => {
         events.timer_cleared = false;
     }
 
-    function call_handler(new_recipient, conversation_is_valid) {
+    function call_handler(new_recipient) {
         clear_events();
-        typing_status.handle_text_input(worker, new_recipient, conversation_is_valid);
+        typing_status.handle_text_input(worker, new_recipient);
     }
 
     function call_stop() {
@@ -70,7 +70,7 @@ run_test('basics', () => {
     };
 
     // Start talking to alice.
-    call_handler("alice", true);
+    call_handler("alice");
     assert.deepEqual(typing_status.state, {
         next_send_start_time: make_time(5 + 10),
         idle_timer: 'idle_timer_stub',
@@ -86,7 +86,7 @@ run_test('basics', () => {
 
     // type again 3 seconds later
     worker.get_current_time = returns_time(8);
-    call_handler("alice", true);
+    call_handler("alice");
     assert.deepEqual(typing_status.state, {
         next_send_start_time: make_time(5 + 10),
         idle_timer: 'idle_timer_stub',
@@ -103,7 +103,7 @@ run_test('basics', () => {
     // type after 15 secs, so that we can notify the server
     // again
     worker.get_current_time = returns_time(18);
-    call_handler("alice", true);
+    call_handler("alice");
     assert.deepEqual(typing_status.state, {
         next_send_start_time: make_time(18 + 10),
         idle_timer: 'idle_timer_stub',
@@ -148,7 +148,7 @@ run_test('basics', () => {
 
     // Start talking to alice again.
     worker.get_current_time = returns_time(50);
-    call_handler("alice", true);
+    call_handler("alice");
     assert.deepEqual(typing_status.state, {
         next_send_start_time: make_time(50 + 10),
         idle_timer: 'idle_timer_stub',
@@ -178,7 +178,7 @@ run_test('basics', () => {
 
     // Start talking to alice again.
     worker.get_current_time = returns_time(80);
-    call_handler("alice", true);
+    call_handler("alice");
     assert.deepEqual(typing_status.state, {
         next_send_start_time: make_time(80 + 10),
         idle_timer: 'idle_timer_stub',
@@ -193,7 +193,7 @@ run_test('basics', () => {
     assert(events.idle_callback);
 
     // Switch to an invalid conversation.
-    call_handler('not-alice', false);
+    call_handler(undefined);
     assert.deepEqual(typing_status.state, {
         next_send_start_time: undefined,
         idle_timer: undefined,
@@ -207,7 +207,7 @@ run_test('basics', () => {
     });
 
     // Switch to another invalid conversation.
-    call_handler('another-bogus-one', false);
+    call_handler(undefined);
     assert.deepEqual(typing_status.state, {
         next_send_start_time: undefined,
         idle_timer: undefined,
@@ -222,7 +222,7 @@ run_test('basics', () => {
 
     // Start talking to alice again.
     worker.get_current_time = returns_time(170);
-    call_handler("alice", true);
+    call_handler("alice");
     assert.deepEqual(typing_status.state, {
         next_send_start_time: make_time(170 + 10),
         idle_timer: 'idle_timer_stub',
@@ -244,7 +244,7 @@ run_test('basics', () => {
         events.started = true;
     };
 
-    call_handler("bob", true);
+    call_handler("bob");
     assert.deepEqual(typing_status.state, {
         next_send_start_time: make_time(171 + 10),
         idle_timer: 'idle_timer_stub',
@@ -281,12 +281,12 @@ run_test('basics', () => {
 
     // User ids of poeple in compose narrow doesn't change and is same as stat.current_recipent
     // so counts of function should increase except stop_last_notification
-    typing_status.handle_text_input(worker, typing.get_recipient(), true);
+    typing_status.handle_text_input(worker, typing.get_recipient());
     assert.deepEqual(call_count.maybe_ping_server, 1);
     assert.deepEqual(call_count.start_or_extend_idle_timer, 1);
     assert.deepEqual(call_count.stop_last_notification, 0);
 
-    typing_status.handle_text_input(worker, typing.get_recipient(), true);
+    typing_status.handle_text_input(worker, typing.get_recipient());
     assert.deepEqual(call_count.maybe_ping_server, 2);
     assert.deepEqual(call_count.start_or_extend_idle_timer, 2);
     assert.deepEqual(call_count.stop_last_notification, 0);
@@ -294,7 +294,7 @@ run_test('basics', () => {
     // change in recipient and new_recipient should make us
     // call typing_status.stop_last_notification
     compose_pm_pill.get_user_ids_string = () => '2,3,4';
-    typing_status.handle_text_input(worker, typing.get_recipient(), true);
+    typing_status.handle_text_input(worker, typing.get_recipient());
     assert.deepEqual(call_count.maybe_ping_server, 2);
     assert.deepEqual(call_count.start_or_extend_idle_timer, 3);
     assert.deepEqual(call_count.stop_last_notification, 1);

--- a/frontend_tests/node_tests/typing_status.js
+++ b/frontend_tests/node_tests/typing_status.js
@@ -58,11 +58,6 @@ run_test('basics', () => {
         typing_status.update(worker, new_recipient);
     }
 
-    function call_stop() {
-        clear_events();
-        typing_status.stop(worker);
-    }
-
     worker = {
         get_current_time: returns_time(5),
         notify_server_start: notify_server_start,
@@ -133,7 +128,7 @@ run_test('basics', () => {
     });
 
     // Call stop with nothing going on.
-    call_stop();
+    call_handler(undefined);
     assert.deepEqual(typing_status.state, {
         next_send_start_time: undefined,
         idle_timer: undefined,
@@ -163,7 +158,7 @@ run_test('basics', () => {
     assert(events.idle_callback);
 
     // Explicitly stop alice.
-    call_stop();
+    call_handler(undefined);
     assert.deepEqual(typing_status.state, {
         next_send_start_time: undefined,
         idle_timer: undefined,

--- a/frontend_tests/node_tests/typing_status.js
+++ b/frontend_tests/node_tests/typing_status.js
@@ -16,7 +16,7 @@ run_test('basics', () => {
 
     // invalid conversation basically does nothing
     var worker = {};
-    typing_status.handle_text_input(worker, undefined);
+    typing_status.update(worker, undefined);
 
     // Start setting up more testing state.
     typing_status.initialize_state();
@@ -55,7 +55,7 @@ run_test('basics', () => {
 
     function call_handler(new_recipient) {
         clear_events();
-        typing_status.handle_text_input(worker, new_recipient);
+        typing_status.update(worker, new_recipient);
     }
 
     function call_stop() {
@@ -281,12 +281,12 @@ run_test('basics', () => {
 
     // User ids of poeple in compose narrow doesn't change and is same as stat.current_recipent
     // so counts of function should increase except stop_last_notification
-    typing_status.handle_text_input(worker, typing.get_recipient());
+    typing_status.update(worker, typing.get_recipient());
     assert.deepEqual(call_count.maybe_ping_server, 1);
     assert.deepEqual(call_count.start_or_extend_idle_timer, 1);
     assert.deepEqual(call_count.stop_last_notification, 0);
 
-    typing_status.handle_text_input(worker, typing.get_recipient());
+    typing_status.update(worker, typing.get_recipient());
     assert.deepEqual(call_count.maybe_ping_server, 2);
     assert.deepEqual(call_count.start_or_extend_idle_timer, 2);
     assert.deepEqual(call_count.stop_last_notification, 0);
@@ -294,7 +294,7 @@ run_test('basics', () => {
     // change in recipient and new_recipient should make us
     // call typing_status.stop_last_notification
     compose_pm_pill.get_user_ids_string = () => '2,3,4';
-    typing_status.handle_text_input(worker, typing.get_recipient());
+    typing_status.update(worker, typing.get_recipient());
     assert.deepEqual(call_count.maybe_ping_server, 2);
     assert.deepEqual(call_count.start_or_extend_idle_timer, 3);
     assert.deepEqual(call_count.stop_last_notification, 1);

--- a/frontend_tests/node_tests/typing_status.js
+++ b/frontend_tests/node_tests/typing_status.js
@@ -266,6 +266,7 @@ run_test('basics', () => {
 
     const call_count = {
         maybe_ping_server: 0,
+        actually_ping_server: 0,
         start_or_extend_idle_timer: 0,
         stop_last_notification: 0,
     };
@@ -280,12 +281,12 @@ run_test('basics', () => {
 
     // User ids of poeple in compose narrow doesn't change and is same as stat.current_recipent
     // so counts of function should increase except stop_last_notification
-    typing_status.handle_text_input(worker, typing.get_recipient(), false);
+    typing_status.handle_text_input(worker, typing.get_recipient(), true);
     assert.deepEqual(call_count.maybe_ping_server, 1);
     assert.deepEqual(call_count.start_or_extend_idle_timer, 1);
     assert.deepEqual(call_count.stop_last_notification, 0);
 
-    typing_status.handle_text_input(worker, typing.get_recipient(), false);
+    typing_status.handle_text_input(worker, typing.get_recipient(), true);
     assert.deepEqual(call_count.maybe_ping_server, 2);
     assert.deepEqual(call_count.start_or_extend_idle_timer, 2);
     assert.deepEqual(call_count.stop_last_notification, 0);
@@ -293,8 +294,8 @@ run_test('basics', () => {
     // change in recipient and new_recipient should make us
     // call typing_status.stop_last_notification
     compose_pm_pill.get_user_ids_string = () => '2,3,4';
-    typing_status.handle_text_input(worker, typing.get_recipient(), false);
+    typing_status.handle_text_input(worker, typing.get_recipient(), true);
     assert.deepEqual(call_count.maybe_ping_server, 2);
-    assert.deepEqual(call_count.start_or_extend_idle_timer, 2);
+    assert.deepEqual(call_count.start_or_extend_idle_timer, 3);
     assert.deepEqual(call_count.stop_last_notification, 1);
 });

--- a/frontend_tests/node_tests/typing_status.js
+++ b/frontend_tests/node_tests/typing_status.js
@@ -16,7 +16,7 @@ run_test('basics', () => {
 
     // invalid conversation basically does nothing
     var worker = {};
-    typing_status.update(worker, undefined);
+    typing_status.update(worker, null);
 
     // Start setting up more testing state.
     typing_status.initialize_state();
@@ -128,7 +128,7 @@ run_test('basics', () => {
     });
 
     // Call stop with nothing going on.
-    call_handler(undefined);
+    call_handler(null);
     assert.deepEqual(typing_status.state, {
         next_send_start_time: undefined,
         idle_timer: undefined,
@@ -158,7 +158,7 @@ run_test('basics', () => {
     assert(events.idle_callback);
 
     // Explicitly stop alice.
-    call_handler(undefined);
+    call_handler(null);
     assert.deepEqual(typing_status.state, {
         next_send_start_time: undefined,
         idle_timer: undefined,
@@ -188,7 +188,7 @@ run_test('basics', () => {
     assert(events.idle_callback);
 
     // Switch to an invalid conversation.
-    call_handler(undefined);
+    call_handler(null);
     assert.deepEqual(typing_status.state, {
         next_send_start_time: undefined,
         idle_timer: undefined,
@@ -202,7 +202,7 @@ run_test('basics', () => {
     });
 
     // Switch to another invalid conversation.
-    call_handler(undefined);
+    call_handler(null);
     assert.deepEqual(typing_status.state, {
         next_send_start_time: undefined,
         idle_timer: undefined,

--- a/static/js/typing.js
+++ b/static/js/typing.js
@@ -39,10 +39,6 @@ function is_valid_conversation(user_ids_array) {
         return false;
     }
 
-    if (compose_pm_pill.has_unconverted_data()) {
-        return true;
-    }
-
     var compose_empty = !compose_state.has_message_content();
     if (compose_empty) {
         return false;

--- a/static/js/typing.js
+++ b/static/js/typing.js
@@ -72,7 +72,7 @@ exports.initialize = function () {
     // We send a stop-typing notification immediately when compose is
     // closed/cancelled
     $(document).on('compose_canceled.zulip compose_finished.zulip', function () {
-        typing_status.stop(worker);
+        typing_status.update(worker, undefined);
     });
 };
 

--- a/static/js/typing.js
+++ b/static/js/typing.js
@@ -75,8 +75,6 @@ function notify_server_stop(user_ids_array) {
 exports.get_recipient = get_user_ids_array;
 exports.initialize = function () {
     var worker = {
-        get_recipient: exports.get_recipient,
-        is_valid_conversation: is_valid_conversation,
         get_current_time: get_current_time,
         notify_server_start: notify_server_start,
         notify_server_stop: notify_server_stop,
@@ -85,7 +83,9 @@ exports.initialize = function () {
     $(document).on('input', '#compose-textarea', function () {
         // If our previous state was no typing notification, send a
         // start-typing notice immediately.
-        typing_status.handle_text_input(worker);
+        var new_recipient = exports.get_recipient();
+        typing_status.handle_text_input(
+            worker, new_recipient, is_valid_conversation(new_recipient));
     });
 
     // We send a stop-typing notification immediately when compose is

--- a/static/js/typing.js
+++ b/static/js/typing.js
@@ -26,7 +26,7 @@ function send_typing_notification_ajax(user_ids_array, operation) {
 function get_user_ids_array() {
     var user_ids_string = compose_pm_pill.get_user_ids_string();
     if (user_ids_string === "") {
-        return;
+        return null;
     }
 
     return people.user_ids_string_to_ids_array(user_ids_string);
@@ -65,14 +65,14 @@ exports.initialize = function () {
         // If our previous state was no typing notification, send a
         // start-typing notice immediately.
         var new_recipient =
-          is_valid_conversation() ? exports.get_recipient() : undefined;
+          is_valid_conversation() ? exports.get_recipient() : null;
         typing_status.update(worker, new_recipient);
     });
 
     // We send a stop-typing notification immediately when compose is
     // closed/cancelled
     $(document).on('compose_canceled.zulip compose_finished.zulip', function () {
-        typing_status.update(worker, undefined);
+        typing_status.update(worker, null);
     });
 };
 

--- a/static/js/typing.js
+++ b/static/js/typing.js
@@ -66,7 +66,7 @@ exports.initialize = function () {
         // start-typing notice immediately.
         var new_recipient =
           is_valid_conversation() ? exports.get_recipient() : undefined;
-        typing_status.handle_text_input(worker, new_recipient);
+        typing_status.update(worker, new_recipient);
     });
 
     // We send a stop-typing notification immediately when compose is

--- a/static/js/typing.js
+++ b/static/js/typing.js
@@ -48,15 +48,6 @@ function is_valid_conversation(user_ids_array) {
         return false;
     }
 
-    if (compose_state.get_message_type() !== 'private') {
-        // We only use typing indicators in PMs for now.
-        // There was originally some support for having
-        // typing indicators related to stream conversations,
-        // but the initial rollout led to users being
-        // confused by them.  We may revisit this.
-        return false;
-    }
-
     return true;
 }
 

--- a/static/js/typing.js
+++ b/static/js/typing.js
@@ -32,13 +32,7 @@ function get_user_ids_array() {
     return people.user_ids_string_to_ids_array(user_ids_string);
 }
 
-function is_valid_conversation(user_ids_array) {
-    // TODO: Check to make sure we're in a PM conversation
-    //       with valid emails.
-    if (!user_ids_array) {
-        return false;
-    }
-
+function is_valid_conversation() {
     var compose_empty = !compose_state.has_message_content();
     if (compose_empty) {
         return false;
@@ -70,9 +64,9 @@ exports.initialize = function () {
     $(document).on('input', '#compose-textarea', function () {
         // If our previous state was no typing notification, send a
         // start-typing notice immediately.
-        var new_recipient = exports.get_recipient();
-        typing_status.handle_text_input(
-            worker, new_recipient, is_valid_conversation(new_recipient));
+        var new_recipient =
+          is_valid_conversation() ? exports.get_recipient() : undefined;
+        typing_status.handle_text_input(worker, new_recipient);
     });
 
     // We send a stop-typing notification immediately when compose is

--- a/static/shared/js/typing_status.js
+++ b/static/shared/js/typing_status.js
@@ -85,7 +85,7 @@ export function maybe_ping_server(worker, recipient) {
     }
 }
 
-export function handle_text_input(worker, new_recipient, conversation_is_valid) {
+export function handle_text_input(worker, new_recipient) {
     var current_recipient = state.current_recipient;
     if (current_recipient) {
         // We need to use _.isEqual for comparisons; === doesn't work
@@ -107,7 +107,7 @@ export function handle_text_input(worker, new_recipient, conversation_is_valid) 
         stop_last_notification(worker);
     }
 
-    if (!conversation_is_valid) {
+    if (!new_recipient) {
         // If we are not talking to somebody we care about,
         // then there is no more action to take.
         return;

--- a/static/shared/js/typing_status.js
+++ b/static/shared/js/typing_status.js
@@ -130,12 +130,3 @@ export function update(worker, new_recipient) {
     actually_ping_server(worker, new_recipient, current_time);
     start_or_extend_idle_timer(worker);
 }
-
-export function stop(worker) {
-    // We get this if somebody closes the compose box, but
-    // it doesn't necessarily mean we had typing indicators
-    // active before this.
-    if (state.current_recipient) {
-        stop_last_notification(worker);
-    }
-}

--- a/static/shared/js/typing_status.js
+++ b/static/shared/js/typing_status.js
@@ -21,9 +21,7 @@ var TYPING_STOPPED_WAIT_PERIOD = 5000; // 5s
 
         notify_server_start
         notify_server_stop
-        get_recipient
         get_current_time
-        is_valid_conversation
 
     See typing.js for the implementations of the above. (Our
     node tests also act as workers and will stub those functions
@@ -87,10 +85,7 @@ export function maybe_ping_server(worker, recipient) {
     }
 }
 
-export function handle_text_input(worker) {
-    var new_recipient = worker.get_recipient();
-    var conversation_is_valid = worker.is_valid_conversation(new_recipient);
-
+export function handle_text_input(worker, new_recipient, conversation_is_valid) {
     var current_recipient = state.current_recipient;
     if (current_recipient) {
         // We need to use _.isEqual for comparisons; === doesn't work

--- a/static/shared/js/typing_status.js
+++ b/static/shared/js/typing_status.js
@@ -17,8 +17,8 @@ export const state = {};
 
 /** Exported only for tests. */
 export function initialize_state() {
-    state.current_recipient =  undefined;
-    state.next_send_start_time =  undefined;
+    state.current_recipient = null;
+    state.next_send_start_time = undefined;
     state.idle_timer = undefined;
 }
 
@@ -81,9 +81,9 @@ export function maybe_ping_server(worker, recipient) {
  * composing a stream message should be treated like composing no message at
  * all.
  *
- * Call with `new_recipient` of `undefined` when the user actively stops
+ * Call with `new_recipient` of `null` when the user actively stops
  * composing a message.  If the user switches from one set of recipients to
- * another, there's no need to call with `undefined` in between; the
+ * another, there's no need to call with `null` in between; the
  * implementation tracks the change and behaves appropriately.
  *
  * See docs/subsystems/typing-indicators.md for detailed background on the
@@ -92,12 +92,12 @@ export function maybe_ping_server(worker, recipient) {
  * @param {*} worker Callbacks for reaching the real world.  See typing.js
  *   for implementations.
  * @param {*} new_recipient The users the PM being composed is addressed to,
- *   as a sorted array of user IDs; or `undefined` if no PM is being
- *   composed anymore.
+ *   as a sorted array of user IDs; or `null` if no PM is being composed
+ *   anymore.
  */
 export function update(worker, new_recipient) {
     var current_recipient = state.current_recipient;
-    if (current_recipient) {
+    if (current_recipient !== null) {
         // We need to use _.isEqual for comparisons; === doesn't work
         // on arrays.
         if (_.isEqual(new_recipient, current_recipient)) {
@@ -117,7 +117,7 @@ export function update(worker, new_recipient) {
         stop_last_notification(worker);
     }
 
-    if (!new_recipient) {
+    if (new_recipient === null) {
         // If we are not talking to somebody we care about,
         // then there is no more action to take.
         return;

--- a/static/shared/js/typing_status.js
+++ b/static/shared/js/typing_status.js
@@ -89,8 +89,9 @@ export function maybe_ping_server(worker, recipient) {
 
 export function handle_text_input(worker) {
     var new_recipient = worker.get_recipient();
-    var current_recipient = state.current_recipient;
+    var conversation_is_valid = worker.is_valid_conversation(new_recipient);
 
+    var current_recipient = state.current_recipient;
     if (current_recipient) {
         // We need to use _.isEqual for comparisons; === doesn't work
         // on arrays.
@@ -111,7 +112,7 @@ export function handle_text_input(worker) {
         stop_last_notification(worker);
     }
 
-    if (!worker.is_valid_conversation(new_recipient)) {
+    if (!conversation_is_valid) {
         // If we are not talking to somebody we care about,
         // then there is no more action to take.
         return;

--- a/static/shared/js/typing_status.js.flow
+++ b/static/shared/js/typing_status.js.flow
@@ -16,5 +16,3 @@ declare export function update(
   worker: Worker,
   new_recipient: RecipientUserIds | void,
 ): void;
-
-declare export function stop(worker: Worker): void;

--- a/static/shared/js/typing_status.js.flow
+++ b/static/shared/js/typing_status.js.flow
@@ -14,5 +14,5 @@ type Worker = {|
 
 declare export function update(
   worker: Worker,
-  new_recipient: RecipientUserIds | void,
+  new_recipient: RecipientUserIds | null
 ): void;

--- a/static/shared/js/typing_status.js.flow
+++ b/static/shared/js/typing_status.js.flow
@@ -12,7 +12,7 @@ type Worker = {|
   notify_server_stop: RecipientUserIds => void
 |};
 
-declare export function handle_text_input(
+declare export function update(
   worker: Worker,
   new_recipient: RecipientUserIds | void,
 ): void;

--- a/static/shared/js/typing_status.js.flow
+++ b/static/shared/js/typing_status.js.flow
@@ -15,7 +15,6 @@ type Worker = {|
 declare export function handle_text_input(
   worker: Worker,
   new_recipient: RecipientUserIds | void,
-  conversation_is_valid: boolean
 ): void;
 
 declare export function stop(worker: Worker): void;

--- a/static/shared/js/typing_status.js.flow
+++ b/static/shared/js/typing_status.js.flow
@@ -7,13 +7,15 @@
 type RecipientUserIds = number[];
 
 type Worker = {|
-  get_recipient: () => RecipientUserIds | void,
-  is_valid_conversation: (RecipientUserIds | void) => boolean,
   get_current_time: () => number, // as ms since epoch
   notify_server_start: RecipientUserIds => void,
   notify_server_stop: RecipientUserIds => void
 |};
 
-declare export function handle_text_input(Worker): void;
+declare export function handle_text_input(
+  worker: Worker,
+  new_recipient: RecipientUserIds | void,
+  conversation_is_valid: boolean
+): void;
 
-declare export function stop(Worker): void;
+declare export function stop(worker: Worker): void;

--- a/static/shared/package.json
+++ b/static/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zulip/shared",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "Apache-2.0",
   "dependencies": {
     "underscore": "^1.9.1"


### PR DESCRIPTION
The main effect of this is to make the API and implementation simpler and easier to reason about, and the API embed fewer assumptions. The main motivation for that is to make it fit much more naturally in another client: the mobile app currently has [a wrapper around this module](https://github.com/zulip/zulip-mobile/blob/ab62aadc86a8f61387c099586b8b6859fba7b17e/src/users/usersActions.js#L70) that presents essentially the same interface as this branch does.

The commit "typing status: Cut unconverted_data conditional." fixes a small bug, where we didn't send typing notifications in a certain case even though the user types out a PM and sends it.


**Testing Plan:**

Unit tests, and also manual testing on dev server.

I also have a draft branch to switch mobile to use this (deleting about 60 lines of code :tada:), and it works too.
