### PR TITLE
Change 24-hour time settings to a dropdown

### DIFF
--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -54,6 +54,8 @@ exports.set_up = function () {
     meta.loaded = true;
     $("#display-settings-status").hide();
 
+    $("#user_timeformat").val(page_params.twenty_four_hour_time);
+
     $("#user_timezone").val(page_params.timezone);
 
     $("#demote_inactive_streams").val(page_params.demote_inactive_streams);
@@ -112,8 +114,8 @@ exports.set_up = function () {
         window.location.reload();
     });
 
-    $("#twenty_four_hour_time").change(function () {
-        var data = {twenty_four_hour_time: JSON.stringify(this.checked)};
+    $("#user_timeformat").change(function () {
+        var data = {twenty_four_hour_time: this.value};
         change_display_setting(data, '#time-settings-status');
     });
 
@@ -179,7 +181,7 @@ exports.report_emojiset_change = function () {
 };
 
 exports.update_page = function () {
-    $("#twenty_four_hour_time").prop('checked', page_params.twenty_four_hour_time);
+    $("#twenty_four_hour_time").prop('selectedIndex', page_params.twenty_four_hour_time);
     $("#left_side_userlist").prop('checked', page_params.left_side_userlist);
     $("#default_language_name").text(page_params.default_language_name);
     $("#translate_emoticons").prop('checked', page_params.translate_emoticons);

--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -47,13 +47,20 @@
             <h3 class="inline-block">{{t "Time settings" }}</h3>
             <div class="alert-notification" id="time-settings-status"></div>
 
-            {{> settings_checkbox
-              setting_name="twenty_four_hour_time"
-              is_checked=page_params.twenty_four_hour_time
-              label=settings_label.twenty_four_hour_time}}
+            <div class="input-group">
+                <label for="twenty_four_hour_time" class="dropdown-title">{{t "Time Format" }}</label>
+                <select name="twenty_four_hour_time" id="user_timeformat">
+                    {{#unless page_params.twenty_four_hour_time}}
+                    <option></option>
+                    {{/unless}}
+
+                    <option value="true">24-hour time (17:00 instead of 5:00 PM)</option>
+                    <option value="false">12-hour time</option>
+                </select>
+            </div>
 
             <div class="input-group">
-                <label for="timezone" class="dropdown-title">{{t "Time zone" }}</label>
+                <label for="timezone" class="dropdown-title">{{t "Time Zone" }}</label>
                 <select name="timezone" id="user_timezone">
                     {{#unless page_params.timezone}}
                     <option></option>

--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -48,7 +48,7 @@
             <div class="alert-notification" id="time-settings-status"></div>
 
             <div class="input-group">
-                <label for="twenty_four_hour_time" class="dropdown-title">{{t "Time Format" }}</label>
+                <label for="twenty_four_hour_time" class="dropdown-title">{{t "Time format" }}</label>
                 <select name="twenty_four_hour_time" id="user_timeformat">
                     {{#unless page_params.twenty_four_hour_time}}
                     <option></option>
@@ -60,7 +60,7 @@
             </div>
 
             <div class="input-group">
-                <label for="timezone" class="dropdown-title">{{t "Time Zone" }}</label>
+                <label for="timezone" class="dropdown-title">{{t "Time zone" }}</label>
                 <select name="timezone" id="user_timezone">
                     {{#unless page_params.timezone}}
                     <option></option>


### PR DESCRIPTION
It was considered that a checkbox would make the feature look too "12 hour centric". So it was proposed to change it into a dropdown in issue #12553  (link:https://github.com/zulip/zulip/issues/12553).

Testing done in my local system, an Ubuntu. Ran test-all in /tools directory.

Fixes #12553 

![Screenshot from 2019-11-03 23-57-41](https://user-images.githubusercontent.com/40913303/68090135-4785a080-fe96-11e9-9248-ce47253d853d.png)
