### PR TITLE
Install sgrep as an external linter

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -385,6 +385,9 @@ def main(options):
     # Install shellcheck.
     run_as_root(["tools/setup/install-shellcheck"])
 
+    # Install sgrep.
+    run_as_root(["tools/setup/install-sgrep"])
+
     setup_venvs.main()
 
     run_as_root(["cp", REPO_STOPWORDS_PATH, TSEARCH_STOPWORDS_PATH])

--- a/tools/lint
+++ b/tools/lint
@@ -92,6 +92,11 @@ def run():
                                   description="Checks commit messages for common formatting errors."
                                   "(config: .gitlint)")
 
+    sgrep_command = ["sgrep-lint", "--config=./tools/sgrep.yml", "--error"]
+    linter_config.external_linter('sgrep-py', [*sgrep_command, "--lang=python"], ['py'],
+                                  description="Syntactic Grep (sgrep) Code Search Tool "
+                                  "(config: ./tools/sgrep.yml")
+
     @linter_config.lint
     def custom_py():
         # type: () -> int

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -415,9 +415,6 @@ python_rules = RuleList(
          'description': "Don't use datetime in backend code.\n"
          "See https://zulip.readthedocs.io/en/latest/contributing/code-style.html#naive-datetime-objects",
          },
-        {'pattern': r'render_to_response\(',
-         'description': "Use render() instead of render_to_response().",
-         },
         {'pattern': 'from os.path',
          'description': "Don't use from when importing from the standard library",
          },

--- a/tools/setup/install-sgrep
+++ b/tools/setup/install-sgrep
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+version=0.4.9b5
+tarball=sgrep-$version-ubuntu-16.04.tgz
+sha256=9e57323fd0eb9133b7ff301a6be8361c073c3bfe6e6959ca1b622e5abc176e03
+tarball_url=https://github.com/returntocorp/sgrep/releases/download/v$version/$tarball
+
+if ! out="$(sgrep-lint --version 2>/dev/null)" || [[ "$out" != "$version" ]]
+then
+    tmpdir="$(mktemp -d)"
+    trap 'rm -r "$tmpdir"' EXIT
+    cd "$tmpdir"
+    wget -nv "$tarball_url"
+    sha256sum -c <<< "$sha256  $tarball"
+    tar -xzf "$tarball" -C /usr/local/lib/
+    ln -sf /usr/local/lib/sgrep-lint-files/sgrep-lint /usr/local/bin/sgrep-lint
+    ln -sf /usr/local/lib/sgrep-lint-files/sgrep /usr/local/bin/sgrep
+fi

--- a/tools/sgrep.yml
+++ b/tools/sgrep.yml
@@ -1,0 +1,18 @@
+# See https://github.com/returntocorp/sgrep/blob/develop/docs/config.md for sgrep rule format
+
+rules:
+  - id: deprecated-render-usage
+    pattern: django.shortcuts.render_to_response(...)
+    message: Use render() (from django.shortcuts) instead of render_to_response()
+    languages: [python]
+    severity: ERROR
+  - id: useless-if-body
+    patterns:
+        - pattern: |
+            if $X:
+                $S
+            else:
+                $S
+    message: "useless if statment; both blocks have the same body"
+    languages: [python]
+    severity: ERROR

--- a/version.py
+++ b/version.py
@@ -27,4 +27,4 @@ LATEST_DESKTOP_VERSION = "4.0.3"
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '75.5'
+PROVISION_VERSION = '75.6'


### PR DESCRIPTION
Hi Zulip team,

