### PR TITLE
puppet: Fix zuli-redis.conf path typo

### DIFF
--- a/puppet/zulip/manifests/redis.pp
+++ b/puppet/zulip/manifests/redis.pp
@@ -19,20 +19,40 @@ class zulip::redis {
   package { $redis_packages: ensure => 'installed' }
 
   $file = "${redis_dir}/redis.conf"
-  $zulip_redisconf = "${redis_dir}/zuli-redis.conf"
+  $zulip_redisconf = "${redis_dir}/zulip-redis.conf"
   $line = "include ${zulip_redisconf}"
   exec { 'redis':
     unless  => "/bin/grep -Fxqe '${line}' '${file}'",
     path    => '/bin',
     command => "bash -c \"(/bin/echo; /bin/echo '# Include Zulip-specific configuration'; /bin/echo '${line}') >> '${file}'\"",
     require => [Package[$redis],
-                File[$zulip_redisconf]],
+                File[$zulip_redisconf],
+                Exec['rediscleanup-zuli-redis']],
+  }
+
+  # Fix the typo in the path to $zulip_redisconf introduced in
+  # 071e32985c1207f20043e1cf28f82300d9f23f31 without triggering a
+  # redis restart.
+  $legacy_wrong_filename = "${redis_dir}/zuli-redis.conf"
+  exec { 'rediscleanup-zuli-redis':
+    onlyif   => "test -e ${legacy_wrong_filename}",
+    command  => "
+      mv ${legacy_wrong_filename} ${zulip_redisconf}
+      perl -0777 -pe '
+        if (m|^\\Q${line}\\E\$|m) {
+          s|^\\n?(:?# Include Zulip-specific configuration\\n)?include \\Q${legacy_wrong_filename}\\E\\n||m;
+        } else {
+          s|^include \\Q${legacy_wrong_filename}\\E\$|${line}|m;
+        }
+      ' -i /etc/redis/redis.conf
+    ",
+    provider => shell,
   }
 
   $redis_password = zulipsecret('secrets', 'redis_password', '')
   file { $zulip_redisconf:
     ensure  => file,
-    require => Package[$redis],
+    require => [Package[$redis], Exec['rediscleanup-zuli-redis']],
     owner   => 'redis',
     group   => 'redis',
     mode    => '0640',

--- a/puppet/zulip/manifests/redis.pp
+++ b/puppet/zulip/manifests/redis.pp
@@ -26,13 +26,7 @@ class zulip::redis {
     path    => '/bin',
     command => "bash -c \"(/bin/echo; /bin/echo '# Include Zulip-specific configuration'; /bin/echo '${line}') >> '${file}'\"",
     require => [Package[$redis],
-                File[$zulip_redisconf],
-                Exec['rediscleanup']],
-  }
-
-  exec { 'rediscleanup':
-    onlyif  => "echo '80a4cee76bac751576c3db8916fc50a6ea319428 ${file}' | sha1sum -c",
-    command => "head -n-3 ${file} | sponge ${file}",
+                File[$zulip_redisconf]],
   }
 
   $redis_password = zulipsecret('secrets', 'redis_password', '')


### PR DESCRIPTION
**Testing Plan:** Ran `zulip-puppet-apply` on a xenial production install, both with

```
…

# Include Zulip-specific configuration
include /etc/redis/zuli-redis.conf
```

and with

```
…

# Include Zulip-specific configuration
include /etc/redis/zulip-redis.conf

# Include Zulip-specific configuration
include /etc/redis/zuli-redis.conf
```