### PR TITLE
user status: Focus status input box on modal display.

### DIFF
--- a/static/js/user_status_ui.js
+++ b/static/js/user_status_ui.js
@@ -18,8 +18,14 @@ exports.open_overlay = function () {
     const old_status_text = user_status.get_status_text(user_id);
     const field = exports.input_field();
     field.val(old_status_text);
-    field.select();
-    field.focus();
+
+    // The timeout of 200ms here corresponds to the 0.2s transition in
+    // app_components.scss:279, which also animates visibility. The timeout
+    // exists because visibility:hidden elements can't be focused by JS.
+    setTimeout(() => {
+        field.select();
+        field.focus();
+    }, 200);
     exports.toggle_clear_message_button();
 
     const button = exports.submit_button();


### PR DESCRIPTION
The code for focusing the text box already exists - but it's buggy. Adding **at least** 30ms of timeout before calling 'focus()' fixes this. Checked for [0...20] ms, doesn't work - 30ms is the minimum timeout required for this to work.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Manually, in the browser UI.



**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![focus](https://user-images.githubusercontent.com/7714968/76140706-3b4b6300-6083-11ea-81a1-54790bd56adb.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
