### PR TITLE
Validate cache keys before sending to memcached

### DIFF
--- a/tools/test-api
+++ b/tools/test-api
@@ -78,7 +78,7 @@ with test_server_running(force=options.force, external_host='zulipdev.com:9981')
     # Test error payloads
     client = Client(
         email=email,
-        api_key='abcedrsdfd',
+        api_key='X'*32,
         site=site
     )
     test_invalid_api_key(client)

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -21,9 +21,9 @@ from zerver.lib.exceptions import UnexpectedWebhookEventType
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.subdomains import get_subdomain, user_matches_subdomain
 from zerver.lib.timestamp import datetime_to_timestamp, timestamp_to_datetime
-from zerver.lib.utils import statsd, is_remote_server
+from zerver.lib.utils import statsd, is_remote_server, has_api_key_format
 from zerver.lib.exceptions import JsonableError, ErrorCode, \
-    InvalidJSONError, InvalidAPIKeyError, \
+    InvalidJSONError, InvalidAPIKeyError, InvalidAPIKeyFormatError, \
     OrganizationAdministratorRequired
 from zerver.lib.types import ViewFuncT
 from zerver.lib.validator import to_non_negative_int
@@ -266,6 +266,9 @@ def validate_account_and_subdomain(request: HttpRequest, user_profile: UserProfi
         raise JsonableError(_("Account is not associated with this subdomain"))
 
 def access_user_by_api_key(request: HttpRequest, api_key: str, email: Optional[str]=None) -> UserProfile:
+    if not has_api_key_format(api_key):
+        raise InvalidAPIKeyFormatError()
+
     try:
         user_profile = get_user_profile_by_api_key(api_key)
     except UserProfile.DoesNotExist:

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -216,6 +216,11 @@ class InvalidAPIKeyError(JsonableError):
     def msg_format() -> str:
         return _("Invalid API key")
 
+class InvalidAPIKeyFormatError(InvalidAPIKeyError):
+    @staticmethod
+    def msg_format() -> str:
+        return _("Malformed API key")
+
 class UnexpectedWebhookEventType(JsonableError):
     code = ErrorCode.UNEXPECTED_WEBHOOK_EVENT_TYPE
     data_fields = ['webhook_name', 'event_type']

--- a/zerver/lib/utils.py
+++ b/zerver/lib/utils.py
@@ -6,6 +6,7 @@ import hashlib
 import heapq
 import itertools
 import os
+import re
 import string
 from time import sleep
 from itertools import zip_longest
@@ -116,6 +117,9 @@ def generate_api_key() -> str:
     altchars = ''.join([choices[ord(os.urandom(1)) % 62] for _ in range(2)]).encode("utf-8")
     api_key = base64.b64encode(os.urandom(24), altchars=altchars).decode("utf-8")
     return api_key
+
+def has_api_key_format(key: str) -> bool:
+    return bool(re.fullmatch(r"([A-Za-z0-9]){32}", key))
 
 def query_chunker(queries: List[Any],
                   id_collector: Optional[Set[int]]=None,

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -25,6 +25,7 @@ from zerver.lib.test_classes import (
 from zerver.lib.response import json_response, json_success
 from zerver.lib.users import get_api_key
 from zerver.lib.user_agent import parse_user_agent
+from zerver.lib.utils import generate_api_key, has_api_key_format
 from zerver.lib.request import \
     REQ, has_request_variables, RequestVariableMissingError, \
     RequestVariableConversionError, RequestConfusingParmsError
@@ -1291,6 +1292,17 @@ class TestValidateApiKey(ZulipTestCase):
         zulip_realm = get_realm('zulip')
         self.webhook_bot = get_user('webhook-bot@zulip.com', zulip_realm)
         self.default_bot = get_user('default-bot@zulip.com', zulip_realm)
+
+    def test_has_api_key_format(self) -> None:
+        self.assertFalse(has_api_key_format("TooShort"))
+        # Has an invalid character:
+        self.assertFalse(has_api_key_format("32LONGXXXXXXXXXXXXXXXXXXXXXXXXX-"))
+        # Too long:
+        self.assertFalse(has_api_key_format("33LONGXXXXXXXXXXXXXXXXXXXXXXXXXXX"))
+
+        self.assertTrue(has_api_key_format("VIzRVw2CspUOnEm9Yu5vQiQtJNkvETkp"))
+        for i in range(0, 10):
+            self.assertTrue(has_api_key_format(generate_api_key()))
 
     def test_validate_api_key_if_profile_does_not_exist(self) -> None:
         with self.assertRaises(JsonableError):


### PR DESCRIPTION
PR for https://github.com/zulip/zulip/issues/13504

The cache key validation change came out a lot bigger than intended. But I do think that the most sane approach is to validate in the base functions ``cache_*`` in order to have all the codepaths that could send an invalid cache key covered (such as ``bulk_fetch`` and so on). The upside is the resulting increased test coverage.