### PR TITLE
docs: Fix typos in upgrade-or-modify.md.

### DIFF
--- a/docs/production/export-and-import.md
+++ b/docs/production/export-and-import.md
@@ -145,7 +145,7 @@ and you may want to backup separately:
 
 For completeness, Zulip's backups do not include certain highly
 transient state that Zulip doesn't store in a database.  For example,
-typing status data, API rate-limiting counters, and RabbitMQ queues of
+typing status data, API rate-limiting counters, and RabbitMQ queues
 that are essentially always empty in a healthy server (like outgoing
 emails to send).  You can check whether these queues are empty using
 `rabbitmqctl list_queues`.

--- a/docs/production/upgrade-or-modify.md
+++ b/docs/production/upgrade-or-modify.md
@@ -420,7 +420,7 @@ master or an official release.
 The exception to this rule is when we ask or encourage a user to apply
 a change to their production system to help verify the fix resolves
 the issue for them.  You can expect the Zulip community to be
-responsive in debugging any problems any caused by a patch we asked
+responsive in debugging any problems caused by a patch we asked
 you to apply.
 
 ### Upgrading to master
@@ -438,7 +438,7 @@ While it's possible to backport these sorts of changes, you're
 unlikely to succeed without help from the core team via a support
 contract.
 
-If you need an unreleased feature, the best path is usually to to
+If you need an unreleased feature, the best path is usually to
 upgrade to Zulip master using [upgrade-zulip-from-git][].  Before
 upgrading to master, make sure you understand:
 


### PR DESCRIPTION
Not just upgrade-or-modify.md, but I can't update the title.