### PR TITLE
Notify user to download new config file .

### DIFF
--- a/static/templates/bot_avatar_row.hbs
+++ b/static/templates/bot_avatar_row.hbs
@@ -31,7 +31,7 @@
             <div class="value">{{email}}</div>
         </div>
         {{#if is_active}}
-        <div class="api_key">
+        <div class="api_key"title="{{t 'If refreshing API key download the newly generated config file'}}">
             <span class="field">{{t "API key" }}</span>
             <div class="api-key-value-and-button no-select">
                 <!-- have the `.text-select` in `.no-select` so that the value doesn't have trailing whitespace. -->
@@ -47,4 +47,3 @@
         {{/if}}
         <div class="bot_error alert alert-error hide"></div>
     </div>
-</li>


### PR DESCRIPTION
If a user might regenerate the API key for some reason(x).He needs to download new config file .On hovering over the API key he will get the prompt to download the new config file.Partial fix of #533.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
