### PR TITLE
[WIP] Recent topics

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -324,6 +324,7 @@
                 "realm_logo": false,
                 "realm_night_logo": false,
                 "recent_senders": false,
+                "recent_topics": false,
                 "reload": false,
                 "reload_state": false,
                 "reminder": false,

--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -96,6 +96,7 @@ set_global('alert_words', {});
 alert_words.process_message = noop;
 
 // We can also bring in real code:
+zrequire('muting');
 zrequire('recent_senders');
 zrequire('unread');
 zrequire('stream_topic_history');

--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -99,6 +99,7 @@ alert_words.process_message = noop;
 zrequire('recent_senders');
 zrequire('unread');
 zrequire('stream_topic_history');
+zrequire('recent_topics');
 
 // And finally require the module that we will test directly:
 zrequire('message_store');

--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -92,6 +92,8 @@ const messages = {
 const noop = () => undefined;
 
 set_global('alert_words', {});
+set_global('Handlebars', global.make_handlebars());
+set_global('$', global.make_zjquery());
 
 alert_words.process_message = noop;
 

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -11,6 +11,7 @@ zrequire('FetchStatus', 'js/fetch_status');
 zrequire('Filter', 'js/filter');
 zrequire('MessageListData', 'js/message_list_data');
 zrequire('message_list');
+zrequire('muting');
 zrequire('recent_topics');
 zrequire('people');
 

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -11,6 +11,7 @@ zrequire('FetchStatus', 'js/fetch_status');
 zrequire('Filter', 'js/filter');
 zrequire('MessageListData', 'js/message_list_data');
 zrequire('message_list');
+zrequire('recent_topics');
 zrequire('people');
 
 set_global('page_params', {

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -37,6 +37,7 @@ set_global('server_events', {});
 set_global('stream_list', {
     maybe_scroll_narrow_into_view: () => {},
 });
+set_global('Handlebars', global.make_handlebars());
 
 const alice = {
     email: 'alice@example.com',

--- a/frontend_tests/node_tests/recent_senders.js
+++ b/frontend_tests/node_tests/recent_senders.js
@@ -113,4 +113,7 @@ run_test('process_message_for_senders', () => {
         true);
 
     assert.equal(rs.compare_by_recency({}, {}, next_id += 1, ''), 0);
+
+    assert.equal(rs.get_topic_recent_senders(stream1, topic1)[0], 2);
+    assert.equal(rs.get_topic_recent_senders(stream1, topic1)[1], 1);
 });

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -1,0 +1,160 @@
+const rt = zrequire('recent_topics');
+
+const people = {
+    is_my_user_id: function (id) {
+        return id === 1;
+    },
+};
+
+set_global('people', people);
+
+// Custom Data
+
+// New stream
+const stream1 = 1;
+
+// Topics in the stream
+const topic1 = "topic-1";  // No Other sender
+const topic2 = "topic-2";  // Other sender
+const topic3 = "topic-3";  // User not present
+const topic4 = "topic-4";  // User not present
+const topic5 = "topic-5";  // other sender
+const topic6 = "topic-6";  // other sender
+
+// sender1 == current user
+// sender2 == any other user
+const sender1 = 1;
+const sender2 = 2;
+
+const messages = [];
+
+messages[0] = {
+    stream_id: stream1,
+    timestamp: 1000,
+    topic: topic1,
+    sender_id: sender1,
+    type: 'stream',
+};
+
+messages[1] = {
+    stream_id: stream1,
+    timestamp: 1010,
+    topic: topic2,
+    sender_id: sender1,
+    type: 'stream',
+};
+
+messages[2] = {
+    stream_id: stream1,
+    timestamp: messages[1].timestamp + 1,
+    topic: topic2,
+    sender_id: sender2,
+    type: 'stream',
+};
+
+messages[3] = {
+    stream_id: stream1,
+    timestamp: 1020,
+    topic: topic3,
+    sender_id: sender2,
+    type: 'stream',
+};
+
+messages[4] = {
+    stream_id: stream1,
+    timestamp: 1030,
+    topic: topic4,
+    sender_id: sender2,
+    type: 'stream',
+};
+
+messages[5] = {
+    stream_id: stream1,
+    timestamp: 1040,
+    topic: topic5,
+    sender_id: sender1,
+    type: 'stream',
+};
+
+messages[6] = {
+    stream_id: stream1,
+    timestamp: messages[5].timestamp + 1,
+    topic: topic5,
+    sender_id: sender2,
+    type: 'stream',
+};
+
+messages[7] = {
+    stream_id: stream1,
+    timestamp: 1050,
+    topic: topic6,
+    sender_id: sender1,
+    type: 'stream',
+};
+
+messages[8] = {
+    stream_id: stream1,
+    timestamp: messages[7].timestamp + 1,
+    topic: topic6,
+    sender_id: sender2,
+    type: 'stream',
+};
+
+run_test('basic assertions', () => {
+
+    rt.process_messages(messages);
+    let all_topics = rt.get();
+
+    // Check for expected lengths.
+    assert(all_topics.size, 4); // Participated in 4 topics.
+
+    // Last message was sent by us.
+    assert(all_topics.has(stream1 + ':' + topic1));
+
+    // Last message was sent by them.
+    assert(all_topics.has(stream1 + ':' + topic2));
+
+    // No message was sent by us.
+    assert(!all_topics.has(stream1 + ':' + topic3));
+    assert(!all_topics.has(stream1 + ':' + topic4));
+
+    // Last message was sent by them.
+    assert(all_topics.has(stream1 + ':' + topic5));
+    assert(all_topics.has(stream1 + ':' + topic6));
+
+    // Send new message to topic1
+    rt.process_message({
+        stream_id: stream1,
+        timestamp: messages[1].timestamp + 1,
+        topic: topic1,
+        sender_id: sender1,
+        type: 'stream',
+    });
+
+    // Send new message to topic5
+    rt.process_message({
+        stream_id: stream1,
+        timestamp: messages[6].timestamp + 2,
+        topic: topic5,
+        sender_id: sender2,
+        type: 'stream',
+    });
+
+    // Send new message to topic6
+    rt.process_message({
+        stream_id: stream1,
+        timestamp: messages[8].timestamp + 1,
+        topic: topic6,
+        sender_id: sender2,
+        type: 'stream',
+    });
+
+    all_topics = rt.get();
+
+    // Check for expected lengths.
+    assert(all_topics.size, 4); // Participated in 4 topics.
+    assert(all_topics.has(stream1 + ':' + topic1));
+    assert(all_topics.has(stream1 + ':' + topic5));
+    assert(all_topics.has(stream1 + ':' + topic6));
+
+});

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -1,4 +1,9 @@
 const rt = zrequire('recent_topics');
+zrequire('timerender');
+zrequire('hashchange');
+zrequire('unread');
+zrequire('hash_util');
+zrequire('stream_data');
 
 const people = {
     is_my_user_id: function (id) {
@@ -6,7 +11,13 @@ const people = {
     },
 };
 
-set_global('people', people);
+set_global('Handlebars', global.make_handlebars());
+set_global('$', global.make_zjquery());
+set_global('people', {
+    get_by_user_id: () => { return new Map(); },
+    is_my_user_id: people.is_my_user_id,
+});
+set_global('XDate', zrequire('XDate', 'xdate'));
 
 // Custom Data
 
@@ -126,6 +137,13 @@ messages[9] = {
 };
 
 run_test('basic assertions', () => {
+
+    $('#recent_topics_table').html = () => {};
+    // node throws error that helper t not defined
+    // without this.
+    global.stub_templates(function () {
+        return '<recent table stub>';
+    });
 
     rt.process_messages(messages);
     let all_topics = rt.get();

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -1,5 +1,4 @@
 const rt = zrequire('recent_topics');
-zrequire('timerender');
 zrequire('hashchange');
 zrequire('unread');
 zrequire('hash_util');
@@ -26,6 +25,16 @@ set_global('people', {
 set_global('XDate', zrequire('XDate', 'xdate'));
 set_global('recent_senders', {
     get_topic_recent_senders: () => { return [1, 2]; },
+});
+set_global('i18n', {
+    t: () => {
+        const time = new XDate(1000 * 1000);
+        return timerender.render_now(time).time_str;
+    },
+});
+set_global('timerender', {
+    render_now: () => timerender.render_now,
+    stringify_time: () => { return 'Today'; },
 });
 
 // Custom Data

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -21,6 +21,15 @@ const topic4 = "topic-4";  // User not present
 const topic5 = "topic-5";  // other sender
 const topic6 = "topic-6";  // other sender
 
+const topic7 = "topic-7";  // muted topic
+set_global('muting', {
+    get_muted_topics: () => {
+        return [
+            (stream1, topic7),
+        ];
+    },
+});
+
 // sender1 == current user
 // sender2 == any other user
 const sender1 = 1;
@@ -100,6 +109,14 @@ messages[8] = {
     type: 'stream',
 };
 
+messages[9] = {
+    stream_id: stream1,
+    timestamp: 1060,
+    topic: topic7,
+    sender_id: sender1,
+    type: 'stream',
+};
+
 run_test('basic assertions', () => {
 
     rt.process_messages(messages);
@@ -146,6 +163,15 @@ run_test('basic assertions', () => {
         timestamp: messages[8].timestamp + 1,
         topic: topic6,
         sender_id: sender2,
+        type: 'stream',
+    });
+
+    // Send new message to topic7 (muted)
+    rt.process_message({
+        stream_id: stream1,
+        timestamp: messages[8].timestamp + 1,
+        topic: topic7,
+        sender_id: sender1,
         type: 'stream',
     });
 

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -37,6 +37,14 @@ const sender2 = 2;
 
 const messages = [];
 
+set_global('message_list', {
+    all: {
+        all_messages: function () {
+            return messages;
+        },
+    },
+});
+
 messages[0] = {
     stream_id: stream1,
     timestamp: 1000,
@@ -183,4 +191,14 @@ run_test('basic assertions', () => {
     assert(all_topics.has(stream1 + ':' + topic5));
     assert(all_topics.has(stream1 + ':' + topic6));
 
+});
+
+run_test('process_topic', () => {
+
+    rt.topics = new Map();
+    rt.process_topic(stream1, topic1);
+
+    const all_topics = rt.get();
+
+    assert(all_topics.size, 1); // Only 1 msg in the topic.
 });

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -10,7 +10,13 @@ const people = {
         return id === 1;
     },
 };
-
+set_global('overlays', {
+    close_callback: () => {},
+    open_overlay: (opts) => {
+        overlays.close_callback = opts.on_close;
+    },
+});
+zrequire('hashchange');
 set_global('Handlebars', global.make_handlebars());
 set_global('$', global.make_zjquery());
 set_global('people', {
@@ -219,4 +225,9 @@ run_test('process_topic', () => {
     const all_topics = rt.get();
 
     assert(all_topics.size, 1); // Only 1 msg in the topic.
+});
+
+run_test('launch', () => {
+    rt.launch();
+    overlays.close_callback();
 });

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -24,6 +24,9 @@ set_global('people', {
     is_my_user_id: people.is_my_user_id,
 });
 set_global('XDate', zrequire('XDate', 'xdate'));
+set_global('recent_senders', {
+    get_topic_recent_senders: () => { return [1, 2]; },
+});
 
 // Custom Data
 

--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -192,6 +192,7 @@ import "../ui_init.js";
 import "../emoji_picker.js";
 import "../compose_ui.js";
 import "../panels.js";
+import "../recent_topics.js";
 import "../settings_ui.js";
 import "../search_pill.js";
 import "../search_pill_widget.js";

--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -222,6 +222,7 @@ import "../../styles/left-sidebar.scss";
 import "../../styles/right-sidebar.scss";
 import "../../styles/lightbox.scss";
 import "../../styles/popovers.scss";
+import "../../styles/recents.scss";
 import "../../styles/typing_notifications.scss";
 import "../../styles/hotspots.scss";
 import "../../styles/night_mode.scss";

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -346,6 +346,14 @@ exports.initialize = function () {
         muting_ui.mute(stream_id, topic);
     });
 
+    // MARK TOPIC AS READ
+    $('body').on('click', '.on_hover_topic_read', function (e) {
+        e.stopPropagation();
+        const stream_id = parseInt($(e.currentTarget).attr('data-stream-id'), 10);
+        const topic = $(e.currentTarget).attr('data-topic-name');
+        unread_ops.mark_topic_as_read(stream_id, topic);
+    });
+
     // RECIPIENT BARS
 
     function get_row_id_for_narrowing(narrow_link_elem) {

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -346,12 +346,19 @@ exports.initialize = function () {
         muting_ui.mute(stream_id, topic);
     });
 
-    // MARK TOPIC AS READ
+    // RECENT TOPIC UI HANDLERS
     $('body').on('click', '.on_hover_topic_read', function (e) {
         e.stopPropagation();
         const stream_id = parseInt($(e.currentTarget).attr('data-stream-id'), 10);
         const topic = $(e.currentTarget).attr('data-topic-name');
         unread_ops.mark_topic_as_read(stream_id, topic);
+    });
+
+    $('body').on('click', '.on_hover_topic_bookmark', function (e) {
+        e.stopPropagation();
+        const stream_id = parseInt($(e.currentTarget).attr('data-stream-id'), 10);
+        const topic = $(e.currentTarget).attr('data-topic-name');
+        recent_topics.toggle_bookmark_topic(stream_id, topic);
     });
 
     // RECIPIENT BARS

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -371,6 +371,19 @@ exports.initialize = function () {
         recent_topics.set_filter(filter);
     });
 
+    // All table rows without header
+    $('body').on('keyup', '#recent_topics_search', _.debounce(function () {
+        const $rows = $('.recents_table tr').slice(1);
+        const val = '^(?=.*\\b' + $.trim($(this).val()).split(/\s+/).join('\\b)(?=.*\\b') + ').*$';
+        const reg = RegExp(val, 'i');
+        let text;
+
+        $rows.show().filter(function () {
+            text = $(this).text().replace(/\s+/g, ' ');
+            return !reg.test(text);
+        }).hide();
+    }, 300));
+
     // RECIPIENT BARS
 
     function get_row_id_for_narrowing(narrow_link_elem) {

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -612,6 +612,11 @@ exports.initialize = function () {
         compose_actions.cancel();
     });
 
+    $("#recenttopics-popup-button").click(function (e) {
+        e.stopPropagation();
+        hashchange.go_to_location('recents');
+    });
+
     $("#streams_inline_cog").click(function (e) {
         e.stopPropagation();
         hashchange.go_to_location('streams/subscribed');

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -361,6 +361,16 @@ exports.initialize = function () {
         recent_topics.toggle_bookmark_topic(stream_id, topic);
     });
 
+    $('body').on('click', '.btn-recent-filters', function (e) {
+        e.stopPropagation();
+        if ($(e.currentTarget).hasClass('btn-recent-selected')) {
+            return;
+        }
+        const filter = e.currentTarget.dataset.filter;
+        // $('.btn-recent-filters').removeClass('btn-recent-selected');
+        recent_topics.set_filter(filter);
+    });
+
     // RECIPIENT BARS
 
     function get_row_id_for_narrowing(narrow_link_elem) {

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -363,12 +363,7 @@ exports.initialize = function () {
 
     $('body').on('click', '.btn-recent-filters', function (e) {
         e.stopPropagation();
-        if ($(e.currentTarget).hasClass('btn-recent-selected')) {
-            return;
-        }
-        const filter = e.currentTarget.dataset.filter;
-        // $('.btn-recent-filters').removeClass('btn-recent-selected');
-        recent_topics.set_filter(filter);
+        recent_topics.set_filter(e.currentTarget.dataset.filter);
     });
 
     // All table rows without header

--- a/static/js/global.d.ts
+++ b/static/js/global.d.ts
@@ -99,6 +99,7 @@ declare let reactions: any;
 declare let realm_icon: any;
 declare let realm_logo: any;
 declare let recent_senders: any;
+declare let recent_topics: any;
 declare let reload: any;
 declare let reload_state: any;
 declare let reminder: any;

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -63,7 +63,7 @@ const state = {
 
 function is_overlay_hash(hash) {
     // Hash changes within this list are overlays and should not unnarrow (etc.)
-    const overlay_list = ["streams", "drafts", "settings", "organization", "invite"];
+    const overlay_list = ["streams", "drafts", "settings", "organization", "invite", "recents"];
     const main_hash = hash_util.get_hash_category(hash);
 
     return overlay_list.includes(main_hash);
@@ -122,6 +122,7 @@ function do_hashchange_normal(from_reload) {
     case "#streams":
     case "#organization":
     case "#settings":
+    case "#recents":
         blueslip.error('overlay logic skipped for: ' + hash);
         break;
     }
@@ -223,6 +224,11 @@ function do_hashchange_overlay(old_hash) {
 
     if (base === "invite") {
         invite.launch();
+        return;
+    }
+
+    if (base === 'recents') {
+        recent_topics.launch();
         return;
     }
 }

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -106,6 +106,7 @@ const keypress_mappings = {
     113: {name: 'query_streams', message_view_only: true}, // 'q'
     114: {name: 'reply_message', message_view_only: true}, // 'r'
     115: {name: 'narrow_by_recipient', message_view_only: true}, // 's'
+    116: {name: 'open_recents', message_view_only: true}, // 't'
     117: {name: 'show_sender_info', message_view_only: true}, // 'u'
     118: {name: 'show_lightbox', message_view_only: true}, // 'v'
     119: {name: 'query_users', message_view_only: true}, // 'w'
@@ -464,6 +465,10 @@ exports.process_hotkey = function (e, hotkey) {
             overlays.close_overlay('drafts');
             return true;
         }
+        if (event_name === 'open_recents' && overlays.recents_open()) {
+            overlays.close_overlay('recents');
+            return true;
+        }
         return false;
     }
 
@@ -665,6 +670,9 @@ exports.process_hotkey = function (e, hotkey) {
         return true;
     case 'copy_with_c':
         copy_and_paste.copy_handler();
+        return true;
+    case 'open_recents':
+        recent_topics.launch();
         return true;
     }
 

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -303,6 +303,16 @@ exports.update_messages = function update_messages(events) {
 
         notifications.received_messages([msg]);
         alert_words.process_message(msg);
+
+        if (topic_edited) {
+            const stream_id = event.stream_id;
+            const old_topic = util.get_edit_event_orig_topic(event);
+
+            // reprocess the old and new topics.
+            [old_topic, new_topic].forEach((topic) => {
+                recent_topics.process_topic(stream_id, topic);
+            });
+        }
     }
 
     // If a topic was edited, we re-render the whole view to get any

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -308,6 +308,7 @@ exports.update_messages = function update_messages(events) {
             const stream_id = event.stream_id;
             const old_topic = util.get_edit_event_orig_topic(event);
 
+            recent_senders.process_topic_edit(stream_id, old_topic, new_topic);
             // reprocess the old and new topics.
             [old_topic, new_topic].forEach((topic) => {
                 recent_topics.process_topic(stream_id, topic);

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -99,6 +99,7 @@ exports.insert_new_messages = function insert_new_messages(messages, sent_by_thi
     notifications.received_messages(messages);
     stream_list.update_streams_sidebar();
     pm_list.update_private_messages();
+    recent_topics.process_messages(messages);
 };
 
 exports.update_messages = function update_messages(events) {

--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -49,6 +49,7 @@ function process_result(data, opts) {
     activity.process_loaded_messages(messages);
     stream_list.update_streams_sidebar();
     pm_list.update_private_messages();
+    recent_topics.process_messages(messages);
 
     if (opts.pre_scroll_cont !== undefined) {
         opts.pre_scroll_cont(data);

--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -112,6 +112,7 @@ exports.mute = function (stream_id, topic) {
         title_text: i18n.t("Topic muted"),
         undo_button_text: i18n.t("Unmute"),
     });
+    recent_topics.update_muted_topics();
 };
 
 exports.unmute = function (stream_id, topic) {
@@ -124,6 +125,7 @@ exports.unmute = function (stream_id, topic) {
     exports.rerender();
     exports.persist_unmute(stream_id, topic);
     feedback_widget.dismiss();
+    recent_topics.process_topic(stream_id, topic);
 };
 
 exports.toggle_mute = function (message) {

--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -36,6 +36,10 @@ exports.drafts_open = function () {
     return open_overlay_name === 'drafts';
 };
 
+exports.recents_open = function () {
+    return open_overlay_name === 'recents';
+};
+
 // To address bugs where mouse might apply to the streams/settings
 // overlays underneath an open modal within those settings UI, we add
 // this inline style to '.overlay.show', overriding the

--- a/static/js/recent_senders.js
+++ b/static/js/recent_senders.js
@@ -61,4 +61,18 @@ exports.compare_by_recency = function (user_a, user_b, stream_id, topic) {
     return 0;
 };
 
+exports.get_topic_recent_senders = function (stream_id, topic) {
+    const topic_dict = topic_senders.get(stream_id);
+    let sender_message_ids = new Map();
+    if (topic_dict !== undefined) {
+        sender_message_ids = topic_dict.get(topic);
+    }
+    const sorted_senders = Array.from(sender_message_ids.entries()).sort(
+        (s1, s2) => { return s1[1] - s2[1]; }
+    );
+    const recent_senders = [];
+    sorted_senders.forEach((item) => { recent_senders.push(item[0]); });
+    return recent_senders;
+};
+
 window.recent_senders = exports;

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -1,3 +1,5 @@
+const util = require("./util");
+
 const topics = new Map(); // Key is stream-id:topic.
 
 exports.process_messages = function (messages) {
@@ -58,6 +60,15 @@ exports.update_muted_topics = function () {
         const key = elem.stream_id + ':' + elem.topic;
         topics.delete(key);
     }
+};
+
+exports.process_topic = function (stream_id, topic) {
+    // Delete topic if it exists
+    // and procoess it again, this ensures that we haven't
+    // missed processing any msg.
+    topics.delete(stream_id + ':' + topic);
+    const msgs = util.get_messages_in_topic(stream_id, topic);
+    exports.process_messages(msgs);
 };
 
 window.recent_topics = exports;

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -72,8 +72,32 @@ exports.process_topic = function (stream_id, topic) {
     exports.process_messages(msgs);
 };
 
+function format_values() {
+    const topics_array = [];
+    exports.get().forEach(function (elem, key) {
+        const stream_name = stream_data.maybe_get_stream_name(
+            elem.last_msg.stream_id) || elem.last_msg.stream_name;
+        const stream_id = parseInt(key.split(':')[0], 10);
+        const topic = key.split(':')[1];
+        const time = new XDate(elem.last_msg.timestamp * 1000);
+        const time_stamp = timerender.last_seen_status_from_date(time);
+        topics_array.push({
+            stream_id: stream_id,
+            stream_name: stream_name,
+            topic: topic,
+            unread_count: unread.unread_topic_counter.get(stream_id, topic),
+            timestamp: time_stamp,
+            stream_url: hash_util.by_stream_uri(stream_id),
+            topic_url: hash_util.by_stream_topic_uri(stream_id, topic),
+        });
+    });
+    return topics_array;
+}
+
 exports.launch = function () {
-    const rendered_body = render_recent_topics_body();
+    const rendered_body = render_recent_topics_body({
+        recent_topics: format_values(),
+    });
     $('#recent_topics_table').html(rendered_body);
 
     overlays.open_overlay({

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -5,6 +5,7 @@ const topics = new Map(); // Key is stream-id:topic.
 
 exports.process_messages = function (messages) {
     messages.forEach(exports.process_message);
+    // exports.update() is called via this call too
     exports.update_muted_topics();
 };
 
@@ -61,6 +62,7 @@ exports.update_muted_topics = function () {
         const key = elem.stream_id + ':' + elem.topic;
         topics.delete(key);
     }
+    exports.update();
 };
 
 exports.process_topic = function (stream_id, topic) {

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -94,11 +94,15 @@ function format_values() {
     return topics_array;
 }
 
-exports.launch = function () {
+exports.update = function () {
     const rendered_body = render_recent_topics_body({
         recent_topics: format_values(),
     });
     $('#recent_topics_table').html(rendered_body);
+};
+
+exports.launch = function () {
+    exports.update();
 
     overlays.open_overlay({
         name: 'recents',

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -1,4 +1,5 @@
 const util = require("./util");
+const render_recent_topics_body = require('../templates/recent_topics_list.hbs');
 
 const topics = new Map(); // Key is stream-id:topic.
 
@@ -69,6 +70,19 @@ exports.process_topic = function (stream_id, topic) {
     topics.delete(stream_id + ':' + topic);
     const msgs = util.get_messages_in_topic(stream_id, topic);
     exports.process_messages(msgs);
+};
+
+exports.launch = function () {
+    const rendered_body = render_recent_topics_body();
+    $('#recent_topics_table').html(rendered_body);
+
+    overlays.open_overlay({
+        name: 'recents',
+        overlay: $('#recent_overlay'),
+        on_close: function () {
+            hashchange.exit_overlay();
+        },
+    });
 };
 
 window.recent_topics = exports;

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -1,0 +1,55 @@
+const topics = new Map(); // Key is stream-id:topic.
+
+exports.process_messages = function (messages) {
+    messages.forEach(exports.process_message);
+};
+
+function reduce_message(msg) {
+    return {
+        id: msg.id,
+        timestamp: msg.timestamp,
+        stream_id: msg.stream_id,
+        stream_name: msg.stream,
+        topic: msg.topic,
+        sender_id: msg.sender_id,
+        type: msg.type,
+    };
+}
+
+exports.process_message = function (msg) {
+    const is_ours = people.is_my_user_id(msg.sender_id);
+    // only process stream msgs in which current user's msg is present.
+    const is_relevant = is_ours && msg.type === 'stream';
+    const key = msg.stream_id + ':' + msg.topic;
+    const topic = topics.get(key);
+    // Process msg if it's not user's but we are tracking the topic.
+    if (topic === undefined && !is_relevant) {
+        return false;
+    }
+    // Add new topic if msg is_relevant
+    if (!topic) {
+        topics.set(key, {
+            last_msg: reduce_message(msg),
+        });
+        return true;
+    }
+    // Update last messages sent to topic.
+    if (topic.last_msg.timestamp <= msg.timestamp) {
+        topic.last_msg = reduce_message(msg);
+    }
+    topics.set(key, topic);
+    return true;
+};
+
+function get_sorted_topics() {
+    // Sort all recent topics by last message time.
+    return new Map(Array.from(topics.entries()).sort(function (a, b) {
+        return  b[1].last_msg.timestamp -  a[1].last_msg.timestamp;
+    }));
+}
+
+exports.get = function () {
+    return get_sorted_topics();
+};
+
+window.recent_topics = exports;

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -2,6 +2,7 @@ const topics = new Map(); // Key is stream-id:topic.
 
 exports.process_messages = function (messages) {
     messages.forEach(exports.process_message);
+    exports.update_muted_topics();
 };
 
 function reduce_message(msg) {
@@ -50,6 +51,13 @@ function get_sorted_topics() {
 
 exports.get = function () {
     return get_sorted_topics();
+};
+
+exports.update_muted_topics = function () {
+    for (const elem of muting.get_muted_topics()) {
+        const key = elem.stream_id + ':' + elem.topic;
+        topics.delete(key);
+    }
 };
 
 window.recent_topics = exports;

--- a/static/js/starred_messages.js
+++ b/static/js/starred_messages.js
@@ -13,14 +13,15 @@ exports.initialize = function () {
 exports.add = function (ids) {
     for (const id of ids) {
         exports.ids.add(id);
+        recent_topics.change_starred(id, 'add');
     }
-
     exports.rerender_ui();
 };
 
 exports.remove = function (ids) {
     for (const id of ids) {
         exports.ids.delete(id);
+        recent_topics.change_starred(id, 'remove');
     }
 
     exports.rerender_ui();
@@ -34,6 +35,17 @@ exports.get_starred_msg_ids = function () {
     return Array.from(exports.ids);
 };
 
+exports.unstar_topic = function (stream_id, topic) {
+    const all_starred = exports.get_starred_msg_ids();
+    all_starred.forEach((msg_id) => {
+        const message = message_store.get(msg_id);
+        if (message.stream_id === stream_id &&
+                message.topic.toLowerCase() === topic.toLowerCase()) {
+            message_flags.toggle_starred_and_update_server(message);
+        }
+    });
+};
+
 exports.rerender_ui = function () {
     let count = exports.count();
 
@@ -43,6 +55,7 @@ exports.rerender_ui = function () {
     }
 
     top_left_corner.update_starred_count(count);
+    recent_topics.update();
 };
 
 window.starred_messages = exports;

--- a/static/js/unread_ui.js
+++ b/static/js/unread_ui.js
@@ -46,6 +46,7 @@ exports.update_unread_counts = function () {
     stream_list.update_dom_with_unread_counts(res);
     pm_list.update_dom_with_unread_counts(res);
     topic_list.update();
+    recent_topics.update();
     notifications.update_pm_count(res.private_message_count);
     const notifiable_unread_count = unread.calculate_notifiable_count(res);
     notifications.update_title_count(notifiable_unread_count);

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -332,3 +332,11 @@ exports.clean_user_content_links = function (html) {
     }
     return content.innerHTML;
 };
+
+exports.get_messages_in_topic = function (stream_id, topic) {
+    return message_list.all.all_messages().filter(x => {
+        return x.type === 'stream' &&
+               x.stream_id === stream_id &&
+               x.topic === topic;
+    });
+}

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -59,7 +59,8 @@ li.show-more-topics {
 }
 
 #streams_inline_cog,
-#streams_filter_icon {
+#streams_filter_icon,
+#recenttopics-popup-button {
     float: right;
     opacity: 0.50;
     font-size: 13px;

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -377,6 +377,7 @@ on a dark background, and don't change the dark labels dark either. */
 
     thead,
     .drafts-container .drafts-header,
+    .recents-container .recents-header,
     .nav > li > a:hover,
     .subscriptions-container .subscriptions-header,
     .grey-box,

--- a/static/styles/recents.scss
+++ b/static/styles/recents.scss
@@ -1,0 +1,59 @@
+.recents-container {
+    position: relative;
+    height: 95%;
+    background-color: hsl(0, 0%, 100%);
+    border-radius: 4px;
+    padding: 0px;
+    width: 58%;
+    overflow: hidden;
+    max-width: 1200px;
+    max-height: 1000px;
+    display: flex;
+    flex-direction: column;
+
+    @media (max-width: 1130px) {
+        max-width: 60%;
+    }
+
+    @media (max-width: 700px) {
+        height: 95%;
+        max-width: none;
+        width: 90%;
+    }
+
+    .recents-header {
+        padding-top: 4px;
+        padding-bottom: 8px;
+        text-align: center;
+        border-bottom: 1px solid hsl(0, 0%, 87%);
+
+        h1 {
+            margin: 0;
+            font-size: 1.1em;
+            text-transform: uppercase;
+        }
+
+        .exit {
+            font-weight: 400;
+            position: absolute;
+            top: 10px;
+            right: 10px;
+            color: hsl(0, 0%, 67%);
+            cursor: pointer;
+
+            .exit-sign {
+                position: relative;
+                top: 3px;
+                margin-left: 3px;
+                font-size: 1.5rem;
+                font-weight: 600;
+                cursor: pointer;
+            }
+        }
+    }
+
+    .recents-list {
+        margin: auto;
+        overflow: auto;
+    }
+}

--- a/static/styles/recents.scss
+++ b/static/styles/recents.scss
@@ -55,5 +55,47 @@
     .recents-list {
         margin: auto;
         overflow: auto;
+
+        .recent_avatars {
+            display: inline-flex; /* Causes LI items to display in row. */
+            list-style-type: none;
+            margin: auto; /* Centers vertically / horizontally in flex container. */
+            height: 15px !important;
+
+            /*
+                By using the row-reverse layout, the visual ordering will be opposite of
+                the DOM ordering. This will allows us to stack the items in the opposite
+                direction of the natural stacking order without having to mess with the
+                zIndex value. The MAJOR DOWNSIDE is that the HTML itself now reads
+                backwards, which super janky.
+            */
+            flex-direction: row-reverse;
+        }
+
+        .recent_avatars__item {
+            height: 15px;
+            margin: 0px 0px 0px 0px;
+            padding: 0px 0px 0px 0px;
+            position: relative;
+            width: 15px; /* Forces flex items to be smaller than their contents. */
+        }
+
+        .recent_avatars__img,
+        .recent_avatars__initials,
+        .recent_avatars__others {
+            border: 1px solid hsl(221.1, 23.5%, 15.9%);
+            border-left: 0 !important;
+            border-radius: 6px;
+            color: hsl(0, 0%, 100%);
+            display: block;
+            height: 15px;
+            line-height: 15px;
+            text-align: center;
+            width: 15px;
+        }
+
+        .recent_avatars__others {
+            background-color: hsl(205.2, 76.5%, 50%);
+        }
     }
 }

--- a/static/styles/recents.scss
+++ b/static/styles/recents.scss
@@ -7,7 +7,7 @@
     width: 58%;
     overflow: hidden;
     max-width: 1200px;
-    max-height: 1000px;
+    max-height: 70vh;
     display: flex;
     flex-direction: column;
 
@@ -53,7 +53,6 @@
     }
 
     .recents-list {
-        margin: auto;
         overflow: auto;
 
         .recent_avatars {

--- a/static/styles/recents.scss
+++ b/static/styles/recents.scss
@@ -21,6 +21,11 @@
         width: 90%;
     }
 
+    #recent_topics_search {
+        @media (max-width: 1250px) {
+            margin-top: 10px;
+        }
+    }
 
     .recents-list {
         overflow: hidden !important;

--- a/static/styles/recents.scss
+++ b/static/styles/recents.scss
@@ -21,6 +21,19 @@
         width: 90%;
     }
 
+
+    .recents-list {
+        overflow: hidden !important;
+    }
+
+    .tableFixHead {
+        padding: 10px;
+        padding-top: 0px !important;
+        overflow-y: auto;
+        max-height: 100%;
+    }
+    .tableFixHead thead th { position: sticky; top: 0; z-index: 1000;}
+
     .recents-header {
         padding-top: 4px;
         padding-bottom: 8px;

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1090,11 +1090,13 @@ a.message_label_clickable:hover {
     opacity: 1.0;
 }
 
-.on_hover_topic_mute {
+.on_hover_topic_mute,
+.on_hover_topic_read {
     opacity: 0.2;
 }
 
-.on_hover_topic_mute:hover {
+.on_hover_topic_mute:hover,
+.on_hover_topic_read:hover {
     cursor: pointer;
     opacity: 1.0;
 }

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1105,7 +1105,7 @@ a.message_label_clickable:hover {
 }
 
 #recent_topics_filter_buttons {
-    margin-bottom: 10px;
+    padding: 10px;
 }
 
 #recent_topics_search {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1091,14 +1091,17 @@ a.message_label_clickable:hover {
 }
 
 .on_hover_topic_mute,
-.on_hover_topic_read {
+.on_hover_topic_read,
+.on_hover_topic_bookmark {
     opacity: 0.2;
+    &:hover {
+        cursor: pointer;
+        opacity: 1.0;
+    }
 }
 
-.on_hover_topic_mute:hover,
-.on_hover_topic_read:hover {
-    cursor: pointer;
-    opacity: 1.0;
+.bookmarked {
+    opacity: 1.0 !important;
 }
 
 .edit_content {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1108,6 +1108,11 @@ a.message_label_clickable:hover {
     margin-bottom: 10px;
 }
 
+#recent_topics_search {
+    margin-left: 20px !important;
+    width: 350px !important;
+}
+
 .btn-recent-filters {
     border-radius: 40px;    
 }

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1104,6 +1104,18 @@ a.message_label_clickable:hover {
     opacity: 1.0 !important;
 }
 
+#recent_topics_filter_buttons {
+    margin-bottom: 10px;
+}
+
+.btn-recent-filters {
+    border-radius: 40px;    
+}
+
+.btn-recent-selected {
+    background-color: hsl(0, 4%, 80%) !important;
+}
+
 .edit_content {
     width: 12px;
     display: inline-block;

--- a/static/templates/recent.hbs
+++ b/static/templates/recent.hbs
@@ -1,6 +1,10 @@
 <tr id="{{stream_id}}:{{topic}}">
     <td class="recent_unread_count">
+        {{#if unread_count}}
         {{unread_count}}
+        {{else}}
+        <i class="fa fa-check" aria-hidden="true"></i>
+        {{/if}}
     </td>
     <td class="recent_stream_name">
         <a href="{{stream_url}}">{{stream_name}}</a>

--- a/static/templates/recent.hbs
+++ b/static/templates/recent.hbs
@@ -1,0 +1,21 @@
+<tr id="{{stream_id}}:{{topic}}">
+    <td class="recent_unread_count">
+        {{unread_count}}
+    </td>
+    <td class="recent_stream_name">
+        <a href="{{stream_url}}">{{stream_name}}</a>
+    </td>
+    <td class="recent_topic_name">
+        <a href="{{topic_url}}">{{topic}}</a>
+    </td>
+    <td class="recent_actions">
+        <i class="fa fa-bell-slash on_hover_topic_mute recipient_bar_icon" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Mute topic' }} (M)" role="button" tabindex="0" aria-label="{{t 'Mute topic' }} (M)"></i>
+        <i class="fa fa-check-circle on_hover_topic_read recipient_bar_icon" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Mark as read' }} (R)" role="button" tabindex="0" aria-label="{{t 'Mark as read' }} (R)"></i>
+    </td>
+    <td class='recent_users'>
+        {{!-- USER ICONS --}}
+    </td>
+    <td class="recent_timestamp">
+        {{ timestamp }}
+    </td>
+</tr>

--- a/static/templates/recent.hbs
+++ b/static/templates/recent.hbs
@@ -13,7 +13,17 @@
         <i class="fa fa-check-circle on_hover_topic_read recipient_bar_icon" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Mark as read' }} (R)" role="button" tabindex="0" aria-label="{{t 'Mark as read' }} (R)"></i>
     </td>
     <td class='recent_users'>
-        {{!-- USER ICONS --}}
+        <ul class="recent_avatars">
+            <li class="recent_avatars__item">
+                <span class="recent_avatars__others">+3</span>
+            </li>
+            <li class="recent_avatars__item">
+                <img src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d=identicon&version=1&s=50" class="recent_avatars__img" />
+            </li>
+            <li class="recent_avatars__item">
+                <img src="https://secure.gravatar.com/avatar/6d8cad0fd00256e7b40691d27ddfd466?d=identicon&version=1&s=50" class="recent_avatars__img" />
+            </li>
+        </ul>
     </td>
     <td class="recent_timestamp">
         {{ timestamp }}

--- a/static/templates/recent.hbs
+++ b/static/templates/recent.hbs
@@ -14,15 +14,16 @@
     </td>
     <td class='recent_users'>
         <ul class="recent_avatars">
+            {{#if count_senders}}
             <li class="recent_avatars__item">
-                <span class="recent_avatars__others">+3</span>
+                <span class="recent_avatars__others">+{{count_senders}}</span>
             </li>
-            <li class="recent_avatars__item">
-                <img src="https://secure.gravatar.com/avatar/0f030c97ab51312c7bbffd3966198ced?d=identicon&version=1&s=50" class="recent_avatars__img" />
+            {{/if}}
+            {{#each senders}}
+            <li class="recent_avatars__item" title="{{this.full_name}}">
+                <img src="{{this.avatar_url}}" class="recent_avatars__img" />
             </li>
-            <li class="recent_avatars__item">
-                <img src="https://secure.gravatar.com/avatar/6d8cad0fd00256e7b40691d27ddfd466?d=identicon&version=1&s=50" class="recent_avatars__img" />
-            </li>
+            {{/each}}
         </ul>
     </td>
     <td class="recent_timestamp">

--- a/static/templates/recent.hbs
+++ b/static/templates/recent.hbs
@@ -15,6 +15,7 @@
     <td class="recent_actions">
         <i class="fa fa-bell-slash on_hover_topic_mute recipient_bar_icon" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Mute topic' }} (M)" role="button" tabindex="0" aria-label="{{t 'Mute topic' }} (M)"></i>
         <i class="fa fa-check-circle on_hover_topic_read recipient_bar_icon" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Mark as read' }} (R)" role="button" tabindex="0" aria-label="{{t 'Mark as read' }} (R)"></i>
+        <i class="fa fa-bookmark on_hover_topic_bookmark recipient_bar_icon {{#if bookmarked}}bookmarked{{/if}}" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Mark as read' }} (R)" role="button" tabindex="0" aria-label="{{t 'Mark as read' }} (R)"></i>
     </td>
     <td class='recent_users'>
         <ul class="recent_avatars">

--- a/static/templates/recent_topics_list.hbs
+++ b/static/templates/recent_topics_list.hbs
@@ -1,0 +1,12 @@
+<table>
+    {{!-- DO WE NEED HEADERS? (THEY DON'T LOOK BAD :) --}}
+    <tr>
+        <th>Unread</th>
+        <th>Stream</th>
+        <th>Topic</th>
+        <th>Actions</th>
+        <th>Active Users</th>
+        <th>Last message</th>
+    </tr>
+    {{!-- RECENT TOPICS LIST --}}
+</table>

--- a/static/templates/recent_topics_list.hbs
+++ b/static/templates/recent_topics_list.hbs
@@ -9,4 +9,7 @@
         <th>Last message</th>
     </tr>
     {{!-- RECENT TOPICS LIST --}}
+    {{#each recent_topics}}
+    {{> recent}}
+    {{/each}}
 </table>

--- a/static/templates/recent_topics_list.hbs
+++ b/static/templates/recent_topics_list.hbs
@@ -1,15 +1,21 @@
-<table>
-    {{!-- DO WE NEED HEADERS? (THEY DON'T LOOK BAD :) --}}
-    <tr>
-        <th>Unread</th>
-        <th>Stream</th>
-        <th>Topic</th>
-        <th>Actions</th>
-        <th>Active Users</th>
-        <th>Last message</th>
-    </tr>
-    {{!-- RECENT TOPICS LIST --}}
-    {{#each recent_topics}}
-    {{> recent}}
-    {{/each}}
-</table>
+<div class="modal-body" data-simplebar data-simplebar-auto-hide="true">
+    <div class="table-responsive">
+        <table class="recents_table table table-striped table-bordered table-responsive table-hover">
+            {{!-- DO WE NEED HEADERS? (THEY DON'T LOOK BAD :) --}}
+            <thead class="thead-dark">
+                <tr>
+                    <th>Unread</th>
+                    <th>Stream</th>
+                    <th>Topic</th>
+                    <th>Actions</th>
+                    <th>Active Users</th>
+                    <th>Last message</th>
+                </tr>
+            </thead>
+            {{!-- RECENT TOPICS LIST --}}
+            {{#each recent_topics}}
+            {{> recent}}
+            {{/each}}
+        </table>
+    </div>
+</div>

--- a/static/templates/recent_topics_list.hbs
+++ b/static/templates/recent_topics_list.hbs
@@ -1,15 +1,12 @@
-
-<div class="modal-body" data-simplebar data-simplebar-auto-hide="true">
-    <div id="recent_topics_filter_buttons" class="btn-group" role="group" aria-label="Recent Topics">
-        <button data-filter="all" type="button" class="btn btn-default btn-recent-filters">All</button>
-        <button data-filter="unread" type="button" class="btn btn-default btn-recent-filters">Unread</button>
-        <button data-filter="bookmarked" type="button" class="btn btn-default btn-recent-filters">Bookmarked</button>
-        <button data-filter="participated" type="button" class="btn btn-default btn-recent-filters">Participated</button>
-        <input type="text" id="recent_topics_search" placeholder="Search Stream / Topics names" aria-label="search-topics">
-    </div>
-    <div class="table-responsive">
+<div id="recent_topics_filter_buttons" class="btn-group" role="group" aria-label="Recent Topics">
+    <button data-filter="all" type="button" class="btn btn-default btn-recent-filters">All</button>
+    <button data-filter="unread" type="button" class="btn btn-default btn-recent-filters">Unread</button>
+    <button data-filter="bookmarked" type="button" class="btn btn-default btn-recent-filters">Bookmarked</button>
+    <button data-filter="participated" type="button" class="btn btn-default btn-recent-filters">Participated</button>
+    <input type="text" id="recent_topics_search" placeholder="Search Stream / Topics names" aria-label="search-topics">
+</div>
+    <div class="tableFixHead">
         <table class="recents_table table table-striped table-bordered table-responsive table-hover">
-            {{!-- DO WE NEED HEADERS? (THEY DON'T LOOK BAD :) --}}
             <thead class="thead-dark">
                 <tr>
                     <th>Unread</th>
@@ -26,4 +23,3 @@
             {{/each}}
         </table>
     </div>
-</div>

--- a/static/templates/recent_topics_list.hbs
+++ b/static/templates/recent_topics_list.hbs
@@ -1,4 +1,10 @@
+
 <div class="modal-body" data-simplebar data-simplebar-auto-hide="true">
+    <div id="recent_topics_filter_buttons" class="btn-group" role="group" aria-label="Recent Topics">
+        <button data-filter="all" type="button" class="btn btn-default btn-recent-filters">All</button>
+        <button data-filter="unread" type="button" class="btn btn-default btn-recent-filters">Unread</button>
+        <button data-filter="bookmarked" type="button" class="btn btn-default btn-recent-filters">Bookmarked</button>
+    </div>
     <div class="table-responsive">
         <table class="recents_table table table-striped table-bordered table-responsive table-hover">
             {{!-- DO WE NEED HEADERS? (THEY DON'T LOOK BAD :) --}}

--- a/static/templates/recent_topics_list.hbs
+++ b/static/templates/recent_topics_list.hbs
@@ -1,20 +1,20 @@
 <div id="recent_topics_filter_buttons" class="btn-group" role="group" aria-label="Recent Topics">
-    <button data-filter="all" type="button" class="btn btn-default btn-recent-filters">All</button>
-    <button data-filter="unread" type="button" class="btn btn-default btn-recent-filters">Unread</button>
-    <button data-filter="bookmarked" type="button" class="btn btn-default btn-recent-filters">Bookmarked</button>
-    <button data-filter="participated" type="button" class="btn btn-default btn-recent-filters">Participated</button>
+    <button data-filter="all" type="button" class="btn btn-default btn-recent-filters">{{t 'All' }}</button>
+    <button data-filter="unread" type="button" class="btn btn-default btn-recent-filters">{{t 'Unread' }}</button>
+    <button data-filter="bookmarked" type="button" class="btn btn-default btn-recent-filters">{{t 'Bookmarked' }}</button>
+    <button data-filter="participated" type="button" class="btn btn-default btn-recent-filters">{{t 'Participated' }}</button>
     <input type="text" id="recent_topics_search" placeholder="Search Stream / Topics names" aria-label="search-topics">
 </div>
     <div class="tableFixHead">
         <table class="recents_table table table-striped table-bordered table-responsive table-hover">
             <thead class="thead-dark">
                 <tr>
-                    <th>Unread</th>
-                    <th>Stream</th>
-                    <th>Topic</th>
-                    <th>Actions</th>
-                    <th>Active Users</th>
-                    <th>Last message</th>
+                    <th>{{t 'Unread' }}</th>
+                    <th>{{t 'Stream' }}</th>
+                    <th>{{t 'Topic' }}</th>
+                    <th>{{t 'Actions' }}</th>
+                    <th>{{t 'Active users' }}</th>
+                    <th>{{t 'Last message' }}</th>
                 </tr>
             </thead>
             {{!-- RECENT TOPICS LIST --}}

--- a/static/templates/recent_topics_list.hbs
+++ b/static/templates/recent_topics_list.hbs
@@ -3,7 +3,7 @@
     <button data-filter="unread" type="button" class="btn btn-default btn-recent-filters">{{t 'Unread' }}</button>
     <button data-filter="bookmarked" type="button" class="btn btn-default btn-recent-filters">{{t 'Bookmarked' }}</button>
     <button data-filter="participated" type="button" class="btn btn-default btn-recent-filters">{{t 'Participated' }}</button>
-    <input type="text" id="recent_topics_search" placeholder="Search Stream / Topics names" aria-label="search-topics">
+    <input type="text" id="recent_topics_search" placeholder="{{t 'Search Stream / Topic' }}" aria-label="search-topics">
 </div>
     <div class="tableFixHead">
         <table class="recents_table table table-striped table-bordered table-responsive table-hover">

--- a/static/templates/recent_topics_list.hbs
+++ b/static/templates/recent_topics_list.hbs
@@ -4,6 +4,7 @@
         <button data-filter="all" type="button" class="btn btn-default btn-recent-filters">All</button>
         <button data-filter="unread" type="button" class="btn btn-default btn-recent-filters">Unread</button>
         <button data-filter="bookmarked" type="button" class="btn btn-default btn-recent-filters">Bookmarked</button>
+        <button data-filter="participated" type="button" class="btn btn-default btn-recent-filters">Participated</button>
         <input type="text" id="recent_topics_search" placeholder="Search Stream / Topics names" aria-label="search-topics">
     </div>
     <div class="table-responsive">

--- a/static/templates/recent_topics_list.hbs
+++ b/static/templates/recent_topics_list.hbs
@@ -4,6 +4,7 @@
         <button data-filter="all" type="button" class="btn btn-default btn-recent-filters">All</button>
         <button data-filter="unread" type="button" class="btn btn-default btn-recent-filters">Unread</button>
         <button data-filter="bookmarked" type="button" class="btn btn-default btn-recent-filters">Bookmarked</button>
+        <input type="text" id="recent_topics_search" placeholder="Search Stream / Topics names" aria-label="search-topics">
     </div>
     <div class="table-responsive">
         <table class="recents_table table table-striped table-bordered table-responsive table-hover">

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -45,6 +45,7 @@
 {% include "zerver/app/lightbox_overlay.html" %}
 {% include "zerver/app/subscriptions.html" %}
 {% include "zerver/app/drafts.html" %}
+{% include "zerver/app/recents.html" %}
 <div id="settings_overlay_container" class="overlay" data-overlay="settings" aria-hidden="true">
     {% include "zerver/app/settings_overlay.html" %}
 </div>

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -60,6 +60,7 @@
         <div id="streams_list" class="zoom-out">
             <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title" data-toggle="tooltip" title="{{ _('Filter streams') }}">{{ _('STREAMS') }}</h4>
                 <i id="streams_inline_cog" class='fa fa-cog' aria-hidden="true" data-toggle="tooltip" title="{{ _('Subscribe, add, or configure streams') }}"></i>
+                <i id="recenttopics-popup-button" class='fa fa-clock-o' aria-hidden="true" data-toggle="tooltip" title="{{ _('Recent Topics') }} (some-key)"></i>
                 <i id="streams_filter_icon" class='fa fa-search' aria-hidden="true" data-toggle="tooltip" title="{{ _('Filter streams') }} (q)"></i>
                 <div class="input-append notdisplayed stream_search_section">
                     <input class="stream-list-filter" type="text" autocomplete="off" placeholder="{{ _('Search streams') }}" />

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -60,7 +60,7 @@
         <div id="streams_list" class="zoom-out">
             <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title" data-toggle="tooltip" title="{{ _('Filter streams') }}">{{ _('STREAMS') }}</h4>
                 <i id="streams_inline_cog" class='fa fa-cog' aria-hidden="true" data-toggle="tooltip" title="{{ _('Subscribe, add, or configure streams') }}"></i>
-                <i id="recenttopics-popup-button" class='fa fa-clock-o' aria-hidden="true" data-toggle="tooltip" title="{{ _('Recent Topics') }} (some-key)"></i>
+                <i id="recenttopics-popup-button" class='fa fa-clock-o' aria-hidden="true" data-toggle="tooltip" title="{{ _('Recent Topics') }} (t)"></i>
                 <i id="streams_filter_icon" class='fa fa-search' aria-hidden="true" data-toggle="tooltip" title="{{ _('Filter streams') }} (q)"></i>
                 <div class="input-append notdisplayed stream_search_section">
                     <input class="stream-list-filter" type="text" autocomplete="off" placeholder="{{ _('Search streams') }}" />

--- a/templates/zerver/app/recents.html
+++ b/templates/zerver/app/recents.html
@@ -1,0 +1,19 @@
+<div id="recents_table">
+    <div id="recent_overlay" class="overlay new-style" data-overlay="recents">
+        <div class="flex overlay-content">
+            <div class="recents-container modal-bg">
+                <div class="recents-header">
+                    <h1>{% trans %}Recent Topics{% endtrans %}</h1>
+                    <div class="exit">
+                        <span class="exit-sign">&times;</span>
+                    </div>
+                    <div class="recent-hotkey-reminder">
+                        {% trans %}Pro tip: You can use 'some-key' to open your Recent messages.{% endtrans %}
+                    </div>
+                </div>
+                <div class="recents-list" id="recent_topics_table">
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/zerver/app/recents.html
+++ b/templates/zerver/app/recents.html
@@ -8,7 +8,7 @@
                         <span class="exit-sign">&times;</span>
                     </div>
                     <div class="recent-hotkey-reminder">
-                        {% trans %}Pro tip: You can use 'some-key' to open your Recent messages.{% endtrans %}
+                        {% trans %}Pro tip: You can use 't' to open your Recent messages.{% endtrans %}
                     </div>
                 </div>
                 <div class="recents-list" id="recent_topics_table">

--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -119,7 +119,7 @@ export default (env?: string): webpack.Configuration[] => {
                                     'if', 'unless', 'each', 'with',
                                     // The ones below are defined in static/js/templates.js
                                     'plural', 'eq', 'and', 'or', 'not',
-                                    't', 'tr', 'rendered_markdown', 'recent_topics_filter',
+                                    't', 'tr', 'rendered_markdown',
                                 ],
                                 preventIndent: true,
                             },

--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -119,7 +119,7 @@ export default (env?: string): webpack.Configuration[] => {
                                     'if', 'unless', 'each', 'with',
                                     // The ones below are defined in static/js/templates.js
                                     'plural', 'eq', 'and', 'or', 'not',
-                                    't', 'tr', 'rendered_markdown',
+                                    't', 'tr', 'rendered_markdown', 'recent_topics_filter',
                                 ],
                                 preventIndent: true,
                             },


### PR DESCRIPTION
Events:
- [x] Topic Mute Updates
- [ ] Stream Mute Updates https://chat.zulip.org/#narrow/stream/6-frontend/topic/.236605.20%28Recent.20Topics%29/near/854026
- [x] Topic Edits
- [x] Stream Edits
- [ ] Stream Deletion

 * Should deleted streams be displayed in recent topics?  They are currently displayed as 
`DEACTIVATED:"Stream Name"`, we can work with the formatting to display it as
 `Stream Name (Deleted)`


Features:
- [x] Keyboard Navigation 
- [x] Mute/Unmute Topic 
- [x] Mark Topic as read
- [x] Display recent users
- [x] Open via hotkey
- [x] Show only starred topics
- [x] Add search bar for searching topics


Other UI things todo:
- [ ] Only update components that are required
- [x] Make headers fixed


Followup things to do:
- [ ] Add a keybind for cycling through recent topics. User should be able to specify which combination of filters to cycle through.
- [ ] follow/unfollow a stream+topic pair for notifications (#14555 adds backend for this)
- [ ] Add announcement section

Current Discussion Link - https://chat.zulip.org/#narrow/stream/6-frontend/topic/.236605.20(Recent.20Topics)
Relevant issues: #6605, #4271 and #12309 (this issue should require a different PR however).
Started with rebase of #7714.

Thanks @aero31aero for helping me get started with this 👍 