### PR TITLE
api: Refactor get_members_backend in zerver/views/users.py

### DIFF
--- a/templates/zerver/api/get-user.md
+++ b/templates/zerver/api/get-user.md
@@ -33,8 +33,8 @@ You may pass the `client_gravatar` or `include_custom_profile_fields` query para
 
 #### Return values
 
-* `members`: A list with a single dictionary that contains information
-  about a particular user or bot.
+* `user`: A dictionary that contains information about a particular user
+          or bot.
     * `email`: The email address of the user or bot.
     * `is_bot`: A boolean specifying whether the user is a bot or not.
     * `avatar_url`: URL to the user's gravatar. `None` if the `client_gravatar`

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1171,17 +1171,15 @@ paths:
                 allOf:
                 - $ref: '#/components/schemas/JsonSuccess'
                 - properties:
-                    members:
-                      type: array
-                      description: A list `member` containing a single object with
-                        details of a user in the realm (like their email, name,
-                        avatar, user type...).
+                    user:
+                      type: object
+                      description: A dictionary with the details of a user in the realm
+                       (like their email, name, avatar, user type...).
                 - example:
                     {
                        "msg": "",
                        "result": "success",
-                       "members": [
-                          {
+                       "user": {
                              "date_joined": "2019-10-20T07:50:53.729659+00:00",
                              "full_name": "King Hamlet",
                              "is_guest": false,
@@ -1223,7 +1221,8 @@ paths:
                              "is_active": true,
                              "email": "hamlet@zulip.com"
                           }
-                       ]
+
+
                     }
 
     patch:

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -421,16 +421,16 @@ class RealmTest(ZulipTestCase):
         # Check normal user cannot access email
         result = self.api_get(cordelia.delivery_email, "/api/v1/users/%s" % (hamlet.id,))
         self.assert_json_success(result)
-        self.assertEqual(result.json()['members'][0]['email'],
+        self.assertEqual(result.json()['user']['email'],
                          'user%s@zulip.testserver' % (hamlet.id,))
-        self.assertEqual(result.json()['members'][0].get('delivery_email'), None)
+        self.assertEqual(result.json()['user'].get('delivery_email'), None)
 
         # Check administrator gets delivery_email with EMAIL_ADDRESS_VISIBILITY_ADMINS
         result = self.api_get(user_profile.delivery_email, "/api/v1/users/%s" % (hamlet.id,))
         self.assert_json_success(result)
-        self.assertEqual(result.json()['members'][0]['email'],
+        self.assertEqual(result.json()['user']['email'],
                          'user%s@zulip.testserver' % (hamlet.id,))
-        self.assertEqual(result.json()['members'][0].get('delivery_email'),
+        self.assertEqual(result.json()['user'].get('delivery_email'),
                          hamlet.delivery_email)
 
         req = dict(email_address_visibility = ujson.dumps(Realm.EMAIL_ADDRESS_VISIBILITY_NOBODY))
@@ -446,9 +446,9 @@ class RealmTest(ZulipTestCase):
         # EMAIL_ADDRESS_VISIBILITY_NOBODY
         result = self.api_get(user_profile.delivery_email, "/api/v1/users/%s" % (hamlet.id,))
         self.assert_json_success(result)
-        self.assertEqual(result.json()['members'][0]['email'],
+        self.assertEqual(result.json()['user']['email'],
                          'user%s@zulip.testserver' % (hamlet.id,))
-        self.assertEqual(result.json()['members'][0].get('delivery_email'), None)
+        self.assertEqual(result.json()['user'].get('delivery_email'), None)
 
     def test_change_stream_creation_policy(self) -> None:
         # We need an admin user.

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1341,16 +1341,16 @@ class GetProfileTest(ZulipTestCase):
         # Tests the GET ../users/{id} api endpoint.
         user = self.example_user('hamlet')
         result = ujson.loads(self.client_get('/json/users/{}'.format(user.id)).content)
-        self.assertEqual(result['members'][0]['email'], user.email)
-        self.assertEqual(result['members'][0]['full_name'], user.full_name)
-        self.assertIn("user_id", result['members'][0])
-        self.assertNotIn("profile_data", result['members'][0])
-        self.assertFalse(result['members'][0]['is_bot'])
-        self.assertFalse(result['members'][0]['is_admin'])
+        self.assertEqual(result['user']['email'], user.email)
+        self.assertEqual(result['user']['full_name'], user.full_name)
+        self.assertIn("user_id", result['user'])
+        self.assertNotIn("profile_data", result['user'])
+        self.assertFalse(result['user']['is_bot'])
+        self.assertFalse(result['user']['is_admin'])
 
         result = ujson.loads(self.client_get('/json/users/{}?include_custom_profile_fields=true'.format(user.id)).content)
 
-        self.assertIn('profile_data', result['members'][0])
+        self.assertIn('profile_data', result['user'])
         result = self.client_get('/json/users/{}?'.format(30))
         self.assert_json_error(result, "No such user")
 

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -416,11 +416,21 @@ def get_members_backend(request: HttpRequest, user_profile: UserProfile, user_id
     if user_id is not None:
         target_user = access_user_by_id(user_profile, user_id, allow_deactivated=True,
                                         read_only=True)
+        key = "user"
+    else:
+        key = "members"
 
     members = get_raw_user_data(realm, user_profile, client_gravatar=client_gravatar,
                                 target_user=target_user,
                                 include_custom_profile_fields=include_custom_profile_fields)
-    return json_success({'members': members.values()})
+
+    data = None  # type: Union[List[Dict[str, str]], Dict[str, str], None]
+    if user_id is not None:
+        data = members[int(user_id)]
+    else:
+        data = [members[k] for k in members]
+
+    return json_success({key: data})
 
 @require_realm_admin
 @has_request_variables


### PR DESCRIPTION
This refactors get_members_backend to return user data of a single
user in the form of a dictionary (earlier being a list with a single
dictionary).
This also refactors it to return the data with an appropriate key
(inside a dictionary), "user" or "members", according to the type of
data being returned.
