### PR TITLE
notifications: Added notification sound when user clicks on allow.

### DIFF
--- a/static/js/panels.js
+++ b/static/js/panels.js
@@ -76,6 +76,7 @@ exports.initialize = function () {
     $(".request-desktop-notifications").on("click", function (e) {
         e.preventDefault();
         $(this).closest(".alert").hide();
+        $("#notifications-area").find("audio")[0].play();
         notifications.request_desktop_notifications_permission();
         resize_app();
     });


### PR DESCRIPTION
When the user clicks on "allow notifications", the default notification
sound is played to notify the user that notifications have been turned
on.

Fixes: #14433
