### PR TITLE
Toggle full width in wide screens

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -586,6 +586,12 @@ const event_fixtures = {
         setting: true,
     },
 
+    update_display_settings__wide_screen: {
+        type: 'update_display_settings',
+        setting_name: 'wide_screen',
+        setting: true,
+    },
+
     update_display_settings__twenty_four_hour_time: {
         type: 'update_display_settings',
         setting_name: 'twenty_four_hour_time',
@@ -1394,6 +1400,11 @@ with_overrides(function (override) {
     dispatch(event);
     assert_same(page_params.twenty_four_hour_time, true);
     assert_same(called, true);
+
+    event = event_fixtures.update_display_settings__wide_screen;
+    page_params.wide_screen = false;
+    dispatch(event);
+    assert_same(page_params.wide_screen, true);
 
     event = event_fixtures.update_display_settings__translate_emoticons;
     page_params.translate_emoticons = false;

--- a/frontend_tests/node_tests/i18n.js
+++ b/frontend_tests/node_tests/i18n.js
@@ -44,6 +44,7 @@ run_test('tr_tag', () => {
             password_auth_enabled: false,
             avatar_url: "http://example.com",
             left_side_userlist: false,
+            wide_screen: false,
             twenty_four_hour_time: false,
             enable_stream_desktop_notifications: false,
             enable_stream_push_notifications: false,

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -204,9 +204,9 @@ exports.resize_stream_filters_container = function (h) {
 exports.resize_page_components = function () {
     let sidebar;
 
-    if (page_params.left_side_userlist) {
-        const css_narrow_mode = message_viewport.is_narrow();
+    const css_narrow_mode = message_viewport.is_narrow();
 
+    if (page_params.left_side_userlist) {
         $("#top_navbar").removeClass("rightside-userlist");
 
         const right_items = $('.right-sidebar-items').expectOne();
@@ -223,6 +223,28 @@ exports.resize_page_components = function () {
         } else if (!css_narrow_mode && narrow_window) {
             // move stuff to the right sidebar (wide mode)
             narrow_window = false;
+            popovers.set_userlist_placement("right");
+            sidebar = $("#right-sidebar").expectOne();
+            sidebar.append(right_items);
+            $("#buddy_list_wrapper").css("margin", '');
+            $("#userlist-toggle").css("display", '');
+            $("#invite-user-link").show();
+        }
+    }
+
+    if (!css_narrow_mode) {
+        if (page_params.wide_screen) {
+            $("#top_navbar").removeClass("rightside-userlist");
+            const right_items = $('.right-sidebar-items').expectOne();
+            right_items.hide();
+            $(".column-middle").css("margin-right", "10px");
+            popovers.set_userlist_placement("left");
+            $("#buddy_list_wrapper").css("margin", "0px");
+            $("#userlist-toggle").css("display", "none");
+            $("#invite-user-link").hide();
+        } else {
+            $("#top_navbar").removeClass("rightside-userlist");
+            const right_items = $('.right-sidebar-items').expectOne();
             popovers.set_userlist_placement("right");
             sidebar = $("#right-sidebar").expectOne();
             sidebar.append(right_items);

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -386,6 +386,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             'high_contrast_mode',
             'night_mode',
             'left_side_userlist',
+            'wide_screen',
             'timezone',
             'twenty_four_hour_time',
             'translate_emoticons',
@@ -404,6 +405,10 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             if (current_msg_list === message_list.narrowed) {
                 message_list.narrowed.rerender();
             }
+        }
+        if (event.setting_name === 'wide_screen') {
+            // TODO: Make this change the view immediately rather
+            // than requiring a reload or page resize.
         }
         if (event.setting_name === 'high_contrast_mode') {
             $("body").toggleClass("high-contrast");

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -76,6 +76,7 @@ function setup_settings_label() {
         fluid_layout_width: i18n.t("Use full width on wide screens"),
         high_contrast_mode: i18n.t("High contrast mode"),
         left_side_userlist: i18n.t("Show user list on left sidebar in narrow windows"),
+        wide_screen: i18n.t("Use full width for messages on wide screens (removes user's list)"),
         night_mode: i18n.t("Night mode"),
         starred_message_counts: i18n.t("Show counts for starred messages"),
         twenty_four_hour_time: i18n.t("Time format"),

--- a/static/js/settings_config.js
+++ b/static/js/settings_config.js
@@ -45,6 +45,7 @@ exports.get_all_display_settings = () => ({
             "night_mode",
             "high_contrast_mode",
             "left_side_userlist",
+            "wide_screen",
             "starred_message_counts",
             "fluid_layout_width",
         ],

--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -51,6 +51,15 @@ exports.set_up = function () {
             } else {
                 change_display_setting(data, "#display-settings-status");
             }
+
+            if (["wide_screen"].includes(setting)) {
+                change_display_setting(
+                    data,
+                    "#display-settings-status",
+                    i18n.t("Saved. Please <a class='reload_link'>reload</a> for the change to take effect."), true);
+            } else {
+                change_display_setting(data, "#display-settings-status");
+            }
         });
     }
 
@@ -144,6 +153,7 @@ exports.report_emojiset_change = async function () {
 
 exports.update_page = function () {
     $("#left_side_userlist").prop('checked', page_params.left_side_userlist);
+    $("#wide_screen").prop('checked', page_params.wide_screen);
     $("#default_language_name").text(page_params.default_language_name);
     $("#translate_emoticons").prop('checked', page_params.translate_emoticons);
     $("#night_mode").prop('checked', page_params.night_mode);

--- a/zerver/migrations/0273_userprofile_wide_screen.py
+++ b/zerver/migrations/0273_userprofile_wide_screen.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0272_realm_default_code_block_language'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='userprofile',
+            name='wide_screen',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -926,6 +926,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
     # UI vars
     enter_sends = models.NullBooleanField(default=False)  # type: Optional[bool]
     left_side_userlist = models.BooleanField(default=False)  # type: bool
+    wide_screen = models.BooleanField(default=False)  # type: bool
 
     # display settings
     default_language = models.CharField(default='en', max_length=MAX_LANGUAGE_ID_LENGTH)  # type: str
@@ -1007,6 +1008,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
         fluid_layout_width=bool,
         high_contrast_mode=bool,
         left_side_userlist=bool,
+        wide_screen=bool,
         night_mode=bool,
         starred_message_counts=bool,
         timezone=str,

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -223,6 +223,7 @@ class HomeTest(ZulipTestCase):
             "user_status",
             "warn_no_email",
             "webpack_public_path",
+            "wide_screen",
             "wildcard_mentions_notify",
             "zulip_version",
         ]

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -2573,6 +2573,7 @@ class UserSignUpTest(InviteUserBase):
 
         # Make an account in the Zulip realm, but we're not copying from there.
         hamlet_in_zulip.left_side_userlist = True
+        hamlet_in_zulip.wide_screen = True
         hamlet_in_zulip.default_language = "de"
         hamlet_in_zulip.emojiset = "twitter"
         hamlet_in_zulip.high_contrast_mode = True
@@ -2592,6 +2593,7 @@ class UserSignUpTest(InviteUserBase):
 
         hamlet = get_user(self.example_email("hamlet"), realm)
         self.assertEqual(hamlet.left_side_userlist, False)
+        self.assertEqual(hamlet.wide_screen, False)
         self.assertEqual(hamlet.default_language, "en")
         self.assertEqual(hamlet.emojiset, "google-blob")
         self.assertEqual(hamlet.high_contrast_mode, False)
@@ -2611,6 +2613,7 @@ class UserSignUpTest(InviteUserBase):
             self.client_post("/json/users/me/avatar", {'file': image_file})
         hamlet_in_zulip.refresh_from_db()
         hamlet_in_zulip.left_side_userlist = True
+        hamlet_in_zulip.wide_screen = True
         hamlet_in_zulip.default_language = "de"
         hamlet_in_zulip.emojiset = "twitter"
         hamlet_in_zulip.high_contrast_mode = True
@@ -2641,6 +2644,7 @@ class UserSignUpTest(InviteUserBase):
 
         hamlet_in_lear = get_user(email, lear_realm)
         self.assertEqual(hamlet_in_lear.left_side_userlist, True)
+        self.assertEqual(hamlet_in_lear.wide_screen, True)
         self.assertEqual(hamlet_in_lear.default_language, "de")
         self.assertEqual(hamlet_in_lear.emojiset, "twitter")
         self.assertEqual(hamlet_in_lear.high_contrast_mode, True)

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -157,6 +157,7 @@ def update_display_settings_backend(
         translate_emoticons: Optional[bool]=REQ(validator=check_bool, default=None),
         default_language: Optional[bool]=REQ(validator=check_string, default=None),
         left_side_userlist: Optional[bool]=REQ(validator=check_bool, default=None),
+        wide_screen: Optional[bool]=REQ(validator=check_bool, default=None),
         emojiset: Optional[str]=REQ(validator=check_string_in(
             emojiset_choices), default=None),
         demote_inactive_streams: Optional[int]=REQ(validator=check_int_in(


### PR DESCRIPTION
This commit adds functionality to toggle between full width message box for wide screens by moving the users list to the left-sidebar.
Fixes #14160

![Peek 2020-03-29 09-16](https://user-images.githubusercontent.com/43504292/77839818-02903c80-719e-11ea-8bce-a56d091d0158.gif)

