### PR TITLE
Design: Fixes poor line wrapping of long stream names.

### DIFF
--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -847,7 +847,6 @@ form#add_new_subscription {
         margin-top: -5px;
         margin-right: 5px;
         text-decoration: none;
-        line-height: 16px;
     }
 
     .editable-section {

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -794,11 +794,15 @@ form#add_new_subscription {
 
         .stream-name {
             display: inline-block;
+            position: relative;
             font-size: 1.5em;
             font-weight: 600;
             margin-left: -3px;
-            white-space: normal;
-            word-break: break-all;
+            padding-bottom: 5px;
+            white-space: nowrap;
+            width: 270px;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
 
         .deactivate,
@@ -844,7 +848,6 @@ form#add_new_subscription {
         margin-right: 5px;
         text-decoration: none;
         line-height: 16px;
-        vertical-align: middle;
     }
 
     .editable-section {

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -800,9 +800,17 @@ form#add_new_subscription {
             margin-left: -3px;
             padding-bottom: 5px;
             white-space: nowrap;
-            width: 270px;
-            overflow: hidden;
-            text-overflow: ellipsis;
+            max-width: 20ch;
+            // width: 270px;
+           
+
+            .stream-name-editable {
+                display: block;
+                max-width: 25ch;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                float: left;
+            }
         }
 
         .deactivate,

--- a/static/templates/subscription_settings.hbs
+++ b/static/templates/subscription_settings.hbs
@@ -15,7 +15,7 @@
             <div class="large-icon hash" style="color: {{color}}"></div>
             {{/if}}
             <div class="stream-name">
-                <span class="stream-name-editable editable-section">{{name}}</span>
+                <span title="{{name}}" class="stream-name-editable editable-section" >{{name}}</span>
                 {{#if can_change_name_description}}
                 <span class="editable" data-make-editable=".stream-name-editable"></span>
                 <span class="checkmark" data-finish-editing=".stream-name-editable">✓</span>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
In continuation of #13250.
The previous PR shortened long stream names by use of ellipses, due to
which the edit button was not visible in case of too long stream name.

The edit button is now visible.

Further work: Configuring the method of editing long stream names, which
is a bit buggy right now.

Screenshots:

<img width="266" alt="stream-name-edit" src="https://user-images.githubusercontent.com/47082523/74086825-bf262580-4aac-11ea-847d-157019ed1c29.png">



**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
