### PR TITLE
Fix #13486 (handle FillState when importing data from an old realm)

### DIFF
--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -381,8 +381,9 @@ class TestCountStats(AnalyticsTestCase):
         do_fill_count_stat_at_hour(stat, self.TIME_ZERO, self.default_realm)
         self.assertTableState(RealmCount, ['value', 'subgroup'],
                               [[1, 'true'], [1, 'false']])
-        # No aggregation to InstallationCount with realm constraint
-        self.assertTableState(InstallationCount, ['value', 'subgroup'], [])
+        self.assertTableState(InstallationCount,
+                              ['value', 'subgroup'],
+                              [[1, 'true'], [1, 'false']])
         self.assertTableState(UserCount, [], [])
         self.assertTableState(StreamCount, [], [])
 
@@ -451,8 +452,8 @@ class TestCountStats(AnalyticsTestCase):
         self.assertTableState(RealmCount, ['value', 'subgroup', 'realm'],
                               [[2, 'false', self.default_realm],
                                [3, 'true', self.default_realm]])
-        # No aggregation to InstallationCount with realm constraint
-        self.assertTableState(InstallationCount, ['value', 'subgroup'], [])
+        self.assertTableState(InstallationCount, ['value', 'subgroup'],
+                                                 [[2, 'false'], [3, 'true']])
         self.assertTableState(StreamCount, [], [])
 
     def test_messages_sent_by_message_type(self) -> None:
@@ -550,8 +551,9 @@ class TestCountStats(AnalyticsTestCase):
         self.assertTableState(RealmCount, ['value', 'subgroup'],
                               [[1, 'private_message'], [1, 'private_stream'],
                                [1, 'public_stream'], [1, 'huddle_message']])
-        # No aggregation to InstallationCount with realm constraint
-        self.assertTableState(InstallationCount, ['value', 'subgroup'], [])
+        self.assertTableState(InstallationCount, ['value', 'subgroup'],
+                              [[1, 'private_message'], [1, 'private_stream'],
+                               [1, 'public_stream'], [1, 'huddle_message']])
         self.assertTableState(StreamCount, [], [])
 
     def test_messages_sent_to_recipients_with_same_id(self) -> None:
@@ -640,8 +642,8 @@ class TestCountStats(AnalyticsTestCase):
                                [1, website_client_id, user2]])
         self.assertTableState(RealmCount, ['value', 'subgroup'],
                               [[1, website_client_id], [2, client2_id]])
-        # No aggregation to InstallationCount with realm constraint
-        self.assertTableState(InstallationCount, ['value', 'subgroup'], [])
+        self.assertTableState(InstallationCount, ['value', 'subgroup'],
+                              [[1, website_client_id], [2, client2_id]])
         self.assertTableState(StreamCount, [], [])
 
     def test_messages_sent_to_stream_by_is_bot(self) -> None:
@@ -710,8 +712,7 @@ class TestCountStats(AnalyticsTestCase):
                                [1, 'true', stream1]])
         self.assertTableState(RealmCount, ['value', 'subgroup', 'realm'],
                               [[1, 'false'], [1, 'true']])
-        # No aggregation to InstallationCount with realm constraint
-        self.assertTableState(InstallationCount, ['value', 'subgroup'], [])
+        self.assertTableState(InstallationCount, ['value', 'subgroup'], [[1, 'false'], [1, 'true']])
         self.assertTableState(UserCount, [], [])
 
     def create_interval(self, user: UserProfile, start_offset: timedelta,
@@ -787,8 +788,7 @@ class TestCountStats(AnalyticsTestCase):
                               [[1, user2], [1, user2]])
         self.assertTableState(RealmCount, ['value', 'realm'],
                               [[2, self.default_realm]])
-        # No aggregation to InstallationCount with realm constraint
-        self.assertTableState(InstallationCount, ['value'], [])
+        self.assertTableState(InstallationCount, ['value'], [[2]])
         self.assertTableState(StreamCount, [], [])
 
     def test_15day_actives(self) -> None:
