### PR TITLE
feat: Sponsored organisation in signup flow

### DIFF
--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -196,4 +196,38 @@ $(function () {
     $("body").on("click", "#choose_email .choose-email-box", function () {
         this.parentNode.submit();
     });
+
+    const offer_details_behavior = function () {
+        const selected_object = $("#organization_type_select").val();
+        const offer_details = $("#offer_details");
+        const repository_link_input = $("#repository_link_input");
+        const organization_nature_input = $("#organization_nature_input");
+        const organization_website_input = $("#organization_website_input");
+        const offer_details_help_box = $("#offer_details_help_box");
+        if (selected_object === "Open-source") {
+            offer_details.show();
+            repository_link_input.show();
+            organization_nature_input.hide();
+            organization_website_input.hide();
+            offer_details_help_box.text(i18n.t("You may qualify for the standard plan for free. Please provide your official repository link."));
+        } else if (selected_object === "Education" || selected_object === "Non-profit") {
+            offer_details.show();
+            repository_link_input.hide();
+            organization_nature_input.show();
+            organization_website_input.show();
+            offer_details_help_box.text(i18n.t("You may qualify for a discount on the standard plan."));
+        } else if (selected_object === "Other") {
+            offer_details.show();
+            repository_link_input.hide();
+            organization_nature_input.show();
+            organization_website_input.hide();
+            offer_details_help_box.text(i18n.t("You may qualify for a discount on the standard plan."));
+        } else {
+            offer_details.hide();
+        }
+    };
+
+    $('#organization_type_select').on('change', function () {
+        offer_details_behavior();
+    });
 });

--- a/static/styles/portico/portico-signin.scss
+++ b/static/styles/portico/portico-signin.scss
@@ -897,6 +897,14 @@ button.login-social-button {
     font-size: 22px;
 }
 
+#organization_type_select_section {
+    position: relative;
+    top: 15px;
+    margin-bottom: 20px;
+    margin-top: 10px;
+    font-size: 22px;
+}
+
 #source_realm_select {
     font-size: 1.2rem;
     height: 45px;
