### PR TITLE
openapi: Make zulip.yaml pass validation on swagger editor.

### DIFF
--- a/templates/zerver/api/add-subscriptions.md
+++ b/templates/zerver/api/add-subscriptions.md
@@ -84,20 +84,20 @@ the `principals` argument, like so:
 
 A typical successful JSON response may look like:
 
-{generate_code_example|/users/me/subscriptions:post|fixture(200_without_principals)}
+{generate_code_example|/users/me/subscriptions:post|fixture(200_0)}
 
 A typical successful JSON response when the user is already subscribed to
 the streams specified:
 
-{generate_code_example|/users/me/subscriptions:post|fixture(200_already_subscribed)}
+{generate_code_example|/users/me/subscriptions:post|fixture(200_1)}
 
 A typical response for when the requesting user does not have access to
 a private stream and `authorization_errors_fatal` is `True`:
 
-{generate_code_example|/users/me/subscriptions:post|fixture(400_unauthorized_errors_fatal_true)}
+{generate_code_example|/users/me/subscriptions:post|fixture(400_0)}
 
 
 A typical response for when the requesting user does not have access to
 a private stream and `authorization_errors_fatal` is `False`:
 
-{generate_code_example|/users/me/subscriptions:post|fixture(400_unauthorized_errors_fatal_false)}
+{generate_code_example|/users/me/subscriptions:post|fixture(400_1)}

--- a/templates/zerver/api/delete-message.md
+++ b/templates/zerver/api/delete-message.md
@@ -37,9 +37,9 @@ A typical successful JSON response may look like:
 
 An example JSON response for when the specified message does not exist:
 
-{generate_code_example|/messages/{message_id}:delete|fixture(400_invalid_message)}
+{generate_code_example|/messages/{message_id}:delete|fixture(400_0)}
 
 An example JSON response for when the user making the query does not
 have permission to delete the message:
 
-{generate_code_example|/messages/{message_id}:delete|fixture(400_not_admin)}
+{generate_code_example|/messages/{message_id}:delete|fixture(400_1)}

--- a/templates/zerver/api/mute-topics.md
+++ b/templates/zerver/api/mute-topics.md
@@ -35,9 +35,9 @@ A typical successful JSON response may look like:
 An example JSON response for when an `add` operation is requested for a topic
 that has already been muted:
 
-{generate_code_example|/users/me/subscriptions/muted_topics:patch|fixture(400_topic_already_muted)}
+{generate_code_example|/users/me/subscriptions/muted_topics:patch|fixture(400_0)}
 
 An example JSON response for when a `remove` operation is requested for a
 topic that had not been previously muted:
 
-{generate_code_example|/users/me/subscriptions/muted_topics:patch|fixture(400_topic_not_muted)}
+{generate_code_example|/users/me/subscriptions/muted_topics:patch|fixture(400_1)}

--- a/templates/zerver/api/rest-error-handling.md
+++ b/templates/zerver/api/rest-error-handling.md
@@ -21,18 +21,18 @@ errors common to many endpoints:
 
 A typical failed JSON response for when the API key is invalid:
 
-{generate_code_example|/rest-error-handling:post|fixture(400_invalid_api_key)}
+{generate_code_example|/rest-error-handling:post|fixture(400_0)}
 
 ## Missing request argument(s)
 
 A typical failed JSON response for when a required request argument
 is not supplied:
 
-{generate_code_example|/rest-error-handling:post|fixture(400_missing_request_argument_error)}
+{generate_code_example|/rest-error-handling:post|fixture(400_1)}
 
 ## User not authorized for query
 
 A typical failed JSON response for when the user is not authorized
 for a query:
 
-{generate_code_example|/rest-error-handling:post|fixture(400_user_not_authorized_error)}
+{generate_code_example|/rest-error-handling:post|fixture(400_2)}

--- a/templates/zerver/api/send-message.md
+++ b/templates/zerver/api/send-message.md
@@ -120,9 +120,9 @@ A typical successful JSON response may look like:
 A typical failed JSON response for when a stream message is sent to a stream
 that does not exist:
 
-{generate_code_example|/messages:post|fixture(400_non_existing_stream)}
+{generate_code_example|/messages:post|fixture(400_0)}
 
 A typical failed JSON response for when a private message is sent to a user
 that does not exist:
 
-{generate_code_example|/messages:post|fixture(400_non_existing_user)}
+{generate_code_example|/messages:post|fixture(400_1)}

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -62,7 +62,7 @@ def add_subscriptions(client):
     # {code_example|end}
 
     validate_against_openapi_schema(result, '/users/me/subscriptions', 'post',
-                                    '200_without_principals')
+                                    '200_0')
 
     # {code_example|start}
     # To subscribe another user to a stream, you may pass in
@@ -87,7 +87,7 @@ def test_add_subscriptions_already_subscribed(client):
     )
 
     validate_against_openapi_schema(result, '/users/me/subscriptions', 'post',
-                                    '200_already_subscribed')
+                                    '200_1')
 
 def test_authorization_errors_fatal(client, nonadmin_client):
     # type: (Client, Client) -> None
