### PR TITLE
middleware: Add client version to log and other logging improvements.

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -165,7 +165,7 @@ def process_client(request: HttpRequest, user_profile: UserProfile,
                    skip_update_user_activity: bool=False,
                    query: Optional[str]=None) -> None:
     if client_name is None:
-        client_name = get_client_name(request)
+        client_name = request.client_name
 
     # We could check for a browser's name being "Mozilla", but
     # e.g. Opera and MobileSafari don't set that, and it seems

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -298,6 +298,7 @@ class HostRequestMock:
         self.method = ''
         self.body = ''
         self.content_type = ''
+        self.client_name = ''
 
     def get_host(self) -> str:
         return self.host

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -24,6 +24,7 @@ from zerver.lib.html_to_text import get_content_description
 from zerver.lib.rate_limiter import RateLimitResult
 from zerver.lib.response import json_error, json_response_from_error
 from zerver.lib.subdomains import get_subdomain
+from zerver.lib.user_agent import parse_user_agent
 from zerver.lib.types import ViewFuncT
 from zerver.lib.utils import statsd
 from zerver.models import Realm, flush_per_request_caches, get_realm
@@ -229,6 +230,9 @@ class LogRequests(MiddlewareMixin):
     # method here too
     def process_user_agent(self, request: HttpRequest) -> None:
         request.client_name = get_client_name(request)
+        request.client_version = None
+        if request.client_name.startswith("Zulip"):
+            request.client_version = parse_user_agent(request.META["HTTP_USER_AGENT"])["version"]
 
     def process_request(self, request: HttpRequest) -> None:
         maybe_tracemalloc_listen()

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1634,6 +1634,7 @@ class TestZulipLoginRequiredDecorator(ZulipTestCase):
         request.META['PATH_INFO'] = ''
         request.user = hamlet = self.example_user('hamlet')
         request.user.is_verified = lambda: False
+        request.client_name = ''
         self.login_user(hamlet)
         request.session = self.client.session
         request.get_host = lambda: 'zulip.testserver'
@@ -1649,6 +1650,7 @@ class TestZulipLoginRequiredDecorator(ZulipTestCase):
             request.META['PATH_INFO'] = ''
             request.user = hamlet = self.example_user('hamlet')
             request.user.is_verified = lambda: False
+            request.client_name = ''
             self.login_user(hamlet)
             request.session = self.client.session
             request.get_host = lambda: 'zulip.testserver'
@@ -1675,6 +1677,7 @@ class TestZulipLoginRequiredDecorator(ZulipTestCase):
             request.META['PATH_INFO'] = ''
             request.user = hamlet = self.example_user('hamlet')
             request.user.is_verified = lambda: True
+            request.client_name = ''
             self.login_user(hamlet)
             request.session = self.client.session
             request.get_host = lambda: 'zulip.testserver'

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -222,6 +222,7 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
             request._requestor_for_logs = old_request._requestor_for_logs
         request.user = old_request.user
         request.client = old_request.client
+        request.client_name = old_request.client_name
 
         # The saved_response attribute, if present, causes
         # rest_dispatch to return the response immediately before

--- a/zerver/tornado/handlers.py
+++ b/zerver/tornado/handlers.py
@@ -223,6 +223,7 @@ class AsyncDjangoHandler(tornado.web.RequestHandler, base.BaseHandler):
         request.user = old_request.user
         request.client = old_request.client
         request.client_name = old_request.client_name
+        request.client_version = old_request.client_version
 
         # The saved_response attribute, if present, causes
         # rest_dispatch to return the response immediately before


### PR DESCRIPTION
The first commit uses get_client_name in LogRequests's process_request and removes its usage in process_client.
The second commit adds request.client_version to LogRequest's process_request.
The third commit changes write_log_line so that it now shows client version if available. 
The fourth commit uses client id instead of client name for logging.

Fixes #14067 .