### PR TITLE
hotkey: Optimize processing_text.

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -160,20 +160,15 @@ exports.get_keypress_hotkey = function (e) {
     return keypress_mappings[e.which];
 };
 
-exports.processing_text = (function () {
-    const selector = [
-        'input:focus',
-        'select:focus',
-        'textarea:focus',
-        '#compose-send-button:focus',
-        '.editable-section:focus',
-        '.pill-container div:focus',
-    ].join(",");
-
-    return function () {
-        return $(selector).length > 0;
-    };
-}());
+exports.processing_text = function () {
+    const $focused_elt = $(":focus");
+    return $focused_elt.is("input") ||
+        $focused_elt.is("select") ||
+        $focused_elt.is("textarea") ||
+        $focused_elt.hasClass("editable-section") ||
+        $focused_elt.hasClass("pill-container") ||
+        $focused_elt.attr("id") === "compose-send-button";
+};
 
 exports.is_editing_stream_name = function (e) {
     return $(e.target).is(".editable-section");


### PR DESCRIPTION
Profiles of typing in the Zulip webapp's compose box after opening the
stream creation widget showed that hotkey.processing_text was a
significant expense.  There's no good reason for this -- the function
just needs to inspect the focused element; it just was written with a
sloppy selector.

While there's a secondary issue that, there's no good reason for this
extremely latency-sensitive code path (typing an additional character)
to be doing something extremely inefficient.
