### PR TITLE
run-dev: Call process queue with DJANGO_AUTORELOAD_ENV.

### DIFF
--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -10,6 +10,7 @@ import traceback
 
 from urllib.parse import urlunparse
 
+from django.utils.autoreload import DJANGO_AUTORELOAD_ENV
 # check for the venv
 from lib import sanity_check
 sanity_check.check_venv(__file__)
@@ -141,7 +142,8 @@ cmds = [['./manage.py', 'runserver'] +
         manage_args + runserver_args + ['127.0.0.1:%d' % (django_port,)],
         ['env', 'PYTHONUNBUFFERED=1', './manage.py', 'runtornado'] +
         manage_args + ['127.0.0.1:%d' % (tornado_port,)],
-        ['./manage.py', 'process_queue', '--all'] + manage_args,
+        ['env', '{}=true'.format(DJANGO_AUTORELOAD_ENV),
+         './manage.py', 'process_queue', '--all'] + manage_args,
         ['env', 'PGHOST=127.0.0.1',  # Force password authentication using .pgpass
          './puppet/zulip/files/postgresql/process_fts_updates'],
         ['./manage.py', 'deliver_scheduled_messages'],


### PR DESCRIPTION
This should fix https://chat.zulip.org/#narrow/stream/43-automated-testing/topic/test-run-dev.20failures.20on.20circleci
Ran 100+ iterations of test-run-dev with this change and didn't get the failure.