### PR TITLE
forms: Show user.delivery_email in password reset form.

### DIFF
--- a/templates/zerver/reset_confirm.html
+++ b/templates/zerver/reset_confirm.html
@@ -19,7 +19,7 @@
                 <div class="input-box" id="email-section">
                     <label for="id_email">{{ _("Email") }}</label>
                     <div>
-                        <input type="text" name="name" placeholder='{{ form.user.email }}' disabled />
+                        <input type="text" name="name" placeholder='{{ form.user.delivery_email }}' disabled />
                     </div>
                 </div>
 


### PR DESCRIPTION
.email shows the dummy userXXXX@domain.com style email, which is
will be confusing for users and is most likely an unintentional bug.

Result:
![image](https://user-images.githubusercontent.com/45007152/77931538-d4912200-729b-11ea-82b1-15fa8ec6498f.png)
