### PR TITLE
Portico sign in

### DIFF
--- a/static/styles/portico/portico-signin.scss
+++ b/static/styles/portico/portico-signin.scss
@@ -334,7 +334,9 @@ html {
         outline: none;
         color: hsl(0, 0%, 100%);
         background-color: hsl(213, 23%, 25%);
-        margin-top: 25px;
+
+        margin: 25px 0 5px;
+        height: 50px;
 
         border: none;
         border-radius: 4px;

--- a/static/styles/portico/portico-signin.scss
+++ b/static/styles/portico/portico-signin.scss
@@ -399,8 +399,8 @@ html {
         input[type=text],
         input[type=email],
         input[type=password] {
-            padding: 9px 32px 11px 12px;
-            margin: 25px 0 4px;
+            padding: 10px 32px 10px 12px;
+            margin: 25px 0 5px;
 
             font-family: "Source Sans Pro";
             font-size: 1.2rem;


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR fixes a bug in some portico pages to align the vertical height of submit buttons with their inputs.

I'm aware of https://zulipchat.com/accounts/find/ and https://zulipchat.com/new/.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before:
![image](https://user-images.githubusercontent.com/33805964/78617719-d2c7ef80-7895-11ea-9429-a0a0e3c7b647.png)
![image](https://user-images.githubusercontent.com/33805964/78618414-20ddf280-7898-11ea-86d8-883efbfca995.png)

After:
![image](https://user-images.githubusercontent.com/33805964/78617765-00149d80-7896-11ea-9f21-64a7b5f133bc.png)
![image](https://user-images.githubusercontent.com/33805964/78617786-0f93e680-7896-11ea-8b01-3e656465668c.png)

**Testing Plan:** <!-- How have you tested? -->
man-test on FF and chrome.

TODO:
This scss looks like it needs a lot of work. It does not look great on very narrow view ports. (will add gif later) The current fix (last commit) is also sub-optimal, since it uses "height" property and fixes a static value instead of using % or performing calc. But correcting that would be difficult.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
