### PR TITLE
api: Refactor POST /messages/{message_id}/reactions endpoint

### DIFF
--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -64,16 +64,21 @@ class ReactionEmojiTest(ZulipTestCase):
             'emoji_name': 'smile'
         }
 
+        base_query = Reaction.objects.filter(user_profile=sender,
+                                             message=Message.objects.get(id=1),
+                                             )
         result = self.api_post(sender, '/api/v1/messages/1/reactions',
                                reaction_info)
         self.assert_json_success(result)
         self.assertEqual(200, result.status_code)
+        self.assertTrue(base_query.filter(emoji_name=reaction_info['emoji_name']).exists())
 
         reaction_info['emoji_name'] = 'green_tick'
         result = self.api_post(sender, '/api/v1/messages/1/reactions',
                                reaction_info)
         self.assert_json_success(result)
         self.assertEqual(200, result.status_code)
+        self.assertTrue(base_query.filter(emoji_name=reaction_info['emoji_name']).exists())
 
     def test_zulip_emoji(self) -> None:
         """
@@ -84,17 +89,21 @@ class ReactionEmojiTest(ZulipTestCase):
             'emoji_name': 'zulip',
             'reaction_type': 'zulip_extra_emoji'
         }
+        base_query = Reaction.objects.filter(user_profile=sender,
+                                             emoji_name=reaction_info['emoji_name'])
 
         result = self.api_post(sender, '/api/v1/messages/1/reactions',
                                reaction_info)
         self.assert_json_success(result)
         self.assertEqual(200, result.status_code)
+        self.assertTrue(base_query.filter(message=Message.objects.get(id=1)).exists())
 
         reaction_info.pop('reaction_type')
         result = self.api_post(sender, '/api/v1/messages/2/reactions',
                                reaction_info)
         self.assert_json_success(result)
         self.assertEqual(200, result.status_code)
+        self.assertTrue(base_query.filter(message=Message.objects.get(id=2)).exists())
 
     def test_valid_emoji_react_historical(self) -> None:
         """

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -69,6 +69,12 @@ class ReactionEmojiTest(ZulipTestCase):
         self.assert_json_success(result)
         self.assertEqual(200, result.status_code)
 
+        reaction_info['emoji_name'] = 'green_tick'
+        result = self.api_post(sender, '/api/v1/messages/1/reactions',
+                               reaction_info)
+        self.assert_json_success(result)
+        self.assertEqual(200, result.status_code)
+
     def test_zulip_emoji(self) -> None:
         """
         Reacting with zulip emoji succeeds
@@ -80,6 +86,12 @@ class ReactionEmojiTest(ZulipTestCase):
         }
 
         result = self.api_post(sender, '/api/v1/messages/1/reactions',
+                               reaction_info)
+        self.assert_json_success(result)
+        self.assertEqual(200, result.status_code)
+
+        reaction_info.pop('reaction_type')
+        result = self.api_post(sender, '/api/v1/messages/2/reactions',
                                reaction_info)
         self.assert_json_success(result)
         self.assertEqual(200, result.status_code)

--- a/zerver/views/reactions.py
+++ b/zerver/views/reactions.py
@@ -26,7 +26,7 @@ def create_historical_message(user_profile: UserProfile, message: Message) -> No
 def add_reaction(request: HttpRequest, user_profile: UserProfile, message_id: int,
                  emoji_name: str=REQ(),
                  emoji_code: Optional[str]=REQ(default=None),
-                 reaction_type: str=REQ(default="unicode_emoji")) -> HttpResponse:
+                 reaction_type: Optional[str]=REQ(default=None)) -> HttpResponse:
     message, user_message = access_message(user_profile, message_id)
 
     if emoji_code is None:
@@ -36,6 +36,10 @@ def add_reaction(request: HttpRequest, user_profile: UserProfile, message_id: in
         # look up the code using the current name->code mapping.
         emoji_code = emoji_name_to_emoji_code(message.sender.realm,
                                               emoji_name)[0]
+
+    if reaction_type is None:
+        reaction_type = emoji_name_to_emoji_code(message.sender.realm,
+                                                 emoji_name)[1]
 
     if Reaction.objects.filter(user_profile=user_profile,
                                message=message,


### PR DESCRIPTION
This refactors add_reaction in zerver.views.reactions to allow
calling POST ../messages/{message_id}/reactions api endpoint with
emoji_name only, even in the case of a custom emoji.