### PR TITLE
improve colors of edit message history #13622

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -583,11 +583,19 @@ on a dark background, and don't change the dark labels dark either. */
         .highlight_text_inserted {
             color: hsl(122, 100%, 81%);
             background-color: hsla(120, 64%, 95%, 0.3);
+padding-left:0.7%;
+padding-right:0.7%;
+border-radius:15%;
         }
 
         .highlight_text_deleted {
             text-decoration: line-through;
             background-color: hsla(7, 54%, 62%, 0.38);
+	    color: hsl(360,78%,69%);
+background-color: hsl(360, 90%, 19%);
+padding-left:0.7%;
+padding-right:0.7%;
+border-radius:15%;
         }
     }
 

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -583,19 +583,19 @@ on a dark background, and don't change the dark labels dark either. */
         .highlight_text_inserted {
             color: hsl(122, 100%, 81%);
             background-color: hsla(120, 64%, 95%, 0.3);
-padding-left:0.7%;
-padding-right:0.7%;
-border-radius:15%;
+	    padding-left:0.7%;
+	    padding-right:0.7%;	
+	    border-radius:15%;
         }
 
         .highlight_text_deleted {
             text-decoration: line-through;
             background-color: hsla(7, 54%, 62%, 0.38);
 	    color: hsl(360,78%,69%);
-background-color: hsl(360, 90%, 19%);
-padding-left:0.7%;
-padding-right:0.7%;
-border-radius:15%;
+	    background-color: hsl(360, 90%, 19%);
+	    padding-left:0.7%;
+	    padding-right:0.7%;
+	    border-radius:15%;
         }
     }
 

--- a/static/styles/rendered_markdown.scss
+++ b/static/styles/rendered_markdown.scss
@@ -138,13 +138,21 @@
     /* Highlighting for message edit history */
     .highlight_text_inserted {
         color: hsl(122, 72%, 30%);
-        background-color: hsl(120, 64%, 95%);
+background-color: hsl(117,57%,88%);
+padding-left:0.7%;
+padding-right:0.7%;
+border-radius:15%;
     }
 
     .highlight_text_deleted {
-        color: hsl(0, 0%, 73%);
+color: hsl(332,65%,-28%);
+background-color: hsl(7, 70%, 87%);
+padding-left:0.7%;
+padding-right:0.7%;
+border-radius:15%;
+       
         text-decoration: line-through;
-        background-color: hsl(7, 90%, 92%);
+        
         word-break: break-all;
     }
 

--- a/static/styles/rendered_markdown.scss
+++ b/static/styles/rendered_markdown.scss
@@ -137,21 +137,21 @@
 
     /* Highlighting for message edit history */
     .highlight_text_inserted {
-        color: hsl(122, 72%, 30%);
-	background-color: hsl(117,57%,88%);
-	padding-left:0.7%;
-	padding-right:0.7%;
-	border-radius:15%;
+            color: hsl(122, 72%, 30%);
+	    background-color: hsl(117,57%,88%);
+	    padding-left:0.7%;
+	    padding-right:0.7%;
+            border-radius:15%;
     }
 
     .highlight_text_deleted {
-	color: hsl(332,65%,-28%);
-	background-color: hsl(7, 70%, 87%);
-	padding-left:0.7%;
-	padding-right:0.7%;
-	border-radius:15%;
-        text-decoration: line-through;
-        word-break: break-all;
+	    color: hsl(332,65%,-28%);
+            background-color: hsl(7, 70%, 87%);
+	    padding-left:0.7%;
+	    padding-right:0.7%;
+	    border-radius:15%;
+            text-decoration: line-through;
+            word-break: break-all;
     }
 
     /* LaTeX styling */

--- a/static/styles/rendered_markdown.scss
+++ b/static/styles/rendered_markdown.scss
@@ -138,21 +138,19 @@
     /* Highlighting for message edit history */
     .highlight_text_inserted {
         color: hsl(122, 72%, 30%);
-background-color: hsl(117,57%,88%);
-padding-left:0.7%;
-padding-right:0.7%;
-border-radius:15%;
+	background-color: hsl(117,57%,88%);
+	padding-left:0.7%;
+	padding-right:0.7%;
+	border-radius:15%;
     }
 
     .highlight_text_deleted {
-color: hsl(332,65%,-28%);
-background-color: hsl(7, 70%, 87%);
-padding-left:0.7%;
-padding-right:0.7%;
-border-radius:15%;
-       
+	color: hsl(332,65%,-28%);
+	background-color: hsl(7, 70%, 87%);
+	padding-left:0.7%;
+	padding-right:0.7%;
+	border-radius:15%;
         text-decoration: line-through;
-        
         word-break: break-all;
     }
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
Hi, I want you to accept and merge this pull request into the master branch. I am very new to open source contribution and version control systems. If i have done anything wrong, please let me know.
I added some border radius and changed the text and background color for better visibility and readabilty for both the day and night schemes. 
i am also uploading the screen shots of the changes that i made below:
![Screenshot from 2020-02-07 11-50-46](https://user-images.githubusercontent.com/49960157/74015816-5d37c400-49b7-11ea-94da-47b2f03e4d9a.png)
![Screenshot from 2020-02-07 11-50-46](https://user-images.githubusercontent.com/49960157/74015820-5e68f100-49b7-11ea-81b4-f4acb023d511.png)
