### PR TITLE
Detach perfectscrollbar from pm list

### DIFF
--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -5,7 +5,12 @@ set_global('resize', {
     resize_stream_filters_container: function () {},
 });
 set_global('ui', {
-    set_up_scrollbar: function () {},
+    set_up_scrollbar: function (selector) {
+        selector.perfectScrollbar = null;
+    },
+    destroy_scrollbar: function (selector) {
+        delete selector.perfectScrollbar;
+    },
 });
 set_global('stream_popover', {
     hide_topic_popover: function () {},
@@ -129,6 +134,8 @@ run_test('expand_and_update_private_messages', () => {
     var collapsed;
     $('#private-container').remove = function () {
         collapsed = true;
+        // Ensure the scrollbar was destroyed before remove was called
+        assert.strictEqual(this.perfectScrollbar, undefined);
     };
 
     global.templates.render = function (template_name) {

--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -62,6 +62,9 @@ function set_pm_conversation_count(user_ids_string, count) {
 
 function remove_expanded_private_messages() {
     stream_popover.hide_topic_popover();
+    if ($("#private-container").length !== 0) {
+        ui.destroy_scrollbar($("#private-container"));
+    }
     $("#private-container").remove();
     resize.resize_stream_filters_container();
 }

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -39,8 +39,12 @@ exports.reset_scrollbar = function (element_selector) {
     }
 };
 
-exports.destroy_scrollbar = function (element) {
-    element[0].perfectScrollbar.destroy();
+exports.destroy_scrollbar = function (element_selector) {
+    var element = element_selector[0];
+    if (element.perfectScrollbar !== undefined) {
+        element.perfectScrollbar.destroy();
+        delete element.perfectScrollbar;
+    }
 };
 
 function update_message_in_all_views(message_id, callback) {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

This PR plugs a DOM node leak where removed PM div and children would never get garbage collected due to a live perfectScrollbar JS object being attached and never removed.

**Testing Plan:** <!-- How have you tested? -->
Deployed in a testing environment over 24 hours and maintained DOM Node counts across patched and unpatched instances

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
