### PR TITLE
Update API docs usage example

### DIFF
--- a/docs/documentation/api.md
+++ b/docs/documentation/api.md
@@ -76,12 +76,16 @@ one writes a Markdown file block that looks something like this:
 ```
 {start_tabs}
 {tab|python}
+
 {generate_code_example(python)|/messages/render:post|example}
+
+{tab|js}
+...
+
 {tab|curl}
-curl -X POST {{ api_url }}/v1/messages/render \
-...
-{tab|javascript}
-...
+
+{generate_code_example(curl)|/messages/render:post|example}
+
 {end_tabs}
 ```
 


### PR DESCRIPTION
The current view of how api usage example is being documented doesn't match what's in the code.
  This PR updates that.

## Initially

```
{start_tabs}
{tab|python}
{generate_code_example(python)|/messages/render:post|example}
{tab|curl}
curl -X POST {{ api_url }}/v1/messages/render \
...
{tab|javascript}
...
{end_tabs}
```

## Updated

```
{start_tabs}
{tab|python}

{generate_code_example(python)|/messages/render:post|example}

{tab|js}
...

{tab|curl}

{generate_code_example(curl)|/messages/render:post|example}

{end_tabs}
```