### PR TITLE
stream_edit: Fix closing settings overlay after closing permission modal.

### DIFF
--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -36,6 +36,21 @@ exports.drafts_open = function () {
     return open_overlay_name === 'drafts';
 };
 
+// This just adds the inline style to '.overlay.show',
+// which is the element behind the current modal,
+// and overrides the "pointer-events: all" style in
+// app_components.scss.
+exports.disable_background_mouse_events = function () {
+    $('.overlay.show').attr("style", "pointer-events: none");
+};
+
+// This removes only the inline-style of the element that
+// was added in disable_background_mouse_events and
+// enables the background mouse events.
+exports.enable_background_mouse_events = function () {
+    $('.overlay.show').attr("style", null);
+};
+
 exports.active_modal = function () {
     if (!exports.is_modal_open()) {
         blueslip.error("Programming error — Called active_modal when there is no modal open");
@@ -99,7 +114,7 @@ exports.open_modal = function (name) {
 
     $("#" + name).modal("show").attr("aria-hidden", false);
     // Disable background mouse events when modal is active
-    $('.overlay.show').attr("style", "pointer-events: none");
+    exports.disable_background_mouse_events();
     // Remove previous alert messages from modal, if exists.
     $("#" + name).find(".alert").hide();
     $("#" + name).find(".alert-notification").html("");
@@ -163,7 +178,7 @@ exports.close_modal = function (name) {
 
     $("#" + name).modal("hide").attr("aria-hidden", true);
     // Enable mouse events for the background as the modal closes.
-    $('.overlay.show').attr("style", null);
+    exports.enable_background_mouse_events();
 
 };
 

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -408,6 +408,7 @@ function change_stream_privacy(e) {
         url: "/json/streams/" + stream_id,
         data: data,
         success: function () {
+            overlays.close_modal('stream_privacy_modal');
             $("#stream_privacy_modal").remove();
             // The rest will be done by update stream event we will get.
         },
@@ -535,6 +536,7 @@ exports.initialize = function () {
     $("#subscriptions_table").on('click', '.close-privacy-modal', function (e) {
         // This fixes a weird bug in which, subscription_settings hides
         // unexpectedly by clicking the cancel button.
+        overlays.enable_background_mouse_events();
         e.stopPropagation();
     });
 


### PR DESCRIPTION

When stream_post_policy modal is closed either after saving or using
cancel button or cross button, the pointer-events is set to none which
does not allow to close the stream settings overlay on one click.

Added overlay.close_modal on saving such that pointer-events:none is
removed.

Added line which removes pointer-events:none again on clicking cancel
button or close icon.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before - 
![stream](https://user-images.githubusercontent.com/35494118/77829195-8585a880-7146-11ea-88ab-d29d7ae1fef0.gif)

After -
![stream_after](https://user-images.githubusercontent.com/35494118/77829414-e497ed00-7147-11ea-91a5-3afdd7b00c7f.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
