### PR TITLE
version: Set ZULIP_VERSION = "2.1.dev+git"

### DIFF
--- a/version.py
+++ b/version.py
@@ -1,6 +1,6 @@
 import os
 
-ZULIP_VERSION = "2.0.6+git"
+ZULIP_VERSION = "2.1.dev+git"
 # Add information on number of commits and commit hash to version, if available
 zulip_git_version_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'zulip-git-version')
 if os.path.exists(zulip_git_version_file):


### PR DESCRIPTION
Since we don’t support downgrading from `master` to any 2.0.x release, we shouldn’t set a `ZULIP_VERSION` that might lead someone to mistake any such downgrade for an upgrade.  `ZULIP_VERSION` should always be at least a minor version ahead of `LATEST_RELEASE_VERSION`, except on the release branch.