### PR TITLE
org settings: Fix error of wrong type of argument passed to InDict.has().

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -419,7 +419,7 @@ exports.on_load_success = function (realm_people_data) {
     });
 
     $(".admin_user_table, .admin_bot_table").on("click", ".open-user-form", function (e) {
-        const user_id = $(e.currentTarget).attr("data-user-id");
+        const user_id = parseInt($(e.currentTarget).attr("data-user-id"), 10);
         const person = people.get_person_from_user_id(user_id);
 
         if (!person) {


### PR DESCRIPTION
This fixes the error where we pass `user_id` of 'string' type as the
argument instead of 'integer' to `exports.get_person_from_user_id` which
further passes `user_id` to InDict.has() function which accepts integer
argument only.

Discussion link: https://github.com/zulip/zulip/pull/12956#issuecomment-573657787

![Peek 2020-01-15 00-11](https://user-images.githubusercontent.com/40331304/72372060-acc5ff80-372b-11ea-8cbb-c24e9c497649.gif)


<!-- What's this PR for?  (Just a link to an issue is fine.) -->

