### PR TITLE
settings: Show token for outgoing webhook bot.

### DIFF
--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -50,6 +50,9 @@ exports.bot_error = function (bot_id, xhr) {
 };
 
 function add_bot_row(info) {
+    if (info.type === "Outgoing webhook") {
+        info.token = bot_data.get_services(info.user_id)[0].token;
+    }
     const row = $(render_bot_avatar_row(info));
     if (info.is_active) {
         $('#active_bots_list').append(row);
@@ -86,6 +89,7 @@ exports.render_bots = function () {
             avatar_url: elem.avatar_url,
             api_key: elem.api_key,
             is_active: elem.is_active,
+            is_outgoing_webhook: elem.bot_type === 3,
             zuliprc: 'zuliprc', // Most browsers do not allow filename starting with `.`
         });
         user_owns_an_active_bot = user_owns_an_active_bot || elem.is_active;

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -836,15 +836,23 @@ input[type=checkbox].inline-block {
     width: calc(100% - 75px);
 }
 
-.bots_list .name {
+.bots_list .bot-name-type {
+    margin: 7px 5px;
+    line-height: 1.3em;
+}
+
+.bots_list .bot-name-type .name {
     font-weight: 600;
     font-size: 1.1rem;
-    margin: 7px 5px;
-
     overflow: hidden;
-    line-height: 1.3em;
     text-overflow: ellipsis;
-    white-space: pre;
+    white-space: nowrap;
+}
+
+.bots_list .bot-name-type .type {
+    font-weight: 500;
+    font-size: 1.1rem;
+    float: right;
 }
 
 .bots_list .regenerate_bot_api_key {
@@ -890,13 +898,20 @@ input[type=checkbox].inline-block {
     position: relative;
     display: inline-block;
     width: calc(50% - 10px);
-    max-height: 220px;
     margin: 5px;
 
     border-radius: 4px;
     box-sizing: border-box;
 
     overflow: auto;
+}
+
+#active_bots_list .bot-information-box {
+    height: 220px;
+}
+
+#inactive_bots_list .bot-information-box {
+    max-height: 220px;
 }
 
 .bots_list img.avatar {
@@ -908,8 +923,7 @@ input[type=checkbox].inline-block {
     box-shadow: 0px 0px 4px hsla(0, 0%, 0%, 0.1);
 }
 
-.bots_list .email,
-.bots_list .type {
+.bots_list .email {
     margin-bottom: 5px;
 }
 

--- a/static/templates/bot_avatar_row.hbs
+++ b/static/templates/bot_avatar_row.hbs
@@ -2,7 +2,10 @@
     <div class="image overflow-hidden">
         <img src="{{avatar_url}}" class="avatar" />
         <div class="details">
-            <div class="name">{{name}}</div>
+            <div class="bot-name-type">
+                <div class="type">{{type}}</div>
+                <div class="name" title={{name}}>{{name}}</div>
+            </div>
             {{#if is_active}}
             <div class="edit-bot-buttons">
                 <button type="submit" class="btn open_edit_bot_form" data-sidebar-form="edit-bot" title="{{t 'Edit bot' }}" data-email="{{email}}">
@@ -22,28 +25,30 @@
         </div>
     </div>
     <div class="bot_info" data-user-id="{{user_id}}">
-        <div class="type">
-            <div class="field">{{t "Bot type" }}</div>
-            <div class="value">{{type}}</div>
-        </div>
         <div class="email">
             <div class="field">{{t "Bot email" }}</div>
             <div class="value">{{email}}</div>
         </div>
         {{#if is_active}}
-        <div class="api_key">
-            <span class="field">{{t "API key" }}</span>
-            <div class="api-key-value-and-button no-select">
-                <!-- have the `.text-select` in `.no-select` so that the value doesn't have trailing whitespace. -->
-                <span class="value text-select">{{api_key}}</span>
-                <button type="submit" class="button no-style btn-secondary regenerate_bot_api_key" title="{{t 'Generate new API key' }}" data-user-id="{{user_id}}">
-                    <i class="fa fa-refresh" aria-hidden="true"></i>
-                </button>
+            {{#if is_outgoing_webhook}}
+            <div class="token">
+                <div class="field">{{t "Bot token" }}</div>
+                <div class="value">{{token}}</div>
             </div>
-            <div class="api_key_error text-error"></div>
-        </div>
+            {{/if}}
+            <div class="api_key">
+                <span class="field">{{t "API key" }}</span>
+                <div class="api-key-value-and-button no-select">
+                    <!-- have the `.text-select` in `.no-select` so that the value doesn't have trailing whitespace. -->
+                    <span class="value text-select">{{api_key}}</span>
+                    <button type="submit" class="button no-style btn-secondary regenerate_bot_api_key" title="{{t 'Generate new API key' }}" data-user-id="{{user_id}}">
+                        <i class="fa fa-refresh" aria-hidden="true"></i>
+                    </button>
+                </div>
+                <div class="api_key_error text-error"></div>
+            </div>
         {{else}}
-        <button class="button round btn-warning reactivate_bot" title="{{t 'Reactivate bot' }}" data-user-id="{{user_id}}">{{t "Reactivate bot" }}</button>
+            <button class="button round btn-warning reactivate_bot" title="{{t 'Reactivate bot' }}" data-user-id="{{user_id}}">{{t "Reactivate bot" }}</button>
         {{/if}}
         <div class="bot_error alert alert-error hide"></div>
     </div>


### PR DESCRIPTION
Bot token is displayed for outgoing webhook bots in the "Your Bots"
section of settings and position of displaying bot type is changed
to top right.

Fixes #12943

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
I have tested it manually and it does not require any changes in already written tests or addition of tests.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot from 2019-12-19 20-08-03](https://user-images.githubusercontent.com/35494118/71182122-897a7280-229b-11ea-937f-2f067227fd75.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
