### PR TITLE
[WIP] registration: Handle mobile and desktop flows.

### DIFF
--- a/zerver/lib/sessions.py
+++ b/zerver/lib/sessions.py
@@ -1,13 +1,15 @@
 import logging
 
+from datetime import timedelta
 from django.conf import settings
 from django.contrib.auth import SESSION_KEY, get_user_model
 from django.contrib.sessions.models import Session
 from django.utils.timezone import now as timezone_now
 from importlib import import_module
-from typing import List, Mapping, Optional
+from typing import Any, List, Mapping, Optional
 
 from zerver.models import Realm, UserProfile, get_user_profile_by_id
+from zerver.lib.timestamp import datetime_to_timestamp, timestamp_to_datetime
 
 session_engine = import_module(settings.SESSION_ENGINE)
 
@@ -53,3 +55,26 @@ def delete_all_deactivated_user_sessions() -> None:
         if not user_profile.is_active or user_profile.realm.deactivated:
             logging.info("Deactivating session for deactivated user %s" % (user_profile.id,))
             delete_session(session)
+
+def set_expirable_session_var(session: Session, var_name: str, var_value: Any, expiry_seconds: int) -> None:
+    expire_at = datetime_to_timestamp(timezone_now() + timedelta(seconds=expiry_seconds))
+    session[var_name] = {'value': var_value, 'expire_at': expire_at}
+
+def get_expirable_session_var(session: Session, var_name: str, default_value: Any=None,
+                              delete: bool=False) -> Any:
+    if var_name not in session:
+        return default_value
+
+    try:
+        value, expire_at = (session[var_name]['value'], session[var_name]['expire_at'])
+    except (KeyError, TypeError) as e:
+        logging.warning("get_expirable_session_var: Variable {}: {}".format(var_name, e))
+        return default_value
+
+    if timestamp_to_datetime(expire_at) < timezone_now():
+        del session[var_name]
+        return default_value
+
+    if delete:
+        del session[var_name]
+    return value

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -85,6 +85,8 @@ class RedirectAndLogIntoSubdomainTestCase(ZulipTestCase):
                                     'full_name_validated': False,
                                     'subdomain': realm.subdomain,
                                     'is_signup': False,
+                                    'desktop_flow_otp': None,
+                                    'mobile_flow_otp': None,
                                     'multiuse_object_key': ''})
 
         response = redirect_and_log_into_subdomain(realm, name, email,
@@ -96,6 +98,8 @@ class RedirectAndLogIntoSubdomainTestCase(ZulipTestCase):
                                     'full_name_validated': False,
                                     'subdomain': realm.subdomain,
                                     'is_signup': True,
+                                    'desktop_flow_otp': None,
+                                    'mobile_flow_otp': None,
                                     'multiuse_object_key': 'key'
                                     })
 
@@ -109,6 +113,8 @@ class RedirectAndLogIntoSubdomainTestCase(ZulipTestCase):
                                     'full_name_validated': True,
                                     'subdomain': realm.subdomain,
                                     'is_signup': True,
+                                    'desktop_flow_otp': None,
+                                    'mobile_flow_otp': None,
                                     'multiuse_object_key': 'key'
                                     })
 

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -29,6 +29,7 @@ from zerver.lib.push_notifications import push_notifications_enabled
 from zerver.lib.redis_utils import get_redis_client, get_dict_from_redis, put_dict_in_redis
 from zerver.lib.request import REQ, has_request_variables, JsonableError
 from zerver.lib.response import json_success, json_error
+from zerver.lib.sessions import set_expirable_session_var
 from zerver.lib.subdomains import get_subdomain, is_subdomain_root_or_alias
 from zerver.lib.user_agent import parse_user_agent
 from zerver.lib.users import get_api_key
@@ -82,6 +83,8 @@ def create_preregistration_user(email: str, request: HttpRequest, realm_creation
     )
 
 def maybe_send_to_registration(request: HttpRequest, email: str, full_name: str='',
+                               mobile_flow_otp: Optional[str]=None,
+                               desktop_flow_otp: Optional[str]=None,
                                is_signup: bool=False, password_required: bool=True,
                                multiuse_object_key: str='',
                                full_name_validated: bool=False) -> HttpResponse:
