### PR TITLE
Includes all of user's messages in home view 

### DIFF
--- a/static/js/message_list_data.js
+++ b/static/js/message_list_data.js
@@ -169,7 +169,7 @@ MessageListData.prototype = {
         return messages.filter(
             message =>
                 !muting.is_topic_muted(message.stream_id, message.topic) ||
-                message.mentioned
+                message.mentioned || message.sent_by_me
         );
     },
 

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -167,6 +167,7 @@ function populate_group_from_message_container(group, message_container) {
         group.match_topic = util.get_match_topic(message_container.msg);
         group.stream_url = message_container.stream_url;
         group.topic_url = message_container.topic_url;
+        group.muted_and_sentbyme = muting.is_topic_muted(message_container.msg.stream_id, message_container.msg.topic)
         const sub = stream_data.get_sub(message_container.msg.stream);
         if (sub === undefined) {
             // Hack to handle unusual cases like the tutorial where

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -167,7 +167,8 @@ function populate_group_from_message_container(group, message_container) {
         group.match_topic = util.get_match_topic(message_container.msg);
         group.stream_url = message_container.stream_url;
         group.topic_url = message_container.topic_url;
-        group.muted_and_sentbyme = muting.is_topic_muted(message_container.msg.stream_id, message_container.msg.topic)
+        group.muted_and_sentbyme = muting.is_topic_muted(message_container.msg.stream_id, 
+            message_container.msg.topic);
         const sub = stream_data.get_sub(message_container.msg.stream);
         if (sub === undefined) {
             // Hack to handle unusual cases like the tutorial where

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -167,8 +167,8 @@ function populate_group_from_message_container(group, message_container) {
         group.match_topic = util.get_match_topic(message_container.msg);
         group.stream_url = message_container.stream_url;
         group.topic_url = message_container.topic_url;
-        group.muted_and_sentbyme = muting.is_topic_muted(message_container.msg.stream_id, 
-            message_container.msg.topic);
+        group.muted_and_sentbyme = muting.is_topic_muted(message_container.msg.stream_id,
+                                                         message_container.msg.topic);
         const sub = stream_data.get_sub(message_container.msg.stream);
         if (sub === undefined) {
             // Hack to handle unusual cases like the tutorial where

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1076,6 +1076,14 @@ a.message_label_clickable:hover {
     opacity: 0.2;
 }
 
+.muted_and_sentbyme {
+    color: hsl(0, 0%, 53%);
+    padding-left: 3px;
+    opacity: 1.0;
+    font-weight: 400;
+    font-size: 10px;
+}
+
 .always_visible_topic_edit {
     opacity: .7;
 }

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1084,14 +1084,6 @@ a.message_label_clickable:hover {
     font-size: 10px;
 }
 
-.muted_and_sentbyme {
-    color: hsl(0, 0%, 53%);
-    padding-left: 3px;
-    opacity: 1.0;
-    font-weight: 400;
-    font-size: 10px;
-}
-
 .always_visible_topic_edit {
     opacity: .7;
 }

--- a/static/templates/recipient_row.hbs
+++ b/static/templates/recipient_row.hbs
@@ -51,6 +51,9 @@
                 </span>
 
                 <i class="fa fa-bell-slash on_hover_topic_mute recipient_bar_icon" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Mute topic' }} (M)" role="button" tabindex="0" aria-label="{{t 'Mute topic' }} (M)"></i>
+                {{#if muted_and_sentbyme}}
+                <span class="muted_and_sentbyme" tabindex="0">(MUTED)</span>
+                {{/if}}
                 <span class="recipient_row_date {{#if group_date_divider_html}}{{else}}hide-date{{/if}}">{{{date}}}</span>
             </span>
         </div>

--- a/templates/zerver/help/format-your-message-using-markdown.md
+++ b/templates/zerver/help/format-your-message-using-markdown.md
@@ -10,7 +10,8 @@ to allow you to easily format your messages.
 * [Emphasis](#emphasis)
 * [Lists](#lists)
 * [Links and images](#links)
-* [Code and TeX](#code)
+* [Code blocks](#code)
+* [LaTeX](#latex)
 * [Quotes](#quotes)
 * [Emoji and emoticons](#emoji-and-emoticons)
 * [Mentions](#mentions)
@@ -120,12 +121,17 @@ to display content without any syntax highlighting.
 Inline: $$O(n^2)$$
 
 Displayed:
-```tex
+``` math
 \int_a^b f(t)\, dt = F(b) - F(a)
 ```
 ~~~
 
 ![](/static/images/help/markdown-latex.png)
+
+Zulip's LaTeX rendering is powered by [KaTeX](https://katex.org).
+Their [support table](https://katex.org/docs/support_table.html) is a
+helpful resource for checking what's supported or how to express
+something.
 
 ## Quotes
 


### PR DESCRIPTION
**About** 
All of the user's messages will appear in the home view even from muted topics. If the topic is muted, then only the user's own messages will appear under the topic in the home view.  If the topic is muted then "(MUTED)" will be displayed on the message heading, so users are aware why only their own messages show up under the topic. 
Fixes #2083 

**Testing Plan:** 
We manually tested by muting and unmuting topics and ensuring the correct messages were displayed.

**GIFs or Screenshots:** 
Screen recording: https://drive.google.com/file/d/1EOeLt12e7KVKB7Doise4g8I8B8ohm0Mu/view?usp=sharing
In this video the user is Cordelia Lear. When the Venice3 topic is muted, only Cordelia's messages are shown in the home screen for this topic. 



