### PR TITLE
package.json: Set "private": true to prevent NPM publication

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "license": "Apache-2.0",
   "description": "",
+  "private": true,
   "main": "",
   "dependencies": {
     "@babel/core": "^7.5.5",


### PR DESCRIPTION
https://docs.npmjs.com/files/package.json#private

Although our “package” is named zulip, it is not https://www.npmjs.com/package/zulip and should not be published there.