### PR TITLE
Refactor zulip.yaml

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2346,23 +2346,7 @@ paths:
           type: boolean
           default: false
         example: true
-      - name: event_types
-        in: query
-        description: "A JSON-encoded array indicating which types of events
-          you're interested in. Values that you might find useful include:
-          <br/> <br/>
-          * **message** (messages), <br/>
-          * **subscription** (changes in your subscriptions), <br/>
-          * **realm_user** (changes in the list of users in your realm)
-          <br/> <br/>
-          If you do not specify this argument, you will receive all events,
-          and have to filter out the events not relevant to your client in
-          your client code. For most applications, one is only interested in
-          messages, so one specifies: `event_types=['message']`"
-        schema:
-          type: array
-          items:
-            type: string
+      - $ref: '#/components/parameters/Event_types'
         example: ['message']
       - name: all_public_streams
         in: query
@@ -3240,30 +3224,8 @@ paths:
             type: string
         example: narrow=['stream', 'Denmark']
         required: false
-      - name: event_types
-        in: query
-        description: |
-          A JSON-encoded array indicating which types of events you're
-          interested in. Values that you might find useful include:
-
-            * **message** (messages)
-            * **subscription** (changes in your subscriptions)
-            * **realm_user** (changes to users in the organization and
-              their properties, such as their name).
-
-          If you do not specify this argument, you will receive all
-          events, and have to filter out the events not relevant to
-          your client in your client code.  For most applications, one
-          is only interested in messages, so one specifies:
-          `event_types=['message']`
-        schema:
-          type: array
-          items:
-            type: string
-          default:
+      - $ref: '#/components/parameters/Event_types'
         example: event_types=['message']
-        required: false
-        default: null
       security:
       - basicAuth: []
   /rest-error-handling:
@@ -3539,3 +3501,32 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/JsonSuccess'
+
+  ####################
+  # Shared parameters
+  ####################
+  parameters:
+    Event_types:
+      name: event_types
+      in: query
+      description: |
+        A JSON-encoded array indicating which types of events you're
+        interested in. Values that you might find useful include:
+
+          * **message** (messages)
+          * **subscription** (changes in your subscriptions)
+          * **realm_user** (changes to users in the organization and
+            their properties, such as their name).
+
+        If you do not specify this argument, you will receive all
+        events, and have to filter out the events not relevant to
+        your client in your client code.  For most applications, one
+        is only interested in messages, so one specifies:
+        `event_types=['message']`
+      schema:
+        type: array
+        items:
+          type: string
+        default:
+      required: false
+      default: null

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3240,12 +3240,7 @@ paths:
             application/json:
               schema:
                 allOf:
-                - $ref: '#/components/schemas/JsonError'
-                - example:
-                    {
-                        "msg": "Invalid API key",
-                        "result": "error"
-                    }
+                - $ref: '#/components/schemas/InvalidApiKeyError'
         '400_missing_request_argument_error':
           description: |
             Bad request.
@@ -3253,19 +3248,7 @@ paths:
             application/json:
               schema:
                 allOf:
-                - $ref: '#/components/schemas/CodedError'
-                - properties:
-                    var_name:
-                      type: string
-                      description: |
-                        It contains the information about the missing argument.
-                - example:
-                    {
-                        "code": "REQUEST_VARIABLE_MISSING",
-                        "msg": "Missing 'content' argument",
-                        "result": "error",
-                        "var_name": "content"
-                    }
+                - $ref: '#/components/schemas/MissingArgumentError'
         '400_user_not_authorized_error':
           description: |
             Bad request.
@@ -3273,13 +3256,7 @@ paths:
             application/json:
               schema:
                 allOf:
-                - $ref: '#/components/schemas/CodedError'
-                - example:
-                    {
-                        "code": "BAD_REQUEST",
-                        "msg": "User not authorized for this query",
-                        "result": "error"
-                    }
+                - $ref: '#/components/schemas/UserNotAuthorizedError'
   /zulip-outgoing-webhook:
     post:
       description: |
@@ -3490,6 +3467,38 @@ components:
               type: string
             description: A list of names of streams that the requesting
               user/bot was not authorized to subscribe to.
+    InvalidApiKeyError:
+      allOf:
+      - $ref: '#/components/schemas/JsonError'
+      - example:
+          {
+              "msg": "Invalid API key",
+              "result": "error"
+          }
+    MissingArgumentError:
+      allOf:
+      - $ref: '#/components/schemas/CodedError'
+      - properties:
+          var_name:
+            type: string
+            description: |
+              It contains the information about the missing argument.
+      - example:
+          {
+              "code": "REQUEST_VARIABLE_MISSING",
+              "msg": "Missing 'content' argument",
+              "result": "error",
+              "var_name": "content"
+          }
+    UserNotAuthorizedError:
+      allOf:
+      - $ref: '#/components/schemas/CodedError'
+      - example:
+          {
+              "code": "BAD_REQUEST",
+              "msg": "User not authorized for this query",
+              "result": "error"
+          }
 
   ###################
   # Shared responses


### PR DESCRIPTION
This PR is for the followups of #14432 and #14203. It stores the content of repeating parameters (`event_types`) and schemas (`/rest-error-handling` examples) in components so they can be reused again.