### PR TITLE
Hide some organization settings from a user.

### DIFF
--- a/static/js/realm_icon.js
+++ b/static/js/realm_icon.js
@@ -3,6 +3,9 @@ exports.build_realm_icon_widget = function (upload_function) {
         return $('#realm_icon_file_input').expectOne();
     };
 
+    if (!page_params.is_admin) {
+        return;
+    }
     if (page_params.realm_icon_source === 'G') {
         $("#realm_icon_delete_button").hide();
     } else {

--- a/static/js/realm_logo.js
+++ b/static/js/realm_logo.js
@@ -13,6 +13,10 @@ exports.build_realm_logo_widget = function (upload_function, is_night) {
         return file_input_elem.expectOne();
     };
 
+    if (!page_params.is_admin) {
+        return;
+    }
+
     if (page_params.realm_logo_source === 'D') {
         delete_button_elem.hide();
     } else {

--- a/static/templates/settings/organization_profile_admin.hbs
+++ b/static/templates/settings/organization_profile_admin.hbs
@@ -34,6 +34,7 @@
                 <input type="file" name="realm_icon_file_input" class="notvisible"
                   id="realm_icon_file_input" value="{{t 'Upload profile picture' }}"/>
             </div>
+            {{#if is_admin}}
             <div class="inline-block avatar-controls">
                 <div id="realm_icon_file_input_error" class="alert text-error"></div>
                 <button class="button rounded sea-green w-200 block input-size"
@@ -44,6 +45,7 @@
                 <button class="button rounded btn-danger w-200 m-t-10 block input-size"
                   id="realm_icon_delete_button">{{t 'Delete profile picture' }}</button>
             </div>
+            {{/if}}
         </div>
         <a href="/login/?preview=true" target="_blank" class="button rounded sea-green w-200 block" id="id_org_profile_preview">
             {{t 'Preview organization profile' }}

--- a/static/templates/settings/realm-logo-widget.hbs
+++ b/static/templates/settings/realm-logo-widget.hbs
@@ -4,6 +4,7 @@
         <input type="file" name="realm-logo-file-input"
           class="realm-logo-file-input notvisible" value="{{t 'Upload logo' }}"/>
     </div>
+    {{#if is_admin}}
     <div class="inline-block avatar-controls">
         <div class="realm-logo-file-input-error alert text-error"></div>
         {{#if plan_includes_wide_organization_logo}}
@@ -16,4 +17,5 @@
         </button>
         {{/if}}
     </div>
+    {{/if}}
 </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/14313

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/20909078/77832352-62192880-715b-11ea-8e5e-6433e107910c.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
According to discussion, removed the buttons to add/remove profile photo.
