### PR TITLE
message_events: Fixed editing message bug.

### DIFF
--- a/frontend_tests/node_tests/message_events.js
+++ b/frontend_tests/node_tests/message_events.js
@@ -17,8 +17,10 @@ set_global('page_params', {});
 set_global('pm_list', {});
 set_global('stream_list', {});
 set_global('unread_ui', {});
+set_global('unread', {});
 
 alert_words.process_message = () => {};
+unread.process_updated_message = () => {};
 
 const alice = {
     email: 'alice@example.com',

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -119,6 +119,16 @@ exports.update_messages = function update_messages(events) {
 
         msgs_to_rerender.push(msg);
 
+        // Before updating booleans, we need to check whether the user was
+        // mentioned previously in the message. It will be used to remove
+        // the message from unread_mentions_counter list if the user isn't
+        // mentioned anymore.
+        const prev_unmuted_mention = msg.type === 'stream' && msg.mentioned &&
+                                     !muting.is_topic_muted(msg.stream_id,
+                                                            util.get_message_topic(msg));
+
+        const prev_mentioned = msg.mentioned_me_directly || prev_unmuted_mention;
+
         message_store.update_booleans(msg, event.flags);
 
         unread.update_message_for_mention(msg);
@@ -302,6 +312,7 @@ exports.update_messages = function update_messages(events) {
 
         notifications.received_messages([msg]);
         alert_words.process_message(msg);
+        unread.process_updated_message(msg, prev_mentioned);
     }
 
     // If a topic was edited, we re-render the whole view to get any


### PR DESCRIPTION
When a message is updated and user is mentioned in the message after updating, the user is not notified, neither the message is entered in his mentioned list.

The problem is that the `mention_user_ids` property is being sent with the update event to the client but it was not being processed correctly on the client side.

This PR adds message in the `unread_mentions_counter` list if the user is mentioned in that message after being updated. If the message is already read by the user, then the mention is ignored (just like Slack).