### PR TITLE
login: Make authentication_methods data available to JavaScript.

### DIFF
--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -178,6 +178,12 @@ def login_context(request: HttpRequest) -> Dict[str, Any]:
     context['external_authentication_methods'] = get_external_method_dicts(realm)
     context['no_auth_enabled'] = no_auth_enabled
 
+    # Include external_authentication_methods in page_params for use
+    # by the desktop client.
+    context['page_params'] = dict(
+        external_authentication_methods = context['external_authentication_methods']
+    )
+
     return context
 
 def latest_info_context() -> Dict[str, str]:


### PR DESCRIPTION
This is intended to simplify overriding these buttons' controls in the
desktop app to do the authentication in the user's default browser.

Needs testing, both that this suffices for the desktop use case (One thing that might be a good idea is to extend the dictionary with an ID to be used for the button) and of course server tests.