### PR TITLE
docs: Add fix for vagrant network problem.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -135,6 +135,10 @@ set -o pipefail
 # something that we don't want to happen when running provision in a
 # development environment not using Vagrant.
 
+# Set up connection inside container
+IP=$(/sbin/ip route | awk '/defualt/ { print $3}')
+ip route add default via $IP
+
 # Set the Ubuntu mirror
 [ ! '#{ubuntu_mirror}' ] || sudo sed -i 's|http://\\(\\w*\\.\\)*archive\\.ubuntu\\.com/ubuntu/\\? |#{ubuntu_mirror} |' /etc/apt/sources.list
 

--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -752,6 +752,19 @@ If this is already enabled in your BIOS, double-check that you are running a
 For further information about troubleshooting vagrant timeout errors [see
 this post](http://stackoverflow.com/questions/22575261/vagrant-stuck-connection-timeout-retrying#22575302).
 
+#### Network related issues with vagrant
+
+If you are facing network issues inside vagrant machine even after having
+a stable network connection, you can add these lines in `$provision_script`
+variable:
+
+```
+# Set up connection inside container
+IP=$(/sbin/ip route | awk '/defualt/ { print $3}')
+ip route add default via $IP
+```
+in the VagrantFile present in your cloned directory.
+
 #### Vagrant was unable to communicate with the guest machine
 
 If you see the following error when you run `vagrant up`:


### PR DESCRIPTION
Vagrant sometimes fails to connect to the internet even after a stable internet connection. Due to it, provision and many tests fail to run. This commit adds a temporary fix in the documentation for this network issue([reference](https://github.com/hashicorp/vagrant/issues/8234#issuecomment-408554908)).
Temporary fix for #14300 