### PR TITLE
portico: Add return to login button to password reset

### DIFF
--- a/static/styles/portico/portico-signin.scss
+++ b/static/styles/portico/portico-signin.scss
@@ -633,16 +633,16 @@ button.login-social-button:active {
 }
 
 .login-page-container .right-side .actions,
-.forgot-password-container .actions {
+.back-to-login-wrapper {
     margin: 20px 0px 0px;
     text-align: left;
 }
 
-.forgot-password-container .actions {
+.back-to-login-wrapper {
     line-height: 0;
 }
 
-.forgot-password-container .actions .back-to-login i {
+.back-to-login-wrapper .back-to-login i {
     position: relative;
     top: 5px;
 

--- a/templates/zerver/include/back_to_login_component.html
+++ b/templates/zerver/include/back_to_login_component.html
@@ -1,0 +1,3 @@
+<div class="back-to-login-wrapper if-zulip-electron"><!-- only show if on `ZulipElectron` -->
+    <a class="back-to-login" href="{{login_url}}"><i class="fa fa-arrow-left"></i> Back to the login page</a>
+</div>

--- a/templates/zerver/reset.html
+++ b/templates/zerver/reset.html
@@ -31,9 +31,7 @@
                     </div>
                 </div>
             </form>
-            <div class="actions if-zulip-electron"><!-- only show if on `ZulipElectron` -->
-                <a class="back-to-login" href="{{login_url}}"><i class="fa fa-arrow-left"></i> Back to the login page</a>
-            </div>
+            {% include 'zerver/include/back_to_login_component.html' %}
         </div>
     </div>
 </div>

--- a/templates/zerver/reset_emailed.html
+++ b/templates/zerver/reset_emailed.html
@@ -12,6 +12,7 @@
             <div class="white-box">
                 <p>{{ _('Check your email in a few minutes to finish the process.') }}</p>
                 {% include 'zerver/dev_env_email_access_details.html' %}
+                {% include 'zerver/include/back_to_login_component.html' %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
Adds return to login button in page, where Password Reset flow is completed. 
The HTML part, having return to login link in Password Reset's first step page was exported into separate template file and used in both cases.

#13378

PW Reset / Emailed Dev:
![image](https://user-images.githubusercontent.com/3249003/68813930-0eacaf00-0680-11ea-96bc-8165db7e5a6b.png)

PW Reset / Emailed Non-Dev:
![image](https://user-images.githubusercontent.com/3249003/68813935-1409f980-0680-11ea-8ed0-eb5312ef524e.png)
