### PR TITLE
zjsunit: Use assert in strict mode

### DIFF
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -289,7 +289,7 @@ run_test('huddle_fraction_present', () => {
 
     assert.equal(
         buddy_data.huddle_fraction_present(huddle),
-        '0.50');
+        0.5);
 
     huddle = 'alice@zulip.com,fred@zulip.com,jill@zulip.com,mark@zulip.com';
     huddle = people.emails_strings_to_user_ids_string(huddle);
@@ -389,7 +389,7 @@ run_test('PM_update_dom_counts', () => {
 
     activity.update_dom_with_unread_counts({pm_count: counts});
     assert(li.hasClass('user-with-count'));
-    assert.equal(value.text(), 5);
+    assert.equal(value.text(), "5");
 
     counts.set(pm_key, 0);
 
@@ -414,7 +414,7 @@ run_test('group_update_dom_counts', () => {
 
     activity.update_dom_with_unread_counts({pm_count: counts});
     assert(li.hasClass('group-with-count'));
-    assert.equal(value.text(), 5);
+    assert.equal(value.text(), "5");
 
     counts.set(pm_key, 0);
 

--- a/frontend_tests/node_tests/billing_helpers.js
+++ b/frontend_tests/node_tests/billing_helpers.js
@@ -151,10 +151,10 @@ run_test("update_charged_amount", () => {
     page_params.seat_count = 35;
 
     helpers.update_charged_amount(prices, "annual");
-    assert.equal($("#charged_amount").text(), 80 * 35);
+    assert.equal($("#charged_amount").text(), (80 * 35).toString());
 
     helpers.update_charged_amount(prices, "monthly");
-    assert.equal($("#charged_amount").text(), 8 * 35);
+    assert.equal($("#charged_amount").text(), (8 * 35).toString());
 });
 
 run_test("show_license_section", () => {

--- a/frontend_tests/node_tests/buddy_list.js
+++ b/frontend_tests/node_tests/buddy_list.js
@@ -52,7 +52,7 @@ run_test('basics', () => {
 
     buddy_list.get_data_from_keys = (opts) => {
         const keys = opts.keys;
-        assert.deepEqual(keys, [alice.user_id.toString()]);
+        assert.deepEqual(keys, [alice.user_id]);
         return 'data-stub';
     };
 
@@ -81,7 +81,7 @@ run_test('basics', () => {
     buddy_list.get_li_from_key = (opts) => {
         const key = opts.key;
 
-        assert.equal(key, alice.user_id.toString());
+        assert.equal(key, alice.user_id);
         return alice_li;
     };
 

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -411,7 +411,7 @@ run_test('marked', () => {
 run_test('topic_links', () => {
     let message = {type: 'stream', topic: "No links here"};
     markdown.add_topic_links(message);
-    assert.equal(util.get_topic_links(message).length, []);
+    assert.equal(util.get_topic_links(message).length, 0);
 
     message = {type: 'stream', topic: "One #123 link here"};
     markdown.add_topic_links(message);

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -275,7 +275,7 @@ function test_submit_settings_form(submit_form) {
 
     let expected_value = {
         bot_creation_policy: '1',
-        invite_to_stream_policy: 1,
+        invite_to_stream_policy: '1',
         email_address_visibility: '1',
         add_emoji_by_admins_only: false,
         create_stream_policy: '2',
@@ -589,7 +589,7 @@ function test_sync_realm_settings() {
         page_params.realm_message_content_edit_limit_seconds = 120;
 
         settings_org.sync_realm_settings('message_content_edit_limit_seconds');
-        assert.equal($("#id_realm_message_content_edit_limit_minutes").val(), 2);
+        assert.equal($("#id_realm_message_content_edit_limit_minutes").val(), "2");
     }
 
     {
@@ -624,7 +624,7 @@ function test_sync_realm_settings() {
         page_params.realm_message_content_edit_limit_seconds = 120;
 
         settings_org.sync_realm_settings('message_content_edit_limit_seconds');
-        assert.equal($("#id_realm_message_content_edit_limit_minutes").val(), 2);
+        assert.equal($("#id_realm_message_content_edit_limit_minutes").val(), "2");
     }
 
     {
@@ -730,9 +730,9 @@ function test_discard_changes_button(discard_changes) {
     assert.equal(allow_edit_history.prop('checked'), true);
     assert.equal(allow_community_topic_editing.prop('checked'), true);
     assert.equal(msg_edit_limit_setting.val(), "upto_one_hour");
-    assert.equal(message_content_edit_limit_minutes.val(), 60);
+    assert.equal(message_content_edit_limit_minutes.val(), "60");
     assert.equal(msg_delete_limit_setting.val(), "upto_two_min");
-    assert.equal(message_content_delete_limit_minutes.val(), 2);
+    assert.equal(message_content_delete_limit_minutes.val(), "2");
 
     settings_org.change_save_button_state = stubbed_function;
 }

--- a/frontend_tests/node_tests/settings_profile_fields.js
+++ b/frontend_tests/node_tests/settings_profile_fields.js
@@ -129,8 +129,8 @@ run_test('populate_profile_fields', () => {
                 hint: 'lunch',
                 type: CHOICE_NAME,
                 choices: [
-                    {order: 0, value: 0, text: 'lunch'},
-                    {order: 1, value: 1, text: 'dinner'},
+                    {order: 0, value: '0', text: 'lunch'},
+                    {order: 1, value: '1', text: 'dinner'},
                 ],
                 is_choice_field: true,
                 is_external_account_field: false,

--- a/frontend_tests/node_tests/templates.js
+++ b/frontend_tests/node_tests/templates.js
@@ -282,11 +282,11 @@ run_test('admin_invites_list', () => {
 
     assert.equal($(buttons[0]).text().trim(), "translated: Revoke");
     assert($(buttons[0]).hasClass("revoke"));
-    assert.equal($(buttons[0]).attr("data-invite-id"), 0);
+    assert.equal($(buttons[0]).attr("data-invite-id"), "0");
 
     assert.equal($(buttons[3]).text().trim(), "translated: Resend");
     assert($(buttons[3]).hasClass("resend"));
-    assert.equal($(buttons[3]).attr("data-invite-id"), 1);
+    assert.equal($(buttons[3]).attr("data-invite-id"), "1");
 
     const span = $(html).find(".email").first();
     assert.equal(span.text(), "alice@zulip.com");
@@ -417,7 +417,7 @@ run_test('alert_word_settings_item', () => {
     assert.equal(title.length, 1);
     assert.equal(title.text().trim(), 'translated: Add a new alert word');
     assert.equal(textbox.length, 1);
-    assert.equal(textbox.attr('maxlength'), 100);
+    assert.equal(textbox.attr('maxlength'), '100');
     assert.equal(textbox.attr('placeholder'), 'translated: Alert word');
     assert.equal(textbox.attr('class'), 'required');
     assert.equal(button.length, 1);
@@ -438,7 +438,7 @@ run_test('bankruptcy_modal', () => {
     };
     const html = render('bankruptcy_modal', args);
     const count = $(html).find("p b");
-    assert.equal(count.text(), 99);
+    assert.equal(count.text(), "99");
 });
 
 run_test('settings/admin_auth_methods_list', () => {
@@ -606,7 +606,7 @@ run_test('custom_user_profile_field', () => {
     const field = {name: "GitHub user name", id: 2, hint: "Or link to profile"};
     const args = {field: field, field_value: {value: "@GitHub", rendered_value: "<p>@GitHub</p>"}, field_type: "text"};
     const html = render('settings/custom_user_profile_field', args);
-    assert.equal($(html).attr('data-field-id'), 2);
+    assert.equal($(html).attr('data-field-id'), "2");
     assert.equal($(html).find('.custom_user_field_value').val(), "@GitHub");
     assert.equal($(html).find('.field_hint').text(), "Or link to profile");
     assert.equal($(html).find('label').text(), "GitHub user name");
@@ -1307,11 +1307,11 @@ run_test('subscription_stream_privacy_modal', () => {
 
     const stream_post_policy = $(html).find("input[name=stream-post-policy]");
     assert.equal(stream_post_policy[0].value,
-                 stream_data.stream_post_policy_values.everyone.code);
+                 stream_data.stream_post_policy_values.everyone.code.toString());
     assert.equal(stream_post_policy[1].value,
-                 stream_data.stream_post_policy_values.admins.code);
+                 stream_data.stream_post_policy_values.admins.code.toString());
     assert.equal(stream_post_policy[2].value,
-                 stream_data.stream_post_policy_values.non_new_members.code);
+                 stream_data.stream_post_policy_values.non_new_members.code.toString());
 
     const button = $(html).find("#change-stream-privacy-button");
     assert(button.hasClass("btn-danger"));
@@ -1673,7 +1673,7 @@ run_test('muted_topic_ui_row', () => {
     html += '</tbody>';
     html += '</table>';
 
-    assert.equal($(html).find("tr").attr("data-stream-id"), 99);
+    assert.equal($(html).find("tr").attr("data-stream-id"), "99");
     assert.equal($(html).find("tr").attr("data-topic"), "pizza");
 });
 

--- a/frontend_tests/node_tests/typing_status.js
+++ b/frontend_tests/node_tests/typing_status.js
@@ -118,7 +118,7 @@ run_test('basics', () => {
     assert.deepEqual(typing_status.state, {
         next_send_start_time: undefined,
         idle_timer: undefined,
-        current_recipient: undefined,
+        current_recipient: null,
     });
     assert.deepEqual(events, {
         idle_callback: undefined,
@@ -132,7 +132,7 @@ run_test('basics', () => {
     assert.deepEqual(typing_status.state, {
         next_send_start_time: undefined,
         idle_timer: undefined,
-        current_recipient: undefined,
+        current_recipient: null,
     });
     assert.deepEqual(events, {
         idle_callback: undefined,
@@ -162,7 +162,7 @@ run_test('basics', () => {
     assert.deepEqual(typing_status.state, {
         next_send_start_time: undefined,
         idle_timer: undefined,
-        current_recipient: undefined,
+        current_recipient: null,
     });
     assert.deepEqual(events, {
         idle_callback: undefined,
@@ -192,7 +192,7 @@ run_test('basics', () => {
     assert.deepEqual(typing_status.state, {
         next_send_start_time: undefined,
         idle_timer: undefined,
-        current_recipient: undefined,
+        current_recipient: null,
     });
     assert.deepEqual(events, {
         idle_callback: undefined,
@@ -206,7 +206,7 @@ run_test('basics', () => {
     assert.deepEqual(typing_status.state, {
         next_send_start_time: undefined,
         idle_timer: undefined,
-        current_recipient: undefined,
+        current_recipient: null,
     });
     assert.deepEqual(events, {
         idle_callback: undefined,

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -6,7 +6,6 @@ zrequire('stream_data');
 zrequire('util');
 zrequire('unread');
 zrequire('settings_notifications');
-const Dict = zrequire('dict').Dict;
 const FoldDict = zrequire('fold_dict').FoldDict;
 const IntDict = zrequire('int_dict').IntDict;
 
@@ -33,13 +32,13 @@ const social = {
 };
 stream_data.add_sub(social);
 
-const zero_counts = {
-    private_message_count: 0,
-    home_unread_messages: 0,
-    mentioned_message_count: 0,
-    stream_count: new IntDict(),
-    pm_count: new Dict(),
-};
+function assert_zero_counts(counts) {
+    assert.equal(counts.private_message_count, 0);
+    assert.equal(counts.home_unread_messages, 0);
+    assert.equal(counts.mentioned_message_count, 0);
+    assert.equal(counts.stream_count.size, 0);
+    assert.equal(counts.pm_count.size, 0);
+}
 
 function test_notifiable_count(home_unread_messages, expected_notifiable_count) {
     set_global('page_params', {
@@ -61,13 +60,13 @@ function test_notifiable_count(home_unread_messages, expected_notifiable_count) 
 
 run_test('empty_counts_while_narrowed', () => {
     const counts = unread.get_counts();
-    assert.deepEqual(counts, zero_counts);
+    assert_zero_counts(counts);
     test_notifiable_count(counts.home_unread_messages, 0);
 });
 
 run_test('empty_counts_while_home', () => {
     const counts = unread.get_counts();
-    assert.deepEqual(counts, zero_counts);
+    assert_zero_counts(counts);
     test_notifiable_count(counts.home_unread_messages, 0);
 });
 
@@ -563,7 +562,7 @@ run_test('declare_bankruptcy', () => {
     unread.declare_bankruptcy();
 
     const counts = unread.get_counts();
-    assert.deepEqual(counts, zero_counts);
+    assert_zero_counts(counts);
     test_notifiable_count(counts.home_unread_messages, 0);
 });
 

--- a/frontend_tests/node_tests/upgrade.js
+++ b/frontend_tests/node_tests/upgrade.js
@@ -39,7 +39,7 @@ run_test("initialize", () => {
         if (form_name === "autopay") {
             assert.equal(stripe_token, "stripe_add_card_token");
         } else if (form_name === "invoice") {
-            assert.equal(stripe_token, null);
+            assert.equal(stripe_token, undefined);
         } else {
             throw Error("Unhandled case");
         }

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -11,7 +11,7 @@ require("@babel/register")({
     plugins: ["rewire-ts"],
 });
 
-global.assert = require('assert');
+global.assert = require('assert').strict;
 global._ = require('underscore/underscore.js');
 const _ = global._;
 

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -329,9 +329,11 @@ exports.make_new_elem = function (selector, opts) {
         stop: function () {
             return self;
         },
-        text: function (arg) {
-            if (arg !== undefined) {
-                text = arg;
+        text: function (...args) {
+            if (args.length !== 0) {
+                if (args[0] !== undefined) {
+                    text = args[0].toString();
+                }
                 return self;
             }
             return text;

--- a/static/js/colorspace.js
+++ b/static/js/colorspace.js
@@ -38,9 +38,9 @@ exports.getDecimalColor = function (hexcolor) {
 };
 
 exports.getLighterColor = function (rgb, lightness) {
-    return {r: (lightness * 255 + (1 - lightness) * rgb.r).toFixed(),
-            g: (lightness * 255 + (1 - lightness) * rgb.g).toFixed(),
-            b: (lightness * 255 + (1 - lightness) * rgb.b).toFixed()};
+    return {r: Math.round(lightness * 255 + (1 - lightness) * rgb.r),
+            g: Math.round(lightness * 255 + (1 - lightness) * rgb.g),
+            b: Math.round(lightness * 255 + (1 - lightness) * rgb.b)};
 };
 
 exports.getHexColor = function (rgb) {

--- a/static/js/settings_user_groups.js
+++ b/static/js/settings_user_groups.js
@@ -115,8 +115,8 @@ exports.populate_user_groups = function () {
             if (is_user_group_changed() &&
                !cancel_button.is(':visible')) {
                 saved_button.fadeOut(0);
-                cancel_button.css({display: 'inline-block', opacity: 0}).fadeTo(400, 1);
-                save_instructions.css({display: 'block', opacity: 0}).fadeTo(400, 1);
+                cancel_button.css({display: 'inline-block', opacity: '0'}).fadeTo(400, 1);
+                save_instructions.css({display: 'block', opacity: '0'}).fadeTo(400, 1);
             } else if (!is_user_group_changed() &&
                 cancel_button.is(':visible')) {
                 cancel_button.fadeOut();
@@ -131,7 +131,7 @@ exports.populate_user_groups = function () {
             if (!saved_button.is(':visible')) {
                 cancel_button.fadeOut(0);
                 save_instructions.fadeOut(0);
-                saved_button.css({display: 'inline-block', opacity: 0}).fadeTo(400, 1).delay(2000).fadeTo(400, 0);
+                saved_button.css({display: 'inline-block', opacity: '0'}).fadeTo(400, 1).delay(2000).fadeTo(400, 0);
             }
         }
 

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -82,7 +82,7 @@ exports.last_seen_status_from_date = function (last_active_date, current_date) {
 
     const days = Math.floor(hours / 24);
     if (days === 1) {
-        return [i18n.t("Yesterday")];
+        return i18n.t("Yesterday");
     }
 
     if (days < 90) {


### PR DESCRIPTION
This makes `assert.equal` and `assert.deepEqual` compare using `===` rather than `==`, to catch more bugs.

https://nodejs.org/api/assert.html#assert_strict_mode