### PR TITLE
js: Automatically convert var to let and const

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -367,6 +367,7 @@
         // Updated regex expressions are currently being tested in casper
         // files and will decide about a potential future enforcement of this rule.
         "no-useless-escape": "off",
+        "no-var": "error",
         "space-unary-ops": "error",
         "no-whitespace-before-property": "error",
         "no-with": "error",
@@ -411,6 +412,15 @@
         "yoda": "error"
     },
     "overrides": [
+        {
+            "files": [
+                "frontend_tests/casper_tests/*.js",
+                "frontend_tests/casper_lib/*.js"
+            ],
+            "rules": {
+                "no-var": "off" // PhantomJS doesn’t support let, const
+            }
+        },
         {
             "files": ["**/*.ts"],
             "parser": "@typescript-eslint/parser",

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -202,7 +202,7 @@ function get_last_seen(active_status, last_seen) {
         return last_seen;
     }
 
-    var last_seen_text = i18n.t('Last active: __last_seen__', {last_seen: last_seen});
+    const last_seen_text = i18n.t('Last active: __last_seen__', {last_seen: last_seen});
     return last_seen_text;
 }
 
@@ -226,7 +226,7 @@ exports.get_title_data = function (user_ids_string, is_group) {
             person.bot_owner_full_name = people.get_person_from_user_id(
                 person.bot_owner_id).full_name;
 
-            var bot_owner_name = i18n.t('Owner: __name__', {name: person.bot_owner_full_name});
+            const bot_owner_name = i18n.t('Owner: __name__', {name: person.bot_owner_full_name});
 
             return {
                 first_line: person.full_name,

--- a/static/js/condense.js
+++ b/static/js/condense.js
@@ -10,9 +10,9 @@ This library implements two related, similar concepts:
 
 */
 
-var Dict = require('./dict').Dict;
+const Dict = require('./dict').Dict;
 
-var _message_content_height_cache = new Dict();
+let _message_content_height_cache = new Dict();
 
 function show_more_link(row) {
     row.find(".message_condenser").hide();
@@ -25,13 +25,13 @@ function show_condense_link(row) {
 }
 
 function condense_row(row) {
-    var content = row.find(".message_content");
+    const content = row.find(".message_content");
     content.addClass("condensed");
     show_more_link(row);
 }
 
 function uncondense_row(row) {
-    var content = row.find(".message_content");
+    const content = row.find(".message_content");
     content.removeClass("condensed");
     show_condense_link(row);
 }
@@ -39,12 +39,12 @@ function uncondense_row(row) {
 exports.uncollapse = function (row) {
     // Uncollapse a message, restoring the condensed message [More] or
     // [Condense] link if necessary.
-    var message = current_msg_list.get(rows.id(row));
+    const message = current_msg_list.get(rows.id(row));
     message.collapsed = false;
     message_flags.save_uncollapsed(message);
 
-    var process_row = function process_row(row) {
-        var content = row.find(".message_content");
+    const process_row = function process_row(row) {
+        const content = row.find(".message_content");
         content.removeClass("collapsed");
 
         if (message.condensed === true) {
@@ -65,7 +65,7 @@ exports.uncollapse = function (row) {
     };
 
     // We also need to collapse this message in the home view
-    var home_row = home_msg_list.get_row(rows.id(row));
+    const home_row = home_msg_list.get_row(rows.id(row));
 
     process_row(row);
     process_row(home_row);
@@ -74,7 +74,7 @@ exports.uncollapse = function (row) {
 exports.collapse = function (row) {
     // Collapse a message, hiding the condensed message [More] or
     // [Condense] link if necessary.
-    var message = current_msg_list.get(rows.id(row));
+    const message = current_msg_list.get(rows.id(row));
     message.collapsed = true;
 
     if (message.locally_echoed) {
@@ -87,13 +87,13 @@ exports.collapse = function (row) {
 
     message_flags.save_collapsed(message);
 
-    var process_row = function process_row(row) {
+    const process_row = function process_row(row) {
         row.find(".message_content").addClass("collapsed");
         show_more_link(row);
     };
 
     // We also need to collapse this message in the home view
-    var home_row = home_msg_list.get_row(rows.id(row));
+    const home_row = home_msg_list.get_row(rows.id(row));
 
     process_row(row);
     process_row(home_row);
@@ -115,14 +115,14 @@ exports.toggle_collapse = function (message) {
     // * If the message is fully visible, either because it's too short to
     //   condense or because it's already uncondensed, collapse it
 
-    var row = current_msg_list.get_row(message.id);
+    const row = current_msg_list.get_row(message.id);
     if (!row) {
         return;
     }
 
-    var content = row.find(".message_content");
-    var is_condensable = content.hasClass("could-be-condensed");
-    var is_condensed = content.hasClass("condensed");
+    const content = row.find(".message_content");
+    const is_condensable = content.hasClass("could-be-condensed");
+    const is_condensed = content.hasClass("condensed");
     if (message.collapsed) {
         if (is_condensable) {
             message.condensed = true;
@@ -157,7 +157,7 @@ function get_message_height(elem, message_id) {
     }
 
     // shown to be ~2.5x faster than Node.getBoundingClientRect().
-    var height = elem.offsetHeight;
+    const height = elem.offsetHeight;
     _message_content_height_cache.set(message_id, height);
     return height;
 }
@@ -175,14 +175,14 @@ exports.show_message_expander = function (row) {
 };
 
 exports.condense_and_collapse = function (elems) {
-    var height_cutoff = message_viewport.height() * 0.65;
+    const height_cutoff = message_viewport.height() * 0.65;
 
     _.each(elems, function (elem) {
-        var content = $(elem).find(".message_content");
-        var message = current_msg_list.get(rows.id($(elem)));
+        const content = $(elem).find(".message_content");
+        const message = current_msg_list.get(rows.id($(elem)));
         if (content !== undefined && message !== undefined) {
-            var message_height = get_message_height(elem, message.id);
-            var long_message = message_height > height_cutoff;
+            const message_height = get_message_height(elem, message.id);
+            const long_message = message_height > height_cutoff;
             if (long_message) {
                 // All long messages are flagged as such.
                 content.addClass("could-be-condensed");
@@ -220,9 +220,9 @@ exports.initialize = function () {
     $("#home").on("click", ".message_expander", function () {
         // Expanding a message can mean either uncollapsing or
         // uncondensing it.
-        var row = $(this).closest(".message_row");
-        var message = current_msg_list.get(rows.id(row));
-        var content = row.find(".message_content");
+        const row = $(this).closest(".message_row");
+        const message = current_msg_list.get(rows.id(row));
+        const content = row.find(".message_content");
         if (message.collapsed) {
             // Uncollapse.
             exports.uncollapse(row);
@@ -236,7 +236,7 @@ exports.initialize = function () {
     });
 
     $("#home").on("click", ".message_condenser", function () {
-        var row = $(this).closest(".message_row");
+        const row = $(this).closest(".message_row");
         current_msg_list.get(rows.id(row)).condensed = true;
         condense_row(row);
     });

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -1,12 +1,12 @@
-var render_message_edit_form = require('../templates/message_edit_form.hbs');
-var render_message_edit_history = require('../templates/message_edit_history.hbs');
-var render_topic_edit_form = require('../templates/topic_edit_form.hbs');
+const render_message_edit_form = require('../templates/message_edit_form.hbs');
+const render_message_edit_history = require('../templates/message_edit_history.hbs');
+const render_topic_edit_form = require('../templates/topic_edit_form.hbs');
 
-var currently_editing_messages = {};
-var currently_deleting_messages = [];
-var currently_echoing_messages = {};
+const currently_editing_messages = {};
+let currently_deleting_messages = [];
+const currently_echoing_messages = {};
 
-var editability_types = {
+const editability_types = {
     NO: 1,
     NO_LONGER: 2,
     // Note: TOPIC_ONLY does not include stream messages with no topic sent
@@ -21,7 +21,7 @@ var editability_types = {
 exports.editability_types = editability_types;
 
 function is_topic_editable(message, edit_limit_seconds_buffer) {
-    var now = new XDate();
+    const now = new XDate();
     edit_limit_seconds_buffer = edit_limit_seconds_buffer || 0;
 
     if (!page_params.realm_allow_message_editing) {
@@ -82,7 +82,7 @@ function get_editability(message, edit_limit_seconds_buffer) {
         return editability_types.NO;
     }
 
-    var now = new XDate();
+    const now = new XDate();
     if (page_params.realm_message_content_edit_limit_seconds + edit_limit_seconds_buffer +
         now.diffSeconds(message.timestamp * 1000) > 0 && message.sent_by_me) {
         return editability_types.FULL;
@@ -118,7 +118,7 @@ exports.get_deletability = function (message) {
     }
 
     if (page_params.realm_allow_message_deleting) {
-        var now = new XDate();
+        const now = new XDate();
         if (page_params.realm_message_content_delete_limit_seconds +
             now.diffSeconds(message.timestamp * 1000) > 0) {
             return true;
@@ -136,7 +136,7 @@ exports.update_message_topic_editing_pencil = function () {
 };
 
 exports.show_topic_edit_spinner = function (row) {
-    var spinner = row.find(".topic_edit_spinner");
+    const spinner = row.find(".topic_edit_spinner");
     loading.make_indicator(spinner);
     $(spinner).removeAttr("style");
     $(".topic_edit_save").hide();
@@ -144,14 +144,14 @@ exports.show_topic_edit_spinner = function (row) {
 };
 
 function handle_edit_keydown(from_topic_edited_only, e) {
-    var row;
-    var code = e.keyCode || e.which;
+    let row;
+    const code = e.keyCode || e.which;
 
     if ($(e.target).hasClass("message_edit_content") && code === 13) {
         // Pressing enter to save edits is coupled with enter to send
         if (composebox_typeahead.should_enter_send(e)) {
             row = $(".message_edit_content").filter(":focus").closest(".message_row");
-            var message_edit_save_button = row.find(".message_edit_save");
+            const message_edit_save_button = row.find(".message_edit_save");
             if (message_edit_save_button.attr('disabled') === "disabled") {
                 // In cases when the save button is disabled
                 // we need to disable save on pressing enter
@@ -179,8 +179,8 @@ function handle_edit_keydown(from_topic_edited_only, e) {
 }
 
 function timer_text(seconds_left) {
-    var minutes = Math.floor(seconds_left / 60);
-    var seconds = seconds_left % 60;
+    const minutes = Math.floor(seconds_left / 60);
+    const seconds = seconds_left % 60;
     if (minutes >= 1) {
         return i18n.t("__minutes__ min to edit", {minutes: minutes.toString()});
     } else if (seconds_left >= 10) {
@@ -192,10 +192,10 @@ function timer_text(seconds_left) {
 function edit_message(row, raw_content) {
     row.find(".message_reactions").hide();
     condense.hide_message_expander(row);
-    var content_top = row.find('.message_top_line')[0]
+    const content_top = row.find('.message_top_line')[0]
         .getBoundingClientRect().top;
 
-    var message = current_msg_list.get(rows.id(row));
+    const message = current_msg_list.get(rows.id(row));
 
     // We potentially got to this function by clicking a button that implied the
     // user would be able to edit their message.  Give a little bit of buffer in
@@ -205,18 +205,18 @@ function edit_message(row, raw_content) {
     // a buffer in case their computer is slow, or stalled for a second, etc
     // If you change this number also change edit_limit_buffer in
     // zerver.views.messages.update_message_backend
-    var seconds_left_buffer = 5;
-    var editability = get_editability(message, seconds_left_buffer);
-    var is_editable = editability === exports.editability_types.TOPIC_ONLY ||
+    const seconds_left_buffer = 5;
+    const editability = get_editability(message, seconds_left_buffer);
+    const is_editable = editability === exports.editability_types.TOPIC_ONLY ||
                        editability === exports.editability_types.FULL;
-    var max_file_upload_size = page_params.max_file_upload_size;
-    var file_upload_enabled = false;
+    const max_file_upload_size = page_params.max_file_upload_size;
+    let file_upload_enabled = false;
 
     if (max_file_upload_size > 0) {
         file_upload_enabled = true;
     }
 
-    var form = $(render_message_edit_form({
+    const form = $(render_message_edit_form({
         is_stream: message.type === 'stream',
         message_id: message.id,
         is_editable: is_editable,
@@ -228,7 +228,7 @@ function edit_message(row, raw_content) {
         minutes_to_edit: Math.floor(page_params.realm_message_content_edit_limit_seconds / 60),
     }));
 
-    var edit_obj = {form: form, raw_content: raw_content};
+    const edit_obj = {form: form, raw_content: raw_content};
     currently_editing_messages[message.id] = edit_obj;
     current_msg_list.show_edit_message(row, edit_obj);
 
@@ -236,11 +236,11 @@ function edit_message(row, raw_content) {
 
     upload.feature_check($('#attach_files_' + rows.id(row)));
 
-    var message_edit_content = row.find('textarea.message_edit_content');
-    var message_edit_topic = row.find('input.message_edit_topic');
-    var message_edit_topic_propagate = row.find('select.message_edit_topic_propagate');
-    var message_edit_countdown_timer = row.find('.message_edit_countdown_timer');
-    var copy_message = row.find('.copy_message');
+    const message_edit_content = row.find('textarea.message_edit_content');
+    const message_edit_topic = row.find('input.message_edit_topic');
+    const message_edit_topic_propagate = row.find('select.message_edit_topic_propagate');
+    const message_edit_countdown_timer = row.find('.message_edit_countdown_timer');
+    const copy_message = row.find('.copy_message');
 
     if (editability === editability_types.NO) {
         message_edit_content.prop("readonly", "readonly");
@@ -261,8 +261,8 @@ function edit_message(row, raw_content) {
         new ClipboardJS(copy_message[0]);
     } else if (editability === editability_types.FULL) {
         copy_message.remove();
-        var edit_id = "#message_edit_content_" + rows.id(row);
-        var listeners = resize.watch_manual_resize(edit_id);
+        const edit_id = "#message_edit_content_" + rows.id(row);
+        const listeners = resize.watch_manual_resize(edit_id);
         if (listeners) {
             currently_editing_messages[rows.id(row)].listeners = listeners;
         }
@@ -294,16 +294,16 @@ function edit_message(row, raw_content) {
         // Give them at least 10 seconds.
         // If you change this number also change edit_limit_buffer in
         // zerver.views.messages.update_message_backend
-        var min_seconds_to_edit = 10;
-        var now = new XDate();
-        var seconds_left = page_params.realm_message_content_edit_limit_seconds +
+        const min_seconds_to_edit = 10;
+        const now = new XDate();
+        let seconds_left = page_params.realm_message_content_edit_limit_seconds +
             now.diffSeconds(message.timestamp * 1000);
         seconds_left = Math.floor(Math.max(seconds_left, min_seconds_to_edit));
 
         // I believe this needs to be defined outside the countdown_timer, since
         // row just refers to something like the currently selected message, and
         // can change out from under us
-        var message_edit_save = row.find('button.message_edit_save');
+        const message_edit_save = row.find('button.message_edit_save');
         // Do this right away, rather than waiting for the timer to do its first update,
         // since otherwise there is a noticeable lag
         message_edit_countdown_timer.text(timer_text(seconds_left));
@@ -338,23 +338,23 @@ function edit_message(row, raw_content) {
     } else {
         message_edit_content.focus();
         // Put cursor at end of input.
-        var contents = message_edit_content.val();
+        const contents = message_edit_content.val();
         message_edit_content.val('');
         message_edit_content.val(contents);
     }
 
     // Scroll to keep the top of the message content text in the same
     // place visually, adjusting for border and padding.
-    var edit_top = message_edit_content[0].getBoundingClientRect().top;
-    var scroll_by = edit_top - content_top + 5 - 14;
+    const edit_top = message_edit_content[0].getBoundingClientRect().top;
+    const scroll_by = edit_top - content_top + 5 - 14;
 
     edit_obj.scrolled_by = scroll_by;
     message_viewport.scrollTop(message_viewport.scrollTop() + scroll_by);
 
     if (feature_flags.propagate_topic_edits && !message.locally_echoed) {
-        var original_topic = util.get_message_topic(message);
+        const original_topic = util.get_message_topic(message);
         message_edit_topic.keyup(function () {
-            var new_topic = message_edit_topic.val();
+            const new_topic = message_edit_topic.val();
             message_edit_topic_propagate.toggle(new_topic !== original_topic && new_topic !== "");
         });
     }
@@ -362,8 +362,8 @@ function edit_message(row, raw_content) {
 
 function start_edit_maintaining_scroll(row, content) {
     edit_message(row, content);
-    var row_bottom = row.height() + row.offset().top;
-    var composebox_top = $("#compose").offset().top;
+    const row_bottom = row.height() + row.offset().top;
+    const composebox_top = $("#compose").offset().top;
     if (row_bottom > composebox_top) {
         message_viewport.scrollTop(message_viewport.scrollTop() + row_bottom - composebox_top);
     }
@@ -384,7 +384,7 @@ function start_edit_with_content(row, content, edit_box_open_callback) {
 }
 
 exports.start = function (row, edit_box_open_callback) {
-    var message = current_msg_list.get(rows.id(row));
+    const message = current_msg_list.get(rows.id(row));
     if (message === undefined) {
         blueslip.error("Couldn't find message ID for edit " + rows.id(row));
         return;
@@ -395,7 +395,7 @@ exports.start = function (row, edit_box_open_callback) {
         return;
     }
 
-    var msg_list = current_msg_list;
+    const msg_list = current_msg_list;
     channel.get({
         url: '/json/messages/' + message.id,
         idempotent: true,
@@ -409,12 +409,12 @@ exports.start = function (row, edit_box_open_callback) {
 };
 
 exports.start_topic_edit = function (recipient_row) {
-    var form = $(render_topic_edit_form());
+    const form = $(render_topic_edit_form());
     current_msg_list.show_edit_topic(recipient_row, form);
     form.keydown(_.partial(handle_edit_keydown, true));
-    var msg_id = rows.id_for_recipient_row(recipient_row);
-    var message = current_msg_list.get(msg_id);
-    var topic = util.get_message_topic(message);
+    const msg_id = rows.id_for_recipient_row(recipient_row);
+    const message = current_msg_list.get(msg_id);
+    let topic = util.get_message_topic(message);
     if (topic === compose.empty_topic_placeholder()) {
         topic = '';
     }
@@ -426,15 +426,15 @@ exports.is_editing = function (id) {
 };
 
 exports.end = function (row) {
-    var message = current_msg_list.get(rows.id(row));
+    const message = current_msg_list.get(rows.id(row));
     if (message !== undefined &&
         currently_editing_messages[message.id] !== undefined) {
-        var scroll_by = currently_editing_messages[message.id].scrolled_by;
+        const scroll_by = currently_editing_messages[message.id].scrolled_by;
         message_viewport.scrollTop(message_viewport.scrollTop() - scroll_by);
 
         // Clean up resize event listeners
-        var listeners = currently_editing_messages[message.id].listeners;
-        var edit_box = document.querySelector("#message_edit_content_" + message.id);
+        const listeners = currently_editing_messages[message.id].listeners;
+        const edit_box = document.querySelector("#message_edit_content_" + message.id);
         if (listeners !== undefined) {
             // Event listeners to cleanup are only set in some edit types
             edit_box.removeEventListener("mousedown", listeners[0]);
@@ -456,22 +456,22 @@ exports.end = function (row) {
 };
 
 exports.save = function (row, from_topic_edited_only) {
-    var msg_list = current_msg_list;
-    var message_id;
+    const msg_list = current_msg_list;
+    let message_id;
 
     if (row.hasClass('recipient_row')) {
         message_id = rows.id_for_recipient_row(row);
     } else {
         message_id = rows.id(row);
     }
-    var message = current_msg_list.get(message_id);
-    var changed = false;
-    var edit_locally_echoed = false;
+    const message = current_msg_list.get(message_id);
+    let changed = false;
+    let edit_locally_echoed = false;
 
-    var new_content = row.find(".message_edit_content").val();
-    var topic_changed = false;
-    var new_topic;
-    var old_topic = util.get_message_topic(message);
+    const new_content = row.find(".message_edit_content").val();
+    let topic_changed = false;
+    let new_topic;
+    const old_topic = util.get_message_topic(message);
 
     if (message.type === "stream") {
         if (from_topic_edited_only) {
@@ -495,11 +495,11 @@ exports.save = function (row, from_topic_edited_only) {
         return;
     }
 
-    var request = {message_id: message.id};
+    const request = {message_id: message.id};
     if (topic_changed) {
         util.set_message_topic(request, new_topic);
         if (feature_flags.propagate_topic_edits) {
-            var selected_topic_propagation = row.find("select.message_edit_topic_propagate").val() || "change_later";
+            const selected_topic_propagation = row.find("select.message_edit_topic_propagate").val() || "change_later";
             request.propagate_mode = selected_topic_propagation;
         }
         changed = true;
@@ -556,7 +556,7 @@ exports.save = function (row, from_topic_edited_only) {
         url: '/json/messages/' + message.id,
         data: request,
         success: function () {
-            var spinner = row.find(".topic_edit_spinner");
+            const spinner = row.find(".topic_edit_spinner");
             loading.destroy_indicator(spinner);
 
             if (edit_locally_echoed) {
@@ -569,8 +569,8 @@ exports.save = function (row, from_topic_edited_only) {
                 message_id = rows.id(row);
 
                 if (edit_locally_echoed) {
-                    var echoed_message = message_store.get(message_id);
-                    var echo_data = currently_echoing_messages[message_id];
+                    const echoed_message = message_store.get(message_id);
+                    const echo_data = currently_echoing_messages[message_id];
 
                     delete echoed_message.local_edit_timestamp;
                     delete currently_echoing_messages[message_id];
@@ -591,7 +591,7 @@ exports.save = function (row, from_topic_edited_only) {
                     }
                 }
 
-                var message = channel.xhr_error_message(i18n.t("Error saving edit"), xhr);
+                const message = channel.xhr_error_message(i18n.t("Error saving edit"), xhr);
                 row.find(".edit_error").text(message).show();
             }
         },
@@ -606,7 +606,7 @@ exports.maybe_show_edit = function (row, id) {
 };
 
 exports.edit_last_sent_message = function () {
-    var msg = current_msg_list.get_last_message_sent_by_me();
+    const msg = current_msg_list.get_last_message_sent_by_me();
 
     if (!msg) {
         return;
@@ -617,12 +617,12 @@ exports.edit_last_sent_message = function () {
         return;
     }
 
-    var msg_editability_type = exports.get_editability(msg, 5);
+    const msg_editability_type = exports.get_editability(msg, 5);
     if (msg_editability_type !== editability_types.FULL) {
         return;
     }
 
-    var msg_row = current_msg_list.get_row(msg.id);
+    const msg_row = current_msg_list.get_row(msg.id);
     if (!msg_row) {
         // This should never happen, since we got the message above
         // from current_msg_list.
@@ -646,17 +646,17 @@ exports.show_history = function (message) {
         url: "/json/messages/" + message.id + "/history",
         data: {message_id: JSON.stringify(message.id)},
         success: function (data) {
-            var content_edit_history = [];
-            var prev_timestamp;
+            const content_edit_history = [];
+            let prev_timestamp;
             _.each(data.message_history, function (msg, index) {
                 // Format timestamp nicely for display
-                var timestamp = timerender.get_full_time(msg.timestamp);
-                var item = {
+                const timestamp = timerender.get_full_time(msg.timestamp);
+                const item = {
                     timestamp: moment(timestamp).format("h:mm A"),
                     display_date: moment(timestamp).format("MMMM D, YYYY"),
                 };
                 if (msg.user_id) {
-                    var person = people.get_person_from_user_id(msg.user_id);
+                    const person = people.get_person_from_user_id(msg.user_id);
                     item.edited_by = person.full_name;
                 }
 
@@ -702,7 +702,7 @@ function hide_delete_btn_show_spinner(deleting) {
     if (deleting) {
         $('do_delete_message_button').attr('disabled', 'disabled');
         $('#delete_message_modal > div.modal-footer > button').hide();
-        var delete_spinner = $("#do_delete_message_spinner");
+        const delete_spinner = $("#do_delete_message_spinner");
         loading.make_indicator(delete_spinner, { abs_positioned: true });
     } else {
         loading.destroy_indicator($("#do_delete_message_spinner"));
@@ -761,7 +761,7 @@ exports.delete_topic = function (stream_id, topic_name) {
 exports.handle_narrow_deactivated = function () {
     _.each(currently_editing_messages, function (elem, idx) {
         if (current_msg_list.get(idx) !== undefined) {
-            var row = current_msg_list.get_row(idx);
+            const row = current_msg_list.get_row(idx);
             current_msg_list.show_edit_message(row, elem);
         }
     });

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -1,20 +1,20 @@
-var render_compose_notification = require('../templates/compose_notification.hbs');
-var render_notification = require('../templates/notification.hbs');
+const render_compose_notification = require('../templates/compose_notification.hbs');
+const render_notification = require('../templates/notification.hbs');
 
-var notice_memory = {};
+let notice_memory = {};
 
 // When you start Zulip, window_has_focus should be true, but it might not be the
 // case after a server-initiated reload.
-var window_has_focus = document.hasFocus && document.hasFocus();
+let window_has_focus = document.hasFocus && document.hasFocus();
 
-var supports_sound;
+let supports_sound;
 
-var unread_pms_favicon = '/static/images/favicon/favicon-pms.png';
-var current_favicon;
-var previous_favicon;
-var flashing = false;
+const unread_pms_favicon = '/static/images/favicon/favicon-pms.png';
+let current_favicon;
+let previous_favicon;
+let flashing = false;
 
-var notifications_api;
+let notifications_api;
 
 exports.set_notification_api = function (n) {
     notifications_api = n;
@@ -33,9 +33,9 @@ if (window.webkitNotifications) {
         },
         requestPermission: window.Notification.requestPermission,
         createNotification: function createNotification(icon, title, content, tag) {
-            var notification_object = new window.Notification(title, {icon: icon,
-                                                                      body: content,
-                                                                      tag: tag});
+            const notification_object = new window.Notification(title, {icon: icon,
+                                                                        body: content,
+                                                                        tag: tag});
             notification_object.show = function () {};
             notification_object.cancel = function () { notification_object.close(); };
             return notification_object;
@@ -79,7 +79,7 @@ exports.initialize = function () {
         window_has_focus = false;
     });
 
-    var audio = $("<audio>");
+    const audio = $("<audio>");
     if (audio[0].canPlayType === undefined) {
         supports_sound = false;
     } else {
@@ -87,7 +87,7 @@ exports.initialize = function () {
 
         $("#notifications-area").append(audio);
         audio.append($("<source>").attr("loop", "yes"));
-        var source = $("#notifications-area audio source");
+        const source = $("#notifications-area audio source");
 
         if (audio[0].canPlayType('audio/ogg; codecs="vorbis"')) {
             source.attr("type", "audio/ogg");
@@ -95,7 +95,7 @@ exports.initialize = function () {
             source.attr("type", "audio/mpeg");
         }
 
-        var audio_file_without_extension
+        const audio_file_without_extension
             = "/static/audio/notification_sounds/" + page_params.notification_sound;
         source.attr("src", get_audio_file_path(audio[0], audio_file_without_extension));
     }
@@ -104,9 +104,9 @@ exports.initialize = function () {
 function update_notification_sound_source() {
     // Simplified version of the source creation in `exports.initialize`, for
     // updating the source instead of creating it for the first time.
-    var audio = $("#notifications-area audio");
-    var source = $("#notifications-area audio source");
-    var audio_file_without_extension
+    const audio = $("#notifications-area audio");
+    const source = $("#notifications-area audio source");
+    const audio_file_without_extension
         = "/static/audio/notification_sounds/" + page_params.notification_sound;
     source.attr("src", get_audio_file_path(audio[0], audio_file_without_extension));
 
@@ -124,7 +124,7 @@ exports.permission_state = function () {
     return window.Notification.permission;
 };
 
-var new_message_count = 0;
+let new_message_count = 0;
 
 exports.update_title_count = function (count) {
     new_message_count = count;
@@ -133,9 +133,9 @@ exports.update_title_count = function (count) {
 
 exports.redraw_title = function () {
     // Update window title and favicon to reflect unread messages in current view
-    var n;
+    let n;
 
-    var new_title = (new_message_count ? "(" + new_message_count + ") " : "")
+    const new_title = (new_message_count ? "(" + new_message_count + ") " : "")
         + narrow.narrow_title + " - "
         + page_params.realm_name + " - "
         + "Zulip";
@@ -230,7 +230,7 @@ exports.window_has_focus = function () {
 };
 
 function in_browser_notify(message, title, content, raw_operators, opts) {
-    var notification_html = $(render_notification({
+    const notification_html = $(render_notification({
         gravatar_url: people.small_avatar_url(message),
         title: title,
         content: content,
@@ -254,7 +254,7 @@ function in_browser_notify(message, title, content, raw_operators, opts) {
 }
 
 exports.notify_above_composebox = function (note, link_class, link_msg_id, link_text) {
-    var notification_html = $(render_compose_notification({
+    const notification_html = $(render_compose_notification({
         note: note,
         link_class: link_class,
         link_msg_id: link_msg_id,
@@ -272,8 +272,8 @@ if (window.electron_bridge !== undefined) {
     // to narrow to the message being sent.
     window.electron_bridge.send_notification_reply_message_supported = true;
     window.electron_bridge.on_event('send_notification_reply_message', function (message_id, reply) {
-        var message = message_store.get(message_id);
-        var data = {
+        const message = message_store.get(message_id);
+        const data = {
             type: message.type,
             content: reply,
             to: message.type === 'private' ? message.reply_to : message.stream,
@@ -306,23 +306,23 @@ if (window.electron_bridge !== undefined) {
 }
 
 function process_notification(notification) {
-    var i;
-    var notification_object;
-    var key;
-    var content;
-    var other_recipients;
-    var message = notification.message;
-    var title = message.sender_full_name;
-    var msg_count = 1;
-    var notification_source;
-    var raw_operators = [];
-    var opts = {trigger: "notification click"};
+    let i;
+    let notification_object;
+    let key;
+    let content;
+    let other_recipients;
+    const message = notification.message;
+    let title = message.sender_full_name;
+    let msg_count = 1;
+    let notification_source;
+    let raw_operators = [];
+    const opts = {trigger: "notification click"};
     // Convert the content to plain text, replacing emoji with their alt text
     content = $('<div/>').html(message.content);
     ui.replace_emoji_with_text(content);
     content = content.text();
 
-    var topic = util.get_message_topic(message);
+    const topic = util.get_message_topic(message);
 
     if (message.is_me_message) {
         content = message.sender_full_name + content.slice(3);
@@ -398,7 +398,7 @@ function process_notification(notification) {
 
     // Firefox on Ubuntu claims to do webkitNotifications but its notifications are terrible
     if (notification.desktop_notify && /webkit/i.test(navigator.userAgent)) {
-        var icon_url = people.small_avatar_url(message);
+        const icon_url = people.small_avatar_url(message);
         notice_memory[key] = {
             obj: notifications_api.createNotification(icon_url, title, content, message.id),
             msg_count: msg_count,
@@ -597,7 +597,7 @@ function get_message_header(message) {
 }
 
 exports.get_local_notify_mix_reason = function (message) {
-    var row = current_msg_list.get_row(message.id);
+    const row = current_msg_list.get_row(message.id);
     if (row.length > 0) {
         // If our message is in the current message list, we do
         // not have a mix, so we are happy.
@@ -645,7 +645,7 @@ exports.notify_local_mixes = function (messages, need_user_to_scroll) {
             return;
         }
 
-        var reason = exports.get_local_notify_mix_reason(message);
+        let reason = exports.get_local_notify_mix_reason(message);
 
         if (!reason) {
             if (need_user_to_scroll) {
@@ -661,10 +661,10 @@ exports.notify_local_mixes = function (messages, need_user_to_scroll) {
             return;
         }
 
-        var link_msg_id = message.id;
-        var link_class = "compose_notification_narrow_by_topic";
-        var link_text = i18n.t("Narrow to __- message_recipient__",
-                               {message_recipient: get_message_header(message)});
+        const link_msg_id = message.id;
+        const link_class = "compose_notification_narrow_by_topic";
+        const link_text = i18n.t("Narrow to __- message_recipient__",
+                                 {message_recipient: get_message_header(message)});
 
         exports.notify_above_composebox(reason, link_class, link_msg_id, link_text);
     });
@@ -677,8 +677,8 @@ exports.notify_messages_outside_current_search = function (messages) {
         if (!people.is_current_user(message.sender_email)) {
             return;
         }
-        var link_text = i18n.t("Narrow to __- message_recipient__",
-                               {message_recipient: get_message_header(message)});
+        const link_text = i18n.t("Narrow to __- message_recipient__",
+                                 {message_recipient: get_message_header(message)});
         exports.notify_above_composebox(i18n.t("Sent! Your recent message is outside the current search."),
                                         "compose_notification_narrow_by_topic",
                                         message.id,
@@ -693,14 +693,14 @@ exports.clear_compose_notifications = function () {
 };
 
 exports.reify_message_id = function (opts) {
-    var old_id = opts.old_id;
-    var new_id = opts.new_id;
+    const old_id = opts.old_id;
+    const new_id = opts.new_id;
 
     // If a message ID that we're currently storing (as a link) has changed,
     // update that link as well
     _.each($('#out-of-view-notification a'), function (e) {
-        var elem = $(e);
-        var message_id = elem.data('message-id');
+        const elem = $(e);
+        const message_id = elem.data('message-id');
 
         if (message_id === old_id) {
             elem.data('message-id', new_id);
@@ -710,13 +710,13 @@ exports.reify_message_id = function (opts) {
 
 exports.register_click_handlers = function () {
     $('#out-of-view-notification').on('click', '.compose_notification_narrow_by_topic', function (e) {
-        var message_id = $(e.currentTarget).data('message-id');
+        const message_id = $(e.currentTarget).data('message-id');
         narrow.by_topic(message_id, {trigger: 'compose_notification'});
         e.stopPropagation();
         e.preventDefault();
     });
     $('#out-of-view-notification').on('click', '.compose_notification_scroll_to_message', function (e) {
-        var message_id = $(e.currentTarget).data('message-id');
+        const message_id = $(e.currentTarget).data('message-id');
         current_msg_list.select_id(message_id);
         navigate.scroll_to_selected();
         e.stopPropagation();

--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -1,4 +1,4 @@
-var render_tab_bar = require('../templates/tab_bar.hbs');
+const render_tab_bar = require('../templates/tab_bar.hbs');
 
 function make_tab(title, hash, data, extra_class, home) {
     return {active: "inactive",
@@ -10,15 +10,15 @@ function make_tab(title, hash, data, extra_class, home) {
 }
 
 function make_tab_data() {
-    var tabs = [];
-    var filter = narrow_state.filter();
+    const tabs = [];
+    const filter = narrow_state.filter();
 
     function filtered_to_non_home_view_stream() {
         if (!filter.has_operator('stream')) {
             return false;
         }
-        var stream_name = filter.operands('stream')[0];
-        var stream_id = stream_data.get_stream_id(stream_name);
+        const stream_name = filter.operands('stream')[0];
+        const stream_id = stream_data.get_stream_id(stream_name);
         if (!stream_id) {
             return true;
         }
@@ -46,10 +46,10 @@ function make_tab_data() {
     }
 
     if (narrow_state.active() && narrow_state.operators().length > 0) {
-        var stream;
-        var ops = narrow_state.operators();
+        let stream;
+        const ops = narrow_state.operators();
         // Second breadcrumb item
-        var hashed = hash_util.operators_to_hash(ops.slice(0, 1));
+        let hashed = hash_util.operators_to_hash(ops.slice(0, 1));
         if (filter.has_operator("stream")) {
             stream = filter.operands("stream")[0];
             tabs.push(make_tab(stream, hashed, stream, 'stream'));
@@ -60,8 +60,8 @@ function make_tab_data() {
                                undefined, 'private_message '));
 
             if (filter.has_operator("pm-with")) {
-                var emails = filter.operands("pm-with")[0].split(',');
-                var names = _.map(emails, function (email) {
+                const emails = filter.operands("pm-with")[0].split(',');
+                const names = _.map(emails, function (email) {
                     if (!people.get_by_email(email)) {
                         return email;
                     }
@@ -88,7 +88,7 @@ function make_tab_data() {
         } else if (filter.has_operand("is", "mentioned")) {
             tabs.push(make_tab("Mentions", hashed));
         } else if (filter.has_operator("sender")) {
-            var sender = filter.operands("sender")[0];
+            let sender = filter.operands("sender")[0];
             if (people.get_by_email(sender)) {
                 sender = people.get_by_email(sender).full_name;
             }
@@ -102,7 +102,7 @@ function make_tab_data() {
         // Third breadcrumb item for stream-topic naarrows
         if (filter.has_operator("stream") &&
             filter.has_operator("topic")) {
-            var topic = filter.operands("topic")[0];
+            const topic = filter.operands("topic")[0];
             hashed = hash_util.operators_to_hash(ops.slice(0, 2));
 
             tabs.push(make_tab(topic, hashed, null));
@@ -120,17 +120,17 @@ function make_tab_data() {
 }
 
 exports.colorize_tab_bar = function () {
-    var stream_tab = $('#tab_list .stream');
+    const stream_tab = $('#tab_list .stream');
     if (stream_tab.length > 0) {
-        var stream_name = stream_tab.data('name');
+        let stream_name = stream_tab.data('name');
         if (stream_name === undefined) {
             return;
         }
         stream_name = stream_name.toString();
 
-        var color_for_stream = stream_data.get_color(stream_name);
-        var stream_dark = stream_color.get_color_class(color_for_stream);
-        var stream_light = colorspace.getHexColor(
+        const color_for_stream = stream_data.get_color(stream_name);
+        const stream_dark = stream_color.get_color_class(color_for_stream);
+        const stream_light = colorspace.getHexColor(
             colorspace.getLighterColor(
                 colorspace.getDecimalColor(color_for_stream), 0.2));
 
@@ -152,13 +152,13 @@ exports.colorize_tab_bar = function () {
 };
 
 function build_tab_bar() {
-    var tabs = make_tab_data();
+    const tabs = make_tab_data();
 
-    var tab_bar = $("#tab_bar");
+    const tab_bar = $("#tab_bar");
     tab_bar.empty();
 
     tabs[tabs.length - 1].active = "active";
-    var rendered =  render_tab_bar({tabs: tabs});
+    const rendered =  render_tab_bar({tabs: tabs});
 
     tab_bar.append(rendered);
     exports.colorize_tab_bar();

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -14,13 +14,13 @@ exports.feature_check = function (upload_button) {
 };
 
 exports.options = function (config) {
-    var textarea;
-    var send_button;
-    var send_status;
-    var send_status_close;
-    var error_msg;
-    var upload_bar;
-    var file_input;
+    let textarea;
+    let send_button;
+    let send_status;
+    let send_status_close;
+    let error_msg;
+    let upload_bar;
+    let file_input;
 
     switch (config.mode) {
     case 'compose':
@@ -45,13 +45,13 @@ exports.options = function (config) {
         throw Error("Invalid upload mode!");
     }
 
-    var hide_upload_status = function () {
+    const hide_upload_status = function () {
         send_button.prop("disabled", false);
         send_status.removeClass("alert-info").hide();
         $('div.progress.active').remove();
     };
 
-    var drop = function () {
+    const drop = function () {
         send_button.attr("disabled", "");
         send_status.addClass("alert-info").show();
         send_status_close.one('click', function () {
@@ -62,7 +62,7 @@ exports.options = function (config) {
         });
     };
 
-    var uploadStarted = function (i, file) {
+    const uploadStarted = function (i, file) {
         error_msg.html($("<p>").text(i18n.t("Uploading…")));
         // file.lastModified is unique for each upload, and was previously used to track each
         // upload. But, when an image is pasted into Safari, it looks like the lastModified time
@@ -77,12 +77,12 @@ exports.options = function (config) {
         compose_ui.insert_syntax_and_focus("[Uploading " + file.name + "…]()", textarea);
     };
 
-    var progressUpdated = function (i, file, progress) {
+    const progressUpdated = function (i, file, progress) {
         $("#" + upload_bar + '-' + file.trackingId).width(progress + "%");
     };
 
-    var uploadError = function (error_code, server_response, file) {
-        var msg;
+    const uploadError = function (error_code, server_response, file) {
+        let msg;
         send_status.addClass("alert-error").removeClass("alert-info");
         send_button.prop("disabled", false);
         if (file !== undefined) {
@@ -99,7 +99,7 @@ exports.options = function (config) {
         case 'FileTooLarge':
             if (page_params.max_file_upload_size > 0) {
                 // sanitization not needed as the file name is not potentially parsed as HTML, etc.
-                var context = {
+                const context = {
                     file_name: file.name,
                     file_size: page_params.max_file_upload_size,
                 };
@@ -114,7 +114,7 @@ exports.options = function (config) {
             msg = i18n.t("Sorry, the file was too large.");
             break;
         case 400: {
-            var server_message = server_response && server_response.msg;
+            const server_message = server_response && server_response.msg;
             msg = server_message || i18n.t("An unknown error occurred.");
             break;
         }
@@ -125,12 +125,12 @@ exports.options = function (config) {
         error_msg.text(msg);
     };
 
-    var uploadFinished = function (i, file, response) {
+    const uploadFinished = function (i, file, response) {
         if (response.uri === undefined) {
             return;
         }
-        var split_uri = response.uri.split("/");
-        var filename = split_uri[split_uri.length - 1];
+        const split_uri = response.uri.split("/");
+        const filename = split_uri[split_uri.length - 1];
         // Urgh, yet another hack to make sure we're "composing"
         // when text gets added into the composebox.
         if (config.mode === 'compose' && !compose_state.composing()) {
@@ -140,15 +140,15 @@ exports.options = function (config) {
             textarea.focus();
         }
 
-        var uri = make_upload_absolute(response.uri);
+        const uri = make_upload_absolute(response.uri);
 
         if (i === -1) {
             // This is a paste, so there's no filename. Show the image directly
-            var pasted_image_uri = "[pasted image](" + uri + ")";
+            const pasted_image_uri = "[pasted image](" + uri + ")";
             compose_ui.replace_syntax("[Uploading " + file.name + "…]()", pasted_image_uri, textarea);
         } else {
             // This is a dropped file, so make the filename a link to the image
-            var filename_uri = "[" + filename + "](" + uri + ")";
+            const filename_uri = "[" + filename + "](" + uri + ")";
             compose_ui.replace_syntax("[Uploading " + file.name + "…]()", filename_uri, textarea);
         }
         compose_ui.autosize_textarea();


### PR DESCRIPTION
This commit was automatically generated by `tools/lint --only=eslint --fix`, except for the `.eslintrc.json` change itself.

It’s a large diff that’s likely to merge-conflict with a lot of other work, but those conflicts are easy to resolve by running ESLint on each commit.

There are other ways we could approach this migration, but I’m putting this out here as a starting point for discussion (and if it ends up also being an ending point, great).

**Testing Plan:** Dev server