### PR TITLE
[WIP] Rate limiter refactor to allow straightforward adding/changing of implementations

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -28,7 +28,7 @@ from zerver.lib.exceptions import JsonableError, ErrorCode, \
 from zerver.lib.types import ViewFuncT
 from zerver.lib.validator import to_non_negative_int
 
-from zerver.lib.rate_limiter import rate_limit_request_by_entity, RateLimitedUser
+from zerver.lib.rate_limiter import RateLimitedUser
 from zerver.lib.request import REQ, has_request_variables
 
 from functools import wraps
@@ -744,8 +744,7 @@ def rate_limit_user(request: HttpRequest, user: UserProfile, domain: str) -> Non
     if the user has been rate limited, otherwise returns and modifies request to contain
     the rate limit information"""
 
-    entity = RateLimitedUser(user, domain=domain)
-    rate_limit_request_by_entity(request, entity)
+    RateLimitedUser(user, domain=domain).rate_limit_request(request)
 
 def rate_limit(domain: str='api_by_user') -> Callable[[ViewFuncT], ViewFuncT]:
     """Rate-limits a view. Takes an optional 'domain' param if you wish to

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -19,7 +19,7 @@ from zerver.lib.email_validation import email_allowed_for_realm, \
     validate_email_not_already_in_realm
 from zerver.lib.name_restrictions import is_reserved_subdomain, is_disposable_domain
 from zerver.lib.rate_limiter import RateLimited, get_rate_limit_result_from_request, \
-    RateLimitedObject, rate_limit_entity
+    RateLimitedObject
 from zerver.lib.request import JsonableError
 from zerver.lib.send_email import send_email, FromAddress
 from zerver.lib.subdomains import get_subdomain, is_root_domain_available
@@ -314,7 +314,7 @@ class RateLimitedPasswordResetByEmail(RateLimitedObject):
         return settings.RATE_LIMITING_RULES['password_reset_form_by_email']
 
 def rate_limit_password_reset_form_by_email(email: str) -> None:
-    ratelimited, _ = rate_limit_entity(RateLimitedPasswordResetByEmail(email))
+    ratelimited, _ = RateLimitedPasswordResetByEmail(email).rate_limit()
     if ratelimited:
         raise RateLimited
 

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -309,7 +309,7 @@ class RateLimitedPasswordResetByEmail(RateLimitedObject):
         return "Email: {}".format(self.email)
 
     def key(self) -> str:
-        return "{}:{}".format(type(self), self.email)
+        return "{}:{}".format(type(self).__name__, self.email)
 
     def rules(self) -> List[Tuple[int, int]]:
         return settings.RATE_LIMITING_RULES['password_reset_form_by_email']

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -305,9 +305,6 @@ class RateLimitedPasswordResetByEmail(RateLimitedObject):
         self.email = email
         super().__init__()
 
-    def __str__(self) -> str:
-        return "Email: {}".format(self.email)
-
     def key(self) -> str:
         return "{}:{}".format(type(self).__name__, self.email)
 

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -308,7 +308,7 @@ class RateLimitedPasswordResetByEmail(RateLimitedObject):
     def __str__(self) -> str:
         return "Email: {}".format(self.email)
 
-    def key_fragment(self) -> str:
+    def key(self) -> str:
         return "{}:{}".format(type(self), self.email)
 
     def rules(self) -> List[Tuple[int, int]]:

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -303,6 +303,7 @@ class ZulipPasswordResetForm(PasswordResetForm):
 class RateLimitedPasswordResetByEmail(RateLimitedObject):
     def __init__(self, email: str) -> None:
         self.email = email
+        super().__init__()
 
     def __str__(self) -> str:
         return "Email: {}".format(self.email)

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -445,7 +445,7 @@ class RateLimitedRealmMirror(RateLimitedObject):
         super().__init__()
 
     def key(self) -> str:
-        return "emailmirror:{}:{}".format(type(self.realm), self.realm.id)
+        return "{}:{}".format(type(self).__name__, self.realm.string_id)
 
     def rules(self) -> List[Tuple[int, int]]:
         return settings.RATE_LIMITING_MIRROR_REALM_RULES

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -444,7 +444,7 @@ class RateLimitedRealmMirror(RateLimitedObject):
         self.realm = realm
         super().__init__()
 
