### PR TITLE
stream: Add support for sending user_id to endpoint when subscribing users.

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -2219,6 +2219,12 @@ def get_active_user(email: str, realm: Realm) -> UserProfile:
 def get_user_profile_by_id_in_realm(uid: int, realm: Realm) -> UserProfile:
     return UserProfile.objects.select_related().get(id=uid, realm=realm)
 
+def get_active_user_profile_by_id_in_realm(uid: int, realm: Realm) -> UserProfile:
+    user_profile = get_user_profile_by_id_in_realm(uid, realm)
+    if not user_profile.is_active:
+        raise UserProfile.DoesNotExist()
+    return user_profile
+
 def get_user_including_cross_realm(email: str, realm: Optional[Realm]=None) -> UserProfile:
     if is_cross_realm_bot_email(email):
         return get_system_bot(email)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3767,13 +3767,15 @@ components:
       name: principals
       in: query
       description: |
-        A list of email addresses of the users that will be subscribed/unsubscribed
+        A list of email addresses or user ids of the users that will be subscribed/unsubscribed
         to the streams specified in the `subscriptions` argument. If not provided, then
         the requesting user/bot is subscribed.
       schema:
         type: array
         items:
-          type: string
+          oneOf:
+            - type: string
+            - type: integer
         default: []
       example: ['ZOE@zulip.com']
     ReactionType:

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -456,6 +456,9 @@ do not match the types declared in the implementation of {}.\n""".format(functio
                         subtypes.append(VARMAP[st])
                     self.assertTrue(len(subtypes) > 1)
                     sub_type = self.get_type_by_priority(subtypes)
+                elif "oneOf" in items.keys():
+                    sub_type = VARMAP[element["schema"]["items"]["oneOf"][0]["type"]]
+                    self.assertIsNotNone(sub_type)
                 else:
                     sub_type = VARMAP[element["schema"]["items"]["type"]]
                     self.assertIsNotNone(sub_type)

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -30,7 +30,7 @@ from zerver.lib.validator import check_string, check_int, check_list, check_dict
     check_bool, check_variable_type, check_capped_string, check_color, check_dict_only, \
     check_int_in
 from zerver.models import UserProfile, Stream, Realm, UserMessage, \
-    get_system_bot, get_active_user
+    get_system_bot, get_active_user, get_active_user_profile_by_id_in_realm
 
 from collections import defaultdict
 import ujson
@@ -40,16 +40,19 @@ class PrincipalError(JsonableError):
     data_fields = ['principal']
     http_status_code = 403
 
-    def __init__(self, principal: str) -> None:
-        self.principal: str = principal
+    def __init__(self, principal: Union[int, str]) -> None:
+        self.principal: Union[int, str] = principal
 
     @staticmethod
     def msg_format() -> str:
         return _("User not authorized to execute queries on behalf of '{principal}'")
 
-def principal_to_user_profile(agent: UserProfile, principal: str) -> UserProfile:
+def principal_to_user_profile(agent: UserProfile, principal: Union[str, int]) -> UserProfile:
     try:
-        return get_active_user(principal, agent.realm)
+        if isinstance(principal, str):
+            return get_active_user(principal, agent.realm)
+        else:
+            return get_active_user_profile_by_id_in_realm(principal, agent.realm)
     except UserProfile.DoesNotExist:
         # We have to make sure we don't leak information about which users
         # are registered for Zulip in a different realm.  We could do
@@ -249,11 +252,19 @@ def compose_views(
 def remove_subscriptions_backend(
         request: HttpRequest, user_profile: UserProfile,
         streams_raw: Iterable[str]=REQ("subscriptions", validator=check_list(check_string)),
-        principals: Optional[Iterable[str]]=REQ(validator=check_list(check_string), default=None),
+        principals: Optional[Iterable[Union[str, int]]]=REQ(validator=check_variable_type([
+            check_list(check_string), check_list(check_int)]), default=None),
 ) -> HttpResponse:
 
     removing_someone_else = principals and \
         set(principals) != {user_profile.email}
+
+    removing_someone_else = False
+    if principals:
+        if all(isinstance(val, str) for val in principals):
+            removing_someone_else = set(principals) != {user_profile.email}
+        else:
+            removing_someone_else = set(principals) != {user_profile.id}
 
     if removing_someone_else and not user_profile.is_realm_admin:
         # You can only unsubscribe other people from a stream if you are a realm
@@ -315,7 +326,8 @@ def add_subscriptions_backend(
             Stream.STREAM_POST_POLICY_TYPES), default=Stream.STREAM_POST_POLICY_EVERYONE),
         history_public_to_subscribers: Optional[bool]=REQ(validator=check_bool, default=None),
         announce: bool=REQ(validator=check_bool, default=False),
-        principals: List[str]=REQ(validator=check_list(check_string), default=[]),
+        principals: List[Union[str, int]]=REQ(validator=check_variable_type([
+            check_list(check_string), check_list(check_int)]), default=[]),
         authorization_errors_fatal: bool=REQ(validator=check_bool, default=True),
 ) -> HttpResponse:
     stream_dicts = []


### PR DESCRIPTION
This PR modifies the backend to accept user ids when subscribing users
to streams.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
