### PR TITLE
reactions.scss: Use grey text for reactions we haven't reacted to.

### DIFF
--- a/static/styles/reactions.scss
+++ b/static/styles/reactions.scss
@@ -16,6 +16,9 @@
 
         &.reacted {
             background-color: hsl(195, 50%, 95%);
+            .message_reaction_count {
+                color: hsl(200, 100%, 40%);
+            }
         }
 
         &:hover {
@@ -53,7 +56,7 @@
         font-size: 0.8em;
         display: inline-block;
         vertical-align: top;
-        color: hsl(200, 100%, 40%);
+        color: hsl(0, 0%, 33%);
         margin: 0px 1px 0px 0px;
         line-height: 1em;
     }


### PR DESCRIPTION
The previous blue styling gave the impresstion that you had already
reacted to a message. We preserve the blue text for after you've
reacted to keep a larger visual difference between the two states.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://chat.zulip.org/#narrow/stream/101-design

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:**

![image](https://user-images.githubusercontent.com/8033238/70838995-bb6d7e00-1e30-11ea-85a2-20a917f0fffe.png)
