### PR TITLE
stream settings: Fixing a bug where the stream-list in the stream set…

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -506,6 +506,7 @@ exports.setup_page = function (callback) {
     // continue the strategy that we re-render everything from scratch.
     // Also, we'll always go back to the "Subscribed" tab.
     function initialize_components() {
+        subscribed_only = true;
         exports.toggler = components.toggle({
             child_wants_focus: true,
             values: [


### PR DESCRIPTION
…tings would list all streams but wold show the 'Subscribed' label enabled by resetting the control variable when setting up the page.

Fixes: #13297

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![giphy](https://user-images.githubusercontent.com/16260725/69920616-cb688380-1468-11ea-9840-6a918f2273a0.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
