### PR TITLE
security: Send SameSite=Lax cookies

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -179,3 +179,6 @@ decorator
 
 # Needed for SAML authentication.
 python3-saml
+
+# Use SameSite cookies in legacy Django (remove with Django 2.1)
+django-cookies-samesite

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -245,6 +245,8 @@ https://github.com/zulip/django-auth-ldap/archive/e26d0ef2a7ff77ab3fdd7b6578a760
 django-bitfield==1.9.6 \
     --hash=sha256:d32fc6610f80b0b17a832a487ae18860a563d9a9842259d0d37ae1e62a1854ab \
     --hash=sha256:e8d4dc8727d4d655f1f740771beb6566d1928f7270c1c020cf5af278784f2843
+django-cookies-samesite==0.2.0 \
+    --hash=sha256:b393f8e2e1c758af952ea10afe44fe837a68a182119fdfbab2fa00f67deded0e
 django-formtools==2.1 \
     --hash=sha256:7703793f1675aa6e871f9fed147e8563816d7a5b9affdc5e3459899596217f7c \
     --hash=sha256:cb2bd7c29c2104278e5a0e76f7ff256b9570acf11485d547ee0c1b35347359fb \

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -161,6 +161,8 @@ https://github.com/zulip/django-auth-ldap/archive/e26d0ef2a7ff77ab3fdd7b6578a760
 django-bitfield==1.9.6 \
     --hash=sha256:d32fc6610f80b0b17a832a487ae18860a563d9a9842259d0d37ae1e62a1854ab \
     --hash=sha256:e8d4dc8727d4d655f1f740771beb6566d1928f7270c1c020cf5af278784f2843
+django-cookies-samesite==0.2.0 \
+    --hash=sha256:b393f8e2e1c758af952ea10afe44fe837a68a182119fdfbab2fa00f67deded0e
 django-formtools==2.1 \
     --hash=sha256:7703793f1675aa6e871f9fed147e8563816d7a5b9affdc5e3459899596217f7c \
     --hash=sha256:cb2bd7c29c2104278e5a0e76f7ff256b9570acf11485d547ee0c1b35347359fb \

--- a/version.py
+++ b/version.py
@@ -26,4 +26,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/03/01/zulip-2-0-relea
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '61.0'
+PROVISION_VERSION = '61.1'

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -567,6 +567,7 @@ MIDDLEWARE = (
     'zerver.middleware.JsonErrorHandler',
     'zerver.middleware.RateLimitMiddleware',
     'zerver.middleware.FlushDisplayRecipientCache',
+    'django_cookies_samesite.middleware.CookiesSameSite',
     'django.middleware.common.CommonMiddleware',
     'zerver.middleware.SessionHostDomainMiddleware',
     'django.middleware.locale.LocaleMiddleware',
@@ -776,6 +777,9 @@ if PRODUCTION:
     domain = get_config('django', 'cookie_domain', None)
     if domain is not None:
         CSRF_COOKIE_DOMAIN = '.' + domain
+
+# Enable SameSite cookies (default in Django 2.1)
+SESSION_COOKIE_SAMESITE = 'Lax'
 
 # Prevent Javascript from reading the CSRF token from cookies.  Our code gets
 # the token from the DOM, which means malicious code could too.  But hiding the


### PR DESCRIPTION
Send the `csrftoken` and `sessionid` cookies with `SameSite=Lax`. This adds a layer of defense against CSRF attacks and matches the new [default in Django 2.1](https://docs.djangoproject.com/en/2.1/releases/2.1/#samesite-cookies). This can be reverted when we upgrade to Django ≥ 2.1.

**Testing Plan:** Dev server, production on https://andersk.zulipdev.org.