### PR TITLE
bots: Render bot owner name in bots settings as link to show owner profile

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -134,16 +134,11 @@ function populate_users(realm_people_data) {
             // Convert bot type id to string for viewing to the users.
             user.bot_type = settings_bots.type_id_to_string(user.bot_type);
 
-            // TODO: This is a messy way to handle bot owners.
-            // Ideally, we'd send the user ID to the template, render
-            // owner names as a link, and have that link take the
-            // browser to that user's profile.  But showing the user's
-            // full name is simpler and doesn't look broken, so we do
-            // that for now.
             if (user.bot_owner_id !== null) {
                 user.bot_owner_full_name = people.get_person_from_user_id(
                     user.bot_owner_id).full_name;
             } else {
+                user.no_owner = true;
                 user.bot_owner_full_name = i18n.t("No owner");
             }
             bots.push(user);
@@ -433,6 +428,14 @@ exports.on_load_success = function (realm_people_data) {
         };
 
         settings_ui.do_settings_change(channel.post, url, data, status, opts);
+    });
+
+    $('.admin_bot_table').on('click', '.user_row .view_user_profile', function (e) {
+        const owner_id = $(e.target).attr('data-owner-id');
+        const owner = people.get_person_from_user_id(owner_id);
+        popovers.show_user_profile(owner);
+        e.stopPropagation();
+        e.preventDefault();
     });
 
     $(".admin_user_table, .admin_bot_table").on("click", ".open-user-form", function (e) {

--- a/static/templates/admin_user_list.hbs
+++ b/static/templates/admin_user_list.hbs
@@ -31,7 +31,13 @@
         {{#if ../can_modify}}
         <span class="owner">{{bot_owner_delivery_email}}</span>
         {{else}}
-        <span class="owner">{{bot_owner_full_name}}</span>
+        <span class="owner">
+            {{#if no_owner }}
+            {{bot_owner_full_name}}
+            {{else}}
+            <a data-owner-id="{{bot_owner_id}}" href="#" class="view_user_profile">{{bot_owner_full_name}}</a>
+            {{/if}}
+        </span>
         {{/if}}
     </td>
     <td>


### PR DESCRIPTION
If owner exists, show owner name as link in org. settings which on click
trigger owner profile popup.

Fixes: #13388.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#13388 

**Testing Plan:** <!-- How have you tested? -->
Opened the settings page and clicked on owner name and checked if the owner profile popup open or not.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![issue13388](https://user-images.githubusercontent.com/52816811/69525725-bbdfcb00-0f8e-11ea-833f-1325dbd4f53a.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
