### PR TITLE
tsconfig: Disable automatic inclusion of type packages

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "paths": {
             "*": ["static/js/types/*"],
         },
-        "typeRoots": ["static/js/types"],
+        "types": [],
 
         /* Typescript 3.4 added the --incremental flag but its API is not
          * currently public so ts-loader cannot use it yet.


### PR DESCRIPTION
Automatic inclusion is for files with global declarations, as opposed to files declared as modules.  `typeRoots` already had the side effect of disabling the default automatic inclusion for `node_modules`.  Since we also don’t need it for `static/js/types`, we may as well disable it completely.