### PR TITLE
Added option to lower email addresses

### DIFF
--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -5,6 +5,7 @@ from zerver.models import UserProfile, Recipient, Subscription, Realm, Stream, \
 from zerver.lib.upload import copy_avatar
 from zerver.lib.hotspots import copy_hotpots
 from zerver.lib.utils import generate_api_key
+from django.conf import settings
 
 import ujson
 
@@ -52,6 +53,8 @@ def create_user_profile(realm: Realm, email: str, password: Optional[str],
                         enter_sends: bool = False) -> UserProfile:
     now = timezone_now()
     email = UserManager.normalize_email(email)
+    if settings.LOWER_EMAIL_ADDRESSES:
+        email = email.lower()
 
     user_profile = UserProfile(is_staff=False, is_active=active,
                                full_name=full_name, short_name=short_name,

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -22,6 +22,7 @@ ADD_TOKENS_TO_NOREPLY_ADDRESS = True
 TOKENIZED_NOREPLY_EMAIL_ADDRESS = "noreply-{token}@" + EXTERNAL_HOST.split(":")[0]
 PHYSICAL_ADDRESS = ''
 FAKE_EMAIL_DOMAIN = EXTERNAL_HOST.split(":")[0]
+LOWER_EMAIL_ADDRESSES = False
 
 # SMTP settings
 EMAIL_HOST = None  # type: Optional[str]

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -97,6 +97,12 @@ EXTERNAL_HOST = 'zulip.example.com'
 # confirmation emails when ADD_TOKENS_TO_NOREPLY_ADDRESS=False.
 #NOREPLY_EMAIL_ADDRESS = 'noreply@example.com'
 
+# Setting controls whether to lower all email-adresses. If LOWER_EMAIL_ADDRESSES=True,
+# users can login without taking care of case-sensitivity. This setting should not be changed
+# after the database was created as entries might contain upper-case-emails. If so,
+# the database has to be rewritten.
+#LOWER_EMAIL_ADDRESSES = False
+
 # Many countries and bulk mailers require certain types of email to display
 # a physical mailing address to comply with anti-spam legislation.
 # Non-commercial and non-public-facing installations are unlikely to need


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Related to #13500

**Testing Plan:** <!-- How have you tested? -->

As this is a work in progress, no testing has been done yet.

**Missing:**
When a user logs in or resets their password, the email address has to be converted to lowercase too. This should be the same for all platforms.