### PR TITLE
design: Simplebar usage in some modals.

### DIFF
--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -1,6 +1,6 @@
 <div class="overlay-modal" id="keyboard-shortcuts" tabindex="-1" role="dialog"
   aria-label="{{ _('Keyboard shortcuts') }}">
-    <div class="modal-body" tabindex="0">
+    <div class="modal-body" tabindex="0" data-simplebar data-simplebar-auto-hide="false">
         <div>
             <table class="hotkeys_table table table-striped table-bordered table-condensed">
                 <thead>

--- a/templates/zerver/app/markdown_help.html
+++ b/templates/zerver/app/markdown_help.html
@@ -1,6 +1,6 @@
 <div class="overlay-modal hide" id="message-formatting" tabindex="-1" role="dialog"
     aria-label="{{ _('Message formatting') }}">
-    <div class="modal-body" tabindex="0">
+    <div class="modal-body" tabindex="0" data-simplebar data-simplebar-auto-hide="false">
         <div id="markdown-instructions">
             <table class="table table-striped table-condensed table-rounded table-bordered help-table">
                 <thead>

--- a/templates/zerver/app/search_operators.html
+++ b/templates/zerver/app/search_operators.html
@@ -1,6 +1,6 @@
 <div class="overlay-modal hide" id="search-operators" tabindex="-1" role="dialog"
   aria-label="{{ _('Search operators') }}">
-    <div class="modal-body" tabindex="0">
+    <div class="modal-body" tabindex="0" data-simplebar data-simplebar-auto-hide="false">
         <table class="table table-striped table-condensed table-rounded table-bordered help-table">
             <thead>
                 <tr>


### PR DESCRIPTION
The simplebar is the default scrollbar throughout majority of Zulip but
it was missing in "Keyboard shortcuts", "Message formatting" and "Search
operators" modals. Added simplebar in the 3 modals.

IMAGES-
<img width="413" alt="keyboard shortcutspng" src="https://user-images.githubusercontent.com/47082523/76162528-a1f47d80-6164-11ea-84de-74a4c406f568.png">
<img width="413" alt="message formating" src="https://user-images.githubusercontent.com/47082523/76162531-a325aa80-6164-11ea-95af-a7e7050b53d6.png">
<img width="419" alt="search operators" src="https://user-images.githubusercontent.com/47082523/76162532-a3be4100-6164-11ea-8805-c76cd5638798.png">
