### PR TITLE
design: Make non-editable text-box more distinguishable.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -263,6 +263,8 @@ function edit_message(row, raw_content) {
     if (editability === editability_types.NO) {
         message_edit_content.prop("readonly", "readonly");
         message_edit_topic.prop("readonly", "readonly");
+        message_edit_content.attr("disabled", "disabled");
+        message_edit_topic.attr("disabled", "disabled");
         new ClipboardJS(copy_message[0]);
     } else if (editability === editability_types.NO_LONGER) {
         // You can currently only reach this state in non-streams. If that
@@ -270,10 +272,12 @@ function edit_message(row, raw_content) {
         // in streams), then we'll need to disable
         // row.find('input.message_edit_topic') as well.
         message_edit_content.prop("readonly", "readonly");
+        message_edit_content.attr("disabled", "disabled");
         message_edit_countdown_timer.text(i18n.t("View source"));
         new ClipboardJS(copy_message[0]);
     } else if (editability === editability_types.TOPIC_ONLY) {
         message_edit_content.prop("readonly", "readonly");
+        message_edit_content.attr("disabled", "disabled");
         // Hint why you can edit the topic but not the message content
         message_edit_countdown_timer.text(i18n.t("Topic editing only"));
         new ClipboardJS(copy_message[0]);


### PR DESCRIPTION
Earlier, the non-editable text-boxes(on clicking view source/edit
topic) were not so apparent due to the absence of `disabled` attribute.
Adding the `disabled` attribute makes them consistent with the approach
for non-editable text-boxes and text-areas in organization settings
(for non-admins).

Fixes: #14375

Screenshots:

Earlier-
![image](https://user-images.githubusercontent.com/47082523/78946188-aa333600-7adf-11ea-809d-191b229a5359.png)

Changed:
<img width="576" alt="textbox3" src="https://user-images.githubusercontent.com/47082523/78946217-c3d47d80-7adf-11ea-8cfd-99522595c101.png">
