### PR TITLE
styles: Fix SimpleBar hover styling for simplebar@5.1.0

### DIFF
--- a/static/styles/components.scss
+++ b/static/styles/components.scss
@@ -85,15 +85,6 @@ a.no-underline:hover {
             width: 15px;
             transition: width 0.2s ease;
         }
-
-        .simplebar-scrollbar {
-            transition: width 0.2s ease 1s;
-
-            &.simplebar-hover {
-                width: 11px;
-                transition: width 0.2s ease;
-            }
-        }
     }
 
     &.simplebar-horizontal {


### PR DESCRIPTION
Follow an [upstream adjustment](https://github.com/Grsmto/simplebar/issues/420
) to the styling of the vertical scrollbar (but not the horizontal scrollbar).