### PR TITLE
actions: Optimize query in get_occupied_streams.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5,7 +5,7 @@ from typing import (
 from typing_extensions import TypedDict
 
 import django.db.utils
-from django.db.models import Count
+from django.db.models import Count, Exists, OuterRef
 from django.contrib.contenttypes.models import ContentType
 from django.utils.html import escape
 from django.utils.translation import ugettext as _
@@ -5399,12 +5399,14 @@ def do_remove_realm_domain(realm_domain: RealmDomain) -> None:
 def get_occupied_streams(realm: Realm) -> QuerySet:
     # TODO: Make a generic stub for QuerySet
     """ Get streams with subscribers """
-    subs_filter = Subscription.objects.filter(active=True, user_profile__realm=realm,
-                                              user_profile__is_active=True).values('recipient_id')
-    stream_ids = Recipient.objects.filter(
-        type=Recipient.STREAM, id__in=subs_filter).values('type_id')
-
-    return Stream.objects.filter(id__in=stream_ids, realm=realm, deactivated=False)
+    exists_expression = Exists(
+        Subscription.objects.filter(active=True, user_profile__is_active=True,
+                                    user_profile__realm=realm,
+                                    recipient_id=OuterRef('recipient_id'))
+    )
+    occupied_streams = Stream.objects.filter(realm=realm, deactivated=False) \
+        .annotate(occupied=exists_expression).filter(occupied=True)
+    return occupied_streams
 
 def get_web_public_streams(realm: Realm) -> List[Dict[str, Any]]:
     query = Stream.objects.filter(realm=realm, deactivated=False, is_web_public=True)


### PR DESCRIPTION
Unless I missed something and the new query is incorrect, I think this should close #13874 with this speedup.

Tested on my laptop, set up with:
` ./manage.py populate_db --extra_users 2000 --extra-streams 1000`

`get_occupied_streams` is the old function, `get_occupied_streams3` is the new one:
```
In [21]: x=time.time(); list(get_occupied_streams(realm)); print(time.time()-x)
1.1932027339935303

In [22]: x=time.time(); list(get_occupied_streams(realm)); print(time.time()-x)
1.1918518543243408

In [23]: x=time.time(); list(get_occupied_streams(realm)); print(time.time()-x)
1.1889464855194092

In [24]: x=time.time(); list(get_occupied_streams3(realm)); print(time.time()-x)
0.048899173736572266

In [25]: x=time.time(); list(get_occupied_streams3(realm)); print(time.time()-x)
0.05948901176452637

In [26]: x=time.time(); list(get_occupied_streams3(realm)); print(time.time()-x)
0.051645755767822266
```

This is the query Django generates:
```SQL
 SELECT "zerver_stream"."id",
       "zerver_stream"."name",
       "zerver_stream"."realm_id",
       "zerver_stream"."date_created",
       "zerver_stream"."deactivated",
       "zerver_stream"."description",
       "zerver_stream"."rendered_description",
       "zerver_stream"."recipient_id",
       "zerver_stream"."invite_only",
       "zerver_stream"."history_public_to_subscribers",
       "zerver_stream"."is_web_public",
       "zerver_stream"."stream_post_policy",
       "zerver_stream"."is_in_zephyr_realm",
       "zerver_stream"."email_token",
       "zerver_stream"."message_retention_days",
       "zerver_stream"."first_message_id",
       EXISTS(SELECT U0."id",
                     U0."user_profile_id",
                     U0."recipient_id",
                     U0."active",
                     U0."is_muted",
                     U0."color",
                     U0."pin_to_top",
                     U0."desktop_notifications",
                     U0."audible_notifications",
                     U0."push_notifications",
                     U0."email_notifications",
                     U0."wildcard_mentions_notify"
              FROM   "zerver_subscription" U0
                     INNER JOIN "zerver_userprofile" U2
                             ON ( U0."user_profile_id" = U2."id" )
              WHERE  ( U0."active" = true
                       AND U0."recipient_id" =
                           ( "zerver_stream"."recipient_id" )
                       AND U2."is_active" = true
                       AND U2."realm_id" = 5 )) AS "occupied"
FROM   "zerver_stream"
WHERE  ( "zerver_stream"."deactivated" = false
         AND "zerver_stream"."realm_id" = 5
         AND EXISTS(SELECT U0."id",
                           U0."user_profile_id",
                           U0."recipient_id",
                           U0."active",
                           U0."is_muted",
                           U0."color",
                           U0."pin_to_top",
                           U0."desktop_notifications",
                           U0."audible_notifications",
                           U0."push_notifications",
                           U0."email_notifications",
                           U0."wildcard_mentions_notify"
                    FROM   "zerver_subscription" U0
                           INNER JOIN "zerver_userprofile" U2
                                   ON ( U0."user_profile_id" = U2."id" )
                    WHERE  ( U0."active" = true
                             AND U0."recipient_id" = (
                                 "zerver_stream"."recipient_id" )
                             AND U2."is_active" = true
                             AND U2."realm_id" = 5 )) = true )  
```

