### PR TITLE
[WIP] Changed 'forgotten password' to not ask for an email

### DIFF
--- a/templates/zerver/reset.html
+++ b/templates/zerver/reset.html
@@ -9,6 +9,7 @@
 
         <div class="app-main forgot-password-container white-box new-style">
 
+
             <p>Forgot your password? No problem, we'll send a link to reset your password to the email you signed up with.</p>
 
             <form method="post" class="form-horizontal" action="{{ url('zerver.views.auth.password_reset') }}">


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR is for https://github.com/zulip/zulip/issues/6342
Issue #6342

**Testing Plan:** <!-- How have you tested? -->
I sent a password reset request and checked the email at localhost:9991/email.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
On clicking the "Forgotten Password?" link, you'll be redirected to see this screen:
![Screenshot](https://user-images.githubusercontent.com/6205961/77847801-5b32fa00-71dd-11ea-9a51-715c92783231.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->

