### PR TITLE
upload: Set the value of file input element to empty after upload.

### DIFF
--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -284,6 +284,7 @@ run_test('file_input', () => {
     const event = {
         target: {
             files: files,
+            value: "C:\fakepath\portland.png",
         },
     };
     let upload_files_called = false;

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -165,6 +165,7 @@ exports.setup_upload = function (config) {
     $("body").on("change", exports.get_item("file_input_identifier", config), (event) => {
         const files = event.target.files;
         exports.upload_files(uppy, config, files);
+        event.target.value = "";
     });
 
     const drag_drop_container = exports.get_item("drag_drop_container", config);


### PR DESCRIPTION
Otherwise, if a user tries to upload the same file again the on change
event handler would not be called since there is no change in the value.
