### PR TITLE
Message edit .save() and .end() refactor

### DIFF
--- a/frontend_tests/node_tests/message_events.js
+++ b/frontend_tests/node_tests/message_events.js
@@ -107,7 +107,7 @@ run_test('update_messages', () => {
 
     const side_effects = [
         'condense.un_cache_message_content_height',
-        'message_edit.end',
+        'message_edit.end_message_row_edit',
         'notifications.received_messages',
         'unread_ui.update_unread_counts',
         'stream_list.update_streams_sidebar',

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -252,37 +252,37 @@ exports.initialize = function () {
     $("body").on("click", ".topic_edit_save", function (e) {
         const recipient_row = $(this).closest(".recipient_row");
         message_edit.show_topic_edit_spinner(recipient_row);
-        message_edit.save(recipient_row, true);
+        message_edit.save_inline_topic_edit(recipient_row);
         e.stopPropagation();
         popovers.hide_all();
     });
     $("body").on("click", ".topic_edit_cancel", function (e) {
         const recipient_row = $(this).closest(".recipient_row");
-        current_msg_list.hide_edit_topic_on_recipient_row(recipient_row);
+        message_edit.end_inline_topic_edit(recipient_row);
         e.stopPropagation();
         popovers.hide_all();
     });
     $("body").on("click", ".message_edit_save", function (e) {
         const row = $(this).closest(".message_row");
-        message_edit.save(row, false);
+        message_edit.save_message_row_edit(row);
         e.stopPropagation();
         popovers.hide_all();
     });
     $("body").on("click", ".message_edit_cancel", function (e) {
         const row = $(this).closest(".message_row");
-        message_edit.end(row);
+        message_edit.end_message_row_edit(row);
         e.stopPropagation();
         popovers.hide_all();
     });
     $("body").on("click", ".message_edit_close", function (e) {
         const row = $(this).closest(".message_row");
-        message_edit.end(row);
+        message_edit.end_message_row_edit(row);
         e.stopPropagation();
         popovers.hide_all();
     });
     $("body").on("click", ".copy_message", function (e) {
         const row = $(this).closest(".message_row");
-        message_edit.end(row);
+        message_edit.end_message_row_edit(row);
         row.find(".alert-msg").text(i18n.t("Copied!"));
         row.find(".alert-msg").css("display", "block");
         row.find(".alert-msg").delay(1000).fadeOut(300);

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -251,7 +251,6 @@ exports.initialize = function () {
     });
     $("body").on("click", ".topic_edit_save", function (e) {
         const recipient_row = $(this).closest(".recipient_row");
-        message_edit.show_topic_edit_spinner(recipient_row);
         message_edit.save_inline_topic_edit(recipient_row);
         e.stopPropagation();
         popovers.hide_all();

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -156,44 +156,47 @@ exports.end_if_focused = function () {
 function handle_edit_keydown(from_topic_edited_only, e) {
     let row;
     const code = e.keyCode || e.which;
-
-    // Handle escape keys in the message_edit form.
-    if (code === 27) {
-        exports.end_if_focused();
-        e.stopPropagation();
-        e.preventDefault();
-        return;
-    }
-
-    if ($(e.target).hasClass("message_edit_content") && code === 13) {
-        // Pressing enter to save edits is coupled with enter to send
-        if (composebox_typeahead.should_enter_send(e)) {
-            row = $(".message_edit_content").filter(":focus").closest(".message_row");
-            const message_edit_save_button = row.find(".message_edit_save");
-            if (message_edit_save_button.attr('disabled') === "disabled") {
-                // In cases when the save button is disabled
-                // we need to disable save on pressing enter
-                // Prevent default to avoid new-line on pressing
-                // enter inside the textarea in this case
+    switch (code) {
+        case 13:
+            if ($(e.target).hasClass("message_edit_content")) {
+                // Pressing enter to save edits is coupled with enter to send
+                if (composebox_typeahead.should_enter_send(e)) {
+                    row = $(".message_edit_content").filter(":focus").closest(".message_row");
+                    const message_edit_save_button = row.find(".message_edit_save");
+                    if (message_edit_save_button.attr('disabled') === "disabled") {
+                        // In cases when the save button is disabled
+                        // we need to disable save on pressing enter
+                        // Prevent default to avoid new-line on pressing
+                        // enter inside the textarea in this case
+                        e.preventDefault();
+                        return;
+                    }
+                } else {
+                    composebox_typeahead.handle_enter($(e.target), e);
+                    return;
+                }
+            } else if (($(e.target).hasClass("message_edit_topic") ||
+                                       $(e.target).hasClass("message_edit_topic_propagate"))) {
+                row = $(e.target).closest(".message_row");
+                exports.save(row, from_topic_edited_only);
+                e.stopPropagation();
                 e.preventDefault();
-                return;
+            } else if (e.target.id === "inline_topic_edit") {
+                row = $(e.target).closest(".recipient_row");
+                exports.show_topic_edit_spinner(row);
+                exports.save(row, from_topic_edited_only);
+                e.stopPropagation();
+                e.preventDefault();
             }
-        } else {
-            composebox_typeahead.handle_enter($(e.target), e);
             return;
-        }
-    } else if (code === 13 && ($(e.target).hasClass("message_edit_topic") ||
-                               $(e.target).hasClass("message_edit_topic_propagate"))) {
-        row = $(e.target).closest(".message_row");
-    } else if (e.target.id === "inline_topic_edit" && code === 13) {
-        row = $(e.target).closest(".recipient_row");
-        exports.show_topic_edit_spinner(row);
-    } else {
-        return;
+        case 27: // Handle escape keys in the message_edit form.
+            exports.end_if_focused();
+            e.stopPropagation();
+            e.preventDefault();
+            return;
+        default:
+            return;
     }
-    e.stopPropagation();
-    e.preventDefault();
-    exports.save(row, from_topic_edited_only);
 }
 
 function timer_text(seconds_left) {

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -143,9 +143,17 @@ exports.show_topic_edit_spinner = function (row) {
     $(".topic_edit_cancel").hide();
 };
 
-exports.end_if_focused = function () {
-    const focused_elem = $(".message_edit").find(':focus');
+exports.end_if_focused_on_inline_topic_edit = function () {
+    const focused_elem = $(".topic_edit_form").find(':focus');
+    if (focused_elem.length === 1) {
+        focused_elem.blur();
+        const recipient_row = focused_elem.closest('.recipient_row');
+        exports.end_inline_topic_edit(recipient_row);
+    }
+};
 
+exports.end_if_focused_on_message_row_edit = function () {
+    const focused_elem = $(".message_edit").find(':focus');
     if (focused_elem.length === 1) {
         focused_elem.blur();
         const row = focused_elem.closest('.message_row');
@@ -186,7 +194,7 @@ function handle_message_row_edit_keydown(e) {
         }
         return;
     case 27: // Handle escape keys in the message_edit form.
-        exports.end_if_focused();
+        exports.end_if_focused_on_message_row_edit();
         e.stopPropagation();
         e.preventDefault();
         return;
@@ -203,6 +211,11 @@ function handle_inline_topic_edit_keydown(e) {
         row = $(e.target).closest(".recipient_row");
         exports.show_topic_edit_spinner(row);
         exports.save_inline_topic_edit(row);
+        e.stopPropagation();
+        e.preventDefault();
+        return;
+    case 27: // handle escape
+        exports.end_if_focused_on_inline_topic_edit();
         e.stopPropagation();
         e.preventDefault();
         return;

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -542,7 +542,11 @@ exports.save_inline_topic_edit = function (row) {
             loading.destroy_indicator(spinner);
         },
         error: function (xhr) {
-            // do nothing
+            if (msg_list === current_msg_list) {
+                message_id = rows.id_for_recipient_row(row);
+                const message = channel.xhr_error_message(i18n.t("Error saving edit"), xhr);
+                row.find(".edit_error").text(message).css('display', 'inline-block');
+            }
         },
     });
 };

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -209,7 +209,6 @@ function handle_inline_topic_edit_keydown(e) {
     switch (code) {
     case 13: // Handle enter key in the recipient bar/inline topic edit form
         row = $(e.target).closest(".recipient_row");
-        exports.show_topic_edit_spinner(row);
         exports.save_inline_topic_edit(row);
         e.stopPropagation();
         e.preventDefault();
@@ -518,6 +517,8 @@ exports.save_inline_topic_edit = function (row) {
         exports.end_inline_topic_edit(row);
         return;
     }
+
+    exports.show_topic_edit_spinner(row);
 
     if (message.locally_echoed) {
         if (topic_changed) {

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -135,7 +135,7 @@ exports.update_messages = function update_messages(events) {
 
         const row = current_msg_list.get_row(event.message_id);
         if (row.length > 0) {
-            message_edit.end(row);
+            message_edit.end_message_row_edit(row);
         }
 
         const new_topic = util.get_edit_event_topic(event);

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -304,7 +304,7 @@ exports.MessageList.prototype = {
     },
 
     show_edit_message: function MessageList_show_edit_message(row, edit_obj) {
-        row.find(".message_edit_form").empty().append(edit_obj.form);
+        row.find(".message_edit_form").append(edit_obj.form);
         row.find(".message_content, .status-message, .message_controls").hide();
         row.find(".message_edit").css("display", "block");
         autosize(row.find(".message_edit_content"));
@@ -312,12 +312,13 @@ exports.MessageList.prototype = {
 
     hide_edit_message: function MessageList_hide_edit_message(row) {
         row.find(".message_content, .status-message, .message_controls").show();
+        row.find(".message_edit_form").empty();
         row.find(".message_edit").hide();
         row.trigger("mouseleave");
     },
 
     show_edit_topic_on_recipient_row: function (recipient_row, form) {
-        recipient_row.find(".topic_edit_form").empty().append(form);
+        recipient_row.find(".topic_edit_form").append(form);
         recipient_row.find('.on_hover_topic_edit').hide();
         recipient_row.find('.edit_content_button').hide();
         recipient_row.find(".stream_topic").hide();
@@ -328,6 +329,7 @@ exports.MessageList.prototype = {
         recipient_row.find(".stream_topic").show();
         recipient_row.find('.on_hover_topic_edit').show();
         recipient_row.find('.edit_content_button').show();
+        recipient_row.find(".topic_edit_form").empty();
         recipient_row.find(".topic_edit").hide();
     },
 

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1231,6 +1231,13 @@ div.focused_table {
 .topic_edit {
     display: none;
     line-height: 22px;
+    .alert {
+        display: inline-block;
+        margin: 0;
+        padding: 0 10px;
+        line-height: 17px;
+        font-size: 14px;
+    }
 }
 
 #inline_topic_edit,

--- a/static/templates/topic_edit_form.hbs
+++ b/static/templates/topic_edit_form.hbs
@@ -5,6 +5,6 @@
       autocomplete="off" />
     <button type="button" class="topic_edit_save small_square_button small_square_check"><i class="fa fa-check" aria-hidden="true"></i></button>
     <button type="button" class="topic_edit_cancel small_square_button small_square_x"><i class="fa fa-remove" aria-hidden="true"></i></button>
+    <div class="alert alert-error edit_error" style="display: none"></div>
     <div class="topic_edit_spinner"></div>
-    <div class="alert alert-error edit_error hide"></div>
 </form>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This is a draft PR intended to illustrate an approach to refactoring message_edit .save() and .end() endpoints. The commits are separate in the hopes of making review easier, the idea is to squash them all together if this approach is acceptable. Using "inline_topic_edit" (instead of eg "recipient_bar_edit") is an intentional choice to stay close to the html class name.

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
