### PR TITLE
Added title "User Profile (u)" on hover on avatar and name 

### DIFF
--- a/static/templates/me_message.hbs
+++ b/static/templates/me_message.hbs
@@ -1,10 +1,10 @@
 <span class="message_sender no-select">
-    <span class="sender_info_hover">
+    <span class="sender_info_hover" title="{{t 'User profile' }} (u)">
         {{> message_avatar}}
     </span>
 
     <span class="sender-status">
-        <span class="sender_info_hover sender_name-in-status auto-select" role="button" tabindex="0">{{msg/sender_full_name}}</span>
+        <span class="sender_info_hover sender_name-in-status auto-select" title="{{t 'User profile' }} (u)" role="button" tabindex="0">{{msg/sender_full_name}}</span>
         {{#if sender_is_bot}}
         <i class="zulip-icon bot" aria-label="{{t 'Bot' }}"></i>
         {{/if}}

--- a/static/templates/message_body.hbs
+++ b/static/templates/message_body.hbs
@@ -1,6 +1,6 @@
 <div class="message_top_line">
     {{#unless status_message}}
-    <span class="message_sender sender_info_hover no-select">
+    <span class="message_sender sender_info_hover no-select" title="{{t 'User profile' }} (u)">
         {{#if include_sender}}
 
             {{> message_avatar}}


### PR DESCRIPTION
message_body.hbs file modified to display title "User profile (u)" on hovering over the avatar and name.
Fixes #12769

**Testing Plan:** 
- Tested using ./tools/test-all


**GIFs or Screenshots:** 
![image](https://user-images.githubusercontent.com/33183263/71532418-3a76b200-2919-11ea-9af5-f29360d72b43.png)
)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
