### PR TITLE
JS: Fix minor bug which causes infinite saving message on selecting same emojiset in Settings.

### DIFF
--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -137,6 +137,10 @@ exports.set_up = function () {
     });
     $(".emojiset_choice").click(function () {
         const data = {emojiset: JSON.stringify($(this).val())};
+        const current_emojiset = JSON.stringify(page_params.emojiset);
+        if (current_emojiset === data.emojiset) {
+            return;
+        }
         const spinner = $("#emoji-settings-status").expectOne();
         loading.make_indicator(spinner, {text: settings_ui.strings.saving });
 


### PR DESCRIPTION
When user selects an emojiset, it first checks whether the current emojiset is same or not. If same, it does nothing, hence avoiding the infinite saving message.

It solves issue #13684 
