### PR TITLE
lint: Run mypy with --no-error-summary

### DIFF
--- a/tools/lint
+++ b/tools/lint
@@ -79,7 +79,7 @@ def run():
                                   "(zerver/openapi/zulip.yaml) ")
     linter_config.external_linter('shellcheck', ['shellcheck', '-x'], ['sh'],
                                   description="Standard shell script linter.")
-    command = ['tools/run-mypy']
+    command = ['tools/run-mypy', '--quiet']
     if args.force:
         command.append('--force')
     linter_config.external_linter('mypy', command, ['py'], pass_targets=False,

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -5,6 +5,7 @@ import os
 import sys
 import argparse
 import subprocess
+from typing import List
 
 from zulint import lister
 
@@ -31,6 +32,8 @@ parser.add_argument('-a', '--all', action='store_true',
                     help="check all files, bypassing the default exclude list")
 parser.add_argument('--force', action="store_true",
                     help="run tests despite possible provisioning problems")
+parser.add_argument("--quiet", action="store_true",
+                    help="suppress mypy summary output")
 args = parser.parse_args()
 
 assert_provisioning_status_ok(args.force)
@@ -66,7 +69,10 @@ if not python_files and not pyi_files:
     print("There are no files to run mypy on.")
     sys.exit(0)
 
-mypy_args = python_files + pyi_files
+mypy_args = []  # type: List[str]
+if args.quiet:
+    mypy_args += ["--no-error-summary"]
+mypy_args += ["--"] + python_files + pyi_files
 rc = subprocess.call([mypy_command] + mypy_args)
 
 if rc != 0:


### PR DESCRIPTION
This suppresses the mypy message “Success: no issues found in 1085 source files” or “Found 1 error in 1 file (checked 1085 source files)” in the output of lint.