### PR TITLE
js: Always use e.stopPropogate in click handlers.

### DIFF
--- a/chomp.py
+++ b/chomp.py
@@ -1,0 +1,50 @@
+import glob
+import os
+import re
+
+FNS = 'static/js/*.js'
+
+def fix_file(fn):
+    with open(fn) as f:
+        lines = f.readlines()
+
+    with open(fn, 'r') as f:
+        string = ""
+        stack_ops = False
+        stack_count = 0
+        for line in lines:
+            if not stack_ops:
+                c = re.findall('\.on\(\'click\'.*({)', line, re.DOTALL)
+                if c:
+                    # start stack ops,
+                    stack_ops = True
+                    stack_count = 1
+                    string = line
+            else:
+                open_brace = re.findall('.*({)', line, re.DOTALL)
+                close_brace = re.findall('.*(})', line, re.DOTALL)
+                string += line
+
+                # xor
+                if bool(open_brace) != bool(close_brace):
+                    if open_brace:
+                        stack_count += 1
+                    else:
+                        stack_count -= 1
+                if (stack_count == 0):
+                    if not re.findall('e\.stopPropagation\(\)', string):
+                        print(f.name)
+                        print(string)
+                        stack_ops = False
+                
+
+
+def run():
+    os.system('git checkout ' + FNS)
+
+    for fn in glob.glob(FNS):
+        fix_file(fn)
+
+    os.system('git diff')
+
+run()


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR is to help us find all the places where we may have missed using e.stopPropagation() and e.preventDefault().

Related to the discussion at https://github.com/zulip/zulip/pull/12517,
Have a look at https://github.com/zulip/zulip/search?p=2&q=e.stopPropagation&type=Issues to see why we might need this.

TODO:
actually add e.stopPropagation() wherever needed (automatically)
and validate that nothing gets broken (manual?)
do the same for e.preventDefault()

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Those links on terminal are clickable.
![links on terminal are clickable](https://user-images.githubusercontent.com/33805964/75469097-66172680-59b4-11ea-9ac9-683bc10cb9dc.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
