### PR TITLE
doc: Add/Update docs in help center

### DIFF
--- a/templates/zerver/help/change-who-can-create-and-manage-user-groups.md
+++ b/templates/zerver/help/change-who-can-create-and-manage-user-groups.md
@@ -1,0 +1,19 @@
+# Change who can create and manage user groups
+
+{!admin-only.md!}
+
+By default, anyone other than guests can [create and manage user groups](/help/user-groups) to the
+organization. However, you can change your organization's settings to only
+allow administrators to create and manage user groups.
+
+### Change who can create and manage user groups
+
+{start_tabs}
+
+{settings_tab|organization-permissions}
+
+2. Under **Other permissions**, configure **Who can create and manage user groups**.
+
+{!save-changes.md!}
+
+{end_tabs}

--- a/templates/zerver/help/change-your-profile-picture.md
+++ b/templates/zerver/help/change-your-profile-picture.md
@@ -16,3 +16,14 @@ You can also upload a custom profile picture to Zulip.
 2. Under **Profile picture**, click **Upload new profile picture** and choose an image to upload.
 
 {end_tabs}
+
+### Set profile picture back to gravatar
+
+{start_tabs}
+
+{settings_tab|your-account}
+
+2. Under **Profile picture**, click on the **(X)** icon present on the top right corner of the profile picture.
+This will remove your current profile picture and set back to the gravatar.
+
+{end_tabs}

--- a/templates/zerver/help/getting-started-with-zulip.md
+++ b/templates/zerver/help/getting-started-with-zulip.md
@@ -14,7 +14,7 @@ or desktop experience.
 
 ## Set up your account
 
-- [Set a profile picture](/help/set-your-profile-picture)
+- [Set a profile picture](/help/change-your-profile-picture)
 - Get the [mobile and desktop apps](/apps)
 - [Browse and subscribe to streams](/help/browse-and-subscribe-to-streams)
 - [Configure your notifications](/#settings/notifications) to work the way

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -121,6 +121,7 @@
 * [Restrict stream invitation](/help/configure-who-can-invite-to-streams)
 * [Restrict private messages](/help/restrict-private-messages)
 * [Change who can add custom emoji](/help/only-allow-admins-to-add-emoji)
+* [Create and manage user groups](/help/change-who-can-create-and-manage-user-groups)
 * [Block image and link previews](/help/allow-image-link-previews)
 * [Restrict name and email changes](/help/restrict-name-and-email-changes)
 * [Disable message edit history](/help/disable-message-edit-history)

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -12,7 +12,7 @@
 * [Edit your profile](/help/edit-your-profile)
 * [Change your password](/help/change-your-password)
 * [Review your settings](/help/review-your-settings)
-* [Set your profile picture](/help/set-your-profile-picture)
+* [Change your profile picture](/help/change-your-profile-picture)
 * [Change your language](/help/change-your-language)
 * [Use 24-hour time](/help/change-the-time-format)
 * [Joining an organization](/help/join-a-zulip-organization)

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -124,6 +124,7 @@
 * [Create and manage user groups](/help/change-who-can-create-and-manage-user-groups)
 * [Block image and link previews](/help/allow-image-link-previews)
 * [Restrict name and email changes](/help/restrict-name-and-email-changes)
+* [Restrict profile picture change](/help/restrict-profile-picture-change)
 * [Disable message edit history](/help/disable-message-edit-history)
 * [Manage editing of old messages](/help/configure-message-editing-and-deletion)
 * [Hide message content in emails](/help/hide-message-content-in-emails)

--- a/templates/zerver/help/restrict-profile-picture-change.md
+++ b/templates/zerver/help/restrict-profile-picture-change.md
@@ -1,0 +1,16 @@
+# Restrict Profile picture change
+
+{!admin-only.md!}
+
+By default, any user can [change their profile picture](/help/change-your-profile-picture).
+You can instead prevent users from changing their profile picture.
+
+{start_tabs}
+
+{settings_tab|organization-permissions}
+
+2. Under the **User identity**, select **Prevent users from changing their avatar**.
+
+{!save-changes.md!}
+
+{end_tabs}

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -158,7 +158,7 @@ def users_to_zerver_userprofile(slack_data_dir: str, users: List[ZerverFieldsT],
             user_id = user_id_count
 
         email = get_user_email(user, domain_name)
-        # ref: https://chat.zulip.org/help/set-your-profile-picture
+        # ref: https://chat.zulip.org/help/change-your-profile-picture
         avatar_url = build_avatar_url(slack_user_id, user['team_id'],
                                       user['profile']['avatar_hash'])
         build_avatar(user_id, realm_id, email, avatar_url, timestamp, avatar_list)


### PR DESCRIPTION
Add documentation for 'Who can create and manage user groups' 
Fixes: #14298 