### PR TITLE
Use cross emoji for indicating "never" in message editing and stream privacy docs

### DIFF
--- a/templates/zerver/help/configure-message-editing-and-deletion.md
+++ b/templates/zerver/help/configure-message-editing-and-deletion.md
@@ -13,17 +13,19 @@ is highly configurable. Two things are true under any configuration:
 * Message content can only ever be modified by the original author.
 * Any message can be deleted at any time by an organization administrator.
 
-|                                    | Admins   | Members |
-|---                                 |---       |---      |
-| Edit your message content          | [1]      | [1]     |
-| Edit others' message content       |          |         |
-| Edit your message topics           | [1]      | [1]     |
-| Add a topic to a topicless message | [1]      | [1]     |
-| Edit others' message topics        | [1]      | [1, 2]  |
-| Delete your messages               | &#10004; | [3]     |
-| Delete others' messages            | &#10004; |         |
+|                                    | Admins           | Members         |
+|---                                 |---               |---              |
+| Edit your message content          | [1]              | [1]             |
+| Edit others' message content       | &#10060;&#xfe0e; | &#10060;&#xfe0e;|
+| Edit your message topics           | [1]              | [1]             |
+| Add a topic to a topicless message | [1]              | [1]             |
+| Edit others' message topics        | [1]              | [1, 2]          |
+| Delete your messages               | &#10004;         | [3]             |
+| Delete others' messages            | &#10004;         | &#10060;&#xfe0e;|
 
 &#10004; - Always
+
+&#10060;&#xfe0e; - Never
 
 1 - Controlled by **Allow message editing**.
 

--- a/templates/zerver/help/configure-message-editing-and-deletion.md
+++ b/templates/zerver/help/configure-message-editing-and-deletion.md
@@ -23,6 +23,8 @@ is highly configurable. Two things are true under any configuration:
 | Delete your messages               | &#10004; | [3]     |
 | Delete others' messages            | &#10004; |         |
 
+&#10004; - Always
+
 1 - Controlled by **Allow message editing**.
 
 2 - Controlled by **Users can edit the topic of any message**.

--- a/templates/zerver/help/configure-message-editing-and-deletion.md
+++ b/templates/zerver/help/configure-message-editing-and-deletion.md
@@ -23,11 +23,11 @@ is highly configurable. Two things are true under any configuration:
 | Delete your messages               | &#10004; | [3]     |
 | Delete others' messages            | &#10004; |         |
 
-[1] Controlled by **Allow message editing**.
+1 - Controlled by **Allow message editing**.
 
-[2] Controlled by **Users can edit the topic of any message**.
+2 - Controlled by **Users can edit the topic of any message**.
 
-[3] Controlled by **Allow message deleting**.
+3 - Controlled by **Allow message deleting**.
 
 There are a few useful things to understand about the message editing
 settings.

--- a/templates/zerver/help/stream-permissions.md
+++ b/templates/zerver/help/stream-permissions.md
@@ -43,22 +43,24 @@ private stream messages:
 
 ### Public streams
 
-|                       | Org admins | Members   | Guests
-|---                    |---         |---        |---
-| Join                  | &#10004;   | &#10004;  |
-| Unsubscribe           | &#9726;    | &#9726;   | &#9726;
-| Add others            | &#10004;   | &#10004;  |
-| See subscriber list   | &#10004;   | &#10004;  | &#9726;
-| See full history      | &#10004;   | &#10004;  | &#9726;
-| See estimated traffic | &#10004;   | &#10004;  | &#9726;
-| Post                  | &#10004;   | &#10038;  | &#10038;
-| Change the privacy    | &#10004;   |           |
-| Rename                | &#10004;   |           |
-| Edit the description  | &#10004;   |           |
-| Remove others         | &#10004;   |           |
-| Delete                | &#10004;   |           |
+|                       | Org admins | Members           | Guests
+|---                    |---         |---                |---
+| Join                  | &#10004;   | &#10004;          | &#10060;&#xfe0e;
+| Unsubscribe           | &#9726;    | &#9726;           | &#9726;
+| Add others            | &#10004;   | &#10004;          | &#10060;&#xfe0e;
+| See subscriber list   | &#10004;   | &#10004;          | &#9726;
+| See full history      | &#10004;   | &#10004;          | &#9726;
+| See estimated traffic | &#10004;   | &#10004;          | &#9726;
+| Post                  | &#10004;   | &#10038;          | &#10038;
+| Change the privacy    | &#10004;   | &#10060;&#xfe0e;  | &#10060;&#xfe0e;
+| Rename                | &#10004;   | &#10060;&#xfe0e;  | &#10060;&#xfe0e;
+| Edit the description  | &#10004;   | &#10060;&#xfe0e;  | &#10060;&#xfe0e;
+| Remove others         | &#10004;   | &#10060;&#xfe0e;  | &#10060;&#xfe0e;
+| Delete                | &#10004;   | &#10060;&#xfe0e;  | &#10060;&#xfe0e;
 
