### PR TITLE
docs: Deprecate support for Xenial and Stretch.

### DIFF
--- a/docs/production/requirements.md
+++ b/docs/production/requirements.md
@@ -4,9 +4,9 @@ To run a Zulip server, you will need:
 * A dedicated machine or VM
 * A supported OS:
   * Ubuntu 18.04 Bionic
-  * Ubuntu 16.04 Xenial
-  * Debian 9 Stretch
+  * Ubuntu 16.04 Xenial (deprecated)
   * Debian 10 Buster
+  * Debian 9 Stretch  (deprecated)
 * At least 2GB RAM, and 10GB disk space
   * If you expect 100+ users: 4GB RAM, and 2 CPUs
 * A hostname in DNS
@@ -29,12 +29,13 @@ can't support you, but
 
 #### Operating System
 
-Ubuntu 18.04 Bionic, Ubuntu 16.04 Xenial, Debian Buster and Debian
-Stretch are supported for running Zulip in production.  64-bit is
-recommended.  We also recommend installing on the newest option you're
-comfortable with, to save your organization the work of upgrading
-(Ubuntu Trusty [reached end of life in April 2019][trusty-eol]; Zulip
-2.0 was the last major release to support it).
+Ubuntu 18.04 Bionic, Debian Busterm, Ubuntu 16.04 Xenial (deprecated),
+and Debian Stretch (deprecated) are supported for running Zulip in
+production.  64-bit is recommended.  We also recommend installing on
+the newest option you're comfortable with, to save your organization
+the work of upgrading (Ubuntu Trusty [reached end of life in April
+2019][trusty-eol]; Zulip 2.0 was the last major release to support
+it).
 
 If you're using Ubuntu, the
 [Ubuntu universe repository][ubuntu-repositories] must be

--- a/docs/production/upgrade-or-modify.md
+++ b/docs/production/upgrade-or-modify.md
@@ -186,7 +186,7 @@ custom configuration.
 ## Upgrading the operating system
 
 When you upgrade the operating system on which Zulip is installed
-(E.g. Ubuntu 16.06 Xenial to Ubuntu 18.04 Bionic), you need to take
+(E.g. Ubuntu 16.04 Xenial to Ubuntu 18.04 Bionic), you need to take
 some additional steps to update your Zulip installation, documented
 below.
 
@@ -196,18 +196,21 @@ instructions for other supported platforms.
 
 ### Upgrading from Ubuntu 16.04 Xenial to 18.04 Bionic
 
-1. First, as the Zulip user, stop the Zulip server and run the following
-to back up the system:
+1. Upgrade your server to the latest Zulip `2.1.x` release, since
+   newer releases don't support Ubuntu 16.04 Xenial.
+
+2. As the Zulip user, stop the Zulip server and run the following
+   to back up the system:
 
     ```
     supervisorctl stop all
     /home/zulip/deployments/current/manage.py backup --output=/home/zulip/release-upgrade.backup.tar.gz
     ```
 
-2. Switch to the root user and upgrade the operating system using the
-OS's standard tooling.  E.g. for Ubuntu, this means running
-`do-release-upgrade` and following the prompts until it completes
-successfully:
+3. Switch to the root user and upgrade the operating system using the
+   OS's standard tooling.  E.g. for Ubuntu, this means running
+   `do-release-upgrade` and following the prompts until it completes
+   successfully:
 
     ```
     sudo -i # Or otherwise get a root shell
@@ -220,8 +223,8 @@ successfully:
     currently installed version.  But it's not important; the next
     step will re-install Zulip's configuration in any case.
 
-3. As root, upgrade the database installation and OS configuration to
-match the new OS version:
+4. As root, upgrade the database installation and OS configuration to
+   match the new OS version:
 
     ```
     touch /usr/share/postgresql/10/pgroonga_setup.sql.applied
@@ -235,10 +238,11 @@ match the new OS version:
     systemctl restart memcached
     ```
 
-4. At this point, you are now running the version of postgres that
-comes with the new Ubuntu version.  Finally, we need to reinstall the
-current version of Zulip, which among other things will recompile
-Zulip's Python module dependencies for your new version of Python:
+5. At this point, you are now running the version of postgres that
+   comes with the new Ubuntu version.  Finally, we need to reinstall
+   the current version of Zulip, which among other things will
+   recompile Zulip's Python module dependencies for your new version
+   of Python:
 
     ```
     rm -rf /srv/zulip-venv-cache/*
@@ -253,14 +257,14 @@ working correctly.
 
 ### Upgrading from Ubuntu 14.04 Trusty to 16.04 Xenial
 
-First, make sure you upgrade your server to the latest Zulip `2.0.x`,
-since newer releases don't support Ubuntu 14.04 Trusty.
-
-1. Same as for Xenial to Bionic.
+1. Upgrade your server to the latest Zulip `2.0.x` release, since newer
+   releases don't support Ubuntu 14.04 Trusty.
 
 2. Same as for Xenial to Bionic.
 
-3. As root, upgrade the database installation and OS configuration to
+3. Same as for Xenial to Bionic.
+
+4. As root, upgrade the database installation and OS configuration to
 match the new OS version:
 
     ```
@@ -275,7 +279,41 @@ match the new OS version:
     service memcached restart
     ```
 
-4. Same as for Xenial to Bionic.
+5. Same as for Xenial to Bionic.
+
+### Upgrading from Debian Stretch to Debian Buster
+
+1. Upgrade your server to the latest Zulip `2.1.x` release, since newer
+   releases don't support Debian Stretch.
+
+2. Same as for Xenial to Bionic, above.
+
+3. Follow [Debian's instructions to upgrade the OS][debian-upgrade-os].
+
+   [debian-upgrade-os]: https://www.debian.org/releases/buster/amd64/release-notes/ch-upgrading.html
+
+   When prompted for you how to upgrade configuration
+   files for services that Zulip manages like `redis`, `postgres`,
+   `nginx`, and `memcached`, the best choice is `N` to keep the
+   currently installed version.  But it's not important; the next
+   step will re-install Zulip's configuration in any case.
+
+4. As root, upgrade the database installation and OS configuration to
+   match the new OS version:
+
+    ```
+    apt remove upstart -y
+    /home/zulip/deployments/current/scripts/zulip-puppet-apply -f
+    pg_dropcluster 9.5 main --stop
+    systemctl stop postgresql
+    pg_upgradecluster -m upgrade 9.3 main
+    pg_dropcluster 9.3 main
+    apt remove postgresql-9.3
+    systemctl start postgresql
+    service memcached restart
+    ```
+
+5. Same as for Xenial to Bionic.
 
 ## Modifying Zulip
 


### PR DESCRIPTION
Also make sure our documentation for upgrading is reasonable for
Stretch => Buster.

Our reasoning for deprecating support for these releases is as follows:

* Ubuntu 16.04 Xenial reached desktop EOL last year; and will reach
  EOL on the server in about a year.

* Debian Stretch will each EOL in 2020 (the precise date is unclear in
  Debian's documentation, but based on past precedent it's in the next
  couple months).

* Both Ubuntu 16.04 and Debian Stretch use Python 3.5 as the system
  Python, which will reach EOL in September 2020 (and we're already
  seeing various third-party dependencies that we use drop support for
  them).

* While there is LTS support for these older releases, it's not clear it's
  going to be worth the added engineering effort for us to maintain EOL
  releases of the base OSes that we support.

* We have clear upgrade instructions for moving to Debian Buster and
  Ubuntu 18.04, which are each over a year old.
