### PR TITLE
openapi: Fix minor error in zulip.yaml

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1121,8 +1121,8 @@ paths:
           type: string
         example: 4e/m2A3MSqFnWRLUf9SaPzQ0Up_/zulip.txt
         required: True
-        responses:
-          '200':
+      responses:
+        '200':
           description: Success.
           content:
             application/json:


### PR DESCRIPTION
A spacing was misaligned in zulip.yaml.