### PR TITLE
Fix lstrip() calls.

### DIFF
--- a/zerver/views/development/integrations.py
+++ b/zerver/views/development/integrations.py
@@ -70,13 +70,13 @@ def get_fixtures(request: HttpResponse,
 
         headers_raw = get_fixture_http_headers(integration_name,
                                                "".join(fixture.split(".")[:-1]))
-        headers = {}
-        for header in headers_raw:
-            if header.startswith("HTTP_"):  # HTTP_ is a prefix intended for Django.
-                headers[header.lstrip("HTTP_")] = headers_raw[header]
-            else:
-                headers[header] = headers_raw[header]
 
+        def fix_name(header: str) -> str:
+            if header.startswith("HTTP_"):  # HTTP_ is a prefix intended for Django.
+                return header[len("HTTP_"):]
+            return header
+
+        headers = {fix_name(k): v for k, v in headers_raw.items()}
         fixtures[fixture] = {"body": body, "headers": headers}
 
     return json_success({"fixtures": fixtures})

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -107,7 +107,7 @@ class MarkdownDirectoryView(ApiURLView):
             with open(article_path) as article_file:
                 first_line = article_file.readlines()[0]
             # Strip the header and then use the first line to get the article title
-            article_title = first_line.strip().lstrip("# ")
+            article_title = first_line.lstrip("#").strip()
             if context["not_index_page"]:
                 context["OPEN_GRAPH_TITLE"] = "%s (%s)" % (article_title, title_base)
             else:


### PR DESCRIPTION
We might want to consider a lint rule here, but these were the only two places we misused lstrip() in the codebase, so maybe not a huge thing to watch for.

The second use of lstrip() was certainly harmless but probably unintentional.