### PR TITLE
bugdown: Parse urls correctly to set potential_attachment_urls.

### DIFF
--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -73,11 +73,6 @@ INLINE_MIME_TYPES = [
 class RealmUploadQuotaError(JsonableError):
     code = ErrorCode.REALM_UPLOAD_QUOTA
 
-def attachment_url_to_path_id(attachment_url: str) -> str:
-    path_id_raw = re.sub(r'[/\-]user[\-_]uploads[/\.-]', '', attachment_url)
-    # Remove any extra '.' after file extension. These are probably added by the user
-    return re.sub('[.]+$', '', path_id_raw, re.M)
-
 def sanitize_name(value: str) -> str:
     """
     Sanitizes a value to be safe to store in a Linux filesystem, in

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1699,14 +1699,6 @@ class Message(AbstractMessage):
                                    'website', 'ios', 'android')) or (
                                        'desktop app' in sending_client)
 
-    @property
-    def potential_attachment_urls(self) -> List[str]:
-        return getattr(self, '_potential_attachment_urls', [])
-
-    @potential_attachment_urls.setter
-    def potential_attachment_urls(self, urls: List[str]) -> None:
-        self._potential_attachment_urls = urls
-
     @staticmethod
     def is_status_message(content: str, rendered_content: str) -> bool:
         """

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2762,8 +2762,9 @@ class EventsRegisterTest(ZulipTestCase):
             ('upload_space_used', equals(6)),
         ])
 
-        self.subscribe(self.example_user("hamlet"), "Denmark")
-        body = "First message ...[zulip.txt](http://localhost:9991" + data['uri'] + ")"
+        hamlet = self.example_user("hamlet")
+        self.subscribe(hamlet, "Denmark")
+        body = "First message ...[zulip.txt](http://{}".format(hamlet.realm.host) + data['uri'] + ")"
         events = self.do_test(
             lambda: self.send_stream_message(self.example_email("hamlet"), "Denmark", body, "test"),
             num_events=2)

--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -132,6 +132,7 @@ class ArchiveMessagesTestingBase(RetentionTestingBase):
         user_profile = self.example_user("hamlet")
         sender_email = user_profile.email
         sample_size = 10
+        host = user_profile.realm.host
         realm_id = get_realm("zulip").id
         dummy_files = [
             ('zulip.txt', '%s/31/4CBjtTLYZhk66pZrF8hnYGwc/zulip.txt' % (realm_id,), sample_size),
@@ -143,9 +144,9 @@ class ArchiveMessagesTestingBase(RetentionTestingBase):
             create_attachment(file_name, path_id, user_profile, size)
 
         self.subscribe(user_profile, "Denmark")
-        body = ("Some files here ... [zulip.txt](http://localhost:9991/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/zulip.txt)" +
-                " http://localhost:9991/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/temp_file.py.... Some more...." +
-                " http://localhost:9991/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/abc.py").format(id=realm_id)
+        body = ("Some files here ... [zulip.txt](http://{host}/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/zulip.txt)" +
+                " http://{host}/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/temp_file.py.... Some more...." +
+                " http://{host}/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/abc.py").format(id=realm_id, host=host)
 
         expired_message_id = self.send_stream_message(sender_email, "Denmark", body)
         actual_message_id = self.send_stream_message(sender_email, "Denmark", body)
@@ -535,17 +536,17 @@ class MoveMessageToArchiveGeneral(MoveMessageToArchiveBase):
     def test_archiving_messages_with_attachment(self) -> None:
         self._create_attachments()
         realm_id = get_realm("zulip").id
-
+        host = get_realm("zulip").host
         body1 = """Some files here ...[zulip.txt](
-            http://localhost:9991/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/zulip.txt)
-            http://localhost:9991/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/temp_file.py ....
-            Some more.... http://localhost:9991/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/abc.py
-        """.format(id=realm_id)
+            http://{host}/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/zulip.txt)
+            http://{host}/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/temp_file.py ....
+            Some more.... http://{host}/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/abc.py
+        """.format(id=realm_id, host=host)
         body2 = """Some files here
-            http://localhost:9991/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/zulip.txt ...
-            http://localhost:9991/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/hello.txt ....
-            http://localhost:9991/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/new.py ....
-        """.format(id=realm_id)
+            http://{host}/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/zulip.txt ...
+            http://{host}/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/hello.txt ....
+            http://{host}/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/new.py ....
+        """.format(id=realm_id, host=host)
 
         msg_ids = [
             self.send_personal_message(self.sender, self.recipient, body1),
@@ -598,14 +599,14 @@ class MoveMessageToArchiveGeneral(MoveMessageToArchiveBase):
         # Make sure that attachments still in use in other messages don't get deleted:
         self._create_attachments()
         realm_id = get_realm("zulip").id
-
+        host = get_realm("zulip").host
         body = """Some files here ...[zulip.txt](
-            http://localhost:9991/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/zulip.txt)
-            http://localhost:9991/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/temp_file.py ....
-            Some more.... http://localhost:9991/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/abc.py ...
-            http://localhost:9991/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/new.py ....
-            http://localhost:9991/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/hello.txt ....
-        """.format(id=realm_id)
+            http://{host}/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/zulip.txt)
+            http://{host}/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/temp_file.py ....
+            Some more.... http://{host}/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/abc.py ...
+            http://{host}/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/new.py ....
+            http://{host}/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/hello.txt ....
+        """.format(id=realm_id, host=host)
 
         msg_id = self.send_personal_message(self.sender, self.recipient, body)
         # Simulate a reply with the same contents.


### PR DESCRIPTION
The initial implementation didn't handle relative urls properly.
We fix this by using urllib to extract the paths. We also add a
check on the hostname; either its empty (relative url) or the
server's current hostname.

Since we're operating only on the path, we remove the check for
leading '/' in attachment_url_to_path_id.
