### PR TITLE
export-and-import: Update repo url of Zulip Archive.

### DIFF
--- a/docs/production/export-and-import.md
+++ b/docs/production/export-and-import.md
@@ -41,7 +41,7 @@ service (or back):
   situations where an easily machine-parsable export format is desired.
 
 * Zulip also has an [HTML archive
-  tool](https://github.com/zulip/zulip_archive), which is primarily
+  tool](https://github.com/zulip/zulip-archive), which is primarily
   intended for public archives, but can also be useful to
   inexpensively preserve public stream conversations when
   decommissioning a Zulip organization.


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Turns out there is another Zulip Archive repo url in the documentation: https://github.com/zulip/zulip/pull/13406#issuecomment-554142604.

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
