### PR TITLE
nginx: Enable TLS 1.3 if supported

### DIFF
--- a/puppet/zulip/manifests/nginx.pp
+++ b/puppet/zulip/manifests/nginx.pp
@@ -65,7 +65,7 @@ class zulip::nginx {
     group   => 'root',
     mode    => '0644',
     notify  => Service['nginx'],
-    source  => 'puppet:///modules/zulip/nginx/nginx.conf',
+    content => template('zulip/nginx.conf.template.erb'),
   }
 
   file { '/etc/nginx/uwsgi_params':

--- a/puppet/zulip/templates/nginx.conf.template.erb
+++ b/puppet/zulip/templates/nginx.conf.template.erb
@@ -53,7 +53,11 @@ http {
     ssl_session_cache shared:SSL:50m;
     ssl_session_tickets off;
     ssl_dhparam /etc/nginx/dhparam.pem;
+<% if scope["zulip::base::release_name"] == "stretch" or scope["zulip::base::release_name"] == "xenial" -%>
     ssl_protocols TLSv1.2;
+<% else -%>
+    ssl_protocols TLSv1.2 TLSv1.3;
+<% end -%>
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers off;
     ssl_stapling on;


### PR DESCRIPTION
**Testing Plan:** Production tested on stretch (TLS 1.2), buster (TLS 1.2+1.3), and bionic (TLS 1.2+1.3).