### PR TITLE
topic: Remove 7 days restriction for editing topics.

### DIFF
--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -1,8 +1,5 @@
-import datetime
-
 from django.db import connection
 from django.db.models.query import QuerySet, Q
-from django.utils.timezone import now as timezone_now
 
 from sqlalchemy.sql import (
     column,
@@ -124,15 +121,7 @@ def update_messages_for_topic_edit(message: Message,
                                    new_stream: Optional[Stream]) -> List[Message]:
     propagate_query = Q(recipient = message.recipient, subject = orig_topic_name)
     if propagate_mode == 'change_all':
-        # We only change messages up to 7 days in the past, to avoid hammering our
-        # DB by changing an unbounded amount of messages
-        #
-        # TODO: Look at removing this restriction and/or add a "change_last_week"
-        # option; this behavior feels buggy.
-        before_bound = timezone_now() - datetime.timedelta(days=7)
-
-        propagate_query = (propagate_query & ~Q(id = message.id) &
-                           Q(date_sent__range=(before_bound, timezone_now())))
+        propagate_query = propagate_query & ~Q(id = message.id)
     if propagate_mode == 'change_later':
         propagate_query = propagate_query & Q(id__gt = message.id)
 


### PR DESCRIPTION
Previously, we had a restriction that we could only edit and move the topics of 7 days old messages. This buggy behaviour is now removed as in this PR.

Fixes #14492.
Part of #13912.

**Testing Plan:**
1. Unit tests.
2. Tested manually by using `./manage.py populate_db -n10000` with modified `choose_date_sent()` to populate old messages.