### PR TITLE
Mobile Website : Gradient Removed From The Footer

### DIFF
--- a/static/styles/portico/landing-page.scss
+++ b/static/styles/portico/landing-page.scss
@@ -3535,6 +3535,27 @@ nav ul li.active::after {
     .tour .carousel-inner .call-to-action {
         margin: 10px auto;
     }
+
+    .gradients .gradient.dark-blue {
+        background: none;
+    }
+    
+    .gradients .gradient.green {
+        background: none;
+    }
+    
+    .gradients .gradient.blue {
+        background: none;
+    }
+    
+    .gradients .gradient.sunburst {
+        background: none;
+    }
+    
+    .gradients .gradient.white-fade {
+        background: none;
+
+    }
 }
 
 @media (max-width: 640px) {
@@ -3683,17 +3704,6 @@ nav ul li.active::after {
     /* the gradients leave the bottom of the text and the button white so we
        want to have the gradients stay darker for longer.
     */
-    .gradients .gradient.green {
-        background: linear-gradient(-25deg, transparent 10%, hsl(156, 47%, 47%) 80%);
-    }
-
-    .gradients .gradient.blue {
-        background: linear-gradient(25deg, transparent 10%, hsl(196, 38%, 51%) 80%);
-    }
-
-    .gradients .gradient.sunburst {
-        background: linear-gradient(5deg, transparent 20%, hsl(49, 71%, 68%) 80%);
-    }
 }
 
 @media (max-width: 375px) {

--- a/static/styles/portico/landing-page.scss
+++ b/static/styles/portico/landing-page.scss
@@ -3554,7 +3554,6 @@ nav ul li.active::after {
     
     .gradients .gradient.white-fade {
         background: none;
-
     }
 }
 


### PR DESCRIPTION
The gradient has been removed from the footer. Only the mobile websites with maximum width 686px was having the issue so in landing-page.scss the following changes are made:
1) For max width upto 686px all the gradients are set to none.
2) There was a declaration of gradient for maxwidth of 450px and now it has been removed from it.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

This is the pr for #13375



**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![image](https://user-images.githubusercontent.com/18120004/69901738-8f231d80-13ab-11ea-8c3d-27035cf943aa.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
