### PR TITLE
Add support for python3.8 and CI running for focal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,9 +143,44 @@ jobs:
       - *save_cache_requirements
       - *run_backend_tests
 
+  "focal-backend-frontend-python3.8":
+      docker:
+        # This is built from tools/circleci/images/focal/Dockerfile.
+        # Focal ships with Python 3.8.2.
+        - image: arpit551/circleci:focal-test
+
+      working_directory: ~/zulip
+
+      steps:
+        - checkout
+
+        - *create_cache_directories
+        - *restore_cache_package_json
+        - *restore_cache_requirements
+        - *install_dependencies
+        - *save_cache_package_json
+        - *save_cache_requirements
+        - *run_backend_tests
+        - *run_frontend_tests
+        # We only need to upload coverage reports on whichever platform
+        # runs the frontend tests.
+        - *upload_coverage_report
+
+        - store_artifacts:
+            path: ./var/casper/
+            destination: casper
+
+        - store_artifacts:
+            path: ../../../tmp/zulip-test-event-log/
+            destination: test-reports
+
+        - store_test_results:
+              path: ./var/xunit-test-results/casper/
+
 workflows:
   version: 2
   build:
     jobs:
       - "xenial-backend-frontend-python3.5"
       - "bionic-backend-python3.6"
+      - "focal-backend-frontend-python3.8"

--- a/docs/development/overview.md
+++ b/docs/development/overview.md
@@ -28,7 +28,7 @@ performs well.
 Zulip also supports a wide range of ways to install the Zulip
 development environment:
 
-* On **Ubuntu** 18.04 Bionic and 16.04 Xenial and **Debian** 9
+* On **Ubuntu** 20.04 Focal, 18.04 Bionic, 16.04 Xenial, **Debian** 9
   Stretch and 10 Buster, you can easily
   **[install without using Vagrant][install-direct]**.
 * On **other Linux/UNIX** distributions, you'll need to follow slightly different

--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -11,7 +11,7 @@ Contents:
 If you'd like to install a Zulip development environment on a computer
 that's running one of:
 
-* Ubuntu 19.04 Disco, 18.10 Cosmic, 18.04 Bionic, 16.04 Xenial
+* Ubuntu 20.04 Focal, 19.04 Disco, 18.10 Cosmic, 18.04 Bionic, 16.04 Xenial
 * Debian 9 Stretch or 10 Buster
 * Centos 7 (beta)
 * Fedora 29 (beta)

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -132,8 +132,8 @@ python-magic
 # these tightly, including fetching content not included in the normal
 # release tarballs (which is a bug).  So we need to pin it makes sense
 # to pin a version from Git rather than a release.
-https://github.com/zulip/python-zulip-api/archive/804501610b6a205334e71b4e441fca60acf650da.zip#egg=zulip==0.6.1_git&subdirectory=zulip
-https://github.com/zulip/python-zulip-api/archive/804501610b6a205334e71b4e441fca60acf650da.zip#egg=zulip_bots==0.6.1+git&subdirectory=zulip_bots
+https://github.com/zulip/python-zulip-api/archive/0.6.3.zip/#egg=zulip==0.6.3_git&subdirectory=zulip
+https://github.com/zulip/python-zulip-api/archive/0.6.3.zip/#egg=zulip_bots==0.6.3+git&subdirectory=zulip_bots
 
 # Used for Hesiod lookups, etc.
 py3dns

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -236,6 +236,9 @@ defusedxml==0.6.0 \
 disposable-email-domains==0.0.57 \
     --hash=sha256:0f443152526d33e017e429cc9c7ed59b2feb8d1331f1feecb339fa4a3f43c99a \
     --hash=sha256:beb3eada4902a5105fffeb534b62724365d6cc7010f4bc698a532aa0378b3466
+distro==1.4.0 \
+    --hash=sha256:362dde65d846d23baee4b5c058c8586f219b5a54be1cf5fc6ff55c4578392f57 \
+    --hash=sha256:eedf82a470ebe7d010f1872c17237c79ab04097948800029994fa458e52fb4b4
 https://github.com/zulip/django-auth-ldap/archive/e26d0ef2a7ff77ab3fdd7b6578a76081f780778c.zip#egg=django-auth-ldap==2.0.0zulip1 \
     --hash=sha256:1a104fdb5085ef9340996ae82d4b302f99c39c5d9d60d4ae55bcc7c1f58cb65e
 django-bitfield==2.0.1 \
@@ -972,10 +975,10 @@ zope.interface==4.7.1 \
     # via scrapy, twisted
 https://github.com/zulip/zulint/archive/aaed679f1ad38b230090eadd3870b7682500f60c.zip#egg=zulint==0.0.1 \
     --hash=sha256:9779afff26553119756e7be59d8a4adccda6758bf26483cc18a33cffe2efac60
-https://github.com/zulip/python-zulip-api/archive/804501610b6a205334e71b4e441fca60acf650da.zip#egg=zulip==0.6.1_git&subdirectory=zulip \
-    --hash=sha256:270cebf4554a3a2fb1c95190168c952ef97081541ed2be0a83f00fb48e29928a
-https://github.com/zulip/python-zulip-api/archive/804501610b6a205334e71b4e441fca60acf650da.zip#egg=zulip_bots==0.6.1+git&subdirectory=zulip_bots \
-    --hash=sha256:270cebf4554a3a2fb1c95190168c952ef97081541ed2be0a83f00fb48e29928a
+https://github.com/zulip/python-zulip-api/archive/0.6.3.zip/#egg=zulip==0.6.3_git&subdirectory=zulip \
+    --hash=sha256:78a09c5e9f4177cab6f062dcb16c645b5814c07907fefaa6d0c196f28b9f6d95
+https://github.com/zulip/python-zulip-api/archive/0.6.3.zip/#egg=zulip_bots==0.6.3+git&subdirectory=zulip_bots \
+    --hash=sha256:78a09c5e9f4177cab6f062dcb16c645b5814c07907fefaa6d0c196f28b9f6d95
 zxcvbn==4.4.28 \
     --hash=sha256:151bd816817e645e9064c354b13544f85137ea3320ca3be1fb6873ea75ef7dc1
 

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -157,6 +157,9 @@ defusedxml==0.6.0 \
 disposable-email-domains==0.0.57 \
     --hash=sha256:0f443152526d33e017e429cc9c7ed59b2feb8d1331f1feecb339fa4a3f43c99a \
     --hash=sha256:beb3eada4902a5105fffeb534b62724365d6cc7010f4bc698a532aa0378b3466
