### PR TITLE
SAML Authentication with Entitlements

### DIFF
--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -254,6 +254,9 @@ SOCIAL_AUTH_SAML_ENABLED_IDPS = {
         # the left end of the login/register buttons for this IDP.
         # The default of None results in a text-only button.
         # "display_icon": "/path/to/icon.png",
+        
+        # Activate checking entitlements for strict SAML authentication control
+        # "requiredEntitlements": ["urn:oid:1.3.6.1.4.1.5923.1.1.1.9"],
     }
 }
 


### PR DESCRIPTION
While allowing log in a user with SAML backend we need some extra control, this patch provides an (optional) control mechanism.
if you not enable requiredEntitlements from settings.py it flows standard way. otherwise checks entitlements which in eduPersonEntitlements


**Testing Plan:** <!-- How have you tested? -->
1. enable requiredEntitlements and add an entitlement urn
2. Try to login with SAML to see.
3. raise AuthForbidden if the user should not be authenticated, or do nothing to allow the login pipeline to continue.