### PR TITLE
night_mode: Render the message instead of showing raw `/night` text.

### DIFF
--- a/static/js/zcommand.js
+++ b/static/js/zcommand.js
@@ -53,7 +53,8 @@ exports.enter_day_mode = function () {
             night_mode.disable();
             feedback_widget.show({
                 populate: function (container) {
-                    container.text(data.msg);
+                    const rendered_msg = marked(data.msg).trim();
+                    container.html(rendered_msg);
                 },
                 on_undo: function () {
                     exports.send({
@@ -74,7 +75,8 @@ exports.enter_night_mode = function () {
             night_mode.enable();
             feedback_widget.show({
                 populate: function (container) {
-                    container.text(data.msg);
+                    const rendered_msg = marked(data.msg).trim();
+                    container.html(rendered_msg);
                 },
                 on_undo: function () {
                     exports.send({

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -567,6 +567,7 @@ on a dark background, and don't change the dark labels dark either. */
 
     #feedback_container,
     .rendered_markdown code,
+    .feedback_content code,
     .typeahead.dropdown-menu {
         background-color: hsl(212, 25%, 15%);
         border-color: hsla(0, 0%, 0%, 0.5);


### PR DESCRIPTION
Current behavior: 
![image](https://user-images.githubusercontent.com/8033238/72965787-3b4d1780-3de3-11ea-8930-5bfd0a9466d2.png)

Fixed behavior:
![image](https://user-images.githubusercontent.com/8033238/72965716-122c8700-3de3-11ea-823c-629bc26afbb1.png)
![image](https://user-images.githubusercontent.com/8033238/72965734-19ec2b80-3de3-11ea-90a5-69bef71795a8.png)
