### PR TITLE
docs: Document integration request process.

### DIFF
--- a/static/styles/portico/integrations.scss
+++ b/static/styles/portico/integrations.scss
@@ -436,6 +436,18 @@ $category-text: hsl(219, 23%, 33%);
         }
     }
 
+    .integration-request {
+        padding: 10px 0px;
+
+        p {
+            padding-bottom: 10px;
+        }
+
+        .button {
+            padding: 11px 25px 11px 25px;
+        }
+    }
+
     /* -- integration instructions -- */
 
     #integration-instructions-group {

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -84,6 +84,7 @@
 ## Tools & customization
 * [Bots and integrations](/help/bots-and-integrations)
 * [Add a bot or integration](/help/add-a-bot-or-integration)
+* [Request an integration](/help/request-an-integration)
 * [Create a poll](/help/create-a-poll)
 * [Night mode](/help/night-mode)
 * [Enable emoticon translations](/help/enable-emoticon-translations)

--- a/templates/zerver/help/request-an-integration.md
+++ b/templates/zerver/help/request-an-integration.md
@@ -1,0 +1,26 @@
+# Request an integration
+
+Zulip provides its user over 100 native integrations. Several hundred more are
+available through [Hubot](https://hubot.github.com/), [Zapier](https://zapier.com/home),
+and [IFTTT](https://ifttt.com/) but there can be times where you don’t find an integration
+or bot you need.
+
+In such cases, you can request the integration by filing a feature request on our
+GitHub issues page. While filing a feature request please provide as much detail
+and context as possible.
+
+## Filing an issue
+
+{start_tabs}
+
+1. Go to [Zulip's Issue page](https://github.com/zulip/zulip/issues).
+
+2. Click **New issue**.
+
+3. Fill out the fields, and click **Submit new issue**.
+
+!!! warn ""
+    Make sure no issue exists for the same integration request or feature
+    and once you are sure you can file an issue for the integration you want.
+
+{end_tabs}

--- a/templates/zerver/integrations/index.html
+++ b/templates/zerver/integrations/index.html
@@ -133,6 +133,12 @@
                                 <h3 class="integration-name create-your-own">{% trans %}Create your own!{% endtrans %}</h3>
                             </div>
                         </a>
+                        <div class="integration-request center">
+                            <p>Don't see an integration you use? Learn how you can request it.</p>
+                            <a href="/help/request-an-integration" class="button green">
+                                Learn more
+                            </a>
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
There was no proper documentation to guide user to request an integration.
The following changes documents the whole process and links it from the
`/integrations/` page making it visible to the end-user.

Fixes #7935.

Integration Page:
![image](https://user-images.githubusercontent.com/23737560/78842071-abe7f580-7a1c-11ea-876a-c4b4f949c3e0.png)

Documentation Page:
![image](https://user-images.githubusercontent.com/23737560/78842043-95419e80-7a1c-11ea-87d9-dc8046df9184.png)
