### PR TITLE
unread_color: Changing the color of unread marker in night mode

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -134,7 +134,7 @@ on a dark background, and don't change the dark labels dark either. */
 
     .topic-unread-count,
     .private_message_count {
-        background-color: hsla(105, 2%, 50%, 0.5);
+        background-color: hsl(0, 0%, 7%);
     }
 
     .pill-container {


### PR DESCRIPTION
Changing the color of unread marker in both stream and pm to a
darker color in night mode.
https://github.com/zulip/zulip/issues/12799
Before:
![Screenshot from 2020-03-18 13-27-46](https://user-images.githubusercontent.com/42106909/76940739-cd275b80-6920-11ea-8bfe-de2684250571.png)
After:
![Screenshot from 2020-03-18 13-27-09](https://user-images.githubusercontent.com/42106909/76940763-d44e6980-6920-11ea-9e11-0e98d3088d22.png)
Check the last message in both images.