### PR TITLE
settings: Add option to disable video call in org settings.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -50,6 +50,10 @@ set_global('settings_bots', {
     update_bot_permissions_ui: noop,
 });
 
+set_global('compose', {
+    update_video_chat_button_display: noop,
+});
+
 set_global('settings_exports', {
     populate_exports_table: function (exports) {
         return exports;

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -187,6 +187,9 @@ $(".top_left_starred_messages").set_find_results('.count', count_stub);
 
 $("#tab_list .stream").length = 0;
 
+compose.compute_show_video_chat_button = () => {};
+$("#below-compose-content .video_link").toggle = () => {};
+
 run_test('initialize_everything', () => {
     ui_init.initialize_everything();
 });

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -48,6 +48,26 @@ function show_all_everyone_warnings() {
     user_acknowledged_all_everyone = false;
 }
 
+exports.compute_show_video_chat_button = function () {
+    const available_providers = page_params.realm_available_video_chat_providers;
+    if (page_params.realm_video_chat_provider === available_providers.disabled.id) {
+        return false;
+    }
+
+    if (page_params.realm_video_chat_provider === available_providers.jitsi_meet.id &&
+         !page_params.jitsi_server_url) {
+        return false;
+    }
+
+    return true;
+};
+
+exports.update_video_chat_button_display = function () {
+    const show_video_chat_button = exports.compute_show_video_chat_button();
+    $("#below-compose-content .video_link").toggle(show_video_chat_button);
+    $(".message-edit-feature-group .video_link").toggle(show_video_chat_button);
+};
+
 exports.clear_all_everyone_warnings = function () {
     $("#compose-all-everyone").hide();
     $("#compose-all-everyone").empty();
@@ -906,6 +926,7 @@ exports.warn_if_mentioning_unsubscribed_user = function (mentioned) {
 };
 
 exports.initialize = function () {
+    $("#below-compose-content .video_link").toggle(exports.compute_show_video_chat_button());
     $('#stream_message_recipient_stream,#stream_message_recipient_topic,#private_message_recipient').on('keyup', update_fade);
     $('#stream_message_recipient_stream,#stream_message_recipient_topic,#private_message_recipient').on('change', update_fade);
     $('#compose-textarea').on('keydown', function (event) {
@@ -1048,13 +1069,14 @@ exports.initialize = function () {
             target_textarea = $("#message_edit_content_" + edit_message_id);
         }
 
-        if (page_params.jitsi_server_url === null) {
-            return;
-        }
-
         let video_call_link;
         const video_call_id = util.random_int(100000000000000, 999999999999999);
         const available_providers = page_params.realm_available_video_chat_providers;
+        const show_video_chat_button = exports.compute_show_video_chat_button();
+
+        if (!show_video_chat_button) {
+            return;
+        }
 
         if (page_params.realm_video_chat_provider === available_providers.google_hangouts.id) {
             video_call_link = "https://hangouts.google.com/hangouts/_/" + page_params.realm_google_hangouts_domain + "/" + video_call_id;

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -234,6 +234,8 @@ function edit_message(row, raw_content) {
         file_upload_enabled = true;
     }
 
+    const show_video_chat_button = compose.compute_show_video_chat_button();
+
     const form = $(render_message_edit_form({
         is_stream: message.type === 'stream',
         message_id: message.id,
@@ -243,6 +245,7 @@ function edit_message(row, raw_content) {
         topic: message.topic,
         content: raw_content,
         file_upload_enabled: file_upload_enabled,
+        show_video_chat_button: show_video_chat_button,
         minutes_to_edit: Math.floor(page_params.realm_message_content_edit_limit_seconds / 60),
     }));
 

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -118,7 +118,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             message_content_allowed_in_email_notifications: noop,
             signup_notifications_stream_id: noop,
             emails_restricted_to_domains: noop,
-            video_chat_provider: noop,
+            video_chat_provider: compose.update_video_chat_button_display,
             waiting_period_threshold: noop,
             zoom_user_id: noop,
             zoom_api_key: noop,

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -788,7 +788,7 @@ exports.build_page = function () {
             input_elem = $(input_elem);
             if (check_property_changed(input_elem)) {
                 const input_value = exports.get_input_element_value(input_elem);
-                if (input_value) {
+                if (input_value !== null) {
                     const property_name = input_elem.attr('id').replace("id_realm_", "");
                     data[property_name] = JSON.stringify(input_value);
                 }

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -44,7 +44,9 @@
                     {{#if file_upload_enabled}}
                     <a class="message-control-button fa fa-paperclip notdisplayed" aria-hidden="true" id="attach_files_{{message_id}}" href="#" title="{{t "Attach files" }}"></a>
                     {{/if}}
+                    {{#if show_video_chat_button}}
                     <a class="message-control-button fa fa-video-camera video_link" aria-hidden="true" href="#" data-message-id="{{message_id}}" title="{{t "Add video call" }}"></a>
+                    {{/if}}
                     <a id="undo_markdown_preview_{{message_id}}" class="message-control-button fa fa-edit" aria-hidden="true" style="display:none;" title="{{t 'Write' }}"></a>
                     <a id="markdown_preview_{{message_id}}" class="message-control-button fa fa-eye" aria-hidden="true" title="{{t 'Preview' }}"></a>
                 </div>

--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -100,9 +100,7 @@
                                     {% if max_file_upload_size > 0 %}
                                     <a class="message-control-button fa fa-paperclip notdisplayed" aria-hidden="true" id="attach_files" href="#" title="{{ _('Attach files') }}"></a>
                                     {% endif %}
-                                    {% if jitsi_server_url %}
                                     <a class="message-control-button fa fa-video-camera video_link" aria-hidden="true" href="#" title="{{ _('Add video call') }}"></a>
-                                    {% endif %}
                                     <a id="undo_markdown_preview" class="message-control-button fa fa-edit" aria-hidden="true" style="display:none;" title="{{ _('Write') }}"></a>
                                     <a id="markdown_preview" class="message-control-button fa fa-eye" aria-hidden="true" title="{{ _('Preview') }}"></a>
                                     <a class="drafts-link" href="#drafts" title="{{ _('Drafts') }} (d)">{{ _('Drafts') }}</a>

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -301,6 +301,10 @@ class Realm(models.Model):
     upload_quota_gb = models.IntegerField(null=True)  # type: Optional[int]
 
     VIDEO_CHAT_PROVIDERS = {
+        'disabled': {
+            'name': u"None",
+            'id': 0
+        },
         'jitsi_meet': {
             'name': u"Jitsi Meet",
             'id': 1

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -498,7 +498,7 @@ class RealmTest(ZulipTestCase):
             invite_to_stream_policy=10,
             email_address_visibility=10,
             message_retention_days=10,
-            video_chat_provider=0,
+            video_chat_provider=4,
             waiting_period_threshold=-10,
             digest_weekday=10,
             user_group_edit_policy=10,
@@ -533,11 +533,17 @@ class RealmTest(ZulipTestCase):
         self.assertEqual(get_realm('zulip').video_chat_provider, Realm.VIDEO_CHAT_PROVIDERS['jitsi_meet']['id'])
         self.login('iago')
 
-        invalid_video_chat_provider_value = 0
+        invalid_video_chat_provider_value = 4
         req = {"video_chat_provider": ujson.dumps(invalid_video_chat_provider_value)}
         result = self.client_patch('/json/realm', req)
         self.assert_json_error(result,
                                ("Invalid video_chat_provider {}").format(invalid_video_chat_provider_value))
+
+        req = {"video_chat_provider": ujson.dumps(Realm.VIDEO_CHAT_PROVIDERS['disabled']['id'])}
+        result = self.client_patch('/json/realm', req)
+        self.assert_json_success(result)
+        self.assertEqual(get_realm('zulip').video_chat_provider,
+                         Realm.VIDEO_CHAT_PROVIDERS['disabled']['id'])
 
         req = {"video_chat_provider": ujson.dumps(Realm.VIDEO_CHAT_PROVIDERS['google_hangouts']['id'])}
         result = self.client_patch('/json/realm', req)


### PR DESCRIPTION
Option is added to video_chat_provider settings for disabling
video calls.

Video call icon is hidden in two cases-
1. video_chat_provider is set to disabled.
2. video_chat_provider is set to Jitsi and settings.JITSI_SERVER_URL
   is none.

Fixes #14483

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->Relevant tests are added and modified.



**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![video_call](https://user-images.githubusercontent.com/35494118/78725920-60ffac80-794e-11ea-87f8-8d3dfc1b05d2.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
