### PR TITLE
Fix behaviour of PM list with deactivated user.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -288,6 +288,13 @@ run_test("validate", () => {
     compose_state.private_message_recipient("bob@example.com");
     assert(compose.validate());
 
+    people.deactivate(bob);
+    assert(!compose.validate());
+    assert.equal(
+        $("#compose-error-msg").html(),
+        i18n.t("The user bob@example.com has been deactivated", {}),
+    );
+
     page_params.realm_is_zephyr_mirror_realm = true;
     assert(compose.validate());
     page_params.realm_is_zephyr_mirror_realm = false;
@@ -840,6 +847,9 @@ run_test("finish", () => {
         compose_state.set_message_type("private");
         compose_state.private_message_recipient = function () {
             return "bob@example.com";
+        };
+        people.is_person_active = function () {
+            return true;
         };
 
         let compose_finished_event_checked = false;

--- a/frontend_tests/node_tests/input_pill.js
+++ b/frontend_tests/node_tests/input_pill.js
@@ -2,6 +2,7 @@
 
 set_global("$", global.make_zjquery());
 zrequire("input_pill");
+zrequire("people");
 
 zrequire("templates");
 
@@ -48,6 +49,14 @@ function pill_html(value, data_id, img_src) {
 run_test("basics", () => {
     const config = {};
 
+    const hamlet = {
+        email: "hamlet@example.com",
+        user_id: 1,
+        full_name: "Hamlet",
+    };
+
+    people.add_active_user(hamlet);
+
     blueslip.expect("error", "Pill needs container.");
     input_pill.create(config);
 
@@ -70,6 +79,7 @@ run_test("basics", () => {
         display_value: "JavaScript",
         language: "js",
         img_src: example_img_link,
+        user_id: hamlet.user_id,
     };
 
     let inserted_before;
@@ -83,28 +93,67 @@ run_test("basics", () => {
     widget.appendValidatedData(item);
     assert(inserted_before);
 
-    assert.deepEqual(widget.items(), [item]);
+    people.deactivate(hamlet);
+
+    inserted_before = false;
+    pill_input.before = function (elem) {
+        inserted_before = true;
+        assert(elem.hasClass("deactivated-user-pill"));
+        const html = elem.html();
+        assert(html.includes("(deactivated)"));
+    };
+
+    widget.appendValidatedData(item);
+    assert(inserted_before);
+
+    assert.deepEqual(widget.items(), [item, item]);
 });
 
 function set_up() {
     set_global("$", global.make_zjquery());
+
+    const user_blue = {
+        email: "blue@example.com",
+        full_name: "BLUE",
+        user_id: 1,
+    };
+
+    const user_red = {
+        email: "red@example.com",
+        full_name: "RED",
+        user_id: 2,
+    };
+
+    const user_yellow = {
+        email: "yellow@example.com",
+        full_name: "YELLOW",
+        user_id: 3,
+    };
+
     const items = {
         blue: {
-            display_value: "BLUE",
+            display_value: user_blue.full_name,
             description: "color of the sky",
             img_src: example_img_link,
+            user_id: user_blue.user_id,
         },
 
         red: {
-            display_value: "RED",
+            display_value: user_red.full_name,
             description: "color of stop signs",
+            user_id: user_red.user_id,
         },
 
         yellow: {
-            display_value: "YELLOW",
+            display_value: user_yellow.full_name,
             description: "color of bananas",
+            user_id: user_yellow.user_id,
         },
     };
+
+    people.add_active_user(user_blue);
+    people.add_active_user(user_red);
+    people.add_active_user(user_yellow);
 
     const pill_input = $.create("pill_input");
 

--- a/frontend_tests/node_tests/input_pill.js
+++ b/frontend_tests/node_tests/input_pill.js
@@ -133,20 +133,17 @@ function set_up() {
     const items = {
         blue: {
             display_value: user_blue.full_name,
-            description: "color of the sky",
             img_src: example_img_link,
             user_id: user_blue.user_id,
         },
 
         red: {
             display_value: user_red.full_name,
-            description: "color of stop signs",
             user_id: user_red.user_id,
         },
 
         yellow: {
             display_value: user_yellow.full_name,
-            description: "color of bananas",
             user_id: user_yellow.user_id,
         },
     };

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -263,7 +263,7 @@ run_test("basics", () => {
     assert.equal(people.get_non_active_human_ids().length, 1);
     assert.equal(people.get_active_human_count(), 1);
     assert.equal(people.is_active_user_for_popover(isaac.user_id), false);
-    assert.equal(people.is_valid_email_for_compose(isaac.email), false);
+    assert.equal(people.is_valid_email_for_compose(isaac.email), true);
 
     people.add_active_user(bot_botson);
     assert.equal(people.is_active_user_for_popover(bot_botson.user_id), true);
@@ -989,7 +989,7 @@ run_test("initialize", () => {
     assert(people.is_cross_realm_email("bot@example.com"));
     assert(people.is_valid_email_for_compose("bot@example.com"));
     assert(people.is_valid_email_for_compose("alice@example.com"));
-    assert(!people.is_valid_email_for_compose("retiree@example.com"));
+    assert(people.is_valid_email_for_compose("retiree@example.com"));
     assert(!people.is_valid_email_for_compose("totally-bogus-username@example.com"));
     assert(people.is_valid_bulk_emails_for_compose(["bot@example.com", "alice@example.com"]));
     assert(!people.is_valid_bulk_emails_for_compose(["not@valid.com", "alice@example.com"]));

--- a/frontend_tests/node_tests/top_left_corner.js
+++ b/frontend_tests/node_tests/top_left_corner.js
@@ -57,6 +57,12 @@ run_test("narrowing", () => {
     top_left_corner.handle_narrow_activated(filter);
     assert(!pm_expanded);
 
+    pm_expanded = false;
+    people.deactivate(alice);
+    filter = new Filter([{operator: "pm-with", operand: "alice@example.com"}]);
+    top_left_corner.handle_narrow_activated(filter);
+    assert(pm_expanded);
+
     filter = new Filter([{operator: "is", operand: "mentioned"}]);
     top_left_corner.handle_narrow_activated(filter);
     assert($(".top_left_mentions").hasClass("active-filter"));

--- a/static/js/input_pill.js
+++ b/static/js/input_pill.js
@@ -102,21 +102,50 @@ exports.create = function (opts) {
 
             store.pills.push(payload);
 
-            const has_image = item.img_src !== undefined;
+            if (people.is_person_active(item.user_id)) {
+                payload.$element = this.renderActiveUserData(payload);
+            } else {
+                payload.$element = this.renderDeactivatedUserData(payload);
+            }
+
+            store.$input.before(payload.$element);
+        },
+
+        renderActiveUserData(payload) {
+            const has_image = payload.item.img_src !== undefined;
 
             const opts = {
                 id: payload.id,
-                display_value: item.display_value,
+                display_value: payload.item.display_value,
                 has_image,
             };
 
             if (has_image) {
-                opts.img_src = item.img_src;
+                opts.img_src = payload.item.img_src;
             }
 
             const pill_html = render_input_pill(opts);
-            payload.$element = $(pill_html);
-            store.$input.before(payload.$element);
+            return $(pill_html);
+        },
+
+        renderDeactivatedUserData(payload) {
+            const has_image = payload.item.img_src !== undefined;
+
+            const opts = {
+                id: payload.id,
+                display_value: payload.item.display_value + " (deactivated)",
+                has_image,
+            };
+
+            if (has_image) {
+                opts.img_src = payload.item.img_src;
+            }
+
+            const pill_html = render_input_pill(opts);
+            const $pill = $(pill_html);
+            $pill.addClass("deactivated-user-pill");
+            $pill.prop("title", i18n.t("Can't send messages to the deactivated user"));
+            return $pill;
         },
 
         // this appends a pill to the end of the container but before the

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -688,15 +688,11 @@ exports.small_avatar_url = function (message) {
 };
 
 exports.is_valid_email_for_compose = function (email) {
-    if (exports.is_cross_realm_email(email)) {
-        return true;
-    }
-
     const person = exports.get_by_email(email);
     if (!person) {
         return false;
     }
-    return active_user_dict.has(person.user_id);
+    return true;
 };
 
 exports.is_valid_bulk_emails_for_compose = function (emails) {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1469,6 +1469,10 @@ div.focused_table {
     }
 }
 
+.deactivated-user-pill {
+    background-color: hsl(0, 86%, 86%) !important;
+}
+
 #message_view_header {
     z-index: 2;
     float: left;


### PR DESCRIPTION
Previously, clicking a deactivated user in the PM list caused the list to collapse without any explanation.

The PR fixes this in the following steps:
* Allow the deactivated user's pills in the compose box like any other user.
* Customize deactivated user's pill and add a tooltip to visually distinguish it from the active users (as shown in the screenshot).
* If someone tries to send a message to the deactivated user, show a compose error (as shown in the screenshot).

Fixes #13766.

**Testing Plan:**
Unit tests.

**Screenshot:**
![Screenshot from 2020-07-29 06-31-11](https://user-images.githubusercontent.com/45683359/88746327-bcf07a00-d165-11ea-9afe-5c76de380be1.png)
