### PR TITLE
compose: Improved warning for wildcard mentions.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -525,7 +525,7 @@ run_test('compose_all_everyone', () => {
     const button = $(html).find("button").first();
     assert.equal(button.text(), "translated: Yes, send");
     const error_msg = $(html).find('span.compose-all-everyone-msg').text().trim();
-    assert.equal(error_msg, "translated: Are you sure you want to mention all 101 people in this stream?");
+    assert.equal(error_msg, "translated: Are you sure you want to mention all 101 people in this stream?  This will send email and mobile push notifications to most of those 101 users.  If you don't want to do that, please edit your message to remove the mention.");
 });
 
 run_test('compose_announce', () => {

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -525,7 +525,7 @@ run_test('compose_all_everyone', () => {
     const button = $(html).find("button").first();
     assert.equal(button.text(), "translated: Yes, send");
     const error_msg = $(html).find('span.compose-all-everyone-msg').text().trim();
-    assert.equal(error_msg, "translated: Are you sure you want to mention all 101 people in this stream?  This will send email and mobile push notifications to most of those 101 users.  If you don't want to do that, please edit your message to remove the mention.");
+    assert.equal(error_msg, "translated: Are you sure you want to mention all 101 people in this stream?  This will send email and mobile push notifications to most of those 101 users.  If you don't want to do that, please edit your message to remove the @all mention.");
 });
 
 run_test('compose_announce', () => {

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -33,7 +33,8 @@ function make_uploads_relative(content) {
 function show_all_everyone_warnings() {
     const stream_count = stream_data.get_subscriber_count(compose_state.stream_name()) || 0;
 
-    const all_everyone_template = render_compose_all_everyone({count: stream_count, mention: wildcard_mention});
+    const all_everyone_template = render_compose_all_everyone({count: stream_count,
+            mention: wildcard_mention});
     const error_area_all_everyone = $("#compose-all-everyone");
 
     // only show one error for any number of @all or @everyone mentions

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -16,6 +16,7 @@ const render_compose_private_stream_alert = require("../templates/compose_privat
 
 let user_acknowledged_all_everyone;
 let user_acknowledged_announce;
+let wildcard_mention;
 
 exports.all_everyone_warn_threshold = 15;
 exports.announce_warn_threshold = 60;
@@ -32,7 +33,7 @@ function make_uploads_relative(content) {
 function show_all_everyone_warnings() {
     const stream_count = stream_data.get_subscriber_count(compose_state.stream_name()) || 0;
 
-    const all_everyone_template = render_compose_all_everyone({count: stream_count});
+    const all_everyone_template = render_compose_all_everyone({count: stream_count, mention: wildcard_mention});
     const error_area_all_everyone = $("#compose-all-everyone");
 
     // only show one error for any number of @all or @everyone mentions
@@ -834,6 +835,7 @@ exports.initialize = function () {
 
             // warn if @all, @everyone or @stream is mentioned
             if (data.mentioned.full_name  === 'all' || data.mentioned.full_name === 'everyone' || data.mentioned.full_name === 'stream') {
+                wildcard_mention = data.mentioned.full_name;
                 return; // don't check if @all or @everyone is subscribed to a stream
             }
 

--- a/static/templates/compose_all_everyone.hbs
+++ b/static/templates/compose_all_everyone.hbs
@@ -1,6 +1,12 @@
 <div class="compose-all-everyone">
     <span class="compose-all-everyone-msg">
-        {{#tr this}}Are you sure you want to mention all <strong>__count__</strong> people in this stream?{{/tr}}
+        {{#tr this}}
+        Are you sure you want to mention all <strong>__count__</strong> people in this stream?
+        <br />
+        This will send email and mobile push notifications to most of those <strong>__count__</strong> users.
+        <br />
+        If you don't want to do that, please edit your message to remove the mention.
+        {{/tr}}
     </span>
     <span class="compose-all-everyone-controls">
         <button type="button" class="btn btn-warning compose-all-everyone-confirm">{{t "Yes, send" }}</button>

--- a/static/templates/compose_all_everyone.hbs
+++ b/static/templates/compose_all_everyone.hbs
@@ -5,7 +5,7 @@
         <br />
         This will send email and mobile push notifications to most of those <strong>__count__</strong> users.
         <br />
-        If you don't want to do that, please edit your message to remove the mention.
+        If you don't want to do that, please edit your message to remove the <strong>@__mention__</strong> mention.
         {{/tr}}
     </span>
     <span class="compose-all-everyone-controls">


### PR DESCRIPTION
Edited the warning to clearly state that most members/most stream members
will be notified on using wildcard mentions (e.g. @all).

Fixes: #13636
Further Work: Adding the option to remove mention (maybe through a cross).

Screenshots :
Before-
![13636 old](https://user-images.githubusercontent.com/47082523/72347877-1c71c580-36ff-11ea-9265-f2474b3dbc1b.png)
After-
<img width="572" alt="13636" src="https://user-images.githubusercontent.com/47082523/72347893-21cf1000-36ff-11ea-87e8-39d4f5bf2612.png">


<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
