### PR TITLE
login: Make authentication_methods data available to JavaScript

### DIFF
--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -73,11 +73,12 @@ page can be easily identified in it's respective JavaScript file -->
                             {% endif %}
                         {% endif %}
 
-                        {% for backend in external_authentication_methods %}
+                        {% for backend in page_params.external_authentication_methods %}
                         <div class="login-social">
                             <form class="form-inline" action="{{ backend.signup_url }}" method="get">
                                 <input type='hidden' name='multiuse_object_key' value='{{ multiuse_object_key }}' />
-                                <button class="login-social-button full-width" {% if backend.display_icon %} style="background-image:url({{ backend.display_icon }})"  {% endif %}>
+                                <button id="register_{{ backend.button_id_suffix }}" class="login-social-button full-width"
+                                  {% if backend.display_icon %} style="background-image:url({{ backend.display_icon }})"  {% endif %}>
                                     {{ _('Sign up with %(identity_provider)s', identity_provider=backend.display_name) }}
                                 </button>
                             </form>

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -114,11 +114,12 @@ page can be easily identified in it's respective JavaScript file. -->
 
                     {% endif %} <!-- if password_auth_enabled -->
 
-                    {% for backend in external_authentication_methods %}
+                    {% for backend in page_params.external_authentication_methods %}
                     <div class="login-social">
                         <form class="social_login_form form-inline" action="{{ backend.login_url }}" method="get">
                             <input type="hidden" name="next" value="{{ next }}">
-                            <button class="login-social-button" {% if backend.display_icon %} style="background-image:url({{ backend.display_icon }})"  {% endif %}>
+                            <button id="login_{{ backend.button_id_suffix }}" class="login-social-button"
+                              {% if backend.display_icon %} style="background-image:url({{ backend.display_icon }})"  {% endif %}>
                                 {{ _('Log in with %(identity_provider)s', identity_provider=backend.display_name) }}
                             </button>
                         </form>

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -178,6 +178,15 @@ def login_context(request: HttpRequest) -> Dict[str, Any]:
     context['external_authentication_methods'] = get_external_method_dicts(realm)
     context['no_auth_enabled'] = no_auth_enabled
 
+    # Include another copy of external_authentication_methods in page_params for use
+    # by the desktop client. We expand it with IDs of the <button> elements corresponding
+    # to the authentication methods.
+    context['page_params'] = dict(
+        external_authentication_methods = get_external_method_dicts(realm)
+    )
+    for auth_dict in context['page_params']['external_authentication_methods']:
+        auth_dict['button_id_suffix'] = "auth_button_%s" % (auth_dict['name'],)
+
     return context
 
 def latest_info_context() -> Dict[str, str]:

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1948,6 +1948,9 @@ class DevGetEmailsTest(ZulipTestCase):
             self.assert_json_error_contains(result, "Dev environment not enabled.", 400)
 
 class ExternalMethodDictsTests(ZulipTestCase):
+    def get_configured_saml_backend_idp_names(self) -> List[str]:
+        return settings.SOCIAL_AUTH_SAML_ENABLED_IDPS.keys()
+
     def test_get_external_method_dicts_correctly_sorted(self) -> None:
         with self.settings(
             AUTHENTICATION_BACKENDS=('zproject.backends.EmailAuthBackend',
@@ -1968,6 +1971,29 @@ class ExternalMethodDictsTests(ZulipTestCase):
                     reverse=True
                 )]
             )
+
+    def test_get_external_method_buttons(self) -> None:
+        with self.settings(
+            AUTHENTICATION_BACKENDS=('zproject.backends.EmailAuthBackend',
+                                     'zproject.backends.GitHubAuthBackend',
+                                     'zproject.backends.GoogleAuthBackend',
+                                     'zproject.backends.SAMLAuthBackend')
+        ):
+            saml_idp_names = self.get_configured_saml_backend_idp_names()
+            expected_button_id_strings = [
+                'id="{}_auth_button_github"',
+                'id="{}_auth_button_google"'
+            ]
+            for name in saml_idp_names:
+                expected_button_id_strings.append('id="{}_auth_button_saml:%s"' % (name,))
+
+            result = self.client_get("/login/")
+            self.assert_in_success_response([string.format("login") for string in expected_button_id_strings],
+                                            result)
+
+            result = self.client_get("/register/")
+            self.assert_in_success_response([string.format("register") for string in expected_button_id_strings],
+                                            result)
 
 class FetchAuthBackends(ZulipTestCase):
     def assert_on_error(self, error: Optional[str]) -> None:

--- a/zerver/tests/test_templates.py
+++ b/zerver/tests/test_templates.py
@@ -1,15 +1,18 @@
 # -*- coding: utf-8 -*-
 
+import mock
 import re
 from typing import Any, Dict, Iterable
 import logging
 
+from django.contrib.auth.models import AnonymousUser
 from django.test import override_settings
 from django.template.loader import get_template
 from django.test.client import RequestFactory
 
 from jinja2.exceptions import UndefinedError
 
+from zerver.context_processors import login_context
 from zerver.lib.exceptions import InvalidMarkdownIncludeStatement
 from zerver.lib.test_helpers import get_all_templates
 from zerver.lib.test_classes import (
@@ -199,6 +202,12 @@ of syntax errors.  There are two common causes for this test failing:
             realm_icon_url=lambda _: "url",
             realm=realm,
         )
+
+        # A necessary block to make login_context available to templates.
+        request = mock.MagicMock()
+        request.user = AnonymousUser()
+        request.realm = realm
+        context.update(login_context(request))
 
         context.update(kwargs)
         return context

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -703,13 +703,13 @@ def login_page(request: HttpRequest, **kwargs: Any) -> HttpResponse:
 
     if 'username' in request.POST:
         extra_context['email'] = request.POST['username']
+    extra_context.update(login_context(request))
 
     if settings.TWO_FACTOR_AUTHENTICATION_ENABLED:
         return start_two_factor_auth(request, extra_context=extra_context,
                                      **kwargs)
 
     try:
-        extra_context.update(login_context(request))
         template_response = django_login_page(
             request, authentication_form=OurAuthenticationForm,
             extra_context=extra_context, **kwargs)


### PR DESCRIPTION
Expands on the idea in https://github.com/zulip/zulip/pull/13770, with generation of button ids to make the buttons easier to find for the app.

The change in the 2nd commit caused ``TestTwoFactor`` to fail due to template rendering error - showing the two factor code paths render these templates and thus it's a bug they don't have ``login_context`` applied to their context, so the first commit fixes that.