### PR TITLE
portico: Typographical nitpicking

### DIFF
--- a/static/styles/portico/landing-page.scss
+++ b/static/styles/portico/landing-page.scss
@@ -1666,6 +1666,10 @@ nav ul li.active::after {
     margin-right: -3px;
 }
 
+.portico-landing .testimonials blockquote::after {
+    content: "”";
+}
+
 .portico-landing .testimonials blockquote + cite {
     display: block;
     margin-top: 5px;
@@ -2346,6 +2350,10 @@ nav ul li.active::after {
     content: "“";
     margin-left: -10px;
     margin-right: -3px;
+}
+
+.portico-landing.why-page .testimonials blockquote::after {
+    content: "”";
 }
 
 .portico-landing.why-page .testimonials blockquote + cite {

--- a/templates/zerver/atlassian.md
+++ b/templates/zerver/atlassian.md
@@ -1,8 +1,8 @@
 Zulip runs on-premises or in the cloud, and integrates with the rest of
-Atlassian's products. The following describes some typical steps for
-migrating from Atlassian's HipChat or Stride to Zulip.
+Atlassian’s products. The following describes some typical steps for
+migrating from Atlassian’s HipChat or Stride to Zulip.
 
-## Do a trial of Zulip
+## Do a trial of Zulip.
 
 * [Install Zulip on-premise](https://zulip.readthedocs.io/en/stable/production/install.html)
 or [create a Zulip Cloud organization](https://zulipchat.com/new) on
@@ -17,25 +17,25 @@ server has around 10,000 users with several hundred weekly actives.
 threads on the [community server](https://chat.zulip.org) and/or read
 [Why Zulip](/why-zulip). Zulip has a unique threading model that makes
 everybody more productive, but those in meetings all day are often the
-first people to "get it" and be strong advocates for Zulip internally.
+first people to “get it” and be strong advocates for Zulip internally.
 
 A user experience trial of a team chat tool like Zulip works best if
 you have a team spend a week using it as their primary work
 communication tool; this allows the trial group to get familiar with
 the tool (and with Zulip, experience the magic of topics).
 
-## Import your HipChat data
+## Import your HipChat data.
 
 You can export from HipChat or Stride, and import into Zulip Cloud or Zulip
 on-premise. Instructions are available [here](/help/import-from-hipchat).
 
-If you're importing into Zulip Cloud, we recommend doing a test import
+If you’re importing into Zulip Cloud, we recommend doing a test import
 with us a few days before, and then scheduling a migration date to
 make sure there is as little interruption in service as possible. The
 import can take anywhere from a few seconds to several hours depending
 on how much data you have.
 
-## Set up third-party integrations
+## Set up third-party integrations.
 
 Zulip has over [100 native integrations](/integrations), and hundreds more
 through Zapier, Hubot, and IFTTT.
@@ -48,9 +48,9 @@ Instructions for integrating with [JIRA](/integrations/doc/jira),
 
 We recommend integrating via [Zapier](/integrations/doc/zapier) for
 Confluence, Bamboo, Fisheye, Crucible, Crowd, and Sourcetree. Email
-<support@zulipchat.com> if you get stuck and we'd be happy to help you out.
+<support@zulipchat.com> if you get stuck and we’d be happy to help you out.
 
-## Read our guides
+## Read our guides.
 
 We have a guide for
 [setting up your Zulip organization](/help/getting-your-organization-started-with-zulip),
@@ -59,10 +59,10 @@ as well as a [guide for new Zulip users](/help/getting-started-with-zulip).
 You may also want to send out material like [Why Zulip](/why-zulip), the
 [tour on the Zulip homepage](/), or our
 [guide to streams and topics](/help/about-streams-and-topics) to users being
-migrated, so that everyone gets a running start with Zulip's thread-based
+migrated, so that everyone gets a running start with Zulip’s thread-based
 chat model.
 
-## Decide on a payment plan
+## Decide on a payment plan.
 
 See [zulipchat.com/plans](https://zulipchat.com/plans) for Cloud
 pricing, or email <support@zulipchat.com> for on-premise support

--- a/templates/zerver/faq.html
+++ b/templates/zerver/faq.html
@@ -1,7 +1,7 @@
 <div class="faqs">
     <div class="padded-content">
         <header>
-            <h1>Frequently Asked Questions</h1>
+            <h1>Frequently asked questions</h1>
         </header>
         <div class="faq-box">
             <div class="faq">
@@ -17,7 +17,7 @@
                     institutions, groups of friends, and in other
                     scenarios where most of the users are not fulltime
                     employees of the customer. Generally, only closed
-                    organizations that also pay their members'
+                    organizations that also pay their members’
                     salaries pay full price.  Just contact
                     sales@zulipchat.com and we&rsquo;d be happy to
                     discuss your situation!
@@ -39,7 +39,7 @@
                     of users, including Fortune 500 companies like Akamai,
                     and open source communities like
                     <a href="https://www.recurse.com/blog/112-how-rc-uses-zulip">The
-                    Recurse Center</a>. If you'd like to see a large Zulip
+                    Recurse Center</a>. If you’d like to see a large Zulip
                     in action, the
                     <a href="https://chat.zulip.org">Zulip
                     community server</a> has thousands of accounts and hundreds of weekly active users, and is run on a single machine with 8GB of RAM.
@@ -64,7 +64,7 @@
                     <a href="https://zulip.readthedocs.io/en/latest/production/export-and-import.html">on-premise</a>) ensure you can always move
                     from our hosting to yours (and back). If
                     you&rsquo;d like to do a migration, email
-                    support@zulipchat.com and we'll get you started!
+                    support@zulipchat.com and we’ll get you started!
                 </p>
             </div>
             <div class="faq">

--- a/templates/zerver/features.html
+++ b/templates/zerver/features.html
@@ -12,14 +12,14 @@
 <div class="portico-landing features-app">
     <section class="hero">
         <div class="copy">
-            <h1>Powerful group chat</h1>
+            <h1>Powerful group chat.</h1>
             <h2>First class threading on top of everything you could want from real-time chat.</h2>
         </div>
     </section>
 
     <section class="messages">
         <div class="features">
-            <h2>Beautiful messaging</h2>
+            <h2>Beautiful messaging.</h2>
 
             <div class="feature-block">
                 <h3>MARKDOWN OPTIMIZED FOR CHAT</h3>
@@ -37,13 +37,13 @@
             </div>
             <div class="feature-block">
                 <h3>INLINE IMAGE, VIDEO, AND TWEET PREVIEWS</h3>
-                <p>Send a link and we'll automatically generate a
+                <p>Send a link and we’ll automatically generate a
                 preview; click the preview to see it at full scale.</p>
             </div>
             <div class="feature-block">
                 <h3>DRAG-AND-DROP FILE UPLOADS</h3>
                 <p>
-                    Drag a file into the compose box and we'll upload
+                    Drag a file into the compose box and we’ll upload
                     and preview it for you. Sharing and discussing
                     work with team mates has never been easier.
                 </p>
@@ -72,7 +72,7 @@
         <svg class="envelope" height="500" width="100" preserveAspectRatio="none" viewBox="0 0 100 100">
             <polygon points="0,0 100,0 50,50" style="fill: #fafafa;" />
         </svg>
-        <h2>Highly configurable notifications</h2>
+        <h2>Highly configurable notifications.</h2>
 
         <div class="center">
             <div class="image-block"></div>
@@ -90,7 +90,7 @@
 
     <section class="keyboard-shortcuts">
         <div class="feature-block">
-            <h3>Keyboard Shortcuts</h3>
+            <h3>Keyboard shortcuts.</h3>
             <p>Communicate as efficiently as you use your favorite
                 text editor.  Anything you can do with a mouse, you
                 can do even faster from the keyboard.
@@ -102,7 +102,7 @@
     </section>
 
     <section>
-        <h2>Apps, Integrations, and API</h2>
+        <h2>Apps, integrations, and API.</h2>
 
         <a class="feature-block" href="/integrations" target="_blank">
             <h3>INTEGRATIONS</h3>
@@ -115,7 +115,7 @@
         <a class="feature-block" href="/api" target="_blank">
             <h3>API</h3>
             <p>
-                Want to roll your own notifications? We've got a
+                Want to roll your own notifications? We’ve got a
                 dead-simple RESTful API and Python bindings that will make
                 integrations—both sending and receiving—a snap!
             </p>
@@ -137,7 +137,7 @@
     </section>
 
     <section>
-        <h2>And everything else you need...</h2>
+        <h2>And everything else you need…</h2>
 
         <a class="feature-block" href="/security" target="_blank">
             <h3>ENTERPRISE-GRADE SECURITY</h3>
@@ -185,12 +185,12 @@
         </a>
         <div class="feature-block">
             <h3>PERSISTENCE</h3>
-            <p>We're always receiving messages for you, even when
-            you're logged out or away from your computer.</p>
+            <p>We’re always receiving messages for you, even when
+            you’re logged out or away from your computer.</p>
         </div>
         <a class="feature-block" href="/help/edit-or-delete-a-message" target="_blank">
             <h3>MESSAGE EDITING</h3>
-            <p>Don't worry, you can always fix that typo, either in
+            <p>Don’t worry, you can always fix that typo, either in
             the body of message or its topic.</p>
         </a>
         <div class="feature-block">
@@ -199,7 +199,7 @@
         </div>
         <a class="feature-block" href="/help/view-and-edit-your-message-drafts" target="_blank">
             <h3>SAVED DRAFTS</h3>
-            <p>Zulip's drafts make it easy to write longer messages
+            <p>Zulip’s drafts make it easy to write longer messages
             without worrying about losing your work.</p>
         </a>
         <a class="feature-block" href="https://zulip.readthedocs.io/en/latest/contributing/accessibility.html" target="_blank">
@@ -272,7 +272,7 @@
         <a class="feature-block" href="/help/create-your-organization-profile" target="_blank">
             <h3>CUSTOM BRANDING</h3>
             <p>
-                Use your logo instead of Zulip's in the desktop and webapp.
+                Use your logo instead of Zulip’s in the desktop and webapp.
             </p>
         </a>
         <a class="feature-block" href="/integrations/communication" target="_blank">

--- a/templates/zerver/for-companies.html
+++ b/templates/zerver/for-companies.html
@@ -15,8 +15,8 @@
 
 <div class="portico-landing why-page">
     <div class="hero">
-        <h1 class="center">{% trans %}The best chat for workplaces{% endtrans %}</h1>
-        <p>Make better use of your managers' time, integrate your remote workers, and replace your low-content meetings</p>
+        <h1 class="center">{% trans %}The best chat for workplaces.{% endtrans %}</h1>
+        <p>Make better use of your managers’ time, integrate your remote workers, and replace your low-content meetings.</p>
     </div>
     <div class="main">
         <div class="padded-content">

--- a/templates/zerver/for-mystery-hunt.html
+++ b/templates/zerver/for-mystery-hunt.html
@@ -17,7 +17,7 @@
     <div class="hero bg-pycon mit">
         <div class="bg-dimmer"></div>
         <div class="content">
-            <h1 class="center">The best chat for mystery hunt</h1>
+            <h1 class="center">The best chat for mystery hunt.</h1>
             <p></p>
         </div>
     </div>

--- a/templates/zerver/for-open-source.html
+++ b/templates/zerver/for-open-source.html
@@ -20,8 +20,8 @@
     <div class="hero bg-pycon">
         <div class="bg-dimmer"></div>
         <div class="content">
-            <h1 class="center">{% trans %}Zulip for open source{% endtrans %}</h1>
-            <p>Grow your community with fun, thoughtful, and inclusive discussion</p>
+            <h1 class="center">{% trans %}Zulip for open source.{% endtrans %}</h1>
+            <p>Grow your community with fun, thoughtful, and inclusive discussion.</p>
         </div>
     </div>
     <div class="main">
@@ -48,7 +48,7 @@
                                 with clarity, ensuring the right people can
                                 pay attention to the right messages. This
                                 makes our large-group discussion far more
-                                manageable than what we've experienced with
+                                manageable than what we’ve experienced with
                                 Skype and Slack.”
                             </blockquote>
                             <cite>Grahame Grieve, founder, FHIR health care standards body</cite>
@@ -56,7 +56,7 @@
                         <div class="item quote-container">
                             <blockquote>
                                 Choosing Zulip over Slack as our group chat is one
-                                of the best decisions we've ever made. Zulip makes
+                                of the best decisions we’ve ever made. Zulip makes
                                 it easy for our community of 1000 Recursers around
                                 the world to stay involved, even years after their
                                 batches finish. No other tool has a user
@@ -68,7 +68,7 @@
                         <div class="item quote-container">
                             <blockquote>
                                 Wikimedia uses Zulip for its participation
-                                in open source mentoring programs. Zulip's
+                                in open source mentoring programs. Zulip’s
                                 threaded discussions help busy organization
                                 administrators and mentors stay in close
                                 communication with students during all
@@ -79,15 +79,15 @@
                         <div class="item quote-container">
                             <blockquote>
                                 I highly recommend Zulip to other communities.
-                                We're coming from Freenode as our only
+                                We’re coming from Freenode as our only
                                 real-time communication so the difference is
                                 night and day. Slack is a no-go for many due
-                                to not being FLOSS, and I'm concerned about
+                                to not being FLOSS, and I’m concerned about
                                 vendor lock-in if they were to stop being so
                                 generous.
 
-                                Slack's threading model is much worse than
-                                Zulip's IMO. The streams/topics flow is an
+                                Slack’s threading model is much worse than
+                                Zulip’s IMO. The streams/topics flow is an
                                 incredibly intuitive way to keep track of
                                 everything that is going on.
                             </blockquote>

--- a/templates/zerver/for-working-groups-and-communities.html
+++ b/templates/zerver/for-working-groups-and-communities.html
@@ -15,8 +15,8 @@
 
 <div class="portico-landing why-page">
     <div class="hero">
-        <h1 class="center">{% trans %}The best chat for working groups and communities{% endtrans %}</h1>
-        <p>Make good use of your users' time, and engage your community with thoughtful, organized discussion</p>
+        <h1 class="center">{% trans %}The best chat for working groups and communities.{% endtrans %}</h1>
+        <p>Make good use of your users’ time, and engage your community with thoughtful, organized discussion.</p>
     </div>
     <div class="main">
         <div class="padded-content">

--- a/templates/zerver/for/companies.md
+++ b/templates/zerver/for/companies.md
@@ -1,5 +1,5 @@
-Zulip's threading allows asynchronous discussion to happen over chat, which
-completely changes what chat can be used for in a company. Zulip's threading
+Zulip’s threading allows asynchronous discussion to happen over chat, which
+completely changes what chat can be used for in a company. Zulip’s threading
 allows managers to weigh in on discussions even when they can only check in
 once a day, it allows workers to participate in discussions even when they
 live in different time zones, and it allows neighboring teams to keep tabs
@@ -7,37 +7,37 @@ on conversations that might affect them.
 
 Communication is at the core of the operation of every large business. Many
 senior personnel spend most of their days in meetings, and many decisions
-have to bubble up a management chain because employees on the ground don't
+have to bubble up a management chain because employees on the ground don’t
 have enough context. Employers also lose out on remote talent because
 communication with remote team members is too burdensome with their existing
 tools.
 
 No chat product comes even close to Zulip in terms of enabling serious
 discussion, engaging remote participants, spreading knowledge to neighboring
-teams, and making efficient use of managers' time.
+teams, and making efficient use of managers’ time.
 
-If you haven't read [why Zulip](/why-zulip), read that first. We've also
+If you haven’t read [why Zulip](/why-zulip), read that first. We’ve also
 collected a list of features we think will be of particular interest for
 companies using Zulip.
 
-### On-premises and in the cloud
+### On-premises and in the cloud.
 
 High quality export and import tools make it easy to start with Zulip in the
 cloud, knowing that you can move to a on-premises deployment (or back) if
 your budget or security needs change.
 
-### No vendor lock-in
+### No vendor lock-in.
 
-Zulip's license (Apache 2) and
+Zulip’s license (Apache 2) and
 [published code base](https://github.com/zulip/zulip) means you will
 always be able to run Zulip on your own servers, for free, forever.
 
-### Highly customizable
+### Highly customizable.
 
-In addition to Zulip's well-designed API and extensive integration library,
-Zulip's codebase is easy to get into. With over 100K words of developer
+In addition to Zulip’s well-designed API and extensive integration library,
+Zulip’s codebase is easy to get into. With over 100K words of developer
 documentation, 93% test coverage, full static typing of our python codebase,
-and world-class tooling, Zulip's codebase is a pleasure to work with. Just
+and world-class tooling, Zulip’s codebase is a pleasure to work with. Just
 ask any of the hundreds of developers, including high school students, who
 have contributed significant code to Zulip!
 
@@ -47,11 +47,11 @@ artificial message delay feature for emergency training. Think of a product
 you use every day at work. What would you change about it if your dev ops
 team could have a go at it for a week?
 
-### Scale to thousands of users
+### Scale to thousands of users.
 
 Zulip teams are still snappy at thousands of users.
 
-### Hundreds of integrations
+### Hundreds of integrations.
 
 Get events from GitHub, Stripe, Travis CI, JIRA, and
 [hundreds of other tools](/integrations) right in Zulip. Use topics to give
@@ -60,13 +60,13 @@ external sites with
 [custom linkification filters](/help/add-a-custom-linkification-filter) like
 `Z1234` for Zendesk ticket #1234.
 
-### Rich message formatting
+### Rich message formatting.
 
-Zulip's [chat-optimized Markdown](/help/format-your-message-using-markdown)
+Zulip’s [chat-optimized Markdown](/help/format-your-message-using-markdown)
 helps you express your ideas clearly with bulleted lists, code blocks,
 pasted screenshots, uploaded files, and more.
 
-### Easy authentication
+### Easy authentication.
 
 Restrict sign-up by email domain, use a single sign-on solution, or send
 invitations by email.

--- a/templates/zerver/for/mystery-hunt.md
+++ b/templates/zerver/for/mystery-hunt.md
@@ -1,26 +1,26 @@
-Zulip was started in 2012 by four SIPB alums. We think it's the best team
+Zulip was started in 2012 by four SIPB alums. We think it’s the best team
 chat tool for mystery hunt teams.
 
 **How is this different from Slack?**
 
 In Slack, IRC, and nearly every other team chat application, users subscribe
-to chat rooms ("channels"), and get all the messages sent to each channel in
+to chat rooms (“channels”), and get all the messages sent to each channel in
 a chronological dump. The model is largely designed to support real-time
-conversation, where it's easy to participate if you're online, but not easy
+conversation, where it’s easy to participate if you’re online, but not easy
 to come back a few hours later and reply to a conversation that started
 while you were gone.
 
 In Zulip, there is an additional layer of organization in each channel:
-messages have topics (like "puzzle: duck konundrum"), so it is easy to
+messages have topics (like “puzzle: duck konundrum”), so it is easy to
 follow conversational threads. It also makes it easy for someone to come
 back after 8 hours (okay, 4 hours) of sleep, catch up on the state of
 various puzzles, and answer questions even if a question was asked many
 hours ago.
 
-**You have to write a topic for every message you send? Sounds like a bit much ..**
+**You have to write a topic for every message you send? Sounds like a bit much…**
 
 Nope! Just the first person writing a message to a given topic has to write
-it out. Replies to that message are automatically grouped in the way you'd
+it out. Replies to that message are automatically grouped in the way you’d
 expect. Sending a message in Zulip feels just as lightweight as sending a
 message in SMS, Google Hangouts, or Slack.
 
@@ -37,13 +37,13 @@ self-hosted installation.
 **Can I integrate Zulip with my current puzzlehunting software?**
 
 Yup. Zulip has a well thought out [API](https://zulipchat.com/api/), and
-it's easy to write bots that send things into or out of Zulip.
+it’s easy to write bots that send things into or out of Zulip.
 
 **Where can I test it out?**
 
 [Click here](https://zulipchat.com/new) to create an organization; it
 only takes only about 30 seconds. If you decide to continue using it, just email
-support@zulipchat.com to tell us you're a mystery hunt team.
+support@zulipchat.com to tell us you’re a mystery hunt team.
 
 **Where do I go for further information?**
 
@@ -52,7 +52,7 @@ free to post in
 [#mystery hunt](https://chat.zulip.org/#narrow/stream/mystery.20hunt) or
 anywhere else that seems appropriate.
 
-**Help! I'm trapped in a mystery hunt puzzle.**
+**Help! I’m trapped in a mystery hunt puzzle.**
 
 This is not a puzzle! But feel free take a look at
 [Zulip for companies](/for/companies),

--- a/templates/zerver/for/open-source.md
+++ b/templates/zerver/for/open-source.md
@@ -2,9 +2,9 @@ The Zulip core developers have decades of combined experience leading
 and growing open source communities. We use Zulip to fashion the
 day-to-day experience of being a part of our project. No other chat
 product comes close to Zulip in facilitating contributor engagement,
-facilitating inclusion, and making efficient use of everyone's time.
+facilitating inclusion, and making efficient use of everyone’s time.
 
-If you haven't read [why Zulip](/why-zulip), read that first.  The
+If you haven’t read [why Zulip](/why-zulip), read that first.  The
 challenges with the Slack/Discord/IRC model discussed there are even
 more important for open source projects:
 
@@ -12,7 +12,7 @@ more important for open source projects:
   every time zone.  Traditional open source communication tools like
   email, forums, and issue trackers work well in this context, because
   you can communicate effectively asynchronously.  A Slack community
-  is a bad experience if you're rarely online at the same time as most
+  is a bad experience if you’re rarely online at the same time as most
   other members, and a result, Slack represents a huge regression in
   the global inclusivity of open source projects.
 * Most contributors and potential contributors have other fulltime
@@ -20,7 +20,7 @@ more important for open source projects:
   project.  Because catching up on history in an active Slack
   organization is a huge waste of time, these part-time community
   members cannot efficiently use their time participating in an active
-  Slack.  So either they don't participate in the Slack, or they do,
+  Slack.  So either they don’t participate in the Slack, or they do,
   and their other contributions to the project suffer.
 * Maintainers are busy people and almost uniformly report that they
   wish they had more time to do focus work on their project.  Because
@@ -44,12 +44,12 @@ and effectively retain volunteer contributors.
 
 ------------------------------------------
 
-Zulip's topic-based threading model solves these problems:
+Zulip’s topic-based threading model solves these problems:
 
 * Contributors in any time zone can send messages and expect to get a
   reply and have an effective (potentially asynchronous) conversation
   with the rest of the community.
-* Zulip's topic-based theading helps include part-time contributors in
+* Zulip’s topic-based theading helps include part-time contributors in
   two major ways.  First, they can easily browse what conversations
   happened while they were away from the community, and prioritize
   which conversations to read now, skip, or read later (e.g. on the
@@ -59,9 +59,9 @@ Zulip's topic-based threading model solves these problems:
   needed), allowing them to fully participate in the work of the
   community.
 * Maintainers can effectively participate in a Zulip community without
-  being continuously online.  Using Zulip's [keyboard
-  shortcuts](/help/keyboard-shortcuts), it's extremely efficient to
-  inspect every potentially relevant thread and reply wherever one's
+  being continuously online.  Using Zulip’s [keyboard
+  shortcuts](/help/keyboard-shortcuts), it’s extremely efficient to
+  inspect every potentially relevant thread and reply wherever one’s
   feedback is useful, and replying hours after a question was asked is
   still a good contributor experience.  As a result, maintainers can
   do multi-hour sessions of focus work while still being available to
@@ -74,7 +74,7 @@ Zulip's topic-based threading model solves these problems:
 You can see this in action in our own
 [chat.zulip.org](https://chat.zulip.org) community, which sends
 thousands of messages a week.  We often get feedback from contributors
-around the world that they love how responsive Zulip's project leaders
+around the world that they love how responsive Zulip’s project leaders
 are in public Zulip conversations.  We are able to achieve this
 despite the project leaders collectively spending only a few hours a
 day managing the community and spending most of their time integrating
@@ -87,51 +87,51 @@ community succeed too!
 
 ------------------------------------------
 
-Below, we've collected a list of [Zulip features](/features) that are
+Below, we’ve collected a list of [Zulip features](/features) that are
 particularly useful to open source communities.
 
-### Free hosting at zulipchat.com
+### Free hosting at zulipchat.com.
 
-The hosting is supported by (and is identical to) zulipchat.com's
+The hosting is supported by (and is identical to) zulipchat.com’s
 commercial offerings. This offer extends to any community involved in
 supporting free and open source software: development projects, foundations,
 meetups, hackathons, conference committees, and more. If you’re not sure
 whether your organization qualifies, send us an email at
 support@zulipchat.com.
 
-### Moderation suite
+### Moderation suite.
 
 Moderation is a big part of making an open community work. Zulip was built
 for open communities from the beginning and comes with
 [moderation tools](/help/moderating-open-organizations) out of the box.
 
-### Open invitations
+### Open invitations.
 
 Allow anyone to
 [join without an invitation](/help/allow-anyone-to-join-without-an-invitation).
 You can also link to your Zulip with a [badge](/help/linking-to-zulip)
 in your readme document.
 
-### Authenticate with GitHub or GitLab
+### Authenticate with GitHub or GitLab.
 
 Allow (or require) users to authenticate with their [GitHub or GitLab
 account](/help/configure-authentication-methods), instead of with a
 username and password.
 [github-auth]: https://github.com/zulip/zulip/blob/7e9926233/zproject/prod_settings_template.py#L112
 
-### Import from Slack, Mattermost, or Gitter
+### Import from Slack, Mattermost, or Gitter.
 
 Import your existing organization from [Slack](/help/import-from-slack),
 [Mattermost](/help/import-from-mattermost), or
 [Gitter](/help/import-from-gitter).
 
-### Syntax highlighting
+### Syntax highlighting.
 
 [Full Markdown support](/help/format-your-message-using-markdown), including
 syntax highlighting, makes it easy to discuss code, paste an error message,
 or explain a complicated point. Full LaTeX support as well.
 
-### Permalink to conversations
+### Permalink to conversations.
 
 Zulip makes it easy to get a [permanent link to a
 conversation](/help/link-to-a-message-or-conversation), which you can
@@ -139,26 +139,26 @@ use in your issue tracker, forum, or anywhere else. Zulip’s
 topic-based threading helps keep conversations coherent and organized
 so they are useful for posterity.
 
-### Link from chat to issues
+### Link from chat to issues.
 
 Efficiently refer to issues or code reviews with notation like `#1234` or
 `T1234`. You can set up any regex as a
 [custom linkification filter](/help/add-a-custom-linkification-filter) for
 your organization.
 
-### Hundreds of integrations
+### Hundreds of integrations.
 
 Get events from GitHub, Travis CI, JIRA, and
 [hundreds of other tools](/integrations) right in Zulip. Topics give each
 issue its own place for discussion.
 
-### Mirror IRC or Matrix
+### Mirror IRC or Matrix.
 
 Two-way integrations with [IRC](/integrations/doc/irc) and
 [Matrix](/integrations/doc/matrix), and one-way integration with
 [Slack](/integrations/doc/slack) (get Slack messages in Zulip).
 
-### Scales to 10,000s of members
+### Scales to 10,000s of members.
 
 Zulip is designed to perform well in common use cases for open source
 projects, with features like [soft
@@ -166,14 +166,14 @@ deactivation](https://zulip.readthedocs.io/en/latest/subsystems/sending-messages
 to make message delivery efficient even when sending to a stream with
 10,000s of inactive subscribers.
 
-### Full-text search of all public history
+### Full-text search of all public history.
 
-Zulip's [full-text search](/help/search-for-messages) supports
-searching the organization's entire public history via the
+Zulip’s [full-text search](/help/search-for-messages) supports
+searching the organization’s entire public history via the
 `streams:public` search operator, allowing Zulip to provide all the
 benefits of a searchable project forum.
 
-### Public archive
+### Public archive.
 
 Allow search engines to index your chat, with a read-only view of your
 public streams. Zulip’s topic-based threading keeps conversations coherent
@@ -183,20 +183,20 @@ Currently implemented as an [out-of-tree
 tool](https://github.com/zulip/zulip-archive), though a native feature
 built into the Zulip server is coming soon.
 
-### Logged-out public access (coming soon)
+### Logged-out public access (coming soon).
 
 [Coming soon](https://github.com/zulip/zulip/issues/13172): Allow
-users to read and search public stream history in Zulip's UI without
+users to read and search public stream history in Zulip’s UI without
 first creating an account.
 
-### Quality data export
+### Quality data export.
 
 Our high quality [export](/help/export-your-organization) and
 [import](https://zulip.readthedocs.io/en/latest/production/export-and-import.html)
 tools ensure you can always move from
 [zulipchat.com](https://zulipchat.com) hosting to your own servers.
 
-### Free and open source
+### Free and open source.
 
 Unlike many modern "open source" applications that are actually Open
 Core, Zulip is 100% Free and Open Source software.  All code,
@@ -210,7 +210,7 @@ We love helping other open source communities and prioritize feature
 requests from open source communities the same way we prioritize
 feature requests from paying customers.
 
-So if there's something we could improve to make Zulip the obvious
+So if there’s something we could improve to make Zulip the obvious
 choice either for you or your community, [open an
 issue](https://github.com/zulip/zulip/issues), [submit a
 patch](https://zulip.readthedocs.io/en/latest/development/overview.html),

--- a/templates/zerver/for/working-groups-and-communities.md
+++ b/templates/zerver/for/working-groups-and-communities.md
@@ -5,11 +5,11 @@ spending many hours per week on the organization, much of the value of the
 community may come from a large number of members or potential members who
 have an unrelated job and thus may have less than an hour a week to spend on
 the organization. In such an organization, making it easy for someone to
-participate when they don't have time to read everything can be the
+participate when they don’t have time to read everything can be the
 difference between a robust, growing community and one that stagnates.
 
-Some of Zulip's earliest users were part-time organizations, so we have given
-a lot of thought to the problems such groups face. Zulip's topic-based
+Some of Zulip’s earliest users were part-time organizations, so we have given
+a lot of thought to the problems such groups face. Zulip’s topic-based
 threading
 
 * Makes the catching-up experience fast and fun, even if a user has been
@@ -20,12 +20,12 @@ threading
   so that users that drop by occasionally can contribute rather than just
   lurk.
 
-Zulip's topic-based threading also allows for more thoughtful discussion,
+Zulip’s topic-based threading also allows for more thoughtful discussion,
 since more people are able to chime in on any given conversation. It also
-makes it easy to start new threads, so digressions don't take over a
+makes it easy to start new threads, so digressions don’t take over a
 conversation.
 
-If you haven't read [why Zulip](/why-zulip), read that first. If your
+If you haven’t read [why Zulip](/why-zulip), read that first. If your
 organization is a technical group that will be sharing code, you may want to
 read [Zulip for open source](/for/open-source) as well. Finally, one of our
 earliest communities, the Recurse Center, wrote an
@@ -36,13 +36,13 @@ want to include as you build your community.
 Two additional points of note:
 
 * **Pay as you go**: We host many pro-social groups for free, and
-  non-commercial entities at a greatly reduced price. Even if you don't fall
+  non-commercial entities at a greatly reduced price. Even if you don’t fall
   into any such bucket, Zulip only charges for users that have been active
-  in the last two weeks. So feel free to invite anyone you'd like, even if
-  you're not sure if they'll end up sticking around!
+  in the last two weeks. So feel free to invite anyone you’d like, even if
+  you’re not sure if they’ll end up sticking around!
 
-* **Smart digest emails (coming soon)**: Zulip's topic-based threading makes
+* **Smart digest emails (coming soon)**: Zulip’s topic-based threading makes
   it easier for algorithms to guess which messages and conversations will be
-  interesting to users that haven't checked in in a while. Occasional
+  interesting to users that haven’t checked in in a while. Occasional
   interesting digests sent to inactive users is a great way to bring users
   back into the group.

--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -29,7 +29,7 @@
     <div class="hero">
         <div class="content">
             <header>
-                <h1>Chat for distributed teams</h1>
+                <h1>Chat for distributed teams.</h1>
                 <p>
                     Zulip combines the immediacy of real-time chat with an email
                     threading model. <br class="line-break-desktop">With Zulip, you can catch
@@ -165,7 +165,7 @@
         <div class="left-side">
             <div class="content">
                 <header>
-                    <h1>Apps for every platform</h1>
+                    <h1>Apps for every platform.</h1>
                 </header>
                 <p>
                     Zulip has modern apps for every major platform,
@@ -345,7 +345,7 @@
         <div class="flex">
             <img src="/static/images/landing-page/opensource.svg" alt=""/>
             <div class="il-block">
-                <h1>Open Source</h1>
+                <h1>Open source.</h1>
                 <p>
                     Zulip is <a href="https://github.com/zulip/zulip">100% open source software</a>,
                     built by a vibrant community of hundreds of developers
@@ -375,7 +375,7 @@
     <div class="integrations">
         <div class="content">
             <header>
-                <h1>Seamless integrations with everything you use</h1>
+                <h1>Seamless integrations with everything you use.</h1>
             </header>
             <p>
                 Zulip has more than 90 native integrations. Several hundred more
@@ -483,7 +483,7 @@
                         <div class="item quote-container">
                             <blockquote>
                                 Choosing Zulip over Slack as our group chat is one
-                                of the best decisions we've ever made. Zulip makes
+                                of the best decisions we’ve ever made. Zulip makes
                                 it easy for our community of 1000 Recursers around
                                 the world to stay involved, even years after their
                                 batches finish. No other tool has a user
@@ -507,7 +507,7 @@
 
             <div class="company-container">
                 <header>
-                    <h2 class="float left">Trusted by thousands of teams</h2>
+                    <h2 class="float left">Trusted by thousands of teams.</h2>
                     <div class="float clear"></div>
                 </header>
                 <div class="company-box">

--- a/templates/zerver/history.html
+++ b/templates/zerver/history.html
@@ -42,13 +42,13 @@
 
                 <p>
                     Zulip, Inc. was acquired by Dropbox in early 2014, while the product
-                    was still in private beta.  Zulip's beta
+                    was still in private beta.  Zulip’s beta
                     users <a href="https://www.recurse.com/blog/90-zulip-supporting-oss-at-the-recurse-center">loved
-                    Zulip's unique user experience</a> and continued using it, despite
+                    Zulip’s unique user experience</a> and continued using it, despite
                     the fact that the product was not being actively developed.  After a
                     year and a half, Dropbox generously decided to
                     <a href="https://blogs.dropbox.com/tech/2015/09/open-sourcing-zulip-a-dropbox-hack-week-project/">release Zulip as open source software</a>
-                    so that Zulip's users could continue enjoying the software.
+                    so that Zulip’s users could continue enjoying the software.
                 </p>
 
                 <p>
@@ -76,9 +76,9 @@
                 <p>
                     At first, the Zulip open source project was
                     maintained with just a bit of lead developer Tim
-                    Abbott's nights and weekends.  However, the
+                    Abbott’s nights and weekends.  However, the
                     community steadily gained new contributors, and
-                    has now grown to be one of the world's largest and
+                    has now grown to be one of the world’s largest and
                     most active open source projects.  We highlight a
                     few milestones below:
                 </p>
@@ -126,7 +126,7 @@
 
                 <p>
                     In 2016, Tim Abbott started a company, Kandra Labs, to
-                    steward and financially sustain Zulip's development.  Kandra
+                    steward and financially sustain Zulip’s development.  Kandra
                     Labs was soon awarded
                     a <a href="https://seedfund.nsf.gov/">large grant</a> from
                     the US National Science Foundation, and also acquired
@@ -140,7 +140,7 @@
                     deployments.
                 </p>
                 <p>
-                    As of October 2018 the hosted service was seeing 4x year
+                    As of October 2018 the hosted service was seeing 4× year
                     over year growth in daily active users, and the
                     on-premise product was seeing rapid adoption (fueled
                     partly by the sunsetting of HipChat server).

--- a/templates/zerver/plans.html
+++ b/templates/zerver/plans.html
@@ -14,7 +14,7 @@
     <div class="main">
         <div class="pricing-model">
             <div class="padded-content">
-                <h1>Get started today</h1>
+                <h1>Get started today.</h1>
 
                 <div class="pricing-container">
                     <div class="block">
@@ -26,7 +26,7 @@
                             <div class="text-content">
                                 <h2>Free</h2>
                                 <div class="description">
-                                    Try Zulip for an unlimited period of time
+                                    Try Zulip for an unlimited period of time.
                                 </div>
                                 <hr />
                                 <ul class="feature-list">
@@ -59,7 +59,7 @@
                             <div class="text-content">
                                 <h2>Standard</h2>
                                 <div class="description">
-                                    Make Zulip your home
+                                    Make Zulip your home.
                                 </div>
                                 <hr />
                                 <ul class="feature-list">
@@ -108,7 +108,7 @@
                             <div class="text-content">
                                 <h2>Community support</h2>
                                 <div class="description">
-                                    Install your own Zulip server
+                                    Install your own Zulip server.
                                 </div>
                                 <hr />
                                 <ul class="feature-list">
@@ -134,7 +134,7 @@
                             <div class="text-content">
                                 <h2>Enterprise</h2>
                                 <div class="description">
-                                    For mission-critical installations
+                                    For mission-critical installations.
                                 </div>
                                 <hr />
                                 <ul class="feature-list">

--- a/templates/zerver/why-zulip.md
+++ b/templates/zerver/why-zulip.md
@@ -4,7 +4,7 @@ We talk about Slack in the discussion below, but the problems apply equally
 to other apps with Slack’s conversation model, including Hipchat, IRC,
 Mattermost, Discord, Spark, and others.
 
-## Reading busy Slack channels is extremely inefficient
+## Reading busy Slack channels is extremely inefficient.
 
 Anyone who wakes up to this frequently can tell you it is not fun.
 
@@ -14,7 +14,7 @@ The lack of organization and context in Slack channels means that anyone
 using Slack heavily has to manually scan through hundreds of messages a day
 to find the content that is relevant to them.
 
-## Senior people rarely use large Slack channels
+## Senior people rarely use large Slack channels.
 
 Slack channels are even worse for managers and other people involved in
 multiple projects. Even modest usage of Slack leads to more channel messages
@@ -23,19 +23,19 @@ a day than most managers have time to handle.
 In practice, in organizations that use Slack, many senior personnel
 (sensibly) don’t read their channel messages at all, or only read a handful
 of smaller channels. This means you now have a company communication
-platform ... with everyone but the decision makers.
+platform…with everyone but the decision makers.
 
-## Channels rapidly devolve into GIF posts
+## Channels rapidly devolve into GIF posts.
 
 Once a channel reaches dozens of messages a day, substantive conversations
 become increasingly difficult or even impossible. If you send a thoughtful
 question at 10am, anyone who checks in after lunch is too late to reply,
 since someone else will have already started another conversation in that
-channel. This means that even moderately busy channels can't be used for
+channel. This means that even moderately busy channels can’t be used for
 serious discussion, and they devolve into a mix of quick questions and
 random spam.
 
-## Remote workers can’t participate
+## Remote workers can’t participate.
 
 This means that workers in different timezones can only effectively
 collaborate during the narrow windows when everyone is at their
@@ -50,7 +50,7 @@ In contrast, the Zulip team has over 30 core team members distributed
 across a dozen time zones, and uses only Zulip and GitHub issues for
 communication (no email lists, video meetings, etc).
 
-## Teams that love Slack are often mostly using DMs and small channels
+## Teams that love Slack are often mostly using DMs and small channels.
 
 Slack is great for private messages (&ldquo;DMs&rdquo;), integrations, and quick
 questions when everyone’s online. Most glowing reviews of Slack are
@@ -86,7 +86,7 @@ knowledge within the team, and leads to only managers having the full
 picture on projects. Having discussions accessible to larger lists allows
 more stakeholders to stay in the loop.
 
-## Asynchronous communication is fundamental to productive work
+## Asynchronous communication is fundamental to productive work.
 
 These problems are all symptoms of the underlying fact that the channel
 model used by Slack and similar tools is a really bad way to structure
@@ -132,7 +132,7 @@ and reply in context, even to conversations that started hours or days ago.
 
 <img src="/static/images/why-zulip/zulip-reply-later.png" class="zulip-reply-later-image" alt="Zulip reply later">
 
-## Zulip changes how you can operate
+## Zulip changes how you can operate.
 
 It’s simple in concept, but switching from Slack to Zulip can
 transform how your organization communicates:
@@ -141,7 +141,7 @@ transform how your organization communicates:
   thus effectively participate in the chat community.
 * More discussions can be moved from meetings and email to chat.
 * Individual contributors can do focused work instead of paging
-  through GIFs making sure they don't miss anything important.
+  through GIFs making sure they don’t miss anything important.
 * Remote workers can participate in an equal way to people present in
   person.
 * Employees don’t need to be glued to their keyboard or phone in order


### PR DESCRIPTION
Punctuate marketing headings with a period.  Fix a couple of title-cased headings to sentense case.  Consistently use curly apostrophes, curly quotation marks, and Unicode ellipses.

**GIFs or Screenshots:**
![screenshot](https://user-images.githubusercontent.com/26471/76910610-ba9f1a80-686b-11ea-8266-5cf95a6f2539.png)
