### PR TITLE
templates: Add a bottom text in find account (https://zulipchat.com/accounts/find/)

### DIFF
--- a/static/styles/portico/portico-signin.scss
+++ b/static/styles/portico/portico-signin.scss
@@ -38,6 +38,7 @@ html {
         &:hover {
             text-decoration: none;
             color: hsl(156, 62%, 61%);
+            cursor: pointer;
         }
     }
 }

--- a/templates/zerver/find_account.html
+++ b/templates/zerver/find_account.html
@@ -53,6 +53,9 @@
             </div>
             {% endif %}
         </div>
+        <div class="bottom-text">
+          <p>Just getting started? <a href="/new/">Create a new Zulip organization</a></p>
+        </div>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
In [https://zulipchat.com/accounts/find/](url) there is not a link to send a user
who has never used Zulip before to [https://zulipchat.com/new/](url) so the user
could make a new Zulip organization. So I think it could be a good idea to give the
user this option.

Before:
![1](https://user-images.githubusercontent.com/43316964/76667061-b6d07700-6591-11ea-9015-d9f7d8752369.png)

After:
![2](https://user-images.githubusercontent.com/43316964/76667052-b59f4a00-6591-11ea-9cc3-a676fc275fea.png)