### PR TITLE
muting: Update the settings/muted-topics page UI.

### DIFF
--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -189,7 +189,7 @@ def check_list(sub_validator: Optional[Validator], length: Optional[int]=None) -
 
     @set_type_structure(type_structure)
     def f(var_name: str, val: object) -> Optional[str]:
-        if not isinstance(val, list):
+        if not (isinstance(val, list) or isinstance(val, tuple)):
             return _('%s is not a list') % (var_name,)
 
         if length is not None and length != len(val):

--- a/zerver/tests/test_muting.py
+++ b/zerver/tests/test_muting.py
@@ -77,7 +77,7 @@ class MutedTopicsTests(ZulipTestCase):
                 result = self.api_patch(user, url, data)
                 self.assert_json_success(result)
 
-            self.assertIn([stream.name, 'Verona3', mock_date_muted], get_topic_mutes(user))
+            self.assertIn((stream.name, 'Verona3', mock_date_muted), get_topic_mutes(user))
             self.assertTrue(topic_is_muted(user, stream.id, 'Verona3'))
             self.assertTrue(topic_is_muted(user, stream.id, 'verona3'))
 
@@ -110,7 +110,7 @@ class MutedTopicsTests(ZulipTestCase):
                 topic_name='Verona3',
                 date_muted=datetime(2020, 1, 1),
             )
-            self.assertIn([stream.name, 'Verona3', mock_date_muted], get_topic_mutes(user))
+            self.assertIn((stream.name, 'Verona3', mock_date_muted), get_topic_mutes(user))
 
             result = self.api_patch(user, url, data)
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This is a continuation of [PR#13702](https://github.com/zulip/zulip/pull/13702)
This updates the `#settings/muted-topics` page by refactoring `set_up_muted_topics_ui` to use `list_render`. And also include a new field `date_muted`.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![topic_mutes_ui](https://user-images.githubusercontent.com/40122794/74605303-f029da00-50ec-11ea-837a-29452aca5ac2.gif)
EDIT: Updated the gif as the previous gif contained a bug (if a topic gets unmuted, then the table rerenders with the streams sorted instead of the current sort configuration).