### PR TITLE
Add LazySet for subscribers.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -9,6 +9,8 @@ const noop = function () {};
 set_global('$', global.make_zjquery());
 set_global('i18n', global.stub_i18n);
 
+const LazySet = zrequire('lazy_set.js').LazySet;
+
 const _navigator = {
     platform: '',
 };
@@ -1328,13 +1330,13 @@ run_test('on_events', () => {
     (function test_stream_name_completed_triggered() {
         const handler = $(document).get_on_handler('streamname_completed.zulip');
         stream_data.add_sub(compose_state.stream_name(), {
-            subscribers: Dict.from_array([1, 2]),
+            subscribers: LazySet([1, 2]),
         });
 
         let data = {
             stream: {
                 name: 'Denmark',
-                subscribers: Dict.from_array([1, 2, 3]),
+                subscribers: LazySet([1, 2, 3]),
             },
         };
 
@@ -1379,7 +1381,7 @@ run_test('on_events', () => {
             stream: {
                 invite_only: true,
                 name: 'Denmark',
-                subscribers: Dict.from_array([1]),
+                subscribers: LazySet([1]),
             },
         };
 

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -1412,6 +1412,7 @@ with_overrides(function (override) {
 
     global.with_stub(function (stub) {
         event = event_fixtures.update_display_settings__demote_inactive_streams;
+        override('stream_data.set_filter_out_inactives', noop);
         override('stream_list.update_streams_sidebar', stub.f);
         page_params.demote_inactive_streams = 1;
         dispatch(event);

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -304,6 +304,7 @@ run_test('is_active', () => {
 
     page_params.demote_inactive_streams =
         settings_display.demote_inactive_streams_values.automatic.code;
+    stream_data.set_filter_out_inactives();
 
     sub = {name: 'pets', subscribed: false, stream_id: 111};
     stream_data.add_sub('pets', sub);
@@ -334,6 +335,7 @@ run_test('is_active', () => {
 
     page_params.demote_inactive_streams =
         settings_display.demote_inactive_streams_values.always.code;
+    stream_data.set_filter_out_inactives();
 
     sub = {name: 'pets', subscribed: false, stream_id: 111};
     stream_data.add_sub('pets', sub);
@@ -361,6 +363,7 @@ run_test('is_active', () => {
 
     page_params.demote_inactive_streams =
         settings_display.demote_inactive_streams_values.never.code;
+    stream_data.set_filter_out_inactives();
 
     sub = {name: 'pets', subscribed: false, stream_id: 111};
     stream_data.add_sub('pets', sub);

--- a/frontend_tests/node_tests/stream_sort.js
+++ b/frontend_tests/node_tests/stream_sort.js
@@ -45,13 +45,18 @@ stream_data.add_sub(pneumonia.name, pneumonia);
 stream_data.add_sub(clarinet.name, clarinet);
 stream_data.add_sub(weaving.name, weaving);
 
+function sort_groups(query) {
+    const streams = stream_data.subscribed_streams();
+    return stream_sort.sort_groups(streams, query);
+}
+
 with_overrides(function (override) {
     override('stream_data.is_active', function (sub) {
         return sub.name !== "pneumonia";
     });
 
     // Test sorting into categories/alphabetized
-    let sorted = stream_sort.sort_groups("");
+    let sorted = sort_groups("");
     assert.deepEqual(sorted.pinned_streams, ['scalene']);
     assert.deepEqual(sorted.normal_streams, ['clarinet', 'fast tortoise']);
     assert.deepEqual(sorted.dormant_streams, ['pneumonia']);
@@ -66,7 +71,7 @@ with_overrides(function (override) {
     assert.equal(stream_sort.next_stream_id(pneumonia.stream_id), undefined);
 
     // Test filtering
-    sorted = stream_sort.sort_groups("s");
+    sorted = sort_groups("s");
     assert.deepEqual(sorted.pinned_streams, ['scalene']);
     assert.deepEqual(sorted.normal_streams, []);
     assert.deepEqual(sorted.dormant_streams, []);
@@ -76,19 +81,19 @@ with_overrides(function (override) {
     assert.equal(stream_sort.next_stream_id(clarinet.stream_id), undefined);
 
     // Test searching entire word, case-insensitive
-    sorted = stream_sort.sort_groups("PnEuMoNiA");
+    sorted = sort_groups("PnEuMoNiA");
     assert.deepEqual(sorted.pinned_streams, []);
     assert.deepEqual(sorted.normal_streams, []);
     assert.deepEqual(sorted.dormant_streams, ['pneumonia']);
 
     // Test searching part of word
-    sorted = stream_sort.sort_groups("tortoise");
+    sorted = sort_groups("tortoise");
     assert.deepEqual(sorted.pinned_streams, []);
     assert.deepEqual(sorted.normal_streams, ['fast tortoise']);
     assert.deepEqual(sorted.dormant_streams, []);
 
     // Test searching stream with spaces
-    sorted = stream_sort.sort_groups("fast t");
+    sorted = sort_groups("fast t");
     assert.deepEqual(sorted.pinned_streams, []);
     assert.deepEqual(sorted.normal_streams, ['fast tortoise']);
     assert.deepEqual(sorted.dormant_streams, []);

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -124,8 +124,8 @@ run_test('filter_table', () => {
     assert.deepEqual(sub_table_append, [
         '.stream-row-poland',
         '.stream-row-pomona',
-        '.stream-row-denmark',
         '.stream-row-cpp',
+        '.stream-row-denmark',
     ]);
 
     // Search with multiple keywords
@@ -180,8 +180,8 @@ run_test('filter_table', () => {
     assert.deepEqual(sub_table_append, [
         '.stream-row-pomona',
         '.stream-row-poland',
-        '.stream-row-denmark',
         '.stream-row-cpp',
+        '.stream-row-denmark',
     ]);
 
     // active stream-row is not included in results

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -17,6 +17,7 @@ zrequire('marked', 'third/marked/lib/marked');
 const actual_pygments_data = zrequire('actual_pygments_data', 'generated/pygments_data');
 zrequire('settings_org');
 const th = zrequire('typeahead_helper');
+const LazySet = zrequire('lazy_set.js').LazySet;
 
 stream_data.create_streams([
     {name: 'Dev', subscribed: true, color: 'blue', stream_id: 1},
@@ -24,13 +25,9 @@ stream_data.create_streams([
 ]);
 
 run_test('sort_streams', () => {
-    const popular = {num_items: function () {
-        return 10;
-    }};
+    const popular = LazySet([1, 2, 3, 4, 5, 6]);
 
-    const unpopular = {num_items: function () {
-        return 2;
-    }};
+    const unpopular = LazySet([1]);
 
     let test_streams = [
         {name: 'Dev', pin_to_top: false, subscribers: unpopular, subscribed: true},

--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -31,6 +31,7 @@ import "../search_util.js";
 import "../keydown_util.js";
 import "../lightbox_canvas.js";
 import "../rtl.js";
+import "../lazy_set.js";
 import "../dict.ts";
 import "../scroll_util.js";
 import "../components.js";

--- a/static/js/color_data.js
+++ b/static/js/color_data.js
@@ -1,5 +1,3 @@
-const Dict = require('./dict').Dict;
-
 // These colors are used now for streams.
 const stream_colors = [
     "#76ce90", "#fae589", "#a6c7e5", "#e79ab5",
@@ -35,17 +33,8 @@ exports.claim_color = function (color) {
 };
 
 exports.claim_colors = function (subs) {
-    const used_colors = new Dict();
-
-    _.each(subs, function (sub) {
-        if (sub.color) {
-            used_colors.set(sub.color, true);
-        }
-    });
-
-    _.each(used_colors.keys(), function (color) {
-        exports.claim_color(color);
-    });
+    const colors = new Set(_.pluck(subs, 'color'));
+    colors.forEach(exports.claim_color);
 };
 
 exports.pick_color = function () {

--- a/static/js/lazy_set.js
+++ b/static/js/lazy_set.js
@@ -1,0 +1,70 @@
+exports.LazySet = function (vals) {
+    /*
+        This class is optimized for a very
+        particular use case.
+
+        We often have lots of subscribers on
+        a stream.  We get an array from the
+        backend, because it's JSON.
+
+        Often the only operation we need
+        on subscribers is to get the length,
+        which is plenty cheap as an array.
+
+        Making an array from a set is cheap
+        for one stream, but it's expensive
+        for all N streams at page load.
+
+        Once somebody does an operation
+        where sets are useful, such
+        as has/add/del, we convert it over
+        to a set for a one-time cost.
+    */
+    const self = {};
+    self.arr = vals;
+    self.set = undefined;
+
+    self.keys = function () {
+        if (self.set !== undefined) {
+            return Array.from(self.set);
+        }
+        return self.arr;
+    };
+
+    function make_set() {
+        if (self.set !== undefined) {
+            return;
+        }
+        self.set = new Set(self.arr);
+        self.arr = undefined;
+    }
+
+    self.num_items = function () {
+        if (self.set !== undefined) {
+            return self.set.size;
+        }
+
+        return self.arr.length;
+    };
+
+    self.map = function (f) {
+        return _.map(self.keys(), f);
+    };
+
+    self.has = function (v) {
+        make_set();
+        return self.set.has(v);
+    };
+
+    self.add = function (v) {
+        make_set();
+        self.set.add(v);
+    };
+
+    self.del = function (v) {
+        make_set();
+        self.set.delete(v);
+    };
+
+    return self;
+};

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -409,6 +409,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
         }
         if (event.setting_name === 'demote_inactive_streams') {
             stream_list.update_streams_sidebar();
+            stream_data.set_filter_out_inactives();
         }
         if (event.setting_name === 'dense_mode') {
             $("body").toggleClass("less_dense_mode");

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -1,4 +1,5 @@
 const Dict = require('./dict').Dict;
+const LazySet = require('./lazy_set').LazySet;
 
 
 // The stream_info variable maps stream names to stream properties objects
@@ -74,7 +75,7 @@ exports.unsubscribe_myself = function (sub) {
 
 exports.add_sub = function (stream_name, sub) {
     if (!_.has(sub, 'subscribers')) {
-        sub.subscribers = Dict.from_array([]);
+        sub.subscribers = LazySet([]);
     }
 
     stream_info.set(stream_name, sub);
@@ -507,7 +508,7 @@ exports.maybe_get_stream_name = function (stream_id) {
 };
 
 exports.set_subscribers = function (sub, user_ids) {
-    sub.subscribers = Dict.from_array(user_ids || []);
+    sub.subscribers = LazySet(user_ids || []);
 };
 
 exports.add_subscriber = function (stream_name, user_id) {
@@ -521,7 +522,7 @@ exports.add_subscriber = function (stream_name, user_id) {
         blueslip.error("We tried to add invalid subscriber: " + user_id);
         return false;
     }
-    sub.subscribers.set(user_id, true);
+    sub.subscribers.add(user_id);
 
     return true;
 };

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -1,6 +1,79 @@
 const Dict = require('./dict').Dict;
 const LazySet = require('./lazy_set').LazySet;
 
+const BinaryDict = function (pred) {
+    /*
+        This class is optimized for subscriptions.
+        Typically you only subscribe to a small
+        minority of streams, and most common
+        operations don't care about unsubscribed
+        streams:
+
+            - search bar search
+            - build left sidebar
+            - autocomplete #stream_links
+            - autocomplete stream in compose
+    */
+
+    const self = {};
+    self.trues = new Dict({fold_case: true});
+    self.falses = new Dict({fold_case: true});
+
+    self.true_values = function () {
+        return self.trues.values();
+    };
+
+    self.num_true_items = function () {
+        return self.trues.num_items();
+    };
+
+    self.false_values = function () {
+        return self.falses.values();
+    };
+
+    self.values = function () {
+        const trues = self.trues.values();
+        const falses = self.falses.values();
+        const both = trues.concat(falses);
+        return both;
+    };
+
+    self.get = function (k) {
+        const res = self.trues.get(k);
+
+        if (res !== undefined) {
+            return res;
+        }
+
+        return self.falses.get(k);
+    };
+
+    self.set = function (k, v) {
+        if (pred(v)) {
+            self.set_true(k, v);
+        } else {
+            self.set_false(k, v);
+        }
+    };
+
+    self.set_true = function (k, v) {
+        self.falses.del(k);
+        self.trues.set(k, v);
+    };
+
+    self.set_false = function (k, v) {
+        self.trues.del(k);
+        self.falses.set(k, v);
+    };
+
+    self.del = function (k) {
+        self.trues.del(k);
+        self.falses.del(k);
+    };
+
+
+    return self;
+};
 
 // The stream_info variable maps stream names to stream properties objects
 // Call clear_subscriptions() to initialize it.
@@ -11,7 +84,10 @@ let filter_out_inactives = false;
 const stream_ids_by_name = new Dict({fold_case: true});
 
 exports.clear_subscriptions = function () {
-    stream_info = new Dict({fold_case: true});
+    stream_info = new BinaryDict(function (sub) {
+        return sub.subscribed;
+    });
+
     subs_by_stream_id = new Dict();
 };
 
@@ -20,7 +96,7 @@ exports.clear_subscriptions();
 exports.set_filter_out_inactives = function () {
     if (page_params.demote_inactive_streams ===
             settings_display.demote_inactive_streams_values.automatic.code) {
-        filter_out_inactives = exports.subscribed_subs().length >= 30;
+        filter_out_inactives = exports.num_subscribed_subs() >= 30;
     } else if (page_params.demote_inactive_streams ===
             settings_display.demote_inactive_streams_values.always.code) {
         filter_out_inactives = true;
@@ -63,6 +139,7 @@ exports.subscribe_myself = function (sub) {
     exports.add_subscriber(sub.name, user_id);
     sub.subscribed = true;
     sub.newly_subscribed = true;
+    stream_info.set_true(sub.name, sub);
 };
 
 exports.unsubscribe_myself = function (sub) {
@@ -71,6 +148,7 @@ exports.unsubscribe_myself = function (sub) {
     exports.remove_subscriber(sub.name, user_id);
     sub.subscribed = false;
     sub.newly_subscribed = false;
+    stream_info.set_false(sub.name, sub);
 };
 
 exports.add_sub = function (stream_name, sub) {
@@ -209,12 +287,16 @@ exports.get_updated_unsorted_subs = function () {
     return all_subs;
 };
 
+exports.num_subscribed_subs = function () {
+    return stream_info.num_true_items();
+};
+
 exports.subscribed_subs = function () {
-    return _.where(stream_info.values(), {subscribed: true});
+    return stream_info.true_values();
 };
 
 exports.unsubscribed_subs = function () {
-    return _.where(stream_info.values(), {subscribed: false});
+    return stream_info.false_values();
 };
 
 exports.subscribed_streams = function () {

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -34,7 +34,6 @@ exports.is_filtering_inactives = function () {
 };
 
 exports.is_active = function (sub) {
-    exports.set_filter_out_inactives();
     if (!filter_out_inactives || sub.pin_to_top) {
         // If users don't want to filter inactive streams
         // to the bottom, we respect that setting and don't

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -36,12 +36,9 @@ exports.is_sub_settings_active = function (sub) {
 };
 
 exports.get_email_of_subscribers = function (subscribers) {
-    const emails = [];
-    subscribers.each(function (o, i) {
-        const email = people.get_person_from_user_id(i).email;
-        emails.push(email);
+    return subscribers.map(function (user_id) {
+        return people.get_person_from_user_id(user_id).email;
     });
-    return emails;
 };
 
 function clear_edit_panel() {

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -216,7 +216,7 @@ function build_stream_sidebar_li(sub) {
         is_muted: stream_data.is_muted(sub.stream_id) === true,
         invite_only: sub.invite_only,
         is_web_public: sub.is_web_public,
-        color: stream_data.get_color(name),
+        color: sub.color,
         pin_to_top: sub.pin_to_top,
     };
     args.dark_background = stream_color.get_color_class(args.color);

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -91,7 +91,7 @@ exports.build_stream_list = function () {
 
     // The main logic to build the list is in stream_sort.js, and
     // we get three lists of streams (pinned/normal/dormant).
-    const stream_groups = stream_sort.sort_groups(get_search_term());
+    const stream_groups = stream_sort.sort_groups(streams, get_search_term());
 
     if (stream_groups.same_as_before) {
         return;

--- a/static/js/stream_sort.js
+++ b/static/js/stream_sort.js
@@ -33,8 +33,7 @@ function filter_streams_by_search(streams, search_term) {
     return filtered_streams;
 }
 
-exports.sort_groups = function (search_term) {
-    let streams = stream_data.subscribed_streams();
+exports.sort_groups = function (streams, search_term) {
     if (streams.length === 0) {
         return;
     }


### PR DESCRIPTION
This defers O(N*S) operations, where

    N = number of streams
    S = number of subscribers per stream

In many cases we never do an O(N) operation on
a stream.  Exceptions include:

    - checking stream links from the compose box
    - editing a stream
    - adding members to a newly added stream

An operations that used to be O(N)--computing
the number of subscribers--is now O(1), and we
don't even pay O(N) on a one-time basis to
compute it (not counting the cost to build the
array from JSON, but we have to do that).

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
