### PR TITLE
Clean up `test_get_all_profiles_avatar_urls`.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -1,7 +1,8 @@
 from contextlib import contextmanager
 from email.utils import parseaddr
 from fakeldap import MockLDAP
-from typing import (cast, Any, Dict, Iterable, Iterator, List, Optional,
+from typing import (cast, Any, Callable, Dict, Iterable,
+                    Iterator, List, Optional,
                     Tuple, Union, Set)
 
 from django.apps import apps
@@ -819,6 +820,36 @@ class ZulipTestCase(TestCase):
         return [
             r for r in data
             if r['id'] == db_id][0]
+
+    def findOne(self,
+                lst: List[Any],
+                predicate: Callable[[Any], bool],
+                member_name: str) -> Any:
+        matches = [
+            item for item in lst
+            if predicate(item)
+        ]
+
+        if len(matches) == 1:
+            # Happy path!
+            return matches[0]
+
+        print('\nERROR: findOne fails on this list:\n')
+
+        for item in lst:
+            print(item)
+
+        if len(matches) == 0:
+            raise ValueError(
+                'No matches: {}'.format(member_name)
+            )
+
+        raise ValueError(
+            'Too many matches ({}): {}'.format(
+                len(matches),
+                member_name
+            )
+        )
 
     def init_default_ldap_database(self) -> None:
         """

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1383,16 +1383,20 @@ class GetProfileTest(ZulipTestCase):
         self.assert_json_error(result, "Invalid message ID")
 
     def test_get_all_profiles_avatar_urls(self) -> None:
-        user_profile = self.example_user('hamlet')
-        result = self.api_get(self.example_user("hamlet"), "/api/v1/users")
+        hamlet = self.example_user('hamlet')
+        result = self.api_get(hamlet, "/api/v1/users")
         self.assert_json_success(result)
 
-        for user in result.json()['members']:
-            if user['email'] == self.example_email("hamlet"):
-                self.assertEqual(
-                    user['avatar_url'],
-                    avatar_url(user_profile),
-                )
+        my_user = self.findOne(
+            result.json()['members'],
+            lambda user: user['email'] == hamlet.email,
+            'member for Hamlet'
+        )
+
+        self.assertEqual(
+            my_user['avatar_url'],
+            avatar_url(hamlet),
+        )
 
 class FakeEmailDomainTest(ZulipTestCase):
     @override_settings(FAKE_EMAIL_DOMAIN="invaliddomain")


### PR DESCRIPTION
This test was using the anti-pattern of doing an
assertion inside a conditional.

I added the `findOne` helper to make it easier
to write robust tests for scenarios like this.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
