### PR TITLE
lint: Tell ShellCheck to look for sourced files at relative paths

### DIFF
--- a/scripts/setup/postgres-init-db
+++ b/scripts/setup/postgres-init-db
@@ -37,7 +37,7 @@ fi
 # Drop any open connections to any old database.  Hackishly call using
 # `source`, because postgres user may not be able to read this directory
 # if unpacked by root.
-# shellcheck source=/dev/null
+# shellcheck source=terminate-psql-sessions
 source "$(dirname "$0")/terminate-psql-sessions" postgres zulip zulip_base
 
 (

--- a/tools/lint
+++ b/tools/lint
@@ -77,7 +77,7 @@ def run():
     linter_config.external_linter('openapi', ['node', 'tools/check-openapi'], ['yaml'],
                                   description="Validates our OpenAPI/Swagger API documentation"
                                   "(zerver/openapi/zulip.yaml) ")
-    linter_config.external_linter('shellcheck', ['shellcheck', '-x'], ['sh'],
+    linter_config.external_linter('shellcheck', ['shellcheck', '-x', '-P', 'SCRIPTDIR'], ['sh'],
                                   description="Standard shell script linter.")
     command = ['tools/run-mypy', '--quiet']
     if args.force:


### PR DESCRIPTION
This uses the new `-P` option of ShellCheck 0.7.0.