### PR TITLE
dev-docs-setup: Add installation instructions for WSL 2.

### DIFF
--- a/docs/development/setup-advanced.md
+++ b/docs/development/setup-advanced.md
@@ -3,6 +3,7 @@
 Contents:
 
 * [Installing directly on Ubuntu, Debian, Centos, or Fedora](#installing-directly-on-ubuntu-debian-centos-or-fedora)
+* [Installing directly on Windows 10](#installing-directly-on-windows-10-experimental)
 * [Installing manually on other Linux/UNIX](#installing-manually-on-unix)
 * [Installing directly on cloud9](#installing-on-cloud9)
 
@@ -54,6 +55,62 @@ Once you've done the above setup, you can pick up the [documentation
 on using the Zulip development
 environment](../development/setup-vagrant.html#step-4-developing),
 ignoring the parts about `vagrant` (since you're not using it).
+
+## Installing directly on Windows 10 (Experimental)
+
+We will be using Microsoft's new feature [WSL 2](https://docs.microsoft.com/en-us/windows/wsl/wsl2-about)
+for installation. So, first install WSL 2 by following the instructions provided by Microsoft
+[here](https://docs.microsoft.com/en-us/windows/wsl/wsl2-install). Install `Ubuntu 18.04` as your linux
+distribution from the Microsoft Store.
+
+Launch `Ubuntu 18.04` shell and run the following commands:
+
+```
+sudo apt update && sudo apt upgrade
+sudo apt install rabbitmq-server memcached redis-server postgresql
+```
+
+Open `/etc/rabbitmq/Rabbitmq.conf` file using:
+
+```
+sudo vim /etc/rabbitmq/Rabbitmq.conf
+```
+
+Add the following lines at the end of your file:
+
+```
+NODE_IP_ADDRESS=127.0.0.1
+NODE_PORT=5672
+```
+
+Then start [cloning your fork of the Zulip repository][zulip-rtd-git-cloning]
+and [connecting the Zulip upstream repository][zulip-rtd-git-connect]:
+
+```
+git clone --config pull.rebase https://github.com/YOURUSERNAME/zulip.git
+cd zulip
+git remote add -f upstream https://github.com/zulip/zulip.git
+```
+
+Start the servers using `./tools/wsl/start_services` and run:
+(click `Allow access` if you get popups for Windows Firewall blocking some services)
+
+```
+./tools/provision
+source /srv/zulip-py3-venv/bin/activate
+./tools/run-dev.py  # starts the development server
+```
+```eval_rst
+.. note::
+    If you shutdown WSL, you will have to manually start
+    the database services using ``./tools/wsl/start_services``.
+```
+
+Once you've done the above setup, you can pick up the [documentation
+on using the Zulip development
+environment](../development/setup-vagrant.html#step-4-developing),
+ignoring the parts about `vagrant` (since you're not using it).
+
 
 ## Installing manually on Unix
 

--- a/docs/development/setup-vagrant.md
+++ b/docs/development/setup-vagrant.md
@@ -153,6 +153,11 @@ Debian](https://docs.docker.com/install/linux/docker-ce/debian/).
 
 #### Windows 10
 
+```eval_rst
+.. note::
+    As an alternative you can try the `WSL 2 setup <../development/setup-advanced.html#installing-directly-on-windows-10-experimental>`_.
+```
+
 1. Install [Git for Windows][git-bash], which installs *Git BASH*.
 2. Install [VirtualBox][vbox-dl] (latest).
 3. Install [Vagrant][vagrant-dl] (latest).

--- a/tools/wsl/start_services
+++ b/tools/wsl/start_services
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# These services are no longer running when WSL is restarted
+# and hence they have to be manually started.
+sudo service rabbitmq-server start && sudo service memcached start\
+ && sudo service redis-server start && sudo service postgresql start


### PR DESCRIPTION
Instructions were added by doing the setup on Ubuntu 18.04 WSL 2. While
the setup should be similar for other distributions supported by our
`./tools/provision` script, it has not been tested.

czo discussion - https://chat.zulip.org/#narrow/stream/49-development-help/topic/Running.20Zulip.20on.20Windows.20(WSL)
