### PR TITLE
tictactoe: Fix type confusion.

### DIFF
--- a/static/js/tictactoe_widget.js
+++ b/static/js/tictactoe_widget.js
@@ -130,7 +130,8 @@ exports.activate = function (opts) {
 
         elem.find("button.tictactoe-square").on('click', function (e) {
             e.stopPropagation();
-            const idx = $(e.target).attr('data-idx');
+            const str_idx = $(e.target).attr('data-idx');
+            const idx = parseInt(str_idx, 10);
 
             const data = tictactoe_data.handle.square_click.outbound(idx);
             callback(data);


### PR DESCRIPTION
With the new Map, we want to make sure we
convert the square number into an int.

The symptom here was you'd click on the
square, and the data would get passed
around via the event system, but when
we went to draw the board, the idx value
was a string.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
