### PR TITLE
messages: Copy a markdown text from multiple messages.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -290,6 +290,7 @@
                 "markdown": false,
                 "marked": false,
                 "md5": false,
+                "message_copy": false,
                 "message_edit": false,
                 "message_events": false,
                 "message_fetch": false,

--- a/frontend_tests/node_tests/message_copy.js
+++ b/frontend_tests/node_tests/message_copy.js
@@ -1,0 +1,252 @@
+const noop = function () {};
+
+set_global('$', global.make_zjquery());
+set_global('XDate', zrequire('XDate', 'xdate'));
+
+zrequire('rows');
+zrequire('message_copy');
+
+const date_format = function (ts) {
+    const time = new XDate(ts * 1000);
+    const tz_offset = -time.getTimezoneOffset() / 60;
+    return time.toLocaleDateString() + " " + time.toLocaleTimeString() +
+    ' (UTC' + (tz_offset < 0 ? '' : '+') + tz_offset + ')';
+};
+
+const copy_selected_messages = message_copy.copy_selected_messages;
+const push_message = message_copy.push_message;
+const select_message = message_copy.select_message;
+const select_until_message = message_copy.select_until_message;
+const show_copied_alert = message_copy.show_copied_alert;
+const clean_copied_messages = message_copy.clean_copied_messages;
+const clipboard_error_handler = message_copy.clipboard_error_handler;
+const clipboard_success_handler = message_copy.clipboard_success_handler;
+const concat_markdown = message_copy.concat_markdown;
+const messages = message_copy.messages;
+
+const message_box_id = 85;
+const raw_content_get =  date_format(1582394301) + ' @_**aaron**: first message';
+const messages_list = [
+    {
+        id: 85,
+    },
+    {
+        id: 86,
+    },
+    {
+        id: 89,
+    },
+    {
+        id: 90,
+    },
+];
+
+function stub_channel_get(success_value) {
+    set_global('channel', {
+        get: function (opts) {
+            opts.success(success_value);
+        },
+    });
+}
+
+set_global('rows', {
+    id: function (row) {
+        return row.id;
+    },
+});
+
+set_global('i18n', {
+    t: function (text) {
+        return text;
+    },
+});
+
+set_global('popovers', {
+    hide_actions_popover: noop,
+});
+
+set_global('ClipboardJS', function (sel) {
+    assert.equal(sel, '#btn_copy_message_markdown_' + message_box_id);
+    this.on = function () {};
+});
+
+run_test('copy selected messages', () => {
+    const message_row_1 = $('#zhome' + messages_list[0].id);
+    message_row_1.id = messages_list[0].id;
+    message_row_1.length = 1;
+    const message_row_2 = $('#zhome' + messages_list[1].id);
+    message_row_2.id = messages_list[1].id;
+    message_row_2.length = 1;
+    const message_row_3 = $('#zhome' + messages_list[2].id);
+    message_row_3.id = messages_list[2].id;
+    message_row_3.length = 1;
+    const message_row_4 = $('#zhome' + messages_list[3].id);
+    message_row_4.id = messages_list[3].id;
+    message_row_4.length = 1;
+
+    const selected_messages = $(".copy_selected_message");
+    selected_messages.data = [message_row_1, message_row_2, message_row_3, message_row_4];
+    selected_messages.eq = function (index) {
+        return selected_messages.data[index];
+    };
+    message_copy.push_message = noop;
+    message_copy.concat_markdown = function () {
+        return raw_content_get;
+    };
+    stub_channel_get({
+        messages: [],
+    });
+    copy_selected_messages(message_box_id);
+    assert.equal($('#copy_message_markdown_' + message_box_id).val(), raw_content_get);
+
+});
+
+run_test('push a message', () => {
+    const message_row_1 = $('#zhome' + messages_list[0].id);
+    message_row_1.id = messages_list[0].id;
+    const message_row_2 = $('#zhome' + messages_list[1].id);
+    message_row_2.id = messages_list[1].id;
+    push_message(message_row_1);
+    push_message(message_row_2);
+    assert.equal(messages[0], messages_list[0].id);
+});
+
+run_test('select a message', () => {
+    const message_box = $('<div class="message_box">');
+    const message_row = $('#zhome' + messages_list[0].id);
+    message_box.closest = function () {
+        return message_row;
+    };
+
+    // selecting a message
+    select_message(message_box);
+    assert.equal($('#zhome' + messages_list[0].id).hasClass("copy_selected_message"), true);
+    // unselecting
+    select_message(message_box);
+    assert.equal($('#zhome' + messages_list[0].id).hasClass("copy_selected_message"), false);
+});
+
+run_test('select a message range and clean copied', () => {
+    const message_row_1 = $('#zhome' + messages_list[0].id);
+    message_row_1.id = messages_list[0].id;
+    message_row_1.length = 1;
+    const message_row_2 = $('#zhome' + messages_list[1].id);
+    message_row_2.id = messages_list[1].id;
+    message_row_2.length = 1;
+    const message_row_3 = $('#zhome' + messages_list[2].id);
+    message_row_3.id = messages_list[2].id;
+    message_row_3.length = 1;
+    const message_row_4 = $('#zhome' + messages_list[3].id);
+    message_row_4.id = messages_list[3].id;
+    message_row_4.length = 1;
+
+    set_global('rows', {
+        next_visible: function (row) {
+            switch (row.id) {
+            case messages_list[0].id:
+                return message_row_2;
+            case messages_list[1].id:
+                return message_row_3;
+            case messages_list[2].id:
+                return message_row_4;
+            case messages_list[3].id:
+                return { length: 0 };
+            }
+        },
+        id: function (row) {
+            return row.id;
+        },
+    });
+
+    // Selecting a range of messages
+    select_until_message(message_row_1, message_row_4);
+
+    assert.equal(message_row_1.hasClass("copy_selected_message"), true);
+    assert.equal(message_row_2.hasClass("copy_selected_message"), true);
+    assert.equal(message_row_3.hasClass("copy_selected_message"), true);
+    assert.equal(message_row_4.hasClass("copy_selected_message"), true);
+
+
+    const selected_messages = $(".copy_selected_message");
+    selected_messages.data = [message_row_1, message_row_2, message_row_3, message_row_4];
+    selected_messages.removeClass = function () {
+        for (const msg of selected_messages.data) {
+            msg.removeClass("copy_selected_message");
+        }
+    };
+
+    // Cleaning the selected messages
+
+    $('#messages_markdown_' + messages_list[0].id).show();
+    assert($('#messages_markdown_' + messages_list[0].id).visible());
+    $('#copy_message_markdown_' + messages_list[0].id).val(raw_content_get);
+    clean_copied_messages(messages_list[0].id);
+
+    assert.equal(message_row_1.hasClass("copy_selected_message"), false);
+    assert.equal(message_row_2.hasClass("copy_selected_message"), false);
+    assert.equal(message_row_3.hasClass("copy_selected_message"), false);
+    assert.equal(message_row_4.hasClass("copy_selected_message"), false);
+
+    assert(!$('#messages_markdown_' + messages_list[0].id).visible());
+    assert.equal($('#copy_message_markdown_' + messages_list[0].id).val(), '');
+
+    // When the first message is before the second one
+
+    select_until_message(message_row_4, message_row_1);
+
+    assert.equal(message_row_1.hasClass("copy_selected_message"), false);
+    assert.equal(message_row_2.hasClass("copy_selected_message"), false);
+    assert.equal(message_row_3.hasClass("copy_selected_message"), false);
+    assert.equal(message_row_4.hasClass("copy_selected_message"), false);
+});
+
+run_test('show copied alert', () => {
+    const alert_src = $('<span class="alert-msg pull-right"></span>');
+    const alert = $(".selected_message[zid='" + messages_list[0].id + "']");
+    alert.set_find_results('.alert-msg', alert_src);
+    alert_src.delay = function () {
+        return alert_src;
+    };
+    alert_src.fadeOut = function () {
+        return alert_src;
+    };
+
+    show_copied_alert(messages_list[0].id);
+    assert.equal(alert_src.text(), "Copied!");
+
+    message_copy.show_copied_alert = noop;
+    message_copy.clean_copied_messages = noop;
+    const event = {
+        trigger: $.create('trigger'),
+    };
+    event.trigger.attr('data-message', message_box_id);
+    clipboard_success_handler(event);
+    clipboard_error_handler(event);
+});
+
+run_test('concatenate markdown', () => {
+    const messages = [
+        {
+            timestamp: 1582394301,
+            sender_full_name: "Polonius",
+            content: "Strange violin",
+        },
+        {
+            timestamp: 1582520201,
+            sender_full_name: "Aaron",
+            content: "Basketball player",
+        },
+    ];
+    const date_1 = date_format(messages[0].timestamp);
+    const date_2 = date_format(messages[1].timestamp);
+
+    const expected = date_1.concat(" @_**" + messages[0].sender_full_name + "**: \n\n")
+        .concat(messages[0].content + "\n\n")
+        .concat(date_2)
+        .concat(" @_**" + messages[1].sender_full_name + "**: \n\n")
+        .concat(messages[1].content + "\n\n");
+
+    const markdown = concat_markdown(messages);
+    assert.equal(markdown, expected);
+
+});

