### PR TITLE
mention option EMAIL_USE_SSL for smtp providers on port 465

### DIFF
--- a/docs/production/email.md
+++ b/docs/production/email.md
@@ -198,9 +198,7 @@ aren't receiving emails from Zulip:
   should be in `/var/log/zulip/errors.log`, along with any other
   exceptions Zulip encounters.
   
-* If your SMTP provider uses SSL on port 465 (and not TLS on port 587), it is not enough
-  to change the EMAIL_PORT in `/etc/zulip/settings.py`. Additionally, you must change the directive 
-  "EMAIL_USE_TLS = True", and instead use a directive "EMAIL_USE_SSL = True".
+* If your SMTP provider uses SSL on port 465 (and not TLS on port 587), it is not enough to change the EMAIL_PORT in `/etc/zulip/settings.py`. Additionally, you must change the directive "EMAIL_USE_TLS = True", and instead use a directive "EMAIL_USE_SSL = True".
 
 * Zulip's email sending configuration is based on the standard Django
   [SMTP backend](https://docs.djangoproject.com/en/2.0/topics/email/#smtp-backend)

--- a/docs/production/email.md
+++ b/docs/production/email.md
@@ -197,6 +197,10 @@ aren't receiving emails from Zulip:
 * If attempting to send an email throws an exception, a traceback
   should be in `/var/log/zulip/errors.log`, along with any other
   exceptions Zulip encounters.
+  
+* If your SMTP provider uses SSL on port 465 (and not TLS on port 587), it is not enough
+  to change the EMAIL_PORT in `/etc/zulip/settings.py`. Additionally, you must change the directive 
+  "EMAIL_USE_TLS = True", and instead use a directive "EMAIL_USE_SSL = True".
 
 * Zulip's email sending configuration is based on the standard Django
   [SMTP backend](https://docs.djangoproject.com/en/2.0/topics/email/#smtp-backend)


### PR DESCRIPTION
I found the solution by simply trying out EMAIL_USE_SSL and it worked. I had problems with sending emails (did not work at all, there wasn't even a connection going on - I checked with tcpdump. Then I found this: To use port 465, you need to call smtplib.SMTP_SSL(). Currently, it looks like Django only uses smtplib.SMTP() (source: https://code.djangoproject.com/ticket/9575).

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
No connection was possible to any SMTP provider that was offering smtp over ssl on port 465.

**Testing Plan:** <!-- How have you tested? -->
I tested on my own zulip server.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
