### PR TITLE
Add provision support for Ubuntu 20.04(Focal).

### DIFF
--- a/scripts/lib/build-pgroonga
+++ b/scripts/lib/build-pgroonga
@@ -2,7 +2,7 @@
 set -x
 set -e
 
-PGROONGA_VERSION="2.1.8"
+PGROONGA_VERSION="2.2.3"
 
 cd "$(mktemp -d)"
 

--- a/scripts/lib/create-production-venv
+++ b/scripts/lib/create-production-venv
@@ -10,7 +10,7 @@ if ZULIP_PATH not in sys.path:
 
 from scripts.lib.zulip_tools import os_families, overwrite_symlink, run, parse_os_release
 from scripts.lib.setup_venv import (
-    setup_virtualenv, VENV_DEPENDENCIES, REDHAT_VENV_DEPENDENCIES,
+    setup_virtualenv, get_venv_dependencies, REDHAT_VENV_DEPENDENCIES,
     FEDORA_VENV_DEPENDENCIES
 )
 
@@ -20,6 +20,9 @@ args = parser.parse_args()
 
 # install dependencies for setting up the virtualenv
 distro_info = parse_os_release()
+vendor = distro_info['ID']
+os_version = distro_info['VERSION_ID']
+VENV_DEPENDENCIES = get_venv_dependencies(vendor, os_version)
 if "debian" in os_families():
     run(["apt-get", "-y", "install"] + VENV_DEPENDENCIES)
 elif "fedora" in os_families():

--- a/scripts/lib/setup-apt-repo
+++ b/scripts/lib/setup-apt-repo
@@ -42,6 +42,8 @@ if [[ "$release" =~ ^(xenial|bionic|cosmic|disco|eoan)$ ]] ; then
 deb http://ppa.launchpad.net/groonga/ppa/ubuntu $release main
 deb-src http://ppa.launchpad.net/groonga/ppa/ubuntu $release main
 EOF
+elif [[ "$release" =~ ^(focal)$ ]] ; then
+    echo "Currently Groonga do not have a ppa package for Focal so we need to build pgroonga from the source"
 elif [[ "$release" =~ ^(stretch|buster)$ ]] ; then
     apt-key add "$SCRIPTS_PATH"/setup/pgroonga-debian.asc
     cat >$SOURCES_FILE <<EOF

--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -23,7 +23,6 @@ VENV_DEPENDENCIES = [
     "libldap2-dev",
     "libmemcached-dev",
     "python3-dev",          # Needed to install typed-ast dependency of mypy
-    "python-dev",
     "python3-pip",
     "python-pip",
     "virtualenv",
@@ -44,6 +43,10 @@ VENV_DEPENDENCIES = [
     # another call to `apt install` for.
     "jq",                   # Used by scripts/lib/install-node to check yarn version
 ]
+
+# python-dev is depreciated in Focal but can be used as python2-dev.
+# So it is removed from VENV_DEPENDENCIES and added here.
+PYTHON_DEV_DEPENDENCY = "python{}-dev"
 
 COMMON_YUM_VENV_DEPENDENCIES = [
     "libffi-devel",
@@ -98,6 +101,13 @@ YUM_THUMBOR_VENV_DEPENDENCIES = [
     "libpng-devel",
     "gifsicle",
 ]
+
+def get_venv_dependencies(vendor, os_version):
+    # type: (str, str) -> List[str]
+    if vendor == 'ubuntu' and os_version == '20.04':
+        return VENV_DEPENDENCIES + [PYTHON_DEV_DEPENDENCY.format("2"), ]
+    else:
+        return VENV_DEPENDENCIES + [PYTHON_DEV_DEPENDENCY.format(""), ]
 
 def install_venv_deps(pip, requirements_file, python2):
     # type: (str, str, bool) -> None

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -5,7 +5,6 @@ import logging
 import argparse
 import platform
 import subprocess
-import glob
 import hashlib
 
 os.environ["PYTHONUNBUFFERED"] = "y"
@@ -306,11 +305,12 @@ def main(options):
     if "debian" in os_families():
         sha_sum.update(open('scripts/lib/setup-apt-repo', 'rb').read())
     else:
-        # hash the content of setup-yum-repo and build-*
+        # hash the content of setup-yum-repo*
         sha_sum.update(open('scripts/lib/setup-yum-repo', 'rb').read())
-        build_paths = glob.glob("scripts/lib/build-")
-        for bp in build_paths:
-            sha_sum.update(open(bp, 'rb').read())
+
+    # hash the content of build-pgroonga if pgroonga is built from source
+    if BUILD_PGROONGA_FROM_SOURCE:
+        sha_sum.update(open('scripts/lib/build-pgroonga', 'rb').read())
 
     new_apt_dependencies_hash = sha_sum.hexdigest()
     last_apt_dependencies_hash = None

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -16,7 +16,7 @@ from scripts.lib.zulip_tools import run_as_root, ENDC, WARNING, \
     get_dev_uuid_var_path, FAIL, os_families, parse_os_release, \
     overwrite_symlink
 from scripts.lib.setup_venv import (
-    VENV_DEPENDENCIES, REDHAT_VENV_DEPENDENCIES,
+    get_venv_dependencies, REDHAT_VENV_DEPENDENCIES,
     THUMBOR_VENV_DEPENDENCIES, YUM_THUMBOR_VENV_DEPENDENCIES,
     FEDORA_VENV_DEPENDENCIES
 )
@@ -107,6 +107,8 @@ else:
             print("To upgrade, run `vagrant destroy`, and then recreate the Vagrant guest.\n")
             print("See: https://zulip.readthedocs.io/en/latest/development/setup-vagrant.html")
     sys.exit(1)
+
+VENV_DEPENDENCIES = get_venv_dependencies(vendor, os_version)
 
 COMMON_DEPENDENCIES = [
     "memcached",

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -92,6 +92,8 @@ elif vendor == "ubuntu" and os_version in ["18.04", "18.10"]:  # bionic, cosmic
     POSTGRES_VERSION = "10"
 elif vendor == "ubuntu" and os_version in ["19.04", "19.10"]:  # disco, eoan
     POSTGRES_VERSION = "11"
+elif vendor == "ubuntu" and os_version == "20.04":  # focal
+    POSTGRES_VERSION = "12"
 elif vendor == "fedora" and os_version == "29":
     POSTGRES_VERSION = "10"
 elif vendor == "rhel" and os_version.startswith("7."):
@@ -146,7 +148,7 @@ COMMON_YUM_DEPENDENCIES = COMMON_DEPENDENCIES + [
 ] + YUM_THUMBOR_VENV_DEPENDENCIES
 
 BUILD_PGROONGA_FROM_SOURCE = False
-if vendor == 'debian' and os_version in []:
+if vendor == 'debian' and os_version in [] or vendor == 'ubuntu' and os_version in ['20.04']:
     # For platforms without a pgroonga release, we need to build it
     # from source.
     BUILD_PGROONGA_FROM_SOURCE = True


### PR DESCRIPTION
Added provision support in Ubuntu 20.04(Focal).

Though we need to upgrade transifex-client to 0.13.7 if we are using the python provided by Ubuntu 20.04 (python3.8.2).
**Testing Plan:** 
Tested on VirtualBox with Focal iso provided by ubuntu(daily builds).

Work Towards [#13738](https://github.com/zulip/zulip/issues/13738)
.