### PR TITLE
url_preview: Discard url in oembed if server returns invalid json.

### DIFF
--- a/zerver/lib/url_preview/oembed.py
+++ b/zerver/lib/url_preview/oembed.py
@@ -1,12 +1,13 @@
 from typing import Optional, Dict, Any
 from pyoembed import oEmbed, PyOembedException
+import json
 
 def get_oembed_data(url: str,
                     maxwidth: Optional[int]=640,
                     maxheight: Optional[int]=480) -> Optional[Dict[str, Any]]:
     try:
         data = oEmbed(url, maxwidth=maxwidth, maxheight=maxheight)
-    except PyOembedException:
+    except (PyOembedException, json.decoder.JSONDecodeError):
         return None
 
     oembed_resource_type = data.get('type', '')

--- a/zerver/tests/test_link_embed.py
+++ b/zerver/tests/test_link_embed.py
@@ -114,6 +114,16 @@ class OembedTestCase(ZulipTestCase):
         data = get_oembed_data(url)
         self.assertIsNone(data)
 
+    @mock.patch('pyoembed.requests.get')
+    def test_invalid_json_in_response(self, get: Any) -> None:
+        get.return_value = response = mock.Mock()
+        response.headers = {'content-type': 'application/json'}
+        response.ok = True
+        response.text = '{invalid json}'
+        url = 'http://instagram.com/p/BLtI2WdAymy'
+        data = get_oembed_data(url)
+        self.assertIsNone(data)
+
     def test_oembed_html(self) -> None:
         html = '<iframe src="//www.instagram.com/embed.js"></iframe>'
         stripped_html = strip_cdata(html)


### PR DESCRIPTION
This fixes the scenario where we'd get errors in the
FetchLinksEmbedData queue processor if oembed got invalid json from the
URL.