### PR TITLE
integrations: Add links and topics to Taiga webhook message.

### DIFF
--- a/zerver/webhooks/taiga/fixtures/issue_changed_blocked.json
+++ b/zerver/webhooks/taiga/fixtures/issue_changed_blocked.json
@@ -1,0 +1,120 @@
+{
+    "action": "change",
+    "type": "issue",
+    "by": {
+        "id": 404067,
+        "permalink": "https://tree.taiga.io/profile/orientor",
+        "username": "orientor",
+        "full_name": "Aditya Verma",
+        "photo": null,
+        "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+    },
+    "date": "2020-02-07T18:51:40.986Z",
+    "data": {
+        "custom_attributes_values": {},
+        "id": 1311625,
+        "ref": 49,
+        "created_date": "2020-02-06T17:00:01.089Z",
+        "modified_date": "2020-02-07T18:51:40.744Z",
+        "finished_date": null,
+        "due_date": "2020-03-08",
+        "due_date_reason": "",
+        "subject": "Issues",
+        "external_reference": null,
+        "watchers": [],
+        "description": "Issue",
+        "tags": [],
+        "permalink": "https://tree.taiga.io/project/orientor-sd/issue/49",
+        "project": {
+            "id": 351023,
+            "permalink": "https://tree.taiga.io/project/orientor-sd",
+            "name": "sd",
+            "logo_big_url": null
+        },
+        "milestone": {
+            "id": 254091,
+            "name": "eres",
+            "slug": "eres",
+            "estimated_start": "2020-01-30",
+            "estimated_finish": "2020-02-13",
+            "created_date": "2020-01-29T22:33:36.885Z",
+            "modified_date": "2020-01-29T22:33:36.908Z",
+            "closed": false ,
+            "dispoFnibility": 0.0,
+            "permalink": "https://tree.taiga.io/project/orientor-sd/taskboard/eres",
+            "project": {
+                "id": 351023,
+                "permalink": "https://tree.taiga.io/project/orientor-sd",
+                "name": "sd",
+                "logo_big_url": null
+            },
+            "owner": {
+                "id": 404067,
+                "permalink": "https://tree.taiga.io/profile/orientor",
+                "username": "orientor",
+                "full_name": "Aditya Verma",
+                "photo": null,
+                "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+            }
+        },
+        "owner": {
+            "id": 404067,
+            "permalink": "https://tree.taiga.io/profile/orientor",
+            "username": "orientor",
+            "full_name": "Aditya Verma",
+            "photo": null,
+            "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+        },
+        "assigned_to": {
+            "id": 404067,
+            "permalink": "https://tree.taiga.io/profile/orientor",
+            "username": "orientor",
+            "full_name": "Aditya Verma",
+            "photo": null,
+            "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+        },
+        "status": {
+            "id": 2460905,
+            "name": "New",
+            "slug": "new",
+            "color": "#8C2318",
+            "is_closed": false
+        },
+        "type": {
+            "id": 1060464,
+            "name": "Question",
+            "color": "#ba89a8"
+        },
+        "priority": {
+            "id": 1055659,
+            "name": "High",
+            "color": "#CC0000"
+        },
+        "severity": {
+            "id": 1753852,
+            "name": "Minor",
+            "color": "#669933"
+        }
+    },
+    "change": {
+        "comment": "",
+        "comment_html": "",
+        "delete_comment_date": null,
+        "comment_versions": null,
+        "edit_comment_date": null,
+        "diff": {
+            "is_blocked": {
+                "from": false,
+                "to": true
+            },
+            "blocked_note_diff": {
+                "from": null,
+                "to": "asd"
+            },
+            "blocked_note_html": {
+                "from": "",
+                "to": "<p>asd</p>"
+            }
+        }
+    }
+}

--- a/zerver/webhooks/taiga/fixtures/issue_changed_due_date.json
+++ b/zerver/webhooks/taiga/fixtures/issue_changed_due_date.json
@@ -1,0 +1,112 @@
+{
+    "action": "change",
+    "type": "issue",
+    "by": {
+        "id": 404067,
+        "permalink": "https://tree.taiga.io/profile/orientor",
+        "username": "orientor",
+        "full_name": "Aditya Verma",
+        "photo": null,
+        "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+    },
+    "date": "2020-02-07T18:51:54.846Z",
+    "data": {
+        "custom_attributes_values": {},
+        "id": 1311625,
+        "ref": 49,
+        "created_date": "2020-02-06T17:00:01.089Z",
+        "modified_date": "2020-02-07T18:51:54.729Z",
+        "finished_date": null,
+        "due_date": "2020-02-22",
+        "due_date_reason": "",
+        "subject": "Issues",
+        "external_reference": null,
+        "watchers": [],
+        "description": "Issue",
+        "tags": [],
+        "permalink": "https://tree.taiga.io/project/orientor-sd/issue/49",
+        "project": {
+            "id": 351023,
+            "permalink": "https://tree.taiga.io/project/orientor-sd",
+            "name": "sd",
+            "logo_big_url": null
+        },
+        "milestone": {
+            "id": 254091,
+            "name": "eres",
+            "slug": "eres",
+            "estimated_start": "2020-01-30",
+            "estimated_finish": "2020-02-13",
+            "created_date": "2020-01-29T22:33:36.885Z",
+            "modified_date": "2020-01-29T22:33:36.908Z",
+            "closed": false,
+            "disponibility": 0.0,
+            "permalink": "https://tree.taiga.io/project/orientor-sd/taskboard/eres",
+            "project": {
+                "id": 351023,
+                "permalink": "https://tree.taiga.io/project/orientor-sd",
+                "name": "sd",
+                "logo_big_url": null
+            },
+            "owner": {
+                "id": 404067,
+                "permalink": "https://tree.taiga.io/profile/orientor",
+                "username": "orientor",
+                "full_name": "Aditya Verma",
+                "photo": null,
+                "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+            }
+        },
+        "owner": {
+            "id": 404067,
+            "permalink": "https://tree.taiga.io/profile/orientor",
+            "username": "orientor",
+            "full_name": "Aditya Verma",
+            "photo": null,
+            "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+        },
+        "assigned_to": {
+            "id": 404067,
+            "permalink": "https://tree.taiga.io/profile/orientor",
+            "username": "orientor",
+            "full_name": "Aditya Verma",
+            "photo": null,
+            "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+        },
+        "status": {
+            "id": 2460905,
+            "name": "New",
+            "slug": "new",
+            "color": "#8C2318",
+            "is_closed": false
+        },
+        "type": {
+            "id": 1060464,
+            "name": "Question",
+            "color": "#ba89a8"
+        },
+        "priority": {
+            "id": 1055659,
+            "name": "High",
+            "color": "#CC0000"
+        },
+        "severity": {
+            "id": 1753852,
+            "name": "Minor",
+            "color": "#669933"
+        }
+    },
+    "change": {
+        "comment": "",
+        "comment_html": "",
+        "delete_comment_date": null,
+        "comment_versions": null,
+        "edit_comment_date": null,
+        "diff": {
+            "due_date": {
+                "from": "2020-03-08",
+                "to": "2020-02-22"
+            }
+        }
+    }
+}

--- a/zerver/webhooks/taiga/fixtures/issue_changed_new_due_date.json
+++ b/zerver/webhooks/taiga/fixtures/issue_changed_new_due_date.json
@@ -1,0 +1,80 @@
+{
+    "action": "change",
+    "type": "issue",
+    "by": {
+        "id": 404067,
+        "permalink": "https://tree.taiga.io/profile/orientor",
+        "username": "orientor",
+        "full_name": "Aditya Verma",
+        "photo": null,
+        "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+    },
+    "date": "2020-02-07T19:28:03.115Z",
+    "data": {
+        "custom_attributes_values": {},
+        "id": 1312074,
+        "ref": 53,
+        "created_date": "2020-02-07T19:12:17.220Z",
+        "modified_date": "2020-02-07T19:28:02.990Z",
+        "finished_date": null,
+        "due_date": "2020-02-22",
+        "due_date_reason": "asd",
+        "subject": "Nice Issue",
+        "external_reference": null,
+        "watchers": [],
+        "description": "asdasd",
+        "tags": [],
+        "permalink": "https://tree.taiga.io/project/orientor-sd/issue/53",
+        "project": {
+            "id": 351023,
+            "permalink": "https://tree.taiga.io/project/orientor-sd",
+            "name": "sd",
+            "logo_big_url": null
+        },
+        "milestone": null,
+        "owner": {
+            "id": 404067,
+            "permalink": "https://tree.taiga.io/profile/orientor",
+            "username": "orientor",
+            "full_name": "Aditya Verma",
+            "photo": null,
+            "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+        },
+        "assigned_to": null,
+        "status": {
+            "id": 2460905,
+            "name": "New",
+            "slug": "new",
+            "color": "#8C2318",
+            "is_closed": false
+        },
+        "type": {
+            "id": 1060463,
+            "name": "Bug",
+            "color": "#89BAB4"
+        },
+        "priority": {
+            "id": 1055658,
+            "name": "Normal",
+            "color": "#669933"
+        },
+        "severity": {
+            "id": 1753853,
+            "name": "Normal",
+            "color": "#0000FF"
+        }
+    },
+    "change": {
+        "comment": "",
+        "comment_html": "",
+        "delete_comment_date": null,
+        "comment_versions": null,
+        "edit_comment_date": null,
+        "diff": {
+            "due_date": {
+                "from": null,
+                "to": "2020-02-22"
+            }
+        }
+    }
+}

--- a/zerver/webhooks/taiga/fixtures/issue_changed_new_sprint.json
+++ b/zerver/webhooks/taiga/fixtures/issue_changed_new_sprint.json
@@ -1,0 +1,105 @@
+{
+    "action": "change",
+    "type": "issue",
+    "by": {
+        "id": 404067,
+        "permalink": "https://tree.taiga.io/profile/orientor",
+        "username": "orientor",
+        "full_name": "Aditya Verma",
+        "photo": null,
+        "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+    },
+    "date": "2020-02-07T19:12:28.768Z",
+    "data": {
+        "custom_attributes_values": {},
+        "id": 1312074,
+        "ref": 53,
+        "created_date": "2020-02-07T19:12:17.220Z",
+        "modified_date": "2020-02-07T19:12:28.627Z",
+        "finished_date": null,
+        "due_date": null,
+        "due_date_reason": "",
+        "subject": "Nice Issue",
+        "external_reference": null,
+        "watchers": [],
+        "description": "asdasd",
+        "tags": [],
+        "permalink": "https://tree.taiga.io/project/orientor-sd/issue/53",
+        "project": {
+            "id": 351023,
+            "permalink": "https://tree.taiga.io/project/orientor-sd",
+            "name": "sd",
+            "logo_big_url": null
+        },
+        "milestone": {
+            "id": 254091,
+            "name": "eres",
+            "slug": "eres",
+            "estimated_start": "2020-01-30",
+            "estimated_finish": "2020-02-13",
+            "created_date": "2020-01-29T22:33:36.885Z",
+            "modified_date": "2020-01-29T22:33:36.908Z",
+            "closed": false,
+            "disponibility": 0.0,
+            "permalink": "https://tree.taiga.io/project/orientor-sd/taskboard/eres",
+            "project": {
+                "id": 351023,
+                "permalink": "https://tree.taiga.io/project/orientor-sd",
+                "name": "sd",
+                "logo_big_url": null
+            },
+            "owner": {
+                "id": 404067,
+                "permalink": "https://tree.taiga.io/profile/orientor",
+                "username": "orientor",
+                "full_name": "Aditya Verma",
+                "photo": null,
+                "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+            }
+        },
+        "owner": {
+            "id": 404067,
+            "permalink": "https://tree.taiga.io/profile/orientor",
+            "username": "orientor",
+            "full_name": "Aditya Verma",
+            "photo": null,
+            "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+        },
+        "assigned_to": null,
+        "status": {
+            "id": 2460905,
+            "name": "New",
+            "slug": "new",
+            "color": "#8C2318",
+            "is_closed": false
+        },
+        "type": {
+            "id": 1060463,
+            "name": "Bug",
+            "color": "#89BAB4"
+        },
+        "priority": {
+            "id": 1055658,
+            "name": "Normal",
+            "color": "#669933"
+        },
+        "severity": {
+            "id": 1753853,
+            "name": "Normal",
+            "color": "#0000FF"
+        }
+    },
+    "change": {
+        "comment": "",
+        "comment_html": "",
+        "delete_comment_date": null,
+        "comment_versions": null,
+        "edit_comment_date": null,
+        "diff": {
+            "milestone": {
+                "from": null,
+                "to": "eres"
+            }
+        }
+    }
+}

--- a/zerver/webhooks/taiga/fixtures/issue_changed_remove_sprint.json
+++ b/zerver/webhooks/taiga/fixtures/issue_changed_remove_sprint.json
@@ -1,0 +1,80 @@
+{
+    "action": "change",
+    "type": "issue",
+    "by": {
+        "id": 404067,
+        "permalink": "https://tree.taiga.io/profile/orientor",
+        "username": "orientor",
+        "full_name": "Aditya Verma",
+        "photo": null,
+        "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+    },
+    "date": "2020-02-07T19:22:46.455Z",
+    "data": {
+        "custom_attributes_values": {},
+        "id": 1312074,
+        "ref": 53,
+        "created_date": "2020-02-07T19:12:17.220Z",
+        "modified_date": "2020-02-07T19:22:46.298Z",
+        "finished_date": null,
+        "due_date": null,
+        "due_date_reason": "",
+        "subject": "Nice Issue",
+        "external_reference": null,
+        "watchers": [],
+        "description": "asdasd",
+        "tags": [],
+        "permalink": "https://tree.taiga.io/project/orientor-sd/issue/53",
+        "project": {
+            "id": 351023,
+            "permalink": "https://tree.taiga.io/project/orientor-sd",
+            "name": "sd",
+            "logo_big_url": null
+        },
+        "milestone": null,
+        "owner": {
+            "id": 404067,
+            "permalink": "https://tree.taiga.io/profile/orientor",
+            "username": "orientor",
+            "full_name": "Aditya Verma",
+            "photo": null,
+            "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+        },
+        "assigned_to": null,
+        "status": {
+            "id": 2460905,
+            "name": "New",
+            "slug": "new",
+            "color": "#8C2318",
+            "is_closed": false
+        },
+        "type": {
+            "id": 1060463,
+            "name": "Bug",
+            "color": "#89BAB4"
+        },
+        "priority": {
+            "id": 1055658,
+            "name": "Normal",
+            "color": "#669933"
+        },
+        "severity": {
+            "id": 1753853,
+            "name": "Normal",
+            "color": "#0000FF"
+        }
+    },
+    "change": {
+        "comment": "",
+        "comment_html": "",
+        "delete_comment_date": null,
+        "comment_versions": null,
+        "edit_comment_date": null,
+        "diff": {
+            "milestone": {
+                "from": "eres",
+                "to": null
+            }
+        }
+    }
+}

--- a/zerver/webhooks/taiga/fixtures/issue_changed_unblocked.json
+++ b/zerver/webhooks/taiga/fixtures/issue_changed_unblocked.json
@@ -1,0 +1,120 @@
+{
+    "action": "change",
+    "type": "issue",
+    "by": {
+        "id": 404067,
+        "permalink": "https://tree.taiga.io/profile/orientor",
+        "username": "orientor",
+        "full_name": "Aditya Verma",
+        "photo": null,
+        "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+    },
+    "date": "2020-02-07T18:51:46.082Z",
+    "data": {
+        "custom_attributes_values": {},
+        "id": 1311625,
+        "ref": 49,
+        "created_date": "2020-02-06T17:00:01.089Z",
+        "modified_date": "2020-02-07T18:51:45.973Z",
+        "finished_date": null,
+        "due_date": "2020-03-08",
+        "due_date_reason": "",
+        "subject": "Issues",
+        "external_reference": null,
+        "watchers": [],
+        "description": "Issue",
+        "tags": [],
+        "permalink": "https://tree.taiga.io/project/orientor-sd/issue/49",
+        "project": {
+            "id": 351023,
+            "permalink": "https://tree.taiga.io/project/orientor-sd",
+            "name": "sd",
+            "logo_big_url": null
+        },
+        "milestone": {
+            "id": 254091,
+            "name": "eres",
+            "slug": "eres",
+            "estimated_start": "2020-01-30",
+            "estimated_finish": "2020-02-13",
+            "created_date": "2020-01-29T22:33:36.885Z",
+            "modified_date": "2020-01-29T22:33:36.908Z",
+            "closed": false,
+            "disponibility": 0.0,
+            "permalink": "https://tree.taiga.io/project/orientor-sd/taskboard/eres",
+            "project": {
+                "id": 351023,
+                "permalink": "https://tree.taiga.io/project/orientor-sd",
+                "name": "sd",
+                "logo_big_url": null
+            },
+            "owner": {
+                "id": 404067,
+                "permalink": "https://tree.taiga.io/profile/orientor",
+                "username": "orientor",
+                "full_name": "Aditya Verma",
+                "photo": null,
+                "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+            }
+        },
+        "owner": {
+            "id": 404067,
+            "permalink": "https://tree.taiga.io/profile/orientor",
+            "username": "orientor",
+            "full_name": "Aditya Verma",
+            "photo": null,
+            "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+        },
+        "assigned_to": {
+            "id": 404067,
+            "permalink": "https://tree.taiga.io/profile/orientor",
+            "username": "orientor",
+            "full_name": "Aditya Verma",
+            "photo": null,
+            "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+        },
+        "status": {
+            "id": 2460905,
+            "name": "New",
+            "slug": "new",
+            "color": "#8C2318",
+            "is_closed": false
+        },
+        "type": {
+            "id": 1060464,
+            "name": "Question",
+            "color": "#ba89a8"
+        },
+        "priority": {
+            "id": 1055659,
+            "name": "High",
+            "color": "#CC0000"
+        },
+        "severity": {
+            "id": 1753852,
+            "name": "Minor",
+            "color": "#669933"
+        }
+    },
+    "change": {
+        "comment": "",
+        "comment_html": "",
+        "delete_comment_date": null,
+        "comment_versions": null,
+        "edit_comment_date": null,
+        "diff": {
+            "is_blocked": {
+                "from": true,
+                "to": false
+            },
+            "blocked_note_diff": {
+                "from": null,
+                "to": "<del >asd</del>"
+            },
+            "blocked_note_html": {
+                "from": "<p>asd</p>",
+                "to": ""
+            }
+        }
+    }
+}

--- a/zerver/webhooks/taiga/fixtures/issue_created_link.json
+++ b/zerver/webhooks/taiga/fixtures/issue_created_link.json
@@ -1,0 +1,67 @@
+{
+    "action": "create",
+    "type": "issue",
+    "by": {
+        "id": 404067,
+        "permalink": "https://tree.taiga.io/profile/orientor",
+        "username": "orientor",
+        "full_name": "Aditya Verma",
+        "photo": null,
+        "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+    },
+    "date": "2020-02-06T17:00:01.314Z",
+    "data": {
+        "custom_attributes_values": {},
+        "id": 1311625,
+        "ref": 49,
+        "created_date": "2020-02-06T17:00:01.089Z",
+        "modified_date": "2020-02-06T17:00:01.123Z",
+        "finished_date": null,
+        "due_date": null,
+        "due_date_reason": "",
+        "subject": "Issues",
+        "external_reference": null,
+        "watchers": [],
+        "description": "Issue",
+        "tags": [],
+        "permalink": "https://tree.taiga.io/project/orientor-sd/issue/49",
+        "project": {
+            "id": 351023,
+            "permalink": "https://tree.taiga.io/project/orientor-sd",
+            "name": "sd",
+            "logo_big_url": null
+        },
+        "milestone": null,
+        "owner": {
+            "id": 404067,
+            "permalink": "https://tree.taiga.io/profile/orientor",
+            "username": "orientor",
+            "full_name": "Aditya Verma",
+            "photo": null,
+            "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+        },
+        "assigned_to": null,
+        "status": {
+            "id": 2460905,
+            "name": "New",
+            "slug": "new",
+            "color": "#8C2318",
+            "is_closed": false
+        },
+        "type": {
+            "id": 1060463,
+            "name": "Bug",
+            "color": "#89BAB4"
+        },
+        "priority": {
+            "id": 1055658,
+            "name": "Normal",
+            "color": "#669933"
+        },
+        "severity": {
+            "id": 1753853,
+            "name": "Normal",
+            "color": "#0000FF"
+        }
+    }
+}

--- a/zerver/webhooks/taiga/fixtures/relateduserstory_created_link.json
+++ b/zerver/webhooks/taiga/fixtures/relateduserstory_created_link.json
@@ -1,0 +1,121 @@
+{
+    "action": "create",
+    "type": "relateduserstory",
+    "by": {
+        "id": 404067,
+        "permalink": "https://tree.taiga.io/profile/orientor",
+        "username": "orientor",
+        "full_name": "Aditya Verma",
+        "photo": null,
+        "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+    },
+    "date": "2020-02-07T20:07:37.791Z",
+    "data": {
+        "id": 513543,
+        "user_story": {
+            "custom_attributes_values": {},
+            "id": 3133511,
+            "ref": 54,
+            "project": {
+                "id": 351023,
+                "permalink": "https://tree.taiga.io/project/orientor-sd",
+                "name": "sd",
+                "logo_big_url": null
+            },
+            "is_closed": false,
+            "created_date": "2020-02-07T19:33:07.473Z",
+            "modified_date": "2020-02-07T19:49:10.782Z",
+            "finish_date": null,
+            "due_date": null,
+            "due_date_reason": "",
+            "subject": "Nice Issue",
+            "client_requirement": false,
+            "team_requirement": false,
+            "generated_from_issue": 1312074,
+            "generated_from_task": null,
+            "external_reference": null,
+            "tribe_gig": null,
+            "watchers": [404067],
+            "is_blocked": false,
+            "blocked_note": "",
+            "description": "asdasd",
+            "tags": ["xo", "dsa"],
+            "permalink": "https://tree.taiga.io/project/orientor-sd/us/54",
+            "owner": {
+                "id": 404067,
+                "permalink": "https://tree.taiga.io/profile/orientor",
+                "username": "orientor",
+                "full_name": "Aditya Verma",
+                "photo": null,
+                "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+            },
+            "assigned_to": null,
+            "assigned_users": [],
+            "points": [{
+                "role": "UX",
+                "name": "0",
+                "value": 0.0
+            }, {
+                "role": "Design",
+                "name": "0",
+                "value": 0.0
+            }, {
+                "role": "Front",
+                "name": "0",
+                "value": 0.0
+            }, {
+                "role": "Back",
+                "name": "0",
+                "value": 0.0
+            }],
+            "status": {
+                "id": 2107163,
+                "name": "New",
+                "slug": "new",
+                "color": "#999999",
+                "is_closed": false,
+                "is_archived": false
+            },
+            "milestone": null
+        },
+        "epic": {
+            "custom_attributes_values": {},
+            "id": 121028,
+            "ref": 42,
+            "created_date": "2020-01-31T21:13:50.083Z",
+            "modified_date": "2020-01-31T21:13:50.103Z",
+            "subject": "ASAS",
+            "watchers": [],
+            "description": "ASDASDASDASDASD",
+            "tags": [],
+            "permalink": "https://tree.taiga.io/project/orientor-sd/epic/42",
+            "project": {
+                "id": 351023,
+                "permalink": "https://tree.taiga.io/project/orientor-sd",
+                "name": "sd",
+                "logo_big_url": null
+            },
+            "owner": {
+                "id": 404067,
+                "permalink": "https://tree.taiga.io/profile/orientor",
+                "username": "orientor",
+                "full_name": "Aditya Verma",
+                "photo": null,
+                "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+            },
+            "assigned_to": null,
+            "status": {
+                "id": 1616801,
+                "name": "New",
+                "slug": "new",
+                "color": "#999999",
+                "is_closed": false
+            },
+            "epics_order": 1580505230066,
+            "color": "#3465a4",
+            "client_requirement": false,
+            "team_requirement": false
+        },
+        "order": 1581106057670
+    }
+}

--- a/zerver/webhooks/taiga/fixtures/task_changed_blocked_link.json
+++ b/zerver/webhooks/taiga/fixtures/task_changed_blocked_link.json
@@ -1,0 +1,144 @@
+{
+    "action": "change",
+    "type": "task",
+    "by": {
+        "id": 404067,
+        "permalink": "https://tree.taiga.io/profile/orientor",
+        "username": "orientor",
+        "full_name": "Aditya Verma",
+        "photo": null,
+        "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+    },
+    "date": "2020-02-08T06:48:55.064Z",
+    "data": {
+        "custom_attributes_values": {},
+        "id": 3268157,
+        "ref": 56,
+        "created_date": "2020-02-08T06:45:23.305Z",
+        "modified_date": "2020-02-08T06:48:54.944Z",
+        "finished_date": null,
+        "due_date": null,
+        "due_date_reason": "",
+        "subject": "nice task",
+        "us_order": 1581144323286,
+        "taskboard_order": 1581144323286,
+        "is_iocaine": false,
+        "external_reference": null,
+        "watchers": [],
+        "is_blocked": true,
+        "blocked_note": "as",
+        "description": "",
+        "tags": [],
+        "permalink": "https://tree.taiga.io/project/orientor-sd/task/56",
+        "project": {
+            "id": 351023,
+            "permalink": "https://tree.taiga.io/project/orientor-sd",
+            "name": "sd",
+            "logo_big_url": null
+        },
+        "owner": {
+            "id": 404067,
+            "permalink": "https://tree.taiga.io/profile/orientor",
+            "username": "orientor",
+            "full_name": "Aditya Verma",
+            "photo": null,
+            "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+        },
+        "assigned_to": null,
+        "status": {
+            "id": 1754937,
+            "name": "New",
+            "slug": "new",
+            "color": "#999999",
+            "is_closed": false
+        },
+        "user_story": {
+            "custom_attributes_values": {},
+            "id": 3133511,
+            "ref": 54,
+            "project": {
+                "id": 351023,
+                "permalink": "https://tree.taiga.io/project/orientor-sd",
+                "name": "sd",
+                "logo_big_url": null
+            },
+            "is_closed": false,
+            "created_date": "2020-02-07T19:33:07.473Z",
+            "modified_date": "2020-02-07T19:49:10.782Z",
+            "finish_date": null,
+            "due_date": null,
+            "due_date_reason": "",
+            "subject": "Nice Issue",
+            "client_requirement": false,
+            "team_requirement": false,
+            "generated_from_issue": 1312074,
+            "generated_from_task": null,
+            "external_reference": null,
+            "tribe_gig": null,
+            "watchers": [404067],
+            "is_blocked": false,
+            "blocked_note": "",
+            "description": "asdasd",
+            "tags": ["xo", "dsa"],
+            "permalink": "https://tree.taiga.io/project/orientor-sd/us/54",
+            "owner": {
+                "id": 404067,
+                "permalink": "https://tree.taiga.io/profile/orientor",
+                "username": "orientor",
+                "full_name": "Aditya Verma",
+                "photo": null,
+                "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+            },
+            "assigned_to": null,
+            "assigned_users": [],
+            "points": [{
+                "role": "UX",
+                "name": "0",
+                "value": 0.0
+            }, {
+                "role": "Design",
+                "name": "0",
+                "value": 0.0
+            }, {
+                "role": "Front",
+                "name": "0",
+                "value": 0.0
+            }, {
+                "role": "Back",
+                "name": "0",
+                "value": 0.0
+            }],
+            "status": {
+                "id": 2107163,
+                "name": "New",
+                "slug": "new",
+                "color": "#999999",
+                "is_closed": false,
+                "is_archived": false
+            },
+            "milestone": null
+        },
+        "milestone": null
+    },
+    "change": {
+        "comment": "",
+        "comment_html": "",
+        "delete_comment_date": null,
+        "comment_versions": null,
+        "edit_comment_date": null,
+        "diff": {
+            "is_blocked": {
+                "from": false,
+                "to": true
+            },
+            "blocked_note_diff": {
+                "from": null,
+                "to": "<ins>as</ins>"
+            },
+            "blocked_note_html": {
+                "from": "",
+                "to": "<p>as</p>"
+            }
+        }
+    }
+}

--- a/zerver/webhooks/taiga/fixtures/task_changed_due_date.json
+++ b/zerver/webhooks/taiga/fixtures/task_changed_due_date.json
@@ -1,0 +1,136 @@
+{
+    "action": "change",
+    "type": "task",
+    "by": {
+        "id": 404067,
+        "permalink": "https://tree.taiga.io/profile/orientor",
+        "username": "orientor",
+        "full_name": "Aditya Verma",
+        "photo": null,
+        "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+    },
+    "date": "2020-02-08T07:00:37.778Z",
+    "data": {
+        "custom_attributes_values": {},
+        "id": 3268157,
+        "ref": 56,
+        "created_date": "2020-02-08T06:45:23.305Z",
+        "modified_date": "2020-02-08T07:00:37.651Z",
+        "finished_date": null,
+        "due_date": "2020-02-15",
+        "due_date_reason": "",
+        "subject": "nice task",
+        "us_order": 1581144323286,
+        "taskboard_order": 1581144323286,
+        "is_iocaine": false,
+        "external_reference": null,
+        "watchers": [],
+        "is_blocked": false,
+        "blocked_note": "",
+        "description": "",
+        "tags": [],
+        "permalink": "https://tree.taiga.io/project/orientor-sd/task/56",
+        "project": {
+            "id": 351023,
+            "permalink": "https://tree.taiga.io/project/orientor-sd",
+            "name": "sd",
+            "logo_big_url": null
+        },
+        "owner": {
+            "id": 404067,
+            "permalink": "https://tree.taiga.io/profile/orientor",
+            "username": "orientor",
+            "full_name": "Aditya Verma",
+            "photo": null,
+            "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+        },
+        "assigned_to": null,
+        "status": {
+            "id": 1754937,
+            "name": "New",
+            "slug": "new",
+            "color": "#999999",
+            "is_closed": false
+        },
+        "user_story": {
+            "custom_attributes_values": {},
+            "id": 3133511,
+            "ref": 54,
+            "project": {
+                "id": 351023,
+                "permalink": "https://tree.taiga.io/project/orientor-sd",
+                "name": "sd",
+                "logo_big_url": null
+            },
+            "is_closed": false,
+            "created_date": "2020-02-07T19:33:07.473Z",
+            "modified_date": "2020-02-07T19:49:10.782Z",
+            "finish_date": null,
+            "due_date": null,
+            "due_date_reason": "",
+            "subject": "Nice Issue",
+            "client_requirement": false,
+            "team_requirement": false,
+            "generated_from_issue": 1312074,
+            "generated_from_task": null,
+            "external_reference": null,
+            "tribe_gig": null,
+            "watchers": [404067],
+            "is_blocked": false,
+            "blocked_note": "",
+            "description": "asdasd",
+            "tags": ["xo", "dsa"],
+            "permalink": "https://tree.taiga.io/project/orientor-sd/us/54",
+            "owner": {
+                "id": 404067,
+                "permalink": "https://tree.taiga.io/profile/orientor",
+                "username": "orientor",
+                "full_name": "Aditya Verma",
+                "photo": null,
+                "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+            },
+            "assigned_to": null,
+            "assigned_users": [],
+            "points": [{
+                "role": "UX",
+                "name": "0",
+                "value": 0.0
+            }, {
+                "role": "Design",
+                "name": "0",
+                "value": 0.0
+            }, {
+                "role": "Front",
+                "name": "0",
+                "value": 0.0
+            }, {
+                "role": "Back",
+                "name": "0",
+                "value": 0.0
+            }],
+            "status": {
+                "id": 2107163,
+                "name": "New",
+                "slug": "new",
+                "color": "#999999",
+                "is_closed": false,
+                "is_archived": false
+            },
+            "milestone": null
+        },
+        "milestone": null
+    },
+    "change": {
+        "comment": "",
+        "comment_html": "",
+        "delete_comment_date": null,
+        "comment_versions": null,
+        "edit_comment_date": null,
+        "diff": {
+            "due_date": {
+                "from": "2020-02-22",
+                "to": "2020-02-15"
+            }
+        }
+    }
+}

--- a/zerver/webhooks/taiga/fixtures/task_changed_new_due_date.json
+++ b/zerver/webhooks/taiga/fixtures/task_changed_new_due_date.json
@@ -1,0 +1,136 @@
+{
+    "action": "change",
+    "type": "task",
+    "by": {
+        "id": 404067,
+        "permalink": "https://tree.taiga.io/profile/orientor",
+        "username": "orientor",
+        "full_name": "Aditya Verma",
+        "photo": null,
+        "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+    },
+    "date": "2020-02-08T06:55:10.650Z",
+    "data": {
+        "custom_attributes_values": {},
+        "id": 3268157,
+        "ref": 56,
+        "created_date": "2020-02-08T06:45:23.305Z",
+        "modified_date": "2020-02-08T06:55:10.555Z",
+        "finished_date": null,
+        "due_date": "2020-02-22",
+        "due_date_reason": "",
+        "subject": "nice task",
+        "us_order": 1581144323286,
+        "taskboard_order": 1581144323286,
+        "is_iocaine": false,
+        "external_reference": null,
+        "watchers": [],
+        "is_blocked": false,
+        "blocked_note": "",
+        "description": "",
+        "tags": [],
+        "permalink": "https://tree.taiga.io/project/orientor-sd/task/56",
+        "project": {
+            "id": 351023,
+            "permalink": "https://tree.taiga.io/project/orientor-sd",
+            "name": "sd",
+            "logo_big_url": null
+        },
+        "owner": {
+            "id": 404067,
+            "permalink": "https://tree.taiga.io/profile/orientor",
+            "username": "orientor",
+            "full_name": "Aditya Verma",
+            "photo": null,
+            "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+        },
+        "assigned_to": null,
+        "status": {
+            "id": 1754937,
+            "name": "New",
+            "slug": "new",
+            "color": "#999999",
+            "is_closed": false
+        },
+        "user_story": {
+            "custom_attributes_values": {},
+            "id": 3133511,
+            "ref": 54,
+            "project": {
+                "id": 351023,
+                "permalink": "https://tree.taiga.io/project/orientor-sd",
+                "name": "sd",
+                "logo_big_url": null
+            },
+            "is_closed": false,
+            "created_date": "2020-02-07T19:33:07.473Z",
+            "modified_date": "2020-02-07T19:49:10.782Z",
+            "finish_date": null,
+            "due_date": null,
+            "due_date_reason": "",
+            "subject": "Nice Issue",
+            "client_requirement": false,
+            "team_requirement": false,
+            "generated_from_issue": 1312074,
+            "generated_from_task": null,
+            "external_reference": null,
+            "tribe_gig": null,
+            "watchers": [404067],
+            "is_blocked": false,
+            "blocked_note": "",
+            "description": "asdasd",
+            "tags": ["xo", "dsa"],
+            "permalink": "https://tree.taiga.io/project/orientor-sd/us/54",
+            "owner": {
+                "id": 404067,
+                "permalink": "https://tree.taiga.io/profile/orientor",
+                "username": "orientor",
+                "full_name": "Aditya Verma",
+                "photo": null,
+                "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+            },
+            "assigned_to": null,
+            "assigned_users": [],
+            "points": [{
+                "role": "UX",
+                "name": "0",
+                "value": 0.0
+            }, {
+                "role": "Design",
+                "name": "0",
+                "value": 0.0
+            }, {
+                "role": "Front",
+                "name": "0",
+                "value": 0.0
+            }, {
+                "role": "Back",
+                "name": "0",
+                "value": 0.0
+            }],
+            "status": {
+                "id": 2107163,
+                "name": "New",
+                "slug": "new",
+                "color": "#999999",
+                "is_closed": false,
+                "is_archived": false
+            },
+            "milestone": null
+        },
+        "milestone": null
+    },
+    "change": {
+        "comment": "",
+        "comment_html": "",
+        "delete_comment_date": null,
+        "comment_versions": null,
+        "edit_comment_date": null,
+        "diff": {
+            "due_date": {
+                "from": null,
+                "to": "2020-02-22"
+            }
+        }
+    }
+}

--- a/zerver/webhooks/taiga/fixtures/userstory_changed_due_date.json
+++ b/zerver/webhooks/taiga/fixtures/userstory_changed_due_date.json
@@ -1,0 +1,92 @@
+{
+    "action": "change",
+    "type": "userstory",
+    "by": {
+        "id": 404067,
+        "permalink": "https://tree.taiga.io/profile/orientor",
+        "username": "orientor",
+        "full_name": "Aditya Verma",
+        "photo": null,
+        "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+    },
+    "date": "2020-02-08T07:31:03.704Z",
+    "data": {
+        "custom_attributes_values": {},
+        "id": 3133511,
+        "ref": 54,
+        "project": {
+            "id": 351023,
+            "permalink": "https://tree.taiga.io/project/orientor-sd",
+            "name": "sd",
+            "logo_big_url": null
+        },
+        "is_closed": false,
+        "created_date": "2020-02-07T19:33:07.473Z",
+        "modified_date": "2020-02-08T07:31:03.559Z",
+        "finish_date": null,
+        "due_date": "2020-02-22",
+        "due_date_reason": "",
+        "subject": "Nice Issue",
+        "client_requirement": false,
+        "team_requirement": false,
+        "generated_from_issue": 1312074,
+        "generated_from_task": null,
+        "external_reference": null,
+        "tribe_gig": null,
+        "watchers": [404067],
+        "is_blocked": false,
+        "blocked_note": "",
+        "description": "asdasd",
+        "tags": ["xo", "dsa"],
+        "permalink": "https://tree.taiga.io/project/orientor-sd/us/54",
+        "owner": {
+            "id": 404067,
+            "permalink": "https://tree.taiga.io/profile/orientor",
+            "username": "orientor",
+            "full_name": "Aditya Verma",
+            "photo": null,
+            "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+        },
+        "assigned_to": null,
+        "assigned_users": [],
+        "points": [{
+            "role": "UX",
+            "name": "0",
+            "value": 0.0
+        }, {
+            "role": "Design",
+            "name": "0",
+            "value": 0.0
+        }, {
+            "role": "Front",
+            "name": "0",
+            "value": 0.0
+        }, {
+            "role": "Back",
+            "name": "0",
+            "value": 0.0
+        }],
+        "status": {
+            "id": 2107163,
+            "name": "New",
+            "slug": "new",
+            "color": "#999999",
+            "is_closed": false,
+            "is_archived": false
+        },
+        "milestone": null
+    },
+    "change": {
+        "comment": "",
+        "comment_html": "",
+        "delete_comment_date": null,
+        "comment_versions": null,
+        "edit_comment_date": null,
+        "diff": {
+            "due_date": {
+                "from": "2020-02-15",
+                "to": "2020-02-22"
+            }
+        }
+    }
+}

--- a/zerver/webhooks/taiga/fixtures/userstory_changed_new_due_date.json
+++ b/zerver/webhooks/taiga/fixtures/userstory_changed_new_due_date.json
@@ -1,0 +1,92 @@
+{
+    "action": "change",
+    "type": "userstory",
+    "by": {
+        "id": 404067,
+        "permalink": "https://tree.taiga.io/profile/orientor",
+        "username": "orientor",
+        "full_name": "Aditya Verma",
+        "photo": null,
+        "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+    },
+    "date": "2020-02-08T07:42:35.196Z",
+    "data": {
+        "custom_attributes_values": {},
+        "id": 3133822,
+        "ref": 58,
+        "project": {
+            "id": 351023,
+            "permalink": "https://tree.taiga.io/project/orientor-sd",
+            "name": "sd",
+            "logo_big_url": null
+        },
+        "is_closed": false,
+        "created_date": "2020-02-08T07:41:23.565Z",
+        "modified_date": "2020-02-08T07:42:35.082Z",
+        "finish_date": null,
+        "due_date": "2020-02-15",
+        "due_date_reason": "",
+        "subject": "random",
+        "client_requirement": true,
+        "team_requirement": false,
+        "generated_from_issue": 1312134,
+        "generated_from_task": null,
+        "external_reference": null,
+        "tribe_gig": null,
+        "watchers": [],
+        "is_blocked": false,
+        "blocked_note": "",
+        "description": "",
+        "tags": [],
+        "permalink": "https://tree.taiga.io/project/orientor-sd/us/58",
+        "owner": {
+            "id": 404067,
+            "permalink": "https://tree.taiga.io/profile/orientor",
+            "username": "orientor",
+            "full_name": "Aditya Verma",
+            "photo": null,
+            "gravatar_id": "b72a822f0f5b7cf0c159a707af5150a1"
+        },
+        "assigned_to": null,
+        "assigned_users": [],
+        "points": [{
+            "role": "UX",
+            "name": "0",
+            "value": 0.0
+        }, {
+            "role": "Design",
+            "name": "0",
+            "value": 0.0
+        }, {
+            "role": "Front",
+            "name": "0",
+            "value": 0.0
+        }, {
+            "role": "Back",
+            "name": "0",
+            "value": 0.0
+        }],
+        "status": {
+            "id": 2107163,
+            "name": "New",
+            "slug": "new",
+            "color": "#999999",
+            "is_closed": false,
+            "is_archived": false
+        },
+        "milestone": null
+    },
+    "change": {
+        "comment": "",
+        "comment_html": "",
+        "delete_comment_date": null,
+        "comment_versions": null,
+        "edit_comment_date": null,
+        "diff": {
+            "due_date": {
+                "from": null,
+                "to": "2020-02-15"
+            }
+        }
+    }
+}

--- a/zerver/webhooks/taiga/tests.py
+++ b/zerver/webhooks/taiga/tests.py
@@ -13,229 +13,285 @@ class TaigaHookTests(WebhookTestCase):
         self.url = self.build_webhook_url(topic=self.TOPIC)
 
     def test_taiga_userstory_deleted(self) -> None:
-        message = u'TomaszKolek deleted user story **New userstory**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) deleted user story **New userstory**.'
         self.send_and_test_stream_message("userstory_deleted", self.TOPIC, message)
 
     def test_taiga_userstory_created(self) -> None:
-        message = u'TomaszKolek created user story **New userstory**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) created user story **New userstory**.'
         self.send_and_test_stream_message("userstory_created", self.TOPIC, message)
 
     def test_taiga_userstory_changed_unblocked(self) -> None:
-        message = u'TomaszKolek unblocked user story **UserStory**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) unblocked user story **UserStory**.'
         self.send_and_test_stream_message("userstory_changed_unblocked", self.TOPIC, message)
 
     def test_taiga_userstory_changed_subject(self) -> None:
-        message = u'TomaszKolek renamed user story from UserStory to **UserStoryNewSubject**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) renamed user story from UserStory to **UserStoryNewSubject**.'
         self.send_and_test_stream_message("userstory_changed_subject", self.TOPIC, message)
 
     def test_taiga_userstory_changed_status(self) -> None:
-        message = u'TomaszKolek changed status of user story **UserStory** from Ready to In progress.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) changed status of user story **UserStory** from Ready to In progress.'
         self.send_and_test_stream_message("userstory_changed_status", self.TOPIC, message)
 
     def test_taiga_userstory_changed_reassigned(self) -> None:
-        message = u'TomaszKolek reassigned user story **UserStory** from TomaszKolek to HanSolo.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) reassigned user story **UserStory** from TomaszKolek to HanSolo.'
         self.send_and_test_stream_message("userstory_changed_reassigned", self.TOPIC, message)
 
     def test_taiga_userstory_changed_unassigned(self) -> None:
-        message = u'TomaszKolek unassigned user story **UserStory**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) unassigned user story **UserStory**.'
         self.send_and_test_stream_message("userstory_changed_unassigned", self.TOPIC, message)
 
     def test_taiga_userstory_changed_points(self) -> None:
-        message = u'TomaszKolek changed estimation of user story **UserStory**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) changed estimation of user story **UserStory**.'
         self.send_and_test_stream_message("userstory_changed_points", self.TOPIC, message)
 
     def test_taiga_userstory_changed_new_sprint(self) -> None:
-        message = u'TomaszKolek added user story **UserStory** to sprint Sprint1.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) added user story **UserStory** to sprint Sprint1.'
         self.send_and_test_stream_message("userstory_changed_new_sprint", self.TOPIC, message)
 
     def test_taiga_userstory_changed_sprint(self) -> None:
-        message = u'TomaszKolek changed sprint of user story **UserStory** from Sprint1 to Sprint2.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) changed sprint of user story **UserStory** from Sprint1 to Sprint2.'
         self.send_and_test_stream_message("userstory_changed_sprint", self.TOPIC, message)
 
     def test_taiga_userstory_changed_remove_sprint(self) -> None:
-        message = u'TomaszKolek removed user story **UserStory** from sprint Sprint2.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) removed user story **UserStory** from sprint Sprint2.'
         self.send_and_test_stream_message("userstory_changed_remove_sprint", self.TOPIC, message)
 
     def test_taiga_userstory_changed_description(self) -> None:
-        message = u'TomaszKolek updated description of user story **UserStory**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) updated description of user story **UserStory**.'
         self.send_and_test_stream_message("userstory_changed_description", self.TOPIC, message)
 
     def test_taiga_userstory_changed_closed(self) -> None:
-        message = u'TomaszKolek changed status of user story **UserStory** from New to Done.\nTomaszKolek closed user story **UserStory**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) changed status of user story **UserStory** from New to Done.\n[TomaszKolek](https://tree.taiga.io/profile/kolaszek) closed user story **UserStory**.'
         self.send_and_test_stream_message("userstory_changed_closed", self.TOPIC, message)
 
     def test_taiga_userstory_changed_reopened(self) -> None:
-        message = u'TomaszKolek changed status of user story **UserStory** from Done to Ready.\nTomaszKolek reopened user story **UserStory**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) changed status of user story **UserStory** from Done to Ready.\n[TomaszKolek](https://tree.taiga.io/profile/kolaszek) reopened user story **UserStory**.'
         self.send_and_test_stream_message("userstory_changed_reopened", self.TOPIC, message)
 
     def test_taiga_userstory_changed_blocked(self) -> None:
-        message = u'TomaszKolek blocked user story **UserStory**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) blocked user story **UserStory**.'
         self.send_and_test_stream_message("userstory_changed_blocked", self.TOPIC, message)
 
     def test_taiga_userstory_changed_assigned(self) -> None:
-        message = u'TomaszKolek assigned user story **UserStory** to TomaszKolek.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) assigned user story **UserStory** to TomaszKolek.'
         self.send_and_test_stream_message("userstory_changed_assigned", self.TOPIC, message)
 
     def test_taiga_userstory_comment_added(self) -> None:
-        message = u'TomaszKolek commented on user story **UserStory**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) commented on user story **UserStory**.'
         self.send_and_test_stream_message("userstory_changed_comment_added", self.TOPIC, message)
 
+    def test_taiga_userstory_changed_due_date(self) -> None:
+        message = (u'[Aditya Verma](https://tree.taiga.io/profile/orientor) changed due date of user story ' +
+                   '[Nice Issue](https://tree.taiga.io/project/orientor-sd/us/54) from 2020-02-15 to 2020-02-22.')
+        self.send_and_test_stream_message("userstory_changed_due_date", self.TOPIC, message)
+
+    def test_taiga_userstory_changed_new_due_date(self) -> None:
+        message = u'[Aditya Verma](https://tree.taiga.io/profile/orientor) set due date of user story [random](https://tree.taiga.io/project/orientor-sd/us/58) to 2020-02-15.'
+        self.send_and_test_stream_message("userstory_changed_new_due_date", self.TOPIC, message)
+
     def test_taiga_task_created(self) -> None:
-        message = u'TomaszKolek created task **New Task**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) created task **New Task**.'
         self.send_and_test_stream_message("task_created", self.TOPIC, message)
 
     def test_taiga_task_changed_user_stories(self) -> None:
-        message = u'Eeshan Garg added task **Get this task done** to sprint Another one.\nEeshan Garg moved task **Get this task done** from user story #7 Yaar ne scirra! to #8 A related user story, which is epic.'
+        message = u'[Eeshan Garg](https://tree.taiga.io/profile/eeshangarg) added task **Get this task done** to sprint Another one.\n[Eeshan Garg](https://tree.taiga.io/profile/eeshangarg) moved task **Get this task done** from user story #7 Yaar ne scirra! to #8 A related user story, which is epic.'
         self.send_and_test_stream_message("task_changed_user_stories", self.TOPIC, message)
 
     def test_taiga_task_changed_status(self) -> None:
-        message = u'TomaszKolek changed status of task **New Task** from New to In progress.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) changed status of task **New Task** from New to In progress.'
         self.send_and_test_stream_message("task_changed_status", self.TOPIC, message)
 
     def test_taiga_task_changed_blocked(self) -> None:
-        message = u'TomaszKolek blocked task **New Task**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) blocked task **New Task**.'
         self.send_and_test_stream_message("task_changed_blocked", self.TOPIC, message)
 
+    def test_taiga_task_changed_blocked_link(self) -> None:
+        message = u'[Aditya Verma](https://tree.taiga.io/profile/orientor) blocked task [nice task](https://tree.taiga.io/project/orientor-sd/task/56).'
+        self.send_and_test_stream_message("task_changed_blocked_link", self.TOPIC, message)
+
     def test_taiga_task_changed_unblocked(self) -> None:
-        message = u'TomaszKolek unblocked task **New Task**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) unblocked task **New Task**.'
         self.send_and_test_stream_message("task_changed_unblocked", self.TOPIC, message)
 
     def test_taiga_task_changed_assigned(self) -> None:
-        message = u'TomaszKolek assigned task **New Task** to TomaszKolek.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) assigned task **New Task** to TomaszKolek.'
         self.send_and_test_stream_message("task_changed_assigned", self.TOPIC, message)
 
     def test_taiga_task_changed_reassigned(self) -> None:
-        message = u'TomaszKolek reassigned task **New Task** from HanSolo to TomaszKolek.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) reassigned task **New Task** from HanSolo to TomaszKolek.'
         self.send_and_test_stream_message("task_changed_reassigned", self.TOPIC, message)
 
     def test_taiga_task_changed_subject(self) -> None:
-        message = u'TomaszKolek renamed task New Task to **New Task Subject**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) renamed task New Task to **New Task Subject**.'
         self.send_and_test_stream_message("task_changed_subject", self.TOPIC, message)
 
     def test_taiga_task_changed_description(self) -> None:
-        message = u'TomaszKolek updated description of task **New Task**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) updated description of task **New Task**.'
         self.send_and_test_stream_message("task_changed_description", self.TOPIC, message)
 
     def test_taiga_task_deleted(self) -> None:
-        message = u'TomaszKolek deleted task **New Task**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) deleted task **New Task**.'
         self.send_and_test_stream_message("task_deleted", self.TOPIC, message)
 
     def test_taiga_task_changed_comment_added(self) -> None:
-        message = u'TomaszKolek commented on task **New Task**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) commented on task **New Task**.'
         self.send_and_test_stream_message("task_changed_comment_added", self.TOPIC, message)
 
+    def test_taiga_task_changed_due_date(self) -> None:
+        message = (u'[Aditya Verma](https://tree.taiga.io/profile/orientor) changed due date of task' +
+                   ' [nice task](https://tree.taiga.io/project/orientor-sd/task/56) from 2020-02-22 to 2020-02-15.')
+        self.send_and_test_stream_message("task_changed_due_date", self.TOPIC, message)
+
+    def test_taiga_task_changed_new_due_date(self) -> None:
+        message = u'[Aditya Verma](https://tree.taiga.io/profile/orientor) set due date of task [nice task](https://tree.taiga.io/project/orientor-sd/task/56) to 2020-02-22.'
+        self.send_and_test_stream_message("task_changed_new_due_date", self.TOPIC, message)
+
     def test_taiga_sprint_created(self) -> None:
-        message = u'TomaszKolek created sprint **New sprint**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) created sprint **New sprint**.'
         self.send_and_test_stream_message("sprint_created", self.TOPIC, message)
 
     def test_taiga_sprint_deleted(self) -> None:
-        message = u'TomaszKolek deleted sprint **New name**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) deleted sprint **New name**.'
         self.send_and_test_stream_message("sprint_deleted", self.TOPIC, message)
 
     def test_taiga_sprint_changed_time(self) -> None:
-        message = u'TomaszKolek changed estimated finish of sprint **New sprint** from 2017-01-24 to 2017-01-25.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) changed estimated finish of sprint **New sprint** from 2017-01-24 to 2017-01-25.'
         self.send_and_test_stream_message("sprint_changed_time", self.TOPIC, message)
 
     def test_taiga_sprint_changed_name(self) -> None:
-        message = u'TomaszKolek renamed sprint from New sprint to **New name**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) renamed sprint from New sprint to **New name**.'
         self.send_and_test_stream_message("sprint_changed_name", self.TOPIC, message)
 
     def test_taiga_issue_created(self) -> None:
-        message = u'TomaszKolek created issue **New issue**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) created issue **New issue**.'
         self.send_and_test_stream_message("issue_created", self.TOPIC, message)
 
+    def test_taiga_issue_created_link(self) -> None:
+        message = u'[Aditya Verma](https://tree.taiga.io/profile/orientor) created issue [Issues](https://tree.taiga.io/project/orientor-sd/issue/49).'
+        self.send_and_test_stream_message("issue_created_link", self.TOPIC, message)
+
     def test_taiga_issue_deleted(self) -> None:
-        message = u'TomaszKolek deleted issue **New issue**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) deleted issue **New issue**.'
         self.send_and_test_stream_message("issue_deleted", self.TOPIC, message)
 
     def test_taiga_issue_changed_assigned(self) -> None:
-        message = u'TomaszKolek assigned issue **New issue** to TomaszKolek.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) assigned issue **New issue** to TomaszKolek.'
         self.send_and_test_stream_message("issue_changed_assigned", self.TOPIC, message)
 
     def test_taiga_issue_changed_reassigned(self) -> None:
-        message = u'TomaszKolek reassigned issue **New issue** from TomaszKolek to HanSolo.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) reassigned issue **New issue** from TomaszKolek to HanSolo.'
         self.send_and_test_stream_message("issue_changed_reassigned", self.TOPIC, message)
 
     def test_taiga_issue_changed_subject(self) -> None:
-        message = u'TomaszKolek renamed issue New issue to **New issueNewSubject**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) renamed issue New issue to **New issueNewSubject**.'
         self.send_and_test_stream_message("issue_changed_subject", self.TOPIC, message)
 
     def test_taiga_issue_changed_description(self) -> None:
-        message = u'TomaszKolek updated description of issue **New issue**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) updated description of issue **New issue**.'
         self.send_and_test_stream_message("issue_changed_description", self.TOPIC, message)
 
     def test_taiga_issue_changed_type(self) -> None:
-        message = u'TomaszKolek changed type of issue **New issue** from Bug to Question.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) changed type of issue **New issue** from Bug to Question.'
         self.send_and_test_stream_message("issue_changed_type", self.TOPIC, message)
 
     def test_taiga_issue_changed_status(self) -> None:
-        message = u'TomaszKolek changed status of issue **New issue** from New to In progress.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) changed status of issue **New issue** from New to In progress.'
         self.send_and_test_stream_message("issue_changed_status", self.TOPIC, message)
 
     def test_taiga_issue_changed_severity(self) -> None:
-        message = u'TomaszKolek changed severity of issue **New issue** from Normal to Minor.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) changed severity of issue **New issue** from Normal to Minor.'
         self.send_and_test_stream_message("issue_changed_severity", self.TOPIC, message)
 
     def test_taiga_issue_changed_priority(self) -> None:
-        message = u'TomaszKolek changed priority of issue **New issue** from Normal to Low.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) changed priority of issue **New issue** from Normal to Low.'
         self.send_and_test_stream_message("issue_changed_priority", self.TOPIC, message)
 
     def test_taiga_issue_changed_comment_added(self) -> None:
-        message = u'TomaszKolek commented on issue **New issue**.'
+        message = u'[TomaszKolek](https://tree.taiga.io/profile/kolaszek) commented on issue **New issue**.'
         self.send_and_test_stream_message("issue_changed_comment_added", self.TOPIC, message)
 
+    def test_taiga_issue_changed_blocked(self) -> None:
+        message = u'[Aditya Verma](https://tree.taiga.io/profile/orientor) blocked issue [Issues](https://tree.taiga.io/project/orientor-sd/issue/49).'
+        self.send_and_test_stream_message("issue_changed_blocked", self.TOPIC, message)
+
+    def test_taiga_issue_changed_unblocked(self) -> None:
+        message = u'[Aditya Verma](https://tree.taiga.io/profile/orientor) unblocked issue [Issues](https://tree.taiga.io/project/orientor-sd/issue/49).'
+        self.send_and_test_stream_message("issue_changed_unblocked", self.TOPIC, message)
+
+    def test_taiga_issue_changed_due_date(self) -> None:
+        message = (u'[Aditya Verma](https://tree.taiga.io/profile/orientor) changed due date of issue [Issues](https://tree.taiga.io/project/orientor-sd/issue/49) ' +
+                   'from 2020-03-08 to 2020-02-22.')
+        self.send_and_test_stream_message("issue_changed_due_date", self.TOPIC, message)
+
+    def test_taiga_issue_changed_new_due_date(self) -> None:
+        message = u'[Aditya Verma](https://tree.taiga.io/profile/orientor) set due date of issue [Nice Issue](https://tree.taiga.io/project/orientor-sd/issue/53) to 2020-02-22.'
+        self.send_and_test_stream_message("issue_changed_new_due_date", self.TOPIC, message)
+
+    def test_taiga_issue_changed_new_sprint(self) -> None:
+        message = u'[Aditya Verma](https://tree.taiga.io/profile/orientor) added issue [Nice Issue](https://tree.taiga.io/project/orientor-sd/issue/53) to sprint eres.'
+        self.send_and_test_stream_message("issue_changed_new_sprint", self.TOPIC, message)
+
+    def test_taiga_issue_changed_remove_sprint(self) -> None:
+        message = u'[Aditya Verma](https://tree.taiga.io/profile/orientor) detached issue [Nice Issue](https://tree.taiga.io/project/orientor-sd/issue/53) from sprint eres.'
+        self.send_and_test_stream_message("issue_changed_remove_sprint", self.TOPIC, message)
+
     def test_taiga_epic_created(self) -> None:
-        message = u'Eeshan Garg created epic **Zulip is awesome!**'
+        message = u'[Eeshan Garg](https://tree.taiga.io/profile/eeshangarg) created epic **Zulip is awesome!**.'
         self.send_and_test_stream_message("epic_created", self.TOPIC, message)
 
     def test_taiga_epic_changed_assigned(self) -> None:
-        message = u'Eeshan Garg assigned epic **Zulip is awesome!** to Eeshan Garg.'
+        message = u'[Eeshan Garg](https://tree.taiga.io/profile/eeshangarg) assigned epic **Zulip is awesome!** to Eeshan Garg.'
         self.send_and_test_stream_message("epic_changed_assigned", self.TOPIC, message)
 
     def test_taiga_epic_changed_unassigned(self) -> None:
-        message = u'Eeshan Garg unassigned epic **Zulip is awesome!**'
+        message = u'[Eeshan Garg](https://tree.taiga.io/profile/eeshangarg) unassigned epic **Zulip is awesome!**.'
         self.send_and_test_stream_message("epic_changed_unassigned", self.TOPIC, message)
 
     def test_taiga_epic_changed_reassigned(self) -> None:
-        message = u'Eeshan Garg reassigned epic **Zulip is awesome!** from Eeshan Garg to Angela Johnson.'
+        message = u'[Eeshan Garg](https://tree.taiga.io/profile/eeshangarg) reassigned epic **Zulip is awesome!** from Eeshan Garg to Angela Johnson.'
         self.send_and_test_stream_message("epic_changed_reassigned", self.TOPIC, message)
 
     def test_taiga_epic_changed_blocked(self) -> None:
-        message = u'Eeshan Garg blocked epic **Zulip is awesome!**'
+        message = u'[Eeshan Garg](https://tree.taiga.io/profile/eeshangarg) blocked epic **Zulip is awesome!**.'
         self.send_and_test_stream_message("epic_changed_blocked", self.TOPIC, message)
 
     def test_taiga_epic_changed_unblocked(self) -> None:
-        message = u'Eeshan Garg unblocked epic **Zulip is awesome!**'
+        message = u'[Eeshan Garg](https://tree.taiga.io/profile/eeshangarg) unblocked epic **Zulip is awesome!**.'
         self.send_and_test_stream_message("epic_changed_unblocked", self.TOPIC, message)
 
     def test_taiga_epic_changed_status(self) -> None:
-        message = u'Eeshan Garg changed status of epic **Zulip is awesome!** from New to In progress.'
+        message = u'[Eeshan Garg](https://tree.taiga.io/profile/eeshangarg) changed status of epic **Zulip is awesome!** from New to In progress.'
         self.send_and_test_stream_message("epic_changed_status", self.TOPIC, message)
 
     def test_taiga_epic_changed_renamed(self) -> None:
-        message = u'Eeshan Garg renamed epic from **Zulip is awesome!** to **Zulip is great!**'
+        message = u'[Eeshan Garg](https://tree.taiga.io/profile/eeshangarg) renamed epic from **Zulip is awesome!** to **Zulip is great!**.'
         self.send_and_test_stream_message("epic_changed_renamed", self.TOPIC, message)
 
     def test_taiga_epic_changed_description(self) -> None:
-        message = u'Eeshan Garg updated description of epic **Zulip is great!**'
+        message = u'[Eeshan Garg](https://tree.taiga.io/profile/eeshangarg) updated description of epic **Zulip is great!**.'
         self.send_and_test_stream_message("epic_changed_description", self.TOPIC, message)
 
     def test_taiga_epic_changed_commented(self) -> None:
-        message = u'Eeshan Garg commented on epic **Zulip is great!**'
+        message = u'[Eeshan Garg](https://tree.taiga.io/profile/eeshangarg) commented on epic **Zulip is great!**.'
         self.send_and_test_stream_message("epic_changed_commented", self.TOPIC, message)
 
     def test_taiga_epic_deleted(self) -> None:
-        message = u'Eeshan Garg deleted epic **Zulip is great!**'
+        message = u'[Eeshan Garg](https://tree.taiga.io/profile/eeshangarg) deleted epic **Zulip is great!**.'
         self.send_and_test_stream_message("epic_deleted", self.TOPIC, message)
 
     def test_taiga_relateduserstory_created(self) -> None:
-        message = u'Eeshan Garg added a related user story **A related user story** to the epic **This is Epic!**'
+        message = u'[Eeshan Garg](https://tree.taiga.io/profile/eeshangarg) added a related user story **A related user story** to the epic **This is Epic!**.'
         self.send_and_test_stream_message("relateduserstory_created", self.TOPIC, message)
 
+    def test_taiga_relateduserstory_created_link(self) -> None:
+        message = (u'[Aditya Verma](https://tree.taiga.io/profile/orientor) added a related user story [Nice Issue](https://tree.taiga.io/project/orientor-sd/us/54) ' +
+                   'to the epic [ASAS](https://tree.taiga.io/project/orientor-sd/epic/42).')
+        self.send_and_test_stream_message("relateduserstory_created_link", self.TOPIC, message)
+
     def test_taiga_relateduserstory_deleted(self) -> None:
-        message = u'Eeshan Garg removed a related user story **A related user story, which is epic** from the epic **This is Epic!**'
+        message = u'[Eeshan Garg](https://tree.taiga.io/profile/eeshangarg) removed a related user story **A related user story, which is epic** from the epic **This is Epic!**.'
         self.send_and_test_stream_message("relateduserstory_deleted", self.TOPIC, message)
 
     def test_taiga_webhook_test(self) -> None:
-        message = u'Jan triggered a test of the Taiga integration.'
+        message = u'[Jan](https://tree.taiga.io/profile/kostek) triggered a test of the Taiga integration.'
         self.send_and_test_stream_message("webhook_test", self.TOPIC, message)

--- a/zerver/webhooks/taiga/view.py
+++ b/zerver/webhooks/taiga/view.py
@@ -6,7 +6,6 @@ Tips for notification output:
 value should always be in bold; otherwise the subject of US/task
 should be in bold.
 """
-import string
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from django.http import HttpRequest, HttpResponse
@@ -23,109 +22,128 @@ from zerver.models import UserProfile
 def api_taiga_webhook(request: HttpRequest, user_profile: UserProfile,
                       message: Dict[str, Any]=REQ(argument_type='body')) -> HttpResponse:
     parsed_events = parse_message(message)
-
     content_lines = []
     for event in parsed_events:
         content_lines.append(generate_content(event) + '\n')
     content = "".join(sorted(content_lines))
     topic = 'General'
-
+    if message["data"].get("milestone") is not None:
+        if message["data"]["milestone"].get("name") is not None:
+            topic = message["data"]["milestone"]["name"]
     check_send_webhook_message(request, user_profile, topic, content)
 
     return json_success()
 
 templates = {
     'epic': {
-        'create': u'{user} created epic **{subject}**.',
-        'set_assigned_to': u'{user} assigned epic **{subject}** to {new}.',
-        'unset_assigned_to': u'{user} unassigned epic **{subject}**.',
-        'changed_assigned_to': u'{user} reassigned epic **{subject}**'
+        'create': u'[{user}]({user_link}) created epic {subject}.',
+        'set_assigned_to': u'[{user}]({user_link}) assigned epic {subject} to {new}.',
+        'unset_assigned_to': u'[{user}]({user_link}) unassigned epic {subject}.',
+        'changed_assigned_to': u'[{user}]({user_link}) reassigned epic {subject}'
         ' from {old} to {new}.',
-        'blocked': u'{user} blocked epic **{subject}**.',
-        'unblocked': u'{user} unblocked epic **{subject}**.',
-        'changed_status': u'{user} changed status of epic **{subject}**'
+        'blocked': u'[{user}]({user_link}) blocked epic {subject}.',
+        'unblocked': u'[{user}]({user_link}) unblocked epic {subject}.',
+        'changed_status': u'[{user}]({user_link}) changed status of epic {subject}'
         ' from {old} to {new}.',
-        'renamed': u'{user} renamed epic from **{old}** to **{new}**.',
-        'description_diff': u'{user} updated description of epic **{subject}**.',
-        'commented': u'{user} commented on epic **{subject}**.',
-        'delete': u'{user} deleted epic **{subject}**.',
+        'renamed': u'[{user}]({user_link}) renamed epic from **{old}** to **{new}**.',
+        'description_diff': u'[{user}]({user_link}) updated description of epic {subject}.',
+        'commented': u'[{user}]({user_link}) commented on epic {subject}.',
+        'delete': u'[{user}]({user_link}) deleted epic {subject}.',
     },
     'relateduserstory': {
-        'create': (u'{user} added a related user story '
-                   u'**{userstory_subject}** to the epic **{epic_subject}**.'),
-        'delete': (u'{user} removed a related user story ' +
-                   u'**{userstory_subject}** from the epic **{epic_subject}**.'),
+        'create': (u'[{user}]({user_link}) added a related user story '
+                   u'{userstory_subject} to the epic {epic_subject}.'),
+        'delete': (u'[{user}]({user_link}) removed a related user story ' +
+                   u'{userstory_subject} from the epic {epic_subject}.'),
     },
     'userstory': {
-        'create': u'{user} created user story **{subject}**.',
-        'set_assigned_to': u'{user} assigned user story **{subject}** to {new}.',
-        'unset_assigned_to': u'{user} unassigned user story **{subject}**.',
-        'changed_assigned_to': u'{user} reassigned user story **{subject}**'
+        'create': u'[{user}]({user_link}) created user story {subject}.',
+        'set_assigned_to': u'[{user}]({user_link}) assigned user story {subject} to {new}.',
+        'unset_assigned_to': u'[{user}]({user_link}) unassigned user story {subject}.',
+        'changed_assigned_to': u'[{user}]({user_link}) reassigned user story {subject}'
         ' from {old} to {new}.',
-        'points': u'{user} changed estimation of user story **{subject}**.',
-        'blocked': u'{user} blocked user story **{subject}**.',
-        'unblocked': u'{user} unblocked user story **{subject}**.',
-        'set_milestone': u'{user} added user story **{subject}** to sprint {new}.',
-        'unset_milestone': u'{user} removed user story **{subject}** from sprint {old}.',
-        'changed_milestone': u'{user} changed sprint of user story **{subject}** from {old}'
+        'points': u'[{user}]({user_link}) changed estimation of user story {subject}.',
+        'blocked': u'[{user}]({user_link}) blocked user story {subject}.',
+        'unblocked': u'[{user}]({user_link}) unblocked user story {subject}.',
+        'set_milestone': u'[{user}]({user_link}) added user story {subject} to sprint {new}.',
+        'unset_milestone': u'[{user}]({user_link}) removed user story {subject} from sprint {old}.',
+        'changed_milestone': u'[{user}]({user_link}) changed sprint of user story {subject} from {old}'
         ' to {new}.',
-        'changed_status': u'{user} changed status of user story **{subject}**'
+        'changed_status': u'[{user}]({user_link}) changed status of user story {subject}'
         ' from {old} to {new}.',
-        'closed': u'{user} closed user story **{subject}**.',
-        'reopened': u'{user} reopened user story **{subject}**.',
-        'renamed': u'{user} renamed user story from {old} to **{new}**.',
-        'description_diff': u'{user} updated description of user story **{subject}**.',
-        'commented': u'{user} commented on user story **{subject}**.',
-        'delete': u'{user} deleted user story **{subject}**.'
+        'closed': u'[{user}]({user_link}) closed user story {subject}.',
+        'reopened': u'[{user}]({user_link}) reopened user story {subject}.',
+        'renamed': u'[{user}]({user_link}) renamed user story from {old} to **{new}**.',
+        'description_diff': u'[{user}]({user_link}) updated description of user story {subject}.',
+        'commented': u'[{user}]({user_link}) commented on user story {subject}.',
+        'delete': u'[{user}]({user_link}) deleted user story {subject}.',
+        'due_date': u'[{user}]({user_link}) changed due date of user story {subject}'
+        ' from {old} to {new}.',
+        'set_due_date': u'[{user}]({user_link}) set due date of user story {subject}'
+        ' to {new}.',
     },
     'milestone': {
-        'create': u'{user} created sprint **{subject}**.',
-        'renamed': u'{user} renamed sprint from {old} to **{new}**.',
-        'estimated_start': u'{user} changed estimated start of sprint **{subject}**'
+        'create': u'[{user}]({user_link}) created sprint {subject}.',
+        'renamed': u'[{user}]({user_link}) renamed sprint from {old} to **{new}**.',
+        'estimated_start': u'[{user}]({user_link}) changed estimated start of sprint {subject}'
         ' from {old} to {new}.',
-        'estimated_finish': u'{user} changed estimated finish of sprint **{subject}**'
+        'estimated_finish': u'[{user}]({user_link}) changed estimated finish of sprint {subject}'
         ' from {old} to {new}.',
-        'delete': u'{user} deleted sprint **{subject}**.'
+        'set_estimated_start': u'[{user}]({user_link}) changed estimated start of sprint {subject}'
+        ' to {new}.',
+        'set_estimated_finish': u'[{user}]({user_link}) set estimated finish of sprint {subject}'
+        ' to {new}.',
+        'delete': u'[{user}]({user_link}) deleted sprint {subject}.'
     },
     'task': {
-        'create': u'{user} created task **{subject}**.',
-        'set_assigned_to': u'{user} assigned task **{subject}** to {new}.',
-        'unset_assigned_to': u'{user} unassigned task **{subject}**.',
-        'changed_assigned_to': u'{user} reassigned task **{subject}**'
+        'create': u'[{user}]({user_link}) created task {subject}.',
+        'set_assigned_to': u'[{user}]({user_link}) assigned task {subject} to {new}.',
+        'unset_assigned_to': u'[{user}]({user_link}) unassigned task {subject}.',
+        'changed_assigned_to': u'[{user}]({user_link}) reassigned task {subject}'
         ' from {old} to {new}.',
-        'blocked': u'{user} blocked task **{subject}**.',
-        'unblocked': u'{user} unblocked task **{subject}**.',
-        'set_milestone': u'{user} added task **{subject}** to sprint {new}.',
-        'changed_milestone': u'{user} changed sprint of task '
-                             '**{subject}** from {old} to {new}.',
-        'changed_status': u'{user} changed status of task **{subject}**'
+        'blocked': u'[{user}]({user_link}) blocked task {subject}.',
+        'unblocked': u'[{user}]({user_link}) unblocked task {subject}.',
+        'changed_status': u'[{user}]({user_link}) changed status of task {subject}'
         ' from {old} to {new}.',
-        'renamed': u'{user} renamed task {old} to **{new}**.',
-        'description_diff': u'{user} updated description of task **{subject}**.',
-        'commented': u'{user} commented on task **{subject}**.',
-        'delete': u'{user} deleted task **{subject}**.',
-        'changed_us': u'{user} moved task **{subject}** from user story {old} to {new}.'
+        'renamed': u'[{user}]({user_link}) renamed task {old} to **{new}**.',
+        'description_diff': u'[{user}]({user_link}) updated description of task {subject}.',
+        'set_milestone': u'[{user}]({user_link}) added task {subject} to sprint {new}.',
+        'commented': u'[{user}]({user_link}) commented on task {subject}.',
+        'delete': u'[{user}]({user_link}) deleted task {subject}.',
+        'changed_us': u'[{user}]({user_link}) moved task {subject} from user story {old} to {new}.',
+        'due_date': u'[{user}]({user_link}) changed due date of task {subject}'
+        ' from {old} to {new}.',
+        'set_due_date': u'[{user}]({user_link}) set due date of task {subject}'
+        ' to {new}.',
     },
     'issue': {
-        'create': u'{user} created issue **{subject}**.',
-        'set_assigned_to': u'{user} assigned issue **{subject}** to {new}.',
-        'unset_assigned_to': u'{user} unassigned issue **{subject}**.',
-        'changed_assigned_to': u'{user} reassigned issue **{subject}**'
+        'create': u'[{user}]({user_link}) created issue {subject}.',
+        'set_assigned_to': u'[{user}]({user_link}) assigned issue {subject} to {new}.',
+        'unset_assigned_to': u'[{user}]({user_link}) unassigned issue {subject}.',
+        'changed_assigned_to': u'[{user}]({user_link}) reassigned issue {subject}'
         ' from {old} to {new}.',
-        'changed_priority': u'{user} changed priority of issue '
-                            '**{subject}** from {old} to {new}.',
-        'changed_severity': u'{user} changed severity of issue '
-                            '**{subject}** from {old} to {new}.',
-        'changed_status': u'{user} changed status of issue **{subject}**'
+        'set_milestone': u'[{user}]({user_link}) added issue {subject} to sprint {new}.',
+        'unset_milestone': u'[{user}]({user_link}) detached issue {subject} from sprint {old}.',
+        'changed_priority': u'[{user}]({user_link}) changed priority of issue '
+                            '{subject} from {old} to {new}.',
+        'changed_severity': u'[{user}]({user_link}) changed severity of issue '
+                            '{subject} from {old} to {new}.',
+        'changed_status': u'[{user}]({user_link}) changed status of issue {subject}'
                            ' from {old} to {new}.',
-        'changed_type': u'{user} changed type of issue **{subject}** from {old} to {new}.',
-        'renamed': u'{user} renamed issue {old} to **{new}**.',
-        'description_diff': u'{user} updated description of issue **{subject}**.',
-        'commented': u'{user} commented on issue **{subject}**.',
-        'delete': u'{user} deleted issue **{subject}**.'
+        'changed_type': u'[{user}]({user_link}) changed type of issue {subject} from {old} to {new}.',
+        'renamed': u'[{user}]({user_link}) renamed issue {old} to **{new}**.',
+        'description_diff': u'[{user}]({user_link}) updated description of issue {subject}.',
+        'commented': u'[{user}]({user_link}) commented on issue {subject}.',
+        'delete': u'[{user}]({user_link}) deleted issue {subject}.',
+        'due_date': u'[{user}]({user_link}) changed due date of issue {subject}'
+        ' from {old} to {new}.',
+        'set_due_date': u'[{user}]({user_link}) set due date of issue {subject}'
+        ' to {new}.',
+        'blocked': u'[{user}]({user_link}) blocked issue {subject}.',
+        'unblocked': u'[{user}]({user_link}) unblocked issue {subject}.',
     },
     'webhook_test': {
-        'test': u'{user} triggered a test of the Taiga integration.'
+        'test': u'[{user}]({user_link}) triggered a test of the Taiga integration.'
     },
 }
 
@@ -134,14 +152,8 @@ return_type = Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]
 def get_old_and_new_values(change_type: str,
                            message: Mapping[str, Any]) -> return_type:
     """ Parses the payload and finds previous and current value of change_type."""
-    if change_type in ['subject', 'name', 'estimated_finish', 'estimated_start']:
-        old = message["change"]["diff"][change_type]["from"]
-        new = message["change"]["diff"][change_type]["to"]
-        return old, new
-
     old = message["change"]["diff"][change_type].get("from")
     new = message["change"]["diff"][change_type].get("to")
-
     return old, new
 
 
@@ -152,6 +164,7 @@ def parse_comment(message: Mapping[str, Any]) -> Dict[str, Any]:
         'type': message["type"],
         'values': {
             'user': get_owner_name(message),
+            'user_link': get_owner_link(message),
             'subject': get_subject(message)
         }
     }
@@ -164,8 +177,9 @@ def parse_create_or_delete(message: Mapping[str, Any]) -> Dict[str, Any]:
             'event': message["action"],
             'values': {
                 'user': get_owner_name(message),
-                'epic_subject': message['data']['epic']['subject'],
-                'userstory_subject': message['data']['user_story']['subject'],
+                'user_link': get_owner_link(message),
+                'epic_subject': get_epic_subject(message),
+                'userstory_subject': get_userstory_subject(message),
             }
         }
 
@@ -174,7 +188,8 @@ def parse_create_or_delete(message: Mapping[str, Any]) -> Dict[str, Any]:
         'event': message["action"],
         'values': {
             'user': get_owner_name(message),
-            'subject': get_subject(message)
+            'user_link': get_owner_link(message),
+            'subject': get_subject(message),
         }
     }
 
@@ -184,6 +199,7 @@ def parse_change_event(change_type: str, message: Mapping[str, Any]) -> Optional
     evt = {}  # type: Dict[str, Any]
     values = {
         'user': get_owner_name(message),
+        'user_link': get_owner_link(message),
         'subject': get_subject(message)
     }  # type: Dict[str, Any]
 
@@ -224,9 +240,12 @@ def parse_change_event(change_type: str, message: Mapping[str, Any]) -> Optional
         old, new = get_old_and_new_values(change_type, message)
         values.update({'old': old, 'new': new})
 
-    elif change_type in ["estimated_finish", "estimated_start"]:
+    elif change_type in ["estimated_finish", "estimated_start", "due_date"]:
         old, new = get_old_and_new_values(change_type, message)
-        if not old == new:
+        if not old:
+            event_type = "set_" + change_type
+            values["new"] = new
+        elif not old == new:
             event_type = change_type
             values.update({'old': old, 'new': new})
         else:
@@ -251,6 +270,7 @@ def parse_webhook_test(message: Mapping[str, Any]) -> Dict[str, Any]:
         "event": "test",
         "values": {
             "user": get_owner_name(message),
+            "user_link": get_owner_link(message),
             "end_type": "test"
         }
     }
@@ -278,25 +298,28 @@ def generate_content(data: Mapping[str, Any]) -> str:
     """ Gets the template string and formats it with parsed data. """
     template = templates[data['type']][data['event']]
     content = template.format(**data['values'])
-    end_type = 'end_type'
-    if template.endswith('{subject}**.'):
-        end_type = 'subject'
-    elif template.endswith('{epic_subject}**.'):
-        end_type = 'epic_subject'
-    elif template.endswith('{new}.') or template.endswith('{new}**.'):
-        end_type = 'new'
-    elif template.endswith('{old}.') or template.endswith('{old}**.'):
-        end_type = 'old'
-    end = data['values'].get(end_type)
-
-    if end[-1] in string.punctuation:
-        content = content[:-1]
-
     return content
 
 def get_owner_name(message: Mapping[str, Any]) -> str:
     return message["by"]["full_name"]
 
+def get_owner_link(message: Mapping[str, Any]) -> str:
+    return message['by']['permalink']
+
 def get_subject(message: Mapping[str, Any]) -> str:
     data = message["data"]
-    return data.get("subject", data.get("name"))
+    if 'permalink' in data:
+        return '[' + data.get('subject', data.get('name')) + ']' + '(' + data['permalink'] + ')'
+    return '**' + data.get('subject', data.get('name')) + '**'
+
+def get_epic_subject(message: Mapping[str, Any]) -> str:
+    if 'permalink' in message['data']['epic']:
+        return ('[' + message['data']['epic']['subject'] + ']' +
+                '(' + message['data']['epic']['permalink'] + ')')
+    return '**' + message['data']['epic']['subject'] + '**'
+
+def get_userstory_subject(message: Mapping[str, Any]) -> str:
+    if 'permalink' in message['data']['user_story']:
+        us_data = message['data']['user_story']
+        return '[' + us_data['subject'] + ']' + '(' + us_data['permalink'] + ')'
+    return '**' + message['data']['user_story']['subject'] + '**'


### PR DESCRIPTION
In the current Taiga Integration webhook messages look like:

> User did this
But Taiga webhook got upgraded and now provides link support as well. So use the permalink in the template if available so that it now looks like:

> [User](www.google.com) did [this](www.google.com).

Otherwise show the old Taiga messge as support for the older Taiga version has also been preserved.

To do this, change all the templates and create new functions which check the webhook JSON and 
return the username, issue name, subject name, etc. based on the link availabilty in JSON file.

Also add more events which were not covered in the previous Taiga implimentation.

If some activity happens under a particular 'sprint' in Taiga then publish the webhook message of that activity under the 'sprint name' topic, which is available in the webhook JSON, so that it is more clear to the users.

Change the tests accordingly and added new tests for the events that the current Taiga integration was lacking and also for old events with new added links.

Fixes #13698 . 