### PR TITLE
stream_data: Remove stream_name param from add_sub().

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -118,7 +118,7 @@ run_test('validate_stream_message_address_info', () => {
         name: 'social',
         subscribed: true,
     };
-    stream_data.add_sub('social', sub);
+    stream_data.add_sub(sub);
     assert(compose.validate_stream_message_address_info('social'));
 
     $('#stream_message_recipient_stream').select(noop);
@@ -126,7 +126,7 @@ run_test('validate_stream_message_address_info', () => {
     assert.equal($('#compose-error-msg').html(), "translated: <p>The stream <b>foobar</b> does not exist.</p><p>Manage your subscriptions <a href='#streams/all'>on your Streams page</a>.</p>");
 
     sub.subscribed = false;
-    stream_data.add_sub('social', sub);
+    stream_data.add_sub(sub);
     global.stub_templates(function (template_name) {
         assert.equal(template_name, 'compose_not_subscribed');
         return 'compose_not_subscribed_stub';
@@ -144,7 +144,7 @@ run_test('validate_stream_message_address_info', () => {
 
     sub.name = 'Frontend';
     sub.stream_id = 102;
-    stream_data.add_sub('Frontend', sub);
+    stream_data.add_sub(sub);
     channel.post = function (payload) {
         assert.equal(payload.data.stream, 'Frontend');
         payload.data.subscribed = false;
@@ -296,7 +296,7 @@ run_test('validate_stream_message', () => {
         name: 'social',
         subscribed: true,
     };
-    stream_data.add_sub('social', sub);
+    stream_data.add_sub(sub);
     compose_state.stream_name('social');
     assert(compose.validate());
     assert(!$("#compose-all-everyone").visible());
@@ -339,7 +339,7 @@ run_test('test_validate_stream_message_post_policy', () => {
         return 2;
     };
     compose_state.topic('subject102');
-    stream_data.add_sub('stream102', sub);
+    stream_data.add_sub(sub);
     assert(!compose.validate());
     assert.equal($('#compose-error-msg').html(), i18n.t("Only organization admins are allowed to post to this stream."));
 
@@ -872,7 +872,8 @@ function test_raw_file_drop(raw_drop_func) {
 }
 
 run_test('warn_if_private_stream_is_linked', () => {
-    stream_data.add_sub(compose_state.stream_name(), {
+    stream_data.add_sub({
+        name: compose_state.stream_name(),
         subscribers: new LazySet([1, 2]),
         stream_id: 99,
     });
@@ -1077,7 +1078,7 @@ run_test('needs_subscribe_warning', () => {
         name: 'random',
         subscribed: true,
     };
-    stream_data.add_sub('random', sub);
+    stream_data.add_sub(sub);
     assert.equal(compose.needs_subscribe_warning(), false);
 
     people.get_active_user_for_email = function () {
@@ -1301,7 +1302,7 @@ run_test('on_events', () => {
         blueslip.clear_test_data();
 
         // !sub will result in true here and we check the success code path.
-        stream_data.add_sub('test', subscription);
+        stream_data.add_sub(subscription);
         $('#stream_message_recipient_stream').val('test');
         let all_invite_children_called = false;
         $("#compose_invite_users").children = function () {
@@ -1365,7 +1366,7 @@ run_test('on_events', () => {
 
         assert(compose_not_subscribed_called);
 
-        stream_data.add_sub('test', subscription);
+        stream_data.add_sub(subscription);
         $('#stream_message_recipient_stream').val('test');
         $("#compose-send-status").show();
 
@@ -1633,7 +1634,7 @@ run_test('create_message_object', () => {
         name: 'social',
         subscribed: true,
     };
-    stream_data.add_sub('social', sub);
+    stream_data.add_sub(sub);
 
     const page = {
         '#stream_message_recipient_stream': 'social',

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -149,7 +149,7 @@ run_test('start', () => {
         name: 'Denmark',
         stream_id: 1,
     };
-    stream_data.add_sub('Denmark', denmark);
+    stream_data.add_sub(denmark);
 
     global.narrow_state.set_compose_defaults = function () {
         const opts = {};
@@ -179,7 +179,7 @@ run_test('start', () => {
         name: 'social',
         stream_id: 2,
     };
-    stream_data.add_sub('social', social);
+    stream_data.add_sub(social);
 
     // More than 1 subscription, do not autofill
     opts = {};

--- a/frontend_tests/node_tests/compose_fade.js
+++ b/frontend_tests/node_tests/compose_fade.js
@@ -39,7 +39,7 @@ run_test('set_focused_recipient', () => {
         subscribed: true,
         can_access_subscribers: true,
     };
-    stream_data.add_sub('social', sub);
+    stream_data.add_sub(sub);
     stream_data.set_subscribers(sub, [me.user_id, alice.user_id]);
 
     global.$ = function (selector) {

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -162,9 +162,9 @@ const netherland_stream = {
     subscribed: false,
 };
 
-stream_data.add_sub('Sweden', sweden_stream);
-stream_data.add_sub('Denmark', denmark_stream);
-stream_data.add_sub('The Netherlands', netherland_stream);
+stream_data.add_sub(sweden_stream);
+stream_data.add_sub(denmark_stream);
+stream_data.add_sub(netherland_stream);
 
 set_global('$', global.make_zjquery());
 

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -519,7 +519,7 @@ function make_sub(name, stream_id) {
         name: name,
         stream_id: stream_id,
     };
-    global.stream_data.add_sub(name, sub);
+    global.stream_data.add_sub(sub);
 }
 
 run_test('predicate_basics', () => {

--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -67,7 +67,7 @@ zrequire('settings_display');
 
 run_test('stream_data', () => {
     assert.equal(stream_data.get_sub_by_name('Denmark'), undefined);
-    stream_data.add_sub('Denmark', denmark_stream);
+    stream_data.add_sub(denmark_stream);
     const sub = stream_data.get_sub_by_name('Denmark');
     assert.equal(sub.color, 'blue');
 });
@@ -596,7 +596,7 @@ const social_stream = {
 };
 
 run_test('set_up_filter', () => {
-    stream_data.add_sub('Social', social_stream);
+    stream_data.add_sub(social_stream);
 
     const filter_terms = [
         {operator: 'stream', operand: 'Social'},

--- a/frontend_tests/node_tests/hash_util.js
+++ b/frontend_tests/node_tests/hash_util.js
@@ -24,7 +24,7 @@ const frontend = {
     name: 'frontend',
 };
 
-stream_data.add_sub('frontend', frontend);
+stream_data.add_sub(frontend);
 
 run_test('hash_util', () => {
     // Test encodeHashComponent

--- a/frontend_tests/node_tests/hashchange.js
+++ b/frontend_tests/node_tests/hashchange.js
@@ -64,7 +64,7 @@ run_test('operators_round_trip', () => {
         name: 'Florida, USA',
         stream_id: 987,
     };
-    stream_data.add_sub(florida_stream.name, florida_stream);
+    stream_data.add_sub(florida_stream);
     operators = [
         {operator: 'stream', operand: 'Florida, USA'},
     ];

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -153,10 +153,10 @@ const edgecase_stream_2 = {
     stream_id: 4,
     is_muted: false,
 };
-stream_data.add_sub('Denmark', denmark);
-stream_data.add_sub('social', social);
-stream_data.add_sub('Bobby <h1>Tables</h1>', edgecase_stream);
-stream_data.add_sub('Bobby <h1', edgecase_stream_2);
+stream_data.add_sub(denmark);
+stream_data.add_sub(social);
+stream_data.add_sub(edgecase_stream);
+stream_data.add_sub(edgecase_stream_2);
 // Note: edgecase_stream cannot be mentioned because it is caught by
 // streamTopicHandler and it would be parsed as edgecase_stream_2.
 

--- a/frontend_tests/node_tests/muting.js
+++ b/frontend_tests/node_tests/muting.js
@@ -35,10 +35,10 @@ const unknown = {
     name: 'whatever',
 };
 
-stream_data.add_sub(design.name, design);
-stream_data.add_sub(devel.name, devel);
-stream_data.add_sub(office.name, office);
-stream_data.add_sub(social.name, social);
+stream_data.add_sub(design);
+stream_data.add_sub(devel);
+stream_data.add_sub(office);
+stream_data.add_sub(social);
 
 run_test('basics', () => {
     assert(!muting.is_topic_muted(devel.stream_id, 'java'));

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -111,7 +111,7 @@ run_test('show_empty_narrow_message', () => {
     assert($('#nonsubbed_private_nonexistent_stream_narrow_message').visible());
 
     // for non sub public stream
-    stream_data.add_sub('ROME', {name: 'ROME', stream_id: 99});
+    stream_data.add_sub({name: 'ROME', stream_id: 99});
     stream_data.update_calculated_fields(stream_data.get_sub("ROME"));
     set_filter([['stream', 'Rome']]);
     narrow.show_empty_narrow_message();
@@ -222,8 +222,8 @@ run_test('show_invalid_narrow_message', () => {
     narrow_state.reset_current_filter();
     const display = $("#empty_search_stop_words_string");
 
-    stream_data.add_sub('streamA', {name: 'streamA', stream_id: 88});
-    stream_data.add_sub('streamB', {name: 'streamB', stream_id: 77});
+    stream_data.add_sub({name: 'streamA', stream_id: 88});
+    stream_data.add_sub({name: 'streamB', stream_id: 77});
 
     set_filter([['stream', 'streamA'], ['stream', 'streamB']]);
     narrow.show_empty_narrow_message();
@@ -270,7 +270,7 @@ run_test('narrow_to_compose_target', () => {
 
     // --- Tests for stream messages ---
     global.compose_state.get_message_type = () => 'stream';
-    stream_data.add_sub('ROME', {name: 'ROME', stream_id: 99});
+    stream_data.add_sub({name: 'ROME', stream_id: 99});
     global.compose_state.stream_name = () => 'ROME';
     global.topic_data.get_recent_names = () => ['one', 'two', 'three'];
 

--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -60,7 +60,7 @@ const denmark = {
     stream_id: 1,
     is_muted: true,
 };
-stream_data.add_sub('Denmark', denmark);
+stream_data.add_sub(denmark);
 
 function test_helper() {
     let events = [];

--- a/frontend_tests/node_tests/narrow_state.js
+++ b/frontend_tests/node_tests/narrow_state.js
@@ -22,7 +22,7 @@ run_test('stream', () => {
     assert(!narrow_state.active());
 
     const test_stream = {name: 'Test', stream_id: 15};
-    stream_data.add_sub('Test', test_stream);
+    stream_data.add_sub(test_stream);
 
     assert(!narrow_state.is_for_stream_id(test_stream.stream_id));
 
@@ -160,7 +160,7 @@ run_test('set_compose_defaults', () => {
     set_filter([['topic', 'duplicate'], ['topic', 'duplicate']]);
     assert.deepEqual(narrow_state.set_compose_defaults(), {});
 
-    stream_data.add_sub('ROME', {name: 'ROME', stream_id: 99});
+    stream_data.add_sub({name: 'ROME', stream_id: 99});
     set_filter([['stream', 'rome']]);
 
     const stream_test = narrow_state.set_compose_defaults();
@@ -219,7 +219,7 @@ run_test('stream', () => {
     assert.equal(narrow_state.stream_id(), undefined);
 
     const sub = {name: 'Foo', stream_id: 55};
-    stream_data.add_sub('Foo', sub);
+    stream_data.add_sub(sub);
     assert.equal(narrow_state.stream_id(), 55);
     assert.deepEqual(narrow_state.stream_sub(), sub);
 

--- a/frontend_tests/node_tests/narrow_unread.js
+++ b/frontend_tests/node_tests/narrow_unread.js
@@ -68,7 +68,7 @@ run_test('get_unread_ids', () => {
         ],
     };
 
-    stream_data.add_sub(sub.name, sub);
+    stream_data.add_sub(sub);
 
     unread_ids = candidate_ids();
     assert.equal(unread_ids, undefined);

--- a/frontend_tests/node_tests/notifications.js
+++ b/frontend_tests/node_tests/notifications.js
@@ -49,8 +49,8 @@ const muted = {
     wildcard_mentions_notify: null,
 };
 
-stream_data.add_sub('general', general);
-stream_data.add_sub('muted', muted);
+stream_data.add_sub(general);
+stream_data.add_sub(muted);
 
 muting.add_muted_topic(general.stream_id, 'muted topic');
 

--- a/frontend_tests/node_tests/settings_muting.js
+++ b/frontend_tests/node_tests/settings_muting.js
@@ -12,7 +12,7 @@ const frontend = {
     stream_id: 101,
     name: 'frontend',
 };
-stream_data.add_sub('frontend', frontend);
+stream_data.add_sub(frontend);
 
 run_test('settings', () => {
 

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -68,10 +68,10 @@ run_test('basics', () => {
         is_muted: true,
         invite_only: false,
     };
-    stream_data.add_sub('Denmark', denmark);
-    stream_data.add_sub('social', social);
+    stream_data.add_sub(denmark);
+    stream_data.add_sub(social);
     assert(stream_data.all_subscribed_streams_are_in_home_view());
-    stream_data.add_sub('test', test);
+    stream_data.add_sub(test);
     assert(!stream_data.all_subscribed_streams_are_in_home_view());
 
     assert.equal(stream_data.get_sub('denmark'), denmark);
@@ -119,7 +119,7 @@ run_test('renames', () => {
         color: 'red',
         stream_id: id,
     };
-    stream_data.add_sub('Denmark', sub);
+    stream_data.add_sub(sub);
     sub = stream_data.get_sub('Denmark');
     assert.equal(sub.color, 'red');
     sub = stream_data.get_sub_by_id(id);
@@ -146,7 +146,7 @@ run_test('unsubscribe', () => {
     let sub = {name: 'devel', subscribed: false, stream_id: 1};
 
     // set up our subscription
-    stream_data.add_sub('devel', sub);
+    stream_data.add_sub(sub);
     sub.subscribed = true;
     stream_data.set_subscribers(sub, [me.user_id]);
 
@@ -169,7 +169,7 @@ run_test('subscribers', () => {
     stream_data.clear_subscriptions();
     let sub = {name: 'Rome', subscribed: true, stream_id: 1};
 
-    stream_data.add_sub('Rome', sub);
+    stream_data.add_sub(sub);
 
     const fred = {
         email: 'fred@zulip.com',
@@ -257,7 +257,7 @@ run_test('subscribers', () => {
     // Verify defensive code in set_subscribers, where the second parameter
     // can be undefined.
     stream_data.set_subscribers(sub);
-    stream_data.add_sub('Rome', sub);
+    stream_data.add_sub(sub);
     stream_data.add_subscriber('Rome', brutus.user_id);
     sub.subscribed = true;
     assert(stream_data.is_user_subscribed('Rome', brutus.user_id));
@@ -308,7 +308,7 @@ run_test('is_active', () => {
     stream_data.set_filter_out_inactives();
 
     sub = {name: 'pets', subscribed: false, stream_id: 111};
-    stream_data.add_sub('pets', sub);
+    stream_data.add_sub(sub);
 
     assert(stream_data.is_active(sub));
 
@@ -339,7 +339,7 @@ run_test('is_active', () => {
     stream_data.set_filter_out_inactives();
 
     sub = {name: 'pets', subscribed: false, stream_id: 111};
-    stream_data.add_sub('pets', sub);
+    stream_data.add_sub(sub);
 
     assert(!stream_data.is_active(sub));
 
@@ -354,7 +354,7 @@ run_test('is_active', () => {
     assert(!stream_data.is_active(sub));
 
     sub = {name: 'lunch', subscribed: false, stream_id: 222};
-    stream_data.add_sub('lunch', sub);
+    stream_data.add_sub(sub);
 
     assert(stream_data.is_active(sub));
 
@@ -367,7 +367,7 @@ run_test('is_active', () => {
     stream_data.set_filter_out_inactives();
 
     sub = {name: 'pets', subscribed: false, stream_id: 111};
-    stream_data.add_sub('pets', sub);
+    stream_data.add_sub(sub);
 
     assert(stream_data.is_active(sub));
 
@@ -395,7 +395,7 @@ run_test('admin_options', () => {
             is_muted: true,
             invite_only: false,
         };
-        stream_data.add_sub(sub.name, sub);
+        stream_data.add_sub(sub);
         return sub;
     }
 
@@ -462,9 +462,9 @@ run_test('stream_settings', () => {
         stream_post_policy: stream_data.stream_post_policy_values.admins.code,
     };
     stream_data.clear_subscriptions();
-    stream_data.add_sub(cinnamon.name, cinnamon);
-    stream_data.add_sub(amber.name, amber);
-    stream_data.add_sub(blue.name, blue);
+    stream_data.add_sub(cinnamon);
+    stream_data.add_sub(amber);
+    stream_data.add_sub(blue);
 
     let sub_rows = stream_data.get_streams_for_settings_page();
     assert.equal(sub_rows[0].color, 'blue');
@@ -534,10 +534,10 @@ run_test('default_stream_names', () => {
 
     stream_data.clear_subscriptions();
     stream_data.set_realm_default_streams([announce, general]);
-    stream_data.add_sub('announce', announce);
-    stream_data.add_sub('public_stream', public_stream);
-    stream_data.add_sub('private_stream', private_stream);
-    stream_data.add_sub('general', general);
+    stream_data.add_sub(announce);
+    stream_data.add_sub(public_stream);
+    stream_data.add_sub(private_stream);
+    stream_data.add_sub(general);
 
     let names = stream_data.get_non_default_stream_names();
     assert.deepEqual(names, ['public', 'private']);
@@ -554,7 +554,7 @@ run_test('delete_sub', () => {
     };
 
     stream_data.clear_subscriptions();
-    stream_data.add_sub('Canada', canada);
+    stream_data.add_sub(canada);
 
     assert(stream_data.is_subscribed('Canada'));
     assert(stream_data.get_sub('Canada').stream_id, canada.stream_id);
@@ -584,7 +584,7 @@ run_test('get_subscriber_count', () => {
     assert.equal(blueslip.get_test_logs('warn').length, 1);
     blueslip.clear_test_data();
 
-    stream_data.add_sub('India', india);
+    stream_data.add_sub(india);
     assert.equal(stream_data.get_subscriber_count('India'), 0);
 
     const fred = {
@@ -621,7 +621,7 @@ run_test('notifications', () => {
         wildcard_mentions_notify: null,
     };
     stream_data.clear_subscriptions();
-    stream_data.add_sub('India', india);
+    stream_data.add_sub(india);
 
     assert(!stream_data.receives_notifications('Indiana', "desktop_notifications"));
     assert(!stream_data.receives_notifications('Indiana', "audible_notifications"));
@@ -694,8 +694,8 @@ run_test('is_muted', () => {
         is_muted: true,
     };
 
-    stream_data.add_sub('tony', tony);
-    stream_data.add_sub('jazy', jazy);
+    stream_data.add_sub(tony);
+    stream_data.add_sub(jazy);
     assert(!stream_data.is_stream_muted_by_name('tony'));
     assert(stream_data.is_stream_muted_by_name('jazy'));
     assert(stream_data.is_stream_muted_by_name('EEXISTS'));
@@ -717,7 +717,7 @@ run_test('remove_default_stream', () => {
         is_muted: true,
     };
 
-    stream_data.add_sub('remove_me', remove_me);
+    stream_data.add_sub(remove_me);
     stream_data.set_realm_default_streams([remove_me]);
     stream_data.remove_default_stream(remove_me.stream_id);
     assert(!stream_data.get_default_status('remove_me'));
@@ -818,7 +818,7 @@ run_test('initialize', () => {
         stream_id: 89,
     };
 
-    stream_data.add_sub('foo', foo);
+    stream_data.add_sub(foo);
     stream_data.initialize();
     assert.equal(page_params.notifications_stream, "foo");
 });
@@ -845,7 +845,7 @@ run_test('filter inactives', () => {
             newly_subscribed: false,
             stream_id: stream_id,
         };
-        stream_data.add_sub(name, sub);
+        stream_data.add_sub(sub);
     });
     stream_data.initialize();
     assert(stream_data.is_filtering_inactives());
@@ -902,7 +902,7 @@ run_test('invite_streams', () => {
     stream_data.clear_subscriptions();
     people.init();
 
-    stream_data.add_sub('Orie', orie);
+    stream_data.add_sub(orie);
     stream_data.set_realm_default_streams([orie]);
 
     const expected_list = ['Orie'];
@@ -913,7 +913,7 @@ run_test('invite_streams', () => {
         name: 'Inviter',
         subscribed: true,
     };
-    stream_data.add_sub('Inviter', inviter);
+    stream_data.add_sub(inviter);
 
     expected_list.push('Inviter');
     assert.deepEqual(stream_data.invite_streams(), expected_list);
@@ -939,7 +939,7 @@ run_test('get_invite_stream_data', () => {
     stream_data.clear_subscriptions();
     people.init();
 
-    stream_data.add_sub('Orie', orie);
+    stream_data.add_sub(orie);
     stream_data.set_realm_default_streams([orie]);
 
     const expected_list = [{
@@ -956,7 +956,7 @@ run_test('get_invite_stream_data', () => {
         invite_only: true,
         subscribed: true,
     };
-    stream_data.add_sub('Inviter', inviter);
+    stream_data.add_sub(inviter);
 
     expected_list.push({
         name: 'Inviter',

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -32,7 +32,7 @@ const frontend = {
     invite_only: false,
 };
 
-stream_data.add_sub(frontend.name, frontend);
+stream_data.add_sub(frontend);
 
 run_test('update_property', () => {
     // Invoke error for non-existent stream/property
@@ -374,7 +374,7 @@ const dev_help = {
     is_muted: true,
     invite_only: false,
 };
-stream_data.add_sub(dev_help.name, dev_help);
+stream_data.add_sub(dev_help);
 
 run_test('remove_deactivated_user_from_all_streams', () => {
     subs.rerender_subscriptions_settings = () => {};

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -52,7 +52,7 @@ run_test('create_sidebar_row', () => {
         subscribed: true,
         pin_to_top: true,
     };
-    global.stream_data.add_sub('devel', devel);
+    global.stream_data.add_sub(devel);
 
     const social = {
         name: 'social',
@@ -60,7 +60,7 @@ run_test('create_sidebar_row', () => {
         color: 'green',
         subscribed: true,
     };
-    global.stream_data.add_sub('social', social);
+    global.stream_data.add_sub(social);
 
     global.unread.num_unread_for_stream = function () {
         return 42;
@@ -178,7 +178,7 @@ run_test('pinned_streams_never_inactive', () => {
         subscribed: true,
         pin_to_top: true,
     };
-    global.stream_data.add_sub('devel', devel);
+    global.stream_data.add_sub(devel);
 
     const social = {
         name: 'social',
@@ -186,7 +186,7 @@ run_test('pinned_streams_never_inactive', () => {
         color: 'green',
         subscribed: true,
     };
-    global.stream_data.add_sub('social', social);
+    global.stream_data.add_sub(social);
 
     // we use social and devel created in create_social_sidebar_row() and create_devel_sidebar_row()
 
@@ -223,7 +223,7 @@ run_test('pinned_streams_never_inactive', () => {
 set_global('$', global.make_zjquery());
 
 function add_row(sub) {
-    global.stream_data.add_sub(sub.name, sub);
+    global.stream_data.add_sub(sub);
     const row = {
         update_whether_active: function () {},
         get_li: function () {
@@ -714,7 +714,7 @@ run_test('refresh_pin', () => {
         pin_to_top: false,
     };
 
-    stream_data.add_sub(sub.name, sub);
+    stream_data.add_sub(sub);
 
     const pinned_sub = _.extend(sub, {
         pin_to_top: true,

--- a/frontend_tests/node_tests/stream_sort.js
+++ b/frontend_tests/node_tests/stream_sort.js
@@ -41,11 +41,11 @@ const weaving = {
     pin_to_top: false,
 };
 
-stream_data.add_sub(scalene.name, scalene);
-stream_data.add_sub(fast_tortoise.name, fast_tortoise);
-stream_data.add_sub(pneumonia.name, pneumonia);
-stream_data.add_sub(clarinet.name, clarinet);
-stream_data.add_sub(weaving.name, weaving);
+stream_data.add_sub(scalene);
+stream_data.add_sub(fast_tortoise);
+stream_data.add_sub(pneumonia);
+stream_data.add_sub(clarinet);
+stream_data.add_sub(weaving);
 
 function sort_groups(query) {
     const streams = stream_data.subscribed_streams();

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -66,7 +66,7 @@ run_test('filter_table', () => {
     ];
 
     for (const sub of sub_row_data) {
-        stream_data.add_sub(sub.name, sub);
+        stream_data.add_sub(sub);
     }
 
     let populated_subs;

--- a/frontend_tests/node_tests/topic_data.js
+++ b/frontend_tests/node_tests/topic_data.js
@@ -72,7 +72,7 @@ run_test('is_complete_for_stream_id', () => {
         stream_id: 444,
         first_message_id: 1000,
     };
-    stream_data.add_sub(sub.name, sub);
+    stream_data.add_sub(sub);
 
     message_list.all = {
         empty: () => false,
@@ -115,7 +115,7 @@ run_test('server_history', () => {
         stream_id: 66,
     };
     const stream_id = sub.stream_id;
-    stream_data.add_sub(sub.name, sub);
+    stream_data.add_sub(sub);
 
     message_list.all.fetch_status.has_found_newest = () => false;
 

--- a/frontend_tests/node_tests/topic_list_data.js
+++ b/frontend_tests/node_tests/topic_list_data.js
@@ -15,7 +15,7 @@ const general = {
     name: 'general',
 };
 
-stream_data.add_sub('general', general);
+stream_data.add_sub(general);
 
 function clear() {
     narrow_state.topic = () => undefined;

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -31,7 +31,7 @@ const social = {
     subscribed: true,
     is_muted: false,
 };
-stream_data.add_sub('social', social);
+stream_data.add_sub(social);
 
 const zero_counts = {
     private_message_count: 0,

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -183,12 +183,12 @@ exports.unsubscribe_myself = function (sub) {
     stream_info.set_false(sub.name, sub);
 };
 
-exports.add_sub = function (stream_name, sub) {
+exports.add_sub = function (sub) {
     if (!_.has(sub, 'subscribers')) {
         sub.subscribers = new LazySet([]);
     }
 
-    stream_info.set(stream_name, sub);
+    stream_info.set(sub.name, sub);
     subs_by_stream_id.set(sub.stream_id, sub);
 };
 
@@ -730,7 +730,7 @@ exports.create_sub_from_server_data = function (stream_name, attrs) {
 
     exports.update_calculated_fields(sub);
 
-    exports.add_sub(stream_name, sub);
+    exports.add_sub(sub);
 
     return sub;
 };


### PR DESCRIPTION
We just get the stream_name from the sub struct now.

This mostly affects node tests.

The only place in real code where we called add_sub()
was when we initialized data from the server.
