### PR TITLE
right sidebar: Fix invite more users

### DIFF
--- a/templates/zerver/help/configure-authentication-methods.md
+++ b/templates/zerver/help/configure-authentication-methods.md
@@ -7,7 +7,9 @@ account, or your GitHub account. You can restrict users to logging in
 via only a subset of these methods.
 
 LDAP and various custom SSO login methods are currently restricted to
-self-hosted Zulips only.  SAML authentication is supported by Zulip
+self-hosted Zulips only. Please take a look at [inviting new users](/help/invite-new-users)
+on how to adjust the "who can invite" setting.
+SAML authentication is supported by Zulip
 Cloud but requires contacting support@zulipchat.com to configure it.
 
 **Note:** If you are running your own server,

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -260,3 +260,17 @@ def validate_user_custom_profile_data(realm_id: int,
         result = validate_user_custom_profile_field(realm_id, field, item['value'])
         if result is not None:
             raise JsonableError(result)
+
+def compute_show_invites_and_add_stream(user_profile: UserProfile):
+
+    show_invites = True
+    show_add_streams = True
+
+    # Some realms only allow admins to invite users
+    if user_profile.realm.invite_by_admins_only and not user_profile.is_realm_admin:
+        show_invites = False
+    if user_profile.is_guest:
+        show_invites = False
+        show_add_streams = False
+        
+    return show_invites, show_add_streams

--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -261,7 +261,7 @@ def validate_user_custom_profile_data(realm_id: int,
         if result is not None:
             raise JsonableError(result)
 
-def compute_show_invites_and_add_stream(user_profile: UserProfile):
+def compute_show_invites_and_add_stream(user_profile: UserProfile) -> List[bool]:
 
     show_invites = True
     show_add_streams = True
@@ -272,5 +272,5 @@ def compute_show_invites_and_add_stream(user_profile: UserProfile):
     if user_profile.is_guest:
         show_invites = False
         show_add_streams = False
-        
-    return show_invites, show_add_streams
+
+    return [show_invites, show_add_streams]

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -63,7 +63,7 @@ from zproject.backends import ZulipDummyBackend, EmailAuthBackend, \
     ZulipLDAPException, query_ldap, sync_user_from_ldap, SocialAuthMixin, \
     PopulateUserLDAPError, SAMLAuthBackend, saml_auth_enabled, email_belongs_to_ldap, \
     get_external_method_dicts, AzureADAuthBackend, check_password_strength, \
-    ZulipLDAPUser, only_auth_enabled
+    ZulipLDAPUser
 
 from zerver.views.auth import (maybe_send_to_registration,
                                _subdomain_token_salt)
@@ -484,15 +484,6 @@ class AuthBackendTest(ZulipTestCase):
             backend.get_verified_emails = orig_get_verified_emails
             httpretty.disable()
             httpretty.reset()
-
-    def test_only_auth_enabled_ldap(self) -> None:
-        with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',)):
-            self.assertTrue(only_auth_enabled(["LDAP"], None))
-
-    def test_only_auth_enabled_multiple(self) -> None:
-        with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',
-                                                    'zproject.backends.GitHubAuthBackend')):
-            self.assertFalse(only_auth_enabled(["GitHub"], None))
 
 class CheckPasswordStrengthTest(ZulipTestCase):
     def test_check_password_strength(self) -> None:

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -63,7 +63,7 @@ from zproject.backends import ZulipDummyBackend, EmailAuthBackend, \
     ZulipLDAPException, query_ldap, sync_user_from_ldap, SocialAuthMixin, \
     PopulateUserLDAPError, SAMLAuthBackend, saml_auth_enabled, email_belongs_to_ldap, \
     get_external_method_dicts, AzureADAuthBackend, check_password_strength, \
-    ZulipLDAPUser
+    ZulipLDAPUser, only_auth_enabled
 
 from zerver.views.auth import (maybe_send_to_registration,
                                _subdomain_token_salt)
@@ -484,6 +484,15 @@ class AuthBackendTest(ZulipTestCase):
             backend.get_verified_emails = orig_get_verified_emails
             httpretty.disable()
             httpretty.reset()
