### PR TITLE
Navless versions of /terms and /privacy

### DIFF
--- a/templates/zerver/landing_nav.html
+++ b/templates/zerver/landing_nav.html
@@ -1,3 +1,4 @@
+{% if not isolated_page %}
 <nav class="portico-header">
     <div class="content">
         <a class="brand logo" href="{{ root_domain_uri }}">
@@ -59,3 +60,4 @@
     </div>
     <svg height="32px" class="hamburger" style="enable-background:new 0 0 32 32;" version="1.1" viewBox="0 0 32 32" width="32px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M4,10h24c1.104,0,2-0.896,2-2s-0.896-2-2-2H4C2.896,6,2,6.896,2,8S2.896,10,4,10z M28,14H4c-1.104,0-2,0.896-2,2  s0.896,2,2,2h24c1.104,0,2-0.896,2-2S29.104,14,28,14z M28,22H4c-1.104,0-2,0.896-2,2s0.896,2,2,2h24c1.104,0,2-0.896,2-2  S29.104,22,28,22z"/></svg>
 </nav>
+{% endif %}

--- a/templates/zerver/portico.html
+++ b/templates/zerver/portico.html
@@ -10,7 +10,9 @@
 {% block content %}
 <div class="portico-container" data-platform="{{ platform }}">
     <div class="portico-wrap">
+        {% if not isolated_page %}
         {% include 'zerver/portico-header.html' %}
+        {% endif %}
         <div class="app portico-page {% block portico_class_name %}{% endblock %}">
             <div class="app-main portico-page-container{% block hello_page_container %}{% endblock %}">
                 {% block portico_content %}
@@ -18,6 +20,8 @@
             </div>
         </div>
     </div>
+    {% if not isolated_page %}
     {% include 'zerver/footer.html' %}
+    {% endif %}
 </div>
 {% endblock %}

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -299,6 +299,18 @@ def home_real(request: HttpRequest) -> HttpResponse:
 def desktop_home(request: HttpRequest) -> HttpResponse:
     return HttpResponseRedirect(reverse('zerver.views.home.home'))
 
+def get_isolated_page(request: HttpRequest) -> bool:
+    '''Accept a GET param `?nav=no` to render an isolated, navless page.'''
+    return request.GET.get('nav') == 'no'
+
+def terms_view(request: HttpRequest) -> HttpResponse:
+    return render(request, 'zerver/terms.html',
+                  context={'isolated_page': get_isolated_page(request)})
+
+def privacy_view(request: HttpRequest) -> HttpResponse:
+    return render(request, 'zerver/privacy.html',
+                  context={'isolated_page': get_isolated_page(request)})
+
 def apps_view(request: HttpRequest, _: str) -> HttpResponse:
     if settings.ZILENCER_ENABLED:
         return render(request, 'zerver/apps.html')

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -562,8 +562,8 @@ i18n_urls = [
     url(r'^atlassian/$', TemplateView.as_view(template_name='zerver/atlassian.html')),
 
     # Terms of Service and privacy pages.
-    url(r'^terms/$', TemplateView.as_view(template_name='zerver/terms.html'), name='terms'),
-    url(r'^privacy/$', TemplateView.as_view(template_name='zerver/privacy.html'), name='privacy'),
+    url(r'^terms/$', zerver.views.home.terms_view, name='terms'),
+    url(r'^privacy/$', zerver.views.home.privacy_view, name='privacy'),
 
     url(r'^config-error/google$', TemplateView.as_view(
         template_name='zerver/config_error.html',),


### PR DESCRIPTION
We'll use these in the mobile app, for the "Settings > Legal > Terms of service" and "Settings > Legal > Privacy policy" screens.

**Testing Plan:** <!-- How have you tested? -->

Dev server. No change at plain `/terms/` or `/privacy/`; with `?nav=no`, everything's the same except the nav vanishes.

