### PR TITLE
emails: Set alt attribute to empty for leading images

### DIFF
--- a/templates/zerver/emails/confirm_new_email.source.html
+++ b/templates/zerver/emails/confirm_new_email.source.html
@@ -1,7 +1,7 @@
 {% extends "zerver/emails/compiled/email_base_default.html" %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/email_logo.png" alt="{{ _('Zulip logo') }}"/>
+<img src="{{ email_images_base_uri }}/email_logo.png" alt=""/>
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/emails/confirm_registration.source.html
+++ b/templates/zerver/emails/confirm_registration.source.html
@@ -1,7 +1,7 @@
 {% extends "zerver/emails/compiled/email_base_default.html" %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/registration_confirmation.png" alt="{{ _('Turtle with envelope') }}"/>
+<img src="{{ email_images_base_uri }}/registration_confirmation.png" alt=""/>
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/emails/custom_email_base.pre.html
+++ b/templates/zerver/emails/custom_email_base.pre.html
@@ -1,7 +1,7 @@
 {% extends "zerver/emails/compiled/email_base_default.html" %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/email_logo.png" alt="{{ _('Zulip logo') }}"/>
+<img src="{{ email_images_base_uri }}/email_logo.png" alt=""/>
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/emails/find_team.source.html
+++ b/templates/zerver/emails/find_team.source.html
@@ -1,7 +1,7 @@
 {% extends "zerver/emails/compiled/email_base_default.html" %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/email_logo.png" alt="{{ _('Zulip logo') }}"/>
+<img src="{{ email_images_base_uri }}/email_logo.png" alt=""/>
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/emails/followup_day1.source.html
+++ b/templates/zerver/emails/followup_day1.source.html
@@ -1,7 +1,7 @@
 {% extends "zerver/emails/compiled/email_base_default.html" %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/email_logo.png" alt="{{ _('Zulip logo') }}"/>
+<img src="{{ email_images_base_uri }}/email_logo.png" alt=""/>
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/emails/followup_day2.source.html
+++ b/templates/zerver/emails/followup_day2.source.html
@@ -1,7 +1,7 @@
 {% extends "zerver/emails/compiled/email_base_default.html" %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/day2_1.png" alt="{{ _('Octopus box with heart') }}"/>
+<img src="{{ email_images_base_uri }}/day2_1.png" alt=""/>
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/emails/invitation.source.html
+++ b/templates/zerver/emails/invitation.source.html
@@ -1,7 +1,7 @@
 {% extends "zerver/emails/compiled/email_base_default.html" %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/registration_confirmation.png" alt="{{ _('Turtle with envelope') }}"/>
+<img src="{{ email_images_base_uri }}/registration_confirmation.png" alt=""/>
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/emails/invitation_reminder.source.html
+++ b/templates/zerver/emails/invitation_reminder.source.html
@@ -1,7 +1,7 @@
 {% extends "zerver/emails/compiled/email_base_default.html" %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/invitation_reminder.png" alt="{{ _('Mailbox with envelope') }}"/>
+<img src="{{ email_images_base_uri }}/invitation_reminder.png" alt=""/>
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/emails/notify_change_in_email.source.html
+++ b/templates/zerver/emails/notify_change_in_email.source.html
@@ -1,7 +1,7 @@
 {% extends "zerver/emails/compiled/email_base_default.html" %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/email_logo.png" alt="{{ _('Zulip logo') }}"/>
+<img src="{{ email_images_base_uri }}/email_logo.png" alt=""/>
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/emails/notify_new_login.source.html
+++ b/templates/zerver/emails/notify_new_login.source.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/email_logo.png" alt="{{ _('Zulip logo') }}"/>
+<img src="{{ email_images_base_uri }}/email_logo.png" alt=""/>
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/emails/password_reset.source.html
+++ b/templates/zerver/emails/password_reset.source.html
@@ -1,7 +1,7 @@
 {% extends "zerver/emails/compiled/email_base_default.html" %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/email_logo.png" alt="{{ _('Zulip logo') }}"/>
+<img src="{{ email_images_base_uri }}/email_logo.png" alt=""/>
 {% endblock %}
 
 {% block content %}

--- a/templates/zerver/emails/realm_reactivation.source.html
+++ b/templates/zerver/emails/realm_reactivation.source.html
@@ -1,7 +1,7 @@
 {% extends "zerver/emails/compiled/email_base_default.html" %}
 
 {% block illustration %}
-<img src="{{ email_images_base_uri }}/registration_confirmation.png" alt="{{ _('Turtle with envelope') }}"/>
+<img src="{{ email_images_base_uri }}/registration_confirmation.png" alt=""/>
 {% endblock %}
 
 {% block content %}

--- a/version.py
+++ b/version.py
@@ -26,4 +26,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/12/13/zulip-2-1-relea
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '67.1'
+PROVISION_VERSION = '67.2'


### PR DESCRIPTION
See https://chat.zulip.org/#narrow/stream/9-issues/topic/.22Turtle.20with.20envelope.22.20image.20name.20in.20Gmail.20inbox.20view

![Screenshot from 2020-01-24 13-22-38](https://user-images.githubusercontent.com/7190633/73053004-a0207480-3eac-11ea-94b0-d7c3a0f2c031.png)