@@ -92,6 +95,22 @@ def maybe_send_to_registration(request: HttpRequest, email: str, full_name: str=
     depending on is_signup, whether the email address can join the
     organization (checked in HomepageForm), and similar details.
     """
+
+    # In the desktop and mobile flows, the sign up happens in the browser,
+    # and at the end, with the user account created, we pass the appropriate data
+    # to the app. To keep track of the information about mobile/desktop flow,
+    # we store it in the session.
+    # Session is the chosen form of storage in order for it to persist through user mistakes
+    # leading to failed sign up (so that they can try again and upon success still go to the app)
+    # and to be tied specifically to the browser.
+    assert not (mobile_flow_otp and desktop_flow_otp)
+    if mobile_flow_otp:
+        set_expirable_session_var(request.session, 'registration_mobile_flow_otp', mobile_flow_otp,
+                                  expiry_seconds=3600)
+    elif desktop_flow_otp:
+        set_expirable_session_var(request.session, 'registration_desktop_flow_otp', desktop_flow_otp,
+                                  expiry_seconds=3600)
+
     if multiuse_object_key:
         from_multiuse_invite = True
         multiuse_obj = Confirmation.objects.get(confirmation_key=multiuse_object_key).content_object
@@ -172,7 +191,9 @@ def maybe_send_to_registration(request: HttpRequest, email: str, full_name: str=
     context = login_context(request)
     extra_context = {'form': form, 'current_url': lambda: url,
                      'from_multiuse_invite': from_multiuse_invite,
-                     'multiuse_object_key': multiuse_object_key}  # type: Mapping[str, Any]
+                     'multiuse_object_key': multiuse_object_key,
+                     'mobile_flow_otp': mobile_flow_otp,
+                     'desktop_flow_otp': desktop_flow_otp}  # type: Mapping[str, Any]
     context.update(extra_context)
     return render(request, 'zerver/accounts_home.html', context=context)
 
@@ -183,6 +204,8 @@ def redirect_to_subdomain_login_url() -> HttpResponseRedirect:
 
 def register_remote_user(request: HttpRequest, remote_username: str,
                          full_name: str='',
+                         mobile_flow_otp: Optional[str]=None,
+                         desktop_flow_otp: Optional[str]=None,
                          is_signup: bool=False,
                          multiuse_object_key: str='',
                          full_name_validated: bool=False) -> HttpResponse:
@@ -191,6 +214,8 @@ def register_remote_user(request: HttpRequest, remote_username: str,
     # there's no associated Zulip user account.  Consider sending
     # the request to registration.
     return maybe_send_to_registration(request, email, full_name, password_required=False,
+                                      mobile_flow_otp=mobile_flow_otp,
+                                      desktop_flow_otp=desktop_flow_otp,
                                       is_signup=is_signup, multiuse_object_key=multiuse_object_key,
                                       full_name_validated=full_name_validated)
 
@@ -222,7 +247,10 @@ def login_or_register_remote_user(request: HttpRequest, remote_username: str,
     """
     if user_profile is None or user_profile.is_mirror_dummy:
         return register_remote_user(request, remote_username, full_name,
-                                    is_signup=is_signup, multiuse_object_key=multiuse_object_key,
+                                    is_signup=is_signup,
+                                    mobile_flow_otp=mobile_flow_otp,
+                                    desktop_flow_otp=desktop_flow_otp,
+                                    multiuse_object_key=multiuse_object_key,
                                     full_name_validated=full_name_validated)
 
     # Otherwise, the user has successfully authenticated to an
@@ -523,6 +551,8 @@ def log_into_subdomain(request: HttpRequest, token: str) -> HttpResponse:
     full_name = data.get('name', '')
     is_signup = data.get('is_signup', False)
     redirect_to = data.get('next', '')
+    mobile_flow_otp = data.get('mobile_flow_otp')
+    desktop_flow_otp = data.get('desktop_flow_otp')
     full_name_validated = data.get('full_name_validated', False)
     multiuse_object_key = data.get('multiuse_object_key', '')
 
@@ -558,6 +588,8 @@ def log_into_subdomain(request: HttpRequest, token: str) -> HttpResponse:
     return login_or_register_remote_user(request, email_address, user_profile,
                                          full_name,
                                          is_signup=is_signup, redirect_to=redirect_to,
+                                         mobile_flow_otp=mobile_flow_otp,
+                                         desktop_flow_otp=desktop_flow_otp,
                                          multiuse_object_key=multiuse_object_key,
                                          full_name_validated=full_name_validated)
 
@@ -577,10 +609,14 @@ def get_login_data(token: str, should_delete: bool=True) -> Optional[Dict[str, A
 
 def redirect_and_log_into_subdomain(realm: Realm, full_name: str, email_address: str,
                                     is_signup: bool=False, redirect_to: str='',
+                                    mobile_flow_otp: Optional[str]=None,
+                                    desktop_flow_otp: Optional[str]=None,
                                     multiuse_object_key: str='',
-                                    full_name_validated: bool=False) -> HttpResponse:
+                                    full_name_validated: bool=False,) -> HttpResponse:
     data = {'name': full_name, 'email': email_address, 'subdomain': realm.subdomain,
             'is_signup': is_signup, 'next': redirect_to,
+            'mobile_flow_otp': mobile_flow_otp,
+            'desktop_flow_otp': desktop_flow_otp,
             'multiuse_object_key': multiuse_object_key,
             'full_name_validated': full_name_validated}
     token = store_login_data(data)

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -1168,20 +1168,25 @@ def social_auth_finish(backend: Any,
             extra_kwargs["desktop_flow_otp"] = desktop_flow_otp
             extra_kwargs["realm"] = realm
 
-        # For mobile and desktop app authentication, login_or_register_remote_user
-        # will redirect to a special zulip:// URL that is handled by
-        # the app after a successful authentication; so we can
-        # redirect directly from here, saving a round trip over what
-        # we need to do to create session cookies on the right domain
-        # in the web login flow (below).
-        return login_or_register_remote_user(
-            strategy.request, email_address,
-            user_profile, full_name,
-            is_signup=is_signup,
-            redirect_to=redirect_to,
-            full_name_validated=full_name_validated,
-            **extra_kwargs
-        )
+        if user_profile is not None and not user_profile.is_mirror_dummy:
+            # For mobile and desktop app authentication, login_or_register_remote_user
+            # will redirect to a special zulip:// URL that is handled by
+            # the app after a successful authentication; so we can
+            # redirect directly from here, saving a round trip over what
+            # we need to do to create session cookies on the right domain
+            # in the web login flow (below).
+            return login_or_register_remote_user(
+                strategy.request, email_address,
+                user_profile, full_name,
+                is_signup=is_signup,
+                redirect_to=redirect_to,
+                full_name_validated=full_name_validated,
+                **extra_kwargs
+            )
+        else:
+            # The user needs to register, so we need to go the realm's
+            # subdomain for that.
+            pass
 
     # If this authentication code were executing on
     # subdomain.zulip.example.com, we would just call
@@ -1201,7 +1206,9 @@ def social_auth_finish(backend: Any,
         is_signup=is_signup,
         redirect_to=redirect_to,
         multiuse_object_key=multiuse_object_key,
-        full_name_validated=full_name_validated
+        full_name_validated=full_name_validated,
+        mobile_flow_otp=mobile_flow_otp,
+        desktop_flow_otp=desktop_flow_otp
     )
 
 class SocialAuthMixin(ZulipAuthMixin, ExternalAuthMethod):


### PR DESCRIPTION
This doesn't have tests and doesn't try to handle all corner cases yet, and was only very briefly manually tested (seems to work). I'm posting this to get feedback on whether this is a direction we want to go in.

The essence of the approach is:
1. In social flow if user account doesn't exist, go to ``redirect_and_log_into_subdomain`` and plumb the OTP params through the functions in this path.
2. In ``maybe_send_to_registration`` save them into the session. These values are set to expire in 1 hour, because if someone is doing the process that much later, I think they're no longer expecting to go back to the app.
3. At the end of the registration process, in ``login_and_go_to_home`` we check for these session variables, and if set, we finish the flow accordingly.
4. This will redirect the user to the app through ``zulip://``, where it should do its normal end-of-otp-flow things to login the user. I think it would be nice to have another step here, through a page where where the user can choose if they want to go to the app or continue in the browser.