### PR TITLE
Remove get_personal/stream_recipient functions

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -99,7 +99,6 @@ from zerver.models import Realm, RealmEmoji, Stream, UserProfile, UserActivity, 
     ScheduledEmail, MAX_TOPIC_NAME_LENGTH, \
     MAX_MESSAGE_LENGTH, get_client, get_stream, \
     get_user_profile_by_id, PreregistrationUser, \
-    get_stream_recipient, \
     email_allowed_for_realm, email_to_username, \
     get_user_by_delivery_email, get_stream_cache_key, active_non_guest_user_ids, \
     UserActivityInterval, active_user_ids, get_active_streams, \
@@ -3676,8 +3675,8 @@ def do_rename_stream(stream: Stream,
                    'realm': stream.realm.string_id,
                    'new_name': new_name})
 
-    recipient = get_stream_recipient(stream.id)
-    messages = Message.objects.filter(recipient=recipient).only("id")
+    recipient_id = stream.recipient_id
+    messages = Message.objects.filter(recipient_id=recipient_id).only("id")
 
     # Update the display recipient and stream, which are easy single
     # items to set.
@@ -3686,7 +3685,7 @@ def do_rename_stream(stream: Stream,
     if old_cache_key != new_cache_key:
         cache_delete(old_cache_key)
         cache_set(new_cache_key, stream)
-    cache_set(display_recipient_cache_key(recipient.id), stream.name)
+    cache_set(display_recipient_cache_key(recipient_id), stream.name)
 
     # Delete cache entries for everything else, which is cheaper and
     # clearer than trying to set them. display_recipient is the out of

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -97,7 +97,7 @@ from zerver.models import Realm, RealmEmoji, Stream, UserProfile, UserActivity, 
     UserHotspot, MultiuseInvite, ScheduledMessage, UserStatus, \
     Client, DefaultStream, DefaultStreamGroup, UserPresence, \
     ScheduledEmail, MAX_TOPIC_NAME_LENGTH, \
-    MAX_MESSAGE_LENGTH, get_client, get_stream, get_personal_recipient, \
+    MAX_MESSAGE_LENGTH, get_client, get_stream, \
     get_user_profile_by_id, PreregistrationUser, \
     get_stream_recipient, \
     email_allowed_for_realm, email_to_username, \
@@ -935,8 +935,8 @@ def create_mirror_user_if_needed(realm: Realm, email: str,
 
 def send_welcome_bot_response(message: MutableMapping[str, Any]) -> None:
     welcome_bot = get_system_bot(settings.WELCOME_BOT)
-    human_recipient = get_personal_recipient(message['message'].sender.id)
-    if Message.objects.filter(sender=welcome_bot, recipient=human_recipient).count() < 2:
+    human_recipient_id = message['message'].sender.recipient_id
+    if Message.objects.filter(sender=welcome_bot, recipient_id=human_recipient_id).count() < 2:
         internal_send_private_message(
             message['realm'], welcome_bot, message['message'].sender,
             "Congratulations on your first reply! :tada:\n\n"

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -24,10 +24,6 @@ from zerver.worker import queue_processors
 from zerver.lib.integrations import WEBHOOK_INTEGRATIONS
 from zerver.views.auth import get_login_data
 
-from zerver.lib.actions import (
-    get_stream_recipient,
-)
-
 from zerver.models import (
     get_stream,
     Client,
@@ -235,9 +231,9 @@ def most_recent_message(user_profile: UserProfile) -> Message:
 
 def get_subscription(stream_name: str, user_profile: UserProfile) -> Subscription:
     stream = get_stream(stream_name, user_profile.realm)
-    recipient = get_stream_recipient(stream.id)
+    recipient_id = stream.recipient_id
     return Subscription.objects.get(user_profile=user_profile,
-                                    recipient=recipient, active=True)
+                                    recipient_id=recipient_id, active=True)
 
 def get_user_messages(user_profile: UserProfile) -> List[Message]:
     query = UserMessage.objects. \

--- a/zerver/lib/topic_mutes.py
+++ b/zerver/lib/topic_mutes.py
@@ -5,7 +5,6 @@ from zerver.lib.topic import (
     topic_match_sa,
 )
 from zerver.models import (
-    get_stream_recipient,
     get_stream,
     MutedTopic,
     UserProfile
@@ -47,12 +46,12 @@ def set_topic_mutes(user_profile: UserProfile, muted_topics: List[List[str]],
         date_muted = timezone_now()
     for stream_name, topic_name in muted_topics:
         stream = get_stream(stream_name, user_profile.realm)
-        recipient = get_stream_recipient(stream.id)
+        recipient_id = stream.recipient_id
 
         add_topic_mute(
             user_profile=user_profile,
             stream_id=stream.id,
-            recipient_id=recipient.id,
+            recipient_id=recipient_id,
             topic_name=topic_name,
             date_muted=date_muted,
         )

--- a/zerver/management/commands/merge_streams.py
+++ b/zerver/management/commands/merge_streams.py
@@ -5,8 +5,7 @@ from zerver.lib.actions import bulk_add_subscriptions, \
     bulk_remove_subscriptions, do_deactivate_stream
 from zerver.lib.cache import cache_delete_many, to_dict_cache_key_id
 from zerver.lib.management import ZulipBaseCommand
-from zerver.models import Message, Subscription, get_stream, \
-    get_stream_recipient
+from zerver.models import Message, Subscription, get_stream
 
 
 def bulk_delete_cache_keys(message_ids_to_clear: List[int]) -> None:
@@ -34,8 +33,8 @@ class Command(ZulipBaseCommand):
         stream_to_keep = get_stream(options["stream_to_keep"], realm)
         stream_to_destroy = get_stream(options["stream_to_destroy"], realm)
 
-        recipient_to_destroy = get_stream_recipient(stream_to_destroy.id)
-        recipient_to_keep = get_stream_recipient(stream_to_keep.id)
+        recipient_to_destroy = stream_to_destroy.recipient
+        recipient_to_keep = stream_to_keep.recipient
 
         # The high-level approach here is to move all the messages to
         # the surviving stream, deactivate all the subscriptions on

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1571,9 +1571,6 @@ def get_recipient_cache_key(type: int, type_id: int) -> str:
 def get_recipient(type: int, type_id: int) -> Recipient:
     return Recipient.objects.get(type_id=type_id, type=type)
 
-def get_stream_recipient(stream_id: int) -> Recipient:
-    return get_recipient(Recipient.STREAM, stream_id)
-
 def get_huddle_recipient(user_profile_ids: Set[int]) -> Recipient:
 
     # The caller should ensure that user_profile_ids includes

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1574,9 +1574,6 @@ def get_recipient(type: int, type_id: int) -> Recipient:
 def get_stream_recipient(stream_id: int) -> Recipient:
     return get_recipient(Recipient.STREAM, stream_id)
 
-def get_personal_recipient(user_profile_id: int) -> Recipient:
-    return get_recipient(Recipient.PERSONAL, user_profile_id)
-
 def get_huddle_recipient(user_profile_ids: Set[int]) -> Recipient:
 
     # The caller should ensure that user_profile_ids includes

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -13,7 +13,7 @@ from django.utils.timezone import now as timezone_now
 from io import StringIO
 
 from zerver.models import (
-    get_client, get_stream_recipient, get_stream, get_realm, get_system_bot,
+    get_client, get_stream, get_realm, get_system_bot,
     Message, RealmDomain, Recipient, UserMessage, UserPresence, UserProfile,
     Realm, Subscription, Stream, flush_per_request_caches, UserGroup, Service,
     Attachment, PreregistrationUser, get_user_by_delivery_email, MultiuseInvite,
@@ -1528,7 +1528,7 @@ class EventsRegisterTest(ZulipTestCase):
             ('muted_topics', check_list(check_list(check_string, 2))),
         ])
         stream = get_stream('Denmark', self.user_profile.realm)
-        recipient = get_stream_recipient(stream.id)
+        recipient = stream.recipient
         events = self.do_test(lambda: do_mute_topic(
             self.user_profile, stream, recipient, "topic"))
         error = muted_topics_checker('events[0]', events[0])
@@ -2935,7 +2935,7 @@ class GetUnreadMsgsTest(ZulipTestCase):
                    topic_name: str) -> None:
         realm = user_profile.realm
         stream = get_stream(stream_name, realm)
-        recipient = get_stream_recipient(stream.id)
+        recipient = stream.recipient
 
         add_topic_mute(
             user_profile=user_profile,

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -85,7 +85,6 @@ from zerver.models import (
     get_realm,
     get_stream,
     get_stream_recipient,
-    get_personal_recipient,
     get_huddle_hash,
 )
 
@@ -788,10 +787,8 @@ class ImportExportTest(ZulipTestCase):
                 Stream.objects.get(name='Verona', realm=r).id
             )
 
-        def get_recipient_user(r: Realm) -> UserProfile:
-            return get_personal_recipient(
-                UserProfile.objects.get(full_name='Iago', realm=r).id
-            )
+        def get_recipient_user(r: Realm) -> Recipient:
+            return UserProfile.objects.get(full_name='Iago', realm=r).recipient
 
         assert_realm_values(lambda r: get_recipient_stream(r).type)
         assert_realm_values(lambda r: get_recipient_user(r).type)
@@ -999,7 +996,8 @@ class ImportExportTest(ZulipTestCase):
 
         # Check recipient_id was generated correctly for the imported users and streams.
         for user_profile in UserProfile.objects.filter(realm=imported_realm):
-            self.assertEqual(user_profile.recipient_id, get_personal_recipient(user_profile.id).id)
+            self.assertEqual(user_profile.recipient_id, Recipient.objects.get(type=Recipient.PERSONAL,
+                                                                              type_id=user_profile.id).id)
         for stream in Stream.objects.filter(realm=imported_realm):
             self.assertEqual(stream.recipient_id, get_stream_recipient(stream.id).id)
 

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -84,7 +84,6 @@ from zerver.models import (
     get_active_streams,
     get_realm,
     get_stream,
-    get_stream_recipient,
     get_huddle_hash,
 )
 
@@ -725,7 +724,7 @@ class ImportExportTest(ZulipTestCase):
         add_topic_mute(
             user_profile=sample_user,
             stream_id=stream.id,
-            recipient_id=get_stream_recipient(stream.id).id,
+            recipient_id=stream.recipient.id,
             topic_name=u'Verona2')
 
         # data to test import of botstoragedata and botconfigdata
@@ -782,10 +781,8 @@ class ImportExportTest(ZulipTestCase):
         )
 
         # test recipients
-        def get_recipient_stream(r: Realm) -> Stream:
-            return get_stream_recipient(
-                Stream.objects.get(name='Verona', realm=r).id
-            )
+        def get_recipient_stream(r: Realm) -> Recipient:
+            return Stream.objects.get(name='Verona', realm=r).recipient
 
         def get_recipient_user(r: Realm) -> Recipient:
             return UserProfile.objects.get(full_name='Iago', realm=r).recipient
@@ -999,7 +996,7 @@ class ImportExportTest(ZulipTestCase):
             self.assertEqual(user_profile.recipient_id, Recipient.objects.get(type=Recipient.PERSONAL,
                                                                               type_id=user_profile.id).id)
         for stream in Stream.objects.filter(realm=imported_realm):
-            self.assertEqual(stream.recipient_id, get_stream_recipient(stream.id).id)
+            self.assertEqual(stream.recipient_id, stream.recipient.id)
 
     def test_import_files_from_local(self) -> None:
 

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -15,7 +15,6 @@ from zerver.lib.test_classes import (
 )
 
 from zerver.models import (
-    get_stream_recipient,
     Subscription,
     UserPresence,
 )
@@ -211,7 +210,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         '''
         cordelia = self.example_user('cordelia')
         stream = self.subscribe(cordelia, 'Scotland')
-        recipient = get_stream_recipient(stream.id)
+        recipient = stream.recipient
         cordelia_subscription = Subscription.objects.get(
             user_profile_id=cordelia.id,
             recipient=recipient,

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -89,7 +89,7 @@ from zerver.models import (
     MAX_MESSAGE_LENGTH, MAX_TOPIC_NAME_LENGTH,
     Message, Realm, Recipient, Stream, UserMessage, UserProfile, Attachment,
     RealmAuditLog, RealmDomain, get_realm, UserPresence, Subscription,
-    get_stream, get_stream_recipient, get_system_bot, get_user, Reaction,
+    get_stream, get_system_bot, get_user, Reaction,
     flush_per_request_caches, ScheduledMessage, get_huddle_recipient,
     bulk_get_huddle_user_ids, get_huddle_user_ids,
     get_display_recipient, RealmFilter,
@@ -155,7 +155,7 @@ class TopicHistoryTest(ZulipTestCase):
         self.login(email)
 
         stream = get_stream(stream_name, user_profile.realm)
-        recipient = get_stream_recipient(stream.id)
+        recipient = stream.recipient
 
         def create_test_message(topic: str) -> int:
             # TODO: Clean this up to send messages the normal way.
@@ -925,7 +925,7 @@ class StreamMessagesTest(ZulipTestCase):
         message_content = 'whatever'
         stream = get_stream('Denmark', realm)
         topic_name = 'lunch'
-        recipient = get_stream_recipient(stream.id)
+        recipient = stream.recipient
         sending_client = make_client(name="test suite")
 
         for i in range(num_extra_users):
@@ -4164,7 +4164,7 @@ class SoftDeactivationMessageTest(ZulipTestCase):
         topic_name = 'foo'
 
         def send_fake_message(message_content: str, stream: Stream) -> Message:
-            recipient = get_stream_recipient(stream.id)
+            recipient = stream.recipient
             message = Message(sender = sender,
                               recipient = recipient,
                               content = message_content,

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -92,7 +92,7 @@ from zerver.models import (
     get_stream, get_stream_recipient, get_system_bot, get_user, Reaction,
     flush_per_request_caches, ScheduledMessage, get_huddle_recipient,
     bulk_get_huddle_user_ids, get_huddle_user_ids,
-    get_personal_recipient, get_display_recipient, RealmFilter,
+    get_display_recipient, RealmFilter,
 )
 
 
@@ -4620,7 +4620,7 @@ class MessageHydrationTest(ZulipTestCase):
         cordelia = self.example_user('cordelia')
         message_id = self.send_personal_message(hamlet.email, cordelia.email, 'test')
 
-        cordelia_recipient = get_personal_recipient(cordelia.id)
+        cordelia_recipient = cordelia.recipient
         # Cause the display_recipient to get cached:
         get_display_recipient(cordelia_recipient)
 

--- a/zerver/tests/test_muting.py
+++ b/zerver/tests/test_muting.py
@@ -7,7 +7,6 @@ from zerver.lib.stream_topic import StreamTopicTarget
 
 from zerver.models import (
     get_stream,
-    get_stream_recipient,
     UserProfile,
     MutedTopic
 )
@@ -25,7 +24,7 @@ class MutedTopicsTests(ZulipTestCase):
         cordelia  = self.example_user('cordelia')
         realm = hamlet.realm
         stream = get_stream(u'Verona', realm)
-        recipient = get_stream_recipient(stream.id)
+        recipient = stream.recipient
         topic_name = 'teST topic'
 
         stream_topic_target = StreamTopicTarget(
@@ -92,7 +91,7 @@ class MutedTopicsTests(ZulipTestCase):
         self.login(email)
 
         stream = get_stream(u'Verona', realm)
-        recipient = get_stream_recipient(stream.id)
+        recipient = stream.recipient
 
         url = '/api/v1/users/me/subscriptions/muted_topics'
         payloads = [
@@ -123,7 +122,7 @@ class MutedTopicsTests(ZulipTestCase):
         self.login(email)
 
         stream = get_stream('Verona', realm)
-        recipient = get_stream_recipient(stream.id)
+        recipient = stream.recipient
         add_topic_mute(
             user_profile=user,
             stream_id=stream.id,

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -11,7 +11,7 @@ from sqlalchemy.sql.elements import ClauseElement
 from zerver.models import (
     Realm, Subscription, Recipient, Stream,
     get_display_recipient, get_realm, get_stream,
-    UserMessage, get_stream_recipient, Message
+    UserMessage, Message
 )
 from zerver.lib.actions import (
     do_set_realm_property,
@@ -68,11 +68,11 @@ def get_sqlalchemy_query_params(query: ClauseElement) -> Dict[str, object]:
 
 def get_recipient_id_for_stream_name(realm: Realm, stream_name: str) -> str:
     stream = get_stream(stream_name, realm)
-    return get_stream_recipient(stream.id).id
+    return stream.recipient.id
 
 def mute_stream(realm: Realm, user_profile: str, stream_name: str) -> None:
     stream = get_stream(stream_name, realm)
-    recipient = get_stream_recipient(stream.id)
+    recipient = stream.recipient
     subscription = Subscription.objects.get(recipient=recipient, user_profile=user_profile)
     subscription.is_muted = True
     subscription.save()
@@ -1077,7 +1077,7 @@ class GetOldMessagesTest(ZulipTestCase):
         query_ids = {}  # type: Dict[str, Union[int, str]]
 
         scotland_stream = get_stream('Scotland', hamlet_user.realm)
-        query_ids['scotland_recipient'] = get_stream_recipient(scotland_stream.id).id
+        query_ids['scotland_recipient'] = scotland_stream.recipient_id
         query_ids['hamlet_id'] = hamlet_user.id
         query_ids['othello_id'] = othello_user.id
         query_ids['hamlet_recipient'] = hamlet_user.recipient_id
@@ -2628,7 +2628,7 @@ class GetOldMessagesTest(ZulipTestCase):
         self.assertEqual(len(queries), 1)
 
         stream = get_stream('Scotland', realm)
-        recipient_id = get_stream_recipient(stream.id).id
+        recipient_id = stream.recipient.id
         cond = '''AND NOT (recipient_id = {scotland} AND upper(subject) = upper('golf'))'''.format(scotland=recipient_id)
         self.assertIn(cond, queries[0]['sql'])
 

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -10,7 +10,7 @@ from sqlalchemy.sql.elements import ClauseElement
 
 from zerver.models import (
     Realm, Subscription, Recipient, Stream,
-    get_display_recipient, get_personal_recipient, get_realm, get_stream,
+    get_display_recipient, get_realm, get_stream,
     UserMessage, get_stream_recipient, Message
 )
 from zerver.lib.actions import (
@@ -1080,8 +1080,8 @@ class GetOldMessagesTest(ZulipTestCase):
         query_ids['scotland_recipient'] = get_stream_recipient(scotland_stream.id).id
         query_ids['hamlet_id'] = hamlet_user.id
         query_ids['othello_id'] = othello_user.id
-        query_ids['hamlet_recipient'] = get_personal_recipient(hamlet_user.id).id
-        query_ids['othello_recipient'] = get_personal_recipient(othello_user.id).id
+        query_ids['hamlet_recipient'] = hamlet_user.recipient_id
+        query_ids['othello_recipient'] = othello_user.recipient_id
         recipients = Recipient.objects.filter(
             type=Recipient.STREAM,
             type_id__in=Stream.objects.filter(realm=hamlet_user.realm, invite_only=False),

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -26,7 +26,7 @@ from zerver.views.invite import get_invitee_emails_set
 from zerver.views.development.registration import confirmation_key
 
 from zerver.models import (
-    get_realm, get_user, get_stream_recipient, CustomProfileField,
+    get_realm, get_user, CustomProfileField,
     CustomProfileFieldValue, DefaultStream, PreregistrationUser,
     Realm, Recipient, Message, ScheduledEmail, UserProfile, UserMessage,
     Stream, Subscription, flush_per_request_caches, get_system_bot,
@@ -1830,13 +1830,13 @@ class RealmCreationTest(ZulipTestCase):
                 (Realm.DEFAULT_NOTIFICATION_STREAM_NAME, 'with the topic', 3),
                 (Realm.INITIAL_PRIVATE_STREAM_NAME, 'private stream', 1)]:
             stream = get_stream(stream_name, realm)
-            recipient = get_stream_recipient(stream.id)
+            recipient = stream.recipient
             messages = Message.objects.filter(recipient=recipient).order_by('date_sent')
             self.assertEqual(len(messages), message_count)
             self.assertIn(text, messages[0].content)
 
         # Check signup messages
-        recipient = get_stream_recipient(signups_stream.id)
+        recipient = signups_stream.recipient
         messages = Message.objects.filter(recipient=recipient).order_by('id')
         self.assertEqual(len(messages), 2)
         self.assertIn('Signups enabled', messages[0].content)

--- a/zerver/tests/test_unread.py
+++ b/zerver/tests/test_unread.py
@@ -7,7 +7,6 @@ from django.db import connection
 from zerver.models import (
     get_realm,
     get_stream,
-    get_stream_recipient,
     get_user,
     Subscription,
     UserMessage,
@@ -390,7 +389,7 @@ class FixUnreadTests(ZulipTestCase):
 
         def mute_stream(stream_name: str) -> None:
             stream = get_stream(stream_name, realm)
-            recipient = get_stream_recipient(stream.id)
+            recipient = stream.recipient
             subscription = Subscription.objects.get(
                 user_profile=user,
                 recipient=recipient
@@ -400,7 +399,7 @@ class FixUnreadTests(ZulipTestCase):
 
         def mute_topic(stream_name: str, topic_name: str) -> None:
             stream = get_stream(stream_name, realm)
-            recipient = get_stream_recipient(stream.id)
+            recipient = stream.recipient
 
             add_topic_mute(
                 user_profile=user,

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -20,7 +20,7 @@ from zerver.models import UserProfile, Recipient, Realm, \
     get_source_profile, get_system_bot, \
     ScheduledEmail, check_valid_user_ids, \
     get_user_by_id_in_realm_including_cross_realm, CustomProfileField, \
-    InvalidFakeEmailDomain, get_fake_email_domain, get_personal_recipient
+    InvalidFakeEmailDomain, get_fake_email_domain
 
 from zerver.lib.avatar import avatar_url, get_gravatar_url
 from zerver.lib.exceptions import JsonableError
@@ -647,7 +647,8 @@ class AdminCreateUserTest(ZulipTestCase):
         self.assertEqual(new_user.short_name, 'Romeo')
 
         # Make sure the recipient field is set correctly.
-        self.assertEqual(new_user.recipient, get_personal_recipient(new_user.id))
+        self.assertEqual(new_user.recipient, Recipient.objects.get(type=Recipient.PERSONAL,
+                                                                   type_id=new_user.id))
 
         # we can't create the same user twice.
         result = self.client_post("/json/users", valid_params)

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -16,7 +16,7 @@ from zerver.lib.test_classes import (
 
 from zerver.models import UserProfile, Recipient, Realm, \
     RealmDomain, UserHotspot, get_client, \
-    get_user, get_realm, get_stream, get_stream_recipient, \
+    get_user, get_realm, get_stream, \
     get_source_profile, get_system_bot, \
     ScheduledEmail, check_valid_user_ids, \
     get_user_by_id_in_realm_including_cross_realm, CustomProfileField, \
@@ -1053,7 +1053,7 @@ class RecipientInfoTest(ZulipTestCase):
             self.subscribe(user, stream_name)
 
         stream = get_stream(stream_name, realm)
-        recipient = get_stream_recipient(stream.id)
+        recipient = stream.recipient
 
         stream_topic = StreamTopicTarget(
             stream_id=stream.id,

--- a/zerver/views/archive.py
+++ b/zerver/views/archive.py
@@ -5,7 +5,7 @@ from django.shortcuts import render
 from django.template import loader
 from zerver.lib.streams import get_stream_by_id
 
-from zerver.models import Message, get_stream_recipient, UserProfile
+from zerver.models import Message, UserProfile
 from zerver.lib.avatar import get_gravatar_url
 from zerver.lib.response import json_success
 from zerver.lib.timestamp import datetime_to_timestamp
@@ -87,8 +87,6 @@ def get_web_public_topics_backend(request: HttpRequest, stream_id: int) -> HttpR
     if not stream.is_web_public:
         return json_success(dict(topics=[]))
 
-    recipient = get_stream_recipient(stream.id)
-
-    result = get_topic_history_for_web_public_stream(recipient=recipient)
+    result = get_topic_history_for_web_public_stream(recipient=stream.recipient)
 
     return json_success(dict(topics=result))


### PR DESCRIPTION
``recipient`` has been denormalized into ``UserProfile, Stream``, so we can get rid of these functions.