### PR TITLE
ui-fix: Re-sorting of list_render when data gets updated or the same list_render object created again.

### DIFF
--- a/static/js/list_render.js
+++ b/static/js/list_render.js
@@ -284,6 +284,10 @@ exports.create = function ($container, list, opts) {
                 }
             });
 
+            if (opts.parent_container) {
+                opts.parent_container.on("click", "[data-sort]", exports.handle_sort);
+            }
+
             if (opts.filter.element) {
                 opts.filter.element.on(opts.filter.event || "input", function () {
                     const self = this;
@@ -346,11 +350,6 @@ exports.create = function ($container, list, opts) {
     // Save the instance for potential future retrieval if a name is provided.
     if (opts.name) {
         DEFAULTS.instances.set(opts.name, prototype);
-    }
-
-    // Attach click handler to column heads for sorting rows accordingly
-    if (opts.parent_container) {
-        opts.parent_container.on("click", "[data-sort]", exports.handle_sort);
     }
 
     return prototype;


### PR DESCRIPTION
Previously, when list_render.create was called, if a list_render with the
given name existed, it returned the list_render object with the previous
properties, without the property to sort the lists added. I changed the
code to add the 'click' event to the table columns to sort the data
even if the list_render is being reloaded from a previously created
list_render.

Does not cause any breaking change.

Fixes #14175 
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? --> - 


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  --> -


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
