### PR TITLE
Stream Settings: Fixing error messages

### DIFF
--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -200,6 +200,8 @@ run_test('subscribers', () => {
         ]
     );
 
+    assert.equal(stream_data.potential_subscribers_length(sub), 4);
+
     stream_data.set_subscribers(sub, [me.user_id, fred.user_id, george.user_id]);
     stream_data.update_calculated_fields(sub);
     assert(stream_data.is_user_subscribed('Rome', me.user_id));
@@ -213,6 +215,8 @@ run_test('subscribers', () => {
             not_fred.user_id,
         ]
     );
+
+    assert.equal(stream_data.potential_subscribers_length(sub), 1);
 
     stream_data.set_subscribers(sub, []);
 

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -402,6 +402,10 @@ exports.potential_subscribers = function (sub) {
 
 };
 
+exports.potential_subscribers_length = function (sub) {
+    return exports.potential_subscribers(sub).length;
+};
+
 exports.update_stream_email_address = function (sub, email) {
     sub.email_address = email;
 };

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -83,6 +83,14 @@ function get_sub_for_target(target) {
     return sub;
 }
 
+function update_no_users_display(sub) {
+    if (stream_data.potential_subscribers_length(sub) === 0) {
+        $('.no_more_users_info').show();
+    } else {
+        $('.no_more_users_info').hide();
+    }
+}
+
 exports.open_edit_panel_for_row = function (stream_row) {
     const sub = get_sub_for_target(stream_row);
 
@@ -197,6 +205,8 @@ function show_subscription_settings(sub_row) {
 
     const users = exports.get_users_from_subscribers(sub.subscribers);
     exports.sort_but_pin_current_user_on_top(users);
+
+    update_no_users_display(sub);
 
     list_render.create(list, users, {
         name: "stream_subscribers/" + stream_id,
@@ -584,6 +594,7 @@ exports.initialize = function () {
             }
             stream_subscription_info_elem.addClass("text-success")
                 .removeClass("text-error");
+            update_no_users_display(sub);
         }
 
         function invite_failure(xhr) {
@@ -621,6 +632,7 @@ exports.initialize = function () {
             }
             stream_subscription_info_elem.addClass('text-success')
                 .removeClass('text-error');
+            $('.no_more_users_info').hide();
         }
 
         function removal_failure() {

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -277,7 +277,7 @@ form#add_new_subscription {
 
             tbody:empty::after,
             &:empty::after {
-                content: "No subscribers to this stream.";
+                content: "No matching subscribers.";
                 display: block;
 
                 text-align: center;

--- a/static/templates/subscription_members.hbs
+++ b/static/templates/subscription_members.hbs
@@ -3,6 +3,7 @@
     <div class="subscriber_list_settings">
         <label class="sub_settings_title float-left">
             {{t "Stream membership" }}
+            <div class="no_more_users_info small text-error" style="display: none">{{t 'No users to add.' }}</div>
             <div class="stream_subscription_info small"></div>
         </label>
         <div class="subscriber_list_add float-right">


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/11669

UPDATE:- Implemented all changes.

Solves parts 1,3,4. Part 2 (typeahead) has already been completed somewhere before.

Related discussions (for choosing message for user not found):-
https://chat.zulip.org/#narrow/stream/9-issues/topic/Unable.20to.20find.20user

PART 1 (User not found):-
![not_found](https://user-images.githubusercontent.com/42106909/77825091-1c456b80-712d-11ea-8bb5-f8de76452e53.gif)

PART 2 (No matching subs):-
![Screenshot from 2020-03-28 19-27-32](https://user-images.githubusercontent.com/42106909/77825101-29faf100-712d-11ea-80c8-ebdb3ad4d231.png)

PART 3 (No users to add):-
![add_user](https://user-images.githubusercontent.com/42106909/77825069-fddf7000-712c-11ea-807e-ad6a4dddf4e9.gif)

User email is missing
![Screenshot from 2020-04-26 20-52-44](https://user-images.githubusercontent.com/42106909/80312976-e2d44e80-8805-11ea-8f3f-869e4dc83e75.png)
