### PR TITLE
ui: Disable "Sign up" button on registration page.

### DIFF
--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -40,9 +40,9 @@ $(function () {
             // is created.
             element.next('.help-inline.alert.alert-error').remove();
             if (element.next().is('label[for="' + element.attr('id') + '"]')) {
-                error.insertAfter(element.next()).addClass('help-inline alert alert-error');
+                error.insertAfter(element.next()).addClass('help-inline text-error');
             } else {
-                error.insertAfter(element).addClass('help-inline alert alert-error');
+                error.insertAfter(element).addClass('help-inline text-error');
             }
         },
         highlight: highlight('error'),

--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -196,4 +196,12 @@ $(function () {
     $("body").on("click", "#choose_email .choose-email-box", function () {
         this.parentNode.submit();
     });
+
+    document.getElementById('id_terms').checked = false;
+
+    $('#id_terms').on('change', function () {
+        const isChecked = this.checked;
+        document.getElementById('user-register-button').disabled = !isChecked;
+        document.getElementById('user-register-button').style.opacity = !isChecked ? 0.6 : 1;
+    });
 });

--- a/static/styles/portico/portico-signin.scss
+++ b/static/styles/portico/portico-signin.scss
@@ -287,11 +287,12 @@ html {
     .terms-of-service .text-error {
         position: relative;
         display: block;
-        top: -5px;
+        top: 20px;
         padding: 0;
         height: 0;
+        left: 1px;
 
-        font-size: 0.7em;
+        font-size: 0.75em;
         font-weight: 600;
     }
 }

--- a/static/styles/portico/portico-signin.scss
+++ b/static/styles/portico/portico-signin.scss
@@ -782,6 +782,7 @@ button.login-social-button {
         margin: 25px auto 30px;
         width: 330px;
         border-radius: 4px;
+        opacity: 0.6;
     }
 
     #id_team_subdomain.subdomain {

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -227,7 +227,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
                 </div>
                 {% endif %}
                 <div class="register-button-box">
-                    <button class="register-button" type="submit">{{ _('Sign up') }}</button>
+                    <button class="register-button" id="user-register-button" type="submit" disabled>{{ _('Sign up') }}</button>
                     <input type="hidden" name="next" value="{{ next }}" />
                 </div>
             </div>


### PR DESCRIPTION
"Sign up" button on /accounts/register page is disabled until the "Terms
and Conditions" checkbox is checked.

Fixes #14004

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

before checking the checkbox:
![2020-02-25_23-47-16-1920x1080](https://user-images.githubusercontent.com/43504292/75275174-1c023980-582a-11ea-99a2-ae618f50a806.png)

after checking the checkbox:
![2020-02-25_23-47-23-1920x1080](https://user-images.githubusercontent.com/43504292/75275178-1dcbfd00-582a-11ea-93be-0b55d5ef8ed2.png)
![Peek 2020-02-25 23-56](https://user-images.githubusercontent.com/43504292/75275442-8dda8300-582a-11ea-8f95-aaf467102180.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
