### PR TITLE
hashchange: Update state.old_hash before returning early

### DIFF
--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -228,15 +228,12 @@ function do_hashchange_overlay(old_hash) {
 }
 
 function hashchanged(from_reload, e) {
+    const old_hash = e && (e.oldURL ? new URL(e.oldURL).hash : state.old_hash);
+    state.old_hash = window.location.hash;
+
     if (state.is_internal_change) {
         state.is_internal_change = false;
         return;
-    }
-
-    let old_hash;
-    if (e) {
-        old_hash = "#" + (e.oldURL || state.old_hash).split(/#/).slice(1).join("");
-        state.old_hash = window.location.hash;
     }
 
     if (is_overlay_hash(window.location.hash)) {


### PR DESCRIPTION
This fixes a bug where you can’t open the same overlay twice in a row in IE 11, which doesn’t support `HashChangeEvent.oldURL`; it was exposed by commit 05be16e051b1fd797429ff50cb90644543730a17 (late 2018).

While here, parse the hash from `oldURL` in a less ad-hoc way.

**Testing Plan:** Dev server. If you don’t have easy access to IE 11, you can reproduce in a modern browser by replacing `e.oldURL` with `undefined`.

Cc @showell