### PR TITLE
static: Fix unreachable edit button in stream name

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -763,6 +763,21 @@ exports.initialize = function () {
                     break;
                 }
             }
+
+            //Adjust the font size of the input so it can always be
+            //on the view without overflowing other context.
+
+            if ($(this).parent().hasClass("stream-name")) {
+              let defaultFontSize = 21;
+              let maxWidthOfTheInput = 270;
+              let averageWidthOfTheInput =150;
+
+              if ($(this).width() >= maxWidthOfTheInput) {
+                  $(this).css("font-size", "-=0.2em")
+              } else if ($(this).width()<=averageWidthOfTheInput && $(this).css("font-size").replace(/[^-\d\.]/g, '') < defaultFontSize) {
+                  $(this).css("font-size", "+=0.2em")
+              }
+            }
         });
 
         $("body").on("click", "[data-make-editable]", function () {

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -801,8 +801,6 @@ form#add_new_subscription {
             padding-bottom: 5px;
             white-space: nowrap;
             width: 270px;
-            overflow: hidden;
-            text-overflow: ellipsis;
         }
 
         .deactivate,


### PR DESCRIPTION
We use javascript to adjust the font-size every time the text in the stream name input is too big, so that the edit button can be seen. Also the overflow hidden has been removed.

#14260 
#13139

Example of the above solution:

![a1](https://user-images.githubusercontent.com/43316964/77144048-8c008a00-6a8d-11ea-897b-bc1851de09c8.gif)
