### PR TITLE
narrow: bugfix: Update stream list height after rendering completes.

### DIFF
--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -8,6 +8,11 @@ zrequire('Filter', 'js/filter');
 set_global('page_params', {
     stop_words: ['what', 'about'],
 });
+set_global('resize', {
+    resize_page_components: () => {},
+    resize_stream_filters_container: () => {},
+});
+
 
 zrequire('narrow');
 

--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -2,6 +2,9 @@ const util = zrequire('util');
 set_global('$', global.make_zjquery());
 
 zrequire('narrow_state');
+set_global('resize', {
+    resize_stream_filters_container: () => {},
+});
 zrequire('stream_data');
 zrequire('Filter', 'js/filter');
 zrequire('MessageListData', 'js/message_list_data');

--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -1,9 +1,6 @@
 set_global('$', global.make_zjquery());
 
 set_global('narrow_state', {});
-set_global('resize', {
-    resize_stream_filters_container: function () {},
-});
 set_global('ui', {
     get_content_element: element => element,
 });

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -325,6 +325,7 @@ exports.activate = function (raw_operators, opts) {
 
     msg_list.initial_core_time = new Date();
     setTimeout(function () {
+        resize.resize_stream_filters_container();
         msg_list.initial_free_time = new Date();
         maybe_report_narrow_time(msg_list);
     }, 0);
@@ -818,6 +819,7 @@ exports.deactivate = function () {
 
     unnarrow_times.initial_core_time = new Date();
     setTimeout(function () {
+        resize.resize_stream_filters_container();
         unnarrow_times.initial_free_time = new Date();
         report_unnarrow_time();
     });

--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -27,7 +27,6 @@ function set_count(count) {
 function remove_expanded_private_messages() {
     stream_popover.hide_topic_popover();
     ui.get_content_element($("#private-container")).empty();
-    resize.resize_stream_filters_container();
 }
 
 exports.close = function () {
@@ -145,7 +144,6 @@ exports.expand = function () {
     private_messages_open = true;
     stream_popover.hide_topic_popover();
     exports.update_private_messages();
-    resize.resize_stream_filters_container();
     if (exports.is_all_privates()) {
         $(".top_left_private_messages").addClass('active-filter');
     }


### PR DESCRIPTION
When switching from Private Messages narrow to
All messages narrow, stream list max-height was not
correctly updated. Stream list max-height was calculated
 before new height were updated by browser for
All message narrow.

Inshort:
Stream list max-height was being updated before the browser could
render height for `#global_filters`. Calling resize after narrow
removes this issue.

czo discussion: https://chat.zulip.org/#narrow/stream/6-frontend/topic/Streams.20list.20glitch