### PR TITLE
Fix lightbox ZID lookup from message_store

### DIFF
--- a/frontend_tests/node_tests/lightbox.js
+++ b/frontend_tests/node_tests/lightbox.js
@@ -1,9 +1,11 @@
 zrequire('lightbox');
 
 set_global('blueslip', global.make_zblueslip());
-set_global('message_store', {
-    get: () => ({}),
-});
+
+const _message_store = new Map();
+_message_store.set(1234, { sender_full_name: "Test User" });
+
+set_global('message_store', _message_store);
 set_global('Image', class Image {});
 set_global('overlays', {
     close_overlay: () => {},
@@ -21,9 +23,14 @@ run_test('pan_and_zoom', () => {
 
     const img = '<img src="./image.png" data-src-fullsize="./original.png">';
     const link = '<a href="https://zulip.com"></a>';
-    const msg = '<div [zid]></div>';
+
+    /* Due to how zquery works, we have to use a literal [zid] in the element,
+       since that's what the code looks for and we have to manually set the attr
+       that should be returned from the store. */
+    const msg = $('<div [zid]></div>');
+    msg.attr("zid", "1234");
     $(img).set_parent($(link));
-    $(link).set_parent($(msg));
+    $(link).set_parent(msg);
 
     // Used by render_lightbox_list_images
     $.stub_selector('.focused_table .message_inline_image img', []);
@@ -43,10 +50,14 @@ run_test('open_url', () => {
     const link = '<a></a>';
     $(link).attr('href', url);
     const div = '<div class="youtube-video"></div>';
-    const msg = '<div [zid]></div>';
+    /* Due to how zquery works, we have to use a literal [zid] in the element,
+       since that's what the code looks for and we have to manually set the attr
+       that should be returned from the store. */
+    const msg = $('<div [zid]></div>');
+    msg.attr("zid", "1234");
     $(img).set_parent($(link));
     $(link).set_parent($(div));
-    $(div).set_parent($(msg));
+    $(div).set_parent(msg);
 
     // Used by render_lightbox_list_images
     $.stub_selector('.focused_table .message_inline_image img', []);

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -134,7 +134,8 @@ exports.open = function (image, options) {
             sender_full_name = people.my_full_name();
         } else {
             const $message = $parent.closest("[zid]");
-            const message = message_store.get($message.attr("zid"));
+            const zid = parseInt($message.attr("zid"), 10);
+            const message = message_store.get(zid);
             if (message === undefined) {
                 blueslip.error("Lightbox for unknown message " + $message.attr("zid"));
             }

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -138,8 +138,9 @@ exports.open = function (image, options) {
             const message = message_store.get(zid);
             if (message === undefined) {
                 blueslip.error("Lightbox for unknown message " + $message.attr("zid"));
+            } else {
+                sender_full_name = message.sender_full_name;
             }
-            sender_full_name = message.sender_full_name;
         }
         payload = {
             user: sender_full_name,


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

This is a fix for #9549 

**Testing Plan:** <!-- How have you tested? -->

1. I had a production instance of this issue, which manifested as the lightbox not opening when clicking an attached image. I used the Chrome debugger to figure out what was wrong with the state, applied a fix locally, and tested the fix.
2. I amended the unit tests to actually provide a Map() as the backing store for the message_store mock and to do a lookup from it, which causes the old codepath to fail as described in the issue. The new code passes the test.