### PR TITLE
moved new topic creation from bottom to left sidebar

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -665,6 +665,11 @@ exports.initialize = function () {
     $("#compose_buttons").click(handle_compose_click);
     $(".compose-content").click(handle_compose_click);
 
+    $(document).on('click', '#new_topic', (function () {
+        popovers.hide_mobile_message_buttons_popover();
+        compose_actions.start('stream', {trigger: 'new topic button'});
+    }));    
+
     $("#compose_close").click(function () {
         compose_actions.cancel();
     });

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -665,10 +665,10 @@ exports.initialize = function () {
     $("#compose_buttons").click(handle_compose_click);
     $(".compose-content").click(handle_compose_click);
 
-    $(document).on('click', '#new_topic', (function () {
+    $(document).on('click', '#new_topic', function () {
         popovers.hide_mobile_message_buttons_popover();
         compose_actions.start('stream', {trigger: 'new topic button'});
-    }));    
+    });
 
     $("#compose_close").click(function () {
         compose_actions.cancel();

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -151,7 +151,7 @@ exports.widget = function (parent_elem, my_stream_id) {
         ul.append(new_topic_li);
 
         return ul;
-    };    
+    };
 
     self.build_more_topics_section = function (more_topics_unreads) {
         const show_more_html = render_more_topics({

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -1,5 +1,6 @@
 const render_more_topics = require('../templates/more_topics.hbs');
 const render_topic_list_item = require('../templates/topic_list_item.hbs');
+const render_new_topic = require('../templates/new_topic.hbs');
 const Dict = require('./dict').Dict;
 
 /*
@@ -144,8 +145,13 @@ exports.widget = function (parent_elem, my_stream_id) {
         if (topic_names.length > max_topics || !stream_data.all_topics_in_cache(sub)) {
             ul.append(show_more);
         }
+
+        // add new topic
+        const new_topic_li = $(render_new_topic());
+        ul.append(new_topic_li);
+
         return ul;
-    };
+    };    
 
     self.build_more_topics_section = function (more_topics_unreads) {
         const show_more_html = render_more_topics({

--- a/static/templates/more_topics.hbs
+++ b/static/templates/more_topics.hbs
@@ -1,6 +1,6 @@
 <li class="topic-list-item show-more-topics bottom_left_row {{#unless more_topics_unreads}}zero-topic-unreads{{/unless}}">
     <span class='topic-box'>
-        <a class="topic-name" href="#">{{t "more topics" }}</a>
+        <a class="topic-name" href="#">{{t "... more topics" }}</a>
         <div class="topic-unread-count {{#unless more_topics_unreads}}zero_count{{/unless}}">
             <div class="value">{{more_topics_unreads}}</div>
         </div>

--- a/static/templates/new_topic.hbs
+++ b/static/templates/new_topic.hbs
@@ -1,4 +1,4 @@
-<li class='topic-list-item bottom_left_row zero-topic-unreads compose_stream_button'>
+<li class='bottom_left_row zero-topic-unreads compose_stream_button'>
     <div>
         <a class='small' id="new_topic">+ new topic</a>
     </div>

--- a/static/templates/new_topic.hbs
+++ b/static/templates/new_topic.hbs
@@ -1,0 +1,5 @@
+<li class='topic-list-item bottom_left_row zero-topic-unreads compose_stream_button' title='New topic (c)'>
+    <div>
+        <a class='small' id="new_topic" style="display:block">+ new topic</a>
+    </div> 
+</li>

--- a/static/templates/new_topic.hbs
+++ b/static/templates/new_topic.hbs
@@ -1,5 +1,5 @@
 <li class='topic-list-item bottom_left_row zero-topic-unreads compose_stream_button' title='New topic (c)'>
     <div>
-        <a class='small' id="new_topic" style="display:block">+ new topic</a>
-    </div> 
+        <a class='small' id="new_topic">+ new topic</a>
+    </div>
 </li>

--- a/static/templates/new_topic.hbs
+++ b/static/templates/new_topic.hbs
@@ -1,4 +1,4 @@
-<li class='topic-list-item bottom_left_row zero-topic-unreads compose_stream_button' title='New topic (c)'>
+<li class='topic-list-item bottom_left_row zero-topic-unreads compose_stream_button'>
     <div>
         <a class='small' id="new_topic">+ new topic</a>
     </div>

--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -21,13 +21,6 @@
                         <span>+</span>
                     </button>
                 </span>
-                <span class="new_message_button">
-                    <button type="button" class="button small rounded compose_stream_button"
-                      id="left_bar_compose_stream_button_big"
-                      title="{{ _('New topic') }} (c)">
-                        <span class="compose_stream_button_label">{{ _('New topic') }}</span>
-                    </button>
-                </span>
                 {% if not embedded %}
                 <span class="new_message_button">
                     <button type="button" class="button small rounded compose_private_button"


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Issue: https://github.com/zulip/zulip/issues/13480

**Testing Plan:** <!-- How have you tested? -->
Previously, creating a new topic was not very intuitive for users. The button was on the bottom of the screen instead of in the left sidebar where the list of streams and topics is located. I added a "new topic" element to the left sidebar that does the same thing that the current "new topic" button does. I tested by clicking on that element and verifying that it behaves correctly.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/34848190/70590031-66ff9f80-1b9f-11ea-98e0-2ce571d90edf.png)

![image](https://user-images.githubusercontent.com/34848190/70590065-88f92200-1b9f-11ea-8ea3-7f1a12c567ad.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
