### PR TITLE
hotkeys: Fix "n" key behavior in some narrows.

### DIFF
--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -37,37 +37,6 @@ const ray = {
     full_name: 'Raymond',
 };
 
-run_test('stream_topic', () => {
-    set_filter([['stream', 'Foo'], ['topic', 'Bar'], ['search', 'Yo']]);
-
-    set_global('current_msg_list', {
-    });
-
-    global.current_msg_list.selected_message = function () {};
-
-    let stream_topic = narrow.stream_topic();
-
-    assert.deepEqual(stream_topic, {
-        stream: 'Foo',
-        topic: 'Bar',
-    });
-
-    global.current_msg_list.selected_message = function () {
-        return {
-            stream: 'Stream1',
-            topic: 'Topic1',
-        };
-    };
-
-    stream_topic = narrow.stream_topic();
-
-    assert.deepEqual(stream_topic, {
-        stream: 'Stream1',
-        topic: 'Topic1',
-    });
-
-});
-
 run_test('uris', () => {
     people.add(ray);
     people.add(alice);

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -541,27 +541,6 @@ exports.update_selection = function (opts) {
     unread_ops.process_visible();
 };
 
-exports.stream_topic = function () {
-    // This function returns the stream/topic that we most
-    // specifically care about, according (mostly) to the
-    // currently selected message.
-    const msg = current_msg_list.selected_message();
-
-    if (msg) {
-        return {
-            stream: msg.stream || undefined,
-            topic: msg.topic || undefined,
-        };
-    }
-
-    // We may be in an empty narrow.  In that case we use
-    // our narrow parameters to return the stream/topic.
-    return {
-        stream: narrow_state.stream(),
-        topic: narrow_state.topic(),
-    };
-};
-
 exports.activate_stream_for_cycle_hotkey = function (stream_name) {
     // This is the common code for A/D hotkeys.
     const filter_expr = [
@@ -604,11 +583,10 @@ exports.stream_cycle_forward = function () {
 };
 
 exports.narrow_to_next_topic = function () {
-    const curr_info = exports.stream_topic();
-
-    if (!curr_info) {
-        return;
-    }
+    const curr_info = {
+        stream: narrow_state.stream(),
+        topic: narrow_state.topic(),
+    };
 
     const next_narrow = topic_generator.get_next_topic(
         curr_info.stream,


### PR DESCRIPTION
If you were in the "Starred messages" narrow and
your pointer was on a message with the stream/topic
of "social/lunch", we wouldn't move you to the unread
messages for that topic.

I fixed this by removing the code that looked at
the current message's topic.  Instead, we only look
at the active narrow to figure out the "next" topic
to go to.

Fixes #14120.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
