### PR TITLE
[WIP]frontend: Fix normal users cannot see their invitee list.

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "babel-plugin-rewire-ts": "^1.3.3",
     "casperjs": "casperjs/casperjs",
     "difflib": "^0.2.4",
-    "eslint": "^6.6.0",
+    "eslint": "^6.8.0",
     "eslint-plugin-empty-returns": "^1.0.2",
     "jsdom": "^16.1.0",
     "nyc": "^15.0.0",

--- a/templates/zerver/app/settings_overlay.html
+++ b/templates/zerver/app/settings_overlay.html
@@ -140,11 +140,11 @@
                     <div class="text">{{ _('Custom profile fields') }}</div>
                 </li>
                 {% endif %}
-                {% if is_admin %}
                 <li tabindex="0" data-section="invites-list-admin">
                     <i class="icon fa fa-user" aria-hidden="true"></i>
                     <div class="text">{{ _('Invitations') }}</div>
                 </li>
+                {% if is_admin %}
                 <li tabindex="0" data-section="data-exports-admin">
                     <i class="icon fa fa-database" aria-hidden="true"></i>
                     <div class="text">{{ _('Data exports') }}</div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4182,7 +4182,7 @@ eslint-visitor-keys@^1.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@^6.6.0:
+eslint@^6.8.0:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.8.0.tgz#62262d6729739f9275723824302fb227c8c93ffb"
   integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5204,7 +5204,8 @@ def do_get_user_invites(user_profile: UserProfile) -> List[Dict[str, Any]]:
     lowest_datetime = timezone_now() - datetime.timedelta(days=days_to_activate)
     prereg_users = PreregistrationUser.objects.exclude(status=active_value).filter(
         invited_at__gte=lowest_datetime,
-        referred_by__realm=user_profile.realm)
+        referred_by__realm=user_profile.realm,
+        referred_by=user_profile)
 
     invites = []
 

--- a/zerver/views/invite.py
+++ b/zerver/views/invite.py
@@ -59,9 +59,12 @@ def get_invitee_emails_set(invitee_emails_raw: str) -> Set[str]:
         invitee_emails.add(email.strip())
     return invitee_emails
 
-@require_realm_admin
+@require_member_or_admin
+@has_request_variables
 def get_user_invites(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
     all_users = do_get_user_invites(user_profile)
+    print("User email:", user_profile.short_name)
+    print("all users:", all_users)
     return json_success({'invites': all_users})
 
 @require_realm_admin


### PR DESCRIPTION
The invites sent by a normal user were not accessible to him.

Fixes: https://github.com/zulip/zulip/issues/14007

Earlier there was no invitations link when we view the organization settings. I have added the changes and now its working the same way like in the admin account.

Follow up: Should I make a similar workflow for the member user or change the current code so that it addresses both the users[example: changing invites-admin-list -> invites-list]

