### PR TITLE
blueslip_stacktrace: Handle promises in sourceCache.

### DIFF
--- a/static/js/blueslip_stacktrace.ts
+++ b/static/js/blueslip_stacktrace.ts
@@ -48,12 +48,12 @@ export function clean_function_name(
     };
 }
 
-const sourceCache: { [source: string]: string } = {};
+const sourceCache: { [source: string]: string | Promise<string> } = {};
 
 const stack_trace_gps = new StackTraceGPS({ sourceCache });
 
-function get_context(location: StackFrame.StackFrame): NumberedLine[] | undefined {
-    const sourceContent = sourceCache[location.getFileName()];
+async function get_context(location: StackFrame.StackFrame): Promise<NumberedLine[] | undefined> {
+    const sourceContent = await sourceCache[location.getFileName()];
     if (sourceContent === undefined) {
         return undefined;
     }
@@ -84,7 +84,7 @@ export async function display_stacktrace(error: string, stack: string): Promise<
                 show_path: clean_path(location.getFileName()),
                 line_number: location.getLineNumber(),
                 function_name: clean_function_name(location.getFunctionName()),
-                context: get_context(location),
+                context: await get_context(location),
             };
         })
     );

--- a/static/js/types/stacktrace-gps/index.d.ts
+++ b/static/js/types/stacktrace-gps/index.d.ts
@@ -5,7 +5,7 @@ import SourceMap from "source-map";
 
 declare namespace StackTraceGPS {
     type StackTraceGPSOptions = {
-        sourceCache?: { [url: string]: string };
+        sourceCache?: { [url: string]: string | Promise<string> };
         sourceMapConsumerCache?: { [sourceMappingUrl: string]: SourceMap.SourceMapConsumer };
         offline?: boolean;
         ajax?(url: string): Promise<string>;


### PR DESCRIPTION
Fixes “TypeError: sourceContent.split is not a function” at blueslip_stacktrace.ts:60 when there’s another error during page load.