### PR TITLE
Fix wording for "end of result from your personal history"

### DIFF
--- a/templates/zerver/app/home.html
+++ b/templates/zerver/app/home.html
@@ -24,7 +24,7 @@
             {% trans %}
             End of results from your
             <a href="/help/search-for-messages#searching-shared-history"
-              target="_blank">personal history</a>.
+              target="_blank">history</a>.
             Consider <a class="search-shared-history" href="">searching all public streams</a>.
             {% endtrans %}
         </p>

--- a/templates/zerver/help/search-for-messages.md
+++ b/templates/zerver/help/search-for-messages.md
@@ -54,7 +54,7 @@ shared history](/help/stream-permissions), including messages sent
 before you joined the stream (or organization) or those sent to public
 streams you are not subscribed to.
 
-By default, Zulip searches messages in your personal history, i.e. the
+By default, Zulip searches messages in your history, i.e. the
 messages you actually received.  This avoids cluttering search results
 with irrelevant messages from public streams you're not interested in.
 


### PR DESCRIPTION
Fixes #13851 

Fixed the words in "End of result from personal history" to "End of result from your history".
Made the changes in the documents linked to it.

**Testing Plan**
![Screenshot_20200214_182606](https://user-images.githubusercontent.com/53488062/74533495-bc697b80-4f57-11ea-8402-56d07de54020.png)


![Screenshot_20200214_181544](https://user-images.githubusercontent.com/53488062/74532923-6811cc00-4f56-11ea-9c60-c70616953189.png)

