### PR TITLE
refactor: Extract settings_display_config.

### DIFF
--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -63,7 +63,6 @@ set_global('i18n', global.stub_i18n);
 
 zrequire('stream_data');
 set_global('i18n', global.stub_i18n);
-zrequire('settings_display');
 
 run_test('stream_data', () => {
     assert.equal(stream_data.get_sub_by_name('Denmark'), undefined);

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -24,7 +24,7 @@ zrequire('Filter', 'js/filter');
 zrequire('MessageListData', 'js/message_list_data');
 zrequire('MessageListView', 'js/message_list_view');
 zrequire('message_list');
-zrequire('settings_display', 'js/settings_display');
+const settings_config = zrequire("settings_config");
 
 const me = {
     email: 'me@zulip.com',
@@ -301,7 +301,7 @@ run_test('is_active', () => {
     let sub;
 
     page_params.demote_inactive_streams =
-        settings_display.demote_inactive_streams_values.automatic.code;
+        settings_config.demote_inactive_streams_values.automatic.code;
     stream_data.set_filter_out_inactives();
 
     sub = {name: 'pets', subscribed: false, stream_id: 111};
@@ -332,7 +332,7 @@ run_test('is_active', () => {
     assert(stream_data.is_active(sub));
 
     page_params.demote_inactive_streams =
-        settings_display.demote_inactive_streams_values.always.code;
+        settings_config.demote_inactive_streams_values.always.code;
     stream_data.set_filter_out_inactives();
 
     sub = {name: 'pets', subscribed: false, stream_id: 111};
@@ -360,7 +360,7 @@ run_test('is_active', () => {
     assert(stream_data.is_active(sub));
 
     page_params.demote_inactive_streams =
-        settings_display.demote_inactive_streams_values.never.code;
+        settings_config.demote_inactive_streams_values.never.code;
     stream_data.set_filter_out_inactives();
 
     sub = {name: 'pets', subscribed: false, stream_id: 111};

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -24,7 +24,6 @@ set_global('page_params', {
     is_admin: false,
     realm_users: [],
 });
-zrequire('settings_display');
 
 stream_color.initialize();
 

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -124,8 +124,6 @@ zrequire('user_status');
 zrequire('user_status_ui');
 const ui_init = zrequire('ui_init');
 
-zrequire('settings_display');
-
 set_global('$', global.make_zjquery());
 
 const document_stub = $.create('document-stub');

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -1,3 +1,4 @@
+const settings_config = require("./settings_config");
 const render_admin_tab = require('../templates/admin_tab.hbs');
 
 const admin_settings_label = {
@@ -31,7 +32,7 @@ exports.build_page = function () {
         server_inline_image_preview: page_params.server_inline_image_preview,
         realm_inline_url_embed_preview: page_params.realm_inline_url_embed_preview,
         server_inline_url_embed_preview: page_params.server_inline_url_embed_preview,
-        realm_default_twenty_four_hour_time_values: settings_display.twenty_four_hour_time_values,
+        realm_default_twenty_four_hour_time_values: settings_config.twenty_four_hour_time_values,
         realm_authentication_methods: page_params.realm_authentication_methods,
         realm_create_stream_policy: page_params.realm_create_stream_policy,
         realm_invite_to_stream_policy: page_params.realm_invite_to_stream_policy,

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -1,3 +1,4 @@
+const settings_config = require("./settings_config");
 const render_settings_tab = require('../templates/settings_tab.hbs');
 
 $("body").ready(function () {
@@ -109,13 +110,13 @@ exports.build_page = function () {
         timezones: moment.tz.names(),
         can_create_new_bots: settings_bots.can_create_new_bots(),
         settings_label: exports.settings_label,
-        demote_inactive_streams_values: settings_display.demote_inactive_streams_values,
-        twenty_four_hour_time_values: settings_display.twenty_four_hour_time_values,
+        demote_inactive_streams_values: settings_config.demote_inactive_streams_values,
+        twenty_four_hour_time_values: settings_config.twenty_four_hour_time_values,
         notification_settings: settings_notifications.all_notifications.settings,
         desktop_icon_count_display_values: settings_notifications.desktop_icon_count_display_values,
         push_notification_tooltip:
             settings_notifications.all_notifications.push_notification_tooltip,
-        display_settings: settings_display.all_display_settings,
+        display_settings: settings_config.get_all_display_settings(),
         user_can_change_name: settings_account.user_can_change_name(),
         user_can_change_avatar: settings_account.user_can_change_avatar(),
     });

--- a/static/js/settings_config.js
+++ b/static/js/settings_config.js
@@ -1,0 +1,54 @@
+/*
+    We keep config values for Display Settings
+    in a separate file to break dependencies.
+
+    In particular, stream_data.js only cares
+    about demote_inactive_streams_values, and
+    we don't want it to depend on settings_display.js,
+    which brings in lots of indirect dependencies
+    that aren't relevant to it.
+*/
+
+exports.demote_inactive_streams_values = {
+    automatic: {
+        code: 1,
+        description: i18n.t("Automatic"),
+    },
+    always: {
+        code: 2,
+        description: i18n.t("Always"),
+    },
+    never: {
+        code: 3,
+        description: i18n.t("Never"),
+    },
+};
+
+exports.twenty_four_hour_time_values = {
+    twenty_four_hour_clock: {
+        value: true,
+        description: i18n.t("24-hour clock (17:00)"),
+    },
+    twelve_hour_clock: {
+        value: false,
+        description: i18n.t("12-hour clock (5:00 PM)"),
+    },
+};
+
+exports.get_all_display_settings = () => ({
+    settings: {
+        user_display_settings: [
+            "dense_mode",
+            "night_mode",
+            "high_contrast_mode",
+            "left_side_userlist",
+            "starred_message_counts",
+            "fluid_layout_width",
+        ],
+    },
+    render_only: {
+        high_contrast_mode: page_params.development_environment,
+        dense_mode: page_params.development_environment,
+    },
+});
+

--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -1,3 +1,5 @@
+const settings_config = require("./settings_config");
+
 const meta = {
     loaded: false,
 };
@@ -18,49 +20,6 @@ function change_display_setting(data, status_element, success_msg, sticky) {
     settings_ui.do_settings_change(channel.patch, '/json/settings/display', data, status_element, opts);
 }
 
-exports.demote_inactive_streams_values = {
-    automatic: {
-        code: 1,
-        description: i18n.t("Automatic"),
-    },
-    always: {
-        code: 2,
-        description: i18n.t("Always"),
-    },
-    never: {
-        code: 3,
-        description: i18n.t("Never"),
-    },
-};
-
-exports.twenty_four_hour_time_values = {
-    twenty_four_hour_clock: {
-        value: true,
-        description: i18n.t("24-hour clock (17:00)"),
-    },
-    twelve_hour_clock: {
-        value: false,
-        description: i18n.t("12-hour clock (5:00 PM)"),
-    },
-};
-
-exports.all_display_settings = {
-    settings: {
-        user_display_settings: [
-            "dense_mode",
-            "night_mode",
-            "high_contrast_mode",
-            "left_side_userlist",
-            "starred_message_counts",
-            "fluid_layout_width",
-        ],
-    },
-    render_only: {
-        high_contrast_mode: page_params.development_environment,
-        dense_mode: page_params.development_environment,
-    },
-};
-
 exports.set_up = function () {
     meta.loaded = true;
     $("#display-settings-status").hide();
@@ -77,7 +36,8 @@ exports.set_up = function () {
         overlays.close_modal('default_language_modal');
     });
 
-    for (const setting of exports.all_display_settings.settings.user_display_settings) {
+    const all_display_settings = settings_config.get_all_display_settings();
+    for (const setting of all_display_settings.settings.user_display_settings) {
         $("#" + setting).change(function () {
             const data = {};
             data[setting] = JSON.stringify($(this).prop('checked'));

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -2,6 +2,7 @@ const util = require("./util");
 const IntDict = require('./int_dict').IntDict;
 const FoldDict = require('./fold_dict').FoldDict;
 const LazySet = require('./lazy_set').LazySet;
+const settings_config = require("./settings_config");
 
 const BinaryDict = function (pred) {
     /*
@@ -116,10 +117,10 @@ exports.clear_subscriptions();
 
 exports.set_filter_out_inactives = function () {
     if (page_params.demote_inactive_streams ===
-            settings_display.demote_inactive_streams_values.automatic.code) {
+            settings_config.demote_inactive_streams_values.automatic.code) {
         filter_out_inactives = exports.num_subscribed_subs() >= 30;
     } else if (page_params.demote_inactive_streams ===
-            settings_display.demote_inactive_streams_values.always.code) {
+            settings_config.demote_inactive_streams_values.always.code) {
         filter_out_inactives = true;
     } else {
         filter_out_inactives = false;

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -111,6 +111,7 @@ EXEMPT_FILES = {
     'static/js/server_events.js',
     'static/js/settings_account.js',
     'static/js/settings_bots.js',
+    'static/js/settings_config.js',
     'static/js/settings_display.js',
     'static/js/settings_emoji.js',
     'static/js/settings_exports.js',


### PR DESCRIPTION
Extracting this module breaks some dependencies
on settings_display.js (which has some annoying
transitive dependencies, including jQuery).

In particular this isolates stream_data from
from settings_display.js.

Two of the three structures that we moved here
weren't even directly used by settings_display.js,
since we do a lot of rendering in the modules
admin.js and setting.js.

We make get_all_display_settings() a function
to avoid a require-time dependency on page_params.

Breaking the dependencies simplifies a few
node tests.

Most of the node test complexity came from the
following commit in March 2019:

    5a130097bf1fc1ee9b7453192defa983f6afb90c

The commit itself seems harmless enough, but
dependencies can have a somewhat "viral" nature,
where making stream_data depend on settings_display
causes us to modify four different node tests.
