### PR TITLE
settings UI: Make the settings avatar delete/edit UI slicker.

### DIFF
--- a/static/images/tail-spin.svg
+++ b/static/images/tail-spin.svg
@@ -1,0 +1,31 @@
+<svg width="40" height="38" viewBox="0 0 38 38" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <linearGradient x1="8.042%" y1="0%" x2="65.682%" y2="23.865%" id="a">
+            <stop stop-color="#fff" stop-opacity="0" offset="0%"/>
+            <stop stop-color="#fff" stop-opacity=".631" offset="63.146%"/>
+            <stop stop-color="#fff" offset="100%"/>
+        </linearGradient>
+    </defs>
+    <g fill="none" fill-rule="evenodd">
+        <g transform="translate(1 1)">
+            <path d="M36 18c0-9.94-8.06-18-18-18" id="Oval-2" stroke="url(#a)" stroke-width="2">
+                <animateTransform
+                    attributeName="transform"
+                    type="rotate"
+                    from="0 18 18"
+                    to="360 18 18"
+                    dur="0.9s"
+                    repeatCount="indefinite" />
+            </path>
+            <circle fill="#fff" cx="36" cy="18" r="1">
+                <animateTransform
+                    attributeName="transform"
+                    type="rotate"
+                    from="0 18 18"
+                    to="360 18 18"
+                    dur="0.9s"
+                    repeatCount="indefinite" />
+            </circle>
+        </g>
+    </g>
+</svg>

--- a/static/js/avatar.js
+++ b/static/js/avatar.js
@@ -68,13 +68,15 @@ exports.build_user_avatar_widget = function (upload_function) {
         });
     });
 
-    return upload_widget.build_direct_upload_widget(
-        get_file_input,
-        $("#user_avatar_file_input_error").expectOne(),
-        $("#user_avatar_upload_button").expectOne(),
-        upload_function,
-        page_params.max_avatar_file_size
-    );
+    if (settings_account.user_can_change_avatar()) {
+        return upload_widget.build_direct_upload_widget(
+            get_file_input,
+            $("#user_avatar_file_input_error").expectOne(),
+            $("#user-settings-avatar").expectOne(),
+            upload_function,
+            page_params.max_avatar_file_size
+        );
+    }
 };
 
 window.avatar = exports;

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -75,6 +75,23 @@ exports.update_avatar_change_display = function () {
     }
 };
 
+function display_avatar_upload_complete() {
+    $('#user-avatar-background').css({display: 'none'});
+    $('#user-avatar-spinner').css({display: 'none'});
+    $('#user_avatar_upload_button').show();
+    $('#user_avatar_delete_button').show();
+
+}
+
+function display_avatar_upload_started() {
+    $("#user-avatar-source").hide();
+    $('#user-avatar-background').css({display: 'block'});
+    $('#user-avatar-spinner').css({display: 'block'});
+    $('#user_avatar_upload_button').hide();
+    $('#user_avatar_delete_button').hide();
+}
+
+
 function settings_change_error(message, xhr) {
     ui_report.error(message, xhr, $('#account-settings-status').expectOne());
 }
