### PR TITLE
stream_edit: Fix realm time sync of notifications setting checkbox.

### DIFF
--- a/static/js/compose_fade.js
+++ b/static/js/compose_fade.js
@@ -241,10 +241,7 @@ exports.update_rendered_message_groups = function (message_groups, get_element) 
 };
 
 exports.initialize = function () {
-    $(document).on('peer_subscribe.zulip', function () {
-        exports.update_faded_users();
-    });
-    $(document).on('peer_unsubscribe.zulip', function () {
+    $(document).on('peer_subscribe.zulip peer_unsubscribe.zulip', function () {
         exports.update_faded_users();
     });
 };

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -756,6 +756,12 @@ exports.handle_global_notification_updates = function (notification_name, settin
         page_params[notification_name] = setting;
     }
 
+    if (settings_notifications.all_notifications.settings.stream_notification_settings.indexOf(
+        notification_name) !== -1) {
+        notification_name = notification_name.replace("enable_stream_", "");
+        stream_ui_updates.update_notification_setting_checkbox(notification_name);
+    }
+
     if (notification_name === "notification_sound") {
         // Change the sound source with the new page `notification_sound`.
         update_notification_sound_source();

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -311,9 +311,9 @@ function stream_setting_clicked(e) {
     if (e.currentTarget.id === 'sub_is_muted_setting') {
         return;
     }
-    const checkbox_div = $(e.target).closest(".sub_setting_checkbox");
+
+    const checkbox = $(e.currentTarget).find('.sub_setting_control');
     const sub = get_sub_for_target(e.target);
-    const checkbox = checkbox_div.find('.sub_setting_control');
     const setting = checkbox.attr('name');
     if (!sub) {
         blueslip.error('undefined sub in stream_setting_clicked()');

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -308,6 +308,9 @@ function stream_is_muted_clicked(e) {
 }
 
 function stream_setting_clicked(e) {
+    if (e.currentTarget.id === 'sub_is_muted_setting') {
+        return;
+    }
     const checkbox_div = $(e.target).closest(".sub_setting_checkbox");
     const sub = get_sub_for_target(e.target);
     const checkbox = checkbox_div.find('.sub_setting_control');
@@ -517,13 +520,8 @@ exports.initialize = function () {
     $("#subscriptions_table").on("click", "#sub_is_muted_setting",
                                  stream_is_muted_clicked);
 
-    _.each(Object.keys(settings_labels), function (setting) {
-        if (setting === "is_muted") {
-            return;
-        }
-        $("#subscriptions_table").on("click", "#sub_" + setting + "_setting",
-                                     stream_setting_clicked);
-    });
+    $("#subscriptions_table").on("click", ".sub_setting_checkbox",
+                                 stream_setting_clicked);
 
     $("#subscriptions_table").on("submit", ".subscriber_list_add form", function (e) {
         e.preventDefault();

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -650,16 +650,10 @@ exports.initialize = function () {
         }
     });
 
-    $(document).on('peer_subscribe.zulip', function (e, data) {
+    $(document).on('peer_subscribe.zulip peer_unsubscribe.zulip', function (e, data) {
         const sub = stream_data.get_sub(data.stream_name);
         subs.rerender_subscriptions_settings(sub);
     });
-
-    $(document).on('peer_unsubscribe.zulip', function (e, data) {
-        const sub = stream_data.get_sub(data.stream_name);
-        subs.rerender_subscriptions_settings(sub);
-    });
-
 };
 
 window.stream_edit = exports;

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -96,6 +96,16 @@ exports.update_change_stream_privacy_settings = function (sub) {
     }
 };
 
+exports.update_notification_setting_checkbox = function (notification_name) {
+    const stream_row = $('#subscriptions_table .stream-row.active');
+    if (!stream_row.length) {
+        return;
+    }
+    const stream_id = stream_row.data('stream-id');
+    $(`#${notification_name}_${stream_id}`).prop("checked", stream_data.receives_notifications(
+        stream_data.maybe_get_stream_name(stream_id), notification_name));
+};
+
 exports.update_stream_row_in_settings_tab = function (sub) {
     // This function display/hide stream row in stream settings tab,
     // used to display immediate effect of add/removal subscription event.


### PR DESCRIPTION
This fixes the buggy behavior for streams which inherits the notification
setting from UserProfile, and are actively opened in "Streams > Stream
settings", if a user has opened two browser windows, and changes the
notification setting from "Settings > Notifications", then the changes
don't reflect such "Streams > Stream settings" notification setting
checkboxes for such stream.

Partially fixes: #12304.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Stream sync](https://user-images.githubusercontent.com/40331304/73746537-6b999c00-477b-11ea-952d-35daaab224fe.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
