### PR TITLE
Improvements to find-account page

### DIFF
--- a/templates/zerver/emails/find_team.source.html
+++ b/templates/zerver/emails/find_team.source.html
@@ -5,21 +5,29 @@
 {% endblock %}
 
 {% block content %}
-<p>{% trans %}Hi {{ user_name }},{% endtrans %}</p>
+    {% if realm_name %}
+    <p>{% trans %}Hi {{ user_name }},{% endtrans %}</p>
 
-<p>{% trans %}You can log in to your Zulip organization, {{ realm_name }}, at the following link:{% endtrans %}</p>
+    <p>{% trans %}You can log in to your Zulip organization, {{ realm_name }}, at the following link:{% endtrans %}</p>
 
-<table width="100%" border="0" cellspacing="0" cellpadding="0">
-    <tr>
-        <td align="center">
-            <a href="{{ realm_uri }}">{{ realm_uri }}</a>
-        </td>
-    </tr>
-</table>
+    <table width="100%" border="0" cellspacing="0" cellpadding="0">
+        <tr>
+            <td align="center">
+                <a href="{{ realm_uri }}">{{ realm_uri }}</a>
+            </td>
+        </tr>
+    </table>
 
-<p>{% trans %}The email address associated with your account is {{ email }}.{% endtrans %}</p>
+    <p>{% trans %}The email address associated with your account is {{ email }}.{% endtrans %}</p>
 
-<p>{% trans %}If you have trouble logging in, please contact Zulip support by replying to this email.{% endtrans %}</p>
+    <p>{% trans %}If you have trouble logging in, please contact Zulip support by replying to this email.{% endtrans %}</p>
 
-<p>{{ _("Thanks for using Zulip!") }}</p>
+    <p>{{ _("Thanks for using Zulip!") }}</p>
+    {% else %}
+    <p>{% trans %}Hi,{% endtrans %}</p>
+
+    <p>{% trans %}This email address is not associated with any active
+    Zulip account hosed by <a href="{{ realm_uri }}">{{ external_host }}</a>.{% endtrans %}</p>
+
+    {% endif %}
 {% endblock %}

--- a/templates/zerver/emails/find_team.subject.txt
+++ b/templates/zerver/emails/find_team.subject.txt
@@ -1,1 +1,5 @@
-{{ _("Your Zulip login page") }}
+{% if realm_name %}
+    {{ _("Your Zulip login page") }}
+{% else %}
+    {{ _("No Zulip account found") }}
+{% endif %}

--- a/templates/zerver/emails/find_team.txt
+++ b/templates/zerver/emails/find_team.txt
@@ -1,3 +1,4 @@
+{% if realm_name %}
 {% trans -%}
 Hi {{ user_name }},
 {%- endtrans %}
@@ -16,3 +17,16 @@ You can log in to your Zulip organization, {{ realm_name }}, at the following li
 
 
 {{ _("Thanks for using Zulip!") }}
+{% else %}
+{% trans -%}
+Hi,
+{%- endtrans %}
+
+
+{% trans %}Seems like your email address isn't registered with any Zulip organization.{% endtrans %}
+
+
+{% trans %}This email address is not associated with any active Zulip account hosed by {{ external_host }}.{% endtrans %}
+
+
+{% endif%}

--- a/templates/zerver/find_account.html
+++ b/templates/zerver/find_account.html
@@ -12,7 +12,7 @@
             {% if emails %}
             <div id="results">
                 <p>
-                    Emails sent! You will only receive emails at addresses associated
+                    Emails sent! You will soon receive emails at addresses associated
                     with Zulip organizations. The addresses entered on the previous page
                     are listed below:
                 </p>

--- a/zerver/views/development/email_log.py
+++ b/zerver/views/development/email_log.py
@@ -87,7 +87,7 @@ def generate_all_emails(request: HttpRequest) -> HttpResponse:
 
     # Find account email
     result = client.post('/accounts/find/', {'emails': registered_email}, **host_kwargs)
-    assert result.status_code == 302
+    assert result.status_code == 200
 
     # New login email
     logged_in = client.login(dev_auth_username=registered_email, realm=realm)


### PR DESCRIPTION
Partially Fixed #3128 

- [ ]  You shouldn't be able to click "Find team" if you don't have a valid list of email addresses. Slack does this really nicely: https://slack.com/signin/find
- [x]  We should send an email regardless of whether they are in a Zulip org or not. 
- [ ]  The followup page should have links to resend the email or enter a different email address. 
- [x]  The URL of the followup page currently has the email as a URL parameter, which should be removed.

**Testing Plan:** <!-- How have you tested? -->
Creating multiple organizations on local workspace and attach a user to multiple user.
Enter multiple email id on /accounts/find page a mix or single org account, multiple org account, email not registered on any org.