### PR TITLE
fix casing errors when creating new topic

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -196,13 +196,15 @@ function create_message_object() {
         message.to = stream_name;
         message.stream = stream_name;
         const sub = stream_data.get_sub(stream_name);
+        // if sub exists, get the topic list from corresponding streamid.
+        // if the current topic name matches with the one already stored, 
+        // make the current topic name the same letter casing 
+        // as the one already stored.
         if (sub) {
             message.stream_id = sub.stream_id;
-            // if sub exists, get the topic list from the corresponding stream id.
-            // if the current topic name matches with the one already stored, make the current topic name the same letter casing as the one already stored.
             const topic_list = topic_data.get_recent_names (sub.stream_id);
-            for (eachTopic in topic_list){
-                if (eachTopic.toLowerCase() == topic.toLowerCase()) {
+            for (var eachTopic in topic_list) {
+                if (eachTopic.toLowerCase() === topic.toLowerCase()) {
                     topic = eachTopic;
                     break;
                 }

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -197,8 +197,8 @@ function create_message_object() {
         message.stream = stream_name;
         const sub = stream_data.get_sub(stream_name);
         // if sub exists, get the topic list from corresponding streamid.
-        // if the current topic name matches with the one already stored, 
-        // make the current topic name the same letter casing 
+        // if the current topic name matches with the one already stored,
+        // make the current topic name the same letter casing
         // as the one already stored.
         if (sub) {
             message.stream_id = sub.stream_id;


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/12725

**Testing Plan:** <!-- How have you tested? -->
Previously: When creating the same topic that already exists, the casing will override the previous ones and the parts of the front-end would reflect the new casing while parts of the front-end displayed the old casing, so it was very consistent.

With the new changes to fix the issue, I tested by:
1. Created a new topic "HELLO" in my local repository in stream "test".
2. Created a new topic "hello" in my local repository in stream "test".
3. Now, the new topic "hello" doesn't override the casing of the topic "HELLO" that already exists.

**Solution Details:**
My solution to the issue was getting all the topic lists from the stream that the user wants the create a topic in. After getting the topic list, I would loop through it to check current topic matched any of the topics in the existing topic list. If there was a match, I would change the letter casing of the current topic to the casing of the existing topic. For example, "Hello"(current topic in same stream) -> "HELLO"(existing topic in same stream). With the new code, the casing will be consistent throughout the webpage  and new topic casing will not override the old one. 