### PR TITLE
hotkeys: disable 'q' and 'w' hotkey when settings dropdown is open

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -200,6 +200,9 @@ run_test('basic_chars', () => {
     set_global('hotspots', {
         is_open: return_false,
     });
+    set_global('gear_menu', {
+        is_open: return_false,
+    });
 
     // All letters should return false if we are composing text.
     hotkey.processing_text = return_true;

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -543,6 +543,12 @@ exports.process_hotkey = function (e, hotkey) {
         }
     }
 
+    // Disable out of message_view_only hotkeys when
+    // settings gear menu is open.
+    if (hotkey.message_view_only && gear_menu.is_open()) {
+        return false;
+    }
+
     // The next two sections date back to 00445c84 and are Mac/Chrome-specific,
     // and they should possibly be eliminated in favor of keeping standard
     // browser behavior.

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -101,12 +101,12 @@ const keypress_mappings = {
     107: {name: 'vim_up', message_view_only: true}, // 'k'
     110: {name: 'n_key', message_view_only: false}, // 'n'
     112: {name: 'p_key', message_view_only: false}, // 'p'
-    113: {name: 'query_streams', message_view_only: false}, // 'q'
+    113: {name: 'query_streams', message_view_only: true}, // 'q'
     114: {name: 'reply_message', message_view_only: true}, // 'r'
     115: {name: 'narrow_by_recipient', message_view_only: true}, // 's'
     117: {name: 'show_sender_info', message_view_only: true}, // 'u'
     118: {name: 'show_lightbox', message_view_only: true}, // 'v'
-    119: {name: 'query_users', message_view_only: false}, // 'w'
+    119: {name: 'query_users', message_view_only: true}, // 'w'
     120: {name: 'compose_private_message', message_view_only: true}, // 'x'
 };
 


### PR DESCRIPTION
Add message_view_only property to 'q' and 'w' hotkeys

Fixes:#11990

**GIFs or Screenshots:**
Without dropdown menu opened:-
![Peek 2020-02-04 01-22](https://user-images.githubusercontent.com/43504292/73685939-157e1780-46ed-11ea-9835-0e895c1378f2.gif)
With dropdown menu open:-
![Peek 2020-02-04 01-23](https://user-images.githubusercontent.com/43504292/73685970-23339d00-46ed-11ea-968e-447f67b3555d.gif)


