### PR TITLE
Fix improve colors of message edit history

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -583,11 +583,18 @@ on a dark background, and don't change the dark labels dark either. */
         .highlight_text_inserted {
             color: hsl(122, 100%, 81%);
             background-color: hsla(120, 64%, 95%, 0.3);
+            padding-left: 0.7%;
+            padding-right: 0.7%;
+            border-radius: 15%;
         }
 
         .highlight_text_deleted {
+            color: hsl(360, 78%, 69%);
             text-decoration: line-through;
-            background-color: hsla(7, 54%, 62%, 0.38);
+            background-color: hsl(360, 90%, 19%);
+            padding-left: 0.7%;
+            padding-right: 0.7%;
+            border-radius: 15%;
         }
     }
 

--- a/static/styles/rendered_markdown.scss
+++ b/static/styles/rendered_markdown.scss
@@ -138,13 +138,19 @@
     /* Highlighting for message edit history */
     .highlight_text_inserted {
         color: hsl(122, 72%, 30%);
-        background-color: hsl(120, 64%, 95%);
+        background-color: hsl(117, 57%, 88%);
+        padding-left: 0.7%;
+        padding-right: 0.7%;
+        border-radius: 15%;
     }
 
     .highlight_text_deleted {
-        color: hsl(0, 0%, 73%);
+        color: hsl(332, 65%, -28%);
+        background-color: hsl(7, 70%, 87%);
         text-decoration: line-through;
-        background-color: hsl(7, 90%, 92%);
+        padding-left: 0.7%;
+        padding-right: 0.7%;
+        border-radius: 15%;
         word-break: break-all;
     }
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
Hi,
I am new the open source contribution and version control systems. I saw this issue under good first issues and also unsolved but in progress. As this is a simple issue i tried t change the colors for better visibility and the screen shots are given below. Please let me know for any further changes or recommendations.
![Screenshot from 2020-02-07 11-50-25](https://user-images.githubusercontent.com/49960157/74100697-c2c2b680-4b57-11ea-935d-663a62bf88b5.png)
![Screenshot from 2020-02-07 11-50-46](https://user-images.githubusercontent.com/49960157/74100700-c3f3e380-4b57-11ea-9609-29d0e797ac14.png)

