### PR TITLE
auth: Create a new page hop for desktop auth.

### DIFF
--- a/static/styles/portico/portico.scss
+++ b/static/styles/portico/portico.scss
@@ -1719,3 +1719,17 @@ input.new-organization-button {
 .table .json-api-example code {
     white-space: pre-wrap;
 }
+
+.desktop-redirect-box {
+    text-align: center;
+}
+
+.desktop-redirect-links {
+    margin-top: 20px;
+    text-decoration: underline;
+    color: hsl(0, 0%, 50%);
+}
+
+.desktop-redirect-image {
+    margin-bottom: 20px;
+}

--- a/templates/zerver/desktop_redirect.html
+++ b/templates/zerver/desktop_redirect.html
@@ -1,0 +1,18 @@
+{% extends "zerver/portico.html" %}
+
+{% block customhead %}
+<meta http-equiv="Refresh" content="2; {{ desktop_url }}">
+{% endblock %}
+
+{% block content %}
+<div class="flex">
+    <div class="desktop-redirect-box">
+        <img class="avatar desktop-redirect-image" src="{{ realm_icon_url }}" alt=""/><br>
+        Redirecting to your Zulip app...
+        <div class="desktop-redirect-links">
+            <a id="desktop-redirect-link" href="{{ desktop_url }}">If you weren't redirected, click here.</a><br>
+            <a href="{{ browser_url }}">Or, continue in your browser.</a>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Create a new page for desktop auth flow, in which
users can select one from going to the app or
continue the flow in the browser.

Backend tests remain to be fixed. Need some help to fix those. @mateuszmandera FYI.

Also, I think class names are a bit weird. Suggestions to change them welcome.
