### PR TITLE
auth: Include user-input email in some error messages in the login form.

### DIFF
--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -39,10 +39,10 @@ MIT_VALIDATION_ERROR = u'That user does not exist at MIT or is a ' + \
                        u'<a href="https://ist.mit.edu/email-lists">mailing list</a>. ' + \
                        u'If you want to sign up an alias for Zulip, ' + \
                        u'<a href="mailto:support@zulipchat.com">contact us</a>.'
-WRONG_SUBDOMAIN_ERROR = "Your Zulip account is not a member of the " + \
+WRONG_SUBDOMAIN_ERROR = "Your Zulip account %(username)s is not a member of the " + \
                         "organization associated with this subdomain.  " + \
                         "Please contact your organization administrator with any questions."
-DEACTIVATED_ACCOUNT_ERROR = u"Your account is no longer active. " + \
+DEACTIVATED_ACCOUNT_ERROR = u"Your account %(username)s is no longer active. " + \
                             u"Please contact your organization administrator to reactivate it."
 PASSWORD_TOO_WEAK_ERROR = u"The password is too weak."
 
@@ -315,12 +315,14 @@ class OurAuthenticationForm(AuthenticationForm):
                 # We exclude mirror dummy accounts here. They should be treated as the
                 # user never having had an account, so we let them fall through to the
                 # normal invalid_login case below.
-                raise ValidationError(mark_safe(DEACTIVATED_ACCOUNT_ERROR))
+                raise ValidationError(mark_safe(DEACTIVATED_ACCOUNT_ERROR),
+                                      params={'username': username})
 
             if return_data.get("invalid_subdomain"):
                 logging.warning("User %s attempted to password login to wrong subdomain %s" %
                                 (username, subdomain))
-                raise ValidationError(mark_safe(WRONG_SUBDOMAIN_ERROR))
+                raise ValidationError(mark_safe(WRONG_SUBDOMAIN_ERROR),
+                                      params={'username': username})
 
             if self.user_cache is None:
                 raise forms.ValidationError(

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1207,7 +1207,7 @@ class InactiveUserTest(ZulipTestCase):
 
         result = self.login_with_return(self.example_email("hamlet"))
         self.assert_in_response(
-            "Your account is no longer active.",
+            "Your account {} is no longer active.".format(self.example_email("hamlet")),
             result)
 
     def test_login_deactivated_mirror_dummy(self) -> None:
@@ -1250,7 +1250,8 @@ class InactiveUserTest(ZulipTestCase):
                                            'password': password})
         with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.EmailAuthBackend',)):
             self.assertFalse(form.is_valid())
-            self.assertIn("Your account is no longer active", str(form.errors))
+            self.assertIn("Your account {} is no longer active".format(user_profile.delivery_email),
+                          str(form.errors))
 
     def test_webhook_deactivated_user(self) -> None:
         """

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -472,7 +472,8 @@ class LoginTest(ZulipTestCase):
         do_deactivate_user(user_profile)
         result = self.login_with_return(self.example_email("hamlet"), "xxx")
         self.assertEqual(result.status_code, 200)
-        self.assert_in_response("Your account is no longer active.", result)
+        self.assert_in_response("Your account {} is no longer active.".format(self.example_email('hamlet')),
+                                result)
         self.assert_logged_in_user_id(None)
 
     def test_login_bad_password(self) -> None:
@@ -492,8 +493,10 @@ class LoginTest(ZulipTestCase):
             result = self.login_with_return(self.mit_email("sipbtest"), "xxx")
             mock_warning.assert_called_once()
         self.assertEqual(result.status_code, 200)
-        self.assert_in_response("Your Zulip account is not a member of the "
-                                "organization associated with this subdomain.", result)
+        expected_error = ("Your Zulip account %s is not a member of the " +
+                          "organization associated with this subdomain.")
+        self.assert_in_response(expected_error % (self.mit_email("sipbtest"),),
+                                result)
         self.assert_logged_in_user_id(None)
 
     def test_login_invalid_subdomain(self) -> None:


### PR DESCRIPTION
Fixes #13126.