### PR TITLE
ui: replace all mute icons from eye/eye-slash with bell/bell-slash.

### DIFF
--- a/static/templates/actions_popover_content.hbs
+++ b/static/templates/actions_popover_content.hbs
@@ -62,7 +62,7 @@
     {{#if can_mute_topic}}
     <li>
         <a href="#" class="popover_mute_topic" data-msg-stream-id="{{stream_id}}" data-msg-topic="{{topic}}">
-            <i class="fa fa-eye-slash" aria-hidden="true"></i>
+            <i class="fa fa-bell-slash" aria-hidden="true"></i>
             {{#tr this}}Mute the topic <b>__topic__</b>{{/tr}} <span class="hotkey-hint">(M)</span>
         </a>
     </li>
@@ -71,7 +71,7 @@
     {{#if can_unmute_topic}}
     <li>
         <a href="#" class="popover_unmute_topic" data-msg-stream-id="{{stream_id}}" data-msg-topic="{{topic}}">
-            <i class="fa fa-eye" aria-hidden="true"></i>
+            <i class="fa fa-bell" aria-hidden="true"></i>
             {{#tr this}}Unmute the topic <b>__topic__</b>{{/tr}}
         </a>
     </li>

--- a/static/templates/recipient_row.hbs
+++ b/static/templates/recipient_row.hbs
@@ -50,7 +50,7 @@
                     <span class="topic_edit_form" id="{{id}}"></span>
                 </span>
 
-                <i class="fa fa-eye-slash on_hover_topic_mute" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Mute topic' }} (M)" role="button" tabindex="0" aria-label="{{t 'Mute topic' }} (M)"></i>
+                <i class="fa fa-bell-slash on_hover_topic_mute" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Mute topic' }} (M)" role="button" tabindex="0" aria-label="{{t 'Mute topic' }} (M)"></i>
                 <span class="recipient_row_date {{#if group_date_divider_html}}{{else}}hide-date{{/if}}">{{{date}}}</span>
             </span>
         </div>

--- a/static/templates/stream_sidebar_actions.hbs
+++ b/static/templates/stream_sidebar_actions.hbs
@@ -25,10 +25,10 @@
     <li>
         <a class="toggle_home">
             {{#if stream.is_muted}}
-                <i class="fa fa-eye" aria-hidden="true"></i>
+                <i class="fa fa-bell" aria-hidden="true"></i>
                 {{#tr this}}Unmute the stream <b>__stream.name__</b>{{/tr}}
             {{else}}
-                <i class="fa fa-eye-slash" aria-hidden="true"></i>
+                <i class="fa fa-bell-slash" aria-hidden="true"></i>
                 {{#tr this}}Mute the stream <b>__stream.name__</b>{{/tr}}
             {{/if}}
         </a>

--- a/static/templates/topic_sidebar_actions.hbs
+++ b/static/templates/topic_sidebar_actions.hbs
@@ -10,7 +10,7 @@
     {{#if can_mute_topic}}
     <li>
         <a href="#" class="sidebar-popover-mute-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
-            <i class="fa fa-eye-slash" aria-hidden="true"></i>
+            <i class="fa fa-bell-slash" aria-hidden="true"></i>
             {{#tr this}}Mute the topic <b>__topic_name__</b>{{/tr}}
         </a>
     </li>
@@ -19,7 +19,7 @@
     {{#if can_unmute_topic}}
     <li>
         <a href="#" class="sidebar-popover-unmute-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
-            <i class="fa fa-eye" aria-hidden="true"></i>
+            <i class="fa fa-bell" aria-hidden="true"></i>
             {{#tr this}}Unmute the topic <b>__topic_name__</b>{{/tr}}
         </a>
     </li>

--- a/templates/zerver/app/settings_overlay.html
+++ b/templates/zerver/app/settings_overlay.html
@@ -40,7 +40,7 @@
                 </li>
                 {% endif %}
                 <li tabindex="0" data-section="muted-topics">
-                    <i class="icon fa fa-eye-slash" aria-hidden="true"></i>
+                    <i class="icon fa fa-bell-slash" aria-hidden="true"></i>
                     <div class="text">{{ _('Muted topics') }}</div>
                 </li>
             </ul>


### PR DESCRIPTION
eye/eye-slash icon is generally used for toggling hiding actions and we are using that same icon for mute action which can be a bit confusing

Image
![Screenshot from 2020-03-07 08-33-33](https://user-images.githubusercontent.com/32801674/76135606-5cde2780-604e-11ea-80a1-c12b6319b321.png)
