### PR TITLE
alert words: Limit alert word length to 100.

### DIFF
--- a/zerver/views/alert_words.py
+++ b/zerver/views/alert_words.py
@@ -5,7 +5,7 @@ from zerver.models import UserProfile
 
 from zerver.lib.request import has_request_variables, REQ
 from zerver.lib.response import json_success
-from zerver.lib.validator import check_list, check_string
+from zerver.lib.validator import check_list, check_string, check_capped_string
 
 from zerver.lib.actions import do_add_alert_words, do_remove_alert_words
 from zerver.lib.alert_words import user_alert_words
@@ -19,7 +19,7 @@ def clean_alert_words(alert_words: List[str]) -> List[str]:
 
 @has_request_variables
 def add_alert_words(request: HttpRequest, user_profile: UserProfile,
-                    alert_words: List[str]=REQ(validator=check_list(check_string))
+                    alert_words: List[str]=REQ(validator=check_list(check_capped_string(100)))
                     ) -> HttpResponse:
     do_add_alert_words(user_profile, clean_alert_words(alert_words))
     return json_success({'alert_words': user_alert_words(user_profile)})


### PR DESCRIPTION
We do limit the length to 100 in the frontend, but no such check
exists in the backend.

Check that a new alert word has a maximum length of 100 in the
alert_words endpoint.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

An issue tracking this does not exist.

**Testing Plan:** <!-- How have you tested? -->

No tests exist for the modified file.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![image](https://user-images.githubusercontent.com/7714968/79595075-dbbd8a00-80fb-11ea-8348-cccb107e7a13.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
