### PR TITLE
portico: decrease too much extra space over the main title for small …

### DIFF
--- a/static/styles/portico/landing-page.scss
+++ b/static/styles/portico/landing-page.scss
@@ -3324,7 +3324,7 @@ nav ul li.active::after {
 
     .portico-landing.apps .hero .info .flex,
     .portico-landing.apps .hero .image .flex {
-        height: 300px;
+        height: 200px;
         min-height: 0px;
         width: 100%;
     }


### PR DESCRIPTION
as discussed [here](https://github.com/zulip/zulip/pull/14084#issuecomment-595946885)
this will decrease the spacing over the main title (Zulip for ...)

Before:
![Screenshot from 2020-03-24 03-10-23](https://user-images.githubusercontent.com/32801674/77366160-70db9600-6d7d-11ea-8cd9-e3264d24f8f4.png)

Now:
![Screenshot from 2020-03-24 03-12-28](https://user-images.githubusercontent.com/32801674/77366144-67522e00-6d7d-11ea-8e59-218196bfef3c.png)





