### PR TITLE
tests: For ldap tests, give each ldap user a unique password.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -763,11 +763,15 @@ class ZulipTestCase(TestCase):
         """
         directory = ujson.loads(self.fixture_data("directory.json", type="ldap"))
 
-        # Load binary attributes. If in "directory", an attribute as its value
-        # has a string starting with "file:", the rest of the string is assumed
-        # to be a path to the file from which binary data should be loaded,
-        # as the actual value of the attribute in ldap.
         for dn, attrs in directory.items():
+            if 'uid' in attrs:
+                # Generate a password for the ldap account:
+                attrs['userPassword'] = [self.ldap_password(attrs['uid'][0]), ]
+
+            # Load binary attributes. If in "directory", an attribute as its value
+            # has a string starting with "file:", the rest of the string is assumed
+            # to be a path to the file from which binary data should be loaded,
+            # as the actual value of the attribute in ldap.
             for attr, value in attrs.items():
                 if isinstance(value, str) and value.startswith("file:"):
                     with open(value[5:], 'rb') as f:
@@ -805,9 +809,8 @@ class ZulipTestCase(TestCase):
         """
         return self.example_user_ldap_username_map[username]
 
-    def ldap_password(self) -> str:
-        # Currently all ldap users have password "testing"
-        return "testing"
+    def ldap_password(self, uid: str) -> str:
+        return "{}_ldap_password".format(uid)
 
 class WebhookTestCase(ZulipTestCase):
     """

--- a/zerver/tests/fixtures/ldap/directory.json
+++ b/zerver/tests/fixtures/ldap/directory.json
@@ -9,7 +9,6 @@
         "cn": ["King Hamlet"],
         "uid": ["hamlet"],
         "mail": ["hamlet@zulip.com"],
-        "userPassword": ["testing"],
         "userAccountControl": ["512"],
         "sn": ["Hamlet"],
         "homePhone": ["123456789"],
@@ -22,7 +21,6 @@
         "cn": ["Cordelia Lear"],
         "uid": ["cordelia"],
         "mail": ["cordelia@zulip.com"],
-        "userPassword": ["testing"],
         "sn": ["Cordelia"]
     },
 
@@ -31,7 +29,6 @@
         "cn": ["aaron"],
         "uid": ["letham"],
         "mail": ["aaron@zulip.com"],
-        "userPassword": ["testing"],
         "sn": ["aaron"]
     },
 
@@ -39,7 +36,6 @@
         "objectClass": ["user"],
         "cn": ["New LDAP fullname"],
         "uid": ["newuser"],
-        "userPassword": ["testing"],
         "sn": ["shortname"],
         "homePhone": ["a-new-number"],
         "jpegPhoto": "file:static/images/team/tim.png"
@@ -49,7 +45,6 @@
         "objectClass": ["user"],
         "cn": ["Last"],
         "uid": ["newuser_splitname"],
-        "userPassword": ["testing"],
         "sn": ["First"]
     },
 
@@ -57,7 +52,6 @@
         "objectClass": ["user"],
         "cn": ["New LDAP fullname"],
         "uid": ["newuser_with_email"],
-        "userPassword": ["testing"],
         "sn": ["shortname"],
         "mail": ["newuser_email@zulip.com"]
     },
@@ -66,7 +60,6 @@
         "objectClass": ["user"],
         "cn": ["New LDAP fullname"],
         "uid": ["newuser_email_as_uid@zulip.com"],
-        "userPassword": ["testing"],
         "sn": ["shortname"]
     },
 
@@ -74,7 +67,6 @@
         "objectClass": ["user"],
         "cn": ["New LDAP fullname"],
         "uid": ["user1_with_shared_email"],
-        "userPassword": ["testing"],
         "sn": ["shortname"],
         "mail": ["shared_email@zulip.com"]
     },
@@ -83,7 +75,6 @@
         "objectClass": ["user"],
         "cn": ["New LDAP fullname"],
         "uid": ["user2_with_shared_email"],
-        "userPassword": ["testing"],
         "sn": ["shortname"],
         "mail": ["shared_email@zulip.com"]
     }

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -59,7 +59,8 @@ class TestFollowupEmails(ZulipTestCase):
         ldap_user_attr_map = {'full_name': 'cn', 'short_name': 'sn'}
 
         with self.settings(AUTH_LDAP_USER_ATTR_MAP=ldap_user_attr_map):
-            self.login_with_return("newuser_email_as_uid@zulip.com", self.ldap_password())
+            self.login_with_return("newuser_email_as_uid@zulip.com",
+                                   self.ldap_password("newuser_email_as_uid@zulip.com"))
             user = UserProfile.objects.get(email="newuser_email_as_uid@zulip.com")
             scheduled_emails = ScheduledEmail.objects.filter(users=user)
 
@@ -78,7 +79,7 @@ class TestFollowupEmails(ZulipTestCase):
                 LDAP_APPEND_DOMAIN='zulip.com',
                 AUTH_LDAP_USER_ATTR_MAP=ldap_user_attr_map,
         ):
-            self.login_with_return("newuser@zulip.com", self.ldap_password())
+            self.login_with_return("newuser@zulip.com", self.ldap_password("newuser"))
 
             user = UserProfile.objects.get(email="newuser@zulip.com")
             scheduled_emails = ScheduledEmail.objects.filter(users=user)
@@ -98,7 +99,7 @@ class TestFollowupEmails(ZulipTestCase):
                 LDAP_EMAIL_ATTR='mail',
                 AUTH_LDAP_USER_ATTR_MAP=ldap_user_attr_map,
         ):
-            self.login_with_return("newuser_with_email", self.ldap_password())
+            self.login_with_return("newuser_with_email", self.ldap_password("newuser_with_email"))
             user = UserProfile.objects.get(email="newuser_email@zulip.com")
             scheduled_emails = ScheduledEmail.objects.filter(users=user)
 

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -270,7 +270,7 @@ class ChangeSettingsTest(ZulipTestCase):
             result = self.client_patch(
                 "/json/settings",
                 dict(
-                    old_password=self.ldap_password(),  # hamlet's password in ldap
+                    old_password=self.ldap_password("hamlet"),  # hamlet's password in ldap
                     new_password="ignored",
                 ))
             self.assert_json_error(result, "Your Zulip password is managed in LDAP")

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1859,7 +1859,8 @@ class RealmCreationTest(ZulipTestCase):
         self.init_default_ldap_database()
 
         with self.settings(LDAP_EMAIL_ATTR="mail"):
-            self.check_able_to_create_realm("newuser_email@zulip.com", self.ldap_password())
+            self.check_able_to_create_realm("newuser_email@zulip.com",
+                                            self.ldap_password("newuser_with_email"))
 
     def test_create_realm_as_system_bot(self) -> None:
         result = self.client_post('/new/', {'email': 'notification-bot@zulip.com'})
@@ -2662,7 +2663,7 @@ class UserSignUpTest(InviteUserBase):
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',
                                                 'zproject.backends.ZulipDummyBackend'))
     def test_ldap_registration_from_confirmation(self) -> None:
-        password = self.ldap_password()
+        password = self.ldap_password("newuser")
         email = "newuser@zulip.com"
         subdomain = "zulip"
         self.init_default_ldap_database()
@@ -2730,7 +2731,7 @@ class UserSignUpTest(InviteUserBase):
                                                 'zproject.backends.ZulipLDAPUserPopulator',
                                                 'zproject.backends.ZulipDummyBackend'))
     def test_ldap_populate_only_registration_from_confirmation(self) -> None:
-        password = self.ldap_password()
+        password = self.ldap_password("newuser")
         email = "newuser@zulip.com"
         subdomain = "zulip"
         self.init_default_ldap_database()
@@ -2791,7 +2792,7 @@ class UserSignUpTest(InviteUserBase):
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',
                                                 'zproject.backends.ZulipDummyBackend'))
     def test_ldap_registration_end_to_end(self) -> None:
-        password = self.ldap_password()
+        password = self.ldap_password("newuser")
         email = "newuser@zulip.com"
         subdomain = "zulip"
 
@@ -2859,7 +2860,7 @@ class UserSignUpTest(InviteUserBase):
 
         subdomain = 'zulip'
         email = 'newuser_splitname@zulip.com'
-        password = self.ldap_password()
+        password = self.ldap_password("newuser_splitname")
         with patch('zerver.views.registration.get_subdomain', return_value=subdomain):
             result = self.client_post('/register/', {'email': email})
 
@@ -2905,7 +2906,7 @@ class UserSignUpTest(InviteUserBase):
 
         This test verifies that flow.
         """
