### PR TITLE
tools: Add and use require_clean_work_tree.

### DIFF
--- a/tools/fetch-pull-request
+++ b/tools/fetch-pull-request
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-if ! git diff-index --quiet HEAD; then
-    echo "There are uncommitted changes:"
-    git status --short
-    echo "Doing nothing to avoid losing your work."
-    exit 1
-fi
+this_file=$(readlink -f "${BASH_SOURCE[0]}")
+# shellcheck source=lib/git-tools.bash
+. "${this_file%/*}"/lib/git-tools.bash
+
+require_clean_work_tree 'check out PR as branch'
 
 request_id="$1"
 remote=${2:-"upstream"}

--- a/tools/fetch-pull-request
+++ b/tools/fetch-pull-request
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 set -e
-set -x
 
 if ! git diff-index --quiet HEAD; then
-    set +x
     echo "There are uncommitted changes:"
     git status --short
     echo "Doing nothing to avoid losing your work."
     exit 1
 fi
+
 request_id="$1"
 remote=${2:-"upstream"}
+
+set -x
 git fetch "$remote" "pull/$request_id/head"
 git checkout -B "review-original-${request_id}"
 git reset --hard FETCH_HEAD

--- a/tools/fetch-rebase-pull-request
+++ b/tools/fetch-rebase-pull-request
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-if ! git diff-index --quiet HEAD; then
-    echo "There are uncommitted changes:"
-    git status --short
-    echo "Doing nothing to avoid losing your work."
-    exit 1
-fi
+this_file=$(readlink -f "${BASH_SOURCE[0]}")
+# shellcheck source=lib/git-tools.bash
+. "${this_file%/*}"/lib/git-tools.bash
+
+require_clean_work_tree 'check out PR as branch'
 
 request_id="$1"
 remote=${2:-"upstream"}

--- a/tools/fetch-rebase-pull-request
+++ b/tools/fetch-rebase-pull-request
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 set -e
-set -x
 
 if ! git diff-index --quiet HEAD; then
-    set +x
     echo "There are uncommitted changes:"
     git status --short
     echo "Doing nothing to avoid losing your work."
     exit 1
 fi
+
 request_id="$1"
 remote=${2:-"upstream"}
+
+set -x
 git fetch "$remote" "pull/$request_id/head"
 git checkout -B "review-${request_id}" "$remote/master"
 git reset --hard FETCH_HEAD

--- a/tools/lib/git-tools.bash
+++ b/tools/lib/git-tools.bash
@@ -1,0 +1,35 @@
+# shellcheck shell=bash
+
+# Borrowed from Git's git-sh-setup.
+#
+# See git.git commit 92c62a3f4 (from 2010!); as of 2020 with Git 2.26,
+# this function has only needed one edit since then, adding localization
+# with gettext, which we can omit.
+require_clean_work_tree () {
+    git rev-parse --verify HEAD >/dev/null || exit 1
+    git update-index -q --ignore-submodules --refresh
+    err=0
+
+    if ! git diff-files --quiet --ignore-submodules
+    then
+        echo >&2 "Cannot $1: You have unstaged changes."
+        err=1
+    fi
+
+    if ! git diff-index --cached --quiet --ignore-submodules HEAD --
+    then
+        if [ $err = 0 ]
+        then
+            echo >&2 "Cannot $1: Your index contains uncommitted changes."
+        else
+            echo >&2 "Additionally, your index contains uncommitted changes."
+        fi
+        err=1
+    fi
+
+    if [ $err = 1 ]
+    then
+        test -n "$2" && echo >&2 "$2"
+        exit 1
+    fi
+}

--- a/tools/lib/git-tools.bash
+++ b/tools/lib/git-tools.bash
@@ -6,7 +6,7 @@
 # this function has only needed one edit since then, adding localization
 # with gettext, which we can omit.
 require_clean_work_tree () {
-    local action="$1" message="${2-}"
+    local action="$1"
 
     git rev-parse --verify HEAD >/dev/null || exit 1
     git update-index -q --ignore-submodules --refresh
@@ -27,7 +27,8 @@ require_clean_work_tree () {
     fi
 
     if [ $err = 1 ]; then
-        [ -n "$message" ] && echo >&2 "$message"
+        git status --short
+        echo >&2 "Doing nothing to avoid losing your work."
         exit 1
     fi
 }

--- a/tools/lib/git-tools.bash
+++ b/tools/lib/git-tools.bash
@@ -6,30 +6,28 @@
 # this function has only needed one edit since then, adding localization
 # with gettext, which we can omit.
 require_clean_work_tree () {
+    local action="$1" message="${2-}"
+
     git rev-parse --verify HEAD >/dev/null || exit 1
     git update-index -q --ignore-submodules --refresh
-    err=0
+    local err=0
 
-    if ! git diff-files --quiet --ignore-submodules
-    then
-        echo >&2 "Cannot $1: You have unstaged changes."
+    if ! git diff-files --quiet --ignore-submodules; then
+        echo >&2 "Cannot $action: You have unstaged changes."
         err=1
     fi
 
-    if ! git diff-index --cached --quiet --ignore-submodules HEAD --
-    then
-        if [ $err = 0 ]
-        then
-            echo >&2 "Cannot $1: Your index contains uncommitted changes."
+    if ! git diff-index --cached --quiet --ignore-submodules HEAD --; then
+        if [ $err = 0 ]; then
+            echo >&2 "Cannot $action: Your index contains uncommitted changes."
         else
             echo >&2 "Additionally, your index contains uncommitted changes."
         fi
         err=1
     fi
 
-    if [ $err = 1 ]
-    then
-        test -n "$2" && echo >&2 "$2"
+    if [ $err = 1 ]; then
+        [ -n "$message" ] && echo >&2 "$message"
         exit 1
     fi
 }

--- a/tools/reset-to-pull-request
+++ b/tools/reset-to-pull-request
@@ -39,13 +39,11 @@ if [ -z "$request_id" ]; then
     usage
 fi
 
-if ! git diff-index --quiet HEAD; then
-    set +x
-    echo "There are uncommitted changes:"
-    git status --short
-    echo "Doing nothing to avoid losing your work."
-    exit 1
-fi
+this_file=$(readlink -f "${BASH_SOURCE[0]}")
+# shellcheck source=lib/git-tools.bash
+. "${this_file%/*}"/lib/git-tools.bash
+
+require_clean_work_tree 'reset to PR'
 
 if [ -z "$pseudo_remote" ]; then
     set -x


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

Fix [a bug that made](https://chat.zulip.org/#narrow/stream/9-issues/topic/.2E.2Ftools.2Ffetch-pull-request.20issue/near/834435) the tools/*-pull-request tools basically unusable on Windows. Also clean them up a little in general.

**Testing Plan:** <!-- How have you tested? -->

Tried the tools locally (on Linux) and they continue to do their jobs. @vinitS101, who reported the bug, tried a patch with the key logic change and it fixed the bug.