@@ -112,7 +112,7 @@ def test_authorization_errors_fatal(client, nonadmin_client):
     )
 
     validate_against_openapi_schema(result, '/users/me/subscriptions', 'post',
-                                    '400_unauthorized_errors_fatal_false')
+                                    '400_0')
 
     result = nonadmin_client.add_subscriptions(
         streams=[
@@ -122,7 +122,7 @@ def test_authorization_errors_fatal(client, nonadmin_client):
     )
 
     validate_against_openapi_schema(result, '/users/me/subscriptions', 'post',
-                                    '400_unauthorized_errors_fatal_true')
+                                    '400_1')
 
 @openapi_test_function("/users/{email}/presence:get")
 def get_user_presence(client):
@@ -413,7 +413,7 @@ def test_user_not_authorized_error(nonadmin_client):
     # type: (Client) -> None
     result = nonadmin_client.get_streams(include_all_active=True)
 
-    validate_against_openapi_schema(result, '/rest-error-handling', 'post', '400_user_not_authorized_error')
+    validate_against_openapi_schema(result, '/rest-error-handling', 'post', '400_2')
 
 def get_subscribers(client):
     # type: (Client) -> None
@@ -718,7 +718,7 @@ def test_nonexistent_stream_error(client):
     result = client.send_message(request)
 
     validate_against_openapi_schema(result, '/messages', 'post',
-                                    '400_non_existing_stream')
+                                    '400_0')
 
 def test_private_message_invalid_recipient(client):
     # type: (Client) -> None
@@ -730,7 +730,7 @@ def test_private_message_invalid_recipient(client):
     result = client.send_message(request)
 
     validate_against_openapi_schema(result, '/messages', 'post',
-                                    '400_non_existing_user')
+                                    '400_1')
 
 @openapi_test_function("/messages/{message_id}:patch")
 def update_message(client, message_id):
@@ -804,7 +804,7 @@ def test_delete_message_edit_permission_error(client, nonadmin_client):
     result = nonadmin_client.delete_message(result['id'])
 
     validate_against_openapi_schema(result, '/messages/{message_id}', 'delete',
-                                    '400_not_admin')
+                                    '400_1')
 
 @openapi_test_function("/messages/{message_id}/history:get")
 def get_message_history(client, message_id):
@@ -1098,13 +1098,13 @@ def update_user_group_members(client, group_id):
 def test_invalid_api_key(client_with_invalid_key):
     # type: (Client) -> None
     result = client_with_invalid_key.list_subscriptions()
-    validate_against_openapi_schema(result, '/rest-error-handling', 'post', '400_invalid_api_key')
+    validate_against_openapi_schema(result, '/rest-error-handling', 'post', '400_0')
 
 def test_missing_request_argument(client):
     # type: (Client) -> None
     result = client.render_message({})
 
-    validate_against_openapi_schema(result, '/rest-error-handling', 'post', '400_missing_request_argument_error')
+    validate_against_openapi_schema(result, '/rest-error-handling', 'post', '400_1')
 
 
 def test_invalid_stream_error(client):

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -615,25 +615,21 @@ paths:
                         "id": 42,
                         "result": "success"
                     }
-        '400_non_existing_stream':
+        '400':
           description: Bad request.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NonExistingStreamError'
-        '400_non_existing_user':
-          description: Bad request.
-          content:
-            application/json:
-              schema:
-                allOf:
-                - $ref: '#/components/schemas/CodedError'
-                - example:
-                    {
-                        "code": "BAD_REQUEST",
-                        "msg": "Invalid email 'eeshan@zulip.com'",
-                        "result": "error"
-                    }
+                oneOf:
+                - $ref: '#/components/schemas/NonExistingStreamError'
+                - allOf:
+                  - $ref: '#/components/schemas/CodedError'
+                  - example:
+                      {
+                          "code": "BAD_REQUEST",
+                          "msg": "Invalid email 'eeshan@zulip.com'",
+                          "result": "error"
+                      }
   /messages/{message_id}:
     get:
       description: |
@@ -768,25 +764,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/JsonSuccess'
-        '400_invalid_message':
+        '400':
           description: Bad request.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InvalidMessageError'
-        '400_not_admin':
-          description: Bad request.
-          content:
-            application/json:
-              schema:
-                allOf:
-                - $ref: '#/components/schemas/CodedError'
-                - example:
-                    {
-                        "code": "BAD_REQUEST",
-                        "msg": "You don't have permission to delete this message",
-                        "result": "error"
-                    }
+                oneOf:
+                - $ref: '#/components/schemas/InvalidMessageError'
+                - allOf:
+                  - $ref: '#/components/schemas/CodedError'
+                  - example:
+                      {
+                          "code": "BAD_REQUEST",
+                          "msg": "You don't have permission to delete this message",
+                          "result": "error"
+                      }
   /messages/{message_id}/history:
     get:
       description: |
@@ -1918,71 +1910,63 @@ paths:
           type: boolean
         example: true
       responses:
