### PR TITLE
ui-fix: Made User info popover to hide when drop-down menu opened.

### DIFF
--- a/frontend_tests/casper_lib/common.js
+++ b/frontend_tests/casper_lib/common.js
@@ -120,10 +120,11 @@ exports.then_click = function (selector) {
 };
 
 exports.then_log_out = function () {
+    var menu_selector_disabled = '#settings-dropdown[class="disabled"]';
     var menu_selector = '#settings-dropdown';
     var logout_selector = 'a[href="#logout"]';
 
-    casper.waitUntilVisible(menu_selector, function () {
+    casper.waitWhileVisible(menu_selector_disabled, function () {
         casper.click(menu_selector);
 
         casper.waitUntilVisible(logout_selector, function () {

--- a/static/js/gear_menu.js
+++ b/static/js/gear_menu.js
@@ -86,6 +86,9 @@ exports.update_org_settings_menu_item = function () {
 exports.initialize = function () {
     exports.update_org_settings_menu_item();
 
+    $('#gear-menu').on('click', function () {
+        popovers.hide_all();
+    });
     $('#gear-menu a[data-toggle="tab"]').on('show', function (e) {
         // Save the position of our old tab away, before we switch
         const old_tab = $(e.relatedTarget).attr('href');

--- a/static/js/gear_menu.js
+++ b/static/js/gear_menu.js
@@ -86,6 +86,7 @@ exports.update_org_settings_menu_item = function () {
 exports.initialize = function () {
     exports.update_org_settings_menu_item();
 
+    $('#gear-menu a[data-toggle="dropdown"]').removeClass("disabled");
     $('#gear-menu').on('click', function () {
         popovers.hide_all();
     });

--- a/static/js/gear_menu.js
+++ b/static/js/gear_menu.js
@@ -88,7 +88,7 @@ exports.initialize = function () {
 
     $('#gear-menu a[data-toggle="dropdown"]').removeClass("disabled");
     $('#gear-menu').on('click', function () {
-        popovers.hide_all();
+        popovers.hide_all_popovers();
     });
     $('#gear-menu a[data-toggle="tab"]').on('show', function (e) {
         // Save the position of our old tab away, before we switch

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1135,6 +1135,13 @@ exports.hide_all = function () {
     exports.hide_userlist_sidebar();
     stream_popover.hide_streamlist_sidebar();
     exports.hide_all_except_sidebars();
+    $(".dropdown").removeClass("open");
+};
+
+exports.hide_all_popovers = function () {
+    exports.hide_userlist_sidebar();
+    stream_popover.hide_streamlist_sidebar();
+    exports.hide_all_except_sidebars();
 };
 
 exports.set_userlist_placement = function (placement) {

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -700,7 +700,7 @@ exports.show_sender_info = function () {
 // side effect of closing popovers, which we don't want.  So we
 // suppress the first hide from scrolling after a resize using this
 // variable.
-let suppress_scroll_hide = false;
+let suppress_scroll_hide = true;
 
 exports.set_suppress_scroll_hide = function () {
     suppress_scroll_hide = true;
@@ -1072,15 +1072,15 @@ exports.register_click_handlers = function () {
     });
 
     (function () {
-        let last_scroll = 0;
+        let last_scroll = new Date().getTime();
 
         $('.app').on('scroll', function () {
+            const date = new Date().getTime();
             if (suppress_scroll_hide) {
                 suppress_scroll_hide = false;
+                last_scroll = date;
                 return;
             }
-
-            const date = new Date().getTime();
 
             // only run `popovers.hide_all()` if the last scroll was more
             // than 250ms ago.

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -466,10 +466,10 @@ exports.initialize_everything = function () {
     search.initialize();
     tutorial.initialize();
     notifications.initialize();
-    gear_menu.initialize();
     settings_panel_menu.initialize();
     settings_sections.initialize();
     settings_toggle.initialize();
+    gear_menu.initialize();
     hashchange.initialize();
     pointer.initialize();
     unread_ui.initialize();

--- a/templates/zerver/app/navbar.html
+++ b/templates/zerver/app/navbar.html
@@ -54,7 +54,7 @@
             <div id="navbar-buttons" {%if embedded %} style="visibility: hidden"{% endif %}>
                 <ul class="nav" role="navigation">
                     <li class="dropdown actual-dropdown-menu" id="gear-menu">
-                        <a id="settings-dropdown" href="#" role="button" class="dropdown-toggle" data-target="nada" data-toggle="dropdown" title="{{ _('Menu') }} (g)">
+                        <a id="settings-dropdown" href="#" role="button" class="dropdown-toggle disabled" data-target="nada" data-toggle="dropdown" title="{{ _('Menu') }} (g)">
                             <i class="fa fa-cog" aria-hidden="true"></i><i class="fa fa-caret-down settings-dropdown-caret" aria-hidden="true"></i>
                         </a>
                         <ul class="dropdown-menu" role="menu" aria-labelledby="settings-dropdown">


### PR DESCRIPTION
Issue Link: https://github.com/zulip/zulip/issues/14220
Issue Name: User info popover does not hide when clicking on menu

When the user info popover is opened by clicking on the down
chevron followed by opening the dropdown menu by clicking on the
gear icon, both the popover and the dropdown are visible on the
screen at the same time. Ideally, on clicking on the drop-down
menu the user-info popover should hide. This is done by using the
popovers.hide_all() function defined in popovers.js. This function
is called when the dropdown menu is being made visible, in the file
bootstrap.js, just after the clearMenus() function. This gives us
the behavior required.

**Testing Plan:** Tested using ./tools/test-js-with-node .

Fixes #14220.