### PR TITLE
Deduplicate `create_internal_realm` between populate_db and initialize_voyager_db 

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -106,6 +106,7 @@ not_yet_fully_covered = {path for target in [
     # Low priority for coverage
     'zerver/lib/ccache.py',
     'zerver/lib/generate_test_data.py',
+    'zerver/lib/server_initialization.py',
     'zerver/lib/test_fixtures.py',
     'zerver/lib/test_runner.py',
     'zerver/openapi/python_examples.py',

--- a/zerver/lib/server_initialization.py
+++ b/zerver/lib/server_initialization.py
@@ -1,0 +1,28 @@
+from django.conf import settings
+
+from zerver.lib.actions import do_change_is_admin
+from zerver.lib.bulk_create import bulk_create_users
+from zerver.models import Realm, UserProfile, email_to_username, get_system_bot
+
+from typing import Iterable, Optional, Set, Tuple
+
+def create_internal_realm() -> None:
+    internal_realm = Realm.objects.create(string_id=settings.SYSTEM_BOT_REALM)
+
+    internal_realm_bots = [(bot['name'], bot['email_template'] % (settings.INTERNAL_BOT_DOMAIN,))
+                           for bot in settings.INTERNAL_BOTS]
+    create_users(internal_realm, internal_realm_bots, bot_type=UserProfile.DEFAULT_BOT)
+
+    # Initialize the email gateway bot as an API Super User
+    email_gateway_bot = get_system_bot(settings.EMAIL_GATEWAY_BOT)
+    do_change_is_admin(email_gateway_bot, True, permission="api_super_user")
+
+def create_users(realm: Realm, name_list: Iterable[Tuple[str, str]],
+                 bot_type: Optional[int]=None,
+                 bot_owner: Optional[UserProfile]=None) -> None:
+    user_set = set()  # type: Set[Tuple[str, str, str, bool]]
+    for full_name, email in name_list:
+        short_name = email_to_username(email)
+        user_set.add((email, full_name, short_name, True))
+    tos_version = settings.TOS_VERSION if bot_type is None else None
+    bulk_create_users(realm, user_set, bot_type=bot_type, bot_owner=bot_owner, tos_version=tos_version)

--- a/zerver/lib/server_initialization.py
+++ b/zerver/lib/server_initialization.py
@@ -23,11 +23,11 @@ def create_internal_realm() -> None:
     do_change_is_admin(email_gateway_bot, True, permission="api_super_user")
 
 def create_users(realm: Realm, name_list: Iterable[Tuple[str, str]],
+                 tos_version: Optional[str]=None,
                  bot_type: Optional[int]=None,
                  bot_owner: Optional[UserProfile]=None) -> None:
     user_set = set()  # type: Set[Tuple[str, str, str, bool]]
     for full_name, email in name_list:
         short_name = email_to_username(email)
         user_set.add((email, full_name, short_name, True))
-    tos_version = settings.TOS_VERSION if bot_type is None else None
     bulk_create_users(realm, user_set, bot_type=bot_type, bot_owner=bot_owner, tos_version=tos_version)

--- a/zerver/lib/server_initialization.py
+++ b/zerver/lib/server_initialization.py
@@ -8,17 +8,17 @@ from zerver.models import Realm, UserProfile, email_to_username, get_client, \
 from typing import Iterable, Optional, Tuple
 
 def create_internal_realm() -> None:
-    internal_realm = Realm.objects.create(string_id=settings.SYSTEM_BOT_REALM)
+    realm = Realm.objects.create(string_id=settings.SYSTEM_BOT_REALM)
 
     # Create the "website" and "API" clients:
     get_client("website")
     get_client("API")
 
-    internal_realm_bots = [(bot['name'], bot['email_template'] % (settings.INTERNAL_BOT_DOMAIN,))
-                           for bot in settings.INTERNAL_BOTS]
-    create_users(internal_realm, internal_realm_bots, bot_type=UserProfile.DEFAULT_BOT)
+    internal_bots = [(bot['name'], bot['email_template'] % (settings.INTERNAL_BOT_DOMAIN,))
+                     for bot in settings.INTERNAL_BOTS]
+    create_users(realm, internal_bots, bot_type=UserProfile.DEFAULT_BOT)
     # Set the owners for these bots to the bots themselves
-    bots = UserProfile.objects.filter(email__in=[bot_info[1] for bot_info in internal_realm_bots])
+    bots = UserProfile.objects.filter(email__in=[bot_info[1] for bot_info in internal_bots])
     for bot in bots:
         bot.bot_owner = bot
         bot.save()

--- a/zerver/lib/server_initialization.py
+++ b/zerver/lib/server_initialization.py
@@ -2,12 +2,17 @@ from django.conf import settings
 
 from zerver.lib.actions import do_change_is_admin
 from zerver.lib.bulk_create import bulk_create_users
-from zerver.models import Realm, UserProfile, email_to_username, get_system_bot
+from zerver.models import Realm, UserProfile, email_to_username, get_client, \
+    get_system_bot
 
 from typing import Iterable, Optional, Set, Tuple
 
 def create_internal_realm() -> None:
     internal_realm = Realm.objects.create(string_id=settings.SYSTEM_BOT_REALM)
+
+    # Create the "website" and "API" clients:
+    get_client("website")
+    get_client("API")
 
     internal_realm_bots = [(bot['name'], bot['email_template'] % (settings.INTERNAL_BOT_DOMAIN,))
                            for bot in settings.INTERNAL_BOTS]

--- a/zerver/lib/server_initialization.py
+++ b/zerver/lib/server_initialization.py
@@ -5,7 +5,7 @@ from zerver.lib.bulk_create import bulk_create_users
 from zerver.models import Realm, UserProfile, email_to_username, get_client, \
     get_system_bot
 
-from typing import Iterable, Optional, Set, Tuple
+from typing import Iterable, Optional, Tuple
 
 def create_internal_realm() -> None:
     internal_realm = Realm.objects.create(string_id=settings.SYSTEM_BOT_REALM)
@@ -26,7 +26,7 @@ def create_users(realm: Realm, name_list: Iterable[Tuple[str, str]],
                  tos_version: Optional[str]=None,
                  bot_type: Optional[int]=None,
                  bot_owner: Optional[UserProfile]=None) -> None:
-    user_set = set()  # type: Set[Tuple[str, str, str, bool]]
+    user_set = set()
     for full_name, email in name_list:
         short_name = email_to_username(email)
         user_set.add((email, full_name, short_name, True))

--- a/zerver/lib/server_initialization.py
+++ b/zerver/lib/server_initialization.py
@@ -17,6 +17,11 @@ def create_internal_realm() -> None:
     internal_realm_bots = [(bot['name'], bot['email_template'] % (settings.INTERNAL_BOT_DOMAIN,))
                            for bot in settings.INTERNAL_BOTS]
     create_users(internal_realm, internal_realm_bots, bot_type=UserProfile.DEFAULT_BOT)
+    # Set the owners for these bots to the bots themselves
+    bots = UserProfile.objects.filter(email__in=[bot_info[1] for bot_info in internal_realm_bots])
+    for bot in bots:
+        bot.bot_owner = bot
+        bot.save()
 
     # Initialize the email gateway bot as an API Super User
     email_gateway_bot = get_system_bot(settings.EMAIL_GATEWAY_BOT)

--- a/zerver/management/commands/initialize_voyager_db.py
+++ b/zerver/management/commands/initialize_voyager_db.py
@@ -13,12 +13,13 @@ settings.TORNADO_SERVER = None
 
 def create_users(realm: Realm, name_list: Iterable[Tuple[str, str]],
                  tos_version: Optional[str]=None,
-                 bot_type: Optional[int]=None) -> None:
+                 bot_type: Optional[int]=None,
+                 bot_owner: Optional[UserProfile]=None) -> None:
     user_set = set()
     for full_name, email in name_list:
         short_name = email_to_username(email)
         user_set.add((email, full_name, short_name, True))
-    bulk_create_users(realm, user_set, bot_type=bot_type, tos_version=tos_version)
+    bulk_create_users(realm, user_set, bot_type=bot_type, bot_owner=bot_owner, tos_version=tos_version)
 
 class Command(BaseCommand):
     help = "Populate an initial database for Zulip Voyager"

--- a/zerver/management/commands/initialize_voyager_db.py
+++ b/zerver/management/commands/initialize_voyager_db.py
@@ -4,10 +4,8 @@ from typing import Any
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from zerver.lib.actions import do_change_is_admin
-from zerver.lib.server_initialization import create_users
-from zerver.models import Realm, UserProfile, get_client, \
-    get_system_bot
+from zerver.lib.server_initialization import create_internal_realm
+from zerver.models import Realm
 
 settings.TORNADO_SERVER = None
 
@@ -25,24 +23,7 @@ class Command(BaseCommand):
         if Realm.objects.count() > 0:
             print("Database already initialized; doing nothing.")
             return
-        realm = Realm.objects.create(string_id=settings.SYSTEM_BOT_REALM)
-
-        # Create the "website" and "API" clients:
-        get_client("website")
-        get_client("API")
-
-        internal_bots = [(bot['name'], bot['email_template'] % (settings.INTERNAL_BOT_DOMAIN,))
-                         for bot in settings.INTERNAL_BOTS]
-        create_users(realm, internal_bots, bot_type=UserProfile.DEFAULT_BOT)
-        # Set the owners for these bots to the bots themselves
-        bots = UserProfile.objects.filter(email__in=[bot_info[1] for bot_info in internal_bots])
-        for bot in bots:
-            bot.bot_owner = bot
-            bot.save()
-
-        # Initialize the email gateway bot as an API Super User
-        email_gateway_bot = get_system_bot(settings.EMAIL_GATEWAY_BOT)
-        do_change_is_admin(email_gateway_bot, True, permission="api_super_user")
+        create_internal_realm()
 
         self.stdout.write("Successfully populated database with initial data.\n")
         self.stdout.write("Please run ./manage.py generate_realm_creation_link "

--- a/zerver/management/commands/initialize_voyager_db.py
+++ b/zerver/management/commands/initialize_voyager_db.py
@@ -37,6 +37,7 @@ class Command(BaseCommand):
             return
         realm = Realm.objects.create(string_id=settings.SYSTEM_BOT_REALM)
 
+        # Create the "website" and "API" clients:
         get_client("website")
         get_client("API")
 

--- a/zerver/management/commands/initialize_voyager_db.py
+++ b/zerver/management/commands/initialize_voyager_db.py
@@ -11,12 +11,14 @@ from zerver.models import Realm, UserProfile, email_to_username, get_client, \
 
 settings.TORNADO_SERVER = None
 
-def create_users(realm: Realm, name_list: Iterable[Tuple[str, str]], bot_type: Optional[int]=None) -> None:
+def create_users(realm: Realm, name_list: Iterable[Tuple[str, str]],
+                 tos_version: Optional[str]=None,
+                 bot_type: Optional[int]=None) -> None:
     user_set = set()
     for full_name, email in name_list:
         short_name = email_to_username(email)
         user_set.add((email, full_name, short_name, True))
-    bulk_create_users(realm, user_set, bot_type)
+    bulk_create_users(realm, user_set, bot_type=bot_type, tos_version=tos_version)
 
 class Command(BaseCommand):
     help = "Populate an initial database for Zulip Voyager"

--- a/zerver/management/commands/initialize_voyager_db.py
+++ b/zerver/management/commands/initialize_voyager_db.py
@@ -1,25 +1,15 @@
 from argparse import ArgumentParser
-from typing import Any, Iterable, Optional, Tuple
+from typing import Any
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from zerver.lib.actions import do_change_is_admin
-from zerver.lib.bulk_create import bulk_create_users
-from zerver.models import Realm, UserProfile, email_to_username, get_client, \
+from zerver.lib.server_initialization import create_users
+from zerver.models import Realm, UserProfile, get_client, \
     get_system_bot
 
 settings.TORNADO_SERVER = None
-
-def create_users(realm: Realm, name_list: Iterable[Tuple[str, str]],
-                 tos_version: Optional[str]=None,
-                 bot_type: Optional[int]=None,
-                 bot_owner: Optional[UserProfile]=None) -> None:
-    user_set = set()
-    for full_name, email in name_list:
-        short_name = email_to_username(email)
-        user_set.add((email, full_name, short_name, True))
-    bulk_create_users(realm, user_set, bot_type=bot_type, bot_owner=bot_owner, tos_version=tos_version)
 
 class Command(BaseCommand):
     help = "Populate an initial database for Zulip Voyager"

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3183,7 +3183,7 @@ class SubscriptionAPITest(ZulipTestCase):
                 dict(principals=ujson.dumps([user1.email, user2.email])),
                 invite_only=True,
             )
-        self.assert_length(queries, 38)
+        self.assert_length(queries, 40)
 
         # Test creating a public stream with announce when realm has a notification stream.
         notifications_stream = get_stream(self.streams[0], self.test_realm)

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -502,12 +502,6 @@ class Command(BaseCommand):
             generate_and_send_messages(job)
 
         if options["delete"]:
-            # Create the "website" and "API" clients; if we don't, the
-            # default values in zerver/decorators.py will not work
-            # with the Django test suite.
-            get_client("website")
-            get_client("API")
-
             if options["test_suite"]:
                 # Create test users; the MIT ones are needed to test
                 # the Zephyr mirroring codepaths.

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -262,7 +262,7 @@ class Command(BaseCommand):
                 email = fname.lower() + '@zulip.com'
                 names.append((full_name, email))
 
-            create_users(zulip_realm, names)
+            create_users(zulip_realm, names, tos_version=settings.TOS_VERSION)
 
             iago = get_user("iago@zulip.com", zulip_realm)
             do_change_is_admin(iago, True)
@@ -510,13 +510,13 @@ class Command(BaseCommand):
                     ("Athena Consulting Exchange User (MIT)", "starnine@mit.edu"),
                     ("Esp Classroom (MIT)", "espuser@mit.edu"),
                 ]
