### PR TITLE
tests: Use email/delivery_email more explicitly.

### DIFF
--- a/analytics/tests/test_views.py
+++ b/analytics/tests/test_views.py
@@ -334,6 +334,8 @@ class TestGetChartData(ZulipTestCase):
 
 class TestSupportEndpoint(ZulipTestCase):
     def test_search(self) -> None:
+        self.reset_emails_in_zulip_realm()
+
         def check_hamlet_user_query_result(result: HttpResponse) -> None:
             self.assert_in_success_response(['<span class="label">user</span>\n', '<h3>King Hamlet</h3>',
                                              '<b>Email</b>: hamlet@zulip.com', '<b>Is active</b>: True<br>',

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -216,6 +216,7 @@ class StripeTestCase(ZulipTestCase):
         super().setUp()
         # This test suite is not robust to users being added in populate_db. The following
         # hack ensures get_latest_seat_count is fixed, even as populate_db changes.
+        self.reset_emails_in_zulip_realm()
         realm = get_realm('zulip')
         seat_count = get_latest_seat_count(realm)
         assert(seat_count >= 6)

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -78,15 +78,15 @@ class TestRealmAuditLog(ZulipTestCase):
     def test_change_email(self) -> None:
         now = timezone_now()
         user = self.example_user('hamlet')
-        email = 'test@example.com'
-        do_change_user_delivery_email(user, email)
+        new_email = 'test@example.com'
+        do_change_user_delivery_email(user, new_email)
         self.assertEqual(RealmAuditLog.objects.filter(event_type=RealmAuditLog.USER_EMAIL_CHANGED,
                                                       event_time__gte=now).count(), 1)
-        self.assertEqual(email, user.email)
+        self.assertEqual(new_email, user.delivery_email)
 
         # Test the RealmAuditLog stringification
         audit_entry = RealmAuditLog.objects.get(event_type=RealmAuditLog.USER_EMAIL_CHANGED, event_time__gte=now)
-        self.assertTrue(str(audit_entry).startswith("<RealmAuditLog: <UserProfile: test@example.com %s> %s " % (user.realm, RealmAuditLog.USER_EMAIL_CHANGED)))
+        self.assertTrue(str(audit_entry).startswith("<RealmAuditLog: <UserProfile: %s %s> %s " % (user.email, user.realm, RealmAuditLog.USER_EMAIL_CHANGED)))
 
     def test_change_avatar_source(self) -> None:
         now = timezone_now()

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -52,8 +52,8 @@ from zerver.lib.test_classes import (
 )
 from zerver.models import \
     get_realm, email_to_username, CustomProfileField, CustomProfileFieldValue, \
-    UserProfile, PreregistrationUser, Realm, RealmDomain, get_user, MultiuseInvite, \
-    clear_supported_auth_backends_cache, PasswordTooWeakError
+    UserProfile, PreregistrationUser, Realm, RealmDomain, MultiuseInvite, \
+    clear_supported_auth_backends_cache, PasswordTooWeakError, get_user_by_delivery_email
 from zerver.signals import JUST_CREATED_THRESHOLD
 
 from confirmation.models import Confirmation, create_confirmation_link
@@ -196,7 +196,7 @@ class AuthBackendTest(ZulipTestCase):
                            return_value=True):
             return_data = {}  # type: Dict[str, bool]
             user = EmailAuthBackend().authenticate(request=mock.MagicMock(),
-                                                   username=self.example_email('hamlet'),
+                                                   username=user_profile.delivery_email,
                                                    realm=get_realm("zulip"),
                                                    password=password,
                                                    return_data=return_data)
@@ -313,7 +313,7 @@ class AuthBackendTest(ZulipTestCase):
     def test_ldap_backend(self) -> None:
         self.init_default_ldap_database()
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
+        email = user_profile.delivery_email
         password = self.ldap_password('hamlet')
         self.setup_subdomain(user_profile)
 
@@ -387,7 +387,7 @@ class AuthBackendTest(ZulipTestCase):
             'token_type': 'bearer'
         }
         github_email_data = [
-            dict(email=user.email,
+            dict(email=user.delivery_email,
                  verified=True,
                  primary=True),
             dict(email="nonprimary@zulip.com",
@@ -395,7 +395,7 @@ class AuthBackendTest(ZulipTestCase):
             dict(email="ignored@example.com",
                  verified=False),
         ]
-        google_email_data = dict(email=user.email,
+        google_email_data = dict(email=user.delivery_email,
                                  name=user.full_name,
                                  email_verified=True)
         backends_to_test = {
@@ -432,7 +432,7 @@ class AuthBackendTest(ZulipTestCase):
             # pipeline when we display an email picker for the GitHub
             # authentication backend.  We do that here.
             def return_email() -> Dict[str, str]:
-                return {'email': user.email}
+                return {'email': user.delivery_email}
             backend.strategy.request_data = return_email
 
             result = orig_authenticate(backend, **kwargs)
@@ -540,7 +540,9 @@ class RateLimitAuthenticationTests(ZulipTestCase):
                                                    password=password,
                                                    return_data=dict())
 
-        self.do_test_auth_rate_limiting(attempt_authentication, user_profile.email, password, 'wrong_password',
+        self.do_test_auth_rate_limiting(attempt_authentication,
+                                        user_profile.delivery_email,
+                                        password, 'wrong_password',
                                         user_profile)
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',),
@@ -557,7 +559,9 @@ class RateLimitAuthenticationTests(ZulipTestCase):
                                                        password=password,
                                                        return_data=dict())
 
-        self.do_test_auth_rate_limiting(attempt_authentication, user_profile.email, password, 'wrong_password',
+        self.do_test_auth_rate_limiting(attempt_authentication,
+                                        user_profile.delivery_email,
+                                        password, 'wrong_password',
                                         user_profile)
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.EmailAuthBackend',
@@ -579,10 +583,12 @@ class RateLimitAuthenticationTests(ZulipTestCase):
                                 password=password,
                                 return_data=dict())
 
-        self.do_test_auth_rate_limiting(attempt_authentication, user_profile.email,
+        self.do_test_auth_rate_limiting(attempt_authentication,
+                                        user_profile.delivery_email,
                                         email_password, 'wrong_password',
                                         user_profile)
-        self.do_test_auth_rate_limiting(attempt_authentication, user_profile.email,
+        self.do_test_auth_rate_limiting(attempt_authentication,
+                                        user_profile.delivery_email,
                                         ldap_password, 'wrong_password',
                                         user_profile)
 
@@ -624,7 +630,7 @@ class DesktopFlowTestingLib(ZulipTestCase):
         result = self.client_get(browser_url)
         self.assertEqual(result.status_code, 302)
         realm = get_realm("zulip")
-        user_profile = get_user(email, realm)
+        user_profile = get_user_by_delivery_email(email, realm)
         self.assert_logged_in_user_id(user_profile.id)
 
     def verify_desktop_app_url_and_return_key(self, url: str, email: str, desktop_flow_otp: str) -> str:
@@ -655,7 +661,7 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.user_profile = self.example_user('hamlet')
-        self.email = self.user_profile.email
+        self.email = self.user_profile.delivery_email
         self.name = self.user_profile.full_name
         self.backend = self.BACKEND_CLASS
         self.backend.strategy = DjangoStrategy(storage=BaseDjangoStorage())
@@ -1070,7 +1076,7 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase):
             self.assertEqual(query_params["realm"], ['http://zulip.testserver'])
             self.assertEqual(query_params["email"], [email])
             encrypted_api_key = query_params["otp_encrypted_api_key"][0]
-            user_api_keys = get_all_api_keys(get_user(email, realm))
+            user_api_keys = get_all_api_keys(get_user_by_delivery_email(email, realm))
             self.assertIn(otp_decrypt_api_key(encrypted_api_key, mobile_flow_otp), user_api_keys)
             return
         elif desktop_flow_otp:
@@ -1079,7 +1085,7 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase):
         else:
             self.assertEqual(result.status_code, 302)
 
-        user_profile = get_user(email, realm)
+        user_profile = get_user_by_delivery_email(email, realm)
         self.assert_logged_in_user_id(user_profile.id)
         self.assertEqual(user_profile.full_name, expected_final_name)
 
@@ -2077,7 +2083,7 @@ class GoogleAuthBackendTest(SocialAuthBase):
              'key': confirmation_key,
              'terms': True})
         self.assertEqual(result.status_code, 302)
-        new_user = get_user('new@zulip.com', realm)
+        new_user = get_user_by_delivery_email('new@zulip.com', realm)
         new_streams = self.get_streams(new_user)
         self.assertEqual(sorted(new_streams), stream_names)
 
@@ -2105,14 +2111,14 @@ class JSONFetchAPIKeyTest(ZulipTestCase):
         self.login_user(user)
         result = self.client_post("/json/fetch_api_key",
                                   dict(user_profile=user,
-                                       password=initial_password(user.email)))
+                                       password=initial_password(user.delivery_email)))
         self.assert_json_success(result)
 
     def test_not_loggedin(self) -> None:
         user = self.example_user('hamlet')
         result = self.client_post("/json/fetch_api_key",
                                   dict(user_profile=user,
-                                       password=initial_password(user.email)))
+                                       password=initial_password(user.delivery_email)))
         self.assert_json_error(result,
                                "Not logged in: API authentication or user session required", 401)
 
