### PR TITLE
static/js: Fix custom numeric emojis not working in reactions.

### DIFF
--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -253,7 +253,7 @@ function maybe_select_emoji(e) {
             if (exports.is_composition(first_emoji)) {
                 first_emoji.click();
             } else {
-                toggle_reaction(first_emoji.data("emoji-name"));
+                toggle_reaction(first_emoji.attr("data-emoji-name"));
             }
         }
     }
@@ -267,7 +267,7 @@ exports.toggle_selected_emoji = function () {
         return;
     }
 
-    const emoji_name = $(selected_emoji).data("emoji-name");
+    const emoji_name = $(selected_emoji).attr("data-emoji-name");
 
     toggle_reaction(emoji_name);
 };
@@ -619,12 +619,12 @@ exports.register_click_handlers = function () {
         // if the user has reacted to this message with this emoji
         // the reaction is removed
         // otherwise, the reaction is added
-        const emoji_name = $(this).data("emoji-name");
+        const emoji_name = $(this).attr("data-emoji-name");
         toggle_reaction(emoji_name);
     });
 
     $(document).on('click', '.emoji-popover-emoji.composition', function (e) {
-        const emoji_name = $(this).data("emoji-name");
+        const emoji_name = $(this).attr("data-emoji-name");
         const emoji_text = ':' + emoji_name + ':';
         // The following check will return false if emoji was not selected in
         // message edit form.


### PR DESCRIPTION
Changes .data() Jquery methods to .attr() to prevent unnecessary data
type conversions of the emoji name.

Tested the fix manually and verified the test-js-with-node test suite.

Fixes: #14377

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
