### PR TITLE
Push bouncer error handling

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -15,7 +15,6 @@ from django.db.models import F
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import ugettext as _
 import gcm
-import requests
 import ujson
 
 from zerver.decorator import statsd_increment
@@ -23,8 +22,7 @@ from zerver.lib.avatar import absolute_avatar_url
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.message import access_message, \
     bulk_access_messages_expect_usermessage, huddle_users
-from zerver.lib.remote_server import send_to_push_bouncer, send_json_to_push_bouncer, \
-    PushNotificationBouncerRetryLaterError
+from zerver.lib.remote_server import send_to_push_bouncer, send_json_to_push_bouncer
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.models import PushDeviceToken, Message, Recipient, \
     UserMessage, UserProfile, \
@@ -668,14 +666,10 @@ def handle_remove_push_notification(user_profile_id: int, message_ids: List[int]
     gcm_payload, gcm_options = get_remove_payload_gcm(user_profile, message_ids)
 
     if uses_notification_bouncer():
-        try:
-            send_notifications_to_bouncer(user_profile_id,
-                                          {},
-                                          gcm_payload,
-                                          gcm_options)
-        except requests.ConnectionError:  # nocoverage
-            raise PushNotificationBouncerRetryLaterError(
-                "ConnectionError while trying to connect to the bouncer")
+        send_notifications_to_bouncer(user_profile_id,
+                                      {},
+                                      gcm_payload,
+                                      gcm_options)
     else:
         android_devices = list(PushDeviceToken.objects.filter(
             user=user_profile, kind=PushDeviceToken.GCM))
@@ -744,15 +738,11 @@ def handle_push_notification(user_profile_id: int, missed_message: Dict[str, Any
     logger.info("Sending push notifications to mobile clients for user %s" % (user_profile_id,))
 
     if uses_notification_bouncer():
-        try:
-            send_notifications_to_bouncer(user_profile_id,
-                                          apns_payload,
-                                          gcm_payload,
-                                          gcm_options)
-            return
-        except requests.ConnectionError:
-            raise PushNotificationBouncerRetryLaterError(
-                "ConnectionError while trying to connect to the bouncer")
+        send_notifications_to_bouncer(user_profile_id,
+                                      apns_payload,
+                                      gcm_payload,
+                                      gcm_options)
+        return
 
     android_devices = list(PushDeviceToken.objects.filter(user=user_profile,
                                                           kind=PushDeviceToken.GCM))

--- a/zerver/lib/remote_server.py
+++ b/zerver/lib/remote_server.py
@@ -17,6 +17,9 @@ from zerver.models import RealmAuditLog
 class PushNotificationBouncerException(Exception):
     pass
 
+class PushNotificationBouncerRetryLaterError(JsonableError):
+    pass
+
 def send_to_push_bouncer(method: str,
                          endpoint: str,
                          post_data: Union[str, Dict[str, Any]],

--- a/zerver/lib/remote_server.py
+++ b/zerver/lib/remote_server.py
@@ -57,9 +57,10 @@ def send_to_push_bouncer(method: str,
                                timeout=30,
                                verify=True,
                                headers=headers)
-    except requests.exceptions.ConnectionError:
+    except (requests.exceptions.Timeout, requests.exceptions.SSLError,
+            requests.exceptions.ConnectionError) as e:
         raise PushNotificationBouncerRetryLaterError(
-            "ConnectionError while trying to connect to push notification bouncer")
+            "{} while trying to connect to push notification bouncer".format(e.__class__.__name__))
 
     if res.status_code >= 500:
         # 500s should be resolved by the people who run the push

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -262,7 +262,7 @@ class PushBouncerNotificationTest(BouncerTestCase):
             self.assert_json_error(result, 'Invalid APNS token')
 
     @override_settings(PUSH_NOTIFICATION_BOUNCER_URL='https://push.zulip.org.example.com')
-    @mock.patch('zerver.lib.push_notifications.requests.request')
+    @mock.patch('zerver.lib.remote_server.requests.request')
     def test_push_bouncer_api(self, mock_request: Any) -> None:
         """This is a variant of the below test_push_api, but using the full
         push notification bouncer flow
@@ -348,7 +348,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
     TIME_ZERO = datetime.datetime(1988, 3, 14).replace(tzinfo=timezone_utc)
 
     @override_settings(PUSH_NOTIFICATION_BOUNCER_URL='https://push.zulip.org.example.com')
-    @mock.patch('zerver.lib.push_notifications.requests.request')
+    @mock.patch('zerver.lib.remote_server.requests.request')
     def test_analytics_api(self, mock_request: Any) -> None:
         """This is a variant of the below test_push_api, but using the full
         push notification bouncer flow
@@ -457,7 +457,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
             self.assert_json_error(result, "Invalid data.")
 
     @override_settings(PUSH_NOTIFICATION_BOUNCER_URL='https://push.zulip.org.example.com')
-    @mock.patch('zerver.lib.push_notifications.requests.request')
+    @mock.patch('zerver.lib.remote_server.requests.request')
     def test_analytics_api_invalid(self, mock_request: Any) -> None:
         """This is a variant of the below test_push_api, but using the full
         push notification bouncer flow
@@ -481,7 +481,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
     # Servers on Zulip 2.0.6 and earlier only send realm_counts and installation_counts data,
     # and don't send realmauditlog_rows. Make sure that continues to work.
     @override_settings(PUSH_NOTIFICATION_BOUNCER_URL='https://push.zulip.org.example.com')
-    @mock.patch('zerver.lib.push_notifications.requests.request')
+    @mock.patch('zerver.lib.remote_server.requests.request')
     def test_old_two_table_format(self, mock_request: Any) -> None:
         mock_request.side_effect = self.bounce_request
         # Send fixture generated with Zulip 2.0 code
@@ -496,7 +496,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
 
     # Make sure we aren't sending data we don't mean to, even if we don't store it.
     @override_settings(PUSH_NOTIFICATION_BOUNCER_URL='https://push.zulip.org.example.com')
-    @mock.patch('zerver.lib.push_notifications.requests.request')
+    @mock.patch('zerver.lib.remote_server.requests.request')
     def test_only_sending_intended_realmauditlog_data(self, mock_request: Any) -> None:
         mock_request.side_effect = self.bounce_request
         user = self.example_user('hamlet')
@@ -529,7 +529,7 @@ class AnalyticsBouncerTest(BouncerTestCase):
             send_analytics_to_remote_server()
 
     @override_settings(PUSH_NOTIFICATION_BOUNCER_URL='https://push.zulip.org.example.com')
-    @mock.patch('zerver.lib.push_notifications.requests.request')
+    @mock.patch('zerver.lib.remote_server.requests.request')
     def test_realmauditlog_data_mapping(self, mock_request: Any) -> None:
         mock_request.side_effect = self.bounce_request
         user = self.example_user('hamlet')
@@ -647,7 +647,7 @@ class HandlePushNotificationTest(PushNotificationTest):
             'trigger': 'private_message',
         }
         with self.settings(PUSH_NOTIFICATION_BOUNCER_URL=''), \
-                mock.patch('zerver.lib.push_notifications.requests.request',
+                mock.patch('zerver.lib.remote_server.requests.request',
                            side_effect=self.bounce_request), \
                 mock.patch('zerver.lib.push_notifications.gcm_client') as mock_gcm, \
                 self.mock_apns() as mock_apns, \
@@ -703,7 +703,7 @@ class HandlePushNotificationTest(PushNotificationTest):
             'trigger': 'private_message',
         }
         with self.settings(PUSH_NOTIFICATION_BOUNCER_URL=''), \
-                mock.patch('zerver.lib.push_notifications.requests.request',
+                mock.patch('zerver.lib.remote_server.requests.request',
                            side_effect=self.bounce_request), \
                 mock.patch('zerver.lib.push_notifications.gcm_client') as mock_gcm, \
                 mock.patch('zerver.lib.push_notifications.send_notifications_to_bouncer',

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1005,14 +1005,16 @@ class TestAPNs(PushNotificationTest):
         """
         import zerver.lib.push_notifications
         zerver.lib.push_notifications._apns_client_initialized = False
-        with self.settings(APNS_CERT_FILE='/foo.pem'), \
-                mock.patch('apns2.client.APNsClient') as mock_client:
-            client = get_apns_client()
-            self.assertEqual(mock_client.return_value, client)
-        # Reset the values set by `get_apns_client` so that we don't
-        # leak changes to the rest of the world.
-        zerver.lib.push_notifications._apns_client_initialized = False
-        zerver.lib.push_notifications._apns_client = None
+        try:
+            with self.settings(APNS_CERT_FILE='/foo.pem'), \
+                    mock.patch('apns2.client.APNsClient') as mock_client:
+                client = get_apns_client()
+                self.assertEqual(mock_client.return_value, client)
+        finally:
+            # Reset the values set by `get_apns_client` so that we don't
+            # leak changes to the rest of the world.
+            zerver.lib.push_notifications._apns_client_initialized = False
+            zerver.lib.push_notifications._apns_client = None
 
     def test_not_configured(self) -> None:
         with mock.patch('zerver.lib.push_notifications.get_apns_client') as mock_get, \

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Dict, List, Mapping, Tuple
 
 from zerver.lib.email_mirror import RateLimitedRealmMirror
 from zerver.lib.email_mirror_helpers import encode_email_address
+from zerver.lib.queue import MAX_REQUEST_RETRIES
 from zerver.lib.rate_limiter import RateLimiterLockingException, clear_history
 from zerver.lib.send_email import FromAddress
 from zerver.lib.test_helpers import simulated_queue_client
@@ -387,7 +388,7 @@ class WorkerTest(ZulipTestCase):
                     patch('logging.exception'):
                 worker.start()
 
-        self.assertEqual(data['failed_tries'], 4)
+        self.assertEqual(data['failed_tries'], 1 + MAX_REQUEST_RETRIES)
 
     def test_signups_worker_retries(self) -> None:
         """Tests the retry logic of signups queue."""
@@ -416,7 +417,7 @@ class WorkerTest(ZulipTestCase):
                                   ZULIP_FRIENDS_LIST_ID='id'):
                 worker.start()
 
-        self.assertEqual(data['failed_tries'], 4)
+        self.assertEqual(data['failed_tries'], 1 + MAX_REQUEST_RETRIES)
 
     def test_signups_worker_existing_member(self) -> None:
         fake_client = self.FakeClient()


### PR DESCRIPTION
For issue https://github.com/zulip/zulip/issues/13294

I've spent some time looking into using python-zulip-api but didn't find a simple way (for example in ``send_to_push_bouncer`` we have the ``extra_headers`` parameter that's used  to set the content-type when sending the payload in json form, which python-zulip-api doesn't support right now) so I limited myself to just catching the various ``requests`` exceptions for now. Adding usage of session, or further exploring how to use python-zulip-api could be a follow-up to this PR.

This still involves a whole bunch of plumbing changes to handle bouncer errors on the various codepaths, and I'm not sure if this is the best approach, but at least it's the most reasonable way I've managed to come up with for now.