@@ -2128,7 +2134,7 @@ class FetchAPIKeyTest(ZulipTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.user_profile = self.example_user('hamlet')
-        self.email = self.user_profile.email
+        self.email = self.user_profile.delivery_email
 
     def test_success(self) -> None:
         result = self.client_post("/api/v1/fetch_api_key",
@@ -2182,7 +2188,7 @@ class DevFetchAPIKeyTest(ZulipTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.user_profile = self.example_user('hamlet')
-        self.email = self.user_profile.email
+        self.email = self.user_profile.delivery_email
 
     def test_success(self) -> None:
         result = self.client_post("/api/v1/dev_fetch_api_key",
@@ -2414,7 +2420,7 @@ class TestTwoFactor(ZulipTestCase):
 class TestDevAuthBackend(ZulipTestCase):
     def test_login_success(self) -> None:
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
+        email = user_profile.delivery_email
         data = {'direct_email': email}
         result = self.client_post('/accounts/login/local/', data)
         self.assertEqual(result.status_code, 302)
@@ -2423,7 +2429,7 @@ class TestDevAuthBackend(ZulipTestCase):
     def test_login_success_with_2fa(self) -> None:
         user_profile = self.example_user('hamlet')
         self.create_default_device(user_profile)
-        email = user_profile.email
+        email = user_profile.delivery_email
         data = {'direct_email': email}
         with self.settings(TWO_FACTOR_AUTHENTICATION_ENABLED=True):
             result = self.client_post('/accounts/login/local/', data)
@@ -2456,7 +2462,7 @@ class TestDevAuthBackend(ZulipTestCase):
 
     def test_login_with_subdomain(self) -> None:
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
+        email = user_profile.delivery_email
         data = {'direct_email': email}
 
         result = self.client_post('/accounts/login/local/', data)
@@ -2532,7 +2538,7 @@ class TestDevAuthBackend(ZulipTestCase):
 class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
     def test_login_success(self) -> None:
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
+        email = user_profile.delivery_email
         with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',)):
             result = self.client_post('/accounts/login/sso/', REMOTE_USER=email)
             self.assertEqual(result.status_code, 302)
@@ -2600,7 +2606,7 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
 
     def test_login_success_under_subdomains(self) -> None:
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
+        email = user_profile.delivery_email
         with mock.patch('zerver.views.auth.get_subdomain', return_value='zulip'):
             with self.settings(
                     AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',)):
@@ -2612,7 +2618,7 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',))
     def test_login_mobile_flow_otp_success_email(self) -> None:
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
+        email = user_profile.delivery_email
         user_profile.date_joined = timezone_now() - datetime.timedelta(seconds=61)
         user_profile.save()
         mobile_flow_otp = '1234abcd' * 8
@@ -2654,7 +2660,7 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',))
     def test_login_mobile_flow_otp_success_username(self) -> None:
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
+        email = user_profile.delivery_email
         remote_user = email_to_username(email)
         user_profile.date_joined = timezone_now() - datetime.timedelta(seconds=61)
         user_profile.save()
@@ -2697,7 +2703,7 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
                                                 'zproject.backends.ZulipDummyBackend'))
     def test_login_desktop_flow_otp_success_email(self) -> None:
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
+        email = user_profile.delivery_email
         user_profile.date_joined = timezone_now() - datetime.timedelta(seconds=61)
         user_profile.save()
         desktop_flow_otp = '1234abcd' * 8
@@ -2726,7 +2732,7 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
                                                 'zproject.backends.ZulipDummyBackend'))
     def test_login_desktop_flow_otp_success_username(self) -> None:
         user_profile = self.example_user('hamlet')
-        email = user_profile.email
+        email = user_profile.delivery_email
         remote_user = email_to_username(email)
         user_profile.date_joined = timezone_now() - datetime.timedelta(seconds=61)
         user_profile.save()
@@ -2755,7 +2761,7 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
         login_or_register_remote_user."""
         def test_with_redirect_to_param_set_as_next(next: str='') -> HttpResponse:
             user_profile = self.example_user('hamlet')
-            email = user_profile.email
+            email = user_profile.delivery_email
             with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',)):
                 result = self.client_post('/accounts/login/sso/?next=' + next, REMOTE_USER=email)
             return result
@@ -2789,7 +2795,7 @@ class TestJWTLogin(ZulipTestCase):
             auth_key = settings.JWT_AUTH_KEYS['zulip']
             web_token = jwt.encode(payload, auth_key).decode('utf8')
 
-            user_profile = get_user(email, realm)
+            user_profile = get_user_by_delivery_email(email, realm)
             data = {'json_web_token': web_token}
             result = self.client_post('/accounts/login/jwt/', data)
             self.assertEqual(result.status_code, 302)
@@ -2956,7 +2962,7 @@ class DjangoToLDAPUsernameTests(ZulipTestCase):
         """
         With AUTH_LDAP_REVERSE_EMAIL_SEARCH configured, django_to_ldap_username
         should be able to translate an email to ldap username,
-        and thus it should be possible to authenticate through user_profile.email.
+        and thus it should be possible to authenticate through user_profile.delivery_email.
         """
         realm = get_realm("zulip")
         user_profile = self.example_user("hamlet")
@@ -2966,7 +2972,7 @@ class DjangoToLDAPUsernameTests(ZulipTestCase):
 
         with self.settings(LDAP_EMAIL_ATTR='mail'):
             self.assertEqual(
-                authenticate(request=mock.MagicMock(), username=user_profile.email,
+                authenticate(request=mock.MagicMock(), username=user_profile.delivery_email,
                              password=self.ldap_password('hamlet'), realm=realm),
                 user_profile)
 
@@ -3061,7 +3067,7 @@ class TestLDAP(ZulipLDAPTestCase):
                                                      realm=get_realm('zulip'))
 
             assert(user_profile is not None)
-            self.assertEqual(user_profile.email, self.example_email("hamlet"))
+            self.assertEqual(user_profile.delivery_email, self.example_email("hamlet"))
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_login_success_with_username(self) -> None:
@@ -3109,9 +3115,10 @@ class TestLDAP(ZulipLDAPTestCase):
             othello.set_password(password)
             othello.save()
 
-            self.assertEqual(email_belongs_to_ldap(realm, othello.email), False)
+            self.assertEqual(email_belongs_to_ldap(realm, othello.delivery_email), False)
             user_profile = EmailAuthBackend().authenticate(request=mock.MagicMock(),
-                                                           username=othello.email, password=password,
+                                                           username=othello.delivery_email,
+                                                           password=password,
                                                            realm=realm)
             self.assertEqual(user_profile, othello)
 
@@ -3157,7 +3164,7 @@ class TestLDAP(ZulipLDAPTestCase):
         email = self.example_email("hamlet")
         user_profile, created = backend.get_or_build_user(str(email), _LDAPUser())
         self.assertFalse(created)
-        self.assertEqual(user_profile.email, email)
+        self.assertEqual(user_profile.delivery_email, email)
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_get_or_build_user_when_user_does_not_exist(self) -> None:
@@ -3171,7 +3178,7 @@ class TestLDAP(ZulipLDAPTestCase):
             email = 'newuser@zulip.com'
             user_profile, created = backend.get_or_build_user(email, _LDAPUser())
             self.assertTrue(created)
-            self.assertEqual(user_profile.email, email)
+            self.assertEqual(user_profile.delivery_email, email)
             self.assertEqual(user_profile.full_name, 'Full Name')
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
@@ -3273,7 +3280,7 @@ class TestLDAP(ZulipLDAPTestCase):
                                                      username=self.example_email('hamlet'),
                                                      password=self.ldap_password('hamlet'),
                                                      realm=get_realm('acme'))
-            self.assertEqual(user_profile.email, self.example_email('hamlet'))
+            self.assertEqual(user_profile.delivery_email, self.example_email('hamlet'))
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_login_success_with_valid_subdomain(self) -> None:
@@ -3283,7 +3290,7 @@ class TestLDAP(ZulipLDAPTestCase):
                                                      password=self.ldap_password('hamlet'),
                                                      realm=get_realm('zulip'))
             assert(user_profile is not None)
-            self.assertEqual(user_profile.email, self.example_email("hamlet"))
+            self.assertEqual(user_profile.delivery_email, self.example_email("hamlet"))
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_login_failure_due_to_deactivated_user(self) -> None:
@@ -3309,7 +3316,7 @@ class TestLDAP(ZulipLDAPTestCase):
                                                      password=self.ldap_password("newuser"),
                                                      realm=get_realm('zulip'))
             assert(user_profile is not None)
-            self.assertEqual(user_profile.email, 'newuser@acme.com')
+            self.assertEqual(user_profile.delivery_email, 'newuser@acme.com')
             self.assertEqual(user_profile.full_name, 'New LDAP fullname')
             self.assertEqual(user_profile.realm.string_id, 'zulip')
 
@@ -3328,7 +3335,7 @@ class TestLDAP(ZulipLDAPTestCase):
                                                      password=self.ldap_password("newuser_splitname"),
                                                      realm=get_realm('zulip'))
             assert(user_profile is not None)
-            self.assertEqual(user_profile.email, 'newuser_splitname@zulip.com')
+            self.assertEqual(user_profile.delivery_email, 'newuser_splitname@zulip.com')
             self.assertEqual(user_profile.full_name, 'First Last')
             self.assertEqual(user_profile.realm.string_id, 'zulip')
 
@@ -3443,7 +3450,13 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
     def test_user_in_multiple_realms(self) -> None:
         test_realm = do_create_realm('test', 'test', False)
         hamlet = self.example_user('hamlet')
-        hamlet2 = do_create_user(hamlet.email, None, test_realm, hamlet.full_name, hamlet.short_name)
+        email = hamlet.delivery_email
+        hamlet2 = do_create_user(
+            email,
+            None,
+            test_realm,
+            hamlet.full_name,
+            hamlet.short_name)
 
         self.change_ldap_user_attr('hamlet', 'cn', 'Second Hamlet')
         expected_call_args = [hamlet2, 'Second Hamlet', None]
@@ -3453,10 +3466,10 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
                 f.assert_called_once_with(*expected_call_args)
 
                 # Get the updated model and make sure the full name is changed correctly:
-                hamlet2 = get_user(hamlet.email, test_realm)
+                hamlet2 = get_user_by_delivery_email(email, test_realm)
                 self.assertEqual(hamlet2.full_name, "Second Hamlet")
                 # Now get the original hamlet and make he still has his name unchanged:
-                hamlet = get_user(hamlet.email, get_realm("zulip"))
+                hamlet = self.example_user('hamlet')
                 self.assertEqual(hamlet.full_name, "King Hamlet")
 
     def test_user_not_found_in_ldap(self) -> None:
@@ -3466,7 +3479,8 @@ class TestZulipLDAPUserPopulator(ZulipLDAPTestCase):
             othello = self.example_user("othello")  # othello isn't in our test directory
             mock_logger = mock.MagicMock()
             result = sync_user_from_ldap(othello, mock_logger)
-            mock_logger.warning.assert_called_once_with("Did not find %s in LDAP." % (othello.email,))
+            mock_logger.warning.assert_called_once_with(
+                "Did not find %s in LDAP." % (othello.delivery_email,))
             self.assertFalse(result)
 
             do_deactivate_user(othello)
@@ -3830,16 +3844,17 @@ class EmailValidatorTestCase(ZulipTestCase):
         )
         self.assertIn('containing + are not allowed', error)
 
-        errors = get_existing_user_errors(realm, {cordelia.email})
-        error, is_deactivated = errors[cordelia.email]
+        cordelia_email = cordelia.delivery_email
+        errors = get_existing_user_errors(realm, {cordelia_email})
+        error, is_deactivated = errors[cordelia_email]
         self.assertEqual(False, is_deactivated)
         self.assertEqual(error, 'Already has an account.')
 
         cordelia.is_active = False
         cordelia.save()
 
-        errors = get_existing_user_errors(realm, {cordelia.email})
-        error, is_deactivated = errors[cordelia.email]
+        errors = get_existing_user_errors(realm, {cordelia_email})
+        error, is_deactivated = errors[cordelia_email]
         self.assertEqual(True, is_deactivated)
         self.assertEqual(error, 'Account has been deactivated.')
 
@@ -3850,8 +3865,12 @@ class LDAPBackendTest(ZulipTestCase):
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',))
     def test_non_existing_realm(self) -> None:
         self.init_default_ldap_database()
-        email = self.example_email('hamlet')
-        data = {'username': email, 'password': initial_password(email)}
+        user = self.example_user('hamlet')
+
+        data = dict(
+            username=user.delivery_email,
+            password=initial_password(user.delivery_email)
+        )
         error_type = ZulipLDAPAuthBackend.REALM_IS_NONE_ERROR
         error = ZulipLDAPConfigurationError('Realm is None', error_type)
         with mock.patch('zproject.backends.ZulipLDAPAuthBackend.get_or_build_user',

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -149,6 +149,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_length(queries, 3)
 
     def test_add_bot(self) -> None:
+        hamlet = self.example_user('hamlet')
         self.login('hamlet')
         self.assert_num_bots_equal(0)
         events = []  # type: List[Mapping[str, Any]]
@@ -164,18 +165,20 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             dict(
                 type='realm_bot',
                 op='add',
-                bot=dict(email='hambot-bot@zulip.testserver',
-                         user_id=bot.id,
-                         bot_type=bot.bot_type,
-                         full_name='The Bot of Hamlet',
-                         is_active=True,
-                         api_key=result['api_key'],
-                         avatar_url=result['avatar_url'],
-                         default_sending_stream=None,
-                         default_events_register_stream=None,
-                         default_all_public_streams=False,
-                         services=[],
-                         owner=self.example_email('hamlet'))
+                bot=dict(
+                    email='hambot-bot@zulip.testserver',
+                    user_id=bot.id,
+                    bot_type=bot.bot_type,
+                    full_name='The Bot of Hamlet',
+                    is_active=True,
+                    api_key=result['api_key'],
+                    avatar_url=result['avatar_url'],
+                    default_sending_stream=None,
+                    default_events_register_stream=None,
+                    default_all_public_streams=False,
+                    services=[],
+                    owner=hamlet.email,
+                ),
             ),
             event['event']
         )
@@ -330,11 +333,12 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         is sent when add_subscriptions_backend is called in the above api call.
         """
         hamlet = self.example_user('hamlet')
+        iago = self.example_user('iago')
         self.login_user(hamlet)
 
         # Normal user i.e. not a bot.
         request_data = {
-            'principals': '["' + self.example_email('iago') + '"]'
+            'principals': '["' + iago.email + '"]'
         }
         events = []  # type: List[Mapping[str, Any]]
         with tornado_redirected_to_list(events):
@@ -391,18 +395,20 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             dict(
                 type='realm_bot',
                 op='add',
-                bot=dict(email='hambot-bot@zulip.testserver',
-                         user_id=profile.id,
-                         full_name='The Bot of Hamlet',
-                         bot_type=profile.bot_type,
-                         is_active=True,
-                         api_key=result['api_key'],
-                         avatar_url=result['avatar_url'],
-                         default_sending_stream='Denmark',
-                         default_events_register_stream=None,
-                         default_all_public_streams=False,
-                         services=[],
-                         owner=self.example_email('hamlet'))
+                bot=dict(
+                    email='hambot-bot@zulip.testserver',
+                    user_id=profile.id,
+                    full_name='The Bot of Hamlet',
+                    bot_type=profile.bot_type,
+                    is_active=True,
+                    api_key=result['api_key'],
+                    avatar_url=result['avatar_url'],
+                    default_sending_stream='Denmark',
+                    default_events_register_stream=None,
+                    default_all_public_streams=False,
+                    services=[],
+                    owner=user_profile.email,
+                ),
             ),
             event['event']
         )
