### PR TITLE
ldap: Fix development environment configuration.

### DIFF
--- a/zerver/lib/dev_ldap_directory.py
+++ b/zerver/lib/dev_ldap_directory.py
@@ -35,16 +35,19 @@ def generate_dev_ldap_dir(mode: str, num_users: int=8) -> Dict[str, Dict[str, An
         }
         if mode == 'a':
             ldap_dir['uid=' + email + ',ou=users,dc=zulip,dc=com'] = dict(
+                uid=[email, ],
                 thumbnailPhoto=[profile_images[i % len(profile_images)], ],
                 userAccountControl=[LDAP_USER_ACCOUNT_CONTROL_NORMAL, ],
                 **common_data)
         elif mode == 'b':
             ldap_dir['uid=' + email_username + ',ou=users,dc=zulip,dc=com'] = dict(
+                uid=[email_username, ],
                 jpegPhoto=[profile_images[i % len(profile_images)], ],
                 **common_data)
         elif mode == 'c':
             ldap_dir['uid=' + email_username + ',ou=users,dc=zulip,dc=com'] = dict(
-                email=email,
+                uid=[email_username, ],
+                email=[email, ],
                 **common_data)
 
     return ldap_dir

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -109,16 +109,20 @@ FAKE_LDAP_MODE = None  # type: Optional[str]
 # FAKE_LDAP_NUM_USERS = 8
 
 if FAKE_LDAP_MODE:
+    import ldap
+    from django_auth_ldap.config import LDAPSearch
     # To understand these parameters, read the docs in
     # prod_settings_template.py and on ReadTheDocs.
     LDAP_APPEND_DOMAIN = None
-    AUTH_LDAP_USER_DN_TEMPLATE = 'uid=%(user)s,ou=users,dc=zulip,dc=com'
+    AUTH_LDAP_USER_SEARCH = LDAPSearch("ou=users,dc=zulip,dc=com",
+                                       ldap.SCOPE_ONELEVEL, "(uid=%(user)s)")
+    AUTH_LDAP_REVERSE_EMAIL_SEARCH = LDAPSearch("ou=users,dc=zulip,dc=com",
+                                                ldap.SCOPE_ONELEVEL, "(email=%(email)s)")
 
     if FAKE_LDAP_MODE == 'a':
-        import ldap
-        from django_auth_ldap.config import LDAPSearch
-        AUTH_LDAP_USER_SEARCH = LDAPSearch("ou=users,dc=zulip,dc=com",
-                                           ldap.SCOPE_SUBTREE, "(email=%(user)s)")
+        AUTH_LDAP_REVERSE_EMAIL_SEARCH = LDAPSearch("ou=users,dc=zulip,dc=com",
+                                                    ldap.SCOPE_ONELEVEL, "(uid=%(email)s)")
+        AUTH_LDAP_USERNAME_ATTR = "uid"
         AUTH_LDAP_USER_ATTR_MAP = {
             "full_name": "cn",
             "avatar": "thumbnailPhoto",
@@ -136,6 +140,7 @@ if FAKE_LDAP_MODE:
             "custom_profile_field__phone_number": "phoneNumber",
         }
     elif FAKE_LDAP_MODE == 'c':
+        AUTH_LDAP_USERNAME_ATTR = "uid"
         LDAP_EMAIL_ATTR = 'email'
         AUTH_LDAP_USER_ATTR_MAP = {
             "full_name": "cn",


### PR DESCRIPTION
This takes care of the neccessary update of the development ldap config, after all the recent changes to the ldap code broke it. Now all three modes seem to work correctly.
Unfortunately testing is manual - I went through all three modes checking that things seem to be as intended.

