### PR TITLE
tests: Use users in send_*_message.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -462,39 +462,35 @@ class ZulipTestCase(TestCase):
         )
         return [cast(str, get_display_recipient(sub.recipient)) for sub in subs]
 
-    def send_personal_message(self, from_email: str, to_email: str, content: str="test content",
-                              sender_realm: str="zulip",
+    def send_personal_message(self, from_user: UserProfile, to_user: UserProfile, content: str="test content",
                               sending_client_name: str="test suite") -> int:
-        sender = get_user(from_email, get_realm(sender_realm))
-
-        recipient_list = [to_email]
+        recipient_list = [to_user.email]
         (sending_client, _) = Client.objects.get_or_create(name=sending_client_name)
 
         return check_send_message(
-            sender, sending_client, 'private', recipient_list, None,
+            from_user, sending_client, 'private', recipient_list, None,
             content
         )
 
-    def send_huddle_message(self, from_email: str, to_emails: List[str], content: str="test content",
-                            sender_realm: str="zulip",
+    def send_huddle_message(self,
+                            from_user: UserProfile,
+                            to_users: List[UserProfile],
+                            content: str="test content",
                             sending_client_name: str="test suite") -> int:
-        sender = get_user(from_email, get_realm(sender_realm))
-
+        to_emails = [u.email for u in to_users]
         assert(len(to_emails) >= 2)
 
         (sending_client, _) = Client.objects.get_or_create(name=sending_client_name)
 
         return check_send_message(
-            sender, sending_client, 'private', to_emails, None,
+            from_user, sending_client, 'private', to_emails, None,
             content
         )
 
-    def send_stream_message(self, sender_email: str, stream_name: str, content: str="test content",
-                            topic_name: str="test", sender_realm: str="zulip",
+    def send_stream_message(self, sender: UserProfile, stream_name: str, content: str="test content",
+                            topic_name: str="test",
                             recipient_realm: Optional[Realm]=None,
                             sending_client_name: str="test suite") -> int:
-        sender = get_user(sender_email, get_realm(sender_realm))
-
         (sending_client, _) = Client.objects.get_or_create(name=sending_client_name)
 
         return check_send_stream_message(

--- a/zerver/openapi/curl_param_value_generators.py
+++ b/zerver/openapi/curl_param_value_generators.py
@@ -60,7 +60,7 @@ def patch_openapi_example_values(entry: str, params: List[Dict[str, Any]],
                                 "/messages/{message_id}:patch", "/messages/{message_id}:delete"])
 def iago_message_id() -> Dict[str, int]:
     return {
-        "message_id": helpers.send_stream_message(helpers.example_email("iago"), "Denmark")
+        "message_id": helpers.send_stream_message(helpers.example_user("iago"), "Denmark")
     }
 
 @openapi_param_value_generator(["/messages/flags:post"])
@@ -70,7 +70,7 @@ def update_flags_message_ids() -> Dict[str, List[int]]:
 
     messages = []
     for _ in range(3):
-        messages.append(helpers.send_stream_message(helpers.example_email("iago"), stream_name))
+        messages.append(helpers.send_stream_message(helpers.example_user("iago"), stream_name))
     return {
         "messages": messages,
     }
@@ -101,7 +101,7 @@ def get_denmark_stream_id_and_topic() -> Dict[str, Any]:
     topic_name = "Tivoli Gardens"
 
     helpers.subscribe(helpers.example_user("iago"), stream_name)
-    helpers.send_stream_message(helpers.example_email("hamlet"), stream_name, topic_name=topic_name)
+    helpers.send_stream_message(helpers.example_user("hamlet"), stream_name, topic_name=topic_name)
 
     return {
         "stream_id": helpers.get_stream_id(stream_name),
@@ -136,7 +136,7 @@ def get_events() -> Dict[str, Any]:
     helpers.subscribe(profile, "Verona")
     client = Client.objects.create(name="curl-test-client-1")
     response = do_events_register(profile, client, event_types=['message', 'realm_emoji'])
-    helpers.send_stream_message(helpers.example_email("hamlet"), "Verona")
+    helpers.send_stream_message(helpers.example_user("hamlet"), "Verona")
     return {
         "queue_id": response["queue_id"],
         "last_event_id": response["last_event_id"],

--- a/zerver/tests/test_alert_words.py
+++ b/zerver/tests/test_alert_words.py
@@ -133,7 +133,7 @@ class AlertWordTests(ZulipTestCase):
 
     def message_does_alert(self, user_profile: UserProfile, message: str) -> bool:
         """Send a bunch of messages as othello, so Hamlet is notified"""
-        self.send_stream_message(self.example_email("othello"), "Denmark", message)
+        self.send_stream_message(self.example_user("othello"), "Denmark", message)
         user_message = most_recent_usermessage(user_profile)
         return 'has_alert_word' in user_message.flags_list()
 
@@ -172,7 +172,7 @@ class AlertWordTests(ZulipTestCase):
         result = self.client_post('/json/users/me/alert_words', {'alert_words': ujson.dumps(['ALERT'])})
 
         content = 'this is an ALERT for you'
-        self.send_stream_message(me_email, "Denmark", content)
+        self.send_stream_message(user_profile, "Denmark", content)
         self.assert_json_success(result)
 
         original_message = most_recent_message(user_profile)

--- a/zerver/tests/test_archive.py
+++ b/zerver/tests/test_archive.py
@@ -34,7 +34,7 @@ class GlobalPublicStreamTest(ZulipTestCase):
 
         def send_msg_and_get_result(msg: str) -> HttpResponse:
             self.send_stream_message(
-                self.example_email("iago"),
+                self.example_user("iago"),
                 "Test Public Archives",
                 msg,
                 'TopicGlobal'
@@ -92,7 +92,7 @@ class WebPublicTopicHistoryTest(ZulipTestCase):
         test_stream = self.make_stream('Test Public Archives')
 
         self.send_stream_message(
-            self.example_email("iago"),
+            self.example_user("iago"),
             "Test Public Archives",
             'Test Message',
             'TopicGlobal'
@@ -110,31 +110,31 @@ class WebPublicTopicHistoryTest(ZulipTestCase):
         do_change_stream_web_public(test_stream, True)
 
         self.send_stream_message(
-            self.example_email("iago"),
+            self.example_user("iago"),
             "Test Public Archives",
             'Test Message 3',
             topic_name='first_topic'
         )
         self.send_stream_message(
-            self.example_email("iago"),
+            self.example_user("iago"),
             "Test Public Archives",
             'Test Message',
             topic_name='TopicGlobal'
         )
         self.send_stream_message(
-            self.example_email("iago"),
+            self.example_user("iago"),
             "Test Public Archives",
             'Test Message 2',
             topic_name='topicglobal'
         )
         self.send_stream_message(
-            self.example_email("iago"),
+            self.example_user("iago"),
             "Test Public Archives",
             'Test Message 3',
             topic_name='second_topic'
         )
         self.send_stream_message(
-            self.example_email("iago"),
+            self.example_user("iago"),
             "Test Public Archives",
             'Test Message 4',
             topic_name='TopicGlobal'

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -2005,7 +2005,7 @@ class BugdownErrorTests(ZulipTestCase):
             # We don't use assertRaisesRegex because it seems to not
             # handle i18n properly here on some systems.
             with self.assertRaises(JsonableError):
-                self.send_stream_message(self.example_email("othello"), "Denmark", message)
+                self.send_stream_message(self.example_user("othello"), "Denmark", message)
 
     def test_ultra_long_rendering(self) -> None:
         """A rendered message with an ultra-long lenght (> 10 * MAX_MESSAGE_LENGTH)

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -271,9 +271,9 @@ class TestDigestEmailMessages(ZulipTestCase):
         sending_client = get_client(client)
         message_ids = []  # List[int]
         for sender_name in senders:
-            email = self.example_email(sender_name)
-            content = 'some content for {} from {}'.format(stream, email)
-            message_id = self.send_stream_message(email, stream, content)
+            sender = self.example_user(sender_name)
+            content = 'some content for {} from {}'.format(stream, sender_name)
+            message_id = self.send_stream_message(sender, stream, content)
             message_ids.append(message_id)
         Message.objects.filter(id__in=message_ids).update(sending_client=sending_client)
         return message_ids

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -173,8 +173,8 @@ class TestMissedMessages(ZulipTestCase):
 
     def _realm_name_in_missed_message_email_subject(self, realm_name_in_notifications: bool) -> None:
         msg_id = self.send_personal_message(
-            self.example_email('othello'),
-            self.example_email('hamlet'),
+            self.example_user('othello'),
+            self.example_user('hamlet'),
             'Extremely personal message!',
         )
         verify_body_include = ['Extremely personal message!']
@@ -187,12 +187,12 @@ class TestMissedMessages(ZulipTestCase):
     def _extra_context_in_missed_stream_messages_mention(self, send_as_user: bool,
                                                          show_message_content: bool=True) -> None:
         for i in range(0, 11):
-            self.send_stream_message(self.example_email('othello'), "Denmark", content=str(i))
+            self.send_stream_message(self.example_user('othello'), "Denmark", content=str(i))
         self.send_stream_message(
-            self.example_email('othello'), "Denmark",
+            self.example_user('othello'), "Denmark",
             '11', topic_name='test2')
         msg_id = self.send_stream_message(
-            self.example_email('othello'), "denmark",
+            self.example_user('othello'), "denmark",
             '@**King Hamlet**')
 
         if show_message_content:
@@ -223,12 +223,12 @@ class TestMissedMessages(ZulipTestCase):
     def _extra_context_in_missed_stream_messages_wildcard_mention(self, send_as_user: bool,
                                                                   show_message_content: bool=True) -> None:
         for i in range(1, 6):
-            self.send_stream_message(self.example_email('othello'), "Denmark", content=str(i))
+            self.send_stream_message(self.example_user('othello'), "Denmark", content=str(i))
         self.send_stream_message(
-            self.example_email('othello'), "Denmark",
+            self.example_user('othello'), "Denmark",
             '11', topic_name='test2')
         msg_id = self.send_stream_message(
-            self.example_email('othello'), "denmark",
+            self.example_user('othello'), "denmark",
             '@**all**')
 
         if show_message_content:
@@ -257,12 +257,12 @@ class TestMissedMessages(ZulipTestCase):
 
     def _extra_context_in_missed_stream_messages_email_notify(self, send_as_user: bool) -> None:
         for i in range(0, 11):
-            self.send_stream_message(self.example_email('othello'), "Denmark", content=str(i))
+            self.send_stream_message(self.example_user('othello'), "Denmark", content=str(i))
         self.send_stream_message(
-            self.example_email('othello'), "Denmark",
+            self.example_user('othello'), "Denmark",
             '11', topic_name='test2')
         msg_id = self.send_stream_message(
-            self.example_email('othello'), "denmark",
+            self.example_user('othello'), "denmark",
             '12')
         verify_body_include = [
             "Othello, the Moor of Venice: 1 2 3 4 5 6 7 8 9 10 12 -- ",
@@ -273,9 +273,9 @@ class TestMissedMessages(ZulipTestCase):
 
     def _extra_context_in_missed_stream_messages_mention_two_senders(self, send_as_user: bool) -> None:
         for i in range(0, 3):
-            self.send_stream_message(self.example_email('cordelia'), "Denmark", str(i))
+            self.send_stream_message(self.example_user('cordelia'), "Denmark", str(i))
         msg_id = self.send_stream_message(
-            self.example_email('othello'), "Denmark",
+            self.example_user('othello'), "Denmark",
             '@**King Hamlet**')
         verify_body_include = [
             "Cordelia Lear: 0 1 2 Othello, the Moor of Venice: @**King Hamlet** -- ",
@@ -289,8 +289,8 @@ class TestMissedMessages(ZulipTestCase):
                                                           message_content_disabled_by_user: bool=False,
                                                           message_content_disabled_by_realm: bool=False) -> None:
         msg_id = self.send_personal_message(
-            self.example_email('othello'),
-            self.example_email('hamlet'),
+            self.example_user('othello'),
+            self.example_user('hamlet'),
             'Extremely personal message!',
         )
 
@@ -322,8 +322,8 @@ class TestMissedMessages(ZulipTestCase):
 
     def _reply_to_email_in_personal_missed_stream_messages(self, send_as_user: bool) -> None:
         msg_id = self.send_personal_message(
-            self.example_email('othello'),
-            self.example_email('hamlet'),
+            self.example_user('othello'),
+            self.example_user('hamlet'),
             'Extremely personal message!',
         )
         verify_body_include = ['Reply to this email directly, or view it in Zulip']
@@ -332,8 +332,8 @@ class TestMissedMessages(ZulipTestCase):
 
     def _reply_warning_in_personal_missed_stream_messages(self, send_as_user: bool) -> None:
         msg_id = self.send_personal_message(
-            self.example_email('othello'),
-            self.example_email('hamlet'),
+            self.example_user('othello'),
+            self.example_user('hamlet'),
             'Extremely personal message!',
         )
         verify_body_include = ['Do not reply to this email.']
@@ -343,10 +343,10 @@ class TestMissedMessages(ZulipTestCase):
     def _extra_context_in_huddle_missed_stream_messages_two_others(self, send_as_user: bool,
                                                                    show_message_content: bool=True) -> None:
         msg_id = self.send_huddle_message(
-            self.example_email('othello'),
+            self.example_user('othello'),
             [
-                self.example_email('hamlet'),
-                self.example_email('iago'),
+                self.example_user('hamlet'),
+                self.example_user('iago'),
             ],
             'Group personal message!',
         )
@@ -372,11 +372,11 @@ class TestMissedMessages(ZulipTestCase):
 
     def _extra_context_in_huddle_missed_stream_messages_three_others(self, send_as_user: bool) -> None:
         msg_id = self.send_huddle_message(
-            self.example_email('othello'),
+            self.example_user('othello'),
             [
-                self.example_email('hamlet'),
-                self.example_email('iago'),
-                self.example_email('cordelia'),
+                self.example_user('hamlet'),
+                self.example_user('iago'),
+                self.example_user('cordelia'),
             ],
             'Group personal message!',
         )
@@ -386,11 +386,11 @@ class TestMissedMessages(ZulipTestCase):
         self._test_cases(msg_id, verify_body_include, email_subject, send_as_user)
 
     def _extra_context_in_huddle_missed_stream_messages_many_others(self, send_as_user: bool) -> None:
-        msg_id = self.send_huddle_message(self.example_email('othello'),
-                                          [self.example_email('hamlet'),
-                                           self.example_email('iago'),
-                                           self.example_email('cordelia'),
-                                           self.example_email('prospero')],
+        msg_id = self.send_huddle_message(self.example_user('othello'),
+                                          [self.example_user('hamlet'),
+                                           self.example_user('iago'),
+                                           self.example_user('cordelia'),
+                                           self.example_user('prospero')],
                                           'Group personal message!')
 
         verify_body_include = ['Othello, the Moor of Venice: Group personal message! -- Reply']
@@ -399,7 +399,7 @@ class TestMissedMessages(ZulipTestCase):
 
     def _deleted_message_in_missed_stream_messages(self, send_as_user: bool) -> None:
         msg_id = self.send_stream_message(
-            self.example_email('othello'), "denmark",
+            self.example_user('othello'), "denmark",
             '@**King Hamlet** to be deleted')
 
         hamlet = self.example_user('hamlet')
@@ -412,8 +412,8 @@ class TestMissedMessages(ZulipTestCase):
         self.assertEqual(len(mail.outbox), 0)
 
     def _deleted_message_in_personal_missed_stream_messages(self, send_as_user: bool) -> None:
-        msg_id = self.send_personal_message(self.example_email('othello'),
-                                            self.example_email('hamlet'),
+        msg_id = self.send_personal_message(self.example_user('othello'),
+                                            self.example_user('hamlet'),
                                             'Extremely personal message! to be deleted!')
 
         hamlet = self.example_user('hamlet')
@@ -427,10 +427,10 @@ class TestMissedMessages(ZulipTestCase):
 
     def _deleted_message_in_huddle_missed_stream_messages(self, send_as_user: bool) -> None:
         msg_id = self.send_huddle_message(
-            self.example_email('othello'),
+            self.example_user('othello'),
             [
-                self.example_email('hamlet'),
-                self.example_email('iago'),
+                self.example_user('hamlet'),
+                self.example_user('iago'),
             ],
             'Group personal message!',
         )
@@ -597,7 +597,7 @@ class TestMissedMessages(ZulipTestCase):
         realm = get_realm("zulip")
 
         msg_id = self.send_personal_message(
-            self.example_email('othello'), self.example_email('hamlet'),
+            self.example_user('othello'), self.example_user('hamlet'),
             'Extremely personal message with a realm emoji :green_tick:!')
         realm_emoji_id = realm.get_active_emoji()['green_tick']['id']
         realm_emoji_url = "http://zulip.testserver/user_avatars/%s/emoji/images/%s.png" % (
@@ -611,7 +611,7 @@ class TestMissedMessages(ZulipTestCase):
         hamlet.emojiset = 'twitter'
         hamlet.save(update_fields=['emojiset'])
         msg_id = self.send_personal_message(
-            self.example_email('othello'), self.example_email('hamlet'),
+            self.example_user('othello'), self.example_user('hamlet'),
             'Extremely personal message with a hamburger :hamburger:!')
         verify_body_include = ['<img alt=":hamburger:" src="http://zulip.testserver/static/generated/emoji/images-twitter-64/1f354.png" title="hamburger" style="height: 20px;">']
         email_subject = 'PMs with Othello, the Moor of Venice'
@@ -619,7 +619,7 @@ class TestMissedMessages(ZulipTestCase):
 
     def test_stream_link_in_missed_message(self) -> None:
         msg_id = self.send_personal_message(
-            self.example_email('othello'), self.example_email('hamlet'),
+            self.example_user('othello'), self.example_user('hamlet'),
             'Come and join us in #**Verona**.')
         stream_id = get_stream('Verona', get_realm('zulip')).id
         href = "http://zulip.testserver/#narrow/stream/{stream_id}-Verona".format(stream_id=stream_id)
@@ -629,14 +629,14 @@ class TestMissedMessages(ZulipTestCase):
 
     def test_sender_name_in_missed_message(self) -> None:
         hamlet = self.example_user('hamlet')
-        msg_id_1 = self.send_stream_message(self.example_email('iago'),
+        msg_id_1 = self.send_stream_message(self.example_user('iago'),
                                             "Denmark",
                                             '@**King Hamlet**')
-        msg_id_2 = self.send_stream_message(self.example_email('iago'),
+        msg_id_2 = self.send_stream_message(self.example_user('iago'),
                                             "Verona",
                                             '* 1\n *2')
-        msg_id_3 = self.send_personal_message(self.example_email('iago'),
-                                              hamlet.email,
+        msg_id_3 = self.send_personal_message(self.example_user('iago'),
+                                              hamlet,
                                               'Hello')
 
         handle_missedmessage_emails(hamlet.id, [
@@ -661,11 +661,11 @@ class TestMissedMessages(ZulipTestCase):
 
     def test_multiple_missed_personal_messages(self) -> None:
         hamlet = self.example_user('hamlet')
-        msg_id_1 = self.send_personal_message(self.example_email('othello'),
-                                              hamlet.email,
+        msg_id_1 = self.send_personal_message(self.example_user('othello'),
+                                              hamlet,
                                               'Personal Message 1')
-        msg_id_2 = self.send_personal_message(self.example_email('iago'),
-                                              hamlet.email,
+        msg_id_2 = self.send_personal_message(self.example_user('iago'),
+                                              hamlet,
                                               'Personal Message 2')
 
         handle_missedmessage_emails(hamlet.id, [
@@ -680,10 +680,10 @@ class TestMissedMessages(ZulipTestCase):
 
     def test_multiple_stream_messages(self) -> None:
         hamlet = self.example_user('hamlet')
-        msg_id_1 = self.send_stream_message(self.example_email('othello'),
+        msg_id_1 = self.send_stream_message(self.example_user('othello'),
                                             "Denmark",
                                             'Message1')
-        msg_id_2 = self.send_stream_message(self.example_email('iago'),
+        msg_id_2 = self.send_stream_message(self.example_user('iago'),
                                             "Denmark",
                                             'Message2')
 
@@ -698,10 +698,10 @@ class TestMissedMessages(ZulipTestCase):
     def test_multiple_stream_messages_and_mentions(self) -> None:
         """Subject should be stream name and topic as usual."""
         hamlet = self.example_user('hamlet')
-        msg_id_1 = self.send_stream_message(self.example_email('iago'),
+        msg_id_1 = self.send_stream_message(self.example_user('iago'),
                                             "Denmark",
                                             'Regular message')
-        msg_id_2 = self.send_stream_message(self.example_email('othello'),
+        msg_id_2 = self.send_stream_message(self.example_user('othello'),
                                             "Denmark",
                                             '@**King Hamlet**')
 
@@ -723,17 +723,17 @@ class TestMissedMessages(ZulipTestCase):
         self.subscribe(user, stream_name)
         late_subscribed_user = self.example_user('hamlet')
 
-        self.send_stream_message(user.email,
+        self.send_stream_message(user,
                                  stream_name,
                                  'Before subscribing')
 
         self.subscribe(late_subscribed_user, stream_name)
 
-        self.send_stream_message(user.email,
+        self.send_stream_message(user,
                                  stream_name,
                                  "After subscribing")
 
-        mention_msg_id = self.send_stream_message(user.email,
+        mention_msg_id = self.send_stream_message(user,
                                                   stream_name,
                                                   '@**King Hamlet**')
 
@@ -751,13 +751,13 @@ class TestMissedMessages(ZulipTestCase):
     def test_stream_mentions_multiple_people(self) -> None:
         """Subject should be stream name and topic as usual."""
         hamlet = self.example_user('hamlet')
-        msg_id_1 = self.send_stream_message(self.example_email('iago'),
+        msg_id_1 = self.send_stream_message(self.example_user('iago'),
                                             "Denmark",
                                             '@**King Hamlet**')
-        msg_id_2 = self.send_stream_message(self.example_email('othello'),
+        msg_id_2 = self.send_stream_message(self.example_user('othello'),
                                             "Denmark",
                                             '@**King Hamlet**')
-        msg_id_3 = self.send_stream_message(self.example_email('cordelia'),
+        msg_id_3 = self.send_stream_message(self.example_user('cordelia'),
                                             "Denmark",
                                             'Regular message')
 
@@ -773,10 +773,10 @@ class TestMissedMessages(ZulipTestCase):
     def test_multiple_stream_messages_different_topics(self) -> None:
         """Should receive separate emails for each topic within a stream."""
         hamlet = self.example_user('hamlet')
-        msg_id_1 = self.send_stream_message(self.example_email('othello'),
+        msg_id_1 = self.send_stream_message(self.example_user('othello'),
                                             "Denmark",
                                             'Message1')
-        msg_id_2 = self.send_stream_message(self.example_email('iago'),
+        msg_id_2 = self.send_stream_message(self.example_user('iago'),
                                             "Denmark",
                                             'Message2',
                                             topic_name="test2")

--- a/zerver/tests/test_embedded_bot_system.py
+++ b/zerver/tests/test_embedded_bot_system.py
@@ -23,7 +23,7 @@ class TestEmbeddedBotMessaging(ZulipTestCase):
 
     def test_pm_to_embedded_bot(self) -> None:
         assert self.bot_profile is not None
-        self.send_personal_message(self.user_profile.email, self.bot_profile.email,
+        self.send_personal_message(self.user_profile, self.bot_profile,
                                    content="help")
         last_message = self.get_last_message()
         self.assertEqual(last_message.content, "beep boop")
@@ -37,7 +37,7 @@ class TestEmbeddedBotMessaging(ZulipTestCase):
 
     def test_stream_message_to_embedded_bot(self) -> None:
         assert self.bot_profile is not None
-        self.send_stream_message(self.user_profile.email, "Denmark",
+        self.send_stream_message(self.user_profile, "Denmark",
                                  content="@**{}** foo".format(self.bot_profile.full_name),
                                  topic_name="bar")
         last_message = self.get_last_message()
@@ -48,7 +48,7 @@ class TestEmbeddedBotMessaging(ZulipTestCase):
         self.assertEqual(display_recipient, "Denmark")
 
     def test_stream_message_not_to_embedded_bot(self) -> None:
-        self.send_stream_message(self.user_profile.email, "Denmark",
+        self.send_stream_message(self.user_profile, "Denmark",
                                  content="foo", topic_name="bar")
         last_message = self.get_last_message()
         self.assertEqual(last_message.content, "foo")
@@ -57,7 +57,7 @@ class TestEmbeddedBotMessaging(ZulipTestCase):
         assert self.bot_profile is not None
         with patch('zulip_bots.bots.helloworld.helloworld.HelloWorldHandler.initialize',
                    create=True) as mock_initialize:
-            self.send_stream_message(self.user_profile.email, "Denmark",
+            self.send_stream_message(self.user_profile, "Denmark",
                                      content="@**{}** foo".format(self.bot_profile.full_name),
                                      topic_name="bar")
             mock_initialize.assert_called_once()
@@ -67,7 +67,7 @@ class TestEmbeddedBotMessaging(ZulipTestCase):
         with patch('zulip_bots.bots.helloworld.helloworld.HelloWorldHandler.handle_message',
                    side_effect=EmbeddedBotQuitException("I'm quitting!")):
             with patch('logging.warning') as mock_logging:
-                self.send_stream_message(self.user_profile.email, "Denmark",
+                self.send_stream_message(self.user_profile, "Denmark",
                                          content="@**{}** foo".format(self.bot_profile.full_name),
                                          topic_name="bar")
                 mock_logging.assert_called_once_with("I'm quitting!")
@@ -84,7 +84,7 @@ class TestEmbeddedBotFailures(ZulipTestCase):
         service_profile.name = 'invalid'
         service_profile.save()
         with patch('logging.error') as logging_error_mock:
-            self.send_stream_message(user_profile.email, "Denmark",
+            self.send_stream_message(user_profile, "Denmark",
                                      content="@**{}** foo".format(bot_profile.full_name),
                                      topic_name="bar")
             logging_error_mock.assert_called_once_with(

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -200,7 +200,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
 
         client = allocate_client_descriptor(queue_data)
 
-        self.send_stream_message(cordelia.email, stream_name)
+        self.send_stream_message(cordelia, stream_name)
 
         self.assertEqual(len(client.event_queue.contents()), 1)
 
@@ -253,7 +253,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         client_descriptor = allocate_event_queue()
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             # To test the missed_message hook, we first need to send a message
-            msg_id = self.send_stream_message(self.example_email("iago"), "Denmark")
+            msg_id = self.send_stream_message(self.example_user("iago"), "Denmark")
 
             # Verify that nothing happens if you call it as not the
             # "last client descriptor", in which case the function
@@ -275,7 +275,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         # Test the hook with a private message; this should trigger notifications
         client_descriptor = allocate_event_queue()
         self.assertTrue(client_descriptor.event_queue.empty())
-        msg_id = self.send_personal_message(self.example_email("iago"), email)
+        msg_id = self.send_personal_message(self.example_user("iago"), user_profile)
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
             mock_enqueue.assert_called_once()
@@ -289,7 +289,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         # Test the hook with a mention; this should trigger notifications
         client_descriptor = allocate_event_queue()
         self.assertTrue(client_descriptor.event_queue.empty())
-        msg_id = self.send_stream_message(self.example_email("iago"), "Denmark",
+        msg_id = self.send_stream_message(self.example_user("iago"), "Denmark",
                                           content="@**King Hamlet** what's up?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
@@ -304,7 +304,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         # Test the hook with a wildcard mention; this should trigger notifications
         client_descriptor = allocate_event_queue()
         self.assertTrue(client_descriptor.event_queue.empty())
-        msg_id = self.send_stream_message(self.example_email("iago"), "Denmark",
+        msg_id = self.send_stream_message(self.example_user("iago"), "Denmark",
                                           content="@**all** what's up?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
@@ -320,7 +320,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         # themself using a human client; should not notify.
         client_descriptor = allocate_event_queue()
         self.assertTrue(client_descriptor.event_queue.empty())
-        msg_id = self.send_stream_message(self.example_email("hamlet"), "Denmark",
+        msg_id = self.send_stream_message(self.example_user("hamlet"), "Denmark",
                                           content="@**all** what's up?",
                                           sending_client_name="website")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
@@ -337,7 +337,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         change_subscription_properties(user_profile, stream, sub, {'is_muted': True})
         client_descriptor = allocate_event_queue()
         self.assertTrue(client_descriptor.event_queue.empty())
-        msg_id = self.send_stream_message(self.example_email("iago"), "Denmark",
+        msg_id = self.send_stream_message(self.example_user("iago"), "Denmark",
                                           content="@**all** what's up?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
@@ -355,7 +355,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         user_profile.save()
         client_descriptor = allocate_event_queue()
         self.assertTrue(client_descriptor.event_queue.empty())
-        msg_id = self.send_stream_message(self.example_email("iago"), "Denmark",
+        msg_id = self.send_stream_message(self.example_user("iago"), "Denmark",
                                           content="@**all** what's up?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
@@ -377,7 +377,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         sub.save()
         client_descriptor = allocate_event_queue()
         self.assertTrue(client_descriptor.event_queue.empty())
-        msg_id = self.send_stream_message(self.example_email("iago"), "Denmark",
+        msg_id = self.send_stream_message(self.example_user("iago"), "Denmark",
                                           content="@**all** what's up?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
@@ -397,7 +397,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         change_subscription_properties(user_profile, stream, sub, {'push_notifications': True})
         client_descriptor = allocate_event_queue()
         self.assertTrue(client_descriptor.event_queue.empty())
-        msg_id = self.send_stream_message(self.example_email("iago"), "Denmark",
+        msg_id = self.send_stream_message(self.example_user("iago"), "Denmark",
                                           content="what's up everyone?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
@@ -415,7 +415,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
                                        {'push_notifications': False,
                                         'email_notifications': True})
         self.assertTrue(client_descriptor.event_queue.empty())
-        msg_id = self.send_stream_message(self.example_email("iago"), "Denmark",
+        msg_id = self.send_stream_message(self.example_user("iago"), "Denmark",
                                           content="what's up everyone?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
@@ -436,7 +436,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
 
         self.assertTrue(client_descriptor.event_queue.empty())
         do_mute_topic(user_profile, stream, sub.recipient, "mutingtest")
-        msg_id = self.send_stream_message(self.example_email("iago"), "Denmark",
+        msg_id = self.send_stream_message(self.example_user("iago"), "Denmark",
                                           content="what's up everyone?", topic_name="mutingtest")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)
@@ -457,7 +457,7 @@ class MissedMessageNotificationsTest(ZulipTestCase):
 
         self.assertTrue(client_descriptor.event_queue.empty())
         change_subscription_properties(user_profile, stream, sub, {'is_muted': True})
-        msg_id = self.send_stream_message(self.example_email("iago"), "Denmark",
+        msg_id = self.send_stream_message(self.example_user("iago"), "Denmark",
                                           content="what's up everyone?")
         with mock.patch("zerver.tornado.event_queue.maybe_enqueue_notifications") as mock_enqueue:
             missedmessage_hook(user_profile.id, client_descriptor, True)

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -811,7 +811,7 @@ class HomeTest(ZulipTestCase):
 
     def send_test_message(self, content: str, sender_name: str='iago',
                           stream_name: str='Denmark', topic_name: str='foo') -> None:
-        sender = self.example_email(sender_name)
+        sender = self.example_user(sender_name)
         self.send_stream_message(sender, stream_name,
                                  content=content, topic_name=topic_name)
 

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -98,11 +98,10 @@ from zerver.lib.test_helpers import (
 
 class QueryUtilTest(ZulipTestCase):
     def _create_messages(self) -> None:
-        for email in [self.example_email('cordelia'),
-                      self.example_email('hamlet'),
-                      self.example_email('iago')]:
+        for name in ['cordelia', 'hamlet', 'iago']:
+            user = self.example_user(name)
             for _ in range(5):
-                self.send_personal_message(email, self.example_email('othello'))
+                self.send_personal_message(user, self.example_user('othello'))
 
     @slow('creates lots of data')
     def test_query_chunker(self) -> None:
@@ -458,9 +457,10 @@ class ImportExportTest(ZulipTestCase):
     def test_zulip_realm(self) -> None:
         realm = Realm.objects.get(string_id='zulip')
 
-        pm_a_msg_id = self.send_personal_message(self.example_email("AARON"), "default-bot@zulip.com")
-        pm_b_msg_id = self.send_personal_message("default-bot@zulip.com", self.example_email("iago"))
-        pm_c_msg_id = self.send_personal_message(self.example_email("othello"), self.example_email("hamlet"))
+        default_bot = self.example_user('default_bot')
+        pm_a_msg_id = self.send_personal_message(self.example_user("AARON"), default_bot)
+        pm_b_msg_id = self.send_personal_message(default_bot, self.example_user("iago"))
+        pm_c_msg_id = self.send_personal_message(self.example_user("othello"), self.example_user("hamlet"))
 
         realm_emoji = RealmEmoji.objects.get(realm=realm)
         realm_emoji.delete()
@@ -502,10 +502,10 @@ class ImportExportTest(ZulipTestCase):
         hamlet = self.example_user('hamlet')
         user_ids = set([cordelia.id, hamlet.id])
 
-        pm_a_msg_id = self.send_personal_message(self.example_email("AARON"), self.example_email("othello"))
-        pm_b_msg_id = self.send_personal_message(self.example_email("cordelia"), self.example_email("iago"))
-        pm_c_msg_id = self.send_personal_message(self.example_email("hamlet"), self.example_email("othello"))
-        pm_d_msg_id = self.send_personal_message(self.example_email("iago"), self.example_email("hamlet"))
+        pm_a_msg_id = self.send_personal_message(self.example_user("AARON"), self.example_user("othello"))
+        pm_b_msg_id = self.send_personal_message(self.example_user("cordelia"), self.example_user("iago"))
+        pm_c_msg_id = self.send_personal_message(self.example_user("hamlet"), self.example_user("othello"))
+        pm_d_msg_id = self.send_personal_message(self.example_user("iago"), self.example_user("hamlet"))
 
         realm_emoji = RealmEmoji.objects.get(realm=realm)
         realm_emoji.delete()
@@ -542,42 +542,42 @@ class ImportExportTest(ZulipTestCase):
         create_stream_if_needed(realm, "Private A", invite_only=True)
         self.subscribe(self.example_user("iago"), "Private A")
         self.subscribe(self.example_user("othello"), "Private A")
-        self.send_stream_message(self.example_email("iago"), "Private A", "Hello Stream A")
+        self.send_stream_message(self.example_user("iago"), "Private A", "Hello Stream A")
 
         create_stream_if_needed(realm, "Private B", invite_only=True)
         self.subscribe(self.example_user("prospero"), "Private B")
-        stream_b_message_id = self.send_stream_message(self.example_email("prospero"),
+        stream_b_message_id = self.send_stream_message(self.example_user("prospero"),
                                                        "Private B", "Hello Stream B")
         self.subscribe(self.example_user("hamlet"), "Private B")
 
         create_stream_if_needed(realm, "Private C", invite_only=True)
         self.subscribe(self.example_user("othello"), "Private C")
         self.subscribe(self.example_user("prospero"), "Private C")
-        stream_c_message_id = self.send_stream_message(self.example_email("othello"),
+        stream_c_message_id = self.send_stream_message(self.example_user("othello"),
                                                        "Private C", "Hello Stream C")
 
         # Create huddles
-        self.send_huddle_message(self.example_email("iago"), [self.example_email("cordelia"),
-                                                              self.example_email("AARON")])
+        self.send_huddle_message(self.example_user("iago"), [self.example_user("cordelia"),
+                                                             self.example_user("AARON")])
         huddle_a = Huddle.objects.last()
-        self.send_huddle_message(self.example_email("ZOE"), [self.example_email("hamlet"),
-                                                             self.example_email("AARON"),
-                                                             self.example_email("othello")])
+        self.send_huddle_message(self.example_user("ZOE"), [self.example_user("hamlet"),
+                                                            self.example_user("AARON"),
+                                                            self.example_user("othello")])
         huddle_b = Huddle.objects.last()
 
         huddle_c_message_id = self.send_huddle_message(
-            self.example_email("AARON"), [self.example_email("cordelia"),
-                                          self.example_email("ZOE"),
-                                          self.example_email("othello")])
+            self.example_user("AARON"), [self.example_user("cordelia"),
+                                         self.example_user("ZOE"),
+                                         self.example_user("othello")])
 
         # Create PMs
-        pm_a_msg_id = self.send_personal_message(self.example_email("AARON"), self.example_email("othello"))
-        pm_b_msg_id = self.send_personal_message(self.example_email("cordelia"), self.example_email("iago"))
-        pm_c_msg_id = self.send_personal_message(self.example_email("hamlet"), self.example_email("othello"))
-        pm_d_msg_id = self.send_personal_message(self.example_email("iago"), self.example_email("hamlet"))
+        pm_a_msg_id = self.send_personal_message(self.example_user("AARON"), self.example_user("othello"))
+        pm_b_msg_id = self.send_personal_message(self.example_user("cordelia"), self.example_user("iago"))
+        pm_c_msg_id = self.send_personal_message(self.example_user("hamlet"), self.example_user("othello"))
+        pm_d_msg_id = self.send_personal_message(self.example_user("iago"), self.example_user("hamlet"))
 
         # Send message advertising export and make users react
-        self.send_stream_message(self.example_email("othello"), "Verona",
+        self.send_stream_message(self.example_user("othello"), "Verona",
                                  topic_name="Export",
                                  content="Thumbs up for export")
         message = Message.objects.last()
@@ -698,24 +698,24 @@ class ImportExportTest(ZulipTestCase):
         RealmEmoji.objects.get(realm=original_realm).delete()
         # data to test import of huddles
         huddle = [
-            self.example_email('hamlet'),
-            self.example_email('othello')
+            self.example_user('hamlet'),
+            self.example_user('othello')
         ]
         self.send_huddle_message(
-            self.example_email('cordelia'), huddle, 'test huddle message'
+            self.example_user('cordelia'), huddle, 'test huddle message'
         )
 
         user_mention_message = '@**King Hamlet** Hello'
-        self.send_stream_message(self.example_email("iago"), "Verona", user_mention_message)
+        self.send_stream_message(self.example_user("iago"), "Verona", user_mention_message)
 
         stream_mention_message = 'Subscribe to #**Denmark**'
-        self.send_stream_message(self.example_email("hamlet"), "Verona", stream_mention_message)
+        self.send_stream_message(self.example_user("hamlet"), "Verona", stream_mention_message)
 
         user_group_mention_message = 'Hello @*hamletcharacters*'
-        self.send_stream_message(self.example_email("othello"), "Verona", user_group_mention_message)
+        self.send_stream_message(self.example_user("othello"), "Verona", user_group_mention_message)
 
         special_characters_message = "```\n'\n```\n@**Polonius**"
-        self.send_stream_message(self.example_email("iago"), "Denmark", special_characters_message)
+        self.send_stream_message(self.example_user("iago"), "Denmark", special_characters_message)
 
         sample_user = self.example_user('hamlet')
 

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -406,7 +406,7 @@ class TestExport(ZulipTestCase):
 
     def test_command_with_consented_message_id(self) -> None:
         realm = get_realm("zulip")
-        self.send_stream_message(self.example_email("othello"), "Verona",
+        self.send_stream_message(self.example_user("othello"), "Verona",
                                  topic_name="Export",
                                  content="Thumbs up for export")
         message = Message.objects.last()

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -45,8 +45,8 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         self.login(hamlet.email)
 
         message_id = self.send_personal_message(
-            hamlet.email,
-            cordelia.email,
+            hamlet,
+            cordelia,
             content='no mention'
         )
 
@@ -75,7 +75,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         self.subscribe(cordelia, 'Scotland')
 
         message_id = self.send_stream_message(
-            hamlet.email,
+            hamlet,
             'Scotland',
             content=content,
         )

--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -21,7 +21,7 @@ class TestGenericOutgoingWebhookService(ZulipTestCase):
 
         # TODO: Ideally, this test would use the full flow, rather
         # than making a mock message like this.
-        message_id = self.send_stream_message(self.example_email('othello'),
+        message_id = self.send_stream_message(self.example_user('othello'),
                                               "Denmark", content="@**test**")
         message = Message.objects.get(id=message_id)
         wide_message_dict = MessageDict.wide_dict(message)

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -149,7 +149,7 @@ class TestOutgoingWebhookMessaging(ZulipTestCase):
 
     @mock.patch('requests.request', return_value=ResponseMock(200, {"response_string": "Hidley ho, I'm a webhook responding!"}))
     def test_pm_to_outgoing_webhook_bot(self, mock_requests_request: mock.Mock) -> None:
-        self.send_personal_message(self.user_profile.email, self.bot_profile.email,
+        self.send_personal_message(self.user_profile, self.bot_profile,
                                    content="foo")
         last_message = self.get_last_message()
         self.assertEqual(last_message.content, "Hidley ho, I'm a webhook responding!")
@@ -163,7 +163,7 @@ class TestOutgoingWebhookMessaging(ZulipTestCase):
 
     @mock.patch('requests.request', return_value=ResponseMock(200, {"response_string": "Hidley ho, I'm a webhook responding!"}))
     def test_stream_message_to_outgoing_webhook_bot(self, mock_requests_request: mock.Mock) -> None:
-        self.send_stream_message(self.user_profile.email, "Denmark",
+        self.send_stream_message(self.user_profile, "Denmark",
                                  content="@**{}** foo".format(self.bot_profile.full_name),
                                  topic_name="bar")
         last_message = self.get_last_message()

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -957,7 +957,8 @@ class HandlePushNotificationTest(PushNotificationTest):
         not long-term idle; we fake it, though, in the sense that the user should
         not have received the message in the first place"""
         self.make_stream('public_stream')
-        message_id = self.send_stream_message("iago@zulip.com", "public_stream", "test")
+        sender = self.example_user('iago')
+        message_id = self.send_stream_message(sender, "public_stream", "test")
         missed_message = {'message_id': message_id}
         with mock.patch('zerver.lib.push_notifications.logger.error') as mock_logger, \
                 mock.patch('zerver.lib.push_notifications.push_notifications_enabled', return_value = True) as mock_push_notifications:
@@ -977,7 +978,8 @@ class HandlePushNotificationTest(PushNotificationTest):
         self.subscribe(self.user_profile, 'public_stream')
         do_soft_deactivate_users([self.user_profile])
 
-        message_id = self.send_stream_message("iago@zulip.com", "public_stream", "test")
+        sender = self.example_user('iago')
+        message_id = self.send_stream_message(sender, "public_stream", "test")
         missed_message = {
             'message_id': message_id,
             'trigger': 'stream_push_notify',
@@ -1136,8 +1138,8 @@ class TestGetAPNsPayload(PushNotificationTest):
     def test_get_message_payload_apns_personal_message(self) -> None:
         user_profile = self.example_user("othello")
         message_id = self.send_personal_message(
-            self.sender.email,
-            user_profile.email,
+            self.sender,
+            user_profile,
             'Content of personal message',
         )
         message = Message.objects.get(id=message_id)
@@ -1170,8 +1172,8 @@ class TestGetAPNsPayload(PushNotificationTest):
     def test_get_message_payload_apns_huddle_message(self, mock_push_notifications: mock.MagicMock) -> None:
         user_profile = self.example_user("othello")
         message_id = self.send_huddle_message(
-            self.sender.email,
-            [self.example_email('othello'), self.example_email('cordelia')])
+            self.sender,
+            [self.example_user('othello'), self.example_user('cordelia')])
         message = Message.objects.get(id=message_id)
         message.trigger = 'private_message'
         payload = get_message_payload_apns(user_profile, message)
@@ -1306,8 +1308,8 @@ class TestGetAPNsPayload(PushNotificationTest):
     def test_get_message_payload_apns_redacted_content(self) -> None:
         user_profile = self.example_user("othello")
         message_id = self.send_huddle_message(
-            self.sender.email,
-            [self.example_email('othello'), self.example_email('cordelia')])
+            self.sender,
+            [self.example_user('othello'), self.example_user('cordelia')])
         message = Message.objects.get(id=message_id)
         message.trigger = 'private_message'
         payload = get_message_payload_apns(user_profile, message)
@@ -1756,7 +1758,7 @@ class TestClearOnRead(ZulipTestCase):
         hamlet.save()
         stream = self.subscribe(hamlet, "Denmark")
 
-        message_ids = [self.send_stream_message(self.example_email("iago"),
+        message_ids = [self.send_stream_message(self.example_user("iago"),
                                                 stream.name,
                                                 "yo {}".format(i))
                        for i in range(n_msgs)]

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -173,26 +173,26 @@ class WorkerTest(ZulipTestCase):
         othello = self.example_user('othello')
 
         hamlet1_msg_id = self.send_personal_message(
-            from_email=cordelia.email,
-            to_email=hamlet.email,
+            from_user=cordelia,
+            to_user=hamlet,
             content='hi hamlet',
         )
 
         hamlet2_msg_id = self.send_personal_message(
-            from_email=cordelia.email,
-            to_email=hamlet.email,
+            from_user=cordelia,
+            to_user=hamlet,
             content='goodbye hamlet',
         )
 
         hamlet3_msg_id = self.send_personal_message(
-            from_email=cordelia.email,
-            to_email=hamlet.email,
+            from_user=cordelia,
+            to_user=hamlet,
             content='hello again hamlet',
         )
 
         othello_msg_id = self.send_personal_message(
-            from_email=cordelia.email,
-            to_email=othello.email,
+            from_user=cordelia,
+            to_user=othello,
             content='where art thou, othello?',
         )
 

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -90,7 +90,7 @@ class ReactionEmojiTest(ZulipTestCase):
         """
         stream_name = "Saxony"
         self.subscribe(self.example_user("cordelia"), stream_name)
-        message_id = self.send_stream_message(self.example_email("cordelia"), stream_name)
+        message_id = self.send_stream_message(self.example_user("cordelia"), stream_name)
 
         user_profile = self.example_user('hamlet')
         sender = user_profile.email
@@ -650,7 +650,7 @@ class DefaultEmojiReactionTests(EmojiReactionBase):
         """
         stream_name = "Saxony"
         self.subscribe(self.example_user("cordelia"), stream_name)
-        message_id = self.send_stream_message(self.example_email("cordelia"), stream_name)
+        message_id = self.send_stream_message(self.example_user("cordelia"), stream_name)
 
         user_profile = self.example_user('hamlet')
 
@@ -814,7 +814,7 @@ class ReactionAPIEventTest(EmojiReactionBase):
         pm_sender = self.example_user('hamlet')
         pm_recipient = self.example_user('othello')
         reaction_sender = pm_recipient
-        pm_id = self.send_personal_message(pm_sender.email, pm_recipient.email)
+        pm_id = self.send_personal_message(pm_sender, pm_recipient)
         expected_recipient_ids = set([pm_sender.id, pm_recipient.id])
         reaction_info = {
             'emoji_name': 'hamburger',
@@ -851,7 +851,7 @@ class ReactionAPIEventTest(EmojiReactionBase):
         pm_sender = self.example_user('hamlet')
         pm_recipient = self.example_user('othello')
         reaction_sender = pm_recipient
-        pm_id = self.send_personal_message(pm_sender.email, pm_recipient.email)
+        pm_id = self.send_personal_message(pm_sender, pm_recipient)
         expected_recipient_ids = set([pm_sender.id, pm_recipient.id])
         reaction_info = {
             'emoji_name': 'hamburger',

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -848,10 +848,10 @@ class ScrubRealmTest(ZulipTestCase):
         UserMessage.objects.all().delete()
 
         for i in range(5):
-            self.send_stream_message(iago.email, "Scotland")
-            self.send_stream_message(othello.email, "Scotland")
-            self.send_stream_message(cordelia.email, "Shakespeare", sender_realm="lear")
-            self.send_stream_message(king.email, "Shakespeare", sender_realm="lear")
+            self.send_stream_message(iago, "Scotland")
+            self.send_stream_message(othello, "Scotland")
+            self.send_stream_message(cordelia, "Shakespeare")
+            self.send_stream_message(king, "Shakespeare")
 
         Attachment.objects.filter(realm=zulip).delete()
         Attachment.objects.create(realm=zulip, owner=iago, path_id="a/b/temp1.txt")

--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -99,8 +99,7 @@ class ArchiveMessagesTestingBase(RetentionTestingBase):
         # send messages from mit.edu realm and change messages pub date
         sender = self.mit_user('espuser')
         recipient = self.mit_user('starnine')
-        msg_ids = [self.send_personal_message(sender.email, recipient.email,
-                                              sender_realm='zephyr')
+        msg_ids = [self.send_personal_message(sender, recipient)
                    for i in range(message_quantity)]
 
         self._change_messages_date_sent(msg_ids, date_sent)
@@ -132,7 +131,6 @@ class ArchiveMessagesTestingBase(RetentionTestingBase):
 
     def _send_messages_with_attachments(self) -> Dict[str, int]:
         user_profile = self.example_user("hamlet")
-        sender_email = user_profile.email
         sample_size = 10
         host = user_profile.realm.host
         realm_id = get_realm("zulip").id
@@ -150,9 +148,11 @@ class ArchiveMessagesTestingBase(RetentionTestingBase):
                 " http://{host}/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/temp_file.py.... Some more...." +
                 " http://{host}/user_uploads/{id}/31/4CBjtTLYZhk66pZrF8hnYGwc/abc.py").format(id=realm_id, host=host)
 
-        expired_message_id = self.send_stream_message(sender_email, "Denmark", body)
-        actual_message_id = self.send_stream_message(sender_email, "Denmark", body)
-        other_message_id = self.send_stream_message("othello@zulip.com", "Denmark", body)
+        expired_message_id = self.send_stream_message(user_profile, "Denmark", body)
+        actual_message_id = self.send_stream_message(user_profile, "Denmark", body)
+
+        othello = self.example_user('othello')
+        other_message_id = self.send_stream_message(othello, "Denmark", body)
         self._change_messages_date_sent([expired_message_id], timezone_now() - timedelta(days=MIT_REALM_DAYS + 1))
         return {'expired_message_id': expired_message_id, 'actual_message_id': actual_message_id,
                 'other_user_message_id': other_message_id}
@@ -227,7 +227,7 @@ class TestArchiveMessagesGeneral(ArchiveMessagesTestingBase):
 
     def test_different_stream_realm_policies(self) -> None:
         verona = get_stream("Verona", self.zulip_realm)
-        hamlet = self.example_email("hamlet")
+        hamlet = self.example_user("hamlet")
 
         msg_id = self.send_stream_message(hamlet, "Verona", "test")
         usermsg_ids = self._get_usermessage_ids([msg_id])
@@ -476,8 +476,8 @@ class TestArchivingReactions(ArchiveMessagesTestingBase, EmojiReactionBase):
 class MoveMessageToArchiveBase(RetentionTestingBase):
     def setUp(self) -> None:
         super().setUp()
-        self.sender = 'hamlet@zulip.com'
-        self.recipient = 'cordelia@zulip.com'
+        self.sender = self.example_user('hamlet')
+        self.recipient = self.example_user('cordelia')
 
     def _create_attachments(self) -> None:
         sample_size = 10
@@ -613,8 +613,8 @@ class MoveMessageToArchiveGeneral(MoveMessageToArchiveBase):
         msg_id = self.send_personal_message(self.sender, self.recipient, body)
         # Simulate a reply with the same contents.
         reply_msg_id = self.send_personal_message(
-            from_email=self.recipient,
-            to_email=self.sender,
+            from_user=self.recipient,
+            to_user=self.sender,
             content=body,
         )
 
@@ -749,8 +749,8 @@ class TestCleaningArchive(ArchiveMessagesTestingBase):
 class TestDoDeleteMessages(ZulipTestCase):
     def test_do_delete_messages_multiple(self) -> None:
         realm = get_realm("zulip")
-        cordelia_email = self.example_email('cordelia')
-        message_ids = [self.send_stream_message(cordelia_email, "Denmark", str(i)) for i in range(0, 10)]
+        cordelia = self.example_user('cordelia')
+        message_ids = [self.send_stream_message(cordelia, "Denmark", str(i)) for i in range(0, 10)]
         messages = Message.objects.filter(id__in=message_ids)
 
         with queries_captured() as queries:
@@ -771,7 +771,7 @@ class TestDoDeleteMessages(ZulipTestCase):
         realm = get_realm("zulip")
         cordelia = self.example_user('cordelia')
         hamlet = self.example_user('hamlet')
-        message_id = self.send_personal_message(cordelia.delivery_email, hamlet.delivery_email)
+        message_id = self.send_personal_message(cordelia, hamlet)
         message = Message.objects.get(id=message_id)
 
         event = {

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -156,9 +156,9 @@ class AddNewUserHistoryTest(ZulipTestCase):
         stream = Stream.objects.get(realm=realm, name='Denmark')
         DefaultStream.objects.create(stream=stream, realm=realm)
         # Make sure at least 3 messages are sent to Denmark and it's a default stream.
-        message_id = self.send_stream_message(self.example_email('hamlet'), stream.name, "test 1")
-        self.send_stream_message(self.example_email('hamlet'), stream.name, "test 2")
-        self.send_stream_message(self.example_email('hamlet'), stream.name, "test 3")
+        message_id = self.send_stream_message(self.example_user('hamlet'), stream.name, "test 1")
+        self.send_stream_message(self.example_user('hamlet'), stream.name, "test 2")
+        self.send_stream_message(self.example_user('hamlet'), stream.name, "test 3")
 
         with patch("zerver.lib.actions.add_new_user_history"):
             self.register(self.nonreg_email('test'), "test")
@@ -169,7 +169,7 @@ class AddNewUserHistoryTest(ZulipTestCase):
 
         # Sent a message afterwards to trigger a race between message
         # sending and `add_new_user_history`.
-        race_message_id = self.send_stream_message(self.example_email('hamlet'),
+        race_message_id = self.send_stream_message(self.example_user('hamlet'),
                                                    streams[0].name, "test")
 
         # Overwrite ONBOARDING_UNREAD_MESSAGES to 2
@@ -1043,13 +1043,13 @@ class InviteUserTest(InviteUserBase):
         self.make_stream(private_stream_name, invite_only=True)
         self.subscribe(user_profile, private_stream_name)
         public_msg_id = self.send_stream_message(
-            self.example_email("hamlet"),
+            self.example_user("hamlet"),
             "Denmark",
             topic_name="Public topic",
             content="Public message",
         )
         secret_msg_id = self.send_stream_message(
-            self.example_email("hamlet"),
+            self.example_user("hamlet"),
             private_stream_name,
             topic_name="Secret topic",
             content="Secret message",

--- a/zerver/tests/test_soft_deactivation.py
+++ b/zerver/tests/test_soft_deactivation.py
@@ -41,8 +41,7 @@ class UserSoftDeactivationTests(ZulipTestCase):
 
         # We are sending this message to ensure that users have at least
         # one UserMessage row.
-        self.send_huddle_message(users[0].email,
-                                 [user.email for user in users])
+        self.send_huddle_message(users[0], users)
 
         with mock.patch('logging.info'):
             do_soft_deactivate_users(users)
@@ -87,8 +86,8 @@ class UserSoftDeactivationTests(ZulipTestCase):
             self.example_user('iago'),
             self.example_user('cordelia'),
         ]
-        self.send_huddle_message(users[0].email,
-                                 [user.email for user in users])
+        self.send_huddle_message(users[0], users)
+
         with mock.patch('logging.info'):
             do_soft_deactivate_users(users)
         for user in users:
@@ -139,7 +138,7 @@ class UserSoftDeactivationTests(ZulipTestCase):
         for user in users:
             self.assertTrue(user.long_term_idle)
 
-        message_id = self.send_stream_message(hamlet.email, stream, 'Hello world!')
+        message_id = self.send_stream_message(hamlet, stream, 'Hello world!')
         already_received = UserMessage.objects.filter(message_id=message_id).count()
         with mock.patch('logging.info'):
             do_catch_up_soft_deactivated_users(users)
@@ -188,7 +187,7 @@ class UserSoftDeactivationTests(ZulipTestCase):
 
         # Verify that deactivated users are caught up automatically
 
-        message_id = self.send_stream_message(sender.email, stream_name)
+        message_id = self.send_stream_message(sender, stream_name)
         received_count = UserMessage.objects.filter(user_profile__in=users,
                                                     message_id=message_id).count()
         self.assertEqual(0, received_count)
@@ -204,7 +203,7 @@ class UserSoftDeactivationTests(ZulipTestCase):
         # Verify that deactivated users are NOT caught up if
         # AUTO_CATCH_UP_SOFT_DEACTIVATED_USERS is off
 
-        message_id = self.send_stream_message(sender.email, stream_name)
+        message_id = self.send_stream_message(sender, stream_name)
         received_count = UserMessage.objects.filter(user_profile__in=users,
                                                     message_id=message_id).count()
         self.assertEqual(0, received_count)

--- a/zerver/tests/test_submessage.py
+++ b/zerver/tests/test_submessage.py
@@ -20,7 +20,7 @@ class TestBasics(ZulipTestCase):
         stream_name = 'Verona'
 
         message_id = self.send_stream_message(
-            sender_email=cordelia.email,
+            sender=cordelia,
             stream_name=stream_name,
         )
 
@@ -80,7 +80,7 @@ class TestBasics(ZulipTestCase):
         cordelia = self.example_user('cordelia')
         stream_name = 'Verona'
         message_id = self.send_stream_message(
-            sender_email=cordelia.email,
+            sender=cordelia,
             stream_name=stream_name,
         )
         self.login(cordelia.email)
@@ -95,8 +95,8 @@ class TestBasics(ZulipTestCase):
 
         hamlet = self.example_user('hamlet')
         bad_message_id = self.send_personal_message(
-            from_email=hamlet.email,
-            to_email=hamlet.email,
+            from_user=hamlet,
+            to_user=hamlet,
         )
         payload = dict(
             message_id=bad_message_id,
@@ -111,7 +111,7 @@ class TestBasics(ZulipTestCase):
         hamlet = self.example_user('hamlet')
         stream_name = 'Verona'
         message_id = self.send_stream_message(
-            sender_email=cordelia.email,
+            sender=cordelia,
             stream_name=stream_name,
         )
         self.login(cordelia.email)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -3122,9 +3122,9 @@ class SubscriptionAPITest(ZulipTestCase):
         self.subscribe(random_user, "stream2")
         self.subscribe(random_user, "private_stream")
 
-        self.send_stream_message(random_user.email, "stream1", "test", "test")
-        self.send_stream_message(random_user.email, "stream2", "test", "test")
-        self.send_stream_message(random_user.email, "private_stream", "test", "test")
+        self.send_stream_message(random_user, "stream1", "test", "test")
+        self.send_stream_message(random_user, "stream2", "test", "test")
+        self.send_stream_message(random_user, "private_stream", "test", "test")
 
         def get_unread_stream_data() -> List[Dict[str, Any]]:
             raw_unread_data = get_raw_unread_data(user)
@@ -3445,15 +3445,16 @@ class InviteOnlyStreamTest(ZulipTestCase):
         If you try to send a message to an invite-only stream to which
         you aren't subscribed, you'll get a 400.
         """
-        self.login(self.example_email("hamlet"))
+        user = self.example_user('hamlet')
+        self.login(user.email)
         # Create Saxony as an invite-only stream.
         self.assert_json_success(
-            self.common_subscribe_to_streams(self.example_email("hamlet"), ["Saxony"],
+            self.common_subscribe_to_streams(user.email, ["Saxony"],
                                              invite_only=True))
 
-        email = self.example_email("cordelia")
+        cordelia = self.example_user("cordelia")
         with self.assertRaises(JsonableError):
-            self.send_stream_message(email, "Saxony")
+            self.send_stream_message(cordelia, "Saxony")
 
     def test_list_respects_invite_only_bit(self) -> None:
         """

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1283,7 +1283,7 @@ class GetProfileTest(ZulipTestCase):
     def common_get_profile(self, user_id: str) -> Dict[str, Any]:
         # Assumes all users are example users in realm 'zulip'
         user_profile = self.example_user(user_id)
-        self.send_stream_message(user_profile.email, "Verona", "hello")
+        self.send_stream_message(user_profile, "Verona", "hello")
 
         result = self.api_get(user_profile.email, "/api/v1/users/me")
 
@@ -1365,8 +1365,8 @@ class GetProfileTest(ZulipTestCase):
         Ensure GET /users/me returns a proper pointer id after the pointer is updated
         """
 
-        id1 = self.send_stream_message(self.example_email("othello"), "Verona")
-        id2 = self.send_stream_message(self.example_email("othello"), "Verona")
+        id1 = self.send_stream_message(self.example_user("othello"), "Verona")
+        id2 = self.send_stream_message(self.example_user("othello"), "Verona")
 
         json = self.common_get_profile("hamlet")
 


### PR DESCRIPTION
This commit mostly makes our tests less
noisy, since emails are no longer an important
detail of sending messages (they're not even
really used in the API).

It also sets us up to have more scrutiny
on delivery_email/email in the future
for things that actually matter.  (This is
a prep commit for something along those
lines, kind of hard to explain the full
plan.)