@@ -904,6 +912,19 @@ button.login-social-button {
     &:focus {
         outline: none;
     }
+}
+
+#organization_type_select {
+    font-size: 1.2rem;
+    height: 45px;
+    width: 325px;
+    &:focus {
+        outline: none;
+    }
+}
+
+#offer_details {
+    display: none;
 }
 
 .goto-account-page {

--- a/templates/zerver/emails/organization_info.html
+++ b/templates/zerver/emails/organization_info.html
@@ -1,0 +1,20 @@
+{% extends "zerver/emails/compiled/email_base_default.html" %}
+
+{% block illustration %}
+<img src="{{ email_images_base_uri }}/email_logo.png" alt=""/>
+{% endblock %}
+
+{% block content %}
+<p>{{ _('New organization details') }}</p>
+
+<p>
+    <li>{{ _('Organization Name:') }} {{ realm_name }} <br/></li>
+    <li>{{ _('Organization Type:') }} {{ organization_type }}<br/></li>
+    {% if repository_link %} <li>{{ _('Repository Link:') }} {{ repository_link }}<br/></li> {% endif %}
+    {% if organization_nature %} <li>{{ _('Organization Nature:') }} {{ organization_nature }}<br/></li> {% endif %}
+    {% if organization_website %} <li>{{ _('Organization Website:') }} {{ organization_website }}<br/></li> {% endif %}
+    {% if organization_description %} <li>{{ _('Organization Description:') }} {{ organization_description }}<br/></li> {% endif %}
+    <li>{{ _('Realm Link:') }} {{ realm_uri }}<br/></li>
+
+</p>
+{% endblock %}

--- a/templates/zerver/emails/organization_info.subject.txt
+++ b/templates/zerver/emails/organization_info.subject.txt
@@ -1,0 +1,5 @@
+{% if realm_creation %}
+{% trans -%}
+{{ realm_name }}: New organization registration details
+{% endtrans %}
+{% endif %}

--- a/templates/zerver/emails/organization_info.txt
+++ b/templates/zerver/emails/organization_info.txt
@@ -1,0 +1,18 @@
+{% extends "zerver/emails/compiled/email_base_default.html" %}
+
+{% block illustration %}
+<img src="{{ email_images_base_uri }}/email_logo.png" alt=""/>
+{% endblock %}
+
+{% block content %}
+{{ _('New organization details') }}
+
+{{ _('Organization Name:') }} {{ realm_name }} <br/>
+{{ _('Organization Type:') }} {{ organization_type }}<br/>
+{% if repository_link %} {{ _('Repository Link:') }} {{ repository_link }}<br/> {% endif %}
+{% if organization_nature %} {{ _('Organization Nature:') }} {{ organization_nature }}<br/> {% endif %}
+{% if organization_website %} {{ _('Organization Website:') }} {{ organization_website }}<br/> {% endif %}
+{% if organization_description %} {{ _('Organization Description:') }} {{ organization_description }}<br/> {% endif %}
+{{ _('Realm Link:') }} {{ realm_uri }}<br/>
+
+{% endblock %}

--- a/templates/zerver/organization_signup.html
+++ b/templates/zerver/organization_signup.html
@@ -1,0 +1,49 @@
+{% block portico_content %}
+
+<div class="input-box">
+    <div class="input-box">
+        <label class="inline-block">{{ _('Organization type') }}</label>
+    </div>
+    <div id="organization_type_select_section" class="input-group inline-block">
+        <select class="organization_type" name="organization_type" id="organization_type_select">
+            <option value="Corporate">{{_('Corporate')}}</option>
+            <option value="Open-source">{{_('Open Source')}}</option>
+            <option value="Education">{{_('Education')}}</option>
+            <option value="Non-profit">{{_('Non-Profit')}}</option>
+            <option value="Other">{{_('Other')}}</option>
+        </select>
+    </div>
+</div>
+<div id="offer_details">
+    <div class="input-box">
+        <div class="help-box margin-top" id="offer_details_help_box"></div>
+        <div id="repository_link_input">
+            <div class="input-box">
+                <label for="repository_link_label" class="inline-block label-title">{{ _('Repository Link') }}</label>
+                <div class="inline-block relative">
+                    <input id="repository_link_label" class="required" type="text"
+                      name="repository_link" required />
+                </div>
+            </div>
+        </div>
+        <div id="organization_nature_input">
+            <div class="input-box">
+                <label for="organization_nature_label" class="inline-block label-title">{{ _('Briefly describe the nature of your organization') }}</label>
+                <div class="inline-block relative">
+                    <input id="organization_nature" class="required" type="text"
+                      name="organization_nature" required />
+                </div>
+            </div>
+        </div>
+        <div id="organization_website_input">
+            <div class="input-box">
+                <label for="organization_website_label" class="inline-block label-title">{{ _('Website of your organization') }}</label>
+                <div class="inline-block relative">
+                    <input id="organization_website" class="required" type="text"
+                      name="organization_website" required />
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -23,61 +23,64 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
 
             <section class="org-registration">
                 {% if creating_new_team %}
-                <div class="input-box">
-                    <div class="inline-block relative">
-                        <input id="id_team_name" class="required" type="text"
-                          placeholder="Acme or Ακμή"
-                          value="{% if form.realm_name.value() %}{{ form.realm_name.value() }}{% endif %}"
-                          name="realm_name" maxlength={{ MAX_REALM_NAME_LENGTH }} required />
-                    </div>
-                    <label for="id_team_name" class="inline-block label-title">{{ _('Organization name') }}</label>
-                    {% if form.realm_name.errors %}
-                        {% for error in form.realm_name.errors %}
-                        <p class="help-inline text-error">{{ error }}</p>
-                        {% endfor %}
-                    {% endif %}
-
-                    <div class="help-box margin-top">
-                        {{ _('Shorter is better than longer.') }}
-                    </div>
-                </div>
-
-                <div class="input-box">
-                    <label class="static org-url">
-                        {{ _('Organization URL') }}
-                    </label>
-                    {% if root_domain_available %}
-                    <label class="checkbox static" for="realm_in_root_domain">
-                        <input type="checkbox" name="realm_in_root_domain" id="realm_in_root_domain"
-                          {% if not form.realm_subdomain.value() and not form.realm_subdomain.errors %}checked="checked"{% endif %}/>
-                        <span></span>
-                        {% trans %}Use {{ external_host }}{% endtrans %}
-                    </label>
-                    {% endif %}
-
-                    <div id="subdomain_section" {% if root_domain_available and
-                      not form.realm_subdomain.errors and not form.realm_subdomain.value() %}style="display: none;"{% endif %}>
-                        <div class="or"><span>{{ _('OR') }}</span></div>
+                    <div class="input-box">
                         <div class="inline-block relative">
-                            <input id="id_team_subdomain"
-                              class="{% if root_domain_landing_page %}required{% endif %} subdomain" type="text"
-                              placeholder="acme"
-                              value="{% if form.realm_subdomain.value() %}{{ form.realm_subdomain.value() }}{% endif %}"
-                              name="realm_subdomain" maxlength={{ MAX_REALM_SUBDOMAIN_LENGTH }}
-                              {% if root_domain_landing_page %}required{% endif %} />
-                            <label for="id_team_subdomain" class="realm_subdomain_label">.{{ external_host }}</label>
-                            <p id="id_team_subdomain_error_client" class="error help-inline text-error"></p>
+                            <input id="id_team_name" class="required" type="text"
+                              placeholder="Acme or Aκμή"
+                              value="{% if form.realm_name.value() %}{{ form.realm_name.value() }}{% endif %}"
+                              name="realm_name" maxlength={{ MAX_REALM_NAME_LENGTH }} required />
                         </div>
-                        {% if form.realm_subdomain.errors %}
-                            {% for error in form.realm_subdomain.errors %}
-                            <p class="error help-inline text-error team_subdomain_error_server">{{ error }}</p>
+                        <label for="id_team_name" class="inline-block label-title">{{ _('Organization name') }}</label>
+                        {% if form.realm_name.errors %}
+                            {% for error in form.realm_name.errors %}
+                            <p class="help-inline text-error">{{ error }}</p>
                             {% endfor %}
                         {% endif %}
+
+                        <div class="help-box margin-top">
+                            {{ _('Shorter is better than longer.') }}
+                        </div>
                     </div>
-                    <div class="help-box margin-top">
-                        {{ _("The address you'll use to log in to your organization.") }}
+
+                    <div class="input-box">
+                        <label class="static org-url">
+                            {{ _('Organization URL') }}
+                        </label>
+                        {% if root_domain_available %}
+                        <label class="checkbox static" for="realm_in_root_domain">
+                            <input type="checkbox" name="realm_in_root_domain" id="realm_in_root_domain"
+                              {% if not form.realm_subdomain.value() and not form.realm_subdomain.errors %}checked="checked"{% endif %}/>
+                            <span></span>
+                            {% trans %}Use {{ external_host }}{% endtrans %}
+                        </label>
+                        {% endif %}
+
+                        <div id="subdomain_section" {% if root_domain_available and
+                          not form.realm_subdomain.errors and not form.realm_subdomain.value() %}style="display: none;"{% endif %}>
+                            <div class="or"><span>{{ _('OR') }}</span></div>
+                            <div class="inline-block relative">
+                                <input id="id_team_subdomain"
+                                  class="{% if root_domain_landing_page %}required{% endif %} subdomain" type="text"
+                                  placeholder="acme"
+                                  value="{% if form.realm_subdomain.value() %}{{ form.realm_subdomain.value() }}{% endif %}"
+                                  name="realm_subdomain" maxlength={{ MAX_REALM_SUBDOMAIN_LENGTH }}
+                                  {% if root_domain_landing_page %}required{% endif %} />
+                                <label for="id_team_subdomain" class="realm_subdomain_label">.{{ external_host }}</label>
+                                <p id="id_team_subdomain_error_client" class="error help-inline text-error"></p>
+                            </div>
+                            {% if form.realm_subdomain.errors %}
+                                {% for error in form.realm_subdomain.errors %}
+                                <p class="error help-inline text-error team_subdomain_error_server">{{ error }}</p>
+                                {% endfor %}
+                            {% endif %}
+                        </div>
+                        <div class="help-box margin-top">
+                            {{ _("The address you'll use to log in to your organization.") }}
+                        </div>
                     </div>
-                </div>
+                    {% if creating_new_team and billing_enabled %}
+                    {% include 'zerver/organization_signup.html' %}
+                    {% endif %}
                 {% endif %}
             </section>
 

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -26,13 +26,22 @@ def common_context(user: UserProfile) -> Dict[str, Any]:
     """Common context used for things like outgoing emails that don't
     have a request.
     """
+    context = common_context_unauthed(user.realm)
+    context.update({
+        'user_name': user.full_name
+    })
+    return context
+
+def common_context_unauthed(realm: Realm) -> Dict[str, Any]:
+    """Common context used for things like outgoing emails that don't
+    have a request and which are not yet authenticated.
+    """
     return {
-        'realm_uri': user.realm.uri,
-        'realm_name': user.realm.name,
+        'realm_uri': realm.uri,
+        'realm_name': realm.name,
         'root_domain_uri': settings.ROOT_DOMAIN_URI,
         'external_uri_scheme': settings.EXTERNAL_URI_SCHEME,
-        'external_host': settings.EXTERNAL_HOST,
-        'user_name': user.full_name,
+        'external_host': settings.EXTERNAL_HOST
     }
 
 def get_realm_from_request(request: HttpRequest) -> Optional[Realm]:

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -22,6 +22,7 @@ ADD_TOKENS_TO_NOREPLY_ADDRESS = True
 TOKENIZED_NOREPLY_EMAIL_ADDRESS = "noreply-{token}@" + EXTERNAL_HOST.split(":")[0]
 PHYSICAL_ADDRESS = ''
 FAKE_EMAIL_DOMAIN = EXTERNAL_HOST.split(":")[0]
+STAFF_SUBDOMAIN: Optional[str] = None
 
 # SMTP settings
 EMAIL_HOST: Optional[str] = None

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -156,6 +156,7 @@ SEARCH_PILLS_ENABLED = bool(os.getenv('SEARCH_PILLS_ENABLED', False))
 
 BILLING_ENABLED = True
 LANDING_PAGE_NAVBAR_MESSAGE = None
+STAFF_SUBDOMAIN = 'zulip'
 
 # Test Custom TOS template rendering
 TERMS_OF_SERVICE = 'corporate/terms.md'


### PR DESCRIPTION
To make the signup process more streamlined and more clear, add couple of new fields in main registration template. "Organisation Type" - a dropdown which contains a list of organisation types. Also the signup process sends mail to "support@zulipchat.com" with details of the newly registered realm.

fixes: #13755

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![2020-02-13_09-18-32-1282x694](https://user-images.githubusercontent.com/43504292/74399755-d87af900-4e41-11ea-8499-f494689791c3.png)
![2020-02-13_09-20-57-1920x1080](https://user-images.githubusercontent.com/43504292/74399845-2bed4700-4e42-11ea-976d-c153e4e4a221.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
