### PR TITLE
compose: Improved warning for wildcard mentions.

### DIFF
--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -7,8 +7,8 @@
 // and assert truths:
 
 zrequire('util');
-assert(!util.is_all_or_everyone_mentioned('boring text'));
-assert(util.is_all_or_everyone_mentioned('mention @**everyone**'));
+assert(!util.find_wildcard_mentions('boring text'));
+assert(util.find_wildcard_mentions('mention @**everyone**'));
 
 // Let's test with people.js next.  We'll show this technique:
 //  * get a false value

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -519,13 +519,29 @@ run_test('compose_invite_users', () => {
 run_test('compose_all_everyone', () => {
     const args = {
         count: '101',
-        name: 'all',
+        mention: 'all',
     };
-    const html = render('compose_all_everyone', args);
+    let html = render('compose_all_everyone', args);
     const button = $(html).find("button").first();
+
+    // test for @all mention warning.
     assert.equal(button.text(), "translated: Yes, send");
-    const error_msg = $(html).find('span.compose-all-everyone-msg').text().trim();
-    assert.equal(error_msg, "translated: Are you sure you want to mention all 101 people in this stream?");
+    let error_msg = $(html).find('span.compose-all-everyone-msg').text().trim();
+    assert.equal(error_msg, "translated: Are you sure you want to mention all 101 people in this stream?  This will send email and mobile push notifications to most of those 101 users.  If you don't want to do that, please edit your message to remove the @all mention.");
+
+    // test for @everyone warning.
+    args.mention = 'everyone';
+    html = render('compose_all_everyone', args);
+    assert.equal(button.text(), "translated: Yes, send");
+    error_msg = $(html).find('span.compose-all-everyone-msg').text().trim();
+    assert.equal(error_msg, "translated: Are you sure you want to mention all 101 people in this stream?  This will send email and mobile push notifications to most of those 101 users.  If you don't want to do that, please edit your message to remove the @everyone mention.");
+
+    // test for @stream warning.
+    args.mention = 'stream';
+    html = render('compose_all_everyone', args);
+    assert.equal(button.text(), "translated: Yes, send");
+    error_msg = $(html).find('span.compose-all-everyone-msg').text().trim();
+    assert.equal(error_msg, "translated: Are you sure you want to mention all 101 people in this stream?  This will send email and mobile push notifications to most of those 101 users.  If you don't want to do that, please edit your message to remove the @stream mention.");
 });
 
 run_test('compose_announce', () => {

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -222,27 +222,27 @@ run_test('all_and_everyone_mentions_regexp', () => {
 
     let i;
     for (i = 0; i < messages_with_all_mentions.length; i += 1) {
-        assert(util.is_all_or_everyone_mentioned(messages_with_all_mentions[i]));
+        assert(util.find_wildcard_mentions(messages_with_all_mentions[i]));
     }
 
     for (i = 0; i < messages_with_everyone_mentions.length; i += 1) {
-        assert(util.is_all_or_everyone_mentioned(messages_with_everyone_mentions[i]));
+        assert(util.find_wildcard_mentions(messages_with_everyone_mentions[i]));
     }
 
     for (i = 0; i < messages_with_stream_mentions.length; i += 1) {
-        assert(util.is_all_or_everyone_mentioned(messages_with_stream_mentions[i]));
+        assert(util.find_wildcard_mentions(messages_with_stream_mentions[i]));
     }
 
     for (i = 0; i < messages_without_all_mentions.length; i += 1) {
-        assert(!util.is_all_or_everyone_mentioned(messages_without_everyone_mentions[i]));
+        assert(!util.find_wildcard_mentions(messages_without_everyone_mentions[i]));
     }
 
     for (i = 0; i < messages_without_everyone_mentions.length; i += 1) {
-        assert(!util.is_all_or_everyone_mentioned(messages_without_everyone_mentions[i]));
+        assert(!util.find_wildcard_mentions(messages_without_everyone_mentions[i]));
     }
 
     for (i = 0; i < messages_without_stream_mentions.length; i += 1) {
-        assert(!util.is_all_or_everyone_mentioned(messages_without_stream_mentions[i]));
+        assert(!util.find_wildcard_mentions(messages_without_stream_mentions[i]));
     }
 });
 

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -200,9 +200,12 @@ exports.CachedValue.prototype = {
     },
 };
 
-exports.is_all_or_everyone_mentioned = function (message_content) {
-    const all_everyone_re = /(^|\s)(@\*{2}(all|everyone|stream)\*{2})($|\s)/;
-    return all_everyone_re.test(message_content);
+exports.find_wildcard_mentions = function (message_content) {
+    const mention = message_content.match(/(^|\s)(@\*{2}(all|everyone|stream)\*{2})($|\s)/);
+    if (mention === null) {
+        return null;
+    }
+    return mention[3];
 };
 
 exports.move_array_elements_to_front = function util_move_array_elements_to_front(array, selected) {

--- a/static/templates/compose_all_everyone.hbs
+++ b/static/templates/compose_all_everyone.hbs
@@ -1,6 +1,12 @@
 <div class="compose-all-everyone">
     <span class="compose-all-everyone-msg">
-        {{#tr this}}Are you sure you want to mention all <strong>__count__</strong> people in this stream?{{/tr}}
+        {{#tr this}}
+        Are you sure you want to mention all <strong>__count__</strong> people in this stream?
+        <br />
+        This will send email and mobile push notifications to most of those <strong>__count__</strong> users.
+        <br />
+        If you don't want to do that, please edit your message to remove the <strong>@__mention__</strong> mention.
+        {{/tr}}
     </span>
     <span class="compose-all-everyone-controls">
         <button type="button" class="btn btn-warning compose-all-everyone-confirm">{{t "Yes, send" }}</button>


### PR DESCRIPTION
Edited the warning to clearly state that most members/most stream members
will be notified on using wildcard mentions, along with the specific
mention (e.g. @all, @everyone and @stream).

Did a separate check for all wildcard mentions in util.js and stored the
corresponding mention in wildcard_mention inside compose.js.

Fixes: #13636

Screenshots:

Before-
![13636 old](https://user-images.githubusercontent.com/47082523/72679268-a214bd00-3ad3-11ea-825d-2e7f63628d01.png)

After-
<img width="553" alt="@all" src="https://user-images.githubusercontent.com/47082523/72679272-aa6cf800-3ad3-11ea-8bc6-200b29d7f130.png">
<img width="554" alt="@everyone" src="https://user-images.githubusercontent.com/47082523/72679277-b22c9c80-3ad3-11ea-9981-eed46ae2bc61.png">
<img width="554" alt="@stream" src="https://user-images.githubusercontent.com/47082523/72679280-b5c02380-3ad3-11ea-95fd-25907e504a24.png">


