### PR TITLE
[WIP] Reactivate user: Refactor reactivation code to send last_active with events and peer_add events

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -47,6 +47,7 @@ from zerver.lib.message import (
     render_markdown,
     update_first_visible_message_id,
 )
+from zerver.lib.presence import get_presence_for_user
 from zerver.lib.realm_icon import realm_icon_url
 from zerver.lib.realm_logo import get_realm_logo_data
 from zerver.lib.retention import move_messages_to_archive
@@ -85,6 +86,7 @@ from zerver.lib.users import (
     format_user_row,
     get_api_key,
     user_profile_to_user_row,
+    get_raw_user_data,
 )
 from zerver.lib.user_status import (
     update_user_status,
@@ -446,6 +448,41 @@ def notify_created_user(user_profile: UserProfile) -> None:
     event = dict(type="realm_user", op="add", person=person)  # type: Dict[str, Any]
     send_event(user_profile.realm, event, active_user_ids(user_profile.realm_id))
 
+def notify_reactivated_user(user_profile: UserProfile) -> None:
+    user_data = get_raw_user_data(user_profile.realm,
+                                  acting_user=user_profile,
+                                  client_gravatar=False,
+                                  target_user=user_profile)
+    person = user_data[user_profile.id]
+    event = dict(type="realm_user", op="add", person=person)  # type: Dict[str, Any]
+    send_event(user_profile.realm, event, active_user_ids(user_profile.realm_id))
+
+    presence_dict = get_presence_for_user(user_profile)
+    if presence_dict:
+        event = dict(type="presence", email=user_profile.email,
+                     user_id=user_profile.id, server_timestamp=time.time(),
+                     presence=presence_dict[user_profile.email])
+        send_event(user_profile.realm, event, active_user_ids(user_profile.realm_id))
+
+    subscribed_stream_ids = list(get_subscribed_stream_ids_for_user(user_profile))
+    streams = []
+    for stream_id in subscribed_stream_ids:
+        stream = get_stream_by_id_in_realm(stream_id, user_profile.realm)
+        streams.append(stream)
+    all_subscribers_by_stream = get_user_ids_for_streams(streams=streams)
+
+    for stream in streams:
+        subscribed_user_ids = all_subscribers_by_stream[stream.id]
+        peer_user_ids = get_peer_user_ids_for_stream_change(
+            stream=stream,
+            altered_user_ids=[user_profile.id],
+            subscribed_user_ids=subscribed_user_ids,
+        )
+        if peer_user_ids:
+            event = dict(type="subscription", op="peer_add",
+                         subscriptions=[stream.name], user_id=user_profile.id)
+            send_event(user_profile.realm, event, peer_user_ids)
+
 def created_bot_event(user_profile: UserProfile) -> Dict[str, Any]:
     def stream_name(stream: Optional[Stream]) -> Optional[str]:
         if not stream:
@@ -574,9 +611,10 @@ def do_reactivate_user(user_profile: UserProfile, acting_user: Optional[UserProf
     if settings.BILLING_ENABLED:
         update_license_ledger_if_needed(user_profile.realm, event_time)
 
-    notify_created_user(user_profile)
-
-    if user_profile.is_bot:
+    if not user_profile.is_bot:
+        notify_reactivated_user(user_profile)
+    else:
+        notify_created_user(user_profile)
         notify_created_bot(user_profile)
 
 def active_humans_in_realm(realm: Realm) -> Sequence[UserProfile]:

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -392,8 +392,6 @@ def apply_event(state: Dict[str, Any],
                 if 'gravatar.com' in person['avatar_url']:
                     person['avatar_url'] = None
             person['is_active'] = True
-            if not person['is_bot']:
-                person['profile_data'] = {}
             state['raw_users'][person_user_id] = person
         elif event['op'] == "remove":
             state['raw_users'][person_user_id]['is_active'] = False

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -101,6 +101,7 @@ from zerver.lib.actions import (
     remove_members_from_user_group,
     check_delete_user_group,
     do_update_user_custom_profile_data_if_changed,
+    update_user_presence,
 )
 from zerver.lib.bugdown import MentionData
 from zerver.lib.events import (
@@ -2356,6 +2357,65 @@ class EventsRegisterTest(ZulipTestCase):
         self.assert_on_error(error)
 
     def test_do_reactivate_user(self) -> None:
+        user_reactivate_checker = self.check_events_dict([
+            ('type', equals('realm_user')),
+            ('op', equals('add')),
+            ('person', check_dict_only([
+                ('user_id', check_int),
+                ('email', check_string),
+                ('avatar_url', check_none_or(check_string)),
+                ('full_name', check_string),
+                ('is_admin', check_bool),
+                ('is_bot', check_bool),
+                ('is_guest', check_bool),
+                ('is_active', check_bool),
+                ('profile_data', check_none_or(check_dict_only([]))),
+                ('timezone', check_string),
+                ('date_joined', check_string),
+            ])),
+        ])
+
+        peer_add_event_checker = self.check_events_dict([
+            ('type', equals('subscription')),
+            ('op', equals('peer_add')),
+            ('subscriptions', check_list(check_string)),
+            ('user_id', check_int),
+        ])
+
+        presence_event_checker = self.check_events_dict([
+            ('type', equals('presence')),
+            ('email', check_string),
+            ('user_id', check_int),
+            ('server_timestamp', check_float),
+            ('presence', check_dict_only([
+                ('aggregated', check_dict_only([
+                    ('status', equals('active')),
+                    ('timestamp', check_int),
+                    ('client', check_string),
+                ])),
+                ('website', check_dict_only([
+                    ('status', equals('active')),
+                    ('timestamp', check_int),
+                    ('client', check_string),
+                    ('pushable', check_bool),
+                ])),
+            ])),
+        ])
+
+        user = self.example_user("cordelia")
+        do_deactivate_user(user)
+        update_user_presence(user, get_client("website"),
+                             timezone_now(), UserPresence.ACTIVE, True)
+        action = lambda: do_reactivate_user(user)
+        events = self.do_test(action, num_events=3)
+        error = user_reactivate_checker('events[0]', events[0])
+        self.assert_on_error(error)
+        error = presence_event_checker('events[1]', events[1])
+        self.assert_on_error(error)
+        error = peer_add_event_checker('events[2]', events[2])
+        self.assert_on_error(error)
+
+    def test_do_reactivate_bot(self) -> None:
         bot_reactivate_checker = self.check_events_dict([
             ('type', equals('realm_bot')),
             ('op', equals('add')),

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1085,6 +1085,44 @@ class ActivateTest(ZulipTestCase):
             self.assertEqual({hamlet.delivery_email, iago.delivery_email}, set(to_fields))
         self.assertEqual(ScheduledEmail.objects.count(), 0)
 
+    def test_reactivate_user(self) -> None:
+        self.login('iago')
+        cordelia = self.example_user('cordelia')
+        othello = self.example_user('othello')
+        prospero = self.example_user('prospero')
+
+        self.make_stream('private_test_stream', invite_only=True)
+        for user in [cordelia, othello]:
+            self.subscribe(user, 'private_test_stream')
+        self.unsubscribe(prospero, 'Verona')
+
+        user_before_deactivation = cordelia
+        do_deactivate_user(cordelia)
+        events = []  # type: List[Mapping[str, Any]]
+        with tornado_redirected_to_list(events):
+            do_reactivate_user(cordelia)
+
+        realm_user_add_event = events[0]
+        peer_add_to_stream_event = events[1]
+        peer_add_to_private_stream_event = events[2]
+
+        self.assert_length(events, 3)
+        for event in events:
+            self.assertTrue(othello.id in event['users'])
+
+        self.assertTrue(prospero.id in realm_user_add_event['users'])
+        self.assertTrue(prospero.id in peer_add_to_stream_event['users'])
+        self.assertFalse(prospero.id in peer_add_to_private_stream_event['users'])
+
+        self.assertTrue(cordelia.id in realm_user_add_event['users'])
+        self.assertFalse(cordelia.id in peer_add_to_stream_event['users'])
+        self.assertFalse(cordelia.id in peer_add_to_private_stream_event['users'])
+
+        self.assertEqual(user_before_deactivation.full_name, cordelia.full_name)
+        self.assertEqual(user_before_deactivation.delivery_email, cordelia.delivery_email)
+        self.assertEqual(user_before_deactivation.profile_data, cordelia.profile_data)
+        self.assertEqual(user_before_deactivation.alert_words, cordelia.alert_words)
+
 class RecipientInfoTest(ZulipTestCase):
     def test_stream_recipient_info(self) -> None:
         hamlet = self.example_user('hamlet')


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Modify reactivation code to send last_active in realm_user/add event and also send peer_add
events on reactivation.
Modify get_last_active code to use last_active date info from realm_user event to render it in admin_users_list.
 
Fixes #14279 

**Testing Plan:** <!-- How have you tested? --> Tests has been added and exisiting tests have been modified


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
