### PR TITLE
openapi: Use response schema for describing simple success response.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -37,8 +37,8 @@ paths:
       - name: username
         in: query
         description: |
-          The username to be used for authentication (typically, the
-          email address, but it could be an LDAP username).
+          The username to be used for authentication (typically, the email
+          address, but it could be an LDAP username).
         schema:
           type: string
         required: true
@@ -58,10 +58,10 @@ paths:
                 $ref: '#/components/schemas/ApiKeyResponse'
   /dev_fetch_api_key:
     post:
-      description: Gather a token bound to a user account, to identify and
-        authenticate them when making operations with the API. This token must
-        be used as the password in the rest of the endpoints that require
-        Basic authentication.
+      description: |
+        Gather a token bound to a user account, to identify and authenticate
+        them when making operations with the API. This token must be used as the
+        password in the rest of the endpoints that require Basic authentication.
       parameters:
       - name: username
         in: query
@@ -80,33 +80,33 @@ paths:
                 $ref: '#/components/schemas/ApiKeyResponse'
   /events:
     get:
-      description: Receive new events from
-        [a registered event queue](/api/register-queue).
+      description: |
+        Receive new events from [a registered event queue](/api/register-queue).
       parameters:
       - name: queue_id
         in: query
-        description: The ID of a queue that you registered via
-          `POST /api/v1/register`
-          (see [Register a queue](/api/register-queue)).
+        description: |
+          The ID of a queue that you registered via `POST /api/v1/register` (see
+          [Register a queue](/api/register-queue)).
         schema:
           type: string
         example: 1375801870:2942
       - name: last_event_id
         in: query