--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -97,6 +97,7 @@ import "../stream_create.js";
 import "../stream_edit.js";
 import "../subs.js";
 import "../message_edit.js";
+import "../message_copy.js";
 import "../condense.js";
 import "../resize.js";
 import "../list_render.js";

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -90,6 +90,9 @@ exports.initialize = function () {
             return;
         }
 
+        const prev_selected = $(".selected_message");
+        const first_row = $(prev_selected).closest(".message_row");
+
         const row = $(this).closest(".message_row");
         const id = rows.id(row);
 
@@ -98,10 +101,17 @@ exports.initialize = function () {
             return;
         }
 
-        current_msg_list.select_id(id);
-        compose_actions.respond_to_message({trigger: 'message click'});
-        e.stopPropagation();
-        popovers.hide_all();
+        if (e.ctrlKey) {
+            message_copy.select_message(this);
+        } else if (e.shiftKey) {
+            const final_row = $(this).closest(".message_row");
+            message_copy.select_until_message(first_row, final_row);
+        } else {
+            current_msg_list.select_id(id);
+            compose_actions.respond_to_message({trigger: 'message click'});
+            e.stopPropagation();
+            popovers.hide_all();
+        }
     };
 
     // if on normal non-mobile experience, a `click` event should run the message

--- a/static/js/global.d.ts
+++ b/static/js/global.d.ts
@@ -67,6 +67,7 @@ declare let loading: any;
 declare let local_message: any;
 declare let localstorage: any;
 declare let markdown: any;
