### PR TITLE
alert_word: Changing color in night mode.

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -417,6 +417,12 @@ on a dark background, and don't change the dark labels dark either. */
         background-color: hsla(8, 78%, 43%, 0.15);
     }
 
+    .alert-word {
+        background-color: transparent;
+        color: hsl(160, 100%, 75%);
+        font-weight: bold;
+    }
+
     .rendered_markdown .user-mention,
     .rendered_markdown .user-group-mention {
         background: linear-gradient(to bottom, hsla(0, 0%, 0%, 0.2) 0%, hsla(0, 0%, 0%, 0.1) 100%);


### PR DESCRIPTION
Changing color of alert word to a slightly darker shade to make
it easier to read in night mode.

Solves https://github.com/zulip/zulip/issues/12614.

Not sure how soon this will be implemented https://github.com/zulip/zulip/issues/13425 so making this PR for a temporary fix in case it is necessary.

Changing the font color to hsl(160, 100%, 75%) and making it bolder instead of the background color approach in light mode.

Before:
![Screenshot from 2020-03-19 18-06-17](https://user-images.githubusercontent.com/42106909/77068687-fe7d5580-6a0c-11ea-9909-908f2c5c3035.png)
After:
![Screenshot from 2020-03-21 17-34-34](https://user-images.githubusercontent.com/42106909/77226087-a3c63400-6b9b-11ea-9d8e-fcfe1aa2e0bf.png)
