### PR TITLE
settings: Reword setting name in settings menu.

### DIFF
--- a/docs/testing/manual-testing.md
+++ b/docs/testing/manual-testing.md
@@ -465,7 +465,7 @@ Do these tasks as Cordelia.
 - Display settings
     - Right now, these unfortunately require reloads to take effect.
     - Default language (change to Spanish)
-    - User list on left sidebar in narrow windows (verify by making window thinner)
+    - Show user list on left sidebar in narrow windows (verify by making window thinner)
     - 24-hour time (and then test going back to AM/PM)
 - Notifications
     - Stream Message

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -89,7 +89,7 @@ function setup_settings_label() {
         dense_mode: i18n.t("Dense mode"),
         fluid_layout_width: i18n.t("Use full width on wide screens"),
         high_contrast_mode: i18n.t("High contrast mode"),
-        left_side_userlist: i18n.t("User list on left sidebar in narrow windows"),
+        left_side_userlist: i18n.t("Show user list on left sidebar in narrow windows"),
         night_mode: i18n.t("Night mode"),
         starred_message_counts: i18n.t("Show counts for starred messages"),
         twenty_four_hour_time: i18n.t("Time format"),

--- a/templates/zerver/help/move-the-users-list-to-the-left-sidebar.md
+++ b/templates/zerver/help/move-the-users-list-to-the-left-sidebar.md
@@ -13,7 +13,7 @@ You can choose to move the **User list** to the left hand side, under the
 
 {settings_tab|display-settings}
 
-2. Under **Display settings**, select **User list on left sidebar in narrow windows**.
+2. Under **Display settings**, select **Show user list on left sidebar in narrow windows**.
 
 3. Reload the page.
 


### PR DESCRIPTION
In the settings menu, the wording of the option `User list on left sidebar in narrow windows` seems to be confusing about its purpose at first. This PR renames it to `Show user list on left sidebar in narrow windows`.