### PR TITLE
docs: Replace casperjs.org links.

### DIFF
--- a/docs/testing/testing-with-casper.md
+++ b/docs/testing/testing-with-casper.md
@@ -38,7 +38,7 @@ trying to use the Casper debugging tools are:
 ### Print debugging
 
 If you need to use print debugging in casper, you can do using
-`casper.log`; see <http://docs.casperjs.org/en/latest/logging.html> for
+`casper.log`; see <https://web.archive.org/web/20200108115113if_/http://docs.casperjs.org/en/latest/logging.html> for
 details.
 
 You can also enable casper's verbose logging mode using the `--verbose` flag. This
@@ -111,9 +111,9 @@ for writing Casper tests in addition to the debugging notes below:
     will ensure that the UI has finished updating from the previous
     step before Casper attempts to next step. The various wait
     functions supported in Casper are documented in the Casper here:
-    <http://docs.casperjs.org/en/latest/modules/casper.html#waitforselector>
+    <https://web.archive.org/web/20200108100925if_/http://docs.casperjs.org/en/latest/modules/casper.html#waitforselector>
     and the various assert statements available are documented here:
-    <http://docs.casperjs.org/en/latest/modules/tester.html#the-tester-prototype>
+    <https://web.archive.org/web/20190814204845if_/http://docs.casperjs.org/en/latest/modules/tester.html#the-tester-prototype>
 
 -   The `casper.wait` style functions (`waitWhileVisible`,
     `waitUntilVisible`, etc.) cannot be chained together in certain
@@ -183,4 +183,4 @@ for writing Casper tests in addition to the debugging notes below:
     which can lead to confusing failures where the new code you write in
     between two `casper.then` blocks actually runs before either of
     them. See this for more details about how Casper works:
-    <http://docs.casperjs.org/en/latest/faq.html#how-does-then-and-the-step-stack-work>
+    <https://web.archive.org/web/20200107035425if_/http://docs.casperjs.org/en/latest/faq.html#how-does-then-and-the-step-stack-work>

--- a/frontend_tests/casper_tests/02-site.js
+++ b/frontend_tests/casper_tests/02-site.js
@@ -6,7 +6,7 @@
 */
 
 // Provides a few utility functions.
-// See http://casperjs.org/api.html#utils
+// See https://web.archive.org/web/20200110122733if_/http://docs.casperjs.org/en/latest/modules/utils.html
 // For example, utils.dump() prints an Object with nice formatting.
 var common = require('../casper_lib/common.js');
 


### PR DESCRIPTION
As CasperJS is deprecated, their website has gone down. Replaced the
broken links with their Wayback Machine counterparts.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
