### PR TITLE
auth: Set `development_only=True` for `SOCIAL_AUTH_GITLAB_KEY`.

### DIFF
--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -50,7 +50,7 @@ FAKE_LDAP_NUM_USERS = 8
 SOCIAL_AUTH_GITHUB_KEY = get_secret('social_auth_github_key', development_only=True)
 SOCIAL_AUTH_GITHUB_ORG_NAME = None  # type: Optional[str]
 SOCIAL_AUTH_GITHUB_TEAM_ID = None  # type: Optional[str]
-SOCIAL_AUTH_GITLAB_KEY = get_secret('social_auth_gitlab_key')
+SOCIAL_AUTH_GITLAB_KEY = get_secret('social_auth_gitlab_key', development_only=True)
 SOCIAL_AUTH_SUBDOMAIN = None  # type: Optional[str]
 SOCIAL_AUTH_AZUREAD_OAUTH2_SECRET = get_secret('azure_oauth2_secret')
 SOCIAL_AUTH_GOOGLE_KEY = get_secret('social_auth_google_key', development_only=True)


### PR DESCRIPTION
In development env, we use `get_secret` to get
`SOCIAL_AUTH_GITLAB_KEY` from `dev-secrets.conf`. But in
production env, we don't need this as we ask the user
to set that value in `prod_settings_template.py`.

This restricts the code from looking `zulip-secrets.conf`
for `social_auth_gitlab_key` in production env.

I Should have done this while adding GitLab auth. Didn't knew about that argument then.

**Testing Plan:** <!-- How have you tested? -->
Ran tests related to GitLab auth. All tests passed.
