### PR TITLE
[WIP] Install our own Python from Conda

### DIFF
--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -206,6 +206,21 @@ if [ -z "$NO_DIST_UPGRADE" ]; then
     esac
 fi
 
+# Install conda and python
+# This moves us into conda's env with python installed
+case " $os_id $os_id_like " in
+    *' debian '*)
+        "$ZULIP_PATH"/scripts/setup/install-python debian
+        ;;
+    *' rhel '*)
+        "$ZULIP_PATH"/scripts/setup/install-python rhel
+        ;;
+esac
+
+# Activate conda venv
+source /opt/conda/etc/profile.d/conda.sh
+conda activate "$CONDA_VENV_PATH"
+
 case " $os_id $os_id_like " in
     *' debian '*)
         if ! apt-get install -y \

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -225,7 +225,7 @@ case " $os_id $os_id_like " in
     *' debian '*)
         if ! apt-get install -y \
             puppet git curl wget jq \
-            python python3 python-six python3-six crudini \
+            python python-six python3-six crudini \
             "${ADDITIONAL_PACKAGES[@]}"; then
             set +x
             echo -e '\033[0;31m' >&2
@@ -238,7 +238,7 @@ case " $os_id $os_id_like " in
     *' rhel '*)
         if ! yum install -y \
             puppet git curl wget jq \
-            python python3 python-six python3-six crudini \
+            python python-six python3-six crudini \
             "${ADDITIONAL_PACKAGES[@]}"; then
             set +x
             echo -e '\033[0;31m' >&2

