### PR TITLE
mobile sharing: Extract shared/js/typeahead.js.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -1,3 +1,4 @@
+const typeahead = zrequire('typeahead', 'shared/js/typeahead');
 set_global('i18n', global.stub_i18n);
 zrequire('compose_state');
 zrequire('ui_util');
@@ -662,7 +663,7 @@ run_test('initialize', () => {
         assert.equal(actual_value, expected_value);
 
         function matcher(query, person) {
-            query = ct.clean_query_lowercase(query);
+            query = typeahead.clean_query_lowercase(query);
             return ct.query_matches_person(query, person);
         }
 

--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -1,0 +1,55 @@
+const typeahead = zrequire('typeahead', 'shared/js/typeahead');
+
+// The data structures here may be different for
+// different apps; the only key thing is we look
+// at emoji_name and we'll return the entire structures.
+
+const emoji_japanese_post_office = {
+    emoji_name: 'japanese_post_office',
+    url: 'TBD',
+};
+
+const emoji_panda_face = {
+    emoji_name: 'panda_face',
+    emoji_code: '1f43c',
+};
+
+const emoji_smile = {
+    emoji_name: 'smile',
+};
+
+const emoji_tada = {
+    emoji_name: 'tada',
+    random_field: 'whatever',
+};
+
+const emojis = [
+    emoji_japanese_post_office,
+    emoji_panda_face,
+    emoji_smile,
+    emoji_tada,
+];
+
+run_test('get_emoji_matcher', () => {
+    function assert_matches(query, expected) {
+        const matcher = typeahead.get_emoji_matcher(query);
+        assert.deepEqual(
+            _.filter(emojis, matcher),
+            expected
+        );
+    }
+
+    assert_matches('notaemoji', []);
+    assert_matches('da_', []);
+    assert_matches('da ', []);
+
+    assert_matches('da', [emoji_panda_face, emoji_tada]);
+    assert_matches('panda ', [emoji_panda_face]);
+    assert_matches('smil', [emoji_smile]);
+    assert_matches('mile', [emoji_smile]);
+
+    assert_matches(
+        'japanese_post_', [emoji_japanese_post_office]);
+    assert_matches(
+        'japanese post ', [emoji_japanese_post_office]);
+});

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -1,6 +1,7 @@
 require("unorm");  // String.prototype.normalize polyfill for IE11
 const IntDict = require('./int_dict').IntDict;
 const FoldDict = require('./fold_dict').FoldDict;
+const typeahead = require("../shared/js/typeahead");
 
 let people_dict;
 let people_by_name_dict;
@@ -771,12 +772,6 @@ exports.incr_recipient_count = function (user_id) {
     pm_recipient_count_dict.set(user_id, old_count + 1);
 };
 
-const unicode_marks = /\p{M}/gu;
-
-exports.remove_diacritics = function (s) {
-    return s.normalize("NFKD").replace(unicode_marks, "");
-};
-
 exports.get_message_people = function () {
     /*
         message_people are roughly the people who have
@@ -824,7 +819,7 @@ exports.build_termlet_matcher = function (termlet) {
         let full_name = user.full_name;
         if (is_ascii) {
             // Only ignore diacritics if the query is plain ascii
-            full_name = exports.remove_diacritics(full_name);
+            full_name = typeahead.remove_diacritics(full_name);
         }
         const names = full_name.toLowerCase().split(' ');
 

--- a/static/shared/js/typeahead.js
+++ b/static/shared/js/typeahead.js
@@ -1,0 +1,80 @@
+const unicode_marks = /\p{M}/gu;
+
+exports.remove_diacritics = function (s) {
+    return s.normalize("NFKD").replace(unicode_marks, "");
+};
+
+function query_matches_string(query, source_str, split_char) {
+    source_str = exports.remove_diacritics(source_str);
+
+    // If query doesn't contain a separator, we just want an exact
+    // match where query is a substring of one of the target characters.
+    if (query.indexOf(split_char) > 0) {
+        // If there's a whitespace character in the query, then we
+        // require a perfect prefix match (e.g. for 'ab cd ef',
+        // query needs to be e.g. 'ab c', not 'cd ef' or 'b cd
+        // ef', etc.).
+        const queries = query.split(split_char);
+        const sources = source_str.split(split_char);
+        let i;
+
+        for (i = 0; i < queries.length - 1; i += 1) {
+            if (sources[i] !== queries[i]) {
+                return false;
+            }
+        }
+
+        // This block is effectively a final iteration of the last
+        // loop.  What differs is that for the last word, a
+        // partial match at the beginning of the word is OK.
+        if (sources[i] === undefined) {
+            return false;
+        }
+        return sources[i].indexOf(queries[i]) === 0;
+    }
+
+    // For a single token, the match can be anywhere in the string.
+    return source_str.indexOf(query) !== -1;
+}
+
+// This function attempts to match a query with source's attributes.
+// * query is the user-entered search query
+// * Source is the object we're matching from, e.g. a user object
+// * match_attrs are the values associated with the target object that
+// the entered string might be trying to match, e.g. for a user
+// account, there might be 2 attrs: their full name and their email.
+// * split_char is the separator for this syntax (e.g. ' ').
+exports.query_matches_source_attrs = (query, source, match_attrs, split_char) => {
+    return _.any(match_attrs, function (attr) {
+        const source_str = source[attr].toLowerCase();
+        return query_matches_string(query, source_str, split_char);
+    });
+};
+
+function clean_query(query) {
+    query = exports.remove_diacritics(query);
+    // When `abc ` with a space at the end is typed in a
+    // contenteditable widget such as the composebox PM section, the
+    // space at the end was a `no break-space (U+00A0)` instead of
+    // `space (U+0020)`, which lead to no matches in those cases.
+    query = query.replace(/\u00A0/g, String.fromCharCode(32));
+
+    return query;
+}
+
+exports.clean_query_lowercase = function (query) {
+    query = query.toLowerCase();
+    query = clean_query(query);
+    return query;
+};
+
+exports.get_emoji_matcher = (query) => {
+    // replaces spaces with underscores for emoji matching
+    query = query.split(" ").join("_");
+    query = exports.clean_query_lowercase(query);
+
+    return function (emoji) {
+        return exports.query_matches_source_attrs(query, emoji, ["emoji_name"], "_");
+    };
+};
+

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -111,57 +111,58 @@ parser.add_argument('--force', dest='force',
                     default=False, help='Run tests despite possible problems.')
 parser.add_argument('args', nargs=argparse.REMAINDER)
 options = parser.parse_args()
+individual_files = options.args
 
 from tools.lib.test_script import assert_provisioning_status_ok
 
 assert_provisioning_status_ok(options.force)
 
-os.environ['TZ'] = 'UTC'
+def run_tests_via_node_js() -> int:
+    os.environ['TZ'] = 'UTC'
 
-# Add ".js" to the end of all the file arguments, so index.js
-# can actually verify if the file exists or not.
-for index, arg in enumerate(options.args):
-    if not arg.endswith('.js') and not arg.endswith('.ts'):
-        # If it doesn't end with ".js" or ".ts", assume it is a JS file,
-        # since most files are currently JS files.
-        options.args[index] = arg + '.js'
+    # Add ".js" to the end of all the file arguments, so index.js
+    # can actually verify if the file exists or not.
+    for index, arg in enumerate(options.args):
+        if not arg.endswith('.js') and not arg.endswith('.ts'):
+            # If it doesn't end with ".js" or ".ts", assume it is a JS file,
+            # since most files are currently JS files.
+            options.args[index] = arg + '.js'
 
-individual_files = options.args
+    # The index.js test runner is the real "driver" here, and we launch
+    # with either nyc or node, depending on whether we want coverage
+    # reports.  Running under nyc is slower and creates funny
+    # tracebacks, so you generally want to get coverage reports only
+    # after making sure tests will pass.
+    node_tests_cmd = ['node', '--stack-trace-limit=100', INDEX_JS]
+    node_tests_cmd += individual_files
+    if options.coverage:
+        coverage_dir = os.path.join(ROOT_DIR, 'var/node-coverage')
+        coverage_lcov_file = os.path.join(coverage_dir, 'lcov.info')
 
-# The index.js test runner is the real "driver" here, and we launch
-# with either nyc or node, depending on whether we want coverage
-# reports.  Running under nyc is slower and creates funny
-# tracebacks, so you generally want to get coverage reports only
-# after making sure tests will pass.
-node_tests_cmd = ['node', '--stack-trace-limit=100', INDEX_JS]
-node_tests_cmd += individual_files
-if options.coverage:
-    coverage_dir = os.path.join(ROOT_DIR, 'var/node-coverage')
-    coverage_lcov_file = os.path.join(coverage_dir, 'lcov.info')
+        nyc = os.path.join(ROOT_DIR, 'node_modules/.bin/nyc')
+        command = [nyc, '--extension', '.ts']
+        command += ['--report-dir', coverage_dir]
+        command += ['--temp-directory', coverage_dir, '-r=text-summary']
+        command += node_tests_cmd
+        command += ['&&', 'nyc', 'report', '-r=lcov', '-r=json']
+        command += ['>', coverage_lcov_file]
+    else:
+        # Normal testing, no coverage analysis.
+        # Run the index.js test runner, which runs all the other tests.
+        command = node_tests_cmd
 
-    nyc = os.path.join(ROOT_DIR, 'node_modules/.bin/nyc')
-    command = [nyc, '--extension', '.ts']
-    command += ['--report-dir', coverage_dir]
-    command += ['--temp-directory', coverage_dir, '-r=text-summary']
-    command += node_tests_cmd
-    command += ['&&', 'nyc', 'report', '-r=lcov', '-r=json']
-    command += ['>', coverage_lcov_file]
-else:
-    # Normal testing, no coverage analysis.
-    # Run the index.js test runner, which runs all the other tests.
-    command = node_tests_cmd
+    print('Starting node tests...')
 
-print('Starting node tests...')
-
-# If we got this far, we can run the tests!
-try:
-    ret = subprocess.check_call(command)
-except OSError:
-    print('Bad command: %s' % (command,))
-    raise
-except subprocess.CalledProcessError:
-    print('\n** Tests failed, PLEASE FIX! **\n')
-    sys.exit(1)
+    # If we got this far, we can run the tests!
+    try:
+        ret = subprocess.check_call(command)
+    except OSError:
+        print('Bad command: %s' % (command,))
+        raise
+    except subprocess.CalledProcessError:
+        print('\n** Tests failed, PLEASE FIX! **\n')
+        sys.exit(1)
+    return ret
 
 def check_line_coverage(fn, line_coverage, line_mapping, log=True):
     # type: (str, Dict[Any, Any], Dict[Any, Any], bool) -> bool
@@ -224,6 +225,8 @@ def enforce_proper_coverage(coverage_json: Any) -> bool:
 
     problems_encountered = (coverage_lost or coverage_not_enforced)
     return problems_encountered
+
+ret = run_tests_via_node_js()
 
 if options.coverage and ret == 0:
     if not individual_files:

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -16,6 +16,9 @@ sanity_check.check_venv(__file__)
 # Import this after we do the sanity_check so it doesn't crash.
 import ujson
 
+INDEX_JS = 'frontend_tests/zjsunit/index.js'
+NODE_COVERAGE_PATH = 'var/node-coverage/coverage-final.json'
+
 USAGE = '''
     tools/test-js-with-node                      - to run all tests
     tools/test-js-with-node util.js activity.js  - to run just a couple tests
@@ -115,8 +118,6 @@ assert_provisioning_status_ok(options.force)
 
 os.environ['TZ'] = 'UTC'
 
-INDEX_JS = 'frontend_tests/zjsunit/index.js'
-
 # Add ".js" to the end of all the file arguments, so index.js
 # can actually verify if the file exists or not.
 for index, arg in enumerate(options.args):
@@ -176,8 +177,6 @@ def check_line_coverage(fn, line_coverage, line_mapping, log=True):
             print()
         return False
     return True
-
-NODE_COVERAGE_PATH = 'var/node-coverage/coverage-final.json'
 
 def read_coverage() -> Any:
     coverage_json = None

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -23,6 +23,7 @@ USAGE = '''
     '''
 
 enforce_fully_covered = {
+    'static/shared/js/typeahead.js',
     'static/shared/js/typing_status.js',
 
     'static/js/activity.js',
@@ -208,7 +209,7 @@ def enforce_proper_coverage(coverage_json: Any) -> bool:
 
     coverage_not_enforced = False
     for path in coverage_json:
-        if '/static/js/' in path:
+        if '/static/js/' in path or '/static/shared/js' in path:
             relative_path = os.path.relpath(path, ROOT_DIR)
             line_coverage = coverage_json[path]['s']
             line_mapping = coverage_json[path]['statementMap']


### PR DESCRIPTION
This extracts get_emoji_matcher and all the
functions it depended on, most of which were
in composebox_typeahead.js.

We also move remove_diacritics out of the people
module.

This is the first major step for #13728.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
