### PR TITLE
[WIP]settings: Automatically set 24-hour time at account creation

### DIFF
--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -63,7 +63,7 @@ def create_user_profile(realm: Realm, email: str, password: Optional[str],
                                enter_sends=enter_sends,
                                onboarding_steps=ujson.dumps([]),
                                default_language=realm.default_language,
-                               twenty_four_hour_time=realm.default_twenty_four_hour_time,
+                               twenty_four_hour_time=True,
                                delivery_email=email)
     if bot_type or not active:
         password = None

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -254,7 +254,7 @@ class Realm(models.Model):
     allow_community_topic_editing = models.BooleanField(default=True)  # type: bool
 
     # Defaults for new users
-    default_twenty_four_hour_time = models.BooleanField(default=False)  # type: bool
+    default_twenty_four_hour_time = models.BooleanField(default=True)  # type: bool
     default_language = models.CharField(default=u'en', max_length=MAX_LANGUAGE_ID_LENGTH)  # type: str
 
     DEFAULT_NOTIFICATION_STREAM_NAME = u'general'
@@ -953,7 +953,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
     high_contrast_mode = models.BooleanField(default=False)  # type: bool
     night_mode = models.BooleanField(default=False)  # type: bool
     translate_emoticons = models.BooleanField(default=False)  # type: bool
-    twenty_four_hour_time = models.BooleanField(default=False)  # type: bool
+    twenty_four_hour_time = models.BooleanField(default=True)  # type: bool
     starred_message_counts = models.BooleanField(default=False)  # type: bool
 
     # UI setting controlling Zulip's behavior of demoting in the sort


### PR DESCRIPTION
When an account is created, the time should be set to a 24-hour clock.
 
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This solves the issue https://github.com/zulip/zulip/issues/12555.

**Testing Plan:** <!-- How have you tested? -->
I believe that no tests are required.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
