### PR TITLE
Ldap realm creation flow

### DIFF
--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1755,7 +1755,11 @@ class RealmCreationTest(ZulipTestCase):
         # Make sure the realm is created
         realm = get_realm(string_id)
         self.assertEqual(realm.string_id, string_id)
-        self.assertEqual(get_user(email, realm).realm, realm)
+        user = get_user(email, realm)
+        self.assertEqual(user.realm, realm)
+
+        # Check that user is the administrator.
+        self.assertEqual(user.role, UserProfile.ROLE_REALM_ADMINISTRATOR)
 
         # Check defaults
         self.assertEqual(realm.org_type, Realm.CORPORATE)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1728,8 +1728,7 @@ class EmailUnsubscribeTests(ZulipTestCase):
 
 class RealmCreationTest(ZulipTestCase):
     @override_settings(OPEN_REALM_CREATION=True)
-    def check_able_to_create_realm(self, email: str) -> None:
-        password = "test"
+    def check_able_to_create_realm(self, email: str, password: str="test") -> None:
         string_id = "zuliptest"
         # Make sure the realm does not exist
         with self.assertRaises(Realm.DoesNotExist):
@@ -1781,6 +1780,13 @@ class RealmCreationTest(ZulipTestCase):
 
     def test_create_realm_existing_email(self) -> None:
         self.check_able_to_create_realm("hamlet@zulip.com")
+
+    @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
+    def test_create_realm_ldap_email(self) -> None:
+        self.init_default_ldap_database()
+
+        with self.settings(LDAP_EMAIL_ATTR="mail"):
+            self.check_able_to_create_realm("newuser_email@zulip.com", self.ldap_password())
 
     def test_create_realm_as_system_bot(self) -> None:
         result = self.client_post('/new/', {'email': 'notification-bot@zulip.com'})

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -619,9 +619,12 @@ class ZulipLDAPAuthBackend(ZulipLDAPAuthBackendBase):
         opts = {}   # type: Dict[str, Any]
         if self._prereg_user:
             invited_as = self._prereg_user.invited_as
+            realm_creation = self._prereg_user.realm_creation
             opts['prereg_user'] = self._prereg_user
-            opts['is_realm_admin'] = invited_as == PreregistrationUser.INVITE_AS['REALM_ADMIN']
+            opts['is_realm_admin'] = (
+                invited_as == PreregistrationUser.INVITE_AS['REALM_ADMIN']) or realm_creation
             opts['is_guest'] = invited_as == PreregistrationUser.INVITE_AS['GUEST_USER']
+            opts['realm_creation'] = realm_creation
             opts['default_stream_groups'] = get_default_stream_groups(self._realm)
 
         user_profile = do_create_user(username, None, self._realm, full_name, short_name, **opts)


### PR DESCRIPTION
This relates to issue https://github.com/zulip/zulip/issues/9576

While the flow would succesfully create the realm and user, that turned out deceptive, because I noticed that it didn't properly set the user as the admin - and didn't correctly create the initial subscriptions and messages.

These changes fix it:
1. First a commit adding a check that the user is the realm admin in the realm creation tests.
2. Two commits refactoring part of the ``accounts_register`` function a bit.
3. With the above refactorings, it's easy to fix the flow in ``accounts_register`` and improve the plumbing in ldap's ``get_or_build_user``  to get the issue fixed. A test for the ldap case of realm creation is added.