-&#10004; Always
+&#10004; &nbsp; Always
+
+&#10060;&#xfe0e; &nbsp; Never
 
 &#9726; &nbsp; If subscribed to the stream
 
@@ -71,22 +73,24 @@ administrators to post.
 ### Private streams
 
 
-|                       | Org admins | Members   | Guests
-|---                    |---         |---        |---
-| Join                  |            |           |
-| Unsubscribe           | &#9726;    | &#9726;   | &#9726;
-| Add others            | &#9726;    | &#9726;   |
-| See subscriber list   | &#10004;   | &#9726;   | &#9726;
-| See full history      | &#10038;   | &#10038;  | &#10038;
-| See estimated traffic | &#10004;   | &#9726;   | &#9726;
-| Post                  | &#9726;    | &#10038;  | &#10038;
-| Change the privacy    | &#9726;    |           |
-| Rename                | &#10004;   |           |
-| Edit the description  | &#10004;   |           |
-| Remove others         | &#10004;   |           |
-| Delete                | &#10004;   |           |
+|                       | Org admins         | Members           | Guests
+|---                    |---                 |---                |---
+| Join                  | &#10060;&#xfe0e;   | &#10060;&#xfe0e;  | &#10060;&#xfe0e;
+| Unsubscribe           | &#9726;            | &#9726;           | &#9726;
+| Add others            | &#9726;            | &#9726;           | &#10060;&#xfe0e;
+| See subscriber list   | &#10004;           | &#9726;           | &#9726;
+| See full history      | &#10038;           | &#10038;          | &#10038;
+| See estimated traffic | &#10004;           | &#9726;           | &#9726;
+| Post                  | &#9726;            | &#10038;          | &#10038;
+| Change the privacy    | &#9726;            | &#10060;&#xfe0e;  | &#10060;&#xfe0e;
+| Rename                | &#10004;           | &#10060;&#xfe0e;  | &#10060;&#xfe0e;
+| Edit the description  | &#10004;           | &#10060;&#xfe0e;  | &#10060;&#xfe0e;
+| Remove others         | &#10004;           | &#10060;&#xfe0e;  | &#10060;&#xfe0e;
+| Delete                | &#10004;           | &#10060;&#xfe0e;  | &#10060;&#xfe0e;
 
-&#10004; Always
+&#10004; &nbsp; Always
+
+&#10060;&#xfe0e; &nbsp; Never
 
 &#9726; &nbsp; If subscribed to the stream
 


### PR DESCRIPTION
While checking the issue #13658, I noticed some minor issues in https://chat.zulip.org/help/configure-message-editing-and-deletion table. So created this PR to fix some of them.

The main change is that before we used to indicate "Never" by leaving the cell blank in the table. This PR replace the empty cell with cross emoji. Also some other minor improvments are included as seperate commit. 

The combined changes of all commits would looks like this for https://chat.zulip.org/help/configure-message-editing-and-deletion page

### Before this PR

![Screenshot from 2020-01-14 20-10-25](https://user-images.githubusercontent.com/7190633/72353493-2c42d700-370a-11ea-9095-a8f823c4c8db.png)


### Now

![Screenshot from 2020-01-14 20-11-49](https://user-images.githubusercontent.com/7190633/72353524-38c72f80-370a-11ea-884d-b339bc04f9bc.png)
