### PR TITLE
tests: Adjust failing test on 2.1.x branch.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1244,7 +1244,7 @@ class SAMLAuthBackendTest(SocialAuthBase):
             result = self.client_get('/login/saml/')
             self.assertEqual(result.status_code, 302)
             self.assertEqual('/login/', result.url)
-            m.assert_called_with("/login/saml/ : Bad idp param: KeyError: 'idp'.")
+            m.assert_called_with("/login/saml/ : Bad idp param: KeyError: \"'idp'\".")
 
         with mock.patch('zproject.backends.logging.info') as m:
             result = self.client_get('/login/saml/?idp=bad_idp')


### PR DESCRIPTION
The KeyError is getting formatted a bit differently on the 2.1.x branch.
