### PR TITLE
ui: add fade animation in the setting dropdown-menu

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1532,6 +1532,18 @@ div.focused_table {
     top: 30px;
     min-width: 180px;
     box-shadow: 0px 0px 5px hsla(0, 0%, 0%, 0.2);
+    animation-name: dropdownMenuFadeIn;
+    animation-duration: 0.15s;
+}
+
+@keyframes dropdownMenuFadeIn {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
 }
 
 .nav .dropdown-menu a,


### PR DESCRIPTION
This commit will add fade-in effect to the settings dropdown menu like we have in other ui elements(buddy info, stream popover)

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Pr to fix #13916 


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![add settings dropdown fade effect](https://user-images.githubusercontent.com/32801674/74597027-e3ba6880-507d-11ea-971e-7c85164881d9.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
