### PR TITLE
tests: Treat github.com/zulip links as external.

### DIFF
--- a/tools/documentation_crawler/documentation_crawler/spiders/common/spiders.py
+++ b/tools/documentation_crawler/documentation_crawler/spiders/common/spiders.py
@@ -70,8 +70,10 @@ class BaseDocumentationSpider(scrapy.Spider):
             # We also want CI to check any links to built documentation.
             return False
         if 'github.com/zulip' in url:
-            # Finally, links to our own GitHub organization should always work.
-            return False
+            # We want to check these links but due to rate limiting from GitHub, these checks often
+            # fail in the CI. Thus, we should treat these as external links for now.
+            # TODO: Figure out how to test github.com/zulip links in CI.
+            return True
         return True
 
     def check_fragment(self, response: Response) -> None:


### PR DESCRIPTION
Tests for these links often result in rate-limiting from GitHub,
leading to the builds failing in Circle CI. We temporarily mark
github.com/zulip links as external to keep the builds passing.

See https://chat.zulip.org/#narrow/stream/43-automated-testing