### PR TITLE
version control: Add note about paragraph formatting.

### DIFF
--- a/docs/contributing/version-control.md
+++ b/docs/contributing/version-control.md
@@ -143,7 +143,8 @@ automatically catch common mistakes in the commit message itself.
 
 ### Message body:
 
--   The body is written in prose, with full paragraphs.
+-   The body is written in prose, with full paragraphs; each paragraph should
+    be separated from the next by a single blank line.
 -   The body explains:
     -   why and how the change was made
     -   any manual testing you did in addition to running the automated tests


### PR DESCRIPTION
We've been getting a number of submissions lately that haven't used blank lines in between paragraphs, so add that to our style guide.