### PR TITLE
Social backends adjustments

### DIFF
--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -82,7 +82,7 @@ it as follows:
         "Attribute Mapping" with GSuite).  You'll want to connect
         these so that Zulip gets the email address (used as a unique
         user ID) and name for the user.
-     5. The `display_name` and `display_logo` fields are used to
+     5. The `display_name` and `display_icon` fields are used to
         display the login/registration buttons for the IdP.
 
 3. Install the certificate(s) required for SAML authentication.  You

--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -73,7 +73,7 @@ page can be easily identified in it's respective JavaScript file -->
                             {% endif %}
                         {% endif %}
 
-                        {% for backend in social_backends %}
+                        {% for backend in external_authentication_methods %}
                         <div class="login-social">
                             <form class="form-inline" action="{{ backend.signup_url }}" method="get">
                                 <input type='hidden' name='multiuse_object_key' value='{{ multiuse_object_key }}' />

--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -77,7 +77,7 @@ page can be easily identified in it's respective JavaScript file -->
                         <div class="login-social">
                             <form class="form-inline" action="{{ backend.signup_url }}" method="get">
                                 <input type='hidden' name='multiuse_object_key' value='{{ multiuse_object_key }}' />
-                                <button class="login-social-button full-width" {% if backend.display_logo %} style="background-image:url({{ backend.display_logo }})"  {% endif %}>
+                                <button class="login-social-button full-width" {% if backend.display_icon %} style="background-image:url({{ backend.display_icon }})"  {% endif %}>
                                     {{ _('Sign up with %(identity_provider)s', identity_provider=backend.display_name) }}
                                 </button>
                             </form>

--- a/templates/zerver/api/server-settings.md
+++ b/templates/zerver/api/server-settings.md
@@ -54,13 +54,13 @@ Fetch global settings for a Zulip server.
   mobile and desktop apps.
 * `realm_description`: HTML description of the organization, as configured by
   the [organization profile](/help/create-your-organization-profile).
-* `social_backends`: list of dictionaries describing the available social
-  authentication backends (such as google/github/SAML). Each dictionary specifies
-  the name and icon that should be displayed on the login buttons (`display_name`
-  and `display_icon`, where `display_icon` can be the empty string, if no icon
-  is to be displayed), the URLs that should be accessed to initiate login/signup
-  with the backend (`login_url` and `signup_url`) and `name`, which is a unique key
-  for the authentication backend, as well as allowing to figure out its type.
+* `external_authentication_methods`: list of dictionaries describing the available
+  external authentication methods (such as google/github/SAML).
+  Each dictionary specifies the name and icon that should be displayed on the login buttons
+  (`display_name` and `display_icon`, where `display_icon` can be the empty string,
+  if no icon is to be displayed), the URLs that should be accessed to initiate login/signup
+  using the method (`login_url` and `signup_url`) and `name`, which is a unique key
+  for the authentication method, as well as allowing to figure out its type.
   The list is sorted in the order in which these authentication methods should be displayed.
 
 [ldap-auth]: https://zulip.readthedocs.io/en/latest/production/authentication-methods.html#ldap-including-active-directory

--- a/templates/zerver/api/server-settings.md
+++ b/templates/zerver/api/server-settings.md
@@ -58,10 +58,9 @@ Fetch global settings for a Zulip server.
   authentication backends (such as google/github/SAML). Each dictionary specifies
   the name and icon that should be displayed on the login buttons (`display_name`
   and `display_icon`, where `display_icon` can be the empty string, if no icon
-  is to be displayed), the URLs that should be accessed to initiate login/signup
-  with the backend (`login_url` and `signup_url`) and `sort_order` (number
-  specifying in what order to show the login buttons for the social backends -
-  those with higher `sort_order` should be shown first).
+  is to be displayed) and the URLs that should be accessed to initiate login/signup
+  with the backend (`login_url` and `signup_url`). The list is sorted in the order
+  in which these authentication methods should be displayed.
 
 [ldap-auth]: https://zulip.readthedocs.io/en/latest/production/authentication-methods.html#ldap-including-active-directory
 

