### PR TITLE
docs: Recommend users to use user_id instead of email in send-message

### DIFF
--- a/templates/zerver/api/send-message.md
+++ b/templates/zerver/api/send-message.md
@@ -38,8 +38,9 @@ zulip(config).then((client) => {
 // Send a private message
 zulip(config).then((client) => {
     // Send a private message
+    const user_id = 9;
     const params = {
-        to: 'hamlet@example.com',
+        to: [user_id],
         type: 'private',
         content: 'With mirth and laughter let old wrinkles come.',
     }
@@ -64,7 +65,7 @@ curl -X POST {{ api_url }}/v1/messages \
 curl -X POST {{ api_url }}/v1/messages \
     -u BOT_EMAIL_ADDRESS:BOT_API_KEY \
     -d "type=private" \
-    -d "to=hamlet@example.com" \
+    -d "to=[9]" \
     -d $"content=With mirth and laughter let old wrinkles come."
 ```
 

--- a/templates/zerver/api/typing.md
+++ b/templates/zerver/api/typing.md
@@ -25,9 +25,12 @@ const config = {
     zuliprc: 'zuliprc',
 };
 
+const user_id1 = 9;
+const user_id2 = 10;
+
 const typingParams = {
     op: 'start',
-    to: ['iago@zulip.com', 'polonius@zulip.com'],
+    to: [user_id1, user_id2],
 };
 
 zulip(config).then((client) => {

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -646,6 +646,8 @@ def get_raw_message(client, message_id):
 def send_message(client):
     # type: (Client) -> int
 
+    request = {}  # type: Dict[str, Any]
+
     # {code_example|start}
     # Send a stream message
     request = {
@@ -669,11 +671,14 @@ def send_message(client):
     assert result['result'] == 'success'
     assert result['raw_content'] == request['content']
 
+    ensure_users([9], ['hamlet'])
+
     # {code_example|start}
     # Send a private message
+    user_id = 9
     request = {
         "type": "private",
-        "to": "iago@zulip.com",
+        "to": [user_id],
         "content": "With mirth and laughter let old wrinkles come."
     }
     result = client.send_message(request)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -486,11 +486,12 @@ paths:
         required: true
       - name: to
         in: query
-        description: The destination stream, or a CSV/JSON-encoded list
-          containing the usernames (emails) of the recipients.
+        description: For stream messages, either the name or integer ID of the stream.
+          For private messages, either a list containing integer user
+          IDs or a list containing string email addresses.
         schema:
           type: string
-        example: aaron@zulip.com, iago@zulip.com
+        example: [9, 10]
         required: true
       - name: topic
         in: query


### PR DESCRIPTION
I have tested the updated curl and javascript examples as well.

Realted issue https://github.com/zulip/zulip/issues/13286