### PR TITLE
markdown: Escape all HTML entities in user content.

### DIFF
--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -1854,6 +1854,62 @@ class BugdownTest(ZulipTestCase):
             '<p><a href="#narrow/stream/999-hello" title="#narrow/stream/999-hello">hello</a></p>'
         )
 
+    def test_html_entity_conversion(self) -> None:
+        msg = """
+Test raw: Hello, &copy;
+
+Test inline code: `&copy;`
+
+Test fenced code:
+```
+&copy;
+&copy;
+```
+
+Test quote:
+
+~~~quote
+&copy;
+~~~
+
+Test a list:
+
+* &copy;
+* `&copy;`
+* ```&copy;```
+
+Test an indented block:
+
+    &copy;
+""".strip()
+        converted = bugdown_convert(msg)
+        print(converted)
+        expected_output = """
+<p>Test raw: Hello, &amp;copy;</p>
+<p>Test inline code: <code>&amp;copy;</code></p>
+<p>Test fenced code:</p>
+<div class="codehilite"><pre><span></span>&amp;copy;
+&amp;copy;
+</pre></div>
+
+
+<p>Test quote:</p>
+<blockquote>
+<p>&amp;copy;</p>
+</blockquote>
+<p>Test a list:</p>
+<ul>
+<li>&amp;copy;</li>
+<li><code>&amp;copy;</code></li>
+<li><code>&amp;copy;</code></li>
+</ul>
+<p>Test an indented block:</p>
+<div class="codehilite"><pre><span></span>&amp;copy;
+</pre></div>
+""".strip()
+        self.assertEqual(converted, expected_output)
+
+
 class BugdownApiTests(ZulipTestCase):
     def test_render_message_api(self) -> None:
         content = 'That is a **bold** statement'


### PR DESCRIPTION
Users need to be able to use HTML entities in chat and have them be interpreted literally, rather than being rendered as individual characters.

This is an attempt at solving https://github.com/zulip/zulip/issues/12056 - I'm still fairly unfamiliar with the intricacies of the markdown engine, so it's entirely possible that I've gone about this the wrong way, but the tests are passing locally and the behavior seems satisfactory to me.

To accomplish this, I added a preprocessor which subs `&(entity);` to `&amp;(entity);`. This solved almost all cases, but the indented `CodeBlockProcessor` was performing its own escaping which doubled up on the amps, so I subclassed it to remove that. The stock `backtick` processor performed that same escaping, but Bugdown has an existing subclass that doesn't perform any additional escaping. I did test script/HTML injection in indented code blocks and was unable to get HTML tags to render, so I don't think this has exposed any new holes, but it is worth doing more testing.

**Testing Plan:**

Added tests to test_bugdown.py

**GIFs or Screenshots:**

Given the testing message:

    Test raw: Hello, &copy;

    Test inline code: `&copy;`

    Test fenced code:
    ```
    &copy;
    &copy;
    ```

    Test quote:

    ~~~quote
    &copy;
    ~~~

    Test a list:

    * &copy;
    * `&copy;`
    * ```&copy;```

    Test an indented block:

        &copy;

Before:

![image](https://user-images.githubusercontent.com/9830/74472934-ffe0be80-4e5f-11ea-98fd-5d027e266b38.png)

After:

![image](https://user-images.githubusercontent.com/9830/74472767-aed0ca80-4e5f-11ea-8573-aa15aa2416fd.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
