### PR TITLE
data exports: Handle pending and failed exports.

### DIFF
--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -526,7 +526,6 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
         break;
     case 'realm_export':
         settings_exports.populate_exports_table(event.exports);
-        settings_exports.clear_success_banner();
         break;
     }
 

--- a/static/js/settings_exports.js
+++ b/static/js/settings_exports.js
@@ -38,6 +38,8 @@ exports.populate_exports_table = function (exports) {
                             new XDate(data.export_time * 1000)
                         ),
                         url: data.export_url,
+                        failed: data.failed_timestamp,
+                        pending: data.pending,
                     },
                 });
             }

--- a/static/js/settings_exports.js
+++ b/static/js/settings_exports.js
@@ -29,28 +29,34 @@ exports.populate_exports_table = function (exports) {
         name: "admin_exports_list",
         modifier: function (data) {
             let failed_timestamp = data.failed_timestamp;
+            let deleted_timestamp = data.deleted_timestamp;
+
             if (failed_timestamp !== null) {
                 failed_timestamp = timerender.last_seen_status_from_date(
                     new XDate(failed_timestamp * 1000)
                 );
             }
 
-            if (data.deleted_timestamp === null) {
-                return render_admin_export_list({
-                    realm_export: {
-                        id: data.id,
-                        acting_user: people.get_full_name(data.acting_user_id),
-                        // Convert seconds -> milliseconds
-                        event_time: timerender.last_seen_status_from_date(
-                            new XDate(data.export_time * 1000)
-                        ),
-                        url: data.export_url,
-                        time_failed: failed_timestamp,
-                        pending: data.pending,
-                    },
-                });
+            if (deleted_timestamp !== null) {
+                deleted_timestamp = timerender.last_seen_status_from_date(
+                    new XDate(deleted_timestamp * 1000)
+                );
             }
-            return "";
+
+            return render_admin_export_list({
+                realm_export: {
+                    id: data.id,
+                    acting_user: people.get_full_name(data.acting_user_id),
+                    // Convert seconds -> milliseconds
+                    event_time: timerender.last_seen_status_from_date(
+                        new XDate(data.export_time * 1000)
+                    ),
+                    url: data.export_url,
+                    time_failed: failed_timestamp,
+                    pending: data.pending,
+                    time_deleted: deleted_timestamp,
+                },
+            });
         },
         filter: {
             element: exports_table.closest(".settings-section").find(".search"),

--- a/static/js/settings_exports.js
+++ b/static/js/settings_exports.js
@@ -8,18 +8,6 @@ exports.reset = function () {
     meta.loaded = false;
 };
 
-exports.clear_success_banner = function () {
-    const export_status = $('#export_status');
-    if (export_status.hasClass('alert-success')) {
-        // Politely remove our success banner if the export
-        // finishes before the view is closed.
-        export_status.fadeTo(200, 0);
-        setTimeout(function () {
-            export_status.hide();
-        }, 205);
-    }
-};
-
 function sort_user(a, b) {
     const a_name = people.get_full_name(a.acting_user_id).toLowerCase();
     const b_name = people.get_full_name(b.acting_user_id).toLowerCase();
@@ -83,7 +71,7 @@ exports.set_up = function () {
         channel.post({
             url: '/json/export/realm',
             success: function () {
-                ui_report.success(i18n.t("Export started. Check back in a few minutes."), export_status);
+                ui_report.success(i18n.t("Export started. Check back in a few minutes."), export_status, 4000);
             },
             error: function (xhr) {
                 ui_report.error(i18n.t("Export failed"), xhr, export_status);

--- a/static/js/settings_exports.js
+++ b/static/js/settings_exports.js
@@ -28,6 +28,13 @@ exports.populate_exports_table = function (exports) {
     list_render.create(exports_table, Object.values(exports), {
         name: "admin_exports_list",
         modifier: function (data) {
+            let failed_timestamp = data.failed_timestamp;
+            if (failed_timestamp !== null) {
+                failed_timestamp = timerender.last_seen_status_from_date(
+                    new XDate(failed_timestamp * 1000)
+                );
+            }
+
             if (data.deleted_timestamp === null) {
                 return render_admin_export_list({
                     realm_export: {
@@ -38,7 +45,7 @@ exports.populate_exports_table = function (exports) {
                             new XDate(data.export_time * 1000)
                         ),
                         url: data.export_url,
-                        failed: data.failed_timestamp,
+                        time_failed: failed_timestamp,
                         pending: data.pending,
                     },
                 });
@@ -60,6 +67,13 @@ exports.populate_exports_table = function (exports) {
             user: sort_user,
         },
     });
+
+    const spinner = $('.export_row .export_url_spinner');
+    if (spinner.length) {
+        loading.make_indicator(spinner);
+    } else {
+        loading.destroy_indicator(spinner);
+    }
 };
 
 exports.set_up = function () {

--- a/static/templates/admin_export_list.hbs
+++ b/static/templates/admin_export_list.hbs
@@ -8,9 +8,16 @@
     </td>
     <td>
         {{#if url}}
+        <span class="export_status">{{t 'Complete' }}</span>
+        {{else if failed}}
+        <span class="export_status">{{t 'Failed' }}</span>
+        {{else if pending}}
+        <span class="export_status">{{t 'Pending' }}</span>
+        {{/if}}
+    </td>
+    <td>
+        {{#if url}}
         <span class="export_url"><a href="{{url}}" download>{{t 'Download' }}</a></span>
-        {{else}}
-        <span class="export_url">{{t 'The export URL is not yet available... Check back soon.' }}</span>
         {{/if}}
     </td>
     <td class="actions">

--- a/static/templates/admin_export_list.hbs
+++ b/static/templates/admin_export_list.hbs
@@ -8,16 +8,11 @@
     </td>
     <td>
         {{#if url}}
-        <span class="export_status">{{t 'Complete' }}</span>
-        {{else if failed}}
-        <span class="export_status">{{t 'Failed' }}</span>
+        <span class="export_url"><a href="{{url}}" download>{{t 'Complete' }}</a></span>
+        {{else if time_failed}}
+        <span class="export_status">{{t 'Failed' }}: {{time_failed}}</span>
         {{else if pending}}
-        <span class="export_status">{{t 'Pending' }}</span>
-        {{/if}}
-    </td>
-    <td>
-        {{#if url}}
-        <span class="export_url"><a href="{{url}}" download>{{t 'Download' }}</a></span>
+        <div class="export_url_spinner"></div>
         {{/if}}
     </td>
     <td class="actions">

--- a/static/templates/admin_export_list.hbs
+++ b/static/templates/admin_export_list.hbs
@@ -13,12 +13,16 @@
         <span class="export_status">{{t 'Failed' }}: {{time_failed}}</span>
         {{else if pending}}
         <div class="export_url_spinner"></div>
+        {{else if time_deleted}}
+        <span class="export_status">{{t 'Deleted' }}: {{time_deleted}}</span>
         {{/if}}
     </td>
     <td class="actions">
+        {{#unless time_deleted}}
         <button class="button rounded small delete btn-danger" data-export-id="{{id}}">
             <i class="fa fa-trash-o" aria-hidden="true"></i>
         </button>
+        {{/unless}}
     </td>
 </tr>
 {{/with}}

--- a/static/templates/settings/data_exports_admin.hbs
+++ b/static/templates/settings/data_exports_admin.hbs
@@ -36,7 +36,6 @@
                 <th class="active" data-sort="user">{{t "Requesting user" }}</th>
                 <th data-sort="numeric" data-sort-prop="export_time">{{t "Time" }}</th>
                 <th>{{t "Status" }}</th>
-                <th>{{t "File" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>
             <tbody id="admin_exports_table" class="required-text" data-empty="{{t 'No exports.' }}"></tbody>

--- a/static/templates/settings/data_exports_admin.hbs
+++ b/static/templates/settings/data_exports_admin.hbs
@@ -35,6 +35,7 @@
             <thead>
                 <th class="active" data-sort="user">{{t "Requesting user" }}</th>
                 <th data-sort="numeric" data-sort-prop="export_time">{{t "Time" }}</th>
+                <th>{{t "Status" }}</th>
                 <th>{{t "File" }}</th>
                 <th class="actions">{{t "Actions" }}</th>
             </thead>

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5790,8 +5790,12 @@ def do_delete_realm_export(user_profile: UserProfile, export: RealmAuditLog) -> 
     export_extra_data = export.extra_data
     assert export_extra_data is not None
     export_data = ujson.loads(export_extra_data)
+    export_path = export_data.get('export_path')
 
-    delete_export_tarball(export_data.get('export_path'))
+    if export_path:
+        # Allow removal even if the export failed.
+        delete_export_tarball(export_path)
+
     export_data.update({'deleted_timestamp': timezone_now().timestamp()})
     export.extra_data = ujson.dumps(export_data)
     export.save(update_fields=['extra_data'])

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -1762,14 +1762,30 @@ def get_realm_exports_serialized(user: UserProfile) -> List[Dict[str, Any]]:
                                                event_type=RealmAuditLog.REALM_EXPORTED)
     exports_dict = {}
     for export in all_exports:
-        export_data = ujson.loads(export.extra_data)
-        export_url = zerver.lib.upload.upload_backend.get_export_tarball_url(
-            user.realm, export_data['export_path'])
+        pending = True
+        export_url = None
+        deleted_timestamp = None
+        failed_timestamp = None
+
+        if export.extra_data is not None:
+            pending = False
+
+            export_data = ujson.loads(export.extra_data)
+            deleted_timestamp = export_data.get('deleted_timestamp')
+            failed_timestamp = export_data.get('failed_timestamp')
+            export_path = export_data.get('export_path')
+
+            if export_path:
+                export_url = zerver.lib.upload.upload_backend.get_export_tarball_url(
+                    user.realm, export_path)
+
         exports_dict[export.id] = dict(
             id=export.id,
             export_time=export.event_time.timestamp(),
             acting_user_id=export.acting_user.id,
             export_url=export_url,
-            deleted_timestamp=export_data.get('deleted_timestamp'),
+            deleted_timestamp=deleted_timestamp,
+            failed_timestamp=failed_timestamp,
+            pending=pending,
         )
     return sorted(exports_dict.values(), key=lambda export_dict: export_dict['id'])

--- a/zerver/lib/export.py
+++ b/zerver/lib/export.py
@@ -1775,7 +1775,7 @@ def get_realm_exports_serialized(user: UserProfile) -> List[Dict[str, Any]]:
             failed_timestamp = export_data.get('failed_timestamp')
             export_path = export_data.get('export_path')
 
-            if export_path:
+            if export_path and not deleted_timestamp:
                 export_url = zerver.lib.upload.upload_backend.get_export_tarball_url(
                     user.realm, export_path)
 

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2860,7 +2860,7 @@ class EventsRegisterTest(ZulipTestCase):
                 ('id', check_int),
                 ('export_time', check_float),
                 ('acting_user_id', check_int),
-                ('export_url', check_string),
+                ('export_url', equals(None)),
                 ('deleted_timestamp', check_float),
                 ('failed_timestamp', equals(None)),
                 ('pending', check_bool),

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2809,6 +2809,19 @@ class EventsRegisterTest(ZulipTestCase):
         self.assert_on_error(error)
 
     def test_notify_realm_export(self) -> None:
+        pending_schema_checker = self.check_events_dict([
+            ('type', equals('realm_export')),
+            ('exports', check_list(check_dict_only([
+                ('id', check_int),
+                ('export_time', check_float),
+                ('acting_user_id', check_int),
+                ('export_url', equals(None)),
+                ('deleted_timestamp', equals(None)),
+                ('failed_timestamp', equals(None)),
+                ('pending', check_bool),
+            ]))),
+        ])
+
         schema_checker = self.check_events_dict([
             ('type', equals('realm_export')),
             ('exports', check_list(check_dict_only([
@@ -2817,6 +2830,8 @@ class EventsRegisterTest(ZulipTestCase):
                 ('acting_user_id', check_int),
                 ('export_url', check_string),
                 ('deleted_timestamp', equals(None)),
+                ('failed_timestamp', equals(None)),
+                ('pending', check_bool),
             ]))),
         ])
 
@@ -2828,10 +2843,14 @@ class EventsRegisterTest(ZulipTestCase):
             with stdout_suppressed():
                 events = self.do_test(
                     lambda: self.client_post('/json/export/realm'),
-                    state_change_expected=True, num_events=2)
+                    state_change_expected=True, num_events=3)
 
-        # The first event is a message from notification-bot.
-        error = schema_checker('events[1]', events[1])
+        # We first notify when an export is initiated,
+        error = pending_schema_checker('events[0]', events[0])
+        self.assert_on_error(error)
+
+        # The second event is then a message from notification-bot.
+        error = schema_checker('events[2]', events[2])
         self.assert_on_error(error)
 
         # Now we check the deletion of the export.
@@ -2843,6 +2862,8 @@ class EventsRegisterTest(ZulipTestCase):
                 ('acting_user_id', check_int),
                 ('export_url', check_string),
                 ('deleted_timestamp', check_float),
+                ('failed_timestamp', equals(None)),
+                ('pending', check_bool),
             ]))),
         ])
 
@@ -2852,6 +2873,49 @@ class EventsRegisterTest(ZulipTestCase):
             lambda: self.client_delete('/json/export/realm/{id}'.format(id=audit_log_entry.id)),
             state_change_expected=False, num_events=1)
         error = deletion_schema_checker('events[0]', events[0])
+        self.assert_on_error(error)
+
+    def test_notify_realm_export_on_failure(self) -> None:
+        pending_schema_checker = self.check_events_dict([
+            ('type', equals('realm_export')),
+            ('exports', check_list(check_dict_only([
+                ('id', check_int),
+                ('export_time', check_float),
+                ('acting_user_id', check_int),
+                ('export_url', equals(None)),
+                ('deleted_timestamp', equals(None)),
+                ('failed_timestamp', equals(None)),
+                ('pending', check_bool),
+            ]))),
+        ])
+
+        failed_schema_checker = self.check_events_dict([
+            ('type', equals('realm_export')),
+            ('exports', check_list(check_dict_only([
+                ('id', check_int),
+                ('export_time', check_float),
+                ('acting_user_id', check_int),
+                ('export_url', equals(None)),
+                ('deleted_timestamp', equals(None)),
+                ('failed_timestamp', check_float),
+                ('pending', check_bool),
+            ]))),
+        ])
+
+        do_change_is_admin(self.user_profile, True)
+        self.login_user(self.user_profile)
+
+        with mock.patch('zerver.lib.export.do_export_realm',
+                        side_effect=Exception("test")):
+            with stdout_suppressed():
+                events = self.do_test(
+                    lambda: self.client_post('/json/export/realm'),
+                    state_change_expected=False, num_events=2)
+
+        error = pending_schema_checker('events[0]', events[0])
+        self.assert_on_error(error)
+
+        error = failed_schema_checker('events[1]', events[1])
         self.assert_on_error(error)
 
 class FetchInitialStateDataTest(ZulipTestCase):

--- a/zerver/views/realm_export.py
+++ b/zerver/views/realm_export.py
@@ -12,7 +12,7 @@ from zerver.models import RealmAuditLog, UserProfile
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.response import json_error, json_success
 from zerver.lib.export import get_realm_exports_serialized
-from zerver.lib.actions import do_delete_realm_export
+from zerver.lib.actions import do_delete_realm_export, notify_realm_export
 
 import ujson
 
@@ -51,6 +51,10 @@ def export_realm(request: HttpRequest, user: UserProfile) -> HttpResponse:
                                        event_type=event_type,
                                        event_time=event_time,
                                        acting_user=user)
+
+    # Allow for UI updates on a pending export
+    notify_realm_export(user)
+
     # Using the deferred_work queue processor to avoid
     # killing the process after 60s
     event = {'type': "realm_export",


### PR DESCRIPTION
[Discussion on czo](https://chat.zulip.org/#narrow/stream/49-development-help/topic/realm.20export.20500s/near/855209)

Prior to this change, there were reports of 500s in
production due to `export.extra_data` being a
Nonetype.  This was reproducible using the s3
backend in development when a row was created in
the `RealmAuditLog` table, but the export failed in
the `DeferredWorker`.  This left an entry lying
about that was never updated with an `extra_data`
field.

To fix this, we catch any exceptions in the
`DeferredWorker`, and then update `extra_data` to
encode the failure.  We also fix the fact that we
never updated the export UI table with pending exports.

These changes also negated the use for the somewhat
hacky `clear_success_banner` logic.

**Testing Plan:** <!-- How have you tested? -->
`tools/test-backend`
`tools/run-dev.py`
