### PR TITLE
minor: Fix blueslip error to not include NaN.

### DIFF
--- a/frontend_tests/node_tests/lightbox.js
+++ b/frontend_tests/node_tests/lightbox.js
@@ -53,6 +53,8 @@ run_test('youtube', () => {
     const link = $.create('link-stub');
     const msg = $.create('msg-stub');
 
+    msg.attr("zid", "4321");
+
     $(img).attr('src', href);
 
     $(img).closest = (sel) => {

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -133,7 +133,7 @@ exports.open = function (image, options) {
             const zid = rows.id($message);
             const message = message_store.get(zid);
             if (message === undefined) {
-                blueslip.error("Lightbox for unknown message " + rows.id($message));
+                blueslip.error("Lightbox for unknown message " + zid);
             } else {
                 sender_full_name = message.sender_full_name;
             }

--- a/static/js/rows.js
+++ b/static/js/rows.js
@@ -42,7 +42,24 @@ exports.last_visible = function () {
 };
 
 exports.id = function (message_row) {
-    return parseFloat(message_row.attr('zid'));
+    /*
+        For blueslip errors, don't return early, since
+        we may have some code now that actually relies
+        on the NaN behavior here.  We can try to clean
+        that up in the future, but we mainly just want
+        more data now.
+    */
+    if (message_row.length !== 1) {
+        blueslip.error("Caller should pass in a single row.");
+    }
+
+    const zid = message_row.attr('zid');
+
+    if (zid === undefined) {
+        blueslip.error("Calling code passed rows.id a row with no zid attr.");
+    }
+
+    return parseFloat(zid);
 };
 
 const valid_table_names = {


### PR DESCRIPTION
This commit is kinda pointless, but it's still technically a simplification.  The context here was I was trying to track down some blueslip errors.  I think the root of the NaN errors is actually `rows.id` changing behavior slightly, but that's just a guess.