--- a/templates/zerver/api/server-settings.md
+++ b/templates/zerver/api/server-settings.md
@@ -58,9 +58,10 @@ Fetch global settings for a Zulip server.
   authentication backends (such as google/github/SAML). Each dictionary specifies
   the name and icon that should be displayed on the login buttons (`display_name`
   and `display_icon`, where `display_icon` can be the empty string, if no icon
-  is to be displayed) and the URLs that should be accessed to initiate login/signup
-  with the backend (`login_url` and `signup_url`). The list is sorted in the order
-  in which these authentication methods should be displayed.
+  is to be displayed), the URLs that should be accessed to initiate login/signup
+  with the backend (`login_url` and `signup_url`) and `name`, which is a unique key
+  for the authentication backend, as well as allowing to figure out its type.
+  The list is sorted in the order in which these authentication methods should be displayed.
 
 [ldap-auth]: https://zulip.readthedocs.io/en/latest/production/authentication-methods.html#ldap-including-active-directory
 

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -126,7 +126,7 @@ page can be easily identified in it's respective JavaScript file. -->
 
                         {% endif %} <!-- if password_auth_enabled -->
 
-                        {% for backend in social_backends %}
+                        {% for backend in external_authentication_methods %}
                         <div class="login-social">
                             <form class="social_login_form form-inline" action="{{ backend.login_url }}" method="get">
                                 <input type="hidden" name="next" value="{{ next }}">

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -130,7 +130,7 @@ page can be easily identified in it's respective JavaScript file. -->
                         <div class="login-social">
                             <form class="social_login_form form-inline" action="{{ backend.login_url }}" method="get">
                                 <input type="hidden" name="next" value="{{ next }}">
-                                <button class="login-social-button" {% if backend.display_logo %} style="background-image:url({{ backend.display_logo }})"  {% endif %}>
+                                <button class="login-social-button" {% if backend.display_icon %} style="background-image:url({{ backend.display_icon }})"  {% endif %}>
                                     {{ _('Log in with %(identity_provider)s', identity_provider=backend.display_name) }}
                                 </button>
                             </form>

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -175,7 +175,7 @@ def login_context(request: HttpRequest) -> Dict[str, Any]:
         if is_enabled:
             no_auth_enabled = False
 
-    context['social_backends'] = get_social_backend_dicts(realm)
+    context['external_authentication_methods'] = get_social_backend_dicts(realm)
     context['no_auth_enabled'] = no_auth_enabled
 
     return context

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2241,24 +2241,21 @@ paths:
                             "display_name": "SAML",
                             "display_logo": "",
                             "login_url": "/accounts/login/social/saml/idp_name",
-                            "signup_url": "/accounts/register/social/saml/idp_name",
-                            "sort_order": 9999
+                            "signup_url": "/accounts/register/social/saml/idp_name"
                           },
                           {
                             "name": "google",
                             "display_name": "Google",
                             "display_logo": "/static/images/landing-page/logos/googl_e-icon.png",
                             "login_url": "/accounts/login/social/google",
-                            "signup_url": "/accounts/register/social/google",
-                            "sort_order": 150
+                            "signup_url": "/accounts/register/social/google"
                           },
                           {
                             "name": "github",
                             "display_name": "GitHub",
                             "display_logo": "/static/images/landing-page/logos/github-icon.png",
                             "login_url": "/accounts/login/social/github",
-                            "signup_url": "/accounts/register/social/github",
-                            "sort_order": 100
+                            "signup_url": "/accounts/register/social/github"
                           }
                         ]
                     }

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2169,11 +2169,12 @@ paths:
                       description: Each key-value pair in the object indicates
                         whether the authentication method is enabled on this
                         server.
-                    social_backends:
+                    external_authentication_methods:
                       type: array
-                      description: List of "social backend" objects, describing which
-                        social backends are enabled and their parameters - most importantly
-                        the login url, display_name and display_icon.
+                      description: List of dictionaries describing which
+                        external authentication methods are enabled and their
+                        parameters - most importantly the login url, display_name
+                        and display_icon.
                     zulip_version:
                       type: string
                       description: The version of Zulip running in the server.
