### PR TITLE
messages: Create a command to get markdown text from a list of messages.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5914,3 +5914,19 @@ def do_delete_realm_export(user_profile: UserProfile, export: RealmAuditLog) -> 
     export.extra_data = ujson.dumps(export_data)
     export.save(update_fields=['extra_data'])
     notify_realm_export(user_profile)
+
+def get_markdown_messages(user_profile: UserProfile, messages: List[int]) -> str:
+
+    assert messages is not None
+
+    buffer = []
+    for message_id in messages:
+        try:
+            (message, user_message) = access_message(user_profile, message_id)
+        except JsonableError:
+            continue
+        formated_date = message.date_sent.strftime("%Y-%m-%d %H:%M:%S")
+        buffer.append(formated_date + " @**" + message.sender.full_name
+                      + "**: \n\n " + message.content)
+
+    return '\n\n'.join(buffer)

--- a/zerver/management/commands/get_markdown_messages.py
+++ b/zerver/management/commands/get_markdown_messages.py
@@ -1,0 +1,31 @@
+from argparse import ArgumentParser
+from typing import Any
+
+from zerver.lib.actions import get_markdown_messages
+from zerver.lib.management import ZulipBaseCommand
+
+
+class Command(ZulipBaseCommand):
+    help = """Get a list of messages in markdown format."""
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        self.add_realm_args(parser)
+        parser.add_argument('-e', '--email', type=str, required=True,
+                            help='user email address')
+        parser.add_argument(
+            '-m', '--messages',
+            dest='messages',
+            type=str,
+            required=True,
+            help='A comma-separated list of message ids.')
+
+    def handle(self, *args: Any, **options: str) -> None:
+        email = options['email']
+        messages = options['messages']
+        message_ids = set([int(msg.strip()) for msg in messages.split(",")])
+
+        realm = self.get_realm(options)
+        user_profile = self.get_user(email, realm)
+
+        markdown = get_markdown_messages(user_profile, list(message_ids))
+        print(markdown)


### PR DESCRIPTION
* Added a method to get a markdown formatted text from a list.
* Added a CLI command to call run this task:
get_markdown_messages
* Added tests to check this source code

This is an initial development related to:
https://github.com/zulip/zulip/issues/6427
I have developed an management command to get a list of messages formatted in markdown. 
Later, in the frontend we'll use a copy to clipboard action for
getting this text.

* I have tested it, sending a list of message_id and getting the raw text.
* Sendind invalid ids.
* Sending an empty list.
* Sending a list with unauthorized/private messages .