-    def key_fragment(self) -> str:
+    def key(self) -> str:
         return "emailmirror:{}:{}".format(type(self.realm), self.realm.id)
 
     def rules(self) -> List[Tuple[int, int]]:

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -442,6 +442,7 @@ def mirror_email_message(data: Dict[str, str]) -> Dict[str, str]:
 class RateLimitedRealmMirror(RateLimitedObject):
     def __init__(self, realm: Realm) -> None:
         self.realm = realm
+        super().__init__()
 
     def key_fragment(self) -> str:
         return "emailmirror:{}:{}".format(type(self.realm), self.realm.id)

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -450,9 +450,6 @@ class RateLimitedRealmMirror(RateLimitedObject):
     def rules(self) -> List[Tuple[int, int]]:
         return settings.RATE_LIMITING_MIRROR_REALM_RULES
 
-    def __str__(self) -> str:
-        return self.realm.string_id
-
 def rate_limit_mirror_by_realm(recipient_realm: Realm) -> None:
     ratelimited = RateLimitedRealmMirror(recipient_realm).rate_limit()[0]
 

--- a/zerver/lib/email_mirror.py
+++ b/zerver/lib/email_mirror.py
@@ -20,7 +20,7 @@ from zerver.lib.queue import queue_json_publish
 from zerver.lib.utils import generate_random_token
 from zerver.lib.upload import upload_message_file
 from zerver.lib.send_email import FromAddress
-from zerver.lib.rate_limiter import RateLimitedObject, rate_limit_entity
+from zerver.lib.rate_limiter import RateLimitedObject
 from zerver.lib.exceptions import RateLimited
 from zerver.models import Stream, Recipient, MissedMessageEmailAddress, \
     get_display_recipient, \
@@ -453,8 +453,7 @@ class RateLimitedRealmMirror(RateLimitedObject):
         return self.realm.string_id
 
 def rate_limit_mirror_by_realm(recipient_realm: Realm) -> None:
-    entity = RateLimitedRealmMirror(recipient_realm)
-    ratelimited = rate_limit_entity(entity)[0]
+    ratelimited = RateLimitedRealmMirror(recipient_realm).rate_limit()[0]
 
     if ratelimited:
         raise RateLimited()

--- a/zerver/lib/rate_limiter.py
+++ b/zerver/lib/rate_limiter.py
@@ -99,18 +99,11 @@ class RateLimitedObject(ABC):
     def rules(self) -> List[Tuple[int, int]]:
         pass
 
-    @abstractmethod
-    def __str__(self) -> str:
-        pass
-
 class RateLimitedUser(RateLimitedObject):
     def __init__(self, user: UserProfile, domain: str='api_by_user') -> None:
         self.user = user
         self.domain = domain
         super().__init__()
-
-    def __str__(self) -> str:
-        return "Id: {}".format(self.user.id)
 
     def key(self) -> str:
         return "{}:{}:{}".format(type(self).__name__, self.user.id, self.domain)

--- a/zerver/lib/rate_limiter.py
+++ b/zerver/lib/rate_limiter.py
@@ -33,8 +33,8 @@ class RateLimitedObject(ABC):
         self.backend = RedisRateLimiterBackend
 
     def get_keys(self) -> List[str]:
