### PR TITLE
 Issue #13413 PR Refactoring and unit testing

### DIFF
--- a/scripts/setup/inline-email-css
+++ b/scripts/setup/inline-email-css
@@ -5,11 +5,12 @@ import errno
 from premailer import Premailer
 from cssutils import profile
 from cssutils.profiles import Profiles, properties, macros
+from typing import List, Tuple
 
 ZULIP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../')
 
 #This function processes a single template based off of the escaped jinja2 characters
-def process_templates(template, escaped_jinja2_characters):
+def process_templates(template: str, escaped_jinja2_characters: List[Tuple[str, str]]) -> None:
     template_html_source = template + ".source.html"
     compiled_template_path = os.path.join(os.getcwd(), "compiled", template + ".html")
 

--- a/scripts/setup/inline-email-css
+++ b/scripts/setup/inline-email-css
@@ -8,6 +8,41 @@ from cssutils.profiles import Profiles, properties, macros
 
 ZULIP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../')
 
+#This function processes a single template based off of the escaped jinja2 characters
+def process_templates(template, escaped_jinja2_characters):
+    template_html_source = template + ".source.html"
+    compiled_template_path = os.path.join(os.getcwd(), "compiled", template + ".html")
+
+    with open(template_html_source) as template_source_file:
+        template_str = template_source_file.read()
+    output = Premailer(template_str, external_styles=["email.css"]).transform()
+    for escaped, original in escaped_jinja2_characters:
+        output = output.replace(escaped, original)
+    # Premailer.transform will try to complete the DOM tree,
+    # adding html, head, and body tags if they aren't there.
+    # While this is correct for the email_base_default template,
+    # it is wrong for the other templates that extend this
+    # template, since we'll end up with 2 copipes of those tags.
+    # Thus, we strip this stuff out if the template extends
+    # another template.
+    end_block = '</body>\n</html>'
+    start = output.find('{% extends')
+    end = output.rfind(end_block)
+    if start != -1 and end != -1:
+        output = output[start:end]
+    else:
+        # Only the base-default template should not be using this system.
+        assert template == 'email_base_default'
+    if ('zerver/emails/compiled/email_base_default.html' in output or
+            'zerver/emails/email_base_messages.html' in output):
+        assert output.count('<html>') == 0
+        assert output.count('<body>') == 0
+        assert output.count('</html>') == 0
+        assert output.count('</body>') == 0
+    with open(compiled_template_path, 'w') as final_template_file:
+        final_template_file.write(output)
+    return
+
 if __name__ == "__main__":
     escaped_jinja2_characters = [('%7B%7B%20', '{{ '), ('%20%7D%7D', ' }}'), ('&gt;', '>')]
 
@@ -40,39 +75,4 @@ if __name__ == "__main__":
             raise
 
     for template in templates_to_inline:
