### PR TITLE
tests: use test_realm_integer for integer fields in dispatch.js and some minor changes in settings_org tests.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -917,11 +917,29 @@ with_overrides(function (override) {
         assert.equal(page_params[parameter_name], true);
     }
 
+    function test_realm_integer(event, parameter_name) {
+        page_params[parameter_name] = 1;
+        event = {...event};
+        event.value = 2;
+        dispatch(event);
+        assert.equal(page_params[parameter_name], 2);
+
+        event = {...event};
+        event.value = 3;
+        dispatch(event);
+        assert.equal(page_params[parameter_name], 3);
+
+        event = {...event};
+        event.value = 1;
+        dispatch(event);
+        assert.equal(page_params[parameter_name], 1);
+    }
+
     let event = event_fixtures.realm__update__create_stream_policy;
-    test_realm_boolean(event, 'realm_create_stream_policy');
+    test_realm_integer(event, 'realm_create_stream_policy');
 
     event = event_fixtures.realm__update__invite_to_stream_policy;
-    test_realm_boolean(event, 'realm_invite_to_stream_policy');
+    test_realm_integer(event, 'realm_invite_to_stream_policy');
 
     event = event_fixtures.realm__update__invite_required;
     test_realm_boolean(event, 'realm_invite_required');

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -69,6 +69,7 @@ set_global('realm_logo', _realm_logo);
 set_global('ui_report', _ui_report);
 
 const settings_config = zrequire('settings_config');
+const settings_bots = zrequire('settings_bots');
 zrequire('stream_data');
 zrequire('settings_account');
 zrequire('settings_org');
@@ -190,15 +191,17 @@ function createSaveButtons(subsection) {
 
 function test_submit_settings_form(submit_form) {
     Object.assign(page_params, {
-        realm_bot_creation_policy: '2',
-        realm_email_address_visibility: '2',
+        realm_bot_creation_policy: settings_bots.bot_creation_policy_values.restricted.code,
+        realm_email_address_visibility:
+                settings_config.email_address_visibility_values.admins_only.code,
         realm_add_emoji_by_admins_only: true,
         realm_create_stream_by_admins_only: true,
         realm_waiting_period_threshold: 1,
         realm_default_language: '"es"',
-        realm_default_twenty_four_hour_time: 'false',
-        realm_invite_to_stream_policy: 2,
-        realm_create_stream_policy: 1,
+        realm_default_twenty_four_hour_time: false,
+        realm_invite_to_stream_policy:
+                settings_config.invite_to_stream_policy_values.by_admins_only.code,
+        realm_create_stream_policy: settings_config.create_stream_policy_values.by_members.code,
     });
 
     global.patch_builtin('setTimeout', func => func());


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR adds the test_realm_integer helper which is used by integer valued fields now which were incorrectly using test_realm_boolean till now.

Also some changes in settings_org tests to use correct integer values in page_params object instead of string values and also using option values in settings_config.js instead of direct integers.

Fixes #12284.

<!-- How have you tested? -->

 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
