### PR TITLE
js: Modernize away most uses of underscore for objects

### DIFF
--- a/frontend_tests/node_tests/bot_data.js
+++ b/frontend_tests/node_tests/bot_data.js
@@ -141,12 +141,12 @@ run_test('test_basics', () => {
         bot_data.add({...test_bot, user_id: 45, email: 'bot2@zulip.com', owner: 'owner@zulip.com', is_active: true});
         bot_data.add({...test_bot, user_id: 46, email: 'bot3@zulip.com', owner: 'not_owner@zulip.com', is_active: true});
 
-        can_admin = _.pluck(bot_data.get_editable(), 'email');
+        can_admin = bot_data.get_editable().map(bot => bot.email);
         assert.deepEqual(['bot1@zulip.com', 'bot2@zulip.com'], can_admin);
 
         page_params.is_admin = true;
 
-        can_admin = _.pluck(bot_data.get_editable(), 'email');
+        can_admin = bot_data.get_editable().map(bot => bot.email);
         assert.deepEqual(['bot1@zulip.com', 'bot2@zulip.com'], can_admin);
     }());
 

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -521,7 +521,7 @@ run_test('content_typeahead_selected', () => {
 });
 
 function sorted_names_from(subs) {
-    return _.pluck(subs, 'name').sort();
+    return subs.map(sub => sub.name).sort();
 }
 
 run_test('initialize', () => {

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -1155,7 +1155,7 @@ with_overrides(function (override) {
         override('subs.add_sub_to_table', noop);
         dispatch(event);
         const args = stub.get_args('streams');
-        assert_same(_.pluck(args.streams, 'stream_id'), [42, 99]);
+        assert_same(args.streams.map(stream => stream.stream_id), [42, 99]);
     });
 
     // stream delete

--- a/frontend_tests/node_tests/message_list_data.js
+++ b/frontend_tests/node_tests/message_list_data.js
@@ -156,12 +156,12 @@ run_test('more muting', () => {
     });
 
     assert.deepEqual(
-        _.pluck(mld._all_items, 'id'),
+        mld._all_items.map(message => message.id),
         [3, 4, 7, 8]
     );
 
     assert.deepEqual(
-        _.pluck(mld.all_messages(), 'id'),
+        mld.all_messages().map(message => message.id),
         [4, 8]
     );
 
@@ -178,12 +178,12 @@ run_test('more muting', () => {
     const more_info = mld.add_messages(more_messages);
 
     assert.deepEqual(
-        _.pluck(mld._all_items, 'id'),
+        mld._all_items.map(message => message.id),
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     );
 
     assert.deepEqual(
-        _.pluck(mld.all_messages(), 'id'),
+        mld.all_messages().map(message => message.id),
         [2, 4, 6, 8, 10]
     );
 

--- a/frontend_tests/node_tests/narrow_local.js
+++ b/frontend_tests/node_tests/narrow_local.js
@@ -66,7 +66,7 @@ function test_with(fixture) {
     assert.deepEqual(id_info, fixture.expected_id_info);
 
     const msgs = msg_data.all_messages();
-    const msg_ids = _.pluck(msgs, 'id');
+    const msg_ids = msgs.map(message => message.id);
     assert.deepEqual(msg_ids, fixture.expected_msg_ids);
 }
 

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -203,7 +203,7 @@ run_test('populate_user_groups', () => {
 
         (function test_source() {
             const result = config.source.call(fake_context, iago);
-            const emails = _.pluck(result, 'email').sort();
+            const emails = result.map(user => user.email).sort();
             assert.deepEqual(emails, [alice.email, bob.email]);
         }());
 

--- a/static/js/color_data.js
+++ b/static/js/color_data.js
@@ -33,7 +33,7 @@ exports.claim_color = function (color) {
 };
 
 exports.claim_colors = function (subs) {
-    const colors = new Set(_.pluck(subs, 'color'));
+    const colors = new Set(subs.map(sub => sub.color));
     colors.forEach(exports.claim_color);
 };
 

--- a/static/js/hotspots.js
+++ b/static/js/hotspots.js
@@ -237,7 +237,7 @@ exports.close_hotspot_icon = function (elem) {
 function close_read_hotspots(new_hotspots) {
     const unwanted_hotspots = _.difference(
         Array.from(HOTSPOT_LOCATIONS.keys()),
-        _.pluck(new_hotspots, 'name')
+        new_hotspots.map(hotspot => hotspot.name)
     );
 
     for (const hotspot_name of unwanted_hotspots) {

--- a/static/js/input_pill.js
+++ b/static/js/input_pill.js
@@ -223,7 +223,7 @@ exports.create = function (opts) {
         },
 
         items: function () {
-            return _.pluck(store.pills, 'item');
+            return store.pills.map(pill => pill.item);
         },
     };
 

--- a/static/js/message_list_data.js
+++ b/static/js/message_list_data.js
@@ -42,7 +42,7 @@ MessageListData.prototype = {
         if (this._selected_id === -1) {
             return;
         }
-        const ids = _.pluck(this._items, 'id');
+        const ids = this._items.map(message => message.id);
 
         const i = ids.indexOf(this._selected_id);
         if (i === -1) {

--- a/static/js/pm_conversations.js
+++ b/static/js/pm_conversations.js
@@ -67,7 +67,7 @@ exports.recent = (function () {
     self.get_strings = function () {
         // returns array of structs with user_ids_string and
         // message_id
-        return _.pluck(recent_private_messages, 'user_ids_string');
+        return recent_private_messages.map(conversation => conversation.user_ids_string);
     };
 
     self.initialize = function (params) {

--- a/static/js/search_pill.js
+++ b/static/js/search_pill.js
@@ -29,7 +29,7 @@ exports.append_search_string = function (search_string, pill_widget) {
 
 exports.get_search_string_for_current_filter = function (pill_widget) {
     const items = pill_widget.items();
-    const search_strings = _.pluck(items, 'display_value');
+    const search_strings = items.map(item => item.display_value);
     return search_strings.join(' ');
 };
 

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -289,7 +289,7 @@ exports.get_non_default_stream_names = function () {
     subs = subs.filter(
         sub => !exports.is_default_stream_id(sub.stream_id) && (sub.subscribed || !sub.invite_only)
     );
-    const names = _.pluck(subs, 'name');
+    const names = subs.map(sub => sub.name);
     return names;
 };
 
@@ -329,7 +329,7 @@ exports.unsubscribed_subs = function () {
 };
 
 exports.subscribed_streams = function () {
-    return _.pluck(exports.subscribed_subs(), 'name');
+    return exports.subscribed_subs().map(sub => sub.name);
 };
 
 exports.get_invite_stream_data = function () {
@@ -358,12 +358,12 @@ exports.get_invite_stream_data = function () {
 
 exports.invite_streams = function () {
     const invite_list = exports.subscribed_streams();
-    const default_list = _.pluck(page_params.realm_default_streams, 'name');
+    const default_list = page_params.realm_default_streams.map(stream => stream.name);
     return _.union(invite_list, default_list);
 };
 
 exports.get_colors = function () {
-    return _.pluck(exports.subscribed_subs(), 'color');
+    return exports.subscribed_subs().map(sub => sub.color);
 };
 
 exports.update_subscribers_count = function (sub) {
@@ -563,7 +563,7 @@ exports.set_realm_default_streams = function (realm_default_streams) {
 
 exports.get_default_stream_names = function () {
     const streams = Array.from(default_stream_ids).map(exports.get_sub_by_id);
-    const default_stream_names = _.pluck(streams, 'name');
+    const default_stream_names = streams.map(stream => stream.name);
     return default_stream_names;
 };
 

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -221,7 +221,7 @@ exports.initialize_kitchen_sink_stuff = function () {
                     render_end: event.msg_list.view._render_win_end,
                     selected_id_from_idx: messages[event.msg_list.selected_idx()].id,
                     msg_list_sorted: _.isEqual(
-                        _.pluck(messages, 'id'),
+                        messages.map(message => message.id),
                         _.chain(current_msg_list.all_messages()).pluck('id').clone().value().sort()
                     ),
                     found_in_dom: row_from_dom.length,

--- a/static/js/user_pill.js
+++ b/static/js/user_pill.js
@@ -7,7 +7,7 @@ exports.create_item_from_email = function (email, current_items) {
 
     if (!user) {
         if (page_params.realm_is_zephyr_mirror_realm) {
-            const existing_emails = _.pluck(current_items, 'email');
+            const existing_emails = current_items.map(item => item.email);
 
             if (existing_emails.includes(email)) {
                 return;
@@ -26,7 +26,7 @@ exports.create_item_from_email = function (email, current_items) {
         return;
     }
 
-    const existing_ids = _.pluck(current_items, 'user_id');
+    const existing_ids = current_items.map(item => item.user_id);
 
     if (existing_ids.includes(user.user_id)) {
         return;
@@ -66,7 +66,7 @@ exports.append_person = function (opts) {
 
 exports.get_user_ids = function (pill_widget) {
     const items = pill_widget.items();
-    let user_ids = _.pluck(items, 'user_id');
+    let user_ids = items.map(item => item.user_id);
     user_ids = user_ids.filter(Boolean); // be defensive about undefined users
 
     return user_ids;


### PR DESCRIPTION
Companion to #13850, eliminating more uses of `_`.

**Testing Plan:** `test-js-with-node` (every commit), `lint -g frontend` (every commit), `test-js-with-casper`, `run-dev`

Cc @showell
