### PR TITLE
(Fix  CircleCI Flake) Revert "test-run-dev: Use a pipe rather than polling a log file."

### DIFF
--- a/tools/test-run-dev
+++ b/tools/test-run-dev
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 
-import itertools
 import os
 import signal
 import subprocess
 import sys
-import types
+import time
 from typing import Tuple
 
 from lib import sanity_check
@@ -13,40 +12,36 @@ sanity_check.check_venv(__file__)
 
 TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
 
-def start_server(run_dev: "subprocess.Popen[str]") -> Tuple[bool, str]:
-    failure = False
-    i = 0
+def start_server(logfile_name: str) -> Tuple[bool, str]:
+    failure = True
+    key = "Quit the server with CTRL-C."
+    datalog = []
+    with open(logfile_name, 'rb', buffering=0) as logfile:
+        for i in range(200):
+            time.sleep(0.5)
+            print("{}. Polling run-dev...".format(i))
+            new_data = logfile.read().decode()
+            if new_data:
+                datalog.append(new_data)
 
-    def on_timer(signum: int, frame: types.FrameType) -> None:
-        nonlocal failure, i
-        print("{}. Polling run-dev...".format(i))
-        i += 1
-        if i == 200:
-            failure = True
-            run_dev.send_signal(signal.SIGINT)
-            signal.setitimer(signal.ITIMER_REAL, 0, 0)
+            if key in ''.join(datalog):
+                failure = False
+                break
 
-    key = "Quit the server with CTRL-C.\n"
-    old_handler = signal.signal(signal.SIGALRM, on_timer)
-    signal.setitimer(signal.ITIMER_REAL, 0.5, 0.5)
-    log1, log2 = itertools.tee(run_dev.stdout)
-    if key not in log1:
-        failure = True
-    elif not failure:
-        run_dev.send_signal(signal.SIGINT)
-    signal.setitimer(signal.ITIMER_REAL, 0, 0)
-    signal.signal(signal.SIGALRM, old_handler)
-    return failure, ''.join(log2)
+    return failure, ''.join(datalog)
 
 if __name__ == '__main__':
     print("Testing development server start!")
 
-    with subprocess.Popen(
+    logfile_name = '/tmp/run-dev-output'
+    with open(logfile_name, 'wb', buffering=0) as logfile:
+        run_dev = subprocess.Popen(
             [os.path.join(TOOLS_DIR, "run-dev.py")],
-            bufsize=1,  # line buffered
-            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-            universal_newlines=True) as run_dev:
-        failure, log = start_server(run_dev)
+            stdout=logfile, stderr=subprocess.STDOUT)
+        failure, log = start_server(logfile_name)
+
+    run_dev.send_signal(signal.SIGINT)
+    run_dev.wait()
 
     if 'Traceback' in log:
         failure = True


### PR DESCRIPTION
With this change, I'm not able to reproduce the failure locally anymore and I ran lots of rounds on my circleci without getting the `test-run-dev` freeze, so at this point may be worth merging and we can see if it indeed eliminates the flakes.

From commit message:

This should fix spurious failures, where test-run-dev would occasionally
freeze. What exactly about these changes was causing that is still to
potentially be investigated. This is merely meant as a fix to the failures.
This reverts commit 19429c3ad797a5d7541f2e38ad5820318de33bac.