-        '200_without_principals':
+        '200':
           description: Success.
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/AddSubscriptionsResponse'
-                - example:
-                    {
-                        "already_subscribed": {},
-                        "msg": "",
-                        "result": "success",
-                        "subscribed": {
-                            "iago@zulip.com": [
-                                "new stream"
-                            ]
-                        }
-                    }
-        '200_already_subscribed':
+                oneOf:
+                - allOf:
+                  - $ref: '#/components/schemas/AddSubscriptionsResponse'
+                  - example:
+                      {
+                          "already_subscribed": {},
+                          "msg": "",
+                          "result": "success",
+                          "subscribed": {
+                              "iago@zulip.com": [
+                                  "new stream"
+                              ]
+                          }
+                      }
+                - allOf:
+                  - $ref: '#/components/schemas/AddSubscriptionsResponse'
+                  - example:
+                      {
+                          "already_subscribed": {
+                              "newbie@zulip.com": [
+                                  "new stream"
+                              ]
+                          },
+                          "msg": "",
+                          "result": "success",
+                          "subscribed": {}
+                      }
+        '400':
           description: Success.
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/AddSubscriptionsResponse'
-                - example:
-                    {
-                        "already_subscribed": {
-                            "newbie@zulip.com": [
-                                "new stream"
-                            ]
-                        },
-                        "msg": "",
-                        "result": "success",
-                        "subscribed": {}
-                    }
-        '400_unauthorized_errors_fatal_true':
-          description: Success.
-          content:
-            application/json:
-              schema:
-                allOf:
-                - $ref: '#/components/schemas/AddSubscriptionsResponse'
-                - example:
-                    {
-                        "msg": "Unable to access stream (private_stream).",
-                        "result": "error"
-                    }
-        '400_unauthorized_errors_fatal_false':
-          description: Success.
-          content:
-            application/json:
-              schema:
-                allOf:
-                - $ref: '#/components/schemas/AddSubscriptionsResponse'
-                - example:
-                    {
-                        "already_subscribed": {},
-                        "msg": "",
-                        "result": "success",
-                        "subscribed": {},
-                        "unauthorized": [
-                            "private_stream"
-                        ]
-                    }
+                oneOf:
+                - allOf:
+                  - $ref: '#/components/schemas/AddSubscriptionsResponse'
+                  - example:
+                      {
+                          "msg": "Unable to access stream (private_stream).",
+                          "result": "error"
+                      }
+                - allOf:
+                  - $ref: '#/components/schemas/AddSubscriptionsResponse'
+                  - example:
+                      {
+                          "already_subscribed": {},
+                          "msg": "",
+                          "result": "success",
+                          "subscribed": {},
+                          "unauthorized": [
+                              "private_stream"
+                          ]
+                      }
     patch:
       description: |
         Update which streams you are are subscribed to.
@@ -2194,24 +2178,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/JsonSuccess'
-        '400_topic_already_muted':
+        '400':
           description: Bad request.
           content:
             application/json:
               schema:
-                allOf:
+                oneOf:
+                - allOf:
                   - $ref: '#/components/schemas/JsonError'
                   - example:
                       {
                           "msg": "Topic already muted",
                           "result": "error"
                       }
-        '400_topic_not_muted':
-          description: Bad request.
-          content:
-            application/json:
-              schema:
-                allOf:
+                - allOf:
                   - $ref: '#/components/schemas/JsonError'
                   - example:
                       {
@@ -3411,35 +3391,28 @@ paths:
         example: event_types=['message']
       security:
       - basicAuth: []
+      responses:
+      # Makeshift response for this hack entry.
+       '200':
+         description: Success
   /rest-error-handling:
     post:
       description: |
         Common error to many endpoints
       responses:
-        '400_invalid_api_key':
+        '400':
           description: |
             Bad request.
           content:
             application/json:
               schema:
-                allOf:
-                - $ref: '#/components/schemas/InvalidApiKeyError'
-        '400_missing_request_argument_error':
-          description: |
-            Bad request.
-          content:
-            application/json:
-              schema:
-                allOf:
-                - $ref: '#/components/schemas/MissingArgumentError'
-        '400_user_not_authorized_error':
-          description: |
-            Bad request.
-          content:
-            application/json:
-              schema:
-                allOf:
-                - $ref: '#/components/schemas/UserNotAuthorizedError'
+                oneOf:
+                - allOf:
+                  - $ref: '#/components/schemas/InvalidApiKeyError'
+                - allOf:
+                  - $ref: '#/components/schemas/MissingArgumentError'
+                - allOf:
+                  - $ref: '#/components/schemas/UserNotAuthorizedError'
   /zulip-outgoing-webhook:
     post:
       description: |
@@ -3727,6 +3700,5 @@ components:
         type: array
         items:
           type: string
-        default:
+        default: null
       required: false
-      default: null


### PR DESCRIPTION
zulip.yaml is not in compliance with openapi specifications file.
Edit it so that it passes verification as an openapi specification
file.

Fixes #14582 .