### PR TITLE
typing: Deprecate email and fix unnecessary DB churn

### DIFF
--- a/docs/subsystems/typing-indicators.md
+++ b/docs/subsystems/typing-indicators.md
@@ -83,9 +83,7 @@ Requests come into `/json/typing`.  The view mostly calls out
 to `check_send_typing_notification` to do the heavy lifting.
 
 One of the main things that the server does is to simply validate
-the recipients with a call to `recipient_for_emails`.  (We should
-streamline the payload in the request to have user ids instead of
-emails, but of course we will still need to validate recipients.)
+the recipients with a call to `recipient_for_user_ids`.
 
 Once the request has been validated, the server sends events to
 potential recipients of the message.  The event type for that

--- a/docs/subsystems/typing-indicators.md
+++ b/docs/subsystems/typing-indicators.md
@@ -83,7 +83,7 @@ Requests come into `/json/typing`.  The view mostly calls out
 to `check_send_typing_notification` to do the heavy lifting.
 
 One of the main things that the server does is to simply validate
-the recipients with a call to `recipient_for_user_ids`.
+that the `to` users are for valid, active users in the realm.
 
 Once the request has been validated, the server sends events to
 potential recipients of the message.  The event type for that

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -976,12 +976,16 @@ def get_stream_topics(client, stream_id):
 @openapi_test_function("/typing:post")
 def set_typing_status(client):
     # type: (Client) -> None
+    ensure_users([9, 10], ['hamlet', 'iago'])
 
     # {code_example|start}
     # The user has started to type in the group PM with Iago and Polonius
+    user_id1 = 9
+    user_id2 = 10
+
     request = {
         'op': 'start',
-        'to': ['iago@zulip.com', 'polonius@zulip.com']
+        'to': [user_id1, user_id2],
     }
     result = client.set_typing_status(request)
     # {code_example|end}
@@ -990,9 +994,12 @@ def set_typing_status(client):
 
     # {code_example|start}
     # The user has finished typing in the group PM with Iago and Polonius
+    user_id1 = 9
+    user_id2 = 10
+
     request = {
         'op': 'stop',
-        'to': ['iago@zulip.com', 'polonius@zulip.com']
+        'to': [user_id1, user_id2],
     }
     result = client.set_typing_status(request)
     # {code_example|end}

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2914,14 +2914,15 @@ paths:
         required: true
       - name: to
         in: query
-        description: The recipients of the message being typed, in the same format used by the
-          send_message API.  Typing notifications are only supported for private messages,
-          so this should be a JSON-encoded list of email addresses of the message's recipients.
+        description: The user_ids of the recipients of the message being typed.
+          Typing notifications are only supported for private messages.
+          Send a JSON-encoded list of user_ids. (Use a list even if there is
+          only one recipient.)
         schema:
           type: array
           items:
-            type: string
-        example: ["iago@zulip.com", "polonius@zulip.com"]
+            type: integer
+        example: [9, 10]
         required: true
       responses:
         '200':

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -92,7 +92,6 @@ from zerver.lib.actions import (
     do_update_pointer,
     do_update_user_presence,
     do_update_user_status,
-    get_typing_user_profiles,
     log_event,
     lookup_default_stream_groups,
     notify_realm_custom_profile_fields,
@@ -1082,25 +1081,6 @@ class EventsRegisterTest(ZulipTestCase):
         )
         error = schema_checker('events[0]', events[0])
         self.assert_on_error(error)
-
-    def test_get_typing_user_profiles(self) -> None:
-        """
-        Make sure we properly assert failures for recipient types that should not
-        get typing... notifications.
-        """
-
-        sender_profile = self.example_user('cordelia')
-        stream = get_stream('Rome', sender_profile.realm)
-
-        # Test stream
-        with self.assertRaisesRegex(ValueError, 'not supported for streams'):
-            recipient = Recipient.objects.get(type_id=stream.id, type=Recipient.STREAM)
-            get_typing_user_profiles(recipient, sender_profile.id)
-
-        # Test some other recipient type
-        with self.assertRaisesRegex(ValueError, 'Bad recipient type'):
-            recipient = Recipient(type=999)  # invalid type
-            get_typing_user_profiles(recipient, sender_profile.id)
 
     def test_custom_profile_fields_events(self) -> None:
         schema_checker = self.check_events_dict([

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1077,7 +1077,7 @@ class EventsRegisterTest(ZulipTestCase):
 
         events = self.do_test(
             lambda: check_send_typing_notification(
-                self.user_profile, [self.example_email("cordelia")], "start"),
+                self.user_profile, [self.example_user("cordelia").id], "start"),
             state_change_expected=False,
         )
         error = schema_checker('events[0]', events[0])

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -420,6 +420,17 @@ do not match the types declared in the implementation of {}.\n""".format(functio
         AssertionError. """
         openapi_params = set()  # type: Set[Tuple[str, Union[type, Tuple[type, object]]]]
         for element in openapi_parameters:
+            if function.__name__ == 'send_notification_backend':
+                if element['name'] == 'to':
+                    '''
+                    We want users to send ints here, but the mypy
+                    types for send_notification_backend are still
+                    str, because we need backward compatible
+                    support for old versions of mobile that still
+                    send emails for typing requests.
+                    '''
+                    continue
+
             name = element["name"]  # type: str
             schema = element["schema"]
             if 'oneOf' in schema:


### PR DESCRIPTION
This is a follow up to #13998 that avoids breaking old versions of the mobile app.

It includes important fixes related to how we needlessly do logic (including inserts at times) related to Recipient/Subscription/Huddle.