### PR TITLE
portico: Hide download buttons on initial render of `/apps` page.

### DIFF
--- a/templates/zerver/apps.html
+++ b/templates/zerver/apps.html
@@ -22,10 +22,10 @@
                         <h1>Zulip for <span class="platform"></span></h1>
                         <p class="description"></p>
                         <p class="download-instructions">For download instructions, go to the <a class="silver bold" href="/help/desktop-app-install-guide" target="_blank">desktop app install guide</a>.</p>
-                        <a class="desktop-download-link no-action" href=""><span class="button green">Download Zulip for <span class="platform"></span></span></a>
-                        <a class="download-from-google-play-store" href=""><img src='/static/images/store-badges/google-play-badge.png' alt=""/></a>
-                        <a class="download-from-apple-app-store" href=""><img src='/static/images/store-badges/app-store-badge.svg' alt=""/></a>
-                        <span id="download-android-apk"><a href="https://github.com/zulip/zulip-mobile/releases/latest">or manually download APK</a></span>
+                        <a class="desktop-download-link no-action" hidden href=""><span class="button green">Download Zulip for <span class="platform"></span></span></a>
+                        <a class="download-from-google-play-store" hidden href=""><img src='/static/images/store-badges/google-play-badge.png' alt=""/></a>
+                        <a class="download-from-apple-app-store" hidden href=""><img src='/static/images/store-badges/app-store-badge.svg' alt=""/></a>
+                        <span id="download-android-apk" hidden><a href="https://github.com/zulip/zulip-mobile/releases/latest">or manually download APK</a></span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This will hide all the download buttons on the initial render of the `/apps`
page. It'll hide them until the JavaScript is loaded and calls `update_page`
method to render appropriate button.

We are not using JS to hide the buttons as it still will result in displaying the
buttons and not hide them until JS kicks in. Optimal solution is to set them as
hidden HTML elements and let jQuery override it's display attribute later.

Fixes #14134 