-                create_users(mit_realm, testsuite_mit_users)
+                create_users(mit_realm, testsuite_mit_users, tos_version=settings.TOS_VERSION)
 
                 testsuite_lear_users = [
                     ("King Lear", "king@lear.org"),
                     ("Cordelia Lear", "cordelia@zulip.com"),
                 ]
-                create_users(lear_realm, testsuite_lear_users)
+                create_users(lear_realm, testsuite_lear_users, tos_version=settings.TOS_VERSION)
 
             if not options["test_suite"]:
                 # To keep the messages.json fixtures file for the test


### PR DESCRIPTION
Fixes #13736.
Perhaps this has way too many commits, but in these very tiny steps it seems easier to verify correctness.

Notes:
First commit excludes the new ``server_initialization.py`` from coverage - it's implicitly tested as before - by being used in populate_db.
``server_initialization: Set internal bots owners to themselves.`` should be the only behavior change - everything else should be just shuffling code around until things are identical to the letter with initialize_voyager_db.

What remains is the followup:
> Once we've done this, I'd like to add a function in zerver/lib/server_initialization.py for checking if the server has been initialized (it can use the existing Realm check); we'll use this in initialize_voyager_db and then will be able to take advantage of it for checking whether docker-zulip needs to run initialization code.

But this should be trivial to do, once we have these current changes as intended.