### PR TITLE
docs: List the backends in section explaining SOCIAL_AUTH_SUBDOMAIN.

### DIFF
--- a/docs/production/multiple-organizations.md
+++ b/docs/production/multiple-organizations.md
@@ -100,10 +100,15 @@ configuration.
 
 ### Social authentication
 
-If you're using GitHub authentication (or any other authentication
-backend that we implement using python-social-auth), you will likely
-want to set the `SOCIAL_AUTH_SUBDOMAIN` setting to something (`'auth'`
-is a good choice) and update the GitHub authentication callback URL to
+If you're using one of the following authentication methods:
+* Github
+* Google
+* SAML
+* AzureAD
+* (Or any other authentication backend that we implement using python-social-auth)
+
+You will likely want to set the `SOCIAL_AUTH_SUBDOMAIN` setting to something (`'auth'`
+is a good choice) and update the authentication provider's callback URL to
 be that subdomain.  Otherwise, your users will experience confusing
 behavior where attempting to login using a social authentication
 backend will appear to log them out of the other organizations on your


### PR DESCRIPTION
We only mentioned github there. People shouldn't be expected to know which backends we implement using which library, so, while I think it's useful to say
> Or any other authentication backend that we implement using python-social-auth

at the end, we should try to keep the list up-to-date.