### PR TITLE
Provide a better API for anchor=10000000000 

### DIFF
--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -188,7 +188,6 @@ run_test('basics', () => {
             cont: opts.cont,
             pre_scroll_cont: opts.pre_scroll_cont,
             anchor: 1000,
-            use_first_unread_anchor: false,
         });
     };
 

--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -163,7 +163,8 @@ exports.load_messages = function (opts) {
         data.narrow = JSON.stringify(page_params.narrow);
     }
     if (opts.use_first_unread_anchor) {
-        data.use_first_unread_anchor = true;
+        // TODO: Push this convention into the callers
+        data.anchor = null;
     }
 
     if (opts.num_before > 0) {
@@ -226,7 +227,6 @@ exports.load_messages_for_narrow = function (opts) {
         num_before: consts.narrow_before,
         num_after: consts.narrow_after,
         msg_list: msg_list,
-        use_first_unread_anchor: opts.use_first_unread_anchor,
         pre_scroll_cont: opts.pre_scroll_cont,
         cont: function () {
             message_scroll.hide_indicators();

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -222,7 +222,6 @@ exports.activate = function (raw_operators, opts) {
 
     (function fetch_messages() {
         let anchor;
-        let use_first_unread;
 
         // Either we're trying to center the narrow around a
         // particular message ID (which could be max_int), or we're
@@ -230,15 +229,12 @@ exports.activate = function (raw_operators, opts) {
         // unread message is, and center the narrow around that.
         if (id_info.final_select_id !== undefined) {
             anchor = id_info.final_select_id;
-            use_first_unread = false;
         } else {
-            anchor = -1;
-            use_first_unread = true;
+            anchor = "first_unread";
         }
 
         message_fetch.load_messages_for_narrow({
             anchor: anchor,
-            use_first_unread_anchor: use_first_unread,
             cont: function () {
                 if (!select_immediately) {
                     exports.update_selection({

--- a/templates/zerver/api/get-messages.md
+++ b/templates/zerver/api/get-messages.md
@@ -63,7 +63,7 @@ zulip(config).then((client) => {
 
 {tab|curl}
 
-{generate_code_example(curl, exclude=["client_gravatar", "apply_markdown"])|/messages:get|example}
+{generate_code_example(curl, exclude=["client_gravatar", "apply_markdown", "use_first_unread_anchor"])|/messages:get|example}
 
 {end_tabs}
 

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -799,6 +799,7 @@ markdown_docs_length_exclude = {
     "templates/zerver/integrations/perforce.md",
     # Has some example code that could perhaps be wrapped
     "templates/zerver/api/incoming-webhooks-walkthrough.md",
+    "templates/zerver/api/get-messages.md",
     # This macro has a long indented URL
     "templates/zerver/help/include/git-webhook-url-with-branches-indented.md",
     "templates/zerver/api/update-notification-settings.md",

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -489,7 +489,8 @@ class ZulipTestCase(TestCase):
             realm=recipient_realm,
         )
 
-    def get_messages_response(self, anchor: int=1, num_before: int=100, num_after: int=100,
+    def get_messages_response(self, anchor: Union[int, str]=1,
+                              num_before: int=100, num_after: int=100,
                               use_first_unread_anchor: bool=False) -> Dict[str, List[Dict[str, Any]]]:
         post_params = {"anchor": anchor, "num_before": num_before,
                        "num_after": num_after,
@@ -498,7 +499,7 @@ class ZulipTestCase(TestCase):
         data = result.json()
         return data
 
-    def get_messages(self, anchor: int=1, num_before: int=100, num_after: int=100,
+    def get_messages(self, anchor: Union[str, int]=1, num_before: int=100, num_after: int=100,
                      use_first_unread_anchor: bool=False) -> List[Dict[str, Any]]:
         data = self.get_messages_response(anchor, num_before, num_after, use_first_unread_anchor)
         return data['messages']

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -543,15 +543,13 @@ def get_messages(client):
     # type: (Client) -> None
 
     # {code_example|start}
-    # Get the 3 last messages sent by "iago@zulip.com" to the stream "Verona"
+    # Get the 100 last messages sent by "iago@zulip.com" to the stream "Verona"
     request = {
-        'use_first_unread_anchor': True,
-        'num_before': 3,
+        'anchor': 'newest',
+        'num_before': 100,
         'num_after': 0,
         'narrow': [{'operator': 'sender', 'operand': 'iago@zulip.com'},
                    {'operator': 'stream', 'operand': 'Verona'}],
-        'client_gravatar': True,
-        'apply_markdown': True
     }  # type: Dict[str, Any]
     result = client.get_messages(request)
     # {code_example|end}

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -290,6 +290,9 @@ paths:
         in: query
         description: The message ID to fetch messages near.
           Required unless `use_first_unread_anchor` is set to true.
+
+          The special values of `'newest'` and `'oldest'` are also supported
+          for anchoring the query at the most recent or oldest messages.
         schema:
           oneOf:
             - type: string

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -291,7 +291,9 @@ paths:
         description: The message ID to fetch messages near.
           Required unless `use_first_unread_anchor` is set to true.
         schema:
-          type: integer
+          oneOf:
+            - type: string
+            - type: integer
         example: 42
       - name: use_first_unread_anchor
         in: query

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -1373,6 +1373,14 @@ class MessageDictTest(ZulipTestCase):
         self.assert_json_error(
             result, "Missing 'anchor' argument (or set 'use_first_unread_anchor'=True).")
 
+    def test_invalid_anchor(self) -> None:
+        self.login(self.example_email("hamlet"))
+        result = self.client_get(
+            '/json/messages?use_first_unread_anchor=false&num_before=1&num_after=1&anchor=chocolate')
+
+        self.assert_json_error(
+            result, "Invalid anchor")
+
 class SewMessageAndReactionTest(ZulipTestCase):
     def test_sew_messages_and_reaction(self) -> None:
         sender = self.example_user('othello')

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -1371,7 +1371,7 @@ class MessageDictTest(ZulipTestCase):
             '/json/messages?use_first_unread_anchor=false&num_before=1&num_after=1')
 
         self.assert_json_error(
-            result, "Missing 'anchor' argument (or set 'use_first_unread_anchor'=True).")
+            result, "Missing 'anchor' argument.")
 
     def test_invalid_anchor(self) -> None:
         self.login(self.example_email("hamlet"))

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -2076,6 +2076,29 @@ class GetOldMessagesTest(ZulipTestCase):
         self.assertEqual(data['found_newest'], False)
         self.assertEqual(data['history_limited'], False)
 
+        # Verify that with anchor=-1 we always get found_oldest=True
+        # anchor=-1 is arguably invalid input, but it used to be supported
+        with first_visible_id_as(0):
+            data = self.get_messages_response(anchor=-1, num_before=0, num_after=5)
+
+        messages = data['messages']
+        messages_matches_ids(messages, message_ids[0:5])
+        self.assertEqual(data['found_anchor'], False)
+        self.assertEqual(data['found_oldest'], True)
+        self.assertEqual(data['found_newest'], False)
+        self.assertEqual(data['history_limited'], False)
+
+        # And anchor='first' does the same thing.
+        with first_visible_id_as(0):
+            data = self.get_messages_response(anchor='oldest', num_before=0, num_after=5)
+
+        messages = data['messages']
+        messages_matches_ids(messages, message_ids[0:5])
+        self.assertEqual(data['found_anchor'], False)
+        self.assertEqual(data['found_oldest'], True)
+        self.assertEqual(data['found_newest'], False)
+        self.assertEqual(data['history_limited'], False)
+
         data = self.get_messages_response(anchor=message_ids[5], num_before=5, num_after=4)
 
         messages = data['messages']
@@ -2155,6 +2178,17 @@ class GetOldMessagesTest(ZulipTestCase):
         # Verify some additional behavior of found_newest.
         with first_visible_id_as(0):
             data = self.get_messages_response(anchor=LARGER_THAN_MAX_MESSAGE_ID, num_before=5, num_after=0)
+
+        messages = data['messages']
+        self.assert_length(messages, 5)
+        self.assertEqual(data['found_anchor'], False)
+        self.assertEqual(data['found_oldest'], False)
+        self.assertEqual(data['found_newest'], True)
+        self.assertEqual(data['history_limited'], False)
+
+        # The anchor value of 'last' behaves just like LARGER_THAN_MAX_MESSAGE_ID.
+        with first_visible_id_as(0):
+            data = self.get_messages_response(anchor='newest', num_before=5, num_after=0)
 
         messages = data['messages']
         self.assert_length(messages, 5)

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -2447,8 +2447,7 @@ class GetOldMessagesTest(ZulipTestCase):
         # search still gets the first message sent to Hamlet (before he
         # subscribed) and other recent messages to the stream.
         query_params = dict(
-            use_first_unread_anchor='true',
-            anchor=0,
+            anchor="first_unread",
             num_before=10,
             num_after=10,
             narrow='[["stream", "England"]]'
@@ -2484,8 +2483,7 @@ class GetOldMessagesTest(ZulipTestCase):
         self.send_personal_message(self.example_email("othello"), self.example_email("iago"))
 
         query_params = dict(
-            use_first_unread_anchor='true',
-            anchor=0,
+            anchor="first_unread",
             num_before=10,
             num_after=10,
             narrow='[]'
@@ -2532,8 +2530,7 @@ class GetOldMessagesTest(ZulipTestCase):
         self.send_personal_message(self.example_email("othello"), self.example_email("iago"))
 
         query_params = dict(
-            use_first_unread_anchor='true',
-            anchor=0,
+            anchor="first_unread",
             num_before=10,
             num_after=10,
             narrow='[]'
@@ -2563,8 +2560,7 @@ class GetOldMessagesTest(ZulipTestCase):
         user_profile = self.example_user('hamlet')
 
         query_params = dict(
-            use_first_unread_anchor='true',
-            anchor=0,
+            anchor="first_unread",
             num_before=10,
             num_after=10,
             narrow='[]'
@@ -2616,8 +2612,7 @@ class GetOldMessagesTest(ZulipTestCase):
         set_topic_mutes(user_profile, muted_topics)
 
         query_params = dict(
-            use_first_unread_anchor='true',
-            anchor=0,
+            anchor="first_unread",
             num_before=0,
             num_after=0,
             narrow='[["stream", "Scotland"]]'

--- a/zerver/tests/test_unread.py
+++ b/zerver/tests/test_unread.py
@@ -111,11 +111,17 @@ class PointerTest(ZulipTestCase):
         # If we call get_messages with use_first_unread_anchor=True, we
         # should get the message we just sent
         messages_response = self.get_messages_response(
+            anchor="first_unread", num_before=0, num_after=1)
+        self.assertEqual(messages_response['messages'][0]['id'], new_message_id)
+        self.assertEqual(messages_response['anchor'], new_message_id)
+
+        # Test with the old way of expressing use_first_unread_anchor=True
+        messages_response = self.get_messages_response(
             anchor=0, num_before=0, num_after=1, use_first_unread_anchor=True)
         self.assertEqual(messages_response['messages'][0]['id'], new_message_id)
         self.assertEqual(messages_response['anchor'], new_message_id)
 
-        # We want to get the message_id of an arbitrar old message. We can
+        # We want to get the message_id of an arbitrary old message. We can
         # call get_messages with use_first_unread_anchor=False and simply
         # save the first message we're returned.
         messages = self.get_messages(
@@ -145,7 +151,7 @@ class PointerTest(ZulipTestCase):
         # Now if we call get_messages with use_first_unread_anchor=True,
         # we should get the old message we just set to unread
         messages_response = self.get_messages_response(
-            anchor=0, num_before=0, num_after=1, use_first_unread_anchor=True)
+            anchor="first_unread", num_before=0, num_after=1)
         self.assertEqual(messages_response['messages'][0]['id'], old_message_id)
         self.assertEqual(messages_response['anchor'], old_message_id)
 
@@ -167,7 +173,7 @@ class PointerTest(ZulipTestCase):
         # we should not get the old unread message (because it's before the
         # pointer), and instead should get the newly sent unread message
         messages_response = self.get_messages_response(
-            anchor=0, num_before=0, num_after=1, use_first_unread_anchor=True)
+            anchor="first_unread", num_before=0, num_after=1)
         self.assertEqual(messages_response['messages'][0]['id'], new_message_id)
         self.assertEqual(messages_response['anchor'], new_message_id)
 
@@ -182,25 +188,25 @@ class PointerTest(ZulipTestCase):
                                                   "test")
 
         messages_response = self.get_messages_response(
-            anchor=0, num_before=0, num_after=1, use_first_unread_anchor=True)
+            anchor="first_unread", num_before=0, num_after=1)
         self.assertEqual(messages_response['messages'][0]['id'], new_message_id)
         self.assertEqual(messages_response['anchor'], new_message_id)
 
         with mock.patch('zerver.views.messages.get_first_visible_message_id', return_value=new_message_id):
             messages_response = self.get_messages_response(
-                anchor=0, num_before=0, num_after=1, use_first_unread_anchor=True)
+                anchor="first_unread", num_before=0, num_after=1)
         self.assertEqual(messages_response['messages'][0]['id'], new_message_id)
         self.assertEqual(messages_response['anchor'], new_message_id)
 
         with mock.patch('zerver.views.messages.get_first_visible_message_id', return_value=new_message_id + 1):
             messages_reponse = self.get_messages_response(
-                anchor=0, num_before=0, num_after=1, use_first_unread_anchor=True)
+                anchor="first_unread", num_before=0, num_after=1)
         self.assert_length(messages_reponse['messages'], 0)
         self.assertIn('anchor', messages_reponse)
 
         with mock.patch('zerver.views.messages.get_first_visible_message_id', return_value=new_message_id - 1):
             messages = self.get_messages(
-                anchor=0, num_before=0, num_after=1, use_first_unread_anchor=True)
+                anchor="first_unread", num_before=0, num_after=1)
         self.assert_length(messages, 1)
 
 class UnreadCountTests(ZulipTestCase):


### PR DESCRIPTION
This is a prototype implementation for the bundle of ideas we've been discussing in https://github.com/zulip/zulip-mobile/issues/3654, specifically `anchor: "first|last"` type arguments that can enable a cleaner API for clients requesting the latest messages.

Before this is mergable/usable, we'll want to:
* Extend the API docs for the "get messages" API to cover this new feature.
* At least open an issue for making the webapp use this feature.  It's probably a little messy because of how the webapp works with large numbers internally (which is helpful with integer comparisons), but is probably a good idea because of how folks may look at what the webapp sends over the wire when trying to understand our API
* Because this API change extends the behavior of an existing option, we should consider whether to add a mechanism that e.g. mobile clients can use to determine whether the server supports this feature without just trying it and getting an error.  It seems like we could do this in `register_ret` aka the /register response via a `server_capabilities` object that's potentially just a dictionary of options like `get_messages_anchor_supports_last: True` (A dictionary is probably helpful in case any non-boolean values become useful in future extensions).  This would be the analogue of the `client_capabilities` object we added some time ago.  Mobile clients can of course do conditionals based on Zulip server version, but this would be a bit more granular in handling both cherry-picked commits and pre-release versions correctly.
