### PR TITLE
webhooks/ansibletower: Update for AWX 9.1.1.

### DIFF
--- a/zerver/webhooks/ansibletower/fixtures/job_complete_successful_awx_9.1.1.json
+++ b/zerver/webhooks/ansibletower/fixtures/job_complete_successful_awx_9.1.1.json
@@ -1,0 +1,29 @@
+{
+  "id": 1,
+  "name": "Demo Job Template",
+  "url": "https://towerhost/#/jobs/playbook/1",
+  "created_by": "admin",
+  "started": "2020-01-23T09:15:45.741213+00:00",
+  "finished": "2020-01-23T09:15:49.729882+00:00",
+  "status": "successful",
+  "traceback": "",
+  "inventory": "Demo Inventory",
+  "project": "Demo Project",
+  "playbook": "hello_world.yml",
+  "credential": "Demo Credential",
+  "limit": "",
+  "extra_vars": "{}",
+  "hosts": {
+    "localhost": {
+      "failed": false,
+      "changed": 0,
+      "dark": 0,
+      "failures": 0,
+      "ok": 2,
+      "processed": 1,
+      "skipped": 0,
+      "rescued": 0,
+      "ignored": 0
+    }
+  }
+}

--- a/zerver/webhooks/ansibletower/tests.py
+++ b/zerver/webhooks/ansibletower/tests.py
@@ -55,6 +55,19 @@ Job: [#2674 System - Deploy - Zabbix Agent](http://awx.example.co.uk/#/jobs/play
 
         self.send_and_test_stream_message('job_successful', expected_topic, expected_message)
 
+    def test_ansibletower_nine_job_successful_message(self) -> None:
+        """
+        Test to see if awx/ansibletower 9.x.x job successful notifications are
+        handled just as successfully as prior to 9.x.x.
+        """
+        expected_topic = "Demo Job Template"
+        expected_message = """
+Job: [#1 Demo Job Template](https://towerhost/#/jobs/playbook/1) was successful:
+* localhost: Success
+""".strip()
+
+        self.send_and_test_stream_message('job_complete_successful_awx_9.1.1', expected_topic, expected_message)
+
     def test_ansibletower_job_failed_message(self) -> None:
         """
         Tests if ansibletower job failed notification is handled correctly

--- a/zerver/webhooks/ansibletower/view.py
+++ b/zerver/webhooks/ansibletower/view.py
@@ -30,8 +30,19 @@ def api_ansibletower_webhook(request: HttpRequest, user_profile: UserProfile,
     check_send_webhook_message(request, user_profile, subject, body)
     return json_success()
 
+def extract_friendly_name(payload: Dict[str, Any]) -> str:
+    tentative_job_name = payload.get("friendly_name", "")
+    if not tentative_job_name:
+        url = payload["url"]
+        segments = url.split("/")
+        tentative_job_name = segments[-3]
+        if tentative_job_name == "jobs":
+            tentative_job_name = "Job"
+    return tentative_job_name
+
 def get_body(payload: Dict[str, Any]) -> str:
-    if (payload['friendly_name'] == 'Job'):
+    friendly_name = extract_friendly_name(payload)
+    if (friendly_name == 'Job'):
         hosts_list_data = payload['hosts']
         hosts_data = []
         for host in payload['hosts']:
@@ -51,7 +62,7 @@ def get_body(payload: Dict[str, Any]) -> str:
 
         return ANSIBLETOWER_JOB_MESSAGE_TEMPLATE.format(
             name=payload['name'],
-            friendly_name=payload['friendly_name'],
+            friendly_name=friendly_name,
             id=payload['id'],
             url=payload['url'],
             status=status,
@@ -67,7 +78,7 @@ def get_body(payload: Dict[str, Any]) -> str:
 
         data = {
             "name": payload['name'],
-            "friendly_name": payload['friendly_name'],
+            "friendly_name": friendly_name,
             "id": payload['id'],
             "url": payload['url'],
             "status": status


### PR DESCRIPTION
Add a simple compatibility function for AWX 9.x.x. Before AWX 9.x.x
a "friendly_name" key was sent by default. Afterwards it was removed
from being a default key but we can still more or less determine if
the triggering event was a job from the REST-style URL.

Note: It is also technically possible to add the key back by defining
a custom notification template in AWX/Tower.

Resolves #13295.