### PR TITLE
alert-page: Styling alert words settings page.

### DIFF
--- a/frontend_tests/casper_tests/06-settings.js
+++ b/frontend_tests/casper_tests/06-settings.js
@@ -238,7 +238,7 @@ casper.then(function () {
     casper.click('#create_alert_word_button');
     casper.test.info('Checking that a success message is displayed');
     casper.waitUntilVisible('#alert_word_status', function () {
-        casper.test.assertSelectorHasText('.alert_word_status_text', 'Alert word added successfully!');
+        casper.test.assertSelectorHasText('.alert_word_status_text', 'Alert word \"some phrase\" added successfully!');
         casper.test.info('Closing the status message');
         casper.click('.close-alert-word-status');
         casper.test.info('Checking the status message is hidden');

--- a/frontend_tests/node_tests/alert_words_ui.js
+++ b/frontend_tests/node_tests/alert_words_ui.js
@@ -88,7 +88,7 @@ run_test('add_alert_word', () => {
     // test success
     success_func();
     assert(alert_word_status.hasClass('alert-success'));
-    assert.equal(alert_word_status_text.text(), "translated: Alert word added successfully!");
+    assert.equal(alert_word_status_text.text(), "translated: Alert word \"zot\" added successfully!");
     assert(alert_word_status.visible());
 });
 

--- a/frontend_tests/node_tests/alert_words_ui.js
+++ b/frontend_tests/node_tests/alert_words_ui.js
@@ -30,9 +30,9 @@ run_test('render_alert_words_ui', () => {
     alert_words_ui.render_alert_words_ui();
 
     assert.deepEqual(appended, [
-        'stub-foo',
-        'stub-bar',
         'stub-',
+        'stub-bar',
+        'stub-foo',
     ]);
     assert(new_alert_word.is_focused());
 });

--- a/static/js/alert_words_ui.js
+++ b/static/js/alert_words_ui.js
@@ -2,9 +2,16 @@ const render_alert_word_settings_item = require('../templates/alert_word_setting
 
 exports.render_alert_words_ui = function () {
     const words = alert_words.get_word_list();
+    words.sort();
     const word_list = $('#alert_words_list');
 
     word_list.find('.alert-word-item').remove();
+
+    const new_alert_word_form = render_alert_word_settings_item({
+        word: '',
+        editing: true,
+    });
+    word_list.append(new_alert_word_form);
 
     for (const alert_word of words) {
         const rendered_alert_word = render_alert_word_settings_item({
@@ -13,12 +20,6 @@ exports.render_alert_words_ui = function () {
         });
         word_list.append(rendered_alert_word);
     }
-
-    const new_alert_word_form = render_alert_word_settings_item({
-        word: '',
-        editing: true,
-    });
-    word_list.append(new_alert_word_form);
 
     // Focus new alert word name text box.
     $('#create_alert_word_name').focus();

--- a/static/js/alert_words_ui.js
+++ b/static/js/alert_words_ui.js
@@ -51,7 +51,8 @@ function add_alert_word(alert_word) {
         url: '/json/users/me/alert_words',
         data: {alert_words: JSON.stringify(words_to_be_added)},
         success: function () {
-            update_alert_word_status(i18n.t("Alert word added successfully!"), false);
+            const message = "Alert word \"" + words_to_be_added + "\" added successfully!";
+            update_alert_word_status(i18n.t(message), false);
         },
         error: function () {
             update_alert_word_status(i18n.t("Error adding alert word!"), true);

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1046,7 +1046,7 @@ input[type=checkbox].inline-block {
     list-style-type: none;
 }
 
-#alert_words_list li.alert-word-item:last-child {
+#alert_words_list li.alert-word-item:first-child {
     background: none;
     margin-top: 8px;
 }

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -574,8 +574,9 @@ input[type=checkbox].inline-block {
 
 .alert-word-information-box {
     position: relative;
-    padding: 10px;
-    margin: 20px auto;
+    padding: 7px;
+    margin: 2px;
+    width: 50%;
 }
 
 .green-bg {
@@ -1055,7 +1056,7 @@ input[type=checkbox].inline-block {
 #attachments_list .edit-attachment-buttons {
     position: absolute;
     right: 20px;
-    top: 5px;
+    top: 0px;
 }
 
 #alert_words_list .alert_word_listing .value {


### PR DESCRIPTION
https://chat.zulip.org/#narrow/stream/6-frontend/topic/Alert.20Words.20Settings

![alert](https://user-images.githubusercontent.com/42106909/79397793-9767a800-7f9c-11ea-9681-9aa7436bd798.gif)

1. Changing adding alert word success message to include the word
2. Reordering form and list. Also sorting list.
3. Styling.