### PR TITLE
tab_bar: Fix colors stream_count and description in nightmode.

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -224,16 +224,16 @@ on a dark background, and don't change the dark labels dark either. */
     .top-navbar-border {
         border-color: hsla(0, 0%, 0%, 0.6);
     }
-    #tab_bar #tab_list li.sub_count::before {
+    #tab_bar #tab_list .sub_count::before {
         background: hsla(0, 0%, 100%, 0.5);
     }
-    #tab_bar #tab_list li.sub_count::after {
+    #tab_bar #tab_list .sub_count::after {
         background: hsla(0, 0%, 100%, 0.5);
     }
 
     #searchbox_legacy {
-        #tab_bar #tab_list li.sub_count,
-        #tab_bar #tab_list li.narrow_description {
+        #tab_bar #tab_list .sub_count,
+        #tab_bar #tab_list .narrow_description {
             color: hsla(0, 0%, 90%, 1);
         }
     }


### PR DESCRIPTION
This fixes a bug which caused by removing an \<li\> based structure on
the navbar. We forgot to update these styles.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/33805964/79616320-5a2d2280-8122-11ea-9c16-3ce856c29c6d.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
