### PR TITLE
stream settings: Fix issues with viewing/editing long stream names.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -768,6 +768,7 @@ exports.initialize = function () {
         $("body").on("click", "[data-make-editable]", function () {
             const selector = $(this).attr("data-make-editable");
             const edit_area = $(this).parent().find(selector);
+            $(selector).removeClass("stream-name-edit-box");
             if (edit_area.attr("contenteditable") === "true") {
                 $("[data-finish-editing='" + selector + "']").hide();
                 edit_area.attr("contenteditable", false);
@@ -776,6 +777,7 @@ exports.initialize = function () {
             } else {
                 $("[data-finish-editing='" + selector + "']").show();
 
+                $(selector).addClass("stream-name-edit-box");
                 edit_area.attr("data-prev-text", edit_area.text().trim())
                     .attr("contenteditable", true);
 
@@ -791,6 +793,7 @@ exports.initialize = function () {
 
         $("body").on("click", "[data-finish-editing]", function (e) {
             const selector = $(this).attr("data-finish-editing");
+            $(selector).removeClass("stream-name-edit-box");
             if (map[selector].on_save) {
                 map[selector].on_save(e);
                 $(this).hide();

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -800,9 +800,20 @@ form#add_new_subscription {
             margin-left: -3px;
             padding-bottom: 5px;
             white-space: nowrap;
-            width: 270px;
-            overflow: hidden;
-            text-overflow: ellipsis;
+            max-width: 260px;
+
+            .stream-name-editable {
+                display: block;
+                max-width: 20ch;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                float: left;
+            }
+
+            .stream-name-edit-box {
+                text-overflow: clip;
+                border-style: groove;
+            }
         }
 
         .deactivate,


### PR DESCRIPTION
In continuation to #13250 

-the stream name edit button is now visible for long names too.
-ellipsis are removed when you click on edit name option.
-added border while editing name to give a text-box feel.

The last two changes are reverted back to original (i.e. ellipsis and no border) once you finish editing the stream name.

P.S.- clicking on anywhere else updates the new name perfectly

If ellipsis were kept-
<img width="260" alt="Annotation 2020-03-07 151720" src="https://user-images.githubusercontent.com/47082523/76141184-c4fd2f80-6087-11ea-9b58-a18cafdad596.png">

Without adding border during editing doesn't exactly convey that the text is editable-
![new](https://user-images.githubusercontent.com/47082523/76141231-3b019680-6088-11ea-92e7-6558a7236cf6.gif)

AFTER CHANGES-
![1](https://user-images.githubusercontent.com/47082523/75089559-feaa4280-557f-11ea-994f-a6833a40f68a.gif)

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