-        password = self.ldap_password()
+        password = self.ldap_password("newuser")
         email = "newuser@zulip.com"
         subdomain = "zulip"
 
@@ -2938,7 +2939,7 @@ class UserSignUpTest(InviteUserBase):
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_ldap_registration_multiple_realms(self) -> None:
-        password = self.ldap_password()
+        password = self.ldap_password("newuser")
         email = "newuser@zulip.com"
 
         self.init_default_ldap_database()
@@ -2972,7 +2973,7 @@ class UserSignUpTest(InviteUserBase):
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',
                                                 'zproject.backends.ZulipDummyBackend'))
     def test_ldap_registration_when_names_changes_are_disabled(self) -> None:
-        password = self.ldap_password()
+        password = self.ldap_password("newuser")
         email = "newuser@zulip.com"
         subdomain = "zulip"
 
@@ -3198,7 +3199,7 @@ class UserSignUpTest(InviteUserBase):
 
         subdomain = 'zulip'
         email = 'newuser@zulip.com'
-        password = self.ldap_password()
+        password = self.ldap_password("newuser")
 
         with self.settings(
                 POPULATE_PROFILE_VIA_LDAP=True,
@@ -3264,7 +3265,7 @@ class UserSignUpTest(InviteUserBase):
         """
         Test `name_changes_disabled` when we are not running under LDAP.
         """
-        password = self.ldap_password()
+        password = self.ldap_password("newuser")
         email = "newuser@zulip.com"
         subdomain = "zulip"
 
@@ -3288,7 +3289,7 @@ class UserSignUpTest(InviteUserBase):
             self.assertEqual(user_profile.full_name, 'New Name')
 
     def test_realm_creation_through_ldap(self) -> None:
-        password = self.ldap_password()
+        password = self.ldap_password("newuser")
         email = "newuser@zulip.com"
         subdomain = "zulip"
         realm_name = "Zulip"
@@ -3703,7 +3704,7 @@ class TwoFactorAuthTest(ZulipTestCase):
         # type: (MagicMock) -> None
         token = 123456
         email = self.example_email('hamlet')
-        password = self.ldap_password()
+        password = self.ldap_password('hamlet')
 
         user_profile = self.example_user('hamlet')
         user_profile.set_password(password)


### PR DESCRIPTION
This is the last remaining follow-up from the ancient https://github.com/zulip/zulip/pull/13256#issuecomment-545194215 - specifically the point:

> We should rework the self.ldap_password function to accept the username as an argument and give the users different passwords. Having every LDAP user possess the same password is a bug land mine where the test isn't testing what one thinks it is.