### PR TITLE
test_classes: Fix bug where UserProfile could be passed to client_post.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -859,7 +859,8 @@ class WebhookTestCase(ZulipTestCase):
         headers = get_fixture_http_headers(self.FIXTURE_DIR_NAME, fixture_name)
         headers = standardize_headers(headers)
         kwargs.update(headers)
-        sender = kwargs.get('sender', self.test_user)
+        # The sender profile shouldn't be passed any further in kwargs, so we pop it.
+        sender = kwargs.pop('sender', self.test_user)
         msg = self.send_json_payload(sender, self.url, payload,
                                      stream_name=None, **kwargs)
         self.do_test_message(msg, expected_message)

--- a/zerver/webhooks/helloworld/tests.py
+++ b/zerver/webhooks/helloworld/tests.py
@@ -38,7 +38,7 @@ class HelloWorldHookTests(WebhookTestCase):
                                            content_type="application/x-www-form-urlencoded")
 
     def test_stream_error_pm_to_bot_owner(self) -> None:
-        # Note taht this is really just a test for check_send_webhook_message
+        # Note that this is really just a test for check_send_webhook_message
         self.STREAM_NAME = 'nonexistent'
         self.url = self.build_webhook_url()
         notification_bot = get_system_bot(settings.NOTIFICATION_BOT)


### PR DESCRIPTION
In this test:
```
    def test_stream_error_pm_to_bot_owner(self) -> None:
        # Note taht this is really just a test for check_send_webhook_message
        self.STREAM_NAME = 'nonexistent'
        self.url = self.build_webhook_url()
        notification_bot = get_system_bot(settings.NOTIFICATION_BOT)
        expected_message = "Your bot `webhook-bot@zulip.com` tried to send a message to stream #**nonexistent**, but that stream does not exist. Click [here](#streams/new) to create it."
        self.send_and_test_private_message('goodbye', expected_message=expected_message,
                                           content_type='application/x-www-form-urlencoded',
                                           sender=notification_bot)
```

the sender kwarg would get passed all the way into client_post.

https://chat.zulip.org/#narrow/stream/49-development-help/topic/JSON.20overflow.20error/near/813398