-        template_html_source = template + ".source.html"
-        compiled_template_path = os.path.join(os.getcwd(), "compiled", template + ".html")
-
-        with open(template_html_source) as template_source_file:
-            template_str = template_source_file.read()
-        output = Premailer(template_str,
-                           external_styles=["email.css"]).transform()
-
-        for escaped, original in escaped_jinja2_characters:
-            output = output.replace(escaped, original)
-
-        # Premailer.transform will try to complete the DOM tree,
-        # adding html, head, and body tags if they aren't there.
-        # While this is correct for the email_base_default template,
-        # it is wrong for the other templates that extend this
-        # template, since we'll end up with 2 copipes of those tags.
-        # Thus, we strip this stuff out if the template extends
-        # another template.
-        end_block = '</body>\n</html>'
-        start = output.find('{% extends')
-        end = output.rfind(end_block)
-        if start != -1 and end != -1:
-            output = output[start:end]
-        else:
-            # Only the base-default template should not be using this system.
-            assert template == 'email_base_default'
-
-        if ('zerver/emails/compiled/email_base_default.html' in output or
-                'zerver/emails/email_base_messages.html' in output):
-            assert output.count('<html>') == 0
-            assert output.count('<body>') == 0
-            assert output.count('</html>') == 0
-            assert output.count('</body>') == 0
-
-        with open(compiled_template_path, 'w') as final_template_file:
-            final_template_file.write(output)
+        process_templates(template, escaped_jinja2_characters)

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -45,6 +45,7 @@ FILES_WITH_LEGACY_SUBJECT = {
     'zerver/lib/feedback.py',
     'zerver/tests/test_new_users.py',
     'zerver/tests/test_email_mirror.py',
+    'zerver/lib/send_email.py',
 
     # These are tied more to our API than our DB model.
     'zerver/openapi/python_examples.py',

--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -168,6 +168,7 @@ def send_email_to_admins(template_prefix: str, realm: Realm, from_name: Optional
                from_address=from_address, context=context)
 
 def send_custom_email(users: List[UserProfile], options: Dict[str, Any]) -> None:
+    
     """
     Can be used directly with from a management shell with
     send_custom_email(user_profile_list, dict(
@@ -218,6 +219,7 @@ def send_custom_email(users: List[UserProfile], options: Dict[str, Any]) -> None
         send_email(email_id, to_user_ids=[user_profile.id],
                    from_address=FromAddress.SUPPORT,
                    from_name=options["from_name"], context=context)
+
 def clear_scheduled_invitation_emails(email: str) -> None:
     """Unlike most scheduled emails, invitation emails don't have an
     existing user object to key off of, so we filter by address here."""

--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -168,7 +168,6 @@ def send_email_to_admins(template_prefix: str, realm: Realm, from_name: Optional
                from_address=from_address, context=context)
 
 def send_custom_email(users: List[UserProfile], options: Dict[str, Any]) -> None:
-    
     """
     Can be used directly with from a management shell with
     send_custom_email(user_profile_list, dict(

--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -5,7 +5,7 @@ from django.utils.timezone import now as timezone_now
 from django.utils.translation import override as override_language
 from django.template.exceptions import TemplateDoesNotExist
 from zerver.models import UserProfile, ScheduledEmail, get_user_profile_by_id, \
-    EMAIL_TYPES, 
+    EMAIL_TYPES, Realm
 from zerver.templatetags.app_filters import render_markdown_path
 
 import datetime

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -127,6 +127,30 @@ class TestFollowupEmails(ZulipTestCase):
         self.assertEqual(len(scheduled_emails), 1)
         email_data = ujson.loads(scheduled_emails[0].data)
         self.assertEqual(email_data["template_prefix"], 'zerver/emails/followup_day1')
+        
+class TestCustomEmails(ZulipTestCase):
+    def test_send_custom_email(self) -> None:
+        hamlet = self.example_user("hamlet")
+        othello = self.example_user("othello")
+        cordelia = self.example_user("cordelia")
+        try:
+            send_custom_email([hamlet, othello, cordelia], dict([
+                ("markdown_template_path","templates/zerver/emails/custom_email_base.pre.html"),
+                ("subject", "Testing custom email"),
+                ("from_name", "Test email") 
+            ]))
+            print("Test was successful")
+        except:
+            print("Exception")
+    def test_send_custom_email_empty(self) -> None:
+        try:
+            send_custom_email([], dict([
+                ("markdown_template_path","templates/zerver/emails/custom_email_base.pre.html"),
+                ("subject", "Testing custom email"),
+                ("from_name", "Test email") 
+            ]))
+        except:
+            print("Exception")
 
 class TestMissedMessages(ZulipTestCase):
     def normalize_string(self, s: str) -> str:

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -136,7 +136,7 @@ class TestCustomEmails(ZulipTestCase):
 
     def test_send_custom_email_group(self) -> None:
         management.call_command("send_custom_email", "--markdown-template-path", "templates/zerver/emails/email_base_default.source.html",
-                                "-u", "hamlet@zulip.com, iago@zulip.com, cordelia@zulip.com", "--from-name", "test", "--subject", "test_email")
+                                "-u", "hamlet@zulip.com, iago@zulip.com", "--from-name", "test", "--subject", "test_email")
 class TestMissedMessages(ZulipTestCase):
     def normalize_string(self, s: str) -> str:
         s = s.strip()

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -10,6 +10,7 @@ from django_auth_ldap.config import LDAPSearch
 from email.utils import formataddr
 from mock import patch, MagicMock
 from typing import List, Optional
+from django.core import management
 
 from zerver.lib.email_notifications import fix_emojis, handle_missedmessage_emails, \
     enqueue_welcome_emails, relative_to_full_url
@@ -127,31 +128,15 @@ class TestFollowupEmails(ZulipTestCase):
         self.assertEqual(len(scheduled_emails), 1)
         email_data = ujson.loads(scheduled_emails[0].data)
         self.assertEqual(email_data["template_prefix"], 'zerver/emails/followup_day1')
-        
+
 class TestCustomEmails(ZulipTestCase):
     def test_send_custom_email(self) -> None:
-        hamlet = self.example_user("hamlet")
-        othello = self.example_user("othello")
-        cordelia = self.example_user("cordelia")
-        try:
-            send_custom_email([hamlet, othello, cordelia], dict([
-                ("markdown_template_path","templates/zerver/emails/custom_email_base.pre.html"),
-                ("subject", "Testing custom email"),
-                ("from_name", "Test email") 
-            ]))
-            print("Test was successful")
-        except:
-            print("Exception")
-    def test_send_custom_email_empty(self) -> None:
-        try:
-            send_custom_email([], dict([
-                ("markdown_template_path","templates/zerver/emails/custom_email_base.pre.html"),
-                ("subject", "Testing custom email"),
-                ("from_name", "Test email") 
-            ]))
-        except:
-            print("Exception")
+        management.call_command("send_custom_email", "--markdown-template-path", "templates/zerver/emails/email_base_default.source.html",
+                                "-u", "hamlet@zulip.com", "--from-name", "test", "--subject", "test_email_basic")
 
+    def test_send_custom_email_group(self) -> None:
+        management.call_command("send_custom_email", "--markdown-template-path", "templates/zerver/emails/email_base_default.source.html",
+                                "-u", "hamlet@zulip.com, iago@zulip.com, cordelia@zulip.com", "--from-name", "test", "--subject", "test_email")
 class TestMissedMessages(ZulipTestCase):
     def normalize_string(self, s: str) -> str:
         s = s.strip()


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/13413

**Testing Plan:** <!-- How have you tested? -->
After the refactoring was done, vagrant provision was ran to check if it can run fully with the refactored inline-email-css. It ran smoothly and when the development environment was launched the templates showed properly without error. 
-----------------------------
Furthermore, the send_custom_email function was moved to send_email.py. The unit testing for this function has been created but unknown if more tests are needed.


