### PR TITLE
portico: Drop font-weight for links from landing-page.scss.

### DIFF
--- a/static/styles/portico/landing-page.scss
+++ b/static/styles/portico/landing-page.scss
@@ -37,7 +37,6 @@ a,
 a:hover,
 a:visited {
     color: hsl(170, 47%, 33%);
-    font-weight: 500;
 }
 
 a.arrow::after {


### PR DESCRIPTION
This commit removes "font-weight: 500;" from landing-page.scss so as
to fix a bug on landing pages that used the `markdown` class to
format content. The bug was caused by "a:hover" from landing-page.scss
overriding the font-weight (600) on links as set by the markdown
class, this caused the text to seem jumpy when one hovered over links.
Fixes: #14387.

I am concerned that this might break styling for links on other pages, I haven't checked... so this might be considered WIP.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before:
![portico-links-weight-before](https://user-images.githubusercontent.com/33805964/77827512-07bc9f80-713c-11ea-9d50-32128fd64421.gif)
After:
![portico-links-weight-after](https://user-images.githubusercontent.com/33805964/77827516-0e4b1700-713c-11ea-99dd-085a01f7e7eb.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
