### PR TITLE
populate_db: Don't restrict email domains by default in tests and dev.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1218,6 +1218,9 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase):
 
     def test_social_auth_registration_without_is_signup_closed_realm(self) -> None:
         """If the user doesn't exist yet in closed realm, give an error"""
+        realm = get_realm("zulip")
+        realm.emails_restricted_to_domains = True
+        realm.save()
         email = "nonexisting@phantom.com"
         name = 'Full Name'
         account_data_dict = self.get_account_data_dict(email=email, name=name)
@@ -3820,7 +3823,8 @@ class EmailValidatorTestCase(ZulipTestCase):
         cordelia = self.example_user('cordelia')
 
         realm = inviter.realm
-
+        do_set_realm_property(realm, 'emails_restricted_to_domains', True)
+        inviter.realm.refresh_from_db()
         error = validate_email_is_valid(
             'fred+5555@zulip.com',
             get_realm_email_validator(realm),

--- a/zerver/tests/test_realm_domains.py
+++ b/zerver/tests/test_realm_domains.py
@@ -5,7 +5,7 @@ from django.db.utils import IntegrityError
 
 from zerver.lib.actions import do_change_is_admin, \
     do_change_realm_domain, do_create_realm, \
-    do_remove_realm_domain
+    do_remove_realm_domain, do_set_realm_property
 from zerver.lib.email_validation import email_allowed_for_realm
 from zerver.lib.domains import validate_domain
 from zerver.lib.test_classes import ZulipTestCase
@@ -16,6 +16,10 @@ import ujson
 
 
 class RealmDomainTest(ZulipTestCase):
+    def setUp(self) -> None:
+        realm = get_realm('zulip')
+        do_set_realm_property(realm, 'emails_restricted_to_domains', True)
+
     def test_list_realm_domains(self) -> None:
         self.login(self.example_email("iago"))
         realm = get_realm('zulip')

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -588,7 +588,7 @@ class LoginTest(ZulipTestCase):
         with queries_captured() as queries:
             self.register(self.nonreg_email('test'), "test")
         # Ensure the number of queries we make is not O(streams)
-        self.assertEqual(len(queries), 79)
+        self.assertEqual(len(queries), 77)
         user_profile = self.nonreg_user('test')
         self.assert_logged_in_user_id(user_profile.id)
         self.assertFalse(user_profile.enable_stream_desktop_notifications)
@@ -846,7 +846,7 @@ class InviteUserTest(InviteUserBase):
         #       the large number of queries), so I just
         #       use an approximate equality check.
         actual_count = len(queries)
-        expected_count = 314
+        expected_count = 312
         if abs(actual_count - expected_count) > 1:
             raise AssertionError('''
                 Unexpected number of queries:
@@ -1122,6 +1122,9 @@ earl-test@zulip.com""", ["Denmark"]))
         """
         Tests inviting with various missing or invalid parameters.
         """
+        realm = get_realm('zulip')
+        do_set_realm_property(realm, 'emails_restricted_to_domains', True)
+
         self.login(self.example_email("hamlet"))
         invitee_emails = "foo@zulip.com"
         self.assert_json_error(self.invite(invitee_emails, []),
@@ -2677,8 +2680,8 @@ class UserSignUpTest(InviteUserBase):
 
     def test_failed_signup_due_to_restricted_domain(self) -> None:
         realm = get_realm('zulip')
-        realm.invite_required = False
-        realm.save()
+        do_set_realm_property(realm, 'invite_required', False)
+        do_set_realm_property(realm, 'emails_restricted_to_domains', True)
 
         request = HostRequestMock(host = realm.host)
         request.session = {}  # type: ignore

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -617,6 +617,7 @@ class AdminCreateUserTest(ZulipTestCase):
         ))
         self.assert_json_error(result, "Bad name or username")
 
+        do_set_realm_property(realm, 'emails_restricted_to_domains', True)
         result = self.client_post("/json/users", dict(
             email='romeo@not-zulip.com',
             password='xxxx',

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -200,7 +200,7 @@ class Command(BaseCommand):
             # welcome-bot (needed for do_create_realm) hasn't been created yet
             create_internal_realm()
             zulip_realm = Realm.objects.create(
-                string_id="zulip", name="Zulip Dev", emails_restricted_to_domains=True,
+                string_id="zulip", name="Zulip Dev", emails_restricted_to_domains=False,
                 description="The Zulip development environment default organization."
                             "  It's great for testing!",
                 invite_required=False, org_type=Realm.CORPORATE)


### PR DESCRIPTION
Discussed in https://chat.zulip.org/#narrow/stream/49-development-help/topic/testing.20Github.20auth/near/825593

The email domain restriction to @zulip.com is annoying in development
environment when trying to test sign up. For consistency, it's best to
have tests use the same default, and the tests that require domain
restriction can be adjusted to set that configuration up for themselves
explicitly.
