### PR TITLE
Remove the "pointer" from Zulip, part 1

### DIFF
--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -138,7 +138,7 @@ function message_range(start, end) {
 const initialize_data = {
     initial_fetch: {
         req: {
-            anchor: 444,
+            anchor: 'first_unread',
             num_before: 200,
             num_after: 200,
             client_gravatar: true,

--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -402,7 +402,9 @@ exports.initialize = function () {
         // near: narrow query, we want to select a specific message.
         anchor = page_params.initial_pointer;
     } else {
-        anchor = page_params.pointer;
+        // Otherwise, we should just use the first unread message in
+        // the user's unmuted history as our anchor.
+        anchor = "first_unread";
     }
     exports.load_messages({
         anchor: anchor,


### PR DESCRIPTION
This does substantial work towards removing the pointer as a concept in Zulip (#8994).  The goal is to get to a place where the server does not send a `pointer` parameter to clients and they don't send such a parameter to the server, either.

This isn't mergable yet, because:
* The commit "pointer: Remove have_initial_messages code." breaks our node tests by making the `message_fetch` initialization code run the main code path.  @showell I'd love some help in figuring out how we want the `ui_init.js` tests to proceed here; one option would be to just skip `message_fetch` in that test; I'm not sure if that makes sense.
* I'm not sure what to replace the last two remaining `message_fetch` references to `page_params.pointer` with; they appear only in this funny corner case where the home view has no messages in it after the initial fetch.  
* It needs some manual testing, and maybe some burn-in on chat.zulip.org.

But I'm otherwise pretty happy with this initial series of commits.  Next steps include:
* Switching our `analytics/` references to look at the "mark message as read" endpoints instead of the pointer endpoints.
* `Updating docs/subsystems/pointer.md` to describe how unread messages work now, and maybe also rename it to `unread.md`.
* Removing the webapp code to send pointer updates to the client (I have a draft commit that I left off this PR).  This will remove 2/3 of `pointer.js`; the rest (for marking messages as read on message selection) we'll end up moving somewhere more sensible, ideally deduplicating it with the similar code in narrows.
* Deleting the `fix_unreads` management command and Inlining `zerver/lib/fix_unreads.py` into `zerver/migrations/0104_fix_unreads.py` so that the code properly lives within the single migration that needs it.
* Removing the API endpoints for the pointer
* Removing the pointer from events.
* Removing the pointer field from the database.
