### PR TITLE
ui: Increased tooltip font-size

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -496,6 +496,7 @@ strong {
     .tooltip-inner {
         background-color: hsla(0, 0%, 7%, 0.8);
         padding: 3px 5px;
+        font-size: 14px;
     }
 }
 


### PR DESCRIPTION
Increased tooltip font-size to 14px.

Fixes #13261

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before:

![2020-02-23_19-25-47-1920x1080](https://user-images.githubusercontent.com/43504292/75113270-52955400-5672-11ea-8a7e-971209342db3.png)

After:

![2020-02-23_19-25-30-1920x1080](https://user-images.githubusercontent.com/43504292/75113273-5f19ac80-5672-11ea-92f0-0ced59ead542.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
