### PR TITLE
minor: Avoid recip.user_id defensive fallback.

### DIFF
--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -179,7 +179,7 @@ exports.add_message_metadata = function (message) {
 
         if (people.is_my_user_id(message.sender_id)) {
             _.each(message.display_recipient, (recip) => {
-                message_user_ids.add(recip.id || recip.user_id);
+                message_user_ids.add(recip.id);
             });
         }
         break;


### PR DESCRIPTION
The recip.id || recip.user_id idiom has only been
needed for some old unit tests.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
