### PR TITLE
tests: Fix type reflection for Python 3.7.

### DIFF
--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -346,12 +346,12 @@ so maybe we shouldn't mark it as intentionally undocumented in the urls.
         E.g. typing.Union[typing.List[typing.Dict[str, typing.Any]], NoneType]
         needs to be mapped to list."""
 
-        if sys.version_info < (3, 6) and type(t) is type(Union):  # nocoverage # in python3.6+
-            origin = Union
-        else:  # nocoverage  # in python3.5. I.E. this is used in python3.6+
-            origin = getattr(t, "__origin__", None)
-
-        if sys.version_info > (3, 6):  # nocoverage  # in < python3.7
+        if sys.version_info < (3, 7):  # nocoverage  # python 3.5-3.6
+            if sys.version_info < (3, 6) and type(t) is type(Union):  # python 3.5 has special consideration for Union
+                origin = Union
+            else:
+                origin = getattr(t, "__origin__", None)
+        else:  # nocoverage  # python3.7+
             origin = getattr(t, "__origin__", None)
             t_name = getattr(t, "_name", None)
             if origin == list:

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -351,6 +351,18 @@ so maybe we shouldn't mark it as intentionally undocumented in the urls.
         else:  # nocoverage  # in python3.5. I.E. this is used in python3.6+
             origin = getattr(t, "__origin__", None)
 
+        if sys.version_info > (3, 6):  # nocoverage  # in < python3.7
+            origin = getattr(t, "__origin__", None)
+            t_name = getattr(t, "_name", None)
+            if origin == list:
+                origin = List
+            elif origin == dict:
+                origin = Dict
+            elif t_name == "Iterable":
+                origin = Iterable
+            elif t_name == "Mapping":
+                origin = Mapping
+
         if not origin:
             # Then it's most likely one of the fundamental data types
             # I.E. Not one of the data types from the "typing" module.


### PR DESCRIPTION
In python 3.5-3.6, generic types had an `__origin__` attribute which indicated which generic they originated from; the code was reflecting on that value to check types against the openapi spec. In python3.7, this changed, and there's no longer an immediately simple way to get this information in all cases. `__origin__` appears to be the implementing class now, returning `list` or `collections.abc.Iterator` rather than `typing.List` and `typing.Iterator`. This adds a sloppy-but-effective mechanism for inferring if a type maps to the List/Dict/Iterator/Mapping types and gets the test suite passing again.

See https://chat.zulip.org/#narrow/stream/49-development-help/topic/python.203.2E7.20suite.20issues

**Testing Plan:**

I've invoked the test suite under Python 3.7 and gotten it to pass. Since the code is constrained to a branch which asserts Python > 3.6, it _shouldn't_ affect the other builds. Fingers crossed...