### PR TITLE
template_parser: Fix Jinja2 tag matching with strip whitespace syntax.

### DIFF
--- a/tools/tests/test_template_parser.py
+++ b/tools/tests/test_template_parser.py
@@ -191,11 +191,35 @@ class ParserTest(unittest.TestCase):
             '''
         validate(text=my_html)
 
-    def test_validate_jinja2_whitespace_markers(self) -> None:
+    def test_validate_jinja2_whitespace_markers_1(self) -> None:
         my_html = '''
         {% if foo -%}
         this is foo
+        {% endif %}
+        '''
+        validate(text=my_html)
+
+    def test_validate_jinja2_whitespace_markers_2(self) -> None:
+        my_html = '''
+        {% if foo %}
+        this is foo
         {%- endif %}
+        '''
+        validate(text=my_html)
+
+    def test_validate_jinja2_whitespace_markers_3(self) -> None:
+        my_html = '''
+        {% if foo %}
+        this is foo
+        {% endif -%}
+        '''
+        validate(text=my_html)
+
+    def test_validate_jinja2_whitespace_markers_4(self) -> None:
+        my_html = '''
+        {%- if foo %}
+        this is foo
+        {% endif %}
         '''
         validate(text=my_html)
 
@@ -203,17 +227,9 @@ class ParserTest(unittest.TestCase):
         my_html = '''
         {% if foo %}
         this is foo
-        {%- endif %}
+        {%- if bar %}
         '''
         self._assert_validate_error('Missing end tag', text=my_html)
-
-    def test_validate_mismatch_jinja2_whitespace_markers_2(self) -> None:
-        my_html = '''
-        {% if foo -%}
-        this is foo
-        {% endif %}
-        '''
-        self._assert_validate_error('No start tag', text=my_html)
 
     def test_validate_jinja2_whitespace_type2_markers(self) -> None:
         my_html = '''
@@ -222,22 +238,6 @@ class ParserTest(unittest.TestCase):
         {% endif %}
         '''
         validate(text=my_html)
-
-    def test_validate_mismatch_jinja2_whitespace_type2_markers(self) -> None:
-        my_html = '''
-        {%- if foo -%}
-        this is foo
-        {%- endif %}
-        '''
-        self._assert_validate_error('Missing end tag', text=my_html)
-
-    def test_validate_incomplete_jinja2_whitespace_type2_markers(self) -> None:
-        my_html = '''
-        {%- if foo %}
-        this is foo
-        {% endif %}
-        '''
-        self._assert_validate_error('Tag missing "-%}" at Line 2 Col 9:"{%- if foo %}"', text=my_html)
 
     def test_tokenize(self) -> None:
         tag = '<meta whatever>bla'


### PR DESCRIPTION
    In this commit, we basically match any kinda of jinja2 start tag,
    no matter its special kind (eg. jinja2_whitespace_stripped_start)
    to any kinda jinja2 end tag (eg. jinja2_whitespace_stripped_end)

    Idea is special operators like  do not change the meaning of
    inline tag and thus matching shouldn't depend upon this.
