### PR TITLE
user profile cards: Fix bug with deactivated user.

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -68,14 +68,27 @@ function copy_email_handler(e) {
 }
 
 function init_email_clipboard() {
+    /*
+        This shows (and enables) the copy-text icon for folks
+        who have names that would overflow past the right
+        edge of our user mention popup.
+    */
     $('.user_popover_email').each(function () {
         if (this.clientWidth < this.scrollWidth) {
             const email_el = $(this);
             const copy_email_icon = email_el.find('i');
-            copy_email_icon.removeClass('hide_copy_icon');
 
-            const copy_email_clipboard = new ClipboardJS(copy_email_icon[0]);
-            copy_email_clipboard.on('success', copy_email_handler);
+            /*
+                For deactivated users, the copy-email icon will
+                not even be present in the HTML, so we don't do
+                anything.  We don't reveal emails for deactivated
+                users.
+            */
+            if (copy_email_icon[0]) {
+                copy_email_icon.removeClass('hide_copy_icon');
+                const copy_email_clipboard = new ClipboardJS(copy_email_icon[0]);
+                copy_email_clipboard.on('success', copy_email_handler);
+            }
         }
     });
 }


### PR DESCRIPTION
We had a user have problems with the user
profile menus that you get when you click
on either sender avatars or mention pills.

If a deactivated user had a long enough email
that we would normally want to un-hide the clipboard
icon for them, we would crash inside of
`init_email_clipboard`, because the icon isn't
there for them.  If the user didn't have the
console open to see the crash, the symptom
became that you would get multiple cards
visible and kind of "stuck".

I chose to fix this by just making the code
defensive with respect to the absence of the
icon, instead of short-circuiting it for
deactivated users.

It's a bit odd that we still have an element
matching `.user_email_popover` in the profile
card for deactivated users, since that element
doesn't actually include an email, but it instead
says "(This user has been deactivated)".  I
considered removing the class, but the CSS
that we use for emails kind of applies here
too.

Testing this is a kind of a pain, as you want
either long emails or to just temporarily hack
this condition to true:

    if (this.clientWidth < this.scrollWidth) {
        // ...
    }

And then test with a deactivated user, of course.

Fixes #14473

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
