### PR TITLE
unread: Replace key_to_bucket Map with Dict/FoldDict/IntDict

### DIFF
--- a/frontend_tests/node_tests/topic_data.js
+++ b/frontend_tests/node_tests/topic_data.js
@@ -2,11 +2,9 @@ zrequire('unread');
 zrequire('util');
 zrequire('stream_data');
 zrequire('topic_data');
-const IntDict = zrequire('int_dict').IntDict;
 
 set_global('channel', {});
 set_global('message_list', {});
-set_global('message_store', {});
 
 run_test('basics', () => {
     const stream_id = 55;
@@ -218,14 +216,10 @@ run_test('test_unread_logic', () => {
         { id: 20, topic: 'UNREAD2' },
     ];
 
-    const message_dict = new IntDict();
-    message_store.get = msg_id => message_dict.get(msg_id);
-
     _.each(msgs, (msg) => {
         msg.type = 'stream';
         msg.stream_id = stream_id;
         msg.unread = true;
-        message_dict.set(msg.id, msg);
     });
 
     unread.process_loaded_messages(msgs);


### PR DESCRIPTION
This reverts commit d84646f0915387fd40c7425b2bdab656e9490a5f (which incorrectly assumed in `unread_topic_counter` that the messages were present in the message store), while fixing the type confusion problem by using `IntDict` for `stream_id` keys.