### PR TITLE
tornado: Rewrite Django integration to duplicate less code.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -76,9 +76,6 @@ strict_optional = False
 [mypy-zerver/management/commands/purge_queue]  #24: error: Item "None" of "Optional[Any]" has no attribute "queue_purge"
 strict_optional = False
 
-[mypy-zerver.tornado.handlers]  # Delayed setup of ASyncDjangoHandler._request_middleware (Optional), line 200 error
-strict_optional = False
-
 # Tests (may be many issues in file; comment is just one error noted)
 
 [mypy-zerver/tests/test_tornado]  #202: error: Item "None" of "Optional[Morsel[Any]]" has no attribute "coded_value"

--- a/zerver/tornado/views.py
+++ b/zerver/tornado/views.py
@@ -1,19 +1,18 @@
 import time
-from typing import Iterable, Optional, Sequence, Union
+from typing import Iterable, Optional, Sequence
 
 import ujson
-from django.core.handlers.base import BaseHandler
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
 
-from zerver.decorator import REQ, RespondAsynchronously, \
-    _RespondAsynchronously, asynchronous, to_non_negative_int, \
+from zerver.decorator import REQ, to_non_negative_int, \
     has_request_variables, internal_notify_view, process_client
 from zerver.lib.response import json_error, json_success
 from zerver.lib.validator import check_bool, check_int, check_list, check_string
 from zerver.models import Client, UserProfile, get_client, get_user_profile_by_id
 from zerver.tornado.event_queue import fetch_events, \
     get_client_descriptor, process_notification
+from zerver.tornado.handlers import AsyncDjangoHandler
 from zerver.tornado.exceptions import BadEventQueueIdError
 
 @internal_notify_view(True)
@@ -33,26 +32,20 @@ def cleanup_event_queue(request: HttpRequest, user_profile: UserProfile,
     client.cleanup()
     return json_success()
 
-@asynchronous
 @internal_notify_view(True)
 @has_request_variables
-def get_events_internal(
-    request: HttpRequest,
-    handler: BaseHandler,
-    user_profile_id: int = REQ(validator=check_int),
-) -> Union[HttpResponse, _RespondAsynchronously]:
+def get_events_internal(request: HttpRequest,
+                        user_profile_id: int = REQ(validator=check_int)) -> HttpResponse:
     user_profile = get_user_profile_by_id(user_profile_id)
     request._email = user_profile.delivery_email
     process_client(request, user_profile, client_name="internal")
-    return get_events_backend(request, user_profile, handler)
+    return get_events_backend(request, user_profile)
 
-@asynchronous
-def get_events(request: HttpRequest, user_profile: UserProfile,
-               handler: BaseHandler) -> Union[HttpResponse, _RespondAsynchronously]:
-    return get_events_backend(request, user_profile, handler)
+def get_events(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
+    return get_events_backend(request, user_profile)
 
 @has_request_variables
-def get_events_backend(request: HttpRequest, user_profile: UserProfile, handler: BaseHandler,
+def get_events_backend(request: HttpRequest, user_profile: UserProfile,
                        # user_client is intended only for internal Django=>Tornado requests
                        # and thus shouldn't be documented for external use.
                        user_client: Optional[Client]=REQ(converter=get_client, default=None,
@@ -78,7 +71,10 @@ def get_events_backend(request: HttpRequest, user_profile: UserProfile, handler:
                                                            intentionally_undocumented=True),
                        lifespan_secs: int=REQ(default=0, converter=to_non_negative_int,
                                               intentionally_undocumented=True)
-                       ) -> Union[HttpResponse, _RespondAsynchronously]:
+                       ) -> HttpResponse:
+    # Extract the Tornado handler from the request
+    handler = request._tornado_handler  # type: AsyncDjangoHandler
+
     if user_client is None:
         valid_user_client = request.client
     else:
@@ -115,8 +111,13 @@ def get_events_backend(request: HttpRequest, user_profile: UserProfile, handler:
         request._log_data['extra'] = result["extra_log_data"]
 
     if result["type"] == "async":
+        # Mark this response with .asynchronous; this will result in
+        # Tornado discarding the response and instead long-polling the
+        # request.  See zulip_finish for more design details.
         handler._request = request
-        return RespondAsynchronously
+        response = json_success()
+        response.asynchronous = True
+        return response
     if result["type"] == "error":
         raise result["exception"]
     return json_success(result["response"])

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -714,6 +714,9 @@ for app_name in settings.EXTRA_INSTALLED_APPS:
 # Tornado views
 urls += [
     # Used internally for communication between Django and Tornado processes
+    #
+    # Since these views don't use rest_dispatch, they cannot have
+    # asynchronous Tornado behavior.
     url(r'^notify_tornado$', zerver.tornado.views.notify, name='zerver.tornado.views.notify'),
     url(r'^api/v1/events/internal$', zerver.tornado.views.get_events_internal),
 ]


### PR DESCRIPTION
Since essentially the first use of Tornado in Zulip, we've been
maintaining our Tornado+Django system, AsyncDjangoHandler, with
several hundred lines of Django code copied into it.

The goal for that code was simple: We wanted a way to use our Django
middleware (for code sharing reasons) inside a Tornado process (since
we wanted to use Tornado for our async events system).

As part of the Django 2.2.x upgrade, I looked at upgrading this
implementation to be based off modern Django, and it's definitely
possible to do that:
* Continue forking load_middleware to save response middleware.
* Continue manually running the Django response middleware.
* Continue working out a hack involving copying all of _get_response
  to change a couple lines allowing us our Tornado code to not
  actually return the Django HttpResponse so we can long-poll.  The
  previous hack of returning None stopped being viable with the Django 2.2
  MiddlewareMixin.__call__ implementation.

But I decided to take this opportunity to look at trying to avoid
copying material Django code, and there is a way to do it:

* Replace RespondAsynchronously with a response.asynchronous attribute
  on the HttpResponse; this causes Django to run its normal plumbing
  happily in a way that should be stable over time, and then we
  proceed to discard the response inside the Tornado `get()` method to
  implement long-polling.  (Better yet might be raising an exception?).
  This lets to eliminate patching of _get_response.

* Calling the normal Django `get_response` method from zulip_finish,
  rather than writing totally custom code to do that.  This resulted
  in some mess with Monkey-patching MiddlewareMixin inside Tornado to
  offer a way to skip running request middleware (to avoid running it
  twice).  This lets us replace copying and monkey-patching
  load_middleware to store response middleware.  I'm not yet sure
  whether this is overall an improvement, but it does reduce the
  Django code we're copying and patching to just a single 5-line function.

* Adding detailed comments explaining how this is supposed to work,
  what problems we encounter, and how we solve various problems, which
  is critical to being able to modify this code in the future.

A key advantage of these changes is that the exact same code should
work on Django 1.11, Django 2.2, and Django 3.x, because we're no
longer copying large blocks of core Django code and thus should be
much less vulnerable to refactors.  There may be a modest performance
downside, in that we now run response middleware twice when
longpolling (once for the request we discard).  We could probably
avoid that with a more aggressive monkey-patching of MiddlewareMixin
to skip response middleware if `response.asynchronous`.

There's a bunch of further cleanups we may want to do with the new,
simplified system.

Extensively tested manually using print statements and asserts to confirm expected 
behavior; test_tornado was also useful.