### PR TITLE
markdown: Better image support.

### DIFF
--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -379,6 +379,24 @@ run_test('quote_and_reply', () => {
         assert.equal(replacement, '@_**Bob Roberts|40** [said](link_to_message):\n````quote\n```\nmultiline code block\nshoudln\'t mess with quotes\n```\n````');
     };
     quote_and_reply(opts);
+
+    current_msg_list.selected_message = function () {
+        return {
+            type: 'stream',
+            stream: 'devel',
+            topic: 'test',
+            reply_to: 'bob',
+            sender_full_name: 'Bob Roberts',
+            sender_id: 40,
+            raw_content: '![image](http://image.com/url.jpg) Explicitly inlined images get reduced to implicit inlining syntax.',
+        };
+    };
+    compose_ui.replace_syntax = function (syntax, replacement) {
+        assert.equal(syntax, '[Quoting…]');
+        assert.equal(replacement, '@_**Bob Roberts|40** [said](link_to_message):\n```quote\n[image](http://image.com/url.jpg) Explicitly inlined images get reduced to implicit inlining syntax.\n```');
+    };
+
+    quote_and_reply(opts);
 });
 
 run_test('get_focus_area', () => {

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -443,7 +443,8 @@ exports.quote_and_reply = function (opts) {
         let content = `@_**${message.sender_full_name}|${message.sender_id}** `;
         content += `[said](${hash_util.by_conversation_and_time_uri(message)}):\n`;
         const fence = fenced_code.get_unused_fence(message.raw_content);
-        content += `${fence}quote\n${message.raw_content}\n${fence}`;
+        const scrubbed_images = message.raw_content.replace(/!(\[.*?\]\(.*?\))/, "$1");
+        content += `${fence}quote\n${scrubbed_images}\n${fence}`;
         compose_ui.replace_syntax('[Quoting…]', content, textarea);
         autosize.update($('#compose-textarea'));
     }

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -355,10 +355,13 @@ exports.initialize = function () {
     };
 
     // Our links have title= and target=_blank
-    r.link = function (href, title, text) {
+    r.link = function (href, title, text, is_link = true) {
         title = title || href;
         if (!text.trim()) {
             text = href;
+        }
+        if (!is_link) {
+            text = '';  // We're dealing with an inline image, hide text.
         }
         const out = '<a href="' + href + '"' + ' target="_blank" title="' +
                   title + '"' + '>' + text + '</a>';

--- a/static/third/marked/lib/marked.js
+++ b/static/third/marked/lib/marked.js
@@ -862,8 +862,8 @@ InlineLexer.prototype.outputLink = function(cap, link) {
     , title = link.title ? escape(link.title) : null;
 
   return cap[0].charAt(0) !== '!'
-    ? this.renderer.link(href, title, this.output(cap[1]))
-    : this.renderer.image(href, title, escape(cap[1]));
+    ? this.renderer.link(href, title, this.output(cap[1]), true)
+    : this.renderer.link(href, title, escape(cap[1]), false);
 };
 InlineLexer.prototype.emoji = function (name) {
   name = escape(name)

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1054,8 +1054,7 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
         unique_urls = {found_url.result[0] for found_url in found_urls}
         # Collect unique URLs which are not quoted as we don't do
         # inline previews for links inside blockquotes.
-        unique_previewable_urls = {found_url.result[0] for found_url in found_urls
-                                   if not found_url.family.in_blockquote}
+        unique_previewable_urls = {found_url.result[0] for found_url in found_urls}
 
         # Set has_link and similar flags whenever a message is processed by bugdown
         if self.markdown.zulip_message:
@@ -1106,6 +1105,9 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
                 if self.is_image(url):
                     self.handle_image_inlining(root, found_url)
                 # We don't have a strong use case for doing url preview for relative links.
+                continue
+
+            if found_url.family.in_blockquote:
                 continue
 
             dropbox_image = self.dropbox_image(url)

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1803,9 +1803,9 @@ class LinkInlineProcessor(markdown.inlinepatterns.LinkInlineProcessor):
             el.text = ''
 
         # Prevent realm_filters from running on the content of a Markdown link, breaking up the link.
-        # This is a monkey-patch, but it might be worth sending a version of this change upstream.
-        if not isinstance(el, str):
-            el.text = markdown.util.AtomicString(el.text)
+        # We should find out some other way to deal with the above, current solution disables any
+        # further parsing inside links. Example: [**hello** world](google.com) doesn't trigger 'strong'.
+        el.text = markdown.util.AtomicString(el.text)
 
         return el
 

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -427,9 +427,9 @@
     },
     {
       "name": "inline_image_link_without_space_before",
-      "input": "Hello![hello](https://github.com). This text will get swallowed up as we wouldn't be rendering any image for it either.",
-      "expected_output": "<p>Hello<a href=\"https://github.com\" target=\"_blank\" title=\"hello\"></a>. This text will get swallowed up as we wouldn't be rendering any image for it either.</p>",
-      "marked_expected_output": "<p>Hello<a href=\"https://github.com\" target=\"_blank\" title=\"https://github.com\"></a>. This text will get swallowed up as we wouldn't be rendering any image for it either.</p>"
+      "input": "Hello![this is an invalid image](https://github.com).",
+      "expected_output": "<p>Hello<a href=\"https://github.com\" target=\"_blank\" title=\"this is an invalid image\"></a>.</p>\n<div class=\"message_inline_image\"><a href=\"https://github.com\" target=\"_blank\" title=\"this is an invalid image\"><img data-src-fullsize=\"/thumbnail?url=https%3A%2F%2Fgithub.com&amp;size=full\" src=\"/thumbnail?url=https%3A%2F%2Fgithub.com&amp;size=thumbnail\"></a></div>",
+      "marked_expected_output": "<p>Hello<a href=\"https://github.com\" target=\"_blank\" title=\"https://github.com\"></a>.</p>"
     },
     {
       "name": "nl2br",

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -414,6 +414,24 @@
       "expected_output": "<p><a href=\"https://github.com\" target=\"_blank\" title=\"https://github.com\">https://github.com</a></p>"
     },
     {
+      "name": "inline_image_link_without_text",
+      "input": "Hello ![](https://www.google.com/images/srpr/logo4w.png).",
+      "expected_output": "<p>Hello <a href=\"https://www.google.com/images/srpr/logo4w.png\" target=\"_blank\" title=\"https://www.google.com/images/srpr/logo4w.png\"></a>.</p>\n<div class=\"message_inline_image\"><a href=\"https://www.google.com/images/srpr/logo4w.png\" target=\"_blank\" title=\"https://www.google.com/images/srpr/logo4w.png\"><img data-src-fullsize=\"/thumbnail?url=https%3A%2F%2Fwww.google.com%2Fimages%2Fsrpr%2Flogo4w.png&amp;size=full\" src=\"/thumbnail?url=https%3A%2F%2Fwww.google.com%2Fimages%2Fsrpr%2Flogo4w.png&amp;size=thumbnail\"></a></div>",
+      "marked_expected_output": "<p>Hello <a href=\"https://www.google.com/images/srpr/logo4w.png\" target=\"_blank\" title=\"https://www.google.com/images/srpr/logo4w.png\"></a>.</p>"
+    },
+    {
+      "name": "inline_image_link_with_text",
+      "input": "Hello ![some alt text here](https://www.google.com/images/srpr/logo4w.png).",
+      "expected_output": "<p>Hello <a href=\"https://www.google.com/images/srpr/logo4w.png\" target=\"_blank\" title=\"some alt text here\"></a>.</p>\n<div class=\"message_inline_image\"><a href=\"https://www.google.com/images/srpr/logo4w.png\" target=\"_blank\" title=\"some alt text here\"><img data-src-fullsize=\"/thumbnail?url=https%3A%2F%2Fwww.google.com%2Fimages%2Fsrpr%2Flogo4w.png&amp;size=full\" src=\"/thumbnail?url=https%3A%2F%2Fwww.google.com%2Fimages%2Fsrpr%2Flogo4w.png&amp;size=thumbnail\"></a></div>",
+      "marked_expected_output": "<p>Hello <a href=\"https://www.google.com/images/srpr/logo4w.png\" target=\"_blank\" title=\"https://www.google.com/images/srpr/logo4w.png\"></a>.</p>"
+    },
+    {
+      "name": "inline_image_link_without_space_before",
+      "input": "Hello![hello](https://github.com). This text will get swallowed up as we wouldn't be rendering any image for it either.",
+      "expected_output": "<p>Hello<a href=\"https://github.com\" target=\"_blank\" title=\"hello\"></a>. This text will get swallowed up as we wouldn't be rendering any image for it either.</p>",
+      "marked_expected_output": "<p>Hello<a href=\"https://github.com\" target=\"_blank\" title=\"https://github.com\"></a>. This text will get swallowed up as we wouldn't be rendering any image for it either.</p>"
+    },
+    {
       "name": "nl2br",
       "input": "test\nbar",
       "expected_output": "<p>test<br>\nbar</p>",


### PR DESCRIPTION
This is an extension of the work from https://github.com/zulip/zulip/pull/12979, which causes explicitly-inlined images in quotes to be rendered, and it strips the explicit syntax in favor of the implicit when quoting a message, which causes the image to not render in subsequent quotes.

**Testing Plan:**

I've been running this on our internal install for a few days now, and it works nicely. I've added tests for both the Python markdown renderer behavior and the frontend compose UI behavior.

**GIFs or Screenshots:** 

![image](https://user-images.githubusercontent.com/9830/74383048-b59e0580-4dab-11ea-8f2a-bd9b88dd81f8.png)