### PR TITLE
sidebars: replace chevron with ellipsis-V icon from the sidebars

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -323,11 +323,16 @@ li.top_left_starred_messages {
     pretty similar.
 */
 .all-messages-arrow,
-.starred-messages-sidebar-arrow,
-.stream-sidebar-arrow {
+.starred-messages-sidebar-arrow {
     top: 3px;
     right: 10px;
     font-size: 0.8em;
+}
+
+.stream-sidebar-arrow {
+    top: 3px;
+    right: 5px;
+    font-size: 1.1em;
 }
 
 /*
@@ -336,9 +341,9 @@ li.top_left_starred_messages {
     which also affects it positioning.
 */
 .topic-sidebar-arrow {
-    top: 1px;
-    right: 10px;
-    font-size: 0.7em;
+    top: 2px;
+    right: 5px;
+    font-size: 1em;
 }
 
 /*

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -35,9 +35,9 @@
 
         .user-list-arrow {
             position: absolute;
-            top: 0px;
-            right: 10px;
-            font-size: 0.8em;
+            top: 1px;
+            right: 5px;
+            font-size: 1.1em;
             display: none;
 
             i {

--- a/static/templates/stream_sidebar_row.hbs
+++ b/static/templates/stream_sidebar_row.hbs
@@ -13,6 +13,6 @@
 
             <div class="count"><div class="value"></div></div>
         </div>
-        <span class="stream-sidebar-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
+        <span class="stream-sidebar-arrow"><i class="fa fa-ellipsis-v" aria-hidden="true"></i></span>
     </div>
 </li>

--- a/static/templates/topic_list_item.hbs
+++ b/static/templates/topic_list_item.hbs
@@ -8,6 +8,6 @@
         </div>
     </span>
     <span class="topic-sidebar-arrow">
-        <i class="fa fa-chevron-down" aria-hidden="true"></i>
+        <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
     </span>
 </li>

--- a/static/templates/user_presence_row.hbs
+++ b/static/templates/user_presence_row.hbs
@@ -12,5 +12,5 @@
         </a>
         <span class="count"><span class="value">{{#if num_unread}}{{num_unread}}{{/if}}</span></span>
     </div>
-    <span class="user-list-arrow"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
+    <span class="user-list-arrow"><i class="fa fa-ellipsis-v" aria-hidden="true"></i></span>
 </li>


### PR DESCRIPTION
Replace chevron icon with ellipsis-v (vertical dots)
Discussion: https://chat.zulip.org/#narrow/stream/101-design/topic/Stream.20Buttons

Right Sidebar
![Screenshot from 2020-03-03 03-39-10](https://user-images.githubusercontent.com/32801674/75724114-abfd2300-5d03-11ea-90c5-5fa73d3fed72.png)

Left sidebar
![Screenshot from 2020-03-03 03-39-15](https://user-images.githubusercontent.com/32801674/75724168-cc2ce200-5d03-11ea-91b0-ae1e72bf3eb6.png)

Fixes #7115 
