### PR TITLE
settings: Fix hovering bug in "Uploaded files" settings.

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -278,6 +278,8 @@ td .button {
                 content: " \f0d8";
                 white-space: pre;
                 display: inline-block;
+                position: absolute;
+                padding-top: 3px;
                 font: normal normal normal 12px/1 FontAwesome;
                 font-size: inherit;
             }


### PR DESCRIPTION
While Hovering over the "Mentioned in","size" column in
"Uploaded files" settings the column width is increasing
since we are using `pesudo element ::after` the bug is fixed by
adding `fixed width` for `mentioned_in=20%` , `size=10%`.
fixes #14559

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
