### PR TITLE
docs: Updated links to python-social-auth docs.

### DIFF
--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -74,7 +74,7 @@ it as follows:
    * Fill out `SOCIAL_AUTH_SAML_ENABLED_IDPS` with data provided by
      your identity provider.  You may find [the python-social-auth
      SAML
-     docs](https://python-social-auth-docs.readthedocs.io/en/latest/backends/saml.html)
+     docs](https://python-social-auth.readthedocs.io/en/latest/backends/saml.html)
      helpful.  You'll need to obtain several values from your IdP's
      metadata and enter them on the right-hand side of this
      Python dictionary:

--- a/templates/zerver/security.md
+++ b/templates/zerver/security.md
@@ -67,7 +67,7 @@ priority.
   (including Okta), AzureAD, and Active Directory/LDAP.  With Zulip
   on-premise, we can support any of the 100+ authentication tools
   supported by
-  [python-social-auth](https://python-social-auth-docs.readthedocs.io/en/latest/backends/index.html#social-backends)
+  [python-social-auth](https://python-social-auth.readthedocs.io/en/latest/backends/index.html#social-backends)
   as well as [any SSO service that has a plugin for
   Apache][apache-sso].
 - Zulip uses the zxcvbn password strength checker by default, and supports

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -227,7 +227,7 @@ SOCIAL_AUTH_SAML_ORG_INFO = {
 }
 SOCIAL_AUTH_SAML_ENABLED_IDPS = {
     # The fields are explained in detail here:
-    #     https://python-social-auth-docs.readthedocs.io/en/latest/backends/saml.html
+    #     https://python-social-auth.readthedocs.io/en/latest/backends/saml.html
     "idp_name": {
         # Configure entity_id and url according to information provided to you by your IdP:
         "entity_id": "https://idp.testshib.org/idp/shibboleth",


### PR DESCRIPTION
The URL seems to have changed.
