### PR TITLE
tornado: Log shard id in all logs coming from tornado processes.

### DIFF
--- a/zerver/lib/logging_util.py
+++ b/zerver/lib/logging_util.py
@@ -161,11 +161,16 @@ def find_log_origin(record: logging.LogRecord) -> str:
         module_name = find_log_caller_module(record)
         if module_name == logger_name or module_name == record.name:
             # Abbreviate a bit.
-            return logger_name
+            pass
         else:
-            return '{}/{}'.format(logger_name, module_name or '?')
-    else:
-        return logger_name
+            logger_name = '{}/{}'.format(logger_name, module_name or '?')
+
+    if settings.RUNNING_INSIDE_TORNADO:
+        from zerver.tornado.ioloop_logging import logging_data
+        shard = logging_data.get('port', 'unknown')
+        logger_name = "{}:shard:{}".format(logger_name, shard)
+
+    return logger_name
 
 log_level_abbrevs = {
     'DEBUG':    'DEBG',


### PR DESCRIPTION
`runtornado.py` puts the `port` in `logging_data` in `ioloop_logging`, so we can take advantage of that and have the shard information on every log generated by tornado processes.