### PR TITLE
Fix: Full name now changes immediately after edit

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -433,6 +433,10 @@ exports.set_up = function () {
         };
         settings_ui.do_settings_change(channel.patch, '/json/settings', data,
                                        $('#account-settings-status').expectOne(), opts);
+        
+        // I'm just changing the text in the full_name_value object if the change is a success
+        const name_val = $('#full_name_value');
+        name_val.text(data.full_name);                               
     });
 
     $('#change_email_button').on('click', function (e) {

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -434,8 +434,7 @@ exports.set_up = function () {
         settings_ui.do_settings_change(channel.patch, '/json/settings', data,
                                        $('#account-settings-status').expectOne(), opts);
         // I'm just changing the text in the full_name_value object if the change is a success
-        const name_val = $('#full_name_value');
-        name_val.text(data.full_name);                            
+        const name_val = $('#full_name_value');name_val.text(data.full_name);            
     });
 
     $('#change_email_button').on('click', function (e) {

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -433,10 +433,9 @@ exports.set_up = function () {
         };
         settings_ui.do_settings_change(channel.patch, '/json/settings', data,
                                        $('#account-settings-status').expectOne(), opts);
-        
         // I'm just changing the text in the full_name_value object if the change is a success
         const name_val = $('#full_name_value');
-        name_val.text(data.full_name);                               
+        name_val.text(data.full_name);                            
     });
 
     $('#change_email_button').on('click', function (e) {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#13820 

I created an instance of the full_name_value object and changed its text after the edit.

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
