### PR TITLE
widgets: Hide edit question icon in poll widget for non-author users.

### DIFF
--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -318,14 +318,14 @@ exports.MessageList.prototype = {
 
     show_edit_topic: function MessageList_show_edit_topic(recipient_row, form) {
         recipient_row.find(".topic_edit_form").empty().append(form);
-        recipient_row.find('.fa-pencil').hide();
+        recipient_row.find('.edit_content_button').hide();
         recipient_row.find(".stream_topic").hide();
         recipient_row.find(".topic_edit").show();
     },
 
     hide_edit_topic: function MessageList_hide_edit_topic(recipient_row) {
         recipient_row.find(".stream_topic").show();
-        recipient_row.find('.fa-pencil').show();
+        recipient_row.find('.edit_content_button').show();
         recipient_row.find(".topic_edit").hide();
     },
 


### PR DESCRIPTION
If a non-author user clicked on view source in a poll and then closed it,
the edit question icon would incorrectly get visible. This made changing
the question in local echo possible for non-author users.

Prevented the edit question icon to get visible for non-author users.

Fixes: #14299
