### PR TITLE
monitoring: Fix check-rabbitmq-consumers

### DIFF
--- a/scripts/nagios/check-rabbitmq-consumers
+++ b/scripts/nagios/check-rabbitmq-consumers
@@ -47,7 +47,7 @@ consumers = defaultdict(int)  # type: Dict[str, int]
 
 sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))))
 queues = {
-    'deferred_work'
+    'deferred_work',
     'digest_emails',
     'email_mirror',
     'embed_links',
@@ -60,7 +60,7 @@ queues = {
     'outgoing_webhooks',
     'signups',
     'slow_queries',
-    'user_activity'
+    'user_activity',
     'user_activity_interval',
     'user_presence',
     # These queues may not be present if settings.TORNADO_PROCESSES > 1


### PR DESCRIPTION
Missing commas in the definition of all the queues to check meant that it would be looking for queues with concatenated names, rather than the correct ones. Added the commas.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->

Tested locally

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