-        key_fragment = self.key_fragment()
-        return ["{}ratelimit:{}:{}".format(KEY_PREFIX, key_fragment, keytype)
+        key = self.key()
+        return ["{}ratelimit:{}:{}".format(KEY_PREFIX, key, keytype)
                 for keytype in ['list', 'zset', 'block']]
 
     def rate_limit(self) -> Tuple[bool, float]:
@@ -92,7 +92,7 @@ class RateLimitedObject(ABC):
         return self.backend.get_api_calls_left(self, max_window, max_calls)
 
     @abstractmethod
-    def key_fragment(self) -> str:
+    def key(self) -> str:
         pass
 
     @abstractmethod
@@ -112,7 +112,7 @@ class RateLimitedUser(RateLimitedObject):
     def __str__(self) -> str:
         return "Id: {}".format(self.user.id)
 
-    def key_fragment(self) -> str:
+    def key(self) -> str:
         return "{}:{}:{}".format(type(self.user), self.user.id, self.domain)
 
     def rules(self) -> List[Tuple[int, int]]:

--- a/zerver/lib/rate_limiter.py
+++ b/zerver/lib/rate_limiter.py
@@ -67,10 +67,6 @@ class RateLimitedObject(ABC):
         self.backend.unblock_access(self.key())
 
     def clear_history(self) -> None:
-        '''
-        This is only used by test code now, where it's very helpful in
-        allowing us to run tests quickly, by giving a user a clean slate.
-        '''
         self.backend.clear_history(self.key())
 
     def max_api_calls(self) -> int:
@@ -149,10 +145,7 @@ class RateLimiterBackend(ABC):
     @classmethod
     @abstractmethod
     def clear_history(cls, entity_key: str) -> None:
-        '''
-        This is only used by test code now, where it's very helpful in
-        allowing us to run tests quickly, by giving a user a clean slate.
-        '''
+        pass
 
     @classmethod
     @abstractmethod
@@ -189,10 +182,6 @@ class RedisRateLimiterBackend(RateLimiterBackend):
 
     @classmethod
     def clear_history(cls, entity_key: str) -> None:
-        '''
-        This is only used by test code now, where it's very helpful in
-        allowing us to run tests quickly, by giving a user a clean slate.
-        '''
         for key in cls.get_keys(entity_key):
             client.delete(key)
 

--- a/zerver/lib/rate_limiter.py
+++ b/zerver/lib/rate_limiter.py
@@ -29,6 +29,9 @@ class RateLimiterLockingException(Exception):
     pass
 
 class RateLimitedObject(ABC):
+    def __init__(self) -> None:
+        self.backend = RedisRateLimiterBackend
+
     def get_keys(self) -> List[str]:
         key_fragment = self.key_fragment()
         return ["{}ratelimit:{}:{}".format(KEY_PREFIX, key_fragment, keytype)
@@ -36,21 +39,7 @@ class RateLimitedObject(ABC):
 
     def rate_limit(self) -> Tuple[bool, float]:
         # Returns (ratelimited, secs_to_freedom)
-        ratelimited, time = is_ratelimited(self)
-
-        if ratelimited:
-            statsd.incr("ratelimiter.limited.%s.%s" % (type(self), str(self)))
-
-        else:
-            try:
-                incr_ratelimit(self)
-            except RateLimiterLockingException:
-                logger.warning("Deadlock trying to incr_ratelimit for %s:%s" % (
-                               type(self).__name__, str(self)))
-                # rate-limit users who are hitting the API so hard we can't update our stats.
-                ratelimited = True
-
-        return ratelimited, time
+        return self.backend.rate_limit_entity(self)
 
     def rate_limit_request(self, request: HttpRequest) -> None:
         ratelimited, time = self.rate_limit()
@@ -75,23 +64,17 @@ class RateLimitedObject(ABC):
 
     def block_access(self, seconds: int) -> None:
         "Manually blocks an entity for the desired number of seconds"
-        _, _, blocking_key = self.get_keys()
-        with client.pipeline() as pipe:
-            pipe.set(blocking_key, 1)
-            pipe.expire(blocking_key, seconds)
-            pipe.execute()
+        self.backend.block_access(self, seconds)
 
     def unblock_access(self) -> None:
-        _, _, blocking_key = self.get_keys()
-        client.delete(blocking_key)
+        self.backend.unblock_access(self)
 
     def clear_history(self) -> None:
         '''
         This is only used by test code now, where it's very helpful in
         allowing us to run tests quickly, by giving a user a clean slate.
         '''
-        for key in self.get_keys():
-            client.delete(key)
+        self.backend.clear_history(self)
 
     def max_api_calls(self) -> int:
         "Returns the API rate limit for the highest limit"
@@ -106,7 +89,7 @@ class RateLimitedObject(ABC):
         the rate-limit will be reset to 0"""
         max_window = self.max_api_window()
         max_calls = self.max_api_calls()
-        return _get_api_calls_left(self, max_window, max_calls)
+        return self.backend.get_api_calls_left(self, max_window, max_calls)
 
     @abstractmethod
     def key_fragment(self) -> str:
@@ -124,6 +107,7 @@ class RateLimitedUser(RateLimitedObject):
     def __init__(self, user: UserProfile, domain: str='api_by_user') -> None:
         self.user = user
         self.domain = domain
+        super().__init__()
 
     def __str__(self) -> str:
         return "Id: {}".format(self.user.id)
@@ -161,138 +145,215 @@ def remove_ratelimit_rule(range_seconds: int, num_requests: int, domain: str='ap
     global rules
     rules[domain] = [x for x in rules[domain] if x[0] != range_seconds and x[1] != num_requests]
 
-def _get_api_calls_left(entity: RateLimitedObject, range_seconds: int, max_calls: int) -> Tuple[int, float]:
-    list_key, set_key, _ = entity.get_keys()
-    # Count the number of values in our sorted set
-    # that are between now and the cutoff
-    now = time.time()
-    boundary = now - range_seconds
+class RateLimiterBackend(ABC):
+    @classmethod
+    @abstractmethod
+    def block_access(cls, entity: RateLimitedObject, seconds: int) -> None:
+        "Manually blocks an entity for the desired number of seconds"
 
-    with client.pipeline() as pipe:
-        # Count how many API calls in our range have already been made
-        pipe.zcount(set_key, boundary, now)
-        # Get the newest call so we can calculate when the ratelimit
-        # will reset to 0
-        pipe.lindex(list_key, 0)
+    @classmethod
+    @abstractmethod
+    def unblock_access(cls, entity: RateLimitedObject) -> None:
+        pass
 
-        results = pipe.execute()
+    @classmethod
+    @abstractmethod
+    def clear_history(cls, entity: RateLimitedObject) -> None:
+        '''
+        This is only used by test code now, where it's very helpful in
+        allowing us to run tests quickly, by giving a user a clean slate.
+        '''
 
-    count = results[0]  # type: int
-    newest_call = results[1]  # type: Optional[bytes]
+    @classmethod
+    @abstractmethod
+    def get_api_calls_left(cls, entity: RateLimitedObject, range_seconds: int,
+                           max_calls: int) -> Tuple[int, float]:
+        pass
 
-    calls_left = max_calls - count
-    if newest_call is not None:
-        time_reset = now + (range_seconds - (now - float(newest_call)))
-    else:
-        time_reset = now
+    @classmethod
+    @abstractmethod
+    def rate_limit_entity(cls, entity: RateLimitedObject) -> Tuple[bool, float]:
+        # Returns (ratelimited, secs_to_freedom)
+        pass
 
-    return calls_left, time_reset
+class RedisRateLimiterBackend(RateLimiterBackend):
+    @classmethod
+    def block_access(cls, entity: RateLimitedObject, seconds: int) -> None:
+        "Manually blocks an entity for the desired number of seconds"
+        _, _, blocking_key = entity.get_keys()
+        with client.pipeline() as pipe:
+            pipe.set(blocking_key, 1)
+            pipe.expire(blocking_key, seconds)
+            pipe.execute()
 
-def is_ratelimited(entity: RateLimitedObject) -> Tuple[bool, float]:
-    "Returns a tuple of (rate_limited, time_till_free)"
-    list_key, set_key, blocking_key = entity.get_keys()
+    @classmethod
+    def unblock_access(cls, entity: RateLimitedObject) -> None:
+        _, _, blocking_key = entity.get_keys()
+        client.delete(blocking_key)
 
-    rules = entity.rules()
+    @classmethod
+    def clear_history(cls, entity: RateLimitedObject) -> None:
+        '''
+        This is only used by test code now, where it's very helpful in
+        allowing us to run tests quickly, by giving a user a clean slate.
+        '''
+        for key in entity.get_keys():
+            client.delete(key)
 
-    if len(rules) == 0:
+    @classmethod
+    def get_api_calls_left(cls, entity: RateLimitedObject, range_seconds: int,
+                           max_calls: int) -> Tuple[int, float]:
+        list_key, set_key, _ = entity.get_keys()
+        # Count the number of values in our sorted set
+        # that are between now and the cutoff
+        now = time.time()
+        boundary = now - range_seconds
+
+        with client.pipeline() as pipe:
+            # Count how many API calls in our range have already been made
+            pipe.zcount(set_key, boundary, now)
+            # Get the newest call so we can calculate when the ratelimit
+            # will reset to 0
+            pipe.lindex(list_key, 0)
+
+            results = pipe.execute()
+
+        count = results[0]  # type: int
+        newest_call = results[1]  # type: Optional[bytes]
+
+        calls_left = max_calls - count
+        if newest_call is not None:
+            time_reset = now + (range_seconds - (now - float(newest_call)))
+        else:
+            time_reset = now
+
+        return calls_left, time_reset
+
+    @classmethod
+    def is_ratelimited(cls, entity: RateLimitedObject) -> Tuple[bool, float]:
+        "Returns a tuple of (rate_limited, time_till_free)"
+        list_key, set_key, blocking_key = entity.get_keys()
+
+        rules = entity.rules()
+
+        if len(rules) == 0:
+            return False, 0.0
+
+        # Go through the rules from shortest to longest,
+        # seeing if this user has violated any of them. First
+        # get the timestamps for each nth items
+        with client.pipeline() as pipe:
+            for _, request_count in rules:
+                pipe.lindex(list_key, request_count - 1)  # 0-indexed list
+
+            # Get blocking info
+            pipe.get(blocking_key)
+            pipe.ttl(blocking_key)
+
+            rule_timestamps = pipe.execute()  # type: List[Optional[bytes]]
+
+        # Check if there is a manual block on this API key
+        blocking_ttl_b = rule_timestamps.pop()
+        key_blocked = rule_timestamps.pop()
+
+        if key_blocked is not None:
+            # We are manually blocked. Report for how much longer we will be
+            if blocking_ttl_b is None:
+                blocking_ttl = 0.5
+            else:
+                blocking_ttl = int(blocking_ttl_b)
+            return True, blocking_ttl
+
+        now = time.time()
+        for timestamp, (range_seconds, num_requests) in zip(rule_timestamps, rules):
+            # Check if the nth timestamp is newer than the associated rule. If so,
+            # it means we've hit our limit for this rule
+            if timestamp is None:
+                continue
+
+            boundary = float(timestamp) + range_seconds
+            if boundary > now:
+                free = boundary - now
+                return True, free
+
+        # No api calls recorded yet
         return False, 0.0
 
-    # Go through the rules from shortest to longest,
-    # seeing if this user has violated any of them. First
-    # get the timestamps for each nth items
-    with client.pipeline() as pipe:
-        for _, request_count in rules:
-            pipe.lindex(list_key, request_count - 1)  # 0-indexed list
+    @classmethod
+    def incr_ratelimit(cls, entity: RateLimitedObject) -> None:
+        """Increases the rate-limit for the specified entity"""
+        list_key, set_key, _ = entity.get_keys()
+        now = time.time()
 
-        # Get blocking info
-        pipe.get(blocking_key)
-        pipe.ttl(blocking_key)
+        # If we have no rules, we don't store anything
+        if len(rules) == 0:
+            return
 
-        rule_timestamps = pipe.execute()  # type: List[Optional[bytes]]
+        # Start redis transaction
+        with client.pipeline() as pipe:
+            count = 0
+            while True:
+                try:
+                    # To avoid a race condition between getting the element we might trim from our list
+                    # and removing it from our associated set, we abort this whole transaction if
+                    # another agent manages to change our list out from under us
+                    # When watching a value, the pipeline is set to Immediate mode
+                    pipe.watch(list_key)
 
-    # Check if there is a manual block on this API key
-    blocking_ttl_b = rule_timestamps.pop()
-    key_blocked = rule_timestamps.pop()
+                    # Get the last elem that we'll trim (so we can remove it from our sorted set)
+                    last_val = pipe.lindex(list_key, entity.max_api_calls() - 1)
 
-    if key_blocked is not None:
-        # We are manually blocked. Report for how much longer we will be
-        if blocking_ttl_b is None:
-            blocking_ttl = 0.5
+                    # Restart buffered execution
+                    pipe.multi()
+
+                    # Add this timestamp to our list
+                    pipe.lpush(list_key, now)
+
+                    # Trim our list to the oldest rule we have
+                    pipe.ltrim(list_key, 0, entity.max_api_calls() - 1)
+
+                    # Add our new value to the sorted set that we keep
+                    # We need to put the score and val both as timestamp,
+                    # as we sort by score but remove by value
+                    pipe.zadd(set_key, {str(now): now})
+
+                    # Remove the trimmed value from our sorted set, if there was one
+                    if last_val is not None:
+                        pipe.zrem(set_key, last_val)
+
+                    # Set the TTL for our keys as well
+                    api_window = entity.max_api_window()
+                    pipe.expire(list_key, api_window)
+                    pipe.expire(set_key, api_window)
+
+                    pipe.execute()
+
+                    # If no exception was raised in the execution, there were no transaction conflicts
+                    break
+                except redis.WatchError:
+                    if count > 10:
+                        raise RateLimiterLockingException()
+                    count += 1
+
+                    continue
+
+    @classmethod
+    def rate_limit_entity(cls, entity: RateLimitedObject) -> Tuple[bool, float]:
+        ratelimited, time = cls.is_ratelimited(entity)
+
+        if ratelimited:
+            statsd.incr("ratelimiter.limited.%s.%s" % (type(entity), str(entity)))
+
         else:
-            blocking_ttl = int(blocking_ttl_b)
-        return True, blocking_ttl
-
-    now = time.time()
-    for timestamp, (range_seconds, num_requests) in zip(rule_timestamps, rules):
-        # Check if the nth timestamp is newer than the associated rule. If so,
-        # it means we've hit our limit for this rule
-        if timestamp is None:
-            continue
-
-        boundary = float(timestamp) + range_seconds
-        if boundary > now:
-            free = boundary - now
-            return True, free
-
-    # No api calls recorded yet
-    return False, 0.0
-
-def incr_ratelimit(entity: RateLimitedObject) -> None:
-    """Increases the rate-limit for the specified entity"""
-    list_key, set_key, _ = entity.get_keys()
-    now = time.time()
-
-    # If we have no rules, we don't store anything
-    if len(rules) == 0:
-        return
-
-    # Start redis transaction
-    with client.pipeline() as pipe:
-        count = 0
-        while True:
             try:
-                # To avoid a race condition between getting the element we might trim from our list
-                # and removing it from our associated set, we abort this whole transaction if
-                # another agent manages to change our list out from under us
-                # When watching a value, the pipeline is set to Immediate mode
-                pipe.watch(list_key)
+                cls.incr_ratelimit(entity)
+            except RateLimiterLockingException:
+                logger.warning("Deadlock trying to incr_ratelimit for %s:%s" % (
+                               type(entity).__name__, str(entity)))
+                # rate-limit users who are hitting the API so hard we can't update our stats.
+                ratelimited = True
 
-                # Get the last elem that we'll trim (so we can remove it from our sorted set)
-                last_val = pipe.lindex(list_key, entity.max_api_calls() - 1)
-
-                # Restart buffered execution
-                pipe.multi()
-
-                # Add this timestamp to our list
-                pipe.lpush(list_key, now)
-
-                # Trim our list to the oldest rule we have
-                pipe.ltrim(list_key, 0, entity.max_api_calls() - 1)
-
-                # Add our new value to the sorted set that we keep
-                # We need to put the score and val both as timestamp,
-                # as we sort by score but remove by value
-                pipe.zadd(set_key, {str(now): now})
-
-                # Remove the trimmed value from our sorted set, if there was one
-                if last_val is not None:
-                    pipe.zrem(set_key, last_val)
-
-                # Set the TTL for our keys as well
-                api_window = entity.max_api_window()
-                pipe.expire(list_key, api_window)
-                pipe.expire(set_key, api_window)
-
-                pipe.execute()
-
-                # If no exception was raised in the execution, there were no transaction conflicts
-                break
-            except redis.WatchError:
-                if count > 10:
-                    raise RateLimiterLockingException()
-                count += 1
-
-                continue
+        return ratelimited, time
 
 class RateLimitResult:
     def __init__(self, entity: RateLimitedObject, secs_to_freedom: float, over_limit: bool,

--- a/zerver/management/commands/rate_limit.py
+++ b/zerver/management/commands/rate_limit.py
@@ -2,8 +2,7 @@ from argparse import ArgumentParser
 from typing import Any
 
 from zerver.lib.management import CommandError, ZulipBaseCommand
-from zerver.lib.rate_limiter import RateLimitedUser, block_access, \
-    unblock_access
+from zerver.lib.rate_limiter import RateLimitedUser
 from zerver.models import UserProfile, get_user_profile_by_api_key
 
 
@@ -59,7 +58,6 @@ class Command(ZulipBaseCommand):
             print("Applying operation to User ID: %s: %s" % (user.id, operation))
 
             if operation == 'block':
-                block_access(RateLimitedUser(user, domain=options['domain']),
-                             options['seconds'])
+                RateLimitedUser(user, domain=options['domain']).block_access(options['seconds'])
             elif operation == 'unblock':
-                unblock_access(RateLimitedUser(user, domain=options['domain']))
+                RateLimitedUser(user, domain=options['domain']).unblock_access()

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -26,7 +26,7 @@ from zerver.lib.db import reset_queries
 from zerver.lib.exceptions import ErrorCode, JsonableError, RateLimited
 from zerver.lib.html_to_text import get_content_description
 from zerver.lib.queue import queue_json_publish
-from zerver.lib.rate_limiter import RateLimitResult, max_api_calls
+from zerver.lib.rate_limiter import RateLimitResult
 from zerver.lib.response import json_error, json_response_from_error
 from zerver.lib.subdomains import get_subdomain
 from zerver.lib.utils import statsd
@@ -352,7 +352,7 @@ class RateLimitMiddleware(MiddlewareMixin):
     def set_response_headers(self, response: HttpResponse,
                              rate_limit_results: List[RateLimitResult]) -> None:
         # The limit on the action that was requested is the minimum of the limits that get applied:
-        limit = min([max_api_calls(result.entity) for result in rate_limit_results])
+        limit = min([result.entity.max_api_calls() for result in rate_limit_results])
         response['X-RateLimit-Limit'] = str(limit)
         # Same principle applies to remaining api calls:
         if all(result.remaining for result in rate_limit_results):

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -40,7 +40,7 @@ from zerver.lib.exceptions import RateLimited
 from zerver.lib.mobile_auth_otp import otp_decrypt_api_key
 from zerver.lib.validator import validate_login_email, \
     check_bool, check_dict_only, check_list, check_string, Validator
-from zerver.lib.rate_limiter import add_ratelimit_rule, remove_ratelimit_rule, clear_history
+from zerver.lib.rate_limiter import add_ratelimit_rule, remove_ratelimit_rule
 from zerver.lib.request import JsonableError
 from zerver.lib.storage import static_path
 from zerver.lib.upload import resize_avatar, MEDIUM_AVATAR_SIZE
@@ -524,7 +524,7 @@ class RateLimitAuthenticationTests(ZulipTestCase):
                         attempt_authentication(username, wrong_password)
             finally:
                 # Clean up to avoid affecting other tests.
-                clear_history(RateLimitedAuthenticationByUsername(username))
+                RateLimitedAuthenticationByUsername(username).clear_history()
                 remove_ratelimit_rule(10, 2, domain='authenticate_by_username')
 
     def test_email_auth_backend_user_based_rate_limiting(self) -> None:

--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -117,7 +117,7 @@ class RateLimitTests(ZulipTestCase):
         user = self.example_user('cordelia')
         RateLimitedUser(user).clear_history()
 
-        with mock.patch('zerver.lib.rate_limiter.incr_ratelimit',
+        with mock.patch('zerver.lib.rate_limiter.RedisRateLimiterBackend.incr_ratelimit',
                         side_effect=RateLimiterLockingException):
             result = self.send_api_message(user, "some stuff")
             self.assertEqual(result.status_code, 429)

--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -7,7 +7,6 @@ from zerver.forms import email_is_not_mit_mailing_list
 
 from zerver.lib.rate_limiter import (
     add_ratelimit_rule,
-    clear_history,
     remove_ratelimit_rule,
     RateLimitedUser,
     RateLimiterLockingException,
@@ -71,7 +70,7 @@ class RateLimitTests(ZulipTestCase):
 
     def test_headers(self) -> None:
         user = self.example_user('hamlet')
-        clear_history(RateLimitedUser(user))
+        RateLimitedUser(user).clear_history()
 
         result = self.send_api_message(user, "some stuff")
         self.assertTrue('X-RateLimit-Remaining' in result)
@@ -80,7 +79,7 @@ class RateLimitTests(ZulipTestCase):
 
     def test_ratelimit_decrease(self) -> None:
         user = self.example_user('hamlet')
-        clear_history(RateLimitedUser(user))
+        RateLimitedUser(user).clear_history()
         result = self.send_api_message(user, "some stuff")
         limit = int(result['X-RateLimit-Remaining'])
 
@@ -90,7 +89,7 @@ class RateLimitTests(ZulipTestCase):
 
     def test_hit_ratelimits(self) -> None:
         user = self.example_user('cordelia')
-        clear_history(RateLimitedUser(user))
+        RateLimitedUser(user).clear_history()
 
         start_time = time.time()
         for i in range(6):
@@ -116,7 +115,7 @@ class RateLimitTests(ZulipTestCase):
     @mock.patch('zerver.lib.rate_limiter.logger.warning')
     def test_hit_ratelimiterlockingexception(self, mock_warn: mock.MagicMock) -> None:
         user = self.example_user('cordelia')
-        clear_history(RateLimitedUser(user))
+        RateLimitedUser(user).clear_history()
 
         with mock.patch('zerver.lib.rate_limiter.incr_ratelimit',
                         side_effect=RateLimiterLockingException):

--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -121,5 +121,5 @@ class RateLimitTests(ZulipTestCase):
                         side_effect=RateLimiterLockingException):
             result = self.send_api_message(user, "some stuff")
             self.assertEqual(result.status_code, 429)
-            mock_warn.assert_called_with("Deadlock trying to incr_ratelimit for RateLimitedUser:Id: %s"
+            mock_warn.assert_called_with("Deadlock trying to incr_ratelimit for RateLimitedUser:%s:api_by_user"
                                          % (user.id,))

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -411,7 +411,8 @@ class WorkerTest(ZulipTestCase):
                     fake_client.queue.append(('email_mirror', data[0]))
                     worker.start()
                     self.assertEqual(mock_mirror_email.call_count, 4)
-                    expected_warn = "Deadlock trying to incr_ratelimit for RateLimitedRealmMirror:zulip"
+                    expected_warn = "Deadlock trying to incr_ratelimit for RateLimitedRealmMirror:%s" % (
+                        realm.string_id,)
                     mock_warn.assert_called_with(expected_warn)
 
     def test_email_sending_worker_retries(self) -> None:

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -13,7 +13,7 @@ from zerver.lib.actions import create_stream_if_needed
 from zerver.lib.email_mirror import RateLimitedRealmMirror
 from zerver.lib.email_mirror_helpers import encode_email_address
 from zerver.lib.queue import MAX_REQUEST_RETRIES
-from zerver.lib.rate_limiter import RateLimiterLockingException, clear_history
+from zerver.lib.rate_limiter import RateLimiterLockingException
 from zerver.lib.remote_server import PushNotificationBouncerRetryLaterError
 from zerver.lib.send_email import FromAddress
 from zerver.lib.test_helpers import simulated_queue_client
@@ -359,7 +359,7 @@ class WorkerTest(ZulipTestCase):
                                          mock_warn: MagicMock) -> None:
         fake_client = self.FakeClient()
         realm = get_realm('zulip')
-        clear_history(RateLimitedRealmMirror(realm))
+        RateLimitedRealmMirror(realm).clear_history()
         stream = get_stream('Denmark', realm)
         stream_to_address = encode_email_address(stream)
         data = [

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -406,7 +406,7 @@ class WorkerTest(ZulipTestCase):
                 self.assertEqual(mock_mirror_email.call_count, 4)
 
                 # If RateLimiterLockingException is thrown, we rate-limit the new message:
-                with patch('zerver.lib.rate_limiter.incr_ratelimit',
+                with patch('zerver.lib.rate_limiter.RedisRateLimiterBackend.incr_ratelimit',
                            side_effect=RateLimiterLockingException):
                     fake_client.queue.append(('email_mirror', data[0]))
                     worker.start()

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -182,6 +182,7 @@ rate_limiting_rules = settings.RATE_LIMITING_RULES['authenticate_by_username']
 class RateLimitedAuthenticationByUsername(RateLimitedObject):
     def __init__(self, username: str) -> None:
         self.username = username
+        super().__init__()
 
     def __str__(self) -> str:
         return "Username: {}".format(self.username)

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -187,7 +187,7 @@ class RateLimitedAuthenticationByUsername(RateLimitedObject):
     def __str__(self) -> str:
         return "Username: {}".format(self.username)
 
-    def key_fragment(self) -> str:
+    def key(self) -> str:
         return "{}:{}".format(type(self), self.username)
 
     def rules(self) -> List[Tuple[int, int]]:

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -184,9 +184,6 @@ class RateLimitedAuthenticationByUsername(RateLimitedObject):
         self.username = username
         super().__init__()
 
-    def __str__(self) -> str:
-        return "Username: {}".format(self.username)
-
     def key(self) -> str:
         return "{}:{}".format(type(self).__name__, self.username)
 

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -188,7 +188,7 @@ class RateLimitedAuthenticationByUsername(RateLimitedObject):
         return "Username: {}".format(self.username)
 
     def key(self) -> str:
-        return "{}:{}".format(type(self), self.username)
+        return "{}:{}".format(type(self).__name__, self.username)
 
     def rules(self) -> List[Tuple[int, int]]:
         return rate_limiting_rules


### PR DESCRIPTION
Still requires cleaning up of comments (for example ``clear_history`` has an old docstring, that's not even correct anymore).

This aims to split our rate limiting logic into two classes mostly: ``RateLimitedObject``, which keep its nature, but we remove redis implementation details from it, and ``RateLimiterBackend`` - which is an interface, on which any implementation can be based. Our current redis-based implementation logic is moved into ``RedisRateLimiterBackend`` - an implementation of the interface.
With this, changing or adding a new implementation just requires making another class like that, and should be independent from any of the more abstract ``RateLimitedObject`` logic. The last commit, though its implementation of details is very incomplete, shows a draft  of how we can add the alternative tornado rate limiter in a decently clean way.