+declare let message_copy: any;
 declare let message_edit: any;
 declare let message_events: any;
 declare let message_fetch: any;

--- a/static/js/message_copy.js
+++ b/static/js/message_copy.js
@@ -1,0 +1,99 @@
+exports.messages = [];
+
+exports.copy_selected_messages = function (message_id) {
+    const selected_messages = $(".copy_selected_message");
+    for (let i = 0; i < selected_messages.length; i = i + 1) {
+        exports.push_message(selected_messages.eq(i));
+    }
+    return channel.get({
+        url: '/json/messages',
+        idempotent: true,
+        data: {
+            anchor: "no_anchor",
+            num_after: 0,
+            num_before: 0,
+            apply_markdown: false,
+            message_id_list: JSON.stringify(exports.messages),
+        },
+        success: function (data) {
+            const markdown = exports.concat_markdown(data.messages);
+            $('#copy_message_markdown_' + message_id).val(markdown);
+            const clipboard = new ClipboardJS('#btn_copy_message_markdown_' + message_id);
+            clipboard.on('success', exports.clipboard_success_handler);
+            clipboard.on('error', exports.clipboard_error_handler);
+        },
+    });
+};
+exports.concat_markdown = function (messages) {
+    let markdown_code = "";
+    messages.forEach((msg) => {
+        const time = new XDate(msg.timestamp * 1000);
+        const tz_offset = -time.getTimezoneOffset() / 60;
+        const date = time.toLocaleDateString() + " " + time.toLocaleTimeString() +
+        ' (UTC' + (tz_offset < 0 ? '' : '+') + tz_offset + ')';
+        markdown_code = markdown_code.concat(date)
+            .concat(" @_**" + msg.sender_full_name + "**: \n\n")
+            .concat(msg.content + "\n\n");
+    });
+    return markdown_code;
+};
+
+exports.clipboard_success_handler = function (e) {
+    const message_id = $(e.trigger).attr('data-message');
+    exports.show_copied_alert(message_id);
+    exports.clean_copied_messages(message_id);
+};
+
+exports.clipboard_error_handler = function (e) {
+    const message_id = $(e.trigger).attr('data-message');
+    exports.clean_copied_messages(message_id);
+};
+
+exports.push_message = function (message_row) {
+    const row = $(message_row);
+    exports.messages.push(rows.id(row));
+};
+
+exports.show_copied_alert = function (message_id) {
+    const row = $(".selected_message[zid='" + message_id + "']");
+    row.find(".alert-msg")
+        .text(i18n.t("Copied!"))
+        .css("display", "block")
+        .delay(1000)
+        .fadeOut(300);
+};
+
+exports.clean_copied_messages = function (message_id) {
+    popovers.hide_actions_popover();
+    $(".copy_selected_message").removeClass("copy_selected_message");
+    $("#messages_markdown_" + message_id).hide();
+    $('#copy_message_markdown_' + message_id).val("");
+    exports.messages = [];
+};
+
+
+exports.select_message = function (message_box) {
+    const row = $(message_box).closest(".message_row");
+    if (row.hasClass("copy_selected_message")) {
+        row.removeClass("copy_selected_message");
+    } else {
+        row.addClass("copy_selected_message");
+    }
+};
+
+exports.select_until_message = function (first_row, final_row) {
+    if (rows.id(first_row) > rows.id(final_row)) {
+        return;
+    }
+    let current = first_row;
+    while (current.length > 0) {
+        current.addClass("copy_selected_message");
+        current = rows.next_visible(current);
+        if (rows.id(current) === rows.id(final_row)) {
+            current.addClass("copy_selected_message");
+            break;
+        }
+    }
+};
+
+window.message_copy = exports;

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -11,6 +11,7 @@ const render_user_group_info_popover_content = require('../templates/user_group_
 const render_user_info_popover_content = require('../templates/user_info_popover_content.hbs');
 const render_user_info_popover_title = require('../templates/user_info_popover_title.hbs');
 const render_user_profile_modal = require("../templates/user_profile_modal.hbs");
+const render_messages_markdown = require("../templates/messages_markdown.hbs");
 
 let current_actions_popover_elem;
 let current_flatpickr_instance;
@@ -496,6 +497,42 @@ exports.toggle_actions_popover = function (element, id) {
     }
 };
 
