### PR TITLE
circleci: Comment out focal backend-frontend job.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,4 +183,4 @@ workflows:
     jobs:
       - "xenial-backend-frontend-python3.5"
       - "bionic-backend-python3.6"
-      - "focal-backend-frontend-python3.8"
+      # - "focal-backend-frontend-python3.8"


### PR DESCRIPTION
This is due to a recent bug that is causing some trouble
while installing python-pip in Focal.
So we are pausing Focal tests until we get stability.
