### PR TITLE
Add LDAP config classes to settings files

### DIFF
--- a/tools/linter_lib/pyflakes.py
+++ b/tools/linter_lib/pyflakes.py
@@ -15,6 +15,16 @@ def check_pyflakes(files: List[str], options: argparse.Namespace) -> bool:
             "zerver/views/realm.py",
             "local variable 'message_retention_days' is assigned to but never used",
         ),
+        # The list of imports from django_auth_ldap which is manually maintained in
+        # django_auth_ldap_exports should be imported "as is" in the production settings.
+        (
+            "",
+            "from zproject.django_auth_ldap_exports import *' used; unable to detect undefined names",
+        ),
+        (
+            "",
+            "'LDAPSearch' may be undefined, or defined from star imports: zproject.django_auth_ldap_exports",
+        ),
         ("settings.py", "settings import *' used; unable to detect undefined names"),
         (
             "settings.py",

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -6,10 +6,10 @@ from scripts.lib.zulip_tools import deport
 from .config import DEVELOPMENT, PRODUCTION, get_secret
 
 if TYPE_CHECKING:
-    from django_auth_ldap.config import LDAPSearch
     from typing_extensions import TypedDict
 
     from zerver.lib.types import SAMLIdPConfigDict
+    from zproject.django_auth_ldap_exports import *
 
 if PRODUCTION:
     from .prod_settings import EXTERNAL_HOST, ZULIP_ADMINISTRATOR

--- a/zproject/django_auth_ldap_exports.py
+++ b/zproject/django_auth_ldap_exports.py
@@ -1,0 +1,34 @@
+from django_auth_ldap.config import (
+    ActiveDirectoryGroupType,
+    GroupOfNamesType,
+    GroupOfUniqueNamesType,
+    LDAPGroupQuery,
+    LDAPSearch,
+    LDAPSearchUnion,
+    MemberDNGroupType,
+    NestedActiveDirectoryGroupType,
+    NestedGroupOfNamesType,
+    NestedGroupOfUniqueNamesType,
+    NestedMemberDNGroupType,
+    NestedOrganizationalRoleGroupType,
+    OrganizationalRoleGroupType,
+    PosixGroupType,
+)
+
+# Suppress pyflakes warnings about unused modules.
+assert (
+    LDAPSearch
+    and LDAPSearchUnion
+    and LDAPGroupQuery
+    and PosixGroupType
+    and MemberDNGroupType
+    and NestedMemberDNGroupType
+    and GroupOfNamesType
+    and NestedGroupOfNamesType
+    and GroupOfUniqueNamesType
+    and NestedGroupOfUniqueNamesType
+    and ActiveDirectoryGroupType
+    and NestedActiveDirectoryGroupType
+    and OrganizationalRoleGroupType
+    and NestedOrganizationalRoleGroupType
+)

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -158,7 +158,8 @@ AUTHENTICATION_BACKENDS: Tuple[str, ...] = (
 ## optionally using LDAP as an authentication mechanism.
 
 import ldap
-from django_auth_ldap.config import GroupOfNamesType, LDAPGroupQuery, LDAPSearch
+
+from zproject.django_auth_ldap_exports import *
 
 ## Connecting to the LDAP server.
 ##


### PR DESCRIPTION
This PR helps in fixing the following issue https://github.com/zulip/docker-zulip/pull/208

I added all public entities from `django_auth_ldap.config`. Its source code is [here](https://github.com/django-auth-ldap/django-auth-ldap/blob/master/django_auth_ldap/config.py).