### PR TITLE
emoji_name: Raise correct exception if emoji_name is missing.

### DIFF
--- a/zerver/lib/emoji.py
+++ b/zerver/lib/emoji.py
@@ -97,9 +97,11 @@ def check_emoji_admin(user_profile: UserProfile, emoji_name: Optional[str]=None)
         raise JsonableError(_("Must be an organization administrator or emoji author"))
 
 def check_valid_emoji_name(emoji_name: str) -> None:
-    if re.match(r'^[0-9a-z.\-_]+(?<![.\-_])$', emoji_name):
-        return
-    raise JsonableError(_("Invalid characters in emoji name"))
+    if emoji_name:
+        if re.match(r'^[0-9a-z.\-_]+(?<![.\-_])$', emoji_name):
+            return
+        raise JsonableError(_("Invalid characters in emoji name"))
+    raise JsonableError(_("Emoji name is missing"))
 
 def get_emoji_url(emoji_file_name: str, realm_id: int) -> str:
     return upload_backend.get_emoji_url(emoji_file_name, realm_id)

--- a/zerver/tests/test_realm_emoji.py
+++ b/zerver/tests/test_realm_emoji.py
@@ -104,6 +104,13 @@ class RealmEmojiTest(ZulipTestCase):
             result = self.client_post('/json/realm/emoji/my_EMoji', info=emoji_data)
         self.assert_json_error(result, 'Invalid characters in emoji name')
 
+    def test_missing_name_exception(self) -> None:
+        self.login('iago')
+        with get_test_image_file('img.png') as fp1:
+            emoji_data = {'f1': fp1}
+            result = self.client_post('/json/realm/emoji/', info=emoji_data)
+        self.assert_json_error(result, 'Emoji name is missing')
+
     def test_upload_admins_only(self) -> None:
         self.login('othello')
         realm = get_realm('zulip')


### PR DESCRIPTION
Adding handling of blank emoji names while uploading custom emoji.
Discussion :- https://chat.zulip.org/#narrow/stream/101-design/topic/Emoji.20Name.20Missing

New exception for no name
![Screenshot from 2020-04-10 17-24-15](https://user-images.githubusercontent.com/42106909/78989115-48f77b00-7b50-11ea-9dd1-b444198bd0cb.png)


Old exception working for invalid characters
![Screenshot from 2020-04-09 01-12-40](https://user-images.githubusercontent.com/42106909/78827643-0e32fd00-7a01-11ea-9886-a7d48abd16cd.png)

