### PR TITLE
Add ZulipRemoteUserBackend to external_authentication_methods

### DIFF
--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -99,9 +99,6 @@ $(function () {
             const email_formaction = $("#login_form").attr('action');
             $("#login_form").attr('action', email_formaction + '/' + window.location.hash);
             $(".social_login_form input[name='next']").attr('value', '/' + window.location.hash);
-
-            const sso_address = $("#sso-login").attr('href');
-            $("#sso-login").attr('href', sso_address + window.location.hash);
         }
     }
 

--- a/static/styles/portico/portico.scss
+++ b/static/styles/portico/portico.scss
@@ -1045,7 +1045,6 @@ input.new-organization-button {
     font-weight: 300;
 }
 
-.login-sso,
 .login-social {
     max-width: 100%;
     min-width: 300px;

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -14,140 +14,127 @@ page can be easily identified in it's respective JavaScript file. -->
         </div>
 
         <div class="app-main login-page-container white-box inline-block">
-            {% if only_sso %}
-                {# SSO users don't have a password. #}
-
-                <div class="login-sso">
-                    <a id="sso-login" href="/accounts/login/sso/?next={{ next }}" class="btn btn-large btn-primary">
-                        {{ _('Log in with %(identity_provider)s', identity_provider="SSO") }}
-                    </a>
-                </div>
-
-            {% else %}
-                {# Non-SSO users. #}
-
-                {% if realm_name %}
-                <div class="left-side">
-                    <div class="org-header">
-                        <img class="avatar" src="{{ realm_icon }}" alt="" />
-                        <div class="info-box">
-                            <div class="organization-name">{{ realm_name }}</div>
-                            <div class="organization-path">{{ realm_uri }}</div>
-                        </div>
-                    </div>
-                    <div class="description">
-                        {{ realm_description|safe }}
+            {% if realm_name %}
+            <div class="left-side">
+                <div class="org-header">
+                    <img class="avatar" src="{{ realm_icon }}" alt="" />
+                    <div class="info-box">
+                        <div class="organization-name">{{ realm_name }}</div>
+                        <div class="organization-path">{{ realm_uri }}</div>
                     </div>
                 </div>
-                {% endif %}
-
-                <div class="right-side">
-                    {% if no_auth_enabled %}
-                        <div class="alert">
-                            <p>No authentication backends are enabled on this
-                            server yet, so it is impossible to login!</p>
-
-                            <p>See the <a href="https://zulip.readthedocs.io/en/latest/production/install.html#step-3-configure-zulip">Zulip
-                            authentication documentation</a> to learn how to configure authentication backends.</p>
-                        </div>
-                    {% else %}
-                        {% if password_auth_enabled %}
-                            <form name="login_form" id="login_form" method="post" class="login-form"
-                              action="{{ url('django.contrib.auth.views.login') }}?next={{ next }}">
-
-                                {% if two_factor_authentication_enabled %}
-                                {{ wizard.management_form }}
-                                {% endif %}
-                                {{ csrf_input }}
-
-                                <!-- .no-validation is for removing the red star in CSS -->
-                                {% if not two_factor_authentication_enabled or wizard.steps.current == 'auth' %}
-                                <div class="input-box no-validation">
-                                    <input id="id_username" type="{% if not require_email_format_usernames %}text{% else %}email{% endif %}"
-                                      name="username" class="{% if require_email_format_usernames %}email {% endif %}required"
-                                      {% if email %} value="{{ email }}" {% else %} value="" autofocus {% endif %}
-                                      maxlength="72" required />
-                                    <label for="id_username">
-                                        {% if not require_email_format_usernames and email_auth_enabled %}
-                                        {{ _('Email or username') }}
-                                        {% elif not require_email_format_usernames %}
-                                        {{ _('Username') }}
-                                        {% else %}
-                                        {{ _('Email') }}
-                                        {% endif %}
-                                    </label>
-                                </div>
-
-                                <div class="input-box no-validation">
-                                    <input id="id_password" name="password" class="required" type="password"
-                                      {% if email %} autofocus {% endif %}
-                                      required />
-                                    <label for="id_password" class="control-label">{{ _('Password') }}</label>
-                                </div>
-                                {% else %}
-                                {% include "two_factor/_wizard_forms.html" %}
-                                {% endif %}
-
-                                {% if form.errors %}
-                                <div class="alert alert-error">
-                                    {% for error in form.errors.values() %}
-                                    <div>{{ error | striptags }}</div>
-                                    {% endfor %}
-                                </div>
-                                {% endif %}
-
-                                {% if already_registered %}
-                                <div class="alert">
-                                    {{ _("You've already registered with this email address. Please log in below.") }}
-                                </div>
-                                {% endif %}
-
-                                {% if is_deactivated %}
-                                <div class="alert">
-                                    {{ deactivated_account_error }}
-                                </div>
-                                {% endif %}
-
-                                {% if subdomain %}
-                                <div class="alert">
-                                    {{ wrong_subdomain_error }}
-                                </div>
-                                {% endif %}
-
-                                <button type="submit" name="button" class="full-width">
-                                    <img class="loader" src="/static/images/loader.svg" alt="" />
-                                    <span class="text">{{ _("Log in") }}</span>
-                                </button>
-                            </form>
-
-                            {% if any_social_backend_enabled %}
-                            <div class="or"><span>{{ _('OR') }}</span></div>
-                            {% endif %}
-
-                        {% endif %} <!-- if password_auth_enabled -->
-
-                        {% for backend in external_authentication_methods %}
-                        <div class="login-social">
-                            <form class="social_login_form form-inline" action="{{ backend.login_url }}" method="get">
-                                <input type="hidden" name="next" value="{{ next }}">
-                                <button class="login-social-button" {% if backend.display_icon %} style="background-image:url({{ backend.display_icon }})"  {% endif %}>
-                                    {{ _('Log in with %(identity_provider)s', identity_provider=backend.display_name) }}
-                                </button>
-                            </form>
-                        </div>
-                        {% endfor %}
-
-                        <div class="actions">
-                            {% if email_auth_enabled %}
-                            <a class="forgot-password" href="/accounts/password/reset/">{{ _('Forgot your password?') }}</a>
-                            {% endif %}
-                            {% if not register_link_disabled %}
-                            <a class="register-link float-right" href="/register/">{{ _('Sign up') }}</a>
-                            {% endif %}
-                        </div>
-                    {% endif %}
+                <div class="description">
+                    {{ realm_description|safe }}
                 </div>
+            </div>
             {% endif %}
+
+            <div class="right-side">
+                {% if no_auth_enabled %}
+                    <div class="alert">
+                        <p>No authentication backends are enabled on this
+                        server yet, so it is impossible to login!</p>
+
+                        <p>See the <a href="https://zulip.readthedocs.io/en/latest/production/install.html#step-3-configure-zulip">Zulip
+                        authentication documentation</a> to learn how to configure authentication backends.</p>
+                    </div>
+                {% else %}
+                    {% if password_auth_enabled %}
+                        <form name="login_form" id="login_form" method="post" class="login-form"
+                          action="{{ url('django.contrib.auth.views.login') }}?next={{ next }}">
+
+                            {% if two_factor_authentication_enabled %}
+                            {{ wizard.management_form }}
+                            {% endif %}
+                            {{ csrf_input }}
+
+                            <!-- .no-validation is for removing the red star in CSS -->
+                            {% if not two_factor_authentication_enabled or wizard.steps.current == 'auth' %}
+                            <div class="input-box no-validation">
+                                <input id="id_username" type="{% if not require_email_format_usernames %}text{% else %}email{% endif %}"
+                                  name="username" class="{% if require_email_format_usernames %}email {% endif %}required"
+                                  {% if email %} value="{{ email }}" {% else %} value="" autofocus {% endif %}
+                                  maxlength="72" required />
+                                <label for="id_username">
+                                    {% if not require_email_format_usernames and email_auth_enabled %}
+                                    {{ _('Email or username') }}
+                                    {% elif not require_email_format_usernames %}
+                                    {{ _('Username') }}
+                                    {% else %}
+                                    {{ _('Email') }}
+                                    {% endif %}
+                                </label>
+                            </div>
+
+                            <div class="input-box no-validation">
+                                <input id="id_password" name="password" class="required" type="password"
+                                  {% if email %} autofocus {% endif %}
+                                  required />
+                                <label for="id_password" class="control-label">{{ _('Password') }}</label>
+                            </div>
+                            {% else %}
+                            {% include "two_factor/_wizard_forms.html" %}
+                            {% endif %}
+
+                            {% if form.errors %}
+                            <div class="alert alert-error">
+                                {% for error in form.errors.values() %}
+                                <div>{{ error | striptags }}</div>
+                                {% endfor %}
+                            </div>
+                            {% endif %}
+
+                            {% if already_registered %}
+                            <div class="alert">
+                                {{ _("You've already registered with this email address. Please log in below.") }}
+                            </div>
+                            {% endif %}
+
+                            {% if is_deactivated %}
+                            <div class="alert">
+                                {{ deactivated_account_error }}
+                            </div>
+                            {% endif %}
+
+                            {% if subdomain %}
+                            <div class="alert">
+                                {{ wrong_subdomain_error }}
+                            </div>
+                            {% endif %}
+
+                            <button type="submit" name="button" class="full-width">
+                                <img class="loader" src="/static/images/loader.svg" alt="" />
+                                <span class="text">{{ _("Log in") }}</span>
+                            </button>
+                        </form>
+
+                        {% if any_social_backend_enabled %}
+                        <div class="or"><span>{{ _('OR') }}</span></div>
+                        {% endif %}
+
+                    {% endif %} <!-- if password_auth_enabled -->
+
+                    {% for backend in external_authentication_methods %}
+                    <div class="login-social">
+                        <form class="social_login_form form-inline" action="{{ backend.login_url }}" method="get">
+                            <input type="hidden" name="next" value="{{ next }}">
+                            <button class="login-social-button" {% if backend.display_icon %} style="background-image:url({{ backend.display_icon }})"  {% endif %}>
+                                {{ _('Log in with %(identity_provider)s', identity_provider=backend.display_name) }}
+                            </button>
+                        </form>
+                    </div>
+                    {% endfor %}
+
+                    <div class="actions">
+                        {% if email_auth_enabled %}
+                        <a class="forgot-password" href="/accounts/password/reset/">{{ _('Forgot your password?') }}</a>
+                        {% endif %}
+                        {% if not register_link_disabled %}
+                        <a class="register-link float-right" href="/register/">{{ _('Sign up') }}</a>
+                        {% endif %}
+                    </div>
+                {% endif %}
+            </div>
         </div>
     </div>
 </div>

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from zerver.models import UserProfile, get_realm, Realm
 from zproject.backends import (
     any_social_backend_enabled,
-    get_social_backend_dicts,
+    get_external_method_dicts,
     password_auth_enabled,
     require_email_format_usernames,
     auth_enabled_helper,
@@ -175,7 +175,7 @@ def login_context(request: HttpRequest) -> Dict[str, Any]:
         if is_enabled:
             no_auth_enabled = False
 
-    context['external_authentication_methods'] = get_social_backend_dicts(realm)
+    context['external_authentication_methods'] = get_external_method_dicts(realm)
     context['no_auth_enabled'] = no_auth_enabled
 
     return context

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1924,6 +1924,7 @@ class ExternalMethodDictsTests(ZulipTestCase):
             AUTHENTICATION_BACKENDS=('zproject.backends.EmailAuthBackend',
                                      'zproject.backends.GitHubAuthBackend',
                                      'zproject.backends.GoogleAuthBackend',
+                                     'zproject.backends.ZulipRemoteUserBackend',
                                      'zproject.backends.SAMLAuthBackend',
                                      'zproject.backends.AzureADAuthBackend')
         ):
@@ -1933,7 +1934,7 @@ class ExternalMethodDictsTests(ZulipTestCase):
             self.assertEqual(
                 [social_backend['name'] for social_backend in external_auth_methods[1:]],
                 [social_backend.name for social_backend in sorted(
-                    [GitHubAuthBackend, AzureADAuthBackend, GoogleAuthBackend],
+                    [ZulipRemoteUserBackend, GitHubAuthBackend, AzureADAuthBackend, GoogleAuthBackend],
                     key=lambda x: x.sort_order,
                     reverse=True
                 )]


### PR DESCRIPTION
The first commit may be an overkill for the simple goal of adding ZulipRemoteUserBackend to the external_authentication_methods list in /server_settings, but it also allows having it share the login button rendering code with social backends. And in the future adding other backends (that arent frmo python-social-auth) will be straightforward. Probably there are some ways to make the design nicer, but I didn't manage to figure them out.

Note: I don't know why GitHub is display the login.html change in the second commit in such a ridiculously unreadable way, but all it does is remove the `` {% if not only_sso %}/{% else %}`` structure, and fix the indentation.

If this approach is decided to be okay, a follow up it would enable could be nice regarding the ``only_sso`` concept. We have snippets of this sort (this one is from portico-header.html):
```
            {% if user_is_authenticated %}
                {% include 'zerver/portico-header-dropdown.html' %}
            {% else %}
                {% if login_link_disabled %}
                {% elif not only_sso %}
                <a href="{{login_url}}">{{ _('Log in') }}</a>
                {% endif %}
            {% endif %}

            {% if register_link_disabled %}
            {% elif only_sso %}
                <a href="{{ url('login-sso') }}">{{ _('Log in') }}</a>
            {% else %}
                {% if user_is_authenticated %}
                {% else %}
                <a href="{{ url('register') }}">{{ _('Sign up') }}</a>
                {% endif %}
            {% endif %}
```

We could replace ``only_sso`` with ``only_one_auth_method_and_is_external`` (preferably a better name can be found) - as the name suggests, it would be true in situations like having only the SSO backend enabled (so the current ``only_sso``), or only Github, or only SAML with one IdP. Then we could have the login link lead to an endpoint that will redirect to the login URL of the unique authentication method enabled for the realm. Basically, what only_sso does, just more general - handling other backends too.

It would be a way of handling what a user requested in his first point here - https://chat.zulip.org/#narrow/stream/3-backend/topic/SAML.20Auth/near/799834

Buttons:
![image](https://user-images.githubusercontent.com/45007152/70562788-ff3c5b00-1b84-11ea-9dca-a7b921ebda2d.png)
ONLY_SSO:
![image](https://user-images.githubusercontent.com/45007152/70563044-707c0e00-1b85-11ea-92dc-12d993957065.png)


/server_settings:
```
  "authentication_methods": {
    "password": true,
    "dev": true,
    "email": true,
    "ldap": false,
    "remoteuser": true,
    "github": true,
    "azuread": false,
    "google": true,
    "saml": true
  },
  "zulip_version": "2.1.0-rc1",
  "push_notifications_enabled": false,
  "is_incompatible": false,
  "email_auth_enabled": true,
  "require_email_format_usernames": true,
  "realm_uri": "http://localhost:9991",
  "realm_name": "Zulip Dev",
  "realm_icon": "https://secure.gravatar.com/avatar/62429d594b6ffc712f54aee976a18b44?d=identicon",
  "realm_description": "<p>The Zulip development environment default organization.  It's great for testing!</p>",
  "external_authentication_methods": [
    {
      "name": "saml:idp_name",
      "display_name": "SAML",
      "display_icon": null,
      "login_url": "/accounts/login/social/saml/idp_name",
      "signup_url": "/accounts/register/social/saml/idp_name"
    },
    {
      "name": "remoteuser",
      "display_name": "SSO",
      "display_icon": null,
      "login_url": "/accounts/login/sso/",
      "signup_url": "/accounts/login/sso/"
    },
    {
      "name": "google",
      "display_name": "Google",
      "display_icon": "/static/images/landing-page/logos/googl_e-icon.png",
      "login_url": "/accounts/login/social/google",
      "signup_url": "/accounts/register/social/google"
    },
    {
      "name": "github",
      "display_name": "GitHub",
      "display_icon": "/static/images/landing-page/logos/github-icon.png",
      "login_url": "/accounts/login/social/github",
      "signup_url": "/accounts/register/social/github"
    }
  ]
}
```