### PR TITLE
unread: Convert ids.push(...a) to a loop

### DIFF
--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -159,7 +159,9 @@ exports.unread_pm_counter = (function () {
         const ids = [];
 
         for (const id_set of bucketer.values()) {
-            ids.push(...Array.from(id_set));
+            for (const id of id_set) {
+                ids.push(id);
+            }
         }
 
         return util.sorted_ids(ids);
@@ -331,9 +333,11 @@ exports.unread_topic_counter = (function () {
 
         const ids = [];
         const sub = stream_data.get_sub_by_id(stream_id);
-        for (const [topic, msgs] of per_stream_bucketer) {
+        for (const [topic, id_set] of per_stream_bucketer) {
             if (sub && !muting.is_topic_muted(stream_id, topic)) {
-                ids.push(...Array.from(msgs));
+                for (const id of id_set) {
+                    ids.push(id);
+                }
             }
         }
 


### PR DESCRIPTION
Calling a function with hundreds of thousands to millions of arguments, depending on the browser, can throw a `RangeError`. This was true of both `ids.push(...a)` and the `[].concat.apply` construction that it replaced in commit 59d55d1e065bfabc105b97dd5664e186dc69f4a0, although the old one was less likely to overflow due to bucketing. Use a loop instead.