### PR TITLE
support: Added noop way of visiting registration and invitation links.

### DIFF
--- a/analytics/views.py
+++ b/analytics/views.py
@@ -1065,8 +1065,11 @@ def get_confirmations(types: List[int], object_ids: List[int],
             expires_in = "Expired"
 
         url = confirmation_url(confirmation.confirmation_key, realm_host, type)
+        support_url = confirmation_url(confirmation.confirmation_key,
+                                       "localhost:9991", type) + "?support=true"
         confirmation_dicts.append({"object": confirmation.content_object,
-                                   "url": url, "type": type, "link_status": link_status,
+                                   "url": url, "support_url": support_url,
+                                   "type": type, "link_status": link_status,
                                    "expires_in": expires_in})
     return confirmation_dicts
 

--- a/confirmation/models.py
+++ b/confirmation/models.py
@@ -44,8 +44,8 @@ def generate_key() -> str:
     return ''.join(generator.choice(string.ascii_lowercase + string.digits) for _ in range(24))
 
 ConfirmationObjT = Union[MultiuseInvite, PreregistrationUser, EmailChangeStatus]
-def get_object_from_key(confirmation_key: str,
-                        confirmation_type: int) -> ConfirmationObjT:
+def get_object_from_key(confirmation_key: str, confirmation_type: int,
+                        update_status: bool=True) -> ConfirmationObjT:
     # Confirmation keys used to be 40 characters
     if len(confirmation_key) not in (24, 40):
         raise ConfirmationKeyException(ConfirmationKeyException.WRONG_LENGTH)
@@ -60,7 +60,7 @@ def get_object_from_key(confirmation_key: str,
         raise ConfirmationKeyException(ConfirmationKeyException.EXPIRED)
 
     obj = confirmation.content_object
-    if hasattr(obj, "status"):
+    if hasattr(obj, "status") and update_status:
         obj.status = getattr(settings, 'STATUS_ACTIVE', 1)
         obj.save(update_fields=['status'])
     return obj

--- a/templates/analytics/support.html
+++ b/templates/analytics/support.html
@@ -83,7 +83,8 @@
             {% if email %}
             <b>Email</b>: {{ email }}<br>
             {% endif %}
-            <b>Link</b>: {{ confirmation.url }}
+            <b>Link</b>: <a href="{{ confirmation.url }}?support=true" target="_blank">
+                View confirmation page</a> or
             <a title="Copy link" class="copy-button" data-copytext="{{ confirmation.url }}">
                 <i class="fa fa-copy"></i>
             </a><br>

--- a/templates/analytics/support.html
+++ b/templates/analytics/support.html
@@ -83,7 +83,7 @@
             {% if email %}
             <b>Email</b>: {{ email }}<br>
             {% endif %}
-            <b>Link</b>: <a href="{{ confirmation.url }}?support=true" target="_blank">
+            <b>Link</b>: <a href="{{ confirmation.support_url }}" target="_blank">
                 View confirmation page</a> or
             <a title="Copy link" class="copy-button" data-copytext="{{ confirmation.url }}">
                 <i class="fa fa-copy"></i>

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -36,6 +36,8 @@ def common_context(user: UserProfile) -> Dict[str, Any]:
     }
 
 def get_realm_from_request(request: HttpRequest) -> Optional[Realm]:
+    if hasattr(request, "patched_realm"):
+        return request.patched_realm
     if hasattr(request, "user") and hasattr(request.user, "realm"):
         return request.user.realm
     if not hasattr(request, "realm"):

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -53,8 +53,12 @@ def check_prereg_key_and_redirect(request: HttpRequest, confirmation_key: str) -
             Confirmation.USER_REGISTRATION, Confirmation.INVITATION, Confirmation.REALM_CREATION]:
         return render_confirmation_key_error(
             request, ConfirmationKeyException(ConfirmationKeyException.DOES_NOT_EXIST))
+
+    # update_status allows the staff member to inspect the /accounts/register page
+    # by preventing the status of the content object to be set to confirmation.settings.STATUS_ACTIVE
+    update_status = not(request.GET.get("support", False) and request.user.is_staff)
     try:
-        get_object_from_key(confirmation_key, confirmation.type)
+        get_object_from_key(confirmation_key, confirmation.type, update_status=update_status)
     except ConfirmationKeyException as exception:
         return render_confirmation_key_error(request, exception)
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Closes #13262

Now the staff member can visit the registration and invitation links without changing the status attribute of PreregistrationUser and EmailChangeStatus classes if the invitation url ends with the support parameter as True.

Works as previously intended if a staff member is not logged in and the support parameter is True.

For a user to change their email, the tests were present.
Added remaining tests.

**Testing Plan:** <!-- How have you tested? -->
tested with ./tools/test-all and '/activity/support'