@@ -461,18 +467,20 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             dict(
                 type='realm_bot',
                 op='add',
-                bot=dict(email='hambot-bot@zulip.testserver',
-                         full_name='The Bot of Hamlet',
-                         user_id=bot_profile.id,
-                         bot_type=bot_profile.bot_type,
-                         is_active=True,
-                         api_key=result['api_key'],
-                         avatar_url=result['avatar_url'],
-                         default_sending_stream=None,
-                         default_events_register_stream='Denmark',
-                         default_all_public_streams=False,
-                         services=[],
-                         owner=self.example_email('hamlet'))
+                bot=dict(
+                    email='hambot-bot@zulip.testserver',
+                    full_name='The Bot of Hamlet',
+                    user_id=bot_profile.id,
+                    bot_type=bot_profile.bot_type,
+                    is_active=True,
+                    api_key=result['api_key'],
+                    avatar_url=result['avatar_url'],
+                    default_sending_stream=None,
+                    default_events_register_stream='Denmark',
+                    default_all_public_streams=False,
+                    services=[],
+                    owner=user_profile.email,
+                ),
             ),
             event['event']
         )
@@ -860,6 +868,8 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
     def test_patch_bot_owner(self) -> None:
         self.login('hamlet')
+        othello = self.example_user('othello')
+
         bot_info = {
             'full_name': u'The Bot of Hamlet',
             'short_name': u'hambot',
@@ -867,14 +877,14 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         result = self.client_post("/json/bots", bot_info)
         self.assert_json_success(result)
         bot_info = {
-            'bot_owner_id': self.example_user('othello').id,
+            'bot_owner_id': othello.id,
         }
         email = 'hambot-bot@zulip.testserver'
         result = self.client_patch("/json/bots/{}".format(self.get_bot_user(email).id), bot_info)
         self.assert_json_success(result)
 
         # Test bot's owner has been changed successfully.
-        self.assertEqual(result.json()['bot_owner'], self.example_email('othello'))
+        self.assertEqual(result.json()['bot_owner'], othello.email)
 
         self.login('othello')
         bot = self.get_bot()

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -216,12 +216,12 @@ class BugdownMiscTest(ZulipTestCase):
             for row in lst
         }
         self.assertEqual(by_id.get(fred2.id), dict(
-            email='fred2@example.com',
+            email=fred2.email,
             full_name='Fred Flintstone',
             id=fred2.id
         ))
         self.assertEqual(by_id.get(fred4.id), dict(
-            email='fred4@example.com',
+            email=fred4.email,
             full_name='Fred Flintstone',
             id=fred4.id
         ))

--- a/zerver/tests/test_cache.py
+++ b/zerver/tests/test_cache.py
@@ -271,7 +271,7 @@ class GenericBulkCachedFetchTest(ZulipTestCase):
             query_function=query_function,
             object_ids=[self.example_email("hamlet")]
         )  # type: Dict[str, UserProfile]
-        self.assertEqual(result, {hamlet.email: hamlet})
+        self.assertEqual(result, {hamlet.delivery_email: hamlet})
 
         flush_cache(Mock())
         # With the cache flushed, the query_function should get called:

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -188,7 +188,7 @@ class EmailChangeTestCase(ZulipTestCase):
                               Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS)
 
         self.login_user(user_profile)
-        old_email = user_profile.email
+        old_email = user_profile.delivery_email
         new_email = 'hamlet-new@zulip.com'
         obj = EmailChangeStatus.objects.create(new_email=new_email,
                                                old_email=old_email,

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -61,7 +61,7 @@ class TestFollowupEmails(ZulipTestCase):
         with self.settings(AUTH_LDAP_USER_ATTR_MAP=ldap_user_attr_map):
             self.login_with_return("newuser_email_as_uid@zulip.com",
                                    self.ldap_password("newuser_email_as_uid@zulip.com"))
-            user = UserProfile.objects.get(email="newuser_email_as_uid@zulip.com")
+            user = UserProfile.objects.get(delivery_email="newuser_email_as_uid@zulip.com")
             scheduled_emails = ScheduledEmail.objects.filter(users=user)
 
             self.assertEqual(len(scheduled_emails), 2)
@@ -81,7 +81,7 @@ class TestFollowupEmails(ZulipTestCase):
         ):
             self.login_with_return("newuser@zulip.com", self.ldap_password("newuser"))
 
-            user = UserProfile.objects.get(email="newuser@zulip.com")
+            user = UserProfile.objects.get(delivery_email="newuser@zulip.com")
             scheduled_emails = ScheduledEmail.objects.filter(users=user)
 
             self.assertEqual(len(scheduled_emails), 2)
@@ -100,7 +100,7 @@ class TestFollowupEmails(ZulipTestCase):
                 AUTH_LDAP_USER_ATTR_MAP=ldap_user_attr_map,
         ):
             self.login_with_return("newuser_with_email", self.ldap_password("newuser_with_email"))
-            user = UserProfile.objects.get(email="newuser_email@zulip.com")
+            user = UserProfile.objects.get(delivery_email="newuser_email@zulip.com")
             scheduled_emails = ScheduledEmail.objects.filter(users=user)
 
             self.assertEqual(len(scheduled_emails), 2)

--- a/zerver/tests/test_i18n.py
+++ b/zerver/tests/test_i18n.py
@@ -46,7 +46,7 @@ class EmailTranslationTestCase(ZulipTestCase):
         # Also remove the "nocoverage" from check_translation above.
         # check_translation("Viele Grüße", "patch", "/json/settings", {"email": "hamlets-new@zulip.com"})
         check_translation("Incrível!", "post", "/accounts/home/", {"email": "new-email@zulip.com"}, HTTP_ACCEPT_LANGUAGE="pt")
-        check_translation("Danke, dass Du", "post", '/accounts/find/', {'emails': hamlet.email})
+        check_translation("Danke, dass Du", "post", '/accounts/find/', {'emails': hamlet.delivery_email})
         check_translation("Hallo", "post", "/json/invites",  {"invitee_emails": "new-email@zulip.com",
                                                               "stream_ids": ujson.dumps([stream.id])})
 

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -471,7 +471,7 @@ class ImportExportTest(ZulipTestCase):
         self.assertEqual(len(data['zerver_userprofile_crossrealm']), 3)
         self.assertEqual(len(data['zerver_userprofile_mirrordummy']), 0)
 
-        exported_user_emails = self.get_set(data['zerver_userprofile'], 'email')
+        exported_user_emails = self.get_set(data['zerver_userprofile'], 'delivery_email')
         self.assertIn(self.example_email('cordelia'), exported_user_emails)
         self.assertIn('default-bot@zulip.com', exported_user_emails)
 
@@ -514,13 +514,13 @@ class ImportExportTest(ZulipTestCase):
 
         data = full_data['realm']
 
-        exported_user_emails = self.get_set(data['zerver_userprofile'], 'email')
+        exported_user_emails = self.get_set(data['zerver_userprofile'], 'delivery_email')
         self.assertIn(self.example_email('iago'), exported_user_emails)
         self.assertIn(self.example_email('hamlet'), exported_user_emails)
         self.assertNotIn('default-bot@zulip.com', exported_user_emails)
         self.assertNotIn(self.example_email('cordelia'), exported_user_emails)
 
-        dummy_user_emails = self.get_set(data['zerver_userprofile_mirrordummy'], 'email')
+        dummy_user_emails = self.get_set(data['zerver_userprofile_mirrordummy'], 'delivery_email')
         self.assertIn(self.example_email('cordelia'), dummy_user_emails)
         self.assertIn(self.example_email('othello'), dummy_user_emails)
         self.assertIn('default-bot@zulip.com', dummy_user_emails)
@@ -595,7 +595,7 @@ class ImportExportTest(ZulipTestCase):
         self.assertEqual(len(data['zerver_userprofile_crossrealm']), 3)
         self.assertEqual(len(data['zerver_userprofile_mirrordummy']), 0)
 
-        exported_user_emails = self.get_set(data['zerver_userprofile'], 'email')
+        exported_user_emails = self.get_set(data['zerver_userprofile'], 'delivery_email')
         self.assertIn(self.example_email('cordelia'), exported_user_emails)
         self.assertIn(self.example_email('hamlet'), exported_user_emails)
         self.assertIn(self.example_email('iago'), exported_user_emails)
@@ -986,8 +986,7 @@ class ImportExportTest(ZulipTestCase):
         # affect how the browser displays the rendered_content so we
         # are okay with using bs4 for this.  lxml package also has
         # similar behavior.
-        orig_polonius_user = UserProfile.objects.get(email=self.example_email("polonius"),
-                                                     realm=original_realm)
+        orig_polonius_user = self.example_user('polonius')
         original_msg = Message.objects.get(content=special_characters_message, sender__realm=original_realm)
         self.assertEqual(
             original_msg.rendered_content,
@@ -995,7 +994,7 @@ class ImportExportTest(ZulipTestCase):
              '<p><span class="user-mention" data-user-id="%s">@Polonius</span></p>' %
              (orig_polonius_user.id,))
         )
