### PR TITLE
tests: Limit email-based logins.

### DIFF
--- a/analytics/tests/test_views.py
+++ b/analytics/tests/test_views.py
@@ -22,7 +22,7 @@ from zerver.models import Client, get_realm, MultiuseInvite
 class TestStatsEndpoint(ZulipTestCase):
     def test_stats(self) -> None:
         self.user = self.example_user('hamlet')
-        self.login(self.user.email)
+        self.login_user(self.user)
         result = self.client_get('/stats')
         self.assertEqual(result.status_code, 200)
         # Check that we get something back
@@ -30,7 +30,7 @@ class TestStatsEndpoint(ZulipTestCase):
 
     def test_guest_user_cant_access_stats(self) -> None:
         self.user = self.example_user('polonius')
-        self.login(self.user.email)
+        self.login_user(self.user)
         result = self.client_get('/stats')
         self.assert_json_error(result, "Not allowed for guest users", 400)
 
@@ -38,15 +38,15 @@ class TestStatsEndpoint(ZulipTestCase):
         self.assert_json_error(result, "Not allowed for guest users", 400)
 
     def test_stats_for_realm(self) -> None:
-        user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        user = self.example_user('hamlet')
+        self.login_user(user)
 
         result = self.client_get('/stats/realm/zulip/')
         self.assertEqual(result.status_code, 302)
 
-        user_profile = self.example_user('hamlet')
-        user_profile.is_staff = True
-        user_profile.save(update_fields=['is_staff'])
+        user = self.example_user('hamlet')
+        user.is_staff = True
+        user.save(update_fields=['is_staff'])
 
         result = self.client_get('/stats/realm/not_existing_realm/')
         self.assertEqual(result.status_code, 302)
@@ -56,15 +56,15 @@ class TestStatsEndpoint(ZulipTestCase):
         self.assert_in_response("Zulip analytics for", result)
 
     def test_stats_for_installation(self) -> None:
-        user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        user = self.example_user('hamlet')
+        self.login_user(user)
 
         result = self.client_get('/stats/installation')
         self.assertEqual(result.status_code, 302)
 
-        user_profile = self.example_user('hamlet')
-        user_profile.is_staff = True
-        user_profile.save(update_fields=['is_staff'])
+        user = self.example_user('hamlet')
+        user.is_staff = True
+        user.save(update_fields=['is_staff'])
 
         result = self.client_get('/stats/installation')
         self.assertEqual(result.status_code, 200)
@@ -75,7 +75,7 @@ class TestGetChartData(ZulipTestCase):
         super().setUp()
         self.realm = get_realm('zulip')
         self.user = self.example_user('hamlet')
-        self.login(self.user.email)
+        self.login_user(self.user)
         self.end_times_hour = [ceiling_to_hour(self.realm.date_created) + timedelta(hours=i)
                                for i in range(4)]
         self.end_times_day = [ceiling_to_day(self.realm.date_created) + timedelta(days=i)
@@ -293,16 +293,16 @@ class TestGetChartData(ZulipTestCase):
         self.assert_json_error_contains(result, 'No analytics data available')
 
     def test_get_chart_data_for_realm(self) -> None:
-        user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        user = self.example_user('hamlet')
+        self.login_user(user)
 
         result = self.client_get('/json/analytics/chart_data/realm/zulip/',
                                  {'chart_name': 'number_of_humans'})
         self.assert_json_error(result, "Must be an server administrator", 400)
 
-        user_profile = self.example_user('hamlet')
-        user_profile.is_staff = True
-        user_profile.save(update_fields=['is_staff'])
+        user = self.example_user('hamlet')
+        user.is_staff = True
+        user.save(update_fields=['is_staff'])
         stat = COUNT_STATS['realm_active_humans::day']
         self.insert_data(stat, [None], [])
 
@@ -315,16 +315,16 @@ class TestGetChartData(ZulipTestCase):
         self.assert_json_success(result)
 
     def test_get_chart_data_for_installation(self) -> None:
-        user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        user = self.example_user('hamlet')
+        self.login_user(user)
 
         result = self.client_get('/json/analytics/chart_data/installation',
                                  {'chart_name': 'number_of_humans'})
         self.assert_json_error(result, "Must be an server administrator", 400)
 
-        user_profile = self.example_user('hamlet')
-        user_profile.is_staff = True
-        user_profile.save(update_fields=['is_staff'])
+        user = self.example_user('hamlet')
+        user.is_staff = True
+        user.save(update_fields=['is_staff'])
         stat = COUNT_STATS['realm_active_humans::day']
         self.insert_data(stat, [None], [])
 
@@ -398,15 +398,13 @@ class TestSupportEndpoint(ZulipTestCase):
                                              '<b>Expires in</b>: 1\xa0day'
                                              ], result)
 
-        cordelia_email = self.example_email("cordelia")
-        self.login(cordelia_email)
+        self.login('cordelia')
 
         result = self.client_get("/activity/support")
         self.assertEqual(result.status_code, 302)
         self.assertEqual(result["Location"], "/login/")
 
-        iago_email = self.example_email("iago")
-        self.login(iago_email)
+        self.login('iago')
 
         result = self.client_get("/activity/support")
         self.assert_in_success_response(['<input type="text" name="q" class="input-xxlarge search-query"'], result)
@@ -436,7 +434,7 @@ class TestSupportEndpoint(ZulipTestCase):
         check_lear_realm_query_result(result)
 
         self.client_post('/accounts/home/', {'email': self.nonreg_email("test")})
-        self.login(iago_email)
+        self.login('iago')
         result = self.client_get("/activity/support", {"q": self.nonreg_email("test")})
         check_preregistration_user_query_result(result, self.nonreg_email("test"))
         check_zulip_realm_query_result(result)
@@ -466,15 +464,15 @@ class TestSupportEndpoint(ZulipTestCase):
         check_zulip_realm_query_result(result)
 
     def test_change_plan_type(self) -> None:
-        cordelia = self.example_user("cordelia")
-        self.login(cordelia.email)
+        cordelia = self.example_user('cordelia')
+        self.login_user(cordelia)
 
         result = self.client_post("/activity/support", {"realm_id": "%s" % (cordelia.realm_id,), "plan_type": "2"})
         self.assertEqual(result.status_code, 302)
         self.assertEqual(result["Location"], "/login/")
 
         iago = self.example_user("iago")
-        self.login(iago.email)
+        self.login_user(iago)
 
         with mock.patch("analytics.views.do_change_plan_type") as m:
             result = self.client_post("/activity/support", {"realm_id": "%s" % (iago.realm_id,), "plan_type": "2"})
@@ -482,16 +480,15 @@ class TestSupportEndpoint(ZulipTestCase):
             self.assert_in_success_response(["Plan type of Zulip Dev changed from self hosted to limited"], result)
 
     def test_attach_discount(self) -> None:
-        lear_realm = get_realm("lear")
-        cordelia_email = self.example_email("cordelia")
-        self.login(cordelia_email)
+        cordelia = self.example_user('cordelia')
+        lear_realm = get_realm('lear')
+        self.login_user(cordelia)
 
         result = self.client_post("/activity/support", {"realm_id": "%s" % (lear_realm.id,), "discount": "25"})
         self.assertEqual(result.status_code, 302)
         self.assertEqual(result["Location"], "/login/")
 
-        iago_email = self.example_email("iago")
-        self.login(iago_email)
+        self.login('iago')
 
         with mock.patch("analytics.views.attach_discount_to_realm") as m:
             result = self.client_post("/activity/support", {"realm_id": "%s" % (lear_realm.id,), "discount": "25"})
@@ -499,16 +496,15 @@ class TestSupportEndpoint(ZulipTestCase):
             self.assert_in_success_response(["Discount of Lear &amp; Co. changed to 25 from None"], result)
 
     def test_activate_or_deactivate_realm(self) -> None:
-        lear_realm = get_realm("lear")
-        cordelia_email = self.example_email("cordelia")
-        self.login(cordelia_email)
+        cordelia = self.example_user('cordelia')
+        lear_realm = get_realm('lear')
+        self.login_user(cordelia)
 
         result = self.client_post("/activity/support", {"realm_id": "%s" % (lear_realm.id,), "status": "deactivated"})
         self.assertEqual(result.status_code, 302)
         self.assertEqual(result["Location"], "/login/")
 
-        iago_email = self.example_email("iago")
-        self.login(iago_email)
+        self.login('iago')
 
         with mock.patch("analytics.views.do_deactivate_realm") as m:
             result = self.client_post("/activity/support", {"realm_id": "%s" % (lear_realm.id,), "status": "deactivated"})
@@ -521,16 +517,15 @@ class TestSupportEndpoint(ZulipTestCase):
             self.assert_in_success_response(["Realm reactivation email sent to admins of Lear"], result)
 
     def test_scrub_realm(self) -> None:
-        lear_realm = get_realm("lear")
-        cordelia_email = self.example_email("cordelia")
-        self.login(cordelia_email)
+        cordelia = self.example_user('cordelia')
+        lear_realm = get_realm('lear')
+        self.login_user(cordelia)
 
         result = self.client_post("/activity/support", {"realm_id": "%s" % (lear_realm.id,), "discount": "25"})
         self.assertEqual(result.status_code, 302)
         self.assertEqual(result["Location"], "/login/")
 
-        iago_email = self.example_email("iago")
-        self.login(iago_email)
+        self.login('iago')
 
         with mock.patch("analytics.views.do_scrub_realm") as m:
             result = self.client_post("/activity/support", {"realm_id": "%s" % (lear_realm.id,), "scrub_realm": "scrub_realm"})

--- a/zerver/tests/test_alert_words.py
+++ b/zerver/tests/test_alert_words.py
@@ -27,8 +27,7 @@ class AlertWordTests(ZulipTestCase):
 
     def test_internal_endpoint(self) -> None:
         user_name = "cordelia"
