### PR TITLE
run-casper: Flush stdout before calling subprocess

### DIFF
--- a/frontend_tests/run-casper
+++ b/frontend_tests/run-casper
@@ -112,7 +112,7 @@ def run_tests(files: Iterable[str], external_host: str) -> None:
         for test_file in test_files:
             test_name = os.path.basename(test_file)
             cmd = ["node_modules/.bin/casperjs"] + remote_debug + verbose + xunit_export + ["test", test_file]
-            print("\n\n===================== %s\nRunning %s\n\n" % (test_name, " ".join(map(shlex.quote, cmd))))
+            print("\n\n===================== %s\nRunning %s\n\n" % (test_name, " ".join(map(shlex.quote, cmd))), flush=True)
             ret = subprocess.call(cmd)
             if ret != 0:
                 break


### PR DESCRIPTION
These markers were not getting correctly interleaved with the test output in the CircleCI logs.