### PR TITLE
Fix user-agents used in automated tests

### DIFF
--- a/zerver/lib/server_initialization.py
+++ b/zerver/lib/server_initialization.py
@@ -14,9 +14,13 @@ def create_internal_realm() -> None:
 
     realm = Realm.objects.create(string_id=settings.SYSTEM_BOT_REALM)
 
-    # Create the "website" and "API" clients:
+    # Create some client objects for common requests.  Not required;
+    # just ensures these get low IDs in production, and in development
+    # avoids an extra database write for the first HTTP requset in
+    # most tests.
     get_client("website")
-    get_client("API")
+    get_client("ZulipMobile")
+    get_client("ZulipElectron")
 
     internal_bots = [(bot['name'], bot['email_template'] % (settings.INTERNAL_BOT_DOMAIN,))
                      for bot in settings.INTERNAL_BOTS]

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -135,6 +135,22 @@ class ZulipTestCase(TestCase):
         elif 'HTTP_HOST' not in kwargs:
             kwargs['HTTP_HOST'] = Realm.host_for_subdomain(self.DEFAULT_SUBDOMAIN)
 
+        # set User-Agent
+        if 'HTTP_AUTHORIZATION' in kwargs:
+            # An API request; use mobile as the default user agent
+            default_user_agent = "ZulipMobile/26.22.145 (iOS 10.3.1)"
+        else:
+            # A webapp request; use a browser User-Agent string.
+            default_user_agent = ("Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
+                                  "AppleWebKit/537.36 (KHTML, like Gecko) " +
+                                  "Chrome/79.0.3945.130 Safari/537.36")
+        if kwargs.get('skip_user_agent'):
+            # Provide a way to disable setting User-Agent if desired.
+            assert 'HTTP_USER_AGENT' not in kwargs
+            del kwargs['skip_user_agent']
+        elif 'HTTP_USER_AGENT' not in kwargs:
+            kwargs['HTTP_USER_AGENT'] = default_user_agent
+
     @instrument_url
     def client_patch(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
         """

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -128,7 +128,7 @@ class ZulipTestCase(TestCase):
     DEFAULT_SUBDOMAIN = "zulip"
     TOKENIZED_NOREPLY_REGEX = settings.TOKENIZED_NOREPLY_EMAIL_ADDRESS.format(token="[a-z0-9_]{24}")
 
-    def set_http_host(self, kwargs: Dict[str, Any]) -> None:
+    def set_http_headers(self, kwargs: Dict[str, Any]) -> None:
         if 'subdomain' in kwargs:
             kwargs['HTTP_HOST'] = Realm.host_for_subdomain(kwargs['subdomain'])
             del kwargs['subdomain']
@@ -142,7 +142,7 @@ class ZulipTestCase(TestCase):
         """
         encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
-        self.set_http_host(kwargs)
+        self.set_http_headers(kwargs)
         return django_client.patch(url, encoded, **kwargs)
 
     @instrument_url
@@ -157,7 +157,7 @@ class ZulipTestCase(TestCase):
         """
         encoded = encode_multipart(BOUNDARY, info)
         django_client = self.client  # see WRAPPER_COMMENT
-        self.set_http_host(kwargs)
+        self.set_http_headers(kwargs)
         return django_client.patch(
             url,
             encoded,
@@ -168,34 +168,34 @@ class ZulipTestCase(TestCase):
     def client_put(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
         encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
-        self.set_http_host(kwargs)
+        self.set_http_headers(kwargs)
         return django_client.put(url, encoded, **kwargs)
 
     @instrument_url
     def client_delete(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
         encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
-        self.set_http_host(kwargs)
+        self.set_http_headers(kwargs)
         return django_client.delete(url, encoded, **kwargs)
 
     @instrument_url
     def client_options(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
         encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
-        self.set_http_host(kwargs)
+        self.set_http_headers(kwargs)
         return django_client.options(url, encoded, **kwargs)
 
     @instrument_url
     def client_head(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
         encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
-        self.set_http_host(kwargs)
+        self.set_http_headers(kwargs)
         return django_client.head(url, encoded, **kwargs)
 
     @instrument_url
     def client_post(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
         django_client = self.client  # see WRAPPER_COMMENT
-        self.set_http_host(kwargs)
+        self.set_http_headers(kwargs)
         return django_client.post(url, info, **kwargs)
 
     @instrument_url
@@ -215,7 +215,7 @@ class ZulipTestCase(TestCase):
     @instrument_url
     def client_get(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
         django_client = self.client  # see WRAPPER_COMMENT
-        self.set_http_host(kwargs)
+        self.set_http_headers(kwargs)
         return django_client.get(url, info, **kwargs)
 
     example_user_map = dict(

--- a/zerver/tests/test_compatibility.py
+++ b/zerver/tests/test_compatibility.py
@@ -78,7 +78,7 @@ class CompatibilityTest(ZulipTestCase):
     '''.strip().split('\n') if case]
 
     def test_compatibility_without_user_agent(self) -> None:
-        result = self.client_get("/compatibility")
+        result = self.client_get("/compatibility", skip_user_agent=True)
         self.assert_json_error(result, 'User-Agent header missing from request')
 
     def test_compatibility(self) -> None:

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2443,7 +2443,7 @@ class SubscriptionAPITest(ZulipTestCase):
                     streams_to_sub,
                     dict(principals=ujson.dumps([user1.email, user2.email])),
                 )
-        self.assert_length(queries, 43)
+        self.assert_length(queries, 42)
 
         self.assert_length(events, 7)
         for ev in [x for x in events if x['event']['type'] not in ('message', 'stream')]:
@@ -2817,7 +2817,7 @@ class SubscriptionAPITest(ZulipTestCase):
         # Make sure Zephyr mirroring realms such as MIT do not get
         # any tornado subscription events
         self.assert_length(events, 0)
-        self.assert_length(queries, 8)
+        self.assert_length(queries, 7)
 
         events = []
         with tornado_redirected_to_list(events):
@@ -2843,7 +2843,7 @@ class SubscriptionAPITest(ZulipTestCase):
                 dict(principals=ujson.dumps([self.test_email])),
             )
         # Make sure we don't make O(streams) queries
-        self.assert_length(queries, 19)
+        self.assert_length(queries, 18)
 
     def test_subscriptions_add_for_principal(self) -> None:
         """
@@ -3232,7 +3232,7 @@ class SubscriptionAPITest(ZulipTestCase):
                 [new_streams[0]],
                 dict(principals=ujson.dumps([user1.email, user2.email])),
             )
