### PR TITLE
middleware: Log user.id/realm.string_id instead of _email.

### DIFF
--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -380,11 +380,11 @@ When you navigate to Zulip in your browser, check your terminal and you
 should see something like:
 
 ```
-2016-05-04 18:21:57,547 INFO     127.0.0.1       GET     302 582ms (+start: 417ms) / (unauth via ?)
+2016-05-04 18:21:57,547 INFO     127.0.0.1       GET     302 582ms (+start: 417ms) / (zulip/unauth via ?)
 [04/May/2016 18:21:57]"GET / HTTP/1.0" 302 0
-2016-05-04 18:21:57,568 INFO     127.0.0.1       GET     301   4ms /login (unauth via ?)
+2016-05-04 18:21:57,568 INFO     127.0.0.1       GET     301   4ms /login (zulip/unauth via ?)
 [04/May/2016 18:21:57]"GET /login HTTP/1.0" 301 0
-2016-05-04 18:21:57,819 INFO     127.0.0.1       GET     200 209ms (db: 7ms/2q) /login/ (unauth via ?)
+2016-05-04 18:21:57,819 INFO     127.0.0.1       GET     200 209ms (db: 7ms/2q) /login/ (zulip/unauth via ?)
 ```
 
 Now you're ready for [Step 4: Developing.](#step-4-developing)
@@ -479,7 +479,7 @@ can halt vagrant from another Terminal/Git BASH window.
 From the window where run-dev.py is running:
 
 ```
-2016-05-04 18:33:13,330 INFO     127.0.0.1       GET     200  92ms /register/ (unauth via ?)
+2016-05-04 18:33:13,330 INFO     127.0.0.1       GET     200  92ms /register/ (zulip/unauth via ?)
 ^C
 KeyboardInterrupt
 (zulip-py3-venv) vagrant@ubuntu-bionic:/srv/zulip$ exit

--- a/docs/subsystems/logging.md
+++ b/docs/subsystems/logging.md
@@ -68,14 +68,14 @@ since the main server log can be very verbose, but the main server log
 can be extremely valuable for investigating performance problems.
 
 ```
-2016-05-20 14:50:22.056 INFO [zr] 127.0.0.1       GET     302 528ms (db: 1ms/1q) (+start: 123ms) / (unauth via ?)
+2016-05-20 14:50:22.056 INFO [zr] 127.0.0.1       GET     302 528ms (db: 1ms/1q) (+start: 123ms) / (zulip/unauth via ?)
 [20/May/2016 14:50:22]"GET / HTTP/1.0" 302 0
-2016-05-20 14:50:22.272 INFO [zr] 127.0.0.1       GET     200 124ms (db: 3ms/2q) /login/ (unauth via ?)
-2016-05-20 14:50:26.333 INFO [zr] 127.0.0.1       POST    302  37ms (db: 6ms/7q) /accounts/login/local/ (unauth via ?)
+2016-05-20 14:50:22.272 INFO [zr] 127.0.0.1       GET     200 124ms (db: 3ms/2q) /login/ (zulip/unauth via ?)
+2016-05-20 14:50:26.333 INFO [zr] 127.0.0.1       POST    302  37ms (db: 6ms/7q) /accounts/login/local/ (zulip/nauth via ?)
 [20/May/2016 14:50:26]"POST /accounts/login/local/ HTTP/1.0" 302 0
-2016-05-20 14:50:26.538 INFO [zr] 127.0.0.1       POST    200  12ms (db: 1ms/2q) (+start: 53ms) /api/v1/events/internal [1463769771:0/0] (cordelia@zulip.com via internal)
-2016-05-20 14:50:26.657 INFO [zr] 127.0.0.1       POST    200  10ms (+start: 8ms) /api/v1/events/internal [1463769771:0/0] (cordelia@zulip.com via internal)
-2016-05-20 14:50:26.959 INFO [zr] 127.0.0.1       GET     200 588ms (db: 26ms/21q) / [1463769771:0] (cordelia@zulip.com via website)
+2016-05-20 14:50:26.538 INFO [zr] 127.0.0.1       POST    200  12ms (db: 1ms/2q) (+start: 53ms) /api/v1/events/internal [1463769771:0/0] (zulip/8 via internal)
+2016-05-20 14:50:26.657 INFO [zr] 127.0.0.1       POST    200  10ms (+start: 8ms) /api/v1/events/internal [1463769771:0/0] (zulip/8 via internal)
+2016-05-20 14:50:26.959 INFO [zr] 127.0.0.1       GET     200 588ms (db: 26ms/21q) / [1463769771:0] (zulip/8 via website)
 ```
 
 The format of this output is:

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -292,7 +292,7 @@ class LogRequests(MiddlewareMixin):
             if hasattr(request, 'user') and hasattr(request.user, 'format_requestor_for_logs'):
                 requestor_for_logs = request.user.format_requestor_for_logs()
             else:
-                requestor_for_logs = "unauth"
+                requestor_for_logs = "%s/unauth" % (get_subdomain(request) or 'root',)
         try:
             client = request.client.name
         except Exception:


### PR DESCRIPTION
This makes the log lines look like
``2020-03-07 17:27:02.455 INFO [zr] 172.17.0.1      GET     200   9ms (lp: 172ms) /json/events [1583601963:0/1/presence] (UserProfile:8:Realm:zulip via website)``

instead of having ``(cordelia@zulip.com via website)``.