### PR TITLE
Improve social auth user-facing error handling

### DIFF
--- a/tools/ci/success-http-headers.template.txt
+++ b/tools/ci/success-http-headers.template.txt
@@ -1,4 +1,4 @@
-HTTP/2 200 
+HTTP/2 200
 server: {nginx_version_string}
 content-type: application/json
 vary: Accept-Encoding

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -460,7 +460,9 @@ class OurAuthenticationForm(AuthenticationForm):
 
             if return_data.get("invalid_subdomain"):
                 logging.warning(
-                    "User %s attempted password login to wrong subdomain %s", username, subdomain
+                    "User attempted password login to wrong subdomain %s. Matching accounts: %s",
+                    subdomain,
+                    return_data.get("matching_user_ids_in_different_realms"),
                 )
                 error_message = _(
                     "Your Zulip account {username} is not a member of the "

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -466,13 +466,9 @@ class OurAuthenticationForm(AuthenticationForm):
                     subdomain,
                     return_data.get("matching_user_ids_in_different_realms"),
                 )
-                error_message = _(
-                    "Your Zulip account {username} is not a member of the "
-                    + "organization associated with this subdomain.  "
-                    + "Please contact your organization administrator with any questions."
-                )
-                error_message = error_message.format(username=username)
-                raise ValidationError(error_message)
+                # We don't want to leak information by revealing there are matching accounts
+                # on different subdomain - so we just fall through to the default error.
+                assert self.user_cache is None
 
             if self.user_cache is None:
                 raise forms.ValidationError(

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -413,6 +413,8 @@ class CreateUserForm(forms.Form):
 
 
 class OurAuthenticationForm(AuthenticationForm):
+    logger = logging.getLogger("zulip.auth.OurAuthenticationForm")
+
     def clean(self) -> Dict[str, Any]:
         username = self.cleaned_data.get("username")
         password = self.cleaned_data.get("password")
@@ -459,7 +461,7 @@ class OurAuthenticationForm(AuthenticationForm):
                 raise ValidationError(error_message)
 
             if return_data.get("invalid_subdomain"):
-                logging.warning(
+                self.logger.info(
                     "User attempted password login to wrong subdomain %s. Matching accounts: %s",
                     subdomain,
                     return_data.get("matching_user_ids_in_different_realms"),

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -823,13 +823,13 @@ class LoginTest(ZulipTestCase):
     def test_login_wrong_subdomain(self) -> None:
         user_profile = self.mit_user("sipbtest")
         email = user_profile.delivery_email
-        with self.assertLogs(level="WARNING") as m:
+        with self.assertLogs("zulip.auth", level="INFO") as m:
             result = self.login_with_return(email, "xxx")
             matching_accounts_dict = {"realm_id": user_profile.realm_id, "id": user_profile.id}
             self.assertEqual(
                 m.output,
                 [
-                    f"WARNING:root:User attempted password login to wrong subdomain zulip. Matching accounts: [{matching_accounts_dict}]"
+                    f"INFO:zulip.auth.OurAuthenticationForm:User attempted password login to wrong subdomain zulip. Matching accounts: [{matching_accounts_dict}]"
                 ],
             )
         self.assertEqual(result.status_code, 200)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -834,8 +834,7 @@ class LoginTest(ZulipTestCase):
             )
         self.assertEqual(result.status_code, 200)
         expected_error = (
-            f"Your Zulip account {email} is not a member of the "
-            + "organization associated with this subdomain."
+            "Please enter a correct email and password. Note that both fields may be case-sensitive"
         )
         self.assert_in_response(expected_error, result)
         self.assert_logged_in_user_id(None)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -821,13 +821,15 @@ class LoginTest(ZulipTestCase):
         self.assert_logged_in_user_id(None)
 
     def test_login_wrong_subdomain(self) -> None:
-        email = self.mit_email("sipbtest")
+        user_profile = self.mit_user("sipbtest")
+        email = user_profile.delivery_email
         with self.assertLogs(level="WARNING") as m:
             result = self.login_with_return(email, "xxx")
+            matching_accounts_dict = {"realm_id": user_profile.realm_id, "id": user_profile.id}
             self.assertEqual(
                 m.output,
                 [
-                    "WARNING:root:User sipbtest@mit.edu attempted password login to wrong subdomain zulip"
+                    f"WARNING:root:User attempted password login to wrong subdomain zulip. Matching accounts: [{matching_accounts_dict}]"
                 ],
             )
         self.assertEqual(result.status_code, 200)

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -219,6 +219,9 @@ def common_get_active_user(
             return None
         if return_data is not None:
             return_data["invalid_subdomain"] = True
+            return_data["matching_user_ids_in_different_realms"] = list(
+                UserProfile.objects.filter(delivery_email__iexact=email).values("realm_id", "id")
+            )
         return None
     if not is_user_active(user_profile, return_data):
         return None


### PR DESCRIPTION
Our social auth error handling used to completely not account for ``SOCIAL_AUTH_SUBDOMAIN``, leading to the user getting stuck on the auth subdomain, which could be confusing. I talked more about it in https://chat.zulip.org/#narrow/stream/3-backend/topic/SOCIAL_AUTH_SUBDOMAIN

We fix error-handling by redirecting users to appropriate endpoints on their realm's URL, and then give the subdomain an error page when accessed directly  to inform the user they shouldn't be there:
![auth_subdomain](https://user-images.githubusercontent.com/45007152/74611624-62062180-50f5-11ea-9a4e-e7d55a09907a.png)

Then, building on top of those changes with an altered commit from https://github.com/zulip/zulip/pull/13844 (adjusting for the feedback received too), fixing #13126.
![error](https://user-images.githubusercontent.com/45007152/74611662-ca550300-50f5-11ea-8454-509344c22a9c.png)

