### PR TITLE
email_mirror: Parse encoded From headers with show_sender=True.

### DIFF
--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -150,7 +150,7 @@ def construct_zulip_body(message: message.Message, realm: Realm, show_sender: bo
         body = '(No email body)'
 
     if show_sender:
-        sender = message.get("From")
+        sender = str(make_header(decode_header(message.get("From"))))
         body = "From: %s\n%s" % (sender, body)
 
     return body

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -345,6 +345,31 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
         self.assertEqual(get_display_recipient(message.recipient), stream.name)
         self.assertEqual(message.topic_name(), incoming_valid_message['Subject'])
 
+    def test_receive_stream_email_show_sender_utf8_encoded_sender(self) -> None:
+        user_profile = self.example_user('hamlet')
+        self.login(user_profile.email)
+        self.subscribe(user_profile, "Denmark")
+        stream = get_stream("Denmark", user_profile.realm)
+
+        stream_to_address = encode_email_address(stream)
+        parts = stream_to_address.split('@')
+        parts[0] += "+show-sender"
+        stream_to_address = '@'.join(parts)
+
+        incoming_valid_message = MIMEText('TestStreamEmailMessages Body')
+        incoming_valid_message['Subject'] = 'TestStreamEmailMessages Subject'
+        incoming_valid_message['From'] = '=?utf-8?b?VGVzdCBVc2Vyw7PEhcSZIDxoYW1sZXRfxJlAenVsaXAuY29tPg==?='
+        incoming_valid_message['To'] = stream_to_address
+        incoming_valid_message['Reply-to'] = self.example_email('othello')
+
+        process_message(incoming_valid_message)
+        message = most_recent_message(user_profile)
+
+        self.assertEqual(message.content, "From: %s\n%s" % ('Test Useróąę <hamlet_ę@zulip.com>',
+                                                            "TestStreamEmailMessages Body"))
+        self.assertEqual(get_display_recipient(message.recipient), stream.name)
+        self.assertEqual(message.topic_name(), incoming_valid_message['Subject'])
+
     def test_receive_stream_email_include_footer_success(self) -> None:
         user_profile = self.example_user('hamlet')
         self.login(user_profile.email)


### PR DESCRIPTION
Fixes an issue reported by user, where we didn't decode the From header when posting it to zulip with the ``show_sender=True`` option.