### PR TITLE
node_cache: Don’t retry copying node_modules; let yarn do its thing

### DIFF
--- a/scripts/lib/node_cache.py
+++ b/scripts/lib/node_cache.py
@@ -82,7 +82,7 @@ def do_yarn_install(target_path, yarn_args, success_stamp, stdout=None, stderr=N
     print("Cached version not found! Installing node modules.")
 
     # Copy the existing node_modules to speed up install
-    if os.path.exists("node_modules"):
+    if os.path.exists("node_modules") and not os.path.exists(cached_node_modules):
         shutil.copytree("node_modules/", cached_node_modules, symlinks=True)
     if os.environ.get('CUSTOM_CA_CERTIFICATES'):
         run([YARN_BIN, "config", "set", "cafile", os.environ['CUSTOM_CA_CERTIFICATES']],


### PR DESCRIPTION
`copytree` throws an error if the target already exists, and we don’t really want to rerun the copy anyway.