-        imported_polonius_user = UserProfile.objects.get(email=self.example_email("polonius"),
+        imported_polonius_user = UserProfile.objects.get(delivery_email=self.example_email("polonius"),
                                                          realm=imported_realm)
         imported_msg = Message.objects.get(content=special_characters_message, sender__realm=imported_realm)
         self.assertEqual(

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -90,6 +90,8 @@ class NarrowBuilderTest(ZulipTestCase):
         self.user_profile = self.example_user('hamlet')
         self.builder = NarrowBuilder(self.user_profile, column('id'))
         self.raw_query = select([column("id")], None, table("zerver_message"))
+        self.hamlet_email = self.example_user('hamlet').email
+        self.othello_email = self.example_user('othello').email
 
     def test_add_term_using_not_defined_operator(self) -> None:
         term = dict(operator='not-defined', operand='any')
@@ -247,11 +249,11 @@ class NarrowBuilderTest(ZulipTestCase):
         self._do_add_term_test(term, 'WHERE upper(subject) != upper(%(param_1)s)')
 
     def test_add_term_using_sender_operator(self) -> None:
-        term = dict(operator='sender', operand=self.example_email("othello"))
+        term = dict(operator='sender', operand=self.othello_email)
         self._do_add_term_test(term, 'WHERE sender_id = %(param_1)s')
 
     def test_add_term_using_sender_operator_and_negated(self) -> None:  # NEGATED
-        term = dict(operator='sender', operand=self.example_email("othello"), negated=True)
+        term = dict(operator='sender', operand=self.othello_email, negated=True)
         self._do_add_term_test(term, 'WHERE sender_id != %(param_1)s')
 
     def test_add_term_using_sender_operator_with_non_existing_user_as_operand(
@@ -260,38 +262,54 @@ class NarrowBuilderTest(ZulipTestCase):
         self.assertRaises(BadNarrowOperator, self._build_query, term)
 
     def test_add_term_using_pm_with_operator_and_not_the_same_user_as_operand(self) -> None:
-        term = dict(operator='pm-with', operand=self.example_email("othello"))
+        term = dict(operator='pm-with', operand=self.othello_email)
         self._do_add_term_test(term, 'WHERE sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s')
 
     def test_add_term_using_pm_with_operator_not_the_same_user_as_operand_and_negated(
             self) -> None:  # NEGATED
-        term = dict(operator='pm-with', operand=self.example_email("othello"), negated=True)
+        term = dict(operator='pm-with', operand=self.othello_email, negated=True)
         self._do_add_term_test(term, 'WHERE NOT (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s)')
 
     def test_add_term_using_pm_with_operator_the_same_user_as_operand(self) -> None:
-        term = dict(operator='pm-with', operand=self.example_email("hamlet"))
+        term = dict(operator='pm-with', operand=self.hamlet_email)
         self._do_add_term_test(term, 'WHERE sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s')
 
     def test_add_term_using_pm_with_operator_the_same_user_as_operand_and_negated(
             self) -> None:  # NEGATED
-        term = dict(operator='pm-with', operand=self.example_email("hamlet"), negated=True)
+        term = dict(operator='pm-with', operand=self.hamlet_email, negated=True)
         self._do_add_term_test(term, 'WHERE NOT (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s)')
 
     def test_add_term_using_pm_with_operator_and_self_and_user_as_operand(self) -> None:
-        term = dict(operator='pm-with', operand='hamlet@zulip.com, othello@zulip.com')
+        myself_and_other = ','.join([
+            self.example_user('hamlet').email,
+            self.example_user('othello').email,
+        ])
+        term = dict(operator='pm-with', operand=myself_and_other)
         self._do_add_term_test(term, 'WHERE sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s')
 
     def test_add_term_using_pm_with_operator_more_than_one_user_as_operand(self) -> None:
-        term = dict(operator='pm-with', operand='cordelia@zulip.com, othello@zulip.com')
+        two_others = ','.join([
+            self.example_user('cordelia').email,
+            self.example_user('othello').email,
+        ])
+        term = dict(operator='pm-with', operand=two_others)
         self._do_add_term_test(term, 'WHERE recipient_id = %(recipient_id_1)s')
 
     def test_add_term_using_pm_with_operator_self_and_user_as_operand_and_negated(
             self) -> None:  # NEGATED
-        term = dict(operator='pm-with', operand='hamlet@zulip.com, othello@zulip.com', negated=True)
+        myself_and_other = ','.join([
+            self.example_user('hamlet').email,
+            self.example_user('othello').email,
+        ])
+        term = dict(operator='pm-with', operand=myself_and_other, negated=True)
         self._do_add_term_test(term, 'WHERE NOT (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s)')
 
     def test_add_term_using_pm_with_operator_more_than_one_user_as_operand_and_negated(self) -> None:
-        term = dict(operator='pm-with', operand='cordelia@zulip.com, othello@zulip.com', negated=True)
+        two_others = ','.join([
+            self.example_user('cordelia').email,
+            self.example_user('othello').email,
+        ])
+        term = dict(operator='pm-with', operand=two_others, negated=True)
         self._do_add_term_test(term, 'WHERE recipient_id != %(recipient_id_1)s')
 
     def test_add_term_using_pm_with_operator_with_comma_noise(self) -> None:
@@ -299,7 +317,7 @@ class NarrowBuilderTest(ZulipTestCase):
         self.assertRaises(BadNarrowOperator, self._build_query, term)
 
     def test_add_term_using_pm_with_operator_with_existing_and_non_existing_user_as_operand(self) -> None:
-        term = dict(operator='pm-with', operand='othello@zulip.com,non-existing@zulip.com')
+        term = dict(operator='pm-with', operand=self.othello_email + ',non-existing@zulip.com')
         self.assertRaises(BadNarrowOperator, self._build_query, term)
 
     def test_add_term_using_id_operator(self) -> None:
@@ -319,19 +337,19 @@ class NarrowBuilderTest(ZulipTestCase):
 
     def test_add_term_using_group_pm_operator_and_not_the_same_user_as_operand(self) -> None:
         # Test wtihout any such group PM threads existing
-        term = dict(operator='group-pm-with', operand=self.example_email("othello"))
+        term = dict(operator='group-pm-with', operand=self.othello_email)
         self._do_add_term_test(term, 'WHERE 1 != 1')
 
         # Test with at least one such group PM thread existing
         self.send_huddle_message(self.user_profile, [self.example_user("othello"),
                                                      self.example_user("cordelia")])
 
-        term = dict(operator='group-pm-with', operand=self.example_email("othello"))
+        term = dict(operator='group-pm-with', operand=self.othello_email)
         self._do_add_term_test(term, 'WHERE recipient_id IN (%(recipient_id_1)s)')
 
     def test_add_term_using_group_pm_operator_not_the_same_user_as_operand_and_negated(
             self) -> None:  # NEGATED
-        term = dict(operator='group-pm-with', operand=self.example_email("othello"), negated=True)
+        term = dict(operator='group-pm-with', operand=self.othello_email, negated=True)
         self._do_add_term_test(term, 'WHERE 1 = 1')
 
     def test_add_term_using_group_pm_operator_with_non_existing_user_as_operand(self) -> None:
@@ -1151,11 +1169,25 @@ class GetOldMessagesTest(ZulipTestCase):
         self.login('hamlet')
         self.get_and_check_messages(dict())
 
+        othello_email = self.example_user('othello').email
+
         # We have to support the legacy tuple style while there are old
         # clients around, which might include third party home-grown bots.
-        self.get_and_check_messages(dict(narrow=ujson.dumps([['pm-with', self.example_email("othello")]])))
+        self.get_and_check_messages(
+            dict(
+                narrow=ujson.dumps(
+                    [['pm-with', othello_email]]
+                )
+            )
+        )
 
-        self.get_and_check_messages(dict(narrow=ujson.dumps([dict(operator='pm-with', operand=self.example_email("othello"))])))
+        self.get_and_check_messages(
+            dict(
+                narrow=ujson.dumps(
+                    [dict(operator='pm-with', operand=othello_email)]
+                )
+            )
+        )
 
     def test_client_avatar(self) -> None:
         """
@@ -1163,6 +1195,9 @@ class GetOldMessagesTest(ZulipTestCase):
         """
         hamlet = self.example_user('hamlet')
         self.login_user(hamlet)
+
+        do_set_realm_property(hamlet.realm, "email_address_visibility",
+                              Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE)
 
         self.send_personal_message(hamlet, self.example_user("iago"))
 
@@ -1243,7 +1278,7 @@ class GetOldMessagesTest(ZulipTestCase):
         for i in range(5):
             message_ids.append(self.send_personal_message(me, self.example_user("iago")))
 
-        narrow = [dict(operator='pm-with', operand=self.example_email("iago"))]
+        narrow = [dict(operator='pm-with', operand=self.example_user("iago").email)]
         self.message_visibility_test(narrow, message_ids, 2)
 
     def test_get_messages_with_narrow_group_pm_with(self) -> None:
@@ -1253,57 +1288,48 @@ class GetOldMessagesTest(ZulipTestCase):
         """
         me = self.example_user("hamlet")
 
+        iago = self.example_user("iago")
+        cordelia = self.example_user("cordelia")
+        othello = self.example_user("othello")
+
         matching_message_ids = []
 
         matching_message_ids.append(
             self.send_huddle_message(
                 me,
-                [
-                    self.example_user("iago"),
-                    self.example_user("cordelia"),
-                    self.example_user("othello"),
-                ],
+                [iago, cordelia, othello]
             ),
         )
 
         matching_message_ids.append(
             self.send_huddle_message(
                 me,
-                [
-                    self.example_user("cordelia"),
-                    self.example_user("othello"),
-                ],
+                [cordelia, othello]
             ),
         )
 
         non_matching_message_ids = []
 
         non_matching_message_ids.append(
-            self.send_personal_message(me, self.example_user("cordelia")),
+            self.send_personal_message(me, cordelia),
         )
 
         non_matching_message_ids.append(
             self.send_huddle_message(
                 me,
-                [
-                    self.example_user("iago"),
-                    self.example_user("othello"),
-                ],
+                [iago, othello]
             ),
         )
 
         non_matching_message_ids.append(
             self.send_huddle_message(
                 self.example_user("cordelia"),
-                [
-                    self.example_user("iago"),
-                    self.example_user("othello"),
-                ],
+                [iago, othello],
             ),
         )
 
         self.login_user(me)
-        test_operands = [self.example_email("cordelia"), self.example_user("cordelia").id]
+        test_operands = [cordelia.email, cordelia.id]
         for operand in test_operands:
             narrow = [dict(operator='group-pm-with', operand=operand)]
             result = self.get_and_check_messages(dict(narrow=ujson.dumps(narrow)))
@@ -1315,37 +1341,31 @@ class GetOldMessagesTest(ZulipTestCase):
         me = self.example_user('hamlet')
         self.login_user(me)
 
+        iago = self.example_user("iago")
+        cordelia = self.example_user("cordelia")
+        othello = self.example_user("othello")
+
         message_ids = []
         message_ids.append(
             self.send_huddle_message(
                 me,
-                [
-                    self.example_user("iago"),
-                    self.example_user("cordelia"),
-                    self.example_user("othello"),
-                ],
+                [iago, cordelia, othello],
             ),
         )
         message_ids.append(
             self.send_huddle_message(
                 me,
-                [
-                    self.example_user("cordelia"),
-                    self.example_user("othello"),
-                ],
+                [cordelia, othello],
             ),
         )
         message_ids.append(
             self.send_huddle_message(
                 me,
-                [
-                    self.example_user("cordelia"),
-                    self.example_user("iago"),
-                ],
+                [cordelia, iago],
             ),
         )
 
-        narrow = [dict(operator='group-pm-with', operand=self.example_email("cordelia"))]
+        narrow = [dict(operator='group-pm-with', operand=cordelia.email)]
         self.message_visibility_test(narrow, message_ids, 1)
 
     def test_include_history(self) -> None:
@@ -1531,20 +1551,25 @@ class GetOldMessagesTest(ZulipTestCase):
         messages sent by that person.
         """
         self.login('hamlet')
+
+        hamlet = self.example_user('hamlet')
+        othello = self.example_user('othello')
+        iago = self.example_user('iago')
+
         # We need to send a message here to ensure that we actually
         # have a stream message in this narrow view.
-        self.send_stream_message(self.example_user("hamlet"), "Scotland")
-        self.send_stream_message(self.example_user("othello"), "Scotland")
-        self.send_personal_message(self.example_user("othello"), self.example_user("hamlet"))
-        self.send_stream_message(self.example_user("iago"), "Scotland")
+        self.send_stream_message(hamlet, "Scotland")
+        self.send_stream_message(othello, "Scotland")
+        self.send_personal_message(othello, hamlet)
+        self.send_stream_message(iago, "Scotland")
 
-        test_operands = [self.example_email("othello"), self.example_user("othello").id]
+        test_operands = [othello.email, othello.id]
         for operand in test_operands:
             narrow = [dict(operator='sender', operand=operand)]
             result = self.get_and_check_messages(dict(narrow=ujson.dumps(narrow)))
 
             for message in result["messages"]:
-                self.assertEqual(message["sender_email"], self.example_email("othello"))
+                self.assertEqual(message["sender_id"], othello.id)
 
     def _update_tsvector_index(self) -> None:
         # We use brute force here and update our text search index
@@ -1611,9 +1636,11 @@ class GetOldMessagesTest(ZulipTestCase):
 
         next_message_id = self.get_last_message().id + 1
 
+        cordelia = self.example_user('cordelia')
+
         for topic, content in messages_to_search:
             self.send_stream_message(
-                sender=self.example_user("cordelia"),
+                sender=cordelia,
                 stream_name="Verona",
                 content=content,
                 topic_name=topic,
@@ -1622,7 +1649,7 @@ class GetOldMessagesTest(ZulipTestCase):
         self._update_tsvector_index()
 
         narrow = [
-            dict(operator='sender', operand=self.example_email("cordelia")),
+            dict(operator='sender', operand=cordelia.email),
             dict(operator='search', operand='lunch'),
         ]
         result = self.get_and_check_messages(dict(
@@ -1946,9 +1973,12 @@ class GetOldMessagesTest(ZulipTestCase):
         returns at most 1 message.
         """
         self.login('cordelia')
-        anchor = self.send_stream_message(self.example_user("cordelia"), "Verona")
 
-        narrow = [dict(operator='sender', operand=self.example_email("cordelia"))]
+        cordelia = self.example_user('cordelia')
+
+        anchor = self.send_stream_message(cordelia, "Verona")
+
+        narrow = [dict(operator='sender', operand=cordelia.email)]
         result = self.get_and_check_messages(dict(narrow=ujson.dumps(narrow),
                                                   anchor=anchor, num_before=0,
                                                   num_after=0))  # type: Dict[str, Any]
@@ -2738,23 +2768,25 @@ recipient_id = %(recipient_id_3)s AND upper(subject) = upper(%(param_2)s))\
 
     def test_get_messages_with_narrow_queries(self) -> None:
         query_ids = self.get_query_ids()
+        hamlet_email = self.example_user('hamlet').email
+        othello_email = self.example_user('othello').email
 
         sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND (sender_id = {othello_id} AND recipient_id = {hamlet_recipient} OR sender_id = {hamlet_id} AND recipient_id = {othello_recipient}) AND message_id = 0) AS anon_1 ORDER BY message_id ASC'
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query({'anchor': 0, 'num_before': 0, 'num_after': 0,
-                                              'narrow': '[["pm-with", "%s"]]' % (self.example_email("othello"),)},
+                                              'narrow': '[["pm-with", "%s"]]' % (othello_email,)},
                                              sql)
 
         sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND (sender_id = {othello_id} AND recipient_id = {hamlet_recipient} OR sender_id = {hamlet_id} AND recipient_id = {othello_recipient}) AND message_id = 0) AS anon_1 ORDER BY message_id ASC'
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query({'anchor': 0, 'num_before': 1, 'num_after': 0,
-                                              'narrow': '[["pm-with", "%s"]]' % (self.example_email("othello"),)},
+                                              'narrow': '[["pm-with", "%s"]]' % (othello_email,)},
                                              sql)
 
         sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND (sender_id = {othello_id} AND recipient_id = {hamlet_recipient} OR sender_id = {hamlet_id} AND recipient_id = {othello_recipient}) ORDER BY message_id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC'
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query({'anchor': 0, 'num_before': 0, 'num_after': 9,
-                                              'narrow': '[["pm-with", "%s"]]' % (self.example_email("othello"),)},
+                                              'narrow': '[["pm-with", "%s"]]' % (othello_email,)},
                                              sql)
 
         sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND (flags & 2) != 0 ORDER BY message_id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC'
@@ -2766,7 +2798,7 @@ recipient_id = %(recipient_id_3)s AND upper(subject) = upper(%(param_2)s))\
         sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND sender_id = {othello_id} ORDER BY message_id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC'
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query({'anchor': 0, 'num_before': 0, 'num_after': 9,
-                                              'narrow': '[["sender", "%s"]]' % (self.example_email("othello"),)},
+                                              'narrow': '[["sender", "%s"]]' % (othello_email,)},
                                              sql)
 
         sql_template = 'SELECT anon_1.message_id \nFROM (SELECT id AS message_id \nFROM zerver_message \nWHERE recipient_id = {scotland_recipient} ORDER BY zerver_message.id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC'
@@ -2803,7 +2835,7 @@ recipient_id = %(recipient_id_3)s AND upper(subject) = upper(%(param_2)s))\
         sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND sender_id = {hamlet_id} AND recipient_id = {hamlet_recipient} ORDER BY message_id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC'
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query({'anchor': 0, 'num_before': 0, 'num_after': 9,
-                                              'narrow': '[["pm-with", "%s"]]' % (self.example_email("hamlet"),)},
+                                              'narrow': '[["pm-with", "%s"]]' % (hamlet_email,)},
                                              sql)
 
         sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND recipient_id = {scotland_recipient} AND (flags & 2) != 0 ORDER BY message_id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC'
@@ -2868,6 +2900,9 @@ WHERE user_profile_id = {hamlet_id} AND (content ILIKE '%jumping%' OR subject IL
     def test_get_messages_with_search_using_email(self) -> None:
         self.login('cordelia')
 
+        othello = self.example_user('othello')
+        cordelia = self.example_user('cordelia')
+
         messages_to_search = [
             ('say hello', 'How are you doing, @**Othello, the Moor of Venice**?'),
             ('lunch plans', 'I am hungry!'),
@@ -2876,7 +2911,7 @@ WHERE user_profile_id = {hamlet_id} AND (content ILIKE '%jumping%' OR subject IL
 
         for topic, content in messages_to_search:
             self.send_stream_message(
-                sender=self.example_user("cordelia"),
+                sender=cordelia,
                 stream_name="Verona",
                 content=content,
                 topic_name=topic,
@@ -2885,8 +2920,8 @@ WHERE user_profile_id = {hamlet_id} AND (content ILIKE '%jumping%' OR subject IL
         self._update_tsvector_index()
 
         narrow = [
-            dict(operator='sender', operand=self.example_email("cordelia")),
-            dict(operator='search', operand=self.example_email("othello")),
+            dict(operator='sender', operand=cordelia.email),
+            dict(operator='search', operand=othello.email),
         ]
         result = self.get_and_check_messages(dict(
             narrow=ujson.dumps(narrow),
@@ -2896,7 +2931,7 @@ WHERE user_profile_id = {hamlet_id} AND (content ILIKE '%jumping%' OR subject IL
         self.assertEqual(len(result['messages']), 0)
 
         narrow = [
-            dict(operator='sender', operand=self.example_email("cordelia")),
+            dict(operator='sender', operand=cordelia.email),
             dict(operator='search', operand='othello'),
         ]
         result = self.get_and_check_messages(dict(
@@ -2911,7 +2946,6 @@ WHERE user_profile_id = {hamlet_id} AND (content ILIKE '%jumping%' OR subject IL
         self.assertEqual(
             meeting_message[MATCH_TOPIC],
             'say hello')
-        othello = self.example_user('othello')
         self.assertEqual(
             meeting_message['match_content'],
             ('<p>How are you doing, <span class="user-mention" data-user-id="%s">' +

--- a/zerver/tests/test_new_users.py
+++ b/zerver/tests/test_new_users.py
@@ -34,13 +34,18 @@ class SendLoginEmailTest(ZulipTestCase):
             user.twenty_four_hour_time = False
             user.date_joined = mock_time - datetime.timedelta(seconds=JUST_CREATED_THRESHOLD + 1)
             user.save()
-            password = initial_password(user.email)
+            password = initial_password(user.delivery_email)
+            login_info = dict(
+                username=user.delivery_email,
+                password=password,
+            )
             firefox_windows = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0"
             user_tz = get_timezone(user.timezone)
             mock_time = datetime.datetime(year=2018, month=1, day=1, tzinfo=utc)
             reference_time = mock_time.astimezone(user_tz).strftime('%A, %B %d, %Y at %I:%M%p %Z')
             with mock.patch('zerver.signals.timezone_now', return_value=mock_time):
-                self.client_post("/accounts/login/", info={"username": user.email, "password": password},
+                self.client_post("/accounts/login/",
+                                 info=login_info,
                                  HTTP_USER_AGENT=firefox_windows)
 
             # email is sent and correct subject
@@ -55,7 +60,8 @@ class SendLoginEmailTest(ZulipTestCase):
             user.twenty_four_hour_time = True
             user.save()
             with mock.patch('zerver.signals.timezone_now', return_value=mock_time):
-                self.client_post("/accounts/login/", info={"username": user.email, "password": password},
+                self.client_post("/accounts/login/",
+                                 info=login_info,
                                  HTTP_USER_AGENT=firefox_windows)
 
             reference_time = mock_time.astimezone(user_tz).strftime('%A, %B %d, %Y at %H:%M %Z')

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -216,13 +216,13 @@ class ReactionMessageIDTest(ZulipTestCase):
         Reacting to a inaccessible (for instance, private) message fails
         """
         pm_sender = self.example_user("hamlet")
-        pm_recipient = self.example_email("othello")
+        pm_recipient = self.example_user("othello")
         reaction_sender = self.example_user("iago")
 
         result = self.api_post(pm_sender,
                                "/api/v1/messages", {"type": "private",
                                                     "content": "Test message",
-                                                    "to": pm_recipient})
+                                                    "to": pm_recipient.email})
         self.assert_json_success(result)
         pm_id = result.json()['id']
         reaction_info = {

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -241,7 +241,7 @@ class RealmTest(ZulipTestCase):
         self.assertIn('Reactivate your Zulip organization', outbox[0].subject)
         self.assertIn('Dear former administrators', outbox[0].body)
         admins = realm.get_human_admin_users()
-        confirmation_url = self.get_confirmation_url_from_outbox(admins[0].email)
+        confirmation_url = self.get_confirmation_url_from_outbox(admins[0].delivery_email)
         response = self.client_get(confirmation_url)
         self.assert_in_success_response(['Your organization has been successfully reactivated'], response)
         realm = get_realm('zulip')
@@ -392,8 +392,9 @@ class RealmTest(ZulipTestCase):
         result = self.client_patch('/json/realm', req)
         self.assert_json_error(result, 'Invalid email_address_visibility')
 
+        self.reset_emails_in_zulip_realm()
         realm = get_realm("zulip")
-        self.assertEqual(realm.email_address_visibility, Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE)
+
         req = dict(email_address_visibility = ujson.dumps(Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS))
         result = self.client_patch('/json/realm', req)
         self.assert_json_success(result)

--- a/zerver/tests/test_report.py
+++ b/zerver/tests/test_report.py
@@ -125,7 +125,7 @@ class TestReport(ZulipTestCase):
             self.assertEqual(report[k], params[k])
 
         self.assertEqual(report['more_info'], dict(foo='bar', draft_content="'**xxxxx**'"))
-        self.assertEqual(report['user_email'], user.email)
+        self.assertEqual(report['user_email'], user.delivery_email)
 
         # Teset with no more_info
         del params['more_info']

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -70,7 +70,7 @@ class ChangeSettingsTest(ZulipTestCase):
             "/json/settings",
             dict(
                 full_name='Foo Bar',
-                old_password=initial_password(user.email),
+                old_password=initial_password(user.delivery_email),
                 new_password='foobar1',
             ))
         self.assert_json_success(json_result)
@@ -86,7 +86,7 @@ class ChangeSettingsTest(ZulipTestCase):
         # with as few moving parts as possible).
         self.assertTrue(
             self.client.login(
-                username=user.email,
+                username=user.delivery_email,
                 password='foobar1',
                 realm=user.realm
             )

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -219,7 +219,7 @@ class PasswordResetTest(ZulipTestCase):
 
     def test_password_reset(self) -> None:
         user = self.example_user("hamlet")
-        email = user.email
+        email = user.delivery_email
         old_password = initial_password(email)
 
         self.login_user(user)
@@ -310,7 +310,7 @@ class PasswordResetTest(ZulipTestCase):
 
     def test_password_reset_for_deactivated_user(self) -> None:
         user_profile = self.example_user("hamlet")
-        email = user_profile.email
+        email = user_profile.delivery_email
         do_deactivate_user(user_profile)
 
         # start the password reset process by supplying an email address
@@ -338,7 +338,7 @@ class PasswordResetTest(ZulipTestCase):
 
     def test_password_reset_with_deactivated_realm(self) -> None:
         user_profile = self.example_user("hamlet")
-        email = user_profile.email
+        email = user_profile.delivery_email
         do_deactivate_realm(user_profile.realm)
 
         # start the password reset process by supplying an email address
@@ -361,7 +361,7 @@ class PasswordResetTest(ZulipTestCase):
     @override_settings(RATE_LIMITING=True)
     def test_rate_limiting(self) -> None:
         user_profile = self.example_user("hamlet")
-        email = user_profile.email
+        email = user_profile.delivery_email
         from django.core.mail import outbox
 
         add_ratelimit_rule(10, 2, domain='password_reset_form_by_email')
@@ -531,7 +531,7 @@ class LoginTest(ZulipTestCase):
     @override_settings(RATE_LIMITING_AUTHENTICATE=True)
     def test_login_bad_password_rate_limiter(self) -> None:
         user_profile = self.example_user("hamlet")
-        email = user_profile.email
+        email = user_profile.delivery_email
         add_ratelimit_rule(10, 2, domain='authenticate_by_username')
 
         start_time = time.time()
@@ -576,6 +576,8 @@ class LoginTest(ZulipTestCase):
         self.assert_logged_in_user_id(None)
 
     def test_register(self) -> None:
+        self.reset_emails_in_zulip_realm()
+
         realm = get_realm("zulip")
         stream_names = ["stream_{}".format(i) for i in range(40)]
         for stream_name in stream_names:
@@ -1074,7 +1076,9 @@ class InviteUserTest(InviteUserBase):
         # The first, from notification-bot to the user who invited the new user.
         second_msg = last_3_messages[1]
         self.assertEqual(second_msg.sender.email, "notification-bot@zulip.com")
-        self.assertTrue(second_msg.content.startswith("alice_zulip.com <`alice@zulip.com`> accepted your"))
+        self.assertTrue(second_msg.content.startswith(
+            "alice_zulip.com <`{}`> accepted your".format(invitee_profile.email)
+        ))
 
         # The second, from welcome-bot to the user who was invited.
         third_msg = last_3_messages[2]
@@ -1477,10 +1481,13 @@ class InvitationsTestCase(InviteUserBase):
                                                 referred_by=user_profile, status=active_value)
         prereg_user_three.save()
 
-        multiuse_invite_one = MultiuseInvite.objects.create(referred_by=self.example_user("hamlet"), realm=realm)
+        hamlet = self.example_user('hamlet')
+        othello = self.example_user('othello')
+
+        multiuse_invite_one = MultiuseInvite.objects.create(referred_by=hamlet, realm=realm)
         create_confirmation_link(multiuse_invite_one, realm.host, Confirmation.MULTIUSE_INVITE)
 
-        multiuse_invite_two = MultiuseInvite.objects.create(referred_by=self.example_user("othello"), realm=realm)
+        multiuse_invite_two = MultiuseInvite.objects.create(referred_by=othello, realm=realm)
         create_confirmation_link(multiuse_invite_two, realm.host, Confirmation.MULTIUSE_INVITE)
         confirmation = Confirmation.objects.last()
         confirmation.date_sent = expired_datetime
@@ -1488,8 +1495,12 @@ class InvitationsTestCase(InviteUserBase):
 
         result = self.client_get("/json/invites")
         self.assertEqual(result.status_code, 200)
-        self.assert_in_success_response(["TestOne@zulip.com", "hamlet@zulip.com"], result)
-        self.assert_not_in_success_response(["TestTwo@zulip.com", "TestThree@zulip.com", "othello@zulip.com"], result)
+        self.assert_in_success_response(
+            ["TestOne@zulip.com", hamlet.email],
+            result)
+        self.assert_not_in_success_response(
+            ["TestTwo@zulip.com", "TestThree@zulip.com", "othello@zulip.com", othello.email],
+            result)
 
     def test_successful_delete_invitation(self) -> None:
         """
@@ -2269,7 +2280,7 @@ class UserSignUpTest(InviteUserBase):
         self.assertEqual(result.status_code, 302)
 
         get_user(email, realm)
-        self.assertEqual(UserProfile.objects.filter(email=email).count(), 2)
+        self.assertEqual(UserProfile.objects.filter(delivery_email=email).count(), 2)
 
     def test_signup_invalid_name(self) -> None:
         """
@@ -2484,8 +2495,8 @@ class UserSignUpTest(InviteUserBase):
         result = self.submit_reg_form_for_user(email,
                                                password,
                                                full_name="New Guy")
-        user_profile = UserProfile.objects.get(email=email)
-        self.assertEqual(user_profile.email, email)
+        user_profile = UserProfile.objects.get(delivery_email=email)
+        self.assertEqual(user_profile.delivery_email, email)
 
         # Now try to to register using the first confirmation url:
         result = self.client_get(first_confirmation_url)
@@ -2542,13 +2553,13 @@ class UserSignUpTest(InviteUserBase):
             "newguy", list(set(default_streams + group1_streams + group2_streams)))
 
     def test_signup_without_user_settings_from_another_realm(self) -> None:
-        email = self.example_email('hamlet')
+        hamlet_in_zulip = self.example_user('hamlet')
+        email = hamlet_in_zulip.delivery_email
         password = "newpassword"
         subdomain = "lear"
         realm = get_realm("lear")
 
         # Make an account in the Zulip realm, but we're not copying from there.
-        hamlet_in_zulip = get_user(self.example_email("hamlet"), get_realm("zulip"))
         hamlet_in_zulip.left_side_userlist = True
         hamlet_in_zulip.default_language = "de"
         hamlet_in_zulip.emojiset = "twitter"
@@ -2577,16 +2588,16 @@ class UserSignUpTest(InviteUserBase):
         self.assertEqual(hamlet.tutorial_status, UserProfile.TUTORIAL_WAITING)
 
     def test_signup_with_user_settings_from_another_realm(self) -> None:
-        email = self.example_email('hamlet')
+        hamlet_in_zulip = self.example_user('hamlet')
+        email = hamlet_in_zulip.delivery_email
         password = "newpassword"
         subdomain = "lear"
         lear_realm = get_realm("lear")
-        zulip_realm = get_realm("zulip")
 
         self.login('hamlet')
         with get_test_image_file('img.png') as image_file:
             self.client_post("/json/users/me/avatar", {'file': image_file})
-        hamlet_in_zulip = get_user(self.example_email("hamlet"), zulip_realm)
+        hamlet_in_zulip.refresh_from_db()
         hamlet_in_zulip.left_side_userlist = True
         hamlet_in_zulip.default_language = "de"
         hamlet_in_zulip.emojiset = "twitter"
@@ -2616,7 +2627,7 @@ class UserSignUpTest(InviteUserBase):
         result = self.submit_reg_form_for_user(email, password, source_realm="zulip",
                                                HTTP_HOST=subdomain + ".testserver")
 
-        hamlet_in_lear = get_user(self.example_email("hamlet"), lear_realm)
+        hamlet_in_lear = get_user(email, lear_realm)
         self.assertEqual(hamlet_in_lear.left_side_userlist, True)
         self.assertEqual(hamlet_in_lear.default_language, "de")
         self.assertEqual(hamlet_in_lear.emojiset, "twitter")
@@ -2624,9 +2635,14 @@ class UserSignUpTest(InviteUserBase):
         self.assertEqual(hamlet_in_lear.enter_sends, True)
         self.assertEqual(hamlet_in_lear.enable_stream_audible_notifications, False)
         self.assertEqual(hamlet_in_lear.tutorial_status, UserProfile.TUTORIAL_FINISHED)
+
         zulip_path_id = avatar_disk_path(hamlet_in_zulip)
-        hamlet_path_id = avatar_disk_path(hamlet_in_zulip)
-        self.assertEqual(open(zulip_path_id, "rb").read(), open(hamlet_path_id, "rb").read())
+        lear_path_id = avatar_disk_path(hamlet_in_lear)
+        zulip_avatar_bits = open(zulip_path_id, 'rb').read()
+        lear_avatar_bits = open(lear_path_id, 'rb').read()
+
+        self.assertTrue(len(zulip_avatar_bits) > 500)
+        self.assertEqual(zulip_avatar_bits, lear_avatar_bits)
 
     def test_signup_invalid_subdomain(self) -> None:
         """
@@ -2913,7 +2929,7 @@ class UserSignUpTest(InviteUserBase):
                                                    HTTP_HOST=subdomain + ".testserver")
             # Didn't create an account
             with self.assertRaises(UserProfile.DoesNotExist):
-                user_profile = UserProfile.objects.get(email=email)
+                user_profile = UserProfile.objects.get(delivery_email=email)
             self.assertEqual(result.status_code, 302)
             self.assertEqual(result.url, "/accounts/login/?email=newuser%40zulip.com")
 
@@ -2923,7 +2939,7 @@ class UserSignUpTest(InviteUserBase):
                                                    full_name=full_name,
                                                    # Pass HTTP_HOST for the target subdomain
                                                    HTTP_HOST=subdomain + ".testserver")
-            user_profile = UserProfile.objects.get(email=email)
+            user_profile = UserProfile.objects.get(delivery_email=email)
             # Name comes from form which was set by LDAP.
             self.assertEqual(user_profile.full_name, full_name)
             # Short name comes from LDAP.
@@ -2966,7 +2982,7 @@ class UserSignUpTest(InviteUserBase):
                                                    full_name="Ignore",
                                                    # Pass HTTP_HOST for the target subdomain
                                                    HTTP_HOST=subdomain + ".testserver")
-            user_profile = UserProfile.objects.get(email=email)
+            user_profile = UserProfile.objects.get(delivery_email=email)
             # Name comes from form which was set by LDAP.
             self.assertEqual(user_profile.full_name, "First Last")
             # Short name comes from LDAP.
@@ -3003,7 +3019,7 @@ class UserSignUpTest(InviteUserBase):
             self.login_with_return(email, password,
                                    HTTP_HOST=subdomain + ".testserver")
 
-            user_profile = UserProfile.objects.get(email=email)
+            user_profile = UserProfile.objects.get(delivery_email=email)
             # Name comes from form which was set by LDAP.
             self.assertEqual(user_profile.full_name, full_name)
             self.assertEqual(user_profile.short_name, 'shortname')
@@ -3035,8 +3051,8 @@ class UserSignUpTest(InviteUserBase):
             self.login_with_return(email, password,
                                    HTTP_HOST=subdomain + ".testserver")
 
-            user_profile = UserProfile.objects.get(email=email, realm=get_realm('zulip'))
-            self.assertEqual(user_profile.email, email)
+            user_profile = UserProfile.objects.get(
+                delivery_email=email, realm=get_realm('zulip'))
             self.logout()
 
             # Test registration in another realm works.
@@ -3044,8 +3060,9 @@ class UserSignUpTest(InviteUserBase):
             self.login_with_return(email, password,
                                    HTTP_HOST=subdomain + ".testserver")
 
-            user_profile = UserProfile.objects.get(email=email, realm=get_realm('test'))
-            self.assertEqual(user_profile.email, email)
+            user_profile = UserProfile.objects.get(
+                delivery_email=email, realm=get_realm('test'))
+            self.assertEqual(user_profile.delivery_email, email)
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',
                                                 'zproject.backends.ZulipDummyBackend'))
@@ -3086,7 +3103,7 @@ class UserSignUpTest(InviteUserBase):
                                                        password,
                                                        # Pass HTTP_HOST for the target subdomain
                                                        HTTP_HOST=subdomain + ".testserver")
-            user_profile = UserProfile.objects.get(email=email)
+            user_profile = UserProfile.objects.get(delivery_email=email)
             # Name comes from LDAP session.
             self.assertEqual(user_profile.full_name, 'New LDAP fullname')
 
@@ -3133,7 +3150,7 @@ class UserSignUpTest(InviteUserBase):
             self.assertEqual(result.status_code, 302)
             # We get redirected back to the login page because password was wrong
             self.assertEqual(result.url, "/accounts/login/?email=newuser%40zulip.com")
-            self.assertFalse(UserProfile.objects.filter(email=email).exists())
+            self.assertFalse(UserProfile.objects.filter(delivery_email=email).exists())
 
         # For the rest of the test we delete the user from ldap.
         del self.mock_ldap.directory["uid=newuser,ou=users,dc=zulip,dc=com"]
@@ -3154,7 +3171,7 @@ class UserSignUpTest(InviteUserBase):
             # We get redirected back to the login page because emails matching LDAP_APPEND_DOMAIN,
             # aren't allowed to create non-ldap accounts.
             self.assertEqual(result.url, "/accounts/login/?email=newuser%40zulip.com")
-            self.assertFalse(UserProfile.objects.filter(email=email).exists())
+            self.assertFalse(UserProfile.objects.filter(delivery_email=email).exists())
 
         # If the email is outside of LDAP_APPEND_DOMAIN, we succesfully create a non-ldap account,
         # with the password managed in the zulip database.
@@ -3180,7 +3197,7 @@ class UserSignUpTest(InviteUserBase):
                                                    HTTP_HOST=subdomain + ".testserver")
             self.assertEqual(result.status_code, 302)
             self.assertEqual(result.url, "http://zulip.testserver/")
-            user_profile = UserProfile.objects.get(email=email)
+            user_profile = UserProfile.objects.get(delivery_email=email)
             # Name comes from the POST request, not LDAP
             self.assertEqual(user_profile.full_name, 'Non-LDAP Full Name')
 
@@ -3227,7 +3244,7 @@ class UserSignUpTest(InviteUserBase):
             self.assertEqual(result.status_code, 302)
             # We get redirected back to the login page because password was wrong
             self.assertEqual(result.url, "/accounts/login/?email=newuser_email%40zulip.com")
-            self.assertFalse(UserProfile.objects.filter(email=email).exists())
+            self.assertFalse(UserProfile.objects.filter(delivery_email=email).exists())
 
         # If the user's email is not in the LDAP directory , though, we
         # successfully create an account with a password in the Zulip
@@ -3266,7 +3283,7 @@ class UserSignUpTest(InviteUserBase):
                                                    HTTP_HOST=subdomain + ".testserver")
             self.assertEqual(result.status_code, 302)
             self.assertEqual(result.url, "http://zulip.testserver/")
-            user_profile = UserProfile.objects.get(email=email)
+            user_profile = UserProfile.objects.get(delivery_email=email)
             # Name comes from the POST request, not LDAP
             self.assertEqual(user_profile.full_name, 'Non-LDAP Full Name')
 
@@ -3310,14 +3327,16 @@ class UserSignUpTest(InviteUserBase):
                                                 'zproject.backends.EmailAuthBackend'))
     def test_ldap_invite_user_as_admin(self) -> None:
         self.ldap_invite_and_signup_as(PreregistrationUser.INVITE_AS['REALM_ADMIN'])
-        user_profile = UserProfile.objects.get(email=self.nonreg_email('newuser'))
+        user_profile = UserProfile.objects.get(
+            delivery_email=self.nonreg_email('newuser'))
         self.assertTrue(user_profile.is_realm_admin)
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',
                                                 'zproject.backends.EmailAuthBackend'))
     def test_ldap_invite_user_as_guest(self) -> None:
         self.ldap_invite_and_signup_as(PreregistrationUser.INVITE_AS['GUEST_USER'])
-        user_profile = UserProfile.objects.get(email=self.nonreg_email('newuser'))
+        user_profile = UserProfile.objects.get(
+            delivery_email=self.nonreg_email('newuser'))
         self.assertTrue(user_profile.is_guest)
 
     @override_settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipLDAPAuthBackend',
@@ -3333,7 +3352,7 @@ class UserSignUpTest(InviteUserBase):
         # Invite user.
         self.ldap_invite_and_signup_as(PreregistrationUser.INVITE_AS['REALM_ADMIN'], streams=[stream_name])
 
-        user_profile = UserProfile.objects.get(email=self.nonreg_email('newuser'))
+        user_profile = UserProfile.objects.get(delivery_email=self.nonreg_email('newuser'))
         self.assertTrue(user_profile.is_realm_admin)
         sub = get_stream_subscriptions_for_user(user_profile).filter(recipient__type_id=stream.id)
         self.assertEqual(len(sub), 1)
@@ -3361,7 +3380,7 @@ class UserSignUpTest(InviteUserBase):
                                                    full_name="New Name",
                                                    # Pass HTTP_HOST for the target subdomain
                                                    HTTP_HOST=subdomain + ".testserver")
-            user_profile = UserProfile.objects.get(email=email)
+            user_profile = UserProfile.objects.get(delivery_email=email)
             # 'New Name' comes from POST data; not from LDAP session.
             self.assertEqual(user_profile.full_name, 'New Name')
 
@@ -3425,7 +3444,7 @@ class UserSignUpTest(InviteUserBase):
         password = "test"
         subdomain = "zephyr"
         user_profile = self.mit_user("sipbtest")
-        email = user_profile.email
+        email = user_profile.delivery_email
         user_profile.is_mirror_dummy = True
         user_profile.is_active = False
         user_profile.save()
@@ -3486,7 +3505,7 @@ class UserSignUpTest(InviteUserBase):
         raise an AssertionError.
         """
         user_profile = self.mit_user("sipbtest")
-        email = user_profile.email
+        email = user_profile.delivery_email
         user_profile.is_mirror_dummy = True
         user_profile.is_active = True
         user_profile.save()
@@ -3505,7 +3524,7 @@ class UserSignUpTest(InviteUserBase):
         user_profile = UserProfile.objects.all().order_by("id").last()
 
         self.assertEqual(result.status_code, 302)
-        self.assertEqual(user_profile.email, email)
+        self.assertEqual(user_profile.delivery_email, email)
         self.assertEqual(result['Location'], "http://zulip.testserver/")
         self.assert_logged_in_user_id(user_profile.id)
 

--- a/zerver/tests/test_unread.py
+++ b/zerver/tests/test_unread.py
@@ -289,16 +289,17 @@ class UnreadCountTests(ZulipTestCase):
         differences = [key for key in expected if expected[key] != event[key]]
         self.assertTrue(len(differences) == 0)
 
+        hamlet = self.example_user('hamlet')
         um = list(UserMessage.objects.filter(message=message_id))
         for msg in um:
-            if msg.user_profile.email == self.example_email("hamlet"):
+            if msg.user_profile.email == hamlet.email:
                 self.assertTrue(msg.flags.read)
             else:
                 self.assertFalse(msg.flags.read)
 
         unrelated_messages = list(UserMessage.objects.filter(message=unrelated_message_id))
         for msg in unrelated_messages:
-            if msg.user_profile.email == self.example_email("hamlet"):
+            if msg.user_profile.email == hamlet.email:
                 self.assertFalse(msg.flags.read)
 
     def test_mark_all_in_invalid_stream_read(self) -> None:
@@ -347,12 +348,12 @@ class UnreadCountTests(ZulipTestCase):
 
         um = list(UserMessage.objects.filter(message=message_id))
         for msg in um:
-            if msg.user_profile.email == self.example_email("hamlet"):
+            if msg.user_profile_id == user_profile.id:
                 self.assertTrue(msg.flags.read)
 
         unrelated_messages = list(UserMessage.objects.filter(message=unrelated_message_id))
         for msg in unrelated_messages:
-            if msg.user_profile.email == self.example_email("hamlet"):
+            if msg.user_profile_id == user_profile.id:
                 self.assertFalse(msg.flags.read)
 
     def test_mark_all_in_invalid_topic_read(self) -> None:

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -16,7 +16,7 @@ from zerver.lib.test_classes import (
 
 from zerver.models import UserProfile, Recipient, Realm, \
     RealmDomain, UserHotspot, get_client, \
-    get_user, get_realm, get_stream, \
+    get_user, get_user_by_delivery_email, get_realm, get_stream, \
     get_source_profile, get_system_bot, \
     ScheduledEmail, check_valid_user_ids, \
     get_user_by_id_in_realm_including_cross_realm, CustomProfileField, \
@@ -127,43 +127,47 @@ class PermissionTest(ZulipTestCase):
 
     def test_admin_api(self) -> None:
         self.login('hamlet')
-        admin = self.example_user('hamlet')
-        user = self.example_user('othello')
-        realm = admin.realm
-        do_change_is_admin(admin, True)
+
+        hamlet = self.example_user('hamlet')
+        othello = self.example_user('othello')
+        iago = self.example_user('iago')
+        realm = hamlet.realm
+
+        # Make hamlet an additional admin
+        do_change_is_admin(hamlet, True)
 
         # Make sure we see is_admin flag in /json/users
         result = self.client_get('/json/users')
         self.assert_json_success(result)
         members = result.json()['members']
-        hamlet = find_dict(members, 'email', self.example_email("hamlet"))
-        self.assertTrue(hamlet['is_admin'])
-        othello = find_dict(members, 'email', self.example_email("othello"))
-        self.assertFalse(othello['is_admin'])
+        hamlet_dict = find_dict(members, 'email', hamlet.email)
+        self.assertTrue(hamlet_dict['is_admin'])
+        othello_dict = find_dict(members, 'email', othello.email)
+        self.assertFalse(othello_dict['is_admin'])
 
         # Giveth
         req = dict(is_admin=ujson.dumps(True))
 
         events = []  # type: List[Mapping[str, Any]]
         with tornado_redirected_to_list(events):
-            result = self.client_patch('/json/users/{}'.format(self.example_user("othello").id), req)
+            result = self.client_patch('/json/users/{}'.format(othello.id), req)
         self.assert_json_success(result)
         admin_users = realm.get_human_admin_users()
-        self.assertTrue(user in admin_users)
+        self.assertTrue(othello in admin_users)
         person = events[0]['event']['person']
-        self.assertEqual(person['email'], self.example_email("othello"))
+        self.assertEqual(person['email'], othello.email)
         self.assertEqual(person['is_admin'], True)
 
         # Taketh away
         req = dict(is_admin=ujson.dumps(False))
         events = []
         with tornado_redirected_to_list(events):
-            result = self.client_patch('/json/users/{}'.format(self.example_user("othello").id), req)
+            result = self.client_patch('/json/users/{}'.format(othello.id), req)
         self.assert_json_success(result)
         admin_users = realm.get_human_admin_users()
-        self.assertFalse(user in admin_users)
+        self.assertFalse(othello in admin_users)
         person = events[0]['event']['person']
-        self.assertEqual(person['email'], self.example_email("othello"))
+        self.assertEqual(person['email'], othello.email)
         self.assertEqual(person['is_admin'], False)
 
         # Cannot take away from last admin
@@ -171,23 +175,25 @@ class PermissionTest(ZulipTestCase):
         req = dict(is_admin=ujson.dumps(False))
         events = []
         with tornado_redirected_to_list(events):
-            result = self.client_patch('/json/users/{}'.format(self.example_user("hamlet").id), req)
+            result = self.client_patch('/json/users/{}'.format(hamlet.id), req)
         self.assert_json_success(result)
         admin_users = realm.get_human_admin_users()
-        self.assertFalse(admin in admin_users)
+        self.assertFalse(hamlet in admin_users)
         person = events[0]['event']['person']
-        self.assertEqual(person['email'], self.example_email("hamlet"))
+        self.assertEqual(person['email'], hamlet.email)
         self.assertEqual(person['is_admin'], False)
         with tornado_redirected_to_list([]):
-            result = self.client_patch('/json/users/{}'.format(self.example_user("iago").id), req)
+            result = self.client_patch('/json/users/{}'.format(iago.id), req)
         self.assert_json_error(result, 'Cannot remove the only organization administrator')
 
         # Make sure only admins can patch other user's info.
         self.login('othello')
-        result = self.client_patch('/json/users/{}'.format(self.example_user("hamlet").id), req)
+        result = self.client_patch('/json/users/{}'.format(hamlet.id), req)
         self.assert_json_error(result, 'Insufficient permission')
 
     def test_admin_api_hide_emails(self) -> None:
+        self.reset_emails_in_zulip_realm()
+
         user = self.example_user('hamlet')
         admin = self.example_user('iago')
         self.login_user(user)
@@ -642,7 +648,7 @@ class AdminCreateUserTest(ZulipTestCase):
         self.assert_json_success(result)
 
         # Romeo is a newly registered user
-        new_user = get_user('romeo@zulip.net', get_realm('zulip'))
+        new_user = get_user_by_delivery_email('romeo@zulip.net', get_realm('zulip'))
         self.assertEqual(new_user.full_name, 'Romeo Montague')
         self.assertEqual(new_user.short_name, 'Romeo')
 
@@ -687,8 +693,8 @@ class UserProfileTest(ZulipTestCase):
         hamlet = self.example_user('hamlet')
         othello = self.example_user('othello')
         dct = get_emails_from_user_ids([hamlet.id, othello.id])
-        self.assertEqual(dct[hamlet.id], self.example_email("hamlet"))
-        self.assertEqual(dct[othello.id], self.example_email("othello"))
+        self.assertEqual(dct[hamlet.id], hamlet.email)
+        self.assertEqual(dct[othello.id], othello.email)
 
     def test_valid_user_id(self) -> None:
         realm = get_realm("zulip")
@@ -759,20 +765,28 @@ class UserProfileTest(ZulipTestCase):
 
     def test_bulk_get_users(self) -> None:
         from zerver.lib.users import bulk_get_users
-        hamlet = self.example_email("hamlet")
-        cordelia = self.example_email("cordelia")
-        webhook_bot = self.example_email("webhook_bot")
-        result = bulk_get_users([hamlet, cordelia], get_realm("zulip"))
-        self.assertEqual(result[hamlet].email, hamlet)
-        self.assertEqual(result[cordelia].email, cordelia)
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        webhook_bot = self.example_user("webhook_bot")
+        result = bulk_get_users(
+            [hamlet.email, cordelia.email],
+            get_realm("zulip")
+        )
+        self.assertEqual(result[hamlet.email].email, hamlet.email)
+        self.assertEqual(result[cordelia.email].email, cordelia.email)
 
-        result = bulk_get_users([hamlet, cordelia, webhook_bot], None,
-                                base_query=UserProfile.objects.all())
-        self.assertEqual(result[hamlet].email, hamlet)
-        self.assertEqual(result[cordelia].email, cordelia)
-        self.assertEqual(result[webhook_bot].email, webhook_bot)
+        result = bulk_get_users(
+            [hamlet.email, cordelia.email, webhook_bot.email],
+            None,
+            base_query=UserProfile.objects.all()
+        )
+        self.assertEqual(result[hamlet.email].email, hamlet.email)
+        self.assertEqual(result[cordelia.email].email, cordelia.email)
+        self.assertEqual(result[webhook_bot.email].email, webhook_bot.email)
 
     def test_get_accounts_for_email(self) -> None:
+        self.reset_emails_in_zulip_realm()
+
         def check_account_present_in_accounts(user: UserProfile, accounts: List[Dict[str, Optional[str]]]) -> None:
             for account in accounts:
                 realm = user.realm
@@ -783,7 +797,7 @@ class UserProfileTest(ZulipTestCase):
 
         lear_realm = get_realm("lear")
         cordelia_in_zulip = self.example_user("cordelia")
-        cordelia_in_lear = get_user("cordelia@zulip.com", lear_realm)
+        cordelia_in_lear = get_user_by_delivery_email("cordelia@zulip.com", lear_realm)
 
         email = "cordelia@zulip.com"
         accounts = get_accounts_for_email(email)
@@ -803,6 +817,7 @@ class UserProfileTest(ZulipTestCase):
         check_account_present_in_accounts(self.example_user("iago"), accounts)
 
     def test_get_source_profile(self) -> None:
+        self.reset_emails_in_zulip_realm()
         iago = get_source_profile("iago@zulip.com", "zulip")
         assert iago is not None
         self.assertEqual(iago.email, "iago@zulip.com")
@@ -1241,6 +1256,7 @@ class RecipientInfoTest(ZulipTestCase):
 
 class BulkUsersTest(ZulipTestCase):
     def test_client_gravatar_option(self) -> None:
+        self.reset_emails_in_zulip_realm()
         self.login('cordelia')
 
         hamlet = self.example_user('hamlet')
@@ -1311,7 +1327,7 @@ class GetProfileTest(ZulipTestCase):
         `get_user`, makes 1 cache query and 1 database query.
         """
         realm = get_realm("zulip")
-        email = self.example_email("hamlet")
+        email = self.example_user("hamlet").email
         with queries_captured() as queries:
             with simulated_empty_cache() as cache_queries:
                 user_profile = get_user(email, realm)
@@ -1321,18 +1337,22 @@ class GetProfileTest(ZulipTestCase):
         self.assertEqual(user_profile.email, email)
 
     def test_get_user_profile(self) -> None:
+        hamlet = self.example_user('hamlet')
+        iago = self.example_user('iago')
+
         self.login('hamlet')
         result = ujson.loads(self.client_get('/json/users/me').content)
         self.assertEqual(result['short_name'], 'hamlet')
-        self.assertEqual(result['email'], self.example_email("hamlet"))
+        self.assertEqual(result['email'], hamlet.email)
         self.assertEqual(result['full_name'], 'King Hamlet')
         self.assertIn("user_id", result)
         self.assertFalse(result['is_bot'])
         self.assertFalse(result['is_admin'])
+        self.assertFalse('delivery_email' in result)
         self.login('iago')
         result = ujson.loads(self.client_get('/json/users/me').content)
         self.assertEqual(result['short_name'], 'iago')
-        self.assertEqual(result['email'], self.example_email("iago"))
+        self.assertEqual(result['email'], iago.email)
         self.assertEqual(result['full_name'], 'Iago')
         self.assertFalse(result['is_bot'])
         self.assertTrue(result['is_admin'])
@@ -1388,7 +1408,7 @@ class GetProfileTest(ZulipTestCase):
         self.assert_json_success(result)
 
         for user in result.json()['members']:
-            if user['email'] == self.example_email("hamlet"):
+            if user['email'] == user_profile.email:
                 self.assertEqual(
                     user['avatar_url'],
                     avatar_url(user_profile),

--- a/zerver/views/presence.py
+++ b/zerver/views/presence.py
@@ -37,7 +37,7 @@ def get_presence_backend(request: HttpRequest, user_profile: UserProfile,
 
     presence_dict = get_presence_for_user(target.id)
     if len(presence_dict) == 0:
-        return json_error(_('No presence data for %s') % (target.email,))
+        return json_error(_('No presence data for user'))
 
     # For initial version, we just include the status and timestamp keys
     result = dict(presence=presence_dict[target.email])

--- a/zerver/webhooks/yo/tests.py
+++ b/zerver/webhooks/yo/tests.py
@@ -13,8 +13,9 @@ class YoHookTests(WebhookTestCase):
         """
         Yo App sends notification whenever user receives a new Yo from another user.
         """
+        cordelia = self.example_user('cordelia')
         self.url = self.build_webhook_url(
-            email="cordelia@zulip.com",
+            email=cordelia.email,
             username="IAGO",
             user_ip="127.0.0.1"
         )


### PR DESCRIPTION
We try to use the correct variation of `email`
or `delivery_email`, even though in some
databases they are the same.

(To find the differences, I temporarily hacked
populate_db to use different values for email
and delivery_email, and reduced email visibility
in the zulip realm to admins only.)

In places where we want the "normal" realm
behavior of showing emails (and having `email`
be the same as `delivery_email`), we use
the new `reset_emails_in_zulip_realm` helper.

A couple random things:

    - I fixed any error messages that were leaking
      the wrong email

    - a test that claimed to rely on the order
      of emails no longer does (we sort user_ids
      instead)

    - we now use user_ids in some place where we used
      to use emails

    - for IRC mirrors I just punted and used
      `reset_emails_in_zulip_realm` in most places

    - for MIT-related tests, I didn't fix email
      vs. delivery_email unless it was obvious

    - see any TODOs added here (in case I forget)

I also explicitly reset the realm to a "normal"
realm for a couple tests that I frankly just didn't
have the energy to debug.  (Also, we do want some
coverage on the normal case, even though it is
"easier" for tests to pass if you mix up `email`
and `delivery_email`.)

In particular, I just reset data for the analytics
and corporate tests.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
