### PR TITLE
restore-backup: Improvements to memcached password handling

### DIFF
--- a/puppet/zulip/manifests/memcached.pp
+++ b/puppet/zulip/manifests/memcached.pp
@@ -22,12 +22,12 @@ class zulip::memcached {
     notify  => Exec[generate_memcached_sasldb2],
   }
   exec { 'generate_memcached_sasldb2':
-    creates => '/etc/sasl2/memcached-sasldb2',
     require => [
       Package[$memcached_packages],
       Package[$zulip::sasl_modules::sasl_module_packages],
       File['/etc/sasl2/memcached-zulip-password'],
     ],
+    refreshonly => true,
     # Pass the hostname explicitly because otherwise saslpasswd2
     # lowercases it and memcached does not.
     command => "bash -c 'saslpasswd2 -p -f /etc/sasl2/memcached-sasldb2 \

--- a/scripts/setup/restore-backup
+++ b/scripts/setup/restore-backup
@@ -100,6 +100,13 @@ def restore_backup(tarball_file):
         run(as_postgres + ["createdb", "-O", "zulip", "-T", "template0", "--", db_name])
 
         if settings.PRODUCTION:
+            # In case we are restoring a backup from an older Zulip
+            # version, there may be new secrets to generate.
+            subprocess.check_call([
+                os.path.join(settings.DEPLOY_ROOT, "scripts", "setup", "generate_secrets.py"),
+                "--production",
+            ])
+
             # If there is a local rabbitmq, we need to reconfigure it
             # to ensure the rabbitmq password matches the value in the
             # restored zulip-secrets.conf.  We need to be careful to


### PR DESCRIPTION
* restore-backup: Run generate_secrets.py.
* puppet: Fix regeneration of memcached-sasldb2 on password changes.

Fixes #13730.

**Testing Plan:** Tested on a 2.1.x production install.