### PR TITLE
register: Fix whitespace.

### DIFF
--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -193,7 +193,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                         (
                         {%- for stream in default_stream_group.streams.all() -%}
                             {{- comma() -}} <div class="stream_name inline-block">#{{ stream.name }}</div>
-                        {% endfor %}
+                        {%- endfor -%}
                         )
                     </label>
                 </div>


### PR DESCRIPTION
This correct change fails the template linter with this error:

```
(zulip-py3-venv) tabbott@coset:~/zulip$ ./tools/lint templates/zerver/register.html 
templates | Traceback (most recent call last):
templates |   File "tools/check-templates", line 180, in <module>
templates |     check_our_files(args.modified, args.all_dups, args.fix, args.targets)
templates |   File "tools/check-templates", line 35, in check_our_files
templates |     check_html_templates(by_lang['html'], all_dups, fix)
templates |   File "tools/check-templates", line 129, in check_html_templates
templates |     validate(fn=fn, check_indent=(fn not in bad_files))
templates |   File "/home/tabbott/zulip/tools/lib/template_parser.py", line 291, in validate
templates |     state.matcher(token)
templates |   File "/home/tabbott/zulip/tools/lib/template_parser.py", line 279, in f
templates |     ''' % (fn, problem, start_token.s, start_line, start_col, end_tag, end_line, end_col))
templates | lib.template_parser.TemplateParserException:
templates |                     fn: templates/zerver/register.html
templates |                     Mismatched tag.
templates |                     start:
templates |                         {%- for stream in default_stream_group.streams.all() -%}
templates |                         line 194, col 25
templates |                     end tag:
templates |                         label
templates |                         line 198, col 21
templates | 
```

It appears to be some sort of subtle bug in the matching of silent Jinja2 tags, and is preventing merging a valuable fix to our default stream groups feature (#13670).

@adnrs96 do you have time to debug this?  It'd be much appreciated.  