### PR TITLE
performance: Speed up search bar highlighting.

### DIFF
--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -85,9 +85,11 @@ run_test('initizalize', () => {
         return 'is:starred';
     };
 
+    search_suggestion.max_num_of_search_results = 99;
     search_query_box.typeahead = (opts) => {
+
         assert.equal(opts.fixed, true);
-        assert.equal(opts.items, 12);
+        assert.equal(opts.items, 99);
         assert.equal(opts.naturalSearch, true);
         assert.equal(opts.helpOnEmptyStrings, true);
         assert.equal(opts.matcher(), true);

--- a/frontend_tests/node_tests/search_legacy.js
+++ b/frontend_tests/node_tests/search_legacy.js
@@ -63,9 +63,10 @@ run_test('initialize', () => {
         assert(search.is_using_input_method);
     };
 
+    search_suggestion.max_num_of_search_results = 999;
     search_query_box.typeahead = (opts) => {
         assert.equal(opts.fixed, true);
-        assert.equal(opts.items, 12);
+        assert.equal(opts.items, 999);
         assert.equal(opts.naturalSearch, true);
         assert.equal(opts.helpOnEmptyStrings, true);
         assert.equal(opts.matcher(), true);

--- a/frontend_tests/node_tests/search_suggestion_legacy.js
+++ b/frontend_tests/node_tests/search_suggestion_legacy.js
@@ -13,6 +13,8 @@ zrequire('unread');
 zrequire('common');
 const search = zrequire('search_suggestion');
 
+search.max_num_of_search_results = 15;
+
 const bob = {
     email: 'bob@zulip.com',
     full_name: 'Bob Roberts',

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -408,22 +408,27 @@ run_test('sort_recipients', () => {
 });
 
 run_test('highlight_with_escaping', () => {
+    function highlight(query, item) {
+        const regex = th.build_highlight_regex(query);
+        return th.highlight_with_escaping_and_regex(regex, item);
+    }
+
     let item = "Denmark";
     let query = "Den";
     let expected = "<strong>Den</strong>mark";
-    let result = th.highlight_with_escaping(query, item);
+    let result = highlight(query, item);
     assert.equal(result, expected);
 
     item = "w3IrD_naMe";
     query = "w3IrD_naMe";
     expected = "<strong>w3IrD_naMe</strong>";
-    result = th.highlight_with_escaping(query, item);
+    result = highlight(query, item);
     assert.equal(result, expected);
 
     item = "development help";
     query = "development h";
     expected = "<strong>development h</strong>elp";
-    result = th.highlight_with_escaping(query, item);
+    result = highlight(query, item);
     assert.equal(result, expected);
 });
 

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -99,6 +99,7 @@ zrequire('upload');
 zrequire('compose');
 zrequire('composebox_typeahead');
 zrequire('narrow');
+zrequire('search_suggestion');
 zrequire('search');
 zrequire('tutorial');
 zrequire('notifications');

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -81,7 +81,7 @@ exports.initialize = function () {
             return suggestions.strings;
         },
         fixed: true,
-        items: 12,
+        items: search_suggestion.max_num_of_search_results,
         helpOnEmptyStrings: true,
         naturalSearch: true,
         highlighter: function (item) {

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -94,9 +94,12 @@ function get_stream_suggestions(last, operators) {
 
     streams = typeahead_helper.sorter(query, streams);
 
+    const regex = typeahead_helper.build_highlight_regex(query);
+    const hilite = typeahead_helper.highlight_with_escaping_and_regex;
+
     const objs = _.map(streams, function (stream) {
         const prefix = 'stream';
-        const highlighted_stream = typeahead_helper.highlight_with_escaping(query, stream);
+        const highlighted_stream = hilite(regex, stream);
         const verb = last.negated ? 'exclude ' : '';
         const description = verb + prefix + ' ' + highlighted_stream;
         const term = {

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -1,3 +1,5 @@
+exports.max_num_of_search_results = 12;
+
 function stream_matches_query(stream_name, q) {
     return common.phrase_match(q, stream_name);
 }
@@ -779,14 +781,21 @@ exports.get_search_result_legacy = function (query) {
         get_has_filter_suggestions,
     ];
 
+    const max_items = exports.max_num_of_search_results;
+
     _.each(filterers, function (filterer) {
-        const suggestions = filterer(last, base_operators);
-        attacher.attach_many(suggestions);
+        if (attacher.result.length < max_items) {
+            const suggestions = filterer(last, base_operators);
+            attacher.attach_many(suggestions);
+        }
     });
 
-    const subset_suggestions = get_operator_subset_suggestions(operators);
-    attacher.concat(subset_suggestions);
-    return attacher.result;
+    if (attacher.result.length < max_items) {
+        const subset_suggestions = get_operator_subset_suggestions(operators);
+        attacher.concat(subset_suggestions);
+    }
+
+    return attacher.result.slice(0, max_items);
 };
 
 exports.get_suggestions_legacy = function (query) {

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -17,28 +17,16 @@ exports.highlight_with_escaping = function (query, item) {
     // item: The string we are trying to appropriately highlight
     query = query.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, '\\$&');
     const regex = new RegExp('(' + query + ')', 'ig');
-    // The result of the split will include the query term, because our regex
-    // has parens in it.
-    // (as per https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/String/split)
-    // However, "not all browsers support this capability", so this is a place to look
-    // if we have an issue here in, e.g. IE.
-    const pieces = item.split(regex);
+
+    return exports.highlight_with_escaping_and_regex(regex, item);
+};
+
+exports.highlight_with_escaping_and_regex = function (regex, item) {
     // We need to assemble this manually (as opposed to doing 'join') because we need to
     // (1) escape all the pieces and (2) the regex is case-insensitive, and we need
     // to know the case of the content we're replacing (you can't just use a bolded
     // version of 'query')
-    let result = "";
-    _.each(pieces, function (piece) {
-        if (piece.match(regex)) {
-            result += "<strong>" + Handlebars.Utils.escapeExpression(piece) + "</strong>";
-        } else {
-            result += Handlebars.Utils.escapeExpression(piece);
-        }
-    });
-    return result;
-};
 
-exports.highlight_with_escaping_and_regex = function (regex, item) {
     const pieces = item.split(regex);
     let result = "";
     _.each(pieces, function (piece) {

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -51,21 +51,23 @@ exports.highlight_with_escaping_and_regex = function (regex, item) {
     return result;
 };
 
-exports.highlight_query_in_phrase = function (query, phrase) {
+exports.make_query_highlighter = function (query) {
     let i;
     query = query.toLowerCase();
     query = query.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, '\\$&');
     const regex = new RegExp('(^' + query + ')', 'ig');
 
-    let result = "";
-    const parts = phrase.split(' ');
-    for (i = 0; i < parts.length; i += 1) {
-        if (i > 0) {
-            result += " ";
+    return function (phrase) {
+        let result = "";
+        const parts = phrase.split(' ');
+        for (i = 0; i < parts.length; i += 1) {
+            if (i > 0) {
+                result += " ";
+            }
+            result += exports.highlight_with_escaping_and_regex(regex, parts[i]);
         }
-        result += exports.highlight_with_escaping_and_regex(regex, parts[i]);
-    }
-    return result;
+        return result;
+    };
 };
 
 exports.render_typeahead_item = function (args) {

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -18,11 +18,6 @@ exports.build_highlight_regex = function (query) {
     return regex;
 };
 
-exports.highlight_with_escaping = function (query, item) {
-    const regex = exports.build_highlight_regex(query);
-    return exports.highlight_with_escaping_and_regex(regex, item);
-};
-
 exports.highlight_with_escaping_and_regex = function (regex, item) {
     // We need to assemble this manually (as opposed to doing 'join') because we need to
     // (1) escape all the pieces and (2) the regex is case-insensitive, and we need

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -11,13 +11,15 @@ exports.get_cleaned_pm_recipients = function (query_string) {
     return recipients;
 };
 
-// Loosely based on Bootstrap's default highlighter, but with escaping added.
-exports.highlight_with_escaping = function (query, item) {
-    // query: The text currently in the searchbox
-    // item: The string we are trying to appropriately highlight
+exports.build_highlight_regex = function (query) {
+    // the regex below is based on bootstrap code
     query = query.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, '\\$&');
     const regex = new RegExp('(' + query + ')', 'ig');
+    return regex;
+};
 
+exports.highlight_with_escaping = function (query, item) {
+    const regex = exports.build_highlight_regex(query);
     return exports.highlight_with_escaping_and_regex(regex, item);
 };
 
@@ -42,8 +44,8 @@ exports.highlight_with_escaping_and_regex = function (regex, item) {
 exports.make_query_highlighter = function (query) {
     let i;
     query = query.toLowerCase();
-    query = query.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, '\\$&');
-    const regex = new RegExp('(^' + query + ')', 'ig');
+
+    const regex = exports.build_highlight_regex(query);
 
     return function (phrase) {
         let result = "";


### PR DESCRIPTION
When we're highlighting all the people that show
up in a search from the search bar, we need
to fairly expensively build a regex from the
query:

    query = query.toLowerCase();
    query = query.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, '\\$&');
    const regex = new RegExp('(^' + query + ')', 'ig');

Even though the final regex is presumably cached, we
still needed to do that `query.replace` for every person.
Even for relatively small numbers of persons, this would
show up in profiles as expensive.

Now we just build the query once by using a pattern
where you call a function outside the loop to build
an inner function that's used in the loop that closes
on the `query` above.  The diff probably shows this
better than I explained it here.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
