### PR TITLE
Improve support for accessing uploaded files on mobile

### DIFF
--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -1,14 +1,19 @@
 from typing import Optional, Tuple, Any
 
+from datetime import timedelta
+
 from django.utils.translation import ugettext as _
 from django.conf import settings
 from django.core.files import File
+from django.core.signing import TimestampSigner, BadSignature
 from django.http import HttpRequest
+from django.urls import reverse
 from jinja2 import Markup as mark_safe
 import unicodedata
 
 from zerver.lib.avatar_hash import user_avatar_path
 from zerver.lib.exceptions import JsonableError, ErrorCode
+from zerver.lib.utils import generate_random_token
 
 from boto.s3.bucket import Bucket
 from boto.s3.key import Key
@@ -19,10 +24,9 @@ from zerver.models import get_user_profile_by_id
 from zerver.models import Attachment
 from zerver.models import Realm, RealmEmoji, UserProfile, Message
 
-from zerver.lib.utils import generate_random_token
-
 import urllib
 import base64
+import binascii
 import os
 import re
 from PIL import Image, ImageOps, ExifTags
@@ -660,6 +664,23 @@ def get_local_file_path(path_id: str) -> Optional[str]:
         return local_path
     else:
         return None
+
+LOCAL_FILE_ACCESS_TOKEN_SALT = "local_file_"
+
+def generate_unauthed_file_access_url(path_id: str) -> str:
+    signed_data = TimestampSigner(salt=LOCAL_FILE_ACCESS_TOKEN_SALT).sign(path_id)
+    token = base64.b16encode(signed_data.encode('utf-8')).decode('utf-8')
+    return reverse('zerver.views.upload.serve_local_file_unauthed', args=[token, ])
+
+def get_local_file_path_id_from_token(token: str) -> Optional[str]:
+    signer = TimestampSigner(salt=LOCAL_FILE_ACCESS_TOKEN_SALT)
+    try:
+        signed_data = base64.b16decode(token).decode('utf-8')
+        path_id = signer.unsign(signed_data, max_age=timedelta(seconds=60))
+    except (BadSignature, binascii.Error):
+        return None
+
+    return path_id
 
 class LocalUploadBackend(ZulipUploadBackend):
     def upload_message_file(self, uploaded_file_name: str, uploaded_file_size: int,

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -44,6 +44,11 @@ DEFAULT_EMOJI_SIZE = 64
 MAX_EMOJI_GIF_SIZE = 128
 MAX_EMOJI_GIF_FILE_SIZE_BYTES = 128 * 1024 * 1024  # 128 kb
 
+# Duration that the signed upload URLs that we redirect to when
+# accessing uploaded files are available for clients to fetch before
+# they expire.
+SIGNED_UPLOAD_URL_DURATION = 60
+
 INLINE_MIME_TYPES = [
     "application/pdf",
     "image/gif",
@@ -323,7 +328,8 @@ def get_file_info(request: HttpRequest, user_file: File) -> Tuple[str, int, Opti
 
 def get_signed_upload_url(path: str) -> str:
     conn = S3Connection(settings.S3_KEY, settings.S3_SECRET_KEY)
-    return conn.generate_url(15, 'GET', bucket=settings.S3_AUTH_UPLOADS_BUCKET, key=path)
+    return conn.generate_url(SIGNED_UPLOAD_URL_DURATION, 'GET',
+                             bucket=settings.S3_AUTH_UPLOADS_BUCKET, key=path)
 
 def get_realm_for_filename(path: str) -> Optional[int]:
     conn = S3Connection(settings.S3_KEY, settings.S3_SECRET_KEY)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1050,6 +1050,43 @@ paths:
                         "result": "success",
                         "uri": "/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/zulip.txt"
                     }
+  /user_uploads/{realm_id_str}/{filename}:
+    get:
+      description: Get a temporary URL for access to the file that doesn't require authentication.
+      parameters:
+      - name: realm_id_str
+        in: path
+        description: The realm id.
+        schema:
+          type: integer
+        example: 1
+        required: True
+      - name: filename
+        in: path
+        description: Path to the file, from the URL of the uploaded file.
+        schema:
+          type: string
+        example: 4e/m2A3MSqFnWRLUf9SaPzQ0Up_/zulip.txt
+        required: True
+        responses:
+          '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/JsonSuccess'
+                - properties:
+                    url:
+                      type: string
+                      description: URL for access to the uploaded file without being authenticated.
+                - example:
+                    {
+                        "msg": "",
+                        "result": "success",
+                        "url": "/user_uploads/temporary/322F32632F39765378464E4C63306D3961396F4970705A4D74424565432F7A756C69702E7478743A316A5053616A3A3938625F44393446466D37357254315F4F414C425A4553464F6A55"
+                    }
+
   /users:
     get:
       description: Retrieve all users in a realm.

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -204,8 +204,9 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         self.send_stream_message(self.example_user("hamlet"), "Denmark", body, "test")
         self.assertIn('title="zulip.txt"', self.get_last_message().rendered_content)
 
-        # Now try the format that's supposed to return 200s
-        result = self.client_get(uri + "?url_only=true")
+        # Now try the endpoint that's supposed to return a temporary url for access
+        # to the file.
+        result = self.client_get('/json' + uri)
         self.assert_json_success(result)
         data = result.json()
         url_only_url = data['url']
@@ -229,7 +230,7 @@ class FileUploadTest(UploadSerializeMixin, ZulipTestCase):
         fp = StringIO("zulip!")
         fp.name = "zulip.txt"
         result = self.client_post("/json/user_uploads", {'file': fp})
-        url = result.json()["uri"] + "?url_only=true"
+        url = '/json' + result.json()["uri"]
 
         start_time = time.time()
         with mock.patch('django.core.signing.time.time', return_value=start_time):
@@ -1621,8 +1622,9 @@ class S3Test(ZulipTestCase):
         redirect_url = response['Location']
         self.assertEqual(b"zulip!", urllib.request.urlopen(redirect_url).read().strip())
 
-        # Now try the format that's supposed to return 200s
-        result = self.client_get(uri + "?url_only=true")
+        # Now try the endpoint that's supposed to return a temporary url for access
+        # to the file.
+        result = self.client_get('/json' + uri)
         self.assert_json_success(result)
         data = result.json()
         url_only_url = data['url']

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -1574,9 +1574,18 @@ class S3Test(ZulipTestCase):
         self.assertEqual(base, uri[:len(base)])
 
         response = self.client_get(uri)
+        self.assertEqual(response.status_code, 302)
         redirect_url = response['Location']
-
         self.assertEqual(b"zulip!", urllib.request.urlopen(redirect_url).read().strip())
+
+        # Now try the format that's supposed to return 200s
+        result = self.client_get(uri + "?url_only=true")
+        self.assert_json_success(result)
+        data = result.json()
+        url_only_url = data['url']
+        self.assertEqual(b"zulip!", urllib.request.urlopen(url_only_url).read().strip())
+        # Verify the URLs are different.
+        self.assertEqual(url_only_url, redirect_url)
 
         self.subscribe(self.example_user("hamlet"), "Denmark")
         body = "First message ...[zulip.txt](http://localhost:9991" + uri + ")"

--- a/zerver/views/upload.py
+++ b/zerver/views/upload.py
@@ -5,16 +5,21 @@ from django.utils.cache import patch_cache_control
 from django.utils.translation import ugettext as _
 
 from zerver.lib.response import json_success, json_error
+from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.upload import upload_message_image_from_request, get_local_file_path, \
     get_signed_upload_url, check_upload_within_quota, INLINE_MIME_TYPES
+from zerver.lib.validator import check_bool
 from zerver.models import UserProfile, validate_attachment_request
 from django.conf import settings
 from django_sendfile import sendfile
 from mimetypes import guess_type
 
-def serve_s3(request: HttpRequest, url_path: str) -> HttpResponse:
-    uri = get_signed_upload_url(url_path)
-    return redirect(uri)
+def serve_s3(request: HttpRequest, url_path: str, url_only: bool) -> HttpResponse:
+    url = get_signed_upload_url(url_path)
+    if url_only:
+        return json_success(dict(url=url))
+
+    return redirect(url)
 
 def serve_local(request: HttpRequest, path_id: str) -> HttpResponse:
     local_path = get_local_file_path(path_id)
@@ -46,8 +51,17 @@ def serve_local(request: HttpRequest, path_id: str) -> HttpResponse:
     patch_cache_control(response, private=True, immutable=True)
     return response
 
+@has_request_variables
 def serve_file_backend(request: HttpRequest, user_profile: UserProfile,
-                       realm_id_str: str, filename: str) -> HttpResponse:
+                       realm_id_str: str, filename: str,
+                       url_only: bool=REQ(validator=check_bool,
+                                          default=False)) -> HttpResponse:
+    """
+    If the client passes url_only, we should return a signed, short-lived URL
+    that the client can use for native mobile download, rather than serving a redirect.
+
+    TODO: Add support for this flow with the LOCAL_UPLOADS_DIR backend.
+    """
     path_id = "%s/%s" % (realm_id_str, filename)
     is_authorized = validate_attachment_request(user_profile, path_id)
 
@@ -58,7 +72,7 @@ def serve_file_backend(request: HttpRequest, user_profile: UserProfile,
     if settings.LOCAL_UPLOADS_DIR is not None:
         return serve_local(request, path_id)
 
-    return serve_s3(request, path_id)
+    return serve_s3(request, path_id, url_only)
 
 def upload_file_backend(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
     if len(request.FILES) == 0:

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -237,6 +237,10 @@ v1_api_and_json_patterns = [
     # user_uploads -> zerver.views.upload
     url(r'^user_uploads$', rest_dispatch,
         {'POST': 'zerver.views.upload.upload_file_backend'}),
+    url(r'^user_uploads/(?P<realm_id_str>(\d*|unk))/(?P<filename>.*)$',
+        rest_dispatch,
+        {'GET': ('zerver.views.upload.serve_file_url_backend',
+                 {'override_api_url_scheme'})}),
 
     # bot_storage -> zerver.views.storage
     url(r'^bot_storage$', rest_dispatch,

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -37,6 +37,7 @@ import zerver.views.digest
 import zerver.views.messages
 from zerver.context_processors import latest_info_context
 import zerver.views.realm_export
+import zerver.views.upload
 
 from zerver.lib.rest import rest_dispatch
 
@@ -588,6 +589,9 @@ urls += [
 # having to rewrite URLs, and is implemented using the
 # 'override_api_url_scheme' flag passed to rest_dispatch
 urls += [
+    url(r'^user_uploads/temporary/([0-9A-Za-z]+)$',
+        zerver.views.upload.serve_local_file_unauthed,
+        name='zerver.views.upload.serve_local_file_unauthed'),
     url(r'^user_uploads/(?P<realm_id_str>(\d*|unk))/(?P<filename>.*)$',
         rest_dispatch,
         {'GET': ('zerver.views.upload.serve_file_backend',


### PR DESCRIPTION
This only addresses the issue for the S3 backend, but should be good enough to develop against.

I think we can do the same feature for the LOCAL_UPLOADS_BACKEND in <50 lines of code as follows:
* If `url_only` is passed, generate a random key, store that key with 60-second expiry in redis with the value being the filename, and return a URL including that key `/user_uploads/signed/{random_key}`.
* When a request for a URL of that form is returned, look up the key in redis and use the existing sendfile code to return the file's content.  

See https://chat.zulip.org/#narrow/stream/243-mobile-team/topic/view.20uploaded.20files/near/849350 for context.

@andersk FYI for security review.

Probably someone not me should do the redis implementation (maybe @mateuszmandera) since it's a bit more involved; Mateusz, feel free to do that in a new commit and add it to this PR.
