### PR TITLE
frontend: Fix hover text for edit topic button.

### DIFF
--- a/static/templates/recipient_row.hbs
+++ b/static/templates/recipient_row.hbs
@@ -39,10 +39,10 @@
 
                 {{! edit topic pencil icon }}
                 {{#if always_visible_topic_edit}}
-                    <i class="fa fa-pencil always_visible_topic_edit" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} role="button" tabindex="0" aria-label="{{t 'Edit' }}"></i>
+                    <i class="fa fa-pencil always_visible_topic_edit" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} title="{{t 'Edit topic' }} (e)" role="button" tabindex="0" aria-label="{{t 'Edit' }}"></i>
                 {{else}}
                     {{#if on_hover_topic_edit}}
-                    <i class="fa fa-pencil on_hover_topic_edit" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} role="button" tabindex="0" aria-label="{{t 'Edit' }}"></i>
+                    <i class="fa fa-pencil on_hover_topic_edit" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} title="{{t 'Edit topic' }} (e)" role="button" tabindex="0" aria-label="{{t 'Edit' }}"></i>
                     {{/if}}
                 {{/if}}
 


### PR DESCRIPTION
There was no hover text for topic edit button. Now it works fine.

Fixes: #14140
