### PR TITLE
Fix hellosign webhook

### DIFF
--- a/zerver/webhooks/hellosign/tests.py
+++ b/zerver/webhooks/hellosign/tests.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from zerver.lib.test_classes import WebhookTestCase
-
+from typing import Dict
 
 class HelloSignHookTests(WebhookTestCase):
     STREAM_NAME = 'hellosign'
@@ -12,21 +12,21 @@ class HelloSignHookTests(WebhookTestCase):
         expected_message = ("The `NDA with Acme Co.` document is awaiting the signature of "
                             "Jack, and was just signed by Jill.")
         self.send_and_test_stream_message('signatures', expected_topic, expected_message,
-                                          content_type="application/x-www-form-urlencoded")
+                                          content_type=None)
 
     def test_signatures_message_signed_by_one(self) -> None:
         expected_topic = "NDA with Acme Co."
         expected_message = ("The `NDA with Acme Co.` document was just signed by Jill.")
         self.send_and_test_stream_message('signatures_signed_by_one_signatory',
                                           expected_topic, expected_message,
-                                          content_type="application/x-www-form-urlencoded")
+                                          content_type=None)
 
     def test_signatures_message_with_four_signatories(self) -> None:
         expected_topic = "Signature doc"
         expected_message = ("The `Signature doc` document is awaiting the signature of "
                             "Eeshan Garg, John Smith, Jane Doe, and Stephen Strange.")
         self.send_and_test_stream_message('signatures_with_four_signatories', expected_topic, expected_message,
-                                          content_type="application/x-www-form-urlencoded")
+                                          content_type=None)
 
     def test_signatures_message_with_own_subject(self) -> None:
         expected_topic = "Our own subject."
@@ -34,7 +34,7 @@ class HelloSignHookTests(WebhookTestCase):
         expected_message = ("The `NDA with Acme Co.` document is awaiting the signature of "
                             "Jack, and was just signed by Jill.")
         self.send_and_test_stream_message('signatures_with_own_subject', expected_topic, expected_message,
-                                          content_type="application/x-www-form-urlencoded", topic=expected_topic)
+                                          content_type=None, topic=expected_topic)
 
-    def get_body(self, fixture_name: str) -> str:
-        return self.webhook_fixture_data("hellosign", fixture_name, file_type="json")
+    def get_body(self, fixture_name: str) -> Dict[str, str]:
+        return {"json": self.webhook_fixture_data("hellosign", fixture_name, file_type="json")}


### PR DESCRIPTION
This is a PR for https://github.com/zulip/zulip/issues/13847

**Testing Plan:**

I've fixed the automated tests so they pass. HelloSign doesn't appear to accept callback URLs with ampersands in them, which puts a damper in my ability to actually test, but I've got a support request open to HelloSign.