### PR TITLE
commit-message-lint: Detect the upstream remote name.

### DIFF
--- a/tools/commit-message-lint
+++ b/tools/commit-message-lint
@@ -8,6 +8,12 @@
 if [ "$TRAVIS" ]; then
     # Work around https://github.com/travis-ci/travis-ci/issues/4596
     range="${TRAVIS_COMMIT_RANGE/.../..}"
+elif [[ "
+$(git remote -v)
+" =~ '
+'([^[:space:]]*)[[:space:]]*(https://github\.com/|ssh://git@github\.com/|git@github\.com:)zulip/zulip(\.git|/)?\ \(fetch\)'
+' ]]; then
+    range="${BASH_REMATCH[1]}/master..HEAD"
 else
     range="upstream/master..HEAD"
 fi


### PR DESCRIPTION
My upstream remote is named `origin`, so `commit-message-lint` was always complaining at me.  Detect the right remote name from the output of `git remote -v`.