### PR TITLE
docs: Document social_backends in /server_settings.

### DIFF
--- a/templates/zerver/api/server-settings.md
+++ b/templates/zerver/api/server-settings.md
@@ -54,6 +54,14 @@ Fetch global settings for a Zulip server.
   mobile and desktop apps.
 * `realm_description`: HTML description of the organization, as configured by
   the [organization profile](/help/create-your-organization-profile).
+* `social_backends`: list of dictionaries describing the available social
+  authentication backends (such as google/github/SAML). Each dictionary specifies
+  the name and icon that should be displayed on the login buttons (`display_name`
+  and `display_icon`, where `display_icon` can be the empty string, if no icon
+  is to be displayed), the URLs that should be accessed to initiate login/signup
+  with the backend (`login_url` and `signup_url`) and `sort_order` (number
+  specifying in what order to show the login buttons for the social backends -
+  those with higher `sort_order` should be shown first).
 
 [ldap-auth]: https://zulip.readthedocs.io/en/latest/production/authentication-methods.html#ldap-including-active-directory
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2143,27 +2143,54 @@ paths:
                         [organization profile](/help/create-your-organization-profile).
                 - example:
                     {
-                        "realm_uri": "http://localhost:9991",
+                        "authentication_methods": {
+                          "password": true,
+                          "dev": true,
+                          "email": true,
+                          "ldap": false,
+                          "remoteuser": false,
+                          "github": true,
+                          "azuread": false,
+                          "google": true,
+                          "saml": true
+                        },
+                        "zulip_version": "2.0.6+git",
                         "push_notifications_enabled": false,
                         "msg": "",
-                        "realm_icon": "https://secure.gravatar.com/avatar/62429d594b6ffc712f54aee976a18b44?d=identicon",
-                        "realm_logo": "/static/images/logo/zulip-org-logo.png",
-                        "realm_night_logo": "static/images/logo/zulip-org-logo.png",
-                        "realm_description": "<p>The Zulip development environment default organization.  It's great for testing!</p>",
+                        "is_incompatible": false,
                         "email_auth_enabled": true,
-                        "zulip_version": "1.9.0-rc1+git",
+                        "require_email_format_usernames": true,
+                        "realm_uri": "http://localhost:9991",
                         "realm_name": "Zulip Dev",
-                        "authentication_methods": {
-                            "github": true,
-                            "ldap": false,
-                            "password": true,
-                            "remoteuser": false,
-                            "email": true,
-                            "google": true,
-                            "dev": true
-                        },
+                        "realm_icon": "https://secure.gravatar.com/avatar/62429d594b6ffc712f54aee976a18b44?d=identicon",
+                        "realm_description": "<p>The Zulip development environment default organization.  It's great for testing!</p>",
                         "result": "success",
-                        "require_email_format_usernames": true
+                        "social_backends": [
+                          {
+                            "name": "saml:idp_name",
+                            "display_name": "SAML",
+                            "display_logo": "",
+                            "login_url": "/accounts/login/social/saml/idp_name",
+                            "signup_url": "/accounts/register/social/saml/idp_name",
+                            "sort_order": 9999
+                          },
+                          {
+                            "name": "google",
+                            "display_name": "Google",
+                            "display_logo": "/static/images/landing-page/logos/googl_e-icon.png",
+                            "login_url": "/accounts/login/google/",
+                            "signup_url": "/accounts/register/social/google",
+                            "sort_order": 150
+                          },
+                          {
+                            "name": "github",
+                            "display_name": "GitHub",
+                            "display_logo": "/static/images/landing-page/logos/github-icon.png",
+                            "login_url": "/accounts/login/social/github",
+                            "signup_url": "/accounts/register/social/github",
+                            "sort_order": 100
+                          }
+                        ]
                     }
   /settings/notifications:
     patch:


### PR DESCRIPTION
This updates the docs for the /server_settings endpoint to document the
newly added social_backends structure.