### PR TITLE
Add support for configuring which realms use which SAML providers in multi-organization servers 

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -2514,14 +2514,16 @@ class ExternalMethodDictsTests(ZulipTestCase):
         ):
             # Calling get_external_method_dicts without a realm returns all methods configured on the server:
             external_auth_methods = get_external_method_dicts()
-            self.assert_length(external_auth_methods, 3)  # 2 IdP + a dict for github auth
-            self.assertEqual(set([external_auth_methods[0]['name'], external_auth_methods[1]['name']]),
-                             set(['saml:test_idp', 'saml:test_idp2']))
+            # 1 IdP enabled for all realms + a dict for github auth
+            self.assert_length(external_auth_methods, 2)
+            self.assertEqual([external_auth_methods[0]['name'], external_auth_methods[1]['name']],
+                             ['saml:test_idp', 'github'])
 
             external_auth_methods = get_external_method_dicts(get_realm("zulip"))
             # Only test_idp enabled for the zulip realm, + github auth.
             self.assert_length(external_auth_methods, 2)
-            self.assertEqual(external_auth_methods[0]['name'], 'saml:test_idp')
+            self.assertEqual([external_auth_methods[0]['name'], external_auth_methods[1]['name']],
+                             ['saml:test_idp', 'github'])
 
             external_auth_methods = get_external_method_dicts(get_realm("zephyr"))
             # Both idps enabled for the zephyr realm, + github auth.

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -1558,6 +1558,9 @@ class SAMLAuthBackend(SocialAuthMixin, SAMLAuth):
         for idp_name, idp_dict in settings.SOCIAL_AUTH_SAML_ENABLED_IDPS.items():
             if realm and not cls.validate_idp_for_subdomain(idp_name, realm.subdomain):
                 continue
+            if realm is None and 'limit_to_subdomains' in idp_dict:
+                # If queried without a realm, only return IdPs that can be used on all realms.
+                continue
 
             saml_dict = dict(
                 name='saml:{}'.format(idp_name),


### PR DESCRIPTION
Also tested manually in the dev environment by having two configured IdP dicts, configuring the limitations for them and trying if things behave as expected.