### PR TITLE
messages: Fix 500 on queries with empty string as search operand.

### DIFF
--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -2347,6 +2347,10 @@ class GetOldMessagesTest(ZulipTestCase):
         for operand in ['is', 'near', 'has', 'id']:
             self.exercise_bad_narrow_operand_using_dict_api(operand, invalid_operands, error_msg)
 
+        # Disallow empty search terms
+        error_msg = 'elem["operand"] cannot be blank.'
+        self.exercise_bad_narrow_operand_using_dict_api('search', [''], error_msg)
+
     # The exercise_bad_narrow_operand helper method uses legacy tuple format to
     # test bad narrow, this method uses the current dict api format
     def exercise_bad_narrow_operand_using_dict_api(self, operator: str,

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -48,7 +48,8 @@ from zerver.lib.topic_mutes import exclude_topic_mutes
 from zerver.lib.utils import statsd
 from zerver.lib.validator import \
     check_list, check_int, check_dict, check_string, check_bool, \
-    check_string_or_int_list, check_string_or_int, check_string_in
+    check_string_or_int_list, check_string_or_int, check_string_in, \
+    check_required_string
 from zerver.lib.zephyr import compute_mit_user_fullname
 from zerver.models import Message, UserProfile, Stream, Subscription, Client,\
     Realm, RealmDomain, Recipient, UserMessage, \
@@ -541,12 +542,15 @@ def narrow_parameter(json: str) -> OptionalNarrowListT:
             # operators_supporting_id, or operators_supporting_ids array.
             operators_supporting_id = ['sender', 'group-pm-with', 'stream']
             operators_supporting_ids = ['pm-with']
+            operators_non_empty_operand = {'search'}
 
             operator = elem.get('operator', '')
             if operator in operators_supporting_id:
                 operand_validator = check_string_or_int
             elif operator in operators_supporting_ids:
                 operand_validator = check_string_or_int_list
+            elif operator in operators_non_empty_operand:
+                operand_validator = check_required_string
             else:
                 operand_validator = check_string
 


### PR DESCRIPTION
The error is PGroonga specific since `pgroonga_query_extract_keywords` does
not handle empty string inputs correctly. This commit adds filtering on the
narrow to ignore searches with empty operands, to fix the bug. If search
with the empty string was the only search term, the search behaves similar
to no narrow being specified.

Closes #14405

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
