### PR TITLE
bot owner: Change null checks to falsy checks.

### DIFF
--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -222,7 +222,7 @@ exports.get_title_data = function (user_ids_string, is_group) {
 
     if (person.is_bot) {
         // Bot has an owner.
-        if (person.bot_owner_id !== null) {
+        if (person.bot_owner_id) {
             person.bot_owner_full_name = people.get_person_from_user_id(
                 person.bot_owner_id).full_name;
 

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -134,7 +134,7 @@ function populate_users(realm_people_data) {
             // Convert bot type id to string for viewing to the users.
             user.bot_type = settings_bots.type_id_to_string(user.bot_type);
 
-            if (user.bot_owner_id !== null) {
+            if (user.bot_owner_id) {
                 user.bot_owner_full_name = people.get_person_from_user_id(
                     user.bot_owner_id).full_name;
             } else {


### PR DESCRIPTION
In our blueslip emails, we have evidence that some
bots have owner_id of `undefined` instead of `null`,
so the overly-specific conditionals were having us
look up an undefined bot owner.

Now we check for truthiness.

I couldn't reproduce the actual `undefined` values,
but this change seems sound.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
