### PR TITLE
Ldap logging

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -3246,7 +3246,8 @@ class TestQueryLDAP(ZulipLDAPTestCase):
     def test_user_not_present(self) -> None:
         # othello doesn't have an entry in our test directory
         values = query_ldap(self.example_email('othello'))
-        self.assertEqual(values, ['No such user found'])
+        self.assert_length(values, 1)
+        self.assertIn('No such user found', values[0])
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_normal_query(self) -> None:

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -534,7 +534,7 @@ class ZulipLDAPAuthBackend(ZulipLDAPAuthBackendBase):
             return None
 
         try:
-            # We want to apss the user's LDAP username into
+            # We want to pass the user's LDAP username into
             # authenticate() below.  If an email address was entered
             # in the login form, we need to use
             # django_to_ldap_username to translate the email address
@@ -551,10 +551,7 @@ class ZulipLDAPAuthBackend(ZulipLDAPAuthBackendBase):
         # against the LDAP database, and assuming those are correct,
         # end up calling `self.get_or_build_user` with the
         # authenticated user's data from LDAP.
-        return ZulipLDAPAuthBackendBase.authenticate(self,
-                                                     request=None,
-                                                     username=username,
-                                                     password=password)
+        return super().authenticate(request=None, username=username, password=password)
 
     def get_or_build_user(self, username: str, ldap_user: _LDAPUser) -> Tuple[UserProfile, bool]:
         """The main function of our authentication backend extension of

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -640,6 +640,7 @@ EMAIL_LOG_PATH = zulip_path("/var/log/zulip/send_email.log")
 EMAIL_MIRROR_LOG_PATH = zulip_path("/var/log/zulip/email_mirror.log")
 EMAIL_DELIVERER_LOG_PATH = zulip_path("/var/log/zulip/email-deliverer.log")
 EMAIL_CONTENT_LOG_PATH = zulip_path("/var/log/zulip/email_content.log")
+LDAP_LOG_PATH = zulip_path("/var/log/zulip/ldap.log")
 LDAP_SYNC_LOG_PATH = zulip_path("/var/log/zulip/sync_ldap_user_data.log")
 QUEUE_ERROR_DIR = zulip_path("/var/log/zulip/queue_error")
 DIGEST_LOG_PATH = zulip_path("/var/log/zulip/digest.log")
@@ -745,6 +746,12 @@ LOGGING = {
             'formatter': 'default',
             'filename': ERROR_FILE_LOG_PATH,
         },
+        'ldap_file': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.WatchedFileHandler',
+            'formatter': 'default',
+            'filename': LDAP_LOG_PATH,
+        },
     },
     'loggers': {
         # The Python logging module uses a hierarchy of logger names for config:
@@ -812,6 +819,11 @@ LOGGING = {
         # },
 
         # other libraries, alphabetized
+        'django_auth_ldap': {
+            'level': 'DEBUG',
+            'handlers': ['console', 'ldap_file', 'errors_file'],
+            'propagate': False,
+        },
         'pika.adapters': {
             # pika is super chatty on INFO.
             'level': 'WARNING',
@@ -853,6 +865,11 @@ LOGGING = {
         },
         'zerver.management.commands.deliver_scheduled_messages': {
             'level': 'DEBUG',
+        },
+        'zulip.ldap': {
+            'level': 'DEBUG',
+            'handlers': ['console', 'ldap_file', 'errors_file'],
+            'propagate': False,
         },
         'zulip.management': {
             'handlers': ['file', 'errors_file'],

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -124,6 +124,7 @@ if not CASPER_TESTS:
     set_loglevel('zulip.requests', 'CRITICAL')
     set_loglevel('zulip.management', 'CRITICAL')
     set_loglevel('django.request', 'ERROR')
+    set_loglevel('django_auth_ldap', 'WARNING')
     set_loglevel('fakeldap', 'ERROR')
     set_loglevel('zulip.send_email', 'ERROR')
     set_loglevel('zerver.lib.push_notifications', 'WARNING')


### PR DESCRIPTION
From the commit message:
Our ldap integration is quite sensitive to misconfigurations, so more
logging is better than less to help debug those issues.
Despite the following docstring on ZulipLDAPException:

"Since this inherits from _LDAPUser.AuthenticationFailed, these will
be caught and logged at debug level inside django-auth-ldap's
authenticate()"

We weren't actually logging anything, because debug level messages were
ignored due to our general logging settings. It is however desirable to
log these errors, as they can prove useful in debugging configuration
problems. The django_auth_ldap logger can get fairly spammy on debug
level, so we delegate ldap logging to a separate file
/var/log/zulip/ldap.log to avoid spamming server.log too much.

