### PR TITLE
tests: Create new test mode for generating stripe fixtures

### DIFF
--- a/docs/subsystems/billing.md
+++ b/docs/subsystems/billing.md
@@ -17,8 +17,7 @@ Stripe makes pretty regular updates to their API. The process for upgrading
 our code is:
 * Go to <https://dashboard.stripe.com/developers> in your Stripe account.
 * Upgrade the API version.
-* Set `GENERATE_STRIPE_FIXTURES = True` in `test_stripe.py`.
-* Run `tools/test-backend corporate/tests/test_stripe.py`
+* Run `tools/test-backend --generate-stripe-fixtures`
 * Fix any failing tests, and manually look through `git diff` to understand
   the changes.
 * If there are no material changes, commit the diff, and open a PR.

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -259,6 +259,10 @@ def main() -> None:
                         action="store_true",
                         default=False,
                         help=("Include webhook tests.  By default, they are skipped for performance."))
+    parser.add_argument('--generate-stripe-fixtures', dest="generate_stripe_fixtures",
+                        action="store_true",
+                        default=False,
+                        help=("Generate Stripe test fixtures by making requests to Stripe test network"))
     parser.add_argument('args', nargs='*')
 
     options = parser.parse_args()
@@ -343,6 +347,14 @@ def main() -> None:
 
     if full_suite and include_webhooks:
         suites.append("zerver.webhooks")
+
+    if options.generate_stripe_fixtures:
+        if full_suite:
+            suites = [
+                "corporate.tests.test_stripe",
+            ]
+            full_suite = False
+        os.environ["GENERATE_STRIPE_FIXTURES"] = "1"
 
     assert_provisioning_status_ok(options.force)
 

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -68,6 +68,8 @@ TUTORIAL_ENABLED = True
 CASPER_TESTS = False
 # This is overridden in test_settings.py for the test suites
 RUNNING_OPENAPI_CURL_TEST = False
+# This is overridden in test_settings.py for the test suites
+GENERATE_STRIPE_FIXTURES = False
 
 # Google Compute Engine has an /etc/boto.cfg that is "nicely
 # configured" to work with GCE's storage service.  However, their

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -54,6 +54,9 @@ if "CASPER_TESTS" in os.environ:
 if "RUNNING_OPENAPI_CURL_TEST" in os.environ:
     RUNNING_OPENAPI_CURL_TEST = True
 
+if "GENERATE_STRIPE_FIXTURES" in os.environ:
+    GENERATE_STRIPE_FIXTURES = True
+
 # Decrease the get_updates timeout to 1 second.
 # This allows CasperJS to proceed quickly to the next test step.
 POLL_TIMEOUT = 1000


### PR DESCRIPTION
Before to generate the Stripe test fixtures one had to manually change the value of the global variable `GENERATE_STRIPE_FIXTURES` to True in test_stripe.py and run the command ./tools/test-backend corporate.tests.test_stripe.py. 

With the changes in this PR, it's no longer required to modify any variables manually and instead running the command `./tools/test-backend --generate-stripe-fixtures` is enough.

CHnages in the PR

- [x] Use settings for controlling the value of `GENERATE_STRIPE_FIXTURES`

- [x] Make `test-backend` set the value of `settings.GENERATE_STRIPE_FIXTURES` using arguments.

- [x] Allow tests to access the internet when test-backend is ran with the argument `--generate-stripe-fixtures`