@@ -860,8 +860,7 @@ class TestCountStats(AnalyticsTestCase):
                               [[1, user1], [1, user2]])
         self.assertTableState(RealmCount, ['value', 'realm'],
                               [[2, self.default_realm]])
-        # No aggregation to InstallationCount with realm constraint
-        self.assertTableState(InstallationCount, ['value'], [])
+        self.assertTableState(InstallationCount, ['value'], [[2]])
         self.assertTableState(StreamCount, [], [])
 
     def test_minutes_active(self) -> None:
@@ -931,8 +930,7 @@ class TestCountStats(AnalyticsTestCase):
                               [[60, user1], [1, user2]])
         self.assertTableState(RealmCount, ['value', 'realm'],
                               [[60 + 1, self.default_realm]])
-        # No aggregation to InstallationCount with realm constraint
-        self.assertTableState(InstallationCount, ['value'], [])
+        self.assertTableState(InstallationCount, ['value'], [[60 + 1]])
         self.assertTableState(StreamCount, [], [])
 
 class TestDoAggregateToSummaryTable(AnalyticsTestCase):

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -23,7 +23,7 @@ import tempfile
 import shutil
 from scripts.lib.zulip_tools import overwrite_symlink
 from zerver.lib.avatar_hash import user_avatar_path_from_ids
-from analytics.models import RealmCount, UserCount, StreamCount
+from analytics.models import FillState, RealmCount, UserCount, StreamCount
 from zerver.models import UserProfile, Realm, Client, Huddle, Stream, \
     UserMessage, Subscription, Message, RealmEmoji, RealmFilter, Reaction, \
     RealmDomain, Recipient, DefaultStream, get_user_profile_by_id, \
@@ -195,9 +195,6 @@ NON_EXPORTED_TABLES = {
     # recompute it after a fillstate import.
     'analytics_installationcount',
 
-    # Fillstate will require some cleverness to do the right partial export.
-    'analytics_fillstate',
-
     # These are for unfinished features; we'll want to add them ot the
     # export before they reach full production status.
     'zerver_defaultstreamgroup',
@@ -233,6 +230,7 @@ MESSAGE_TABLES = {
 # These get their own file as analytics data can be quite large and
 # would otherwise make realm.json unpleasant to manually inspect
 ANALYTICS_TABLES = {
+    'analytics_fillstate',
     'analytics_realmcount',
     'analytics_streamcount',
     'analytics_usercount',
@@ -256,6 +254,7 @@ DATE_FIELDS = {
     'zerver_userprofile': ['date_joined', 'last_login', 'last_reminder'],
     'zerver_realmauditlog': ['event_time'],
     'zerver_userhotspot': ['timestamp'],
+    'analytics_fillstate': ['end_time'],
     'analytics_installationcount': ['end_time'],
     'analytics_realmcount': ['end_time'],
     'analytics_usercount': ['end_time'],
@@ -1697,6 +1696,13 @@ def get_analytics_config() -> Config:
     analytics_config = Config(
         table='zerver_analytics',
         is_seeded=True,
+    )
+
+    Config(
+        table='analytics_fillstate',
+        model=FillState,
+        normal_parent=analytics_config,
+        use_all=True,
     )
 
     Config(

--- a/zerver/lib/server_initialization.py
+++ b/zerver/lib/server_initialization.py
@@ -44,3 +44,6 @@ def create_users(realm: Realm, name_list: Iterable[Tuple[str, str]],
         short_name = email_to_username(email)
         user_set.add((email, full_name, short_name, True))
     bulk_create_users(realm, user_set, bot_type=bot_type, bot_owner=bot_owner, tos_version=tos_version)
+
+def zulip_server_isempty() -> bool:
+    return not Realm.objects.exclude(string_id=settings.SYSTEM_BOT_REALM).exists()


### PR DESCRIPTION
Fixes [issue](https://github.com/zulip/zulip/issues/13486).

This PR is in continuation with [PR](https://github.com/zulip/zulip/pull/13608). First commit is reviewed there.