### PR TITLE
auth: Show a user-facing page when wrong token given to /subdomain/.

### DIFF
--- a/templates/zerver/log_into_subdomain_token_invalid.html
+++ b/templates/zerver/log_into_subdomain_token_invalid.html
@@ -1,0 +1,14 @@
+{% extends "zerver/portico_signup.html" %}
+
+{% block portico_content %}
+<div class="app portico-page">
+    <div class="app-main portico-page-container center-block flex full-page account-creation new-style">
+        <div class="inline-block">
+            <div class="app-main white-box">
+                <h1>The link has expired or is not valid.</h1>
+                Please <a href="{{ login_url }}">log in</a> again.
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -2122,6 +2122,7 @@ class GoogleAuthBackendTest(SocialAuthBase):
             result = self.get_log_into_subdomain(data, force_token=token)
             mock_warn.assert_called_once_with("log_into_subdomain: Invalid token given: %s" % (token,))
         self.assertEqual(result.status_code, 400)
+        self.assert_in_response("The link has expired or is not valid.", result)
 
     def test_prevent_duplicate_signups(self) -> None:
         existing_user = self.example_user('hamlet')

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -523,7 +523,7 @@ def log_into_subdomain(request: HttpRequest, token: str) -> HttpResponse:
     data = get_login_data(token)
     if data is None:
         logging.warning("log_into_subdomain: Invalid token given: %s" % (token,))
-        return HttpResponse(status=400)
+        return render(request, 'zerver/log_into_subdomain_token_invalid.html', status=400)
 
     # We extract fields provided by the caller via the data object.
     # The only fields that are required are email and subdomain (if we


### PR DESCRIPTION
This used to show a blank page. Considering that the links remain valid
only for 15 seconds it's important to show something more informative to
the user.

Perhaps someone will know how to make this look better, but currently that's the page:
![image](https://user-images.githubusercontent.com/45007152/78503630-6e067b00-7757-11ea-91a7-b329d2f6697d.png)
