### PR TITLE
social_auth: Clear session fields leftover from previous auth attempts.

### DIFF
--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -224,6 +224,10 @@ SILENCED_SYSTEM_CHECKS = [
     # backends support the username not being unique; and they do.
     # See: https://docs.djangoproject.com/en/1.11/topics/auth/customizing/#django.contrib.auth.models.CustomUser.USERNAME_FIELD
     "auth.W004",
+    # urls.W003 warns against using colons in the name in url(..., name) because colons are used
+    # for namespaces. We need to override a url entry in the social: namespace, so we use
+    # the colon in this way intentionally.
+    "urls.W003",
 ]
 
 ########################################################################

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -715,6 +715,12 @@ urls += [
 ]
 
 # Python Social Auth
+
+# This overrides the analogical entry in social_django.urls, because we want run our own code
+# at the beginning of social auth process. If deleting this override in the future,
+# it should be possible to remove urls.W003 from SILENCED_SYSTEM_CHECKS.
+urls += [url(r'^login/(?P<backend>[^/]+)/$', zerver.views.auth.social_auth, name='social:begin')]
+
 urls += [url(r'^', include('social_django.urls', namespace='social'))]
 urls += [url(r'^saml/metadata.xml$', zerver.views.auth.saml_sp_metadata)]
 


### PR DESCRIPTION
Fixes #13560.

Tested manually and the commit also has an automated test.

Everything about this is hacky, but I can't see any proper way of doing this - we need upstream to merge https://github.com/python-social-auth/social-core/pull/426. The commit has comments to make things less confusing and to document that all of this should ideally be deleted in the future.