### PR TITLE
ui: Change left and right sidebar scrollbar color

### DIFF
--- a/static/styles/components.scss
+++ b/static/styles/components.scss
@@ -76,6 +76,10 @@ a.no-underline:hover {
     .simplebar-scrollbar::before {
         background-color: hsl(0, 0%, 0%);
         box-shadow: 0px 0px 0px 1px hsla(0, 0%, 100%, 0.33);
+
+        .scrolling_list & {
+            background-color: hsl(0, 0%, 38%);
+        }
     }
 
     &.simplebar-vertical {


### PR DESCRIPTION
Changes left-sidebar and right-sidebar scrollbar color to hsl(0, 0%,
38%).

fixes: #12532

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![2020-02-18_04-22-00-354x462](https://user-images.githubusercontent.com/43504292/74690737-40488f80-5206-11ea-914b-55f3ffab3e1a.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
