### PR TITLE
check-openapi: Restore functionality after OpenAPI definitions moved

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "jquery": "^3.4.1",
     "jquery-caret-plugin": "^1.5.2",
     "jquery-validation": "^1.19.0",
+    "js-yaml": "^3.13.1",
     "katex": "^0.11.1",
     "mini-css-extract-plugin": "^0.9.0",
     "moment": "^2.24.0",

--- a/tools/check-openapi
+++ b/tools/check-openapi
@@ -2,40 +2,15 @@
 
 const SwaggerParser = require('swagger-parser');
 
-function check_duplicate_operationids(file, api) {
-    const operation_ids = [];
-
-    for (const endpoint of api.paths) {
-        for (const value of endpoint) {
-            const operation_id = value.operationId;
-            if (operation_id !== undefined) {
-                if (operation_ids.includes(operation_id)) {
-                    console.error('In', file + ':');
-                    console.error('Duplicate operationId:', operation_id);
-                    process.exitCode = 1;
-                } else {
-                    operation_ids.push(operation_id);
-                }
-            }
-        }
+async function validate_swagger(file) {
+    try {
+        await SwaggerParser.validate(file);
+    } catch (err) {
+        // There is something wrong. Display the validation errors
+        console.error('In', file + ':');
+        console.error(err.message);
+        process.exitCode = 1;
     }
-}
-
-function validate_swagger(file) {
-    SwaggerParser.validate(file)
-        .then(function (api) {
-            // Let's make sure that there aren't any duplicate operationids,
-            // until this issue is fixed:
-            // https://github.com/BigstickCarpet/swagger-parser/issues/68
-            check_duplicate_operationids(file, api);
-            return;
-        })
-        .catch(function (err) {
-            // There is something wrong. Display the validation errors
-            console.error('In', file + ':');
-            console.error(err.message);
-            process.exitCode = 1;
-        });
 }
 
 // Iterate through the changed files, passed in the arguments.

--- a/tools/check-openapi
+++ b/tools/check-openapi
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+const fs = require('fs');
+const jsyaml = require('js-yaml');
 const SwaggerParser = require('swagger-parser');
 
 async function validate_swagger(file) {
@@ -13,12 +15,13 @@ async function validate_swagger(file) {
     }
 }
 
-// Iterate through the changed files, passed in the arguments.
-// The two first arguments are the call to the Node interpreter and this
-// script, hence the starting point at 2.
-for (const file of process.argv.slice(2)) {
-    // Run the validator only for YAML files inside static/swagger
-    if (file.startsWith('static/swagger')) {
-        validate_swagger(file);
+(async () => {
+    // Iterate through the changed files, passed in the arguments.
+    // The two first arguments are the call to the Node interpreter and this
+    // script, hence the starting point at 2.
+    for (const file of process.argv.slice(2)) {
+        if (jsyaml.safeLoad(await fs.promises.readFile(file, 'utf8')).openapi !== undefined) {
+            await validate_swagger(file);
+        }
     }
-}
+})();


### PR DESCRIPTION
Commit 35577a1f66e514585c9210a50ea336ebe42511d6 (#9406) moved the OpenAPI definitions to `zerver/openapi`, and this script was not updated, so it has been validating nothing for two years.

Unfortunately that means a lot of errors have accumulated, and this script only shows the first one, so getting this to pass again is going to be a chore…