### PR TITLE
Update ldap docs to reflect that ldap backend now works for initial realm creation.

### DIFF
--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -137,13 +137,7 @@ optionally using LDAP as an authentication mechanism.
 
 In either configuration, you will need to do the following:
 
-1. Create your organization and first administrator account using
-   another authentication backend (usually `EmailAuthBackend`).  LDAP
-   authentication does not support organization creation at this time;
-   but you can disable `EmailAuthBackend` once you have created the
-   organization.
-
-2. Tell Zulip how to connect to your LDAP server:
+1. Tell Zulip how to connect to your LDAP server:
    * Fill out the section of your `/etc/zulip/settings.py` headed "LDAP
      integration, part 1: Connecting to the LDAP server".
    * If a password is required, put it in
@@ -151,7 +145,7 @@ In either configuration, you will need to do the following:
      `auth_ldap_bind_password`.  For example: `auth_ldap_bind_password
      = abcd1234`.
 
-3. Decide how you want to map the information in your LDAP database to
+2. Decide how you want to map the information in your LDAP database to
    users' account data in Zulip.  For each Zulip user, two closely
    related concepts are:
    * their **email address**.  Zulip needs this in order to send, for
@@ -166,7 +160,7 @@ In either configuration, you will need to do the following:
    Either or both of these might be an attribute of the user records
    in your LDAP database.
 
-4. Tell Zulip how to map the user information in your LDAP database to
+3. Tell Zulip how to map the user information in your LDAP database to
    the form it needs for authentication.  There are three supported
    ways to set up the username and/or email mapping:
 
@@ -184,7 +178,7 @@ In either configuration, you will need to do the following:
       To do this, set `AUTH_LDAP_USER_SEARCH` to query by LDAP
       username, and `LDAP_EMAIL_ATTR = "email"`.
 
-5. In configurations (A) and (C), you need to tell Zulip how to look
+4. In configurations (A) and (C), you need to tell Zulip how to look
    up a user's LDAP data given their user's email address:
 
    * Set `AUTH_LDAP_REVERSE_EMAIL_SEARCH` to a query that will find an


### PR DESCRIPTION
Closes #9576.

I tested on a new production installation, where I configured LDAP, made it the only enabled backend and went through the inital realm creation process - everything seemed to work fine, so I think the issue should be considered fixed.

First realm creation now works fine with the LDAP backend, so that part
of the docs is unnecessary and just complicates the setup process, so it
seems best to just remove it.
