### PR TITLE
ui: Fix search box top-margin

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -82,8 +82,7 @@ li.show-more-topics {
 #stream_filters {
     overflow: visible;
     /* The -1px here prevents the scrollbar from going above the top of the container */
-    margin-top: -1px;
-    margin-bottom: 10px;
+    margin: -1px 10px 10px;
     padding: 0;
     font-weight: normal;
 
@@ -99,7 +98,7 @@ li.show-more-topics {
                 padding-top: 2px;
                 padding-right: 0px;
                 padding-bottom: 2px;
-                padding-left: $topic_indent;
+                padding-left: calc($left_col_size - 3px);
             }
         }
     }
@@ -115,7 +114,7 @@ li.show-more-topics {
     .subscription_block {
         padding: 0px;
         margin-right: 25px;
-        margin-left: $far_left_gutter_size;
+        margin-left: 2px;
         display: flex;
         justify-content: space-between;
         align-items: center;

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -71,6 +71,10 @@ li.show-more-topics {
     margin-right: 10px;
 }
 
+.stream_search_section {
+    margin-top: 2px;
+}
+
 .tooltip {
     max-width: 18em;
 }

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -6,6 +6,12 @@
     text-decoration: none;
 }
 
+#user_search_section .user-list-filter {
+    margin-top: 2px;
+    /* input should be 100% - 6px padding x2 - 1px border x2. */
+    width: calc(95% - 12px -2px);
+}
+
 #user_presences li:hover,
 #user_presences li.highlighted_user {
     background-color: hsl(93, 19%, 88%);


### PR DESCRIPTION
Currently, the top and bottom margins of the search bar are not equal. This PR adds a top-margin in the left-sidebar's and right-sidebar's search box to make the top and bottom margins equal(to make the design consistent). Discussion: [here](https://chat.zulip.org/#narrow/stream/9-issues/topic/Navbar.20close%28x%29.20icon/near/832272)

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before:
![2020-03-17_20-33-33-256x84](https://user-images.githubusercontent.com/43504292/76869621-97399700-688e-11ea-88ee-760630b0d12f.png)
![2020-03-17_20-31-42-331x102](https://user-images.githubusercontent.com/43504292/76869440-5772af80-688e-11ea-8ea5-db9b01e33a1d.png)

After:
![2020-03-17_20-20-11-252x104](https://user-images.githubusercontent.com/43504292/76869306-21cdc680-688e-11ea-8b99-2b55fbd4c363.png)
![2020-03-17_20-27-03-261x91](https://user-images.githubusercontent.com/43504292/76869317-23978a00-688e-11ea-8176-42dc492b5ca8.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
