### PR TITLE
Auth migrations for Django 2.2

### DIFF
--- a/zerver/lib/test_fixtures.py
+++ b/zerver/lib/test_fixtures.py
@@ -102,10 +102,13 @@ def get_migration_status(**options: Any) -> str:
     app_label = options['app_label'] if options.get('app_label') else None
     db = options.get('database', DEFAULT_DB_ALIAS)
     out = StringIO()
+    command_args = ['--list', ]
+    if app_label:
+        command_args.append(app_label)
+
     call_command(
         'showmigrations',
-        '--list',
-        app_label=app_label,
+        *command_args,
         database=db,
         no_color=options.get('no_color', False),
         settings=options.get('settings', os.environ['DJANGO_SETTINGS_MODULE']),

--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -21,7 +21,7 @@ def is_thumbor_enabled() -> bool:
     return settings.THUMBOR_URL != ''
 
 def user_uploads_or_external(url: str) -> bool:
-    return not is_safe_url(url) or url.startswith("/user_uploads/")
+    return not is_safe_url(url, allowed_hosts=None) or url.startswith("/user_uploads/")
 
 def get_source_type(url: str) -> str:
     if not url.startswith('/user_uploads/'):
@@ -38,11 +38,11 @@ def generate_thumbnail_url(path: str,
     path = urljoin("/", path)
 
     if not is_thumbor_enabled():
-        if is_safe_url(path):
+        if is_safe_url(path, allowed_hosts=None):
             return path
         return get_camo_url(path)
 
-    if is_safe_url(path) and not path.startswith("/user_uploads/"):
+    if is_safe_url(path, allowed_hosts=None) and not path.startswith("/user_uploads/"):
         return path
 
     source_type = get_source_type(path)

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -2373,16 +2373,15 @@ class TestDevAuthBackend(ZulipTestCase):
         email = self.example_email("hamlet")
         data = {'direct_email': email}
         with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.EmailAuthBackend',)):
-            with mock.patch('django.core.handlers.exception.logger'):
-                response = self.client_post('/accounts/login/local/', data)
-                self.assertRedirects(response, reverse('dev_not_supported'))
+            response = self.client_post('/accounts/login/local/', data)
+            self.assertRedirects(response, reverse('dev_not_supported'))
 
     def test_login_failure_due_to_nonexistent_user(self) -> None:
         email = 'nonexisting@zulip.com'
         data = {'direct_email': email}
-        with mock.patch('django.core.handlers.exception.logger'):
-            response = self.client_post('/accounts/login/local/', data)
-            self.assertRedirects(response, reverse('dev_not_supported'))
+
+        response = self.client_post('/accounts/login/local/', data)
+        self.assertRedirects(response, reverse('dev_not_supported'))
 
 class TestZulipRemoteUserBackend(ZulipTestCase):
     def test_login_success(self) -> None:

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -57,7 +57,7 @@ ExtraContext = Optional[Dict[str, Any]]
 redis_client = get_redis_client()
 
 def get_safe_redirect_to(url: str, redirect_host: str) -> str:
-    is_url_safe = is_safe_url(url=url, host=redirect_host)
+    is_url_safe = is_safe_url(url=url, allowed_hosts=set(redirect_host))
     if is_url_safe:
         return urllib.parse.urljoin(redirect_host, url)
     else:

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1064,3 +1064,5 @@ CROSS_REALM_BOT_EMAILS = {
 }
 
 THUMBOR_KEY = get_secret('thumbor_key')
+
+TWO_FACTOR_PATCH_ADMIN = False


### PR DESCRIPTION
Addresses parts of https://github.com/zulip/zulip/issues/10835

``auth: Replace deprecated password_reset_confirm.`` requires a test adjustment, because Django does an extra redirect in the process:

```
    @method_decorator(sensitive_post_parameters())
    @method_decorator(never_cache)
    def dispatch(self, *args, **kwargs):
        assert 'uidb64' in kwargs and 'token' in kwargs

        self.validlink = False
        self.user = self.get_user(kwargs['uidb64'])

        if self.user is not None:
            token = kwargs['token']
            if token == INTERNAL_RESET_URL_TOKEN:
                session_token = self.request.session.get(INTERNAL_RESET_SESSION_TOKEN)
                if self.token_generator.check_token(self.user, session_token):
                    # If the token is valid, display the password reset form.
                    self.validlink = True
                    return super().dispatch(*args, **kwargs)
            else:
                if self.token_generator.check_token(self.user, token):
                    # Store the token in the session and redirect to the
                    # password reset form at a URL without the token. That
                    # avoids the possibility of leaking the token in the
                    # HTTP Referer header.
                    self.request.session[INTERNAL_RESET_SESSION_TOKEN] = token
                    redirect_url = self.request.path.replace(token, INTERNAL_RESET_URL_TOKEN)
                    return HttpResponseRedirect(redirect_url)

        # Display the "Password reset unsuccessful" page.
        return self.render_to_response(self.get_context_data())
```
where ``INTERNAL_RESET_URL_TOKEN = 'set-password'``

https://github.com/django/django/blob/aeb8c381789ad93866223f8bd07d09ae5e2edd9e/django/contrib/auth/views.py#L265
