### PR TITLE
[WIP] oauth: Enable social login for desktop via OTP.

### DIFF
--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.contrib.auth import authenticate
 from django.contrib.auth.views import login as django_login_page, \
     logout_then_login as django_logout_then_login
+from django.contrib.auth import login as django_login
 from django.contrib.auth.views import password_reset as django_password_reset
 from django.urls import reverse
 from zerver.decorator import require_post, \
@@ -903,6 +904,15 @@ def password_reset(request: HttpRequest, **kwargs: Any) -> HttpResponse:
                                  template_name='zerver/reset.html',
                                  password_reset_form=ZulipPasswordResetForm,
                                  post_reset_redirect='/accounts/password/reset/done/')
+
+@has_request_variables
+def auth_session_with_api_key(request: HttpRequest, user_profile: UserProfile,
+                              next: str=REQ(default='')) -> HttpResponse:
+    django_login(request, user_profile, 'zproject.backends.ZulipDummyBackend')
+    if next:
+        return HttpResponseRedirect(next)
+    else:
+        return HttpResponseRedirect('/')
 
 @csrf_exempt
 def saml_sp_metadata(request: HttpRequest, **kwargs: Any) -> HttpResponse:  # nocoverage

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -1079,6 +1079,7 @@ def social_auth_finish(backend: Any,
     realm = Realm.objects.get(id=return_data["realm_id"])
     multiuse_object_key = strategy.session_get('multiuse_object_key', '')
     mobile_flow_otp = strategy.session_get('mobile_flow_otp')
+    desktop_flow_otp = strategy.session_get('desktop_flow_otp')
 
     # At this point, we have now confirmed that the user has
     # demonstrated control over the target email address.
@@ -1098,6 +1099,17 @@ def social_auth_finish(backend: Any,
             strategy.request, email_address,
             user_profile, full_name,
             mobile_flow_otp=mobile_flow_otp,
+            is_signup=is_signup,
+            redirect_to=redirect_to,
+            full_name_validated=full_name_validated
+        )
+    
+    # We use a similar flow to authenticate users of the desktop app too.
+    if desktop_flow_otp is not None:
+        return login_or_register_remote_user(
+            strategy.request, email_address,
+            user_profile, full_name,
+            desktop_flow_otp=desktop_flow_otp,
             is_signup=is_signup,
             redirect_to=redirect_to,
             full_name_validated=full_name_validated

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -964,7 +964,7 @@ if REGISTER_LINK_DISABLED is None:
 # SOCIAL AUTHENTICATION SETTINGS
 ########################################################################
 
-SOCIAL_AUTH_FIELDS_STORED_IN_SESSION = ['subdomain', 'is_signup', 'mobile_flow_otp', 'multiuse_object_key']
+SOCIAL_AUTH_FIELDS_STORED_IN_SESSION = ['subdomain', 'is_signup', 'mobile_flow_otp', 'desktop_flow_otp', 'multiuse_object_key']
 SOCIAL_AUTH_LOGIN_ERROR_URL = '/login/'
 
 SOCIAL_AUTH_GITHUB_SECRET = get_secret('social_auth_github_secret')

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -655,8 +655,7 @@ for incoming_webhook in WEBHOOK_INTEGRATIONS:
 urls += [
     url(r'^json/fetch_api_key$', rest_dispatch,
         {'POST': 'zerver.views.auth.json_fetch_api_key'}),
-    url(r'^api/v1/auth_session_with_api_key$', rest_dispatch,
-        {'GET': 'zerver.views.auth.auth_session_with_api_key'})
+    url(r'^auth_session_with_api_key$', zerver.views.auth.auth_session_with_api_key)
 ]
 
 # Mobile-specific authentication URLs

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -655,6 +655,8 @@ for incoming_webhook in WEBHOOK_INTEGRATIONS:
 urls += [
     url(r'^json/fetch_api_key$', rest_dispatch,
         {'POST': 'zerver.views.auth.json_fetch_api_key'}),
+    url(r'^api/v1/auth_session_with_api_key$', rest_dispatch,
+        {'GET': 'zerver.views.auth.auth_session_with_api_key'})
 ]
 
 # Mobile-specific authentication URLs


### PR DESCRIPTION
Moves the login process for desktop app
to browser since there was
no way to verify the authencity of the
auth process for a custom server and to
prevent phishing attacks.

Desktop app PR [here](https://github.com/zulip/zulip-desktop/pull/863/)

**Testing Plan:** <!-- How have you tested? -->
Still working on it. This is currently only to collaborate with others.
