### PR TITLE
docs: Explain link sharing in /api/upload-file.

### DIFF
--- a/templates/zerver/api/upload-file.md
+++ b/templates/zerver/api/upload-file.md
@@ -4,6 +4,15 @@ Upload a single file and get the corresponding URI.
 
 `POST {{ api_url }}/v1/user_uploads`
 
+To share the uploaded file, you will have to prepend the URI with your
+Zulip domain and then you can [send a message][send-message] that contains the
+resulting link.
+You can also manually view all your [Uploaded files][uploaded-files]
+to verify and copy the links to the files you have uploaded.
+
+[uploaded-files]: /help/manage-your-uploaded-files
+[send-message]: /api/send-message
+
 ## Usage examples
 
 {start_tabs}


### PR DESCRIPTION
https://zulipchat.com/api/upload-file should explain that uploading a file doesn’t share it with anyone; you need to then include the URI in a link to it in a Zulip message.

Should we also extend the example code to send a Zulip message containing a proper link to the file?