### PR TITLE
settings user groups: Fix organization admin can not create user groups. 

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -37,7 +37,7 @@ exports.build_page = function () {
         realm_create_stream_policy: page_params.realm_create_stream_policy,
         realm_invite_to_stream_policy: page_params.realm_invite_to_stream_policy,
         realm_user_group_edit_policy: page_params.realm_user_group_edit_policy,
-        USER_GROUP_EDIT_POLICY_MEMBERS: 1,
+        user_group_edit_policy_set_to_everyone: settings_user_groups.user_group_edit_policy_set_to_everyone,
         realm_private_message_policy: page_params.realm_private_message_policy,
         realm_name_changes_disabled: page_params.realm_name_changes_disabled,
         realm_email_changes_disabled: page_params.realm_email_changes_disabled,

--- a/static/js/settings_user_groups.js
+++ b/static/js/settings_user_groups.js
@@ -21,6 +21,10 @@ exports.reload = function () {
 
 const USER_GROUP_EDIT_POLICY_MEMBERS = 1;
 
+exports.user_group_edit_policy_set_to_everyone = function () {
+    return page_params.realm_user_group_edit_policy === USER_GROUP_EDIT_POLICY_MEMBERS;
+};
+
 exports.can_edit = function (group_id) {
     if (page_params.is_admin) {
         return true;
@@ -30,7 +34,7 @@ exports.can_edit = function (group_id) {
         return false;
     }
 
-    if (page_params.realm_user_group_edit_policy !== USER_GROUP_EDIT_POLICY_MEMBERS) {
+    if (!exports.user_group_edit_policy_set_to_everyone()) {
         return false;
     }
 

--- a/static/templates/user_groups_admin.hbs
+++ b/static/templates/user_groups_admin.hbs
@@ -1,6 +1,6 @@
 <div id="user-groups-admin" class="settings-section" data-name="user-groups-admin">
     {{#unless is_admin}}
-        {{#if (eq realm_user_group_edit_policy USER_GROUP_EDIT_POLICY_MEMBERS) }}
+        {{#if user_group_edit_policy_set_to_everyone }}
         <div class="tip">{{t 'Only group members and organization administrators can modify a group.' }}</div>
         {{else}}
         <div class="tip">{{t 'Only organization administrators can modify user groups in this organization.' }}</div>
@@ -11,7 +11,7 @@
         <p>
             {{#tr this}}User groups allow you to <a href="/help/mention-a-user-or-group" target="_blank">mention</a> multiple users at once. When you mention a user group, everyone in the group is notified as if they were individually mentioned.{{/tr}}
         </p>
-        {{#if (or is_admin (eq realm_user_group_edit_policy USER_GROUP_EDIT_POLICY_MEMBERS))}}
+        {{#if (or is_admin user_group_edit_policy_set_to_everyone)}}
         <form class="form-horizontal admin-user-group-form">
             <div class="add-new-user-group-box grey-box">
                 <div class="new-user-group-form">

--- a/static/templates/user_groups_admin.hbs
+++ b/static/templates/user_groups_admin.hbs
@@ -11,7 +11,7 @@
         <p>
             {{#tr this}}User groups allow you to <a href="/help/mention-a-user-or-group" target="_blank">mention</a> multiple users at once. When you mention a user group, everyone in the group is notified as if they were individually mentioned.{{/tr}}
         </p>
-        {{#unless (and (not (eq realm_user_group_edit_policy USER_GROUP_EDIT_POLICY_MEMBERS) (not is_admin)))}}
+        {{#if (or is_admin (eq realm_user_group_edit_policy USER_GROUP_EDIT_POLICY_MEMBERS))}}
         <form class="form-horizontal admin-user-group-form">
             <div class="add-new-user-group-box grey-box">
                 <div class="new-user-group-form">
@@ -31,7 +31,7 @@
                 </div>
             </div>
         </form>
-        {{/unless}}
+        {{/if}}
     {{/unless}}
 
     <div id="user-groups" class="new-style"></div>


### PR DESCRIPTION
The bug was in complex `if` condition, which should mean that users should
be allowed to create a User group only when they are either admin or user
group creation policy is set to everyone.

Fixes: #13909.
