### PR TITLE
styles: Exempt visibility from overlay show transition

### DIFF
--- a/static/styles/app_components.scss
+++ b/static/styles/app_components.scss
@@ -289,7 +289,7 @@
         opacity: 1;
         pointer-events: all;
         visibility: visible;
-        transition-timing-function: ease-out;
+        transition: opacity 0.2s ease-out;
 
         .overlay-content {
             transform: translateY(0px);

--- a/tools/documentation_crawler/documentation_crawler/spiders/common/spiders.py
+++ b/tools/documentation_crawler/documentation_crawler/spiders/common/spiders.py
@@ -69,9 +69,6 @@ class BaseDocumentationSpider(scrapy.Spider):
         if (len(url) > 4 and url[:4] == "file") or ("localhost" in url):
             # We also want CI to check any links to built documentation.
             return False
-        if 'github.com/zulip' in url:
-            # Finally, links to our own GitHub organization should always work.
-            return False
         return True
 
     def check_fragment(self, response: Response) -> None:


### PR DESCRIPTION
This fixes a failure to give focus to a newly shown overlay.

**Testing Plan:** Dev server.