+
+    def test_only_auth_enabled_ldap(self) -> None:
+        with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',)):
+            self.assertTrue(only_auth_enabled(["LDAP"], None))
+
+    def test_only_auth_enabled_multiple(self) -> None:
+        with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',
+                                                    'zproject.backends.GitHubAuthBackend')):
+            self.assertFalse(only_auth_enabled(["GitHub"], None))
 
 class CheckPasswordStrengthTest(ZulipTestCase):
     def test_check_password_strength(self) -> None:

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -4,13 +4,11 @@ import ujson
 
 from django.http import HttpResponse
 from django.utils.timezone import now as timezone_now
-from django.test import override_settings
 from mock import MagicMock, patch
 import urllib
 from typing import Any, Dict
-from zproject.backends import ZulipLDAPAuthBackend
 from zerver.lib.actions import (
-    do_create_user, do_change_logo_source, do_set_realm_property,
+    do_create_user, do_change_logo_source
 )
 from zerver.lib.events import add_realm_logo_fields
 from zerver.lib.test_classes import ZulipTestCase
@@ -19,7 +17,6 @@ from zerver.lib.test_helpers import (
 )
 from zerver.lib.soft_deactivation import do_soft_deactivate_users
 from zerver.lib.test_runner import slow
-from zerver.lib.test_helpers import MockLDAP
 from zerver.lib.users import compute_show_invites_and_add_stream
 from zerver.models import (
     get_realm, get_stream, get_user, UserProfile,
@@ -959,7 +956,7 @@ class HomeTest(ZulipTestCase):
         realm.save()
 
         result = compute_show_invites_and_add_stream(user)
-        self.assertEqual(result,(True,True))
+        self.assertEqual(result, [True, True])
 
     def test_compute_show_invites_and_add_stream_require_admin(self) -> None:
         user = self.example_user("hamlet")
@@ -969,10 +966,10 @@ class HomeTest(ZulipTestCase):
         realm.save()
 
         result = compute_show_invites_and_add_stream(user)
-        self.assertEqual(result,(False,True))
+        self.assertEqual(result, [False, True])
 
     def test_compute_show_invites_and_add_stream_guest(self) -> None:
         user = self.example_user("polonius")
 
         result = compute_show_invites_and_add_stream(user)
-        self.assertEqual(result,(False,False))
+        self.assertEqual(result, [False, False])

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -20,6 +20,7 @@ from zerver.lib.test_helpers import (
 from zerver.lib.soft_deactivation import do_soft_deactivate_users
 from zerver.lib.test_runner import slow
 from zerver.lib.test_helpers import MockLDAP
+from zerver.lib.users import compute_show_invites_and_add_stream
 from zerver.models import (
     get_realm, get_stream, get_user, UserProfile,
     flush_per_request_caches, DefaultStream, Realm,
@@ -664,45 +665,6 @@ class HomeTest(ZulipTestCase):
         html = result.content.decode('utf-8')
         self.assertNotIn('Invite more users', html)
 
-    @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
-    def test_show_invites_for_LDAP_only(self) -> None:
-        user_profile = self.example_user('hamlet')
-        email = user_profile.email
-
-        ldap_patcher = patch('django_auth_ldap.config.ldap.initialize')
-        self.mock_initialize = ldap_patcher.start()
-        self.mock_ldap = MockLDAP()
-        self.mock_initialize.return_value = self.mock_ldap
-        self.backend = ZulipLDAPAuthBackend()
-
-        self.mock_ldap.directory = {
-            'uid=hamlet,ou=users,dc=zulip,dc=com': {
-                'userPassword': ['testing', ]
-            }
-        }
-
-        realm = user_profile.realm
-        do_set_realm_property(realm, 'invite_required', True)
-
-        with self.settings(
-                LDAP_APPEND_DOMAIN='zulip.com',
-                AUTH_LDAP_BIND_PASSWORD='',
-                AUTH_LDAP_USER_DN_TEMPLATE='uid=%(user)s,ou=users,dc=zulip,dc=com'):
-
-            self.login(email, password='testing')
-            result = self._get_home_page()
-            html = result.content.decode('utf-8')
-            self.assertIn('Invite more users', html)
-
-            do_set_realm_property(realm, 'invite_required', False)
-
-            result = self._get_home_page()
-            html = result.content.decode('utf-8')
-            self.assertNotIn('Invite more users', html)
-
-        self.mock_ldap.reset()
-        self.mock_initialize.stop()
-
     def test_show_billing(self) -> None:
         customer = Customer.objects.create(realm=get_realm("zulip"), stripe_customer_id="cus_id")
 
@@ -988,3 +950,29 @@ class HomeTest(ZulipTestCase):
         html = result.content.decode('utf-8')
         self.assertIn('google-blob-sprite.css', html)
         self.assertNotIn('text-sprite.css', html)
+
+    def test_compute_show_invites_and_add_stream_admin(self) -> None:
+        user = self.example_user("iago")
+
+        realm = user.realm
+        realm.invite_by_admins_only = True
+        realm.save()
+
+        result = compute_show_invites_and_add_stream(user)
+        self.assertEqual(result,(True,True))
+
+    def test_compute_show_invites_and_add_stream_require_admin(self) -> None:
+        user = self.example_user("hamlet")
+
+        realm = user.realm
+        realm.invite_by_admins_only = True
+        realm.save()
+
+        result = compute_show_invites_and_add_stream(user)
+        self.assertEqual(result,(False,True))
+
+    def test_compute_show_invites_and_add_stream_guest(self) -> None:
+        user = self.example_user("polonius")
+
+        result = compute_show_invites_and_add_stream(user)
+        self.assertEqual(result,(False,False))

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -24,9 +24,9 @@ from zerver.lib.i18n import get_language_list, get_language_name, \
 from zerver.lib.push_notifications import num_push_devices_for_user
 from zerver.lib.streams import access_stream_by_name
 from zerver.lib.subdomains import get_subdomain
+from zerver.lib.users import compute_show_invites_and_add_stream
 from zerver.lib.utils import statsd, generate_random_token
 from two_factor.utils import default_device
-from zproject.backends import only_auth_enabled
 import calendar
 import logging
 import time
@@ -240,17 +240,7 @@ def home_real(request: HttpRequest) -> HttpResponse:
         page_params["enable_desktop_notifications"] = False
 
     statsd.incr('views.home')
-    show_invites = True
-    show_add_streams = True
-
-    # Some realms only allow admins to invite users
-    if user_profile.realm.invite_by_admins_only and not user_profile.is_realm_admin:
-        show_invites = False
-    if user_profile.is_guest:
-        show_invites = False
-        show_add_streams = False
-    if only_auth_enabled(['LDAP'], user_profile.realm) and not user_profile.realm.invite_required:
-        show_invites = False
+    show_invites, show_add_streams = compute_show_invites_and_add_stream(user_profile)
 
     show_billing = False
     show_plans = False

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -26,7 +26,7 @@ from zerver.lib.streams import access_stream_by_name
 from zerver.lib.subdomains import get_subdomain
 from zerver.lib.utils import statsd, generate_random_token
 from two_factor.utils import default_device
-
+from zproject.backends import only_auth_enabled
 import calendar
 import logging
 import time
@@ -249,6 +249,8 @@ def home_real(request: HttpRequest) -> HttpResponse:
     if user_profile.is_guest:
         show_invites = False
         show_add_streams = False
+    if only_auth_enabled(['LDAP'], user_profile.realm) and not user_profile.realm.invite_required:
+        show_invites = False
 
     show_billing = False
     show_plans = False

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -92,16 +92,6 @@ def auth_enabled_helper(backends_to_check: List[str], realm: Optional[Realm]) ->
                 return True
     return False
 
-def only_auth_enabled(backends_to_check: List[str], realm: Optional[Realm]) -> bool:
-    enabled_method_dict = build_method_dict(realm)
-    for supported_backend in supported_auth_backends():
-        for backend_name in backends_to_check:
-            backend = AUTH_BACKEND_NAME_MAP[backend_name]
-            if not enabled_method_dict[backend_name] or not isinstance(supported_backend, backend):
-                return False
-    return True
-
-
 def ldap_auth_enabled(realm: Optional[Realm]=None) -> bool:
     return auth_enabled_helper(['LDAP'], realm)
 


### PR DESCRIPTION
The "invite more users" option should not be present if both

- LDAP is the only auth backend 

- Invitations are not required to join.

Continuing on the work of https://github.com/zulip/zulip/pull/12118

I have made the suggested changes to only_auth_enabled and written 2 tests for the same.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/11685

**Testing Plan:** <!-- How have you tested? -->
I only wrote tests for only_auth_enabled and used the existing test for showing invite users from the previous PR.

<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
