### PR TITLE
api docs: Advertise "topic" argument instead of "subject" on /messages.

### DIFF
--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -582,7 +582,7 @@ def send_message(client):
     request = {
         "type": "stream",
         "to": "Denmark",
-        "subject": "Castle",
+        "topic": "Castle",
         "content": "I come not, friends, to steal away your hearts."
     }
     result = client.send_message(request)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -114,7 +114,7 @@ paths:
                                     "sender_id": 13215,
                                     "sender_realm_str": "example",
                                     "sender_short_name": "othello-bot",
-                                    "subject": "Castle",
+                                    "topic": "Castle",
                                     "subject_links": [],
                                     "timestamp": 1375978403,
                                     "type": "stream"


### PR DESCRIPTION
Reported here: https://chat.zulip.org/#narrow/stream/19-documentation/topic/send.20message.20api

We don't want to use ``subject``, so we should advertise the ``topic`` name for the argument in the API doc.