### PR TITLE
feature-flag: Remove/inline long-obsolete feature flags.

### DIFF
--- a/static/js/feature_flags.js
+++ b/static/js/feature_flags.js
@@ -1,6 +1,5 @@
 // The features below have all settled into their final states and can
 // be removed when we get a chance
-exports.propagate_topic_edits = true;
 exports.clicking_notification_causes_narrow = true;
 exports.reminders_in_message_action_menu = false;
 

--- a/static/js/feature_flags.js
+++ b/static/js/feature_flags.js
@@ -1,6 +1,5 @@
 // The features below have all settled into their final states and can
 // be removed when we get a chance
-exports.clicking_notification_causes_narrow = true;
 exports.reminders_in_message_action_menu = false;
 
 window.feature_flags = exports;

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -351,7 +351,7 @@ function edit_message(row, raw_content) {
     edit_obj.scrolled_by = scroll_by;
     message_viewport.scrollTop(message_viewport.scrollTop() + scroll_by);
 
-    if (feature_flags.propagate_topic_edits && !message.locally_echoed) {
+    if (!message.locally_echoed) {
         const original_topic = message.topic;
         message_edit_topic.keyup(function () {
             const new_topic = message_edit_topic.val();
@@ -496,10 +496,8 @@ exports.save = function (row, from_topic_edited_only) {
     const request = {message_id: message.id};
     if (topic_changed) {
         request.topic = new_topic;
-        if (feature_flags.propagate_topic_edits) {
-            const selected_topic_propagation = row.find("select.message_edit_topic_propagate").val() || "change_later";
-            request.propagate_mode = selected_topic_propagation;
-        }
+        const selected_topic_propagation = row.find("select.message_edit_topic_propagate").val() || "change_later";
+        request.propagate_mode = selected_topic_propagation;
         changed = true;
     }
 

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -408,9 +408,7 @@ function process_notification(notification) {
         });
         notification_object.onclick = function () {
             notification_object.cancel();
-            if (feature_flags.clicking_notification_causes_narrow) {
-                narrow.by_topic(message.id, {trigger: 'notification'});
-            }
+            narrow.by_topic(message.id, {trigger: 'notification'});
             window.focus();
         };
         notification_object.onclose = function () {
@@ -429,9 +427,7 @@ function process_notification(notification) {
                     // We don't need to bring the browser window into focus explicitly
                     // by calling `window.focus()` as well as don't need to clear the
                     // notification since it is the default behavior in Firefox.
-                    if (feature_flags.clicking_notification_causes_narrow) {
-                        narrow.by_topic(message.id, {trigger: 'notification'});
-                    }
+                    narrow.by_topic(message.id, {trigger: 'notification'});
                 };
             } else {
                 in_browser_notify(message, title, content, raw_operators, opts);


### PR DESCRIPTION
I remove/inline two feature flags dating back to 2013.

We can kill the file off altogether by addressing `reminders_in_message_action_menu`.  It's pretty easy to remove the conditionals, including this chunk from the template:

~~~
 20     {{#if should_display_reminder_option}}
 21     <li>
 22         <a href="#" class='reminder_button' data-message-id="{{message_id}}">
 23             <i class="fa fa-bell" aria-hidden="true"></i> {{t "Remind me about this" }}
 24         </a>
 25     </li>
 26     {{/if}}
~~~

Then the only reference to `reminder_button` is its click handler:

~~~
 919     $('body').on('click', '.reminder_button', function (e) {
 920         const message_id = $(e.currentTarget).data('message-id');
 921         exports.render_actions_remind_popover($(".selected_message .actions_hover")[0], message_id);
 922         e.stopPropagation();
 923         e.preventDefault();
 924     });
~~~

But then there's some related code related to `remind.custom` that we should probably also remove.

