### PR TITLE
Refactor lightbox code to fix buggy implementation of the image-list.

### DIFF
--- a/frontend_tests/node_tests/lightbox.js
+++ b/frontend_tests/node_tests/lightbox.js
@@ -30,6 +30,7 @@ run_test('pan_and_zoom', () => {
     img.set_parent(link);
     link.closest = () => msg;
     msg.attr("zid", "1234");
+    img.attr("src", "example");
 
     let fetched_zid;
 

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -85,10 +85,19 @@ function display_video(payload) {
 exports.open = function ($image) {
     // if the asset_map already contains the metadata required to display the
     // asset, just recall that metadata.
-    const $preview_src = $image.attr("src");
+    let $preview_src = $image.attr("src");
     let payload = asset_map.get($preview_src);
     if (payload === undefined) {
-        payload = exports.parse_image_data($image);
+        if ($preview_src.endsWith("&size=full")) {
+            // while fetching an image for canvas, `src` attribute supplies
+            // full-sized image instead of thumbnail, so we have to replace
+            // `size=full` with `size=thumbnail`.
+            $preview_src = $preview_src.replace(/.{4}$/, "thumbnail");
+            payload = asset_map.get($preview_src);
+        }
+        if (payload === undefined) {
+            payload = exports.parse_image_data($image);
+        }
     }
 
     if (payload.type.match("-video")) {

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -91,8 +91,8 @@ exports.open = function (image, options) {
 
     // if the asset_map already contains the metadata required to display the
     // asset, just recall that metadata.
-    const $image_source = $image.attr("data-src-fullsize") || $image.attr("src");
-    let payload = asset_map.get($image_source);
+    const $preview_src = $image.attr("src");
+    let payload = asset_map.get($preview_src);
     if (payload === undefined) {
         payload = exports.parse_image_data($image);
     }
@@ -168,6 +168,7 @@ exports.show_from_selected_message = function () {
 
 // retrieve the metadata from the DOM and store into the asset_map.
 exports.parse_image_data = function ($image) {
+    const $preview_src = $image.attr("src");
     // if wrapped in the .youtube-video class, it will be length = 1, and therefore
     // cast to true.
     const is_youtube_video = !!$image.closest(".youtube-video").length;
@@ -196,7 +197,7 @@ exports.parse_image_data = function ($image) {
         if ($image.attr("data-src-fullsize")) {
             $source = $image.attr("data-src-fullsize");
         } else {
-            $source = $image.attr("src");
+            $source = $preview_src;
         }
     }
     let sender_full_name;
@@ -216,12 +217,12 @@ exports.parse_image_data = function ($image) {
         user: sender_full_name,
         title: $parent.attr("title"),
         type: $type,
-        preview: $image.attr("src"),
+        preview: $preview_src,
         source: $source,
         url: $url,
     };
 
-    asset_map.set($source, payload);
+    asset_map.set($preview_src, payload);
     return payload;
 };
 

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -80,15 +80,13 @@ function display_video(payload) {
 // the image param is optional, but required on the first preview of an image.
 // this will likely be passed in every time but just ignored if the result is already
 // stored in the `asset_map`.
-exports.open = function (image, options) {
+exports.open = function ($image, options) {
     if (!options) {
         options = {
             // default to showing standard images.
             lightbox_canvas: $(".lightbox-canvas-trigger").hasClass("enabled"),
         };
     }
-
-    const $image = $(image);
 
     // if the asset_map already contains the metadata required to display the
     // asset, just recall that metadata.

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -79,9 +79,6 @@ function display_video(payload) {
     $(".image-actions .open").attr("href", payload.url);
 }
 
-// the image param is optional, but required on the first preview of an image.
-// this will likely be passed in every time but just ignored if the result is already
-// stored in the `asset_map`.
 exports.open = function ($image) {
     // if the asset_map already contains the metadata required to display the
     // asset, just recall that metadata.

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -18,6 +18,7 @@ function render_lightbox_list_images(preview_source) {
             }).css({ backgroundImage: "url(" + src + ")"});
 
             $image_list.append(node);
+            exports.parse_image_data(img);
         }, "");
     }
 }
@@ -167,8 +168,15 @@ exports.show_from_selected_message = function () {
 };
 
 // retrieve the metadata from the DOM and store into the asset_map.
-exports.parse_image_data = function ($image) {
+exports.parse_image_data = function (image) {
+    const $image = $(image);
     const $preview_src = $image.attr("src");
+
+    if (asset_map.has($preview_src)) {
+        // check if image's data is already present in asset_map.
+        return;
+    }
+
     // if wrapped in the .youtube-video class, it will be length = 1, and therefore
     // cast to true.
     const is_youtube_video = !!$image.closest(".youtube-video").length;

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -23,13 +23,15 @@ function render_lightbox_list_images(preview_source) {
     }
 }
 
-function display_image(payload, options) {
+function display_image(payload) {
     render_lightbox_list_images(payload.preview);
 
     $(".player-container").hide();
     $(".image-actions, .image-description, .download, .lightbox-canvas-trigger").show();
 
-    if (options.lightbox_canvas === true) {
+    const lightbox_canvas = $(".lightbox-canvas-trigger").hasClass("enabled");
+
+    if (lightbox_canvas === true) {
         const canvas = document.createElement("canvas");
         canvas.setAttribute("data-src", payload.source);
 
@@ -80,14 +82,7 @@ function display_video(payload) {
 // the image param is optional, but required on the first preview of an image.
 // this will likely be passed in every time but just ignored if the result is already
 // stored in the `asset_map`.
-exports.open = function ($image, options) {
-    if (!options) {
-        options = {
-            // default to showing standard images.
-            lightbox_canvas: $(".lightbox-canvas-trigger").hasClass("enabled"),
-        };
-    }
-
+exports.open = function ($image) {
     // if the asset_map already contains the metadata required to display the
     // asset, just recall that metadata.
     const $preview_src = $image.attr("src");
@@ -99,7 +94,7 @@ exports.open = function ($image, options) {
     if (payload.type.match("-video")) {
         display_video(payload);
     } else if (payload.type === "image") {
-        display_image(payload, options);
+        display_image(payload);
     }
 
     if (is_open) {

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -257,9 +257,9 @@ exports.initialize = function () {
 
     $("#lightbox_overlay").on("click", ".image-list .image", function () {
         const $image_list = $(this).parent();
-        const original_image = $(".message_row img[src='" + $(this).attr('data-src') + "']");
+        const $original_image = $(".message_row img[src='" + $(this).attr('data-src') + "']");
 
-        exports.open(original_image);
+        exports.open($original_image);
 
         $(".image-list .image.selected").removeClass("selected");
         $(this).addClass("selected");

--- a/static/js/lightbox_canvas.js
+++ b/static/js/lightbox_canvas.js
@@ -229,6 +229,10 @@ const funcs = {
     // means that the height is less than 100% of the parent height. If so,
     // then we size the photo as w = 100%, h = 100% / 1.5.
     sizeCanvas: function (canvas, meta) {
+        if (canvas.parentNode === null) {
+            return;
+        }
+
         if (typeof meta.onresize === "function") {
             meta.onresize(canvas);
         }


### PR DESCRIPTION
Previously, `lightbox.open()` was responsible for retrieving the image data from the DOM, saving it in `asset_map` and finally displaying the image using that data. This implementation wasn't correct for image list at bottom of the lightbox because the `image` parameter passed to lightbox.open() could contain more than one instances of the image that had to be opened.

This commit refactors the lightbox implementation to fix it's behaviour for the bottom image-list. The changes are as follows:

- Seperated the image data parsing logic from the `lightbox.open()` and moved it into parse_image_data().

- Metadata of all the images is stored in the `asset_map` when an image is opened and the image-list is rendered at the bottom.

- Whenever an image-list element is clicked, the image is directly accessed from `asset_map` rather than relying on the original image element still being findable in the DOM.

Fixes #14152.