### PR TITLE
emails: Made ScheduledEmail objects end up setting the FromAddress value when mail is sent.

### DIFF
--- a/zerver/lib/digest.py
+++ b/zerver/lib/digest.py
@@ -212,7 +212,8 @@ def handle_digest_email(user_profile_id: int, cutoff: float,
         logger.info("Sending digest email for user %s" % (user_profile.id,))
         # Send now, as a ScheduledEmail
         send_future_email('zerver/emails/digest', user_profile.realm, to_user_ids=[user_profile.id],
-                          from_name="Zulip Digest", from_address=FromAddress.NOREPLY, context=context)
+                          from_name="Zulip Digest", from_address=FromAddress.no_reply_placeholder,
+                          context=context)
     return None
 
 def exclude_subscription_modified_streams(user_profile: UserProfile,

--- a/zerver/lib/email_notifications.py
+++ b/zerver/lib/email_notifications.py
@@ -546,7 +546,7 @@ def enqueue_welcome_emails(user: UserProfile, realm_creation: bool=False) -> Non
         from_address = settings.WELCOME_EMAIL_SENDER['email']
     else:
         from_name = None
-        from_address = FromAddress.SUPPORT
+        from_address = FromAddress.support_placeholder
 
     other_account_count = UserProfile.objects.filter(
         delivery_email__iexact=user.delivery_email).exclude(id=user.id).count()

--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -29,6 +29,10 @@ class FromAddress:
     SUPPORT = parseaddr(settings.ZULIP_ADMINISTRATOR)[1]
     NOREPLY = parseaddr(settings.NOREPLY_EMAIL_ADDRESS)[1]
 
+    support_placeholder = "SUPPORT"
+    no_reply_placeholder = 'NO_REPLY'
+    tokenized_no_reply_placeholder = 'TOKENIZED_NO_REPLY'
+
     # Generates an unpredictable noreply address.
     @staticmethod
     def tokenized_no_reply_address() -> str:
@@ -96,6 +100,13 @@ def build_email(template_prefix: str, to_user_ids: Optional[List[int]]=None,
         from_name = "Zulip"
     if from_address is None:
         from_address = FromAddress.NOREPLY
+    if from_address == FromAddress.tokenized_no_reply_placeholder:
+        from_address = FromAddress.tokenized_no_reply_address()
+    if from_address == FromAddress.no_reply_placeholder:
+        from_address = FromAddress.NOREPLY
+    if from_address == FromAddress.support_placeholder:
+        from_address = FromAddress.SUPPORT
+
     from_email = formataddr((from_name, from_address))
     reply_to = None
     if reply_to_email is not None:

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1382,7 +1382,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
             email = data["email"]
             send_future_email(
                 "zerver/emails/invitation_reminder", referrer.realm, to_emails=[email],
-                from_address=FromAddress.NOREPLY, context=context)
+                from_address=FromAddress.no_reply_placeholder, context=context)
         email_jobs_to_deliver = ScheduledEmail.objects.filter(
             scheduled_timestamp__lte=timezone_now())
         self.assertEqual(len(email_jobs_to_deliver), 1)
@@ -1397,7 +1397,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
             email = data["email"]
             send_future_email(
                 "zerver/emails/invitation_reminder", referrer.realm, to_emails=[email],
-                from_address=FromAddress.NOREPLY, context=context)
+                from_address=FromAddress.no_reply_placeholder, context=context)
 
         email_jobs_to_deliver = ScheduledEmail.objects.filter(
             scheduled_timestamp__lte=timezone_now(), type=ScheduledEmail.INVITATION_REMINDER)

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -243,7 +243,7 @@ class ConfirmationEmailWorker(QueueProcessingWorker):
                 "zerver/emails/invitation_reminder",
                 referrer.realm,
                 to_emails=[invitee.email],
-                from_address=FromAddress.tokenized_no_reply_address(),
+                from_address=FromAddress.no_reply_placeholder,
                 language=referrer.realm.default_language,
                 context=context,
                 delay=datetime.timedelta(days=settings.INVITATION_LINK_VALIDITY_DAYS - 2))


### PR DESCRIPTION
Made ScheduledEmail
objects end up setting the FromAddress value when mail is sent not at the time of creation.
Fixes [#11008 ](https://github.com/zulip/zulip/issues/11008)
Tested Manually
