### PR TITLE
Avoid adding invited users to notifications stream unconditionally.

### DIFF
--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -806,7 +806,7 @@ run_test('invite_subscription', () => {
     const html = render('invite_subscription', args);
 
     const input = $(html).find("label").first();
-    assert.equal(input.text().trim(), "devel");
+    assert.equal(input.text().trim(), "#devel");
 });
 
 run_test('single_message', () => {

--- a/static/js/invite.js
+++ b/static/js/invite.js
@@ -123,20 +123,20 @@ function generate_multiuse_invite() {
 }
 
 exports.get_invite_streams = function () {
-    const streams = _.filter(stream_data.get_invite_stream_data(), function (stream) {
-        const is_notifications_stream = stream.name === page_params.notifications_stream;
-        // You can't actually elect to invite someone to the
-        // notifications stream. We won't even show it as a choice unless
-        // it's the only stream you have, or if you've made it private.
-        return stream_data.subscribed_streams().length === 1 ||
-            !is_notifications_stream ||
-            is_notifications_stream && stream.is_invite_only;
-    });
+    const streams = stream_data.get_invite_stream_data();
+
+    function compare_streams(a, b) {
+        return a.name.localeCompare(b.name);
+    }
+    streams.sort(compare_streams);
     return streams;
 };
 
 function update_subscription_checkboxes() {
-    const data = {streams: exports.get_invite_streams()};
+    const data = {
+        streams: exports.get_invite_streams(),
+        notifications_stream: page_params.notifications_stream,
+    };
     const html = render_invite_subscription(data);
     $('#streams_to_add').html(html);
 }

--- a/static/templates/invite_subscription.hbs
+++ b/static/templates/invite_subscription.hbs
@@ -11,7 +11,7 @@
           {{#if default_stream}}checked="checked"{{/if}} />
         <span></span>
         {{#if invite_only}}<i class="fa fa-lock" aria-hidden="true"></i>{{/if}}
-        {{name}}
+        #{{name}}
     </label>
     {{/each}}
 </div>

--- a/static/templates/invite_subscription.hbs
+++ b/static/templates/invite_subscription.hbs
@@ -11,7 +11,11 @@
           {{#if default_stream}}checked="checked"{{/if}} />
         <span></span>
         {{#if invite_only}}<i class="fa fa-lock" aria-hidden="true"></i>{{/if}}
+        {{#if (eq name ../notifications_stream)}}
+        #{{name}} <i>(receives new stream notifications)</i>
+        {{else}}
         #{{name}}
+        {{/if}}
     </label>
     {{/each}}
 </div>

--- a/templates/zerver/app/invite_user.html
+++ b/templates/zerver/app/invite_user.html
@@ -11,9 +11,9 @@
                 {% if development_environment %}
                 <div class="alert" id="dev_env_msg"></div>
                 {% endif %}
-                <div class="control-group">
-                    <label class="control-label" for="invitee_emails">{{ _('Emails (one on each line or comma-separated)') }}</label>
-                    <div class="controls">
+                <div class="input-group">
+                    <label for="invitee_emails">{{ _('Emails (one on each line or comma-separated)') }}</label>
+                    <div>
                         <textarea rows="2" id="invitee_emails" name="invitee_emails" placeholder="{{ _('One or more email addresses...') }}"></textarea>
                         {% if is_admin %}
                         <div id="invite-method-choice">
@@ -29,9 +29,9 @@
                         {% endif %}
                     </div>
                 </div>
-                <div class="control-group">
-                    <label class="control-label" for="invite_as">{{ _('User(s) join as') }}</label>
-                    <div class="controls">
+                <div class="input-group">
+                    <label for="invite_as">{{ _('User(s) join as') }}</label>
+                    <div>
                         <select id="invite_as">
                             <option name="invite_as" value="{{ invite_as.MEMBER }}">{{ _('Members') }}</option>
                             {% if is_admin %}
@@ -41,9 +41,9 @@
                         </select>
                     </div>
                 </div>
-                <div class="control-group">
-                    <label class="control-label">{{ _('Streams they should join') }}</label>
-                    <div class="controls" id="streams_to_add"></div>
+                <div>
+                    <label>{{ _('Streams they should join') }}</label>
+                    <div id="streams_to_add"></div>
                 </div>
             </div>
             <div class="modal-footer">

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -891,27 +891,6 @@ class InviteUserTest(InviteUserBase):
         self.assertTrue(find_key_by_email(email2))
         self.check_sent_emails([email, email2])
 
-    def test_successful_invite_user_with_notifications_stream(self) -> None:
-        """
-        A call to /json/invites with valid parameters unconditionally
-        subscribes the invitee to the notifications stream if it exists and is
-        public.
-        """
-        realm = get_realm('zulip')
-        notifications_stream = get_stream('Verona', realm)
-        realm.notifications_stream_id = notifications_stream.id
-        realm.save()
-
-        self.login(self.example_email("hamlet"))
-        invitee = 'alice-test@zulip.com'
-        self.assert_json_success(self.invite(invitee, ['Denmark']))
-        self.assertTrue(find_key_by_email(invitee))
-        self.check_sent_emails([invitee])
-
-        prereg_user = PreregistrationUser.objects.get(email=invitee)
-        stream_ids = [stream.id for stream in prereg_user.streams.all()]
-        self.assertTrue(notifications_stream.id in stream_ids)
-
     def test_invite_user_signup_initial_history(self) -> None:
         """
         Test that a new user invited to a stream receives some initial

--- a/zerver/views/invite.py
+++ b/zerver/views/invite.py
@@ -37,12 +37,6 @@ def invite_users_backend(request: HttpRequest, user_profile: UserProfile,
 
     invitee_emails = get_invitee_emails_set(invitee_emails_raw)
 
-    # We unconditionally sub you to the notifications stream if it
-    # exists and is public.
-    notifications_stream = user_profile.realm.notifications_stream  # type: Optional[Stream]
-    if notifications_stream and not notifications_stream.invite_only:
-        stream_ids.append(notifications_stream.id)
-
     streams = []  # type: List[Stream]
     for stream_id in stream_ids:
         try:


### PR DESCRIPTION
**What this PR does?**

- In invite users screen, added `#` with the stream names to match how we display them elsewhere.
- Sort the stream names in invite users screen.
- Listed notifications stream along with other streams with a message "recieves notifications for new streams" instead of adding the invited user unconditionally.
- Left-justified the elements in the invite users screen.
- Fixes #13645 

**Testing Plan:**
Unit tests.

**Screenshot:**

![Screenshot from 2020-01-28 00-07-18](https://user-images.githubusercontent.com/45683359/73205292-8f008d80-4162-11ea-83be-55614b944ae7.jpg)
