### PR TITLE
hello: Fix carousel indicator buttons

### DIFF
--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -3,7 +3,7 @@
 {% block customhead %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <!-- Bootstrap 2.3.2-->
-<script src="https://stackpath.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js"></script>
+<script src="https://stackpath.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js" defer></script>
 
 {{ bundle('landing-page') }}
 <style>


### PR DESCRIPTION
Apparently deferring our own Bootstrap (commit f1ecd3c18b9ae9cf914221d8e29ecf0015067ed0, #13164) means that this surprise copy of Bootstrap 2.3.2 also needs to be deferred.  What is this even doing here.

**Testing Plan:** Dev server.