### PR TITLE
requirements: Get transifex-client from apt

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -47,9 +47,6 @@ gitlint
 # Needed for visualising cprofile reports
 snakeviz
 
-# Needed to sync translations from transifex
-transifex-client
-
 # Needed for creating digital ocean droplets
 python-digitalocean
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -651,9 +651,6 @@ python-ldap==3.2.0 \
 python-magic==0.4.15 \
     --hash=sha256:f2674dcfad52ae6c49d4803fa027809540b130db1dec928cfbb9240316831375 \
     --hash=sha256:f3765c0f582d2dfc72c15f3b5a82aecfae9498bd29ca840d72f37d7bd38bfcd5
-python-slugify==1.2.6 \
-    --hash=sha256:7723daf30996db26573176bddcdf5fcb98f66dc70df05c9cb29f2c79b8193245 \
-    # via transifex-client
 python-twitter==3.5 \
     --hash=sha256:45855742f1095aa0c8c57b2983eee3b6b7f527462b50a2fa8437a8b398544d90 \
     --hash=sha256:4a420a6cb6ee9d0c8da457c8a8573f709c2ff2e1a7542e2d38807ebbfe8ebd1d
@@ -725,7 +722,7 @@ requests-oauthlib==1.3.0 \
 requests[security]==2.22.0 \
     --hash=sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4 \
     --hash=sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31 \
-    # via docker, hypchat, matrix-client, moto, premailer, pyoembed, python-digitalocean, python-gcm, python-twitter, requests-oauthlib, responses, social-auth-core, sphinx, stripe, transifex-client, twilio
+    # via docker, hypchat, matrix-client, moto, premailer, pyoembed, python-digitalocean, python-gcm, python-twitter, requests-oauthlib, responses, social-auth-core, sphinx, stripe, twilio
 responses==0.10.9 \
     --hash=sha256:515fd7c024097e5da76e9c4cf719083d181f1c3ddc09c2e0e49284ce863dd263 \
     --hash=sha256:8ce8cb4e7e1ad89336f8865af152e0563d2e7f0e0b86d2cf75f015f819409243
@@ -835,8 +832,6 @@ traitlets==4.3.3 \
     --hash=sha256:70b4c6a1d9019d7b4f6846832288f86998aa3b9207c6821f3578a6a6a467fe44 \
     --hash=sha256:d023ee369ddd2763310e4c3eae1ff649689440d4ae59d7485eb4cfbbe3e359f7 \
     # via ipython
-transifex-client==0.13.8 \
-    --hash=sha256:8c2cc75d6a330c062b8f95c8764dccc9ee4fcabc9ad926fd9f9335c02c7606b3
 twilio==6.35.3 \
     --hash=sha256:4474fa87fde5ea5526e296be782d1b06fc6722f9e4698a503c47b5c2f8b70ea9
 twisted==19.10.0 \
@@ -888,14 +883,10 @@ typing-extensions==3.7.4.1 \
     --hash=sha256:cf8b63fedea4d89bab840ecbb93e75578af28f76f66c35889bd7065f5af88575
 https://github.com/zulip/ultrajson/archive/70ac02becc3e11174cd5072650f885b30daab8a8.zip#egg=ujson==1.35+git \
     --hash=sha256:e95c20f47093dc7376ddf70b95489979375fb6e88b8d7e4b5576d917dda8ef5a
-unidecode==1.1.1 \
-    --hash=sha256:1d7a042116536098d05d599ef2b8616759f02985c85b4fef50c78a5aaf10822a \
-    --hash=sha256:2b6aab710c2a1647e928e36d69c21e76b453cd455f4e2621000e54b2a9b8cce8 \
-    # via python-slugify
 urllib3==1.25.8 \
     --hash=sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc \
     --hash=sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc \
-    # via botocore, requests, transifex-client
+    # via botocore, requests
 virtualenv-clone==0.5.3 \
     --hash=sha256:532f789a5c88adf339506e3ca03326f20ee82fd08ee5586b44dc859b5b4468c5 \
     --hash=sha256:c88ae171a11b087ea2513f260cdac9232461d8e9369bcd1dc143fc399d220557

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -120,6 +120,7 @@ COMMON_DEPENDENCIES = [
     "ca-certificates",      # Explicit dependency in case e.g. wget is already installed
     "puppet",               # Used by lint (`puppet parser validate`)
     "gettext",              # Used by makemessages i18n
+    "transifex-client",     # Needed to sync translations from transifex
     "curl",                 # Used for fetching PhantomJS as wget occasionally fails on redirects
     "moreutils",            # Used for sponge command
     "unzip",                # Needed for Slack import


### PR DESCRIPTION
In the past it has blocked Python library security updates with overly strict version bounds, and we don’t use it as a library, only as a binary.

Skip the `PROVISION_VERSION` bump because we can use the `tx` binary from either location.

**Testing Plan:** Ran `tools/i18n/sync-translations`.