### PR TITLE
nginx: HTTP header fixes

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-common/api_headers
+++ b/puppet/zulip/files/nginx/zulip-include-common/api_headers
@@ -1,3 +1,4 @@
+include /etc/nginx/zulip-include/headers;
 add_header Access-Control-Allow-Origin * always;
 add_header Access-Control-Allow-Headers Authorization always;
 add_header Access-Control-Allow-Methods 'GET, POST, DELETE, PUT, PATCH, HEAD' always;

--- a/puppet/zulip/files/nginx/zulip-include-common/headers
+++ b/puppet/zulip/files/nginx/zulip-include-common/headers
@@ -1,0 +1,5 @@
+# Enable HSTS: tell browsers to always use HTTPS
+add_header Strict-Transport-Security max-age=15768000 always;
+
+# Set X-Frame-Options to deny to prevent clickjacking
+add_header X-Frame-Options DENY always;

--- a/puppet/zulip/files/nginx/zulip-include-common/headers
+++ b/puppet/zulip/files/nginx/zulip-include-common/headers
@@ -3,3 +3,5 @@ add_header Strict-Transport-Security max-age=15768000 always;
 
 # Set X-Frame-Options to deny to prevent clickjacking
 add_header X-Frame-Options DENY always;
+
+add_header X-Content-Type-Options nosniff;

--- a/puppet/zulip/files/nginx/zulip-include-common/headers
+++ b/puppet/zulip/files/nginx/zulip-include-common/headers
@@ -5,3 +5,4 @@ add_header Strict-Transport-Security max-age=15768000 always;
 add_header X-Frame-Options DENY always;
 
 add_header X-Content-Type-Options nosniff;
+add_header X-XSS-Protection "1; mode=block";

--- a/puppet/zulip/files/nginx/zulip-include-frontend/app
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/app
@@ -1,11 +1,7 @@
 access_log /var/log/nginx/access.log;
 error_log /var/log/nginx/error.log;
 
-# Enable HSTS: tell browsers to always use HTTPS
-add_header Strict-Transport-Security max-age=15768000 always;
-
-# Set X-Frame-Options to deny to prevent clickjacking
-add_header X-Frame-Options DENY always;
+include /etc/nginx/zulip-include/headers;
 
 # Serve a custom error page when the app is down
 error_page 502 503 504 /static/webpack-bundles/5xx.html;

--- a/puppet/zulip/files/nginx/zulip-include-maybe/uploads-route.internal
+++ b/puppet/zulip/files/nginx/zulip-include-maybe/uploads-route.internal
@@ -1,7 +1,6 @@
 location /serve_uploads {
     internal;
     include /etc/nginx/zulip-include/api_headers;
-    add_header X-Content-Type-Options nosniff;
     add_header Content-Security-Policy "default-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self'; object-src 'self'; plugin-types application/pdf;";
     include /etc/nginx/zulip-include/uploads.types;
     alias /home/zulip/uploads/files;

--- a/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
+++ b/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
@@ -25,7 +25,6 @@ server {
 <% if @no_serve_uploads == '' -%>
     location /user_avatars {
         include /etc/nginx/zulip-include/headers;
-        add_header X-Content-Type-Options nosniff;
         add_header Content-Security-Policy "default-src 'none' img-src 'self'";
         include /etc/nginx/zulip-include/uploads.types;
         alias /home/zulip/uploads/avatars;

--- a/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
+++ b/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
@@ -24,6 +24,7 @@ server {
 
 <% if @no_serve_uploads == '' -%>
     location /user_avatars {
+        include /etc/nginx/zulip-include/headers;
         add_header X-Content-Type-Options nosniff;
         add_header Content-Security-Policy "default-src 'none' img-src 'self'";
         include /etc/nginx/zulip-include/uploads.types;

--- a/tools/ci/success-http-headers.txt
+++ b/tools/ci/success-http-headers.txt
@@ -10,6 +10,7 @@ WARNING: no certificate subject alternative name matches
   Strict-Transport-Security: max-age=15768000
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
+  X-XSS-Protection: 1; mode=block
 Location: /login/ [following]
 Reusing existing connection to localhost:443.
   HTTP/1.1 200 OK
@@ -20,6 +21,7 @@ Reusing existing connection to localhost:443.
   Strict-Transport-Security: max-age=15768000
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
+  X-XSS-Protection: 1; mode=block
 Length: 6361 (6.2K) [text/html]
 Saving to: ‘/tmp/index.html’
 

--- a/tools/ci/success-http-headers.txt
+++ b/tools/ci/success-http-headers.txt
@@ -9,6 +9,7 @@ WARNING: no certificate subject alternative name matches
   Location: /login/
   Strict-Transport-Security: max-age=15768000
   X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
 Location: /login/ [following]
 Reusing existing connection to localhost:443.
   HTTP/1.1 200 OK
@@ -18,6 +19,7 @@ Reusing existing connection to localhost:443.
   Connection: keep-alive
   Strict-Transport-Security: max-age=15768000
   X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
 Length: 6361 (6.2K) [text/html]
 Saving to: ‘/tmp/index.html’
 


### PR DESCRIPTION
* nginx: Don’t override HSTS, `X-Frame-Options` with other `add_header`s.
  
  The nginx `add_header` directive [doesn’t inherit the way you’d want](https://trac.nginx.org/nginx/ticket/854), so we need to manually simulate inheritance using `include`, like we previously did with `api_headers`.

* nginx: Set `X-Content-Type-Options: nosniff` globally.

* nginx: Set `X-XSS-Protection: 1; mode=block`.

**Testing Plan:** `curl -i https://andersk.zulipdev.org/api/v1/server_settings`
