### PR TITLE
ui: Fix text-error padding.

### DIFF
--- a/static/styles/portico/portico-signin.scss
+++ b/static/styles/portico/portico-signin.scss
@@ -442,6 +442,7 @@ html {
     font-size: 0.7em;
     font-weight: 600;
     padding-left: 0px;
+    padding-top: 0.3rem;
 }
 
 .new-style .get-started {


### PR DESCRIPTION
This PR fixes text-error padding on the sign-in page.


**Testing**:
I have tested the changes on localhost.


**Screenshots:** 
Before:
![Screenshot from 2020-01-03 15-36-32](https://user-images.githubusercontent.com/43616959/71718415-23682080-2e41-11ea-892a-e4ebd4932b23.png)

After:
![Screenshot from 2020-01-03 15-36-03](https://user-images.githubusercontent.com/43616959/71718423-29f69800-2e41-11ea-927b-2a20ac8f6dc9.png)

