### PR TITLE
markdown: Escape HTML entities in inline code blocks.

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -507,7 +507,7 @@ class BacktickPattern(markdown.inlinepatterns.Pattern):
         if m.group(4):
             el = markdown.util.etree.Element(self.tag)
             # Modified to not strip whitespace
-            el.text = markdown.util.AtomicString(m.group(4))
+            el.text = markdown.util.AtomicString(markdown.util.code_escape(m.group(4)))
             return el
         else:
             return m.group(2).replace('\\\\', self.ESCAPED_BSLASH)


### PR DESCRIPTION
This is an iteration on the discussion from https://github.com/zulip/zulip/pull/13902 (itself a solution to https://github.com/zulip/zulip/issues/12056) and is a more conservative approach to the problem.

This fixes an issues that causes HTML entities inside of `inline code
blocks` to be converted rather than being displayed literally.

The upstream markdown library handles this correctly. Bugdown's backtick
processor incorrectly did not apply the code escaping.

**Testing Plan:**

New unit tests plus manual testing.

**GIFs or Screenshots:**

Given input:

    Test raw: Hello, &copy;
    Test inline code: `&copy;`
    Test fenced code:
    ```
    &copy;
    &copy;
    ```
    Test quote:
    ~~~quote
    &copy;
    ~~~
    Test a list:
    * &copy;
    * `&copy;`
    * ```&copy;```

    Test an indented block:

        &copy;

![image](https://user-images.githubusercontent.com/9830/74487023-ae462d00-4e7b-11ea-82e7-d84326c94fc5.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