@@ -2235,7 +2236,7 @@ paths:
                         "realm_icon": "https://secure.gravatar.com/avatar/62429d594b6ffc712f54aee976a18b44?d=identicon",
                         "realm_description": "<p>The Zulip development environment default organization.  It's great for testing!</p>",
                         "result": "success",
-                        "social_backends": [
+                        "external_authentication_methods": [
                           {
                             "name": "saml:idp_name",
                             "display_name": "SAML",

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2173,7 +2173,7 @@ paths:
                       type: array
                       description: List of "social backend" objects, describing which
                         social backends are enabled and their parameters - most importantly
-                        the login url, display_name and display_logo.
+                        the login url, display_name and display_icon.
                     zulip_version:
                       type: string
                       description: The version of Zulip running in the server.
@@ -2239,21 +2239,21 @@ paths:
                           {
                             "name": "saml:idp_name",
                             "display_name": "SAML",
-                            "display_logo": "",
+                            "display_icon": "",
                             "login_url": "/accounts/login/social/saml/idp_name",
                             "signup_url": "/accounts/register/social/saml/idp_name"
                           },
                           {
                             "name": "google",
                             "display_name": "Google",
-                            "display_logo": "/static/images/landing-page/logos/googl_e-icon.png",
+                            "display_icon": "/static/images/landing-page/logos/googl_e-icon.png",
                             "login_url": "/accounts/login/social/google",
                             "signup_url": "/accounts/register/social/google"
                           },
                           {
                             "name": "github",
                             "display_name": "GitHub",
-                            "display_logo": "/static/images/landing-page/logos/github-icon.png",
+                            "display_icon": "/static/images/landing-page/logos/github-icon.png",
                             "login_url": "/accounts/login/social/github",
                             "signup_url": "/accounts/register/social/github"
                           }

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1867,7 +1867,7 @@ class FetchAuthBackends(ZulipTestCase):
             self.assert_json_success(result)
             checker = check_dict_only([
                 ('authentication_methods', check_dict_only(authentication_methods_list)),
-                ('social_backends', check_list(None, length=len(social_backends))),
+                ('external_authentication_methods', check_list(None, length=len(social_backends))),
                 ('email_auth_enabled', check_bool),
                 ('is_incompatible', check_bool),
                 ('require_email_format_usernames', check_bool),
@@ -1881,7 +1881,7 @@ class FetchAuthBackends(ZulipTestCase):
 
         result = self.client_get("/api/v1/server_settings", subdomain="", HTTP_USER_AGENT="")
         check_result(result)
-        self.assertEqual(result.json()['social_backends'], get_social_backend_dicts())
+        self.assertEqual(result.json()['external_authentication_methods'], get_social_backend_dicts())
 
         result = self.client_get("/api/v1/server_settings", subdomain="", HTTP_USER_AGENT="ZulipInvalid")
         self.assertTrue(result.json()["is_incompatible"])

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -837,7 +837,7 @@ def api_get_server_settings(request: HttpRequest) -> HttpResponse:
             "realm_name",
             "realm_icon",
             "realm_description",
-            "social_backends"]:
+            "external_authentication_methods"]:
         if context[settings_item] is not None:
             result[settings_item] = context[settings_item]
     return json_success(result)

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -997,7 +997,7 @@ def social_auth_finish(backend: Any,
 class SocialAuthMixin(ZulipAuthMixin):
     auth_backend_name = "undeclared"
     name = "undeclared"
-    display_logo = None  # type: Optional[str]
+    display_icon = None  # type: Optional[str]
 
     # Used to determine how to order buttons on login form, backend with
     # higher sort order are displayed first.
@@ -1030,7 +1030,7 @@ class GitHubAuthBackend(SocialAuthMixin, GithubOAuth2):
     name = "github"
     auth_backend_name = "GitHub"
     sort_order = 100
-    display_logo = "/static/images/landing-page/logos/github-icon.png"
+    display_icon = "/static/images/landing-page/logos/github-icon.png"
 
     def get_verified_emails(self, *args: Any, **kwargs: Any) -> List[str]:
         access_token = kwargs["response"]["access_token"]
@@ -1096,13 +1096,13 @@ class AzureADAuthBackend(SocialAuthMixin, AzureADOAuth2):
     sort_order = 50
     name = "azuread-oauth2"
     auth_backend_name = "AzureAD"
-    display_logo = "/static/images/landing-page/logos/azuread-icon.png"
+    display_icon = "/static/images/landing-page/logos/azuread-icon.png"
 
 class GoogleAuthBackend(SocialAuthMixin, GoogleOAuth2):
     sort_order = 150
     auth_backend_name = "Google"
     name = "google"
-    display_logo = "/static/images/landing-page/logos/googl_e-icon.png"
+    display_icon = "/static/images/landing-page/logos/googl_e-icon.png"
 
     def get_verified_emails(self, *args: Any, **kwargs: Any) -> List[str]:
         verified_emails = []    # type: List[str]
@@ -1123,7 +1123,7 @@ class SAMLAuthBackend(SocialAuthMixin, SAMLAuth):
     # SAML buttons at the top.
     sort_order = 9999
     # There's no common default logo for SAML authentication.
-    display_logo = ""
+    display_icon = ""
 
     def auth_url(self) -> str:
         """Get the URL to which we must redirect in order to
@@ -1254,17 +1254,17 @@ class SAMLAuthBackend(SocialAuthMixin, SAMLAuth):
 SocialBackendDictT = TypedDict('SocialBackendDictT', {
     'name': str,
     'display_name': str,
-    'display_logo': str,
+    'display_icon': str,
     'login_url': str,
     'signup_url': str,
 })
 
 def create_standard_social_backend_dict(social_backend: SocialAuthMixin) -> SocialBackendDictT:
-    assert social_backend.display_logo is not None
+    assert social_backend.display_icon is not None
     return dict(
         name=social_backend.name,
         display_name=social_backend.auth_backend_name,
-        display_logo=social_backend.display_logo,
+        display_icon=social_backend.display_icon,
         login_url=reverse('login-social', args=(social_backend.name,)),
         signup_url=reverse('signup-social', args=(social_backend.name,)),
     )
@@ -1275,7 +1275,7 @@ def list_saml_backend_dicts(realm: Optional[Realm]=None) -> List[SocialBackendDi
         saml_dict = dict(
             name='saml:{}'.format(idp_name),
             display_name=idp_dict.get('display_name', SAMLAuthBackend.auth_backend_name),
-            display_logo=idp_dict.get('display_logo', SAMLAuthBackend.display_logo),
+            display_icon=idp_dict.get('display_icon', SAMLAuthBackend.display_icon),
             login_url=reverse('login-social-extra-arg', args=('saml', idp_name)),
             signup_url=reverse('signup-social-extra-arg', args=('saml', idp_name)),
         )  # type: SocialBackendDictT

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -224,14 +224,14 @@ SOCIAL_AUTH_SAML_ENABLED_IDPS = {
         # The "x509cert" attribute is automatically read from
         # /etc/zulip/saml/idps/{idp_name}.crt; don't specify it here.
 
-        # Optionally, you can edit display_name and display_logo
+        # Optionally, you can edit display_name and display_icon
         # settings below to change the name and icon that will show on
         # the login button.
         "display_name": "SAML",
         # Path to a square image file containing a logo to appear at
         # the left end of the login/register buttons for this IDP.
         # The default of "" results in a text-only button.
-        "display_logo": "",
+        "display_icon": "",
     }
 }
 

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -215,6 +215,6 @@ SOCIAL_AUTH_SAML_ENABLED_IDPS = {
         "attr_username": "email",
         "attr_email": "email",
         "display_name": "Test IdP",
-        "display_logo": "/static/images/landing-page/logos/saml-icon.png",
+        "display_icon": "/static/images/landing-page/logos/saml-icon.png",
     }
 }


### PR DESCRIPTION
This makes adjustments mentioned in https://github.com/zulip/zulip-mobile/issues/3670
What's missing is making ``RemoteUser`` auth a part of the ``external_authentication_methods`` structure, but that was said to be lower priority.