--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -24,7 +24,6 @@ VENV_DEPENDENCIES = [
     "libldap2-dev",
     "libmemcached-dev",
     "python3-dev",          # Needed to install typed-ast dependency of mypy
-    "python3-pip",
     "python-pip",
     "virtualenv",
     "python3-six",
@@ -80,7 +79,6 @@ REDHAT_VENV_DEPENDENCIES = COMMON_YUM_VENV_DEPENDENCIES + [
 ]
 
 FEDORA_VENV_DEPENDENCIES = COMMON_YUM_VENV_DEPENDENCIES + [
-    "python3-pip",
     "python3-six",
     "virtualenv",  # see https://unix.stackexchange.com/questions/27877/install-virtualenv-on-fedora-16
 ]
@@ -309,7 +307,7 @@ def setup_virtualenv(
         cached_venv_python = os.path.join(target_venv_path, 'bin', 'python')
         same_python = (subprocess.check_output([cached_venv_python, '--version']) ==\
                     subprocess.check_output([conda_python, '--version']))
-
+    print(same_python, "SAME PYTHON")
     if not (os.path.exists(success_stamp) and same_python):
         do_setup_virtualenv(cached_venv_path, requirements_file, python2)
         with open(success_stamp, 'w') as f:

--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -9,6 +9,7 @@ from typing import List, Optional, Tuple, Set
 
 ZULIP_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 VENV_CACHE_PATH = "/srv/zulip-venv-cache"
+CONDA_VENV_PATH = "/srv/zulip-conda-venv"
 
 if 'TRAVIS' in os.environ:
     # In Travis CI, we don't have root access
@@ -324,7 +325,11 @@ def do_setup_virtualenv(venv_path: str, requirements_file: str, python2: bool) -
     if not try_to_copy_venv(venv_path, new_packages):
         # Create new virtualenv.
         run_as_root(["mkdir", "-p", venv_path])
-        run_as_root(["virtualenv", "-p", "python2.7" if python2 else "python3", venv_path])
+        # We need to specify exact python path for inside conda venv otherwise
+        # `virtualenv` always selects system python.
+        # See: https://virtualenv.pypa.io/en/stable/user_guide.html#python-discovery
+        run_as_root(["virtualenv", "-p",
+                     "python2.7" if python2 else f"{CONDA_VENV_PATH}/bin/python3", venv_path])
         run_as_root(["chown", "-R",
                      "{}:{}".format(os.getuid(), os.getgid()), venv_path])
         create_log_entry(get_logfile_name(venv_path), "", set(), new_packages)

--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -298,7 +298,19 @@ def setup_virtualenv(
     else:
         cached_venv_path = os.path.join(VENV_CACHE_PATH, sha1sum, os.path.basename(target_venv_path))
     success_stamp = os.path.join(cached_venv_path, "success-stamp")
-    if not os.path.exists(success_stamp):
+
+    # Check only for python3 since we are installing python3 via conda
+    # will run python version upgrades in future.
+    # Python2 use will soon be dropped.
+    same_python = True
+    if python2 == False:
+        # Check for python version match.
+        conda_python = os.path.join(CONDA_VENV_PATH, 'bin', 'python')
+        cached_venv_python = os.path.join(target_venv_path, 'bin', 'python')
+        same_python = (subprocess.check_output([cached_venv_python, '--version']) ==\
+                    subprocess.check_output([conda_python, '--version']))
+
+    if not (os.path.exists(success_stamp) and same_python):
         do_setup_virtualenv(cached_venv_path, requirements_file, python2)
         with open(success_stamp, 'w') as f:
             f.close()

--- a/scripts/lib/upgrade-zulip-stage-2-start
+++ b/scripts/lib/upgrade-zulip-stage-2-start
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+
+#### UNTESTED & Possibly doesn't work.
+
+# Use conda's python to run further scripts
+bash "$(dirname "$(dirname "$0")")/setup/install-python"
+
+# We can safely run upgrade now.
+sudo bash "$(dirname "$0")/upgrade-zulip-stage-2"

--- a/scripts/setup/install-conda-debian
+++ b/scripts/setup/install-conda-debian
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Use this script to install conda package manager.
+set -e
+set -x
+
+# Using instructions from https://docs.conda.io/projects/conda/en/latest/user-guide/install/rpm-debian.html
+
+cd $(mktemp -d)
+
+# Install conda public GPG key to trusted store
+curl https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc | gpg --dearmor > conda.gpg
+install -o root -g root -m 644 conda.gpg /usr/share/keyrings/conda-archive-keyring.gpg
+
+# Check whether fingerprint is correct (will output an error message otherwise)
+gpg --keyring /usr/share/keyrings/conda-archive-keyring.gpg --no-default-keyring --fingerprint 34161F5BF5EB1D4BFBBB8F0A8AEB4F8B29D82806
+
+# Add conda Debian repo
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/conda-archive-keyring.gpg] https://repo.anaconda.com/pkgs/misc/debrepo/conda stable main" > /etc/apt/sources.list.d/conda.list
+
+# Install!
+apt-get update
+
+# NOTE: Pin conda version?
+apt-get -y install conda

--- a/scripts/setup/install-conda-rhel
+++ b/scripts/setup/install-conda-rhel
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Use this script to install conda package manager.
+set -e
+set -x
+
+# Using instructions from https://docs.conda.io/projects/conda/en/latest/user-guide/install/rpm-debian.html
+
+# Import conda GPG public key
+rpm --import https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc
+
+# Add the Anaconda repository
+cat <<EOF > /etc/yum.repos.d/conda.repo
+[conda]
+name=Conda
+baseurl=https://repo.anaconda.com/pkgs/misc/rpmrepo/conda
+enabled=1
+gpgcheck=1
+gpgkey=https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc
+EOF
+
+# Install it!
+# NOTE: Pin conda version?
+yum install -y conda

--- a/scripts/setup/install-python
+++ b/scripts/setup/install-python
@@ -29,5 +29,5 @@ else
     # Create new conda env with our specified python version
     # Install virtualenv inside conda venv to ensure all commands
     # to virtualenv are run inside conda venv.
-    conda create -y --prefix "$CONDA_VENV_PATH" python="$PYTHON_VERSION" virtualenv
+    conda create -y --prefix "$CONDA_VENV_PATH" python="$PYTHON_VERSION" virtualenv pip
 fi

--- a/scripts/setup/install-python
+++ b/scripts/setup/install-python
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Use this script to install python using conda.
+set -e
+set -x
+
+# Defaults
+PYTHON_VERSION=3.7
+CONDA_VENV_PATH=/srv/zulip-conda-venv
+
+LINUX_DISTRO=$1
+
+# Install Conda
+sudo bash "$(dirname "$(dirname "$0")")/setup/install-conda-$LINUX_DISTRO"
+
+# NOTE: If user is reinstalling should we delete the old venv and create new or just use it??
+# Use old zulip conda venv if it exists.
+if [[ -d "$CONDA_VENV_PATH" ]]; then
+    echo "Using existing zulip conda env"
+
+else
+    # Activate (base) conda env
+    source /opt/conda/etc/profile.d/conda.sh
+    # Give user permission to write to the folder.
+    sudo mkdir "$CONDA_VENV_PATH"
+    # A better way would be to use chown and change
+    # owner to current user but it
+    # would raise complexities in a multiuser setup.
+    sudo chmod a+rwx "$CONDA_VENV_PATH"
+    # Create new conda env with our specified python version
+    # Install virtualenv inside conda venv to ensure all commands
+    # to virtualenv are run inside conda venv.
+    conda create -y --prefix "$CONDA_VENV_PATH" python="$PYTHON_VERSION" virtualenv
+fi

--- a/tools/provision
+++ b/tools/provision
@@ -19,8 +19,33 @@ PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 cd "$PARENT_PATH"
 mkdir -p ../var/log
 LOG_PATH="../var/log/provision.log"
+CONDA_VENV_PATH=/srv/zulip-conda-venv
 
 echo "PROVISIONING STARTING." >> $LOG_PATH
+
+
+# Check for a supported OS release.
+if [ -f /etc/os-release ]; then
+    os_info="$(. /etc/os-release; printf '%s\n' "$ID" "$ID_LIKE")"
+    { read -r os_id; read -r os_id_like || true; } <<< "$os_info"
+fi
+
+# Install conda and python
+case " $os_id $os_id_like " in
+    *' debian '*)
+        "$PARENT_PATH"/../scripts/setup/install-python debian
+        ;;
+    *' rhel '*)
+        "$PARENT_PATH"/../scripts/setup/install-python rhel
+        ;;
+esac
+
+# This will move us into conda's env with python installed
+# If only `python(3)` is specified while creating a env using
+# using `virtualenv`, deafult system python will be used.
+# Please specifiy conda's python explicitly while creating any new venv.
+source /opt/conda/etc/profile.d/conda.sh
+conda activate "$CONDA_VENV_PATH"
 
 # PYTHONUNBUFFERED is important to ensure that tracebacks don't get
 # lost far above where they should be in the output.


### PR DESCRIPTION
- [x]  Write a script to install Python from conda under scripts/setup. Ideally, it should work like our other setup scripts, and pin the major Python version (E.g. 3.7) but install the latest security release within that version. This will require figuring out what path we install it to in both development and production (Ideally, those would be the same to support shebang lines).

- [x]  Integrate that tool into provision

- [ ]  test a development environment upgrade.

- [x]  Integrate that tool into scripts/lib/install.

- [ ] Integrate that tool into scripts/lib/upgrade-zulip-stage-2 and test a production server upgrade (Skipped bcoz of lack of production env)
- [ ] Audit our scripts for any that need to be run before the Zulip. (provision script donesn't require any extra steps.)
- [ ]  Change #! lines for all of our Python scripts (if necessary).
- [ ]  Test a process for upgrading from e.g. Python 3.7.3 to 3.7.4 (including re-compiling our virtualenv, if needed?). We probably will want to fix #12868 as part of this effort.
- [ ] Figure out a process to ensure Python gets updated after Python core security releases.
- [ ] Setup Travis and Circle CI