### PR TITLE
test-locked-requirements fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ aliases:
   - &restore_cache_requirements
     restore_cache:
       keys:
-      - v1-venv-base.{{ .Environment.CIRCLE_JOB }}-{{ checksum "requirements/thumbor.txt" }}-{{ checksum "requirements/dev.txt" }}
+      - v1-venv-base.{{ .Environment.CIRCLE_JOB }}-{{ checksum "requirements/thumbor-dev.txt" }}-{{ checksum "requirements/dev.txt" }}
 
   - &install_dependencies
     run:

--- a/tools/test-locked-requirements
+++ b/tools/test-locked-requirements
@@ -19,7 +19,6 @@ CACHE_DIR = os.path.join(ZULIP_PATH, 'var', 'tmp')
 if 'TRAVIS' in os.environ:
     CACHE_DIR = os.path.join(os.environ['HOME'], 'misc')
 CACHE_FILE = os.path.join(CACHE_DIR, 'requirements_hashes')
-LOCKED_REQS_FILE_NAMES = ['dev.txt', 'docs.txt', 'mypy.txt', 'prod.txt', 'thumbor.txt']
 
 def print_diff(path_file1, path_file2):
     # type: (str, str) -> None
@@ -39,16 +38,17 @@ def test_locked_requirements(tmp_dir):
     # if lock files are present already. If we don't copy these files to the tmp
     # dir then recursive dependencies will get updated to their latest version
     # without any change in the input requirements file and the test will not pass.
-    for fn in LOCKED_REQS_FILE_NAMES:
+    for locked_file in glob.glob(os.path.join(REQS_DIR, "*.txt")):
+        fn = os.path.basename(locked_file)
         locked_file = os.path.join(REQS_DIR, fn)
         test_locked_file = os.path.join(tmp_dir, fn)
         shutil.copyfile(locked_file, test_locked_file)
     subprocess.check_call([os.path.join(TOOLS_DIR, 'update-locked-requirements'), '--output-dir', tmp_dir])
 
     same = True
-    for fn in LOCKED_REQS_FILE_NAMES:
+    for test_locked_file in glob.glob(os.path.join(tmp_dir, "*.txt")):
+        fn = os.path.basename(test_locked_file)
         locked_file = os.path.join(REQS_DIR, fn)
-        test_locked_file = os.path.join(tmp_dir, fn)
         same = same and filecmp.cmp(test_locked_file, locked_file, shallow=False)
 
     return same
@@ -56,11 +56,11 @@ def test_locked_requirements(tmp_dir):
 def get_requirements_hash(tmp_dir, use_test_lock_files=False):
     # type: (str, Optional[bool]) -> str
     sha1 = hashlib.sha1()
-    reqs_files = glob.glob(os.path.join(ZULIP_PATH, "requirements", "*.in"))
+    reqs_files = sorted(glob.glob(os.path.join(REQS_DIR, "*.in")))
     lock_files_path = REQS_DIR
     if use_test_lock_files:
         lock_files_path = tmp_dir
-    reqs_files.extend([os.path.join(lock_files_path, fn) for fn in LOCKED_REQS_FILE_NAMES])
+    reqs_files.extend(sorted(glob.glob(os.path.join(lock_files_path, "*.txt"))))
     for file_path in reqs_files:
         with open(file_path) as fp:
             sha1.update(fp.read().encode("utf-8"))
@@ -109,9 +109,9 @@ def main():
     hash_list.append(valid_hash)
     update_cache(hash_list)
     if not requirements_are_consistent:
-        for fn in LOCKED_REQS_FILE_NAMES:
+        for test_locked_file in glob.glob(os.path.join(tmp_dir, "*.txt")):
+            fn = os.path.basename(test_locked_file)
             locked_file = os.path.join(REQS_DIR, fn)
-            test_locked_file = os.path.join(tmp_dir, fn)
             print_diff(locked_file, test_locked_file)
         # Flush the output to ensure we print the error at the end.
         sys.stdout.flush()

--- a/tools/test-locked-requirements
+++ b/tools/test-locked-requirements
@@ -106,8 +106,7 @@ def main():
     # Cache the hash so that we need not to run the `update_locked_requirements`
     # tool again for checking this set of requirements.
     valid_hash = get_requirements_hash(tmp_dir, use_test_lock_files=True)
-    hash_list.append(valid_hash)
-    update_cache(hash_list)
+    update_cache([h for h in hash_list if h != valid_hash] + [valid_hash])
     if not requirements_are_consistent:
         for test_locked_file in glob.glob(os.path.join(tmp_dir, "*.txt")):
             fn = os.path.basename(test_locked_file)


### PR DESCRIPTION
* test-locked-requirements: Check all locked requirements files.
* test-locked-requirements: Cache only one copy of each valid hash.
* circleci: Update venv cache prefix based on thumbor-dev.txt.