### PR TITLE
tornado: Reuse retry_event functions for failures in tornado queues.

### DIFF
--- a/zerver/management/commands/runtornado.py
+++ b/zerver/management/commands/runtornado.py
@@ -23,7 +23,7 @@ from zerver.tornado.application import create_tornado_application, \
     setup_tornado_rabbitmq
 from zerver.tornado.autoreload import start as zulip_autoreload_start
 from zerver.tornado.event_queue import add_client_gc_hook, \
-    missedmessage_hook, process_notification, setup_event_queue
+    missedmessage_hook, get_wrapped_process_notification, setup_event_queue
 from zerver.tornado.sharding import notify_tornado_queue_name
 
 if settings.USING_RABBITMQ:
@@ -89,8 +89,9 @@ class Command(BaseCommand):
             if settings.USING_RABBITMQ:
                 queue_client = get_queue_client()
                 # Process notifications received via RabbitMQ
-                queue_client.register_json_consumer(notify_tornado_queue_name(int(port)),
-                                                    process_notification)
+                queue_name = notify_tornado_queue_name(int(port))
+                queue_client.register_json_consumer(queue_name,
+                                                    get_wrapped_process_notification(queue_name))
 
             try:
                 # Application is an instance of Django's standard wsgi handler.


### PR DESCRIPTION
We use retry_event in queue_processors.py to handle retrying on failures,
without getting stuck in permanent retry loops if the event ends up
leading to failure on every attempt and we just keep sending NACK to
rabbitmq forever (or until the channel crashes). Tornado queues haven't
been using this, but they should.

Tested manually with some print-debugging. Logs errors like this if a broken event is sent to tornado and goes over the allowed retry limit:
(in this example I delete the `type` from the event to make it broken)
```
2020-04-09 16:29:18.694 ERR  [:9993] Maximum retries exceeded for Tornado notice:{'event': {'message': 101, 'message_dict': {'id': 101, 'sender_id': 10, 'content': 'hhhh', 'recipient_type_id': 9, 'recipient_type': 1, 'recipient_id': 9, 'timestamp': 1586444199, 'client': 'website', 'subject': '', 'sender_realm_id': 2, 'topic_links': [], 'rendered_content': '<p>hhhh</p>', 'is_me_message': False, 'reactions': [], 'submessages': [], 'sender_full_name': 'Iago', 'sender_short_name': 'iago', 'sender_email': 'user10@zulipdev.com', 'sender_delivery_email': 'iago@zulip.com', 'sender_realm_str': 'zulip', 'sender_avatar_source': 'G', 'sender_avatar_version': 1, 'sender_is_mirror_dummy': False, 'display_recipient': [{'email': 'user10@zulipdev.com', 'full_name': 'Iago', 'short_name': 'iago', 'id': 10, 'is_mirror_dummy': False}, {'id': 9, 'email': 'user9@zulipdev.com', 'full_name': 'King Hamlet', 'short_name': 'hamlet', 'is_mirror_dummy': False}], 'type': 'private'}, 'presence_idle_user_ids': [9], 'local_id': '82.01', 'sender_queue_id': '1586444157:0'}, 'users': [{'id': 9, 'flags': [], 'always_push_notify': True, 'stream_push_notify': False, 'stream_email_notify': False, 'wildcard_mention_notify': False}, {'id': 10, 'flags': ['read'], 'always_push_notify': True, 'stream_push_notify': False, 'stream_email_notify': False, 'wildcard_mention_notify': False}], 'failed_tries': 4}
Stack trace:
Traceback (most recent call last):
  File "/srv/zulip/zerver/tornado/event_queue.py", line 1097, in wrapped_process_notification
    process_notification(notice)
  File "/srv/zulip/zerver/tornado/event_queue.py", line 1071, in process_notification
    if event['type'] == "message":
KeyError: 'type'
```