### PR TITLE
babel: Enable loose mode

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,6 +4,7 @@ module.exports = {
             "@babel/preset-env",
             {
                 corejs: 3,
+                loose: true,  // Loose mode for…of loops are 5× faster in Firefox
                 useBuiltIns: "usage",
             },
         ],

--- a/frontend_tests/node_tests/dict.js
+++ b/frontend_tests/node_tests/dict.js
@@ -6,7 +6,7 @@ run_test('basic', () => {
 
     assert.equal(d.size, 0);
 
-    assert.deepEqual([...d.keys()], []);
+    assert.deepEqual(Array.from(d.keys()), []);
 
     d.set('foo', 'bar');
     assert.equal(d.get('foo'), 'bar');
@@ -24,15 +24,15 @@ run_test('basic', () => {
     assert.equal(d.has('bar'), true);
     assert.equal(d.has('baz'), false);
 
-    assert.deepEqual([...d.keys()], ['foo', 'bar']);
-    assert.deepEqual([...d.values()], ['baz', 'qux']);
-    assert.deepEqual([...d], [['foo', 'baz'], ['bar', 'qux']]);
+    assert.deepEqual(Array.from(d.keys()), ['foo', 'bar']);
+    assert.deepEqual(Array.from(d.values()), ['baz', 'qux']);
+    assert.deepEqual(Array.from(d), [['foo', 'baz'], ['bar', 'qux']]);
 
     d.delete('bar');
     assert.equal(d.has('bar'), false);
     assert.strictEqual(d.get('bar'), undefined);
 
-    assert.deepEqual([...d.keys()], ['foo']);
+    assert.deepEqual(Array.from(d.keys()), ['foo']);
 
     const val = ['foo'];
     const res = d.set('abc', val);
@@ -83,12 +83,12 @@ run_test('restricted_keys', () => {
 run_test('construction', () => {
     const d1 = new Dict();
 
-    assert.deepEqual([...d1], []);
+    assert.deepEqual(Array.from(d1), []);
 
     const d2 = new Dict();
     d2.set('foo', 'bar');
     d2.set('baz', 'qux');
-    assert.deepEqual([...d2], [['foo', 'bar'], ['baz', 'qux']]);
+    assert.deepEqual(Array.from(d2), [['foo', 'bar'], ['baz', 'qux']]);
 });
 
 run_test('each', () => {
@@ -97,7 +97,7 @@ run_test('each', () => {
     d.set('banana', 50);
     d.set('carrot', 60);
 
-    let unseen_keys = [...d.keys()];
+    let unseen_keys = Array.from(d.keys());
 
     let cnt = 0;
     for (const [k, v] of d) {

--- a/frontend_tests/node_tests/fold_dict.js
+++ b/frontend_tests/node_tests/fold_dict.js
@@ -6,7 +6,7 @@ run_test('basic', () => {
 
     assert.equal(d.size, 0);
 
-    assert.deepEqual([...d.keys()], []);
+    assert.deepEqual(Array.from(d.keys()), []);
 
     d.set('foo', 'bar');
     assert.equal(d.get('foo'), 'bar');
@@ -24,15 +24,15 @@ run_test('basic', () => {
     assert.equal(d.has('bar'), true);
     assert.equal(d.has('baz'), false);
 
-    assert.deepEqual([...d.keys()], ['foo', 'bar']);
-    assert.deepEqual([...d.values()], ['baz', 'qux']);
-    assert.deepEqual([...d], [['foo', 'baz'], ['bar', 'qux']]);
+    assert.deepEqual(Array.from(d.keys()), ['foo', 'bar']);
+    assert.deepEqual(Array.from(d.values()), ['baz', 'qux']);
+    assert.deepEqual(Array.from(d), [['foo', 'baz'], ['bar', 'qux']]);
 
     d.delete('bar');
     assert.equal(d.has('bar'), false);
     assert.strictEqual(d.get('bar'), undefined);
 
-    assert.deepEqual([...d.keys()], ['foo']);
+    assert.deepEqual(Array.from(d.keys()), ['foo']);
 
     const val = ['foo'];
     const res = d.set('abc', val);
@@ -42,7 +42,7 @@ run_test('basic', () => {
 run_test('case insensitivity', () => {
     const d = new FoldDict();
 
-    assert.deepEqual([...d.keys()], []);
+    assert.deepEqual(Array.from(d.keys()), []);
 
     assert(!d.has('foo'));
     d.set('fOO', 'Hello World');
@@ -51,12 +51,12 @@ run_test('case insensitivity', () => {
     assert(d.has('FOO'));
     assert(!d.has('not_a_key'));
 
-    assert.deepEqual([...d.keys()], ['fOO']);
+    assert.deepEqual(Array.from(d.keys()), ['fOO']);
 
     d.delete('Foo');
     assert.equal(d.has('foo'), false);
 
-    assert.deepEqual([...d.keys()], []);
+    assert.deepEqual(Array.from(d.keys()), []);
 });
 
 run_test('clear', () => {

--- a/frontend_tests/node_tests/int_dict.js
+++ b/frontend_tests/node_tests/int_dict.js
@@ -6,7 +6,7 @@ run_test('basic', () => {
 
     assert.equal(d.size, 0);
 
-    assert.deepEqual([...d.keys()], []);
+    assert.deepEqual(Array.from(d.keys()), []);
 
     d.set(101, 'bar');
     assert.equal(d.get(101), 'bar');
@@ -24,14 +24,14 @@ run_test('basic', () => {
     assert.equal(d.has(102), true);
     assert.equal(d.has(999), false);
 
-    assert.deepEqual([...d.keys()], [101, 102]);
-    assert.deepEqual([...d.values()], ['baz', 'qux']);
+    assert.deepEqual(Array.from(d.keys()), [101, 102]);
+    assert.deepEqual(Array.from(d.values()), ['baz', 'qux']);
 
     d.delete(102);
     assert.equal(d.has(102), false);
     assert.strictEqual(d.get(102), undefined);
 
-    assert.deepEqual([...d.keys()], [101]);
+    assert.deepEqual(Array.from(d.keys()), [101]);
 
     const val = ['fred'];
     const res = d.set(103, val);
@@ -45,7 +45,7 @@ run_test('each', () => {
     d.set(5, 50);
     d.set(6, 60);
 
-    let unseen_keys = [...d.keys()];
+    let unseen_keys = Array.from(d.keys());
 
     let cnt = 0;
     for (const [k, v] of d) {

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -445,7 +445,7 @@ run_test('sort broadcast mentions', () => {
     // Reverse the list to test actual sorting
     // and ensure test coverage for the defensive
     // code.  Also, add in some people users.
-    const test_objs = [...ct.broadcast_mentions()].reverse();
+    const test_objs = Array.from(ct.broadcast_mentions()).reverse();
     test_objs.unshift(zman);
     test_objs.push(a_user);
 

--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -120,7 +120,7 @@ exports.process_loaded_messages = function (messages) {
 };
 
 exports.get_huddles = function () {
-    let huddles = [...huddle_timestamps.keys()];
+    let huddles = Array.from(huddle_timestamps.keys());
     huddles = _.sortBy(huddles, function (huddle) {
         return huddle_timestamps.get(huddle);
     });

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -127,7 +127,7 @@ function filter_user_ids(filter_text, user_ids) {
     });
 
     const user_id_dict = people.filter_people_by_search_terms(persons, search_terms);
-    return [...user_id_dict.keys()];
+    return Array.from(user_id_dict.keys());
 }
 
 exports.matches_filter = function (filter_text, user_id) {

--- a/static/js/bundles/common.js
+++ b/static/js/bundles/common.js
@@ -1,4 +1,5 @@
 import "core-js/features/promise";
+import "core-js/features/symbol";
 import "jquery/dist/jquery.js";
 import "underscore/underscore.js";
 import "../page_params.js";

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -718,7 +718,7 @@ exports.filter_all_persons = function (pred) {
 };
 
 exports.get_realm_persons = function () {
-    return [...active_user_dict.values()];
+    return Array.from(active_user_dict.values());
 };
 
 exports.get_active_human_persons = function () {
@@ -730,7 +730,7 @@ exports.get_active_human_persons = function () {
 
 exports.get_active_user_ids = function () {
     // This includes active users and active bots.
-    return [...active_user_dict.keys()];
+    return Array.from(active_user_dict.keys());
 };
 
 exports.is_cross_realm_email = function (email) {

--- a/static/js/poll_widget.js
+++ b/static/js/poll_widget.js
@@ -44,7 +44,7 @@ exports.poll_data_holder = function (is_my_poll, question, options) {
         const options = [];
 
         for (const [key, obj] of key_to_option) {
-            const voters = [...obj.votes.keys()];
+            const voters = Array.from(obj.votes.keys());
             const current_user_vote = _.contains(voters, me);
 
             options.push({

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -387,7 +387,7 @@ function show_user_group_info_popover(element, group, message) {
         const args = {
             group_name: group.name,
             group_description: group.description,
-            members: sort_group_members(fetch_group_members([...group.members])),
+            members: sort_group_members(fetch_group_members(Array.from(group.members))),
         };
         elt.popover({
             placement: calculate_info_popover_placement(popover_size, elt),

--- a/static/js/settings_user_groups.js
+++ b/static/js/settings_user_groups.js
@@ -87,7 +87,7 @@ exports.populate_user_groups = function () {
         function is_user_group_changed() {
             const draft_group = get_pill_user_ids();
             const group_data = user_groups.get_user_group_from_id(data.id);
-            const original_group = [...group_data.members];
+            const original_group = Array.from(group_data.members);
             const same_groups = _.isEqual(_.sortBy(draft_group), _.sortBy(original_group));
             const description = $('#user-groups #' + data.id + ' .description').text().trim();
             const name = $('#user-groups #' + data.id + ' .name').text().trim();
@@ -138,7 +138,7 @@ exports.populate_user_groups = function () {
         function save_members() {
             const draft_group = get_pill_user_ids();
             const group_data = user_groups.get_user_group_from_id(data.id);
-            const original_group = [...group_data.members];
+            const original_group = Array.from(group_data.members);
             const same_groups = _.isEqual(_.sortBy(draft_group), _.sortBy(original_group));
             if (!draft_group.length || same_groups) {
                 return;

--- a/static/js/starred_messages.js
+++ b/static/js/starred_messages.js
@@ -27,7 +27,7 @@ exports.count = function () {
 };
 
 exports.get_starred_msg_ids = function () {
-    return [...exports.ids];
+    return Array.from(exports.ids);
 };
 
 exports.rerender_ui = function () {

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -166,7 +166,7 @@ exports.is_subscriber_subset = function (sub1, sub2) {
     if (sub1.subscribers && sub2.subscribers) {
         const sub2_set = sub2.subscribers;
 
-        return _.every([...sub1.subscribers.keys()], (key) => {
+        return _.every(Array.from(sub1.subscribers.keys()), (key) => {
             return sub2_set.has(key);
         });
     }
@@ -286,7 +286,7 @@ exports.delete_sub = function (stream_id) {
 };
 
 exports.get_non_default_stream_names = function () {
-    let subs = [...stream_info.values()];
+    let subs = Array.from(stream_info.values());
     subs = _.reject(subs, function (sub) {
         return exports.is_default_stream_id(sub.stream_id) || !sub.subscribed && sub.invite_only;
     });
@@ -295,14 +295,14 @@ exports.get_non_default_stream_names = function () {
 };
 
 exports.get_unsorted_subs = function () {
-    return [...stream_info.values()];
+    return Array.from(stream_info.values());
 };
 
 exports.get_updated_unsorted_subs = function () {
     // This function is expensive in terms of calculating
     // some values (particularly stream counts) but avoids
     // prematurely sorting subs.
-    let all_subs = [...stream_info.values()];
+    let all_subs = Array.from(stream_info.values());
 
     // Add in admin options and stream counts.
     _.each(all_subs, function (sub) {
@@ -324,11 +324,11 @@ exports.num_subscribed_subs = function () {
 };
 
 exports.subscribed_subs = function () {
-    return [...stream_info.true_values()];
+    return Array.from(stream_info.true_values());
 };
 
 exports.unsubscribed_subs = function () {
-    return [...stream_info.false_values()];
+    return Array.from(stream_info.false_values());
 };
 
 exports.subscribed_streams = function () {
@@ -788,7 +788,7 @@ exports.get_streams_for_admin = function () {
         return util.strcmp(a.name, b.name);
     }
 
-    const subs = [...stream_info.values()];
+    const subs = Array.from(stream_info.values());
 
     subs.sort(by_name);
 

--- a/static/js/topic_data.js
+++ b/static/js/topic_data.js
@@ -141,7 +141,7 @@ exports.topic_history = function (stream_id) {
     };
 
     self.get_recent_names = function () {
-        const my_recents = [...topics.values()];
+        const my_recents = Array.from(topics.values());
 
         const missing_topics = unread.get_missing_topics({
             stream_id: stream_id,

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -36,7 +36,7 @@ exports.close = function () {
 exports.zoom_out = function () {
     zoomed = false;
 
-    const stream_ids = [...active_widgets.keys()];
+    const stream_ids = Array.from(active_widgets.keys());
 
     if (stream_ids.length !== 1) {
         blueslip.error('Unexpected number of topic lists to zoom out.');
@@ -230,7 +230,7 @@ exports.widget = function (parent_elem, my_stream_id) {
 };
 
 exports.active_stream_id = function () {
-    const stream_ids = [...active_widgets.keys()];
+    const stream_ids = Array.from(active_widgets.keys());
 
     if (stream_ids.length !== 1) {
         return;
@@ -240,7 +240,7 @@ exports.active_stream_id = function () {
 };
 
 exports.get_stream_li = function () {
-    const widgets = [...active_widgets.values()];
+    const widgets = Array.from(active_widgets.values());
 
     if (widgets.length !== 1) {
         return;

--- a/static/js/typing_data.js
+++ b/static/js/typing_data.js
@@ -47,7 +47,7 @@ exports.get_group_typists = function (group) {
 };
 
 exports.get_all_typists = function () {
-    let typists = _.flatten([...typist_dct.values()], true);
+    let typists = _.flatten(Array.from(typist_dct.values()), true);
     typists = util.sorted_ids(typists);
     typists = _.uniq(typists, true);
     return typists;

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -160,7 +160,7 @@ exports.unread_pm_counter = (function () {
         const lists = [];
 
         for (const id_set of bucketer.values()) {
-            const members = [...id_set];
+            const members = Array.from(id_set);
             lists.push(members);
         }
 
@@ -180,7 +180,7 @@ exports.unread_pm_counter = (function () {
             return [];
         }
 
-        const ids = [...bucket];
+        const ids = Array.from(bucket);
         return util.sorted_ids(ids);
     };
 
@@ -286,7 +286,7 @@ exports.unread_topic_counter = (function () {
             return [];
         }
 
-        let topic_names = [...per_stream_bucketer.keys()];
+        let topic_names = Array.from(per_stream_bucketer.keys());
 
         topic_names = _.reject(topic_names, function (topic_name) {
             return topic_dict.has(topic_name);
@@ -348,7 +348,7 @@ exports.unread_topic_counter = (function () {
         const sub = stream_data.get_sub_by_id(stream_id);
         for (const [topic, msgs] of per_stream_bucketer) {
             if (sub && !muting.is_topic_muted(stream_id, topic)) {
-                topic_lists.push([...msgs]);
+                topic_lists.push(Array.from(msgs));
             }
         }
 
@@ -368,7 +368,7 @@ exports.unread_topic_counter = (function () {
             return [];
         }
 
-        const ids = [...topic_bucket];
+        const ids = Array.from(topic_bucket);
         return util.sorted_ids(ids);
     };
 
@@ -565,13 +565,13 @@ exports.get_msg_ids_for_private = function () {
 };
 
 exports.get_msg_ids_for_mentions = function () {
-    const ids = [...exports.unread_mentions_counter];
+    const ids = Array.from(exports.unread_mentions_counter);
 
     return util.sorted_ids(ids);
 };
 
 exports.get_all_msg_ids = function () {
-    const ids = [...unread_messages];
+    const ids = Array.from(unread_messages);
 
     return util.sorted_ids(ids);
 };

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -297,7 +297,7 @@ exports.unread_topic_counter = (function () {
 
             return {
                 pretty_name: topic_name,
-                message_id: Math.max(...msgs),
+                message_id: Math.max(...Array.from(msgs)),
             };
         });
 

--- a/static/js/user_groups.js
+++ b/static/js/user_groups.js
@@ -55,7 +55,7 @@ exports.get_user_group_from_name = function (name) {
 };
 
 exports.get_realm_user_groups = function () {
-    return [...user_group_by_id_dict.values()].sort(function (a, b) {
+    return Array.from(user_group_by_id_dict.values()).sort(function (a, b) {
         return a.id - b.id;
     });
 };


### PR DESCRIPTION
Due to try-catch deoptimization, Babel strict mode `for…of` loops run about 5× slower in Firefox than Babel loose mode `for…of`, native `for…of`, or `forEach` (which are all about the same speed).  Chrome doesn’t seem to care.

**Testing Plan:** `test-js-with-node`, `run-dev`

Cc @showell (since the `[...x]` → `Array.from(x)` change marginally affects the ergonomics of #13805 which you just reviewed)