### PR TITLE
emoji_preview: Adding preview while uploading custom emoji.

### DIFF
--- a/static/js/emoji.js
+++ b/static/js/emoji.js
@@ -175,13 +175,17 @@ exports.build_emoji_upload_widget = function () {
     const input_error = $('#emoji_file_input_error');
     const clear_button = $('#emoji_image_clear_button');
     const upload_button = $('#emoji_upload_button');
+    const preview_text = $('#emoji_preview_text');
+    const preview_image = $('#emoji_preview_image');
 
     return upload_widget.build_widget(
         get_file_input,
         file_name_field,
         input_error,
         clear_button,
-        upload_button
+        upload_button,
+        preview_text,
+        preview_image
     );
 };
 

--- a/static/js/upload_widget.js
+++ b/static/js/upload_widget.js
@@ -21,6 +21,8 @@ exports.build_widget = function (
     input_error, // jQuery object for error text
     clear_button, // jQuery button to clear last upload choice
     upload_button, // jQuery button to open file dialog
+    preview_text = null,
+    preview_image = null,
     max_file_upload_size
 ) {
     // default value of max upladed file size
@@ -31,6 +33,11 @@ exports.build_widget = function (
         input_error.hide();
         clear_button.show();
         upload_button.hide();
+        if (preview_text !== null) {
+            const image_blob = URL.createObjectURL(file);
+            preview_image.attr('src', image_blob);
+            preview_text.show();
+        }
     }
 
     function clear() {
@@ -39,7 +46,12 @@ exports.build_widget = function (
         file_name_field.text('');
         clear_button.hide();
         upload_button.show();
+        if (preview_text !== null) {
+            preview_text.hide();
+        }
     }
+
+
 
     clear_button.on('click', function (e) {
         clear();

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -774,6 +774,11 @@ input[type=checkbox].inline-block {
     vertical-align: middle;
 }
 
+#emoji_preview_image {
+    width: auto;
+    height: 20px;
+}
+
 .add-new-emoji-box #emoji-file-name {
     color: hsl(0, 0%, 67%);
 }

--- a/static/templates/settings/emoji_settings_admin.hbs
+++ b/static/templates/settings/emoji_settings_admin.hbs
@@ -24,6 +24,9 @@
                 </button>
             </div>
             <span id="emoji_file_input_error" class="text-error"></span>
+            <span style="display: none;" id="emoji_preview_text">
+                Here is a preview of <img id="emoji_preview_image" /> being used.
+            </span>
         </div>
     </form>
 


### PR DESCRIPTION
Solves the preview part of https://github.com/zulip/zulip/issues/9229.

New UI without the preview button.

The settings page
![Screenshot from 2020-03-24 03-06-21](https://user-images.githubusercontent.com/42106909/77366888-00ce0f80-6d7f-11ea-8d3c-ac432e798c19.png)

The emoji being used in messages
![Screenshot from 2020-03-22 17-56-46](https://user-images.githubusercontent.com/42106909/77398052-bf645100-6dcc-11ea-8186-9d1aa8e24247.png)
