### PR TITLE
docs: Add documentation for weekly digest emails.

### DIFF
--- a/templates/zerver/help/disable-digest-emails.md
+++ b/templates/zerver/help/disable-digest-emails.md
@@ -1,0 +1,21 @@
+# Disable weekly digest emails
+
+{!admin-only.md!}
+
+By default, Zulip sends weekly emails to users who haven't been active
+for 5 or more days to regain their interest. These emails include new
+streams created and stream traffic (of subscribed streams) that can intrigue users.
+
+To understand the structure and content type of the digest emails, see a
+[sample digest email](/digest).
+
+## Disable digest emails
+
+{start_tabs}
+
+{settings_tab|organization-settings}
+
+1. Under **Notifications**, toggle
+   **Send weekly digest emails to inactive users**.
+
+{end_tabs}

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -127,6 +127,7 @@
 * [Manage editing of old messages](/help/configure-message-editing-and-deletion)
 * [Hide message content in emails](/help/hide-message-content-in-emails)
 * [Community topic edits](/help/community-topic-edits)
+* [Disable weekly digest emails](/help/disable-digest-emails)
 * [Disable welcome emails](/help/disable-welcome-emails)
 * [Configure notification bot](/help/configure-notification-bot)
 * [Require topics in stream messages](/help/require-topics)


### PR DESCRIPTION
Added documentation explaining the digest emails feature and how to
disable it, along with a link to the /digest.

Resolves: #14136 