### PR TITLE
Remove file upload status texts on failure

### DIFF
--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -194,7 +194,7 @@ run_test('upload_files', () => {
     };
     let compose_ui_insert_syntax_and_focus_called = false;
     compose_ui.insert_syntax_and_focus = (syntax, textarea) => {
-        assert.equal(syntax, "[Uploading budapest.png…]()");
+        assert.equal(syntax, "[translated: Uploading budapest.png…]()");
         assert.equal(textarea, $("#compose-textarea"));
         compose_ui_insert_syntax_and_focus_called = true;
     };
@@ -246,7 +246,7 @@ run_test('upload_files', () => {
     ];
     compose_ui.replace_syntax = (old_syntax, new_syntax, textarea) => {
         compose_ui_replace_syntax_called = true;
-        assert.equal(old_syntax, "[Uploading budapest.png…]()");
+        assert.equal(old_syntax, "[translated: Uploading budapest.png…]()");
         assert.equal(new_syntax, "");
         assert.equal(textarea, $('#compose-textarea'));
     };
@@ -437,7 +437,7 @@ run_test('uppy_events', () => {
                 callbacks[event_name] = callback;
             },
             getFiles: () => {
-                return files;
+                return [...files];
             },
             removeFile: (file_id) => {
                 files = files.filter((file) => {
@@ -476,7 +476,7 @@ run_test('uppy_events', () => {
     let compose_ui_replace_syntax_called = false;
     compose_ui.replace_syntax = (old_syntax, new_syntax, textarea) => {
         compose_ui_replace_syntax_called = true;
-        assert.equal(old_syntax, "[Uploading copenhagen.png…]()");
+        assert.equal(old_syntax, "[translated: Uploading copenhagen.png…]()");
         assert.equal(new_syntax, "[copenhagen.png](https://foo.com/user_uploads/4/cb/rue1c-MlMUjDAUdkRrEM4BTJ/copenhagen.png)");
         assert.equal(textarea, $('#compose-textarea'));
     };
@@ -574,7 +574,7 @@ run_test('uppy_events', () => {
     assert(show_error_message_called);
     compose_ui.replace_syntax = (old_syntax, new_syntax, textarea) => {
         compose_ui_replace_syntax_called = true;
-        assert.equal(old_syntax, "[Uploading copenhagen.png…]()");
+        assert.equal(old_syntax, "[translated: Uploading copenhagen.png…]()");
         assert.equal(new_syntax, "");
         assert.equal(textarea, $('#compose-textarea'));
     };

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -164,6 +164,7 @@ run_test('upload_files', () => {
             assert.equal(params.type, "image/png");
             assert.equal(params.data, files[0]);
         },
+        getFiles: () => [...files],
     };
     let hide_upload_status_called = false;
     upload.hide_upload_status = (config) => {
@@ -236,9 +237,32 @@ run_test('upload_files', () => {
     });
     hide_upload_status_called = false;
     uppy_cancel_all_called = false;
+    let compose_ui_replace_syntax_called = false;
+    files = [
+        {
+            name: "budapest.png",
+            type: "image/png",
+        },
+    ];
+    compose_ui.replace_syntax = (old_syntax, new_syntax, textarea) => {
+        compose_ui_replace_syntax_called = true;
+        assert.equal(old_syntax, "[Uploading budapest.png…]()");
+        assert.equal(new_syntax, "");
+        assert.equal(textarea, $('#compose-textarea'));
+    };
     on_click_close_button_callback();
     assert(uppy_cancel_all_called);
     assert(hide_upload_status_called);
+    assert(compose_ui_autosize_textarea_called);
+    assert(compose_ui_replace_syntax_called);
+    hide_upload_status_called = false;
+    compose_ui_replace_syntax_called = false;
+    $('#compose-textarea').val("user modified text");
+    on_click_close_button_callback();
+    assert(hide_upload_status_called);
+    assert(compose_ui_autosize_textarea_called);
+    assert(compose_ui_replace_syntax_called);
+    assert($('#compose-textarea').val(), "user modified text");
 });
 
 run_test('uppy_config', () => {

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -578,6 +578,7 @@ run_test('uppy_events', () => {
 
     const on_upload_error_callback = callbacks["upload-error"];
     show_error_message_called = false;
+    compose_ui_replace_syntax_called = false;
     upload.show_error_message = (config, message) => {
         show_error_message_called = true;
         assert.equal(config.mode, "compose");
@@ -589,17 +590,30 @@ run_test('uppy_events', () => {
         },
     };
     uppy_cancel_all_called = false;
-    on_upload_error_callback(null, null, response);
+    on_upload_error_callback(file, null, response);
     assert(uppy_cancel_all_called);
     assert(show_error_message_called);
+    assert(compose_ui_replace_syntax_called);
 
+    compose_ui_replace_syntax_called = false;
     upload.show_error_message = (config, message) => {
         show_error_message_called = true;
         assert.equal(config.mode, "compose");
         assert.equal(message, null);
     };
     uppy_cancel_all_called = false;
-    on_upload_error_callback(null, null);
+    on_upload_error_callback(file, null, null);
     assert(uppy_cancel_all_called);
     assert(show_error_message_called);
+    assert(compose_ui_replace_syntax_called);
+    show_error_message_called = false;
+    $('#comepose-textarea').val('user modified text');
+    uppy_cancel_all_called = false;
+    on_upload_error_callback(file, null);
+    assert(uppy_cancel_all_called);
+    assert(show_error_message_called);
+    assert(compose_ui_replace_syntax_called);
+    assert.equal($('#comepose-textarea').val(), 'user modified text');
+
+
 });

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -16,6 +16,10 @@ exports.feature_check = function (upload_button) {
         upload_button.removeClass("notdisplayed");
     }
 };
+exports.get_translated_status = function (file) {
+    const status = i18n.t("Uploading __filename__…", {filename: file.name});
+    return "[" + status + "]()";
+};
 
 exports.get_item = function (key, config) {
     if (!config) {
@@ -102,7 +106,7 @@ exports.upload_files = function (uppy, config, files) {
     exports.get_item("send_status_message", config).html($("<p>").text(i18n.t("Uploading…")));
     exports.get_item("send_status_close_button", config).one('click', function () {
         uppy.getFiles().forEach((file) => {
-            compose_ui.replace_syntax("[Uploading " + file.name + "…]()", "", exports.get_item("textarea", config));
+            compose_ui.replace_syntax(exports.get_translated_status(file), "", exports.get_item("textarea", config));
         });
         compose_ui.autosize_textarea();
         uppy.cancelAll();
@@ -114,7 +118,7 @@ exports.upload_files = function (uppy, config, files) {
 
     for (const file of files) {
         try {
-            compose_ui.insert_syntax_and_focus("[Uploading " + file.name + "…]()", exports.get_item("textarea", config));
+            compose_ui.insert_syntax_and_focus(exports.get_translated_status(file), exports.get_item("textarea", config));
             compose_ui.autosize_textarea();
             uppy.addFile({
                 source: exports.get_item("source", config),
@@ -211,7 +215,7 @@ exports.setup_upload = function (config) {
         }
         const absolute_uri = upload.make_upload_absolute(uri);
         const filename_uri = "[" + filename + "](" + absolute_uri + ")";
-        compose_ui.replace_syntax("[Uploading " + file.name + "…]()", filename_uri, exports.get_item("textarea", config));
+        compose_ui.replace_syntax(exports.get_translated_status(file), filename_uri, exports.get_item("textarea", config));
         compose_ui.autosize_textarea();
     });
 
@@ -264,12 +268,12 @@ exports.setup_upload = function (config) {
         const message = response ? response.body.msg : null;
         uppy.cancelAll();
         exports.show_error_message(config, message);
-        compose_ui.replace_syntax("[Uploading " + file.name + "…]()", "", exports.get_item("textarea", config));
+        compose_ui.replace_syntax(exports.get_translated_status(file), "", exports.get_item("textarea", config));
         compose_ui.autosize_textarea();
     });
 
     uppy.on('restriction-failed', (file) => {
-        compose_ui.replace_syntax("[Uploading " + file.name + "…]()", "", exports.get_item("textarea", config));
+        compose_ui.replace_syntax(exports.get_translated_status(file), "", exports.get_item("textarea", config));
         compose_ui.autosize_textarea();
     });
 

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -101,7 +101,12 @@ exports.upload_files = function (uppy, config, files) {
     exports.get_item("send_status", config).addClass("alert-info").removeClass("alert-error").show();
     exports.get_item("send_status_message", config).html($("<p>").text(i18n.t("Uploading…")));
     exports.get_item("send_status_close_button", config).one('click', function () {
+        uppy.getFiles().forEach((file) => {
+            compose_ui.replace_syntax("[Uploading " + file.name + "…]()", "", exports.get_item("textarea", config));
+        });
+        compose_ui.autosize_textarea();
         uppy.cancelAll();
+        exports.get_item("textarea", config).focus();
         setTimeout(function () {
             exports.hide_upload_status(config);
         }, 500);

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -261,6 +261,11 @@ exports.setup_upload = function (config) {
         exports.show_error_message(config, message);
     });
 
+    uppy.on('restriction-failed', (file) => {
+        compose_ui.replace_syntax("[Uploading " + file.name + "…]()", "", exports.get_item("textarea", config));
+        compose_ui.autosize_textarea();
+    });
+
     return uppy;
 };
 

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -259,6 +259,8 @@ exports.setup_upload = function (config) {
         const message = response ? response.body.msg : null;
         uppy.cancelAll();
         exports.show_error_message(config, message);
+        compose_ui.replace_syntax("[Uploading " + file.name + "…]()", "", exports.get_item("textarea", config));
+        compose_ui.autosize_textarea();
     });
 
     uppy.on('restriction-failed', (file) => {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- Remove 'Uploading file...' message from the compose box when file uploads fail.

**Testing Plan:** <!-- How have you tested? -->
Updated relevant test files.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
For frontend (local) errors:
![local](https://user-images.githubusercontent.com/7714968/76142972-cedb5e80-6098-11ea-9e3a-fe6735b7abdf.gif)

For server side errors: (temp hacked the frontend to ignore file size so the server could reject it)
![server-upload](https://user-images.githubusercontent.com/7714968/76142976-d438a900-6098-11ea-944e-f12fe2cf9159.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
