### PR TITLE
upgrade-zulip: Remove tsearch-extras on upgrade.

### DIFF
--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -6,6 +6,7 @@
 # effect on the very next upgrade.
 import argparse
 import configparser
+import glob
 import hashlib
 import subprocess
 import os
@@ -59,6 +60,13 @@ except (configparser.NoSectionError, configparser.NoOptionError):
 
 # Handle issues around upstart on Ubuntu Xenial
 subprocess.check_call(["./scripts/lib/check-upstart"])
+
+if glob.glob("/usr/share/postgresql/*/extension/tsearch_extras.control"):
+    # Remove legacy tsearch_extras package references
+    subprocess.check_call([
+        "su", "postgres", "-c",
+        'psql -v ON_ERROR_STOP=1 zulip -c "DROP EXTENSION IF EXISTS tsearch_extras;"'])
+    subprocess.check_call(["apt-get", "remove", "-y", "postgresql-*-tsearch-extras"])
 
 if not args.skip_puppet:
     logging.info("Upgrading system packages...")


### PR DESCRIPTION
We stopped using tsearch-extras in Zulip 2.1.0 after Anders figured
out how to achieve its goals with native postgres.  However, we never
did a `DROP EXTENSION` on systems thta had upgraded, which meant that
backups created on systems originally installed with Zulip 2.0.x and
older, and later upgraded to Zulip 2.1.x, could not be restored on
Zulip servers created with a fresh install of Zulip 2.1.x.

We can't do this with a normal database migration, because DROP
EXTENSION has to be done as the postgres user, so we add some custom
migration code in the upgrade-zulip-stage-2 tool.

It's safe to run this whenever tsearch_extras.control is installed because:
* Zulip is AFAIK the only software that ever used tsearch_extras.
* The package was only installed via puppet on production servers configured to
  run a local Zulip database.
* We'll only run this code once per system, because it removes the
  package and thus the control files.

Fixes #13612.
