### PR TITLE
Update docs on the use of yaml description field

### DIFF
--- a/docs/documentation/api.md
+++ b/docs/documentation/api.md
@@ -59,9 +59,7 @@ links to any alternative endpoints the user might want to consider.
 These sections should almost always contain a link to the
 documentation of the relevant feature in `/help/`.
 
-We plan to migrate to storing this description content in the
-`description` field in `zulip.yaml`; currently, the `description`
-section in `zulip.yaml` is not used for anything.
+The description content is stored in the `description` field in the `zulip.yaml` file; which is then taken and displayed under each endpoint.
 
 ### Usage examples
 


### PR DESCRIPTION
Closes #13706 

Docs updated to clearly state how API endpoint description is been gotten.