### PR TITLE
Uniform confirmation messages displayed when fields updated in settings overlay

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -406,9 +406,10 @@ exports.set_up = function () {
                 overlays.close_modal("change_password_modal");
             },
             error_msg_element: change_password_error,
+            with_button: true,
         };
         settings_ui.do_settings_change(channel.patch, '/json/settings', data,
-                                       $('#account-settings-status').expectOne(), opts);
+                                       $('#user_details_section').expectOne(), opts);
         clear_password_change();
     });
 
@@ -430,9 +431,10 @@ exports.set_up = function () {
                 overlays.close_modal("change_full_name_modal");
             },
             error_msg_element: change_full_name_error,
+            with_button: true,
         };
         settings_ui.do_settings_change(channel.patch, '/json/settings', data,
-                                       $('#account-settings-status').expectOne(), opts);
+                                       $('#user_details_section').expectOne(), opts);
     });
 
     $('#change_email_button').on('click', function (e) {
@@ -453,9 +455,10 @@ exports.set_up = function () {
             error_msg_element: change_email_error,
             success_msg: i18n.t('Check your email (%s) to confirm the new address.').replace(
                 "%s", data.email),
+            with_button: true,
         };
         settings_ui.do_settings_change(channel.patch, '/json/settings', data,
-                                       $('#account-settings-status').expectOne(), opts);
+                                       $('#user_details_section').expectOne(), opts);
     });
 
     $('#change_email').on('click', function (e) {

--- a/static/js/settings_ui.js
+++ b/static/js/settings_ui.js
@@ -15,13 +15,10 @@ exports.strings = {
 // UI.  Intended to replace the old system that was built around
 // direct calls to `ui_report`.
 exports.do_settings_change = function (request_method, url, data, status_element, opts) {
-    const spinner = $(status_element).expectOne();
-    spinner.fadeTo(0, 1);
-    loading.make_indicator(spinner, {text: exports.strings.saving});
     let success_msg;
     let success_continuation;
     let error_continuation;
-    let remove_after = 1000;
+    let remove_after;
     const appear_after = 500;
 
     if (opts !== undefined) {
@@ -35,6 +32,11 @@ exports.do_settings_change = function (request_method, url, data, status_element
     if (success_msg === undefined) {
         success_msg = exports.strings.success;
     }
+
+    remove_after = 1000;
+    const spinner = $(status_element).expectOne();
+    spinner.fadeTo(0, 1);
+    loading.make_indicator(spinner, {text: exports.strings.saving});
 
     request_method({
         url: url,

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -2,6 +2,7 @@
     <div class="alert" id="dev-account-settings-status"></div>
     <div class="account-settings-form">
         <div class="inline-block">
+            <div id="user_details_section">
             <form class="email-change-form grid">
                 <h3 class="inline-block">{{t "User settings" }}</h3>
                 <div class="alert-notification" id="account-settings-status"></div>
@@ -139,6 +140,7 @@
                     </button>
                 </div>
             </form>
+            </div>
 
             <h3 class="inline-block" id="custom-field-header" {{#unless page_params.custom_profile_fields}}style="display: none"{{/unless}}>{{t "Profile" }}</h3>
             <form class="form-horizontal custom-profile-fields-form grid"></form>

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -3,143 +3,143 @@
     <div class="account-settings-form">
         <div class="inline-block">
             <div id="user_details_section">
-            <form class="email-change-form grid">
                 <h3 class="inline-block">{{t "User settings" }}</h3>
-                <div class="alert-notification" id="account-settings-status"></div>
-                <div class="input-group user-name-section">
-                    <label class="inline-block title">{{t "Email" }}</label>
-                    <button id='change_email' type="button" class="button btn-link small rounded inline-block" id='email_value'
-                      {{#if (and page_params.realm_email_changes_disabled (not page_params.is_admin))}}disabled="disabled"{{/if}}>
-                        {{page_params.delivery_email}}
-                        <i class="fa fa-pencil"></i>
-                    </button>
-                    <i class="fa fa-question-circle change_email_tooltip settings-info-icon" {{#if (or (not page_params.realm_email_changes_disabled) page_params.is_admin)}}style="display: none;"{{/if}} data-toggle="tooltip"
-                      title="{{t 'Email address changes are disabled in this organization.' }}"></i>
-                </div>
-
-                <div id="change_email_modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog"
-                  aria-labelledby="change_email_modal_label" aria-hidden="true">
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
-                        <h3 class="inline-block" id="change_email_modal_label">{{t "Change email" }}</h3>
-                        <div class="alert-notification change_email_info"></div>
-                    </div>
-                    <div class="modal-body">
-                        <div class="input-group email_change_container">
-                            <label for="email">{{t "New email" }}</label>
-                            <input type="text" name="email" value="{{ page_params.delivery_email }}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
-                        </div>
-                    </div>
-                    <div class="modal-footer">
-                        <button class="button white rounded" type="button" data-dismiss="modal">{{t "Cancel" }}</button>
-                        <button id='change_email_button' class="button rounded sea-green" data-dismiss="modal">{{t "Change" }}</button>
-                    </div>
-                </div>
-            </form>
-
-            {{#if page_params.two_fa_enabled }}
-            <p for="two_factor_auth" class="inline-block title">
-                {{t "Two factor authentication" }}: {{#if page_params.two_fa_enabled_user }}{{t "Enabled" }}{{else}}{{t "Disabled" }}{{/if}}
-                <a target="_blank" id="two_factor_auth" href="/account/two_factor/" title="{{t 'Setup two factor authentication' }}">[{{t "Setup" }}]</a>
-            </p>
-            {{/if}}
-
-            <form class="form-horizontal full-name-change-form">
-                <div class="input-group inline-block grid user-name-parent">
-                    <div class="user-name-section inline-block">
-                        <label for="full_name" class="inline-block title">{{t "Full name" }}</label>
-                        <button type="button" id='change_full_name' class="button btn-link small white rounded inline-block" id="full_name"
-                          {{#unless user_can_change_name}}disabled="disabled"{{/unless}}>
-                            <span id="full_name_value">{{page_params.full_name}}</span>
+                <form class="email-change-form grid">
+                    <div class="alert-notification" id="account-settings-status"></div>
+                    <div class="input-group user-name-section">
+                        <label class="inline-block title">{{t "Email" }}</label>
+                        <button id='change_email' type="button" class="button btn-link small rounded inline-block" id='email_value'
+                          {{#if (and page_params.realm_email_changes_disabled (not page_params.is_admin))}}disabled="disabled"{{/if}}>
+                            {{page_params.delivery_email}}
                             <i class="fa fa-pencil"></i>
                         </button>
-                        <i class="fa fa-question-circle change_name_tooltip settings-info-icon" data-toggle="tooltip"
-                          {{#if user_can_change_name}}style="display:none"{{/if}}
-                          title="{{t 'Name changes are disabled in this organization. Contact an administrator to change your name.' }}"/>
+                        <i class="fa fa-question-circle change_email_tooltip settings-info-icon" {{#if (or (not page_params.realm_email_changes_disabled) page_params.is_admin)}}style="display: none;"{{/if}} data-toggle="tooltip"
+                          title="{{t 'Email address changes are disabled in this organization.' }}"></i>
                     </div>
-                    <div id="change_full_name_modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog"
-                      aria-labelledby="change_full_name_modal_label" aria-hidden="true">
+
+                    <div id="change_email_modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog"
+                      aria-labelledby="change_email_modal_label" aria-hidden="true">
                         <div class="modal-header">
                             <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
-                            <h3 class="inline-block" id="change_full_name_modal_label">{{t "Change full name" }}</h3>
-                            <div class="alert-notification change_full_name_info"></div>
+                            <h3 class="inline-block" id="change_email_modal_label">{{t "Change email" }}</h3>
+                            <div class="alert-notification change_email_info"></div>
                         </div>
                         <div class="modal-body">
-                            <div class="input-group full_name_change_container">
-                                <label for="email">{{t "New full name" }}</label>
-                                <input type="text" name="full_name" value="{{ page_params.full_name }}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
+                            <div class="input-group email_change_container">
+                                <label for="email">{{t "New email" }}</label>
+                                <input type="text" name="email" value="{{ page_params.delivery_email }}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
                             </div>
                         </div>
                         <div class="modal-footer">
                             <button class="button white rounded" type="button" data-dismiss="modal">{{t "Cancel" }}</button>
-                            <button id='change_full_name_button' class="button rounded sea-green" data-dismiss="modal">{{t "Change" }}</button>
+                            <button id='change_email_button' class="button rounded sea-green" data-dismiss="modal">{{t "Change" }}</button>
                         </div>
                     </div>
-                </div>
-            </form>
+                </form>
 
-            <form class="password-change-form grid">
-                {{#if page_params.realm_email_auth_enabled}}
-                <div class="user-name-section">
-                    <label class="inline-block title">{{t "Password" }}</label>
-                    <div class="input-group inline-block" id="pw_change_link">
-                        <button id="change_password" type="button" class="change_password_button btn-link small button rounded inline-block" data-dismiss="modal">********<i class="fa fa-pencil"></i></button>
-                    </div>
-                </div>
+                {{#if page_params.two_fa_enabled }}
+                <p for="two_factor_auth" class="inline-block title">
+                    {{t "Two factor authentication" }}: {{#if page_params.two_fa_enabled_user }}{{t "Enabled" }}{{else}}{{t "Disabled" }}{{/if}}
+                    <a target="_blank" id="two_factor_auth" href="/account/two_factor/" title="{{t 'Setup two factor authentication' }}">[{{t "Setup" }}]</a>
+                </p>
                 {{/if}}
 
-                <div id="change_password_modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog"
-                  aria-labelledby="change_password_modal_label" aria-hidden="true">
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
-                        <h3 class="inline-block" id="change_password_modal_label">{{t "Change password" }}</h3>
-                        <div class="alert-notification change_password_info"></div>
-                    </div>
-                    <div class="flex-row normal">
-                        <div class="field">
-                            <label for="old_password" class="title">{{t "Old password" }}</label>
-                            <input type="password" autocomplete="off" name="old_password" id="old_password" class="w-200 inline-block" value="" />
-                            <div class="info">
-                                <a href="/accounts/password/reset/" class="sea-green" target="_blank">{{t "Forgotten it?" }}</a>
-                            </div>
-
+                <form class="form-horizontal full-name-change-form">
+                    <div class="input-group inline-block grid user-name-parent">
+                        <div class="user-name-section inline-block">
+                            <label for="full_name" class="inline-block title">{{t "Full name" }}</label>
+                            <button type="button" id='change_full_name' class="button btn-link small white rounded inline-block" id="full_name"
+                              {{#unless user_can_change_name}}disabled="disabled"{{/unless}}>
+                                <span id="full_name_value">{{page_params.full_name}}</span>
+                                <i class="fa fa-pencil"></i>
+                            </button>
+                            <i class="fa fa-question-circle change_name_tooltip settings-info-icon" data-toggle="tooltip"
+                              {{#if user_can_change_name}}style="display:none"{{/if}}
+                              title="{{t 'Name changes are disabled in this organization. Contact an administrator to change your name.' }}"/>
                         </div>
-                        <div class="field">
-                            <label for="new_password" class="title">{{t "New password" }}</label>
-                            <input type="password" autocomplete="off" name="new_password" id="new_password" class="w-200 inline-block" value=""
-                              data-min-length="{{ page_params.password_min_length }}" data-min-guesses="{{ page_params.password_min_guesses }}" />
-                            <div class="progress inline-block" id="pw_strength">
-                                <div class="bar bar-danger fade" style="width: 10%;"></div>
+                        <div id="change_full_name_modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog"
+                          aria-labelledby="change_full_name_modal_label" aria-hidden="true">
+                            <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+                                <h3 class="inline-block" id="change_full_name_modal_label">{{t "Change full name" }}</h3>
+                                <div class="alert-notification change_full_name_info"></div>
+                            </div>
+                            <div class="modal-body">
+                                <div class="input-group full_name_change_container">
+                                    <label for="email">{{t "New full name" }}</label>
+                                    <input type="text" name="full_name" value="{{ page_params.full_name }}" autocomplete="off" spellcheck="false" autofocus="autofocus"/>
+                                </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button class="button white rounded" type="button" data-dismiss="modal">{{t "Cancel" }}</button>
+                                <button id='change_full_name_button' class="button rounded sea-green" data-dismiss="modal">{{t "Change" }}</button>
                             </div>
                         </div>
                     </div>
-                    <div class="modal-footer">
-                        <button class="button white rounded" type="button" data-dismiss="modal">{{t "Cancel" }}</button>
-                        <button id='change_password_button' class="button rounded sea-green">{{t "Change" }}</button>
-                    </div>
-                </div>
-            </form>
+                </form>
 
-            <div class="user-role input-group grid">
-                <label for="user_role" class="inline-block title">{{t "Role" }}</label>
-                <span>
-                    {{#if page_params.is_admin}}
-                    {{t "Administrator" }}
-                    {{else if page_params.is_guest}}
-                    {{t "Guest" }}
-                    {{else}}
-                    {{t "Member" }}
+                <form class="password-change-form grid">
+                    {{#if page_params.realm_email_auth_enabled}}
+                    <div class="user-name-section">
+                        <label class="inline-block title">{{t "Password" }}</label>
+                        <div class="input-group inline-block" id="pw_change_link">
+                            <button id="change_password" type="button" class="change_password_button btn-link small button rounded inline-block" data-dismiss="modal">********<i class="fa fa-pencil"></i></button>
+                        </div>
+                    </div>
                     {{/if}}
-                </span>
-            </div>
 
-            <form class="deactivate_account grid">
-                <div class="input-group">
-                    <button type="submit" class="button rounded btn-danger" id="user_deactivate_account_button">
-                        {{t 'Deactivate account' }}
-                    </button>
+                    <div id="change_password_modal" class="modal modal-bg hide fade" tabindex="-1" role="dialog"
+                      aria-labelledby="change_password_modal_label" aria-hidden="true">
+                        <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+                            <h3 class="inline-block" id="change_password_modal_label">{{t "Change password" }}</h3>
+                            <div class="alert-notification change_password_info"></div>
+                        </div>
+                        <div class="flex-row normal">
+                            <div class="field">
+                                <label for="old_password" class="title">{{t "Old password" }}</label>
+                                <input type="password" autocomplete="off" name="old_password" id="old_password" class="w-200 inline-block" value="" />
+                                <div class="info">
+                                    <a href="/accounts/password/reset/" class="sea-green" target="_blank">{{t "Forgotten it?" }}</a>
+                                </div>
+
+                            </div>
+                            <div class="field">
+                                <label for="new_password" class="title">{{t "New password" }}</label>
+                                <input type="password" autocomplete="off" name="new_password" id="new_password" class="w-200 inline-block" value=""
+                                  data-min-length="{{ page_params.password_min_length }}" data-min-guesses="{{ page_params.password_min_guesses }}" />
+                                <div class="progress inline-block" id="pw_strength">
+                                    <div class="bar bar-danger fade" style="width: 10%;"></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button class="button white rounded" type="button" data-dismiss="modal">{{t "Cancel" }}</button>
+                            <button id='change_password_button' class="button rounded sea-green">{{t "Change" }}</button>
+                        </div>
+                    </div>
+                </form>
+
+                <div class="user-role input-group grid">
+                    <label for="user_role" class="inline-block title">{{t "Role" }}</label>
+                    <span>
+                        {{#if page_params.is_admin}}
+                        {{t "Administrator" }}
+                        {{else if page_params.is_guest}}
+                        {{t "Guest" }}
+                        {{else}}
+                        {{t "Member" }}
+                        {{/if}}
+                    </span>
                 </div>
-            </form>
+
+                <form class="deactivate_account grid">
+                    <div class="input-group">
+                        <button type="submit" class="button rounded btn-danger" id="user_deactivate_account_button">
+                            {{t 'Deactivate account' }}
+                        </button>
+                    </div>
+                </form>
             </div>
 
             <h3 class="inline-block" id="custom-field-header" {{#unless page_params.custom_profile_fields}}style="display: none"{{/unless}}>{{t "Profile" }}</h3>

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -4,8 +4,8 @@
         <div class="inline-block">
             <div id="user_details_section">
                 <h3 class="inline-block">{{t "User settings" }}</h3>
+                {{> settings_save_discard_widget section_name="custom_user_name_section" }}
                 <form class="email-change-form grid">
-                    <div class="alert-notification" id="account-settings-status"></div>
                     <div class="input-group user-name-section">
                         <label class="inline-block title">{{t "Email" }}</label>
                         <button id='change_email' type="button" class="button btn-link small rounded inline-block" id='email_value'

--- a/static/templates/settings/settings_save_discard_widget.hbs
+++ b/static/templates/settings/settings_save_discard_widget.hbs
@@ -1,4 +1,3 @@
-{{#if is_admin }}
 <div class="save-button-controls hide">
     <div class="inline-block organization-submission subsection-changes-save">
         <div class="icon-button button primary save-button" type="button" id="org-submit-{{section_name}}" data-status="save">
@@ -19,4 +18,3 @@
     </div>
     <div class="inline-block subsection-failed-status"><p class="hide"></p></div>
 </div>
-{{/if}}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Showing Confirmation messages according to the current conventions.

**Testing Plan:** <!-- How have you tested? -->
No new test cases created. Used the current test cases.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![saving](https://user-images.githubusercontent.com/20909078/75634160-1c873f80-5c31-11ea-9191-4374532cbeb8.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
