### PR TITLE
info_overlay: Fix keyboard accessibility of keyboard shortcuts modal.

### DIFF
--- a/static/js/info_overlay.js
+++ b/static/js/info_overlay.js
@@ -14,7 +14,7 @@ exports.set_up_toggler = function () {
         callback: function (name, key) {
             $(".overlay-modal").hide();
             $("#" + key).show();
-            $("#" + key).find(".modal-body").focus();
+            ui.get_scroll_element($("#" + key).find(".modal-body")).focus();
         },
     };
 
@@ -29,6 +29,7 @@ exports.set_up_toggler = function () {
     });
 
     for (const modal of modals) {
+        ui.get_scroll_element(modal).prop("tabindex", 0);
         keydown_util.handle({
             elem: modal,
             handlers: {

--- a/templates/zerver/app/keyboard_shortcuts.html
+++ b/templates/zerver/app/keyboard_shortcuts.html
@@ -1,6 +1,6 @@
 <div class="overlay-modal" id="keyboard-shortcuts" tabindex="-1" role="dialog"
   aria-label="{{ _('Keyboard shortcuts') }}">
-    <div class="modal-body" tabindex="0" data-simplebar data-simplebar-auto-hide="false">
+    <div class="modal-body" data-simplebar data-simplebar-auto-hide="false">
         <div>
             <table class="hotkeys_table table table-striped table-bordered table-condensed">
                 <thead>

--- a/templates/zerver/app/markdown_help.html
+++ b/templates/zerver/app/markdown_help.html
@@ -1,6 +1,6 @@
 <div class="overlay-modal hide" id="message-formatting" tabindex="-1" role="dialog"
     aria-label="{{ _('Message formatting') }}">
-    <div class="modal-body" tabindex="0" data-simplebar data-simplebar-auto-hide="false">
+    <div class="modal-body" data-simplebar data-simplebar-auto-hide="false">
         <div id="markdown-instructions">
             <table class="table table-striped table-condensed table-rounded table-bordered help-table">
                 <thead>

--- a/templates/zerver/app/search_operators.html
+++ b/templates/zerver/app/search_operators.html
@@ -1,6 +1,6 @@
 <div class="overlay-modal hide" id="search-operators" tabindex="-1" role="dialog"
   aria-label="{{ _('Search operators') }}">
-    <div class="modal-body" tabindex="0" data-simplebar data-simplebar-auto-hide="false">
+    <div class="modal-body" data-simplebar data-simplebar-auto-hide="false">
         <table class="table table-striped table-condensed table-rounded table-bordered help-table">
             <thead>
                 <tr>


### PR DESCRIPTION
Commit 03393631bdded3be89c935f2151b74eebbf29034 (#14142) regressed the keyboard accessibility of the keyboard shortcuts modal.  Fix it by moving `tabindex="0"` to the scrolling element of the SimpleBar.

Fixes #14320.

**Testing Plan:** Dev server.