### PR TITLE
Registration flow changes in configurations with LDAP

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -984,6 +984,18 @@ class SocialAuthBase(ZulipTestCase):
             self.stage_two_of_registration(result, realm, subdomain, email, name, "New LDAP fullname",
                                            skip_registration_form=True)
 
+            # Now try a user that doesn't exist in ldap:
+            email = self.nonreg_email("alice")
+            name = "Alice Social"
+            account_data_dict = self.get_account_data_dict(email=email, name=name)
+            result = self.social_auth_test(account_data_dict,
+                                           expect_choose_email_screen=True,
+                                           subdomain=subdomain, is_signup='1')
+            # Full name should get populated as provided by the social backend, because
+            # this user isn't in the ldap dictionary:
+            self.stage_two_of_registration(result, realm, subdomain, email, name, name,
+                                           skip_registration_form=self.BACKEND_CLASS.full_name_validated)
+
     def test_social_auth_complete(self) -> None:
         with mock.patch('social_core.backends.oauth.BaseOAuth2.process_error',
                         side_effect=AuthFailed('Not found')):

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -2991,9 +2991,29 @@ class UserSignUpTest(InviteUserBase):
             self.assertEqual(result.url, "/accounts/login/?email=newuser%40zulip.com")
             self.assertFalse(UserProfile.objects.filter(email=email).exists())
 
-        # If the user's email is not in the LDAP directory, though, we
-        # successfully create an account with a password in the Zulip
-        # database.
+        # For the rest of the test we delete the user from ldap.
+        del self.mock_ldap.directory["uid=newuser,ou=users,dc=zulip,dc=com"]
+
+        # If the user's email is not in the LDAP directory, but fits LDAP_APPEND_DOMAIN,
+        # we refuse to create the account.
+        with self.settings(
+                POPULATE_PROFILE_VIA_LDAP=True,
+                LDAP_APPEND_DOMAIN='zulip.com',
+                AUTH_LDAP_USER_ATTR_MAP=ldap_user_attr_map,
+        ):
+            result = self.submit_reg_form_for_user(email,
+                                                   password,
+                                                   full_name="Non-LDAP Full Name",
+                                                   # Pass HTTP_HOST for the target subdomain
+                                                   HTTP_HOST=subdomain + ".testserver")
+            self.assertEqual(result.status_code, 302)
+            # We get redirected back to the login page because emails matching LDAP_APPEND_DOMAIN,
+            # aren't allowed to create non-ldap accounts.
+            self.assertEqual(result.url, "/accounts/login/?email=newuser%40zulip.com")
+            self.assertFalse(UserProfile.objects.filter(email=email).exists())
+
+        # If the email is outside of LDAP_APPEND_DOMAIN, we succesfully create a non-ldap account,
+        # with the password managed in the zulip database.
         with self.settings(
                 POPULATE_PROFILE_VIA_LDAP=True,
                 LDAP_APPEND_DOMAIN='example.com',


### PR DESCRIPTION
First commit fixes a small issue where in setups of LDAPPopulator + another backend, the full name on the registration page wouldn't be prefilled if the user isn't in ldap. Instead in those cases it should be pre-filled with the name provided by the backend (if possible - for example social backends provide the name to pre-fill.).

Second commi simplifies ``email_belongs_to_ldap``. It does introduce a behavior change that I think is sensible, but it could be controversial - from the commit message:
> In LDAP_APPEND_DOMAIN configs, email_belongs_to_ldap used to return True
as long as the email's domain matched LDAP_APPEND_DOMAIN, even if it
didn't have an entry in LDAP. Now it will return True if and only if the
email actually has an entry in LDAP. This means that emails matching
LDAP_APPEND_DOMAIN will be allowed to be managed by non-ldap backends,
if they're not actually in the directory.

Third commit addresses the point raises in the first point of https://github.com/zulip/zulip/pull/13381#issuecomment-552008153 - if ZulipLDAPAuthBackend is enabled, we can fall back to creating a non-ldap account if email or social backends are enabled.