### PR TITLE
zjsunit: Clear namespace more aggressively.

### DIFF
--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -113,6 +113,7 @@ try {
         _.throttle = immediate;
         _.debounce = immediate;
 
+        namespace.clear_zulip_refs();
         run_one_module(file);
         namespace.restore();
     });

--- a/frontend_tests/zjsunit/namespace.js
+++ b/frontend_tests/zjsunit/namespace.js
@@ -25,6 +25,25 @@ exports.zrequire = function (name, fn) {
     return require(fn);
 };
 
+exports.clear_zulip_refs = function () {
+    /*
+        This is a big hammer to make sure
+        we are not "borrowing" a transitively
+        required module from a previous test.
+        This kind of leak can make it seems
+        like we've written the second test
+        correctly, but it will fail if we
+        run it standalone.
+    */
+    _.each(require.cache, (_, fn) => {
+        if (fn.indexOf('static/') >= 0) {
+            if (fn.indexOf('static/templates') < 0) {
+                delete require.cache[fn];
+            }
+        }
+    });
+};
+
 exports.restore = function () {
     requires.forEach(function (fn) {
         delete require.cache[require.resolve(fn)];


### PR DESCRIPTION
Let's say you have module hello.js like so:

    // hello.js
    const hello_world = i18n.t('Hello world');
    exports.get_greeting = () => hello_world;

And then two modules like this:

    // apple.js
    const hello = require('hello');

    exports.foo = () => {
        show_greeting(hello.get_greeting());
    };

    // banana.js
    const hello = require('hello');

    exports.foo = () => {
        display_greeting(hello.get_greeting());
    };

The test for apple.js could look like this,
and it won't crash due to the stub:

    set_global('i18n', {t: () => {}});
    zrequire('hello');
    zrequire('apple');

Now let's say your write this broken version
of a test for banana.js:

    zrequire('hello');
    zrequire('banana');

If you run `./tools/test-js-with-node`, the
"banana" test will pass, because while it
does require "hello", it won't actually
*execute* the code that happens at require
time for "hello", because it's already in
the cache.  Here is the code that gets
skipped:

    const hello_world = i18n.t('Hello world');

But then if you try to run the banana test
individually, the above line of code will
cause the test to crash.  And it will crash
even before you actually try to test the
meaningful code here:

    exports.foo = () => {
        display_greeting(hello.get_greeting());
    };

This commit fixes this leak scenario by just
aggressively clearing out things from the
require cache.

This slows tests down by about 10%, which I think
is worth the extra safety here.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