@timabbott, @amanagr, @ievans, myself, and some of the other [sgrep](https://sgrep.dev) maintainers discussed augmenting the regular expressions in [custom_check.py](https://github.com/zulip/zulip/blob/master/tools/linter_lib/custom_check.py) with more robust sgrep patterns. Although the regex checks already do most of what Zulip needs, we discussed their fragility due to lack of syntax-awareness and being difficult to read for new contributors in particular. The goal of this PR is to prototype sgrep as a potential replacement that improves the consistency and quality of custom checking.

sgrep (syntactic grep) is an open-source tool originally built at Facebook which lifts grep-esque code patterns into AST matchers. Compared to regexes these patterns aren’t affected by things like whitespace, comments, newlines, the order of keyword arguments, variable renaming, and other Python nuances.

For example

```py
flask.response.set_cookie(...)
```

will match on

```py
response.set_cookie("hello", "world")

response.set_cookie("hello", # This is a comment
                    "world")
```

We hope that with sgrep it’s easier for OSS projects to enforce custom code standards.

### Overview

@timabbott asked us to open a proof-of-concept PR for evaluation. In this PR we:

1. Install sgrep per [dependencies.md](https://github.com/zulip/zulip/blob/master/docs/subsystems/dependencies.md) guidelines
2. Add a `sgrep.yml` configuration with a few Zulip-specific patterns (discussed below)
3. Run sgrep via `tools/lint`
4. Leave comments in the code for discussion

We only implemented the regex checks for enforcing string internationalization in `json_error()`  and `JsonableError()` responses (see [custom_check.py#L343-364](https://github.com/zulip/zulip/blob/master/tools/linter_lib/custom_check.py#L343-L364)). If there is a different check you’d like to see implemented, please let us know!

sgrep found 7 cases of non-internationalized strings that the existing regex-based check missed. The calls were generally of the form:

```py
json_error(result['msg'])
JsonableError(msg)
json_error(PASSWORD_TOO_WEAK_ERROR)
```

We left comments in the code to discuss these results further and if they need fixing.

Not commented are two classes of findings that we were unsure about:

1. How closely should string internationalization follow the convention of calling `_()` directly within `json_error` and `JsonableError`? There are 13 results where the string is internationalized elsewhere, and then passed in (e.g. by error classes like `BillingError`).
2. How do you decide what errors should and shouldn’t be internationalized? There are 9 calls of the form `return json_error(str(e))` that appear to be returning generic Django or Python errors. Are you ok if these are flagged by sgrep?

If you’d like to experiment with these patterns online, see [sgrep.live/Kgd](https://sgrep.live/Kgd).

### Open Questions

- [ ] Are there Zulip-specific customizations or missing functionality that you’d like to see added? Currently sgrep does not support per-check file ignores.
- [ ] What other patterns would be helpful or valued? Are there patterns you’ve considered but have been unable to express because of grep limitations?

### Testing Plan

Manually verified that sgrep is installed when the Zulip dev environment is provisioned and that sgrep runs when `./tools/lint` is called. Running in the vagrant dev environment sgrep takes ~20 seconds to run. In the same environment, `./tools/lint` (both with and without sgrep) takes ~50 seconds to run. sgrep is not a bottleneck for local linting tools.

The tool output when run over all files is:

```
sgrep     | running 3 rules from 1 config sgrep.yml
sgrep     | corporate/views.py
sgrep     | rule:json_error_uggettext: Argument to json_error should be a literal string enclosed by _()
sgrep     | 105:        return json_error(e.message, data={'error_description': e.description})
sgrep     | 110:        return json_error(error_message, data={'error_description': error_description})
sgrep     | 221:        return json_error(e.message, data={'error_description': e.description})
sgrep     |
sgrep     | zerver/lib/actions.py
sgrep     | rule:jsonableerror_uggettext: Argument to JsonableError should be a literal string enclosed by _()
sgrep     | 1781:            raise JsonableError(e.messages[0])
sgrep     | 2405:            raise JsonableError(e.messages[0])
sgrep     |
sgrep     | zerver/lib/remote_server.py
sgrep     | rule:jsonableerror_uggettext: Argument to JsonableError should be a literal string enclosed by _()
sgrep     | 85:            raise JsonableError(msg)
sgrep     |
sgrep     | zerver/lib/request.py
sgrep     | rule:jsonableerror_uggettext: Argument to JsonableError should be a literal string enclosed by _()
sgrep     | 358:                    raise JsonableError(error)
sgrep     | 364:                    raise JsonableError(error)
sgrep     |
sgrep     | zerver/lib/user_groups.py
sgrep     | rule:jsonableerror_uggettext: Argument to JsonableError should be a literal string enclosed by _()
sgrep     | 15:            raise JsonableError(msg)
sgrep     |
sgrep     | zerver/views/compatibility.py
sgrep     | rule:json_error_uggettext: Argument to json_error should be a literal string enclosed by _()
sgrep     | 83:        return json_error(legacy_compatibility_error_message)
sgrep     | 88:            return json_error(legacy_compatibility_error_message)
sgrep     |
sgrep     | zerver/views/custom_profile_fields.py
sgrep     | rule:jsonableerror_uggettext: Argument to JsonableError should be a literal string enclosed by _()
sgrep     | 41:        raise JsonableError(error)
sgrep     | 45:        raise JsonableError(error)
sgrep     | 59:        raise JsonableError(error)
sgrep     |
sgrep     | zerver/views/email_mirror.py
sgrep     | rule:json_error_uggettext: Argument to json_error should be a literal string enclosed by _()
sgrep     | 21:        return json_error(result['msg'])  # discuss sgrep finding
sgrep     |
sgrep     | zerver/views/messages.py
sgrep     | rule:jsonableerror_uggettext: Argument to JsonableError should be a literal string enclosed by _()
sgrep     | 560:                raise JsonableError(error)
sgrep     |
sgrep     | zerver/views/muting.py
sgrep     | rule:json_error_uggettext: Argument to json_error should be a literal string enclosed by _()
sgrep     | 51:        return json_error(error)
sgrep     |
sgrep     | zerver/views/realm_filters.py
sgrep     | rule:json_error_uggettext: Argument to json_error should be a literal string enclosed by _()
sgrep     | 30:        return json_error(e.messages[0], data={"errors": dict(e)})
sgrep     |
sgrep     | zerver/views/storage.py
sgrep     | rule:json_error_uggettext: Argument to json_error should be a literal string enclosed by _()
sgrep     | 22:        return json_error(str(e))
sgrep     | 35:        return json_error(str(e))
sgrep     | 48:        return json_error(str(e))
sgrep     |
sgrep     | zerver/views/streams.py
sgrep     | rule:json_error_uggettext: Argument to json_error should be a literal string enclosed by _()
sgrep     | 532:        return json_error(e.msg, status=404)  # discuss sgrep finding
sgrep     | 611:            return json_error(property_conversion)  # discuss sgrep finding
sgrep     | rule:jsonableerror_uggettext: Argument to JsonableError should be a literal string enclosed by _()
sgrep     | 238:                raise JsonableError(response.content)
sgrep     |
sgrep     | zerver/views/user_settings.py
sgrep     | rule:json_error_uggettext: Argument to json_error should be a literal string enclosed by _()
sgrep     | 119:            return json_error(error)
sgrep     | 128:            return json_error(e.message)
sgrep     | 230:        return json_error(AVATAR_CHANGES_DISABLED_ERROR)  # discuss sgrep finding
sgrep     | 247:        return json_error(AVATAR_CHANGES_DISABLED_ERROR)  # discuss sgrep finding
sgrep     |
sgrep     | zerver/views/users.py
sgrep     | rule:json_error_uggettext: Argument to json_error should be a literal string enclosed by _()
sgrep     | 462:        return json_error(PASSWORD_TOO_WEAK_ERROR)  # discuss sgrep finding
sgrep     |
sgrep     | zerver/webhooks/librato/view.py
sgrep     | rule:json_error_uggettext: Argument to json_error should be a literal string enclosed by _()
sgrep     | 162:        return json_error(str(e))
sgrep     |
sgrep     | zilencer/views.py
sgrep     | rule:jsonableerror_uggettext: Argument to JsonableError should be a literal string enclosed by _()
sgrep     | 66:        raise JsonableError(e.message)
```