### PR TITLE
docs: Fix documentation error in get_realm_count().

### DIFF
--- a/static/js/people.js
+++ b/static/js/people.js
@@ -69,7 +69,7 @@ exports.get_by_email = function (email) {
 
 exports.get_realm_count = function () {
     // This returns the number of active people in our realm.  It should
-    // exclude bots and deactivated users.
+    // exclude deactivated users and deactivated bots.
     return active_user_dict.size;
 };
 


### PR DESCRIPTION
Fixed documentation error in "get_realm_count()" in people.js. This function gives the total number of active users including bots but it was mentioned that it excludes the bot count.

Fixes: #14215
