### PR TITLE
version: Only let `git describe` match tags beginning with a digit

### DIFF
--- a/tools/cache-zulip-git-version
+++ b/tools/cache-zulip-git-version
@@ -2,4 +2,4 @@
 set -e
 
 cd "$(dirname "$0")/.."
-git describe --tags > zulip-git-version || true
+git describe --tags --match='[0-9]*' > zulip-git-version || true

--- a/zerver/logging_handlers.py
+++ b/zerver/logging_handlers.py
@@ -18,7 +18,7 @@ from version import ZULIP_VERSION
 def try_git_describe() -> Optional[str]:
     try:  # nocoverage
         return subprocess.check_output(
-            ['git', 'describe', '--tags', '--always', '--dirty', '--long'],
+            ['git', 'describe', '--tags', '--match=[0-9]*', '--always', '--dirty', '--long'],
             stderr=subprocess.PIPE,
             cwd=os.path.join(os.path.dirname(__file__), '..'),
         ).strip().decode('utf-8')


### PR DESCRIPTION
This will let us use other tags for things like `@zulip/shared` versions.

**Testing Plan:**

```console
$ tools/cache-zulip-git-version 
$ cat zulip-git-version 
2.0.0-2832-g2aeb281dc1
```