### PR TITLE
messagebox: Add title-text for user profile

### DIFF
--- a/static/templates/me_message.hbs
+++ b/static/templates/me_message.hbs
@@ -1,10 +1,11 @@
 <span class="message_sender no-select">
-    <span class="sender_info_hover">
+    <span class="sender_info_hover" title="{{t 'User profile' }} (u)">
         {{> message_avatar}}
     </span>
-
     <span class="sender-status">
-        <span class="sender_info_hover sender_name-in-status auto-select" role="button" tabindex="0">{{msg/sender_full_name}}</span>
+        <span class="sender_info_hover sender_name-in-status auto-select" role="button" tabindex="0" title="{{t 'User profile' }} (u)">
+            {{msg/sender_full_name}}
+        </span>
         {{#if sender_is_bot}}
         <i class="zulip-icon bot" aria-label="{{t 'Bot' }}"></i>
         {{/if}}

--- a/static/templates/message_body.hbs
+++ b/static/templates/message_body.hbs
@@ -2,14 +2,13 @@
     {{#unless status_message}}
     <span class="message_sender sender_info_hover no-select">
         {{#if include_sender}}
-
+        <span title="{{t 'User profile' }} (u)">
             {{> message_avatar}}
-
             <span class="sender_name auto-select" role="button" tabindex="0">{{msg/sender_full_name}}</span>
             {{#if sender_is_bot}}
             <i class="zulip-icon bot" aria-label="{{t 'Bot' }}"></i>
             {{/if}}
-
+        </span>
         {{/if}}
     </span>
     {{/unless}}


### PR DESCRIPTION


<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes: #12769
added span tag with title attribute to display "User profile (u)"
shortcut key on hovering over the user avatar or full name

**Testing Plan:** <!-- How have you tested? -->
Tested manually in the browser 

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![screenshot](https://user-images.githubusercontent.com/45326319/76862196-ba127e00-6883-11ea-8d22-d4eb7560690d.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
