### PR TITLE
tests: Make zulip realm have email restrictions.

### DIFF
--- a/analytics/tests/test_views.py
+++ b/analytics/tests/test_views.py
@@ -12,6 +12,7 @@ from analytics.models import FillState, \
     RealmCount, UserCount, last_successful_fill
 from analytics.views import rewrite_client_arrays, \
     sort_by_totals, sort_client_labels
+from zerver.lib.test_helpers import reset_emails_in_zulip_realm
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.timestamp import ceiling_to_day, \
     ceiling_to_hour, datetime_to_timestamp
@@ -334,6 +335,8 @@ class TestGetChartData(ZulipTestCase):
 
 class TestSupportEndpoint(ZulipTestCase):
     def test_search(self) -> None:
+        reset_emails_in_zulip_realm()
+
         def check_hamlet_user_query_result(result: HttpResponse) -> None:
             self.assert_in_success_response(['<span class="label">user</span>\n', '<h3>King Hamlet</h3>',
                                              '<b>Email</b>: hamlet@zulip.com', '<b>Is active</b>: True<br>',

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -22,6 +22,7 @@ import stripe
 from zerver.lib.actions import do_deactivate_user, do_create_user, \
     do_activate_user, do_reactivate_user
 from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.test_helpers import reset_emails_in_zulip_realm
 from zerver.lib.timestamp import timestamp_to_datetime, datetime_to_timestamp
 from zerver.models import Realm, UserProfile, get_realm, RealmAuditLog
 from corporate.lib.stripe import catch_stripe_errors, attach_discount_to_realm, \
@@ -219,6 +220,7 @@ class StripeTestCase(ZulipTestCase):
         super().setUp()
         # This test suite is not robust to users being added in populate_db. The following
         # hack ensures get_latest_seat_count is fixed, even as populate_db changes.
+        reset_emails_in_zulip_realm()
         realm = get_realm('zulip')
         seat_count = get_latest_seat_count(realm)
         assert(seat_count >= 6)

--- a/frontend_tests/run-casper
+++ b/frontend_tests/run-casper
@@ -75,6 +75,10 @@ os.makedirs('var/casper', exist_ok=True)
 for f in glob.glob('var/casper/casper-failure*.png'):
     os.remove(f)
 
+def reset_database() -> None:
+    from zerver.lib.test_helpers import reset_emails_in_zulip_realm
+    reset_emails_in_zulip_realm()
+
 def run_tests(files: Iterable[str], external_host: str) -> None:
     test_dir = os.path.join(ZULIP_PATH, 'frontend_tests/casper_tests')
     test_files = []
@@ -118,9 +122,12 @@ def run_tests(files: Iterable[str], external_host: str) -> None:
         return 0
 
     with test_server_running(options.force, external_host):
-        # Important: do this next call inside the `with` block, when Django
+        # Important: do next things inside the `with` block, when Django
         #            will be pointing at the test database.
+        reset_database()
         subprocess.check_call('tools/setup/generate-test-credentials')
+
+        # RUN THE TESTS!!!
         if options.interactive:
             response = input('Press Enter to run tests, "q" to quit: ')
             ret = 1
@@ -131,6 +138,7 @@ def run_tests(files: Iterable[str], external_host: str) -> None:
         else:
             ret = 1
             ret = run_tests()
+
     if ret != 0:
         print("""
 The Casper frontend tests failed!  For help debugging, read:

--- a/tools/test-api
+++ b/tools/test-api
@@ -33,14 +33,17 @@ with test_server_running(force=options.force, external_host='zulipdev.com:9981')
     from zerver.openapi.python_examples import test_the_api, test_invalid_api_key
     from zerver.openapi.test_curl_examples import test_generated_curl_examples_for_success
     from zerver.lib.actions import do_create_user
+    from zerver.lib.test_helpers import reset_emails_in_zulip_realm
     from zerver.lib.users import get_api_key
     from zerver.models import get_user, get_realm
 
     print("Running API tests...")
 
+    reset_emails_in_zulip_realm()
+
     # Prepare the admin client
     email = 'iago@zulip.com'  # Iago is an admin
-    realm = get_realm("zulip")
+    realm = get_realm('zulip')
     user = get_user(email, realm)
     api_key = get_api_key(user)
     site = 'http://zulip.zulipdev.com:9981'

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -283,11 +283,11 @@ class ZulipTestCase(TestCase):
 
     def nonreg_user(self, name: str) -> UserProfile:
         email = self.nonreg_user_map[name]
-        return get_user(email, get_realm("zulip"))
+        return get_user_by_delivery_email(email, get_realm("zulip"))
 
     def example_user(self, name: str) -> UserProfile:
         email = self.example_user_map[name]
-        return get_user(email, get_realm('zulip'))
+        return get_user_by_delivery_email(email, get_realm('zulip'))
 
     def mit_user(self, name: str) -> UserProfile:
         email = self.mit_user_map[name]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -2189,14 +2189,6 @@ def get_user(email: str, realm: Realm) -> UserProfile:
     """
     return UserProfile.objects.select_related().get(email__iexact=email.strip(), realm=realm)
 
-def get_active_user_by_delivery_email(email: str, realm: Realm) -> UserProfile:
-    """Variant of get_user_by_delivery_email that excludes deactivated users.
-    See get_user_by_delivery_email docstring for important usage notes."""
-    user_profile = get_user_by_delivery_email(email, realm)
-    if not user_profile.is_active:
-        raise UserProfile.DoesNotExist()
-    return user_profile
-
 def get_active_user(email: str, realm: Realm) -> UserProfile:
     """Variant of get_user_by_email that excludes deactivated users.
     See get_user docstring for important usage notes."""

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -78,15 +78,15 @@ class TestRealmAuditLog(ZulipTestCase):
     def test_change_email(self) -> None:
         now = timezone_now()
         user = self.example_user('hamlet')
-        email = 'test@example.com'
-        do_change_user_delivery_email(user, email)
+        new_email = 'test@example.com'
+        do_change_user_delivery_email(user, new_email)
         self.assertEqual(RealmAuditLog.objects.filter(event_type=RealmAuditLog.USER_EMAIL_CHANGED,
                                                       event_time__gte=now).count(), 1)
-        self.assertEqual(email, user.email)
+        self.assertEqual(new_email, user.delivery_email)
 
         # Test the RealmAuditLog stringification
         audit_entry = RealmAuditLog.objects.get(event_type=RealmAuditLog.USER_EMAIL_CHANGED, event_time__gte=now)
-        self.assertTrue(str(audit_entry).startswith("<RealmAuditLog: <UserProfile: test@example.com %s> %s " % (user.realm, RealmAuditLog.USER_EMAIL_CHANGED)))
+        self.assertTrue(str(audit_entry).startswith("<RealmAuditLog: <UserProfile: %s %s> %s " % (user.email, user.realm, RealmAuditLog.USER_EMAIL_CHANGED)))
 
     def test_change_avatar_source(self) -> None:
         now = timezone_now()

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -1960,15 +1960,20 @@ class GoogleAuthBackendTest(SocialAuthBase):
             mock_warn.assert_called_once_with("log_into_subdomain: Invalid token given: %s" % (token,))
         self.assertEqual(result.status_code, 400)
 
-    def test_log_into_subdomain_when_is_signup_is_true(self) -> None:
+    def test_prevent_duplicate_signups(self) -> None:
+        existing_user = self.example_user('hamlet')
+        existing_user.delivery_email = 'existing@zulip.com'
+        existing_user.email = 'whatever@zulip.com'
+        existing_user.save()
+
         data = {'name': 'Full Name',
-                'email': self.example_email("hamlet"),
+                'email': 'existing@zulip.com',
                 'subdomain': 'zulip',
                 'is_signup': True,
                 'next': ''}
         result = self.get_log_into_subdomain(data)
         self.assertEqual(result.status_code, 200)
-        self.assert_in_response('hamlet@zulip.com already has an account', result)
+        self.assert_in_response('existing@zulip.com already has an account', result)
 
     def test_log_into_subdomain_when_is_signup_is_true_and_new_user(self) -> None:
         data = {'name': 'New User Name',

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -149,6 +149,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_length(queries, 3)
 
     def test_add_bot(self) -> None:
+        hamlet = self.example_user('hamlet')
         self.login('hamlet')
         self.assert_num_bots_equal(0)
         events = []  # type: List[Mapping[str, Any]]
@@ -164,18 +165,20 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             dict(
                 type='realm_bot',
                 op='add',
-                bot=dict(email='hambot-bot@zulip.testserver',
-                         user_id=bot.id,
-                         bot_type=bot.bot_type,
-                         full_name='The Bot of Hamlet',
-                         is_active=True,
-                         api_key=result['api_key'],
-                         avatar_url=result['avatar_url'],
-                         default_sending_stream=None,
-                         default_events_register_stream=None,
-                         default_all_public_streams=False,
-                         services=[],
-                         owner=self.example_email('hamlet'))
+                bot=dict(
+                    email='hambot-bot@zulip.testserver',
+                    user_id=bot.id,
+                    bot_type=bot.bot_type,
+                    full_name='The Bot of Hamlet',
+                    is_active=True,
+                    api_key=result['api_key'],
+                    avatar_url=result['avatar_url'],
+                    default_sending_stream=None,
+                    default_events_register_stream=None,
+                    default_all_public_streams=False,
+                    services=[],
+                    owner=hamlet.email,
+                ),
             ),
             event['event']
         )
@@ -330,11 +333,12 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         is sent when add_subscriptions_backend is called in the above api call.
         """
         hamlet = self.example_user('hamlet')
+        iago = self.example_user('iago')
         self.login_user(hamlet)
 
         # Normal user i.e. not a bot.
         request_data = {
-            'principals': '["' + self.example_email('iago') + '"]'
+            'principals': '["' + iago.email + '"]'
         }
         events = []  # type: List[Mapping[str, Any]]
         with tornado_redirected_to_list(events):
@@ -391,18 +395,20 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             dict(
                 type='realm_bot',
                 op='add',
-                bot=dict(email='hambot-bot@zulip.testserver',
-                         user_id=profile.id,
-                         full_name='The Bot of Hamlet',
-                         bot_type=profile.bot_type,
-                         is_active=True,
-                         api_key=result['api_key'],
-                         avatar_url=result['avatar_url'],
-                         default_sending_stream='Denmark',
-                         default_events_register_stream=None,
-                         default_all_public_streams=False,
-                         services=[],
-                         owner=self.example_email('hamlet'))
+                bot=dict(
+                    email='hambot-bot@zulip.testserver',
+                    user_id=profile.id,
+                    full_name='The Bot of Hamlet',
+                    bot_type=profile.bot_type,
+                    is_active=True,
+                    api_key=result['api_key'],
+                    avatar_url=result['avatar_url'],
+                    default_sending_stream='Denmark',
+                    default_events_register_stream=None,
+                    default_all_public_streams=False,
+                    services=[],
+                    owner=user_profile.email,
+                ),
             ),
             event['event']
         )
@@ -461,18 +467,20 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
             dict(
                 type='realm_bot',
                 op='add',
-                bot=dict(email='hambot-bot@zulip.testserver',
-                         full_name='The Bot of Hamlet',
-                         user_id=bot_profile.id,
-                         bot_type=bot_profile.bot_type,
-                         is_active=True,
-                         api_key=result['api_key'],
-                         avatar_url=result['avatar_url'],
-                         default_sending_stream=None,
-                         default_events_register_stream='Denmark',
-                         default_all_public_streams=False,
-                         services=[],
-                         owner=self.example_email('hamlet'))
+                bot=dict(
+                    email='hambot-bot@zulip.testserver',
+                    full_name='The Bot of Hamlet',
+                    user_id=bot_profile.id,
+                    bot_type=bot_profile.bot_type,
+                    is_active=True,
+                    api_key=result['api_key'],
+                    avatar_url=result['avatar_url'],
+                    default_sending_stream=None,
+                    default_events_register_stream='Denmark',
+                    default_all_public_streams=False,
+                    services=[],
+                    owner=user_profile.email,
+                ),
             ),
             event['event']
         )
@@ -860,6 +868,8 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
 
     def test_patch_bot_owner(self) -> None:
         self.login('hamlet')
+        othello = self.example_user('othello')
+
         bot_info = {
             'full_name': u'The Bot of Hamlet',
             'short_name': u'hambot',
@@ -867,14 +877,14 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         result = self.client_post("/json/bots", bot_info)
         self.assert_json_success(result)
         bot_info = {
-            'bot_owner_id': self.example_user('othello').id,
+            'bot_owner_id': othello.id,
         }
         email = 'hambot-bot@zulip.testserver'
         result = self.client_patch("/json/bots/{}".format(self.get_bot_user(email).id), bot_info)
         self.assert_json_success(result)
 
         # Test bot's owner has been changed successfully.
-        self.assertEqual(result.json()['bot_owner'], self.example_email('othello'))
+        self.assertEqual(result.json()['bot_owner'], othello.email)
 
         self.login('othello')
         bot = self.get_bot()

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -216,12 +216,12 @@ class BugdownMiscTest(ZulipTestCase):
             for row in lst
         }
         self.assertEqual(by_id.get(fred2.id), dict(
-            email='fred2@example.com',
+            email=fred2.email,
             full_name='Fred Flintstone',
             id=fred2.id
         ))
         self.assertEqual(by_id.get(fred4.id), dict(
-            email='fred4@example.com',
+            email=fred4.email,
             full_name='Fred Flintstone',
             id=fred4.id
         ))

--- a/zerver/tests/test_cache.py
+++ b/zerver/tests/test_cache.py
@@ -271,7 +271,7 @@ class GenericBulkCachedFetchTest(ZulipTestCase):
             query_function=query_function,
             object_ids=[self.example_email("hamlet")]
         )  # type: Dict[str, UserProfile]
-        self.assertEqual(result, {hamlet.email: hamlet})
+        self.assertEqual(result, {hamlet.delivery_email: hamlet})
 
         flush_cache(Mock())
         # With the cache flushed, the query_function should get called:

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -668,12 +668,14 @@ class ListCustomProfileFieldTest(CustomProfileFieldTestCase):
             raise AssertionError("Could not find required data from the response.")
 
         expected_keys_for_iago = {
+            "delivery_email",
             "email", "user_id", "avatar_url", "is_admin", "is_guest", "is_bot",
             "full_name", "timezone", "is_active", "date_joined", "profile_data"}
         self.assertEqual(set(iago_raw_data.keys()), expected_keys_for_iago)
         self.assertNotEqual(iago_raw_data["profile_data"], {})
 
         expected_keys_for_test_bot = {
+            "delivery_email",
             "email", "user_id", "avatar_url", "is_admin", "is_guest", "is_bot", "full_name",
             "timezone", "is_active", "date_joined", "bot_type", "bot_owner_id"}
         self.assertEqual(set(test_bot_raw_data.keys()), expected_keys_for_test_bot)

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -188,7 +188,7 @@ class EmailChangeTestCase(ZulipTestCase):
                               Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS)
 
         self.login_user(user_profile)
-        old_email = user_profile.email
+        old_email = user_profile.delivery_email
         new_email = 'hamlet-new@zulip.com'
         obj = EmailChangeStatus.objects.create(new_email=new_email,
                                                old_email=old_email,

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -52,7 +52,13 @@ class EmailChangeTestCase(ZulipTestCase):
 
     def test_confirm_email_change(self) -> None:
         user_profile = self.example_user('hamlet')
-        old_email = user_profile.email
+        do_set_realm_property(
+            user_profile.realm,
+            'email_address_visibility',
+            Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE,
+        )
+
+        old_email = user_profile.delivery_email
         new_email = 'hamlet-new@zulip.com'
         new_realm = get_realm('zulip')
         self.login('hamlet')

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -61,7 +61,7 @@ class TestFollowupEmails(ZulipTestCase):
         with self.settings(AUTH_LDAP_USER_ATTR_MAP=ldap_user_attr_map):
             self.login_with_return("newuser_email_as_uid@zulip.com",
                                    self.ldap_password("newuser_email_as_uid@zulip.com"))
-            user = UserProfile.objects.get(email="newuser_email_as_uid@zulip.com")
+            user = UserProfile.objects.get(delivery_email="newuser_email_as_uid@zulip.com")
             scheduled_emails = ScheduledEmail.objects.filter(users=user)
 
             self.assertEqual(len(scheduled_emails), 2)
@@ -81,7 +81,7 @@ class TestFollowupEmails(ZulipTestCase):
         ):
             self.login_with_return("newuser@zulip.com", self.ldap_password("newuser"))
 
-            user = UserProfile.objects.get(email="newuser@zulip.com")
+            user = UserProfile.objects.get(delivery_email="newuser@zulip.com")
             scheduled_emails = ScheduledEmail.objects.filter(users=user)
 
             self.assertEqual(len(scheduled_emails), 2)
@@ -100,7 +100,7 @@ class TestFollowupEmails(ZulipTestCase):
                 AUTH_LDAP_USER_ATTR_MAP=ldap_user_attr_map,
         ):
             self.login_with_return("newuser_with_email", self.ldap_password("newuser_with_email"))
-            user = UserProfile.objects.get(email="newuser_email@zulip.com")
+            user = UserProfile.objects.get(delivery_email="newuser_email@zulip.com")
             scheduled_emails = ScheduledEmail.objects.filter(users=user)
 
             self.assertEqual(len(scheduled_emails), 2)

--- a/zerver/tests/test_i18n.py
+++ b/zerver/tests/test_i18n.py
@@ -46,7 +46,7 @@ class EmailTranslationTestCase(ZulipTestCase):
         # Also remove the "nocoverage" from check_translation above.
         # check_translation("Viele Grüße", "patch", "/json/settings", {"email": "hamlets-new@zulip.com"})
         check_translation("Incrível!", "post", "/accounts/home/", {"email": "new-email@zulip.com"}, HTTP_ACCEPT_LANGUAGE="pt")
-        check_translation("Danke, dass Du", "post", '/accounts/find/', {'emails': hamlet.email})
+        check_translation("Danke, dass Du", "post", '/accounts/find/', {'emails': hamlet.delivery_email})
         check_translation("Hallo", "post", "/json/invites",  {"invitee_emails": "new-email@zulip.com",
                                                               "stream_ids": ujson.dumps([stream.id])})
 

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -471,7 +471,7 @@ class ImportExportTest(ZulipTestCase):
         self.assertEqual(len(data['zerver_userprofile_crossrealm']), 3)
         self.assertEqual(len(data['zerver_userprofile_mirrordummy']), 0)
 
-        exported_user_emails = self.get_set(data['zerver_userprofile'], 'email')
+        exported_user_emails = self.get_set(data['zerver_userprofile'], 'delivery_email')
         self.assertIn(self.example_email('cordelia'), exported_user_emails)
         self.assertIn('default-bot@zulip.com', exported_user_emails)
 
@@ -514,13 +514,13 @@ class ImportExportTest(ZulipTestCase):
 
         data = full_data['realm']
 
-        exported_user_emails = self.get_set(data['zerver_userprofile'], 'email')
+        exported_user_emails = self.get_set(data['zerver_userprofile'], 'delivery_email')
         self.assertIn(self.example_email('iago'), exported_user_emails)
         self.assertIn(self.example_email('hamlet'), exported_user_emails)
         self.assertNotIn('default-bot@zulip.com', exported_user_emails)
         self.assertNotIn(self.example_email('cordelia'), exported_user_emails)
 
-        dummy_user_emails = self.get_set(data['zerver_userprofile_mirrordummy'], 'email')
+        dummy_user_emails = self.get_set(data['zerver_userprofile_mirrordummy'], 'delivery_email')
         self.assertIn(self.example_email('cordelia'), dummy_user_emails)
         self.assertIn(self.example_email('othello'), dummy_user_emails)
         self.assertIn('default-bot@zulip.com', dummy_user_emails)
@@ -595,7 +595,7 @@ class ImportExportTest(ZulipTestCase):
         self.assertEqual(len(data['zerver_userprofile_crossrealm']), 3)
         self.assertEqual(len(data['zerver_userprofile_mirrordummy']), 0)
 
-        exported_user_emails = self.get_set(data['zerver_userprofile'], 'email')
+        exported_user_emails = self.get_set(data['zerver_userprofile'], 'delivery_email')
         self.assertIn(self.example_email('cordelia'), exported_user_emails)
         self.assertIn(self.example_email('hamlet'), exported_user_emails)
         self.assertIn(self.example_email('iago'), exported_user_emails)
@@ -986,8 +986,7 @@ class ImportExportTest(ZulipTestCase):
         # affect how the browser displays the rendered_content so we
         # are okay with using bs4 for this.  lxml package also has
         # similar behavior.
-        orig_polonius_user = UserProfile.objects.get(email=self.example_email("polonius"),
-                                                     realm=original_realm)
+        orig_polonius_user = self.example_user('polonius')
         original_msg = Message.objects.get(content=special_characters_message, sender__realm=original_realm)
         self.assertEqual(
             original_msg.rendered_content,
@@ -995,7 +994,7 @@ class ImportExportTest(ZulipTestCase):
              '<p><span class="user-mention" data-user-id="%s">@Polonius</span></p>' %
              (orig_polonius_user.id,))
         )
-        imported_polonius_user = UserProfile.objects.get(email=self.example_email("polonius"),
+        imported_polonius_user = UserProfile.objects.get(delivery_email=self.example_email("polonius"),
                                                          realm=imported_realm)
         imported_msg = Message.objects.get(content=special_characters_message, sender__realm=imported_realm)
         self.assertEqual(

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -60,13 +60,14 @@ from zerver.lib.message import (
 )
 
 from zerver.lib.test_helpers import (
+    get_subscription,
     get_user_messages,
     make_client,
     message_stream_count,
     most_recent_message,
     most_recent_usermessage,
     queries_captured,
-    get_subscription,
+    reset_emails_in_zulip_realm,
 )
 
 from zerver.lib.test_classes import (
@@ -780,14 +781,16 @@ class PersonalMessagesTest(ZulipTestCase):
         self.assertEqual(message.recipient, recipient)
 
         with mock.patch('zerver.models.get_display_recipient', return_value='recip'):
-            self.assertEqual(str(message),
-                             '<Message: recip /  / '
-                             '<UserProfile: test@zulip.com %s>>' % (user_profile.realm,))
+            self.assertEqual(
+                str(message),
+                '<Message: recip /  / '
+                '<UserProfile: {} {}>>'.format(user_profile.email, user_profile.realm))
 
             user_message = most_recent_usermessage(user_profile)
-            self.assertEqual(str(user_message),
-                             '<UserMessage: recip / test@zulip.com ([])>'
-                             )
+            self.assertEqual(
+                str(user_message),
+                '<UserMessage: recip / {} ([])>'.format(user_profile.email)
+            )
 
     @slow("checks several profiles")
     def test_personal_to_self(self) -> None:
@@ -815,20 +818,16 @@ class PersonalMessagesTest(ZulipTestCase):
         recipient = Recipient.objects.get(type_id=user_profile.id, type=Recipient.PERSONAL)
         self.assertEqual(most_recent_message(user_profile).recipient, recipient)
 
-    def assert_personal(self, sender_email: str, receiver_email: str, content: str="testcontent") -> None:
+    def assert_personal(self, sender: UserProfile, receiver: UserProfile, content: str="testcontent") -> None:
         """
         Send a private message from `sender_email` to `receiver_email` and check
         that only those two parties actually received the message.
         """
-        realm = get_realm('zulip')  # Assume realm is always 'zulip'
-        sender = get_user(sender_email, realm)
-        receiver = get_user(receiver_email, realm)
-
         sender_messages = message_stream_count(sender)
         receiver_messages = message_stream_count(receiver)
 
-        other_user_profiles = UserProfile.objects.filter(~Q(email=sender_email) &
-                                                         ~Q(email=receiver_email))
+        other_user_profiles = UserProfile.objects.filter(~Q(id=sender.id) &
+                                                         ~Q(id=receiver.id))
         old_other_messages = []
         for user_profile in other_user_profiles:
             old_other_messages.append(message_stream_count(user_profile))
@@ -857,7 +856,10 @@ class PersonalMessagesTest(ZulipTestCase):
         If you send a personal, only you and the recipient see it.
         """
         self.login('hamlet')
-        self.assert_personal(self.example_email("hamlet"), self.example_email("othello"))
+        self.assert_personal(
+            sender=self.example_user("hamlet"),
+            receiver=self.example_user("othello")
+        )
 
     def test_private_message_policy(self) -> None:
         """
@@ -880,7 +882,11 @@ class PersonalMessagesTest(ZulipTestCase):
         Sending a PM containing non-ASCII characters succeeds.
         """
         self.login('hamlet')
-        self.assert_personal(self.example_email("hamlet"), self.example_email("othello"), u"hümbüǵ")
+        self.assert_personal(
+            sender=self.example_user("hamlet"),
+            receiver=self.example_user("othello"),
+            content="hümbüǵ"
+        )
 
 class StreamMessagesTest(ZulipTestCase):
 
@@ -1036,14 +1042,14 @@ class StreamMessagesTest(ZulipTestCase):
 
     def test_stream_message_unicode(self) -> None:
         receiving_user_profile = self.example_user('iago')
-        sending_user_profile = self.example_user('hamlet')
+        sender = self.example_user('hamlet')
         self.subscribe(receiving_user_profile, "Denmark")
-        self.send_stream_message(sending_user_profile, "Denmark",
+        self.send_stream_message(sender, "Denmark",
                                  content="whatever", topic_name="my topic")
         message = most_recent_message(receiving_user_profile)
         self.assertEqual(str(message),
-                         u'<Message: Denmark / my topic / '
-                         '<UserProfile: hamlet@zulip.com %s>>' % (sending_user_profile.realm,))
+                         '<Message: Denmark / my topic / '
+                         '<UserProfile: {} {}>>'.format(sender.email, sender.realm))
 
     def test_message_mentions(self) -> None:
         user_profile = self.example_user('iago')
@@ -1705,10 +1711,11 @@ class MessagePOSTTest(ZulipTestCase):
         """
         user_profile = self.example_user("hamlet")
         self.login_user(user_profile)
+        othello = self.example_user('othello')
         result = self.client_post("/json/messages", {"type": "private",
                                                      "content": "Test message",
                                                      "client": "test suite",
-                                                     "to": self.example_email("othello")})
+                                                     "to": othello.email})
         self.assert_json_success(result)
         message_id = ujson.loads(result.content.decode())['id']
 
@@ -1716,21 +1723,21 @@ class MessagePOSTTest(ZulipTestCase):
         self.assertEqual(len(recent_conversations), 1)
         recent_conversation = list(recent_conversations.values())[0]
         recipient_id = list(recent_conversations.keys())[0]
-        self.assertEqual(set(recent_conversation['user_ids']), set([self.example_user("othello").id]))
+        self.assertEqual(set(recent_conversation['user_ids']), set([othello.id]))
         self.assertEqual(recent_conversation['max_message_id'], message_id)
 
         # Now send a message to yourself and see how that interacts with the data structure
         result = self.client_post("/json/messages", {"type": "private",
                                                      "content": "Test message",
                                                      "client": "test suite",
-                                                     "to": self.example_email("hamlet")})
+                                                     "to": user_profile.email})
         self.assert_json_success(result)
         self_message_id = ujson.loads(result.content.decode())['id']
 
         recent_conversations = get_recent_private_conversations(user_profile)
         self.assertEqual(len(recent_conversations), 2)
         recent_conversation = recent_conversations[recipient_id]
-        self.assertEqual(set(recent_conversation['user_ids']), set([self.example_user("othello").id]))
+        self.assertEqual(set(recent_conversation['user_ids']), set([othello.id]))
         self.assertEqual(recent_conversation['max_message_id'], message_id)
 
         # Now verify we have the appropriate self-pm data structure
@@ -1790,13 +1797,14 @@ class MessagePOSTTest(ZulipTestCase):
         Sending a personal message to yourself plus another user is successful,
         and counts as a message just to that user.
         """
-        self.login('hamlet')
+        hamlet = self.example_user('hamlet')
+        othello = self.example_user('othello')
+        self.login_user(hamlet)
         result = self.client_post("/json/messages", {
             "type": "private",
             "content": "Test message",
             "client": "test suite",
-            "to": ujson.dumps([self.example_email("othello"),
-                               self.example_email("hamlet")])})
+            "to": ujson.dumps([hamlet.id, othello.id])})
         self.assert_json_success(result)
         msg = self.get_last_message()
         # Verify that we're not actually on the "recipient list"
@@ -1817,33 +1825,35 @@ class MessagePOSTTest(ZulipTestCase):
         """
         Sending a personal message to a deactivated user returns error JSON.
         """
-        target_user_profile = self.example_user("othello")
-        do_deactivate_user(target_user_profile)
+        othello = self.example_user('othello')
+        cordelia = self.example_user('cordelia')
+        do_deactivate_user(othello)
         self.login('hamlet')
-        result = self.client_post("/json/messages", {
-            "type": "private",
-            "content": "Test message",
-            "client": "test suite",
-            "to": self.example_email("othello")})
-        self.assert_json_error(result, "'othello@zulip.com' is no longer using Zulip.")
 
         result = self.client_post("/json/messages", {
             "type": "private",
             "content": "Test message",
             "client": "test suite",
-            "to": ujson.dumps([self.example_email("othello"),
-                               self.example_email("cordelia")])})
-        self.assert_json_error(result, "'othello@zulip.com' is no longer using Zulip.")
+            "to": ujson.dumps([othello.id])})
+        self.assert_json_error(result, "'{}' is no longer using Zulip.".format(othello.email))
+
+        result = self.client_post("/json/messages", {
+            "type": "private",
+            "content": "Test message",
+            "client": "test suite",
+            "to": ujson.dumps([othello.id, cordelia.id])})
+        self.assert_json_error(result, "'{}' is no longer using Zulip.".format(othello.email))
 
     def test_invalid_type(self) -> None:
         """
         Sending a message of unknown type returns error JSON.
         """
         self.login('hamlet')
