### PR TITLE
Convert more stream_ids to ints.

### DIFF
--- a/static/js/stream_color.js
+++ b/static/js/stream_color.js
@@ -76,7 +76,7 @@ exports.update_stream_color = function (sub, color, opts) {
 };
 
 function picker_do_change_color(color) {
-    const stream_id = $(this).attr('stream_id');
+    const stream_id = parseInt($(this).attr('stream_id'), 10);
     const hex_color = color.toHexString();
     subs.set_color(stream_id, hex_color);
 }

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -12,6 +12,20 @@ let current_topic_sidebar_elem;
 let all_messages_sidebar_elem;
 let starred_messages_sidebar_elem;
 
+function elem_to_stream_id(elem) {
+    const stream_id = parseInt(elem.attr('data-stream-id'), 10);
+
+    if (stream_id === undefined) {
+        blueslip.error('could not find stream id');
+    }
+
+    return stream_id;
+}
+
+function topic_popover_stream_id(e) {
+    return elem_to_stream_id($(e.currentTarget));
+}
+
 exports.stream_popped = function () {
     return current_stream_sidebar_elem !== undefined;
 };
@@ -70,7 +84,8 @@ exports.hide_streamlist_sidebar = function () {
 
 
 function stream_popover_sub(e) {
-    const stream_id = $(e.currentTarget).parents('ul').attr('data-stream-id');
+    const elem = $(e.currentTarget).parents('ul');
+    const stream_id = elem_to_stream_id(elem);
     const sub = stream_data.get_sub_by_id(stream_id);
     if (!sub) {
         blueslip.error('Unknown stream: ' + stream_id);
@@ -252,7 +267,8 @@ exports.register_click_handlers = function () {
         e.stopPropagation();
 
         const elt = e.target;
-        const stream_id = $(elt).parents('li').attr('data-stream-id');
+        const stream_li = $(elt).parents('li');
+        const stream_id = elem_to_stream_id(stream_li);
 
         build_stream_popover({
             elt: elt,
@@ -264,7 +280,8 @@ exports.register_click_handlers = function () {
         e.stopPropagation();
 
         const elt = $(e.target).closest('.topic-sidebar-arrow').expectOne()[0];
-        const stream_id = $(elt).closest('.narrow-filter').expectOne().attr('data-stream-id');
+        const stream_li = $(elt).closest('.narrow-filter').expectOne();
+        const stream_id = elem_to_stream_id(stream_li);
         const topic_name = $(elt).closest('li').expectOne().attr('data-topic-name');
 
         build_topic_popover({
@@ -384,15 +401,7 @@ exports.register_stream_handlers = function () {
 
 };
 
-function topic_popover_stream_id(e) {
-    // TODO: use data-stream-id in stream list
-    const stream_id = $(e.currentTarget).attr('data-stream-id');
-
-    return stream_id;
-}
-
 function topic_popover_sub(e) {
-    // TODO: use data-stream-id in stream list
     const stream_id = topic_popover_stream_id(e);
     if (!stream_id) {
         blueslip.error('cannot find stream id');


### PR DESCRIPTION
This fixes some regressions from a recent
commit that might not have been deployed.

9f7be51ce8152881b89191809d235b5183933e18

Even if that change had been deployed, it
should not have been user-facing, but it
would have spammed us with blueslip errors
every time somebody used the stream/topic
popovers in the left sidebar.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
