### PR TITLE
bugdown: Reenable -,+ to begin a markdown list.

### DIFF
--- a/static/third/marked/lib/marked.js
+++ b/static/third/marked/lib/marked.js
@@ -346,7 +346,7 @@ Lexer.prototype.token = function(src, top, bq) {
           listStart.loose = true;
         }
 
-        t = {
+        var t = {
           type: 'list_item_start',
           loose: loose
         };

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1440,16 +1440,12 @@ class OListProcessor(sane_lists.SaneOListProcessor):
         parser.markdown.tab_length = 4
 
 class UListProcessor(sane_lists.SaneUListProcessor):
-    """ Does not accept '+' or '-' as a bullet character. """
+    """ Unordered lists, but with 2-space indent """
 
     def __init__(self, parser: Any) -> None:
         parser.markdown.tab_length = 2
         super().__init__(parser)
         parser.markdown.tab_length = 4
-
-        self.RE = re.compile('^[ ]{0,%d}[*][ ]+(.*)' % (self.tab_length - 1,))
-        self.CHILD_RE = re.compile(r'^[ ]{0,%d}(([*]))[ ]+(.*)' %
-                                   (self.tab_length - 1,))
 
 class ListIndentProcessor(markdown.blockprocessors.ListIndentProcessor):
     """ Process unordered list blocks.
@@ -1502,7 +1498,7 @@ class BugdownListPreprocessor(markdown.preprocessors.Preprocessor):
         directly after a line of text, and inserts a newline between
         to satisfy Markdown"""
 
-    LI_RE = re.compile(r'^[ ]{0,3}(\*|\d\.)[ ]+(.*)', re.MULTILINE)
+    LI_RE = re.compile(r'^[ ]{0,3}([*+-]|\d\.)[ ]+(.*)', re.MULTILINE)
 
     def run(self, lines: List[str]) -> List[str]:
         """ Insert a newline between a paragraph and ulist if missing """

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -156,10 +156,29 @@
       "expected_output": "<p>Hello [world][ref-name]</p>\n<p>[ref-name]: <a href=\"https://google.com\" target=\"_blank\" title=\"https://google.com\">https://google.com</a></p>"
     },
     {
-      "name": "ulist_standard",
+      "name": "ulist_standard_1",
       "input": "Some text with a list:\n\n* One item\n* Two items\n* Three items",
       "expected_output": "<p>Some text with a list:</p>\n<ul>\n<li>One item</li>\n<li>Two items</li>\n<li>Three items</li>\n</ul>",
       "text_content": "Some text with a list:\n\nOne item\nTwo items\nThree items\n"
+    },
+    {
+      "name": "ulist_standard_2",
+      "input": "Some text with a list:\n\n- One item\n- Two items\n- Three items",
+      "expected_output": "<p>Some text with a list:</p>\n<ul>\n<li>One item</li>\n<li>Two items</li>\n<li>Three items</li>\n</ul>",
+      "text_content": "Some text with a list:\n\nOne item\nTwo items\nThree items\n"
+    },
+    {
+      "name": "ulist_standard_3",
+      "input": "Some text with a list:\n\n+ One item\n+ Two items\n+ Three items",
+      "expected_output": "<p>Some text with a list:</p>\n<ul>\n<li>One item</li>\n<li>Two items</li>\n<li>Three items</li>\n</ul>",
+      "text_content": "Some text with a list:\n\nOne item\nTwo items\nThree items\n"
+    },
+    {
+      "name": "ulist_mixed_bullets",
+      "input": "Combine four lists:\n\n* One\n- Two\n+ Three\n- Four\n- Five",
+      "expected_output": "<p>Combine four lists:</p>\n<ul>\n<li>One</li>\n<li>Two</li>\n<li>Three</li>\n<li>Four</li>\n<li>Five</li>\n</ul>",
+      "marked_expected_output": "<p>Combine four lists:</p>\n<ul>\n<li>One</li>\n</ul>\n<ul>\n<li>Two</li>\n</ul>\n<ul>\n<li>Three</li>\n</ul>\n<ul>\n<li>Four</li>\n<li>Five</li>\n</ul>",
+      "text_content": "Combine four lists:\n\nOne\nTwo\nThree\nFour\nFive\n"
     },
     {
       "name": "ulist_hanging",


### PR DESCRIPTION
This commit has a side-effect that we also now allow mixed lists,
but they have different syntax from the commonmark implementation
and our marked output. For example, without the closing li tags:

```
  Input    Bugdown     Marked
-------------------------------------
         <ul>
- Hello    <li>Hello  <ul><li>Hello</ul>
+ World    <li>World  <ul><li>World
+ Again    <li>Again      <li>Again</ul>
* And      <li>And    <ul><li>And
* Again    <li>Again      <li>Again</ul>
         </ul>
```

The bugdown render is in line with what a user in #13447 requests.

Fixes #13477.

**Testing Plan:** <!-- How have you tested? -->
Manual + automated tests.

**GIFs or Screenshots:**

Note how the local echo (below) renders slightly differently from the bugdown output.
![image](https://user-images.githubusercontent.com/8033238/70304425-e8fe6a00-1827-11ea-83d9-30c47188c82b.png)

