### PR TITLE
Link fix

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -824,6 +824,11 @@ td.pointer {
     display: block;
 }
 
+.recipient_bar_icon {
+    padding-left: 2px;
+    padding-right: 2px;
+}
+
 .summary_row .message_header {
     padding: 5px 0px 4px 5px;
 }
@@ -1082,7 +1087,6 @@ a.message_label_clickable:hover {
 }
 
 .on_hover_topic_mute {
-    padding-left: 3px;
     opacity: .1;
 }
 

--- a/static/templates/recipient_row.hbs
+++ b/static/templates/recipient_row.hbs
@@ -33,16 +33,16 @@
                 {{! exterior links (e.g. to a trac ticket) }}
                 {{#each topic_links}}
                 <a href="{{this}}" target="_blank" class="no-underline">
-                    <i class="fa fa-external-link-square" aria-label="{{t 'External link' }}"></i>
+                    <i class="fa fa-external-link-square recipient_bar_icon" aria-label="{{t 'External link' }}"></i>
                 </a>
                 {{/each}}
 
                 {{! edit topic pencil icon }}
                 {{#if always_visible_topic_edit}}
-                    <i class="fa fa-pencil always_visible_topic_edit" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} role="button" tabindex="0" aria-label="{{t 'Edit' }}"></i>
+                    <i class="fa fa-pencil always_visible_topic_edit recipient_bar_icon" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} role="button" tabindex="0" aria-label="{{t 'Edit' }}"></i>
                 {{else}}
                     {{#if on_hover_topic_edit}}
-                    <i class="fa fa-pencil on_hover_topic_edit" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} role="button" tabindex="0" aria-label="{{t 'Edit' }}"></i>
+                    <i class="fa fa-pencil on_hover_topic_edit recipient_bar_icon" {{#unless realm_allow_message_editing}}style="display: none"{{/unless}} role="button" tabindex="0" aria-label="{{t 'Edit' }}"></i>
                     {{/if}}
                 {{/if}}
 
@@ -50,7 +50,7 @@
                     <span class="topic_edit_form" id="{{id}}"></span>
                 </span>
 
-                <i class="fa fa-bell-slash on_hover_topic_mute" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Mute topic' }} (M)" role="button" tabindex="0" aria-label="{{t 'Mute topic' }} (M)"></i>
+                <i class="fa fa-bell-slash on_hover_topic_mute recipient_bar_icon" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Mute topic' }} (M)" role="button" tabindex="0" aria-label="{{t 'Mute topic' }} (M)"></i>
                 <span class="recipient_row_date {{#if group_date_divider_html}}{{else}}hide-date{{/if}}">{{{date}}}</span>
             </span>
         </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Open link icon close to edit pencil icon in message header
https://github.com/zulip/zulip/issues/14364

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/20909078/77736211-fab38980-7031-11ea-89c1-56e9b45d6bfd.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
Improved spacing between recipient_bar_icons by adding new classes to recipient_row.hbs file and
setting appropriate padding values to the classes.

Fixes #14364 