### PR TITLE
Unreads cleanup/improvements.

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -275,11 +275,17 @@ run_test('can_mark_messages_read', () => {
         { operator: 'pm-with', operand: 'joe@example.com,' },
     ];
 
+    const pm_with_negated = [
+        { operator: 'pm-with', operand: 'joe@example.com,', negated: true},
+    ];
+
     const group_pm = [
         { operator: 'pm-with', operand: 'joe@example.com,STEVE@foo.com' },
     ];
     filter = new Filter(pm_with);
     assert(filter.can_mark_messages_read());
+    filter = new Filter(pm_with_negated);
+    assert(!filter.can_mark_messages_read());
     filter = new Filter(group_pm);
     assert(filter.can_mark_messages_read());
     assert_not_mark_read_with_is_operands(group_pm);

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -316,11 +316,28 @@ run_test('can_mark_messages_read', () => {
     const in_home = [
         { operator: 'in', operand: 'home' },
     ];
+    const in_home_negated = [
+        { operator: 'in', operand: 'home', negated: true },
+    ];
     filter = new Filter(in_home);
     assert(filter.can_mark_messages_read());
     assert_not_mark_read_with_is_operands(in_home);
     assert_not_mark_read_with_has_operands(in_home);
     assert_not_mark_read_when_searching(in_home);
+    filter = new Filter(in_home_negated);
+    assert(!filter.can_mark_messages_read());
+
+    // Do not mark messages as read when in an unsupported 'in:*' filter.
+    const in_random = [
+        { operator: 'in', operand: 'xxxxxxxxx' },
+    ];
+    const in_random_negated = [
+        { operator: 'in', operand: 'xxxxxxxxx', negated: true },
+    ];
+    filter = new Filter(in_random);
+    assert(!filter.can_mark_messages_read());
+    filter = new Filter(in_random_negated);
+    assert(!filter.can_mark_messages_read());
 });
 
 run_test('show_first_unread', () => {

--- a/frontend_tests/node_tests/narrow_state.js
+++ b/frontend_tests/node_tests/narrow_state.js
@@ -30,7 +30,6 @@ run_test('stream', () => {
         ['search', 'yo'],
     ]);
     assert(narrow_state.active());
-    assert(!narrow_state.is_reading_mode());
 
     assert.equal(narrow_state.stream(), 'Test');
     assert.equal(narrow_state.stream_id(), test_stream.stream_id);
@@ -59,7 +58,6 @@ run_test('narrowed', () => {
     assert(!narrow_state.narrowed_to_topic());
     assert(!narrow_state.narrowed_by_stream_reply());
     assert.equal(narrow_state.stream_id(), undefined);
-    assert(narrow_state.is_reading_mode());
 
     set_filter([['stream', 'Foo']]);
     assert(!narrow_state.narrowed_to_pms());
@@ -69,7 +67,6 @@ run_test('narrowed', () => {
     assert(!narrow_state.narrowed_to_search());
     assert(!narrow_state.narrowed_to_topic());
     assert(narrow_state.narrowed_by_stream_reply());
-    assert(narrow_state.is_reading_mode());
 
     set_filter([['pm-with', 'steve@zulip.com']]);
     assert(narrow_state.narrowed_to_pms());
@@ -79,7 +76,6 @@ run_test('narrowed', () => {
     assert(!narrow_state.narrowed_to_search());
     assert(!narrow_state.narrowed_to_topic());
     assert(!narrow_state.narrowed_by_stream_reply());
-    assert(narrow_state.is_reading_mode());
 
     set_filter([['stream', 'Foo'], ['topic', 'bar']]);
     assert(!narrow_state.narrowed_to_pms());
@@ -89,7 +85,6 @@ run_test('narrowed', () => {
     assert(!narrow_state.narrowed_to_search());
     assert(narrow_state.narrowed_to_topic());
     assert(!narrow_state.narrowed_by_stream_reply());
-    assert(narrow_state.is_reading_mode());
 
     set_filter([['search', 'grail']]);
     assert(!narrow_state.narrowed_to_pms());
@@ -99,7 +94,6 @@ run_test('narrowed', () => {
     assert(narrow_state.narrowed_to_search());
     assert(!narrow_state.narrowed_to_topic());
     assert(!narrow_state.narrowed_by_stream_reply());
-    assert(!narrow_state.is_reading_mode());
 });
 
 run_test('operators', () => {

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -489,25 +489,6 @@ Filter.prototype = {
         return _.isEqual(term_types, wanted_term_types);
     },
 
-    is_reading_mode: function () {
-        // We only turn on "reading mode" for filters that
-        // have contiguous messages for a narrow, as opposed
-        // to "random access" queries like search:<keyword>
-        // or id:<number> that jump you to parts of the message
-        // view where you might only care about reading the
-        // current message.
-        const term_types = this.sorted_term_types();
-        const wanted_list = [
-            ['stream'],
-            ['stream', 'topic'],
-            ['is-private'],
-            ['pm-with'],
-        ];
-        return _.any(wanted_list, function (wanted_types) {
-            return _.isEqual(wanted_types, term_types);
-        });
-    },
-
     can_bucket_by: function () {
         // TODO: in ES6 use spread operator
         //

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -502,18 +502,6 @@ Filter.prototype = {
         return sorted_terms;
     },
 
-    is_exactly: function () {
-        // TODO: in ES6 use spread operator
-        //
-        // Examples calls:
-        //     filter.is_exactly('stream', 'topic')
-        //     filter.is_exactly('pm-with')
-        const wanted_term_types = [].slice.call(arguments);
-        const term_types = this.sorted_term_types();
-
-        return _.isEqual(term_types, wanted_term_types);
-    },
-
     can_bucket_by: function () {
         // TODO: in ES6 use spread operator
         //

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -409,14 +409,8 @@ Filter.prototype = {
             return true;
         }
 
-        if (this._operators.length === 1) {
-            const elem = this._operators[0];
-
-            if (elem.operator === 'in' && !elem.negated) {
-                if (elem.operand === 'home' || elem.operand === 'all') {
-                    return true;
-                }
-            }
+        if (term_types.length === 1 && _.contains(['in-home', 'in-all'], term_types[0])) {
+            return true;
         }
 
         return false;
@@ -605,7 +599,7 @@ Filter.term_type = function (term) {
 
     result += operator;
 
-    if (_.contains(['is', 'has'], operator)) {
+    if (_.contains(['is', 'has', 'in'], operator)) {
         result += '-' + operand;
     }
 
@@ -614,6 +608,7 @@ Filter.term_type = function (term) {
 
 Filter.sorted_term_types = function (term_types) {
     const levels = [
+        'in',
         'streams',
         'stream', 'topic',
         'pm-with', 'group-pm-with', 'sender',

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -382,13 +382,44 @@ Filter.prototype = {
     },
 
     can_mark_messages_read: function () {
-        return _.every(this._operators, function (elem) {
-            return (_.contains(['stream', 'topic', 'pm-with'], elem.operator)
-                || elem.operator === 'is' && elem.operand === 'private'
-                || elem.operator === 'in' && elem.operand === 'all'
-                || elem.operator === 'in' && elem.operand === 'home')
-                && !elem.negated;
-        });
+        const term_types = this.sorted_term_types();
+
+        if (_.isEqual(term_types, ['stream', 'topic'])) {
+            return true;
+        }
+
+        if (_.isEqual(term_types, ['pm-with'])) {
+            return true;
+        }
+
+        // TODO: Some users really hate it when Zulip marks messages as read
+        // in interleaved views, so we will eventually have a setting
+        // that early-exits before the subsequent checks.
+
+        if (_.isEqual(term_types, ['stream'])) {
+            return true;
+        }
+
+        if (_.isEqual(term_types, ['is-private'])) {
+            return true;
+        }
+
+        if (_.isEqual(term_types, [])) {
+            // All view
+            return true;
+        }
+
+        if (this._operators.length === 1) {
+            const elem = this._operators[0];
+
+            if (elem.operator === 'in' && !elem.negated) {
+                if (elem.operand === 'home' || elem.operand === 'all') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     },
 
     allow_use_first_unread_when_narrowing: function () {

--- a/static/js/narrow_state.js
+++ b/static/js/narrow_state.js
@@ -18,14 +18,6 @@ exports.filter = function () {
     return current_filter;
 };
 
-exports.is_reading_mode = function () {
-    if (current_filter === undefined) {
-        return true;
-    }
-
-    return current_filter.is_reading_mode();
-};
-
 exports.operators = function () {
     if (current_filter === undefined) {
         return new Filter(page_params.narrow).operators();


### PR DESCRIPTION
**Commit 1**

unreads: Remove is_reading_mode(). 

This was a part of an experiment we ran on chat.zulip.org in Jul 2018
and surrounding code that used it never got merged to master.

See: https://chat.zulip.org/#narrow/stream/2-general/topic/un-narrow.20view/near/609506
and https://github.com/zulip/zulip/commit/c407ba517582a1af0bcd5fe080d870897c948511.

---

This is WIP, expecting more commits soon.