### PR TITLE
invitations: Improve experience around reactivating users.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -1716,3 +1716,65 @@ run_test('recipient_row', () => {
     assert(html.indexOf('<script>alert("Hello")</script>') === -1);
     assert(html.indexOf('&lt;script&gt;alert(&quot;Hello&quot;)&lt;/script&gt;') !== -1);
 });
+
+run_test('invitation_failed_error', () => {
+    let err_list = [];
+    err_list.push("hamlet@zulip.com: Account has been deactivated.");
+    let data = {
+        error_message: "We weren't able to invite anyone.",
+        error_list: err_list,
+        is_invitee_deactivated: true,
+        is_admin: true,
+    };
+
+    let html = '<div>';
+    html += render('invitation_failed_error', data);
+    html += '</div>';
+    let p = $(html).find('p#invitation_error_message');
+    assert.equal(p.text().trim(), "We weren't able to invite anyone.");
+    let li = $(html).find("li").first();
+    assert.equal(li.text().trim(), "hamlet@zulip.com: Account has been deactivated.");
+    let p_admin = $(html).find("p#invitation_admin_message");
+    assert.equal(p_admin.text().trim(), 'translated: You can reactivate deactivated users from organization settings.');
+
+    err_list = [];
+    err_list.push("hamlet@zulip.com: Account has been deactivated.");
+    data = {
+        error_message: "We weren't able to invite anyone.",
+        error_list: err_list,
+        is_invitee_deactivated: true,
+        is_admin: false,
+    };
+
+    html = '<div>';
+    html += render('invitation_failed_error', data);
+    html += '</div>';
+    p = $(html).find("p#invitation_error_message");
+    assert.equal(p.text().trim(), "We weren't able to invite anyone.");
+    li = $(html).find("li").first();
+    assert.equal(li.text().trim(), "hamlet@zulip.com: Account has been deactivated.");
+    const msg = $(html).find("p#invitation_non_admin_message");
+    assert.equal(msg.text().trim(), 'translated: Organization administrators can reactivate deactivated users.');
+    p_admin = $(html).find("p#invitation_admin_message");
+    assert.equal(p_admin.length, 0);
+
+    err_list = [];
+    err_list.push("othello@zulip.com: Already has an account.");
+    data = {
+        error_message: "We weren't able to invite anyone.",
+        error_list: err_list,
+        is_invitee_deactivated: false,
+        is_admin: false,
+    };
+
+    html = '<div>';
+    html += render('invitation_failed_error', data);
+    html += '</div>';
+    p = $(html).find("p#invitation_error_message");
+    assert.equal(p.text().trim(), "We weren't able to invite anyone.");
+    li = $(html).find("li").first();
+    assert.equal(li.text().trim(), "othello@zulip.com: Already has an account.");
+    p_admin = $(html).find("p#invitation_admin_message");
+    assert.equal(p_admin.length, 0);
+
+});

--- a/static/js/invite.js
+++ b/static/js/invite.js
@@ -72,14 +72,21 @@ function submit_invitation_form() {
                 // Some users were not invited.
                 const invitee_emails_errored = [];
                 const error_list = [];
+                let is_invitee_deactivated = false;
                 arr.errors.forEach(function (value) {
-                    error_list.push(value.join(': '));
+                    const [email, error_message, deactivated] = value;
+                    error_list.push(`${email}: ${error_message}`);
+                    if (deactivated) {
+                        is_invitee_deactivated = true;
+                    }
                     invitee_emails_errored.push(value[0]);
                 });
 
                 const error_response = render_invitation_failed_error({
                     error_message: arr.msg,
                     error_list: error_list,
+                    is_admin: page_params.is_admin,
+                    is_invitee_deactivated: is_invitee_deactivated,
                 });
                 ui_report.message(error_response, invite_status, "alert-warning");
                 invitee_emails_group.addClass('warning');

--- a/static/templates/invitation_failed_error.hbs
+++ b/static/templates/invitation_failed_error.hbs
@@ -1,6 +1,13 @@
-<p>{{ error_message }}</p>
+<p id="invitation_error_message">{{ error_message }}</p>
 <ul>
     {{#each error_list}}
     <li>{{this}}</li>
     {{/each}}
 </ul>
+{{#if is_invitee_deactivated}}
+    {{#if is_admin}}
+    <p id="invitation_admin_message">{{#tr this}}You can reactivate deactivated users from <a href="#organization/deactivated-users-admin">organization settings.</a>{{/tr}}</p>
+    {{else}}
+    <p id="invitation_non_admin_message">{{t "Organization administrators can reactivate deactivated users." }}</p>
+    {{/if}}
+{{/if}}

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -3279,19 +3279,23 @@ class EmailValidatorTestCase(ZulipTestCase):
         inviter = self.example_user('hamlet')
         cordelia = self.example_user('cordelia')
 
-        error, _ = validate_email(inviter, 'fred+5555@zulip.com')
+        error, _, is_deactivated = validate_email(inviter, 'fred+5555@zulip.com')
+        self.assertEqual(False, is_deactivated)
         self.assertIn('containing + are not allowed', error)
 
-        _, error = validate_email(inviter, cordelia.email)
+        _, error, is_deactivated = validate_email(inviter, cordelia.email)
+        self.assertEqual(False, is_deactivated)
         self.assertEqual(error, 'Already has an account.')
 
         cordelia.is_active = False
         cordelia.save()
 
-        _, error = validate_email(inviter, cordelia.email)
+        _, error, is_deactivated = validate_email(inviter, cordelia.email)
+        self.assertEqual(True, is_deactivated)
         self.assertEqual(error, 'Account has been deactivated.')
 
-        _, error = validate_email(inviter, 'fred-is-fine@zulip.com')
+        _, error, is_deactivated = validate_email(inviter, 'fred-is-fine@zulip.com')
+        self.assertEqual(False, is_deactivated)
         self.assertEqual(error, None)
 
 class LDAPBackendTest(ZulipTestCase):

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -92,7 +92,7 @@ def json_change_settings(request: HttpRequest, user_profile: UserProfile,
     if user_profile.delivery_email != new_email and new_email != '':
         if user_profile.realm.email_changes_disabled and not user_profile.is_realm_admin:
             return json_error(_("Email address changes are disabled in this organization."))
-        error, skipped = validate_email(user_profile, new_email)
+        error, skipped, deactivated = validate_email(user_profile, new_email)
         if error:
             return json_error(error)
         if skipped:


### PR DESCRIPTION
Further work implemented on a previous [pr.](https://github.com/zulip/zulip/pull/11566)
Invite.js and invitation_failed_error template modified to display
appropriate messages to admin and non-admins when they try to invite
a deactivated user.Actions.py modified to send deactivated boolean
flag in the errors list.Node test added for `invitation_failed_error.hbs`.
Fixes #8144 

**GIFs or screenshots**
If logged in person is admin and Hamlet has been deactivated  
![admingif](https://s5.gifyu.com/images/admin.gif)
If logged in person is user and Hamlet has been deactivated
![usergif](https://s5.gifyu.com/images/user.gif)


**Testing Plan:** 
- Login as admin,deactivate user
- Try to invite as admin and non-admin
- Tested using `./tools/test-all`


