### PR TITLE
fold_dict: Reimplement FoldDict using Map

### DIFF
--- a/static/js/fold_dict.ts
+++ b/static/js/fold_dict.ts
@@ -1,5 +1,3 @@
-import * as _ from 'underscore';
-
 /*
     Use this class to manage keys where you don't care
     about case (i.e. case-insensitive).
@@ -15,15 +13,12 @@ import * as _ from 'underscore';
         - etc.
  */
 type KeyValue<V> = { k: string; v: V };
-type Items<V> = {
-    [key: string]: KeyValue<V>;
-};
 
 export class FoldDict<V> {
-    private _items: Items<V> = {};
+    private _items: Map<string, KeyValue<V>> = new Map();
 
     get(key: string): V | undefined {
-        const mapping = this._items[this._munge(key)];
+        const mapping = this._items.get(this._munge(key));
         if (mapping === undefined) {
             return undefined;
         }
@@ -31,45 +26,44 @@ export class FoldDict<V> {
     }
 
     set(key: string, value: V): V {
-        this._items[this._munge(key)] = {k: key, v: value};
+        this._items.set(this._munge(key), {k: key, v: value});
         return value;
     }
 
     has(key: string): boolean {
-        return _.has(this._items, this._munge(key));
+        return this._items.has(this._munge(key));
     }
 
     del(key: string): void {
-        delete this._items[this._munge(key)];
+        this._items.delete(this._munge(key));
     }
 
     keys(): string[] {
-        return _.pluck(_.values(this._items), 'k');
+        return [...this._items.values()].map(({k}) => k);
     }
 
     values(): V[] {
-        return _.pluck(_.values(this._items), 'v');
+        return [...this._items.values()].map(({v}) => v);
     }
 
     items(): [string, V][] {
-        return _.map(_.values(this._items),
-            (mapping: KeyValue<V>): [string, V] => [mapping.k, mapping.v]);
+        return [...this._items.values()].map(({k, v}) => [k, v]);
     }
 
     num_items(): number {
-        return _.keys(this._items).length;
+        return this._items.size;
     }
 
     is_empty(): boolean {
-        return _.isEmpty(this._items);
+        return this._items.size === 0;
     }
 
     each(f: (v: V, k?: string) => void): void {
-        _.each(this._items, (mapping: KeyValue<V>) => f(mapping.v, mapping.k));
+        this._items.forEach(({k, v}) => f(v, k));
     }
 
     clear(): void {
-        this._items = {};
+        this._items.clear();
     }
 
     // Handle case-folding of keys and the empty string.
@@ -79,7 +73,6 @@ export class FoldDict<V> {
             return undefined;
         }
 
-        const str_key = ':' + key.toString().toLowerCase();
-        return str_key;
+        return key.toString().toLowerCase();
     }
 }


### PR DESCRIPTION
Replaces @showell’s #13633 at his request. Performance is approximately equivalent on the microbenchmark provided there, and probably much better for `.keys()` and `.items()` which are not covered by that microbenchmark.