+exports.toggle_messages_markdown = function (element, id) {
+    const last_popover_elem = current_actions_popover_elem;
+    exports.hide_all();
+    if (last_popover_elem !== undefined
+        && last_popover_elem.get()[0] === element) {
+        // We want it to be the case that a user can dismiss a popover
+        // by clicking on the same element that caused the popover.
+        return;
+    }
+
+    current_msg_list.select_id(id);
+    const actions_btn = $(current_msg_list.selected_row()).find(".actions_hover")[0];
+    $(element).closest('.message_row').toggleClass('has_popover has_actions_popover');
+    const elt = $(actions_btn);
+
+    if (elt.data('popover') === undefined) {
+        const message = current_msg_list.get(id);
+
+        const args = {
+            message_id: message.id,
+        };
+
+        const ypos = elt.offset().top;
+        elt.popover({
+            placement: message_viewport.height() - ypos < 220 ? 'top' : 'bottom',
+            title: "",
+            content: render_messages_markdown(args),
+            html: true,
+            trigger: "manual",
+        });
+        message_copy.copy_selected_messages(message.id);
+        elt.popover("show");
+        current_actions_popover_elem = elt;
+    }
+};
+
 exports.render_actions_remind_popover = function (element, id) {
     exports.hide_all();
     $(element).closest('.message_row').toggleClass('has_popover has_actions_popover');
@@ -957,6 +994,22 @@ exports.register_click_handlers = function () {
     });
 
     $('body').on('click', '.flatpickr-calendar', function (e) {
+        e.stopPropagation();
+        e.preventDefault();
+    });
+
+    $('body').on('click', '.copy_selected_messages', function (e) {
+        exports.hide_actions_popover();
+        const message_id = $(this).attr("data-message-id");
+        const row = $(".selected_message[zid='" + message_id + "']");
+        exports.toggle_messages_markdown(row, message_id);
+
+        setTimeout(function () {
+            // The Cliboard library works by focusing to a hidden textarea.
+            // We unfocus this so keyboard shortcuts, etc., will work again.
+            $(":focus").blur();
+        }, 0);
+
         e.stopPropagation();
         e.preventDefault();
     });

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -396,12 +396,30 @@ li,
     z-index: 2;
 }
 
