### PR TITLE
fixed autocomplete for new topics is case-sensitive

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -854,7 +854,10 @@ exports.initialize = function () {
         },
         sorter: function (items) {
             const sorted = typeahead_helper.sorter(this.query, items, function (x) {return x;});
-            if (sorted.length > 0 && sorted.indexOf(this.query) === -1) {
+            // Case-insensitive.
+            if (sorted.length > 0 && 
+                sorted.findIndex(item => this.query.toLowerCase() === 
+                item.toLowerCase()) === -1) {
                 sorted.unshift(this.query);
             }
             return sorted;

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -855,8 +855,8 @@ exports.initialize = function () {
         sorter: function (items) {
             const sorted = typeahead_helper.sorter(this.query, items, function (x) {return x;});
             // Case-insensitive.
-            if (sorted.length > 0 && 
-                sorted.findIndex(item => this.query.toLowerCase() === 
+            if (sorted.length > 0 &&
+                sorted.findIndex(item => this.query.toLowerCase() ===
                 item.toLowerCase()) === -1) {
                 sorted.unshift(this.query);
             }


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/12725

**Testing Plan:** <!-- How have you tested? -->
Previously: When creating the same topic that already exists, the compose drop down menu will show two options:
"TOPIC", "topic" 
when user tries to create a topic called "TOPIC" when "topic" name already exists in the database.

With the new changes to fix the issue, I tested by:
1. Created a new topic "topic" in my local repository in stream "test".
2. Tried to create new topic "TOPIC" in my local repository in stream "test".
3. Now, when user types "TOPIC", he/she only sees one option because I made the feature case-insensitive.

**Solution Details:**
My solution to the issue was comparing strings of the user input topic box with the topics in topic list by converting them to all to lowercase versions. Javascript's indexOf() is case sensitive, so I manually create a lambda function to manually traverse through the topic list to make the composebox typeahead case-insensitive.

This is an important feature to have because if there are two options for the same topic name, it creates confusion for the user. The user might think they he/she is creating a new topic, but in reality, his/her message will be added on to an existing topic if the topic names are the same (since the back-end is case-insensitive).

<img width="1070" alt="Screen Shot 2019-12-10 at 5 14 42 PM" src="https://user-images.githubusercontent.com/39178730/70573752-9b0f9c00-1b70-11ea-9a0f-9c69c00a926d.png">
