### PR TITLE
Add caching for sorted_term_types and can_mark_messages_read

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -357,6 +357,25 @@ run_test('can_mark_messages_read', () => {
     assert(!filter.can_mark_messages_read());
     filter = new Filter(in_random_negated);
     assert(!filter.can_mark_messages_read());
+
+    // test caching of term types
+    // init and stub
+    filter = new Filter(pm_with);
+    filter.stub = filter.calc_can_mark_messages_read;
+    filter.calc_can_mark_messages_read = function () {
+        this.calc_can_mark_messages_read_called = true;
+        return this.stub();
+    };
+
+    // uncached trial
+    filter.calc_can_mark_messages_read_called = false;
+    assert(filter.can_mark_messages_read());
+    assert(filter.calc_can_mark_messages_read_called);
+
+    // cached trial
+    filter.calc_can_mark_messages_read_called = false;
+    assert(filter.can_mark_messages_read());
+    assert(!filter.calc_can_mark_messages_read_called);
 });
 
 run_test('show_first_unread', () => {

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -502,6 +502,13 @@ Filter.prototype = {
     },
 
     sorted_term_types: function () {
+        if (this._sorted_term_types === undefined) {
+            this._sorted_term_types = this._build_sorted_term_types();
+        }
+        return this._sorted_term_types;
+    },
+
+    _build_sorted_term_types: function () {
         const terms = this._operators;
         const term_types = terms.map(Filter.term_type);
         const sorted_terms = Filter.sorted_term_types(term_types);

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -387,7 +387,7 @@ Filter.prototype = {
         return this.has_operator('search');
     },
 
-    can_mark_messages_read: function () {
+    calc_can_mark_messages_read: function () {
         const term_types = this.sorted_term_types();
 
         if (_.isEqual(term_types, ['stream', 'topic'])) {
@@ -424,6 +424,13 @@ Filter.prototype = {
         }
 
         return false;
+    },
+
+    can_mark_messages_read: function () {
+        if (this._can_mark_messages_read === undefined) {
+            this._can_mark_messages_read = this.calc_can_mark_messages_read();
+        }
+        return this._can_mark_messages_read;
     },
 
     allow_use_first_unread_when_narrowing: function () {


### PR DESCRIPTION
Manual and CI tests, small improvement during execution.