### PR TITLE
postgres-init-db: Drop zulip user before trying to create it.

### DIFF
--- a/scripts/setup/postgres-init-db
+++ b/scripts/setup/postgres-init-db
@@ -46,6 +46,7 @@ cd /
 
 su "$POSTGRES_USER" -c 'psql -v ON_ERROR_STOP=1 -e' <<EOF
 DROP DATABASE IF EXISTS zulip;
+DROP USER IF EXISTS zulip;
 EOF
 
 su "$POSTGRES_USER" -c 'psql -v ON_ERROR_STOP=1 -e' < "$(dirname "$0")/create-db.sql"


### PR DESCRIPTION
The intent of the `DROP DATABASE IF EXISTS` block in
`scripts/setup/postgres-init-db` is to get to a clean state with no
Zulip state database, reversing the setup done in
`scripts/setup/create-db.sql`.  However, we neglected to drop the
Zulip user created in that script, so running `postgres-init-db` a
second time was guaranteed to have the user creation in
`create-db.sql` fail.

When we added `ON_ERROR_STOP=1` to the postgres options, the error in
`create-db.sql` became fatal, breaking the Digital Ocean installer.

We fix this by just adding `DROP USER IF EXISTS` as well.

Fixes #13530.
