### PR TITLE
notification settings: List unmatched streams.

### DIFF
--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -639,6 +639,8 @@ run_test('notifications', () => {
         stream_id: 102,
         name: 'India',
         subscribed: true,
+        invite_only: false,
+        is_web_public: false,
         desktop_notifications: null,
         audible_notifications: null,
         email_notifications: null,
@@ -702,6 +704,84 @@ run_test('notifications', () => {
     page_params.enable_stream_email_notifications = true;
     india.email_notifications = false;
     assert(!stream_data.receives_notifications('India', "email_notifications"));
+
+    const canada = {
+        stream_id: 103,
+        name: 'Canada',
+        subscribed: true,
+        invite_only: true,
+        is_web_public: false,
+        desktop_notifications: null,
+        audible_notifications: null,
+        email_notifications: null,
+        push_notifications: null,
+        wildcard_mentions_notify: null,
+    };
+    stream_data.add_sub(canada);
+
+    const antarctica = {
+        stream_id: 104,
+        name: 'Antarctica',
+        subscribed: true,
+        desktop_notifications: null,
+        audible_notifications: null,
+        email_notifications: null,
+        push_notifications: null,
+        wildcard_mentions_notify: null,
+    };
+    stream_data.add_sub(antarctica);
+
+    page_params.enable_stream_desktop_notifications = true;
+    page_params.enable_stream_audible_notifications = true;
+    page_params.enable_stream_email_notifications = false;
+    page_params.enable_stream_push_notifications = false;
+    page_params.wildcard_mentions_notify = true;
+
+    india.desktop_notifications = null;
+    india.audible_notifications = true;
+    india.email_notifications = true;
+    india.push_notifications = true;
+    india.wildcard_mentions_notify = false;
+
+    canada.desktop_notifications = true;
+    canada.audible_notifications = false;
+    canada.email_notifications = true;
+    canada.push_notifications = null;
+    canada.wildcard_mentions_notify = false;
+
+    antarctica.desktop_notifications = true;
+    antarctica.audible_notifications = null;
+    antarctica.email_notifications = false;
+    antarctica.push_notifications = null;
+    antarctica.wildcard_mentions_notify = null;
+
+    const unmatched_streams = stream_data.get_unmatched_streams_for_notification_settings();
+    const expected_streams = [
+        {
+            desktop_notifications: true,
+            audible_notifications: false,
+            email_notifications: true,
+            push_notifications: false,
+            wildcard_mentions_notify: false,
+            invite_only: true,
+            is_web_public: false,
+            stream_name: 'Canada',
+            stream_id: 103,
+        },
+        {
+            desktop_notifications: true,
+            audible_notifications: true,
+            email_notifications: true,
+            push_notifications: true,
+            wildcard_mentions_notify: false,
+            invite_only: false,
+            is_web_public: false,
+            stream_name: 'India',
+            stream_id: 102,
+        },
+    ];
+
+    assert.deepEqual(unmatched_streams, expected_streams);
 });
 
 run_test('is_muted', () => {

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -1,3 +1,5 @@
+const render_stream_specific_notification_row = require('../templates/settings/stream_specific_notification_row.hbs');
+
 const general_notifications_table_columns = [
     /* An array of notification settings of any category like
     * `stream_notification_settings` which makes a single row of
@@ -11,6 +13,14 @@ exports.stream_notification_settings = [
     "enable_stream_audible_notifications",
     "enable_stream_push_notifications",
     "enable_stream_email_notifications",
+    "wildcard_mentions_notify",
+];
+
+const stream_specific_notification_settings = [
+    "desktop_notifications",
+    "audible_notifications",
+    "push_notifications",
+    "email_notifications",
     "wildcard_mentions_notify",
 ];
 
@@ -90,6 +100,7 @@ exports.all_notifications = {
         email_notification_settings: email_notification_settings,
     },
     show_push_notifications_tooltip: {
+        push_notifications: !page_params.realm_push_notifications_enabled,
         enable_online_push_notifications: !page_params.realm_push_notifications_enabled,
     },
 };
@@ -108,6 +119,28 @@ exports.desktop_icon_count_display_values = {
         description: i18n.t("None"),
     },
 };
+
+function rerender_ui() {
+    const unmatched_streams_table = $("#stream-specific-notify-table").expectOne();
+    const unmatched_streams = stream_data.get_unmatched_streams_for_notification_settings();
+
+    list_render.create(unmatched_streams_table, unmatched_streams, {
+        name: "unmatched-streams-list",
+        modifier: function (unmatched_streams) {
+            return render_stream_specific_notification_row({
+                stream: unmatched_streams,
+                stream_specific_notification_settings: stream_specific_notification_settings,
+                is_disabled: exports.all_notifications.show_push_notifications_tooltip,
+            });
+        },
+    }).init();
+
+    if (unmatched_streams.length === 0) {
+        unmatched_streams_table.css("display", "none");
+    } else {
+        unmatched_streams_table.css("display", "table-row-group");
+    }
+}
 
 function change_notification_setting(setting, setting_data, status_element) {
     const data = {};
@@ -134,6 +167,10 @@ exports.set_up = function () {
         e.preventDefault();
         e.stopPropagation();
         const input_elem = $(e.currentTarget);
+        if (input_elem.parents("#stream-specific-notify-table").length) {
+            stream_edit.stream_setting_clicked(e);
+            return;
+        }
         const setting_name = input_elem.attr("name");
         change_notification_setting(setting_name,
                                     settings_org.get_input_element_value(this),
@@ -159,6 +196,7 @@ exports.set_up = function () {
         }
     });
     exports.set_enable_digest_emails_visibility();
+    rerender_ui();
 };
 
 exports.update_page = function () {
@@ -175,6 +213,7 @@ exports.update_page = function () {
 
         $("#" + setting).prop('checked', page_params[setting]);
     }
+    rerender_ui();
 };
 
 window.settings_notifications = exports;

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -351,12 +351,6 @@ function stream_setting_clicked(e) {
         }
     }
     exports.set_stream_property(sub, setting, !sub[setting]);
-
-    // A hack.  Don't change the state of the checkbox if we
-    // clicked on the checkbox itself.
-    if (checkbox[0] !== e.target) {
-        checkbox.prop("checked", !checkbox.prop("checked"));
-    }
 }
 
 exports.bulk_set_stream_property = function (sub_data) {

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -328,12 +328,16 @@ function stream_is_muted_clicked(e) {
     }
 }
 
-function stream_setting_clicked(e) {
+exports.stream_setting_clicked = function (e) {
     if (e.currentTarget.id === 'sub_is_muted_setting') {
         return;
     }
 
-    const checkbox = $(e.currentTarget).find('.sub_setting_control');
+    let checkbox = $(e.currentTarget).find('.sub_setting_control');
+    // sub data is being changed from the notification settings page.
+    if (checkbox.length === 0) {
+        checkbox = $(e.currentTarget);
+    }
     const sub = get_sub_for_target(e.target);
     const setting = checkbox.attr('name');
     if (!sub) {
@@ -351,7 +355,7 @@ function stream_setting_clicked(e) {
         }
     }
     exports.set_stream_property(sub, setting, !sub[setting]);
-}
+};
 
 exports.bulk_set_stream_property = function (sub_data) {
     return channel.post({
@@ -536,7 +540,7 @@ exports.initialize = function () {
                                  stream_is_muted_clicked);
 
     $("#subscriptions_table").on("click", ".sub_setting_checkbox",
-                                 stream_setting_clicked);
+                                 exports.stream_setting_clicked);
 
     $("#subscriptions_table").on("submit", ".subscriber_list_add form", function (e) {
         e.preventDefault();

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -1,5 +1,5 @@
-// In theory, this group of functions should apply the account-level
-// defaults, however, they are only called after a manual override, so
+// In theory, this function should apply the account-level defaults,
+// however, they are only called after a manual override, so
 // doing so is unnecessary with the current code.  Ideally, we'd do a
 // refactor to address that, however.
 function update_stream_setting(sub, value, setting) {

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -677,10 +677,18 @@ input[type=checkbox].inline-block {
         td {
             text-align: center;
             vertical-align: middle;
+            cursor: default;
+
+            .stream-privacy span.hashtag,
+            .filter-icon i {
+                padding-right: 3px;
+            }
         }
 
         td:first-child {
+            text-align: left;
             font-weight: bold;
+            word-break: break-all;
         }
     }
 }

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -35,13 +35,15 @@
                         {{> notification_settings_checkboxes
                           setting_name=this.setting_name
                           is_checked=this.is_checked
-                          is_disabled=this.is_disabled}}
+                          is_disabled=this.is_disabled }}
                         {{/each}}
                     </tr>
                     {{/each}}
                 </tbody>
+                <tbody id="stream-specific-notify-table">
+                    {{> ../settings/stream_specific_notification_row }}
+                </tbody>
             </table>
-            <p>{{t "You can also override these settings for individual streams." }}</p>
         </div>
 
         <div id="other_notifications" class="m-10 inline-block subsection-parent">

--- a/static/templates/settings/notification_settings_checkboxes.hbs
+++ b/static/templates/settings/notification_settings_checkboxes.hbs
@@ -1,6 +1,6 @@
 <td>
     <label class="checkbox">
-        <input type="checkbox" name="{{setting_name}}" id="{{setting_name}}"
+        <input type="checkbox" name="{{setting_name}}" id="{{prefix}}{{setting_name}}"
           {{#if is_disabled}}disabled="disabled"{{/if}}
           {{#if is_checked}}checked="checked"{{/if}} data-setting-widget-type="bool"/>
         <span></span>

--- a/static/templates/settings/stream_specific_notification_row.hbs
+++ b/static/templates/settings/stream_specific_notification_row.hbs
@@ -1,0 +1,17 @@
+<tr class="stream-row" data-stream-id="{{stream.stream_id}}">
+    <td>
+        <span id="stream_privacy_swatch_{{stream.stream_id}}" class="stream-privacy filter-icon">
+            {{> ../stream_privacy
+              invite_only=stream.invite_only
+              is_web_public=stream.is_web_public }}
+        </span>
+        {{stream.stream_name}}
+    </td>
+    {{#each stream_specific_notification_settings}}
+    {{> notification_settings_checkboxes
+      setting_name=this
+      prefix=(lookup ../stream "stream_id")
+      is_checked=(lookup ../stream this)
+      is_disabled=(lookup ../is_disabled this) }}
+    {{/each}}
+</tr>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#9228 

- [x] add function to get the unmatched streams data.
- [ ] update `#settings/notifications` page UI.

Display up till now:
![grid_ui](https://user-images.githubusercontent.com/40122794/77234248-cfb0dc00-6bd2-11ea-8b39-e7035f6c21b1.png)
