### PR TITLE
corporate: Allow customer to go through /upgrade/ if their plan ended.

### DIFF
--- a/corporate/views.py
+++ b/corporate/views.py
@@ -118,7 +118,7 @@ def initial_upgrade(request: HttpRequest) -> HttpResponse:
 
     user = request.user
     customer = Customer.objects.filter(realm=user.realm).first()
-    if customer is not None and CustomerPlan.objects.filter(customer=customer).exists():
+    if customer is not None and get_current_plan(customer) is not None:
         return HttpResponseRedirect(reverse('corporate.views.billing_home'))
 
     percent_off = 0


### PR DESCRIPTION
Change suggested by @rishig 

This specifically fixes an issue where a customer chose monthly payment
plan instead of annual, getting stuck with the higher monthly payments.
With this change, the Customer plan can be set to ENDED and they can go
through /upgrade/ again and choose annual payments.
A proper follow-up should be to make it possible to change between
monthly/annual on the /billing/ page.