-        email = self.example_email(user_name)
-        self.login(email)
+        self.login(user_name)
 
         params = {
             'alert_words': ujson.dumps(['milk', 'cookies'])
@@ -98,7 +97,7 @@ class AlertWordTests(ZulipTestCase):
         self.assertEqual(realm_words[user2.id], ['another'])
 
     def test_json_list_default(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
 
         result = self.client_get('/json/users/me/alert_words')
         self.assert_json_success(result)
@@ -108,20 +107,20 @@ class AlertWordTests(ZulipTestCase):
         hamlet = self.example_user('hamlet')
         add_user_alert_words(hamlet, ['one', 'two', 'three'])
 
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         result = self.client_get('/json/users/me/alert_words')
         self.assert_json_success(result)
         self.assertEqual(result.json()['alert_words'], ['one', 'two', 'three'])
 
     def test_json_list_add(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
 
         result = self.client_post('/json/users/me/alert_words', {'alert_words': ujson.dumps(['one ', '\n two', 'three'])})
         self.assert_json_success(result)
         self.assertEqual(result.json()['alert_words'], ['one', 'two', 'three'])
 
     def test_json_list_remove(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
 
         result = self.client_post('/json/users/me/alert_words', {'alert_words': ujson.dumps(['one', 'two', 'three'])})
         self.assert_json_success(result)
@@ -138,7 +137,7 @@ class AlertWordTests(ZulipTestCase):
         return 'has_alert_word' in user_message.flags_list()
 
     def test_alert_flags(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         user_profile_hamlet = self.example_user('hamlet')
 
         result = self.client_post('/json/users/me/alert_words', {'alert_words': ujson.dumps(['one', 'two', 'three'])})
@@ -166,9 +165,8 @@ class AlertWordTests(ZulipTestCase):
 
     def test_update_alert_words(self) -> None:
         user_profile = self.example_user('hamlet')
-        me_email = user_profile.email
 
-        self.login(me_email)
+        self.login_user(user_profile)
         result = self.client_post('/json/users/me/alert_words', {'alert_words': ujson.dumps(['ALERT'])})
 
         content = 'this is an ALERT for you'

--- a/zerver/tests/test_attachments.py
+++ b/zerver/tests/test_attachments.py
@@ -18,7 +18,7 @@ class AttachmentsTests(ZulipTestCase):
 
     def test_list_by_user(self) -> None:
         user_profile = self.example_user('cordelia')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         result = self.client_get('/json/attachments')
         self.assert_json_success(result)
         attachments = user_attachments(user_profile)
@@ -26,7 +26,7 @@ class AttachmentsTests(ZulipTestCase):
 
     def test_remove_attachment_exception(self) -> None:
         user_profile = self.example_user('cordelia')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         with mock.patch('zerver.lib.attachments.delete_message_image', side_effect=Exception()):
             result = self.client_delete('/json/attachments/{id}'.format(id=self.attachment.id))
         self.assert_json_error(result, "An error occurred while deleting the attachment. Please try again later.")
@@ -34,7 +34,7 @@ class AttachmentsTests(ZulipTestCase):
     @mock.patch('zerver.lib.attachments.delete_message_image')
     def test_remove_attachment(self, ignored: Any) -> None:
         user_profile = self.example_user('cordelia')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         result = self.client_delete('/json/attachments/{id}'.format(id=self.attachment.id))
         self.assert_json_success(result)
         attachments = user_attachments(user_profile)
@@ -42,14 +42,14 @@ class AttachmentsTests(ZulipTestCase):
 
     def test_list_another_user(self) -> None:
         user_profile = self.example_user('iago')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         result = self.client_get('/json/attachments')
         self.assert_json_success(result)
         self.assertEqual(result.json()['attachments'], [])
 
     def test_remove_another_user(self) -> None:
         user_profile = self.example_user('iago')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         result = self.client_delete('/json/attachments/{id}'.format(id=self.attachment.id))
         self.assert_json_error(result, 'Invalid attachment')
         user_profile_to_remove = self.example_user('cordelia')

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -100,7 +100,7 @@ class TestRealmAuditLog(ZulipTestCase):
     def test_change_full_name(self) -> None:
         start = timezone_now()
         new_name = 'George Hamletovich'
-        self.login(self.example_email("iago"))
+        self.login('iago')
         req = dict(full_name=ujson.dumps(new_name))
         result = self.client_patch('/json/users/{}'.format(self.example_user("hamlet").id), req)
         self.assertTrue(result.status_code == 200)

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -268,7 +268,7 @@ class AuthBackendTest(ZulipTestCase):
     def test_login_preview(self) -> None:
         # Test preview=true displays organization login page
         # instead of redirecting to app
-        self.login(self.example_email("iago"))
+        self.login('iago')
         realm = get_realm("zulip")
         result = self.client_get('/login/?preview=true')
         self.assertEqual(result.status_code, 200)
@@ -2100,29 +2100,27 @@ class GoogleAuthBackendTest(SocialAuthBase):
         self.assert_json_error(result, "Invalid subdomain")
 
 class JSONFetchAPIKeyTest(ZulipTestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.user_profile = self.example_user('hamlet')
-        self.email = self.user_profile.email
-
     def test_success(self) -> None:
-        self.login(self.email)
+        user = self.example_user('hamlet')
+        self.login_user(user)
         result = self.client_post("/json/fetch_api_key",
-                                  dict(user_profile=self.user_profile,
-                                       password=initial_password(self.email)))
+                                  dict(user_profile=user,
+                                       password=initial_password(user.email)))
         self.assert_json_success(result)
 
     def test_not_loggedin(self) -> None:
+        user = self.example_user('hamlet')
         result = self.client_post("/json/fetch_api_key",
-                                  dict(user_profile=self.user_profile,
-                                       password=initial_password(self.email)))
+                                  dict(user_profile=user,
+                                       password=initial_password(user.email)))
         self.assert_json_error(result,
                                "Not logged in: API authentication or user session required", 401)
 
     def test_wrong_password(self) -> None:
-        self.login(self.email)
+        user = self.example_user('hamlet')
+        self.login_user(user)
         result = self.client_post("/json/fetch_api_key",
-                                  dict(user_profile=self.user_profile,
+                                  dict(user_profile=user,
                                        password="wrong"))
         self.assert_json_error(result, "Your username or password is incorrect.", 400)
 
@@ -3780,7 +3778,7 @@ class TestAdminSetBackends(ZulipTestCase):
 
     def test_change_enabled_backends(self) -> None:
         # Log in as admin
-        self.login(self.example_email("iago"))
+        self.login('iago')
         result = self.client_patch("/json/realm", {
             'authentication_methods': ujson.dumps({u'Email': False, u'Dev': True})})
         self.assert_json_success(result)
@@ -3790,7 +3788,7 @@ class TestAdminSetBackends(ZulipTestCase):
 
     def test_disable_all_backends(self) -> None:
         # Log in as admin
-        self.login(self.example_email("iago"))
+        self.login('iago')
         result = self.client_patch("/json/realm", {
             'authentication_methods': ujson.dumps({u'Email': False, u'Dev': False})})
         self.assert_json_error(result, 'At least one authentication method must be enabled.')
@@ -3800,7 +3798,7 @@ class TestAdminSetBackends(ZulipTestCase):
 
     def test_supported_backends_only_updated(self) -> None:
         # Log in as admin
-        self.login(self.example_email("iago"))
+        self.login('iago')
         # Set some supported and unsupported backends
         result = self.client_patch("/json/realm", {
             'authentication_methods': ujson.dumps({u'Email': False, u'Dev': True, u'GitHub': False})})

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -59,7 +59,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         return result.json()
 
     def test_bot_domain(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.create_bot()
         self.assertTrue(UserProfile.objects.filter(email='hambot-bot@zulip.testserver').exists())
         # The other cases are hard to test directly, since we don't allow creating bots from
@@ -74,7 +74,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_json_success(result)
 
     def test_add_bot_with_bad_username(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(0)
 
         # Invalid username
@@ -97,7 +97,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
     @override_settings(FAKE_EMAIL_DOMAIN="invaliddomain")
     def test_add_bot_with_invalid_fake_email_domain(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(0)
         bot_info = {
             'full_name': 'The Bot of Hamlet',
@@ -112,7 +112,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_num_bots_equal(0)
 
     def test_add_bot_with_no_name(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(0)
         bot_info = dict(
             full_name='a',
@@ -124,7 +124,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
     def test_json_users_with_bots(self) -> None:
         hamlet = self.example_user('hamlet')
-        self.login(hamlet.email)
+        self.login_user(hamlet)
         self.assert_num_bots_equal(0)
 
         num_bots = 3
@@ -149,7 +149,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_length(queries, 3)
 
     def test_add_bot(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(0)
         events = []  # type: List[Mapping[str, Any]]
         with tornado_redirected_to_list(events):
@@ -189,7 +189,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(bot['user_id'], self.get_bot_user(email).id)
 
     def test_add_bot_with_username_in_use(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(0)
         result = self.create_bot()
         self.assert_num_bots_equal(1)
@@ -215,7 +215,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
     def test_add_bot_with_user_avatar(self) -> None:
         email = 'hambot-bot@zulip.testserver'
         realm = get_realm('zulip')
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(0)
         with get_test_image_file('img.png') as fp:
             self.create_bot(file=fp)
@@ -230,7 +230,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertTrue(os.path.exists(avatar_disk_path(profile)))
 
     def test_add_bot_with_too_many_files(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(0)
         with get_test_image_file('img.png') as fp1, \
                 get_test_image_file('img.gif') as fp2:
@@ -247,7 +247,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
     def test_add_bot_with_default_sending_stream(self) -> None:
         email = 'hambot-bot@zulip.testserver'
         realm = get_realm('zulip')
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(0)
         result = self.create_bot(default_sending_stream='Denmark')
         self.assert_num_bots_equal(1)
@@ -260,7 +260,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
     def test_add_bot_with_default_sending_stream_not_subscribed(self) -> None:
         email = 'hambot-bot@zulip.testserver'
         realm = get_realm('zulip')
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(0)
         result = self.create_bot(default_sending_stream='Rome')
         self.assert_num_bots_equal(1)
@@ -278,7 +278,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
                               Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS)
         user.refresh_from_db()
 
-        self.login(user.delivery_email)
+        self.login_user(user)
         self.assert_num_bots_equal(0)
         events = []  # type: List[Mapping[str, Any]]
         with tornado_redirected_to_list(events):
@@ -330,7 +330,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         is sent when add_subscriptions_backend is called in the above api call.
         """
         hamlet = self.example_user('hamlet')
-        self.login(hamlet.email)
+        self.login_user(hamlet)
 
         # Normal user i.e. not a bot.
         request_data = {
@@ -367,7 +367,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(len(mail.outbox), 0)
 
     def test_add_bot_with_default_sending_stream_private_allowed(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         user_profile = self.example_user('hamlet')
         stream = get_stream("Denmark", user_profile.realm)
         self.subscribe(user_profile, stream.name)
@@ -409,7 +409,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(event['users'], {user_profile.id, })
 
     def test_add_bot_with_default_sending_stream_private_denied(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         realm = self.example_user('hamlet').realm
         stream = get_stream("Denmark", realm)
         self.unsubscribe(self.example_user('hamlet'), "Denmark")
@@ -427,7 +427,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         bot_email = 'hambot-bot@zulip.testserver'
         bot_realm = get_realm('zulip')
 
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(0)
         result = self.create_bot(default_events_register_stream='Denmark')
         self.assert_num_bots_equal(1)
@@ -438,7 +438,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(profile.default_events_register_stream.name, 'Denmark')
 
     def test_add_bot_with_default_events_register_stream_private_allowed(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         user_profile = self.example_user('hamlet')
         stream = self.subscribe(user_profile, 'Denmark')
         do_change_stream_invite_only(stream, True)
@@ -479,7 +479,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(event['users'], {user_profile.id, })
 
     def test_add_bot_with_default_events_register_stream_private_denied(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         realm = self.example_user('hamlet').realm
         stream = get_stream("Denmark", realm)
         self.unsubscribe(self.example_user('hamlet'), "Denmark")
@@ -495,7 +495,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_json_error(result, "Invalid stream name 'Denmark'")
 
     def test_add_bot_with_default_all_public_streams(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(0)
         result = self.create_bot(default_all_public_streams=ujson.dumps(True))
         self.assert_num_bots_equal(1)
@@ -507,7 +507,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(profile.default_all_public_streams, True)
 
     def test_deactivate_bot(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(0)
         self.create_bot()
         self.assert_num_bots_equal(1)
@@ -518,7 +518,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
     def test_deactivate_bogus_bot(self) -> None:
         """Deleting a bogus bot will succeed silently."""
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(0)
         self.create_bot()
         self.assert_num_bots_equal(1)
@@ -528,9 +528,8 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_num_bots_equal(1)
 
     def test_deactivate_bot_with_owner_deactivation(self) -> None:
-        email = self.example_email("hamlet")
         user = self.example_user('hamlet')
-        self.login(email)
+        self.login_user(user)
 
         bot_info = {
             'full_name': u'The Bot of Hamlet',
@@ -555,14 +554,14 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         user = self.example_user('hamlet')
         self.assertFalse(user.is_active)
 
-        self.login(self.example_email("iago"))
+        self.login('iago')
         all_bots = UserProfile.objects.filter(is_bot=True, bot_owner=user, is_active=True)
         bots = [bot for bot in all_bots]
         self.assertEqual(len(bots), 0)
 
     def test_cannot_deactivate_other_realm_bot(self) -> None:
-        realm = get_realm("zephyr")
-        self.login(self.mit_email("starnine"), realm=realm)
+        user = self.mit_user('starnine')
+        self.login_user(user)
         bot_info = {
             'full_name': 'The Bot in zephyr',
             'short_name': 'starn-bot',
@@ -572,21 +571,21 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_json_success(result)
         result = self.client_get("/json/bots", subdomain="zephyr")
         bot_email = result.json()['bots'][0]['username']
-        bot = get_user(bot_email, realm)
-        self.login(self.example_email("iago"))
+        bot = get_user(bot_email, user.realm)
+        self.login('iago')
         result = self.client_delete("/json/bots/{}".format(bot.id))
         self.assert_json_error(result, 'No such bot')
 
     def test_bot_deactivation_attacks(self) -> None:
         """You cannot deactivate somebody else's bot."""
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(0)
         self.create_bot()
         self.assert_num_bots_equal(1)
 
         # Have Othello try to deactivate both Hamlet and
         # Hamlet's bot.
-        self.login(self.example_email('othello'))
+        self.login('othello')
 
         # Cannot deactivate a user as a bot
         result = self.client_delete("/json/bots/{}".format(self.example_user("hamlet").id))
@@ -597,7 +596,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_json_error(result, 'Insufficient permission')
 
         # But we don't actually deactivate the other person's bot.
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(1)
 
         # Cannot deactivate a bot as a user
@@ -606,13 +605,13 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_num_bots_equal(1)
 
     def test_bot_permissions(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(0)
         self.create_bot()
         self.assert_num_bots_equal(1)
 
         # Have Othello try to mess with Hamlet's bots.
-        self.login(self.example_email('othello'))
+        self.login('othello')
         email = 'hambot-bot@zulip.testserver'
 
         result = self.client_post("/json/bots/{}/api_key/regenerate".format(self.get_bot_user(email).id))
@@ -630,7 +629,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         return bots[0]
 
     def test_update_api_key(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.create_bot()
         bot = self.get_bot()
         old_api_key = bot['api_key']
@@ -643,7 +642,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(new_api_key, bot['api_key'])
 
     def test_update_api_key_for_invalid_user(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         invalid_user_id = 1000
         result = self.client_post('/json/bots/{}/api_key/regenerate'.format(invalid_user_id))
         self.assert_json_error(result, 'No such bot')
@@ -652,7 +651,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         bot_email = 'hambot-bot@zulip.testserver'
         bot_realm = get_realm('zulip')
 
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(0)
         self.create_bot(bot_type=UserProfile.DEFAULT_BOT)
         self.assert_num_bots_equal(1)
@@ -664,7 +663,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         bot_email = 'hambot-bot@zulip.testserver'
         bot_realm = get_realm('zulip')
 
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(0)
         self.create_bot(bot_type=UserProfile.INCOMING_WEBHOOK_BOT)
         self.assert_num_bots_equal(1)
@@ -679,7 +678,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             'bot_type': 7,
         }
 
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(0)
         result = self.client_post("/json/bots", bot_info)
         self.assert_num_bots_equal(0)
@@ -697,7 +696,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         bot_realm.save(update_fields=['bot_creation_policy'])
 
         # A regular user cannot create a generic bot
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(0)
         result = self.client_post("/json/bots", bot_info)
         self.assert_num_bots_equal(0)
@@ -711,7 +710,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(profile.bot_type, UserProfile.INCOMING_WEBHOOK_BOT)
 
     def test_no_generic_bot_reactivation_allowed_for_non_admins(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.create_bot(bot_type=UserProfile.DEFAULT_BOT)
 
         bot_realm = get_realm('zulip')
@@ -735,7 +734,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         bot_realm.save(update_fields=['bot_creation_policy'])
 
         # An administrator can create any type of bot
-        self.login(self.example_email('iago'))
+        self.login('iago')
         self.assert_num_bots_equal(0)
         self.create_bot(bot_type=UserProfile.DEFAULT_BOT)
         self.assert_num_bots_equal(1)
@@ -753,7 +752,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         bot_realm.save(update_fields=['bot_creation_policy'])
 
         # A regular user cannot create a generic bot
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(0)
         result = self.client_post("/json/bots", bot_info)
         self.assert_num_bots_equal(0)
@@ -761,7 +760,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
         # Also, a regular user cannot create a incoming bot
         bot_info['bot_type'] = 2
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.assert_num_bots_equal(0)
         result = self.client_post("/json/bots", bot_info)
         self.assert_num_bots_equal(0)
@@ -774,7 +773,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         bot_realm.save(update_fields=['bot_creation_policy'])
 
         # An administrator can create any type of bot
-        self.login(self.example_email('iago'))
+        self.login('iago')
         self.assert_num_bots_equal(0)
         self.create_bot(bot_type=UserProfile.DEFAULT_BOT)
         self.assert_num_bots_equal(1)
@@ -782,7 +781,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(profile.bot_type, UserProfile.DEFAULT_BOT)
 
     def test_patch_bot_full_name(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         bot_info = {
             'full_name': 'The Bot of Hamlet',
             'short_name': 'hambot',
@@ -802,7 +801,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual('Fred', bot['full_name'])
 
     def test_patch_bot_full_name_in_use(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
 
         original_name = 'The Bot of Hamlet'
 
@@ -852,7 +851,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(bot.full_name, 'Hal')
 
     def test_patch_bot_full_name_non_bot(self) -> None:
-        self.login(self.example_email('iago'))
+        self.login('iago')
         bot_info = {
             'full_name': 'Fred',
         }
@@ -860,7 +859,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_json_error(result, "No such bot")
 
     def test_patch_bot_owner(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         bot_info = {
             'full_name': u'The Bot of Hamlet',
             'short_name': u'hambot',
@@ -877,12 +876,12 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         # Test bot's owner has been changed successfully.
         self.assertEqual(result.json()['bot_owner'], self.example_email('othello'))
 
-        self.login(self.example_email('othello'))
+        self.login('othello')
         bot = self.get_bot()
         self.assertEqual('The Bot of Hamlet', bot['full_name'])
 
     def test_patch_bot_owner_bad_user_id(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.create_bot()
         self.assert_num_bots_equal(1)
 
@@ -899,7 +898,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(profile.bot_owner, self.example_user("hamlet"))
 
     def test_patch_bot_owner_deactivated(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.create_bot()
         self.assert_num_bots_equal(1)
 
@@ -918,7 +917,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(profile.bot_owner, self.example_user("hamlet"))
 
     def test_patch_bot_owner_must_be_in_same_realm(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.create_bot()
         self.assert_num_bots_equal(1)
 
@@ -933,7 +932,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(profile.bot_owner, self.example_user("hamlet"))
 
     def test_patch_bot_owner_noop(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.create_bot()
         self.assert_num_bots_equal(1)
 
@@ -950,7 +949,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(profile.bot_owner, self.example_user("hamlet"))
 
     def test_patch_bot_owner_a_bot(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.create_bot()
         self.assert_num_bots_equal(1)
 
@@ -971,7 +970,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(profile.bot_owner, self.example_user("hamlet"))
 
     def test_patch_bot_avatar(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         bot_info = {
             'full_name': 'The Bot of Hamlet',
             'short_name': 'hambot',
@@ -1013,7 +1012,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertTrue(os.path.exists(avatar_disk_path(profile)))
 
     def test_patch_bot_to_stream(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         bot_info = {
             'full_name': 'The Bot of Hamlet',
             'short_name': 'hambot',
@@ -1033,7 +1032,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual('Denmark', bot['default_sending_stream'])
 
     def test_patch_bot_to_stream_not_subscribed(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         bot_info = {
             'full_name': 'The Bot of Hamlet',
             'short_name': 'hambot',
@@ -1053,7 +1052,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual('Rome', bot['default_sending_stream'])
 
     def test_patch_bot_to_stream_none(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         bot_info = {
             'full_name': 'The Bot of Hamlet',
             'short_name': 'hambot',
@@ -1076,7 +1075,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(None, bot['default_sending_stream'])
 
     def test_patch_bot_to_stream_private_allowed(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         user_profile = self.example_user('hamlet')
         stream = self.subscribe(user_profile, "Denmark")
         do_change_stream_invite_only(stream, True)
@@ -1101,7 +1100,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual('Denmark', bot['default_sending_stream'])
 
     def test_patch_bot_to_stream_private_denied(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         realm = self.example_user('hamlet').realm
         stream = get_stream("Denmark", realm)
         self.unsubscribe(self.example_user('hamlet'), "Denmark")
@@ -1122,7 +1121,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_json_error(result, "Invalid stream name 'Denmark'")
 
     def test_patch_bot_to_stream_not_found(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         bot_info = {
             'full_name': 'The Bot of Hamlet',
             'short_name': 'hambot',
@@ -1138,7 +1137,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
     def test_patch_bot_events_register_stream(self) -> None:
         hamlet = self.example_user('hamlet')
-        self.login(hamlet.email)
+        self.login_user(hamlet)
         bot_info = {
             'full_name': 'The Bot of Hamlet',
             'short_name': 'hambot',
@@ -1183,7 +1182,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_json_error_contains(result, 'endpoint does not accept')
 
     def test_patch_bot_events_register_stream_allowed(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         user_profile = self.example_user('hamlet')
         stream = self.subscribe(user_profile, "Denmark")
         do_change_stream_invite_only(stream, True)
@@ -1207,7 +1206,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual('Denmark', bot['default_events_register_stream'])
 
     def test_patch_bot_events_register_stream_denied(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         realm = self.example_user('hamlet').realm
         stream = get_stream("Denmark", realm)
         self.unsubscribe(self.example_user('hamlet'), "Denmark")
@@ -1227,7 +1226,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_json_error(result, "Invalid stream name 'Denmark'")
 
     def test_patch_bot_events_register_stream_none(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         bot_info = {
             'full_name': 'The Bot of Hamlet',
             'short_name': 'hambot',
@@ -1250,7 +1249,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(None, bot['default_events_register_stream'])
 
     def test_patch_bot_events_register_stream_not_found(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         bot_info = {
             'full_name': 'The Bot of Hamlet',
             'short_name': 'hambot',
@@ -1265,7 +1264,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_json_error(result, "Invalid stream name 'missing'")
 
     def test_patch_bot_default_all_public_streams_true(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         bot_info = {
             'full_name': 'The Bot of Hamlet',
             'short_name': 'hambot',
@@ -1285,7 +1284,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(bot['default_all_public_streams'], True)
 
     def test_patch_bot_default_all_public_streams_false(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         bot_info = {
             'full_name': 'The Bot of Hamlet',
             'short_name': 'hambot',
@@ -1305,7 +1304,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assertEqual(bot['default_all_public_streams'], False)
 
     def test_patch_bot_via_post(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         bot_info = {
             'full_name': 'The Bot of Hamlet',
             'short_name': 'hambot',
@@ -1329,7 +1328,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
     def test_patch_bogus_bot(self) -> None:
         """Deleting a bogus bot will succeed silently."""
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.create_bot()
         bot_info = {
             'full_name': 'Fred',
@@ -1340,7 +1339,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_num_bots_equal(1)
 
     def test_patch_outgoing_webhook_bot(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         bot_info = {
             'full_name': u'The Bot of Hamlet',
             'short_name': u'hambot',
@@ -1380,7 +1379,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
     def test_outgoing_webhook_invalid_interface(self):
         # type: () -> None
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         bot_info = {
             'full_name': 'Outgoing Webhook test bot',
             'short_name': 'outgoingservicebot',
@@ -1396,7 +1395,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_json_success(result)
 
     def test_create_outgoing_webhook_bot(self, **extras: Any) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         bot_info = {
             'full_name': 'Outgoing Webhook test bot',
             'short_name': 'outgoingservicebot',
@@ -1439,7 +1438,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             self.assertIsNotNone(get_bot_handler(embedded_bot.name))
 
     def test_outgoing_webhook_interface_type(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         bot_info = {
             'full_name': 'Outgoing Webhook test bot',
             'short_name': 'outgoingservicebot',
@@ -1524,7 +1523,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
     @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", stripe_sample_config_options)
     def test_create_incoming_webhook_bot_with_service_name_and_with_keys(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         bot_metadata = {
             "full_name": "My Stripe Bot",
             "short_name": "my-stripe",
@@ -1540,7 +1539,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
     @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", stripe_sample_config_options)
     def test_create_incoming_webhook_bot_with_service_name_incorrect_keys(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         bot_metadata = {
             "full_name": "My Stripe Bot",
             "short_name": "my-stripe",
@@ -1557,7 +1556,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
     @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", stripe_sample_config_options)
     def test_create_incoming_webhook_bot_with_service_name_without_keys(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         bot_metadata = {
             "full_name": "My Stripe Bot",
             "short_name": "my-stripe",
@@ -1573,7 +1572,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
     @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", stripe_sample_config_options)
     def test_create_incoming_webhook_bot_without_service_name(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         bot_metadata = {
             "full_name": "My Stripe Bot",
             "short_name": "my-stripe",
@@ -1586,7 +1585,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
     @patch("zerver.lib.integrations.WEBHOOK_INTEGRATIONS", stripe_sample_config_options)
     def test_create_incoming_webhook_bot_with_incorrect_service_name(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         bot_metadata = {
             "full_name": "My Stripe Bot",
             "short_name": "my-stripe",

--- a/zerver/tests/test_create_video_call.py
+++ b/zerver/tests/test_create_video_call.py
@@ -7,7 +7,7 @@ class TestVideoCall(ZulipTestCase):
     def setUp(self) -> None:
         super().setUp()
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email, realm=user_profile.realm)
+        self.login_user(user_profile)
 
     def test_create_video_call_success(self) -> None:
         with mock.patch('zerver.lib.actions.request_zoom_video_call_url', return_value={'join_url': 'example.com'}):

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -28,7 +28,7 @@ class CustomProfileFieldTestCase(ZulipTestCase):
 
 class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
     def test_create(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         realm = get_realm('zulip')
         data = {"name": u"Phone", "field_type": "text id"}  # type: Dict[str, Any]
         result = self.client_post("/json/realm/profile_fields", info=data)
@@ -69,7 +69,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
                                u'A field with that label already exists.')
 
     def test_create_choice_field(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         data = {}  # type: Dict[str, Union[str, int]]
         data["name"] = "Favorite programming language"
         data["field_type"] = CustomProfileField.CHOICE
@@ -126,7 +126,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.assert_json_success(result)
 
     def test_create_default_external_account_field(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         realm = get_realm("zulip")
         field_type = CustomProfileField.EXTERNAL_ACCOUNT  # type: int
         field_data = ujson.dumps({
@@ -173,7 +173,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.assert_json_success(result)
 
     def test_create_external_account_field(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         realm = get_realm('zulip')
         data = {}  # type: Dict[str, Union[str, int, Dict[str, str]]]
         data["name"] = "Twitter"
@@ -270,7 +270,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.assert_json_error(result, "A field with that label already exists.")
 
     def test_create_field_of_type_user(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         data = {"name": "Your mentor",
                 "field_type": CustomProfileField.USER,
                 }
@@ -278,7 +278,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.assert_json_success(result)
 
     def test_not_realm_admin(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         result = self.client_post("/json/realm/profile_fields")
         self.assert_json_error(result, u'Must be an organization administrator')
         result = self.client_delete("/json/realm/profile_fields/1")
@@ -286,7 +286,7 @@ class CreateCustomProfileFieldTest(CustomProfileFieldTestCase):
 
 class DeleteCustomProfileFieldTest(CustomProfileFieldTestCase):
     def test_delete(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         realm = get_realm('zulip')
         field = CustomProfileField.objects.get(name="Phone number", realm=realm)
         result = self.client_delete("/json/realm/profile_fields/100")
@@ -300,7 +300,7 @@ class DeleteCustomProfileFieldTest(CustomProfileFieldTestCase):
 
     def test_delete_field_value(self) -> None:
         iago = self.example_user("iago")
-        self.login(iago.email)
+        self.login_user(iago)
         realm = get_realm("zulip")
 
         invalid_field_id = 1234
@@ -347,7 +347,7 @@ class DeleteCustomProfileFieldTest(CustomProfileFieldTestCase):
 
 class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
     def test_update(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         realm = get_realm('zulip')
         result = self.client_patch(
             "/json/realm/profile_fields/100",
@@ -433,7 +433,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.assert_json_success(result)
 
     def test_update_is_aware_of_uniqueness(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         realm = get_realm('zulip')
         field_1 = try_add_realm_custom_profile_field(realm, u"Phone",
                                                      CustomProfileField.SHORT_TEXT)
@@ -450,7 +450,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
             result, u'A field with that label already exists.')
 
     def assert_error_update_invalid_value(self, field_name: str, new_value: object, error_msg: str) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         realm = get_realm('zulip')
         field = CustomProfileField.objects.get(name=field_name, realm=realm)
 
@@ -460,7 +460,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.assert_json_error(result, error_msg)
 
     def test_update_invalid_field(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         data = [{'id': 1234, 'value': '12'}]
         result = self.client_patch("/json/users/me/profile_data", {
             'data': ujson.dumps(data)
@@ -493,7 +493,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
                                                % (invalid_user_id,))
 
     def test_update_profile_data_successfully(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         realm = get_realm('zulip')
         fields = [
             ('Phone number', '*short* text data'),
@@ -556,7 +556,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
                                                "'foobar' is not a valid choice for '{}'.".format(field_name))
 
     def test_update_choice_field_successfully(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         realm = get_realm('zulip')
         field = CustomProfileField.objects.get(name='Favorite editor', realm=realm)
         data = [{
@@ -569,7 +569,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.assert_json_success(result)
 
     def test_null_value_and_rendered_value(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         realm = get_realm("zulip")
 
         quote = try_add_realm_custom_profile_field(
@@ -601,7 +601,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
 
     def test_do_update_value_not_changed(self) -> None:
         iago = self.example_user("iago")
-        self.login(iago.email)
+        self.login_user(iago)
         realm = get_realm("zulip")
 
         # Set field value:
@@ -618,7 +618,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
 
 class ListCustomProfileFieldTest(CustomProfileFieldTestCase):
     def test_list(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         result = self.client_get("/json/realm/profile_fields")
         self.assert_json_success(result)
         self.assertEqual(200, result.status_code)
@@ -626,7 +626,7 @@ class ListCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.assertEqual(len(content["custom_fields"]), self.original_count)
 
     def test_list_order(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         realm = get_realm('zulip')
         order = (
             CustomProfileField.objects.filter(realm=realm)
@@ -689,7 +689,7 @@ class ListCustomProfileFieldTest(CustomProfileFieldTestCase):
                 user_dict["profile_data"]
 
     def test_get_custom_profile_fields_from_api_for_single_user(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         expected_keys = {
             "result", "msg", "pointer", "client_id", "max_message_id", "user_id",
             "avatar_url", "full_name", "email", "is_bot", "is_admin", "short_name",
@@ -704,7 +704,7 @@ class ListCustomProfileFieldTest(CustomProfileFieldTestCase):
 
 class ReorderCustomProfileFieldTest(CustomProfileFieldTestCase):
     def test_reorder(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         realm = get_realm('zulip')
         order = (
             CustomProfileField.objects.filter(realm=realm)
@@ -719,7 +719,7 @@ class ReorderCustomProfileFieldTest(CustomProfileFieldTestCase):
             self.assertEqual(field.id, order[field.order])
 
     def test_reorder_duplicates(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         realm = get_realm('zulip')
         order = (
             CustomProfileField.objects.filter(realm=realm)
@@ -736,7 +736,7 @@ class ReorderCustomProfileFieldTest(CustomProfileFieldTestCase):
             self.assertEqual(field.id, order[field.order])
 
     def test_reorder_unauthorized(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         realm = get_realm('zulip')
         order = (
             CustomProfileField.objects.filter(realm=realm)
@@ -748,7 +748,7 @@ class ReorderCustomProfileFieldTest(CustomProfileFieldTestCase):
         self.assert_json_error(result, "Must be an organization administrator")
 
     def test_reorder_invalid(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         order = [100, 200, 300]
         result = self.client_patch("/json/realm/profile_fields",
                                    info={'order': ujson.dumps(order)})

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -280,6 +280,6 @@ class TestDigestEmailMessages(ZulipTestCase):
 
 class TestDigestContentInBrowser(ZulipTestCase):
     def test_get_digest_content_in_browser(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         result = self.client_get("/digest/")
         self.assert_in_success_response(["Click here to log in to Zulip and catch up."], result)

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -377,7 +377,7 @@ class PlansPageTest(ZulipTestCase):
         self.assertEqual(result.status_code, 302)
         self.assertEqual(result["Location"], "/accounts/login/?next=plans")
         # Test valid domain, with login
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         result = self.client_get("/plans/", subdomain="zulip")
         self.assert_in_success_response(["Current plan"], result)
         # Test root domain, with login on different domain
@@ -405,7 +405,7 @@ class PlansPageTest(ZulipTestCase):
             self.assertEqual(result.status_code, 302)
             self.assertEqual(result["Location"], "https://zulipchat.com/plans")
 
-            self.login(self.example_email("iago"))
+            self.login('iago')
 
             # SELF_HOSTED should hide the local plans page, even if logged in
             result = self.client_get("/plans/", subdomain="zulip")

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -18,14 +18,14 @@ from zerver.models import get_user_by_delivery_email, EmailChangeStatus, get_rea
 
 class EmailChangeTestCase(ZulipTestCase):
     def test_confirm_email_change_with_non_existent_key(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         key = generate_key()
         url = confirmation_url(key, 'testserver', Confirmation.EMAIL_CHANGE)
         response = self.client_get(url)
         self.assert_in_success_response(["Whoops. We couldn't find your confirmation link in the system."], response)
 
     def test_confirm_email_change_with_invalid_key(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         key = 'invalid_key'
         url = confirmation_url(key, 'testserver', Confirmation.EMAIL_CHANGE)
         response = self.client_get(url)
@@ -35,7 +35,7 @@ class EmailChangeTestCase(ZulipTestCase):
         user_profile = self.example_user('hamlet')
         old_email = user_profile.email
         new_email = 'hamlet-new@zulip.com'
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         obj = EmailChangeStatus.objects.create(new_email=new_email,
                                                old_email=old_email,
                                                user_profile=user_profile,
@@ -55,7 +55,7 @@ class EmailChangeTestCase(ZulipTestCase):
         old_email = user_profile.email
         new_email = 'hamlet-new@zulip.com'
         new_realm = get_realm('zulip')
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         obj = EmailChangeStatus.objects.create(new_email=new_email,
                                                old_email=old_email,
                                                user_profile=user_profile,
@@ -83,8 +83,7 @@ class EmailChangeTestCase(ZulipTestCase):
 
     def test_end_to_end_flow(self) -> None:
         data = {'email': 'hamlet-new@zulip.com'}
-        email = self.example_email("hamlet")
-        self.login(email)
+        self.login('hamlet')
         url = '/json/settings'
         self.assertEqual(len(mail.outbox), 0)
         result = self.client_patch(url, data)
@@ -115,8 +114,7 @@ class EmailChangeTestCase(ZulipTestCase):
     def test_unauthorized_email_change(self) -> None:
         data = {'email': 'hamlet-new@zulip.com'}
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
-        self.login(email)
+        self.login_user(user_profile)
         do_set_realm_property(user_profile.realm, 'email_changes_disabled', True)
         url = '/json/settings'
         result = self.client_patch(url, data)
@@ -126,7 +124,7 @@ class EmailChangeTestCase(ZulipTestCase):
                                 result)
         # Realm admins can change their email address even setting is disabled.
         data = {'email': 'iago-new@zulip.com'}
-        self.login(self.example_email("iago"))
+        self.login('iago')
         url = '/json/settings'
         result = self.client_patch(url, data)
         self.assert_in_success_response(['Check your email for a confirmation link.'], result)
@@ -134,8 +132,7 @@ class EmailChangeTestCase(ZulipTestCase):
     def test_email_change_already_taken(self) -> None:
         data = {'email': 'cordelia@zulip.com'}
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
-        self.login(email)
+        self.login_user(user_profile)
 
         url = '/json/settings'
         result = self.client_patch(url, data)
@@ -147,8 +144,7 @@ class EmailChangeTestCase(ZulipTestCase):
     def test_unauthorized_email_change_from_email_confirmation_link(self) -> None:
         data = {'email': 'hamlet-new@zulip.com'}
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
-        self.login(email)
+        self.login_user(user_profile)
         url = '/json/settings'
         self.assertEqual(len(mail.outbox), 0)
         result = self.client_patch(url, data)
@@ -173,16 +169,14 @@ class EmailChangeTestCase(ZulipTestCase):
 
     def test_post_invalid_email(self) -> None:
         data = {'email': 'hamlet-new'}
-        email = self.example_email("hamlet")
-        self.login(email)
+        self.login('hamlet')
         url = '/json/settings'
         result = self.client_patch(url, data)
         self.assert_in_response('Invalid address', result)
 
     def test_post_same_email(self) -> None:
         data = {'email': self.example_email("hamlet")}
-        email = self.example_email("hamlet")
-        self.login(email)
+        self.login('hamlet')
         url = '/json/settings'
         result = self.client_patch(url, data)
         self.assertEqual('success', result.json()['result'])
@@ -193,9 +187,9 @@ class EmailChangeTestCase(ZulipTestCase):
         do_set_realm_property(user_profile.realm, 'email_address_visibility',
                               Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS)
 
+        self.login_user(user_profile)
         old_email = user_profile.email
         new_email = 'hamlet-new@zulip.com'
-        self.login(self.example_email('hamlet'))
         obj = EmailChangeStatus.objects.create(new_email=new_email,
                                                old_email=old_email,
                                                user_profile=user_profile,

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -223,7 +223,7 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
         # build dummy messages for stream
         # test valid incoming stream message is processed properly
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
@@ -247,7 +247,7 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
 
     def test_receive_stream_email_messages_blank_subject_success(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
@@ -271,7 +271,7 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
 
     def test_receive_private_stream_email_messages_success(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.make_stream("private_stream", invite_only=True)
         self.subscribe(user_profile, "private_stream")
         stream = get_stream("private_stream", user_profile.realm)
@@ -296,7 +296,7 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
 
     def test_receive_stream_email_multiple_recipient_success(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
@@ -322,7 +322,7 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
 
     def test_receive_stream_email_show_sender_success(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
@@ -347,7 +347,7 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
 
     def test_receive_stream_email_show_sender_utf8_encoded_sender(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
@@ -372,7 +372,7 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
 
     def test_receive_stream_email_include_footer_success(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
@@ -400,7 +400,7 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
 
     def test_receive_stream_email_include_quotes_success(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
@@ -431,7 +431,7 @@ class TestStreamEmailMessagesSuccess(ZulipTestCase):
 class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
     def test_message_with_valid_attachment(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
         stream_to_address = encode_email_address(stream)
@@ -464,7 +464,7 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
 
     def test_message_with_attachment_utf8_filename(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
         stream_to_address = encode_email_address(stream)
@@ -499,7 +499,7 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
 
     def test_message_with_valid_nested_attachment(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
         stream_to_address = encode_email_address(stream)
@@ -537,7 +537,7 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
 
     def test_message_with_invalid_attachment(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
         stream_to_address = encode_email_address(stream)
@@ -562,7 +562,7 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
 
     def test_receive_plaintext_and_html_prefer_text_html_options(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
         stream_address = "Denmark.{}@testserver".format(stream.email_token)
@@ -597,7 +597,7 @@ class TestEmailMirrorMessagesWithAttachments(ZulipTestCase):
 
     def test_receive_only_plaintext_with_prefer_html_option(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
         stream_address_prefer_html = "Denmark.{}.prefer-html@testserver".format(stream.email_token)
@@ -628,7 +628,7 @@ class TestStreamEmailMessagesEmptyBody(ZulipTestCase):
         # build dummy messages for stream
         # test message with empty body is not sent
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
         stream_to_address = encode_email_address(stream)
@@ -647,7 +647,7 @@ class TestStreamEmailMessagesEmptyBody(ZulipTestCase):
 
     def test_receive_stream_email_messages_no_textual_body(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
         stream_to_address = encode_email_address(stream)
@@ -667,7 +667,7 @@ class TestStreamEmailMessagesEmptyBody(ZulipTestCase):
 
     def test_receive_stream_email_messages_empty_body_after_stripping(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
 
@@ -694,8 +694,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         # build dummy messages for missed messages email reply
         # have Hamlet send Othello a PM. Othello will reply via email
         # Hamlet will receive the message.
-        email = self.example_email('hamlet')
-        self.login(email)
+        self.login('hamlet')
         result = self.client_post("/json/messages", {"type": "private",
                                                      "content": "test_receive_missed_message_email_messages",
                                                      "client": "test suite",
@@ -718,7 +717,6 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
 
         process_message(incoming_valid_message)
 
-        # self.login(self.example_email("hamlet"))
         # confirm that Hamlet got the message
         user_profile = self.example_user('hamlet')
         message = most_recent_message(user_profile)
@@ -733,8 +731,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         # build dummy messages for missed messages email reply
         # have Othello send Iago and Cordelia a PM. Cordelia will reply via email
         # Iago and Othello will receive the message.
-        email = self.example_email('othello')
-        self.login(email)
+        self.login('othello')
         result = self.client_post("/json/messages", {"type": "private",
                                                      "content": "test_receive_missed_message_email_messages",
                                                      "client": "test suite",
@@ -782,8 +779,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
         # Hamlet will see the message in the stream.
         self.subscribe(self.example_user("hamlet"), "Denmark")
         self.subscribe(self.example_user("othello"), "Denmark")
-        email = self.example_email('hamlet')
-        self.login(email)
+        self.login('hamlet')
         result = self.client_post("/json/messages", {"type": "stream",
                                                      "topic": "test topic",
                                                      "content": "test_receive_missed_stream_message_email_messages",
@@ -817,8 +813,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
     def test_missed_stream_message_email_response_tracks_topic_change(self) -> None:
         self.subscribe(self.example_user("hamlet"), "Denmark")
         self.subscribe(self.example_user("othello"), "Denmark")
-        email = self.example_email('hamlet')
-        self.login(email)
+        self.login('hamlet')
         result = self.client_post("/json/messages", {"type": "stream",
                                                      "topic": "test topic",
                                                      "content": "test_receive_missed_stream_message_email_messages",
@@ -858,8 +853,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
     def test_missed_message_email_response_from_deactivated_user(self) -> None:
         self.subscribe(self.example_user("hamlet"), "Denmark")
         self.subscribe(self.example_user("othello"), "Denmark")
-        email = self.example_email('hamlet')
-        self.login(email)
+        self.login('hamlet')
         result = self.client_post("/json/messages", {"type": "stream",
                                                      "topic": "test topic",
                                                      "content": "test_receive_missed_stream_message_email_messages",
@@ -890,8 +884,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
     def test_missed_message_email_response_from_deactivated_realm(self) -> None:
         self.subscribe(self.example_user("hamlet"), "Denmark")
         self.subscribe(self.example_user("othello"), "Denmark")
-        email = self.example_email('hamlet')
-        self.login(email)
+        self.login('hamlet')
         result = self.client_post("/json/messages", {"type": "stream",
                                                      "topic": "test topic",
                                                      "content": "test_receive_missed_stream_message_email_messages",
@@ -922,8 +915,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
     def test_missed_message_email_multiple_responses(self) -> None:
         self.subscribe(self.example_user("hamlet"), "Denmark")
         self.subscribe(self.example_user("othello"), "Denmark")
-        email = self.example_email('hamlet')
-        self.login(email)
+        self.login('hamlet')
 
         result = self.client_post("/json/messages", {"type": "stream",
                                                      "topic": "test topic",
@@ -951,8 +943,7 @@ class TestMissedMessageEmailMessages(ZulipTestCase):
 
 class TestEmptyGatewaySetting(ZulipTestCase):
     def test_missed_message(self) -> None:
-        email = self.example_email('othello')
-        self.login(email)
+        self.login('othello')
         result = self.client_post("/json/messages", {"type": "private",
                                                      "content": "test_receive_missed_message_email_messages",
                                                      "client": "test suite",
@@ -989,8 +980,7 @@ class TestReplyExtraction(ZulipTestCase):
 
         # build dummy messages for stream
         # test valid incoming stream message is processed properly
-        email = self.example_email('hamlet')
-        self.login(email)
+        self.login('hamlet')
         user_profile = self.example_user('hamlet')
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
@@ -1027,8 +1017,7 @@ class TestReplyExtraction(ZulipTestCase):
 
         # build dummy messages for stream
         # test valid incoming stream message is processed properly
-        email = self.example_email('hamlet')
-        self.login(email)
+        self.login('hamlet')
         user_profile = self.example_user('hamlet')
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
@@ -1122,8 +1111,7 @@ class TestScriptMTA(ZulipTestCase):
 class TestEmailMirrorTornadoView(ZulipTestCase):
 
     def send_private_message(self) -> str:
-        email = self.example_email('othello')
-        self.login(email)
+        self.login('othello')
         result = self.client_post(
             "/json/messages",
             {
@@ -1220,7 +1208,7 @@ class TestEmailMirrorTornadoView(ZulipTestCase):
 class TestStreamEmailMessagesSubjectStripping(ZulipTestCase):
     def test_process_message_strips_subject(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
         stream_to_address = encode_email_address(stream)
@@ -1257,7 +1245,7 @@ class TestContentTypeUnspecifiedCharset(ZulipTestCase):
         incoming_message = message_from_string(message_as_string)
 
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
         stream = get_stream("Denmark", user_profile.realm)
         stream_to_address = encode_email_address(stream)
@@ -1285,7 +1273,7 @@ class TestEmailMirrorProcessMessageNoValidRecipient(ZulipTestCase):
 class TestEmailMirrorLogAndReport(ZulipTestCase):
     def test_log_and_report(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "errors")
         stream = get_stream("Denmark", user_profile.realm)
         stream_to_address = encode_email_address(stream)
@@ -1331,7 +1319,7 @@ class TestEmailMirrorLogAndReport(ZulipTestCase):
 
     def test_redact_email_address(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "errors")
         stream = get_stream("Denmark", user_profile.realm)
 

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -403,8 +403,7 @@ class TestMissedMessages(ZulipTestCase):
             '@**King Hamlet** to be deleted')
 
         hamlet = self.example_user('hamlet')
-        email = self.example_email('othello')
-        self.login(email)
+        self.login('othello')
         result = self.client_patch('/json/messages/' + str(msg_id),
                                    {'message_id': msg_id, 'content': ' '})
         self.assert_json_success(result)
@@ -417,8 +416,7 @@ class TestMissedMessages(ZulipTestCase):
                                             'Extremely personal message! to be deleted!')
 
         hamlet = self.example_user('hamlet')
-        email = self.example_email('othello')
-        self.login(email)
+        self.login('othello')
         result = self.client_patch('/json/messages/' + str(msg_id),
                                    {'message_id': msg_id, 'content': ' '})
         self.assert_json_success(result)
@@ -437,8 +435,7 @@ class TestMissedMessages(ZulipTestCase):
 
         hamlet = self.example_user('hamlet')
         iago = self.example_user('iago')
-        email = self.example_email('othello')
-        self.login(email)
+        self.login('othello')
         result = self.client_patch('/json/messages/' + str(msg_id),
                                    {'message_id': msg_id, 'content': ' '})
         self.assert_json_success(result)

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -221,13 +221,12 @@ class MissedMessageNotificationsTest(ZulipTestCase):
         user_profile.enable_online_push_notifications = False
         user_profile.save()
 
-        email = user_profile.email
         # Fetch the Denmark stream for testing
         stream = get_stream("Denmark", user_profile.realm)
         sub = Subscription.objects.get(user_profile=user_profile, recipient__type=Recipient.STREAM,
                                        recipient__type_id=stream.id)
 
-        self.login(email)
+        self.login_user(user_profile)
 
         def change_subscription_properties(user_profile: UserProfile, stream: Stream, sub: Subscription,
                                            properties: Dict[str, bool]) -> None:

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -290,7 +290,7 @@ class GetEventsTest(ZulipTestCase):
         email = user_profile.email
         recipient_user_profile = self.example_user('othello')
         recipient_email = recipient_user_profile.email
-        self.login(email)
+        self.login_user(user_profile)
 
         result = self.tornado_call(get_events, user_profile,
                                    {"apply_markdown": ujson.dumps(True),
@@ -396,7 +396,7 @@ class GetEventsTest(ZulipTestCase):
 
     def test_get_events_narrow(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
 
         def get_message(apply_markdown: bool, client_gravatar: bool) -> Dict[str, Any]:
             result = self.tornado_call(
@@ -2727,7 +2727,7 @@ class EventsRegisterTest(ZulipTestCase):
             ('upload_space_used', equals(6)),
         ])
 
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         fp = StringIO("zulip!")
         fp.name = "zulip.txt"
         data = {'uri': None}
@@ -2808,7 +2808,7 @@ class EventsRegisterTest(ZulipTestCase):
         ])
 
         do_change_is_admin(self.user_profile, True)
-        self.login(self.user_profile.email)
+        self.login_user(self.user_profile)
 
         with mock.patch('zerver.lib.export.do_export_realm',
                         return_value=create_dummy_file('test-export.tar.gz')):
@@ -3503,7 +3503,7 @@ class FetchQueriesTest(ZulipTestCase):
     def test_queries(self) -> None:
         user = self.example_user("hamlet")
 
-        self.login(user.email)
+        self.login_user(user)
 
         flush_per_request_caches()
         with queries_captured() as queries:

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -225,13 +225,11 @@ class HomeTest(ZulipTestCase):
             "zulip_version",
         ]
 
-        email = self.example_email("hamlet")
-
         # Verify fails if logged-out
         result = self.client_get('/')
         self.assertEqual(result.status_code, 302)
 
-        self.login(email)
+        self.login('hamlet')
 
         # Create bot for realm_bots testing. Must be done before fetching home_page.
         bot_info = {
@@ -285,7 +283,7 @@ class HomeTest(ZulipTestCase):
 
     def test_home_under_2fa_without_otp_device(self) -> None:
         with self.settings(TWO_FACTOR_AUTHENTICATION_ENABLED=True):
-            self.login(self.example_email("iago"))
+            self.login('iago')
             result = self._get_home_page()
             # Should be successful because otp device is not configured.
             self.assertEqual(result.status_code, 200)
@@ -294,7 +292,7 @@ class HomeTest(ZulipTestCase):
         with self.settings(TWO_FACTOR_AUTHENTICATION_ENABLED=True):
             user_profile = self.example_user('iago')
             self.create_default_device(user_profile)
-            self.login(user_profile.email)
+            self.login_user(user_profile)
             result = self._get_home_page()
             # User should not log in because otp device is configured but
             # 2fa login function was not called.
@@ -307,7 +305,7 @@ class HomeTest(ZulipTestCase):
 
     def test_num_queries_for_realm_admin(self) -> None:
         # Verify number of queries for Realm admin isn't much higher than for normal users.
-        self.login(self.example_email("iago"))
+        self.login('iago')
         flush_per_request_caches()
         with queries_captured() as queries:
             with patch('zerver.lib.cache.cache_set') as cache_mock:
@@ -323,7 +321,7 @@ class HomeTest(ZulipTestCase):
 
         realm_id = main_user.realm_id
 
-        self.login(main_user.email)
+        self.login_user(main_user)
 
         # Try to make page-load do extra work for various subscribed
         # streams.
@@ -377,8 +375,7 @@ class HomeTest(ZulipTestCase):
 
     def test_terms_of_service(self) -> None:
         user = self.example_user('hamlet')
-        email = user.email
-        self.login(email)
+        self.login_user(user)
 
         for user_tos_version in [None, '1.1', '2.0.3.4']:
             user.tos_version = user_tos_version
@@ -395,8 +392,7 @@ class HomeTest(ZulipTestCase):
 
     def test_terms_of_service_first_time_template(self) -> None:
         user = self.example_user('hamlet')
-        email = user.email
-        self.login(email)
+        self.login_user(user)
 
         user.tos_version = None
         user.save()
@@ -410,8 +406,7 @@ class HomeTest(ZulipTestCase):
             self.assert_in_response("most productive team chat", result)
 
     def test_accept_terms_of_service(self) -> None:
-        email = self.example_email("hamlet")
-        self.login(email)
+        self.login('hamlet')
 
         result = self.client_post('/accounts/accept_terms/')
         self.assertEqual(result.status_code, 200)
@@ -422,8 +417,7 @@ class HomeTest(ZulipTestCase):
         self.assertEqual(result['Location'], '/')
 
     def test_bad_narrow(self) -> None:
-        email = self.example_email("hamlet")
-        self.login(email)
+        self.login('hamlet')
         with patch('logging.warning') as mock:
             result = self._get_home_page(stream='Invalid Stream')
         mock.assert_called_once()
@@ -432,19 +426,17 @@ class HomeTest(ZulipTestCase):
 
     def test_bad_pointer(self) -> None:
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
         user_profile.pointer = 999999
         user_profile.save()
 
-        self.login(email)
+        self.login_user(user_profile)
         with patch('logging.warning') as mock:
             result = self._get_home_page()
         mock.assert_called_once_with('User %s has invalid pointer 999999' % (user_profile.id,))
         self._sanity_check(result)
 
     def test_topic_narrow(self) -> None:
-        email = self.example_email("hamlet")
-        self.login(email)
+        self.login('hamlet')
         result = self._get_home_page(stream='Denmark', topic='lunch')
         self._sanity_check(result)
         html = result.content.decode('utf-8')
@@ -453,11 +445,10 @@ class HomeTest(ZulipTestCase):
                          {"must-revalidate", "no-store", "no-cache"})
 
     def test_notifications_stream(self) -> None:
-        email = self.example_email("hamlet")
         realm = get_realm('zulip')
         realm.notifications_stream_id = get_stream('Denmark', realm).id
         realm.save()
-        self.login(email)
+        self.login('hamlet')
         result = self._get_home_page()
         page_params = self._get_page_params(result)
         self.assertEqual(page_params['realm_notifications_stream_id'], get_stream('Denmark', realm).id)
@@ -491,11 +482,10 @@ class HomeTest(ZulipTestCase):
         return user
 
     def test_signup_notifications_stream(self) -> None:
-        email = self.example_email("hamlet")
         realm = get_realm('zulip')
         realm.signup_notifications_stream = get_stream('Denmark', realm)
         realm.save()
-        self.login(email)
+        self.login('hamlet')
         result = self._get_home_page()
         page_params = self._get_page_params(result)
         self.assertEqual(page_params['realm_signup_notifications_stream_id'], get_stream('Denmark', realm).id)
@@ -504,7 +494,7 @@ class HomeTest(ZulipTestCase):
     def test_people(self) -> None:
         hamlet = self.example_user('hamlet')
         realm = get_realm('zulip')
-        self.login(hamlet.email)
+        self.login_user(hamlet)
 
         for i in range(3):
             self.create_bot(
@@ -626,7 +616,7 @@ class HomeTest(ZulipTestCase):
         user_profile = self.example_user("hamlet")
         stream_name = 'New stream'
         self.subscribe(user_profile, stream_name)
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         result = self._get_home_page(stream=stream_name)
         page_params = self._get_page_params(result)
         self.assertEqual(page_params['narrow_stream'], stream_name)
@@ -637,13 +627,12 @@ class HomeTest(ZulipTestCase):
 
     def test_invites_by_admins_only(self) -> None:
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
 
         realm = user_profile.realm
         realm.invite_by_admins_only = True
         realm.save()
 
-        self.login(email)
+        self.login_user(user_profile)
         self.assertFalse(user_profile.is_realm_admin)
         result = self._get_home_page()
         html = result.content.decode('utf-8')
@@ -657,13 +646,12 @@ class HomeTest(ZulipTestCase):
 
     def test_show_invites_for_guest_users(self) -> None:
         user_profile = self.example_user('polonius')
-        email = user_profile.email
 
         realm = user_profile.realm
         realm.invite_by_admins_only = False
         realm.save()
 
-        self.login(email)
+        self.login_user(user_profile)
         self.assertFalse(user_profile.is_realm_admin)
         self.assertFalse(get_realm('zulip').invite_by_admins_only)
         result = self._get_home_page()
@@ -675,7 +663,7 @@ class HomeTest(ZulipTestCase):
 
         # realm admin, but no CustomerPlan -> no billing link
         user = self.example_user('iago')
-        self.login(user.email)
+        self.login_user(user)
         result_html = self._get_home_page().content.decode('utf-8')
         self.assertNotIn('Billing', result_html)
 
@@ -705,7 +693,7 @@ class HomeTest(ZulipTestCase):
 
     def test_show_plans(self) -> None:
         realm = get_realm("zulip")
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
 
         # Show plans link to all users if plan_type is LIMITED
         realm.plan_type = Realm.LIMITED
@@ -725,8 +713,7 @@ class HomeTest(ZulipTestCase):
         self.assertNotIn('Plans', result_html)
 
     def test_desktop_home(self) -> None:
-        email = self.example_email("hamlet")
-        self.login(email)
+        self.login('hamlet')
         result = self.client_get("/desktop_home")
         self.assertEqual(result.status_code, 301)
         self.assertTrue(result["Location"].endswith("/desktop_home/"))
@@ -784,8 +771,7 @@ class HomeTest(ZulipTestCase):
                          "/static/images/logo/zulip-org-logo.png?version=0")
 
     def test_generate_204(self) -> None:
-        email = self.example_email("hamlet")
-        self.login(email)
+        self.login('hamlet')
         result = self.client_get("/api/v1/generate_204")
         self.assertEqual(result.status_code, 204)
 
@@ -797,8 +783,7 @@ class HomeTest(ZulipTestCase):
         self.assertEqual(sent_time_in_epoch_seconds(user_message), epoch_seconds)
 
     def test_subdomain_homepage(self) -> None:
-        email = self.example_email("hamlet")
-        self.login(email)
+        self.login('hamlet')
         with self.settings(ROOT_DOMAIN_LANDING_PAGE=True):
             with patch('zerver.views.home.get_subdomain', return_value=""):
                 result = self._get_home_page()
@@ -824,7 +809,7 @@ class HomeTest(ZulipTestCase):
         # In this test we make sure if a soft deactivated user had unread
         # messages before deactivation they remain same way after activation.
         long_term_idle_user = self.example_user('hamlet')
-        self.login(long_term_idle_user.email)
+        self.login_user(long_term_idle_user)
         message = 'Test Message 1'
         self.send_test_message(message)
         with queries_captured() as queries:
@@ -836,7 +821,7 @@ class HomeTest(ZulipTestCase):
 
         do_soft_deactivate_users([long_term_idle_user])
 
-        self.login(long_term_idle_user.email)
+        self.login_user(long_term_idle_user)
         message = 'Test Message 2'
         self.send_test_message(message)
         idle_user_msg_list = get_user_messages(long_term_idle_user)
@@ -859,7 +844,7 @@ class HomeTest(ZulipTestCase):
 
         message = 'Test Message 1'
         self.send_test_message(message)
-        self.login(long_term_idle_user.email)
+        self.login_user(long_term_idle_user)
         with queries_captured() as queries:
             self.assertEqual(self.soft_activate_and_get_unread_count(), 2)
         query_count = len(queries)
@@ -883,7 +868,7 @@ class HomeTest(ZulipTestCase):
 
         message = 'Test Message 3'
         self.send_test_message(message)
-        self.login(long_term_idle_user.email)
+        self.login_user(long_term_idle_user)
         with queries_captured() as queries:
             self.assertEqual(self.soft_activate_and_get_unread_count(), 4)
         query_count = len(queries)
@@ -905,7 +890,7 @@ class HomeTest(ZulipTestCase):
         user = self.example_user("hamlet")
         user.default_language = 'es'
         user.save()
-        self.login(user.email)
+        self.login_user(user)
         result = self._get_home_page()
         self.assertEqual(result.status_code, 200)
         with \
@@ -921,7 +906,7 @@ class HomeTest(ZulipTestCase):
         user = self.example_user("hamlet")
         user.default_language = 'es'
         user.save()
-        self.login(user.email)
+        self.login_user(user)
         result = self._get_home_page()
         self.assertEqual(result.status_code, 200)
 

--- a/zerver/tests/test_hotspots.py
+++ b/zerver/tests/test_hotspots.py
@@ -47,7 +47,7 @@ class TestHotspots(ZulipTestCase):
 
     def test_hotspots_url_endpoint(self) -> None:
         user = self.example_user('hamlet')
-        self.login(user.email)
+        self.login_user(user)
         result = self.client_post('/json/users/me/hotspots',
                                   {'hotspot': ujson.dumps('intro_reply')})
         self.assert_json_success(result)

--- a/zerver/tests/test_i18n.py
+++ b/zerver/tests/test_i18n.py
@@ -39,7 +39,7 @@ class EmailTranslationTestCase(ZulipTestCase):
         realm.default_language = "de"
         realm.save()
         stream = get_realm_stream("Denmark", realm.id)
-        self.login(hamlet.email)
+        self.login_user(hamlet)
 
         # TODO: Uncomment and replace with translation once we have German translations for the strings
         # in confirm_new_email.txt.
@@ -121,8 +121,7 @@ class JsonTranslationTestCase(ZulipTestCase):
         dummy_value = "this arg is bad: '{var_name}' (translated to German)"
         mock_gettext.return_value = dummy_value
 
-        email = self.example_email('hamlet')
-        self.login(email)
+        self.login('hamlet')
         result = self.client_post("/json/invites",
                                   HTTP_ACCEPT_LANGUAGE='de')
 
@@ -136,8 +135,7 @@ class JsonTranslationTestCase(ZulipTestCase):
         dummy_value = "Some other language"
         mock_gettext.return_value = dummy_value
 
-        email = self.example_email('hamlet')
-        self.login(email)
+        self.login('hamlet')
         result = self.client_get("/de/accounts/login/jwt/")
 
         self.assert_json_error_contains(result,

--- a/zerver/tests/test_legacy_subject.py
+++ b/zerver/tests/test_legacy_subject.py
@@ -4,7 +4,7 @@ from zerver.lib.test_classes import (
 
 class LegacySubjectTest(ZulipTestCase):
     def test_legacy_subject(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
 
         payload = dict(
             type='stream',

--- a/zerver/tests/test_link_embed.py
+++ b/zerver/tests/test_link_embed.py
@@ -270,7 +270,7 @@ class PreviewTestCase(ZulipTestCase):
     @override_settings(INLINE_URL_EMBED_PREVIEW=True)
     def test_edit_message_history(self) -> None:
         user = self.example_user('hamlet')
-        self.login(user.email)
+        self.login_user(user)
         msg_id = self.send_stream_message(user, "Scotland",
                                           topic_name="editing", content="original")
 
@@ -335,7 +335,7 @@ class PreviewTestCase(ZulipTestCase):
     @override_settings(INLINE_URL_EMBED_PREVIEW=True)
     def test_message_update_race_condition(self) -> None:
         user = self.example_user('hamlet')
-        self.login(user.email)
+        self.login_user(user)
         original_url = 'http://test.org/'
         edited_url = 'http://edited.org/'
         with mock.patch('zerver.lib.actions.queue_json_publish') as patched:
@@ -467,7 +467,7 @@ class PreviewTestCase(ZulipTestCase):
     @override_settings(INLINE_URL_EMBED_PREVIEW=True)
     def test_link_preview_non_html_data(self) -> None:
         user = self.example_user('hamlet')
-        self.login(user.email)
+        self.login_user(user)
         url = 'http://test.org/audio.mp3'
         with mock.patch('zerver.lib.actions.queue_json_publish') as patched:
             msg_id = self.send_stream_message(user, "Scotland", topic_name="foo", content=url)
@@ -495,7 +495,7 @@ class PreviewTestCase(ZulipTestCase):
     @override_settings(INLINE_URL_EMBED_PREVIEW=True)
     def test_link_preview_no_open_graph_image(self) -> None:
         user = self.example_user('hamlet')
-        self.login(user.email)
+        self.login_user(user)
         url = 'http://test.org/foo.html'
         with mock.patch('zerver.lib.actions.queue_json_publish') as patched:
             msg_id = self.send_stream_message(user, "Scotland", topic_name="foo", content=url)
@@ -523,7 +523,7 @@ class PreviewTestCase(ZulipTestCase):
     @override_settings(INLINE_URL_EMBED_PREVIEW=True)
     def test_link_preview_open_graph_image_missing_content(self) -> None:
         user = self.example_user('hamlet')
-        self.login(user.email)
+        self.login_user(user)
         url = 'http://test.org/foo.html'
         with mock.patch('zerver.lib.actions.queue_json_publish') as patched:
             msg_id = self.send_stream_message(user, "Scotland", topic_name="foo", content=url)
@@ -552,7 +552,7 @@ class PreviewTestCase(ZulipTestCase):
     @override_settings(INLINE_URL_EMBED_PREVIEW=True)
     def test_link_preview_no_content_type_header(self) -> None:
         user = self.example_user('hamlet')
-        self.login(user.email)
+        self.login_user(user)
         url = 'http://test.org/'
         with mock.patch('zerver.lib.actions.queue_json_publish') as patched:
             msg_id = self.send_stream_message(user, "Scotland", topic_name="foo", content=url)

--- a/zerver/tests/test_logging_handlers.py
+++ b/zerver/tests/test_logging_handlers.py
@@ -74,8 +74,7 @@ class AdminNotifyHandlerTest(ZulipTestCase):
         handler.emit(record)
 
     def simulate_error(self) -> logging.LogRecord:
-        email = self.example_email('hamlet')
-        self.login(email)
+        self.login('hamlet')
         with patch("zerver.decorator.rate_limit") as rate_limit_patch:
             rate_limit_patch.side_effect = capture_and_throw
             result = self.client_get("/json/users")

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -340,7 +340,7 @@ class TestSendToEmailMirror(ZulipTestCase):
     def test_sending_a_fixture(self) -> None:
         fixture_path = "zerver/tests/fixtures/email/1.txt"
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
 
         call_command(self.COMMAND_NAME, "--fixture={}".format(fixture_path))
@@ -352,7 +352,7 @@ class TestSendToEmailMirror(ZulipTestCase):
     def test_sending_a_json_fixture(self) -> None:
         fixture_path = "zerver/tests/fixtures/email/1.json"
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark")
 
         call_command(self.COMMAND_NAME, "--fixture={}".format(fixture_path))
@@ -364,7 +364,7 @@ class TestSendToEmailMirror(ZulipTestCase):
     def test_stream_option(self) -> None:
         fixture_path = "zerver/tests/fixtures/email/1.txt"
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, "Denmark2")
 
         call_command(self.COMMAND_NAME, "--fixture={}".format(fixture_path), "--stream=Denmark2")

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -42,7 +42,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         hamlet = self.example_user('hamlet')
         cordelia = self.example_user('cordelia')
 
-        self.login(hamlet.email)
+        self.login_user(hamlet)
 
         message_id = self.send_personal_message(
             hamlet,
@@ -70,7 +70,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
         cordelia.enable_online_push_notifications = enable_online_push_notifications
         cordelia.save()
 
-        self.login(hamlet.email)
+        self.login_user(hamlet)
         self.subscribe(hamlet, 'Scotland')
         self.subscribe(cordelia, 'Scotland')
 

--- a/zerver/tests/test_muting.py
+++ b/zerver/tests/test_muting.py
@@ -58,7 +58,7 @@ class MutedTopicsTests(ZulipTestCase):
 
     def test_add_muted_topic(self) -> None:
         user = self.example_user('hamlet')
-        self.login(user.email)
+        self.login_user(user)
 
         stream = get_stream('Verona', user.realm)
 
@@ -86,9 +86,8 @@ class MutedTopicsTests(ZulipTestCase):
 
     def test_remove_muted_topic(self) -> None:
         user = self.example_user('hamlet')
-        email = user.email
         realm = user.realm
-        self.login(email)
+        self.login_user(user)
 
         stream = get_stream(u'Verona', realm)
         recipient = stream.recipient
@@ -117,9 +116,8 @@ class MutedTopicsTests(ZulipTestCase):
 
     def test_muted_topic_add_invalid(self) -> None:
         user = self.example_user('hamlet')
-        email = user.email
         realm = user.realm
-        self.login(email)
+        self.login_user(user)
 
         stream = get_stream('Verona', realm)
         recipient = stream.recipient
@@ -151,9 +149,8 @@ class MutedTopicsTests(ZulipTestCase):
 
     def test_muted_topic_remove_invalid(self) -> None:
         user = self.example_user('hamlet')
-        email = user.email
         realm = user.realm
-        self.login(email)
+        self.login_user(user)
         stream = get_stream('Verona', realm)
 
         url = '/api/v1/users/me/subscriptions/muted_topics'

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -1093,7 +1093,7 @@ class GetOldMessagesTest(ZulipTestCase):
         """
         Test old `/json/messages` returns reactions.
         """
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
 
         def get_content_type(apply_markdown: bool) -> str:
             req = dict(
@@ -1117,11 +1117,11 @@ class GetOldMessagesTest(ZulipTestCase):
         """
         Test old `/json/messages` returns reactions.
         """
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         messages = self.get_and_check_messages(dict())
         message_id = messages['messages'][0]['id']
 
-        self.login(self.example_email("othello"))
+        self.login('othello')
         reaction_name = 'thumbs_up'
         reaction_info = {
             'emoji_name': reaction_name
@@ -1131,7 +1131,7 @@ class GetOldMessagesTest(ZulipTestCase):
         payload = self.client_post(url, reaction_info)
         self.assert_json_success(payload)
 
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         messages = self.get_and_check_messages({})
         message_to_assert = None
         for message in messages['messages']:
@@ -1148,7 +1148,7 @@ class GetOldMessagesTest(ZulipTestCase):
         A call to GET /json/messages with valid parameters returns a list of
         messages.
         """
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         self.get_and_check_messages(dict())
 
         # We have to support the legacy tuple style while there are old
@@ -1162,7 +1162,7 @@ class GetOldMessagesTest(ZulipTestCase):
         The client_gravatar flag determines whether we send avatar_url.
         """
         hamlet = self.example_user('hamlet')
-        self.login(hamlet.email)
+        self.login_user(hamlet)
 
         self.send_personal_message(hamlet, self.example_user("iago"))
 
@@ -1219,7 +1219,7 @@ class GetOldMessagesTest(ZulipTestCase):
                      if not m.is_stream_message()]
         for personal in personals:
             emails = dr_emails(get_display_recipient(personal.recipient))
-            self.login(me.email)
+            self.login_user(me)
             narrow = [dict(operator='pm-with', operand=emails)]  # type: List[Dict[str, Any]]
             result = self.get_and_check_messages(dict(narrow=ujson.dumps(narrow)))
 
@@ -1236,7 +1236,7 @@ class GetOldMessagesTest(ZulipTestCase):
 
     def test_get_visible_messages_with_narrow_pm_with(self) -> None:
         me = self.example_user('hamlet')
-        self.login(me.email)
+        self.login_user(me)
         self.subscribe(self.example_user("hamlet"), 'Scotland')
 
         message_ids = []
@@ -1302,7 +1302,7 @@ class GetOldMessagesTest(ZulipTestCase):
             ),
         )
 
-        self.login(me.email)
+        self.login_user(me)
         test_operands = [self.example_email("cordelia"), self.example_user("cordelia").id]
         for operand in test_operands:
             narrow = [dict(operator='group-pm-with', operand=operand)]
@@ -1313,7 +1313,7 @@ class GetOldMessagesTest(ZulipTestCase):
 
     def test_get_visible_messages_with_narrow_group_pm_with(self) -> None:
         me = self.example_user('hamlet')
-        self.login(me.email)
+        self.login_user(me)
 
         message_ids = []
         message_ids.append(
@@ -1362,7 +1362,7 @@ class GetOldMessagesTest(ZulipTestCase):
         content = 'hello @**King Hamlet**'
         new_message_id = self.send_stream_message(cordelia, stream_name, content=content)
 
-        self.login(hamlet.email)
+        self.login_user(hamlet)
         narrow = [
             dict(operator='stream', operand=stream_name)
         ]
@@ -1394,7 +1394,7 @@ class GetOldMessagesTest(ZulipTestCase):
         A request for old messages with a narrow by stream only returns
         messages for that stream.
         """
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         # We need to subscribe to a stream and then send a message to
         # it to ensure that we actually have a stream message in this
         # narrow view.
@@ -1416,7 +1416,7 @@ class GetOldMessagesTest(ZulipTestCase):
                 self.assertEqual(message["recipient_id"], stream_recipient_id)
 
     def test_get_visible_messages_with_narrow_stream(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.subscribe(self.example_user("hamlet"), 'Scotland')
 
         message_ids = []
@@ -1431,19 +1431,20 @@ class GetOldMessagesTest(ZulipTestCase):
         A request for old messages for a user in the mit.edu relam with unicode
         stream name should be correctly escaped in the database query.
         """
-        self.login(self.mit_email("starnine"), realm=get_realm("zephyr"))
+        user = self.mit_user('starnine')
+        self.login_user(user)
         # We need to susbcribe to a stream and then send a message to
         # it to ensure that we actually have a stream message in this
         # narrow view.
         lambda_stream_name = u"\u03bb-stream"
-        stream = self.subscribe(self.mit_user("starnine"), lambda_stream_name)
+        stream = self.subscribe(user, lambda_stream_name)
         self.assertTrue(stream.is_in_zephyr_realm)
 
         lambda_stream_d_name = u"\u03bb-stream.d"
-        self.subscribe(self.mit_user("starnine"), lambda_stream_d_name)
+        self.subscribe(user, lambda_stream_d_name)
 
-        self.send_stream_message(self.mit_user("starnine"), u"\u03bb-stream")
-        self.send_stream_message(self.mit_user("starnine"), u"\u03bb-stream.d")
+        self.send_stream_message(user, u"\u03bb-stream")
+        self.send_stream_message(user, u"\u03bb-stream.d")
 
         narrow = [dict(operator='stream', operand=u'\u03bb-stream')]
         result = self.get_and_check_messages(dict(num_after=2,
@@ -1465,8 +1466,7 @@ class GetOldMessagesTest(ZulipTestCase):
         topic name should be correctly escaped in the database query.
         """
         mit_user_profile = self.mit_user("starnine")
-        email = mit_user_profile.email
-        self.login(email, realm=get_realm("zephyr"))
+        self.login_user(mit_user_profile)
         # We need to susbcribe to a stream and then send a message to
         # it to ensure that we actually have a stream message in this
         # narrow view.
@@ -1495,12 +1495,11 @@ class GetOldMessagesTest(ZulipTestCase):
         We handle .d grouping for MIT realm personal messages correctly.
         """
         mit_user_profile = self.mit_user("starnine")
-        email = mit_user_profile.email
 
         # We need to susbcribe to a stream and then send a message to
         # it to ensure that we actually have a stream message in this
         # narrow view.
-        self.login(email, realm=mit_user_profile.realm)
+        self.login_user(mit_user_profile)
         self.subscribe(mit_user_profile, "Scotland")
 
         self.send_stream_message(mit_user_profile, "Scotland", topic_name=u".d.d")
@@ -1531,7 +1530,7 @@ class GetOldMessagesTest(ZulipTestCase):
         A request for old messages with a narrow by sender only returns
         messages sent by that person.
         """
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         # We need to send a message here to ensure that we actually
         # have a stream message in this narrow view.
         self.send_stream_message(self.example_user("hamlet"), "Scotland")
@@ -1562,7 +1561,7 @@ class GetOldMessagesTest(ZulipTestCase):
     @override_settings(USING_PGROONGA=False)
     def test_messages_in_narrow(self) -> None:
         user = self.example_user("cordelia")
-        self.login(user.email)
+        self.login_user(user)
 
         def send(content: str) -> int:
             msg_id = self.send_stream_message(
@@ -1595,7 +1594,7 @@ class GetOldMessagesTest(ZulipTestCase):
 
     @override_settings(USING_PGROONGA=False)
     def test_get_messages_with_search(self) -> None:
-        self.login(self.example_email("cordelia"))
+        self.login('cordelia')
 
         messages_to_search = [
             ('breakfast', 'there are muffins in the conference room'),
@@ -1724,7 +1723,7 @@ class GetOldMessagesTest(ZulipTestCase):
 
     @override_settings(USING_PGROONGA=False)
     def test_get_visible_messages_with_search(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.subscribe(self.example_user("hamlet"), 'Scotland')
 
         messages_to_search = [
@@ -1754,7 +1753,7 @@ class GetOldMessagesTest(ZulipTestCase):
         )
         self._update_tsvector_index()
 
-        self.login(self.example_email("cordelia"))
+        self.login('cordelia')
 
         stream_search_narrow = [
             dict(operator='search', operand='special'),
@@ -1772,7 +1771,7 @@ class GetOldMessagesTest(ZulipTestCase):
 
     @override_settings(USING_PGROONGA=True)
     def test_get_messages_with_search_pgroonga(self) -> None:
-        self.login(self.example_email("cordelia"))
+        self.login('cordelia')
 
         next_message_id = self.get_last_message().id + 1
 
@@ -1910,7 +1909,7 @@ class GetOldMessagesTest(ZulipTestCase):
 
     def test_messages_in_narrow_for_non_search(self) -> None:
         user = self.example_user("cordelia")
-        self.login(user.email)
+        self.login_user(user)
 
         def send(content: str) -> int:
             msg_id = self.send_stream_message(
@@ -1946,7 +1945,7 @@ class GetOldMessagesTest(ZulipTestCase):
         Test that specifying an anchor but 0 for num_before and num_after
         returns at most 1 message.
         """
-        self.login(self.example_email("cordelia"))
+        self.login('cordelia')
         anchor = self.send_stream_message(self.example_user("cordelia"), "Verona")
 
         narrow = [dict(operator='sender', operand=self.example_email("cordelia"))]
@@ -1967,7 +1966,7 @@ class GetOldMessagesTest(ZulipTestCase):
             for message in messages:
                 assert(message["id"] in message_ids)
 
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
 
         Message.objects.all().delete()
 
@@ -2211,7 +2210,7 @@ class GetOldMessagesTest(ZulipTestCase):
         anchor, num_before, and num_after are all required
         POST parameters for get_messages.
         """
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
 
         required_args = (("num_before", 1), ("num_after", 1))  # type: Tuple[Tuple[str, int], ...]
 
@@ -2226,7 +2225,7 @@ class GetOldMessagesTest(ZulipTestCase):
         A call to GET /json/messages requesting more than
         MAX_MESSAGES_PER_FETCH messages returns an error message.
         """
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         result = self.client_get("/json/messages", dict(anchor=1, num_before=3000, num_after=3000))
         self.assert_json_error(result, "Too many messages requested (maximum 5000).")
         result = self.client_get("/json/messages", dict(anchor=1, num_before=6000, num_after=0))
@@ -2239,7 +2238,7 @@ class GetOldMessagesTest(ZulipTestCase):
         num_before, num_after, and narrow must all be non-negative
         integers or strings that can be converted to non-negative integers.
         """
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
 
         other_params = [("narrow", {}), ("anchor", 0)]
         int_params = ["num_before", "num_after"]
@@ -2261,7 +2260,7 @@ class GetOldMessagesTest(ZulipTestCase):
         """
         narrow must be a list of string pairs.
         """
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
 
         other_params = [("anchor", 0), ("num_before", 0), ("num_after", 0)]  # type: List[Tuple[str, Union[int, str, bool]]]
 
@@ -2277,7 +2276,7 @@ class GetOldMessagesTest(ZulipTestCase):
         """
         Unrecognized narrow operators are rejected.
         """
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         for operator in ['', 'foo', 'stream:verona', '__init__']:
             narrow = [dict(operator=operator, operand='')]
             params = dict(anchor=0, num_before=0, num_after=0, narrow=ujson.dumps(narrow))
@@ -2286,7 +2285,7 @@ class GetOldMessagesTest(ZulipTestCase):
                                             "Invalid narrow operator: unknown operator")
 
     def test_invalid_narrow_operand_in_dict(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
 
         # str or int is required for sender, group-pm-with, stream
         invalid_operands = [['1'], [2], None]
@@ -2336,7 +2335,7 @@ class GetOldMessagesTest(ZulipTestCase):
         If an invalid stream name is requested in get_messages, an error is
         returned.
         """
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         bad_stream_content = (0, [], ["x", "y"])  # type: Tuple[int, List[None], List[str]]
         self.exercise_bad_narrow_operand("stream", bad_stream_content,
                                          "Bad value for 'narrow'")
@@ -2346,13 +2345,13 @@ class GetOldMessagesTest(ZulipTestCase):
         If an invalid 'pm-with' is requested in get_messages, an
         error is returned.
         """
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         bad_stream_content = (0, [], ["x", "y"])  # type: Tuple[int, List[None], List[str]]
         self.exercise_bad_narrow_operand("pm-with", bad_stream_content,
                                          "Bad value for 'narrow'")
 
     def test_bad_narrow_nonexistent_stream(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         self.exercise_bad_narrow_operand("stream", ['non-existent stream'],
                                          "Invalid narrow operator: unknown stream")
 
@@ -2361,12 +2360,12 @@ class GetOldMessagesTest(ZulipTestCase):
                                                         'Invalid narrow operator: unknown stream')
 
     def test_bad_narrow_nonexistent_email(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         self.exercise_bad_narrow_operand("pm-with", ['non-existent-user@zulip.com'],
                                          "Invalid narrow operator: unknown user")
 
     def test_bad_narrow_pm_with_id_list(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login('hamlet')
         self.exercise_bad_narrow_operand('pm-with', [-24],
                                          "Bad value for 'narrow': [[\"pm-with\",-24]]")
 
@@ -2867,7 +2866,7 @@ WHERE user_profile_id = {hamlet_id} AND (content ILIKE '%jumping%' OR subject IL
 
     @override_settings(USING_PGROONGA=False)
     def test_get_messages_with_search_using_email(self) -> None:
-        self.login(self.example_email("cordelia"))
+        self.login('cordelia')
 
         messages_to_search = [
             ('say hello', 'How are you doing, @**Othello, the Moor of Venice**?'),

--- a/zerver/tests/test_new_users.py
+++ b/zerver/tests/test_new_users.py
@@ -63,8 +63,8 @@ class SendLoginEmailTest(ZulipTestCase):
 
     def test_dont_send_login_emails_if_send_login_emails_is_false(self) -> None:
         self.assertFalse(settings.SEND_LOGIN_EMAILS)
-        email = self.example_email('hamlet')
-        self.login(email)
+        user = self.example_user('hamlet')
+        self.login_user(user)
 
         self.assertEqual(len(mail.outbox), 0)
 
@@ -98,13 +98,13 @@ class SendLoginEmailTest(ZulipTestCase):
         do_change_notification_settings(user, "enable_login_emails", False)
         self.assertFalse(user.enable_login_emails)
         with mock.patch('zerver.signals.timezone_now', return_value=mock_time):
-            self.login(user.email)
+            self.login_user(user)
         self.assertEqual(len(mail.outbox), 0)
 
         do_change_notification_settings(user, "enable_login_emails", True)
         self.assertTrue(user.enable_login_emails)
         with mock.patch('zerver.signals.timezone_now', return_value=mock_time):
-            self.login(user.email)
+            self.login_user(user)
         self.assertEqual(len(mail.outbox), 1)
 
 

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -282,8 +282,7 @@ class PushBouncerNotificationTest(BouncerTestCase):
         """
         mock_request.side_effect = self.bounce_request
         user = self.example_user('cordelia')
-        email = user.email
-        self.login(email)
+        self.login_user(user)
         server = RemoteZulipServer.objects.get(uuid=self.server_uuid)
 
         endpoints = [
@@ -1552,8 +1551,7 @@ class TestNumPushDevicesForUser(PushNotificationTest):
 class TestPushApi(ZulipTestCase):
     def test_push_api(self) -> None:
         user = self.example_user('cordelia')
-        email = user.email
-        self.login(email)
+        self.login_user(user)
 
         endpoints = [
             ('/json/users/me/apns_device_token', 'apple-tokenaz'),

--- a/zerver/tests/test_realm_domains.py
+++ b/zerver/tests/test_realm_domains.py
@@ -21,7 +21,7 @@ class RealmDomainTest(ZulipTestCase):
         do_set_realm_property(realm, 'emails_restricted_to_domains', True)
 
     def test_list_realm_domains(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         realm = get_realm('zulip')
         RealmDomain.objects.create(realm=realm, domain='acme.com', allow_subdomains=True)
         result = self.client_get("/json/realm/domains")
@@ -33,7 +33,7 @@ class RealmDomainTest(ZulipTestCase):
         self.assertEqual(received, expected)
 
     def test_not_realm_admin(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         result = self.client_post("/json/realm/domains")
         self.assert_json_error(result, 'Must be an organization administrator')
         result = self.client_patch("/json/realm/domains/15")
@@ -42,7 +42,7 @@ class RealmDomainTest(ZulipTestCase):
         self.assert_json_error(result, 'Must be an organization administrator')
 
     def test_create_realm_domain(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         data = {'domain': ujson.dumps(''),
                 'allow_subdomains': ujson.dumps(True)}
         result = self.client_post("/json/realm/domains", info=data)
@@ -59,7 +59,7 @@ class RealmDomainTest(ZulipTestCase):
         self.assert_json_error(result, 'The domain acme.com is already a part of your organization.')
 
         mit_user_profile = self.mit_user("sipbtest")
-        self.login(mit_user_profile.email, realm=get_realm("zephyr"))
+        self.login_user(mit_user_profile)
 
         do_change_is_admin(mit_user_profile, True)
 
@@ -68,7 +68,7 @@ class RealmDomainTest(ZulipTestCase):
         self.assert_json_success(result)
 
     def test_patch_realm_domain(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         realm = get_realm('zulip')
         RealmDomain.objects.create(realm=realm, domain='acme.com',
                                    allow_subdomains=False)
@@ -87,7 +87,7 @@ class RealmDomainTest(ZulipTestCase):
         self.assert_json_error(result, 'No entry found for domain non-existent.com.')
 
     def test_delete_realm_domain(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         realm = get_realm('zulip')
         RealmDomain.objects.create(realm=realm, domain='acme.com')
         result = self.client_delete("/json/realm/domains/non-existent.com")
@@ -100,7 +100,7 @@ class RealmDomainTest(ZulipTestCase):
         self.assertTrue(realm.emails_restricted_to_domains)
 
     def test_delete_all_realm_domains(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         realm = get_realm('zulip')
         query = RealmDomain.objects.filter(realm=realm)
 

--- a/zerver/tests/test_realm_export.py
+++ b/zerver/tests/test_realm_export.py
@@ -28,14 +28,14 @@ class RealmExportTest(ZulipTestCase):
 
     def test_export_as_not_admin(self) -> None:
         user = self.example_user('hamlet')
-        self.login(user.email)
+        self.login_user(user)
         with self.assertRaises(JsonableError):
             export_realm(self.client_post, user)
 
     @use_s3_backend
     def test_endpoint_s3(self) -> None:
         admin = self.example_user('iago')
-        self.login(admin.email)
+        self.login_user(admin)
         bucket = create_s3_buckets(settings.S3_AVATAR_BUCKET)[0]
         tarball_path = create_dummy_file('test-export.tar.gz')
 
@@ -94,7 +94,7 @@ class RealmExportTest(ZulipTestCase):
 
     def test_endpoint_local_uploads(self) -> None:
         admin = self.example_user('iago')
-        self.login(admin.email)
+        self.login_user(admin)
         tarball_path = create_dummy_file('test-export.tar.gz')
 
         # Test the export logic.
@@ -153,7 +153,7 @@ class RealmExportTest(ZulipTestCase):
 
     def test_realm_export_rate_limited(self) -> None:
         admin = self.example_user('iago')
-        self.login(admin.email)
+        self.login_user(admin)
 
         current_log = RealmAuditLog.objects.filter(
             event_type=RealmAuditLog.REALM_EXPORTED)
@@ -171,7 +171,7 @@ class RealmExportTest(ZulipTestCase):
 
     def test_upload_and_message_limit(self) -> None:
         admin = self.example_user('iago')
-        self.login(admin.email)
+        self.login_user(admin)
         realm_count = RealmCount.objects.create(realm_id=admin.realm.id,
                                                 end_time=timezone_now(),
                                                 subgroup=1,

--- a/zerver/tests/test_realm_filters.py
+++ b/zerver/tests/test_realm_filters.py
@@ -9,8 +9,7 @@ from zerver.models import RealmFilter, get_realm
 class RealmFilterTest(ZulipTestCase):
 
     def test_list(self) -> None:
-        email = self.example_email('iago')
-        self.login(email)
+        self.login('iago')
         realm = get_realm('zulip')
         do_add_realm_filter(
             realm,
@@ -22,8 +21,7 @@ class RealmFilterTest(ZulipTestCase):
         self.assertEqual(len(result.json()["filters"]), 1)
 
     def test_create(self) -> None:
-        email = self.example_email('iago')
-        self.login(email)
+        self.login('iago')
         data = {"pattern": "", "url_format_string": "https://realm.com/my_realm_filter/%(id)s"}
         result = self.client_post("/json/realm/filters", info=data)
         self.assert_json_error(result, 'This field cannot be blank.')
@@ -97,16 +95,14 @@ class RealmFilterTest(ZulipTestCase):
         self.assertIsNotNone(re.match(data['pattern'], 'zulip/zulip#123'))
 
     def test_not_realm_admin(self) -> None:
-        email = self.example_email('hamlet')
-        self.login(email)
+        self.login('hamlet')
         result = self.client_post("/json/realm/filters")
         self.assert_json_error(result, 'Must be an organization administrator')
         result = self.client_delete("/json/realm/filters/15")
         self.assert_json_error(result, 'Must be an organization administrator')
 
     def test_delete(self) -> None:
-        email = self.example_email('iago')
-        self.login(email)
+        self.login('iago')
         realm = get_realm('zulip')
         filter_id = do_add_realm_filter(
             realm,

--- a/zerver/tests/test_report.py
+++ b/zerver/tests/test_report.py
@@ -32,8 +32,7 @@ class StatsMock:
 
 class TestReport(ZulipTestCase):
     def test_send_time(self) -> None:
-        email = self.example_email('hamlet')
-        self.login(email)
+        self.login('hamlet')
 
         params = dict(
             time=5,
@@ -58,8 +57,7 @@ class TestReport(ZulipTestCase):
         self.assertEqual(stats_mock.func_calls, expected_calls)
 
     def test_narrow_time(self) -> None:
-        email = self.example_email('hamlet')
-        self.login(email)
+        self.login('hamlet')
 
         params = dict(
             initial_core=5,
@@ -80,8 +78,7 @@ class TestReport(ZulipTestCase):
         self.assertEqual(stats_mock.func_calls, expected_calls)
 
     def test_unnarrow_time(self) -> None:
-        email = self.example_email('hamlet')
-        self.login(email)
+        self.login('hamlet')
 
         params = dict(
             initial_core=5,
@@ -101,8 +98,8 @@ class TestReport(ZulipTestCase):
 
     @override_settings(BROWSER_ERROR_REPORTING=True)
     def test_report_error(self) -> None:
-        email = self.example_email('hamlet')
-        self.login(email)
+        user = self.example_user('hamlet')
+        self.login_user(user)
 
         params = fix_params(dict(
             message='hello',
@@ -128,7 +125,7 @@ class TestReport(ZulipTestCase):
             self.assertEqual(report[k], params[k])
 
         self.assertEqual(report['more_info'], dict(foo='bar', draft_content="'**xxxxx**'"))
-        self.assertEqual(report['user_email'], email)
+        self.assertEqual(report['user_email'], user.email)
 
         # Teset with no more_info
         del params['more_info']

--- a/zerver/tests/test_service_bot_system.py
+++ b/zerver/tests/test_service_bot_system.py
@@ -256,7 +256,7 @@ class TestServiceBotStateHandler(ZulipTestCase):
 
     def test_internal_endpoint(self):
         # type: () -> None
-        self.login(self.user_profile.email)
+        self.login_user(self.user_profile)
 
         # Store some data.
         initial_dict = {'key 1': 'value 1', 'key 2': 'value 2', 'key 3': 'value 3'}

--- a/zerver/tests/test_submessage.py
+++ b/zerver/tests/test_submessage.py
@@ -83,7 +83,7 @@ class TestBasics(ZulipTestCase):
             sender=cordelia,
             stream_name=stream_name,
         )
-        self.login(cordelia.email)
+        self.login_user(cordelia)
 
         payload = dict(
             message_id=message_id,
@@ -114,7 +114,7 @@ class TestBasics(ZulipTestCase):
             sender=cordelia,
             stream_name=stream_name,
         )
-        self.login(cordelia.email)
+        self.login_user(cordelia)
 
         payload = dict(
             message_id=message_id,

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -176,7 +176,7 @@ class TestCreateStreams(ZulipTestCase):
     def test_create_api_multiline_description(self) -> None:
         user = self.example_user("hamlet")
         realm = user.realm
-        self.login(user.email)
+        self.login_user(user)
         post_data = {'subscriptions': ujson.dumps([{"name": 'new_stream',
                                                     "description": "multi\nline\ndescription"}]),
                      'invite_only': ujson.dumps(False)}
@@ -253,7 +253,7 @@ class TestCreateStreams(ZulipTestCase):
         self.subscribe(hamlet, announce_stream.name)
 
         notification_bot = UserProfile.objects.get(full_name="Notification Bot")
-        self.login(iago.email)
+        self.login_user(iago)
 
         initial_message_count = Message.objects.count()
         initial_usermessage_count = UserMessage.objects.count()
@@ -328,8 +328,7 @@ class RecipientTest(ZulipTestCase):
 class StreamAdminTest(ZulipTestCase):
     def test_make_stream_public(self) -> None:
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
-        self.login(email)
+        self.login_user(user_profile)
         self.make_stream('private_stream', invite_only=True)
 
         do_change_is_admin(user_profile, True)
@@ -359,8 +358,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_make_stream_private(self) -> None:
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
-        self.login(email)
+        self.login_user(user_profile)
         realm = user_profile.realm
         self.make_stream('public_stream', realm=realm)
 
@@ -378,8 +376,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_make_stream_public_zephyr_mirror(self) -> None:
         user_profile = self.mit_user('starnine')
-        email = user_profile.email
-        self.login(email, realm=get_realm("zephyr"))
+        self.login_user(user_profile)
         realm = user_profile.realm
         self.make_stream('target_stream', realm=realm, invite_only=True)
         self.subscribe(user_profile, 'target_stream')
@@ -399,8 +396,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_make_stream_private_with_public_history(self) -> None:
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
-        self.login(email)
+        self.login_user(user_profile)
         realm = user_profile.realm
         self.make_stream('public_history_stream', realm=realm)
 
@@ -419,8 +415,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_try_make_stream_public_with_private_history(self) -> None:
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
-        self.login(email)
+        self.login_user(user_profile)
         realm = user_profile.realm
         self.make_stream('public_stream', realm=realm)
 
@@ -439,8 +434,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_deactivate_stream_backend(self) -> None:
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
-        self.login(email)
+        self.login_user(user_profile)
         stream = self.make_stream('new_stream')
         self.subscribe(user_profile, stream.name)
         do_change_is_admin(user_profile, True)
@@ -472,8 +466,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_deactivate_stream_backend_requires_existing_stream(self) -> None:
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
-        self.login(email)
+        self.login_user(user_profile)
         self.make_stream('new_stream')
         do_change_is_admin(user_profile, True)
 
@@ -482,7 +475,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_deactivate_stream_backend_requires_realm_admin(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.subscribe(user_profile, 'new_stream')
 
         stream_id = get_stream('new_stream', user_profile.realm).id
@@ -491,7 +484,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_private_stream_live_updates(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
 
         do_change_is_admin(user_profile, True)
 
@@ -540,8 +533,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_rename_stream(self) -> None:
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
-        self.login(email)
+        self.login_user(user_profile)
         realm = user_profile.realm
         stream = self.subscribe(user_profile, 'stream_name1')
         do_change_is_admin(user_profile, True)
@@ -655,8 +647,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_rename_stream_requires_realm_admin(self) -> None:
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
-        self.login(email)
+        self.login_user(user_profile)
         self.make_stream('stream_name1')
 
         stream_id = get_stream('stream_name1', user_profile.realm).id
@@ -666,7 +657,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_notify_on_stream_rename(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         self.make_stream('stream_name1')
 
         stream = self.subscribe(user_profile, 'stream_name1')
@@ -688,7 +679,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_realm_admin_can_update_unsub_private_stream(self) -> None:
         iago = self.example_user('iago')
-        self.login(iago.email)
+        self.login_user(iago)
         result = self.common_subscribe_to_streams(iago, ["private_stream"],
                                                   dict(principals=ujson.dumps([self.example_email("hamlet")])),
                                                   invite_only=True)
@@ -711,8 +702,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_change_stream_description(self) -> None:
         user_profile = self.example_user('iago')
-        email = user_profile.email
-        self.login(email)
+        self.login_user(user_profile)
         realm = user_profile.realm
         self.subscribe(user_profile, 'stream_name1')
 
@@ -769,8 +759,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_change_stream_description_requires_realm_admin(self) -> None:
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
-        self.login(email)
+        self.login_user(user_profile)
 
         self.subscribe(user_profile, 'stream_name1')
         do_change_is_admin(user_profile, False)
@@ -782,7 +771,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_change_to_stream_post_policy_admins(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
 
         self.subscribe(user_profile, 'stream_name1')
         do_change_is_admin(user_profile, True)
@@ -796,7 +785,7 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_change_stream_post_policy_requires_realm_admin(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
 
         self.subscribe(user_profile, 'stream_name1')
         do_change_is_admin(user_profile, False)
@@ -822,8 +811,7 @@ class StreamAdminTest(ZulipTestCase):
         Create a stream for deletion by an administrator.
         """
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
-        self.login(email)
+        self.login_user(user_profile)
         stream = self.make_stream(stream_name, invite_only=invite_only)
 
         # For testing deleting streams you aren't on.
@@ -893,7 +881,7 @@ class StreamAdminTest(ZulipTestCase):
         You must be on the realm to create a stream.
         """
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
 
         other_realm = Realm.objects.create(string_id='other')
         stream = self.make_stream('other_realm_stream', realm=other_realm)
@@ -946,8 +934,7 @@ class StreamAdminTest(ZulipTestCase):
         else:
             user_profile = self.example_user('hamlet')
 
-        email = user_profile.email
-        self.login(email)
+        self.login_user(user_profile)
 
         # Set up the stream.
         stream_name = u"hümbüǵ"
@@ -1040,8 +1027,7 @@ class StreamAdminTest(ZulipTestCase):
         user_profile = self.example_user('hamlet')
         user_profile.date_joined = timezone_now()
         user_profile.save()
-        email = user_profile.email
-        self.login(email)
+        self.login_user(user_profile)
         do_change_is_admin(user_profile, False)
 
         # Allow all members to create streams.
@@ -1115,10 +1101,9 @@ class StreamAdminTest(ZulipTestCase):
 
         do_set_realm_property(hamlet_user.realm, 'invite_to_stream_policy',
                               Realm.INVITE_TO_STREAM_POLICY_WAITING_PERIOD)
-        hamlet_email = hamlet_user.email
         cordelia_email = cordelia_user.email
 
-        self.login(hamlet_email)
+        self.login_user(hamlet_user)
         do_change_is_admin(hamlet_user, True)
 
         # Hamlet creates a stream as an admin..
@@ -1170,10 +1155,9 @@ class StreamAdminTest(ZulipTestCase):
         """
         Trying to unsubscribe an invalid user from a stream fails gracefully.
         """
-        user_profile = self.example_user('hamlet')
-        admin_email = user_profile.email
-        self.login(admin_email)
-        do_change_is_admin(user_profile, True)
+        admin = self.example_user('iago')
+        self.login_user(admin)
+        self.assertTrue(admin.is_realm_admin)
 
         stream_name = u"hümbüǵ"
         self.make_stream(stream_name)
@@ -1214,7 +1198,7 @@ class DefaultStreamTest(ZulipTestCase):
     def test_api_calls(self) -> None:
         user_profile = self.example_user('hamlet')
         do_change_is_admin(user_profile, True)
-        self.login(user_profile.email)
+        self.login_user(user_profile)
 
         stream_name = 'stream ADDED via api'
         ensure_stream(user_profile.realm, stream_name)
@@ -1343,7 +1327,7 @@ class DefaultStreamGroupTest(ZulipTestCase):
             do_create_default_stream_group(realm, new_group_name, "This is group1", remaining_streams)
 
     def test_api_calls(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         user_profile = self.example_user('hamlet')
         realm = user_profile.realm
         do_change_is_admin(user_profile, True)
@@ -1493,7 +1477,7 @@ class DefaultStreamGroupTest(ZulipTestCase):
         self.assert_json_error(result, "Default stream group with id '{}' does not exist.".format(group_id))
 
     def test_invalid_default_stream_group_name(self) -> None:
-        self.login(self.example_email("iago"))
+        self.login('iago')
         user_profile = self.example_user('iago')
         realm = user_profile.realm
 
@@ -1536,7 +1520,7 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         any invalid hex color codes are bounced.
         """
         test_user = self.example_user('hamlet')
-        self.login(test_user.email)
+        self.login_user(test_user)
 
         old_subs, _ = gather_subscriptions(test_user)
         sub = old_subs[0]
@@ -1578,7 +1562,7 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         Updating the color property requires a `stream_id` key.
         """
         test_user = self.example_user('hamlet')
-        self.login(test_user.email)
+        self.login_user(test_user)
         result = self.api_post(test_user, "/api/v1/users/me/subscriptions/properties",
                                {"subscription_data": ujson.dumps([{"property": "color",
                                                                    "value": "#ffffff"}])})
@@ -1590,7 +1574,7 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         Updating the color property requires a subscribed stream.
         """
         test_user = self.example_user("hamlet")
-        self.login(test_user.email)
+        self.login_user(test_user)
 
         subscribed, unsubscribed, never_subscribed = gather_subscriptions_helper(test_user)
         not_subbed = unsubscribed + never_subscribed
@@ -1606,7 +1590,7 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         Updating the color property requires a color.
         """
         test_user = self.example_user('hamlet')
-        self.login(test_user.email)
+        self.login_user(test_user)
         subs = gather_subscriptions(test_user)[0]
         result = self.api_post(test_user, "/api/v1/users/me/subscriptions/properties",
                                {"subscription_data": ujson.dumps([{"property": "color",
@@ -1620,7 +1604,7 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         sets the property.
         """
         test_user = self.example_user('hamlet')
-        self.login(test_user.email)
+        self.login_user(test_user)
 
         subs = gather_subscriptions(test_user)[0]
         sub = subs[0]
@@ -1641,7 +1625,7 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         pin_to_top data pins the stream.
         """
         user = self.example_user('hamlet')
-        self.login(user.email)
+        self.login_user(user)
 
         old_subs, _ = gather_subscriptions(user)
         sub = old_subs[0]
@@ -1660,7 +1644,7 @@ class SubscriptionPropertiesTest(ZulipTestCase):
 
     def test_change_is_muted(self) -> None:
         test_user = self.example_user('hamlet')
-        self.login(test_user.email)
+        self.login_user(test_user)
         subs = gather_subscriptions(test_user)[0]
 
         sub = Subscription.objects.get(recipient__type=Recipient.STREAM,
@@ -1722,7 +1706,7 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         Trying to set a property incorrectly returns a JSON error.
         """
         test_user = self.example_user('hamlet')
-        self.login(test_user.email)
+        self.login_user(test_user)
         subs = gather_subscriptions(test_user)[0]
 
         property_name = "is_muted"
@@ -1792,7 +1776,7 @@ class SubscriptionPropertiesTest(ZulipTestCase):
 
     def test_json_subscription_property_invalid_stream(self) -> None:
         test_user = self.example_user("hamlet")
-        self.login(test_user.email)
+        self.login_user(test_user)
 
         stream_id = 1000
         result = self.api_post(test_user, "/api/v1/users/me/subscriptions/properties",
@@ -1806,7 +1790,7 @@ class SubscriptionPropertiesTest(ZulipTestCase):
         Trying to set an invalid property returns a JSON error.
         """
         test_user = self.example_user('hamlet')
-        self.login(test_user.email)
+        self.login_user(test_user)
         subs = gather_subscriptions(test_user)[0]
         result = self.api_post(test_user, "/api/v1/users/me/subscriptions/properties",
                                {"subscription_data": ujson.dumps([{"property": "bad",
@@ -1818,7 +1802,7 @@ class SubscriptionPropertiesTest(ZulipTestCase):
 class SubscriptionRestApiTest(ZulipTestCase):
     def test_basic_add_delete(self) -> None:
         user = self.example_user('hamlet')
-        self.login(user.email)
+        self.login_user(user)
 
         # add
         request = {
@@ -1840,7 +1824,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
 
     def test_add_with_color(self) -> None:
         user = self.example_user('hamlet')
-        self.login(user.email)
+        self.login_user(user)
 
         # add with color proposition
         request = {
@@ -1862,7 +1846,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
         """
         user = self.example_user('hamlet')
 
-        self.login(user.email)
+        self.login_user(user)
         subs = gather_subscriptions(user)[0]
         result = self.api_patch(user, "/api/v1/users/me/subscriptions/%d" % (subs[0]["stream_id"],),
                                 {'property': 'color', 'value': '#c2c2c2'})
@@ -1875,7 +1859,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
 
         user = self.example_user('hamlet')
 
-        self.login(user.email)
+        self.login_user(user)
         subs = gather_subscriptions(user)[0]
 
         result = self.api_patch(user, "/api/v1/users/me/subscriptions/%d" % (subs[0]["stream_id"],),
@@ -1888,7 +1872,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
         Trying to set an invalid stream id returns a JSON error.
         """
         user = self.example_user("hamlet")
-        self.login(user.email)
+        self.login_user(user)
         result = self.api_patch(user, "/api/v1/users/me/subscriptions/121",
                                 {'property': 'is_muted', 'value': 'somevalue'})
         self.assert_json_error(result,
@@ -1896,7 +1880,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
 
     def test_bad_add_parameters(self) -> None:
         user = self.example_user('hamlet')
-        self.login(user.email)
+        self.login_user(user)
 
         def check_for_error(val: Any, expected_message: str) -> None:
             request = {
@@ -1911,7 +1895,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
 
     def test_bad_principals(self) -> None:
         user = self.example_user('hamlet')
-        self.login(user.email)
+        self.login_user(user)
 
         request = {
             'add': ujson.dumps([{'name': 'my_new_stream'}]),
@@ -1922,7 +1906,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
 
     def test_bad_delete_parameters(self) -> None:
         user = self.example_user('hamlet')
-        self.login(user.email)
+        self.login_user(user)
 
         request = {
             'delete': ujson.dumps([{'name': 'my_test_stream_1'}])
@@ -1932,7 +1916,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
 
     def test_add_or_delete_not_specified(self) -> None:
         user = self.example_user('hamlet')
-        self.login(user.email)
+        self.login_user(user)
 
         result = self.api_patch(user, "/api/v1/users/me/subscriptions", {})
         self.assert_json_error(result,
@@ -1943,7 +1927,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
         Only way to force an error is with a empty string.
         """
         user = self.example_user('hamlet')
-        self.login(user.email)
+        self.login_user(user)
 
         invalid_stream_name = ""
         request = {
@@ -1955,7 +1939,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
 
     def test_stream_name_too_long(self) -> None:
         user = self.example_user('hamlet')
-        self.login(user.email)
+        self.login_user(user)
 
         long_stream_name = "a" * 61
         request = {
@@ -1967,7 +1951,7 @@ class SubscriptionRestApiTest(ZulipTestCase):
 
     def test_stream_name_contains_null(self) -> None:
         user = self.example_user('hamlet')
-        self.login(user.email)
+        self.login_user(user)
 
         stream_name = "abc\000"
         request = {
@@ -2015,7 +1999,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.user_profile = self.example_user('hamlet')
         self.test_email = self.user_profile.email
         self.test_user = self.user_profile
-        self.login(self.test_email)
+        self.login_user(self.user_profile)
         self.test_realm = self.user_profile.realm
         self.streams = self.get_streams(self.user_profile)
 
@@ -3047,7 +3031,7 @@ class SubscriptionAPITest(ZulipTestCase):
         self.assertEqual(num_subscribers_for_stream_id(stream.id), 1)
 
         # A user who is subscribed still sees the stream exists
-        self.login(self.example_email("cordelia"))
+        self.login('cordelia')
         result = self.client_post("/json/subscriptions/exists",
                                   {"stream": stream_name, "autosubscribe": "false"})
         self.assert_json_success(result)
@@ -3140,7 +3124,7 @@ class SubscriptionAPITest(ZulipTestCase):
         admin_user = self.example_user("iago")
         non_admin_user = self.example_user("cordelia")
 
-        self.login(admin_user.email)
+        self.login_user(admin_user)
 
         for stream_name in ["stream1", "stream2", "stream3", ]:
             self.make_stream(stream_name, realm=realm, invite_only=False)
@@ -3249,7 +3233,7 @@ class GetStreamsTest(ZulipTestCase):
         test_bot = self.create_test_bot('foo', hamlet, bot_owner=hamlet)
         assert test_bot is not None
         realm = get_realm('zulip')
-        self.login(hamlet.email)
+        self.login_user(hamlet)
 
         # Check it correctly lists the bot owner's subs with
         # include_owner_subscribed=true
@@ -3377,7 +3361,7 @@ class GetStreamsTest(ZulipTestCase):
         """
         user = self.example_user('hamlet')
         realm = get_realm('zulip')
-        self.login(user.email)
+        self.login_user(user)
 
         # Check it correctly lists the user's subs with include_public=false
         result = self.api_get(user, "/api/v1/streams?include_public=false")
@@ -3407,19 +3391,17 @@ class GetStreamsTest(ZulipTestCase):
                          sorted(all_streams))
 
 class StreamIdTest(ZulipTestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.user_profile = self.example_user('hamlet')
-        self.email = self.user_profile.email
-        self.login(self.email)
-
     def test_get_stream_id(self) -> None:
-        stream = gather_subscriptions(self.user_profile)[0][0]
+        user = self.example_user('hamlet')
+        self.login_user(user)
+        stream = gather_subscriptions(user)[0][0]
         result = self.client_get("/json/get_stream_id?stream=%s" % (stream['name'],))
         self.assert_json_success(result)
         self.assertEqual(result.json()['stream_id'], stream['stream_id'])
 
     def test_get_stream_id_wrong_name(self) -> None:
+        user = self.example_user('hamlet')
+        self.login_user(user)
         result = self.client_get("/json/get_stream_id?stream=wrongname")
         self.assert_json_error(result, u"Invalid stream name 'wrongname'")
 
@@ -3430,7 +3412,7 @@ class InviteOnlyStreamTest(ZulipTestCase):
         you aren't subscribed, you'll get a 400.
         """
         user = self.example_user('hamlet')
-        self.login(user.email)
+        self.login_user(user)
         # Create Saxony as an invite-only stream.
         self.assert_json_success(
             self.common_subscribe_to_streams(user, ["Saxony"],
@@ -3447,7 +3429,7 @@ class InviteOnlyStreamTest(ZulipTestCase):
         """
 
         user = self.example_user('hamlet')
-        self.login(user.email)
+        self.login_user(user)
 
         result1 = self.common_subscribe_to_streams(user, ["Saxony"], invite_only=True)
         self.assert_json_success(result1)
@@ -3479,14 +3461,14 @@ class InviteOnlyStreamTest(ZulipTestCase):
         # Subscribing oneself to an invite-only stream is not allowed
         user_profile = self.example_user('othello')
         email = user_profile.email
-        self.login(email)
+        self.login_user(user_profile)
         result = self.common_subscribe_to_streams(user_profile, [stream_name])
         self.assert_json_error(result, 'Unable to access stream (Saxony).')
 
         # authorization_errors_fatal=False works
         user_profile = self.example_user('othello')
         email = user_profile.email
-        self.login(email)
+        self.login_user(user_profile)
         result = self.common_subscribe_to_streams(user_profile, [stream_name],
                                                   extra_post_data={'authorization_errors_fatal': ujson.dumps(False)})
         self.assert_json_success(result)
@@ -3497,7 +3479,7 @@ class InviteOnlyStreamTest(ZulipTestCase):
 
         # Inviting another user to an invite-only stream is allowed
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         result = self.common_subscribe_to_streams(
             user_profile, [stream_name],
             extra_post_data={'principals': ujson.dumps([self.example_email("othello")])})
@@ -3521,7 +3503,7 @@ class GetSubscribersTest(ZulipTestCase):
         super().setUp()
         self.user_profile = self.example_user('hamlet')
         self.email = self.user_profile.email
-        self.login(self.email)
+        self.login_user(self.user_profile)
 
     def assert_user_got_subscription_notification(self, expected_msg: str) -> None:
         # verify that the user was sent a message informing them about the subscription
@@ -3830,10 +3812,10 @@ class GetSubscribersTest(ZulipTestCase):
         # Create a stream for which Hamlet is the only subscriber.
         stream_name = "Saxony"
         self.common_subscribe_to_streams(self.user_profile, [stream_name])
-        other_email = self.example_email("othello")
+        other_user = self.example_user("othello")
 
         # Fetch the subscriber list as a non-member.
-        self.login(other_email)
+        self.login_user(other_user)
         self.make_successful_subscriber_request(stream_name)
 
     def test_subscriber_private_stream(self) -> None:
@@ -3847,12 +3829,12 @@ class GetSubscribersTest(ZulipTestCase):
 
         stream_id = get_stream(stream_name, self.user_profile.realm).id
         # Verify another user can't get the data.
-        self.login(self.example_email("cordelia"))
+        self.login('cordelia')
         result = self.client_get("/json/streams/%d/members" % (stream_id,))
         self.assert_json_error(result, u'Invalid stream id')
 
         # But an organization administrator can
-        self.login(self.example_email("iago"))
+        self.login('iago')
         result = self.client_get("/json/streams/%d/members" % (stream_id,))
         self.assert_json_success(result)
 
@@ -3901,7 +3883,7 @@ class GetSubscribersTest(ZulipTestCase):
         self.assert_json_error(result, "Invalid stream id")
 
         # Try to fetch the subscriber list as a non-member & realm-admin-user.
-        self.login(self.example_email("iago"))
+        self.login('iago')
         self.make_successful_subscriber_request(stream_name)
 
 class AccessStreamTest(ZulipTestCase):
@@ -3913,7 +3895,7 @@ class AccessStreamTest(ZulipTestCase):
         hamlet = self.example_user('hamlet')
 
         stream_name = "new_private_stream"
-        self.login(hamlet.email)
+        self.login_user(hamlet)
         self.common_subscribe_to_streams(hamlet, [stream_name],
                                          invite_only=True)
         stream = get_stream(stream_name, hamlet.realm)
@@ -3980,7 +3962,7 @@ class AccessStreamTest(ZulipTestCase):
 
     def test_stream_access_by_guest(self) -> None:
         guest_user_profile = self.example_user('polonius')
-        self.login(guest_user_profile.email)
+        self.login_user(guest_user_profile)
         stream_name = "public_stream_1"
         stream = self.make_stream(stream_name, guest_user_profile.realm, invite_only=False)
 

--- a/zerver/tests/test_thumbnail.py
+++ b/zerver/tests/test_thumbnail.py
@@ -34,7 +34,7 @@ class ThumbnailTest(ZulipTestCase):
             settings.S3_AVATAR_BUCKET)
 
         hamlet = self.example_user('hamlet')
-        self.login(hamlet.email)
+        self.login_user(hamlet)
         fp = StringIO("zulip!")
         fp.name = "zulip.jpeg"
 
@@ -88,7 +88,7 @@ class ThumbnailTest(ZulipTestCase):
         self.assertIn(expected_part_url, result.url)
 
         # Test with another user trying to access image using thumbor.
-        self.login(self.example_email("iago"))
+        self.login('iago')
         result = self.client_get("/thumbnail?url=%s&size=full" % (quoted_uri,))
         self.assertEqual(result.status_code, 403, result)
         self.assert_in_response("You are not authorized to view this file.", result)
@@ -96,7 +96,7 @@ class ThumbnailTest(ZulipTestCase):
     def test_external_source_type(self) -> None:
         def run_test_with_image_url(image_url: str) -> None:
             # Test full size image.
-            self.login(self.example_email("hamlet"))
+            self.login('hamlet')
             quoted_url = urllib.parse.quote(image_url, safe='')
             encoded_url = base64.urlsafe_b64encode(image_url.encode()).decode('utf-8')
             result = self.client_get("/thumbnail?url=%s&size=full" % (quoted_url,))
@@ -137,7 +137,7 @@ class ThumbnailTest(ZulipTestCase):
 
             # Test with another user trying to access image using thumbor.
             # File should be always accessible to user in case of external source
-            self.login(self.example_email("iago"))
+            self.login('iago')
             result = self.client_get("/thumbnail?url=%s&size=full" % (quoted_url,))
             self.assertEqual(result.status_code, 302, result)
             expected_part_url = '/smart/filters:no_upscale()/' + encoded_url + '/source_type/external'
@@ -162,7 +162,7 @@ class ThumbnailTest(ZulipTestCase):
             hex_uri = base64.urlsafe_b64encode(uri.encode()).decode('utf-8')
             return url_in_result % (sharpen_filter, hex_uri)
 
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         fp = StringIO("zulip!")
         fp.name = "zulip.jpeg"
 
@@ -246,14 +246,14 @@ class ThumbnailTest(ZulipTestCase):
         self.assertIn(expected_part_url, result.url)
 
         # Test with another user trying to access image using thumbor.
-        self.login(self.example_email("iago"))
+        self.login('iago')
         result = self.client_get("/thumbnail?url=%s&size=full" % (quoted_uri,))
         self.assertEqual(result.status_code, 403, result)
         self.assert_in_response("You are not authorized to view this file.", result)
 
     @override_settings(THUMBOR_URL='127.0.0.1:9995')
     def test_with_static_files(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         uri = '/static/images/cute/turtle.png'
         quoted_uri = urllib.parse.quote(uri[1:], safe='')
         result = self.client_get("/thumbnail?url=%s&size=full" % (quoted_uri,))
@@ -261,7 +261,7 @@ class ThumbnailTest(ZulipTestCase):
         self.assertEqual(uri, result.url)
 
     def test_with_thumbor_disabled(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         fp = StringIO("zulip!")
         fp.name = "zulip.jpeg"
 
@@ -305,7 +305,7 @@ class ThumbnailTest(ZulipTestCase):
         self.assertEqual(base, result.url)
 
     def test_with_different_THUMBOR_URL(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         fp = StringIO("zulip!")
         fp.name = "zulip.jpeg"
 
@@ -337,7 +337,7 @@ class ThumbnailTest(ZulipTestCase):
             hex_uri = base64.urlsafe_b64encode(uri.encode()).decode('utf-8')
             return url_in_result % (sharpen_filter, hex_uri)
 
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         fp = StringIO("zulip!")
         fp.name = "zulip.jpeg"
 

--- a/zerver/tests/test_tornado.py
+++ b/zerver/tests/test_tornado.py
@@ -63,8 +63,8 @@ class TornadoWebTestCase(AsyncHTTPTestCase, ZulipTestCase):
         self.set_http_headers(kwargs)
         self.fetch_async('GET', path, **kwargs)
 
-    def login(self, *args: Any, **kwargs: Any) -> None:
-        super().login(*args, **kwargs)
+    def login_user(self, *args: Any, **kwargs: Any) -> None:
+        super().login_user(*args, **kwargs)
         session_cookie = settings.SESSION_COOKIE_NAME
         session_key = self.client.session.session_key
         self.session_cookie = {
@@ -91,13 +91,13 @@ class TornadoWebTestCase(AsyncHTTPTestCase, ZulipTestCase):
 
 class EventsTestCase(TornadoWebTestCase):
     def test_create_queue(self) -> None:
-        self.login(self.example_email('hamlet'))
+        self.login_user(self.example_user('hamlet'))
         queue_id = self.create_queue()
         self.assertIn(queue_id, event_queue.clients)
 
     def test_events_async(self) -> None:
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         event_queue_id = self.create_queue()
         data = {
             'queue_id': event_queue_id,

--- a/zerver/tests/test_transfer.py
+++ b/zerver/tests/test_transfer.py
@@ -32,7 +32,7 @@ class TransferUploadsToS3Test(ZulipTestCase):
     def test_transfer_avatars_to_s3(self) -> None:
         bucket = create_s3_buckets(settings.S3_AVATAR_BUCKET)[0]
 
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         with get_test_image_file('img.png') as image_file:
             self.client_post("/json/users/me/avatar", {'file': image_file})
 

--- a/zerver/tests/test_tutorial.py
+++ b/zerver/tests/test_tutorial.py
@@ -20,8 +20,8 @@ class TutorialTests(ZulipTestCase):
         internal_send_private_message(welcome_bot.realm, welcome_bot, user, content)
 
     def test_tutorial_status(self) -> None:
-        email = self.example_email('hamlet')
-        self.login(email)
+        user = self.example_user('hamlet')
+        self.login_user(user)
 
         cases = [
             ('started', UserProfile.TUTORIAL_STARTED),
@@ -35,11 +35,10 @@ class TutorialTests(ZulipTestCase):
             self.assertEqual(user.tutorial_status, expected_db_status)
 
     def test_single_response_to_pm(self) -> None:
-        user_email = 'hamlet@zulip.com'
         user = self.example_user('hamlet')
         bot = get_system_bot(settings.WELCOME_BOT)
         content = 'whatever'
-        self.login(user_email)
+        self.login_user(user)
         self.send_personal_message(user, bot, content)
         user_messages = message_stream_count(user)
         expected_response = ("Congratulations on your first reply! :tada:\n\n"
@@ -55,7 +54,7 @@ class TutorialTests(ZulipTestCase):
         user2 = self.example_user('cordelia')
         bot = get_system_bot(settings.WELCOME_BOT)
         content = "whatever"
-        self.login(user1.email)
+        self.login_user(user1)
         self.send_huddle_message(user1, [bot, user2], content)
         user1_messages = message_stream_count(user1)
         self.assertEqual(most_recent_message(user1).content, content)

--- a/zerver/tests/test_unread.py
+++ b/zerver/tests/test_unread.py
@@ -37,7 +37,7 @@ class PointerTest(ZulipTestCase):
         Posting a pointer to /update (in the form {"pointer": pointer}) changes
         the pointer we store for your UserProfile.
         """
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         self.assertEqual(self.example_user('hamlet').pointer, -1)
         msg_id = self.send_stream_message(self.example_user("othello"), "Verona")
         result = self.client_post("/json/users/me/pointer", {"pointer": msg_id})
@@ -61,7 +61,7 @@ class PointerTest(ZulipTestCase):
         Posting json to /json/users/me/pointer which does not contain a pointer key/value pair
         returns a 400 and error message.
         """
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         self.assertEqual(self.example_user('hamlet').pointer, -1)
         result = self.client_post("/json/users/me/pointer", {"foo": 1})
         self.assert_json_error(result, "Missing 'pointer' argument")
@@ -72,7 +72,7 @@ class PointerTest(ZulipTestCase):
         Posting json to /json/users/me/pointer with an invalid pointer returns a 400 and error
         message.
         """
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         self.assertEqual(self.example_user('hamlet').pointer, -1)
         result = self.client_post("/json/users/me/pointer", {"pointer": "foo"})
         self.assert_json_error(result, "Bad value for 'pointer': foo")
@@ -83,7 +83,7 @@ class PointerTest(ZulipTestCase):
         Posting json to /json/users/me/pointer with an out of range (< 0) pointer returns a 400
         and error message.
         """
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         self.assertEqual(self.example_user('hamlet').pointer, -1)
         result = self.client_post("/json/users/me/pointer", {"pointer": -2})
         self.assert_json_error(result, "Bad value for 'pointer': -2")
@@ -95,7 +95,7 @@ class PointerTest(ZulipTestCase):
         return an unread message older than the current pointer, when there's
         no narrow set.
         """
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         # Ensure the pointer is not set (-1)
         self.assertEqual(self.example_user('hamlet').pointer, -1)
 
@@ -177,7 +177,7 @@ class PointerTest(ZulipTestCase):
         self.assertEqual(messages_response['anchor'], new_message_id)
 
     def test_visible_messages_use_first_unread_anchor(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         self.assertEqual(self.example_user('hamlet').pointer, -1)
 
         result = self.client_post("/json/mark_all_as_read")
@@ -222,7 +222,7 @@ class UnreadCountTests(ZulipTestCase):
 
     # Sending a new message results in unread UserMessages being created
     def test_new_message(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         content = "Test message for unset read bit"
         last_msg = self.send_stream_message(self.example_user("hamlet"), "Verona", content)
         user_messages = list(UserMessage.objects.filter(message=last_msg))
@@ -233,7 +233,7 @@ class UnreadCountTests(ZulipTestCase):
                 self.assertFalse(um.flags.read)
 
     def test_update_flags(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
 
         result = self.client_post("/json/messages/flags",
                                   {"messages": ujson.dumps(self.unread_msg_ids),
@@ -262,7 +262,7 @@ class UnreadCountTests(ZulipTestCase):
                 self.assertEqual(msg['flags'], [])
 
     def test_mark_all_in_stream_read(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         user_profile = self.example_user('hamlet')
         stream = self.subscribe(user_profile, "test_stream")
         self.subscribe(self.example_user("cordelia"), "test_stream")
@@ -302,7 +302,7 @@ class UnreadCountTests(ZulipTestCase):
                 self.assertFalse(msg.flags.read)
 
     def test_mark_all_in_invalid_stream_read(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         invalid_stream_id = "12345678"
         result = self.client_post("/json/mark_stream_as_read", {
             "stream_id": invalid_stream_id
@@ -310,7 +310,7 @@ class UnreadCountTests(ZulipTestCase):
         self.assert_json_error(result, 'Invalid stream id')
 
     def test_mark_all_topics_unread_with_invalid_stream_name(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         invalid_stream_id = "12345678"
         result = self.client_post("/json/mark_topic_as_read", {
             "stream_id": invalid_stream_id,
@@ -319,7 +319,7 @@ class UnreadCountTests(ZulipTestCase):
         self.assert_json_error(result, "Invalid stream id")
 
     def test_mark_all_in_stream_topic_read(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         user_profile = self.example_user('hamlet')
         self.subscribe(user_profile, "test_stream")
 
@@ -356,7 +356,7 @@ class UnreadCountTests(ZulipTestCase):
                 self.assertFalse(msg.flags.read)
 
     def test_mark_all_in_invalid_topic_read(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         invalid_topic_name = "abc"
         result = self.client_post("/json/mark_topic_as_read", {
             "stream_id": get_stream("Denmark", get_realm("zulip")).id,
@@ -490,7 +490,7 @@ class PushNotificationMarkReadFlowsTest(ZulipTestCase):
     @mock.patch('zerver.lib.push_notifications.push_notifications_enabled', return_value=True)
     def test_track_active_mobile_push_notifications(self, mock_push_notifications: mock.MagicMock) -> None:
         mock_push_notifications.return_value = True
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         user_profile = self.example_user('hamlet')
         stream = self.subscribe(user_profile, "test_stream")
         second_stream = self.subscribe(user_profile, "second_stream")

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -85,7 +85,7 @@ class UserGroupAPITestCase(ZulipTestCase):
         hamlet = self.example_user('hamlet')
 
         # Test success
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         params = {
             'name': 'support',
             'members': ujson.dumps([hamlet.id]),
@@ -118,7 +118,7 @@ class UserGroupAPITestCase(ZulipTestCase):
     def test_user_group_get(self) -> None:
         # Test success
         user_profile = self.example_user('hamlet')
-        self.login(user_profile.email)
+        self.login_user(user_profile)
         result = self.client_get('/json/user_groups')
         self.assert_json_success(result)
         self.assert_length(result.json()['user_groups'], UserGroup.objects.filter(realm=user_profile.realm).count())
@@ -127,7 +127,7 @@ class UserGroupAPITestCase(ZulipTestCase):
         guest_user = self.example_user('polonius')
 
         # Guest users can't create user group
-        self.login(guest_user.email)
+        self.login_user(guest_user)
         params = {
             'name': 'support',
             'members': ujson.dumps([guest_user.id]),
@@ -138,7 +138,7 @@ class UserGroupAPITestCase(ZulipTestCase):
 
     def test_user_group_update(self) -> None:
         hamlet = self.example_user('hamlet')
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         params = {
             'name': 'support',
             'members': ujson.dumps([hamlet.id]),
@@ -166,7 +166,7 @@ class UserGroupAPITestCase(ZulipTestCase):
         self.logout()
         # Test when user not a member of user group tries to modify it
         cordelia = self.example_user('cordelia')
-        self.login(cordelia.email)
+        self.login_user(cordelia)
         params = {
             'name': 'help',
             'description': 'Troubleshooting',
@@ -177,7 +177,7 @@ class UserGroupAPITestCase(ZulipTestCase):
         self.logout()
         # Test when organization admin tries to modify group
         iago = self.example_user('iago')
-        self.login(iago.email)
+        self.login_user(iago)
         params = {
             'name': 'help',
             'description': 'Troubleshooting',
@@ -188,7 +188,7 @@ class UserGroupAPITestCase(ZulipTestCase):
     def test_user_group_update_by_guest_user(self) -> None:
         hamlet = self.example_user('hamlet')
         guest_user = self.example_user('polonius')
-        self.login(hamlet.email)
+        self.login_user(hamlet)
         params = {
             'name': 'support',
             'members': ujson.dumps([hamlet.id, guest_user.id]),
@@ -199,7 +199,7 @@ class UserGroupAPITestCase(ZulipTestCase):
         user_group = UserGroup.objects.get(name='support')
 
         # Guest user can't edit any detail of an user group
-        self.login(guest_user.email)
+        self.login_user(guest_user)
         params = {
             'name': 'help',
             'description': 'Troubleshooting team',
@@ -209,7 +209,7 @@ class UserGroupAPITestCase(ZulipTestCase):
 
     def test_user_group_update_to_already_existing_name(self) -> None:
         hamlet = self.example_user('hamlet')
-        self.login(hamlet.email)
+        self.login_user(hamlet)
         realm = get_realm('zulip')
         support_user_group = create_user_group('support', [hamlet], realm)
         marketing_user_group = create_user_group('marketing', [hamlet], realm)
@@ -223,7 +223,7 @@ class UserGroupAPITestCase(ZulipTestCase):
 
     def test_user_group_delete(self) -> None:
         hamlet = self.example_user('hamlet')
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         params = {
             'name': 'support',
             'members': ujson.dumps([hamlet.id]),
@@ -254,7 +254,7 @@ class UserGroupAPITestCase(ZulipTestCase):
         self.assertEqual(UserGroup.objects.count(), 2)
         self.logout()
         cordelia = self.example_user('cordelia')
-        self.login(cordelia.email)
+        self.login_user(cordelia)
 
         result = self.client_delete('/json/user_groups/{}'.format(user_group.id))
         self.assert_json_error(result, "Only group members and organization administrators can administer this group.")
@@ -263,7 +263,7 @@ class UserGroupAPITestCase(ZulipTestCase):
         self.logout()
         # Test when organization admin tries to delete group
         iago = self.example_user('iago')
-        self.login(iago.email)
+        self.login_user(iago)
 
         result = self.client_delete('/json/user_groups/{}'.format(user_group.id))
         self.assert_json_success(result)
@@ -273,7 +273,7 @@ class UserGroupAPITestCase(ZulipTestCase):
     def test_user_group_delete_by_guest_user(self) -> None:
         hamlet = self.example_user('hamlet')
         guest_user = self.example_user('polonius')
-        self.login(hamlet.email)
+        self.login_user(hamlet)
         params = {
             'name': 'support',
             'members': ujson.dumps([hamlet.id, guest_user.id]),
@@ -284,13 +284,13 @@ class UserGroupAPITestCase(ZulipTestCase):
         user_group = UserGroup.objects.get(name='support')
 
         # Guest users can't delete any user group(not even those of which they are a member)
-        self.login(guest_user.email)
+        self.login_user(guest_user)
         result = self.client_delete('/json/user_groups/{}'.format(user_group.id))
         self.assert_json_error(result, "Not allowed for guest users")
 
     def test_update_members_of_user_group(self) -> None:
         hamlet = self.example_user('hamlet')
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         params = {
             'name': 'support',
             'members': ujson.dumps([hamlet.id]),
@@ -322,7 +322,7 @@ class UserGroupAPITestCase(ZulipTestCase):
         self.logout()
         # Test when user not a member of user group tries to add members to it
         cordelia = self.example_user('cordelia')
-        self.login(cordelia.email)
+        self.login_user(cordelia)
         add = [cordelia.id]
         params = {'add': ujson.dumps(add)}
         result = self.client_post('/json/user_groups/{}/members'.format(user_group.id),
@@ -333,7 +333,7 @@ class UserGroupAPITestCase(ZulipTestCase):
         self.logout()
         # Test when organization admin tries to add members to group
         iago = self.example_user('iago')
-        self.login(iago.email)
+        self.login_user(iago)
         aaron = self.example_user('aaron')
         add = [aaron.id]
         params = {'add': ujson.dumps(add)}
@@ -346,7 +346,7 @@ class UserGroupAPITestCase(ZulipTestCase):
 
         # For normal testing we again login with hamlet
         self.logout()
-        self.login(hamlet.email)
+        self.login_user(hamlet)
         # Test remove members
         params = {'delete': ujson.dumps([othello.id])}
         result = self.client_post('/json/user_groups/{}/members'.format(user_group.id),
@@ -373,7 +373,7 @@ class UserGroupAPITestCase(ZulipTestCase):
 
         # Test when user not a member of user group tries to remove members
         self.logout()
-        self.login(cordelia.email)
+        self.login_user(cordelia)
         params = {'delete': ujson.dumps([hamlet.id])}
         result = self.client_post('/json/user_groups/{}/members'.format(user_group.id),
                                   info=params)
@@ -383,7 +383,7 @@ class UserGroupAPITestCase(ZulipTestCase):
         self.logout()
         # Test when organization admin tries to remove members from group
         iago = self.example_user('iago')
-        self.login(iago.email)
+        self.login_user(iago)
         result = self.client_post('/json/user_groups/{}/members'.format(user_group.id),
                                   info=params)
         self.assert_json_success(result)
@@ -445,7 +445,7 @@ class UserGroupAPITestCase(ZulipTestCase):
         iago = self.example_user('iago')
         hamlet = self.example_user('hamlet')
         cordelia = self.example_user('cordelia')
-        self.login(iago.email)
+        self.login_user(iago)
         do_set_realm_property(iago.realm, 'user_group_edit_policy',
                               Realm.USER_GROUP_EDIT_POLICY_ADMINS)
 
@@ -490,7 +490,7 @@ class UserGroupAPITestCase(ZulipTestCase):
 
         self.logout()
 
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
 
         # Test creating a group
         params = {

--- a/zerver/tests/test_user_status.py
+++ b/zerver/tests/test_user_status.py
@@ -157,7 +157,7 @@ class UserStatusTest(ZulipTestCase):
         hamlet = self.example_user('hamlet')
         realm_id = hamlet.realm_id
 
-        self.login(hamlet.email)
+        self.login_user(hamlet)
 
         # Try to omit parameter--this should be an error.
         payload = dict()  # type: Dict[str, Any]

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -117,7 +117,7 @@ class PermissionTest(ZulipTestCase):
         self.assertTrue(user_profile in admin_users)
 
     def test_updating_non_existent_user(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         admin = self.example_user('hamlet')
         do_change_is_admin(admin, True)
 
@@ -126,7 +126,7 @@ class PermissionTest(ZulipTestCase):
         self.assert_json_error(result, 'No such user')
 
     def test_admin_api(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         admin = self.example_user('hamlet')
         user = self.example_user('othello')
         realm = admin.realm
@@ -167,7 +167,7 @@ class PermissionTest(ZulipTestCase):
         self.assertEqual(person['is_admin'], False)
 
         # Cannot take away from last admin
-        self.login(self.example_email("iago"))
+        self.login('iago')
         req = dict(is_admin=ujson.dumps(False))
         events = []
         with tornado_redirected_to_list(events):
@@ -183,14 +183,14 @@ class PermissionTest(ZulipTestCase):
         self.assert_json_error(result, 'Cannot remove the only organization administrator')
 
         # Make sure only admins can patch other user's info.
-        self.login(self.example_email("othello"))
+        self.login('othello')
         result = self.client_patch('/json/users/{}'.format(self.example_user("hamlet").id), req)
         self.assert_json_error(result, 'Insufficient permission')
 
     def test_admin_api_hide_emails(self) -> None:
         user = self.example_user('hamlet')
         admin = self.example_user('iago')
-        self.login(user.email)
+        self.login_user(user)
 
         # First, verify client_gravatar works normally
         result = self.client_get('/json/users?client_gravatar=true')
@@ -243,7 +243,7 @@ class PermissionTest(ZulipTestCase):
         # required in apps like the mobile apps.
         # delivery_email is sent for admins.
         admin.refresh_from_db()
-        self.login(admin.delivery_email)
+        self.login_user(admin)
         result = self.client_get('/json/users?client_gravatar=true')
         self.assert_json_success(result)
         members = result.json()['members']
@@ -253,14 +253,14 @@ class PermissionTest(ZulipTestCase):
         self.assertEqual(hamlet['delivery_email'], self.example_email("hamlet"))
 
     def test_user_cannot_promote_to_admin(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         req = dict(is_admin=ujson.dumps(True))
         result = self.client_patch('/json/users/{}'.format(self.example_user('hamlet').id), req)
         self.assert_json_error(result, 'Insufficient permission')
 
     def test_admin_user_can_change_full_name(self) -> None:
         new_name = 'new name'
-        self.login(self.example_email("iago"))
+        self.login('iago')
         hamlet = self.example_user('hamlet')
         req = dict(full_name=ujson.dumps(new_name))
         result = self.client_patch('/json/users/{}'.format(hamlet.id), req)
@@ -272,28 +272,28 @@ class PermissionTest(ZulipTestCase):
         self.assert_json_success(result)
 
     def test_non_admin_cannot_change_full_name(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         req = dict(full_name=ujson.dumps('new name'))
         result = self.client_patch('/json/users/{}'.format(self.example_user('othello').id), req)
         self.assert_json_error(result, 'Insufficient permission')
 
     def test_admin_cannot_set_long_full_name(self) -> None:
         new_name = 'a' * (UserProfile.MAX_NAME_LENGTH + 1)
-        self.login(self.example_email("iago"))
+        self.login('iago')
         req = dict(full_name=ujson.dumps(new_name))
         result = self.client_patch('/json/users/{}'.format(self.example_user('hamlet').id), req)
         self.assert_json_error(result, 'Name too long!')
 
     def test_admin_cannot_set_short_full_name(self) -> None:
         new_name = 'a'
-        self.login(self.example_email("iago"))
+        self.login('iago')
         req = dict(full_name=ujson.dumps(new_name))
         result = self.client_patch('/json/users/{}'.format(self.example_user('hamlet').id), req)
         self.assert_json_error(result, 'Name too short!')
 
     def test_admin_cannot_set_full_name_with_invalid_characters(self) -> None:
         new_name = 'Opheli*'
-        self.login(self.example_email("iago"))
+        self.login('iago')
         req = dict(full_name=ujson.dumps(new_name))
         result = self.client_patch('/json/users/{}'.format(self.example_user('hamlet').id), req)
         self.assert_json_error(result, 'Invalid characters in name!')
@@ -329,7 +329,7 @@ class PermissionTest(ZulipTestCase):
 
     def test_change_regular_member_to_guest(self) -> None:
         iago = self.example_user("iago")
-        self.login(iago.email)
+        self.login_user(iago)
 
         hamlet = self.example_user("hamlet")
         self.assertFalse(hamlet.is_guest)
@@ -357,7 +357,7 @@ class PermissionTest(ZulipTestCase):
 
     def test_change_guest_to_regular_member(self) -> None:
         iago = self.example_user("iago")
-        self.login(iago.email)
+        self.login_user(iago)
 
         polonius = self.example_user("polonius")
         self.assertTrue(polonius.is_guest)
@@ -375,7 +375,7 @@ class PermissionTest(ZulipTestCase):
 
     def test_change_admin_to_guest(self) -> None:
         iago = self.example_user("iago")
-        self.login(iago.email)
+        self.login_user(iago)
         hamlet = self.example_user("hamlet")
         do_change_is_admin(hamlet, True)
         self.assertFalse(hamlet.is_guest)
@@ -409,7 +409,7 @@ class PermissionTest(ZulipTestCase):
 
     def test_change_guest_to_admin(self) -> None:
         iago = self.example_user("iago")
-        self.login(iago.email)
+        self.login_user(iago)
         polonius = self.example_user("polonius")
         self.assertTrue(polonius.is_guest)
         self.assertFalse(polonius.is_realm_admin)
@@ -438,7 +438,7 @@ class PermissionTest(ZulipTestCase):
 
     def test_admin_user_can_change_profile_data(self) -> None:
         realm = get_realm('zulip')
-        self.login(self.example_email("iago"))
+        self.login('iago')
         new_profile_data = []
         cordelia = self.example_user("cordelia")
 
@@ -556,7 +556,7 @@ class PermissionTest(ZulipTestCase):
                 self.assertEqual(field_dict['value'], new_fields[str(field_dict['name'])])
 
     def test_non_admin_user_cannot_change_profile_data(self) -> None:
-        self.login(self.example_email("cordelia"))
+        self.login('cordelia')
         hamlet = self.example_user("hamlet")
         realm = get_realm("zulip")
 
@@ -583,9 +583,8 @@ class AdminCreateUserTest(ZulipTestCase):
         # path.
 
         admin = self.example_user('hamlet')
-        admin_email = admin.email
         realm = admin.realm
-        self.login(admin_email)
+        self.login_user(admin)
         do_change_is_admin(admin, True)
 
         result = self.client_post("/json/users", dict())
@@ -921,7 +920,7 @@ class ActivateTest(ZulipTestCase):
     def test_api(self) -> None:
         admin = self.example_user('othello')
         do_change_is_admin(admin, True)
-        self.login(self.example_email("othello"))
+        self.login('othello')
 
         user = self.example_user('hamlet')
         self.assertTrue(user.is_active)
@@ -939,7 +938,7 @@ class ActivateTest(ZulipTestCase):
     def test_api_with_nonexistent_user(self) -> None:
         admin = self.example_user('othello')
         do_change_is_admin(admin, True)
-        self.login(self.example_email("othello"))
+        self.login('othello')
 
         # Cannot deactivate a user with the bot api
         result = self.client_delete('/json/bots/{}'.format(self.example_user("hamlet").id))
@@ -967,7 +966,7 @@ class ActivateTest(ZulipTestCase):
     def test_api_with_insufficient_permissions(self) -> None:
         non_admin = self.example_user('othello')
         do_change_is_admin(non_admin, False)
-        self.login(self.example_email("othello"))
+        self.login('othello')
 
         # Cannot deactivate a user with the users api
         result = self.client_delete('/json/users/{}'.format(self.example_user("hamlet").id))
@@ -1242,7 +1241,7 @@ class RecipientInfoTest(ZulipTestCase):
 
 class BulkUsersTest(ZulipTestCase):
     def test_client_gravatar_option(self) -> None:
-        self.login(self.example_email('cordelia'))
+        self.login('cordelia')
 
         hamlet = self.example_user('hamlet')
 
@@ -1276,8 +1275,8 @@ class BulkUsersTest(ZulipTestCase):
 
 class GetProfileTest(ZulipTestCase):
 
-    def common_update_pointer(self, email: str, pointer: int) -> None:
-        self.login(email)
+    def common_update_pointer(self, user: UserProfile, pointer: int) -> None:
+        self.login_user(user)
         result = self.client_post("/json/users/me/pointer", {"pointer": pointer})
         self.assert_json_success(result)
 
@@ -1301,8 +1300,8 @@ class GetProfileTest(ZulipTestCase):
         return json
 
     def test_get_pointer(self) -> None:
-        email = self.example_email("hamlet")
-        self.login(email)
+        user = self.example_user("hamlet")
+        self.login_user(user)
         result = self.client_get("/json/users/me/pointer")
         self.assert_json_success(result)
         self.assertIn("pointer", result.json())
@@ -1322,7 +1321,7 @@ class GetProfileTest(ZulipTestCase):
         self.assertEqual(user_profile.email, email)
 
     def test_get_user_profile(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         result = ujson.loads(self.client_get('/json/users/me').content)
         self.assertEqual(result['short_name'], 'hamlet')
         self.assertEqual(result['email'], self.example_email("hamlet"))
@@ -1330,7 +1329,7 @@ class GetProfileTest(ZulipTestCase):
         self.assertIn("user_id", result)
         self.assertFalse(result['is_bot'])
         self.assertFalse(result['is_admin'])
-        self.login(self.example_email("iago"))
+        self.login('iago')
         result = ujson.loads(self.client_get('/json/users/me').content)
         self.assertEqual(result['short_name'], 'iago')
         self.assertEqual(result['email'], self.example_email("iago"))
@@ -1371,11 +1370,12 @@ class GetProfileTest(ZulipTestCase):
 
         json = self.common_get_profile("hamlet")
 
-        self.common_update_pointer(self.example_email("hamlet"), id2)
+        hamlet = self.example_user('hamlet')
+        self.common_update_pointer(hamlet, id2)
         json = self.common_get_profile("hamlet")
         self.assertEqual(json["pointer"], id2)
 
-        self.common_update_pointer(self.example_email("hamlet"), id1)
+        self.common_update_pointer(hamlet, id1)
         json = self.common_get_profile("hamlet")
         self.assertEqual(json["pointer"], id2)  # pointer does not move backwards
 

--- a/zerver/tests/test_zcommand.py
+++ b/zerver/tests/test_zcommand.py
@@ -7,7 +7,7 @@ from zerver.lib.test_classes import (
 class ZcommandTest(ZulipTestCase):
 
     def test_invalid_zcommand(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
 
         payload = dict(command="/boil-ocean")
         result = self.client_post("/json/zcommand", payload)
@@ -18,14 +18,14 @@ class ZcommandTest(ZulipTestCase):
         self.assert_json_error(result, "There should be a leading slash in the zcommand.")
 
     def test_ping_zcommand(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
 
         payload = dict(command="/ping")
         result = self.client_post("/json/zcommand", payload)
         self.assert_json_success(result)
 
     def test_night_zcommand(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         user = self.example_user('hamlet')
         user.night_mode = False
         user.save()
@@ -40,7 +40,7 @@ class ZcommandTest(ZulipTestCase):
         self.assertIn('still in night mode', result.json()['msg'])
 
     def test_day_zcommand(self) -> None:
-        self.login(self.example_email("hamlet"))
+        self.login('hamlet')
         user = self.example_user('hamlet')
         user.night_mode = True
         user.save()

--- a/zerver/tests/test_zephyr.py
+++ b/zerver/tests/test_zephyr.py
@@ -11,8 +11,8 @@ from zerver.models import get_user, get_realm
 
 class ZephyrTest(ZulipTestCase):
     def test_webathena_kerberos_login(self) -> None:
-        email = self.example_email('hamlet')
-        self.login(email)
+        user = self.example_user('hamlet')
+        self.login_user(user)
 
         def post(subdomain: Any, **kwargs: Any) -> HttpResponse:
             params = {k: ujson.dumps(v) for k, v in kwargs.items()}
@@ -29,7 +29,7 @@ class ZephyrTest(ZulipTestCase):
         realm = get_realm('zephyr')
         user = get_user(email, realm)
         api_key = get_api_key(user)
-        self.login(email, realm=realm)
+        self.login_user(user)
 
         def ccache_mock(**kwargs: Any) -> Any:
             return patch('zerver.views.zephyr.make_ccache', **kwargs)


### PR DESCRIPTION
We now have this API...

If you really just need to log in
and not do anything with the actual
user:

    self.login('hamlet')

If you're gonna use the user in the
rest of the test:

    hamlet = self.example_user('hamlet')
    self.login_user(hamlet)

If you are specifically testing
email/password logins (used only in 4 places):

    self.login_by_email(email, password)

And for failures uses this (used twice):

    self.assert_login_failure(email)
