### PR TITLE
Ldap doc adjustments and safer ldap sync command

### DIFF
--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -223,6 +223,7 @@ of the following configurations:
                                        ldap.SCOPE_SUBTREE, "(sAMAccountName=%(user)s)")
     AUTH_LDAP_REVERSE_EMAIL_SEARCH = LDAPSearch("ou=users,dc=example,dc=com",
                                        ldap.SCOPE_SUBTREE, "(mail=%(email)s)")
+    AUTH_LDAP_USERNAME_ATTR = "sAMAccountName"
     ```
 
 * To access by Active Directory email address:
@@ -231,6 +232,7 @@ of the following configurations:
                                        ldap.SCOPE_SUBTREE, "(mail=%(user)s)")
     AUTH_LDAP_REVERSE_EMAIL_SEARCH = LDAPSearch("ou=users,dc=example,dc=com",
                                                 ldap.SCOPE_SUBTREE, "(mail=%(email)s)")
+    AUTH_LDAP_USERNAME_ATTR = "mail"
     ```
 
 **If you are using LDAP for authentication**: you will need to enable

--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -379,6 +379,23 @@ details.
 
 [upstream-ldap-groups]: https://django-auth-ldap.readthedocs.io/en/latest/groups.html#limiting-access
 
+### Troubleshooting
+
+Issues with logging in via LDAP are usually due to some form of misconfiguration
+of the user and email search settings. Some things you can try to get to the
+bottom of the problem:
+
+* Make sure you know which configuration type (A), (B) or (C) is the correct
+  one for your purposes and that you have configured all the required settings
+  according to the instructions for the intended configuration type.
+* Use the `manage.py query_ldap` tool to query for usernames. The output
+  of the command can help determine what the problem is. For the LDAP
+  integration to work, this command should be able to successfully fetch
+  data of the queried user.
+* You can find LDAP-specific logs in `/var/log/zulip/ldap.log`. If you're
+  asking for help with your setup, you should copypaste the recent data from
+  this file.
+
 ## Apache-based SSO with `REMOTE_USER`
 
 If you have any existing SSO solution where a preferred way to deploy

--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -51,7 +51,7 @@ it as follows:
       The `Entity ID` should match the value of
       `SOCIAL_AUTH_SAML_SP_ENTITY_ID` computed in the Zulip settings.
        You can get the correct value by running the following:
-      `/home/zulip/deployments/current/scripts/setup/get-django-setting
+      `/home/zulip/deployments/current/scripts/get-django-setting
        SOCIAL_AUTH_SAML_SP_ENTITY_ID`.
 
     * **SSO URL**:

--- a/docs/production/email.md
+++ b/docs/production/email.md
@@ -62,7 +62,7 @@ find the service's provided "SMTP credentials", and configure Zulip as
 follows:
 
 * The hostname like `EMAIL_HOST = 'smtp.mailgun.org'` in `/etc/zulip/settings.py`
-* The username like `EMAIL_HOST_USER = 'username@example.com` in
+* The username like `EMAIL_HOST_USER = 'username@example.com'` in
   `/etc/zulip/settings.py`.
 * The TLS setting as `EMAIL_USE_TLS = True` in
   `/etc/zulip/settings.py`, for most providers

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -33,7 +33,7 @@ AUTH_LDAP_SERVER_URI = ""
 LDAP_EMAIL_ATTR = None  # type: Optional[str]
 AUTH_LDAP_USERNAME_ATTR = None  # type: Optional[str]
 AUTH_LDAP_REVERSE_EMAIL_SEARCH = None  # type: Optional[LDAPSearch]
-# AUTH_LDAP_CONNECTION_OPTIONS: we set ldap.OPT_REFERRALS below if unset.
+# AUTH_LDAP_CONNECTION_OPTIONS: we set ldap.OPT_REFERRALS in settings.py if unset.
 AUTH_LDAP_CONNECTION_OPTIONS = {}  # type: Dict[int, object]
 # Disable django-auth-ldap caching, to prevent problems with OU changes.
 AUTH_LDAP_CACHE_TIMEOUT = 0
@@ -167,7 +167,7 @@ DEVELOPMENT_LOG_EMAILS = DEVELOPMENT
 #    like zulipchat.com or to work around a problem on another server.
 
 # The following bots are optional system bots not enabled by
-# default.  The default ones are defined in INTERNAL_BOTS, below.
+# default.  The default ones are defined in INTERNAL_BOTS, in settings.py.
 
 # ERROR_BOT sends Django exceptions to an "errors" stream in the
 # system realm.
@@ -222,12 +222,12 @@ REALM_HOSTS = {}  # type: Dict[str, str]
 # testing.
 USING_PGROONGA = False
 
-# How Django should send emails.  Set for most contexts below, but
+# How Django should send emails.  Set for most contexts in settings.py, but
 # available for sysadmin override in unusual cases.
 EMAIL_BACKEND = None  # type: Optional[str]
 
 # Whether to give admins a warning in the web app that email isn't set up.
-# Set below when email isn't configured.
+# Set in settings.py when email isn't configured.
 WARN_NO_EMAIL = False
 
 # Whether to keep extra frontend stack trace data.


### PR DESCRIPTION
This makes some small adjustments to the ldap docs and changes ``sync_ldap_user_data`` to protect from accidentally causing a troublesome state due to deactivating too many users/admins.