### PR TITLE
webpack: Generalize debug-require-webpack-plugin interface

### DIFF
--- a/static/js/bundles/common.js
+++ b/static/js/bundles/common.js
@@ -1,5 +1,6 @@
 import "core-js/features/promise";
 import "core-js/features/symbol";
+import "../../../tools/debug-require";
 import "jquery/dist/jquery.js";
 import "underscore/underscore.js";
 import "../page_params.js";

--- a/tools/debug-require.js
+++ b/tools/debug-require.js
@@ -1,0 +1,11 @@
+/* global __webpack_require__ */
+
+function debugRequire(request) {
+    return __webpack_require__(debugRequire.ids[request]);
+}
+
+debugRequire.initialize = function (ids) {
+    debugRequire.ids = ids;
+};
+
+module.exports = debugRequire;

--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -219,6 +219,7 @@ export default (env?: string): webpack.Configuration[] => {
     // Use the unminified versions of jquery and underscore so that
     // Good error messages show up in production and development in the source maps
     const exposeOptions = [
+        { path: "./debug-require.js", name: "require" },
         { path: "blueimp-md5/js/md5.js" },
         { path: "clipboard/dist/clipboard.js", name: "ClipboardJS" },
         { path: "xdate/src/xdate.js", name: "XDate" },


### PR DESCRIPTION
Now the caller simply imports the debug `require` function as a module, deciding for itself how to expose it and with what name (in our case, we expose it as `require` with `expose-loader`).  Also, remove a stray `console.log`.

**Testing Plan:** Dev server.