### PR TITLE
support: Send confirmation email on realm activation

### DIFF
--- a/analytics/tests/test_views.py
+++ b/analytics/tests/test_views.py
@@ -515,10 +515,10 @@ class TestSupportEndpoint(ZulipTestCase):
             m.assert_called_once_with(lear_realm, self.example_user("iago"))
             self.assert_in_success_response(["Lear &amp; Co. deactivated"], result)
 
-        with mock.patch("analytics.views.do_reactivate_realm") as m:
+        with mock.patch("analytics.views.do_send_realm_reactivation_email") as m:
             result = self.client_post("/activity/support", {"realm_id": "%s" % (lear_realm.id,), "status": "active"})
             m.assert_called_once_with(lear_realm)
-            self.assert_in_success_response(["Lear &amp; Co. reactivated."], result)
+            self.assert_in_success_response(["Realm reactivation email sent to admins of Lear"], result)
 
     def test_scrub_realm(self) -> None:
         lear_realm = get_realm("lear")

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -40,7 +40,7 @@ from zerver.lib.realm_icon import realm_icon_url
 from zerver.views.invite import get_invitee_emails_set
 from zerver.lib.subdomains import get_subdomain_from_hostname
 from zerver.lib.actions import do_change_plan_type, do_deactivate_realm, \
-    do_reactivate_realm, do_scrub_realm
+    do_send_realm_reactivation_email, do_scrub_realm
 from confirmation.settings import STATUS_ACTIVE
 
 if settings.BILLING_ENABLED:
@@ -1098,8 +1098,8 @@ def support(request: HttpRequest) -> HttpResponse:
         status = request.POST.get("status", None)
         if status is not None:
             if status == "active":
-                do_reactivate_realm(realm)
-                context["message"] = "{} reactivated.".format(realm.name)
+                do_send_realm_reactivation_email(realm)
+                context["message"] = "Realm reactivation email sent to admins of {}.".format(realm.name)
             elif status == "deactivated":
                 do_deactivate_realm(realm, request.user)
                 context["message"] = "{} deactivated.".format(realm.name)


### PR DESCRIPTION
Previously we used to reactivate realm directly instead of asking for a confirmation email from realm adminstrators. This PR would change that and instead send a confirmation email to realm admins.