### PR TITLE
portico: Add on hover effect on tour card

### DIFF
--- a/static/styles/portico/landing-page.scss
+++ b/static/styles/portico/landing-page.scss
@@ -1376,6 +1376,11 @@ nav ul li.active::after {
     opacity: 0.4;
 }
 
+.tour .carousel-inner .start-image:hover {
+    box-shadow: 0px 3px 10px hsla(0, 0%, 0%, 0.3);
+    cursor: pointer;
+}
+
 .tour .carousel-inner .tour-item-header {
     margin: 0 0 30px 54px;
     max-width: 700px;


### PR DESCRIPTION
Add box-shadow and change pointer on tour card which appears on hovering over tour card.

Fixes: #12853

**GIFs or Screenshots:**
Hovering Effect:-
![Peek 2020-01-14 03-26](https://user-images.githubusercontent.com/43504292/72295477-ac6f2b00-367d-11ea-9fd4-b6b4b86f824d.gif)
