### PR TITLE
Improve management command system for sending custom emails #13413

### DIFF
--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -40,6 +40,7 @@ FILES_WITH_LEGACY_SUBJECT = {
     'zerver/lib/send_email.py',
     'zerver/tests/test_new_users.py',
     'zerver/tests/test_email_mirror.py',
+    'zerver/tests/test_email_notifications.py',
 
     # These are tied more to our API than our DB model.
     'zerver/openapi/python_examples.py',

--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -12,10 +12,12 @@ from zerver.models import ScheduledEmail, get_user_profile_by_id, \
 
 import datetime
 from email.utils import parseaddr, formataddr
+from email.parser import Parser
+from email.policy import default
+
 import logging
 import ujson
 import hashlib
-import shutil
 
 import os
 from typing import Any, Dict, List, Mapping, Optional, Tuple
@@ -53,6 +55,13 @@ class FromAddress:
         with override_language(language):
             return _("Zulip Account Security")
 
+def get_header(option: Optional[str], header: Optional[str], name: str) -> str:
+    if option and header:
+        raise DoubledEmailArgumentException(name)
+    if not option and not header:
+        raise NoEmailArgumentException(name)
+    return str(option or header)
+
 def send_custom_email(users: List[UserProfile], options: Dict[str, Any]) -> None:
     """
     Can be used directly with from a management shell with
@@ -64,7 +73,9 @@ def send_custom_email(users: List[UserProfile], options: Dict[str, Any]) -> None
     """
 
     with open(options["markdown_template_path"]) as f:
-        email_template_hash = hashlib.sha256(f.read().encode('utf-8')).hexdigest()[0:32]
+        text = f.read()
+        headers = Parser(policy=default).parsestr(text)
+        email_template_hash = hashlib.sha256(text.encode('utf-8')).hexdigest()[0:32]
 
     email_filename = "custom_email_%s.source.html" % (email_template_hash,)
     email_id = "zerver/emails/custom_email_%s" % (email_template_hash,)
@@ -75,7 +86,8 @@ def send_custom_email(users: List[UserProfile], options: Dict[str, Any]) -> None
 
     # First, we render the markdown input file just like our
     # user-facing docs with render_markdown_path.
-    shutil.copyfile(options['markdown_template_path'], plain_text_template_path)
+    with open(plain_text_template_path, "w") as f:
+        f.write(headers.get_payload())
 
     from zerver.templatetags.app_filters import render_markdown_path
     rendered_input = render_markdown_path(plain_text_template_path.replace("templates/", ""))
@@ -90,10 +102,8 @@ def send_custom_email(users: List[UserProfile], options: Dict[str, Any]) -> None
                                                  rendered_input))
 
     with open(subject_path, "w") as f:
-        f.write(options["subject"])
+        f.write(get_header(options.get("subject"), headers.get("subject"), "subject"))
 
-    # Then, we compile the email template using inline_email_css to
-    # add our standard styling to the paragraph tags (etc.).
     inline_template(email_filename)
 
     # Finally, we send the actual emails.
@@ -105,7 +115,9 @@ def send_custom_email(users: List[UserProfile], options: Dict[str, Any]) -> None
         send_email(email_id, to_user_ids=[user_profile.id],
                    from_address=FromAddress.SUPPORT,
                    reply_to_email=options.get("reply_to"),
-                   from_name=options["from_name"], context=context)
+                   from_name=get_header(options.get("from_name"),
+                                        headers.get("from"), "from_name"),
+                   context=context)
 
 def build_email(template_prefix: str, to_user_ids: Optional[List[int]]=None,
                 to_emails: Optional[List[str]]=None, from_name: Optional[str]=None,
@@ -181,6 +193,18 @@ def build_email(template_prefix: str, to_user_ids: Optional[List[int]]=None,
 
 class EmailNotDeliveredException(Exception):
     pass
+
+class DoubledEmailArgumentException(Exception):
+    def __init__(self, argument_name: str) -> None:
+        msg = "Argument %s can't be in both command arguments list and in markdown file" % (
+            argument_name)
+        super().__init__(msg)
+
+class NoEmailArgumentException(Exception):
+    def __init__(self, argument_name: str) -> None:
+        msg = "Argument %s have to be provided either in command arguments list or in markdown file" % (
+            argument_name)
+        super().__init__(msg)
 
 # When changing the arguments to this function, you may need to write a
 # migration to change or remove any emails in ScheduledEmail.

--- a/zerver/management/commands/send_custom_email.py
+++ b/zerver/management/commands/send_custom_email.py
@@ -18,13 +18,11 @@ class Command(ZulipBaseCommand):
                             type=str,
                             help='Path to a markdown-format body for the email')
         parser.add_argument('--subject',
-                            required=True,
                             type=str,
-                            help='Subject line for the email')
+                            help='Subject for the email. It can be declarated in markdown file in headers')
         parser.add_argument('--from-name',
-                            required=True,
                             type=str,
-                            help='From line for the email')
+                            help='From line for the email. It can be declarated in markdown file in headers')
         parser.add_argument('--reply-to',
                             type=str,
                             help='Optional reply-to line for the email')

--- a/zerver/tests/fixtures/email/custom_emails/email_base_headers_no_headers_test.source.html
+++ b/zerver/tests/fixtures/email/custom_emails/email_base_headers_no_headers_test.source.html
@@ -1,0 +1,1 @@
+Test body

--- a/zerver/tests/fixtures/email/custom_emails/email_base_headers_test.source.html
+++ b/zerver/tests/fixtures/email/custom_emails/email_base_headers_test.source.html
@@ -1,0 +1,4 @@
+From: TestFrom
+Subject: Test Subject
+
+Test body


### PR DESCRIPTION
https://github.com/zulip/zulip/issues/13413

*Testing Plan:*
- Unit tested function send_custom_email
- Manually tested running inline_email_css.py program separately
- Manually tested ./manage.py send_custom_email command

I've edited inline-email-css to be a python file, and I've also refactor it a bit, so this code is not one big function, and it should be clearer what it does now.

You can now write headers `From:` and `Subject:` in top of the markdown file provided, instead of writing it in program parameters.

Documentation was properly edited.