### PR TITLE
Change chevron-down to ellipsis-v

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -325,9 +325,10 @@ li.top_left_starred_messages {
 .all-messages-arrow,
 .starred-messages-sidebar-arrow,
 .stream-sidebar-arrow {
-    top: 3px;
+    top: 3.5px;
     right: 10px;
     font-size: 0.8em;
+    padding-left: 10px;
 }
 
 /*

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -297,6 +297,11 @@ li.top_left_starred_messages {
     line-height: 1.1;
 }
 
+/*
+  We use padding-left and padding-right so
+  the ellipsis-v button so we can have a
+  large click area
+*/
 .all-messages-arrow i,
 .stream-sidebar-arrow i,
 .starred-messages-sidebar-arrow i,

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -303,7 +303,7 @@ li.top_left_starred_messages {
 .topic-sidebar-arrow i {
     padding-right: 0.25em;
     display: inline-block;
-    width: 13px;
+    font-size: 14px;
 }
 
 /*

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -301,9 +301,10 @@ li.top_left_starred_messages {
 .stream-sidebar-arrow i,
 .starred-messages-sidebar-arrow i,
 .topic-sidebar-arrow i {
-    padding-right: 0.25em;
+    padding-right: 10px;
     display: inline-block;
     font-size: 14px;
+    padding-left: 10px;
 }
 
 /*
@@ -325,10 +326,9 @@ li.top_left_starred_messages {
 .all-messages-arrow,
 .starred-messages-sidebar-arrow,
 .stream-sidebar-arrow {
-    top: 3.5px;
+    top: 4px;
     right: 10px;
     font-size: 0.8em;
-    padding-left: 10px;
 }
 
 /*
@@ -337,7 +337,7 @@ li.top_left_starred_messages {
     which also affects it positioning.
 */
 .topic-sidebar-arrow {
-    top: 1px;
+    top: 25px;
     right: 10px;
     font-size: 0.7em;
 }

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -337,9 +337,9 @@ li.top_left_starred_messages {
     which also affects it positioning.
 */
 .topic-sidebar-arrow {
-    top: 25px;
+    top: 3.5px;
     right: 10px;
-    font-size: 0.7em;
+    font-size: 10px;
 }
 
 /*

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -35,15 +35,15 @@
 
         .user-list-arrow {
             position: absolute;
-            top: 0px;
+            top: 1px;
             right: 10px;
             font-size: 14px;
             display: none;
+            padding-left: 10px;
 
             i {
                 padding-right: 0.25em;
                 display: inline-block;
-                width: 13px;
             }
 
             &:hover {

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -35,10 +35,16 @@
 
         .user-list-arrow {
             position: absolute;
-            top: 1.5px;
+            top: 1.3px;
             right: 10px;
             font-size: 14px;
             display: none;
+
+            /*
+                For topic chevrons we use a slightly smaller
+                font to show they're "lower" in the hierarchy,
+                which also affects it positioning.
+            */
 
             i {
                 padding-right: 10px;
@@ -46,7 +52,7 @@
                 padding-left: 12px;
             }
 
-            &:hover {
+            i:hover {
                 display: inline;
                 cursor: pointer;
                 color: hsl(0, 0%, 0%);

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -35,15 +35,15 @@
 
         .user-list-arrow {
             position: absolute;
-            top: 1px;
+            top: 1.5px;
             right: 10px;
             font-size: 14px;
             display: none;
-            padding-left: 10px;
 
             i {
-                padding-right: 0.25em;
+                padding-right: 10px;
                 display: inline-block;
+                padding-left: 12px;
             }
 
             &:hover {

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -37,7 +37,7 @@
             position: absolute;
             top: 0px;
             right: 10px;
-            font-size: 0.8em;
+            font-size: 14px;
             display: none;
 
             i {

--- a/static/templates/message_controls.hbs
+++ b/static/templates/message_controls.hbs
@@ -11,7 +11,7 @@
 
     {{#unless msg/locally_echoed}}
     <div class="info actions_hover">
-        <i class="fa fa-chevron-down" title="{{#tr this}}Message actions{{/tr}} (i)" title="{{#tr this}}Message actions{{/tr}}" role="button" aria-haspopup="true" tabindex="0" aria-label="{{#tr this}}Message actions{{/tr}}"></i>
+        <i class="fa fa-ellipsis-v" title="{{#tr this}}Message actions{{/tr}} (i)" title="{{#tr this}}Message actions{{/tr}}" role="button" aria-haspopup="true" tabindex="0" aria-label="{{#tr this}}Message actions{{/tr}}"></i>
     </div>
     {{/unless}}
 

--- a/static/templates/stream_sidebar_row.hbs
+++ b/static/templates/stream_sidebar_row.hbs
@@ -13,6 +13,6 @@
 
             <div class="count"><div class="value"></div></div>
         </div>
-        <span class="stream-sidebar-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
+        <span class="stream-sidebar-arrow"><i class="fa fa-ellipsis-v" aria-hidden="true"></i></span>
     </div>
 </li>

--- a/static/templates/topic_list_item.hbs
+++ b/static/templates/topic_list_item.hbs
@@ -8,6 +8,6 @@
         </div>
     </span>
     <span class="topic-sidebar-arrow">
-        <i class="fa fa-chevron-down" aria-hidden="true"></i>
+        <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
     </span>
 </li>

--- a/static/templates/user_presence_row.hbs
+++ b/static/templates/user_presence_row.hbs
@@ -12,5 +12,5 @@
         </a>
         <span class="count"><span class="value">{{#if num_unread}}{{num_unread}}{{/if}}</span></span>
     </div>
-    <span class="user-list-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
+    <span class="user-list-arrow"><i class="fa fa-ellipsis-v" aria-hidden="true"></i></span>
 </li>

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -13,7 +13,7 @@
                         <span class="value"></span>
                     </span>
                 </a>
-                <span class="arrow all-messages-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
+                <span class="arrow all-messages-arrow"><i class="fa fa-ellipsis-v" aria-hidden="true"></i></span>
             </li>
             <li class="top_left_private_messages">
                 <div class="private_messages_header top_left_row">
@@ -54,7 +54,7 @@
                         <span class="value"></span>
                     </span>
                 </a>
-                <span class="arrow starred-messages-sidebar-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
+                <span class="arrow starred-messages-sidebar-arrow"><i class="fa fa-ellipsis-v" aria-hidden="true"></i></span>
             </li>
         </ul>
         <div id="streams_list" class="zoom-out">
@@ -69,7 +69,7 @@
                 </div>
             </div>
             <div id="topics_header">
-                <a href="" class="show-all-streams"> <i class="fa fa-chevron-left" aria-hidden="true"></i>{{ _('All streams') }}</a>
+                <a href="" class="show-all-streams"> <i class="fa fa-ellipsis-v" aria-hidden="true"></i>{{ _('All streams') }}</a>
             </div>
             <div id="stream-filters-container" class="scrolling_list" data-simplebar>
                 <ul id="stream_filters" class="filters"></ul>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
I change chavron-down button with ellipsis-v to left sidebar, right sidebar, message menu
#7115

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![m4](https://user-images.githubusercontent.com/43316964/75717304-8c510500-5cd9-11ea-8442-a5453d1258c5.png)
![m1](https://user-images.githubusercontent.com/43316964/75717307-8e1ac880-5cd9-11ea-9875-a189c898f01d.png)
![m2](https://user-images.githubusercontent.com/43316964/75717309-8fe48c00-5cd9-11ea-9f95-1c1dba287e4c.png)
![m3](https://user-images.githubusercontent.com/43316964/75717313-9115b900-5cd9-11ea-90d2-95470d6ab65d.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
