### PR TITLE
js: Fix 'last active' is 'Never' 

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -199,6 +199,13 @@ function populate_users(realm_people_data) {
             return $("<span></span>").text(i18n.t("Unknown"));
         }
         if (item.last_active === LAST_ACTIVE_NEVER) {
+            // only two possibilities remain either user has never logged in
+            // or the user was last active more than 2 weeks ago. Check this
+            // by getting data from same place as the sidebar user list
+            const title_data = buddy_data.get_title_data(item.user_id, false);
+            if (title_data.second_line === "Last active: More than 2 weeks ago") {
+                return $("<span></span>").text(i18n.t("More than 2 weeks ago"));
+            }
             return $("<span></span>").text(i18n.t("Never"));
         }
         return timerender.render_date(


### PR DESCRIPTION
Just before returning 'last_active' for settings/users, if
last_active is 'never' it first checks the data from the user sidebar
using 'buddy_data' and accordingly returns last seen.

![Screenshot from 2020-01-21 00-50-43](https://user-images.githubusercontent.com/13984827/72778879-36039780-3c40-11ea-8b61-cda5156495da.png)
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

This solves issue https://github.com/zulip/zulip/issues/13709 .

 <!-- How have you tested? -->


 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
   #-->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
