### PR TITLE
tests: Replace httpretty with responses.

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -20,7 +20,7 @@ coverage
 https://github.com/zulip/fakeldap/archive/ff32deaad34b91d5ba5735f314362c0456c92607.zip#egg=fakeldap==0.6.1zulip
 
 # For testing mock http requests
-httpretty
+responses
 
 # For sorting imports
 isort

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -307,8 +307,6 @@ html2text==2019.9.26 \
 httplib2==0.14.0 \
     --hash=sha256:34537dcdd5e0f2386d29e0e2c6d4a1703a3b982d34c198a5102e6e5d6194b107 \
     --hash=sha256:409fa5509298f739b34d5a652df762cb0042507dc93f6633e306b11289d6249d
-httpretty==0.9.7 \
-    --hash=sha256:66216f26b9d2c52e81808f3e674a6fb65d4bf719721394a1a9be926177e55fbe
 hypchat==0.21 \
     --hash=sha256:ef37a9cd8103bb13ad772b28ba9223ca9d4278371e374450c3ea2918df70a8e9
 hyper==0.7.0 \
@@ -722,8 +720,7 @@ requests[security]==2.22.0 \
     # via docker, hypchat, matrix-client, moto, premailer, pyoembed, python-digitalocean, python-gcm, python-twitter, requests-oauthlib, responses, social-auth-core, sphinx, stripe, transifex-client, twilio
 responses==0.10.7 \
     --hash=sha256:46d4e546a19fc6106bc7e804edd4551ef04690405e41e7e750ebc295d042623b \
-    --hash=sha256:93b1e0f2f960c0f3304ca4436856241d64c33683ef441431b9caf1d05d9d9e23 \
-    # via moto
+    --hash=sha256:93b1e0f2f960c0f3304ca4436856241d64c33683ef441431b9caf1d05d9d9e23
 rsa==4.0 \
     --hash=sha256:14ba45700ff1ec9eeb206a2ce76b32814958a98e372006c8fb76ba820211be66 \
     --hash=sha256:1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487 \

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -4,18 +4,18 @@
 from lib import sanity_check
 sanity_check.check_venv(__file__)
 
-from typing import List, Any
+from typing import List, Iterator
 import glob
 import argparse
+import contextlib
+import mock
 import os
 import shlex
 import sys
 import subprocess
 import tempfile
 import ujson
-import httplib2
-import httpretty
-import requests
+import responses
 
 import django
 from django.conf import settings
@@ -154,32 +154,27 @@ def write_failed_tests(failed_tests: List[str]) -> None:
         with open(FAILED_TEST_PATH, 'w') as f:
             ujson.dump(failed_tests, f)
 
-def block_internet() -> None:
-    # We are blocking internet currently by assuming mostly any test would use
-    # httplib2 to access internet.
-    requests_orig = requests.request
+@contextlib.contextmanager
+def block_internet() -> Iterator[None]:
+    # Monkey-patching - responses library raises requests.ConnectionError when access to an unregistered URL
+    # is attempted. We want to replace that with our own exception, so that it propagates all the way:
+    with mock.patch.object(responses, 'ConnectionError', new=ZulipInternetBlockedError):
+        # We'll run all tests in this context manager. It'll cause an error to be raised (see above comment),
+        # if any code attempts to access the internet.
+        with responses.RequestsMock():
+            yield
 
