### PR TITLE
settings: Use correct email when searching users.

### DIFF
--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -859,6 +859,17 @@ run_test('initialize', () => {
 run_test('matches_user_settings_search', () => {
     const match = people.matches_user_settings_search;
 
+    settings_org.show_email = () => {
+        return false;
+    };
+
+    assert.equal(match({email: 'fred@example.com'}, 'fred'), false);
+    assert.equal(match({full_name: 'Fred Smith'}, 'fr'), true);
+
+    settings_org.show_email = () => {
+        return true;
+    };
+
     page_params.is_admin = true;
     assert.equal(match({delivery_email: 'fred@example.com'}, 'fr'), true);
     assert.equal(

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -984,10 +984,7 @@ function safe_lower(s) {
 }
 
 exports.matches_user_settings_search = function (person, value) {
-    let email = person.email;
-    if (page_params.is_admin && person.delivery_email) {
-        email = person.delivery_email;
-    }
+    const email = exports.email_for_user_settings(person);
 
     return (
         safe_lower(person.full_name).indexOf(value) >= 0 ||


### PR DESCRIPTION
If we aren't showing users emails, then we don't
want to use emails in the search.

And if we are showing users emails, we want to
search on the email that's displayed to them.
For admins this will be delivery_email.

For regular users we arguably shouldn't search
on emails either, since it mostly causes confusion,
but this commit just preserves the current
behavior for those users (unless `show_email` is
false).

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
