### PR TITLE
compose: Improved warning for wildcard mentions

### DIFF
--- a/static/templates/compose_all_everyone.hbs
+++ b/static/templates/compose_all_everyone.hbs
@@ -1,6 +1,10 @@
 <div class="compose-all-everyone">
     <span class="compose-all-everyone-msg">
         {{#tr this}}Are you sure you want to mention all <strong>__count__</strong> people in this stream?{{/tr}}
+        <br>
+        {{#tr this}}This will send email and mobile push notifications to most of those <strong>__count__</strong> users.{{/tr}}
+        <br>
+        If you don't want to do that, please edit your message to remove the mention.
     </span>
     <span class="compose-all-everyone-controls">
         <button type="button" class="btn btn-warning compose-all-everyone-confirm">{{t "Yes, send" }}</button>


### PR DESCRIPTION
Earlier, the warning shown did not clearly state that the wildcard
mentions will notify all users/all stream users. Modified it and a
suggestion to remove the mention.

Fixes: #13636

Screenshots:

Before-
![13636 old](https://user-images.githubusercontent.com/47082523/72344421-327b8800-36f7-11ea-8548-2719656a1464.png)

After-
<img width="572" alt="13636" src="https://user-images.githubusercontent.com/47082523/72344433-39a29600-36f7-11ea-8f3b-2f6062e94471.png">

Further work: Adding option to automatically remove the wildcard mention (through a cross button maybe).
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
