### PR TITLE
user status: Save status on enter keypress.

### DIFF
--- a/static/js/user_status_ui.js
+++ b/static/js/user_status_ui.js
@@ -82,6 +82,14 @@ exports.initialize = function () {
         exports.submit_new_status();
     });
 
+    $('body').on('keypress', '.user_status_overlay .user_status', function (event) {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+
+            exports.submit_new_status();
+        }
+    });
+
     $('body').on('keyup', '.user_status_overlay input.user_status', function () {
         exports.update_button();
         exports.toggle_clear_message_button();


### PR DESCRIPTION
This is a common UX pattern for forms - a user would expect the
input to be submitted on hitting enter.

So, create a 'keypress' event listener on the input field for the
new status, which calls 'submit_new_status' on enter key press.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->



**Testing Plan:** <!-- How have you tested? -->

Manual UI testing in a browser.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![status](https://user-images.githubusercontent.com/7714968/75966240-078c0400-5ef0-11ea-92ab-fb98e19caccf.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
