### PR TITLE
default streams: Change add api to use stream_id.

### DIFF
--- a/static/js/settings_streams.js
+++ b/static/js/settings_streams.js
@@ -57,9 +57,9 @@ exports.update_default_streams_table = function () {
     }
 };
 
-function make_stream_default(stream_name) {
+function make_stream_default(stream_id) {
     const data = {
-        stream_name: stream_name,
+        stream_id: stream_id,
     };
     const default_stream_status = $("#admin-default-stream-status");
     default_stream_status.hide();
@@ -105,7 +105,7 @@ exports.build_page = function () {
             e.preventDefault();
             e.stopPropagation();
             const default_stream_input = $(".create_default_stream");
-            make_stream_default(default_stream_input.val());
+            make_stream_default(stream_data.get_stream_id(default_stream_input.val()));
             default_stream_input[0].value = "";
         }
     });
@@ -125,7 +125,7 @@ exports.build_page = function () {
         e.preventDefault();
         e.stopPropagation();
         const default_stream_input = $(".create_default_stream");
-        make_stream_default(default_stream_input.val());
+        make_stream_default(stream_data.get_stream_id(default_stream_input.val()));
         // Clear value inside input box
         default_stream_input[0].value = "";
     });

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -1219,7 +1219,7 @@ class DefaultStreamTest(ZulipTestCase):
 
         stream_name = 'stream ADDED via api'
         stream = ensure_stream(user_profile.realm, stream_name)
-        result = self.client_post('/json/default_streams', dict(stream_name=stream_name))
+        result = self.client_post('/json/default_streams', dict(stream_id=stream.id))
         self.assert_json_success(result)
         self.assertTrue(stream_name in self.get_default_stream_names(user_profile.realm))
 
@@ -1255,11 +1255,11 @@ class DefaultStreamTest(ZulipTestCase):
         stream_name = "private_stream"
         stream = self.make_stream(stream_name, invite_only=True)
         self.subscribe(self.example_user('iago'), stream_name)
-        result = self.client_post('/json/default_streams', dict(stream_name=stream_name))
-        self.assert_json_error(result, "Invalid stream name '%s'" % (stream_name,))
+        result = self.client_post('/json/default_streams', dict(stream_id=stream.id))
+        self.assert_json_error(result, "Invalid stream id")
 
         self.subscribe(user_profile, stream_name)
-        result = self.client_post('/json/default_streams', dict(stream_name=stream_name))
+        result = self.client_post('/json/default_streams', dict(stream_id=stream.id))
         self.assert_json_success(result)
         self.assertTrue(stream_name in self.get_default_stream_names(user_profile.realm))
 

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -69,8 +69,8 @@ def deactivate_stream_backend(request: HttpRequest,
 @has_request_variables
 def add_default_stream(request: HttpRequest,
                        user_profile: UserProfile,
-                       stream_name: str=REQ()) -> HttpResponse:
-    (stream, recipient, sub) = access_stream_by_name(user_profile, stream_name)
+                       stream_id: int=REQ(validator=check_int)) -> HttpResponse:
+    (stream, recipient, sub) = access_stream_by_id(user_profile, stream_id)
     do_add_default_stream(stream)
     return json_success()
 


### PR DESCRIPTION
This refactors `add_default_stream` in `zerver/views/streams.py` to
take in stream_id as parameter instead of stream_name.

Minor changes have been made to `test_subs.py` and `settings_streams.js` accordingly.