### PR TITLE
Remove overlapping gradient from apps page.

### DIFF
--- a/templates/zerver/apps.html
+++ b/templates/zerver/apps.html
@@ -11,7 +11,6 @@
 {% block portico_content %}
 
 {% include 'zerver/landing_nav.html' %}
-{% include 'zerver/gradients.html' %}
 
 <div class="portico-landing apps">
     <div class="hero">


### PR DESCRIPTION
Fixes #13375 

**Fixing The Issue:**

So the "zerver/gradients.html" file which is causing the issue is itself being only used in 3 pages aside the apps page - Features, Plans and the Home page.
![image](https://user-images.githubusercontent.com/23737560/75011393-87a07b80-54a5-11ea-835d-6868dc176650.png)

The use-case of gradient in all these pages is to apply gradient to the top section of the pages except it's being used to apply gradient to footer in apps page.

This causes inconsistency in appearance of footer throughout the website. The most optimal fix was to remove the gradients include from apps page.

**Testing Plan:** <!-- How have you tested? -->
- Resize the browser viewport.
- Use developer tools to simulate mobile screen.

**GIFs or Screenshots:** 
Before:
![image](https://user-images.githubusercontent.com/23737560/75011536-e7972200-54a5-11ea-8f28-d27dbafd630c.png)

After:
![image](https://user-images.githubusercontent.com/23737560/75011505-d3ebbb80-54a5-11ea-84d5-990f0b4399f9.png)

