### PR TITLE
ui: Fix bottom whitespace in main page.

### DIFF
--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -50,7 +50,7 @@ function get_new_heights() {
     const top_navbar_height = $("#top_navbar").safeOuterHeight(true);
     const invite_user_link_height = $("#invite-user-link").safeOuterHeight(true) || 0;
 
-    res.bottom_whitespace_height = viewport_height * 0.4;
+    res.bottom_whitespace_height = viewport_height * 0.05;
 
     res.main_div_min_height = viewport_height - top_navbar_height;
 
@@ -104,7 +104,7 @@ function left_userlist_get_new_heights() {
 
     // main div
     const top_navbar_height = $(".header").safeOuterHeight(true);
-    res.bottom_whitespace_height = viewport_height * 0.4;
+    res.bottom_whitespace_height = viewport_height * 0.05;
     res.main_div_min_height = viewport_height - top_navbar_height;
 
 


### PR DESCRIPTION
Bottom whitespaces on main app page is reduced from (viewport_height * 0.4) to (viewport_height * 0.05) to make UI look better.

Fixes: #13714 

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Peek 2020-01-23 03-44](https://user-images.githubusercontent.com/43504292/72939328-a8848c80-3d92-11ea-9f54-6e0f393aa234.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
