### PR TITLE
markdown: Set default code block language for quotes and latex as well.

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -920,6 +920,13 @@ function get_header_text() {
     case 'silent_mention':
         tip_text = i18n.t('User will not be notified');
         break;
+    case 'syntax':
+        if (page_params.realm_default_code_block_language !== '') {
+            tip_text = i18n.t("Default is __language__. Use 'text' to disable highlighting.",
+                              {language: page_params.realm_default_code_block_language});
+            break;
+        }
+        return false;
     default:
         return false;
     }


### PR DESCRIPTION
In the original implementation, we were checking for the default language
inside format_code, which resulted in the setting being ignored when set to
quote, math, tex or latex. We shift the validation to `check_for_new_fence`

We also update the tests to use a saner naming scheme for the variables.

Follow up to #14517.