@@ -562,12 +579,7 @@ exports.set_up = function () {
         for (const [i, file] of Array.prototype.entries.call(file_input[0].files)) {
             form_data.append('file-' + i, file);
         }
-
-        $("#user-avatar-source").hide();
-
-        const spinner = $("#upload_avatar_spinner").expectOne();
-        loading.make_indicator(spinner, {text: i18n.t('Uploading profile picture.')});
-
+        display_avatar_upload_started();
         channel.post({
             url: '/json/users/me/avatar',
             data: form_data,
@@ -575,14 +587,13 @@ exports.set_up = function () {
             processData: false,
             contentType: false,
             success: function () {
-                loading.destroy_indicator($("#upload_avatar_spinner"));
-                $("#user_avatar_delete_button").show();
+                display_avatar_upload_complete();
                 $("#user_avatar_file_input_error").hide();
                 $("#user-avatar-source").hide();
                 // Rest of the work is done via the user_events -> avatar_url event we will get
             },
             error: function (xhr) {
-                loading.destroy_indicator($("#upload_avatar_spinner"));
+                display_avatar_upload_complete();
                 if (page_params.avatar_source === 'G') {
                     $("#user-avatar-source").show();
                 }

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1129,6 +1129,17 @@ input[type=checkbox].inline-block {
         height: 100%;
     }
 
+    #user-avatar-background {
+        content: '';
+        background-color: hsl(0, 0%, 0%);
+        height: 100%;
+        width: 100%;
+        opacity: 0.6;
+        z-index: 99;
+        position: absolute;
+        display: none;
+    }
+
     #user_avatar_delete_button {
         cursor: pointer;
         color: hsl(236, 33%, 90%);
@@ -1140,19 +1151,23 @@ input[type=checkbox].inline-block {
         z-index: 99;
     }
 
-    #user-avatar-source {
-        margin-left: 10px;
-        width: 200px;
-        height: 20px;
+    #user_avatar_upload_button {
+        cursor: pointer;
+        color: hsl(236, 33%, 90%);
+        opacity: 0;
+        font-size: 0.85rem;
         position: absolute;
-        bottom: 6px;
-        left: 0%;
-        font-size: 0.9em;
-        visibility: hidden;
+        top: 90px;
+        right: 20px;
+        z-index: 99;
+    }
 
-        a {
-            color: hsl(0, 0%, 100%);
-        }
+    #user-avatar-spinner {
+        position: absolute;
+        top: 40%;
+        right: 40%;
+        z-index: 99;
+        display: none;
     }
 
     .guest-avatar::after {
@@ -1163,21 +1178,31 @@ input[type=checkbox].inline-block {
         #user-avatar-block::after {
             content: '';
             background-color: hsl(0, 0%, 0%);
-            height: 200px;
-            width: 200px;
+            height: 100%;
+            width: 100%;
             opacity: 0.6;
             z-index: 99;
             position: absolute;
+            cursor: pointer;
         }
 
         #user_avatar_delete_button {
             opacity: 1;
         }
 
-        #user-avatar-source {
-            visibility: visible;
-            z-index: 99;
+        #user_avatar_upload_button {
+            opacity: 1;
         }
+    }
+}
+
+#user-avatar-source {
+    position: absolute;
+    font-size: 1em;
+    z-index: 99;
+    a {
+        position: relative;
+        top: 10px;
     }
 }
 

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -154,23 +154,24 @@
 
             <div class="inline-block">
                 <div id="user-settings-avatar">
+                    <div id="user-avatar-background"></div>
                     <div id="user-avatar-block" style="background-image: url({{ page_params.avatar_url_medium }})" {{#if page_params.is_guest}} class="guest-avatar"{{/if}}/>
                     <span id="user_avatar_delete_button" aria-label="{{t 'Delete profile picture'}}" role="button" tabindex="0"
                       {{#unless user_can_change_avatar}}style="display:none"{{/unless}}>
                         &times;
                     </span>
-                    <div id="user-avatar-source">
-                        <a href="https://en.gravatar.com/" target="_blank">{{t "Avatar from Gravatar" }}</a>
-                    </div>
+                    <object id="user-avatar-spinner" type="image/svg+xml" data="/static/images/tail-spin.svg"></object>
+                    <span id="user_avatar_upload_button" aria-label="{{t 'Upload new profile picture'}}" role="button" tabindex="0"
+                      {{#if (and (not page_params.is_admin) page_params.realm_avatar_changes_disabled)}}style="display:none"{{/if}}>
+                        {{t 'Upload new profile picture' }}
+                    </span>
+                </div>
+                <div id="user-avatar-source">
+                    <a href="https://en.gravatar.com/" target="_blank">{{t "Avatar from Gravatar" }}</a>
                 </div>
                 <input type="file" name="user_avatar_file_input" class="notvisible" id="user_avatar_file_input" value="{{t 'Upload profile picture' }}" />
-                <div id="upload_avatar_spinner"></div>
             </div>
             <div class="avatar-controls">
-                <button class="button rounded sea-green w-200 block" id="user_avatar_upload_button"
-                  {{#if (and (not page_params.is_admin) page_params.realm_avatar_changes_disabled)}}style="display:none"{{/if}}>
-                    {{t 'Upload new profile picture' }}
-                </button>
                 <div id="user_avatar_file_input_error" class="text-error"></div>
             </div>
         </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
removed uploading button and spinner in the bottom of the avatar.
added UI for uploading a new avatar triggered by clicking on the
avatar, rather than a button.
added loading indicator for uploading a new avatar
over the avatar area.
Fixes #10255

**Testing Plan:** <!-- How have you tested? -->
Tested manually in the browser

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![avatar_upload_spinner](https://user-images.githubusercontent.com/45326319/78526270-1f102280-77f7-11ea-916b-719920a07580.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
