### PR TITLE
styles: Transition closed overlays to visibility: hidden

### DIFF
--- a/static/styles/app_components.scss
+++ b/static/styles/app_components.scss
@@ -274,8 +274,9 @@
 
     pointer-events: none;
     opacity: 0;
+    visibility: hidden;
 
-    transition: opacity 0.2s ease-in;
+    transition: all 0.2s ease-in;
     overflow: hidden;
 
     .overlay-content {
@@ -287,6 +288,7 @@
     &.show {
         opacity: 1;
         pointer-events: all;
+        visibility: visible;
         transition-timing-function: ease-out;
 
         .overlay-content {


### PR DESCRIPTION
This fixes some buggy `pointer-events` behavior on IE 11, and is presumably better for performance.

**Testing Plan:** Dev server.
