### PR TITLE
revoke_invitations: Revoke remaining invitations after user register.

### DIFF
--- a/confirmation/settings.py
+++ b/confirmation/settings.py
@@ -3,3 +3,4 @@
 __revision__ = '$Id: settings.py 12 2008-11-23 19:38:52Z jarek.zgoda $'
 
 STATUS_ACTIVE = 1
+STATUS_REVOKED = 2

--- a/templates/zerver/confirmation_link_expired_error.html
+++ b/templates/zerver/confirmation_link_expired_error.html
@@ -1,0 +1,14 @@
+{% extends "zerver/portico_signup.html" %}
+
+{% block portico_content %}
+<div class="app portico-page">
+    <div class="app-main portico-page-container center-block flex full-page account-creation new-style">
+        <div class="inline-block">
+            <div class="app-main white-box">
+                <h1>{{ _("The registration link has expired or is not valid.") }}</h1>
+                <a href="{{ login_url }}">{{ _("Log in") }}</a>.
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1467,8 +1467,12 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
     # make sure users can't take a valid confirmation key from another
     # pathway and use it with the invitation url route
     def test_confirmation_key_of_wrong_type(self) -> None:
-        user = self.example_user('hamlet')
-        url = create_confirmation_link(user, 'host', Confirmation.USER_REGISTRATION)
+        email = self.nonreg_email("alice")
+        realm = get_realm('zulip')
+        inviter = self.example_user('iago')
+        prereg_user = PreregistrationUser.objects.create(
+            email=email, referred_by=inviter, realm=realm)
+        url = create_confirmation_link(prereg_user, 'host', Confirmation.USER_REGISTRATION)
         registration_key = url.split('/')[-1]
 
         # Mainly a test of get_object_from_key, rather than of the invitation pathway
@@ -1477,7 +1481,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
         self.assertEqual(cm.exception.error_type, ConfirmationKeyException.DOES_NOT_EXIST)
 
         # Verify that using the wrong type doesn't work in the main confirm code path
-        email_change_url = create_confirmation_link(user, 'host', Confirmation.EMAIL_CHANGE)
+        email_change_url = create_confirmation_link(prereg_user, 'host', Confirmation.EMAIL_CHANGE)
         email_change_key = email_change_url.split('/')[-1]
         url = '/accounts/do_confirm/' + email_change_key
         result = self.client_get(url)
@@ -1485,8 +1489,12 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
                                          "confirmation link in the system."], result)
 
     def test_confirmation_expired(self) -> None:
-        user = self.example_user('hamlet')
-        url = create_confirmation_link(user, 'host', Confirmation.USER_REGISTRATION)
+        email = self.nonreg_email("alice")
+        realm = get_realm('zulip')
+        inviter = self.example_user('iago')
+        prereg_user = PreregistrationUser.objects.create(
+            email=email, referred_by=inviter, realm=realm)
+        url = create_confirmation_link(prereg_user, 'host', Confirmation.USER_REGISTRATION)
         registration_key = url.split('/')[-1]
 
         conf = Confirmation.objects.filter(confirmation_key=registration_key).first()

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1506,6 +1506,27 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
         self.assert_in_success_response(["Whoops. The confirmation link has expired "
                                          "or been deactivated."], result)
 
+    def test_validate_email_not_already_in_realm(self) -> None:
+        email = self.nonreg_email('alice')
+        password = 'password'
+        realm = get_realm('zulip')
+        inviter = self.example_user('iago')
+        prereg_user = PreregistrationUser.objects.create(
+            email=email, referred_by=inviter, realm=realm)
+
+        confirmation_link = create_confirmation_link(prereg_user, 'host', Confirmation.USER_REGISTRATION)
+        registration_key = confirmation_link.split('/')[-1]
+
+        url = "/accounts/register/"
+        self.client_post(url, {"key": registration_key, "from_confirmation": 1, "full_name": "alice"})
+        self.submit_reg_form_for_user(email, password, key=registration_key)
+
+        url = "/accounts/register/"
+        response = self.client_post(url, {"key": registration_key, "from_confirmation": 1, "full_name": "alice"})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse('django.contrib.auth.views.login') + '?email=' +
+                         urllib.parse.quote_plus(email))
+
 class InvitationsTestCase(InviteUserBase):
     def test_do_get_user_invites(self) -> None:
         self.login('iago')

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -76,8 +76,12 @@ def check_prereg_key_and_redirect(request: HttpRequest, confirmation_key: str) -
 
 @require_post
 def accounts_register(request: HttpRequest) -> HttpResponse:
-    key = request.POST['key']
-    confirmation = Confirmation.objects.get(confirmation_key=key)
+    try:
+        key = request.POST.get('key', default='')
+        confirmation = Confirmation.objects.get(confirmation_key=key)
+    except Confirmation.DoesNotExist:
+        return render(request, "zerver/confirmation_link_expired_error.html")
+
     prereg_user = confirmation.content_object
     if prereg_user.status == confirmation_settings.STATUS_REVOKED:
         return render(request, "zerver/confirmation_link_expired_error.html")


### PR DESCRIPTION
If a user receives more than one invitation to join
an organization and accepts one of them, the others
will still be listed in the admin board.

Fixes: #12629

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
