### PR TITLE
code organization: Extract `settings_data.js` (`show_email` and friends)

### DIFF
--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -8,7 +8,6 @@ zrequire('people');
 zrequire('presence');
 zrequire('buddy_data');
 zrequire('user_status');
-zrequire('settings_org');
 zrequire('feature_flags');
 zrequire('message_edit');
 

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -8,6 +8,10 @@ set_global('message_store', {
 
 set_global('i18n', global.stub_i18n);
 
+const settings_config = zrequire('settings_config');
+page_params.realm_email_address_visibility =
+    settings_config.get_email_address_visibility_values().admins_only.code;
+
 zrequire('typeahead_helper');
 set_global('Handlebars', global.make_handlebars());
 zrequire('Filter', 'js/filter');
@@ -36,10 +40,8 @@ function init() {
 }
 init();
 
+page_params.is_admin = true;
 set_global('narrow', {});
-set_global('settings_org', {
-    show_email: () => true,
-});
 
 topic_data.reset();
 
@@ -1072,7 +1074,7 @@ run_test('people_suggestion (Admin only email visibility)', () => {
     only */
     people_suggestion_setup();
     const query = 'te';
-    settings_org.show_email = () => false;
+    page_params.is_admin = false;
     const suggestions = get_suggestions('', query);
     const expected = [
         "te",

--- a/frontend_tests/node_tests/search_suggestion_legacy.js
+++ b/frontend_tests/node_tests/search_suggestion_legacy.js
@@ -7,6 +7,10 @@ set_global('message_store', {
 
 set_global('i18n', global.stub_i18n);
 
+const settings_config = zrequire('settings_config');
+page_params.realm_email_address_visibility =
+    settings_config.get_email_address_visibility_values().admins_only.code;
+
 zrequire('typeahead_helper');
 set_global('Handlebars', global.make_handlebars());
 zrequire('Filter', 'js/filter');
@@ -35,9 +39,8 @@ function init() {
 init();
 
 set_global('narrow', {});
-set_global('settings_org', {
-    show_email: () => true,
-});
+
+page_params.is_admin = true;
 
 topic_data.reset();
 

--- a/frontend_tests/node_tests/settings_data.js
+++ b/frontend_tests/node_tests/settings_data.js
@@ -1,0 +1,41 @@
+const settings_data = zrequire('settings_data');
+
+set_global('page_params', {});
+
+/*
+    Some methods in settings_data are fairly
+    trivial, so the meaningful tests happen
+    at the higher layers, such as when we
+    test people.js.
+*/
+
+const isaac = {
+    email: 'isaac@example.com',
+    delivery_email: 'isaac-delivery@example.com',
+};
+
+run_test('email_for_user_settings', () => {
+    const email = settings_data.email_for_user_settings;
+
+    settings_data.show_email = () => {
+        return false;
+    };
+
+    assert.equal(email(isaac), undefined);
+
+    settings_data.show_email = () => {
+        return true;
+    };
+
+    page_params.is_admin = true;
+    assert.equal(email(isaac), isaac.delivery_email);
+
+    // Fall back to email if delivery_email is not there.
+    assert.equal(
+        email({email: 'foo@example.com'}),
+        'foo@example.com');
+
+    page_params.is_admin = false;
+    assert.equal(email(isaac), isaac.email);
+});
+

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -497,7 +497,7 @@ function test_sync_realm_settings() {
 
         settings_org.sync_realm_settings('create_stream_policy');
         assert.equal($("#id_realm_create_stream_policy").val(),
-                     settings_config.create_stream_policy_values.by_full_members.code);
+                     settings_config.get_create_stream_policy_values().by_full_members.code);
     }
 
     {
@@ -513,7 +513,7 @@ function test_sync_realm_settings() {
 
         settings_org.sync_realm_settings('create_stream_policy');
         assert.equal($("#id_realm_create_stream_policy").val(),
-                     settings_config.create_stream_policy_values.by_members.code);
+                     settings_config.get_create_stream_policy_values().by_members.code);
     }
 
     {
@@ -529,7 +529,7 @@ function test_sync_realm_settings() {
 
         settings_org.sync_realm_settings('create_stream_policy');
         assert.equal($("#id_realm_create_stream_policy").val(),
-                     settings_config.create_stream_policy_values.by_admins_only.code);
+                     settings_config.get_create_stream_policy_values().by_admins_only.code);
     }
 
     {
@@ -545,7 +545,7 @@ function test_sync_realm_settings() {
 
         settings_org.sync_realm_settings('invite_to_stream_policy');
         assert.equal($("#id_realm_invite_to_stream_policy").val(),
-                     settings_config.create_stream_policy_values.by_full_members.code);
+                     settings_config.get_create_stream_policy_values().by_full_members.code);
     }
 
     {
@@ -561,7 +561,7 @@ function test_sync_realm_settings() {
 
         settings_org.sync_realm_settings('invite_to_stream_policy');
         assert.equal($("#id_realm_invite_to_stream_policy").val(),
-                     settings_config.create_stream_policy_values.by_members.code);
+                     settings_config.get_create_stream_policy_values().by_members.code);
     }
 
     {
@@ -577,7 +577,7 @@ function test_sync_realm_settings() {
 
         settings_org.sync_realm_settings('invite_to_stream_policy');
         assert.equal($("#id_realm_invite_to_stream_policy").val(),
-                     settings_config.create_stream_policy_values.by_admins_only.code);
+                     settings_config.get_create_stream_policy_values().by_admins_only.code);
     }
 
     {

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -301,7 +301,7 @@ run_test('is_active', () => {
     let sub;
 
     page_params.demote_inactive_streams =
-        settings_config.demote_inactive_streams_values.automatic.code;
+        settings_config.get_demote_inactive_streams_values().automatic.code;
     stream_data.set_filter_out_inactives();
 
     sub = {name: 'pets', subscribed: false, stream_id: 111};
@@ -332,7 +332,7 @@ run_test('is_active', () => {
     assert(stream_data.is_active(sub));
 
     page_params.demote_inactive_streams =
-        settings_config.demote_inactive_streams_values.always.code;
+        settings_config.get_demote_inactive_streams_values().always.code;
     stream_data.set_filter_out_inactives();
 
     sub = {name: 'pets', subscribed: false, stream_id: 111};
@@ -360,7 +360,7 @@ run_test('is_active', () => {
     assert(stream_data.is_active(sub));
 
     page_params.demote_inactive_streams =
-        settings_config.demote_inactive_streams_values.never.code;
+        settings_config.get_demote_inactive_streams_values().never.code;
     stream_data.set_filter_out_inactives();
 
     sub = {name: 'pets', subscribed: false, stream_id: 111};

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -4,6 +4,11 @@ set_global('md5', function (s) {
     return 'md5-' + s;
 });
 
+const settings_config = zrequire('settings_config');
+page_params.realm_email_address_visibility =
+    settings_config.get_email_address_visibility_values().admins_only.code;
+
+
 set_global('Handlebars', global.make_handlebars());
 zrequire('recent_senders');
 zrequire('pm_conversations');
@@ -15,7 +20,6 @@ zrequire('hash_util');
 zrequire('marked', 'third/marked/lib/marked');
 const pygments_data = zrequire('pygments_data', 'generated/pygments_data.json');
 const actual_pygments_data = Object.assign({}, pygments_data);
-zrequire('settings_org');
 const ct = zrequire('composebox_typeahead');
 const th = zrequire('typeahead_helper');
 const LazySet = zrequire('lazy_set.js').LazySet;
@@ -500,7 +504,7 @@ run_test('highlight_with_escaping', () => {
 
 run_test('render_person when emails hidden', () => {
     // Test render_person with regular person, under hidden email visiblity case
-    settings_org.show_email = () => false;
+    page_params.is_admin = false;
     let rendered = false;
     global.stub_templates(function (template_name, args) {
         assert.equal(template_name, 'typeahead_list_item');
@@ -514,7 +518,7 @@ run_test('render_person when emails hidden', () => {
 });
 
 run_test('render_person', () => {
-    settings_org.show_email = () => true;
+    page_params.is_admin = true;
     // Test render_person with regular person
     let rendered = false;
     global.stub_templates(function (template_name, args) {

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -1,4 +1,5 @@
 const settings_config = require("./settings_config");
+const settings_data = require("./settings_data");
 const render_admin_tab = require('../templates/admin_tab.hbs');
 
 const admin_settings_label = {
@@ -72,7 +73,7 @@ exports.build_page = function () {
         settings_send_digest_emails: page_params.settings_send_digest_emails,
         realm_digest_emails_enabled: page_params.realm_digest_emails_enabled,
         realm_digest_weekday: page_params.realm_digest_weekday,
-        show_email: settings_org.show_email(),
+        show_email: settings_data.show_email(),
         development: page_params.development_environment,
         plan_includes_wide_organization_logo: page_params.plan_includes_wide_organization_logo,
         upgrade_text_for_wide_organization_logo:

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -32,7 +32,8 @@ exports.build_page = function () {
         server_inline_image_preview: page_params.server_inline_image_preview,
         realm_inline_url_embed_preview: page_params.realm_inline_url_embed_preview,
         server_inline_url_embed_preview: page_params.server_inline_url_embed_preview,
-        realm_default_twenty_four_hour_time_values: settings_config.twenty_four_hour_time_values,
+        realm_default_twenty_four_hour_time_values:
+            settings_config.get_twenty_four_hour_time_values(),
         realm_authentication_methods: page_params.realm_authentication_methods,
         realm_create_stream_policy: page_params.realm_create_stream_policy,
         realm_invite_to_stream_policy: page_params.realm_invite_to_stream_policy,
@@ -80,10 +81,14 @@ exports.build_page = function () {
     };
 
     options.admin_settings_label = admin_settings_label;
-    options.msg_edit_limit_dropdown_values = settings_config.msg_edit_limit_dropdown_values;
-    options.msg_delete_limit_dropdown_values = settings_config.msg_delete_limit_dropdown_values;
+    options.msg_edit_limit_dropdown_values =
+        settings_config.get_msg_edit_limit_dropdown_values();
+    options.msg_delete_limit_dropdown_values =
+        settings_config.get_msg_delete_limit_dropdown_values();
     options.bot_creation_policy_values = settings_bots.bot_creation_policy_values;
-    options.email_address_visibility_values = settings_config.email_address_visibility_values;
+    options.email_address_visibility_values =
+        settings_config.get_email_address_visibility_values();
+
     Object.assign(options, settings_org.get_organization_settings_options());
 
     if (options.realm_logo_source !== 'D' && options.realm_night_logo_source === 'D') {

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -2,6 +2,7 @@ const util = require("./util");
 require("unorm");  // String.prototype.normalize polyfill for IE11
 const FoldDict = require('./fold_dict').FoldDict;
 const typeahead = require("../shared/js/typeahead");
+const settings_data = require("./settings_data");
 
 let people_dict;
 let people_by_name_dict;
@@ -213,16 +214,7 @@ exports.reply_to_to_user_ids_string = function (emails_string) {
 exports.get_user_time_preferences = function (user_id) {
     const user_timezone = exports.get_by_user_id(user_id).timezone;
     if (user_timezone) {
-        if (page_params.twenty_four_hour_time) {
-            return {
-                timezone: user_timezone,
-                format: "H:mm",
-            };
-        }
-        return {
-            timezone: user_timezone,
-            format: "h:mm A",
-        };
+        return settings_data.get_time_preferences(user_timezone);
     }
 };
 
@@ -1059,7 +1051,7 @@ function safe_lower(s) {
 }
 
 exports.matches_user_settings_search = function (person, value) {
-    const email = exports.email_for_user_settings(person);
+    const email = settings_data.email_for_user_settings(person);
 
     return safe_lower(person.full_name).includes(value) ||
     safe_lower(email).includes(value);
@@ -1078,18 +1070,6 @@ exports.filter_for_user_settings_search = function (persons, query) {
               See #13554 for more context.
     */
     return persons.filter(person => exports.matches_user_settings_search(person, query));
-};
-
-exports.email_for_user_settings = function (person) {
-    if (!settings_org.show_email()) {
-        return;
-    }
-
-    if (page_params.is_admin && person.delivery_email) {
-        return person.delivery_email;
-    }
-
-    return person.email;
 };
 
 exports.maybe_incr_recipient_count = function (message) {

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1,4 +1,5 @@
 const util = require("./util");
+const settings_data = require("./settings_data");
 const confirmDatePlugin = require("flatpickr/dist/plugins/confirmDate/confirmDate.js");
 const render_actions_popover_content = require('../templates/actions_popover_content.hbs');
 const render_mobile_message_buttons_popover = require('../templates/mobile_message_buttons_popover.hbs');
@@ -181,7 +182,7 @@ function render_user_info_popover(user, popover_element, is_sender_popover, priv
         user_circle_class: buddy_data.get_user_circle_class(user.user_id),
         private_message_class: private_msg_class,
         sent_by_uri: hash_util.by_sender_uri(user.email),
-        show_email: settings_org.show_email(),
+        show_email: settings_data.show_email(),
         show_user_profile: !(user.is_bot || page_params.custom_profile_fields.length === 0),
         user_email: get_visible_email(user),
         user_full_name: user.full_name,
@@ -312,7 +313,7 @@ exports.show_user_profile = function (user) {
         is_me: people.is_current_user(user.email),
         date_joined: moment(user.date_joined).format(dateFormat),
         last_seen: buddy_data.user_last_seen_time_status(user.user_id),
-        show_email: settings_org.show_email(),
+        show_email: settings_data.show_email(),
         user_time: people.get_user_time(user.user_id),
         user_type: people.get_user_type(user.user_id),
         user_is_guest: user.is_guest,

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -1,3 +1,5 @@
+const settings_data = require("./settings_data");
+
 exports.max_num_of_search_results = 12;
 
 function stream_matches_query(stream_name, q) {
@@ -8,7 +10,7 @@ function make_person_highlighter(query) {
     const hilite = typeahead_helper.make_query_highlighter(query);
 
     return function (person) {
-        if (settings_org.show_email()) {
+        if (settings_data.show_email()) {
             return hilite(person.full_name) + " &lt;" + hilite(person.email) + "&gt;";
         }
         return hilite(person.full_name);

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -110,8 +110,8 @@ exports.build_page = function () {
         timezones: moment.tz.names(),
         can_create_new_bots: settings_bots.can_create_new_bots(),
         settings_label: exports.settings_label,
-        demote_inactive_streams_values: settings_config.demote_inactive_streams_values,
-        twenty_four_hour_time_values: settings_config.twenty_four_hour_time_values,
+        demote_inactive_streams_values: settings_config.get_demote_inactive_streams_values(),
+        twenty_four_hour_time_values: settings_config.get_twenty_four_hour_time_values(),
         notification_settings: settings_notifications.all_notifications.settings,
         desktop_icon_count_display_values: settings_notifications.desktop_icon_count_display_values,
         push_notification_tooltip:

--- a/static/js/settings_config.js
+++ b/static/js/settings_config.js
@@ -12,7 +12,7 @@
     API documentation) without a ton of copying.
 */
 
-exports.demote_inactive_streams_values = {
+exports.get_demote_inactive_streams_values = () => ({
     automatic: {
         code: 1,
         description: i18n.t("Automatic"),
@@ -25,9 +25,9 @@ exports.demote_inactive_streams_values = {
         code: 3,
         description: i18n.t("Never"),
     },
-};
+});
 
-exports.twenty_four_hour_time_values = {
+exports.get_twenty_four_hour_time_values = () => ({
     twenty_four_hour_clock: {
         value: true,
         description: i18n.t("24-hour clock (17:00)"),
@@ -36,7 +36,7 @@ exports.twenty_four_hour_time_values = {
         value: false,
         description: i18n.t("12-hour clock (5:00 PM)"),
     },
-};
+});
 
 exports.get_all_display_settings = () => ({
     settings: {
@@ -55,7 +55,7 @@ exports.get_all_display_settings = () => ({
     },
 });
 
-exports.email_address_visibility_values = {
+exports.get_email_address_visibility_values = () => ({
     everyone: {
         code: 1,
         description: i18n.t("Admins, members, and guests"),
@@ -69,9 +69,9 @@ exports.email_address_visibility_values = {
         code: 3,
         description: i18n.t("Admins only"),
     },
-};
+});
 
-exports.create_stream_policy_values = {
+const get_stream_policy_values = () => ({
     by_admins_only: {
         order: 1,
         code: 2,
@@ -87,11 +87,12 @@ exports.create_stream_policy_values = {
         code: 1,
         description: i18n.t("Admins and members"),
     },
-};
+});
 
-exports.invite_to_stream_policy_values = exports.create_stream_policy_values;
+exports.get_create_stream_policy_values = get_stream_policy_values;
+exports.get_invite_to_stream_policy_values = get_stream_policy_values;
 
-exports.user_group_edit_policy_values = {
+exports.get_user_group_edit_policy_values = () => ({
     by_admins_only: {
         order: 1,
         code: 2,
@@ -102,9 +103,9 @@ exports.user_group_edit_policy_values = {
         code: 1,
         description: i18n.t("Admins and members"),
     },
-};
+});
 
-exports.private_message_policy_values = {
+exports.get_private_message_policy_values = () => ({
     by_anyone: {
         order: 1,
         code: 1,
@@ -115,9 +116,9 @@ exports.private_message_policy_values = {
         code: 2,
         description: i18n.t("Private messages disabled"),
     },
-};
+});
 
-const time_limit_dropdown_values = new Map([
+const get_time_limit_dropdown_values = () => new Map([
     ["any_time", {
         text: i18n.t("Any time"),
         seconds: 0,
@@ -149,5 +150,6 @@ const time_limit_dropdown_values = new Map([
         text: i18n.t("Up to N minutes after posting"),
     }],
 ]);
-exports.msg_edit_limit_dropdown_values = time_limit_dropdown_values;
-exports.msg_delete_limit_dropdown_values = time_limit_dropdown_values;
+
+exports.get_msg_edit_limit_dropdown_values = get_time_limit_dropdown_values;
+exports.get_msg_delete_limit_dropdown_values = get_time_limit_dropdown_values;

--- a/static/js/settings_data.js
+++ b/static/js/settings_data.js
@@ -1,0 +1,47 @@
+const settings_config = require("./settings_config");
+
+/*
+    This is a close cousin of settings_config,
+    but this has a bit more logic, and we
+    ensure 100% line coverage on it.
+
+    Our main goal with this code is to isolate
+    some key modules from having to know
+    about page_params and settings_config details.
+*/
+
+exports.show_email = function () {
+    if (page_params.realm_email_address_visibility ===
+        settings_config.get_email_address_visibility_values().everyone.code) {
+        return true;
+    }
+    if (page_params.realm_email_address_visibility ===
+        settings_config.get_email_address_visibility_values().admins_only.code) {
+        return page_params.is_admin;
+    }
+};
+
+exports.email_for_user_settings = function (person) {
+    if (!exports.show_email()) {
+        return;
+    }
+
+    if (page_params.is_admin && person.delivery_email) {
+        return person.delivery_email;
+    }
+
+    return person.email;
+};
+
+exports.get_time_preferences = function (user_timezone) {
+    if (page_params.twenty_four_hour_time) {
+        return {
+            timezone: user_timezone,
+            format: "H:mm",
+        };
+    }
+    return {
+        timezone: user_timezone,
+        format: "h:mm A",
+    };
+};

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -73,18 +73,6 @@ exports.get_organization_settings_options = () => {
     return options;
 };
 
-exports.show_email = function () {
-    // TODO: Extend this when we add support for admins_and_members above.
-    if (page_params.realm_email_address_visibility ===
-        settings_config.get_email_address_visibility_values().everyone.code) {
-        return true;
-    }
-    if (page_params.realm_email_address_visibility ===
-        settings_config.get_email_address_visibility_values().admins_only.code) {
-        return page_params.is_admin;
-    }
-};
-
 exports.get_realm_time_limits_in_minutes = function (property) {
     let val = (page_params[property] / 60).toFixed(1);
     if (parseFloat(val, 10) === parseInt(val, 10)) {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -63,24 +63,24 @@ exports.get_sorted_options_list = function (option_values_object) {
 exports.get_organization_settings_options = () => {
     const options = {};
     options.create_stream_policy_values = exports.get_sorted_options_list(
-        settings_config.create_stream_policy_values);
+        settings_config.get_create_stream_policy_values());
     options.invite_to_stream_policy_values = exports.get_sorted_options_list(
-        settings_config.invite_to_stream_policy_values);
+        settings_config.get_invite_to_stream_policy_values());
     options.user_group_edit_policy_values = exports.get_sorted_options_list(
-        settings_config.user_group_edit_policy_values);
+        settings_config.get_user_group_edit_policy_values());
     options.private_message_policy_values = exports.get_sorted_options_list(
-        settings_config.private_message_policy_values);
+        settings_config.get_private_message_policy_values());
     return options;
 };
 
 exports.show_email = function () {
     // TODO: Extend this when we add support for admins_and_members above.
     if (page_params.realm_email_address_visibility ===
-        settings_config.email_address_visibility_values.everyone.code) {
+        settings_config.get_email_address_visibility_values().everyone.code) {
         return true;
     }
     if (page_params.realm_email_address_visibility ===
-        settings_config.email_address_visibility_values.admins_only.code) {
+        settings_config.get_email_address_visibility_values().admins_only.code) {
         return page_params.is_admin;
     }
 };
@@ -123,7 +123,7 @@ function get_property_value(property_name) {
         if (!page_params.realm_allow_message_editing) {
             return "never";
         }
-        for (const [value, elem] of settings_config.msg_edit_limit_dropdown_values) {
+        for (const [value, elem] of settings_config.get_msg_edit_limit_dropdown_values()) {
             if (elem.seconds === page_params.realm_message_content_edit_limit_seconds) {
                 return value;
             }
@@ -135,7 +135,7 @@ function get_property_value(property_name) {
         if (!page_params.realm_allow_message_deleting) {
             return "never";
         }
-        for (const [value, elem] of settings_config.msg_delete_limit_dropdown_values) {
+        for (const [value, elem] of settings_config.get_msg_delete_limit_dropdown_values()) {
             if (elem.seconds === page_params.realm_message_content_delete_limit_seconds) {
                 return value;
             }
@@ -679,7 +679,6 @@ exports.build_page = function () {
 
     function get_complete_data_for_subsection(subsection) {
         let data = {};
-
         if (subsection === 'msg_editing') {
             const edit_limit_setting_value = $("#id_realm_msg_edit_limit_setting").val();
             if (edit_limit_setting_value === 'never') {
@@ -691,7 +690,7 @@ exports.build_page = function () {
             } else {
                 data.allow_message_editing = true;
                 data.message_content_edit_limit_seconds =
-                    settings_config.msg_edit_limit_dropdown_values.get(
+                    settings_config.get_msg_edit_limit_dropdown_values().get(
                         edit_limit_setting_value
                     ).seconds;
             }
@@ -705,7 +704,7 @@ exports.build_page = function () {
             } else {
                 data.allow_message_deleting = true;
                 data.message_content_delete_limit_seconds =
-                    settings_config.msg_delete_limit_dropdown_values.get(
+                    settings_config.get_msg_delete_limit_dropdown_values().get(
                         delete_limit_setting_value
                     ).seconds;
             }

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -1,3 +1,4 @@
+const settings_data = require("./settings_data");
 const render_admin_user_list = require("../templates/admin_user_list.hbs");
 const render_bot_owner_select = require("../templates/bot_owner_select.hbs");
 const render_user_info_form_modal = require('../templates/user_info_form_modal.hbs');
@@ -210,7 +211,7 @@ function populate_users(realm_people_data) {
             const $row = $(render_admin_user_list({
                 can_modify: page_params.is_admin,
                 is_current_user: people.is_my_user_id(item.user_id),
-                display_email: people.email_for_user_settings(item),
+                display_email: settings_data.email_for_user_settings(item),
                 user: item,
             }));
             $row.find(".last_active").append(get_rendered_last_activity(item));
@@ -246,7 +247,7 @@ function populate_users(realm_people_data) {
         modifier: function (item) {
             return render_admin_user_list({
                 user: item,
-                display_email: people.email_for_user_settings(item),
+                display_email: settings_data.email_for_user_settings(item),
                 can_modify: page_params.is_admin,
             });
         },

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -116,10 +116,10 @@ exports.clear_subscriptions();
 
 exports.set_filter_out_inactives = function () {
     if (page_params.demote_inactive_streams ===
-            settings_config.demote_inactive_streams_values.automatic.code) {
+            settings_config.get_demote_inactive_streams_values().automatic.code) {
         filter_out_inactives = exports.num_subscribed_subs() >= 30;
     } else if (page_params.demote_inactive_streams ===
-            settings_config.demote_inactive_streams_values.always.code) {
+            settings_config.get_demote_inactive_streams_values().always.code) {
         filter_out_inactives = true;
     } else {
         filter_out_inactives = false;

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -2,6 +2,7 @@ const util = require("./util");
 const pygments_data = require("../generated/pygments_data.json");
 const typeahead = require("../shared/js/typeahead");
 const render_typeahead_list_item = require('../templates/typeahead_list_item.hbs');
+const settings_data = require("./settings_data");
 
 // Returns an array of private message recipients, removing empty elements.
 // For example, "a,,b, " => ["a", "b"]
@@ -82,7 +83,7 @@ exports.render_person = function (person) {
             img_src: avatar_url,
             is_person: true,
         };
-        if (settings_org.show_email()) {
+        if (settings_data.show_email()) {
             typeahead_arguments.secondary = person.email;
         }
         html = exports.render_typeahead_item(typeahead_arguments);


### PR DESCRIPTION
This PR creates a nice helper module that breaks some really ugly dependencies in our codebase, while ensuring 100% line coverage.

It requires a prep commit that was originally pushed in #14026.  I added extensive comments to the commit message to try to address some concerns there.  If we're both online later today, it's probably easiest to hash this out over chat.