### PR TITLE
tests: Ensure coverage data files get cleaned up at the end.

### DIFF
--- a/tools/coveragerc
+++ b/tools/coveragerc
@@ -19,6 +19,7 @@ exclude_lines =
     ^\s*\.\.\.
 
 [run]
+data_file=var/.coverage
 omit =
     */zulip-venv-cache/*
     */migrations/*

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -347,8 +347,10 @@ def main() -> None:
     assert_provisioning_status_ok(options.force)
 
     if options.coverage:
+        import atexit
         import coverage
         cov = coverage.Coverage(config_file="tools/coveragerc", concurrency='multiprocessing')
+        atexit.register(lambda: cov.erase())  # Ensure the data file gets cleaned up at the end.
         cov.start()
     if options.profile:
         import cProfile


### PR DESCRIPTION
From commit message:

> Without calling cov.erase() the data file seems to persist and even
pollute future test runs if not removed. Registering an atexit handler
seems like a good, and reasonably clean way to ensure the cleanup
happens.
Fixes #13933.

I think this is cleaner than a more hacky cleanup inserted at the beginning of ``test-backend``? And should be reliable enough, as according to atexit doc:
```
Note: The functions registered via this module are not called when the program is killed by a signal not handled by Python, when a Python fatal internal error is detected, or when os._exit() is called.
```

Which should be sufficiently unlikely to happen between the moment these files come into existence (at the first ``cov.save()`` call) and exit.

I'm wondering about whether we should add these ``.coverage.*`` files to ``.gitignore``, since they normally only exist for short periods of time, and I wouldn't have spotted this bug so easily if I hadn't had these files listed at the top in my VSCode source control bar - so it seems actually useful to have them annoyingly listed :sweat_smile: 
