### PR TITLE
saml: Make the bad idp param KeyError log message more verbose.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1462,13 +1462,13 @@ class SAMLAuthBackendTest(SocialAuthBase):
             result = self.client_get('/login/saml/')
             self.assertEqual(result.status_code, 302)
             self.assertEqual('/login/', result.url)
-            m.assert_called_with("/login/saml/ : Bad idp param.")
+            m.assert_called_with("/login/saml/ : Bad idp param: KeyError: 'idp'.")
 
         with mock.patch('zproject.backends.logging.info') as m:
             result = self.client_get('/login/saml/?idp=bad_idp')
             self.assertEqual(result.status_code, 302)
             self.assertEqual('/login/', result.url)
-            m.assert_called_with("/login/saml/ : Bad idp param.")
+            m.assert_called_with("/login/saml/ : Bad idp param: KeyError: 'bad_idp'.")
 
     def test_social_auth_invalid_email(self) -> None:
         """

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -1392,10 +1392,10 @@ class SAMLAuthBackend(SocialAuthMixin, SAMLAuth):
         try:
             idp_name = self.strategy.request_data()['idp']
             auth = self._create_saml_auth(idp=self.get_idp(idp_name))
-        except KeyError:
+        except KeyError as e:
             # If the above raise KeyError, it means invalid or no idp was specified,
             # we should log that and redirect to the login page.
-            logging.info("/login/saml/ : Bad idp param.")
+            logging.info("/login/saml/ : Bad idp param: KeyError: {}.".format(e))
             return reverse('zerver.views.auth.login_page',
                            kwargs = {'template_name': 'zerver/login.html'})
 


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/31-production-help/topic/SAML.2Fkeycloak.20configuration/near/818834 shows it can be useful to log the exception message.

Original idea was that KeyError was only going to happen there in case
of user passing bad input params to the endpoint, so logging a generic
message seemed sufficient. But this can also happen in case of
misconfiguration, so it's worth logging more info as it may help in
debugging the configuration.
