### PR TITLE
do_delete_messages: Archive the messages in bulk. 

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4657,11 +4657,11 @@ def do_update_message(user_profile: UserProfile, message: Message, topic_name: O
 def do_delete_messages(realm: Realm, messages: Iterable[Message]) -> None:
     message_ids = [message.id for message in messages]
     usermessages = UserMessage.objects.filter(message_id__in=message_ids)
-    message_id_to_notifiable_users = {}  # type: Dict[int, List[Dict[str, int]]]
+    message_id_to_notifiable_users = {}  # type: Dict[int, List[int]]
     for um in usermessages:
         if um.message_id not in message_id_to_notifiable_users:
             message_id_to_notifiable_users[um.message_id] = []
-        message_id_to_notifiable_users[um.message_id].append({"id": um.user_profile_id})
+        message_id_to_notifiable_users[um.message_id].append(um.user_profile_id)
 
     events_and_users_to_notify = []
     for message in messages:

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -1062,6 +1062,13 @@ def process_notification(notice: Mapping[str, Any]) -> None:
         process_message_event(event, cast(Iterable[Mapping[str, Any]], users))
     elif event['type'] == "update_message":
         process_message_update_event(event, cast(Iterable[Mapping[str, Any]], users))
+    elif event['type'] == "delete_message" and isinstance(users[0], dict):
+        # do_delete_messages used to send events with users in dict format {"id": <int>}
+        # This block is here for compatibility with events in that format still in the queue
+        # at the time of upgrade.
+        # TODO: Remove this block in release >= 2.3.
+        user_ids = [user['id'] for user in cast(Iterable[Mapping[str, int]], users)]
+        process_event(event, user_ids)
     elif event['type'] == "presence":
         process_presence_event(event, cast(Iterable[int], users))
     else:

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -945,18 +945,6 @@ def process_event(event: Mapping[str, Any], users: Iterable[int]) -> None:
             if client.accepts_event(event):
                 client.add_event(event)
 
-def process_userdata_event(event_template: Mapping[str, Any], users: Iterable[Mapping[str, Any]]) -> None:
-    for user_data in users:
-        user_profile_id = user_data['id']
-        user_event = dict(event_template)  # shallow copy, but deep enough for our needs
-        for key in user_data.keys():
-            if key != "id":
-                user_event[key] = user_data[key]
-
-        for client in get_client_descriptors_for_user(user_profile_id):
-            if client.accepts_event(user_event):
-                client.add_event(user_event)
-
 def process_message_update_event(event_template: Mapping[str, Any],
                                  users: Iterable[Mapping[str, Any]]) -> None:
     prior_mention_user_ids = set(event_template.get('prior_mention_user_ids', []))
@@ -1074,8 +1062,6 @@ def process_notification(notice: Mapping[str, Any]) -> None:
         process_message_event(event, cast(Iterable[Mapping[str, Any]], users))
     elif event['type'] == "update_message":
         process_message_update_event(event, cast(Iterable[Mapping[str, Any]], users))
-    elif event['type'] == "delete_message":
-        process_userdata_event(event, cast(Iterable[Mapping[str, Any]], users))
     elif event['type'] == "presence":
         process_presence_event(event, cast(Iterable[int], users))
     else:


### PR DESCRIPTION
The added test shows 37 queries - compared to 181 without the change to the function. That seems very much worth it.