### PR TITLE
eslint: Enable sort-imports rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -390,6 +390,7 @@
         "radix": "error",
         "semi": "error",
         "semi-spacing": ["error", {"before": false, "after": true}],
+        "sort-imports": "error",
         "space-before-blocks": "error",
         "space-before-function-paren": [ "error",
             {

--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -3,8 +3,8 @@ const ELECTRON_APP_URL_LINUX = "https://github.com/zulip/zulip-desktop/releases/
 const ELECTRON_APP_URL_MAC = "https://github.com/zulip/zulip-desktop/releases/download/v" + ELECTRON_APP_VERSION + "/Zulip-" + ELECTRON_APP_VERSION + ".dmg";
 const ELECTRON_APP_URL_WINDOWS = "https://github.com/zulip/zulip-desktop/releases/download/v" + ELECTRON_APP_VERSION + "/Zulip-Web-Setup-" + ELECTRON_APP_VERSION + ".exe";
 
+import { detect_user_os } from './tabbed-instructions.js';
 import render_tabs from './team.js';
-import {detect_user_os}  from './tabbed-instructions.js';
 
 export function path_parts() {
     return window.location.pathname.split('/').filter(function (chunk) {

--- a/tools/webpack-helpers.ts
+++ b/tools/webpack-helpers.ts
@@ -1,5 +1,5 @@
-import { basename, resolve } from 'path';
 import { RuleSetRule, RuleSetUseItem } from 'webpack';
+import { basename, resolve } from 'path';
 
 export const cacheLoader: RuleSetUseItem = {
     loader: 'cache-loader',

--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -1,15 +1,15 @@
 import { basename, resolve } from 'path';
+import { cacheLoader, getExposeLoaders } from './webpack-helpers';
 import BundleTracker from 'webpack4-bundle-tracker';
-import webpack from 'webpack';
+import CleanCss from 'clean-css';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import MiniCssExtractPlugin from 'mini-css-extract-plugin';
+import OptimizeCssAssetsPlugin from 'optimize-css-assets-webpack-plugin';
+import TerserPlugin from 'terser-webpack-plugin';
 // The devServer member of webpack.Configuration is managed by the
 // webpack-dev-server package. We are only importing the type here.
 import _webpackDevServer from 'webpack-dev-server';
-import { getExposeLoaders, cacheLoader } from './webpack-helpers';
-import MiniCssExtractPlugin from 'mini-css-extract-plugin';
-import OptimizeCssAssetsPlugin from 'optimize-css-assets-webpack-plugin';
-import CleanCss from 'clean-css';
-import TerserPlugin from 'terser-webpack-plugin';
-import HtmlWebpackPlugin from 'html-webpack-plugin';
+import webpack from 'webpack';
 
 const assets = require('./webpack.assets.json');
 


### PR DESCRIPTION
I figure we should enable this before we have lots of imports.

**Testing Plan:** Dev server