-        self.assert_length(queries, 43)
+        self.assert_length(queries, 42)
 
         # Test creating private stream.
         with queries_captured() as queries:

--- a/zerver/tests/test_tornado.py
+++ b/zerver/tests/test_tornado.py
@@ -37,7 +37,7 @@ class TornadoWebTestCase(AsyncHTTPTestCase, ZulipTestCase):
 
     def client_get(self, path: str, **kwargs: Any) -> HTTPResponse:
         self.add_session_cookie(kwargs)
-        self.set_http_host(kwargs)
+        self.set_http_headers(kwargs)
         if 'HTTP_HOST' in kwargs:
             kwargs['headers']['Host'] = kwargs['HTTP_HOST']
             del kwargs['HTTP_HOST']
@@ -45,7 +45,7 @@ class TornadoWebTestCase(AsyncHTTPTestCase, ZulipTestCase):
 
     def fetch_async(self, method: str, path: str, **kwargs: Any) -> None:
         self.add_session_cookie(kwargs)
-        self.set_http_host(kwargs)
+        self.set_http_headers(kwargs)
         if 'HTTP_HOST' in kwargs:
             kwargs['headers']['Host'] = kwargs['HTTP_HOST']
             del kwargs['HTTP_HOST']
@@ -57,7 +57,7 @@ class TornadoWebTestCase(AsyncHTTPTestCase, ZulipTestCase):
         )
 
     def client_get_async(self, path: str, **kwargs: Any) -> None:
-        self.set_http_host(kwargs)
+        self.set_http_headers(kwargs)
         self.fetch_async('GET', path, **kwargs)
 
     def login(self, *args: Any, **kwargs: Any) -> None:

--- a/zerver/tests/test_tornado.py
+++ b/zerver/tests/test_tornado.py
@@ -37,6 +37,7 @@ class TornadoWebTestCase(AsyncHTTPTestCase, ZulipTestCase):
 
     def client_get(self, path: str, **kwargs: Any) -> HTTPResponse:
         self.add_session_cookie(kwargs)
+        kwargs['skip_user_agent'] = True
         self.set_http_headers(kwargs)
         if 'HTTP_HOST' in kwargs:
             kwargs['headers']['Host'] = kwargs['HTTP_HOST']
@@ -45,6 +46,7 @@ class TornadoWebTestCase(AsyncHTTPTestCase, ZulipTestCase):
 
     def fetch_async(self, method: str, path: str, **kwargs: Any) -> None:
         self.add_session_cookie(kwargs)
+        kwargs['skip_user_agent'] = True
         self.set_http_headers(kwargs)
         if 'HTTP_HOST' in kwargs:
             kwargs['headers']['Host'] = kwargs['HTTP_HOST']
@@ -57,6 +59,7 @@ class TornadoWebTestCase(AsyncHTTPTestCase, ZulipTestCase):
         )
 
     def client_get_async(self, path: str, **kwargs: Any) -> None:
+        kwargs['skip_user_agent'] = True
         self.set_http_headers(kwargs)
         self.fetch_async('GET', path, **kwargs)
 
@@ -78,7 +81,8 @@ class TornadoWebTestCase(AsyncHTTPTestCase, ZulipTestCase):
         kwargs['headers'] = headers
 
     def create_queue(self, **kwargs: Any) -> str:
-        response = self.client_get('/json/events?dont_block=true', subdomain="zulip")
+        response = self.client_get('/json/events?dont_block=true', subdomain="zulip",
+                                   skip_user_agent=True)
         self.assertEqual(response.code, 200)
         body = ujson.loads(response.body)
         self.assertEqual(body['events'], [])


### PR DESCRIPTION
See the commit messages for details, but in short, this makes our automated tests use real `User-Agent` strings for outgoing HTTP requests, rather than sending somewhat unusual HTTP requests that don't specify that header.

The net effect beyond more realistic testing is that it is removes an extra database query in the first HTTP query in each of our automated tests that has been used to create a Client object, which could be annoying when counting database queries.

@showell FYI, feel free to merge if you're happy with this and it passes CI.