### PR TITLE
Allow /etc/zulip to be a symlink

### DIFF
--- a/puppet/zulip/manifests/base.pp
+++ b/puppet/zulip/manifests/base.pp
@@ -119,6 +119,7 @@ class zulip::base {
     mode   => '0644',
     owner  => 'zulip',
     group  => 'zulip',
+    links => 'follow',
   }
   file { ['/etc/zulip/zulip.conf', '/etc/zulip/settings.py']:
     ensure  => 'file',

--- a/puppet/zulip/manifests/base.pp
+++ b/puppet/zulip/manifests/base.pp
@@ -119,7 +119,7 @@ class zulip::base {
     mode   => '0644',
     owner  => 'zulip',
     group  => 'zulip',
-    links => 'follow',
+    links  => 'follow',
   }
   file { ['/etc/zulip/zulip.conf', '/etc/zulip/settings.py']:
     ensure  => 'file',


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR updates the puppet manifest to allow `/etc/zulip` to be a symlink. The current behaviour overwrites `/etc/zulip` if it is link to another directory.

**Testing Plan:** <!-- How have you tested? -->
Ran in a test docker container. Marked as WIP as I'm currently spinning up a dev environment for more testing.


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
