### PR TITLE
stream settings: Fix UI feedback on clicking checkbox to subscribe.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -634,7 +634,7 @@ exports.initialize = function () {
     $("#subscriptions_table").on("click", ".sub_unsub_button", function (e) {
         const sub = get_sub_for_target(e.target);
         const stream_row = $(this).parent();
-        subs.sub_or_unsub(sub);
+        subs.sub_or_unsub(sub, e.currentTarget);
         if (!sub.subscribed) {
             exports.open_edit_panel_for_row(stream_row);
         }

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -633,7 +633,7 @@ exports.initialize = function () {
     // checkmark in the subscriber list.
     $("#subscriptions_table").on("click", ".sub_unsub_button", function (e) {
         const sub = get_sub_for_target(e.target);
-        const stream_row = $(this).parent();
+        const stream_row = $(e.currentTarget).parent();
         subs.sub_or_unsub(sub, e.currentTarget);
         if (!sub.subscribed) {
             exports.open_edit_panel_for_row(stream_row);

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -611,6 +611,22 @@ form#add_new_subscription {
             pointer-events: none;
             visibility: hidden;
         }
+
+        .sub_unsub_status {
+            display: inline-block !important;
+            height: auto !important;
+            width: auto !important;
+
+            .loading_indicator_spinner {
+                width: 100%;
+                height: 100%;
+                margin: 0;
+            }
+
+            .loading_indicator_spinner svg path {
+                fill: hsl(178, 100%, 40%);
+            }
+        }
     }
 
     .checked svg {

--- a/static/templates/subscription.hbs
+++ b/static/templates/subscription.hbs
@@ -6,6 +6,7 @@
         <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100%" height="100%" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
             <path d="M448,71.9c-17.3-13.4-41.5-9.3-54.1,9.1L214,344.2l-99.1-107.3c-14.6-16.6-39.1-17.4-54.7-1.8 c-15.6,15.5-16.4,41.6-1.7,58.1c0,0,120.4,133.6,137.7,147c17.3,13.4,41.5,9.3,54.1-9.1l206.3-301.7 C469.2,110.9,465.3,85.2,448,71.9z"/>
         </svg>
+        <div class='sub_unsub_status'></div>
     </div>
     {{> subscription_setting_icon }}
     <div class="sub-info-box">


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/14481

Before this change, on clicking a checkbox to toggle subscription to a
stream no UI feedback was shown and users could toggle the checkbox
multiple times to send multiple requests causing bugs. This commit
initializes a spinner on clicking the checkbox, to provide a UI feedback
to the user. This commit also disables the checkbox once a request for
subscription has been sent and re-enables the checkbox only after a
response.

**Testing Plan:** <!-- How have you tested? -->
The testing for this has been done by adding a wait of 2 secs in
actions.py for the response. This gives sufficient time to test the
working manually. Also, for error cases an error has been sent from
action.py and the behaviour has been manually observed.


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![streamtoggle](https://user-images.githubusercontent.com/20909078/79463687-c91d5500-8016-11ea-8460-942f95ec55a9.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