+.copy_messages_markdown,
+.copy_messages_markdown:focus {
+    background-color: hsl(0, 0%, 100%);
+    height: 20px;
+    width: 15px;
+    padding: 5px 10px;
+    border: none;
+    position: relative;
+    top: 28px;
+    left: -5px;
+    margin-top: -24px;
+    display: block;
+}
+
 #clipboard_image {
     margin-top: -5px;
     margin-left: -8px;
 }
 
 .copy_message:hover svg path {
+    fill: hsl(0, 0%, 0%);
+}
+
+.copy_messages_markdown:hover svg path {
     fill: hsl(0, 0%, 0%);
 }
 
@@ -648,6 +666,15 @@ td.pointer {
     }
 
     > .reaction_button {
+        display: inline-block;
+        position: relative;
+        color: hsl(0, 0%, 73%);
+        &:hover {
+            color: hsl(200, 100%, 40%);
+        }
+    }
+
+    > .selection_button {
         display: inline-block;
         position: relative;
         color: hsl(0, 0%, 73%);
@@ -1013,6 +1040,39 @@ td.pointer {
         1px 1px 0px 0px hsl(215, 47%, 50%),
         -1px 1px 0px 0px hsl(215, 47%, 50%),
         1px -1px 0px 0px hsl(215, 47%, 50%);
+}
+
+.copy_selected_message .messagebox-content {
+    box-shadow:
+        inset 0px 0px 0px 2px hsl(0, 47%, 50%),
+        -1px -1px 0px 0px hsl(0, 47%, 50%),
+        1px 1px 0px 0px hsl(0, 47%, 50%),
+        -1px 1px 0px 0px hsl(0, 47%, 50%),
+        1px -1px 0px 0px hsl(0, 47%, 50%);
+}
+
+.messages_markdown {
+    border-left: 1px;
+    border-right: 1px;
+    position: relative;
+    display: block;
+}
+
+.messages_markdown .messages_markdown_content {
+    padding: 5px 25px 5px 10px;
+}
+
+.messages_markdown .messages_markdown_content .messages_markdown_show {
+    margin-top: 5px;
+    margin-left: 5px;
+    display: block;
+    position: relative;
+}
+
+.copy_message_markdown {
+    width: 100%;
+    overflow: hidden;
+    overflow-wrap: break-word;
 }
 
 .message_sender {

--- a/static/templates/actions_popover_content.hbs
+++ b/static/templates/actions_popover_content.hbs
@@ -92,6 +92,12 @@
         </a>
     </li>
 
+    <li>
+        <a href="#" class="copy_selected_messages" data-message-id="{{message_id}}">
+            <i class="fa fa-copy" aria-hidden="true"></i> {{t "Copy selected messages" }}
+        </a>
+    </li>
+
     {{#if historical}}
     <li class="small">({{t "Message sent when you were not subscribed" }})</li>
     {{/if}}

--- a/static/templates/messages_markdown.hbs
+++ b/static/templates/messages_markdown.hbs
@@ -1,0 +1,12 @@
+<div id="messages_markdown_{{message_id}}" class="messages_markdown">
+    <div class="messages_markdown_content">
+        <div class="messages_markdown_show">
+            <button class="btn pull-right copy_messages_markdown" id="btn_copy_message_markdown_{{message_id}}" data-message="{{message_id}}" data-toggle="tooltip" title="{{t "Copy and close" }}" data-clipboard-target="#copy_message_markdown_{{message_id}}">
+                <svg height="20" width="18" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg" id="clipboard_image">
+                    <path fill="#777" d="M128 768h256v64H128v-64z m320-384H128v64h320v-64z m128 192V448L384 640l192 192V704h320V576H576z m-288-64H128v64h160v-64zM128 704h160v-64H128v64z m576 64h64v128c-1 18-7 33-19 45s-27 18-45 19H64c-35 0-64-29-64-64V192c0-35 29-64 64-64h192C256 57 313 0 384 0s128 57 128 128h192c35 0 64 29 64 64v320h-64V320H64v576h640V768zM128 256h512c0-35-29-64-64-64h-64c-35 0-64-29-64-64s-29-64-64-64-64 29-64 64-29 64-64 64h-64c-35 0-64 29-64 64z" />
+                </svg>
+            </button>
+            <textarea id="copy_message_markdown_{{message_id}}" class="copy_message_markdown rendered_markdown" maxlength="10000" readonly></textarea>
+        </div>
+    </div>
+</div>

--- a/templates/zerver/api/get-messages.md
+++ b/templates/zerver/api/get-messages.md
@@ -63,7 +63,7 @@ zulip(config).then((client) => {
 
 {tab|curl}
 
-{generate_code_example(curl, exclude=["client_gravatar", "apply_markdown", "use_first_unread_anchor"])|/messages:get|example}
+{generate_code_example(curl, exclude=["client_gravatar", "apply_markdown", "use_first_unread_anchor", "message_id_list"])|/messages:get|example}
 
 {end_tabs}
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -382,6 +382,15 @@ paths:
           type: boolean
           default: false
         example: true
+      - name: message_id_list
+        in: query
+        description: An array containing the IDs of the target messages.
+        schema:
+          type: array
+          items:
+            type: integer
+        example: [5, 82, 95]
+        required: false
       responses:
         '200':
           description: Success.

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -1550,6 +1550,38 @@ class MessageDictTest(ZulipTestCase):
         self.assert_json_error(
             result, "Invalid anchor")
 
+    def test_get_by_ids(self) -> None:
+        # Public messages
+        msg_id_1 = self.send_stream_message(self.example_user("hamlet"), "Denmark",
+                                            topic_name="programming", content="stronger")
+        msg_id_2 = self.send_stream_message(self.example_user("aaron"), "Denmark",
+                                            topic_name="programming", content="train")
+        message_list = [msg_id_1, msg_id_2]
+
+        # Private message
+        self.login("hamlet")
+        msg_id_3 = self.send_personal_message(
+            from_user=self.example_user("hamlet"),
+            to_user=self.example_user("cordelia"),
+            content="**before** edit",
+        )
+
+        result = self.client_get('/json/messages?anchor=first_unread&num_before=0&num_after=0&' +
+                                 'apply_markdown=false&message_id_list=' + ujson.dumps(message_list))
+        self.assertIn('stronger', result.json()['messages'][0]['content'])
+        self.assertIn('train', result.json()['messages'][1]['content'])
+
+        self.login("cordelia")
+        result = self.client_get('/json/messages?anchor=first_unread&num_before=0&num_after=0&' +
+                                 'apply_markdown=false&message_id_list=[99999]')
+        self.assertEqual(result.json()['messages'], [])
+
+        # It doesn't return a private message
+        self.login("othello")
+        result = self.client_get('/json/messages?anchor=first_unread&num_before=0&num_after=0&' +
+                                 'apply_markdown=false&message_id_list=' + ujson.dumps([msg_id_3]))
+        self.assertEqual(result.json()['messages'], [])
+
 class SewMessageAndReactionTest(ZulipTestCase):
     def test_sew_messages_and_reaction(self) -> None:
         sender = self.example_user('othello')

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -885,7 +885,8 @@ class TestCurlExampleGeneration(ZulipTestCase):
             '    --data-urlencode narrow=\'[{"operand": "Denmark", "operator": "stream"}]\' \\',
             "    -d 'client_gravatar=true' \\",
             "    -d 'apply_markdown=false' \\",
-            "    -d 'use_first_unread_anchor=true'",
+            "    -d 'use_first_unread_anchor=true' \\",
+            "    --data-urlencode message_id_list='[5, 82, 95]'",
             '```'
         ]
         self.assertEqual(generated_curl_example, expected_curl_example)
@@ -942,7 +943,7 @@ class TestCurlExampleGeneration(ZulipTestCase):
 
     def test_generate_and_render_curl_example_with_excludes(self) -> None:
         generated_curl_example = self.curl_example("/messages", "GET",
-                                                   exclude=["client_gravatar", "apply_markdown"])
+                                                   exclude=["client_gravatar", "apply_markdown", "message_id_list"])
         expected_curl_example = [
             '```curl',
             'curl -sSX GET -G http://localhost:9991/api/v1/messages \\',

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -790,7 +790,7 @@ def parse_anchor_value(anchor_val: Optional[str],
         return 0
     if anchor_val == "newest":
         return LARGER_THAN_MAX_MESSAGE_ID
-    if anchor_val == "first_unread":
+    if anchor_val == "first_unread" or anchor_val == "no_anchor":
         return None
     try:
         # We don't use `.isnumeric()` to support negative numbers for
@@ -815,11 +815,16 @@ def get_messages_backend(request: HttpRequest, user_profile: UserProfile,
                          use_first_unread_anchor_val: bool=REQ('use_first_unread_anchor',
                                                                validator=check_bool, default=False),
                          client_gravatar: bool=REQ(validator=check_bool, default=False),
-                         apply_markdown: bool=REQ(validator=check_bool, default=True)) -> HttpResponse:
+                         apply_markdown: bool=REQ(validator=check_bool, default=True),
+                         message_id_list: List[int]=REQ(validator=check_list(check_int),
+                                                        default=[])) -> HttpResponse:
     anchor = parse_anchor_value(anchor_val, use_first_unread_anchor_val)
     if num_before + num_after > MAX_MESSAGES_PER_FETCH:
         return json_error(_("Too many messages requested (maximum %s).")
                           % (MAX_MESSAGES_PER_FETCH,))
+
+    # This enable a direct "search by ids" using the ids included in message_list.
+    message_by_ids = len(message_id_list) != 0
 
     if user_profile.realm.email_address_visibility != Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE:
         # If email addresses are only available to administrators,
@@ -890,16 +895,20 @@ def get_messages_backend(request: HttpRequest, user_profile: UserProfile,
         num_after = 0
 
     first_visible_message_id = get_first_visible_message_id(user_profile.realm)
-    query = limit_query_to_range(
-        query=query,
-        num_before=num_before,
-        num_after=num_after,
-        anchor=anchor,
-        anchored_to_left=anchored_to_left,
-        anchored_to_right=anchored_to_right,
-        id_col=inner_msg_id_col,
-        first_visible_message_id=first_visible_message_id,
-    )
+
+    if (not message_by_ids):
+        query = limit_query_to_range(
+            query=query,
+            num_before=num_before,
+            num_after=num_after,
+            anchor=anchor,
+            anchored_to_left=anchored_to_left,
+            anchored_to_right=anchored_to_right,
+            id_col=inner_msg_id_col,
+            first_visible_message_id=first_visible_message_id,
+        )
+    else:
+        query = query.where(column("message_id").in_(message_id_list))
 
     main_query = alias(query)
     query = select(main_query.c, None, main_query).order_by(column("message_id").asc())


### PR DESCRIPTION
This is a new feature for copying to clipboard a markdown
text from a set of selected messages. This is related with #13936 

The user can use:
* Ctrl + click, for selecting (or deselecting) an individual
message.
* Shift + click, for selecting a range of messages from
the current selected message (blue board) to the message
that was clicked.

This change added:
* Mouse events for select messages (click_handlers.js)
* JS module for managing the actions (message_copy.js).
* A new option in the message popover menu.
This include a template and its styles.
* A new endpoint for getting the markdown text.
It is different from /messages (GET), because this is for a
list of messages and it includes additional info like:
message datetime, a sender silent mention
and the message.
* A management command with the same functionality.
* Test for backend actions.
* Test for the new frontend module.
* OpenAPI documentation for the new endpoint.

This is the new feature in action. Ctrl + click for selecting a message and Shift + click for selecting 
the range between the current selected message (blue border) and the clicked message.

![copy-paste-f](https://user-images.githubusercontent.com/43050896/75474678-6805c900-5965-11ea-8a34-ed19348b4495.gif)

For the backend, I have tested:

* Sending a list of message_id and getting the raw text.
* Sendind invalid ids.
* Sending an empty list.
* Sending a list with unauthorized/private messages.
* Sending a list to the endpoint /messages/markdown

For the frontend, I have used zjquery for testing the JS module message_copy,js.
* Select and deselect a message.
* Select multiple messages.
* Clean UI.
* Copy messages.