+        othello = self.example_user('othello')
         result = self.client_post("/json/messages", {"type": "invalid type",
                                                      "content": "Test message",
                                                      "client": "test suite",
-                                                     "to": self.example_email("othello")})
+                                                     "to": othello.email})
         self.assert_json_error(result, "Invalid message type")
 
     def test_empty_message(self) -> None:
@@ -1851,10 +1861,11 @@ class MessagePOSTTest(ZulipTestCase):
         Sending a message that is empty or only whitespace should fail
         """
         self.login('hamlet')
+        othello = self.example_user('othello')
         result = self.client_post("/json/messages", {"type": "private",
                                                      "content": " ",
                                                      "client": "test suite",
-                                                     "to": self.example_email("othello")})
+                                                     "to": othello.email})
         self.assert_json_error(result, "Message must not be empty")
 
     def test_empty_string_topic(self) -> None:
@@ -2137,6 +2148,7 @@ class MessagePOSTTest(ZulipTestCase):
         self.assert_json_error(result, "Mirroring not allowed with recipient user IDs")
 
     def test_send_message_irc_mirror(self) -> None:
+        reset_emails_in_zulip_realm()
         self.login('hamlet')
         bot_info = {
             'full_name': 'IRC bot',
@@ -2187,6 +2199,8 @@ class MessagePOSTTest(ZulipTestCase):
         self.assertEqual(int(datetime_to_timestamp(msg.date_sent)), int(fake_timestamp))
 
     def test_unsubscribed_api_super_user(self) -> None:
+        reset_emails_in_zulip_realm()
+
         cordelia = self.example_user('cordelia')
         stream_name = 'private_stream'
         self.make_stream(stream_name, invite_only=True)
@@ -2312,7 +2326,7 @@ class MessagePOSTTest(ZulipTestCase):
                 email_to_full_name,
             )
 
-        self.assertEqual(mirror_fred_user.email, email)
+        self.assertEqual(mirror_fred_user.delivery_email, email)
         m.assert_called()
 
     def test_guest_user(self) -> None:
@@ -2389,7 +2403,9 @@ class ScheduledMessageTest(ZulipTestCase):
         self.assertEqual(message.delivery_type, ScheduledMessage.REMIND)
 
         # Scheduling a private message is successful.
-        result = self.do_schedule_message('private', self.example_email("othello"),
+        othello = self.example_user('othello')
+        hamlet = self.example_user('hamlet')
+        result = self.do_schedule_message('private', othello.email,
                                           content + ' 3', defer_until_str)
         message = self.last_scheduled_message()
         self.assert_json_success(result)
@@ -2398,14 +2414,14 @@ class ScheduledMessageTest(ZulipTestCase):
         self.assertEqual(message.delivery_type, ScheduledMessage.SEND_LATER)
 
         # Setting a reminder in PM's to other users causes a error.
-        result = self.do_schedule_message('private', self.example_email("othello"),
+        result = self.do_schedule_message('private', othello.email,
                                           content + ' 4', defer_until_str,
                                           delivery_type='remind')
         self.assert_json_error(result, 'Reminders can only be set for streams.')
 
         # Setting a reminder in PM's to ourself is successful.
         # Required by reminders from message actions popover caret feature.
-        result = self.do_schedule_message('private', self.example_email("hamlet"),
+        result = self.do_schedule_message('private', hamlet.email,
                                           content + ' 5', defer_until_str,
                                           delivery_type='remind')
         message = self.last_scheduled_message()
@@ -3284,10 +3300,10 @@ class MirroredMessageUsersTest(ZulipTestCase):
         self.assertTrue(mirror_sender.is_mirror_dummy)
 
     def test_irc_mirror(self) -> None:
+        reset_emails_in_zulip_realm()
         client = get_client(name='irc_mirror')
 
         sender = self.example_user('hamlet')
-        user = sender
 
         recipients = [self.nonreg_email('alice'), 'bob@irc.zulip.com', self.nonreg_email('cordelia')]
 
@@ -3296,7 +3312,7 @@ class MirroredMessageUsersTest(ZulipTestCase):
         request = Request(POST = dict(sender=sender.email, type='private'),
                           client = client)
 
-        mirror_sender = create_mirrored_message_users(request, user, recipients)
+        mirror_sender = create_mirrored_message_users(request, sender, recipients)
 
         self.assertEqual(mirror_sender, sender)
 
@@ -3309,6 +3325,7 @@ class MirroredMessageUsersTest(ZulipTestCase):
         self.assertTrue(bob.is_mirror_dummy)
 
     def test_jabber_mirror(self) -> None:
+        reset_emails_in_zulip_realm()
         client = get_client(name='jabber_mirror')
 
         sender = self.example_user('hamlet')
@@ -3941,9 +3958,9 @@ class LogDictTest(ZulipTestCase):
         self.assertEqual(dct['id'], message.id)
         self.assertEqual(dct['recipient'], 'Denmark')
         self.assertEqual(dct['sender_realm_str'], 'zulip')
-        self.assertEqual(dct['sender_email'], self.example_email("hamlet"))
+        self.assertEqual(dct['sender_email'], user.email)
         self.assertEqual(dct['sender_full_name'], 'King Hamlet')
-        self.assertEqual(dct['sender_id'], self.example_user('hamlet').id)
+        self.assertEqual(dct['sender_id'], user.id)
         self.assertEqual(dct['sender_short_name'], 'hamlet')
         self.assertEqual(dct['sending_client'], 'test suite')
         self.assertEqual(dct[DB_TOPIC_NAME], 'Copenhagen')
@@ -3959,7 +3976,7 @@ class CheckMessageTest(ZulipTestCase):
         message_content = 'whatever'
         addressee = Addressee.for_stream_name(stream_name, topic_name)
         ret = check_message(sender, client, addressee, message_content)
-        self.assertEqual(ret['message'].sender.email, self.example_email("othello"))
+        self.assertEqual(ret['message'].sender.id, sender.id)
 
     def test_bot_pm_feature(self) -> None:
         """We send a PM to a bot's owner if their bot sends a message to

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -90,6 +90,8 @@ class NarrowBuilderTest(ZulipTestCase):
         self.user_profile = self.example_user('hamlet')
         self.builder = NarrowBuilder(self.user_profile, column('id'))
         self.raw_query = select([column("id")], None, table("zerver_message"))
