### PR TITLE
docs: Fix wrong file address in the Matrix Integration docs.

### DIFF
--- a/templates/zerver/help/include/configure-matrix-bridge.md
+++ b/templates/zerver/help/include/configure-matrix-bridge.md
@@ -10,7 +10,8 @@
 1. Inside the virtualenv you created above, run
 
     ```
-    python matrix_bridge.py --write-sample-config matrix_bridge.conf --from-zuliprc <path/to/zuliprc>
+    python zulip/integrations/bridge_with_matrix/matrix_bridge.py \
+    --write-sample-config matrix_bridge.conf --from-zuliprc <path/to/zuliprc>
     ```
 
     where `<path/to/zuliprc>` is the path to the `zuliprc` file you downloaded.
@@ -54,11 +55,11 @@
 1. Run the following command to start the matrix bridge:
 
     ```
-    python matrix_bridge.py -c matrix_bridge.conf
+    python zulip/integrations/bridge_with_matrix/matrix_bridge.py -c matrix_bridge.conf
     ```
 
 !!! tip ""
 
     You can customize the message formatting by
     editing the variables `MATRIX_MESSAGE_TEMPLATE` and `ZULIP_MESSAGE_TEMPLATE`
-    in `zulip/integrations/matrix/matrix_bridge.py`.
+    in `zulip/integrations/bridge_with_matrix/matrix_bridge.py`.

--- a/templates/zerver/help/include/install-matrix.md
+++ b/templates/zerver/help/include/install-matrix.md
@@ -17,5 +17,5 @@
 1. Install the Matrix bridge software in your virtualenv, by running:
 
     ```
-    pip install -r zulip/integrations/matrix/requirements.txt
+    pip install -r zulip/integrations/bridge_with_matrix/requirements.txt
     ```


### PR DESCRIPTION
The matrix integration folder in python-zulip-api changed its name
from matrix to bridge_with_matrix but this was not reflected in
the docs. Change the docs accordingly.

Solves  [#545](https://github.com/zulip/python-zulip-api/issues/545) in the python-zulip-api directory.
