### PR TITLE
Email mirror attachment handling

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -228,14 +228,9 @@ def filter_footer(text: str) -> str:
 
 def extract_and_upload_attachments(message: message.Message, realm: Realm) -> str:
     user_profile = get_system_bot(settings.EMAIL_GATEWAY_BOT)
+
     attachment_links = []
-
-    payload = message.get_payload()
-    if not isinstance(payload, list):
-        # This is not a multipart message, so it can't contain attachments.
-        return ""
-
-    for part in payload:
+    for part in message.walk():
         content_type = part.get_content_type()
         filename = part.get_filename()
         if filename:
@@ -251,7 +246,7 @@ def extract_and_upload_attachments(message: message.Message, realm: Realm) -> st
                 logger.warning("Payload is not bytes (invalid attachment %s in message from %s)." %
                                (filename, message.get("From")))
 
-    return "\n".join(attachment_links)
+    return '\n'.join(attachment_links)
 
 def decode_stream_email_address(email: str) -> Tuple[Stream, Dict[str, bool]]:
     token, options = decode_email_address(email)

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -141,6 +141,8 @@ def construct_zulip_body(message: message.Message, realm: Realm, show_sender: bo
     if not include_footer:
         body = filter_footer(body)
 
+    if not body.endswith('\n'):
+        body += '\n'
     body += extract_and_upload_attachments(message, realm)
     body = body.strip()
     if not body:

--- a/zerver/management/commands/send_to_email_mirror.py
+++ b/zerver/management/commands/send_to_email_mirror.py
@@ -105,12 +105,15 @@ Example:
     def _prepare_message(self, message: Message, realm: Realm, stream_name: str) -> None:
         stream = get_stream(stream_name, realm)
 
+        # The block below ensures that the imported email message doesn't have any recipient-like
+        # headers that are inconsistent with the recipient we want (the stream address).
         recipient_headers = ["X-Gm-Original-To", "Delivered-To",
-                             "Resent-To", "Resent-CC", "To", "CC"]
+                             "Resent-To", "Resent-CC", "CC"]
         for header in recipient_headers:
             if header in message:
                 del message[header]
                 message[header] = encode_email_address(stream)
-                return
 
+        if 'To' in message:
+            del message['To']
         message['To'] = encode_email_address(stream)

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -422,7 +422,7 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
                                                    target_realm=user_profile.realm)
 
         message = most_recent_message(user_profile)
-        self.assertEqual(message.content, "Test body[image.png](https://test_url)")
+        self.assertEqual(message.content, "Test body\n[image.png](https://test_url)")
 
     def test_message_with_invalid_attachment(self) -> None:
         user_profile = self.example_user('hamlet')


### PR DESCRIPTION
First a small commit to fix attachment links getting posted in an awkward-looking way, see for an example: https://chat.zulip.org/#narrow/stream/7-test-here/topic/Mail.20test/near/808809

Then a bugfix to the send_to_email_mirror utility

Finally, fix for https://github.com/zulip/zulip/issues/13416

There also seems to be an issue with the ``------ Original Message -----`` line not being stripped by talon in the form that my email client sends it - but I don't have a fix yet, as this requires figuring out where the issue is and may be better done after updating our talon to its current upstream state (we haven't updated out fork in 2 years and upstream merges some work occasionally) because that may fix this on its own.