### PR TITLE
import: Use re_map_foreign_keys on the realm column of UserPresence.

### DIFF
--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -966,6 +966,7 @@ def do_import_realm(import_dir: Path, subdomain: str, processes: int=1) -> Realm
     fix_datetime_fields(data, 'zerver_userpresence')
     re_map_foreign_keys(data, 'zerver_userpresence', 'user_profile', related_table="user_profile")
     re_map_foreign_keys(data, 'zerver_userpresence', 'client', related_table='client')
+    re_map_foreign_keys(data, 'zerver_userpresence', 'realm', related_table="realm")
     update_model_ids(UserPresence, data, 'user_presence')
     bulk_import_model(data, UserPresence)
 


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/49-development-help/topic/manage.2Epy.20import
FYI @hackerkid @showell 

We forgot to make this adjustment in the recent denormalization of realm
into UserPresence. It's needed for imports to work correctly.