### PR TITLE
urls: Reorder where the accounts/login/google/ endpoint is defined.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2248,7 +2248,7 @@ paths:
                             "name": "google",
                             "display_name": "Google",
                             "display_logo": "/static/images/landing-page/logos/googl_e-icon.png",
-                            "login_url": "/accounts/login/google/",
+                            "login_url": "/accounts/login/social/google",
                             "signup_url": "/accounts/register/social/google",
                             "sort_order": 150
                           },

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -419,18 +419,19 @@ i18n_urls = [
     url(r'^desktop_home/$', zerver.views.home.desktop_home,
         name='zerver.views.home.desktop_home'),
 
-    url(r'^accounts/login/sso/$', zerver.views.auth.remote_user_sso, name='login-sso'),
-    url(r'^accounts/login/jwt/$', zerver.views.auth.remote_user_jwt, name='login-jwt'),
-    url(r'^accounts/login/social/([\w,-]+)$', zerver.views.auth.start_social_login,
-        name='login-social'),
-    url(r'^accounts/login/social/([\w,-]+)/([\w,-]+)$', zerver.views.auth.start_social_login,
-        name='login-social-extra-arg'),
     # Backwards-compatibility (legacy) Google auth URL for the mobile
     # apps; see https://github.com/zulip/zulip/issues/13081 for
     # background.  We can remove this once older versions of the
     # mobile app are no longer present in the wild.
     url(r'^accounts/login/(google)/$', zerver.views.auth.start_social_login,
         name='login-social'),
+
+    url(r'^accounts/login/sso/$', zerver.views.auth.remote_user_sso, name='login-sso'),
+    url(r'^accounts/login/jwt/$', zerver.views.auth.remote_user_jwt, name='login-jwt'),
+    url(r'^accounts/login/social/([\w,-]+)$', zerver.views.auth.start_social_login,
+        name='login-social'),
+    url(r'^accounts/login/social/([\w,-]+)/([\w,-]+)$', zerver.views.auth.start_social_login,
+        name='login-social-extra-arg'),
 
     url(r'^accounts/register/social/([\w,-]+)$',
         zerver.views.auth.start_social_signup,


### PR DESCRIPTION
See https://github.com/zulip/zulip-mobile/issues/3670#issuecomment-548981121 for more detail

Needed so that the google entry in social_backends in /server_settings
shows the new url rather than the legacy accounts/login/google/ url as
the login url.
