### PR TITLE
Added info about zulip-announce RSS feed to install docs

### DIFF
--- a/docs/production/install.md
+++ b/docs/production/install.md
@@ -106,7 +106,8 @@ Learning more:
 * Subscribe to the
 [Zulip announcements email list](https://groups.google.com/forum/#!forum/zulip-announce)
 for server administrators.  This extremely low-traffic list is for
-important announcements, including new releases and security issues. You can also use the [RSS feed](https://groups.google.com/forum/#!aboutgroup/zulip-announce).
+important announcements, including new releases and security issues. You can also use the
+[RSS feed](https://groups.google.com/forum/#!aboutgroup/zulip-announce).
 * Follow [Zulip on Twitter](https://twitter.com/zulip).
 * Learn how to [configure your Zulip server settings](settings.md).
 * Learn about [Backups, export and import](../production/export-and-import.md)

--- a/docs/production/install.md
+++ b/docs/production/install.md
@@ -106,7 +106,7 @@ Learning more:
 * Subscribe to the
 [Zulip announcements email list](https://groups.google.com/forum/#!forum/zulip-announce)
 for server administrators.  This extremely low-traffic list is for
-important announcements, including new releases and security issues.
+important announcements, including new releases and security issues. You can also use the [RSS feed](https://groups.google.com/forum/#!aboutgroup/zulip-announce).
 * Follow [Zulip on Twitter](https://twitter.com/zulip).
 * Learn how to [configure your Zulip server settings](settings.md).
 * Learn about [Backups, export and import](../production/export-and-import.md)


### PR DESCRIPTION
The mailing list can also be subscribed to via RSS/Atom feeds, I just wanted to make that information easier accessible.