### PR TITLE
orgainzation settings: Fix bot owner profile display.

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -404,7 +404,7 @@ exports.on_load_success = function (realm_people_data) {
     });
 
     $('.admin_bot_table').on('click', '.user_row .view_user_profile', function (e) {
-        const owner_id = $(e.target).attr('data-owner-id');
+        const owner_id = parseInt($(e.target).attr('data-owner-id'), 10);
         const owner = people.get_by_user_id(owner_id);
         popovers.show_user_profile(owner);
         e.stopPropagation();


### PR DESCRIPTION

Clicking on the 'Owner' value for a row in the list of bots does
nothing, and causes a blueslip error.
This is because the map object in which we store the users have
integer keys, while we pass the owner id as string.

This is fixed by parsing the owner id to integer before passing it
on.

Fixes #14107.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Manually, in the browser UI.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before: No profile is displayed.
Now:
![bot](https://user-images.githubusercontent.com/7714968/76005025-76894d00-5f30-11ea-80d3-d147ef2f6e2e.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
