### PR TITLE
filter: Add setting to mark messages with near narrows as read.

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -7,6 +7,7 @@ zrequire('Filter', 'js/filter');
 
 set_global('message_store', {});
 set_global('page_params', {});
+set_global('message_viewport', {});
 
 const me = {
     email: 'me@example.com',
@@ -87,6 +88,21 @@ run_test('basics', () => {
     assert(!filter.can_apply_locally());
     assert(filter.can_bucket_by('stream'));
     assert(filter.can_bucket_by('stream', 'topic'));
+
+    message_viewport.bottom_message_visible = () => true;
+
+    operators = [
+        {operator: 'stream', operand: 'foo'},
+        {operator: 'topic', operand: 'bar'},
+        {operator: 'near', operand: 'pizza'},
+    ];
+    filter = new Filter(operators);
+
+    assert(!filter.is_search());
+    assert(filter.can_mark_messages_read());
+    assert(!filter.contains_only_private_messages());
+    assert(!filter.allow_use_first_unread_when_narrowing());
+    assert(filter.can_apply_locally());
 
     // If our only stream operator is negated, then for all intents and purposes,
     // we don't consider ourselves to have a stream operator, because we don't

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -390,6 +390,12 @@ Filter.prototype = {
     calc_can_mark_messages_read: function () {
         const term_types = this.sorted_term_types();
 
+        if (_.isEqual(term_types, ['stream', 'topic', 'near'])) {
+            if (message_viewport.bottom_message_visible()) {
+                return true;
+            }
+        }
+
         if (_.isEqual(term_types, ['stream', 'topic'])) {
             return true;
         }
@@ -434,7 +440,8 @@ Filter.prototype = {
     },
 
     allow_use_first_unread_when_narrowing: function () {
-        return this.can_mark_messages_read() || this.has_operator('is');
+        return !this.has_operator('near') && this.can_mark_messages_read() ||
+            this.has_operator('is');
     },
 
     contains_only_private_messages: function () {


### PR DESCRIPTION
These changes add a new setting in `can_mark_messages_as_read()` to mark messages as read if they are followed from the near link and the oldest unread message in the topic is onscreen.

Fixes #14169.


**Testing Plan:**
- Unit tests.
- Followed a near link with last unread message onscreen.
- Populated 10,000 unread messages and tested near links with two different accounts.