### PR TITLE
settings: Fix incorrect 'last active' begin displayed

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -199,6 +199,13 @@ function populate_users(realm_people_data) {
             return $("<span></span>").text(i18n.t("Unknown"));
         }
         if (item.last_active === LAST_ACTIVE_NEVER) {
+            // only two possibilities remain either user has never logged in
+            // or the user was last active more than 2 weeks ago. Check this
+            // by using same method as sidebar user list
+            const last_active_date = presence.last_active_date(item.user_id);
+            if (last_active_date === undefined) {
+                return $("<span></span>").text(i18n.t("More than 2 weeks ago"));
+            }
             return $("<span></span>").text(i18n.t("Never"));
         }
         return timerender.render_date(


### PR DESCRIPTION
If a user was last active more than two weeks ago, then their 'last active' in 'settings/users' would be displayed as 'Never' instead of 'more than two weeks ago'. But the user sidebar displays the 'last active ' correctly.

Fix this by using the same method for displaying 'last active: More than two weeks ago.' in 'Users/Settings' as that used in 'user sidebar'.
This solves issue #13709 .