### PR TITLE
Cache full names to avoid remove_diacritics

### DIFF
--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -928,6 +928,36 @@ run_test('email_for_user_settings', () => {
     assert.equal(email(isaac), isaac.email);
 });
 
+run_test('get_ascii_full_name', () => {
+    const user = {
+        email: 'francois@example.com',
+        user_id: 93,
+        full_name: 'François DuPont',
+    };
+
+    // François
+    people.add_in_realm(user);
+    assert.equal(people.get_ascii_full_name(user), 'Francois DuPont');
+
+    // Frank
+    people.set_full_name(user, 'Frank DuPont');
+    assert.equal(people.get_ascii_full_name(user), 'Frank DuPont');
+
+    // Noël
+    people.set_full_name(user, 'Noël Bridges');
+    assert.equal(people.get_ascii_full_name(user), 'Noel Bridges');
+
+    // Blank name.  These should be impossible, but we'll be defensive.
+    // Get the name twice to make sure our any cache behavior doesn't
+    // cause strange results.
+    people.set_full_name(user, '');
+    assert.equal(people.get_ascii_full_name(user), '');
+    assert.equal(people.get_ascii_full_name(user), '');
+
+    // undefined
+    assert.equal(people.get_ascii_full_name({}), '');
+});
+
 run_test('emails_strings_to_user_ids_array', function () {
     const steven = {
         email: 'steven@example.com',

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -937,14 +937,20 @@ run_test('get_ascii_full_name', () => {
 
     // François
     people.add_in_realm(user);
+    assert.equal(user._has_ascii_full_name, undefined);
+    assert.equal(user._ascii_full_name, 'Francois DuPont');
     assert.equal(people.get_ascii_full_name(user), 'Francois DuPont');
 
     // Frank
     people.set_full_name(user, 'Frank DuPont');
+    assert.equal(user._has_ascii_full_name, true);
+    assert.equal(user._ascii_full_name, undefined);
     assert.equal(people.get_ascii_full_name(user), 'Frank DuPont');
 
     // Noël
     people.set_full_name(user, 'Noël Bridges');
+    assert.equal(user._has_ascii_full_name, undefined);
+    assert.equal(user._ascii_full_name, 'Noel Bridges');
     assert.equal(people.get_ascii_full_name(user), 'Noel Bridges');
 
     // Blank name.  These should be impossible, but we'll be defensive.

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -755,6 +755,17 @@ exports.incr_recipient_count = function (user_id) {
     pm_recipient_count_dict.set(user_id, old_count + 1);
 };
 
+exports.get_ascii_full_name = function (user) {
+    if (!user.full_name) {
+        // This is mostly for tests, and maybe bots.
+        return '';
+    }
+
+    const ascii_full_name = exports.remove_diacritics(user.full_name);
+
+    return ascii_full_name;
+};
+
 const unicode_marks = /\p{M}/gu;
 
 exports.remove_diacritics = function (s) {
@@ -771,11 +782,15 @@ exports.build_termlet_matcher = function (termlet) {
     const is_ascii = /^[a-z]+$/.test(termlet);
 
     return function (user) {
-        let full_name = user.full_name;
+        let full_name;
+
         if (is_ascii) {
             // Only ignore diacritics if the query is plain ascii
-            full_name = exports.remove_diacritics(full_name);
+            full_name = exports.get_ascii_full_name(user);
+        } else {
+            full_name = user.full_name;
         }
+
         const names = full_name.toLowerCase().split(' ');
 
         return _.any(names, function (name) {


### PR DESCRIPTION
I split this out from #13561  to make it a little easier to pick/choose commits for merging.

The first four commits here should be pretty much no-brainers to merge, and they are gonna remain in both PRs.  If we can got those merged, I'll rebase both, and then they'll be independent PR.

The gist of this PR is that we do lots of manipulating of queries inside loops, and it's better to do that outside of loops, particularly when we're doing expensive things like removing diacritics.

Some of the changes here will also speed up other stuff (like search bar search or user search).