### PR TITLE
wildcard_mentions_notify: Add per-stream override of global setting.

### DIFF
--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -94,6 +94,12 @@ run_test('update_property', () => {
     checkbox = $("#email_notifications_1");
     assert.equal(checkbox.prop('checked'), true);
 
+    // Tests wildcard_mentions_notify notifications
+    stream_events.update_property(1, 'wildcard_mentions_notify', true);
+    assert.equal(frontend.wildcard_mentions_notify, true);
+    checkbox = $("#wildcard_mentions_notify_1");
+    assert.equal(checkbox.prop('checked'), true);
+
     // Test name change
     with_overrides(function (override) {
         global.with_stub(function (stub) {

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -227,6 +227,8 @@ function show_subscription_settings(sub_row) {
 exports.is_notification_setting = function (setting_label) {
     if (setting_label.indexOf("_notifications") > -1) {
         return true;
+    } else if (setting_label.indexOf("_notify") > -1) {
+        return true;
     }
     return false;
 };
@@ -238,6 +240,7 @@ const settings_labels = {
     push_notifications: i18n.t("Mobile notifications"),
     email_notifications: i18n.t("Email notifications"),
     pin_to_top: i18n.t("Pin stream to top of left sidebar"),
+    wildcard_mentions_notify: i18n.t("Notifications for @all/@everyone mentions"),
 };
 
 const check_realm_setting = {

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -50,6 +50,9 @@ exports.update_property = function (stream_id, property, value, other_values) {
             history_public_to_subscribers: other_values.history_public_to_subscribers,
         });
         break;
+    case 'wildcard_mentions_notify':
+        update_stream_setting(sub, value, property);
+        break;
     case 'is_announcement_only':
         subs.update_stream_announcement_only(sub, value);
         break;

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2778,6 +2778,7 @@ def notify_subscriptions_added(user_profile: UserProfile,
                     audible_notifications=subscription.audible_notifications,
                     push_notifications=subscription.push_notifications,
                     email_notifications=subscription.email_notifications,
+                    wildcard_mentions_notify=subscription.wildcard_mentions_notify,
                     description=stream.description,
                     rendered_description=stream.rendered_description,
                     pin_to_top=subscription.pin_to_top,
@@ -4731,7 +4732,7 @@ def gather_subscriptions_helper(user_profile: UserProfile,
     sub_dicts = get_stream_subscriptions_for_user(user_profile).values(
         "recipient_id", "is_muted", "color", "desktop_notifications",
         "audible_notifications", "push_notifications", "email_notifications",
-        "active", "pin_to_top"
+        "wildcard_mentions_notify", "active", "pin_to_top"
     ).order_by("recipient_id")
 
     sub_dicts = list(sub_dicts)
@@ -4817,6 +4818,7 @@ def gather_subscriptions_helper(user_profile: UserProfile,
                        'audible_notifications': sub["audible_notifications"],
                        'push_notifications': sub["push_notifications"],
                        'email_notifications': sub["email_notifications"],
+                       'wildcard_mentions_notify': sub["wildcard_mentions_notify"],
                        'pin_to_top': sub["pin_to_top"],
                        'stream_id': stream["id"],
                        'first_message_id': stream["first_message_id"],

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2495,6 +2495,7 @@ class EventsRegisterTest(ZulipTestCase):
             ('pin_to_top', check_bool),
             ('stream_weekly_traffic', check_none_or(check_int)),
             ('is_old_stream', check_bool),
+            ('wildcard_mentions_notify', check_none_or(check_bool)),
         ]
         if include_subscribers:
             subscription_fields.append(('subscribers', check_list(check_int)))

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -580,7 +580,8 @@ def update_subscription_properties_backend(
                            "audible_notifications": check_bool,
                            "push_notifications": check_bool,
                            "email_notifications": check_bool,
-                           "pin_to_top": check_bool}
+                           "pin_to_top": check_bool,
+                           "wildcard_mentions_notify": check_bool}
     response_data = []
 
     for change in subscription_data:


### PR DESCRIPTION
Adds required API and front-end changes to modify and read the wildcard_mentions_notify field in the Subscription model.

Fixes: #13429.

**Testing Plan:** 

We added some new automated tests for the front-end changes, API changes and model behaviour. We manually checked that the new checkbox is greyed out when the stream is muted and that changing the value of the checkbox persists the change in the database.

We noticed that the wildcard_mentions_notify behaviour for the UserProfile model wasn't quite behaving as expected - see: https://github.com/zulip/zulip/issues/13073#issuecomment-560263081.

**GIFs or Screenshots:** 

![Screen Recording 2019-12-08 at 10 54 30 AM](https://user-images.githubusercontent.com/8661121/70394374-6e5d5800-19a9-11ea-93a8-60408230932e.gif)