### PR TITLE
Fix bugs with topic_list and muting

### DIFF
--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -100,6 +100,9 @@ exports.widget = function (parent_elem, my_stream_id) {
             const is_active_topic = self.active_topic === topic_name.toLowerCase();
 
             if (!zoomed) {
+                // We unconditionally skip showing muted topics when
+                // not zoomed, even if they have unread messages.
+                //
                 // We limit the number of topics we show to at most
                 // max_topics_with_unread when not zoomed.
                 //
@@ -107,7 +110,8 @@ exports.widget = function (parent_elem, my_stream_id) {
                 // is in the set of those with unreads to avoid ending up with
                 // max_topics_with_unread + 1 total topics if the active topic comes
                 // after the first several topics with unread messages.
-                if (topics_selected >= max_topics_with_unread && !is_active_topic) {
+                if (!is_active_topic && (topics_selected >= max_topics_with_unread ||
+                                         muting.is_topic_muted(my_stream_id, topic_name))) {
                     if (num_unread > 0) {
                         more_topics_unreads += num_unread;
                     }

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -112,7 +112,7 @@ exports.widget = function (parent_elem, my_stream_id) {
                 // after the first several topics with unread messages.
                 if (!is_active_topic && (topics_selected >= max_topics_with_unread ||
                                          muting.is_topic_muted(my_stream_id, topic_name))) {
-                    if (num_unread > 0) {
+                    if (num_unread > 0 && !muting.is_topic_muted(my_stream_id, topic_name)) {
                         more_topics_unreads += num_unread;
                     }
                     return;
@@ -232,6 +232,10 @@ exports.widget = function (parent_elem, my_stream_id) {
             // topics"; We need to update the "more topics" count
             // instead in that case; we do this by returning true to
             // notify the caller to accumulate these.
+            if (muting.is_topic_muted(my_stream_id, topic)) {
+                // But we don't count unreads in muted topics.
+                return false;
+            }
             return true;
         }
 


### PR DESCRIPTION
Fixes #13676 and #13677.  

I tested this manually pretty extensively using `manage.py mark_all_messages_unread`; the unit tests for this component aren't good and I didn't have time to rework them to test this logic well.