### PR TITLE
messages: Create a command to get markdown text from a list of messages.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5914,3 +5914,19 @@ def do_delete_realm_export(user_profile: UserProfile, export: RealmAuditLog) -> 
     export.extra_data = ujson.dumps(export_data)
     export.save(update_fields=['extra_data'])
     notify_realm_export(user_profile)
+
+def get_markdown_messages(user_profile: UserProfile, messages: List[int]) -> str:
+
+    assert messages is not None
+
+    buffer = []
+    for message_id in messages:
+        try:
+            (message, user_message) = access_message(user_profile, message_id)
+        except JsonableError:
+            continue
+        formatted_date = message.date_sent.strftime("%Y-%m-%d %H:%M:%S")
+        buffer.append(formatted_date + " @**" + message.sender.full_name
+                      + "**: \n\n " + message.content)
+
+    return '\n\n'.join(buffer)

--- a/zerver/management/commands/get_markdown_messages.py
+++ b/zerver/management/commands/get_markdown_messages.py
@@ -1,0 +1,50 @@
+from argparse import ArgumentParser
+from typing import Any
+
+from zerver.lib.actions import get_markdown_messages
+from zerver.lib.management import ZulipBaseCommand
+
+
+class Command(ZulipBaseCommand):
+    help = """Get a list of messages in markdown format.
+
+It helps to export an specific list of messages in another stream/topic
+by a markdown text.
+It can be useful to check the visibility of the messages before doing a copy of them.
+
+Usage examples:
+
+./manage.py get_markdown_messages -e aaron@zulip.com -m 80,81 > file.txt
+./manage.py get_markdown_messages --email aaron@zulip.com --messages 80,81 > file.txt
+
+Result:
+2020-02-15 15:39:35 @**Polonius**:
+
+ >Such a claim might seem unexpected but fell in line with ...
+
+2020-02-16 16:16:03 @**Prospero from The Tempest**:
+
+ In our research we concentrate our efforts on confirming ...
+"""
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        self.add_realm_args(parser)
+        parser.add_argument('-e', '--email', type=str, required=True,
+                            help='user email address')
+        parser.add_argument(
+            '-m', '--messages',
+            dest='messages',
+            type=str,
+            required=True,
+            help='A comma-separated list of message ids.')
+
+    def handle(self, *args: Any, **options: str) -> None:
+        email = options['email']
+        messages = options['messages']
+        message_ids = set([int(msg.strip()) for msg in messages.split(",")])
+
+        realm = self.get_realm(options)
+        user_profile = self.get_user(email, realm)
+
+        markdown = get_markdown_messages(user_profile, list(message_ids))
+        print(markdown)


### PR DESCRIPTION
* Added a method to get a markdown formatted text from a list.
* Added a CLI command to call run this task:
get_markdown_messages
* Added tests to check this source code.

This is related to: #13936 

I have developed an management command to get a list of messages formatted in markdown.
This is an equivalent feature but in a CLI version, useful for an zulip system administrator that needs to copy messages from a stream/topic to another.
A next step, is add an endpoint url for getting the messages. This endpoint can use the same action "get_markdown_messages" to extract the raw text from the message list.

I have tested it:

* Sending a list of message_id and getting the raw text.
* Sendind invalid ids.
* Sending an empty list.
* Sending a list with unauthorized/private messages.

