### PR TITLE
thumbor: Fix __file__ typo.

### DIFF
--- a/zerver/lib/thumbnail.py
+++ b/zerver/lib/thumbnail.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.utils.http import is_safe_url
 from libthumbor import CryptoURL
 
-ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath('__file__'))))
+ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.append(ZULIP_PATH)
 
 from zthumbor.loaders.helpers import (

--- a/zthumbor/loaders/helpers.py
+++ b/zthumbor/loaders/helpers.py
@@ -6,7 +6,7 @@ import re
 import sys
 from typing import Any, Text, Tuple, Optional
 
-ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath('__file__'))))
+ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.append(ZULIP_PATH)
 
 # Piece of code below relating to secrets conf has been duplicated with that of


### PR DESCRIPTION
Replaced '__file__' typo with __file__ which used to add
wrong path to sys.path.

We cannot fix this typo in thumbor.conf as __file__ is set for modules.
so was giving error 
```
NameError: __file__ is not defined
```

Tested locally.
I am getting this warning though in ./tools/run-dev.py
```
2020-04-12 23:32:16 thumbor:WARNING Error importing bounding_box filter, trimming won't work
```
Not sure if this is due to these changes as after reverting these changes warning was still there.