### PR TITLE
linkifiers: Allow non-admins to filter linkifiers in settings.

### DIFF
--- a/static/js/settings_linkifiers.js
+++ b/static/js/settings_linkifiers.js
@@ -12,9 +12,6 @@ exports.maybe_disable_widgets = function () {
     if (page_params.is_admin) {
         return;
     }
-
-    $(".organization-box [data-name='filter-settings']")
-        .find("input, button, select").attr("disabled", true);
 };
 
 exports.populate_filters = function (filters_data) {


### PR DESCRIPTION
The filter-linkifier input box was disabled which prevented users from
filtering through the linkifiers list. Removed the part of code which
caused the input box to be disabled. This allows users to edit the input
and so filter linkifiers.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/14521


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
