### PR TITLE
provisioning: Support Ubuntu 19.10 eoan

### DIFF
--- a/scripts/lib/setup-apt-repo
+++ b/scripts/lib/setup-apt-repo
@@ -36,13 +36,13 @@ apt-get -y install "${pre_setup_deps[@]}"
 SCRIPTS_PATH="$(dirname "$(dirname "$0")")"
 
 release=$(lsb_release -sc)
-if [ "$release" = "xenial" ] || [ "$release" = "bionic" ] || [ "$release" = "cosmic" ] || [ "$release" = "disco" ]; then
+if [[ "$release" =~ ^(xenial|bionic|cosmic|disco|eoan)$ ]] ; then
     apt-key add "$SCRIPTS_PATH"/setup/pgroonga-ppa.asc
     cat >$SOURCES_FILE <<EOF
 deb http://ppa.launchpad.net/groonga/ppa/ubuntu $release main
 deb-src http://ppa.launchpad.net/groonga/ppa/ubuntu $release main
 EOF
-elif [ "$release" = "stretch" ] || [ "$release" = "buster" ]; then
+elif [[ "$release" =~ ^(stretch|buster)$ ]] ; then
     apt-key add "$SCRIPTS_PATH"/setup/pgroonga-debian.asc
     cat >$SOURCES_FILE <<EOF
 deb https://packages.groonga.org/debian/ $release main

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -91,7 +91,7 @@ elif vendor == "ubuntu" and os_version == "16.04":  # xenial
     POSTGRES_VERSION = "9.5"
 elif vendor == "ubuntu" and os_version in ["18.04", "18.10"]:  # bionic, cosmic
     POSTGRES_VERSION = "10"
-elif vendor == "ubuntu" and os_version == "19.04":  # disco
+elif vendor == "ubuntu" and os_version in ["19.04", "19.10"]:  # disco, eoan
     POSTGRES_VERSION = "11"
 elif vendor == "fedora" and os_version == "29":
     POSTGRES_VERSION = "10"


### PR DESCRIPTION
This adds Ubuntu 19.10 as a valid provisioning target.

The release test in setup-apt-repo was changed from a list of values to
a regex check for brevity.

This was requested as a part of fixing the test suite on Python 3.7, as seen in https://github.com/zulip/zulip/pull/13876#issuecomment-584973074

**Testing Plan:**

I've successfully run tools/provision on my Kubuntu 19.10 work station and gotten the dev environment set up and the test suite passing.