### PR TITLE
icons: fix icons color and opacity

### DIFF
--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -468,14 +468,12 @@ a.message-control-button {
 
 a#markdown_preview {
     margin-left: 2px;
-    color: hsl(0, 0%, 47%);
 }
 
 a#undo_markdown_preview {
     text-decoration: none;
     position: relative;
     font-size: 15px;
-    color: hsl(0, 0%, 47%);
     margin-left: 2px;
 }
 

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1073,7 +1073,7 @@ a.message_label_clickable:hover {
 }
 
 .on_hover_topic_edit {
-    opacity: .1;
+    opacity: 0.2;
 }
 
 .always_visible_topic_edit {
@@ -1087,7 +1087,7 @@ a.message_label_clickable:hover {
 }
 
 .on_hover_topic_mute {
-    opacity: .1;
+    opacity: 0.2;
 }
 
 .on_hover_topic_mute:hover {


### PR DESCRIPTION
Previously:
![Screenshot from 2020-04-12 05-38-39](https://user-images.githubusercontent.com/32801674/79057749-4eed7900-7c82-11ea-9ce8-8fd5373ee6f2.png)

![compose_old](https://user-images.githubusercontent.com/32801674/79057737-37ae8b80-7c82-11ea-90e9-2eb871f41892.gif)


Now:
![Screenshot from 2020-04-12 05-54-30](https://user-images.githubusercontent.com/32801674/79057750-50b73c80-7c82-11ea-86fe-cb603c76a0ab.png)

![compose_new](https://user-images.githubusercontent.com/32801674/79057736-367d5e80-7c82-11ea-9ba5-fb33c2bcd6b3.gif)
