### PR TITLE
social_backends: If no icon is to be displayed, set display_icon to None.

### DIFF
--- a/templates/zerver/api/server-settings.md
+++ b/templates/zerver/api/server-settings.md
@@ -59,7 +59,7 @@ Fetch global settings for a Zulip server.
   google/github/SAML) enabled for this organization. Each dictionary
   specifies the name and icon that should be displayed on the login
   buttons (`display_name` and `display_icon`, where `display_icon` can
-  be the empty string, if no icon is to be displayed), the URLs that
+  be `null`, if no icon is to be displayed), the URLs that
   should be accessed to initiate login/signup using the method
   (`login_url` and `signup_url`) and `name`, which is a unique,
   stable, machine-readable name for the authentication method.  The

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2240,7 +2240,7 @@ paths:
                           {
                             "name": "saml:idp_name",
                             "display_name": "SAML",
-                            "display_icon": "",
+                            "display_icon": null,
                             "login_url": "/accounts/login/social/saml/idp_name",
                             "signup_url": "/accounts/register/social/saml/idp_name"
                           },

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -1142,7 +1142,7 @@ class SAMLAuthBackend(SocialAuthMixin, SAMLAuth):
     # SAML buttons at the top.
     sort_order = 9999
     # There's no common default logo for SAML authentication.
-    display_icon = ""
+    display_icon = None
 
     # The full_name provided by the IdP is very likely the standard
     # employee directory name for the user, and thus what they and
@@ -1279,13 +1279,12 @@ class SAMLAuthBackend(SocialAuthMixin, SAMLAuth):
 SocialBackendDictT = TypedDict('SocialBackendDictT', {
     'name': str,
     'display_name': str,
-    'display_icon': str,
+    'display_icon': Optional[str],
     'login_url': str,
     'signup_url': str,
 })
 
 def create_standard_social_backend_dict(social_backend: SocialAuthMixin) -> SocialBackendDictT:
-    assert social_backend.display_icon is not None
     return dict(
         name=social_backend.name,
         display_name=social_backend.auth_backend_name,

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -230,8 +230,8 @@ SOCIAL_AUTH_SAML_ENABLED_IDPS = {
         "display_name": "SAML",
         # Path to a square image file containing a logo to appear at
         # the left end of the login/register buttons for this IDP.
-        # The default of "" results in a text-only button.
-        "display_icon": "",
+        # The default of None results in a text-only button.
+        # "display_icon": "/path/to/icon.png",
     }
 }
 

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -215,6 +215,6 @@ SOCIAL_AUTH_SAML_ENABLED_IDPS = {
         "attr_username": "email",
         "attr_email": "email",
         "display_name": "Test IdP",
-        "display_icon": "/static/images/landing-page/logos/saml-icon.png",
+        "display_icon": None,
     }
 }


### PR DESCRIPTION
Small adjustment requested in https://github.com/zulip/zulip-mobile/issues/3670#issuecomment-549541290