### PR TITLE
widgets: Add button_row zform widget.

### DIFF
--- a/static/templates/widgets/zform_button_row.hbs
+++ b/static/templates/widgets/zform_button_row.hbs
@@ -1,0 +1,9 @@
+<div class="widget-button-row">
+    {{#each buttons}}
+        {{#if this.title}}
+        <button title="{{ this.title }}"data-idx="{{ this.idx }}">{{ this.label }}</button>
+        {{else}}
+        <button data-idx="{{ this.idx }}">{{ this.label }}</button>
+        {{/if}}
+    {{/each}}
+</div>

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -363,6 +363,25 @@ def check_widget_content(widget_content: object) -> Dict[str, Any]:
 
             return widget_content
 
+        if extra_data['type'] == 'button_row':
+            check_buttons = check_list(
+                check_dict([
+                    ('label', check_string),
+                    ('reply', check_string),
+                ],
+                    [
+                    ('title', check_string)
+                ]),
+            )
+
+            checker = check_dict([
+                ('buttons', check_buttons),
+            ])
+
+            checker('extra_data', extra_data)
+
+            return widget_content
+
         raise ValidationError('unknown zform type: ' + extra_data['type'])
 
     raise ValidationError('unknown widget type: ' + widget_type)

--- a/zerver/tests/test_widgets.py
+++ b/zerver/tests/test_widgets.py
@@ -62,6 +62,28 @@ class WidgetContentTestCase(ZulipTestCase):
 
         check_widget_content(obj)
 
+        extra_data['type'] = 'button_row'
+        extra_data.pop('heading')
+        extra_data.pop('choices')
+
+        assert_error(obj, 'buttons key is missing from extra_data')
+
+        extra_data['buttons'] = [
+            dict(label='foo')
+        ]
+
+        assert_error(obj, 'reply key is missing from extra_data["buttons"][0]')
+
+        extra_data['buttons'] = [
+            dict(label='foo', reply='bar')
+        ]
+        check_widget_content(obj)
+
+        extra_data['buttons'] = [
+            dict(label='foo', reply='bar', title='baz')
+        ]
+        check_widget_content(obj)
+
     def test_message_error_handling(self) -> None:
         sender = self.example_user('cordelia')
         stream_name = 'Verona'


### PR DESCRIPTION
Adds functionality for a row of buttons after a message. This makes interacting with bots easier as common responses won't need to be typed out.


**Testing Plan:**
Manually tested in dev environment, with unit tests for the server validator

**Screenshots:**
![image](https://user-images.githubusercontent.com/10870360/78167362-42794d00-7446-11ea-8517-ba8ab14456ab.png)

```json
{
    "widget_type": "zform",
    "extra_data": {
        "type": "button_row",
        "buttons": [
            {
                "label": "Start Game",
                "reply": "start game"
            },
            {
                "label": "Leaderboard",
                "reply": "leaderboard"
            },
            {
                "label": "Rules",
                "reply": "rules"
            }
        ]
    }
}
```
