### PR TITLE
message edit: Handle ESC better.

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -178,8 +178,6 @@ exports.in_content_editable_widget = function (e) {
 
 // Returns true if we handled it, false if the browser should.
 exports.process_escape_key = function (e) {
-    let row;
-
     if (exports.in_content_editable_widget(e)) {
         return false;
     }
@@ -204,32 +202,7 @@ exports.process_escape_key = function (e) {
         return true;
     }
 
-    if (message_edit.is_editing(current_msg_list.selected_id())) {
-        // Using this definition of "row" instead of "current_msg_list.selected_row()"
-        // because it returns a more complete object.
-        // Necessary for refocusing on message list in Firefox.
-        const message_edit_inputs = $(".message_edit_content, .message_edit_topic");
-        row = message_edit_inputs.filter(":focus").closest(".message_row");
-        row.find('.message_edit_content').blur();
-        message_edit.end(row);
-        return true;
-    }
-
     if (exports.processing_text()) {
-        if ($(".message_edit_content").filter(":focus").length > 0) {
-            row = $(".message_edit_content").filter(":focus").closest(".message_row");
-            row.find('.message_edit_content').blur();
-            message_edit.end(row);
-            return true;
-        }
-
-        if ($(".message_edit_topic").filter(":focus").length > 0) {
-            row = $(".message_edit_topic").filter(":focus").closest(".message_row");
-            row.find('.message_edit_topic').blur();
-            message_edit.end(row);
-            return true;
-        }
-
         if (activity.searching()) {
             activity.escape_search();
             return true;

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -143,9 +143,26 @@ exports.show_topic_edit_spinner = function (row) {
     $(".topic_edit_cancel").hide();
 };
 
+exports.end_if_focused = function () {
+    const focused_elem = $(".message_edit").find(':focus');
+
+    if (focused_elem.length === 1) {
+        focused_elem.blur();
+        const row = focused_elem.closest('.message_row');
+        exports.end(row);
+    }
+};
+
 function handle_edit_keydown(from_topic_edited_only, e) {
     let row;
     const code = e.keyCode || e.which;
+
+    if (code === 27) {
+        exports.end_if_focused();
+        e.stopPropagation();
+        e.preventDefault();
+        return;
+    }
 
     if ($(e.target).hasClass("message_edit_content") && code === 13) {
         // Pressing enter to save edits is coupled with enter to send


### PR DESCRIPTION
We now handle the esc key completely within the
keydown handler that we already have for message
editing.  We allow escape to work no matter what
the focused element is within an edited message,
and we blur that element properly and end the
edit.

We remove all the strange, duplicated logic
from hotkey.js.

This should also fix a blueslip error where the
hotkey code was passing message_edit a jQuery
element with zero length.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
