### PR TITLE
saml: Use rsa-sha256 as the default signature algorithm.

### DIFF
--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 ################################################################
 # Zulip Server settings.
@@ -262,7 +262,7 @@ SOCIAL_AUTH_SAML_SECURITY_CONFIG = {
     # set this to True to enable signing of SAMLRequests using the
     # private key.
     "authnRequestsSigned": False,
-}
+}  # type: Dict[str, Any]
 
 # These SAML settings you likely won't need to modify.
 SOCIAL_AUTH_SAML_SP_ENTITY_ID = 'https://' + EXTERNAL_HOST

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -1001,6 +1001,13 @@ if PRODUCTION:
     SOCIAL_AUTH_SAML_SP_PUBLIC_CERT = get_from_file_if_exists("/etc/zulip/saml/zulip-cert.crt")
     SOCIAL_AUTH_SAML_SP_PRIVATE_KEY = get_from_file_if_exists("/etc/zulip/saml/zulip-private-key.key")
 
+if "signatureAlgorithm" not in SOCIAL_AUTH_SAML_SECURITY_CONFIG:
+    # If the configuration doesn't explicitly specify the algorithm,
+    # we set RSA1 with SHA256 to override the python3-saml default, which uses
+    # insecure SHA1.
+    default_signature_alg = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+    SOCIAL_AUTH_SAML_SECURITY_CONFIG["signatureAlgorithm"] = default_signature_alg
+
 for idp_name, idp_dict in SOCIAL_AUTH_SAML_ENABLED_IDPS.items():
     if DEVELOPMENT:
         idp_dict['entity_id'] = get_secret('saml_entity_id', '')


### PR DESCRIPTION
Fixes the bad python3-saml default, spotted in #13948 

Might be worth pushing this to 2.1.x too I think?
