### PR TITLE
[WIP]api: Refactor GET ../users/{id} api endpoint.

### DIFF
--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -421,16 +421,16 @@ class RealmTest(ZulipTestCase):
         # Check normal user cannot access email
         result = self.api_get(cordelia.delivery_email, "/api/v1/users/%s" % (hamlet.id,))
         self.assert_json_success(result)
-        self.assertEqual(result.json()['members'][0]['email'],
+        self.assertEqual(result.json()['user']['email'],
                          'user%s@zulip.testserver' % (hamlet.id,))
-        self.assertEqual(result.json()['members'][0].get('delivery_email'), None)
+        self.assertEqual(result.json()['user'].get('delivery_email'), None)
 
         # Check administrator gets delivery_email with EMAIL_ADDRESS_VISIBILITY_ADMINS
         result = self.api_get(user_profile.delivery_email, "/api/v1/users/%s" % (hamlet.id,))
         self.assert_json_success(result)
-        self.assertEqual(result.json()['members'][0]['email'],
+        self.assertEqual(result.json()['user']['email'],
                          'user%s@zulip.testserver' % (hamlet.id,))
-        self.assertEqual(result.json()['members'][0].get('delivery_email'),
+        self.assertEqual(result.json()['user'].get('delivery_email'),
                          hamlet.delivery_email)
 
         req = dict(email_address_visibility = ujson.dumps(Realm.EMAIL_ADDRESS_VISIBILITY_NOBODY))
@@ -446,9 +446,9 @@ class RealmTest(ZulipTestCase):
         # EMAIL_ADDRESS_VISIBILITY_NOBODY
         result = self.api_get(user_profile.delivery_email, "/api/v1/users/%s" % (hamlet.id,))
         self.assert_json_success(result)
-        self.assertEqual(result.json()['members'][0]['email'],
+        self.assertEqual(result.json()['user']['email'],
                          'user%s@zulip.testserver' % (hamlet.id,))
-        self.assertEqual(result.json()['members'][0].get('delivery_email'), None)
+        self.assertEqual(result.json()['user'].get('delivery_email'), None)
 
     def test_change_stream_creation_policy(self) -> None:
         # We need an admin user.

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1343,12 +1343,8 @@ class GetProfileTest(ZulipTestCase):
         self.assertEqual(result['members'][0]['email'], user.email)
         self.assertEqual(result['members'][0]['full_name'], user.full_name)
         self.assertIn("user_id", result['members'][0])
-        self.assertNotIn("profile_data", result['members'][0])
         self.assertFalse(result['members'][0]['is_bot'])
         self.assertFalse(result['members'][0]['is_admin'])
-
-        result = ujson.loads(self.client_get('/json/users/{}?include_custom_profile_fields=true'.format(user.id)).content)
-
         self.assertIn('profile_data', result['members'][0])
         result = self.client_get('/json/users/{}?'.format(30))
         self.assert_json_error(result, "No such user")

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1340,12 +1340,13 @@ class GetProfileTest(ZulipTestCase):
         # Tests the GET ../users/{id} api endpoint.
         user = self.example_user('hamlet')
         result = ujson.loads(self.client_get('/json/users/{}'.format(user.id)).content)
-        self.assertEqual(result['members'][0]['email'], user.email)
-        self.assertEqual(result['members'][0]['full_name'], user.full_name)
-        self.assertIn("user_id", result['members'][0])
-        self.assertFalse(result['members'][0]['is_bot'])
-        self.assertFalse(result['members'][0]['is_admin'])
-        self.assertIn('profile_data', result['members'][0])
+        self.assertEqual(result['user']['email'], user.email)
+        self.assertEqual(result['user']['full_name'], user.full_name)
+        self.assertIn("user_id", result['user'])
+        self.assertFalse(result['user']['is_bot'])
+        self.assertFalse(result['user']['is_admin'])
+        self.assertIn('profile_data', result['user'])
+
         result = self.client_get('/json/users/{}?'.format(30))
         self.assert_json_error(result, "No such user")
 

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -416,6 +416,9 @@ def get_members_backend(request: HttpRequest, user_profile: UserProfile, user_id
     if user_id is not None:
         target_user = access_user_by_id(user_profile, user_id, allow_deactivated=True,
                                         read_only=True)
+        # We force-set include_custom_profile_fields to true when user data of a single user
+        # is asked for, i.e., user_id is not None
+        include_custom_profile_fields = True
 
     members = get_raw_user_data(realm, user_profile, client_gravatar=client_gravatar,
                                 target_user=target_user,

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -419,11 +419,21 @@ def get_members_backend(request: HttpRequest, user_profile: UserProfile, user_id
         # We force-set include_custom_profile_fields to true when user data of a single user
         # is asked for, i.e., user_id is not None
         include_custom_profile_fields = True
+        key = "user"
+    else:
+        key = "members"
 
     members = get_raw_user_data(realm, user_profile, client_gravatar=client_gravatar,
                                 target_user=target_user,
                                 include_custom_profile_fields=include_custom_profile_fields)
-    return json_success({'members': members.values()})
+    data = None  # type: Union[List[Dict[str, str]], Dict[str, str], None]
+
+    if user_id is not None:
+        data = members[int(user_id)]
+    else:
+        data = [members[k] for k in members]
+
+    return json_success({key: data})
 
 @require_realm_admin
 @has_request_variables


### PR DESCRIPTION
This follows #12277 .
It refactors GET ../users/{id} to always include custom profile fields .