### PR TITLE
[WIP] mobile web: Fix bugs in message action buttons

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -705,6 +705,34 @@ td.pointer {
         opacity: 1;
         pointer-events: all;
     }
+
+    @media (max-width: 500px) {
+        background-color: hsla(0, 66%, 100%, 0.9);
+        background-clip: content-box;
+    }
+}
+
+.selected_message .message_controls {
+    @media (max-width: 500px) {
+        background-color: hsla(0, 66%, 100%, 0.9);
+        background-clip: content-box;
+
+        .empty-star {
+            opacity: 0.4;
+        }
+
+        > div {
+            opacity: 0.8;
+        }
+    }
+}
+
+// Button visibility in night mode
+.night-mode .messagebox:hover .message_controls,
+.night-mode .selected_message .message_controls {
+    @media screen and (max-width: 500px) {
+        background-color: hsla(211, 27%, 18%, 0.9);
+    }
 }
 
 .include-sender .message_controls {


### PR DESCRIPTION
The three message actions buttons on the top right of a message box had a
few bugs in mobile web related to visibility as explained in #13642 . This fixes those visibility
issues by adding a semi-opaque background and removing the hover property
for these buttons in mobile web view.

Fixes #13642

Tested on mobile view and normal view.
[TODO] :
Some residual issue with the star's opacity not changing.
The edit button does not appear unless hovered on, beyond which it persists.
* This is not working on the first message of a topic ( possibly because of the topic name).
   Should this be fixed?

[QUERIES]:
Should I keep the background for `message_time`? Looks a little odd otherwise.





