### PR TITLE
unminify: Update for webpack chunk splitting

### DIFF
--- a/zerver/lib/unminify.py
+++ b/zerver/lib/unminify.py
@@ -29,22 +29,23 @@ class SourceMap:
         out = ''  # type: str
         for ln in stacktrace.splitlines():
             out += ln + '\n'
-            match = re.search(r'/static/webpack-bundles/(.+)(\.[\.0-9a-f]+\.js):(\d+):(\d+)', ln)
+            match = re.search(r'/static/webpack-bundles/([^:]+):(\d+):(\d+)', ln)
             if match:
                 # Get the appropriate source map for the minified file.
-                minified_src = match.groups()[0] + match.groups()[1]
+                minified_src = match.groups()[0]
                 index = self._index_for(minified_src)
 
-                gen_line, gen_col = list(map(int, match.groups()[2:4]))
+                gen_line, gen_col = list(map(int, match.groups()[1:3]))
                 # The sourcemap lib is 0-based, so subtract 1 from line and col.
                 try:
                     result = index.lookup(line=gen_line-1, column=gen_col-1)
                     display_src = result.src
-                    webpack_prefix = "webpack:///"
-                    if display_src.startswith(webpack_prefix):
-                        display_src = display_src[len(webpack_prefix):]
-                    out += ('       = %s line %d column %d\n' %
-                            (display_src, result.src_line+1, result.src_col+1))
+                    if display_src is not None:
+                        webpack_prefix = "webpack:///"
+                        if display_src.startswith(webpack_prefix):
+                            display_src = display_src[len(webpack_prefix):]
+                        out += ('       = %s line %d column %d\n' %
+                                (display_src, result.src_line+1, result.src_col+1))
                 except IndexError:
                     out += '       [Unable to look up in source map]\n'
 


### PR DESCRIPTION
**Testing Plan:** Production at https://andersk.zulipdev.org

```
Stacktrace:
s@https://andersk.zulipdev.org/static/webpack-bundles/app.a2800d3d6c3357ca4b7f.js:2:401513
       = ./static/js/compose_fade.js line 41 column 28
t.clear_compose@https://andersk.zulipdev.org/static/webpack-bundles/app.a2800d3d6c3357ca4b7f.js:2:403795
       = ./static/js/compose_fade.js line 215 column 5
t.cancel@https://andersk.zulipdev.org/static/webpack-bundles/app.a2800d3d6c3357ca4b7f.js:2:430437
       = ./static/js/compose_actions.js line 24 column 18
t.on_narrow@https://andersk.zulipdev.org/static/webpack-bundles/app.a2800d3d6c3357ca4b7f.js:2:433371
       = ./static/js/compose_actions.js line 486 column 13
t.activate@https://andersk.zulipdev.org/static/webpack-bundles/app.a2800d3d6c3357ca4b7f.js:2:390329
       = ./static/js/narrow.js line 296 column 21
t.by@https://andersk.zulipdev.org/static/webpack-bundles/app.a2800d3d6c3357ca4b7f.js:2:392882
       = ./static/js/narrow.js line 593 column 13
t.set_event_handlers/<@https://andersk.zulipdev.org/static/webpack-bundles/app.a2800d3d6c3357ca4b7f.js:2:305614
       = ./static/js/stream_list.js line 495 column 16
dispatch@https://andersk.zulipdev.org/static/webpack-bundles/708d25cd19e89b0ceb90.js:2:104936
       = /srv/zulip-npm-cache/f4560d41f36e68648a3c73c7d3ccc20cb7bfbb73/node_modules/jquery/dist/jquery.js line 5237 column 27
add/b.handle@https://andersk.zulipdev.org/static/webpack-bundles/708d25cd19e89b0ceb90.js:2:102948
       = /srv/zulip-npm-cache/f4560d41f36e68648a3c73c7d3ccc20cb7bfbb73/node_modules/jquery/dist/jquery.js line 5044 column 28
```