### PR TITLE
drafts: Differentiates between drag and click.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -85,20 +85,23 @@ exports.initialize = function () {
             return;
         }
 
-        if (!(document.getSelection().type === "Range")) {
-            const row = $(this).closest(".message_row");
-            const id = rows.id(row);
-
-            if (message_edit.is_editing(id)) {
-                // Clicks on a message being edited shouldn't trigger a reply.
-                return;
-            }
-
-            current_msg_list.select_id(id);
-            compose_actions.respond_to_message({trigger: 'message click'});
-            e.stopPropagation();
-            popovers.hide_all();
+        if (document.getSelection().type === "Range") {
+            // Drags on the message(to copy message text) shouldn't trigger a reply.
+            return;
         }
+
+        const row = $(this).closest(".message_row");
+        const id = rows.id(row);
+
+        if (message_edit.is_editing(id)) {
+            // Clicks on a message being edited shouldn't trigger a reply.
+            return;
+        }
+
+        current_msg_list.select_id(id);
+        compose_actions.respond_to_message({trigger: 'message click'});
+        e.stopPropagation();
+        popovers.hide_all();
     };
 
     // if on normal non-mobile experience, a `click` event should run the message

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -6,51 +6,6 @@ const render_buddy_list_tooltip_content = require('../templates/buddy_list_toolt
 
 exports.initialize = function () {
 
-    // MOUSE MOVING VS DRAGGING FOR SELECTION DATA TRACKING
-
-    const drag = (function () {
-        let start;
-        let time;
-
-        return {
-            start: function (e) {
-                start = { x: e.offsetX, y: e.offsetY };
-                time = new Date().getTime();
-            },
-
-            end: function (e) {
-                const end = { x: e.offsetX, y: e.offsetY };
-
-                let dist;
-                if (start) {
-                    // get the linear difference between two coordinates on the screen.
-                    dist = Math.sqrt(Math.pow(end.x - start.x, 2) + Math.pow(end.y - start.y, 2));
-                } else {
-                    // this usually happens if someone started dragging from outside of
-                    // a message and finishes their drag inside the message. The intent
-                    // in that case is clearly to select an area, not click a message;
-                    // setting dist to Infinity here will ensure that.
-                    dist = Infinity;
-                }
-
-                this.val = dist;
-                this.time = new Date().getTime() - time;
-
-                start = undefined;
-
-                return dist;
-            },
-            val: null,
-        };
-    }());
-
-    $("#main_div").on("mousedown", ".messagebox", function (e) {
-        drag.start(e);
-    });
-    $("#main_div").on("mouseup", ".messagebox", function (e) {
-        drag.end(e);
-    });
-
     // MESSAGE CLICKING
 
     function is_clickable_message_element(target) {
@@ -130,16 +85,7 @@ exports.initialize = function () {
             return;
         }
 
-        // A tricky issue here is distinguishing hasty clicks (where
-        // the mouse might still move a few pixels between mouseup and
-        // mousedown) from selecting-for-copy.  We handle this issue
-        // by treating it as a click if distance is very small
-        // (covering the long-click case), or fairly small and over a
-        // short time (covering the hasty click case).  This seems to
-        // work nearly perfectly.  Once we no longer need to support
-        // older browsers, we may be able to use the window.selection
-        // API instead.
-        if (drag.val < 5 && drag.time < 150 || drag.val < 2) {
+        if (!(document.getSelection().type === "Range")) {
             const row = $(this).closest(".message_row");
             const id = rows.id(row);
 

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -325,6 +325,10 @@ exports.launch = function () {
 
     function setup_event_handlers() {
         $(".restore-draft").on("click", function (e) {
+            if (document.getSelection().type === "Range") {
+                return;
+            }
+
             e.stopPropagation();
 
             const draft_row = $(this).closest(".draft-row");

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -37,7 +37,6 @@ EXEMPT_FILES = {
     'static/js/billing/helpers.js',
     'static/js/blueslip.js',
     'static/js/blueslip_stacktrace.ts',
-    # Removed temporarily.
     'static/js/channel.js',
     'static/js/click_handlers.js',
     'static/js/compose_actions.js',
@@ -96,7 +95,6 @@ EXEMPT_FILES = {
     'static/js/pointer.js',
     'static/js/poll_widget.js',
     'static/js/popovers.js',
-    # Temporarily missing full coverage
     'static/js/ready.js',
     'static/js/realm_icon.js',
     'static/js/realm_logo.js',


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/14447

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
Differentiates between drag and click in drafts messages.

Trying to select(to copy) some text on a draft message, caused the draft row to be clicked, resulting in the draft being opened. To fix this, a function drag() has been created to identify the duration of the click and the amount of drag. These values are calculated with respect to the mouseup and mousedown positions. These values are then used to determine if the event is a click or a drag.
