### PR TITLE
Enabled replying on a message while editing and The edit bot sidebar now closes upon saving

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -124,8 +124,8 @@ exports.initialize = function () {
             // stopPropagation prevents them from being called.
             return;
         }
-
-        if ($(e.target).is(".message_edit_notice")) {
+        // we do not want to reply if the user is on Save or Cancel button.
+        if ($(e.target).is(".message_edit_notice") || $(e.target).is(".message_edit_save") || $(e.target).is(".message_edit_cancel")) {
             return;
         }
 
@@ -141,11 +141,6 @@ exports.initialize = function () {
         if (drag.val < 5 && drag.time < 150 || drag.val < 2) {
             const row = $(this).closest(".message_row");
             const id = rows.id(row);
-
-            if (message_edit.is_editing(id)) {
-                // Clicks on a message being edited shouldn't trigger a reply.
-                return;
-            }
 
             current_msg_list.select_id(id);
             compose_actions.respond_to_message({trigger: 'message click'});

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -472,6 +472,10 @@ exports.set_up = function () {
                             image_version += 1;
                             image.find('img').attr('src', data.avatar_url + '&v=' + image_version.toString());
                         }
+                        // If the edit is a success then close the sidebar
+                        const $sidebar = $(".form-sidebar");
+                        $sidebar.removeClass("show");
+                        $sidebar.find("#edit_bot").empty();
                     },
                     error: function (xhr) {
                         loading.destroy_indicator(spinner);


### PR DESCRIPTION
#3938
#13644
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
For 3938:
Earlier the code specifically didn't allow reply on message while editing. I deleted the "if" statement preventing that and added the exception that it shouldn't trigger a reply if the user clicks on a button on the edit message box like save or cancel. 

For 13644:
Initially the side-bar for editing bot wouldn't close after hitting save. To achieve that, I copied the "close_sidebar" function from settings.js (static/js/settings.js) and pasted it in settings_bot.js. It is only executed when the edit is a success.

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  [-->]


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
