### PR TITLE
[WIP] rate_limiter: Optimize performance for get_events queries.

### DIFF
--- a/tools/coveragerc
+++ b/tools/coveragerc
@@ -15,6 +15,8 @@ exclude_lines =
     raise UnexpectedWebhookEventType
     # Don't require coverage for blocks only run when type-checking
     if TYPE_CHECKING:
+    # Don't require coverage for abstract methods; they're never called.
+    @abstractmethod
     # Don't require coverage for the settings.LOG_API_EVENT_TYPES code paths
     # These are only run in a special testing mode, so will fail normal coverage.
     if settings.LOG_API_EVENT_TYPES:

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -93,7 +93,6 @@ not_yet_fully_covered = {path for target in [
     'zerver/lib/parallel.py',
     'zerver/lib/profile.py',
     'zerver/lib/queue.py',
-    'zerver/lib/rate_limiter.py',
     'zerver/lib/sqlalchemy_utils.py',
     'zerver/lib/storage.py',
     'zerver/lib/stream_recipient.py',

--- a/zerver/lib/rate_limiter.py
+++ b/zerver/lib/rate_limiter.py
@@ -222,9 +222,6 @@ class RedisRateLimiterBackend(RateLimiterBackend):
         "Returns a tuple of (rate_limited, time_till_free)"
         list_key, set_key, blocking_key = cls.get_keys(entity_key)
 
-        if len(rules) == 0:
-            return False, 0.0
-
         # Go through the rules from shortest to longest,
         # seeing if this user has violated any of them. First
         # get the timestamps for each nth items
@@ -249,6 +246,9 @@ class RedisRateLimiterBackend(RateLimiterBackend):
             else:
                 blocking_ttl = int(blocking_ttl_b)
             return True, blocking_ttl
+
+        if len(rules) == 0:
+            return False, 0.0
 
         now = time.time()
         for timestamp, (range_seconds, num_requests) in zip(rule_timestamps, rules):

--- a/zerver/lib/rate_limiter.py
+++ b/zerver/lib/rate_limiter.py
@@ -369,7 +369,7 @@ class RedisRateLimiterBackend(RateLimiterBackend):
 
         if key_blocked is not None:
             # We are manually blocked. Report for how much longer we will be
-            if blocking_ttl_b is None:
+            if blocking_ttl_b is None:  # nocoverage # defensive code, this should never happen
                 blocking_ttl = 0.5
             else:
                 blocking_ttl = int(blocking_ttl_b)
@@ -436,7 +436,7 @@ class RedisRateLimiterBackend(RateLimiterBackend):
 
                     # If no exception was raised in the execution, there were no transaction conflicts
                     break
-                except redis.WatchError:
+                except redis.WatchError:  # nocoverage # Ideally we'd have a test for this.
                     if count > 10:
                         raise RateLimiterLockingException()
                     count += 1

--- a/zerver/tests/test_rate_limiter.py
+++ b/zerver/tests/test_rate_limiter.py
@@ -83,7 +83,7 @@ class RateLimiterBackendBase(ZulipTestCase):
         """
         This depends on the algorithm used in the backend, and should be defined by the test class.
         """
-        raise NotImplementedError  # nocoverage
+        raise NotImplementedError()
 
     def test_hit_ratelimits(self) -> None:
         obj = self.create_object('test', [(2, 3), ])


### PR DESCRIPTION
The Redis-based rate limiting approach takes a lot of time talking to Redis with 3-4 network requests to Redis on each request.  It had a negative impact on the performance of `get_events()` since this is our single highest-traffic endpoint.

This PR introduces an in-process rate limiting alternate for `/json/events` endpoint. The implementation uses Leaky Bucket algorithm and Python dictionaries instead of Redis. This drops the rate limiting time for `get_events()` from about 3000us to less than 100us (on my system).

Fixes #13913.