### PR TITLE
ui: Fix bug in cursor behaviour.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -51,6 +51,15 @@ exports.initialize = function () {
         drag.end(e);
     });
 
+    // Mouse cursor should not be a pointer in editing mode.
+    $('#main_div').on("mouseover", ".messagebox", function (e) {
+        const row = $(this).closest(".message_row");
+        const id = rows.id(row);
+
+        if (message_edit.is_editing(id)) {
+            e.currentTarget.style.cursor = "default";
+        }
+    });
     // MESSAGE CLICKING
 
     function is_clickable_message_element(target) {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes Issue #3938
I have added an event handler in click_handlers which will now check if the message is in editing mode whenever you "mouseover" over it and set the cursor style to default.

**Testing Plan:** <!-- How have you tested? -->
I ran the test-backend and it gave no errors.
Manually I have tested the following:
1. Replying to a message
2. Using "edit" shortcut key 
3. Using "edit" button
4. Hovering over messages not in edit mode
Linting was a success as well.
As it's a purely visual change I did not write any new tests

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![chrome-capture](https://user-images.githubusercontent.com/33174957/74628308-66751d80-517b-11ea-8a71-41f373fb23f3.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
