### PR TITLE
docs: Remove mention of Dropbox CLA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,8 +75,6 @@ to help.
   [#git help](https://chat.zulip.org/#narrow/stream/44-git-help) if
   you run into any troubles.  Be sure to check out the
   [extremely useful Zulip-specific tools page](https://zulip.readthedocs.io/en/latest/git/zulip-tools.html).
-* Sign the
-  [Dropbox Contributor License Agreement](https://opensource.dropbox.com/cla/).
 
 ### Picking an issue
 


### PR DESCRIPTION
Based on discussion in https://chat.zulip.org/#narrow/stream/19-documentation/topic/CLA and https://chat.zulip.org/#narrow/stream/105-zulipbot/topic/New.20contributor.20definition, it sounds like signing the Dropbox CLA is no longer a requirement, and it's a essentially a documentation bug that it's still mentioned.