-    def internet_guard_requests(*args: Any, **kwargs: Any) -> Any:
-        if httpretty.is_enabled():
-            return requests_orig(*args, **kwargs)
-        raise Exception("Outgoing network requests are not allowed in the Zulip tests. "
-                        "More details and advice are available here:"
-                        "https://zulip.readthedocs.io/en/latest/testing/testing.html#internet-access-inside-test-suites")
-
-    requests.request = internet_guard_requests
-
-    http2lib_request_orig = httplib2.Http.request
-
-    def internet_guard_httplib2(*args: Any, **kwargs: Any) -> Any:
-        if httpretty.is_enabled():
-            return http2lib_request_orig(*args, **kwargs)
-        raise Exception("Outgoing network requests are not allowed in the Zulip tests. "
-                        "More details and advice are available here:"
-                        "https://zulip.readthedocs.io/en/latest/testing/testing.html#internet-access-inside-test-suites")
-    httplib2.Http.request = internet_guard_httplib2
+class ZulipInternetBlockedError(Exception):
+    def __init__(self, original_msg: str) -> None:
+        zulip_msg = (
+            "Outgoing network requests are not allowed in the Zulip tests. "
+            "More details and advice are available here:"
+            "https://zulip.readthedocs.io/en/latest/testing/testing.html#internet-access-inside-test-suites"
+        )
+        msg = "{}\nResponses library error message: {}".format(zulip_msg, original_msg)
+        super().__init__(msg)
 
 def main() -> None:
-    block_internet()
     TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
     os.chdir(os.path.dirname(TOOLS_DIR))
     sys.path.insert(0, os.path.dirname(TOOLS_DIR))
@@ -381,11 +376,12 @@ def main() -> None:
     else:
         print("-- Running tests in serial mode.", flush=True)
 
-    test_runner = TestRunner(failfast=options.fatal_errors, verbosity=2,
-                             parallel=parallel, reverse=options.reverse,
-                             keepdb=True)
-    failures, failed_tests = test_runner.run_tests(suites, full_suite=full_suite,
-                                                   include_webhooks=include_webhooks)
+    with block_internet():
+        test_runner = TestRunner(failfast=options.fatal_errors, verbosity=2,
+                                 parallel=parallel, reverse=options.reverse,
+                                 keepdb=True)
+        failures, failed_tests = test_runner.run_tests(suites, full_suite=full_suite,
+                                                       include_webhooks=include_webhooks)
     write_failed_tests(failed_tests)
 
     templates_not_rendered = test_runner.get_shallow_tested_templates()

--- a/version.py
+++ b/version.py
@@ -26,4 +26,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/12/13/zulip-2-1-relea
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '67.0'
+PROVISION_VERSION = '67.1'

--- a/zerver/tests/test_internet.py
+++ b/zerver/tests/test_internet.py
@@ -1,0 +1,20 @@
+from zerver.lib.test_classes import ZulipTestCase
+
+import responses
+import requests
+
+class ResponsesTest(ZulipTestCase):
+    def test_responses(self) -> None:
+        # With our test setup, accessing the internet should be blocked.
+        with self.assertRaises(Exception):
+            result = requests.request('GET', 'https://www.google.com')
+
+        # A test can invoke its own responses.RequestsMock context manager
+        # and register URLs to mock, accessible from within the context.
+        with responses.RequestsMock() as requests_mock:
+            requests_mock.add(responses.GET, 'https://www.google.com',
+                              body='{}', status=200,
+                              content_type='application/json')
+            result = requests.request('GET', 'https://www.google.com')
+            self.assertEqual(result.status_code, 200)
+            self.assertEqual(result.text, '{}')


### PR DESCRIPTION
This is a blocker for tests for what I'm working on for https://github.com/zulip/zulip/issues/13613 But I believe this change stands on its own merits. What I directly ran into is that if httpretty is active, if the codepaths try to use redis, it will fail and throw an exception. Quoting the commit message:

> responses is an analogical module to httpretty for mocking external
URLs. Most important (in the moment) problem with httpretty is that it
breaks ability to use redis in parts of code where httpretty is enabled.
From more research, the module in general has tendency to have various
troublesome bugs with breaking URLs that it shouldn't be affecting.
responses seems to be less buggy and is much more actively maintained.

This thread from another big project that did this migration makes the argument better than I can - https://github.com/ckan/ckan/issues/4755 and most of their reasons apply just as much to us.

One tricky thing was that our ``block_internet()`` in ``test-backend`` would be conflicting with ``responses``, but instead, ``responses`` can be used to replace our custom logic and block internet access in tests on its own.
