### PR TITLE
settings UI: Add link for help near the setting of link previews

### DIFF
--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -229,7 +229,8 @@
                   setting_name="realm_inline_url_embed_preview"
                   prefix="id_"
                   is_checked=realm_inline_url_embed_preview
-                  label=admin_settings_label.realm_inline_url_embed_preview}}
+                  label=admin_settings_label.realm_inline_url_embed_preview
+                  help="/help/allow-image-link-previews"}}
                 {{/if}}
             </div>
         </div>

--- a/static/templates/settings/settings_checkbox.hbs
+++ b/static/templates/settings/settings_checkbox.hbs
@@ -7,6 +7,11 @@
     </label>
     <label for="{{prefix}}{{setting_name}}" class="inline-block" id="{{prefix}}{{setting_name}}_label">
         {{{label}}}
+        {{#if help}}
+        <a href="{{help}}" target="_blank">
+            <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+        </a>
+        {{/if}}
     </label>
 </div>
 {{/unless}}


### PR DESCRIPTION
Next to the checkbox of "Show previews of linked websites" added a
documentation link in order to help users not confuse its function.
To do this:
- Added the field ```help``` which is the link for the documentation in
```organization_settings_admin.hbs```
- Added the if statement in ```settings_checkbox.hbs``` to check if the above field exists. In case it
exists, a help icon which leads to the documentation link appears.
The specific field was added in order to be able to add a help link in
other settings as well.

Co-authored-by: Katerina Perikou <44238834+kPerikou@users.noreply.github.com>

Fixes: #13450

Screenshot of the result:
![91625608_243591000103640_4164781004692652032_n](https://user-images.githubusercontent.com/43913366/78298515-1f7c9500-753b-11ea-962f-2c9f5f5174df.png)





