### PR TITLE
actions: Make do_change_plan_type support changing plan to SELF_HOSTED

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3471,7 +3471,11 @@ def do_change_plan_type(realm: Realm, plan_type: int) -> None:
                                  realm=realm, event_time=timezone_now(),
                                  extra_data={'old_value': old_value, 'new_value': plan_type})
 
-    if plan_type == Realm.STANDARD:
+    if plan_type == Realm.SELF_HOSTED:
+        realm.max_invites = None  # type: ignore # https://github.com/python/mypy/issues/3004
+        realm.message_visibility_limit = None
+        realm.upload_quota_gb = None
+    elif plan_type == Realm.STANDARD:
         realm.max_invites = Realm.INVITES_STANDARD_REALM_DAILY_MAX
         realm.message_visibility_limit = None
         realm.upload_quota_gb = Realm.UPLOAD_QUOTA_STANDARD

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -457,9 +457,7 @@ class Realm(models.Model):
 
     @property
     def max_invites(self) -> int:
-        if self._max_invites is None:
-            return settings.INVITES_DEFAULT_REALM_DAILY_MAX
-        return self._max_invites
+        return self._max_invites or settings.INVITES_DEFAULT_REALM_DAILY_MAX
 
     @max_invites.setter
     def max_invites(self, value: int) -> None:

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -58,6 +58,7 @@ from zerver.lib.actions import (
     do_change_icon_source,
     do_change_logo_source,
     do_update_user_presence,
+    do_change_plan_type,
 )
 
 from zerver.lib.test_runner import slow
@@ -1159,8 +1160,7 @@ class ImportExportTest(ZulipTestCase):
 
     def test_plan_type(self) -> None:
         realm = get_realm('zulip')
-        realm.plan_type = Realm.STANDARD
-        realm.save(update_fields=['plan_type'])
+        do_change_plan_type(realm, Realm.LIMITED)
 
         self._setup_export_files()
         self._export_realm(realm)
@@ -1169,12 +1169,18 @@ class ImportExportTest(ZulipTestCase):
             with self.settings(BILLING_ENABLED=True):
                 realm = do_import_realm(os.path.join(settings.TEST_WORKER_DIR, 'test-export'),
                                         'test-zulip-1')
-                self.assertTrue(realm.plan_type, Realm.LIMITED)
+                self.assertEqual(realm.plan_type, Realm.LIMITED)
+                self.assertEqual(realm.max_invites, 100)
+                self.assertEqual(realm.upload_quota_gb, 5)
+                self.assertEqual(realm.message_visibility_limit, 10000)
                 self.assertTrue(RealmAuditLog.objects.filter(
                     realm=realm, event_type=RealmAuditLog.REALM_PLAN_TYPE_CHANGED).exists())
             with self.settings(BILLING_ENABLED=False):
                 realm = do_import_realm(os.path.join(settings.TEST_WORKER_DIR, 'test-export'),
                                         'test-zulip-2')
-                self.assertTrue(realm.plan_type, Realm.SELF_HOSTED)
+                self.assertEqual(realm.plan_type, Realm.SELF_HOSTED)
+                self.assertEqual(realm.max_invites, 100)
+                self.assertEqual(realm.upload_quota_gb, None)
+                self.assertEqual(realm.message_visibility_limit, None)
                 self.assertTrue(RealmAuditLog.objects.filter(
                     realm=realm, event_type=RealmAuditLog.REALM_PLAN_TYPE_CHANGED).exists())

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -633,21 +633,32 @@ class RealmTest(ZulipTestCase):
 
         do_change_plan_type(realm, Realm.STANDARD)
         realm = get_realm('zulip')
+        self.assertEqual(realm.plan_type, Realm.STANDARD)
         self.assertEqual(realm.max_invites, Realm.INVITES_STANDARD_REALM_DAILY_MAX)
         self.assertEqual(realm.message_visibility_limit, None)
         self.assertEqual(realm.upload_quota_gb, Realm.UPLOAD_QUOTA_STANDARD)
 
         do_change_plan_type(realm, Realm.LIMITED)
         realm = get_realm('zulip')
+        self.assertEqual(realm.plan_type, Realm.LIMITED)
         self.assertEqual(realm.max_invites, settings.INVITES_DEFAULT_REALM_DAILY_MAX)
         self.assertEqual(realm.message_visibility_limit, Realm.MESSAGE_VISIBILITY_LIMITED)
         self.assertEqual(realm.upload_quota_gb, Realm.UPLOAD_QUOTA_LIMITED)
 
         do_change_plan_type(realm, Realm.STANDARD_FREE)
         realm = get_realm('zulip')
+        self.assertEqual(realm.plan_type, Realm.STANDARD_FREE)
         self.assertEqual(realm.max_invites, Realm.INVITES_STANDARD_REALM_DAILY_MAX)
         self.assertEqual(realm.message_visibility_limit, None)
         self.assertEqual(realm.upload_quota_gb, Realm.UPLOAD_QUOTA_STANDARD)
+
+        do_change_plan_type(realm, Realm.LIMITED)
+
+        do_change_plan_type(realm, Realm.SELF_HOSTED)
+        self.assertEqual(realm.plan_type, Realm.SELF_HOSTED)
+        self.assertEqual(realm.max_invites, settings.INVITES_DEFAULT_REALM_DAILY_MAX)
+        self.assertEqual(realm.message_visibility_limit, None)
+        self.assertEqual(realm.upload_quota_gb, None)
 
 class RealmAPITest(ZulipTestCase):
 

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -632,21 +632,18 @@ class RealmTest(ZulipTestCase):
         self.assertEqual(realm.upload_quota_gb, None)
 
         do_change_plan_type(realm, Realm.STANDARD)
-        realm = get_realm('zulip')
         self.assertEqual(realm.plan_type, Realm.STANDARD)
         self.assertEqual(realm.max_invites, Realm.INVITES_STANDARD_REALM_DAILY_MAX)
         self.assertEqual(realm.message_visibility_limit, None)
         self.assertEqual(realm.upload_quota_gb, Realm.UPLOAD_QUOTA_STANDARD)
 
         do_change_plan_type(realm, Realm.LIMITED)
-        realm = get_realm('zulip')
         self.assertEqual(realm.plan_type, Realm.LIMITED)
         self.assertEqual(realm.max_invites, settings.INVITES_DEFAULT_REALM_DAILY_MAX)
         self.assertEqual(realm.message_visibility_limit, Realm.MESSAGE_VISIBILITY_LIMITED)
         self.assertEqual(realm.upload_quota_gb, Realm.UPLOAD_QUOTA_LIMITED)
 
         do_change_plan_type(realm, Realm.STANDARD_FREE)
-        realm = get_realm('zulip')
         self.assertEqual(realm.plan_type, Realm.STANDARD_FREE)
         self.assertEqual(realm.max_invites, Realm.INVITES_STANDARD_REALM_DAILY_MAX)
         self.assertEqual(realm.message_visibility_limit, None)


### PR DESCRIPTION
Thanks to @xpac1985 reporting, debugging and proposing fix to the issue. The proposed fix was modified slightly by me to set the correct value for max_invites and upload_quota_gb. 

Fixes #13974