### PR TITLE
api: Remove unused /get_auth_backends endpoint.

### DIFF
--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -182,7 +182,6 @@ class OpenAPIArgumentsTest(ZulipTestCase):
         '/dev_list_users',
         '/fetch_api_key',
         '/fetch_google_client_id',
-        '/get_auth_backends',
         '/settings',
         '/submessage',
         '/attachments',

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -808,13 +808,6 @@ def get_auth_backends_data(request: HttpRequest) -> Dict[str, Any]:
         result[key] = auth_enabled_helper([auth_backend_name], realm)
     return result
 
-@csrf_exempt
-def api_get_auth_backends(request: HttpRequest) -> HttpResponse:
-    """Deprecated route; this is to be replaced by api_get_server_settings"""
-    auth_backends = get_auth_backends_data(request)
-    auth_backends['zulip_version'] = ZULIP_VERSION
-    return json_success(auth_backends)
-
 def check_server_incompatibility(request: HttpRequest) -> bool:
     user_agent = parse_user_agent(request.META.get("HTTP_USER_AGENT", "Missing User-Agent"))
     return user_agent['name'] == "ZulipInvalid"

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -669,9 +669,6 @@ v1_api_mobile_patterns = [
     # like the requested subdomains'd realm icon (if known) and
     # server-specific compatibility.
     url(r'^server_settings$', zerver.views.auth.api_get_server_settings),
-    # This is a deprecated old version of api/v1/server_settings that only returns auth backends.
-    url(r'^get_auth_backends$', zerver.views.auth.api_get_auth_backends,
-        name='zerver.views.auth.api_get_auth_backends'),
 
     # This json format view used by the mobile apps accepts a username
     # password/pair and returns an API key.


### PR DESCRIPTION
It should be okay to delete, as discussed in https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/SAML.20authentication/near/792236