### PR TITLE
Cookie cleanup and hardening

### DIFF
--- a/docs/overview/changelog.md
+++ b/docs/overview/changelog.md
@@ -22,6 +22,9 @@ in bursts.
 
 **Upgrade notes:**
 
+- Logged in users may be logged out during this one-time upgrade to
+  transition them to more secure session cookies.
+
 **Full feature changelog:**
 
 - Added new options to control whether the incoming email integration

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -6,16 +6,12 @@ from typing import Any, AnyStr, Dict, \
     Iterable, List, MutableMapping, Optional
 
 from django.conf import settings
-from django.contrib.sessions.backends.base import UpdateError
-from django.contrib.sessions.middleware import SessionMiddleware
-from django.core.exceptions import DisallowedHost, SuspiciousOperation
+from django.core.exceptions import DisallowedHost
 from django.db import connection
 from django.http import HttpRequest, HttpResponse, StreamingHttpResponse
 from django.middleware.common import CommonMiddleware
 from django.shortcuts import render
-from django.utils.cache import patch_vary_headers
 from django.utils.deprecation import MiddlewareMixin
-from django.utils.http import http_date
 from django.utils.translation import ugettext as _
 from django.views.csrf import csrf_failure as html_csrf_failure
 
@@ -396,7 +392,7 @@ class FlushDisplayRecipientCache(MiddlewareMixin):
         flush_per_request_caches()
         return response
 
-class SessionHostDomainMiddleware(SessionMiddleware):
+class HostDomainMiddleware(MiddlewareMixin):
     def process_response(self, request: HttpRequest, response: HttpResponse) -> HttpResponse:
         if getattr(response, "asynchronous", False):
             # This special Tornado "asynchronous" response is
@@ -422,65 +418,6 @@ class SessionHostDomainMiddleware(SessionMiddleware):
                     get_realm(subdomain)
                 except Realm.DoesNotExist:
                     return render(request, "zerver/invalid_realm.html", status=404)
-        """
-        If request.session was modified, or if the configuration is to save the
-        session every time, save the changes and set a session cookie or delete
-        the session cookie if the session has been emptied.
-        """
-        try:
-            accessed = request.session.accessed
-            modified = request.session.modified
-            empty = request.session.is_empty()
-        except AttributeError:
-            pass
-        else:
-            # First check if we need to delete this cookie.
-            # The session should be deleted only if the session is entirely empty
-            if settings.SESSION_COOKIE_NAME in request.COOKIES and empty:
-                response.delete_cookie(
-                    settings.SESSION_COOKIE_NAME,
-                    path=settings.SESSION_COOKIE_PATH,
-                    domain=settings.SESSION_COOKIE_DOMAIN,
-                )
-            else:
-                if accessed:
-                    patch_vary_headers(response, ('Cookie',))
-                if (modified or settings.SESSION_SAVE_EVERY_REQUEST) and not empty:
-                    if request.session.get_expire_at_browser_close():
-                        max_age = None
-                        expires = None
-                    else:
-                        max_age = request.session.get_expiry_age()
-                        expires_time = time.time() + max_age
-                        expires = http_date(expires_time)
-                    # Save the session data and refresh the client cookie.
-                    # Skip session save for 500 responses, refs #3881.
-                    if response.status_code != 500:
-                        try:
-                            request.session.save()
-                        except UpdateError:
-                            raise SuspiciousOperation(
-                                "The request's session was deleted before the "
-                                "request completed. The user may have logged "
-                                "out in a concurrent request, for example."
-                            )
-                        host = request.get_host().split(':')[0]
-
-                        # The subdomains feature overrides the
-                        # SESSION_COOKIE_DOMAIN setting, since the setting
-                        # is a fixed value and with subdomains enabled,
-                        # the session cookie domain has to vary with the
-                        # subdomain.
-                        session_cookie_domain = host
-                        response.set_cookie(
-                            settings.SESSION_COOKIE_NAME,
-                            request.session.session_key, max_age=max_age,
-                            expires=expires, domain=session_cookie_domain,
-                            path=settings.SESSION_COOKIE_PATH,
-                            secure=settings.SESSION_COOKIE_SECURE or None,
-                            httponly=settings.SESSION_COOKIE_HTTPONLY or None,
-                            samesite=settings.SESSION_COOKIE_SAMESITE,
-                        )
         return response
 
 class SetRemoteAddrFromForwardedFor(MiddlewareMixin):

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -387,6 +387,10 @@ if PRODUCTION:
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
 
+    # https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05#section-4.1.3.2
+    SESSION_COOKIE_NAME = "__Host-sessionid"
+    CSRF_COOKIE_NAME = "__Host-csrftoken"
+
 # Prevent Javascript from reading the CSRF token from cookies.  Our code gets
 # the token from the DOM, which means malicious code could too.  But hiding the
 # cookie will slow down some attackers.

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -390,7 +390,7 @@ if PRODUCTION:
 # Prevent Javascript from reading the CSRF token from cookies.  Our code gets
 # the token from the DOM, which means malicious code could too.  But hiding the
 # cookie will slow down some attackers.
-CSRF_COOKIE_PATH = '/;HttpOnly'
+CSRF_COOKIE_HTTPONLY = True
 CSRF_FAILURE_VIEW = 'zerver.middleware.csrf_failure'
 
 if DEVELOPMENT:

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -164,7 +164,8 @@ MIDDLEWARE = (
     'zerver.middleware.RateLimitMiddleware',
     'zerver.middleware.FlushDisplayRecipientCache',
     'zerver.middleware.ZulipCommonMiddleware',
-    'zerver.middleware.SessionHostDomainMiddleware',
+    'zerver.middleware.HostDomainMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -385,11 +386,6 @@ SESSION_COOKIE_SAMESITE = 'Lax'
 if PRODUCTION:
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
-
-    # For get_updates hostname sharding.
-    domain = get_config('django', 'cookie_domain', None)
-    if domain is not None:
-        CSRF_COOKIE_DOMAIN = '.' + domain
 
 # Prevent Javascript from reading the CSRF token from cookies.  Our code gets
 # the token from the DOM, which means malicious code could too.  But hiding the


### PR DESCRIPTION
* middleware: Remove unused `cookie_domain` setting.
  
  Since commit 1d72629dc4e6bfe086fa812208a6f80dd54d87ee, we have been maintaining a patched copy of Django’s `SessionMiddleware.process_response` in order to unconditionally ignore our own optional `cookie_domain` setting that we don’t set.
  
  Instead, let’s not do that.

* settings: Use existing Django setting to mark CSRF cookie `HttpOnly`.
  
  Instead of sneakily injecting `HttpOnly` into the cookie via the path setting, use the setting that was designed for this purpose.

* settings: Harden session and CSRF cookies with `__Host-` prefix.
  
  This defends against cross-origin session fixation attacks.  Renaming the cookies means this one-time upgrade will have the unfortunate side effect of logging everyone out, but they’ll get more secure sessions in return.

**Testing Plan:** Production at https://andersk.zulipdev.org.
