### PR TITLE
tests: Print test-case name in all test failures in fixtures.

### DIFF
--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -380,23 +380,22 @@ class BugdownTest(ZulipTestCase):
                           "translate_emoticons", "ignore"])
 
         for name, test in format_tests.items():
-            # Check that there aren't any unexpected keys as those are often typos
-            self.assertEqual(len(set(test.keys()) - valid_keys), 0)
-
-            # Ignore tests if specified
-            if test.get('ignore', False):
-                continue  # nocoverage
-
-            if test.get('translate_emoticons', False):
-                # Create a userprofile and send message with it.
-                user_profile = self.example_user('othello')
-                do_set_user_display_setting(user_profile, 'translate_emoticons', True)
-                msg = Message(sender=user_profile, sending_client=get_client("test"))
-                converted = render_markdown(msg, test['input'])
-            else:
-                converted = bugdown_convert(test['input'])
-
             with self.subTest(markdown_test_case=name):
+                # Check that there aren't any unexpected keys as those are often typos
+                self.assertEqual(len(set(test.keys()) - valid_keys), 0)
+                # Ignore tests if specified
+                if test.get('ignore', False):
+                    continue  # nocoverage
+
+                if test.get('translate_emoticons', False):
+                    # Create a userprofile and send message with it.
+                    user_profile = self.example_user('othello')
+                    do_set_user_display_setting(user_profile, 'translate_emoticons', True)
+                    msg = Message(sender=user_profile, sending_client=get_client("test"))
+                    converted = render_markdown(msg, test['input'])
+                else:
+                    converted = bugdown_convert(test['input'])
+
                 self.assertEqual(converted, test['expected_output'])
 
         def replaced(payload: str, url: str, phrase: str='') -> str:


### PR DESCRIPTION
Previously, we only printed the test-case when we had an assertion error.
With this change, we also include timeout errors as well as any other
causes for failure.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Here is the final output containing test-case name:

```
======================================================================
ERROR: test_bugdown_fixtures (zerver.tests.test_bugdown.BugdownTest) (markdown_test_case='codeblock_hilite')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/zulip/zerver/lib/bugdown/__init__.py", line 2347, in do_convert
    raise TimeoutExpired()
zerver.lib.timeout.TimeoutExpired: Function call timed out.
```


**Testing Plan:** <!-- How have you tested? -->
Running automated tests.
