### PR TITLE
Re- topic edit typeahead

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -561,7 +561,7 @@ run_test('initialize', () => {
     };
 
     let subject_typeahead_called = false;
-    $('#stream_message_recipient_topic').typeahead = function (options) {
+    const topic_typeahead_stub = function (options) {
         const topics = ['<&>', 'even more ice', 'furniture', 'ice', 'kronor', 'more ice'];
         topic_data.get_recent_names = (stream_id) => {
             assert.equal(stream_id, sweden_stream.stream_id);
@@ -624,6 +624,7 @@ run_test('initialize', () => {
 
         subject_typeahead_called = true;
     };
+    $('#stream_message_recipient_topic').typeahead = topic_typeahead_stub;
 
     let pm_recipient_typeahead_called = false;
     $('#private_message_recipient').typeahead = function (options) {
@@ -1104,6 +1105,14 @@ run_test('initialize', () => {
     assert(compose_textarea_typeahead_called);
     assert(focus_handler_called);
     assert(stream_one_called);
+
+    // Finally, we check that the topic edit typeahead is functionally similar
+    // to the composebox topic typeahead.
+    subject_typeahead_called = false;
+    const form_field = $.create('message_edit_topic');
+    form_field.typeahead = topic_typeahead_stub;
+    ct.initialize_topic_edit_typeahead(form_field, 'Sweden');
+    assert(subject_typeahead_called);
 });
 
 run_test('begins_typeahead', () => {

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -560,7 +560,7 @@ run_test('initialize', () => {
         stream_typeahead_called = true;
     };
 
-    let subject_typeahead_called = false;
+    let topic_typeahead_called = false;
     const topic_typeahead_stub = function (options) {
         const topics = ['<&>', 'even more ice', 'furniture', 'ice', 'kronor', 'more ice'];
         topic_data.get_recent_names = (stream_id) => {
@@ -622,7 +622,7 @@ run_test('initialize', () => {
         expected_value = [];
         assert.deepEqual(actual_value, expected_value);
 
-        subject_typeahead_called = true;
+        topic_typeahead_called = true;
     };
     $('#stream_message_recipient_topic').typeahead = topic_typeahead_stub;
 
@@ -1098,7 +1098,7 @@ run_test('initialize', () => {
     // Now let's make sure that all the stub functions have been called
     // during the initialization.
     assert(stream_typeahead_called);
-    assert(subject_typeahead_called);
+    assert(topic_typeahead_called);
     assert(pm_recipient_typeahead_called);
     assert(pm_recipient_blur_called);
     assert(channel_post_called);
@@ -1108,11 +1108,11 @@ run_test('initialize', () => {
 
     // Finally, we check that the topic edit typeahead is functionally similar
     // to the composebox topic typeahead.
-    subject_typeahead_called = false;
+    topic_typeahead_called = false;
     const form_field = $.create('message_edit_topic');
     form_field.typeahead = topic_typeahead_stub;
     ct.initialize_topic_edit_typeahead(form_field, 'Sweden');
-    assert(subject_typeahead_called);
+    assert(topic_typeahead_called);
 });
 
 run_test('begins_typeahead', () => {

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -2,6 +2,7 @@ set_global('page_params', {realm_is_zephyr_mirror_realm: false});
 set_global('md5', function (s) {
     return 'md5-' + s;
 });
+set_global('$', global.make_zjquery());
 
 const settings_config = zrequire('settings_config');
 page_params.realm_email_address_visibility =

--- a/frontend_tests/node_tests/zjquery.js
+++ b/frontend_tests/node_tests/zjquery.js
@@ -50,10 +50,10 @@ run_test('basics', () => {
 
     widget.attr('data-employee-id', 42);
     assert.equal(widget.attr('data-employee-id'), 42);
-    assert.equal(widget.data('employee-id'), 42);
+    assert.equal(widget.data('employee-id'), undefined);
 
     widget.data('department-id', 77);
-    assert.equal(widget.attr('data-department-id'), 77);
+    assert.equal(widget.attr('data-department-id'), undefined);
     assert.equal(widget.data('department-id'), 77);
 
     widget.html('<b>hello</b>');

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -136,6 +136,7 @@ exports.make_new_elem = function (selector, opts) {
     const parents_result = new Map();
     const properties = new Map();
     const attrs = new Map();
+    const data_store = new Map();
     const classes = new Map();
     const event_store = exports.make_event_store(selector);
 
@@ -161,13 +162,13 @@ exports.make_new_elem = function (selector, opts) {
         },
         data: function (name, val) {
             if (val === undefined) {
-                const data_val = attrs.get('data-' + name);
+                const data_val = data_store.get(name);
                 if (data_val === undefined) {
                     return;
                 }
-                return JSON.parse(data_val);
+                return data_val;
             }
-            attrs.set('data-' + name, val);
+            data_store.set(name, val);
             return self;
         },
         delay: function () {

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -907,6 +907,30 @@ exports.initialize_compose_typeahead = function (selector) {
     });
 };
 
+const topic_typeahead_options = {
+    fixed: true,
+    highlighter: function (item) {
+        return typeahead_helper.render_typeahead_item({ primary: item });
+    },
+    sorter: function (items) {
+        const sorted = typeahead_helper.sorter(this.query, items, function (x) {return x;});
+        if (sorted.length > 0 && !sorted.includes(this.query)) {
+            sorted.unshift(this.query);
+        }
+        return sorted;
+    },
+};
+
+exports.initialize_topic_edit_typeahead = function (form_field, stream_name) {
+    const options = {...topic_typeahead_options,
+                     source: function () {
+                         return exports.topics_seen_for(stream_name);
+                     },
+                     items: 5,
+    };
+    form_field.typeahead(options);
+};
+
 exports.initialize = function () {
     exports.update_emoji_data();
     select_on_focus("stream_message_recipient_stream");
@@ -959,24 +983,14 @@ exports.initialize = function () {
         },
     });
 
-    $("#stream_message_recipient_topic").typeahead({
-        source: function () {
-            const stream_name = compose_state.stream_name();
-            return exports.topics_seen_for(stream_name);
-        },
-        items: 3,
-        fixed: true,
-        highlighter: function (item) {
-            return typeahead_helper.render_typeahead_item({ primary: item });
-        },
-        sorter: function (items) {
-            const sorted = typeahead_helper.sorter(this.query, items, function (x) {return x;});
-            if (sorted.length > 0 && !sorted.includes(this.query)) {
-                sorted.unshift(this.query);
-            }
-            return sorted;
-        },
-    });
+    const options = {...topic_typeahead_options,
+                     source: function () {
+                         const stream_name = compose_state.stream_name();
+                         return exports.topics_seen_for(stream_name);
+                     },
+                     items: 3,
+    };
+    $("#stream_message_recipient_topic").typeahead(options);
 
     $("#private_message_recipient").typeahead({
         source: exports.get_pm_people,

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -358,6 +358,7 @@ function edit_message(row, raw_content) {
             message_edit_topic_propagate.toggle(new_topic !== original_topic && new_topic !== "");
         });
     }
+    composebox_typeahead.initialize_topic_edit_typeahead(message_edit_topic, message.stream);
 }
 
 function start_edit_maintaining_scroll(row, content) {
@@ -416,7 +417,9 @@ exports.start_topic_edit = function (recipient_row) {
     if (topic === compose.empty_topic_placeholder()) {
         topic = '';
     }
-    form.find(".inline_topic_edit").val(topic).select().focus();
+    const inline_topic_edit = form.find(".inline_topic_edit");
+    inline_topic_edit.val(topic).select().focus();
+    composebox_typeahead.initialize_topic_edit_typeahead(inline_topic_edit, message.stream);
 };
 
 exports.is_editing = function (id) {
@@ -451,6 +454,8 @@ exports.end = function (row) {
     // We have to blur out text fields, or else hotkeys.js
     // thinks we are still editing.
     row.find(".message_edit").blur();
+    // Hide the topic editing typeahead, if shown.
+    row.find('input.message_edit_topic').blur();
 };
 
 exports.save = function (row, from_topic_edited_only) {

--- a/static/third/bootstrap-typeahead/typeahead.js
+++ b/static/third/bootstrap-typeahead/typeahead.js
@@ -49,6 +49,16 @@
  *   Our custom changes include all mentions of this.header, some CSS changes
  *   in compose.scss and splitting $container out of $menu so we can insert
  *   additional HTML before $menu.
+ * 
+ * 4. Event swallowing for Enter and Tab:
+ * 
+ *   This allows users to select items from the typeahead, without triggering
+ *   other events such as form submissions (eg when using the inline topic
+ *   edit form). This custom change does not effect selecting of items from
+ *   the typeahead in the search bar (doing so would still trigger search).
+ * 
+ *   Our custom changes are in the 'move' method, (also indicated by a short
+ *   comment there as well).
  * ============================================================ */
 
 !function($){
@@ -303,6 +313,9 @@
       switch(e.keyCode) {
         case 9: // tab
         case 13: // enter
+          // custom change by Zulip to allow user to select item
+          // from typeahead, without eg triggering form submission
+          e.stopPropagation()
         case 27: // escape
           e.preventDefault()
           break


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This is a small tweak to https://github.com/zulip/zulip/pull/14033, I added some changes to typeahead.js, as the first commit, and I removed `is_typeahead_open` and the tests related to it from @aero31aero 's original PR (also removed details about that helper from commit message), the rest of the commits are unchanged from that branch.

This is still a draft (not merge ready) as the changes I made to the third party typeahead have NO TESTS yet, because I'm not sure where to put them.

**Testing Plan:** <!-- How have you tested? -->

Need to add tests for changes to typeahead.js