### PR TITLE
[WIP] Display which user group was mentioned in email/push notifications.

### DIFF
--- a/templates/zerver/emails/missed_message.source.html
+++ b/templates/zerver/emails/missed_message.source.html
@@ -27,6 +27,8 @@
     &mdash;<br>
     {% if mention %}
     You are receiving this because you were mentioned in {{ realm_name }}.<br>
+    {% elif user_group_mentioned %}
+    You are receiving this because @{{ group_name }} was mentioned in {{ realm_name }}.<br>
     {% elif stream_email_notify %}
     You are receiving this because you have email notifications enabled for this stream.<br>
     {% endif %}

--- a/templates/zerver/emails/missed_message.subject.txt
+++ b/templates/zerver/emails/missed_message.subject.txt
@@ -1,7 +1,7 @@
 {% if show_message_content %}
     {% if group_pm %} Group PMs with {{ huddle_display_name }}
     {% elif private_message %} PMs with {{ sender_str }}
-    {% elif stream_email_notify or mention %} #{{ stream_header }}
+    {% elif stream_email_notify or mention or user_group_mentioned %} #{{ stream_header }}
     {% endif %}
 {% else %}
     New missed messages

--- a/templates/zerver/emails/missed_message.txt
+++ b/templates/zerver/emails/missed_message.txt
@@ -19,6 +19,8 @@ See {{ realm_uri }}/help/pm-mention-alert-notifications for more details.
 --
 {% if mention %}
 You are receiving this because you were mentioned in {{ realm_name }}.
+{% elif user_group_mentioned %}
+You are receiving this because @{{ group_name }} was mentioned in {{ realm_name }}.
 {% elif stream_email_notify %}
 You are receiving this because you have email notifications enabled for this stream.
 {% endif %}

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1623,7 +1623,7 @@ class UserMentionPattern(markdown.inlinepatterns.Pattern):
                 user_id = "*"
             elif user:
                 if not silent:
-                    self.markdown.zulip_message.mentions_user_ids.add(user['id'])
+                    self.markdown.zulip_message.mentions_user_ids.update({user['id']: True})
                 name = user['full_name']
                 user_id = str(user['id'])
             else:

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -24,6 +24,7 @@ from zerver.models import (
     receives_offline_email_notifications,
     get_context_for_message,
     Message,
+    UserGroup,
 )
 
 from datetime import timedelta
@@ -328,13 +329,24 @@ def do_send_missedmessage_events_reply_in_zulip(user_profile: UserProfile,
     })
 
     triggers = list(message['trigger'] for message in missed_messages)
+    user_groups_mention_id = list(message['user_group_mention_id'] for message in missed_messages)
     unique_triggers = set(triggers)
+    triggers_count = triggers.count('mentioned') + triggers.count(
+        'wildcard_mentioned') + triggers.count('user_group_mentioned')
     context.update({
         'mention': 'mentioned' in unique_triggers or 'wildcard_mentioned' in unique_triggers,
+        'user_group_mentioned': 'user_group_mentioned' in unique_triggers,
         'stream_email_notify': 'stream_email_notify' in unique_triggers,
-        'mention_count': triggers.count('mentioned') + triggers.count("wildcard_mentioned"),
+        'mention_count': triggers_count,
     })
 
+    if context['user_group_mentioned']:
+        # Getting first non None user_group_id
+        user_group_id = next((id for id in (user_groups_mention_id) if id is not None), None)
+        user_group = UserGroup.objects.get(id=user_group_id, realm=user_profile.realm)
+        if user_group is None:
+            raise AssertionError("No matching user group found")
+        context['group_name'] = user_group.name
     # If this setting (email mirroring integration) is enabled, only then
     # can users reply to email to send message to Zulip. Thus, one must
     # ensure to display warning in the template.
@@ -380,12 +392,13 @@ def do_send_missedmessage_events_reply_in_zulip(user_profile: UserProfile,
             context.update({'huddle_display_name': huddle_display_name})
     elif (missed_messages[0]['message'].recipient.type == Recipient.PERSONAL):
         context.update({'private_message': True})
-    elif (context['mention'] or context['stream_email_notify']):
+    elif (context['mention'] or context['stream_email_notify'] or context['user_group_mentioned']):
         # Keep only the senders who actually mentioned the user
-        if context['mention']:
+        if context['mention'] or context['user_group_mentioned']:
             senders = list(set(m['message'].sender for m in missed_messages
                                if m['trigger'] == 'mentioned' or
-                               m['trigger'] == 'wildcard_mentioned'))
+                               m['trigger'] == 'wildcard_mentioned'
+                               or m['trigger'] == 'user_group_mentioned'))
         message = missed_messages[0]['message']
         stream = Stream.objects.only('id', 'name').get(id=message.recipient.type_id)
         stream_header = "%s > %s" % (stream.name, message.topic_name())
@@ -448,8 +461,10 @@ def do_send_missedmessage_events_reply_in_zulip(user_profile: UserProfile,
 
 def handle_missedmessage_emails(user_profile_id: int,
                                 missed_email_events: Iterable[Dict[str, Any]]) -> None:
-    message_ids = {event.get('message_id'): event.get('trigger') for event in missed_email_events}
-
+    message_ids = {}  # type Dict[str, Any]
+    for event in missed_email_events:
+        message_id = {event.get('message_id'): [event.get('trigger'), event.get('user_group_mention_id')]}
+        message_ids.update(message_id)
     user_profile = get_user_profile_by_id(user_profile_id)
     if not receives_offline_email_notifications(user_profile):
         return
@@ -504,8 +519,15 @@ def handle_missedmessage_emails(user_profile_id: int,
         for m in messages_by_bucket[bucket_tup]:
             unique_messages[m.id] = dict(
                 message=m,
-                trigger=message_ids.get(m.id)
+                trigger=None,
+                user_group_mention_id=None
             )
+            # For non context messages
+            if message_ids.get(m.id) is not None:
+                unique_messages[m.id].update({'trigger': message_ids.get(m.id)[0]})
+                unique_messages[m.id].update({'user_group_mention_id':
+                                              message_ids.get(m.id)[1]})
+
         do_send_missedmessage_events_reply_in_zulip(
             user_profile,
             list(unique_messages.values()),

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -656,7 +656,9 @@ def do_render_markdown(message: Message,
     """
 
     message.mentions_wildcard = False
-    message.mentions_user_ids = set()
+    # mention_user_ids are of type dict where user_id are mapped to either
+    # true (incase of personal mentions) or group_id (incase of Group mentions)
+    message.mentions_user_ids = dict()
     message.mentions_user_group_ids = set()
     message.alert_words = set()
     message.links_for_preview = set()


### PR DESCRIPTION
Extends display logic for mention of user groups in email/push notification.
Fixes [13080](https://github.com/zulip/zulip/issues/13080)