### PR TITLE
Minor cleanups in queue workers

### DIFF
--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -629,16 +629,6 @@ class WorkerTest(ZulipTestCase):
         with self.assertRaises(queue_processors.WorkerDeclarationException):
             TestWorker()
 
-    def test_worker_noconsume(self) -> None:
-        @queue_processors.assign_queue('test_worker')
-        class TestWorker(queue_processors.QueueProcessingWorker):
-            def __init__(self) -> None:
-                super().__init__()
-
-        with self.assertRaises(queue_processors.WorkerDeclarationException):
-            worker = TestWorker()
-            worker.consume({})
-
     def test_get_active_worker_queues(self) -> None:
         worker_queue_count = (len(QueueProcessingWorker.__subclasses__()) +
                               len(EmailSendingWorker.__subclasses__()) +

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -1,4 +1,5 @@
 # Documented in https://zulip.readthedocs.io/en/latest/subsystems/queuing.html
+from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, List, Mapping, Optional, cast, Tuple, TypeVar, Type
 
 import copy
@@ -119,7 +120,7 @@ def retry_send_email_failures(
 
     return wrapper
 
-class QueueProcessingWorker:
+class QueueProcessingWorker(ABC):
     queue_name = None  # type: str
 
     def __init__(self) -> None:
@@ -127,8 +128,9 @@ class QueueProcessingWorker:
         if self.queue_name is None:
             raise WorkerDeclarationException("Queue worker declared without queue_name")
 
+    @abstractmethod
     def consume(self, data: Dict[str, Any]) -> None:
-        raise WorkerDeclarationException("No consumer defined!")
+        pass
 
     def consume_wrapper(self, data: Dict[str, Any]) -> None:
         try:
@@ -184,8 +186,9 @@ class LoopQueueProcessingWorker(QueueProcessingWorker):
             if not self.sleep_only_if_empty or len(events) == 0:
                 time.sleep(self.sleep_delay)
 
+    @abstractmethod
     def consume_batch(self, events: List[Dict[str, Any]]) -> None:
-        raise NotImplementedError
+        pass
 
     def consume(self, event: Dict[str, Any]) -> None:
         """In LoopQueueProcessingWorker, consume is used just for automated tests"""


### PR DESCRIPTION
By commits:
1. There was TODO in the loop queue worker class to share some code with the "regular" worker - I'm not sure if I got the full intent of the TODO right in this change, but at least I figured the exception handling was resusable.
2. Tests for workers based on the loop worker class all do the same, identical mock, so it seemed cleaner to exctract it.
3. I'm not sure if we want to use ABCs like this in general, but I was already looking through this code and decided to submit a commit to see if we want to go with it.