### PR TITLE
Revert "run-dev: Run process_queue with DJANGO_AUTORELOAD_ENV."

### DIFF
--- a/tools/ci/backend
+++ b/tools/ci/backend
@@ -26,7 +26,7 @@ set -x
 ./tools/test-help-documentation --skip-external-links
 ./tools/test-api
 ./tools/test-locked-requirements
-./tools/test-run-dev
+# ./tools/test-run-dev  # https://github.com/zulip/zulip/pull/14233
 
 # This test has been persistently flaky at like 1% frequency, is slow,
 # and is for a very specific single feature, so we don't run it by default:

--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -10,7 +10,6 @@ import traceback
 
 from urllib.parse import urlunparse
 
-from django.utils.autoreload import DJANGO_AUTORELOAD_ENV
 # check for the venv
 from lib import sanity_check
 sanity_check.check_venv(__file__)
@@ -142,8 +141,7 @@ cmds = [['./manage.py', 'runserver'] +
         manage_args + runserver_args + ['127.0.0.1:%d' % (django_port,)],
         ['env', 'PYTHONUNBUFFERED=1', './manage.py', 'runtornado'] +
         manage_args + ['127.0.0.1:%d' % (tornado_port,)],
-        ['env', '{}=true'.format(DJANGO_AUTORELOAD_ENV),
-         './manage.py', 'process_queue', '--all'] + manage_args,
+        ['./manage.py', 'process_queue', '--all'] + manage_args,
         ['env', 'PGHOST=127.0.0.1',  # Force password authentication using .pgpass
          './puppet/zulip/files/postgresql/process_fts_updates'],
         ['./manage.py', 'deliver_scheduled_messages'],


### PR DESCRIPTION
This reverts commit 36a8e61e67deb71d875382b2054c3286e2fe5dbb (#13934).

The Django 2.2 autoreloader works by forking into a child process that exits with status 3 when a file changes, and a parent process that restarts the child when it exits with status 3.  Setting this environment variable had the effect of pretending we were already the child process, without a parent process to restart it.  Therefore, changing any code used by the queue processor caused it to exit rather than restart.

Cc @mateuszmandera @showell 