-        description: The highest event ID in this queue that you've received
-          and wish to acknowledge. See the [code for `call_on_each_event`](https://github.com/zulip/python-zulip-api/blob/master/zulip/zulip/__init__.py)
-          in the [zulip Python module](https://github.com/zulip/python-zulip-api)
-          for an example implementation of correctly processing each event
-          exactly once.
+        description: |
+          The highest event ID in this queue that you've received and wish to acknowledge. See the [code for
+          `call_on_each_event`](https://github.com/zulip/python-zulip-api/blob/master/zulip/zulip/__init__.py) in the [zulip Python
+          module](https://github.com/zulip/python-zulip-api) for an example implementation of correctly processing each event exactly once.
         schema:
           type: integer
         example: -1
       - name: dont_block
         in: query
-        description: Set to `true` if the client is requesting a nonblocking
-          reply. If not specified, the request will block until either a new
-          event is available or a few minutes have passed, in which case the
-          server will send the client a heartbeat event.
+        description: |
+          Set to `true` if the client is requesting a nonblocking reply. If not
+          specified, the request will block until either a new event is available
+          or a few minutes have passed, in which case the server will send the
+          client a heartbeat event.
         schema:
           type: boolean
           default: false
@@ -122,11 +122,11 @@ paths:
                 - properties:
                     events:
                       type: array
-                      description: An array of `event` objects (possibly
-                        zero-length if `dont_block` is set) of events with
-                        IDs newer than `last_event_id`. Event IDs are
-                        guaranteed to be increasing, but they are not
-                        guaranteed to be consecutive.
+                      description: |
+                        An array of `event` objects (possibly zero-length if `dont_block` is
+                        set) of events with IDs newer than `last_event_id`. Event IDs are
+                        guaranteed to be increasing, but they are not guaranteed to be
+                        consecutive.
                 - example:
                     {
                         "events": [
@@ -196,8 +196,9 @@ paths:
       parameters:
       - name: queue_id
         in: query
-        description: The ID of a queue that you registered via
-          `POST /api/v1/register`(see [Register a queue](/api/register-queue).
+        description: |
+          The ID of a queue that you registered via `POST /api/v1/register`(see
+          [Register a queue](/api/register-queue).
         schema:
           type: string
         example: 1375801870:2942
@@ -259,8 +260,9 @@ paths:
                     }
   /mark_all_as_read:
     post:
-      description: Mark all the user's unread messages as read. This is often
-        called "bankruptcy" in Zulip.
+      description: |
+        Mark all the user's unread messages as read. This is often called
+        "bankruptcy" in Zulip.
       responses:
         '200':
           description: Success.
@@ -274,8 +276,8 @@ paths:
       parameters:
       - name: stream_id
         in: query
-        description: The ID of the stream whose messages should be marked as
-          read.
+        description: |
+          The ID of the stream whose messages should be marked as read.
         schema:
           type: integer
         example: 42
@@ -300,8 +302,8 @@ paths:
         required: true
       - name: topic_name
         in: query
-        description: The name of the topic whose messages should be marked as
-          read.
+        description: |
+          The name of the topic whose messages should be marked as read.
         schema:
           type: string
         example: new coffee machine
@@ -320,9 +322,9 @@ paths:
       - name: anchor
         in: query
         description: |
-          Integer message ID to anchor fetching of new messages.
-          Supports special string values for when the client wants the
-          server to compute the anchor to use:
+          Integer message ID to anchor fetching of new messages. Supports special
+          string values for when the client wants the server to compute the anchor
+          to use:
 
           * `newest`: The most recent message.
           * `oldest`: The oldest message.
@@ -361,8 +363,9 @@ paths:
         required: true
       - name: narrow
         in: query
-        description: The narrow where you want to fetch the messages from.
-          See how to [construct a narrow](/api/construct-narrow).
+        description: |
+          The narrow where you want to fetch the messages from. See how to
+          [construct a narrow](/api/construct-narrow).
         schema:
           type: array
           items:
@@ -371,20 +374,21 @@ paths:
         example: [{"operand": "Denmark", "operator": "stream"}]
       - name: client_gravatar
         in: query
-        description: Whether the client supports computing gravatars URLs.  If enabled,
-          `avatar_url` will be included in the response only if there is a Zulip avatar,
-          and will be `null` for users who are using gravatar as their avatar.  This option
-          significantly reduces the compressed size of user data, since gravatar URLs
-          are long, random strings and thus do not compress well.
+        description: |
+          Whether the client supports computing gravatars URLs.  If enabled, `avatar_url`
+          will be included in the response only if there is a Zulip avatar, and will be
+          `null` for users who are using gravatar as their avatar.  This option
+          significantly reduces the compressed size of user data, since gravatar URLs are
+          long, random strings and thus do not compress well.
         schema:
           type: boolean
           default: false
         example: true
       - name: apply_markdown
         in: query
-        description: If `true`, message content is returned in the rendered HTML format.
-          If `false`, message content is returned in the raw markdown-format text that user
-          entered.
+        description: |
+          If `true`, message content is returned in the rendered HTML format. If `false`,
+          message content is returned in the raw markdown-format text that user entered.
         schema:
           type: boolean
           default: true
@@ -414,29 +418,32 @@ paths:
                 - properties:
                     anchor:
                       type: integer
-                      description: The same `anchor` specified in the request (or the computed
-                        one, if `use_first_unread_anchor` is `true`).
+                      description: |
+                        The same `anchor` specified in the request (or the computed one, if
+                        `use_first_unread_anchor` is `true`).
                     found_newest:
                       type: boolean
-                      description: Whether the `messages` list includes the
-                        very newest messages matching the narrow (used by clients that
-                        paginate their requests to decide whether there are more messages
-                        to fetch).
+                      description: |
+                        Whether the `messages` list includes the very newest messages matching
+                        the narrow (used by clients that paginate their requests to decide
+                        whether there are more messages to fetch).
                     found_oldest:
                       type: boolean
-                      description: Whether the `messages` list includes the
-                        very oldest messages matching the narrow (used by clients that
-                        paginate their requests to decide whether there are more messages
-                        to fetch).
+                      description: |
+                        Whether the `messages` list includes the very oldest messages matching
+                        the narrow (used by clients that paginate their requests to decide
+                        whether there are more messages to fetch).
                     found_anchor:
                       type: boolean
-                      description: Whether the anchor message is included in the response.
-                        If the message with the ID specified in the request does not exist or
-                        did not match the narrow, this will be false.
+                      description: |
+                        Whether the anchor message is included in the response. If the message
+                        with the ID specified in the request does not exist or did not match the
+                        narrow, this will be false.
                     history_limited:
                       type: boolean
-                      description: Whether the message history was limited due to plan restrictions.
-                        This flag is set to `true` only when the oldest messages(`found_oldest`)
+                      description: |
+                        Whether the message history was limited due to plan restrictions. This
+                        flag is set to `true` only when the oldest messages(`found_oldest`)
                         matching the narrow is fetched.
                     messages:
                       type: array
@@ -528,8 +535,9 @@ paths:
       parameters:
       - name: type
         in: query
-        description: The type of message to be sent. `private` for a private
-          message and `stream` for a stream message.
+        description: |
+          The type of message to be sent. `private` for a private message and
+          `stream` for a stream message.
         schema:
           type: string
           enum:
@@ -540,9 +548,9 @@ paths:
       - name: to
         in: query
         description: |
-          For stream messages, either the name or integer ID of the stream.
-          For private messages, either a list containing integer user
-          IDs or a list containing string email addresses.
+          For stream messages, either the name or integer ID of the stream. For
+          private messages, either a list containing integer user IDs or a list
+          containing string email addresses.
 
           **Changes**: Support using user/stream IDs was added in Zulip 2.0.0.
         schema:
@@ -551,16 +559,17 @@ paths:
         required: true
       - name: topic
         in: query
-        description: The topic of the message. Only required if `type` is
-          `stream`, ignored otherwise. Maximum length of 60 characters.
+        description: |
+          The topic of the message. Only required if `type` is `stream`, ignored
+          otherwise. Maximum length of 60 characters.
         schema:
           type: string
           default:
         example: Castle
       - name: content
         in: query
-        description: The content of the message. Maximum message size of
-          10000 bytes.
+        description: |
+          The content of the message. Maximum message size of 10000 bytes.
         schema:
           type: string
         example: Hello
@@ -649,17 +658,19 @@ paths:
         required: true
       - name: topic
         in: query
-        description: The topic of the message. Only required for stream
-          messages. Maximum length of 60 characters.
+        description: |
+          The topic of the message. Only required for stream messages. Maximum
+          length of 60 characters.
         schema:
           type: string
           default:
         example: Castle
       - name: propagate_mode
         in: query
-        description: "Which message(s) should be edited: just the one
-          indicated in `message_id`, messages in the same topic that had been
-          sent after this one, or all of them."
+        description: |
+          "Which message(s) should be edited: just the one indicated in
+          `message_id`, messages in the same topic that had been sent after this
+          one, or all of them."
         schema:
           type: string
           enum:
@@ -670,8 +681,8 @@ paths:
         example: change_all
       - name: content
         in: query
-        description: The content of the message. Maximum message size of 10000
-          bytes.
+        description: |
+          The content of the message. Maximum message size of 10000 bytes.
         schema:
           type: string
         example: Hello
@@ -769,9 +780,9 @@ paths:
                       type: array
                       items:
                         type: object
-                      description: A chronologically sorted array of
-                        `snapshot` objects, each one with the values of the
-                        message after the edition.
+                      description: |
+                        A chronologically sorted array of `snapshot` objects, each one with the
+                        values of the message after the edition.
                 - example:
                     {
                         "message_history": [
@@ -846,8 +857,8 @@ paths:
                       type: array
                       items:
                         type: integer
-                      description: An array with the IDs of the modified
-                        messages.
+                      description: |
+                        An array with the IDs of the modified messages.
                 - example:
                     {
                         "msg": "",
@@ -912,10 +923,9 @@ paths:
       - name: emoji_code
         in: query
         description: |
-                     An encoded version of the unicode codepoint.  For
-                     most clients, you won't need this; it's used to
-                     handle a rare corner case when upvoting a unicode
-                     emoji reaction added previously by another user.
+                     An encoded version of the unicode codepoint.  For most clients, you
+                     won't need this; it's used to handle a rare corner case when upvoting a
+                     unicode emoji reaction added previously by another user.
 
                      If the existing reaction was added when the Zulip
                      server was using a previous version of the emoji
@@ -931,8 +941,8 @@ paths:
       - name: reaction_type
         in: query
         description: |
-                     If you are reacting with a [custom emoji](/help/add-custom-emoji),
-                     set `reaction_type` to `realm_emoji`.
+                     If you are reacting with a [custom emoji](/help/add-custom-emoji), set
+                     `reaction_type` to `realm_emoji`.
         schema:
           type: string
         example: 'unicode_emoji'
@@ -983,9 +993,9 @@ paths:
       - name: emoji_code
         in: query
         description: |
-                     Alternative to emoji_name for expressing which emoji to remove.
-                     An encoded version of the unicode codepoint for the emoji
-                     you'd like to remove from the message.
+                     Alternative to emoji_name for expressing which emoji to remove. An
+                     encoded version of the unicode codepoint for the emoji you'd like to
+                     remove from the message.
 
                      Recommended over using `emoji_name` for Zulip apps
                      because this more robustly handles changes in the mapping
@@ -1056,8 +1066,9 @@ paths:
       parameters:
       - name: client_gravatar
         in: query
-        description: The `client_gravatar` field is set to `true` if clients
-          can compute their own gravatars.
+        description: |
+          The `client_gravatar` field is set to `true` if clients can compute
+          their own gravatars.
         schema:
           type: boolean
           default: false
@@ -1065,8 +1076,8 @@ paths:
       - name: include_custom_profile_fields
         in: query
         description: |
-          Set to `true` if the client wants custom profile field data
-          to be included in the response.
+          Set to `true` if the client wants custom profile field data to be
+          included in the response.
 
           **Changes**: New in Zulip 2.1.0.  Previous versions do no offer these
           data via the API.
@@ -1085,8 +1096,9 @@ paths:
                 - properties:
                     members:
                       type: array
-                      description: A list of `user` objects, each containing
-                        details about a user in the organization.
+                      description: |
+                        A list of `user` objects, each containing details about a user in the
+                        organization.
                 - example:
                     {
                        "msg": "",
@@ -1415,8 +1427,8 @@ paths:
       parameters:
       - name: email
         in: path
-        description: The email address of the user whose presence you want to
-          fetch.
+        description: |
+          The email address of the user whose presence you want to fetch.
         schema:
           type: string
         example: iago@zulip.com
@@ -1432,8 +1444,9 @@ paths:
                 - properties:
                     presence:
                       type: object
-                      description: An object containing the presence details
-                        for every client the user has logged into.
+                      description: |
+                        An object containing the presence details for every client the user has
+                        logged into.
                 - example:
                     {
                         "presence": {
@@ -1510,10 +1523,11 @@ paths:
                       example: 1
                     profile_data:
                       type: object
-                      description: A dictionary containing custom profile field data for the user.
-                        Each entry maps the integer ID of a custom profile field in the organization
-                        to a dictionary containing the user's data for that field.  Generally the
-                        data includes just a single `value` key; for those custom profile fields
+                      description: |
+                        A dictionary containing custom profile field data for the user. Each entry
+                        maps the integer ID of a custom profile field in the organization to a
+                        dictionary containing the user's data for that field.  Generally the data
+                        includes just a single `value` key; for those custom profile fields
                         supporting markdown, a `rendered_value` key will also be present.
                 - example:
                     {
@@ -1661,9 +1675,9 @@ paths:
       - name: include_subscribers
         in: query
         description: |
-          Set to `true` if you would like each stream's info to include a
-          list of current subscribers to that stream. (This may be significantly slower
-          in organizations with thousands of users.)
+          Set to `true` if you would like each stream's info to include a list of
+          current subscribers to that stream. (This may be significantly slower in
+          organizations with thousands of users.)
 
           **Changes**: New in Zulip 2.1.0.
         schema:
@@ -1737,11 +1751,12 @@ paths:
       parameters:
       - name: subscriptions
         in: query
-        description: "A list of dictionaries containing the the key `name`
-          and value specifying the name of the stream to subscribe. If the
-          stream does not exist a new stream is created. The description of the
-          stream created can be specified by setting the dictionary key
-          `description` with an appropriate value.
+        description: |
+          "A list of dictionaries containing the the key `name` and value
+          specifying the name of the stream to subscribe. If the stream does not
+          exist a new stream is created. The description of the stream created can
+          be specified by setting the dictionary key `description` with an
+          appropriate value.
 
 
           **Note**: This argument is called `streams` and not `subscriptions`
@@ -1754,17 +1769,19 @@ paths:
         required: true
       - name: invite_only
         in: query
-        description: A boolean specifying whether the streams specified in
-          `subscriptions` are invite-only or not.
+        description: |
+          A boolean specifying whether the streams specified in `subscriptions`
+          are invite-only or not.
         schema:
           type: boolean
           default: false
         example: true
       - name: principals
         in: query
-        description: A list of email addresses of the users that will be
-          subscribed to the streams specified in the `subscriptions` argument.
-          If not provided, then the requesting user/bot is subscribed.
+        description: |
+          A list of email addresses of the users that will be subscribed to the
+          streams specified in the `subscriptions` argument. If not provided, then
+          the requesting user/bot is subscribed.
         schema:
           type: array
           items:
@@ -1773,20 +1790,22 @@ paths:
         example: ['ZOE@zulip.com']
       - name: authorization_errors_fatal
         in: query
-        description: A boolean specifying whether authorization errors (such
-          as when the requesting user is not authorized to access a private
-          stream) should be considered fatal or not. When `True`, an
-          authorization error is reported as such. When set to `False`, the
-          returned JSON payload indicates that there was an authorization
-          error, but the response is still considered a successful one.
+        description: |
+          A boolean specifying whether authorization errors (such as when the
+          requesting user is not authorized to access a private stream) should be
+          considered fatal or not. When `True`, an authorization error is reported
+          as such. When set to `False`, the returned JSON payload indicates that
+          there was an authorization error, but the response is still considered a
+          successful one.
         schema:
           type: boolean
           default: true
         example: false
       - name: history_public_to_subscribers
         in: query
-        description: A boolean indicating if the history should be available to
-          newly subscribed members.
+        description: |
+          A boolean indicating if the history should be available to newly
+          subscribed members.
         schema:
           type: boolean
           default: None
@@ -1808,10 +1827,10 @@ paths:
         example: 1
       - name: announce
         in: query
-        description: If `announce` is `True` and one of the streams specified
-          in `subscriptions` has to be created (i.e. doesn't exist to begin
-          with), an announcement will be made notifying that a new stream was
-          created.
+        description: |
+          If `announce` is `True` and one of the streams specified in
+          `subscriptions` has to be created (i.e. doesn't exist to begin with), an
+          announcement will be made notifying that a new stream was created.
         schema:
           type: boolean
         example: true
@@ -1896,9 +1915,10 @@ paths:
           required: false
         - name: add
           in: query
-          description: A list of objects describing which streams to subscribe to,
-            optionally including per-user subscription parameters (e.g. color)
-            and if the stream is to be created, its description.
+          description: |
+            A list of objects describing which streams to subscribe to, optionally
+            including per-user subscription parameters (e.g. color) and if the
+            stream is to be created, its description.
           schema:
             type: array
             items:
@@ -1938,27 +1958,30 @@ paths:
                 - properties:
                     subscribed:
                       type: object
-                      description: A dictionary where the key is the email address of
-                        the user/bot and the value is a list of the names of the streams
-                        that were subscribed to as a result of the query.
+                      description: |
+                        A dictionary where the key is the email address of the user/bot and the
+                        value is a list of the names of the streams that were subscribed to as a
+                        result of the query.
                     already_subscribed:
                       type: object
-                      description: A dictionary where the key is the email address of
-                        the user/bot and the value is a list of the names of the streams
-                        that the user/bot is already subscribed to.
+                      description: |
+                        A dictionary where the key is the email address of the user/bot and the
+                        value is a list of the names of the streams that the user/bot is already
+                        subscribed to.
                     not_removed:
                       type: array
                       items:
                         type: string
-                      description: A list of the names of streams that the
-                        user is already unsubscribed from, and hence doesn't
-                        need to be unsubscribed.
+                      description: |
+                        A list of the names of streams that the user is already unsubscribed
+                        from, and hence doesn't need to be unsubscribed.
                     removed:
                       type: array
                       items:
                         type: string
-                      description: A list of the names of streams which were
-                        unsubscribed from as a result of the query.
+                      description: |
+                        A list of the names of streams which were unsubscribed from as a result
+                        of the query.
                 - example:
                     {
                         "msg": "",
@@ -1971,13 +1994,14 @@ paths:
                         "result": "success"
                     }
     delete:
-      description: Unsubscribe yourself or other users from one or more
-        streams.
+      description: |
+        Unsubscribe yourself or other users from one or more streams.
       parameters:
       - name: subscriptions
         in: query
-        description: A list of stream names to unsubscribe from. This argument
-          is called `streams` in our Python API.
+        description: |
+          A list of stream names to unsubscribe from. This argument is called
+          `streams` in our Python API.
         schema:
           type: array
           items:
@@ -1986,10 +2010,10 @@ paths:
         required: true
       - name: principals
         in: query
-        description: A list of email addresses of the users that will be
-          unsubscribed from the streams specified in the `subscriptions`
-          argument. If not provided, then the requesting user/bot is
-          unsubscribed.
+        description: |
+          A list of email addresses of the users that will be unsubscribed from
+          the streams specified in the `subscriptions` argument. If not provided,
+          then the requesting user/bot is unsubscribed.
         schema:
           type: array
           items:
@@ -2009,15 +2033,16 @@ paths:
                       type: array
                       items:
                         type: string
-                      description: A list of the names of streams that the
-                        user is already unsubscribed from, and hence doesn't
-                        need to be unsubscribed.
+                      description: |
+                        A list of the names of streams that the user is already unsubscribed
+                        from, and hence doesn't need to be unsubscribed.
                     removed:
                       type: array
                       items:
                         type: string
-                      description: A list of the names of streams which were
-                        unsubscribed from as a result of the query.
+                      description: |
+                        A list of the names of streams which were unsubscribed from as a result
+                        of the query.
                 - example:
                     {
                         "msg": "",
@@ -2035,8 +2060,8 @@ paths:
                 $ref: '#/components/schemas/NonExistingStreamError'
   /users/me/subscriptions/muted_topics:
     patch:
-      description: Toggle muting for a specific topic the user is subscribed
-        to.
+      description: |
+        Toggle muting for a specific topic the user is subscribed to.
       parameters:
       - name: stream
         in: query
@@ -2054,17 +2079,17 @@ paths:
         required: false
       - name: topic
         in: query
-        description: The topic to (un)mute. Note that the request will succeed
-          regardless of whether any messages have been sent to the
-          specified topic.
+        description: |
+          The topic to (un)mute. Note that the request will succeed regardless of
+          whether any messages have been sent to the specified topic.
         schema:
           type: string
         example: dinner
         required: true
       - name: op
         in: query
-        description: Whether to mute (`add`) or unmute (`remove`) the provided
-          topic.
+        description: |
+          Whether to mute (`add`) or unmute (`remove`) the provided topic.
         schema:
           type: string
           enum:
@@ -2110,8 +2135,8 @@ paths:
       - name: emoji_name
         required: true
         in: path
-        description: The name that should be associated with the uploaded
-          emoji image/gif.
+        description: |
+          The name that should be associated with the uploaded emoji image/gif.
         schema:
           type: string
       requestBody:
@@ -2146,8 +2171,9 @@ paths:
                 - properties:
                     emoji:
                       type: object
-                      description: An object that contains `emoji` objects,
-                        each identified with their emoji ID as the key.
+                      description: |
+                        An object that contains `emoji` objects, each identified with their
+                        emoji ID as the key.
                 - example:
                     {
                         "result": "success",
@@ -2168,16 +2194,17 @@ paths:
                     }
   /users/me/subscriptions/properties:
     post:
-      description: Make bulk modifications of the subscription properties on
-        one or more streams the user is subscribed to.
+      description: |
+        Make bulk modifications of the subscription properties on one or more
+        streams the user is subscribed to.
       parameters:
       - name: subscription_data
         in: query
-        description: A list of objects that describe the changes that should
-          be applied in each subscription. Each object represents a
-          subscription, and must have a `stream_id` key that identifies the
-          stream, as well as the `property` being modified and its new
-          `value`.
+        description: |
+          A list of objects that describe the changes that should be applied in
+          each subscription. Each object represents a subscription, and must have
+          a `stream_id` key that identifies the stream, as well as the `property`
+          being modified and its new `value`.
         schema:
           type: array
           items:
@@ -2197,8 +2224,8 @@ paths:
                       type: array
                       items:
                         type: object
-                      description: The same `subscription_data` object sent
-                        by the client for the request.
+                      description: |
+                        The same `subscription_data` object sent by the client for the request.
                 - example:
                     {
                         "subscription_data": [
@@ -2236,11 +2263,12 @@ paths:
                           oneOf:
                             - type: string
                             - type: integer
-                      description: An array of tuples, each representing one of the
-                        linkifiers set up in the organization. Each of these tuples contain the
-                        pattern, the formatted URL and the filter's ID, in that order. See
-                        the [Create linkifiers](/api/add-linkifiers) article for details on what
-                        each field means.
+                      description: |
+                        An array of tuples, each representing one of the linkifiers set up in
+                        the organization. Each of these tuples contain the pattern, the
+                        formatted URL and the filter's ID, in that order. See the [Create
+                        linkifiers](/api/add-linkifiers) article for details on what each field
+                        means.
                 - example:
                     {
                         "msg": "",
@@ -2254,22 +2282,25 @@ paths:
                         "result": "success"
                     }
     post:
-      description: Establish patterns in the messages that should be
-        automatically linkified.
+      description: |
+        Establish patterns in the messages that should be automatically
+        linkified.
       parameters:
       - name: pattern
         in: query
-        description: The [Python regular
-          expression](https://docs.python.org/3/howto/regex.html) that
-          should trigger the linkifier.
+        description: |
+          The [Python regular
+          expression](https://docs.python.org/3/howto/regex.html) that should
+          trigger the linkifier.
         schema:
           type: string
         example: '#(?P<id>[0-9]+)'
         required: true
       - name: url_format_string
         in: query
-        description: The URL used for the link. If you used named groups for
-          the `pattern`, you can insert their content here with
+        description: |
+          The URL used for the link. If you used named groups for the `pattern`,
+          you can insert their content here with
           `%(name_of_the_capturing_group)s`.
         schema:
           type: string
@@ -2313,24 +2344,27 @@ paths:
                 $ref: '#/components/schemas/JsonSuccess'
   /register:
     post:
-      description: This powerful endpoint can be used to register a Zulip
-        "event queue" (subscribed to certain types of "events", or updates to
-        the messages and other Zulip data the current user has access to), as
-        well as to fetch the current state of that data.
+      description: |
+        This powerful endpoint can be used to register a Zulip "event queue"
+        (subscribed to certain types of "events", or updates to the messages and
+        other Zulip data the current user has access to), as well as to fetch
+        the current state of that data.
       parameters:
       - name: apply_markdown
         in: query
-        description: Set to `true` if you would like the content to be
-          rendered in HTML format (otherwise the API will return the raw text
-          that the user entered)
+        description: |
+          Set to `true` if you would like the content to be rendered in HTML
+          format (otherwise the API will return the raw text that the user
+          entered)
         schema:
           type: boolean
           default: false
         example: true
       - name: client_gravatar
         in: query
-        description: The `client_gravatar` field is set to `true` if clients
-          can compute their own gravatars.
+        description: |
+          The `client_gravatar` field is set to `true` if clients can compute
+          their own gravatars.
         schema:
           type: boolean
           default: false
@@ -2338,8 +2372,8 @@ paths:
       - name: slim_presence
         in: query
         description: |
-          Setting this to `true` will make presence dictionaries be
-          keyed by user_id instead of email.
+          Setting this to `true` will make presence dictionaries be keyed by
+          user_id instead of email.
 
           **Changes**: New in Zulip 2.2.
         schema:
@@ -2350,16 +2384,18 @@ paths:
         example: ['message']
       - name: all_public_streams
         in: query
-        description: Set to `True` if you would like to receive events that
-          occur within all public streams.
+        description: |
+          Set to `True` if you would like to receive events that occur within all
+          public streams.
         schema:
           type: boolean
           default: false
         example: true
       - name: include_subscribers
         in: query
-        description: Set to `True` if you would like to receive events that
-          include the subscribers for each stream.
+        description: |
+          Set to `True` if you would like to receive events that include the
+          subscribers for each stream.
         schema:
           type: boolean
           default: false
@@ -2367,9 +2403,8 @@ paths:
       - name: client_capabilities
         in: query
         description: |
-          Dictionary containing details on features the client
-          supports that are relevant to the format of responses sent
-          by the server.
+          Dictionary containing details on features the client supports that are
+          relevant to the format of responses sent by the server.
 
           * `notification_settings_null`: Boolean for whether the
             client can handle the current API with null values for
@@ -2386,8 +2421,9 @@ paths:
           }
       - name: fetch_event_types
         in: query
-        description: Same as the `event_types` argument except that the values
-          in `fetch_event_types` are used to fetch initial data. If
+        description: |
+          Same as the `event_types` argument except that the values in
+          `fetch_event_types` are used to fetch initial data. If
           `fetch_event_types` is not provided, `event_types` is used and if
           `event_types` is not provided, this argument defaults to `None`.
         schema:
@@ -2398,11 +2434,10 @@ paths:
       - name: narrow
         in: query
         description: |
-          A JSON-encoded array of length 2 indicating the narrow
-          for which you'd like to receive events. For instance, to
-          receive events for the stream `Denmark`, you would specify
-          `narrow=['stream', 'Denmark']`. Another example is
-          `narrow=['is', 'private']` for private messages.
+          A JSON-encoded array of length 2 indicating the narrow for which you'd
+          like to receive events. For instance, to receive events for the stream
+          `Denmark`, you would specify `narrow=['stream', 'Denmark']`. Another
+          example is `narrow=['is', 'private']` for private messages.
         schema:
           type: array
           items:
@@ -2422,12 +2457,12 @@ paths:
                 - properties:
                     queue_id:
                       type: string
-                      description: The ID of the queue that has been allocated
-                        for your client.
+                      description: |
+                        The ID of the queue that has been allocated for your client.
                     last_event_id:
                       type: integer
-                      description: The initial value of `last_event_id` to
-                        pass to `GET /api/v1/events`.
+                      description: |
+                        The initial value of `last_event_id` to pass to `GET /api/v1/events`.
                 - example:
                     {
                         "last_event_id": -1,
@@ -2462,36 +2497,37 @@ paths:
                 - properties:
                     authentication_methods:
                       type: object
-                      description: Each key-value pair in the object indicates
-                        whether the authentication method is enabled on this
-                        server.
+                      description: |
+                        Each key-value pair in the object indicates whether the authentication
+                        method is enabled on this server.
                     external_authentication_methods:
                       type: array
-                      description: List of dictionaries describing which
-                        external authentication methods are enabled and their
-                        parameters - most importantly the login url, display_name
-                        and display_icon.
+                      description: |
+                        List of dictionaries describing which external authentication methods
+                        are enabled and their parameters - most importantly the login url,
+                        display_name and display_icon.
                     zulip_version:
                       type: string
                       description: The version of Zulip running in the server.
                     push_notifications_enabled:
                       type: boolean
-                      description: Whether mobile/push notifications are
-                        enabled.
+                      description: |
+                        Whether mobile/push notifications are enabled.
                     is_incompatible:
                       type: boolean
-                      description: Whether the Zulip client that has sent a
-                        request to this endpoint is deemed incompatible with
-                        the server.
+                      description: |
+                        Whether the Zulip client that has sent a request to this endpoint is
+                        deemed incompatible with the server.
                     email_auth_enabled:
                       type: boolean
-                      description: Setting for allowing users authenticate with
-                        an email-password combination.
+                      description: |
+                        Setting for allowing users authenticate with an email-password
+                        combination.
                     require_email_format_usernames:
                       type: boolean
-                      description: Whether usernames should have an email
-                        address format. This is important if your server has
-                        [LDAP authentication](https://zulip.readthedocs.io/en/latest/production/authentication-methods.html#ldap-including-active-directory)
+                      description: |
+                        Whether usernames should have an email address format. This is important if your server has [LDAP
+                        authentication](https://zulip.readthedocs.io/en/latest/production/authentication-methods.html#ldap-including-active-directory)
                         enabled with a username and password combination.
                     realm_uri:
                       type: string
@@ -2501,13 +2537,14 @@ paths:
                       description: The realm's name.
                     realm_icon:
                       type: string
-                      description: The URI of the organization's mobile icon (usually
-                        a square version of the logo).
+                      description: |
+                        The URI of the organization's mobile icon (usually a square version of
+                        the logo).
                     realm_description:
                       type: string
-                      description: HTML description of the organization, as
-                        configured by the
-                        [organization profile](/help/create-your-organization-profile).
+                      description: |
+                        HTML description of the organization, as configured by the [organization
+                        profile](/help/create-your-organization-profile).
                 - example:
                     {
                         "authentication_methods": {
@@ -2593,36 +2630,40 @@ paths:
         example: ding
       - name: enable_desktop_notifications
         in: query
-        description: Enable visual desktop notifications for private messages
-          and @-mentions.
+        description: |
+          Enable visual desktop notifications for private messages and @-mentions.
         schema:
           type: boolean
         example: true
       - name: enable_sounds
         in: query
-        description: Enable audible desktop notifications for private messages
-          and @-mentions.
+        description: |
+          Enable audible desktop notifications for private messages and
+          @-mentions.
         schema:
           type: boolean
         example: true
       - name: enable_offline_email_notifications
         in: query
-        description: Enable email notifications for private messages and
-          @-mentions received when the user is offline.
+        description: |
+          Enable email notifications for private messages and @-mentions received
+          when the user is offline.
         schema:
           type: boolean
         example: true
       - name: enable_offline_push_notifications
         in: query
-        description: Enable mobile notification for private messages and
-          @-mentions received when the user is offline.
+        description: |
+          Enable mobile notification for private messages and @-mentions received
+          when the user is offline.
         schema:
           type: boolean
         example: true
       - name: enable_online_push_notifications
         in: query
-        description: Enable mobile notification for private messages and
-          @-mentions received when the user is online.
+        description: |
+          Enable mobile notification for private messages and @-mentions received
+          when the user is online.
         schema:
           type: boolean
         example: true
@@ -2640,8 +2681,8 @@ paths:
         example: true
       - name: message_content_in_email_notifications
         in: query
-        description: Include the message's content in missed messages email
-          notifications.
+        description: |
+          Include the message's content in missed messages email notifications.
         schema:
           type: boolean
         example: true
@@ -2659,8 +2700,8 @@ paths:
         example: true
       - name: desktop_icon_count_display
         in: query
-        description: >
-          Unread count summary (appears in desktop sidebar and browser tab)
+        description: |
+          > Unread count summary (appears in desktop sidebar and browser tab)
 
            * 1 - All unreads
            * 2 - Private messages and mentions
@@ -2689,51 +2730,52 @@ paths:
                 - properties:
                     enable_desktop_notifications:
                       type: boolean
-                      description: The setting for
-                        `enable_desktop_notifications`, if it was changed in
+                      description: |
+                        The setting for `enable_desktop_notifications`, if it was changed in
                         this request.
                     enable_digest_emails:
                       type: boolean
-                      description: The setting for `enable_digest_emails`, if
-                        it was changed in this request.
+                      description: |
+                        The setting for `enable_digest_emails`, if it was changed in this
+                        request.
                     enable_offline_email_notifications:
                       type: boolean
-                      description: The setting for
-                        `enable_offline_email_notifications`, if it was changed
+                      description: |
+                        The setting for `enable_offline_email_notifications`, if it was changed
                         in this request.
                     enable_offline_push_notifications:
                       type: boolean
-                      description: The setting for
-                        `enable_offline_push_notifications`, if it was changed
+                      description: |
+                        The setting for `enable_offline_push_notifications`, if it was changed
                         in this request.
                     enable_online_push_notifications:
                       type: boolean
-                      description: The setting for
-                        `enable_online_push_notifications`, if it was changed
-                        in this request.
+                      description: |
+                        The setting for `enable_online_push_notifications`, if it was changed in
+                        this request.
                     enable_sounds:
                       type: boolean
-                      description: The setting for `enable_sounds`, if it was
-                        changed in this request.
+                      description: |
+                        The setting for `enable_sounds`, if it was changed in this request.
                     enable_stream_email_notifications:
                       type: boolean
-                      description: The setting for
-                        `enable_stream_email_notifications`, if it was changed
+                      description: |
+                        The setting for `enable_stream_email_notifications`, if it was changed
                         in this request.
                     enable_stream_push_notifications:
                       type: boolean
-                      description: The setting for
-                        `enable_stream_push_notifications`, if it was changed
-                        in this request.
+                      description: |
+                        The setting for `enable_stream_push_notifications`, if it was changed in
+                        this request.
                     enable_stream_audible_notifications:
                       type: boolean
-                      description: The setting for
-                        `enable_stream_audible_notifications`, if it was changed in this
-                        request.
+                      description: |
+                        The setting for `enable_stream_audible_notifications`, if it was changed
+                        in this request.
                     message_content_in_email_notifications:
                       type: boolean
-                      description: The setting for
-                        `message_content_in_email_notifications`, if it was
+                      description: |
+                        The setting for `message_content_in_email_notifications`, if it was
                         changed in this request.
                 - example:
                     {
@@ -2762,8 +2804,9 @@ paths:
         example: false
       - name: include_all_active
         in: query
-        description: Include all active streams. The user must have
-          administrative privileges to use this parameter.
+        description: |
+          Include all active streams. The user must have administrative privileges
+          to use this parameter.
         schema:
           type: boolean
           default: false
@@ -2777,8 +2820,9 @@ paths:
         example: true
       - name: include_owner_subscribed
         in: query
-        description: If the user is a bot, include all streams that the
-          bot's owner is subscribed to.
+        description: |
+          If the user is a bot, include all streams that the bot's owner is
+          subscribed to.
         schema:
           type: boolean
           default: false
@@ -2796,9 +2840,9 @@ paths:
                       type: array
                       items:
                         type: object
-                      description: A list of `stream` objects, which contain a
-                        `description`, a `name`, their `stream_id` and whether
-                        they are `invite_only` or not.
+                      description: |
+                        A list of `stream` objects, which contain a `description`, a `name`,
+                        their `stream_id` and whether they are `invite_only` or not.
                 - example:
                     {
                         "msg": "",
@@ -2994,13 +3038,14 @@ paths:
                     }
   /typing:
     post:
-      description: Send an event indicating that the user has started or
-        stopped typing on their client.
+      description: |
+        Send an event indicating that the user has started or stopped typing on
+        their client.
       parameters:
       - name: op
         in: query
-        description: Whether the user has started (`start`) or stopped (`stop`)
-          to type.
+        description: |
+          Whether the user has started (`start`) or stopped (`stop`) to type.
         schema:
           type: string
           enum:
@@ -3011,10 +3056,10 @@ paths:
       - name: to
         in: query
         description: |
-          The user_ids of the recipients of the message being typed.
-          Typing notifications are only supported for private messages.
-          Send a JSON-encoded list of user_ids. (Use a list even if there is
-          only one recipient.).
+          The user_ids of the recipients of the message being typed. Typing
+          notifications are only supported for private messages. Send a JSON-
+          encoded list of user_ids. (Use a list even if there is only one
+          recipient.).
 
           **Changes**: Before Zulip 2.0, this parameter accepted only a JSON-encoded
           list of email addresses.  The email address-based format is deprecated
@@ -3182,9 +3227,9 @@ paths:
                       type: array
                       items:
                         type: object
-                      description: A list of `user_group` objects, which contain a
-                        `description`, a `name`, their `id` and the list of members
-                        of the user group.
+                      description: |
+                        A list of `user_group` objects, which contain a `description`, a `name`,
+                        their `id` and the list of members of the user group.
                 - example:
                     {
                         "msg": "",
@@ -3213,11 +3258,11 @@ paths:
       - name: narrow
         in: query
         description: |
-          A JSON-encoded array of length 2 indicating the narrow
-          for which you'd like to receive events for. For instance, to receive
-          events for the stream `Denmark`, you would specify
-          `narrow=['stream', 'Denmark']`. Another example is
-          `narrow=['is', 'private']` for private messages. Default is `[]`.
+          A JSON-encoded array of length 2 indicating the narrow for which you'd
+          like to receive events for. For instance, to receive events for the
+          stream `Denmark`, you would specify `narrow=['stream', 'Denmark']`.
+          Another example is `narrow=['is', 'private']` for private messages.
+          Default is `[]`.
         schema:
           type: array
           items:
@@ -3260,8 +3305,8 @@ paths:
   /zulip-outgoing-webhook:
     post:
       description: |
-        Outgoing Webhooks allows to build or set up Zulip integrations which
-        are notified when certain types of messages are sent in Zulip.
+        Outgoing Webhooks allows to build or set up Zulip integrations which are
+        notified when certain types of messages are sent in Zulip.
       responses:
         '200':
           description: |
@@ -3283,13 +3328,13 @@ paths:
                     token:
                       type: string
                       description: |
-                        A string of alphanumeric characters that can be use to authenticate
-                        the webhook request (each bot user uses a fixed token).
+                        A string of alphanumeric characters that can be use to authenticate the
+                        webhook request (each bot user uses a fixed token).
                     message:
                       type: object
                       description: |
-                        A dict containing details on the message which triggered the
-                        outgoing webhook
+                        A dict containing details on the message which triggered the outgoing
+                        webhook
                     bot_email:
                       type: string
                       description: |
@@ -3338,9 +3383,10 @@ components:
     BasicAuth:
       type: http
       scheme: basic
-      description: Basic authentication, with the user's email as the
-        username, and the API key as the password. The API key can be fetched
-        using the `/fetch_api_key` or `/dev_fetch_api_key` endpoints.
+      description: |
+        Basic authentication, with the user's email as the username, and the API
+        key as the password. The API key can be fetched using the
+        `/fetch_api_key` or `/dev_fetch_api_key` endpoints.
 
   schemas:
     JsonResponse:
@@ -3386,8 +3432,8 @@ components:
       - properties:
           api_key:
             type: string
-            description: The API key that can be used to authenticate as the
-              requested user.
+            description: |
+              The API key that can be used to authenticate as the requested user.
           email:
             type: string
             description: The email address of the user who owns the API key.
@@ -3438,8 +3484,8 @@ components:
         - properties:
             stream:
               type: string
-              description: The name of the stream that could not be
-                found.
+              description: |
+                The name of the stream that could not be found.
         - example:
             {
                 "code": "STREAM_DOES_NOT_EXIST",
@@ -3453,20 +3499,23 @@ components:
       - properties:
           subscribed:
             type: object
-            description: A dictionary where the key is the email address of
-              the user/bot and the value is a list of the names of the streams
-              that were subscribed to as a result of the query.
+            description: |
+              A dictionary where the key is the email address of the user/bot and the
+              value is a list of the names of the streams that were subscribed to as a
+              result of the query.
           already_subscribed:
             type: object
-            description: A dictionary where the key is the email address of
-              the user/bot and the value is a list of the names of the streams
-              that the user/bot is already subscribed to.
+            description: |
+              A dictionary where the key is the email address of the user/bot and the
+              value is a list of the names of the streams that the user/bot is already
+              subscribed to.
           unauthorized:
             type: array
             items:
               type: string
-            description: A list of names of streams that the requesting
-              user/bot was not authorized to subscribe to.
+            description: |
+              A list of names of streams that the requesting user/bot was not
+              authorized to subscribe to.
     InvalidApiKeyError:
       allOf:
       - $ref: '#/components/schemas/JsonError'
@@ -3519,8 +3568,8 @@ components:
       name: event_types
       in: query
       description: |
-        A JSON-encoded array indicating which types of events you're
-        interested in. Values that you might find useful include:
+        A JSON-encoded array indicating which types of events you're interested
+        in. Values that you might find useful include:
 
           * **message** (messages)
           * **subscription** (changes in your subscriptions)


### PR DESCRIPTION
In zulip.yaml simple json success response which only contains 'msg'
and 'result' properties has been described repeatedly in multiple
endpoints. Instead, use SimpleSuccess template for such responses
to increase code modularity and reusablility.