### PR TITLE
settings: Reorganize options and add new section in `Organization Per…

### DIFF
--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -30,6 +30,27 @@
                     <a data-toggle="modal" href="#realm_domains_modal">{{t "[Configure]" }}</a>
                     {{/if}}
                 </div>
+                <div class="input-group">
+                    <label for="realm_waiting_period_setting" class="dropdown-title">
+                        {{t "Waiting period before new members turn into full members" }}
+                        <a href="/help/restrict-permissions-of-new-members" target="_blank">
+                            <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+                        </a>
+                    </label>
+                    <select name="realm_waiting_period_setting" id="id_realm_waiting_period_setting" class="prop-element">
+                        <option value="none">{{t "None" }}</option>
+                        <option value="three_days">{{t "3 days" }}</option>
+                        <option value="custom_days">{{t "Custom" }}</option>
+                    </select>
+                </div>
+                {{!-- This setting is hidden unless `custom_days` --}}
+                <div class="dependent-block">
+                    <label for="aitin" class="inline-block">{{t "Waiting period (days)" }}:</label>
+                    <input type="text" id="id_realm_waiting_period_threshold"
+                      name="realm_waiting_period_threshold"
+                      class="admin-realm-time-limit-input prop-element"
+                      value="{{ realm_waiting_period_threshold }}"/>
+                </div>
             </div>
         </div>
 
@@ -57,6 +78,37 @@
                   is_checked=realm_avatar_changes_disabled
                   label=admin_settings_label.realm_avatar_changes_disabled}}
             </div>
+            <div class="input-group">
+                <label for="realm_email_address_visibility">{{t "Who can access user email addresses" }}
+                    <a href="/help/restrict-visibility-of-email-addresses" target="_blank">
+                        <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+                    </a>
+                </label>
+                <select name="realm_email_address_visibility" class="setting-widget prop-element" id="id_realm_email_address_visibility" data-setting-widget-type="integer">
+                    {{> dropdown_options_widget option_values=email_address_visibility_values}}
+                </select>
+            </div>
+        </div>
+
+        <div id="org-stream-permissions" class="org-subsection-parent">
+            <div class="subsection-header">
+                <h3>{{t "Stream permissions" }}</h3>
+                {{> settings_save_discard_widget section_name="stream-permissions" }}
+            </div>
+            <div class="m-10 inline-block organization-permissions-parent">
+                <div class="input-group">
+                    <label for="realm_create_stream_policy" class="dropdown-title">{{t "Who can create streams" }}</label>
+                    <select name="realm_create_stream_policy" id="id_realm_create_stream_policy" class="prop-element" data-setting-widget-type="integer">
+                        {{> dropdown_options_widget option_values=create_stream_policy_values}}
+                    </select>
+                </div>
+                <div class="input-group">
+                    <label for="realm_invite_to_stream_policy" class="dropdown-title">{{t "Who can add users to streams" }}</label>
+                    <select name="realm_invite_to_stream_policy" id="id_realm_invite_to_stream_policy" class="prop-element" data-setting-widget-type="integer">
+                        {{> dropdown_options_widget option_values=invite_to_stream_policy_values}}
+                    </select>
+                </div>
+            </div>
         </div>
 
         <div id="org-other-permissions" class="org-subsection-parent">
@@ -65,42 +117,6 @@
                 {{> settings_save_discard_widget section_name="other-permissions" }}
             </div>
             <div class="m-10 inline-block organization-permissions-parent">
-                <div class="input-group">
-                    <label for="realm_waiting_period_setting" class="dropdown-title">
-                        {{t "Waiting period before new members turn into full members" }}
-                        <a href="/help/restrict-permissions-of-new-members" target="_blank">
-                            <i class="fa fa-question-circle-o" aria-hidden="true"></i>
-                        </a>
-                    </label>
-                    <select name="realm_waiting_period_setting" id="id_realm_waiting_period_setting" class="prop-element">
-                        <option value="none">{{t "None" }}</option>
-                        <option value="three_days">{{t "3 days" }}</option>
-                        <option value="custom_days">{{t "Custom" }}</option>
-                    </select>
-                </div>
-                {{!-- This setting is hidden unless `custom_days` --}}
-                <div class="dependent-block">
-                    <label for="aitin" class="inline-block">{{t "Waiting period (days)" }}:</label>
-                    <input type="text" id="id_realm_waiting_period_threshold"
-                      name="realm_waiting_period_threshold"
-                      class="admin-realm-time-limit-input prop-element"
-                      value="{{ realm_waiting_period_threshold }}"/>
-                </div>
-
-                <div class="input-group">
-                    <label for="realm_create_stream_policy" class="dropdown-title">{{t "Who can create streams" }}</label>
-                    <select name="realm_create_stream_policy" id="id_realm_create_stream_policy" class="prop-element" data-setting-widget-type="integer">
-                        {{> dropdown_options_widget option_values=create_stream_policy_values}}
-                    </select>
-                </div>
-
-                <div class="input-group">
-                    <label for="realm_invite_to_stream_policy" class="dropdown-title">{{t "Who can add users to streams" }}</label>
-                    <select name="realm_invite_to_stream_policy" id="id_realm_invite_to_stream_policy" class="prop-element" data-setting-widget-type="integer">
-                        {{> dropdown_options_widget option_values=invite_to_stream_policy_values}}
-                    </select>
-                </div>
-
                 <div class="input-group">
                     <label for="realm_bot_creation_policy">{{t "Who can add bots" }}</label>
                     <select name="realm_bot_creation_policy" class="setting-widget prop-element" id="id_realm_bot_creation_policy" data-setting-widget-type="integer">
@@ -131,17 +147,6 @@
                     </label>
                     <select name="realm_private_message_policy" class="setting-widget prop-element" id="id_realm_private_message_policy" data-setting-widget-type="integer">
                         {{> dropdown_options_widget option_values=private_message_policy_values}}
-                    </select>
-                </div>
-
-                <div class="input-group">
-                    <label for="realm_email_address_visibility">{{t "Who can access user email addresses" }}
-                        <a href="/help/restrict-visibility-of-email-addresses" target="_blank">
-                            <i class="fa fa-question-circle-o" aria-hidden="true"></i>
-                        </a>
-                    </label>
-                    <select name="realm_email_address_visibility" class="setting-widget prop-element" id="id_realm_email_address_visibility" data-setting-widget-type="integer">
-                        {{> dropdown_options_widget option_values=email_address_visibility_values}}
                     </select>
                 </div>
             </div>


### PR DESCRIPTION
as a consequence of too many options in `Other permissions` section the `Save` button get far up for the bottom most settings.

This commit will reorganize these settings and add a new section so that `Save` button is easily reachable.

Fixes: #14274

Testing is done by manually changing the settings and check whether the settings are getting saved.

![Screenshot from 2020-03-24 02-27-00](https://user-images.githubusercontent.com/32801674/77362485-00ca1180-6d77-11ea-99e5-ff8f341e5975.png)

