### PR TITLE
Added installation guide link and fix broken links

### DIFF
--- a/templates/zerver/help/desktop-app-install-guide.md
+++ b/templates/zerver/help/desktop-app-install-guide.md
@@ -125,5 +125,6 @@ sudo apt install zulip
 
 ## Related articles
 
-* [Connect through a proxy](/help/connect-through-a-proxy)
-* [Add a custom certificate](/help/custom-certificates)
+* [Connect through a proxy](/templates/zerver/help/connect-through-a-proxy.md)
+* [Add a custom certificate](/templates/zerver/help/custom-certificates.md)
+* [Desktop installation guides](/templates/zerver/help/desktop-app-install-guide.md)


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) --> 
Added link of Desktop installation guides for the ease of the user. Fix the following links on [page](https://github.com/zulip/zulip/blob/cfa62700809584003468a982605ef724204a5f21/templates/zerver/help/desktop-app-install-guide.md) 
 - [Connect through a proxy](https://github.com/zulip/zulip/blob/cfa62700809584003468a982605ef724204a5f21/help/connect-through-a-proxy) 
- [Add a custom certificate](https://github.com/zulip/zulip/blob/cfa62700809584003468a982605ef724204a5f21/help/custom-certificates)  

 **Screenshots after changes:** 
![Screenshot 2020-03-13 at 1 00 12 AM](https://user-images.githubusercontent.com/25535045/76560788-f29f0a00-64c7-11ea-97c0-2e1017c57dbd.png)

