### PR TITLE
tooltips: Replace static HTML titles with JS Tooltips.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -536,6 +536,34 @@ exports.initialize = function () {
         $(".tooltip").remove();
     });
 
+    // Tooltips for left sidebar icons.
+    $("#streams_filter_icon").on("mouseenter", (e) => {
+        e.stopPropagation();
+
+        const elem = $(e.currentTarget);
+        const hotkey = '(q)';
+        const title = i18n.t("Filter streams __hotkey__", {hotkey: hotkey});
+
+        ui.create_generic_tooltip(elem, title, "left");
+    });
+    $("#streams_filter_icon").on("mouseleave", (e) => {
+        e.stopPropagation();
+        $(e.currentTarget).tooltip('hide');
+    });
+
+    $("#streams_inline_cog").on("mouseenter", (e) => {
+        e.stopPropagation();
+
+        const elem = $(e.currentTarget);
+        const title = i18n.t("Subscribe, add, or configure streams");
+
+        ui.create_generic_tooltip(elem, title, "left");
+    });
+    $("#streams_inline_cog").on("mouseleave", (e) => {
+        e.stopPropagation();
+        $(e.currentTarget).tooltip('hide');
+    });
+
     function do_render_buddy_list_tooltip(elem, title_data) {
         elem.tooltip({
             template: render_buddy_list_tooltip(),

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -232,6 +232,49 @@ exports.initialize = function () {
         $(e.currentTarget).tooltip('destroy');
     });
 
+    // TOOLTIPS FOR MESSAGE CONTROLs
+    $("#main_div").on("mouseenter", ".actions_hover", (e) => {
+        e.stopPropagation();
+
+        const elem = $(e.currentTarget);
+        const hotkey = '(i)';
+        const title = i18n.t("Message actions __hotkey__", {hotkey: hotkey});
+
+        ui.create_generic_tooltip(elem, title, "bottom");
+    });
+    $('#main_div').on('mouseleave', '.actions_hover', (e) => {
+        e.stopPropagation();
+        $(e.currentTarget).tooltip('hide');
+    });
+
+    $("#main_div").on("mouseenter", ".fa-pencil.edit_content_button", (e) => {
+        e.stopPropagation();
+
+        const elem = $(e.currentTarget);
+        const hotkey = '(e)';
+        const title = i18n.t("Edit __hotkey__", {hotkey: hotkey});
+
+        ui.create_generic_tooltip(elem, title, "bottom");
+    });
+    $('#main_div').on('mouseleave', '.fa-pencil.edit_content_button', (e) => {
+        e.stopPropagation();
+        $(e.currentTarget).tooltip('hide');
+    });
+
+    $("#main_div").on("mouseenter", ".fa-file-code-o.edit_content_button", (e) => {
+        e.stopPropagation();
+
+        const elem = $(e.currentTarget);
+        const hotkey = '(e)';
+        const title = i18n.t("View source __hotkey__", {hotkey: hotkey});
+
+        ui.create_generic_tooltip(elem, title, "bottom");
+    });
+    $('#main_div').on('mouseleave', '.fa-file-code-o.edit_content_button', (e) => {
+        e.stopPropagation();
+        $(e.currentTarget).tooltip('hide');
+    });
+
     // DESTROY PERSISTING TOOLTIPS ON HOVER
 
     $("body").on('mouseenter', '.tooltip', (e) => {

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -691,17 +691,10 @@ exports.register_click_handlers = function () {
 
     $("#main_div").on("mouseenter", ".reaction_button", (e) => {
         e.stopPropagation();
-
         const elem = $(e.currentTarget);
-        const title = i18n.t("Add emoji reaction");
-        elem.tooltip({
-            title: title + " (:)",
-            trigger: 'hover',
-            placement: 'bottom',
-            animation: false,
-        });
-        elem.tooltip('show');
-        $(".tooltip-arrow").remove();
+        const hotkey = '(:)';
+        const title = i18n.t("Add emoji reaction __hotkey__", {hotkey: hotkey});
+        ui.create_generic_tooltip(elem, title, "bottom");
     });
 
     $('#main_div').on('mouseleave', '.reaction_button', (e) => {

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -205,6 +205,18 @@ exports.restore_compose_cursor = function () {
         .caret(saved_compose_cursor);
 };
 
+// Generic tooltip to replace HTML titles.
+exports.create_generic_tooltip = function (elem, title, placement) {
+    elem.tooltip({
+        title: title,
+        trigger: 'hover',
+        placement: placement,
+        animation: false,
+    });
+    elem.tooltip('show');
+    $(".tooltip-arrow").remove();
+};
+
 exports.initialize = function () {
     exports.set_compose_textarea_handlers();
     exports.show_error_for_unsupported_platform();

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -39,9 +39,9 @@ function message_hover(message_row) {
     // But the message edit hover icon is determined by whether the message is still editable
     if (message_edit.get_editability(message) === message_edit.editability_types.FULL &&
         !message.status_message) {
-        message_row.find(".edit_content").html('<i class="fa fa-pencil edit_content_button" aria-hidden="true" title="Edit (e)"></i>');
+        message_row.find(".edit_content").html('<i class="fa fa-pencil edit_content_button" aria-hidden="true" aria-label="Edit (e)"></i>');
     } else {
-        message_row.find(".edit_content").html('<i class="fa fa-file-code-o edit_content_button" aria-hidden="true" title="View source (e)" data-message-id="' + id + '"></i>');
+        message_row.find(".edit_content").html('<i class="fa fa-file-code-o edit_content_button" aria-hidden="true" aria-label="View source (e)" data-message-id="' + id + '"></i>');
     }
 }
 

--- a/static/templates/message_controls.hbs
+++ b/static/templates/message_controls.hbs
@@ -13,7 +13,7 @@
 
     {{#unless msg/locally_echoed}}
     <div class="info actions_hover">
-        <i class="zulip-icon ellipsis-v-solid" title="{{#tr this}}Message actions{{/tr}} (i)" title="{{#tr this}}Message actions{{/tr}}" role="button" aria-haspopup="true" tabindex="0" aria-label="{{#tr this}}Message actions{{/tr}}"></i>
+        <i class="zulip-icon ellipsis-v-solid" role="button" aria-haspopup="true" tabindex="0" aria-label="{{#tr this}}Message actions{{/tr}}"></i>
     </div>
     {{/unless}}
 

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -68,8 +68,8 @@
         </ul>
         <div id="streams_list" class="zoom-out">
             <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title" data-toggle="tooltip" title="{{ _('Filter streams') }}">{{ _('STREAMS') }}</h4>
-                <i id="streams_inline_cog" class='fa fa-cog' aria-hidden="true" data-toggle="tooltip" title="{{ _('Subscribe, add, or configure streams') }}"></i>
-                <i id="streams_filter_icon" class='fa fa-search' aria-hidden="true" data-toggle="tooltip" title="{{ _('Filter streams') }} (q)"></i>
+                <i id="streams_inline_cog" class='fa fa-cog' aria-hidden="true" aria-label="{{ _('Subscribe, add, or configure streams') }}"></i>
+                <i id="streams_filter_icon" class='fa fa-search' aria-hidden="true" aria-label="{{ _('Filter streams') }} (q)"></i>
                 <div class="input-append notdisplayed stream_search_section">
                     <input class="stream-list-filter" type="text" autocomplete="off" placeholder="{{ _('Search streams') }}" />
                     <button type="button" class="btn clear_search_button" id="clear_search_stream_button">


### PR DESCRIPTION
Moved the tooltip creation code to a generic function that can be reused to replace other static HTML titles.

GIF:

![js_tooltips](https://user-images.githubusercontent.com/25329595/79604785-5ababe80-810c-11ea-87a7-d455c5c1b52b.gif)
