### PR TITLE
ui: fix deleted msg color in Message edit history modal

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -451,6 +451,7 @@ on a dark background, and don't change the dark labels dark either. */
         .highlight_text_deleted {
             text-decoration: line-through;
             background-color: hsla(7, 54%, 62%, 0.38);
+            color: hsl(0, 90%, 67%);
         }
     }
 

--- a/static/styles/rendered_markdown.scss
+++ b/static/styles/rendered_markdown.scss
@@ -148,7 +148,7 @@
     }
 
     .highlight_text_deleted {
-        color: hsl(0, 0%, 73%);
+        color: hsl(0, 100%, 50%);
         text-decoration: line-through;
         background-color: hsl(7, 90%, 92%);
         word-break: break-all;


### PR DESCRIPTION
These colors should not have readability issue now, also this colors scheme will follow the same design scene as used for the inserted_text (red test with red bg)
![Screenshot from 2020-03-07 18-32-18](https://user-images.githubusercontent.com/32801674/76144014-1a463a80-60a2-11ea-9533-0d67467fa678.png)
![Screenshot from 2020-03-07 18-32-48](https://user-images.githubusercontent.com/32801674/76144016-1b776780-60a2-11ea-95b2-a58bd1175f29.png)



Fixes #13622


