### PR TITLE
Modify filter streams widget in search settings

### DIFF
--- a/frontend_tests/casper_tests/05-subscriptions.js
+++ b/frontend_tests/casper_tests/05-subscriptions.js
@@ -153,7 +153,7 @@ casper.then(function () {
     // 4 users from Scotland are added.
     // 1 user, Cordelia, is added. Othello (subscribed to Scotland) is not added twice.
     casper.test.assertSelectorHasText('.subscriber-count-text', '5');
-    casper.fill('form#add_new_subscription', {stream_name: 'WASeemio'});
+    casper.sendKeys('#search_stream_name', 'WASeemio', { reset: true });
     casper.click('#add_new_subscription .create_stream_button');
 });
 casper.then(function () {
@@ -165,7 +165,7 @@ casper.then(function () {
     common.wait_for_text('#stream_name_error', 'A stream needs to have a name', function () {
         casper.test.assertTextExists('A stream needs to have a name', "Can't create a stream with an empty name");
         casper.click('form#stream_creation_form button.button.white');
-        casper.fill('form#add_new_subscription', {stream_name: '  '});
+        casper.sendKeys('#search_stream_name', '   ', { reset: true });
         casper.click('#add_new_subscription .create_stream_button');
         casper.fill('form#stream_creation_form', {stream_name: 'Waseemio'});
         casper.click('form#stream_creation_form button.button.sea-green');
@@ -185,16 +185,14 @@ casper.then(function () {
     });
 });
 casper.then(function () {
-    casper.fill('form#add_new_subscription', {stream_name: 'was'});
-    casper.evaluate(function () {
-        $('#add_new_subscription input[type="text"]').expectOne()
-            .trigger($.Event('input'));
-    });
+    casper.sendKeys('#search_stream_name', 'was', { reset: true });
 });
-casper.waitForSelectorTextChange('form#add_new_subscription', function () {
-    casper.test.assertSelectorHasText('.stream-row.notdisplayed .stream-name', 'Verona', 'Verona stream not shown after filtering');
-    casper.test.assertSelectorHasText('.stream-row .stream-name', 'Waseemio', 'Waseemio stream exists after filtering');
-    casper.test.assertSelectorDoesntHaveText('.stream-row.notdisplayed .stream-name', 'Waseemio', 'Waseemio stream shown after filtering');
+casper.then(function () {
+    casper.wait('4000', function () {
+        casper.test.assertSelectorHasText('.stream-row.notdisplayed .stream-name', 'Verona', 'Verona stream not shown after filtering');
+        casper.test.assertSelectorHasText('.stream-row .stream-name', 'Waseemio', 'Waseemio stream exists after filtering');
+        casper.test.assertSelectorDoesntHaveText('.stream-row.notdisplayed .stream-name', 'Waseemio', 'Waseemio stream shown after filtering');
+    });
 });
 
 common.then_log_out();

--- a/frontend_tests/casper_tests/05-subscriptions.js
+++ b/frontend_tests/casper_tests/05-subscriptions.js
@@ -154,7 +154,6 @@ casper.then(function () {
     // 1 user, Cordelia, is added. Othello (subscribed to Scotland) is not added twice.
     casper.test.assertSelectorHasText('.subscriber-count-text', '5');
     casper.sendKeys('#search_stream_name', 'WASeemio', { reset: true });
-    casper.click('#add_new_subscription .create_stream_button');
 });
 casper.then(function () {
     casper.click('#add_new_subscription .create_stream_button');
@@ -165,7 +164,7 @@ casper.then(function () {
     common.wait_for_text('#stream_name_error', 'A stream needs to have a name', function () {
         casper.test.assertTextExists('A stream needs to have a name', "Can't create a stream with an empty name");
         casper.click('form#stream_creation_form button.button.white');
-        casper.sendKeys('#search_stream_name', '   ', { reset: true });
+        casper.fill('form#add_new_subscription', {stream_name: '  '});
         casper.click('#add_new_subscription .create_stream_button');
         casper.fill('form#stream_creation_form', {stream_name: 'Waseemio'});
         casper.click('form#stream_creation_form button.button.sea-green');

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -444,7 +444,7 @@ exports.filter_table = function (query) {
 let subscribed_only = true;
 
 exports.get_search_params = function () {
-    const search_box = $("#add_new_subscription input[type='text']");
+    const search_box = $("#stream_filter input[type='text']");
     const input = search_box.expectOne().val().trim();
     const params = {
         input: input,
@@ -551,8 +551,13 @@ exports.setup_page = function (callback) {
         exports.actually_filter_streams();
         stream_create.set_up_handlers();
 
-        $("#add_new_subscription input[type='text']").on("input", function () {
+        $("#stream_filter input[type='text']").on("input", function () {
             // Debounce filtering in case a user is typing quickly
+            filter_streams();
+        });
+
+        $("#clear_search_stream_name").on("click", function () {
+            $("#stream_filter input[type='text']").val("");
             filter_streams();
         });
 

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -531,12 +531,36 @@ form#add_new_subscription {
 }
 
 #search_stream_name {
-    width: 190px;
+    width: 100%;
     padding: 3px 5px;
-    margin: 2px 0px;
+    margin: 8px 0px;
+    margin-left: 10px;
+    margin-right: -15px !important;
     display: inline-block;
     border-radius: 5px;
     box-shadow: none;
+}
+
+.stream_name_search_section {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    margin-bottom: 0;
+    height: auto;
+    border-bottom: 1px solid hsl(0, 0%, 87%);
+}
+
+.streams-list {
+    position: relative;
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+    height: calc(100% - 85px);
+    width: 100%;
+}
+
+#clear_search_stream_name {
+    right: 5px !important;
 }
 
 .stream-title {
@@ -572,14 +596,6 @@ form#add_new_subscription {
             margin-right: 8px;
         }
     }
-}
-
-.streams-list {
-    position: relative;
-    overflow: auto;
-    -webkit-overflow-scrolling: touch;
-    height: calc(100% - 45px);
-    width: 100%;
 }
 
 .stream-row {
@@ -1029,18 +1045,9 @@ ul.grey-box {
             width: calc(60% - 1px);
         }
     }
-
-    #search_stream_name {
-        width: 100px;
-        margin-top: 2px;
-        margin-bottom: 0px;
-    }
 }
 
 @media (max-width: 1033px) {
-    #search_stream_name {
-        display: none;
-    }
 
     .search-container {
         text-align: center;
@@ -1053,7 +1060,7 @@ ul.grey-box {
     }
 }
 
-@media (max-width: 700px) {
+@media (max-width: 750px) {
     .subscriptions-container {
         position: relative;
         overflow: hidden;

--- a/static/templates/subscription_table_body.hbs
+++ b/static/templates/subscription_table_body.hbs
@@ -11,14 +11,19 @@
             <div class="left">
                 <div class="search-container">
                     <form id="add_new_subscription" class="form-inline" action="">
-                        <input type="text" name="stream_name" id="search_stream_name"
-                          placeholder="{{t 'Filter streams' }}" value="" autocomplete="off" />
                         {{#if can_create_streams}}
                         <input type="submit" class="create_stream_button"
                           value="+" title="{{t 'Create new stream' }} (n)"/>
                         {{/if}}
                         <div class="float-clear"></div>
                     </form>
+                </div>
+                <div class="input-append stream_name_search_section" id="stream_filter">
+                    <input type="text" name="stream_name" id="search_stream_name" autocomplete="off"
+                      placeholder="{{t 'Filter streams' }}" value="" form="add_new_subscription" />
+                    <button type="button" class="btn clear_search_button" id="clear_search_stream_name">
+                        <i class="fa fa-remove" aria-hidden="true"></i>
+                    </button>
                 </div>
                 <div class="streams-list" data-simplebar>
                 </div>


### PR DESCRIPTION
This adds the magnifying glass icon and search box in the second
line for filtering streams in the streams settings. This is to
fix the disappearance of the search widget on narrow screens.
issue: #12898 

**Screenshot:** 
![image](https://user-images.githubusercontent.com/43912285/74882236-bda20a80-5394-11ea-9710-1a4b06061654.png)
