### PR TITLE
docs: Update swagger example to suit V3.0.1.

### DIFF
--- a/docs/documentation/openapi.md
+++ b/docs/documentation/openapi.md
@@ -38,13 +38,13 @@ information in this section rarely changes.
 For example, the `swagger` and `info` objects look like this:
 ```
 # Basic Swagger UI info
-swagger: '2.0'
+openapi: 3.0.1
 info:
-  version: '1.0.0'
+  version: 1.0.0
   title: Zulip REST API
-  description: Powerful open source group chat
+  description: Powerful open source group chat.
   contact:
-    url: https://zulip.org/
+    url: https://zulipchat.com
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html


### PR DESCRIPTION
Initially, the example of the `swagger` and `info` objects displayed in the documentation was based off from `OpenAPI 2.0`.
This update shows the current view on `version 3.0` currently used in the `zulip.yaml` file