### PR TITLE
design: Use CSS instead of disabled property for non-editable text.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -264,23 +264,19 @@ function edit_message(row, raw_content) {
     const copy_message = row.find('.copy_message');
 
     if (editability === editability_types.NO) {
-        message_edit_content.prop("readonly", "readonly");
-        message_edit_topic.prop("readonly", "readonly");
-        message_edit_content.attr("disabled", "disabled");
-        message_edit_topic.attr("disabled", "disabled");
+        message_edit_content.attr("readonly", "readonly");
+        message_edit_topic.attr("readonly", "readonly");
         new ClipboardJS(copy_message[0]);
     } else if (editability === editability_types.NO_LONGER) {
         // You can currently only reach this state in non-streams. If that
         // changes (e.g. if we stop allowing topics to be modified forever
         // in streams), then we'll need to disable
         // row.find('input.message_edit_topic') as well.
-        message_edit_content.prop("readonly", "readonly");
-        message_edit_content.attr("disabled", "disabled");
+        message_edit_content.attr("readonly", "readonly");
         message_edit_countdown_timer.text(i18n.t("View source"));
         new ClipboardJS(copy_message[0]);
     } else if (editability === editability_types.TOPIC_ONLY) {
-        message_edit_content.prop("readonly", "readonly");
-        message_edit_content.attr("disabled", "disabled");
+        message_edit_content.attr("readonly", "readonly");
         // Hint why you can edit the topic but not the message content
         message_edit_countdown_timer.text(i18n.t("Topic editing only"));
         new ClipboardJS(copy_message[0]);

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -90,6 +90,7 @@ on a dark background, and don't change the dark labels dark either. */
 
     /* these are converting grey things to "new grey" */
     *[disabled=disabled],
+    *[readonly=readonly],
     .sidebar-title,
     .recipient_row_date {
         color: inherit;


### PR DESCRIPTION
The disabled property actually prevented text selection, so it seems
better to use CSS through the `readonly="readonly"` property.
For this, swapped .prop() with .attr() since .prop() was setting it as
`readonly=""`.
