### PR TITLE
stream settings: Allow tabbing to the input to add new subscribers

### DIFF
--- a/static/templates/subscription_members.hbs
+++ b/static/templates/subscription_members.hbs
@@ -9,7 +9,7 @@
             <form class="form-inline">
                 <input type="text" class="search" placeholder="{{t 'Search subscribers' }}" />
                 <div class="add_subscribers_container">
-                    <input type="text" name="principal" placeholder="{{t 'Name or email' }}" value="" class="input-block" autocomplete="off" tabindex="-1" />
+                    <input type="text" name="principal" placeholder="{{t 'Name or email' }}" value="" class="input-block" autocomplete="off" />
                     <div class="add_subscriber_btn_wrapper inline-block">
                         <button type="submit" name="add_subscriber" class="button add-subscriber-button small rounded" tabindex="-1">
                             {{t 'Add' }}


### PR DESCRIPTION
68335d9124d816a12ab0e623941d4646944233df commit removed the ability to tab
into this field, since it was a hidden field. This field is no longer
hidden, and this commit restores the ability to tab into it.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->

Tested this in the local dev environment. 

