### PR TITLE
Fix pill-container piece of recent hotkey fix.

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -166,7 +166,7 @@ exports.processing_text = function () {
         $focused_elt.is("select") ||
         $focused_elt.is("textarea") ||
         $focused_elt.hasClass("editable-section") ||
-        $focused_elt.hasClass("pill-container") ||
+        $focused_elt.parents(".pill-container").length >= 1 ||
         $focused_elt.attr("id") === "compose-send-button";
 };
 


### PR DESCRIPTION
This fix recently went on master, although it
hasn't actually been deployed yet (not even to czo),
so user impact should be zero:

0fa67c84d85a0e9505d20e80052678b960a714eb

The fix mostly improved things, but it broke the
logic for pill containers.  The symptom was that
if you tried to autocomplete "Cordelia" in the
pill box we'd instead invoke the "c" hotkey and
try to compose to a stream.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