+distro==1.4.0 \
+    --hash=sha256:362dde65d846d23baee4b5c058c8586f219b5a54be1cf5fc6ff55c4578392f57 \
+    --hash=sha256:eedf82a470ebe7d010f1872c17237c79ab04097948800029994fa458e52fb4b4
 https://github.com/zulip/django-auth-ldap/archive/e26d0ef2a7ff77ab3fdd7b6578a76081f780778c.zip#egg=django-auth-ldap==2.0.0zulip1 \
     --hash=sha256:1a104fdb5085ef9340996ae82d4b302f99c39c5d9d60d4ae55bcc7c1f58cb65e
 django-bitfield==2.0.1 \
@@ -583,10 +586,10 @@ xmlsec==1.3.3 \
 yamole==2.1.6 \
     --hash=sha256:e9b9af803cd856517a5e0ce2a44820c49b7626c83117118a064622829aa8c5a7 \
     --hash=sha256:ea094cc8acee25316c41ab515921253b8dff965e04ac68e922e11bf86aa1cee4
-https://github.com/zulip/python-zulip-api/archive/804501610b6a205334e71b4e441fca60acf650da.zip#egg=zulip==0.6.1_git&subdirectory=zulip \
-    --hash=sha256:270cebf4554a3a2fb1c95190168c952ef97081541ed2be0a83f00fb48e29928a
-https://github.com/zulip/python-zulip-api/archive/804501610b6a205334e71b4e441fca60acf650da.zip#egg=zulip_bots==0.6.1+git&subdirectory=zulip_bots \
-    --hash=sha256:270cebf4554a3a2fb1c95190168c952ef97081541ed2be0a83f00fb48e29928a
+https://github.com/zulip/python-zulip-api/archive/0.6.3.zip/#egg=zulip==0.6.3_git&subdirectory=zulip \
+    --hash=sha256:78a09c5e9f4177cab6f062dcb16c645b5814c07907fefaa6d0c196f28b9f6d95
+https://github.com/zulip/python-zulip-api/archive/0.6.3.zip/#egg=zulip_bots==0.6.3+git&subdirectory=zulip_bots \
+    --hash=sha256:78a09c5e9f4177cab6f062dcb16c645b5814c07907fefaa6d0c196f28b9f6d95
 zxcvbn==4.4.28 \
     --hash=sha256:151bd816817e645e9064c354b13544f85137ea3320ca3be1fb6873ea75ef7dc1
 

--- a/tools/circleci/Dockerfile.template
+++ b/tools/circleci/Dockerfile.template
@@ -92,7 +92,7 @@ RUN apt-get update \
     memcached rabbitmq-server redis-server \
     hunspell-en-us supervisor libssl-dev puppet \
     gettext libffi-dev libfreetype6-dev zlib1g-dev libjpeg-dev \
-    libldap2-dev libmemcached-dev python-dev python-pip \
+    libldap2-dev libmemcached-dev python-pip \
     python-six libxml2-dev libxslt1-dev libpq-dev \
     {extra_packages}
 

--- a/tools/circleci/images.yml
+++ b/tools/circleci/images.yml
@@ -5,3 +5,7 @@ xenial:
 bionic:
   base_image: buildpack-deps:bionic-scm
   extra_packages: postgresql-10 python-dev
+
+focal:
+  base_image: buildpack-deps:focal-scm
+  extra_packages: postgresql-12 python2-dev

--- a/tools/circleci/images.yml
+++ b/tools/circleci/images.yml
@@ -1,7 +1,7 @@
 xenial:
   base_image: buildpack-deps:xenial-scm
-  extra_packages: virtualenv postgresql-9.5
+  extra_packages: virtualenv postgresql-9.5 python-dev
 
 bionic:
   base_image: buildpack-deps:bionic-scm
-  extra_packages: postgresql-10
+  extra_packages: postgresql-10 python-dev

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -170,6 +170,8 @@ if vendor == 'debian' and os_version in [] or vendor == 'ubuntu' and os_version 
             "postgresql-server-dev-{0}",
             "libgroonga-dev",
             "libmsgpack-dev",
+            "clang-9",
+            "llvm-9-dev"
         ]
     ] + VENV_DEPENDENCIES
 elif "debian" in os_families():

--- a/version.py
+++ b/version.py
@@ -26,4 +26,4 @@ LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/12/13/zulip-2-1-relea
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '75.2'
+PROVISION_VERSION = '75.3'


### PR DESCRIPTION
1. Used get_venv_dependencies function to return the correct dependencies for RHEL, Centos, Fedora rather than importing them as separate
 COMMON_YUM_DEPENDENCIES in provision and create-production-venv.
2. Added support for python3.8.
3. Update the documentation to communicate Focal is supported in the development environment.
4. Added base image for focal 20.04.
5. CI running for focal.

Follow-ups for [PR14217](https://github.com/zulip/zulip/pull/14217)

Work Towards [#13738](https://github.com/zulip/zulip/issues/13738)
