### PR TITLE
messages_for_topic: Use stream.recipient_id for more efficient query.

### DIFF
--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -94,9 +94,9 @@ def filter_by_exact_message_topic(query: QuerySet, message: Message) -> QuerySet
 def filter_by_topic_name_via_message(query: QuerySet, topic_name: str) -> QuerySet:
     return query.filter(message__subject__iexact=topic_name)
 
-def messages_for_topic(stream_id: int, topic_name: str) -> QuerySet:
+def messages_for_topic(stream_recipient_id: int, topic_name: str) -> QuerySet:
     return Message.objects.filter(
-        recipient__type_id=stream_id,
+        recipient_id=stream_recipient_id,
         subject__iexact=topic_name,
     )
 

--- a/zerver/views/archive.py
+++ b/zerver/views/archive.py
@@ -43,7 +43,7 @@ def archive(request: HttpRequest,
 
     all_messages = list(
         messages_for_topic(
-            stream_id=stream_id,
+            stream_recipient_id=stream.recipient_id,
             topic_name=topic_name,
         ).select_related('sender').order_by('date_sent')
     )

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -508,7 +508,7 @@ def delete_in_topic(request: HttpRequest, user_profile: UserProfile,
                     topic_name: str=REQ("topic_name")) -> HttpResponse:
     (stream, recipient, sub) = access_stream_by_id(user_profile, stream_id)
 
-    messages = messages_for_topic(stream.id, topic_name)
+    messages = messages_for_topic(stream.recipient_id, topic_name)
     if not stream.is_history_public_to_subscribers():
         # Don't allow the user to delete messages that they don't have access to.
         deletable_message_ids = UserMessage.objects.filter(


### PR DESCRIPTION
Bumped into this additional place where we can take advantage of the recipient_id denormalization.