### PR TITLE
js: Convert objects that should be Map to Map

### DIFF
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -148,10 +148,10 @@ people.initialize_current_user(me.user_id);
 const real_update_huddles = activity.update_huddles;
 activity.update_huddles = () => {};
 
-const presence_info = {};
-presence_info[alice.user_id] = { status: 'inactive' };
-presence_info[fred.user_id] = { status: 'active' };
-presence_info[jill.user_id] = { status: 'active' };
+const presence_info = new Map();
+presence_info.set(alice.user_id, { status: 'inactive' });
+presence_info.set(fred.user_id, { status: 'active' });
+presence_info.set(jill.user_id, { status: 'active' });
 
 presence.presence_info = presence_info;
 
@@ -280,11 +280,11 @@ run_test('huddle_fraction_present', () => {
     let huddle = 'alice@zulip.com,fred@zulip.com,jill@zulip.com,mark@zulip.com';
     huddle = people.emails_strings_to_user_ids_string(huddle);
 
-    let presence_info = {};
-    presence_info[alice.user_id] = { status: 'active' }; // counts as present
-    presence_info[fred.user_id] = { status: 'idle' }; // doest not count as present
+    let presence_info = new Map();
+    presence_info.set(alice.user_id, { status: 'active' }); // counts as present
+    presence_info.set(fred.user_id, { status: 'idle' }); // doest not count as present
     // jill not in list
-    presence_info[mark.user_id] = { status: 'offline' }; // does not count
+    presence_info.set(mark.user_id, { status: 'offline' }); // does not count
     presence.presence_info = presence_info;
 
     assert.equal(
@@ -293,11 +293,11 @@ run_test('huddle_fraction_present', () => {
 
     huddle = 'alice@zulip.com,fred@zulip.com,jill@zulip.com,mark@zulip.com';
     huddle = people.emails_strings_to_user_ids_string(huddle);
-    presence_info = {};
-    presence_info[alice.user_id] = { status: 'idle' };
-    presence_info[fred.user_id] = { status: 'idle' }; // does not count as present
+    presence_info = new Map();
+    presence_info.set(alice.user_id, { status: 'idle' });
+    presence_info.set(fred.user_id, { status: 'idle' }); // does not count as present
     // jill not in list
-    presence_info[mark.user_id] = { status: 'offline' }; // does not count
+    presence_info.set(mark.user_id, { status: 'offline' }); // does not count
     presence.presence_info = presence_info;
 
     assert.equal(
@@ -305,14 +305,14 @@ run_test('huddle_fraction_present', () => {
         undefined);
 });
 
-presence.presence_info = {};
-presence.presence_info[alice.user_id] = { status: activity.IDLE };
-presence.presence_info[fred.user_id] = { status: activity.ACTIVE };
-presence.presence_info[jill.user_id] = { status: activity.ACTIVE };
-presence.presence_info[mark.user_id] = { status: activity.IDLE };
-presence.presence_info[norbert.user_id] = { status: activity.ACTIVE };
-presence.presence_info[zoe.user_id] = { status: activity.ACTIVE };
-presence.presence_info[me.user_id] = { status: activity.ACTIVE };
+presence.presence_info = new Map();
+presence.presence_info.set(alice.user_id, { status: activity.IDLE });
+presence.presence_info.set(fred.user_id, { status: activity.ACTIVE });
+presence.presence_info.set(jill.user_id, { status: activity.ACTIVE });
+presence.presence_info.set(mark.user_id, { status: activity.IDLE });
+presence.presence_info.set(norbert.user_id, { status: activity.ACTIVE });
+presence.presence_info.set(zoe.user_id, { status: activity.ACTIVE });
+presence.presence_info.set(me.user_id, { status: activity.ACTIVE });
 
 function clear_buddy_list() {
     buddy_list.populate({
@@ -517,13 +517,13 @@ run_test('handlers', () => {
     }());
 });
 
-presence.presence_info = {};
-presence.presence_info[alice.user_id] = { status: activity.ACTIVE };
-presence.presence_info[fred.user_id] = { status: activity.ACTIVE };
-presence.presence_info[jill.user_id] = { status: activity.ACTIVE };
-presence.presence_info[mark.user_id] = { status: activity.IDLE };
-presence.presence_info[norbert.user_id] = { status: activity.ACTIVE };
-presence.presence_info[zoe.user_id] = { status: activity.ACTIVE };
+presence.presence_info = new Map();
+presence.presence_info.set(alice.user_id, { status: activity.ACTIVE });
+presence.presence_info.set(fred.user_id, { status: activity.ACTIVE });
+presence.presence_info.set(jill.user_id, { status: activity.ACTIVE });
+presence.presence_info.set(mark.user_id, { status: activity.IDLE });
+presence.presence_info.set(norbert.user_id, { status: activity.ACTIVE });
+presence.presence_info.set(zoe.user_id, { status: activity.ACTIVE });
 
 reset_setup();
 
@@ -589,13 +589,13 @@ run_test('filter_user_ids', () => {
     user_ids = get_user_ids();
     assert.deepEqual(user_ids, [alice.user_id, fred.user_id]);
 
-    presence.presence_info[alice.user_id] = { status: activity.IDLE };
+    presence.presence_info.set(alice.user_id, { status: activity.IDLE });
     user_filter.val('fr,al'); // match fred and alice partials and idle user
     user_ids = get_user_ids();
     assert.deepEqual(user_ids, [fred.user_id, alice.user_id]);
 
     $.stub_selector('.user-list-filter', []);
-    presence.presence_info[alice.user_id] = { status: activity.ACTIVE };
+    presence.presence_info.set(alice.user_id, { status: activity.ACTIVE });
     user_ids = get_user_ids();
     assert.deepEqual(user_ids, [alice.user_id, fred.user_id]);
 });
@@ -797,17 +797,17 @@ run_test('update_presence_info', () => {
         inserted = true;
     };
 
-    presence.presence_info[me.user_id] = undefined;
+    presence.presence_info.delete(me.user_id);
     activity.update_presence_info(me.user_id, info, server_time);
     assert(inserted);
-    assert.deepEqual(presence.presence_info[me.user_id].status, 'active');
+    assert.deepEqual(presence.presence_info.get(me.user_id).status, 'active');
 
-    presence.presence_info[alice.user_id] = undefined;
+    presence.presence_info.delete(alice.user_id);
     activity.update_presence_info(alice.user_id, info, server_time);
     assert(inserted);
 
     const expected = { status: 'active', last_active: 500 };
-    assert.deepEqual(presence.presence_info[alice.user_id], expected);
+    assert.deepEqual(presence.presence_info.get(alice.user_id), expected);
 });
 
 run_test('initialize', () => {

--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -229,7 +229,7 @@ run_test('level', () => {
 });
 
 run_test('level', () => {
-    presence.presence_info = {};
+    presence.presence_info.clear();
     assert.equal(buddy_data.level(me.user_id), 0);
     assert.equal(buddy_data.level(selma.user_id), 3);
 

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -174,7 +174,7 @@ set_global('compose', {
     finish: noop,
 });
 
-emoji.active_realm_emojis = {};
+emoji.active_realm_emojis = new Map();
 emoji.emojis_by_name = emojis_by_name;
 emoji.emojis = emoji_list;
 

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -107,7 +107,7 @@ const emoji_headphones = {
     emoji_code: '1f3a7',
 };
 
-const emojis_by_name = {
+const emojis_by_name = new Map(Object.entries({
     tada: emoji_tada,
     moneybag: emoji_moneybag,
     stadium: emoji_stadium,
@@ -118,8 +118,8 @@ const emojis_by_name = {
     thermometer: emoji_thermometer,
     heart: emoji_heart,
     headphones: emoji_headphones,
-};
-const emoji_list = _.map(emojis_by_name, function (emoji_dict) {
+}));
+const emoji_list = Array.from(emojis_by_name.values(), emoji_dict => {
     if (emoji_dict.is_realm_emoji === true) {
         return {
             emoji_name: emoji_dict.name,

--- a/frontend_tests/node_tests/emoji.js
+++ b/frontend_tests/node_tests/emoji.js
@@ -61,9 +61,9 @@ run_test('initialize', () => {
 });
 
 run_test('get_canonical_name', () => {
-    emoji.active_realm_emojis = {
+    emoji.active_realm_emojis = new Map(Object.entries({
         realm_emoji: 'TBD',
-    };
+    }));
     let canonical_name = emoji.get_canonical_name('realm_emoji');
     assert.equal(canonical_name, 'realm_emoji');
 
@@ -79,9 +79,9 @@ run_test('get_canonical_name', () => {
     canonical_name = emoji.get_canonical_name('+1');
     assert.equal(canonical_name, 'thumbs_up');
 
-    emoji.active_realm_emojis = {
+    emoji.active_realm_emojis = new Map(Object.entries({
         '+1': 'TBD',
-    };
+    }));
     canonical_name = emoji.get_canonical_name('+1');
     assert.equal(canonical_name, '+1');
 

--- a/frontend_tests/node_tests/emoji_picker.js
+++ b/frontend_tests/node_tests/emoji_picker.js
@@ -8,7 +8,7 @@ run_test('initialize', () => {
 
     const complete_emoji_catalog = _.sortBy(emoji_picker.complete_emoji_catalog, 'name');
     assert.equal(complete_emoji_catalog.length, 10);
-    assert.equal(_.keys(emoji.emojis_by_name).length, 1037);
+    assert.equal(emoji.emojis_by_name.size, 1037);
 
     function assert_emoji_category(ele, icon, num) {
         assert.equal(ele.icon, icon);

--- a/frontend_tests/node_tests/notifications.js
+++ b/frontend_tests/node_tests/notifications.js
@@ -308,46 +308,46 @@ run_test('basic_notifications', () => {
     // Send notification.
     notifications.process_notification({message: message_1, desktop_notify: true});
     n = notifications.get_notifications();
-    assert.equal('Jesse Pinkman to general > whatever' in n, true);
-    assert.equal(Object.keys(n).length, 1);
+    assert.equal(n.has('Jesse Pinkman to general > whatever'), true);
+    assert.equal(n.size, 1);
     assert.equal(last_shown_message_id, message_1.id);
 
     // Remove notification.
     notifications.close_notification(message_1);
     n = notifications.get_notifications();
-    assert.equal('Jesse Pinkman to general > whatever' in n, false);
-    assert.equal(Object.keys(n).length, 0);
+    assert.equal(n.has('Jesse Pinkman to general > whatever'), false);
+    assert.equal(n.size, 0);
     assert.equal(last_closed_message_id, message_1.id);
 
     // Send notification.
     message_1.id = 1001;
     notifications.process_notification({message: message_1, desktop_notify: true});
     n = notifications.get_notifications();
-    assert.equal('Jesse Pinkman to general > whatever' in n, true);
-    assert.equal(Object.keys(n).length, 1);
+    assert.equal(n.has('Jesse Pinkman to general > whatever'), true);
+    assert.equal(n.size, 1);
     assert.equal(last_shown_message_id, message_1.id);
 
     // Process same message again. Notification count shouldn't increase.
     message_1.id = 1002;
     notifications.process_notification({message: message_1, desktop_notify: true});
     n = notifications.get_notifications();
-    assert.equal('Jesse Pinkman to general > whatever' in n, true);
-    assert.equal(Object.keys(n).length, 1);
+    assert.equal(n.has('Jesse Pinkman to general > whatever'), true);
+    assert.equal(n.size, 1);
     assert.equal(last_shown_message_id, message_1.id);
 
     // Send another message. Notification count should increase.
     notifications.process_notification({message: message_2, desktop_notify: true});
     n = notifications.get_notifications();
-    assert.equal('Gus Fring to general > lunch' in n, true);
-    assert.equal('Jesse Pinkman to general > whatever' in n, true);
-    assert.equal(Object.keys(n).length, 2);
+    assert.equal(n.has('Gus Fring to general > lunch'), true);
+    assert.equal(n.has('Jesse Pinkman to general > whatever'), true);
+    assert.equal(n.size, 2);
     assert.equal(last_shown_message_id, message_2.id);
 
     // Remove notifications.
     notifications.close_notification(message_1);
     notifications.close_notification(message_2);
     n = notifications.get_notifications();
-    assert.equal('Jesse Pinkman to general > whatever' in n, false);
-    assert.equal(Object.keys(n).length, 0);
+    assert.equal(n.has('Jesse Pinkman to general > whatever'), false);
+    assert.equal(n.size, 0);
     assert.equal(last_closed_message_id, message_2.id);
 });

--- a/frontend_tests/node_tests/presence.js
+++ b/frontend_tests/node_tests/presence.js
@@ -162,23 +162,23 @@ run_test('set_presence_info', () => {
 
     presence.set_info(presences, base_time);
 
-    assert.deepEqual(presence.presence_info[alice.user_id],
+    assert.deepEqual(presence.presence_info.get(alice.user_id),
                      { status: 'active', last_active: 500}
     );
 
-    assert.deepEqual(presence.presence_info[fred.user_id],
+    assert.deepEqual(presence.presence_info.get(fred.user_id),
                      { status: 'idle', last_active: 500}
     );
 
-    assert.deepEqual(presence.presence_info[me.user_id],
+    assert.deepEqual(presence.presence_info.get(me.user_id),
                      { status: 'active', last_active: 500}
     );
 
-    assert.deepEqual(presence.presence_info[zoe.user_id],
+    assert.deepEqual(presence.presence_info.get(zoe.user_id),
                      { status: 'offline', last_active: undefined}
     );
 
-    assert(!presence.presence_info[bot.user_id]);
+    assert(!presence.presence_info.has(bot.user_id));
 
     // Make it seem like realm has a lot of people
     const get_realm_count = people.get_realm_count;
@@ -189,10 +189,9 @@ run_test('set_presence_info', () => {
 
 run_test('last_active_date', () => {
     const unknown_id = 42;
-    presence.presence_info = {
-        1: { last_active: 500 }, // alice.user_id
-        2: {}, // fred.user_id
-    };
+    presence.presence_info.clear();
+    presence.presence_info.set(alice.user_id, { last_active: 500 });
+    presence.presence_info.set(fred.user_id, {});
     set_global('XDate', function (ms) { return {seconds: ms}; });
 
     assert.equal(presence.last_active_date(unknown_id), undefined);
@@ -209,9 +208,9 @@ run_test('set_info_for_user', () => {
         },
     };
 
-    presence.presence_info[alice.user_id] = undefined;
+    presence.presence_info.delete(alice.user_id);
     presence.set_info_for_user(alice.user_id, info, server_time);
 
     const expected = { status: 'active', last_active: 500 };
-    assert.deepEqual(presence.presence_info[alice.user_id], expected);
+    assert.deepEqual(presence.presence_info.get(alice.user_id), expected);
 });

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -5,7 +5,7 @@ zrequire('people');
 zrequire('reactions');
 
 set_global('emoji', {
-    all_realm_emojis: {
+    all_realm_emojis: new Map(Object.entries({
         991: {
             id: '991',
             emoji_name: 'realm_emoji',
@@ -24,7 +24,7 @@ set_global('emoji', {
             emoji_url: 'TBD',
             deactivated: false,
         },
-    },
+    })),
     active_realm_emojis: {
         realm_emoji: {
             id: '991',

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -25,7 +25,7 @@ set_global('emoji', {
             deactivated: false,
         },
     })),
-    active_realm_emojis: {
+    active_realm_emojis: new Map(Object.entries({
         realm_emoji: {
             id: '991',
             emoji_name: 'realm_emoji',
@@ -36,7 +36,7 @@ set_global('emoji', {
             emoji_name: 'zulip',
             emoji_url: 'TBD',
         },
-    },
+    })),
     deactivated_realm_emojis: {
         inactive_realm_emoji: {
             emoji_name: 'inactive_realm_emoji',

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -652,9 +652,9 @@ run_test('render_emoji', () => {
         emoji_name: 'thumbs_up',
         emoji_code: '1f44d',
     };
-    emoji.active_realm_emojis = {
+    emoji.active_realm_emojis = new Map(Object.entries({
         realm_emoji: 'TBD',
-    };
+    }));
 
     global.stub_templates(function (template_name, args) {
         assert.equal(template_name, 'typeahead_list_item');

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -66,6 +66,7 @@ _.each(ignore_modules, (mod) => {
     });
 });
 
+emoji.emojis_by_name = new Map();
 
 zrequire('util');
 

--- a/frontend_tests/node_tests/widgetize.js
+++ b/frontend_tests/node_tests/widgetize.js
@@ -96,14 +96,14 @@ run_test('activate', () => {
     is_widget_elem_inserted = false;
     is_widget_activated = false;
     is_event_handled = false;
-    assert.equal(widgetize.widget_contents[opts.message.id], undefined);
+    assert(!widgetize.widget_contents.has(opts.message.id));
 
     widgetize.activate(opts);
 
     assert(is_widget_elem_inserted);
     assert(is_widget_activated);
     assert(is_event_handled);
-    assert.equal(widgetize.widget_contents[opts.message.id], widget_elem);
+    assert.equal(widgetize.widget_contents.get(opts.message.id), widget_elem);
 
     is_widget_elem_inserted = false;
     is_widget_activated = false;

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -336,7 +336,7 @@ exports.get_items_for_users = function (user_ids) {
 };
 
 exports.huddle_fraction_present = function (huddle) {
-    const user_ids = huddle.split(',');
+    const user_ids = huddle.split(',').map(s => parseInt(s, 10));
 
     let num_present = 0;
     _.each(user_ids, function (user_id) {

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -20,7 +20,7 @@ exports.emoji_collection = [];
 
 exports.update_emoji_data = function () {
     exports.emoji_collection = [];
-    _.each(emoji.emojis_by_name, function (emoji_dict) {
+    for (const emoji_dict of emoji.emojis_by_name.values()) {
         if (emoji_dict.is_realm_emoji === true) {
             exports.emoji_collection.push({
                 emoji_name: emoji_dict.name,
@@ -35,7 +35,7 @@ exports.update_emoji_data = function () {
                 });
             });
         }
-    });
+    }
 };
 
 exports.topics_seen_for = function (stream_name) {

--- a/static/js/emoji.js
+++ b/static/js/emoji.js
@@ -3,7 +3,7 @@
 // emojis. Emoji picker uses this data to derive data for its own use.
 exports.emojis_by_name = new Map();
 
-exports.all_realm_emojis = {};
+exports.all_realm_emojis = new Map();
 exports.active_realm_emojis = {};
 exports.default_emoji_aliases = {};
 
@@ -19,14 +19,16 @@ exports.update_emojis = function update_emojis(realm_emojis) {
     // exports.all_realm_emojis is emptied before adding the realm-specific emoji
     // to it. This makes sure that in case of deletion, the deleted realm_emojis
     // don't persist in exports.active_realm_emojis.
-    exports.all_realm_emojis = {};
+    exports.all_realm_emojis.clear();
     exports.active_realm_emojis = {};
 
     _.each(realm_emojis, function (data) {
-        exports.all_realm_emojis[data.id] = {id: data.id,
-                                             emoji_name: data.name,
-                                             emoji_url: data.source_url,
-                                             deactivated: data.deactivated};
+        exports.all_realm_emojis.set(data.id, {
+            id: data.id,
+            emoji_name: data.name,
+            emoji_url: data.source_url,
+            deactivated: data.deactivated,
+        });
         if (data.deactivated !== true) {
             exports.active_realm_emojis[data.name] = {id: data.id,
                                                       emoji_name: data.name,

--- a/static/js/emoji.js
+++ b/static/js/emoji.js
@@ -5,7 +5,7 @@ exports.emojis_by_name = new Map();
 
 exports.all_realm_emojis = new Map();
 exports.active_realm_emojis = new Map();
-exports.default_emoji_aliases = {};
+exports.default_emoji_aliases = new Map();
 
 const zulip_emoji = {
     id: 'zulip',
@@ -49,10 +49,10 @@ exports.initialize = function initialize() {
     _.each(emoji_codes.names, function (value) {
         const base_name = emoji_codes.name_to_codepoint[value];
 
-        if (exports.default_emoji_aliases.hasOwnProperty(base_name)) {
-            exports.default_emoji_aliases[base_name].push(value);
+        if (exports.default_emoji_aliases.has(base_name)) {
+            exports.default_emoji_aliases.get(base_name).push(value);
         } else {
-            exports.default_emoji_aliases[base_name] = [value];
+            exports.default_emoji_aliases.set(base_name, [value]);
         }
     });
 
@@ -98,7 +98,7 @@ exports.build_emoji_data = function (realm_emojis) {
                     emoji_dict = {
                         name: emoji_name,
                         display_name: emoji_name,
-                        aliases: exports.default_emoji_aliases[codepoint],
+                        aliases: exports.default_emoji_aliases.get(codepoint),
                         is_realm_emoji: false,
                         emoji_code: codepoint,
                         has_reacted: false,

--- a/static/js/emoji.js
+++ b/static/js/emoji.js
@@ -1,7 +1,7 @@
 // `emojis_by_name` is the central data source that is supposed to be
 // used by every widget in the webapp for gathering data for displaying
 // emojis. Emoji picker uses this data to derive data for its own use.
-exports.emojis_by_name = {};
+exports.emojis_by_name = new Map();
 
 exports.all_realm_emojis = {};
 exports.active_realm_emojis = {};
@@ -72,7 +72,7 @@ exports.initialize = function initialize() {
 };
 
 exports.build_emoji_data = function (realm_emojis) {
-    exports.emojis_by_name = {};
+    exports.emojis_by_name.clear();
     let emoji_dict;
     _.each(realm_emojis, function (realm_emoji, realm_emoji_name) {
         emoji_dict = {
@@ -83,14 +83,14 @@ exports.build_emoji_data = function (realm_emojis) {
             url: realm_emoji.emoji_url,
             has_reacted: false,
         };
-        exports.emojis_by_name[realm_emoji_name] = emoji_dict;
+        exports.emojis_by_name.set(realm_emoji_name, emoji_dict);
     });
 
     _.each(emoji_codes.emoji_catalog, function (codepoints) {
         _.each(codepoints, function (codepoint) {
             if (emoji_codes.codepoint_to_name.hasOwnProperty(codepoint)) {
                 const emoji_name = emoji_codes.codepoint_to_name[codepoint];
-                if (!exports.emojis_by_name.hasOwnProperty(emoji_name)) {
+                if (!exports.emojis_by_name.has(emoji_name)) {
                     emoji_dict = {
                         name: emoji_name,
                         display_name: emoji_name,
@@ -99,7 +99,7 @@ exports.build_emoji_data = function (realm_emojis) {
                         emoji_code: codepoint,
                         has_reacted: false,
                     };
-                    exports.emojis_by_name[emoji_name] = emoji_dict;
+                    exports.emojis_by_name.set(emoji_name, emoji_dict);
                 }
             }
         });

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -246,7 +246,7 @@ function get_alias_to_be_used(message_id, emoji_name) {
     if (!emoji.active_realm_emojis.has(emoji_name)) {
         if (emoji_codes.name_to_codepoint.hasOwnProperty(emoji_name)) {
             const codepoint = emoji_codes.name_to_codepoint[emoji_name];
-            aliases = emoji.default_emoji_aliases[codepoint];
+            aliases = emoji.default_emoji_aliases.get(codepoint);
         } else {
             blueslip.error("Invalid emoji name.");
             return;

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -102,9 +102,9 @@ function show_emoji_catalog() {
 exports.generate_emoji_picker_data = function (realm_emojis) {
     exports.complete_emoji_catalog = {};
     exports.complete_emoji_catalog.Custom = [];
-    _.each(realm_emojis, function (realm_emoji, realm_emoji_name) {
+    for (const realm_emoji_name of realm_emojis.keys()) {
         exports.complete_emoji_catalog.Custom.push(emoji.emojis_by_name.get(realm_emoji_name));
-    });
+    }
 
     _.each(emoji_codes.emoji_catalog, function (codepoints, category) {
         exports.complete_emoji_catalog[category] = [];
@@ -243,7 +243,7 @@ function get_alias_to_be_used(message_id, emoji_name) {
     // the passed name as it is.
     const message = message_store.get(message_id);
     let aliases = [emoji_name];
-    if (!emoji.active_realm_emojis.hasOwnProperty(emoji_name)) {
+    if (!emoji.active_realm_emojis.has(emoji_name)) {
         if (emoji_codes.name_to_codepoint.hasOwnProperty(emoji_name)) {
             const codepoint = emoji_codes.name_to_codepoint[emoji_name];
             aliases = emoji.default_emoji_aliases[codepoint];

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -189,8 +189,8 @@ function handleUnicodeEmoji(unicode_emoji) {
 function handleEmoji(emoji_name) {
     const alt_text = ':' + emoji_name + ':';
     const title = emoji_name.split("_").join(" ");
-    if (emoji.active_realm_emojis.hasOwnProperty(emoji_name)) {
-        const emoji_url = emoji.active_realm_emojis[emoji_name].emoji_url;
+    if (emoji.active_realm_emojis.has(emoji_name)) {
+        const emoji_url = emoji.active_realm_emojis.get(emoji_name).emoji_url;
         return '<img alt="' + alt_text + '"' +
                ' class="emoji" src="' + emoji_url + '"' +
                ' title="' + title + '">';

--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -1,4 +1,4 @@
-const stored_messages = {};
+const stored_messages = new Map();
 
 /*
     We keep a set of user_ids for all people
@@ -20,13 +20,11 @@ exports.user_ids = function () {
 };
 
 exports.get = function get(message_id) {
-    return stored_messages[message_id];
+    return stored_messages.get(message_id);
 };
 
 exports.each = function (f) {
-    _.each(stored_messages, function (message) {
-        f(message);
-    });
+    stored_messages.forEach(f);
 };
 
 exports.get_pm_emails = function (message) {
@@ -126,7 +124,7 @@ exports.update_booleans = function (message, flags) {
 };
 
 exports.add_message_metadata = function (message) {
-    const cached_msg = stored_messages[message.id];
+    const cached_msg = stored_messages.get(message.id);
     if (cached_msg !== undefined) {
         // Copy the match topic and content over if they exist on
         // the new message
@@ -189,7 +187,7 @@ exports.add_message_metadata = function (message) {
     if (!message.reactions) {
         message.reactions = [];
     }
-    stored_messages[message.id] = message;
+    stored_messages.set(message.id, message);
     return message;
 };
 
@@ -199,9 +197,9 @@ exports.reify_message_id = function (opts) {
     if (pointer.furthest_read === old_id) {
         pointer.set_furthest_read(new_id);
     }
-    if (stored_messages[old_id]) {
-        stored_messages[new_id] = stored_messages[old_id];
-        delete stored_messages[old_id];
+    if (stored_messages.has(old_id)) {
+        stored_messages.set(new_id, stored_messages.get(old_id));
+        stored_messages.delete(old_id);
     }
 
     _.each([message_list.all, home_msg_list, message_list.narrowed], function (msg_list) {

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -119,13 +119,13 @@ exports.toggle_emoji_reaction = function (message_id, emoji_name) {
         emoji_name: emoji_name,
     };
 
-    if (emoji.active_realm_emojis.hasOwnProperty(emoji_name)) {
+    if (emoji.active_realm_emojis.has(emoji_name)) {
         if (emoji_name === 'zulip') {
             reaction_info.reaction_type = 'zulip_extra_emoji';
         } else {
             reaction_info.reaction_type = 'realm_emoji';
         }
-        reaction_info.emoji_code = emoji.active_realm_emojis[emoji_name].id;
+        reaction_info.emoji_code = emoji.active_realm_emojis.get(emoji_name).id;
     } else if (emoji_codes.name_to_codepoint.hasOwnProperty(emoji_name)) {
         reaction_info.reaction_type = 'unicode_emoji';
         reaction_info.emoji_code = emoji_codes.name_to_codepoint[emoji_name];

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -286,7 +286,7 @@ exports.view.insert_new_reaction = function (opts) {
 
     if (opts.reaction_type !== 'unicode_emoji') {
         context.is_realm_emoji = true;
-        context.url = emoji.all_realm_emojis[emoji_code].emoji_url;
+        context.url = emoji.all_realm_emojis.get(emoji_code).emoji_url;
     }
 
     context.count = 1;
@@ -428,7 +428,7 @@ exports.get_message_reactions = function (message) {
 
         if (reaction.reaction_type !== 'unicode_emoji') {
             reaction.is_realm_emoji = true;
-            reaction.url = emoji.all_realm_emojis[reaction.emoji_code].emoji_url;
+            reaction.url = emoji.all_realm_emojis.get(reaction.emoji_code).emoji_url;
         }
         if (reaction.user_ids.indexOf(page_params.user_id) !== -1) {
             reaction.class = "message_reaction reacted";

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -114,7 +114,7 @@ const LAST_ACTIVE_NEVER = -1;
 const LAST_ACTIVE_UNKNOWN = -2;
 
 function get_last_active(user) {
-    const presence_info = presence.presence_info[user.user_id];
+    const presence_info = presence.presence_info.get(user.user_id);
     if (!presence_info) {
         return LAST_ACTIVE_UNKNOWN;
     }

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -148,7 +148,7 @@ exports.render_emoji = function (item) {
         is_emoji: true,
         primary: item.emoji_name.split("_").join(" "),
     };
-    if (emoji.active_realm_emojis.hasOwnProperty(item.emoji_name)) {
+    if (emoji.active_realm_emojis.has(item.emoji_name)) {
         args.img_src = item.emoji_url;
     } else {
         args.emoji_code = item.emoji_code;

--- a/static/js/vdom.js
+++ b/static/js/vdom.js
@@ -174,30 +174,20 @@ exports.update = (replace_content, find, new_dom, old_dom) => {
 };
 
 exports.update_attrs = (elem, new_attrs, old_attrs) => {
-    function make_dict(attrs) {
-        const dict = {};
-        _.each(attrs, (attr) => {
-            const k = attr[0];
-            const v = attr[1];
-            dict[k] = v;
-        });
-        return dict;
-    }
+    const new_dict = new Map(new_attrs);
+    const old_dict = new Map(old_attrs);
 
-    const new_dict = make_dict(new_attrs);
-    const old_dict = make_dict(old_attrs);
-
-    _.each(new_dict, (v, k) => {
-        if (v !== old_dict[k]) {
+    for (const [k, v] of new_attrs) {
+        if (v !== old_dict.get(k)) {
             elem.attr(k, v);
         }
-    });
+    }
 
-    _.each(old_dict, (v, k) => {
-        if (new_dict[k] === undefined) {
+    for (const [k] of old_attrs) {
+        if (!new_dict.has(k)) {
             elem.removeAttr(k);
         }
-    });
+    }
 };
 
 window.vdom = exports;

--- a/static/js/widgetize.js
+++ b/static/js/widgetize.js
@@ -5,7 +5,7 @@ const widgets = new Map([
     ["zform", zform],
 ]);
 
-const widget_contents = {};
+const widget_contents = new Map();
 exports.widget_contents = widget_contents;
 
 function set_widget_in_message(row, widget_elem) {
@@ -41,7 +41,7 @@ exports.activate = function (in_opts) {
         return;
     }
 
-    let widget_elem = widget_contents[message.id];
+    let widget_elem = widget_contents.get(message.id);
     if (widget_elem) {
         set_widget_in_message(row, widget_elem);
         return;
@@ -58,7 +58,7 @@ exports.activate = function (in_opts) {
         extra_data: extra_data,
     });
 
-    widget_contents[message.id] = widget_elem;
+    widget_contents.set(message.id, widget_elem);
     set_widget_in_message(row, widget_elem);
 
     // Replay any events that already happened.  (This is common
@@ -70,16 +70,16 @@ exports.activate = function (in_opts) {
 };
 
 exports.set_widgets_for_list = function () {
-    _.each(widget_contents, function (widget_elem, idx) {
+    for (const [idx, widget_elem] of widget_contents) {
         if (current_msg_list.get(idx) !== undefined) {
             const row = current_msg_list.get_row(idx);
             set_widget_in_message(row, widget_elem);
         }
-    });
+    }
 };
 
 exports.handle_event = function (widget_event) {
-    const widget_elem = widget_contents[widget_event.message_id];
+    const widget_elem = widget_contents.get(widget_event.message_id);
 
     if (!widget_elem) {
         // It is common for submessage events to arrive on

--- a/static/js/widgetize.js
+++ b/static/js/widgetize.js
@@ -1,9 +1,9 @@
-const widgets = {};
-
-widgets.poll = poll_widget;
-widgets.tictactoe = tictactoe_widget;
-widgets.todo = todo_widget;
-widgets.zform = zform;
+const widgets = new Map([
+    ["poll", poll_widget],
+    ["tictactoe", tictactoe_widget],
+    ["todo", todo_widget],
+    ["zform", zform],
+]);
 
 const widget_contents = {};
 exports.widget_contents = widget_contents;
@@ -23,7 +23,7 @@ exports.activate = function (in_opts) {
 
     events.shift();
 
-    if (!widgets[widget_type]) {
+    if (!widgets.has(widget_type)) {
         blueslip.warn('unknown widget_type', widget_type);
         return;
     }
@@ -51,7 +51,7 @@ exports.activate = function (in_opts) {
     // the HTML that will eventually go in this div.
     widget_elem = $('<div>').addClass('widget-content');
 
-    widgets[widget_type].activate({
+    widgets.get(widget_type).activate({
         elem: widget_elem,
         callback: callback,
         message: message,


### PR DESCRIPTION
As a general rule, any object that is iterated over or has computed properties taken, whose type isn’t dictated by some external source (e.g. a JSON blob), should probably be a `Map` instead (or a `Dict` or `IntDict`, but those will soon be `Map`: #13805). This improves type safety because `Map` keys are not automatically stringified, and there are no `Object.prototype`-related accidents or “magic” keys like `__proto__` to watch out for.

This also replaces a number of irregular uses of `_.each`. I have a branch with most other `_.each` uses automatically converted to modern `for…of` loops, to follow after this PR.

**Testing Plan:** `test-js-with-node`, `lint`, `run-dev`.