### PR TITLE
docs: Create bin directory before fetching rmate file to it

### DIFF
--- a/docs/development/remote.md
+++ b/docs/development/remote.md
@@ -193,6 +193,7 @@ To setup [rmate](https://github.com/textmate/rmate) for VS Code:
 [Remote VSCode](https://marketplace.visualstudio.com/items?itemName=rafaelmaiolla.remote-vscode).
 2. On your remote machine, run:
 ```
+$ mkdir -p ~/bin
 $ curl -Lo ~/bin/rmate https://raw.githubusercontent.com/textmate/rmate/master/bin/rmate
 $ chmod a+x ~/bin/rmate
 ```


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

Running the `curl` command when the directory is not present causes it to fail.

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
