### PR TITLE
openapi/python_examples: Update get_single_user.

### DIFF
--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -220,7 +220,7 @@ def get_single_user(client):
 
     # {code_example|start}
     # If you'd like data on custom profile fields, you can request them as follows:
-    result = client.get_user_by_id(user_id, {'include_custom_profile_fields': True})
+    result = client.get_user_by_id(user_id, include_custom_profile_fields=True)
     # {code_example|end}
     validate_against_openapi_schema(result, '/users/{user_id}', 'get', '200')
 


### PR DESCRIPTION
This updates get_single_user to pass keyword arguments to
get_user_by_id instead of passing a dictionary.

