### PR TITLE
Changed migration_status_test & migration_status_dev to migration_status.

### DIFF
--- a/tools/do-destroy-rebuild-database
+++ b/tools/do-destroy-rebuild-database
@@ -13,7 +13,7 @@ EOF
 
 ./manage.py purge_queue --all
 ./manage.py migrate --noinput
-./manage.py get_migration_status --settings=zproject.settings --output="migration_status_dev"
+./manage.py get_migration_status --settings=zproject.settings --output="$1"
 ./manage.py createcachetable third_party_api_results
 ./manage.py populate_db -n100 --threads=1
 # Ensure that the local user's API key is synced from ~/.zuliprc

--- a/tools/do-destroy-rebuild-test-database
+++ b/tools/do-destroy-rebuild-test-database
@@ -3,4 +3,4 @@ set -e
 set -x
 
 # This is a really simple wrapper script, pretty much for documenting clarity
-"$(dirname "$0")/../tools/setup/generate-fixtures" --force
+"$(dirname "$0")/../tools/setup/generate-fixtures" "$1" --force

--- a/tools/lib/provision_inner.py
+++ b/tools/lib/provision_inner.py
@@ -158,7 +158,7 @@ def main(options: argparse.Namespace) -> int:
         django.setup()
 
         from zerver.lib.test_fixtures import template_database_status, run_db_migrations, \
-            destroy_leaked_test_databases
+            destroy_leaked_test_databases, get_migration_status_path
 
         try:
             from zerver.lib.queue import SimpleQueueClient
@@ -174,8 +174,9 @@ def main(options: argparse.Namespace) -> int:
 
         dev_template_db_status = template_database_status('dev')
         if options.is_force or dev_template_db_status == 'needs_rebuild':
-            run(["tools/setup/postgres-init-dev-db"])
-            run(["tools/do-destroy-rebuild-database"])
+            migration_status_file = get_migration_status_path('dev')
+            run(["tools/setup/postgres-init-dev-db", migration_status_file])
+            run(["tools/do-destroy-rebuild-database", migration_status_file])
         elif dev_template_db_status == 'run_migrations':
             run_db_migrations('dev')
         elif dev_template_db_status == 'current':
@@ -183,8 +184,9 @@ def main(options: argparse.Namespace) -> int:
 
         test_template_db_status = template_database_status('test')
         if options.is_force or test_template_db_status == 'needs_rebuild':
-            run(["tools/setup/postgres-init-test-db"])
-            run(["tools/do-destroy-rebuild-test-database"])
+            migration_status_file = get_migration_status_path('test')
+            run(["tools/setup/postgres-init-test-db", migration_status_file])
+            run(["tools/do-destroy-rebuild-test-database", migration_status_file])
         elif test_template_db_status == 'run_migrations':
             run_db_migrations('test')
         elif test_template_db_status == 'current':

--- a/tools/setup/generate-fixtures
+++ b/tools/setup/generate-fixtures
@@ -11,7 +11,7 @@ CREATE DATABASE zulip_test_template TEMPLATE zulip_test;
 EOF
 }
 
-if  [ "$1" != "--force" ]; then
+if  [ "$2" != "--force" ]; then
     "$(dirname "$0")/../../scripts/setup/terminate-psql-sessions" zulip zulip_test zulip_test_base zulip_test_template
     psql -v ON_ERROR_STOP=1 -h localhost postgres zulip_test << EOF
 DROP DATABASE IF EXISTS zulip_test;
@@ -32,7 +32,7 @@ EOF
 "$(dirname "$0")/../../scripts/setup/flush-memcached"
 
 ./manage.py migrate --noinput
-./manage.py get_migration_status --output="migration_status_test"
+./manage.py get_migration_status --output="$1"
 
 # This next line can be simplified to "-n0" once we fix our app (and tests) with 0 messages.
 ./manage.py populate_db --test-suite -n30 --threads=1 \

--- a/tools/setup/postgres-init-dev-db
+++ b/tools/setup/postgres-init-dev-db
@@ -20,12 +20,12 @@ fi
 
 VAGRANTUSERNAME=$(whoami)
 
-if [[ $# == 0 ]]; then
+if [[ $# == 1 ]]; then
     USERNAME=zulip
     PASSWORD=$("$(dirname "$0")/../../scripts/get-django-setting" LOCAL_DATABASE_PASSWORD)
     DBNAME=zulip
     SEARCH_PATH="$USERNAME",public
-    STATUS_FILE_NAME="migration_status_dev"
+    STATUS_FILE_NAME="$1"
 elif [[ $# == 5 ]]; then
     USERNAME=$1
     PASSWORD=$2

--- a/tools/setup/postgres-init-test-db
+++ b/tools/setup/postgres-init-test-db
@@ -2,4 +2,4 @@
 set -x
 set -e
 
-"$(dirname "$0")/postgres-init-dev-db" zulip_test "$("$(dirname "$0")/../../scripts/get-django-setting" LOCAL_DATABASE_PASSWORD)" zulip_test zulip,public migration_status_test
+"$(dirname "$0")/postgres-init-dev-db" zulip_test "$("$(dirname "$0")/../../scripts/get-django-setting" LOCAL_DATABASE_PASSWORD)" zulip_test zulip,public "$1"


### PR DESCRIPTION
This is a follow up to #13866 for further clean up. It migrates `migration_status_test` and `migration_status_dev` files to be just `{status_dir}/migration_status` with some tweaks inside `tools/setup`.

**Testing Plan:**
Unit tests.