### PR TITLE
puppet: Switch double quoted strings to single quoted

### DIFF
--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -11,12 +11,12 @@ class zulip::app_frontend_base {
       # Needed to access our database
       "postgresql-client-${zulip::base::postgres_version}",
       # Needed for Slack import
-      "unzip",
+      'unzip',
     ]
   } else {
       $web_packages = [
         # Needed for Slack import
-        "unzip",
+        'unzip',
       ]
   }
   zulip::safepackage { $web_packages: ensure => 'installed' }


### PR DESCRIPTION
Resolves these warnings from `puppet-lint`.

```
puppet-lint| puppet/zulip/manifests/app_frontend_base.pp - WARNING: double quoted string containing no variables on line 14
puppet-lint| puppet/zulip/manifests/app_frontend_base.pp - WARNING: double quoted string containing no variables on line 19
```