### PR TITLE
Updated colors for "edit message history"

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -586,7 +586,7 @@ on a dark background, and don't change the dark labels dark either. */
 
         .highlight_text_deleted {
             text-decoration: line-through;
-            background-color: hsla(7, 54%, 62%, 0.38);
+            background-color: hsla(200, 55%, 27%, 0.75);
         }
     }
 

--- a/static/styles/rendered_markdown.scss
+++ b/static/styles/rendered_markdown.scss
@@ -142,9 +142,9 @@
     }
 
     .highlight_text_deleted {
-        color: hsl(0, 0%, 73%);
+        color: hsl(0, 0%, 100%);
         text-decoration: line-through;
-        background-color: hsl(7, 90%, 92%);
+        background-color: hsl(0, 0%, 0%);
         word-break: break-all;
     }
 


### PR DESCRIPTION
<!-- What's this PR for? -->
 Solves issue #13622  

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Normal-mode](https://user-images.githubusercontent.com/44861163/72414722-e2550200-3798-11ea-9dbb-726f5dd60304.png)
![Night-mode](https://user-images.githubusercontent.com/44861163/72414737-e7b24c80-3798-11ea-89b9-e2c503e93e76.png)

Hey, can you please review this PR, or suggest any changes in the same. 