### PR TITLE
night mode: Fix how "x" is displayed on "You have nothing to send!"

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -24,6 +24,10 @@ body.night-mode {
         background-color: hsl(212, 28%, 18%);
     }
 
+    .compose-send-status-close {
+        color: hsl(0, 0%, 100%);
+    }
+
     .message_embed .data-container::after {
         background: linear-gradient(0deg, hsl(212, 28%, 18%), transparent 100%);
     }


### PR DESCRIPTION
Enhance visibility of "x" to dismiss the dialog box of "You have nothing to send!" message.

To achieve this:
- Added class ```compose-send-status-close``` with new color attribute in file ```night_mode.scss```

Fixes: #14459

Co-authored-by: @MariaGkoulta <43913366+MariaGkoulta@users.noreply.github.com>

**Testing Plan:** Tested manually using this [website](https://webaim.org/resources/contrastchecker/) for finding contrast ratio.

**Screenshot:** 
![picture from x](https://user-images.githubusercontent.com/44238834/78604340-59fb7000-7862-11ea-8395-222f8d2f7afe.png)

