### PR TITLE
test-backend, run-casper: Remove proxy vars instead of setting to ""

### DIFF
--- a/frontend_tests/run-casper
+++ b/frontend_tests/run-casper
@@ -18,8 +18,8 @@ ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 os.environ["CASPER_TESTS"] = "1"
 os.environ["PHANTOMJS_EXECUTABLE"] = os.path.join(ZULIP_PATH, "node_modules/.bin/phantomjs")
-os.environ["http_proxy"] = ""
-os.environ["https_proxy"] = ""
+os.environ.pop("http_proxy", "")
+os.environ.pop("https_proxy", "")
 
 usage = """test-js-with-casper [options]
     test-js-with-casper # Run all test files

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -189,8 +189,8 @@ def main() -> None:
     default_parallel = os.cpu_count()
 
     # Remove proxy settings for running backend tests
-    os.environ["http_proxy"] = ""
-    os.environ["https_proxy"] = ""
+    os.environ.pop("http_proxy", "")
+    os.environ.pop("https_proxy", "")
 
     from zerver.lib.test_fixtures import update_test_databases_if_required, \
         remove_test_run_directories


### PR DESCRIPTION
Setting `http_proxy` to the empty string caused a spurious error from `xmlsec`:

```pycon
>>> import os
>>> os.environ["http_proxy"] = ""
>>> import xmlsec
error : Unknown IO error
```