### PR TITLE
test-install: Run lxc-attach with --clear-env

### DIFF
--- a/tools/test-install/destroy-all
+++ b/tools/test-install/destroy-all
@@ -31,6 +31,5 @@ lxc-ls -f \
   | while read -r c
 do
     echo "$c"
-    lxc-stop -n "$c"
-    lxc-destroy -n "$c"
+    lxc-destroy -f -n "$c"
 done

--- a/tools/test-install/install
+++ b/tools/test-install/install
@@ -45,7 +45,7 @@ done
 message="$(cat <<EOF
 
 Container:
-  sudo lxc-attach -n $CONTAINER_NAME
+  sudo lxc-attach --clear-env -n $CONTAINER_NAME
 
 Unpacked tree:
   sudo ls $shared_dir/mnt/zulip-server
@@ -73,7 +73,7 @@ lxc-copy --ephemeral --keepdata -n "$BASE_CONTAINER_NAME" -N "$CONTAINER_NAME" \
 "$THIS_DIR"/lxc-wait -n "$CONTAINER_NAME"
 
 run() {
-    lxc-attach -n "$CONTAINER_NAME" -- "$@"
+    lxc-attach --clear-env -n "$CONTAINER_NAME" -- "$@"
 }
 
 run eatmydata -- /mnt/src/zulip-server/scripts/setup/install --self-signed-cert "${INSTALLER_ARGS[@]}"

--- a/tools/test-install/lxc-wait
+++ b/tools/test-install/lxc-wait
@@ -29,7 +29,7 @@ fi
 # We poll.
 for _ in {1..60}; do
     echo "lxc-wait: $CONTAINER_NAME: polling for boot..." >&2
-    runlevel="$(lxc-attach -n "$CONTAINER_NAME" -- runlevel 2>/dev/null)" \
+    runlevel="$(lxc-attach --clear-env -n "$CONTAINER_NAME" -- runlevel 2>/dev/null)" \
         || { sleep 1; continue; }
     if [ "$runlevel" != "${0%[0-9]}" ]; then
         echo "lxc-wait: $CONTAINER_NAME: booted!" >&2

--- a/tools/test-install/prepare-base
+++ b/tools/test-install/prepare-base
@@ -34,7 +34,7 @@ lxc-start -n "$CONTAINER_NAME"
 "$THIS_DIR"/lxc-wait -n "$CONTAINER_NAME"
 
 run() {
-    lxc-attach -n "$CONTAINER_NAME" -- "$@"
+    lxc-attach --clear-env -n "$CONTAINER_NAME" -- "$@"
 }
 
 run passwd -d root


### PR DESCRIPTION
The host environment variables (especially `PATH`) should not be allowed to pollute the test and could interfere with it.

This allows `test-install` to run on a NixOS host.

**Testing Plan:** Ran `test-install`.