### PR TITLE
Notify user to download new config file .

### DIFF
--- a/static/templates/bot_avatar_row.hbs
+++ b/static/templates/bot_avatar_row.hbs
@@ -31,7 +31,7 @@
             <div class="value">{{email}}</div>
         </div>
         {{#if is_active}}
-        <div class="api_key">
+        <div class="api_key" title="{{t 'If refreshing API key download the newly generated config file' }}">
             <span class="field">{{t "API key" }}</span>
             <div class="api-key-value-and-button no-select">
                 <!-- have the `.text-select` in `.no-select` so that the value doesn't have trailing whitespace. -->


### PR DESCRIPTION
If a user might regenerate the API key for some reason(x).He needs to download new config file .On hovering over the API key user will get the prompt to download the new config file.


This is a partial fix to the larger issue.
https://github.com/zulip/python-zulip-api/issues/533

Also check:
https://chat.zulip.org/#narrow/stream/127-integrations/topic/API.20credential.20feedback


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
