### PR TITLE
setup_path: Fixed KeyError in setup_path for virtualenv>16.7.10.

### DIFF
--- a/scripts/lib/setup_path.py
+++ b/scripts/lib/setup_path.py
@@ -12,5 +12,8 @@ def setup_path() -> None:
         activate_this = os.path.join(venv, "bin", "activate_this.py")
         activate_locals = dict(__file__=activate_this)
         exec(open(activate_this).read(), activate_locals)
-        if not os.path.exists(activate_locals["site_packages"]):
+        # Check that the python version running this function
+        # is same as python version that created the virtualenv.
+        python_version = "python{}.{}".format(*sys.version_info[:2])
+        if not os.path.exists(os.path.join(venv, 'lib', python_version)):
             raise RuntimeError(venv + " was not set up for this Python version")


### PR DESCRIPTION
In virtualenv>16.7.10 site_packages variable is removed from activate_this.py [virtualenv commit](https://github.com/pypa/virtualenv/commit/9569493453a39d63064ed7c20653987ba15c99e5)
The condition we used to check that the virtualenv is compatible [in commit](https://github.com/zulip/zulip/pull/11243/commits/b49fbc86b27cf2e8658bc43578d25d20d8480790)
should be changed for virtualenv>16.7.10


Fixes #14025

Tested on virtualenv 20.0.1