### PR TITLE
subscriber list: Fix display of email addresses in subscribers list.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -91,6 +91,8 @@ zrequire('message_store');
 zrequire('people');
 zrequire('starred_messages');
 zrequire('user_status');
+zrequire('subs');
+zrequire('stream_ui_updates');
 
 zrequire('server_events_dispatch');
 
@@ -236,6 +238,13 @@ const event_fixtures = {
         op: 'update',
         property: 'bot_creation_policy',
         value: 1,
+    },
+
+    realm__update__email_addresses_visibility: {
+        type: 'realm',
+        op: 'update',
+        property: 'email_address_visibility',
+        value: 3,
     },
 
     realm__update__disallow_disposable_email_addresses: {
@@ -933,6 +942,11 @@ with_overrides(function (override) {
 
     event = event_fixtures.realm__update__disallow_disposable_email_addresses;
     test_realm_boolean(event, 'realm_disallow_disposable_email_addresses');
+
+    event = event_fixtures.realm__update__email_addresses_visibility;
+    override('stream_ui_updates.update_subscribers_list', noop);
+    dispatch(event);
+    assert_same(page_params.realm_email_address_visibility, 3);
 
     event = event_fixtures.realm__update_notifications_stream_id;
     override('settings_org.render_notifications_stream_ui', noop);

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -172,7 +172,7 @@ exports.update_subscribers_list = function (sub) {
     if (!sub.can_access_subscribers) {
         $(".subscriber_list_settings_container").hide();
     } else {
-        const emails = stream_edit.get_email_of_subscribers(sub.subscribers);
+        const users = stream_edit.get_person_from_subscribers(sub.subscribers);
 
         /*
             We try to find a subscribers list that is already in the
@@ -187,8 +187,8 @@ exports.update_subscribers_list = function (sub) {
         // Perform re-rendering only when the stream settings form of the corresponding
         // stream is open.
         if (subscribers_list) {
-            stream_edit.sort_but_pin_current_user_on_top(emails);
-            subscribers_list.data(emails);
+            stream_edit.sort_but_pin_current_user_on_top(users);
+            subscribers_list.data(users);
             subscribers_list.render();
         }
         $(".subscriber_list_settings_container").show();

--- a/static/templates/stream_member_list_entry.hbs
+++ b/static/templates/stream_member_list_entry.hbs
@@ -1,6 +1,8 @@
 <tr data-subscriber-email="{{email}}">
     <td class="subscriber-name">{{name}}</td>
+    {{#if show_email}}
     <td class="subscriber-email">{{email}}</td>
+    {{/if}}
     {{#if displaying_for_admin}}
     <td class="unsubscribe">
         <div class="subscriber_list_remove">


### PR DESCRIPTION
Original email address is shown to admin users in subscriber list when
email_address_visibilty is set to "Admins only" by passing delivery_email
at required places.  Email address are not shown to non-admin users when
visibility is set to "Admins only".

Fixes a part of #13541.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Node tests have been updated accordingly.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
