### PR TITLE
docs: Rename "Testing and writing tests" section to "Testing overview".

### DIFF
--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -1,4 +1,4 @@
-# Testing and writing tests
+# Testing overview
 
 Zulip takes pride in its extensive, carefully designed test suites.
 For example, `test-backend` runs a complete test suite (~98% test


### PR DESCRIPTION
The section doesn't really explain anything about actually writing
tests, so "Testing overview" seems like a more fitting name.

Addresses concern raised in https://chat.zulip.org/#narrow/stream/95-new-members/topic/GSoC.202020/near/818364