### PR TITLE
PENDING: Log top n slow queries for / endpoint.

### DIFF
--- a/zerver/lib/db.py
+++ b/zerver/lib/db.py
@@ -21,6 +21,7 @@ def wrapper_execute(self: CursorObj,
         duration = stop - start
         self.connection.queries.append({
             'time': "%.3f" % (duration,),
+            'sql': sql,
         })
 
 class TimeTrackingCursor(cursor):


### PR DESCRIPTION
For now n=3.

We restrict the logging to zulip folks (which
includes our test accounts).

Here is example output:

2020-02-29 14:06:18.546 INFO [zr] top 3 slow SQL report for / (AARON@zulip.com): 0.065 select * from "zerver_message" INNER JOIN "zerver_usermessage" ON ("zerver_message"."id" = "zerver_usermessage"."message_id") WHERE "zerver_usermessage"."user_profile_id" = %s ORDER BY "zerver_message"."id" DESC LIMIT 1
2020-02-29 14:06:18.546 INFO [zr] top 3 slow SQL report for / (AARON@zulip.com): 0.025 select * from "zerver_subscription" INNER JOIN "zerver_recipient" ON ("zerver_subscription"."recipient_id" = "zerver_recipient"."id") WHERE ("zerver_recipient"."type" = %s AND "zerver_subscription"."user_profile_id" = %s AND "zerver_subscription"."active" = %s)
2020-02-29 14:06:18.547 INFO [zr] top 3 slow SQL report for / (AARON@zulip.com): 0.024 select * from "zerver_subscription" INNER JOIN "zerver_recipient" ON ("zerver_subscription"."recipient_id" = "zerver_recipient"."id") WHERE ("zerver_recipient"."type" = %s AND "zerver_subscription"."user_profile_id" = %s) ORDER BY "zerver_subscription"."recipient_id" ASC

Note that the queries use "%s", which mitigates privacy concerns,
even for core Zulip users.
