### PR TITLE
settings page: Change cursor for date input to 'pointer'.

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1543,6 +1543,10 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
     opacity: 1;
 }
 
+#settings_page .custom_user_field_value.datepicker {
+    cursor: pointer;
+}
+
 #settings_page .custom_user_field .person_picker {
     min-width: 206px;
 }


### PR DESCRIPTION
Currently, the cursor for the date input field in the settings page
is 'not-allowed' as it has the disabled attribute because we want
users to pick the date from the date picker. But this leads to
confusion whether the field is editable at all.

Change the cursor to 'pointer' to make it clear that the field has
a click action associated with it.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->

Manual testing in the browser.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before:
![before gif](https://user-images.githubusercontent.com/7714968/75997741-cca4c300-5f25-11ea-9c98-e27cee4f4f48.gif)
After:
![after gif](https://user-images.githubusercontent.com/7714968/75997816-e9d99180-5f25-11ea-809c-6ceff3cb810f.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
