### PR TITLE
Fix copy/paste blueslip error.

### DIFF
--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -57,13 +57,15 @@ how modern browsers deal with copy/paste.  Just test
 your changes carefully.
 */
 function construct_copy_div(div, start_id, end_id) {
-    const start_row = current_msg_list.get_row(start_id);
+    const copy_rows = rows.visible_range(start_id, end_id);
+
+    const start_row = copy_rows[0];
     const start_recipient_row = rows.get_message_recipient_row(start_row);
     const start_recipient_row_id = rows.id_for_recipient_row(start_recipient_row);
     let should_include_start_recipient_header = false;
-
     let last_recipient_row_id = start_recipient_row_id;
-    for (let row = start_row; rows.id(row) <= end_id; row = rows.next_visible(row)) {
+
+    for (const row of copy_rows) {
         const recipient_row_id = rows.id_for_recipient_row(rows.get_message_recipient_row(row));
         // if we found a message from another recipient,
         // it means that we have messages from several recipients,

--- a/static/js/rows.js
+++ b/static/js/rows.js
@@ -41,6 +41,30 @@ exports.last_visible = function () {
     return $('.focused_table .selectable_row').last();
 };
 
+exports.visible_range = function (start_id, end_id) {
+    /*
+        Get all visible rows between start_id
+        and end_in, being inclusive on both ends.
+    */
+
+    const rows = [];
+
+    let row = current_msg_list.get_row(start_id);
+    let msg_id = exports.id(row);
+
+    while (msg_id <= end_id) {
+        rows.push(row);
+
+        if (msg_id >= end_id) {
+            break;
+        }
+        row = exports.next_visible(row);
+        msg_id = exports.id(row);
+    }
+
+    return rows;
+};
+
 exports.is_draft_row = function (row) {
     return row.find('.restore-draft').length >= 1;
 };

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -128,12 +128,12 @@ exports.initialize_kitchen_sink_stuff = function () {
         $("body").addClass("more_dense_mode");
     }
 
-    $("#main_div").on("mouseover", ".message_row", function () {
+    $("#main_div").on("mouseover", ".message_table .message_row", function () {
         const row = $(this).closest(".message_row");
         message_hover(row);
     });
 
-    $("#main_div").on("mouseleave", ".message_row", function () {
+    $("#main_div").on("mouseleave", ".message_table .message_row", function () {
         message_unhover();
     });
 


### PR DESCRIPTION
The first commit here is related to other investigations regarding blueslip errors with rows.id().