### PR TITLE
Invitations are removed from the list too soon.

### DIFF
--- a/confirmation/models.py
+++ b/confirmation/models.py
@@ -43,7 +43,8 @@ def generate_key() -> str:
 
 ConfirmationObjT = Union[MultiuseInvite, PreregistrationUser, EmailChangeStatus]
 def get_object_from_key(confirmation_key: str,
-                        confirmation_type: int) -> ConfirmationObjT:
+                        confirmation_type: int,
+                        activate_object: bool=True) -> ConfirmationObjT:
     # Confirmation keys used to be 40 characters
     if len(confirmation_key) not in (24, 40):
         raise ConfirmationKeyException(ConfirmationKeyException.WRONG_LENGTH)
@@ -58,7 +59,7 @@ def get_object_from_key(confirmation_key: str,
         raise ConfirmationKeyException(ConfirmationKeyException.EXPIRED)
 
     obj = confirmation.content_object
-    if hasattr(obj, "status"):
+    if activate_object and hasattr(obj, "status"):
         obj.status = getattr(settings, 'STATUS_ACTIVE', 1)
         obj.save(update_fields=['status'])
     return obj

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -362,6 +362,8 @@ def process_new_human_user(user_profile: UserProfile,
                            realm_creation: bool=False) -> None:
     mit_beta_user = user_profile.realm.is_zephyr_mirror_realm
     if prereg_user is not None:
+        prereg_user.status = confirmation_settings.STATUS_ACTIVE
+        prereg_user.save(update_fields=['status'])
         streams = prereg_user.streams.all()
         acting_user: Optional[UserProfile] = prereg_user.referred_by
     else:

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -417,7 +417,8 @@ class ZulipTestCase(TestCase):
             from_confirmation: Optional[str]='', full_name: Optional[str]=None,
             timezone: Optional[str]='', realm_in_root_domain: Optional[str]=None,
             default_stream_groups: Optional[List[str]]=[],
-            source_realm: Optional[str]='', **kwargs: Any) -> HttpResponse:
+            source_realm: Optional[str]='',
+            key: Optional[str]=None, **kwargs: Any) -> HttpResponse:
         """
         Stage two of the two-step registration process.
 
@@ -428,13 +429,12 @@ class ZulipTestCase(TestCase):
         """
         if full_name is None:
             full_name = email.replace("@", "_")
-
         payload = {
             'full_name': full_name,
             'password': password,
             'realm_name': realm_name,
             'realm_subdomain': realm_subdomain,
-            'key': find_key_by_email(email),
+            'key': key if key is not None else find_key_by_email(email),
             'timezone': timezone,
             'terms': True,
             'from_confirmation': from_confirmation,

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -56,7 +56,7 @@ def check_prereg_key_and_redirect(request: HttpRequest, confirmation_key: str) -
         return render_confirmation_key_error(
             request, ConfirmationKeyException(ConfirmationKeyException.DOES_NOT_EXIST))
     try:
-        get_object_from_key(confirmation_key, confirmation.type)
+        get_object_from_key(confirmation_key, confirmation.type, activate_object=False)
     except ConfirmationKeyException as exception:
         return render_confirmation_key_error(request, exception)
 
@@ -92,7 +92,6 @@ def accounts_register(request: HttpRequest) -> HttpResponse:
             return render_confirmation_key_error(
                 request, ConfirmationKeyException(ConfirmationKeyException.DOES_NOT_EXIST))
         realm = prereg_user.realm
-
         try:
             email_allowed_for_realm(email, realm)
         except DomainNotAllowedForRealmError:


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Only remove an active invitation from the list (on admin panel) when the user invited successfully register.

This fixes [#12281](https://github.com/zulip/zulip/issues/12281) and is a continuation of PR [#13919](https://github.com/zulip/zulip/pull/13919)

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
