### PR TITLE
push_notifications: In dev, make APNs or GCM config suffice.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -444,7 +444,12 @@ def push_notifications_enabled() -> bool:
         # works -- e.g., that we have ever successfully sent to the bouncer --
         # but this is a good start.
         return True
-    if apns_enabled() and gcm_enabled():  # nocoverage
+    if settings.DEVELOPMENT and (apns_enabled() or gcm_enabled()):  # nocoverage
+        # Since much of the notifications logic is platform-specific, the mobile
+        # developers often work on just one platform at a time, so we should
+        # only require one to be configured.
+        return True
+    elif apns_enabled() and gcm_enabled():  # nocoverage
         # We have the needed configuration to send through APNs and GCM directly
         # (i.e., we are the bouncer, presumably.)  Again, assume it actually works.
         return True


### PR DESCRIPTION
The [current workaround](https://github.com/zulip/zulip-mobile/blob/master/docs/howto/push-notifications.md#current-workaround) to be able to receive notifications in development on iOS takes ~10m from a code change to the new behavior to be observed.

I've been working on the "good first step" toward a better solution, described at ["possible future solution"](https://github.com/zulip/zulip-mobile/blob/master/docs/howto/push-notifications.md#possible-future-solution) on that page; i.e.,

> [to send notifications to a dev build of the app through Apple's sandbox instance of APNs] from a development server, without involving the bouncer

. We still want to explore those other solutions, but they would require more backend changes.

It turns out that my setup was making `push_notifications_enabled()` return False. This PR would loosen the requirement, only on development servers, that notifications be configured for BOTH Android and iOS. It would let it return True if either one is configured, so I don't have to go and configure it for Android when I know the issue at hand is iOS-specific.