### PR TITLE
reactions: Simplify code

### DIFF
--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -140,7 +140,7 @@ run_test('basics', () => {
     const result = reactions.get_message_reactions(message);
     assert.equal(blueslip.get_test_logs('warn').length, 2);
     blueslip.clear_test_data();
-    assert(reactions.current_user_has_reacted_to_emoji(message, 'unicode_emoji,smile,263a'));
+    assert(reactions.current_user_has_reacted_to_emoji(message, 'unicode_emoji,263a'));
     assert(!reactions.current_user_has_reacted_to_emoji(message, 'bogus'));
 
     result.sort(function (a, b) { return a.count - b.count; });
@@ -150,7 +150,7 @@ run_test('basics', () => {
             emoji_name: 'frown',
             reaction_type: 'unicode_emoji',
             emoji_code: '1f641',
-            local_id: 'unicode_emoji,frown,1f641',
+            local_id: 'unicode_emoji,1f641',
             count: 1,
             user_ids: [7],
             label: 'Cali reacted with :frown:',
@@ -161,7 +161,7 @@ run_test('basics', () => {
             emoji_name: 'inactive_realm_emoji',
             reaction_type: 'realm_emoji',
             emoji_code: '992',
-            local_id: 'realm_emoji,inactive_realm_emoji,992',
+            local_id: 'realm_emoji,992',
             count: 1,
             user_ids: [5],
             label: 'You (click to remove) reacted with :inactive_realm_emoji:',
@@ -174,7 +174,7 @@ run_test('basics', () => {
             emoji_name: 'smile',
             reaction_type: 'unicode_emoji',
             emoji_code: '263a',
-            local_id: 'unicode_emoji,smile,263a',
+            local_id: 'unicode_emoji,263a',
             count: 2,
             user_ids: [5, 6],
             label: 'You (click to remove) and Bob van Roberts reacted with :smile:',
@@ -235,7 +235,7 @@ run_test('sending', () => {
         // `process_reaction_click()` codepath supports deleting/adding a deactivated
         // realm emoji.
         global.channel.del = stub.f;
-        reactions.process_reaction_click(message_id, 'realm_emoji,inactive_realm_emoji,992');
+        reactions.process_reaction_click(message_id, 'realm_emoji,992');
         const args = stub.get_args('args').args;
         assert.equal(args.url, '/json/messages/1001/reactions');
         assert.deepEqual(args.data, {
@@ -293,7 +293,7 @@ run_test('get_reaction_section', () => {
 
 run_test('emoji_reaction_title', () => {
     const message_id = 1001;
-    const local_id = 'unicode_emoji,smile,263a';
+    const local_id = 'unicode_emoji,263a';
 
     assert.equal(reactions.get_reaction_title_data(message_id, local_id),
                  "You (click to remove) and Bob van Roberts reacted with :smile:");
@@ -345,7 +345,7 @@ run_test('add_and_remove_reaction', () => {
     assert(insert_called);
 
     // Testing tooltip title data for added reaction.
-    const local_id = 'unicode_emoji,8ball,1f3b1';
+    const local_id = 'unicode_emoji,1f3b1';
     assert.equal(reactions.get_reaction_title_data(alice_event.message_id, local_id),
                  "You (click to remove) reacted with :8ball:");
 
@@ -373,7 +373,7 @@ run_test('add_and_remove_reaction', () => {
     reaction_element.set_find_results('.message_reaction_count', count_element);
 
     message_reactions.find = function (selector) {
-        assert.equal(selector, "[data-reaction-id='unicode_emoji,8ball,1f3b1']");
+        assert.equal(selector, "[data-reaction-id='unicode_emoji,1f3b1']");
         return reaction_element;
     };
 
@@ -445,7 +445,7 @@ run_test('add_and_remove_reaction', () => {
     };
 
     message_reactions.find = function (selector) {
-        assert.equal(selector, "[data-reaction-id='realm_emoji,realm_emoji,991']");
+        assert.equal(selector, "[data-reaction-id='realm_emoji,991']");
         return reaction_element;
     };
     reaction_element.prop = function () {};
@@ -655,16 +655,6 @@ run_test('error_handling', () => {
     assert.equal(blueslip.get_test_logs('error').length, 0);
 });
 
-run_test('get_name_for_alias', () => {
-    const name = reactions.get_name_for_alias(
-        message,
-        7,
-        ['grumble', 'frown', 'scowl']
-    );
-
-    assert.equal(name, 'frown');
-});
-
 message_store.get = () => message;
 
 run_test('remove spurious user', () => {
@@ -711,35 +701,22 @@ run_test('remove last user', () => {
 run_test('local_reaction_id', () => {
     const reaction_info = {
         reaction_type: 'unicode_emoji',
-        emoji_name: 'thumbs_up',
         emoji_code: '1f44d',
     };
     const local_id = reactions.get_local_reaction_id(reaction_info);
-    assert.equal(local_id, 'unicode_emoji,thumbs_up,1f44d');
-
-    const reverse_info = reactions.get_reaction_info(local_id);
-    assert.deepEqual(reverse_info, reaction_info);
+    assert.equal(local_id, 'unicode_emoji,1f44d');
 });
 
 run_test('process_reaction_click', () => {
     const message_id = 1001;
     let expected_reaction_info = {
         reaction_type: 'unicode_emoji',
-        emoji_name: '8ball',
         emoji_code: '1f3b1',
     };
     global.message_store.get = function (message_id) {
         assert.equal(message_id, 1001);
         return message;
     };
-
-    global.with_stub(function (stub) {
-        global.channel.post = stub.f;
-        reactions.process_reaction_click(message_id, 'unicode_emoji,8ball,1f3b1');
-        const args = stub.get_args('args').args;
-        assert.equal(args.url, '/json/messages/1001/reactions');
-        assert.deepEqual(args.data, expected_reaction_info);
-    });
 
     expected_reaction_info = {
         reaction_type: 'unicode_emoji',
@@ -748,7 +725,7 @@ run_test('process_reaction_click', () => {
     };
     global.with_stub(function (stub) {
         global.channel.del = stub.f;
-        reactions.process_reaction_click(message_id, 'unicode_emoji,smile,263a');
+        reactions.process_reaction_click(message_id, 'unicode_emoji,263a');
         const args = stub.get_args('args').args;
         assert.equal(args.url, '/json/messages/1001/reactions');
         assert.deepEqual(args.data, expected_reaction_info);
@@ -798,6 +775,20 @@ run_test('duplicates', () => {
     blueslip.clear_test_data();
     blueslip.set_test_data(
         'error',
-        'server sent duplicate reactions for user 5 (key=unicode_emoji,smile,263a)');
+        'server sent duplicate reactions for user 5 (key=unicode_emoji,263a)');
     reactions.set_clean_reactions(dup_reaction_message);
 });
+
+run_test('process_reaction_click errors', () => {
+    global.message_store.get = () => undefined;
+    blueslip.clear_test_data();
+    blueslip.set_test_data('error', 'reactions: Bad message id: 55');
+    blueslip.set_test_data('error', 'message_id for reaction click is unknown: 55');
+    reactions.process_reaction_click(55, 'whatever');
+
+    global.message_store.get = () => message;
+    blueslip.clear_test_data();
+    blueslip.set_test_data('error', 'Data integrity problem for reaction bad-local-id (message some-msg-id)');
+    reactions.process_reaction_click('some-msg-id', 'bad-local-id');
+});
+

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -234,32 +234,6 @@ function filter_emojis() {
     }
 }
 
-function get_alias_to_be_used(message_id, emoji_name) {
-    // If the user has reacted to this message, then this function
-    // returns the alias of this emoji he used, otherwise, returns
-    // the passed name as it is.
-    const message = message_store.get(message_id);
-    let aliases = [emoji_name];
-    if (!emoji.active_realm_emojis.has(emoji_name)) {
-        if (emoji_codes.name_to_codepoint.hasOwnProperty(emoji_name)) {
-            const codepoint = emoji_codes.name_to_codepoint[emoji_name];
-            aliases = emoji.default_emoji_aliases.get(codepoint);
-        } else {
-            blueslip.error("Invalid emoji name: " + emoji_name);
-            return;
-        }
-    }
-
-    const user_id = page_params.user_id;
-
-    const reaction_name = reactions.get_name_for_alias(message, user_id, aliases);
-
-    if (reaction_name) {
-        return reaction_name;
-    }
-    return emoji_name;
-}
-
 function toggle_reaction(emoji_name) {
     const message_id = current_msg_list.selected_id();
     const message = message_store.get(message_id);
@@ -268,8 +242,7 @@ function toggle_reaction(emoji_name) {
         return;
     }
 
-    const alias = get_alias_to_be_used(message_id, emoji_name);
-    reactions.toggle_emoji_reaction(message_id, alias);
+    reactions.toggle_emoji_reaction(message_id, emoji_name);
 }
 
 function maybe_select_emoji(e) {

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -249,12 +249,13 @@ function get_alias_to_be_used(message_id, emoji_name) {
             return;
         }
     }
+
     const user_id = page_params.user_id;
-    const reaction = message.reactions.find(
-        reaction => reaction.user.id === user_id && aliases.includes(reaction.emoji_name)
-    );
-    if (reaction) {
-        return reaction.emoji_name;
+
+    const reaction_name = reactions.get_name_for_alias(message, user_id, aliases);
+
+    if (reaction_name) {
+        return reaction_name;
     }
     return emoji_name;
 }


### PR DESCRIPTION
I believe this will eliminate some strange bugs we've seen with duplicate emojis.  It should also make it easier to debug things down the road.

To tests this, have two users reacting to each other's messages.  Good things to try are editing messages and switching narrows from stream/topic to just-stream and back.