### PR TITLE
emoji_settings: User's custom emoji on top of table

### DIFF
--- a/static/js/settings_emoji.js
+++ b/static/js/settings_emoji.js
@@ -61,13 +61,41 @@ function sort_author_full_name(a, b) {
     return -1;
 }
 
+function is_author_check(a) {
+    return a.author.full_name === page_params.full_name;
+}
+
+function name_sort(a, b) {
+    if (a.name > b.name) {
+        return 1;
+    } else if (a.name === b.name) {
+        return 0;
+    }
+    return -1;
+}
+
+function emoji_name_sort(a, b) {
+    if (is_author_check(a) === is_author_check(b)) {
+        return name_sort(a, b);
+    } else if (is_author_check(a)) {
+        return -1;
+    }
+    return 1;
+}
+
+exports.sort_but_user_emoji_on_top = function (emoji_data) {
+    emoji_data = Object.values(emoji_data);
+    emoji_data.sort(emoji_name_sort);
+    return emoji_data;
+};
+
 exports.populate_emoji = function (emoji_data) {
     if (!meta.loaded) {
         return;
     }
-
+    emoji_data = exports.sort_but_user_emoji_on_top(emoji_data);
     const emoji_table = $('#admin_emoji_table').expectOne();
-    const emoji_list = list_render.create(emoji_table, Object.values(emoji_data), {
+    const emoji_list = list_render.create(emoji_table, emoji_data, {
         name: "emoji_list",
         modifier: function (item) {
             if (item.deactivated !== true) {
@@ -95,7 +123,6 @@ exports.populate_emoji = function (emoji_data) {
         parent_container: $("#emoji-settings").expectOne(),
     }).init();
 
-    emoji_list.sort("alphabetic", "name");
     emoji_list.add_sort_function("author_full_name", sort_author_full_name);
 
     loading.destroy_indicator($('#admin_page_emoji_loading_indicator'));


### PR DESCRIPTION
Fixes https://github.com/zulip/zulip/issues/8170.

Iago:-
![Screenshot from 2020-04-06 12-21-34](https://user-images.githubusercontent.com/42106909/78513687-0be75d80-77cb-11ea-8300-83f8b3203530.png)
aaron:-
![Screenshot from 2020-04-06 12-21-53](https://user-images.githubusercontent.com/42106909/78513689-0d188a80-77cb-11ea-81bb-c49beb4e4a40.png)
cordelia:-
![Screenshot from 2020-04-06 12-22-08](https://user-images.githubusercontent.com/42106909/78513690-0e49b780-77cb-11ea-8ca7-96f47ed195a3.png)
Random user:-
![Screenshot from 2020-04-06 12-22-26](https://user-images.githubusercontent.com/42106909/78513694-10ac1180-77cb-11ea-967d-0ab534ee96e4.png)

is_author_check() will tell us if the emoji's author is the logged in author or not. Using this, we say, if between 2 other authors or between 2 emoji's belonging to the logged in user, we should sort alphabetically. Then we give a higher priority to the logged in user's emojis.