### PR TITLE
webhook/semaphore: Add only summary line to the notification message.

### DIFF
--- a/zerver/webhooks/semaphore/fixtures/deploy.json
+++ b/zerver/webhooks/semaphore/fixtures/deploy.json
@@ -19,7 +19,7 @@
       "url":"https://github.com/donquixote/knighthood/commit/a490b8d508ebbdab1d77a5c2aefa35ceb2d62daf",
       "author_name":"Don Quixote",
       "author_email":"don@lamancha.com",
-      "message":"Create user account for Rocinante",
+      "message":"Create user account for Rocinante\n\nThe user is an admin user",
       "timestamp":"2016-06-16T18:29:08Z"
    }
 }

--- a/zerver/webhooks/semaphore/fixtures/push.json
+++ b/zerver/webhooks/semaphore/fixtures/push.json
@@ -23,7 +23,7 @@
         "reference": "refs/heads/rw/webhook_impl",
         "pull_request": null,
         "commit_sha": "2d9f5fcec1ca7c68fa7bd44dd58ec4ff65814563",
-        "commit_message": "Implement webhooks for SemaphoreCI",
+        "commit_message": "Implement webhooks for SemaphoreCI\n\nThis implements the webhooks for Semaphore2",
         "branch": {
             "name": "rw/webhook_impl",
             "commit_range": "36ebdf6e906cf3491391442d2f779b512ca49485...2d9f5fcec1ca7c68fa7bd44dd58ec4ff65814563"

--- a/zerver/webhooks/semaphore/view.py
+++ b/zerver/webhooks/semaphore/view.py
@@ -112,7 +112,7 @@ def semaphore_classic(payload: Dict[str, Any]) -> Tuple[str, str, str]:
     commit_id = payload["commit"]["id"]
     commit_url = payload["commit"]["url"]
     author_email = payload["commit"]["author_email"]
-    message = payload["commit"]["message"]
+    message = summary_line(payload["commit"]["message"])
 
     if event == "build":
         build_url = payload["build_url"]
@@ -174,7 +174,7 @@ def semaphore_2(payload: Dict[str, Any]) -> Tuple[str, str, Optional[str]]:
             branch_name=branch_name,
             commit_id=commit_id,
             commit_hash=commit_id[:7],
-            commit_message=payload["revision"]["commit_message"],
+            commit_message=summary_line(payload["revision"]["commit_message"]),
             commit_url=GITHUB_URL_TEMPLATES['commit'].format(repo_url=repo_url, commit_id=commit_id),
         )
         template = GH_PUSH_TEMPLATE if is_github_repo(repo_url) else PUSH_TEMPLATE
@@ -212,3 +212,6 @@ def semaphore_2(payload: Dict[str, Any]) -> Tuple[str, str, Optional[str]]:
 
 def is_github_repo(repo_url: str) -> bool:
     return urlparse(repo_url).hostname == 'github.com'
+
+def summary_line(message: str) -> str:
+    return message.splitlines()[0]


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Commit messages with multiple lines in the body make the notification too noisy. The summary line of the message is sufficient in the notification. 

**Testing Plan:** <!-- How have you tested? -->
Updated the existing test to verify this. 