+        self.hamlet_email = self.example_user('hamlet').email
+        self.othello_email = self.example_user('othello').email
 
     def test_add_term_using_not_defined_operator(self) -> None:
         term = dict(operator='not-defined', operand='any')
@@ -247,11 +249,11 @@ class NarrowBuilderTest(ZulipTestCase):
         self._do_add_term_test(term, 'WHERE upper(subject) != upper(%(param_1)s)')
 
     def test_add_term_using_sender_operator(self) -> None:
-        term = dict(operator='sender', operand=self.example_email("othello"))
+        term = dict(operator='sender', operand=self.othello_email)
         self._do_add_term_test(term, 'WHERE sender_id = %(param_1)s')
 
     def test_add_term_using_sender_operator_and_negated(self) -> None:  # NEGATED
-        term = dict(operator='sender', operand=self.example_email("othello"), negated=True)
+        term = dict(operator='sender', operand=self.othello_email, negated=True)
         self._do_add_term_test(term, 'WHERE sender_id != %(param_1)s')
 
     def test_add_term_using_sender_operator_with_non_existing_user_as_operand(
@@ -260,38 +262,54 @@ class NarrowBuilderTest(ZulipTestCase):
         self.assertRaises(BadNarrowOperator, self._build_query, term)
 
     def test_add_term_using_pm_with_operator_and_not_the_same_user_as_operand(self) -> None:
-        term = dict(operator='pm-with', operand=self.example_email("othello"))
+        term = dict(operator='pm-with', operand=self.othello_email)
         self._do_add_term_test(term, 'WHERE sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s')
 
     def test_add_term_using_pm_with_operator_not_the_same_user_as_operand_and_negated(
             self) -> None:  # NEGATED
-        term = dict(operator='pm-with', operand=self.example_email("othello"), negated=True)
+        term = dict(operator='pm-with', operand=self.othello_email, negated=True)
         self._do_add_term_test(term, 'WHERE NOT (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s)')
 
     def test_add_term_using_pm_with_operator_the_same_user_as_operand(self) -> None:
-        term = dict(operator='pm-with', operand=self.example_email("hamlet"))
+        term = dict(operator='pm-with', operand=self.hamlet_email)
         self._do_add_term_test(term, 'WHERE sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s')
 
     def test_add_term_using_pm_with_operator_the_same_user_as_operand_and_negated(
             self) -> None:  # NEGATED
-        term = dict(operator='pm-with', operand=self.example_email("hamlet"), negated=True)
+        term = dict(operator='pm-with', operand=self.hamlet_email, negated=True)
         self._do_add_term_test(term, 'WHERE NOT (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s)')
 
     def test_add_term_using_pm_with_operator_and_self_and_user_as_operand(self) -> None:
-        term = dict(operator='pm-with', operand='hamlet@zulip.com, othello@zulip.com')
+        myself_and_other = ','.join([
+            self.example_user('hamlet').email,
+            self.example_user('othello').email,
+        ])
+        term = dict(operator='pm-with', operand=myself_and_other)
         self._do_add_term_test(term, 'WHERE sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s')
 
     def test_add_term_using_pm_with_operator_more_than_one_user_as_operand(self) -> None:
-        term = dict(operator='pm-with', operand='cordelia@zulip.com, othello@zulip.com')
+        two_others = ','.join([
+            self.example_user('cordelia').email,
+            self.example_user('othello').email,
+        ])
+        term = dict(operator='pm-with', operand=two_others)
         self._do_add_term_test(term, 'WHERE recipient_id = %(recipient_id_1)s')
 
     def test_add_term_using_pm_with_operator_self_and_user_as_operand_and_negated(
             self) -> None:  # NEGATED
-        term = dict(operator='pm-with', operand='hamlet@zulip.com, othello@zulip.com', negated=True)
+        myself_and_other = ','.join([
+            self.example_user('hamlet').email,
+            self.example_user('othello').email,
+        ])
+        term = dict(operator='pm-with', operand=myself_and_other, negated=True)
         self._do_add_term_test(term, 'WHERE NOT (sender_id = %(sender_id_1)s AND recipient_id = %(recipient_id_1)s OR sender_id = %(sender_id_2)s AND recipient_id = %(recipient_id_2)s)')
 
     def test_add_term_using_pm_with_operator_more_than_one_user_as_operand_and_negated(self) -> None:
-        term = dict(operator='pm-with', operand='cordelia@zulip.com, othello@zulip.com', negated=True)
+        two_others = ','.join([
+            self.example_user('cordelia').email,
+            self.example_user('othello').email,
+        ])
+        term = dict(operator='pm-with', operand=two_others, negated=True)
         self._do_add_term_test(term, 'WHERE recipient_id != %(recipient_id_1)s')
 
     def test_add_term_using_pm_with_operator_with_comma_noise(self) -> None:
@@ -299,7 +317,7 @@ class NarrowBuilderTest(ZulipTestCase):
         self.assertRaises(BadNarrowOperator, self._build_query, term)
 
     def test_add_term_using_pm_with_operator_with_existing_and_non_existing_user_as_operand(self) -> None:
-        term = dict(operator='pm-with', operand='othello@zulip.com,non-existing@zulip.com')
+        term = dict(operator='pm-with', operand=self.othello_email + ',non-existing@zulip.com')
         self.assertRaises(BadNarrowOperator, self._build_query, term)
 
     def test_add_term_using_id_operator(self) -> None:
@@ -319,19 +337,19 @@ class NarrowBuilderTest(ZulipTestCase):
 
     def test_add_term_using_group_pm_operator_and_not_the_same_user_as_operand(self) -> None:
         # Test wtihout any such group PM threads existing
-        term = dict(operator='group-pm-with', operand=self.example_email("othello"))
+        term = dict(operator='group-pm-with', operand=self.othello_email)
         self._do_add_term_test(term, 'WHERE 1 != 1')
 
         # Test with at least one such group PM thread existing
         self.send_huddle_message(self.user_profile, [self.example_user("othello"),
                                                      self.example_user("cordelia")])
 
-        term = dict(operator='group-pm-with', operand=self.example_email("othello"))
+        term = dict(operator='group-pm-with', operand=self.othello_email)
         self._do_add_term_test(term, 'WHERE recipient_id IN (%(recipient_id_1)s)')
 
     def test_add_term_using_group_pm_operator_not_the_same_user_as_operand_and_negated(
             self) -> None:  # NEGATED
-        term = dict(operator='group-pm-with', operand=self.example_email("othello"), negated=True)
+        term = dict(operator='group-pm-with', operand=self.othello_email, negated=True)
         self._do_add_term_test(term, 'WHERE 1 = 1')
 
     def test_add_term_using_group_pm_operator_with_non_existing_user_as_operand(self) -> None:
@@ -1151,11 +1169,25 @@ class GetOldMessagesTest(ZulipTestCase):
         self.login('hamlet')
         self.get_and_check_messages(dict())
 
+        othello_email = self.example_user('othello').email
+
         # We have to support the legacy tuple style while there are old
         # clients around, which might include third party home-grown bots.
-        self.get_and_check_messages(dict(narrow=ujson.dumps([['pm-with', self.example_email("othello")]])))
+        self.get_and_check_messages(
+            dict(
+                narrow=ujson.dumps(
+                    [['pm-with', othello_email]]
+                )
+            )
+        )
 
-        self.get_and_check_messages(dict(narrow=ujson.dumps([dict(operator='pm-with', operand=self.example_email("othello"))])))
+        self.get_and_check_messages(
+            dict(
+                narrow=ujson.dumps(
+                    [dict(operator='pm-with', operand=othello_email)]
+                )
+            )
+        )
 
     def test_client_avatar(self) -> None:
         """
@@ -1163,6 +1195,9 @@ class GetOldMessagesTest(ZulipTestCase):
         """
         hamlet = self.example_user('hamlet')
         self.login_user(hamlet)
+
+        do_set_realm_property(hamlet.realm, "email_address_visibility",
+                              Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE)
 
         self.send_personal_message(hamlet, self.example_user("iago"))
 
@@ -1243,7 +1278,7 @@ class GetOldMessagesTest(ZulipTestCase):
         for i in range(5):
             message_ids.append(self.send_personal_message(me, self.example_user("iago")))
 
-        narrow = [dict(operator='pm-with', operand=self.example_email("iago"))]
+        narrow = [dict(operator='pm-with', operand=self.example_user("iago").email)]
         self.message_visibility_test(narrow, message_ids, 2)
 
     def test_get_messages_with_narrow_group_pm_with(self) -> None:
@@ -1253,57 +1288,48 @@ class GetOldMessagesTest(ZulipTestCase):
         """
         me = self.example_user("hamlet")
 
+        iago = self.example_user("iago")
+        cordelia = self.example_user("cordelia")
+        othello = self.example_user("othello")
+
         matching_message_ids = []
 
         matching_message_ids.append(
             self.send_huddle_message(
                 me,
-                [
-                    self.example_user("iago"),
-                    self.example_user("cordelia"),
-                    self.example_user("othello"),
-                ],
+                [iago, cordelia, othello]
             ),
         )
 
         matching_message_ids.append(
             self.send_huddle_message(
                 me,
-                [
-                    self.example_user("cordelia"),
-                    self.example_user("othello"),
-                ],
+                [cordelia, othello]
             ),
         )
 
         non_matching_message_ids = []
 
         non_matching_message_ids.append(
-            self.send_personal_message(me, self.example_user("cordelia")),
+            self.send_personal_message(me, cordelia),
         )
 
         non_matching_message_ids.append(
             self.send_huddle_message(
                 me,
-                [
-                    self.example_user("iago"),
-                    self.example_user("othello"),
-                ],
+                [iago, othello]
             ),
         )
 
         non_matching_message_ids.append(
             self.send_huddle_message(
                 self.example_user("cordelia"),
-                [
-                    self.example_user("iago"),
-                    self.example_user("othello"),
-                ],
+                [iago, othello],
             ),
         )
 
         self.login_user(me)
-        test_operands = [self.example_email("cordelia"), self.example_user("cordelia").id]
+        test_operands = [cordelia.email, cordelia.id]
         for operand in test_operands:
             narrow = [dict(operator='group-pm-with', operand=operand)]
             result = self.get_and_check_messages(dict(narrow=ujson.dumps(narrow)))
@@ -1315,37 +1341,31 @@ class GetOldMessagesTest(ZulipTestCase):
         me = self.example_user('hamlet')
         self.login_user(me)
 
+        iago = self.example_user("iago")
+        cordelia = self.example_user("cordelia")
+        othello = self.example_user("othello")
+
         message_ids = []
         message_ids.append(
             self.send_huddle_message(
                 me,
-                [
-                    self.example_user("iago"),
-                    self.example_user("cordelia"),
-                    self.example_user("othello"),
-                ],
+                [iago, cordelia, othello],
             ),
         )
         message_ids.append(
             self.send_huddle_message(
                 me,
-                [
-                    self.example_user("cordelia"),
-                    self.example_user("othello"),
-                ],
+                [cordelia, othello],
             ),
         )
         message_ids.append(
             self.send_huddle_message(
                 me,
-                [
-                    self.example_user("cordelia"),
-                    self.example_user("iago"),
-                ],
+                [cordelia, iago],
             ),
         )
 
-        narrow = [dict(operator='group-pm-with', operand=self.example_email("cordelia"))]
+        narrow = [dict(operator='group-pm-with', operand=cordelia.email)]
         self.message_visibility_test(narrow, message_ids, 1)
 
     def test_include_history(self) -> None:
@@ -1531,20 +1551,25 @@ class GetOldMessagesTest(ZulipTestCase):
         messages sent by that person.
         """
         self.login('hamlet')
+
+        hamlet = self.example_user('hamlet')
+        othello = self.example_user('othello')
+        iago = self.example_user('iago')
+
         # We need to send a message here to ensure that we actually
         # have a stream message in this narrow view.
-        self.send_stream_message(self.example_user("hamlet"), "Scotland")
-        self.send_stream_message(self.example_user("othello"), "Scotland")
-        self.send_personal_message(self.example_user("othello"), self.example_user("hamlet"))
-        self.send_stream_message(self.example_user("iago"), "Scotland")
+        self.send_stream_message(hamlet, "Scotland")
+        self.send_stream_message(othello, "Scotland")
+        self.send_personal_message(othello, hamlet)
+        self.send_stream_message(iago, "Scotland")
 
-        test_operands = [self.example_email("othello"), self.example_user("othello").id]
+        test_operands = [othello.email, othello.id]
         for operand in test_operands:
             narrow = [dict(operator='sender', operand=operand)]
             result = self.get_and_check_messages(dict(narrow=ujson.dumps(narrow)))
 
             for message in result["messages"]:
-                self.assertEqual(message["sender_email"], self.example_email("othello"))
+                self.assertEqual(message["sender_id"], othello.id)
 
     def _update_tsvector_index(self) -> None:
         # We use brute force here and update our text search index
@@ -1611,9 +1636,11 @@ class GetOldMessagesTest(ZulipTestCase):
 
         next_message_id = self.get_last_message().id + 1
 
+        cordelia = self.example_user('cordelia')
+
         for topic, content in messages_to_search:
             self.send_stream_message(
-                sender=self.example_user("cordelia"),
+                sender=cordelia,
                 stream_name="Verona",
                 content=content,
                 topic_name=topic,
@@ -1622,7 +1649,7 @@ class GetOldMessagesTest(ZulipTestCase):
         self._update_tsvector_index()
 
         narrow = [
-            dict(operator='sender', operand=self.example_email("cordelia")),
+            dict(operator='sender', operand=cordelia.email),
             dict(operator='search', operand='lunch'),
         ]
         result = self.get_and_check_messages(dict(
@@ -1946,9 +1973,12 @@ class GetOldMessagesTest(ZulipTestCase):
         returns at most 1 message.
         """
         self.login('cordelia')
-        anchor = self.send_stream_message(self.example_user("cordelia"), "Verona")
 
-        narrow = [dict(operator='sender', operand=self.example_email("cordelia"))]
+        cordelia = self.example_user('cordelia')
+
+        anchor = self.send_stream_message(cordelia, "Verona")
+
+        narrow = [dict(operator='sender', operand=cordelia.email)]
         result = self.get_and_check_messages(dict(narrow=ujson.dumps(narrow),
                                                   anchor=anchor, num_before=0,
                                                   num_after=0))  # type: Dict[str, Any]
@@ -2738,23 +2768,25 @@ recipient_id = %(recipient_id_3)s AND upper(subject) = upper(%(param_2)s))\
 
     def test_get_messages_with_narrow_queries(self) -> None:
         query_ids = self.get_query_ids()
+        hamlet_email = self.example_user('hamlet').email
+        othello_email = self.example_user('othello').email
 
         sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND (sender_id = {othello_id} AND recipient_id = {hamlet_recipient} OR sender_id = {hamlet_id} AND recipient_id = {othello_recipient}) AND message_id = 0) AS anon_1 ORDER BY message_id ASC'
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query({'anchor': 0, 'num_before': 0, 'num_after': 0,
-                                              'narrow': '[["pm-with", "%s"]]' % (self.example_email("othello"),)},
+                                              'narrow': '[["pm-with", "%s"]]' % (othello_email,)},
                                              sql)
 
         sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND (sender_id = {othello_id} AND recipient_id = {hamlet_recipient} OR sender_id = {hamlet_id} AND recipient_id = {othello_recipient}) AND message_id = 0) AS anon_1 ORDER BY message_id ASC'
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query({'anchor': 0, 'num_before': 1, 'num_after': 0,
-                                              'narrow': '[["pm-with", "%s"]]' % (self.example_email("othello"),)},
+                                              'narrow': '[["pm-with", "%s"]]' % (othello_email,)},
                                              sql)
 
         sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND (sender_id = {othello_id} AND recipient_id = {hamlet_recipient} OR sender_id = {hamlet_id} AND recipient_id = {othello_recipient}) ORDER BY message_id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC'
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query({'anchor': 0, 'num_before': 0, 'num_after': 9,
-                                              'narrow': '[["pm-with", "%s"]]' % (self.example_email("othello"),)},
+                                              'narrow': '[["pm-with", "%s"]]' % (othello_email,)},
                                              sql)
 
         sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND (flags & 2) != 0 ORDER BY message_id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC'
@@ -2766,7 +2798,7 @@ recipient_id = %(recipient_id_3)s AND upper(subject) = upper(%(param_2)s))\
         sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND sender_id = {othello_id} ORDER BY message_id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC'
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query({'anchor': 0, 'num_before': 0, 'num_after': 9,
-                                              'narrow': '[["sender", "%s"]]' % (self.example_email("othello"),)},
+                                              'narrow': '[["sender", "%s"]]' % (othello_email,)},
                                              sql)
 
         sql_template = 'SELECT anon_1.message_id \nFROM (SELECT id AS message_id \nFROM zerver_message \nWHERE recipient_id = {scotland_recipient} ORDER BY zerver_message.id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC'
@@ -2803,7 +2835,7 @@ recipient_id = %(recipient_id_3)s AND upper(subject) = upper(%(param_2)s))\
         sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND sender_id = {hamlet_id} AND recipient_id = {hamlet_recipient} ORDER BY message_id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC'
         sql = sql_template.format(**query_ids)
         self.common_check_get_messages_query({'anchor': 0, 'num_before': 0, 'num_after': 9,
-                                              'narrow': '[["pm-with", "%s"]]' % (self.example_email("hamlet"),)},
+                                              'narrow': '[["pm-with", "%s"]]' % (hamlet_email,)},
                                              sql)
 
         sql_template = 'SELECT anon_1.message_id, anon_1.flags \nFROM (SELECT message_id, flags \nFROM zerver_usermessage JOIN zerver_message ON zerver_usermessage.message_id = zerver_message.id \nWHERE user_profile_id = {hamlet_id} AND recipient_id = {scotland_recipient} AND (flags & 2) != 0 ORDER BY message_id ASC \n LIMIT 10) AS anon_1 ORDER BY message_id ASC'
@@ -2868,6 +2900,9 @@ WHERE user_profile_id = {hamlet_id} AND (content ILIKE '%jumping%' OR subject IL
     def test_get_messages_with_search_using_email(self) -> None:
         self.login('cordelia')
 
+        othello = self.example_user('othello')
+        cordelia = self.example_user('cordelia')
+
         messages_to_search = [
             ('say hello', 'How are you doing, @**Othello, the Moor of Venice**?'),
             ('lunch plans', 'I am hungry!'),
@@ -2876,7 +2911,7 @@ WHERE user_profile_id = {hamlet_id} AND (content ILIKE '%jumping%' OR subject IL
 
         for topic, content in messages_to_search:
             self.send_stream_message(
-                sender=self.example_user("cordelia"),
+                sender=cordelia,
                 stream_name="Verona",
                 content=content,
                 topic_name=topic,
@@ -2885,8 +2920,8 @@ WHERE user_profile_id = {hamlet_id} AND (content ILIKE '%jumping%' OR subject IL
         self._update_tsvector_index()
 
         narrow = [
-            dict(operator='sender', operand=self.example_email("cordelia")),
-            dict(operator='search', operand=self.example_email("othello")),
+            dict(operator='sender', operand=cordelia.email),
+            dict(operator='search', operand=othello.email),
         ]
         result = self.get_and_check_messages(dict(
             narrow=ujson.dumps(narrow),
@@ -2896,7 +2931,7 @@ WHERE user_profile_id = {hamlet_id} AND (content ILIKE '%jumping%' OR subject IL
         self.assertEqual(len(result['messages']), 0)
 
         narrow = [
-            dict(operator='sender', operand=self.example_email("cordelia")),
+            dict(operator='sender', operand=cordelia.email),
             dict(operator='search', operand='othello'),
         ]
         result = self.get_and_check_messages(dict(
@@ -2911,7 +2946,6 @@ WHERE user_profile_id = {hamlet_id} AND (content ILIKE '%jumping%' OR subject IL
         self.assertEqual(
             meeting_message[MATCH_TOPIC],
             'say hello')
-        othello = self.example_user('othello')
         self.assertEqual(
             meeting_message['match_content'],
             ('<p>How are you doing, <span class="user-mention" data-user-id="%s">' +

--- a/zerver/tests/test_new_users.py
+++ b/zerver/tests/test_new_users.py
@@ -34,13 +34,18 @@ class SendLoginEmailTest(ZulipTestCase):
             user.twenty_four_hour_time = False
             user.date_joined = mock_time - datetime.timedelta(seconds=JUST_CREATED_THRESHOLD + 1)
             user.save()
-            password = initial_password(user.email)
+            password = initial_password(user.delivery_email)
+            login_info = dict(
+                username=user.delivery_email,
+                password=password,
+            )
             firefox_windows = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0"
             user_tz = get_timezone(user.timezone)
             mock_time = datetime.datetime(year=2018, month=1, day=1, tzinfo=utc)
             reference_time = mock_time.astimezone(user_tz).strftime('%A, %B %d, %Y at %I:%M%p %Z')
             with mock.patch('zerver.signals.timezone_now', return_value=mock_time):
-                self.client_post("/accounts/login/", info={"username": user.email, "password": password},
+                self.client_post("/accounts/login/",
+                                 info=login_info,
                                  HTTP_USER_AGENT=firefox_windows)
 
             # email is sent and correct subject
@@ -55,7 +60,8 @@ class SendLoginEmailTest(ZulipTestCase):
             user.twenty_four_hour_time = True
             user.save()
             with mock.patch('zerver.signals.timezone_now', return_value=mock_time):
-                self.client_post("/accounts/login/", info={"username": user.email, "password": password},
+                self.client_post("/accounts/login/",
+                                 info=login_info,
                                  HTTP_USER_AGENT=firefox_windows)
 
             reference_time = mock_time.astimezone(user_tz).strftime('%A, %B %d, %Y at %H:%M %Z')

--- a/zerver/tests/test_presence.py
+++ b/zerver/tests/test_presence.py
@@ -13,13 +13,13 @@ from zerver.lib.statistics import seconds_usage_between
 from zerver.lib.test_helpers import (
     make_client,
     queries_captured,
+    reset_emails_in_zulip_realm,
 )
 from zerver.lib.test_classes import (
     ZulipTestCase,
 )
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.models import (
-    email_to_domain,
     Client,
     PushDeviceToken,
     UserActivity,
@@ -161,53 +161,55 @@ class UserPresenceTests(ZulipTestCase):
     def test_set_idle(self) -> None:
         client = 'website'
 
-        user = self.example_user("hamlet")
-        email = user.email
-        self.login_user(user)
+        hamlet = self.example_user('hamlet')
+        othello = self.example_user('othello')
+
+        self.login_user(hamlet)
 
         result = self.client_post("/json/users/me/presence", {'status': 'idle'})
         self.assert_json_success(result)
         json = result.json()
-        self.assertEqual(json['presences'][email][client]['status'], 'idle')
-        self.assertIn('timestamp', json['presences'][email][client])
-        self.assertIsInstance(json['presences'][email][client]['timestamp'], int)
-        self.assertEqual(list(json['presences'].keys()), [self.example_email("hamlet")])
-        timestamp = json['presences'][email][client]['timestamp']
+        self.assertEqual(json['presences'][hamlet.email][client]['status'], 'idle')
+        self.assertIn('timestamp', json['presences'][hamlet.email][client])
+        self.assertIsInstance(json['presences'][hamlet.email][client]['timestamp'], int)
+        self.assertEqual(list(json['presences'].keys()), [hamlet.email])
+        timestamp = json['presences'][hamlet.email][client]['timestamp']
 
-        user = self.example_user("othello")
-        email = user.email
-        self.login_user(user)
+        self.login_user(othello)
 
         result = self.client_post("/json/users/me/presence", {'status': 'idle'})
         json = result.json()
-        self.assertEqual(json['presences'][email][client]['status'], 'idle')
-        self.assertEqual(json['presences'][self.example_email("hamlet")][client]['status'], 'idle')
-        self.assertEqual(sorted(json['presences'].keys()), [self.example_email("hamlet"), self.example_email("othello")])
-        newer_timestamp = json['presences'][email][client]['timestamp']
+        self.assertEqual(json['presences'][othello.email][client]['status'], 'idle')
+        self.assertEqual(json['presences'][hamlet.email][client]['status'], 'idle')
+        self.assertEqual(set(json['presences'].keys()), {hamlet.email, othello.email})
+        newer_timestamp = json['presences'][othello.email][client]['timestamp']
         self.assertGreaterEqual(newer_timestamp, timestamp)
 
     def test_set_active(self) -> None:
-        self.login('hamlet')
+        hamlet = self.example_user('hamlet')
+        othello = self.example_user('othello')
+
+        self.login_user(hamlet)
+
         client = 'website'
 
         result = self.client_post("/json/users/me/presence", {'status': 'idle'})
 
         self.assert_json_success(result)
-        self.assertEqual(result.json()['presences'][self.example_email("hamlet")][client]['status'], 'idle')
+        self.assertEqual(result.json()['presences'][hamlet.email][client]['status'], 'idle')
 
-        email = self.example_email("othello")
         self.login('othello')
         result = self.client_post("/json/users/me/presence", {'status': 'idle'})
         self.assert_json_success(result)
         json = result.json()
-        self.assertEqual(json['presences'][email][client]['status'], 'idle')
-        self.assertEqual(json['presences'][self.example_email("hamlet")][client]['status'], 'idle')
+        self.assertEqual(json['presences'][othello.email][client]['status'], 'idle')
+        self.assertEqual(json['presences'][hamlet.email][client]['status'], 'idle')
 
         result = self.client_post("/json/users/me/presence", {'status': 'active'})
         self.assert_json_success(result)
         json = result.json()
-        self.assertEqual(json['presences'][email][client]['status'], 'active')
-        self.assertEqual(json['presences'][self.example_email("hamlet")][client]['status'], 'idle')
+        self.assertEqual(json['presences'][othello.email][client]['status'], 'active')
+        self.assertEqual(json['presences'][hamlet.email][client]['status'], 'idle')
 
     @mock.patch("stripe.Customer.list", return_value=[])
     def test_new_user_input(self, unused_mock: mock.Mock) -> None:
@@ -347,14 +349,16 @@ class UserPresenceTests(ZulipTestCase):
         self.logout()
 
         # Ensure we don't see hamlet@zulip.com information leakage
-        self.login('hamlet')
+        hamlet = self.example_user('hamlet')
+        self.login_user(hamlet)
         result = self.client_post("/json/users/me/presence", {'status': 'idle'})
         self.assert_json_success(result)
         json = result.json()
-        self.assertEqual(json['presences'][self.example_email("hamlet")]["website"]['status'], 'idle')
-        # We only want @zulip.com emails
-        for email in json['presences'].keys():
-            self.assertEqual(email_to_domain(email), 'zulip.com')
+        self.assertEqual(json['presences'][hamlet.email]["website"]['status'], 'idle')
+        self.assertEqual(
+            json['presences'].keys(),
+            {hamlet.email}
+        )
 
 class SingleUserPresenceTests(ZulipTestCase):
     def test_email_access(self) -> None:
@@ -378,6 +382,7 @@ class SingleUserPresenceTests(ZulipTestCase):
         self.assert_json_error(result, 'No presence data for email@zulip.com')
 
     def test_single_user_get(self) -> None:
+        reset_emails_in_zulip_realm()
 
         # First, we setup the test with some data
         user = self.example_user("othello")
@@ -431,7 +436,6 @@ class SingleUserPresenceTests(ZulipTestCase):
 class UserPresenceAggregationTests(ZulipTestCase):
     def _send_presence_for_aggregated_tests(self, user: UserProfile, status: str,
                                             validate_time: datetime.datetime) -> Dict[str, Dict[str, Any]]:
-        email = user.email
         self.login_user(user)
         timezone_util = 'zerver.views.presence.timezone_now'
         with mock.patch(timezone_util, return_value=validate_time - datetime.timedelta(seconds=5)):
@@ -444,14 +448,15 @@ class UserPresenceAggregationTests(ZulipTestCase):
                                           HTTP_USER_AGENT="ZulipIOS/1.0")
         latest_result_dict = latest_result.json()
         self.assertDictEqual(
-            latest_result_dict['presences'][email]['aggregated'],
+            latest_result_dict['presences'][user.email]['aggregated'],
             {
                 'status': status,
                 'timestamp': datetime_to_timestamp(validate_time - datetime.timedelta(seconds=2)),
                 'client': 'ZulipAndroid'
             }
         )
-        result = self.client_get("/json/users/%s/presence" % (email,))
+
+        result = self.client_get("/json/users/{}/presence".format(user.email))
         return result.json()
 
     def test_aggregated_info(self) -> None:

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -216,13 +216,13 @@ class ReactionMessageIDTest(ZulipTestCase):
         Reacting to a inaccessible (for instance, private) message fails
         """
         pm_sender = self.example_user("hamlet")
-        pm_recipient = self.example_email("othello")
+        pm_recipient = self.example_user("othello")
         reaction_sender = self.example_user("iago")
 
         result = self.api_post(pm_sender,
                                "/api/v1/messages", {"type": "private",
                                                     "content": "Test message",
-                                                    "to": pm_recipient})
+                                                    "to": pm_recipient.email})
         self.assert_json_success(result)
         pm_id = result.json()['id']
         reaction_info = {

--- a/zerver/tests/test_report.py
+++ b/zerver/tests/test_report.py
@@ -125,7 +125,7 @@ class TestReport(ZulipTestCase):
             self.assertEqual(report[k], params[k])
 
         self.assertEqual(report['more_info'], dict(foo='bar', draft_content="'**xxxxx**'"))
-        self.assertEqual(report['user_email'], user.email)
+        self.assertEqual(report['user_email'], user.delivery_email)
 
         # Teset with no more_info
         del params['more_info']

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -70,7 +70,7 @@ class ChangeSettingsTest(ZulipTestCase):
             "/json/settings",
             dict(
                 full_name='Foo Bar',
-                old_password=initial_password(user.email),
+                old_password=initial_password(user.delivery_email),
                 new_password='foobar1',
             ))
         self.assert_json_success(json_result)
@@ -86,7 +86,7 @@ class ChangeSettingsTest(ZulipTestCase):
         # with as few moving parts as possible).
         self.assertTrue(
             self.client.login(
-                username=user.email,
+                username=user.delivery_email,
                 password='foobar1',
                 realm=user.realm
             )

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -10,7 +10,8 @@ from django.utils.timezone import now as timezone_now
 from zerver.lib import cache
 
 from zerver.lib.test_helpers import (
-    get_subscription, queries_captured, tornado_redirected_to_list
+    get_subscription, queries_captured, tornado_redirected_to_list,
+    reset_emails_in_zulip_realm
 )
 
 from zerver.lib.test_classes import (
@@ -240,6 +241,10 @@ class TestCreateStreams(ZulipTestCase):
         self.assertFalse(stream.history_public_to_subscribers)
 
     def test_auto_mark_stream_created_message_as_read_for_stream_creator(self) -> None:
+        # This test relies on email == delivery_email for
+        # convenience.
+        reset_emails_in_zulip_realm()
+
         realm = Realm.objects.get(name='Zulip Dev')
         iago = self.example_user('iago')
         hamlet = self.example_user('hamlet')
@@ -679,9 +684,11 @@ class StreamAdminTest(ZulipTestCase):
 
     def test_realm_admin_can_update_unsub_private_stream(self) -> None:
         iago = self.example_user('iago')
+        hamlet = self.example_user('hamlet')
+
         self.login_user(iago)
         result = self.common_subscribe_to_streams(iago, ["private_stream"],
-                                                  dict(principals=ujson.dumps([self.example_email("hamlet")])),
+                                                  dict(principals=ujson.dumps([hamlet.email])),
                                                   invite_only=True)
         self.assert_json_success(result)
 
@@ -2654,13 +2661,16 @@ class SubscriptionAPITest(ZulipTestCase):
         Check users getting add_peer_event is correct
         """
         streams_to_sub = ['multi_user_stream']
-        orig_emails_to_subscribe = [self.test_email, self.example_email("othello")]
+        othello = self.example_user('othello')
+        cordelia = self.example_user('cordelia')
+        iago = self.example_user('iago')
+        orig_emails_to_subscribe = [self.test_email, othello.email]
         self.common_subscribe_to_streams(
             self.test_user,
             streams_to_sub,
             dict(principals=ujson.dumps(orig_emails_to_subscribe)))
 
-        new_emails_to_subscribe = [self.example_email("iago"), self.example_email("cordelia")]
+        new_emails_to_subscribe = [iago.email, cordelia.email]
         events = []  # type: List[Mapping[str, Any]]
         with tornado_redirected_to_list(events):
             self.common_subscribe_to_streams(
@@ -2826,15 +2836,18 @@ class SubscriptionAPITest(ZulipTestCase):
         You can't subscribe deactivated people to streams.
         """
         target_profile = self.example_user("cordelia")
-        result = self.common_subscribe_to_streams(self.test_user, "Verona",
-                                                  {"principals": ujson.dumps([target_profile.email])})
+        post_data = dict(
+            principals=ujson.dumps([target_profile.email])
+        )
+        result = self.common_subscribe_to_streams(self.test_user, "Verona", post_data)
         self.assert_json_success(result)
 
         do_deactivate_user(target_profile)
-        result = self.common_subscribe_to_streams(self.test_user, "Denmark",
-                                                  {"principals": ujson.dumps([target_profile.email])})
-        self.assert_json_error(result, "User not authorized to execute queries on behalf of 'cordelia@zulip.com'",
-                               status_code=403)
+        result = self.common_subscribe_to_streams(self.test_user, "Denmark", post_data)
+        self.assert_json_error(
+            result,
+            "User not authorized to execute queries on behalf of '{}'".format(target_profile.email),
+            status_code=403)
 
     def test_subscriptions_add_for_principal_invite_only(self) -> None:
         """
@@ -2851,7 +2864,8 @@ class SubscriptionAPITest(ZulipTestCase):
         You can subscribe other people to streams even if they containing
         non-ASCII characters.
         """
-        self.assert_adding_subscriptions_for_principal(self.example_email("iago"), get_realm('zulip'), [u"hümbüǵ"])
+        iago = self.example_user('iago')
+        self.assert_adding_subscriptions_for_principal(iago.email, get_realm('zulip'), [u"hümbüǵ"])
 
     def test_subscription_add_invalid_principal(self) -> None:
         """
@@ -3447,29 +3461,26 @@ class InviteOnlyStreamTest(ZulipTestCase):
     @slow("lots of queries")
     def test_inviteonly(self) -> None:
         # Creating an invite-only stream is allowed
-        user_profile = self.example_user('hamlet')
-        email = user_profile.email
+        hamlet = self.example_user('hamlet')
+        othello = self.example_user('othello')
+
         stream_name = "Saxony"
 
-        result = self.common_subscribe_to_streams(user_profile, [stream_name], invite_only=True)
+        result = self.common_subscribe_to_streams(hamlet, [stream_name], invite_only=True)
         self.assert_json_success(result)
 
         json = result.json()
-        self.assertEqual(json["subscribed"], {email: [stream_name]})
+        self.assertEqual(json["subscribed"], {hamlet.email: [stream_name]})
         self.assertEqual(json["already_subscribed"], {})
 
         # Subscribing oneself to an invite-only stream is not allowed
-        user_profile = self.example_user('othello')
-        email = user_profile.email
-        self.login_user(user_profile)
-        result = self.common_subscribe_to_streams(user_profile, [stream_name])
+        self.login_user(othello)
+        result = self.common_subscribe_to_streams(othello, [stream_name])
         self.assert_json_error(result, 'Unable to access stream (Saxony).')
 
         # authorization_errors_fatal=False works
-        user_profile = self.example_user('othello')
-        email = user_profile.email
-        self.login_user(user_profile)
-        result = self.common_subscribe_to_streams(user_profile, [stream_name],
+        self.login_user(othello)
+        result = self.common_subscribe_to_streams(othello, [stream_name],
                                                   extra_post_data={'authorization_errors_fatal': ujson.dumps(False)})
         self.assert_json_success(result)
         json = result.json()
@@ -3478,31 +3489,29 @@ class InviteOnlyStreamTest(ZulipTestCase):
         self.assertEqual(json["already_subscribed"], {})
 
         # Inviting another user to an invite-only stream is allowed
-        user_profile = self.example_user('hamlet')
-        self.login_user(user_profile)
+        self.login_user(hamlet)
         result = self.common_subscribe_to_streams(
-            user_profile, [stream_name],
-            extra_post_data={'principals': ujson.dumps([self.example_email("othello")])})
+            hamlet, [stream_name],
+            extra_post_data={'principals': ujson.dumps([othello.email])})
         self.assert_json_success(result)
         json = result.json()
-        self.assertEqual(json["subscribed"], {self.example_email("othello"): [stream_name]})
+        self.assertEqual(json["subscribed"], {othello.email: [stream_name]})
         self.assertEqual(json["already_subscribed"], {})
 
         # Make sure both users are subscribed to this stream
-        stream_id = get_stream(stream_name, user_profile.realm).id
-        result = self.api_get(user_profile, "/api/v1/streams/%d/members" % (stream_id,))
+        stream_id = get_stream(stream_name, hamlet.realm).id
+        result = self.api_get(hamlet, "/api/v1/streams/%d/members" % (stream_id,))
         self.assert_json_success(result)
         json = result.json()
 
-        self.assertTrue(self.example_email("othello") in json['subscribers'])
-        self.assertTrue(self.example_email('hamlet') in json['subscribers'])
+        self.assertTrue(othello.email in json['subscribers'])
+        self.assertTrue(hamlet.email in json['subscribers'])
 
 class GetSubscribersTest(ZulipTestCase):
 
     def setUp(self) -> None:
         super().setUp()
         self.user_profile = self.example_user('hamlet')
-        self.email = self.user_profile.email
         self.login_user(self.user_profile)
 
     def assert_user_got_subscription_notification(self, expected_msg: str) -> None:
@@ -3562,7 +3571,11 @@ class GetSubscribersTest(ZulipTestCase):
         for stream_name in streams:
             self.make_stream(stream_name)
 
-        users_to_subscribe = [self.email, self.example_email("othello"), self.example_email("cordelia")]
+        users_to_subscribe = [
+            self.user_profile.email,
+            self.example_user("othello").email,
+            self.example_user("cordelia").email,
+        ]
         ret = self.common_subscribe_to_streams(
             self.user_profile,
             streams,
@@ -3591,7 +3604,7 @@ class GetSubscribersTest(ZulipTestCase):
         ret = self.common_subscribe_to_streams(
             self.user_profile,
             ["stream_invite_only_1"],
-            dict(principals=ujson.dumps([self.email])),
+            dict(principals=ujson.dumps([self.user_profile.email])),
             invite_only=True)
         self.assert_json_success(ret)
 
@@ -3626,8 +3639,8 @@ class GetSubscribersTest(ZulipTestCase):
         """
         realm = get_realm("zulip")
         users_to_subscribe = [
-            self.example_email("othello"),
-            self.example_email("cordelia"),
+            self.example_user("othello").email,
+            self.example_user("cordelia").email,
         ]
 
         public_streams = [

--- a/zerver/tests/test_unread.py
+++ b/zerver/tests/test_unread.py
@@ -289,16 +289,17 @@ class UnreadCountTests(ZulipTestCase):
         differences = [key for key in expected if expected[key] != event[key]]
         self.assertTrue(len(differences) == 0)
 
+        hamlet = self.example_user('hamlet')
         um = list(UserMessage.objects.filter(message=message_id))
         for msg in um:
-            if msg.user_profile.email == self.example_email("hamlet"):
+            if msg.user_profile.email == hamlet.email:
                 self.assertTrue(msg.flags.read)
             else:
                 self.assertFalse(msg.flags.read)
 
         unrelated_messages = list(UserMessage.objects.filter(message=unrelated_message_id))
         for msg in unrelated_messages:
-            if msg.user_profile.email == self.example_email("hamlet"):
+            if msg.user_profile.email == hamlet.email:
                 self.assertFalse(msg.flags.read)
 
     def test_mark_all_in_invalid_stream_read(self) -> None:
@@ -347,12 +348,12 @@ class UnreadCountTests(ZulipTestCase):
 
         um = list(UserMessage.objects.filter(message=message_id))
         for msg in um:
-            if msg.user_profile.email == self.example_email("hamlet"):
+            if msg.user_profile_id == user_profile.id:
                 self.assertTrue(msg.flags.read)
 
         unrelated_messages = list(UserMessage.objects.filter(message=unrelated_message_id))
         for msg in unrelated_messages:
-            if msg.user_profile.email == self.example_email("hamlet"):
+            if msg.user_profile_id == user_profile.id:
                 self.assertFalse(msg.flags.read)
 
     def test_mark_all_in_invalid_topic_read(self) -> None:

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -6,9 +6,12 @@ from typing import (Any, Dict, Iterable, List, Mapping,
                     Optional, TypeVar, Union)
 
 from zerver.lib.test_helpers import (
-    queries_captured, simulated_empty_cache,
-    tornado_redirected_to_list, get_subscription,
+    get_subscription,
     most_recent_message,
+    queries_captured,
+    reset_emails_in_zulip_realm,
+    simulated_empty_cache,
+    tornado_redirected_to_list,
 )
 from zerver.lib.test_classes import (
     ZulipTestCase,
@@ -16,7 +19,7 @@ from zerver.lib.test_classes import (
 
 from zerver.models import UserProfile, Recipient, Realm, \
     RealmDomain, UserHotspot, get_client, \
-    get_user, get_realm, get_stream, \
+    get_user, get_user_by_delivery_email, get_realm, get_stream, \
     get_source_profile, get_system_bot, \
     ScheduledEmail, check_valid_user_ids, \
     get_user_by_id_in_realm_including_cross_realm, CustomProfileField, \
@@ -127,43 +130,47 @@ class PermissionTest(ZulipTestCase):
 
     def test_admin_api(self) -> None:
         self.login('hamlet')
-        admin = self.example_user('hamlet')
-        user = self.example_user('othello')
-        realm = admin.realm
-        do_change_is_admin(admin, True)
+
+        hamlet = self.example_user('hamlet')
+        othello = self.example_user('othello')
+        iago = self.example_user('iago')
+        realm = hamlet.realm
+
+        # Make hamlet an additional admin
+        do_change_is_admin(hamlet, True)
 
         # Make sure we see is_admin flag in /json/users
         result = self.client_get('/json/users')
         self.assert_json_success(result)
         members = result.json()['members']
-        hamlet = find_dict(members, 'email', self.example_email("hamlet"))
-        self.assertTrue(hamlet['is_admin'])
-        othello = find_dict(members, 'email', self.example_email("othello"))
-        self.assertFalse(othello['is_admin'])
+        hamlet_dict = find_dict(members, 'email', hamlet.email)
+        self.assertTrue(hamlet_dict['is_admin'])
+        othello_dict = find_dict(members, 'email', othello.email)
+        self.assertFalse(othello_dict['is_admin'])
 
         # Giveth
         req = dict(is_admin=ujson.dumps(True))
 
         events = []  # type: List[Mapping[str, Any]]
         with tornado_redirected_to_list(events):
-            result = self.client_patch('/json/users/{}'.format(self.example_user("othello").id), req)
+            result = self.client_patch('/json/users/{}'.format(othello.id), req)
         self.assert_json_success(result)
         admin_users = realm.get_human_admin_users()
-        self.assertTrue(user in admin_users)
+        self.assertTrue(othello in admin_users)
         person = events[0]['event']['person']
-        self.assertEqual(person['email'], self.example_email("othello"))
+        self.assertEqual(person['email'], othello.email)
         self.assertEqual(person['is_admin'], True)
 
         # Taketh away
         req = dict(is_admin=ujson.dumps(False))
         events = []
         with tornado_redirected_to_list(events):
-            result = self.client_patch('/json/users/{}'.format(self.example_user("othello").id), req)
+            result = self.client_patch('/json/users/{}'.format(othello.id), req)
         self.assert_json_success(result)
         admin_users = realm.get_human_admin_users()
-        self.assertFalse(user in admin_users)
+        self.assertFalse(othello in admin_users)
         person = events[0]['event']['person']
-        self.assertEqual(person['email'], self.example_email("othello"))
+        self.assertEqual(person['email'], othello.email)
         self.assertEqual(person['is_admin'], False)
 
         # Cannot take away from last admin
@@ -171,23 +178,25 @@ class PermissionTest(ZulipTestCase):
         req = dict(is_admin=ujson.dumps(False))
         events = []
         with tornado_redirected_to_list(events):
-            result = self.client_patch('/json/users/{}'.format(self.example_user("hamlet").id), req)
+            result = self.client_patch('/json/users/{}'.format(hamlet.id), req)
         self.assert_json_success(result)
         admin_users = realm.get_human_admin_users()
-        self.assertFalse(admin in admin_users)
+        self.assertFalse(hamlet in admin_users)
         person = events[0]['event']['person']
-        self.assertEqual(person['email'], self.example_email("hamlet"))
+        self.assertEqual(person['email'], hamlet.email)
         self.assertEqual(person['is_admin'], False)
         with tornado_redirected_to_list([]):
-            result = self.client_patch('/json/users/{}'.format(self.example_user("iago").id), req)
+            result = self.client_patch('/json/users/{}'.format(iago.id), req)
         self.assert_json_error(result, 'Cannot remove the only organization administrator')
 
         # Make sure only admins can patch other user's info.
         self.login('othello')
-        result = self.client_patch('/json/users/{}'.format(self.example_user("hamlet").id), req)
+        result = self.client_patch('/json/users/{}'.format(hamlet.id), req)
         self.assert_json_error(result, 'Insufficient permission')
 
     def test_admin_api_hide_emails(self) -> None:
+        reset_emails_in_zulip_realm()
+
         user = self.example_user('hamlet')
         admin = self.example_user('iago')
         self.login_user(user)
@@ -642,7 +651,7 @@ class AdminCreateUserTest(ZulipTestCase):
         self.assert_json_success(result)
 
         # Romeo is a newly registered user
-        new_user = get_user('romeo@zulip.net', get_realm('zulip'))
+        new_user = get_user_by_delivery_email('romeo@zulip.net', get_realm('zulip'))
         self.assertEqual(new_user.full_name, 'Romeo Montague')
         self.assertEqual(new_user.short_name, 'Romeo')
 
@@ -687,8 +696,8 @@ class UserProfileTest(ZulipTestCase):
         hamlet = self.example_user('hamlet')
         othello = self.example_user('othello')
         dct = get_emails_from_user_ids([hamlet.id, othello.id])
-        self.assertEqual(dct[hamlet.id], self.example_email("hamlet"))
-        self.assertEqual(dct[othello.id], self.example_email("othello"))
+        self.assertEqual(dct[hamlet.id], hamlet.email)
+        self.assertEqual(dct[othello.id], othello.email)
 
     def test_valid_user_id(self) -> None:
         realm = get_realm("zulip")
@@ -759,20 +768,28 @@ class UserProfileTest(ZulipTestCase):
 
     def test_bulk_get_users(self) -> None:
         from zerver.lib.users import bulk_get_users
-        hamlet = self.example_email("hamlet")
-        cordelia = self.example_email("cordelia")
-        webhook_bot = self.example_email("webhook_bot")
-        result = bulk_get_users([hamlet, cordelia], get_realm("zulip"))
-        self.assertEqual(result[hamlet].email, hamlet)
-        self.assertEqual(result[cordelia].email, cordelia)
+        hamlet = self.example_user("hamlet")
+        cordelia = self.example_user("cordelia")
+        webhook_bot = self.example_user("webhook_bot")
+        result = bulk_get_users(
+            [hamlet.email, cordelia.email],
+            get_realm("zulip")
+        )
+        self.assertEqual(result[hamlet.email].email, hamlet.email)
+        self.assertEqual(result[cordelia.email].email, cordelia.email)
 
-        result = bulk_get_users([hamlet, cordelia, webhook_bot], None,
-                                base_query=UserProfile.objects.all())
-        self.assertEqual(result[hamlet].email, hamlet)
-        self.assertEqual(result[cordelia].email, cordelia)
-        self.assertEqual(result[webhook_bot].email, webhook_bot)
+        result = bulk_get_users(
+            [hamlet.email, cordelia.email, webhook_bot.email],
+            None,
+            base_query=UserProfile.objects.all()
+        )
+        self.assertEqual(result[hamlet.email].email, hamlet.email)
+        self.assertEqual(result[cordelia.email].email, cordelia.email)
+        self.assertEqual(result[webhook_bot.email].email, webhook_bot.email)
 
     def test_get_accounts_for_email(self) -> None:
+        reset_emails_in_zulip_realm()
+
         def check_account_present_in_accounts(user: UserProfile, accounts: List[Dict[str, Optional[str]]]) -> None:
             for account in accounts:
                 realm = user.realm
@@ -783,7 +800,7 @@ class UserProfileTest(ZulipTestCase):
 
         lear_realm = get_realm("lear")
         cordelia_in_zulip = self.example_user("cordelia")
-        cordelia_in_lear = get_user("cordelia@zulip.com", lear_realm)
+        cordelia_in_lear = get_user_by_delivery_email("cordelia@zulip.com", lear_realm)
 
         email = "cordelia@zulip.com"
         accounts = get_accounts_for_email(email)
@@ -803,6 +820,7 @@ class UserProfileTest(ZulipTestCase):
         check_account_present_in_accounts(self.example_user("iago"), accounts)
 
     def test_get_source_profile(self) -> None:
+        reset_emails_in_zulip_realm()
         iago = get_source_profile("iago@zulip.com", "zulip")
         assert iago is not None
         self.assertEqual(iago.email, "iago@zulip.com")
@@ -1241,6 +1259,7 @@ class RecipientInfoTest(ZulipTestCase):
 
 class BulkUsersTest(ZulipTestCase):
     def test_client_gravatar_option(self) -> None:
+        reset_emails_in_zulip_realm()
         self.login('cordelia')
 
         hamlet = self.example_user('hamlet')
@@ -1311,7 +1330,7 @@ class GetProfileTest(ZulipTestCase):
         `get_user`, makes 1 cache query and 1 database query.
         """
         realm = get_realm("zulip")
-        email = self.example_email("hamlet")
+        email = self.example_user("hamlet").email
         with queries_captured() as queries:
             with simulated_empty_cache() as cache_queries:
                 user_profile = get_user(email, realm)
@@ -1321,18 +1340,22 @@ class GetProfileTest(ZulipTestCase):
         self.assertEqual(user_profile.email, email)
 
     def test_get_user_profile(self) -> None:
+        hamlet = self.example_user('hamlet')
+        iago = self.example_user('iago')
+
         self.login('hamlet')
         result = ujson.loads(self.client_get('/json/users/me').content)
         self.assertEqual(result['short_name'], 'hamlet')
-        self.assertEqual(result['email'], self.example_email("hamlet"))
+        self.assertEqual(result['email'], hamlet.email)
         self.assertEqual(result['full_name'], 'King Hamlet')
         self.assertIn("user_id", result)
         self.assertFalse(result['is_bot'])
         self.assertFalse(result['is_admin'])
+        self.assertFalse('delivery_email' in result)
         self.login('iago')
         result = ujson.loads(self.client_get('/json/users/me').content)
         self.assertEqual(result['short_name'], 'iago')
-        self.assertEqual(result['email'], self.example_email("iago"))
+        self.assertEqual(result['email'], iago.email)
         self.assertEqual(result['full_name'], 'Iago')
         self.assertFalse(result['is_bot'])
         self.assertTrue(result['is_admin'])

--- a/zerver/views/presence.py
+++ b/zerver/views/presence.py
@@ -21,7 +21,7 @@ from zerver.lib.response import json_success, json_error
 from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.validator import check_bool, check_capped_string
 from zerver.models import UserActivity, UserPresence, UserProfile, \
-    get_active_user_by_delivery_email
+    get_active_user
 
 def get_presence_backend(request: HttpRequest, user_profile: UserProfile,
                          email: str) -> HttpResponse:
@@ -29,7 +29,7 @@ def get_presence_backend(request: HttpRequest, user_profile: UserProfile,
     # bots and other clients.  We may want to add slim_presence
     # support for it (or just migrate its API wholesale) later.
     try:
-        target = get_active_user_by_delivery_email(email, user_profile.realm)
+        target = get_active_user(email, user_profile.realm)
     except UserProfile.DoesNotExist:
         return json_error(_('No such user'))
     if target.is_bot:
@@ -37,7 +37,7 @@ def get_presence_backend(request: HttpRequest, user_profile: UserProfile,
 
     presence_dict = get_presence_for_user(target.id)
     if len(presence_dict) == 0:
-        return json_error(_('No presence data for %s') % (target.email,))
+        return json_error(_('No presence data for %s') % (email,))
 
     # For initial version, we just include the status and timestamp keys
     result = dict(presence=presence_dict[target.email])

--- a/zerver/webhooks/yo/tests.py
+++ b/zerver/webhooks/yo/tests.py
@@ -13,8 +13,9 @@ class YoHookTests(WebhookTestCase):
         """
         Yo App sends notification whenever user receives a new Yo from another user.
         """
+        cordelia = self.example_user('cordelia')
         self.url = self.build_webhook_url(
-            email="cordelia@zulip.com",
+            email=cordelia.email,
             username="IAGO",
             user_ip="127.0.0.1"
         )


### PR DESCRIPTION
This is a superset of #14201 (which is tests only).

This PR also optimizes `bulk_create_users` and changes how we populate our test database.
