### PR TITLE
do_delete_messages: Handle empty set of messages passed as input.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4648,6 +4648,9 @@ def do_update_message(user_profile: UserProfile, message: Message, topic_name: O
 
 def do_delete_messages(realm: Realm, messages: Iterable[Message]) -> None:
     message_ids = [message.id for message in messages]
+    if not message_ids:
+        return
+
     usermessages = UserMessage.objects.filter(message_id__in=message_ids)
     message_id_to_notifiable_users = {}  # type: Dict[int, List[Dict[str, int]]]
     for um in usermessages:

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -328,10 +328,25 @@ class TopicDeleteTest(ZulipTestCase):
         self.assert_json_success(result)
         self.assertEqual(self.get_last_message().id, last_msg_id)
 
+        # Try to delete all messages in the topic again. There are no messages accessible
+        # to the administrator, so this should do nothing.
+        result = self.client_post(endpoint, {
+            "topic_name": topic_name
+        })
+        self.assert_json_success(result)
+        self.assertEqual(self.get_last_message().id, last_msg_id)
+
         # Make the stream's history public to subscribers
         do_change_stream_invite_only(stream, invite_only=True,
                                      history_public_to_subscribers=True)
         # Delete the topic should now remove all messages
+        result = self.client_post(endpoint, {
+            "topic_name": topic_name
+        })
+        self.assert_json_success(result)
+        self.assertEqual(self.get_last_message().id, initial_last_msg_id)
+
+        # Delete again, to test the edge case of deleting an empty topic.
         result = self.client_post(endpoint, {
             "topic_name": topic_name
         })


### PR DESCRIPTION
/delete_topic endpoint could be used to request the deletion of a topic,
that would cause do_delete_messages to be called with an empty set in
these cases:
1. Requesting deletion of an empty stream.
2. Requesting deletion of a topic in a private stream with history not
   public to subscribers, if the requesting admin doesn't have access to
   any of the messages in that topic.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
