### PR TITLE
[WIP] API endpoint to authenticate session with api key

### DIFF
--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.contrib.auth import authenticate
 from django.contrib.auth.views import login as django_login_page, \
     logout_then_login as django_logout_then_login
+from django.contrib.auth import login as django_login
 from django.contrib.auth.views import password_reset as django_password_reset
 from django.urls import reverse
 from zerver.decorator import require_post, \
@@ -903,6 +904,15 @@ def password_reset(request: HttpRequest, **kwargs: Any) -> HttpResponse:
                                  template_name='zerver/reset.html',
                                  password_reset_form=ZulipPasswordResetForm,
                                  post_reset_redirect='/accounts/password/reset/done/')
+
+@has_request_variables
+def auth_session_with_api_key(request: HttpRequest, user_profile: UserProfile,
+                              next: str=REQ(default='')) -> HttpResponse:
+    django_login(request, user_profile, 'zproject.backends.ZulipDummyBackend')
+    if next:
+        return HttpResponseRedirect(next)
+    else:
+        return HttpResponseRedirect('/')
 
 @csrf_exempt
 def saml_sp_metadata(request: HttpRequest, **kwargs: Any) -> HttpResponse:  # nocoverage

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -655,8 +655,7 @@ for incoming_webhook in WEBHOOK_INTEGRATIONS:
 urls += [
     url(r'^json/fetch_api_key$', rest_dispatch,
         {'POST': 'zerver.views.auth.json_fetch_api_key'}),
-    url(r'^api/v1/auth_session_with_api_key$', rest_dispatch,
-        {'GET': 'zerver.views.auth.auth_session_with_api_key'})
+    url(r'^auth_session_with_api_key$', zerver.views.auth.auth_session_with_api_key)
 ]
 
 # Mobile-specific authentication URLs

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -655,6 +655,8 @@ for incoming_webhook in WEBHOOK_INTEGRATIONS:
 urls += [
     url(r'^json/fetch_api_key$', rest_dispatch,
         {'POST': 'zerver.views.auth.json_fetch_api_key'}),
+    url(r'^api/v1/auth_session_with_api_key$', rest_dispatch,
+        {'GET': 'zerver.views.auth.auth_session_with_api_key'})
 ]
 
 # Mobile-specific authentication URLs


### PR DESCRIPTION
Okay, so this is very-WIP and probably far from how we'll actually end up wanting this API, but I'm pushing this WIP PR so that Desktop app folks can have something to test on and to start discussing the actual shape in which we want this.

1. This currently uses our REST API framework (that's why it has always no new code, ``rest_dispatch`` handles everything except setting the session). So the way to use this is to do HTTP Basic Auth with the ``email:api_key`` pair (just like our other REST API endpoints). But I'm not sure if what this endpoint does can be considered "REST", so perhaps this is not apprioprate?
2. Current endpoint path is ``api/v1/auth_session_with_api_key``. Do we prefer something better? (both the name and path.)
3. The actual most straight-forward way to do this would to write an extra backend that authenticates via email+api key. It would be always enabled, and these credentials could be passed through the normal login form. Wouldn't that make sense?