### PR TITLE
provision: switch Focal to use PGroonga from PPA.

### DIFF
--- a/scripts/lib/setup-apt-repo
+++ b/scripts/lib/setup-apt-repo
@@ -36,14 +36,12 @@ apt-get -y install "${pre_setup_deps[@]}"
 SCRIPTS_PATH="$(dirname "$(dirname "$0")")"
 
 release=$(lsb_release -sc)
-if [[ "$release" =~ ^(xenial|bionic|cosmic|disco|eoan)$ ]] ; then
+if [[ "$release" =~ ^(xenial|bionic|cosmic|disco|eoan|focal)$ ]] ; then
     apt-key add "$SCRIPTS_PATH"/setup/pgroonga-ppa.asc
     cat >$SOURCES_FILE <<EOF
 deb http://ppa.launchpad.net/groonga/ppa/ubuntu $release main
 deb-src http://ppa.launchpad.net/groonga/ppa/ubuntu $release main
 EOF
-elif [[ "$release" =~ ^(focal)$ ]] ; then
-    echo "Currently Groonga do not have a ppa package for Focal so we need to build pgroonga from the source"
 elif [[ "$release" =~ ^(stretch|buster)$ ]] ; then
     apt-key add "$SCRIPTS_PATH"/setup/pgroonga-debian.asc
     cat >$SOURCES_FILE <<EOF

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -160,7 +160,7 @@ COMMON_YUM_DEPENDENCIES = COMMON_DEPENDENCIES + [
 ] + YUM_THUMBOR_VENV_DEPENDENCIES
 
 BUILD_PGROONGA_FROM_SOURCE = False
-if vendor == 'debian' and os_version in [] or vendor == 'ubuntu' and os_version in ['20.04']:
+if vendor == 'debian' and os_version in [] or vendor == 'ubuntu' and os_version in []:
     # For platforms without a pgroonga release, we need to build it
     # from source.
     BUILD_PGROONGA_FROM_SOURCE = True


### PR DESCRIPTION
Since Groonga packages for Ubuntu 20.04 Focal are now available
in their ppa so stopped building pgroonga from the source.



