### PR TITLE
settings page: Apply dark theme to 'code' elements in night mode.

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -566,8 +566,7 @@ on a dark background, and don't change the dark labels dark either. */
     }
 
     #feedback_container,
-    .rendered_markdown code,
-    .feedback_content code,
+    code,
     .typeahead.dropdown-menu {
         background-color: hsl(212, 25%, 15%);
         border-color: hsla(0, 0%, 0%, 0.5);


### PR DESCRIPTION
The example regexes for linkifier settings are not themed according
to the user's dark theme setting.

Modfiy 'night_mode.scss' to fix that.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Manually, in the browser.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

Before:
![image](https://user-images.githubusercontent.com/7714968/76000342-9406e880-5f29-11ea-94e0-7b76323d9e6d.png)


After:
![image](https://user-images.githubusercontent.com/7714968/76000299-86516300-5f29-11ea-8de1-7fd95b05b828.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
