### PR TITLE
[WIP]messages: Return shallow copy of object.

### DIFF
--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -2,6 +2,7 @@ import datetime
 import ujson
 import zlib
 import ahocorasick
+import copy
 
 from django.utils.translation import ugettext as _
 from django.utils.timezone import now as timezone_now
@@ -194,13 +195,20 @@ class MessageDict:
         MessageDict.bulk_hydrate_recipient_info(objs)
 
         for obj in objs:
-            MessageDict.finalize_payload(obj, apply_markdown, client_gravatar)
+            MessageDict._finalize_payload(obj, apply_markdown, client_gravatar)
 
     @staticmethod
     def finalize_payload(obj: Dict[str, Any],
                          apply_markdown: bool,
                          client_gravatar: bool,
-                         keep_rendered_content: bool=False) -> None:
+                         keep_rendered_content: bool=False) -> Dict[str, Any]:
+        new_obj = copy.copy(obj)
+        MessageDict._finalize_payload(new_obj, apply_markdown, client_gravatar, keep_rendered_content)
+        return new_obj
+
+    @staticmethod
+    def _finalize_payload(obj: Dict[str, Any], apply_markdown: bool, client_gravatar: bool,
+                          keep_rendered_content: bool=False) -> None:
         MessageDict.set_sender_avatar(obj, client_gravatar)
         if apply_markdown:
             obj['content_type'] = 'text/html'

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -32,8 +32,8 @@ class GenericOutgoingWebhookService(OutgoingWebhookServiceInterface):
         # outgoing webhook to indicate whether it wants the raw
         # Markdown or the rendered HTML, we leave both the content and
         # rendered_content fields in the message payload.
-        MessageDict.finalize_payload(event['message'], False, False,
-                                     keep_rendered_content=True)
+        event['message'] = MessageDict.finalize_payload(event['message'], False, False,
+                                                        keep_rendered_content=True)
 
         request_data = {"data": event['command'],
                         "message": event['message'],

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -2492,7 +2492,7 @@ class EditMessageTest(ZulipTestCase):
                       content: Optional[str]=None) -> Message:
         msg = Message.objects.get(id=msg_id)
         cached = MessageDict.wide_dict(msg)
-        MessageDict.finalize_payload(cached, apply_markdown=False, client_gravatar=False)
+        cached = MessageDict.finalize_payload(cached, apply_markdown=False, client_gravatar=False)
 
         uncached = MessageDict.to_dict_uncached_helper(msg)
         MessageDict.post_process_dicts([uncached], apply_markdown=False, client_gravatar=False)

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -2416,7 +2416,7 @@ class GetOldMessagesTest(ZulipTestCase):
         m.rendered_content = m.rendered_content_version = None
         m.content = 'test content'
         d = MessageDict.wide_dict(m)
-        MessageDict.finalize_payload(d, apply_markdown=True, client_gravatar=False)
+        d = MessageDict.finalize_payload(d, apply_markdown=True, client_gravatar=False)
         self.assertEqual(d['content'], '<p>test content</p>')
 
     def common_check_get_messages_query(self, query_params: Dict[str, object], expected: str) -> None:

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -841,7 +841,7 @@ def process_message_event(event_template: Mapping[str, Any], users: Iterable[Map
         if 'sender_delivery_email' not in dct:  # nocoverage
             dct['sender_delivery_email'] = dct['sender_email']
 
-        MessageDict.finalize_payload(dct, apply_markdown, client_gravatar)
+        dct = MessageDict.finalize_payload(dct, apply_markdown, client_gravatar)
         return dct
 
     # Extra user-specific data to include


### PR DESCRIPTION
When more than one outgoing webhooks are configured, the message which
is send to the webhook bot passes through finalise_payload fucntion
multiple times which mutated the message dict in a way that many keys
were lost from the dict obj.