### PR TITLE
Fix longer strings not being translated.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -536,7 +536,7 @@ run_test('compose_announce', () => {
     const button = $(html).find("button").first();
     assert.equal(button.text(), "translated: Yes, send");
     const error_msg = $(html).find('span.compose-announce-msg').text().trim();
-    assert.equal(error_msg, "translated:         This stream is reserved for announcements.\n        \n        Are you sure you want to message all 101 people in this stream?");
+    assert.equal(error_msg, "translated: This stream is reserved for announcements.  Are you sure you want to message all 101 people in this stream?");
 });
 
 run_test('compose_not_subscribed', () => {

--- a/static/js/templates.js
+++ b/static/js/templates.js
@@ -69,7 +69,7 @@ Handlebars.registerHelper('tr', function (context, options) {
     //     1. `context` is very important. It can be `this` or an
     //        object or key of the current context.
     //     2. Use `__` instead of `{{` and `}}` to declare expressions
-    const result = i18n.t(options.fn(context), context);
+    const result = i18n.t(options.fn(context).trim().split("\n").map(s => s.trim()).join(" "), context);
     return new Handlebars.SafeString(result);
 });
 


### PR DESCRIPTION
When strings are tagged for translation using `tr this` the
strings are passed as it is along with new line and tab
characters but the translation data has a single line string.
This commit removes all those characters before being translated
using `i18n.t`.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

Fixes [#13389](https://github.com/zulip/zulip/issues/13389)

**Testing Plan:** <!-- How have you tested? -->
Have tested this manually by checking if those strings that
were not translated earlier were translated.

