### PR TITLE
message_list: Hide topic edit pencil icon in the edit mode.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -309,7 +309,7 @@ exports.initialize = function () {
     });
     $("body").on("click", ".topic_edit_cancel", function (e) {
         const recipient_row = $(this).closest(".recipient_row");
-        current_msg_list.hide_edit_topic(recipient_row);
+        current_msg_list.hide_edit_topic_on_recipient_row(recipient_row);
         e.stopPropagation();
         popovers.hide_all();
     });

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -426,7 +426,7 @@ exports.start = function (row, edit_box_open_callback) {
 
 exports.start_topic_edit = function (recipient_row) {
     const form = $(render_topic_edit_form());
-    current_msg_list.show_edit_topic(recipient_row, form);
+    current_msg_list.show_edit_topic_on_recipient_row(recipient_row, form);
     form.keydown(_.partial(handle_edit_keydown, true));
     const msg_id = rows.id_for_recipient_row(recipient_row);
     const message = current_msg_list.get(msg_id);
@@ -461,7 +461,7 @@ exports.end = function (row) {
         current_msg_list.hide_edit_message(row);
     }
     if (row !== undefined) {
-        current_msg_list.hide_edit_topic(row);
+        current_msg_list.hide_edit_topic_on_recipient_row(row);
     }
     condense.show_message_expander(row);
     row.find(".message_reactions").show();

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -318,6 +318,7 @@ exports.MessageList.prototype = {
 
     show_edit_topic: function MessageList_show_edit_topic(recipient_row, form) {
         recipient_row.find(".topic_edit_form").empty().append(form);
+        recipient_row.find('.on_hover_topic_edit').hide();
         recipient_row.find('.edit_content_button').hide();
         recipient_row.find(".stream_topic").hide();
         recipient_row.find(".topic_edit").show();
@@ -325,6 +326,7 @@ exports.MessageList.prototype = {
 
     hide_edit_topic: function MessageList_hide_edit_topic(recipient_row) {
         recipient_row.find(".stream_topic").show();
+        recipient_row.find('.on_hover_topic_edit').show();
         recipient_row.find('.edit_content_button').show();
         recipient_row.find(".topic_edit").hide();
     },

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -316,7 +316,7 @@ exports.MessageList.prototype = {
         row.trigger("mouseleave");
     },
 
-    show_edit_topic: function MessageList_show_edit_topic(recipient_row, form) {
+    show_edit_topic_on_recipient_row: function (recipient_row, form) {
         recipient_row.find(".topic_edit_form").empty().append(form);
         recipient_row.find('.on_hover_topic_edit').hide();
         recipient_row.find('.edit_content_button').hide();
@@ -324,7 +324,7 @@ exports.MessageList.prototype = {
         recipient_row.find(".topic_edit").show();
     },
 
-    hide_edit_topic: function MessageList_hide_edit_topic(recipient_row) {
+    hide_edit_topic_on_recipient_row: function (recipient_row) {
         recipient_row.find(".stream_topic").show();
         recipient_row.find('.on_hover_topic_edit').show();
         recipient_row.find('.edit_content_button').show();


### PR DESCRIPTION
The pencil icon incorrectly appeared after it was clicked to switch to the
topic edit mode. 51a8873579b9d4bb95219cd4a5c859fa972fa06b seems to have
introduced this bug.

Closes #14460

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Tested in the local development environment, to ensure the topic edit pencil icon doesn't appear when editing topic.
Also, verified in the local dev environment that the poll edit pencil doesn't appear for non author users. 
