### PR TITLE
narrow: Show starred messages from muted topics in starred message view.

### DIFF
--- a/frontend_tests/node_tests/narrow_state.js
+++ b/frontend_tests/node_tests/narrow_state.js
@@ -60,6 +60,7 @@ run_test('narrowed', () => {
     assert(!narrow_state.narrowed_to_topic());
     assert(!narrow_state.narrowed_by_stream_reply());
     assert.equal(narrow_state.stream_id(), undefined);
+    assert(!narrow_state.narrowed_to_starred());
 
     set_filter([['stream', 'Foo']]);
     assert(!narrow_state.narrowed_to_pms());
@@ -69,6 +70,7 @@ run_test('narrowed', () => {
     assert(!narrow_state.narrowed_to_search());
     assert(!narrow_state.narrowed_to_topic());
     assert(narrow_state.narrowed_by_stream_reply());
+    assert(!narrow_state.narrowed_to_starred());
 
     set_filter([['pm-with', 'steve@zulip.com']]);
     assert(narrow_state.narrowed_to_pms());
@@ -78,6 +80,7 @@ run_test('narrowed', () => {
     assert(!narrow_state.narrowed_to_search());
     assert(!narrow_state.narrowed_to_topic());
     assert(!narrow_state.narrowed_by_stream_reply());
+    assert(!narrow_state.narrowed_to_starred());
 
     set_filter([['stream', 'Foo'], ['topic', 'bar']]);
     assert(!narrow_state.narrowed_to_pms());
@@ -87,6 +90,7 @@ run_test('narrowed', () => {
     assert(!narrow_state.narrowed_to_search());
     assert(narrow_state.narrowed_to_topic());
     assert(!narrow_state.narrowed_by_stream_reply());
+    assert(!narrow_state.narrowed_to_starred());
 
     set_filter([['search', 'grail']]);
     assert(!narrow_state.narrowed_to_pms());
@@ -96,6 +100,17 @@ run_test('narrowed', () => {
     assert(narrow_state.narrowed_to_search());
     assert(!narrow_state.narrowed_to_topic());
     assert(!narrow_state.narrowed_by_stream_reply());
+    assert(!narrow_state.narrowed_to_starred());
+
+    set_filter([['is', 'starred']]);
+    assert(!narrow_state.narrowed_to_pms());
+    assert(!narrow_state.narrowed_by_reply());
+    assert(!narrow_state.narrowed_by_pm_reply());
+    assert(!narrow_state.narrowed_by_topic_reply());
+    assert(!narrow_state.narrowed_to_search());
+    assert(!narrow_state.narrowed_to_topic());
+    assert(!narrow_state.narrowed_by_stream_reply());
+    assert(narrow_state.narrowed_to_starred());
 });
 
 run_test('operators', () => {
@@ -132,6 +147,8 @@ run_test('muting_enabled', () => {
     set_filter([['is', 'private']]);
     assert(!narrow_state.muting_enabled());
 
+    set_filter([['is', 'starred']]);
+    assert(!narrow_state.muting_enabled());
 });
 
 run_test('set_compose_defaults', () => {

--- a/static/js/narrow_state.js
+++ b/static/js/narrow_state.js
@@ -333,9 +333,16 @@ exports.narrowed_to_search = function () {
     return current_filter !== undefined && current_filter.is_search();
 };
 
+exports.narrowed_to_starred = function () {
+    if (current_filter === undefined) {
+        return false;
+    }
+    return current_filter.has_operand("is", "starred");
+};
+
 exports.muting_enabled = function () {
     return !exports.narrowed_to_topic() && !exports.narrowed_to_search() &&
-            !exports.narrowed_to_pms();
+            !exports.narrowed_to_pms() && !exports.narrowed_to_starred();
 };
 
 exports.is_for_stream_id = function (stream_id) {


### PR DESCRIPTION
Starred messages from muted topics were not shown in the starred
messages view. Condition for muting_enabled is modified accordingly
such that the starred messages from muted topics are shown in the
starred messages narrowed view.

Fixes #13548

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Node tests are updated accordingly and the change is manually tested.



**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
