### PR TITLE
api_docs: Deduplicate common constructs in zulip.yaml

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -914,18 +914,7 @@ paths:
         `POST {{ api_url }}/v1/messages/{message_id}/reactions`
       parameters:
       - $ref: '#/components/parameters/MessageId'
-      - name: emoji_name
-        in: query
-        description: |
-          Name of the emoji you want to add as as a reaction.
-
-          To find an emoji's name, hover over a message to reveal
-          three icons on the right, then click the smiley face icon.
-          Images of available reaction emojis appear. Hover over the
-          emoji you want, and note that emoji's text name.
-        schema:
-          type: string
-        example: 'octopus'
+      - $ref: '#/components/parameters/EmojiName'
         required: true
       - name: emoji_code
         in: query
@@ -987,20 +976,7 @@ paths:
         `DELETE {{ api_url }}/v1/messages/{message_id}/reactions`
       parameters:
       - $ref: '#/components/parameters/MessageId'
-      - name: emoji_name
-        in: query
-        description: |
-          Name of the emoji you want to delete from a reaction.
-
-          To find an emoji's name, hover over a message to
-          reveal three icons on the right, then click the smiley face icon.
-          Images of available reaction emojis appear. Hover over the emoji
-          you want, and note that emoji's text name.
-
-          Ignored if emoji_code is also passed.
-        schema:
-          type: string
-        example: 'octopus'
+      - $ref: '#/components/parameters/EmojiName'
         required: false
       - name: emoji_code
         in: query
@@ -3840,3 +3816,16 @@ components:
         type: boolean
         default: false
       example: true
+    EmojiName:
+      name: emoji_name
+      in: query
+      description: |
+        Name of the emoji.
+
+        To find an emoji's name, hover over a message to reveal
+        three icons on the right, then click the smiley face icon.
+        Images of available reaction emojis appear. Hover over the
+        emoji you want, and note that emoji's text name.
+      schema:
+        type: string
+      example: 'octopus'

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1112,18 +1112,7 @@ paths:
         `GET {{ api_url }}/v1/users`
       parameters:
       - $ref: '#/components/parameters/ClientGravatar'
-      - name: include_custom_profile_fields
-        in: query
-        description: |
-          Set to `true` if the client wants custom profile field data to be
-          included in the response.
-
-          **Changes**: New in Zulip 2.1.0.  Previous versions do no offer these
-          data via the API.
-        schema:
-          type: boolean
-          default: false
-        example: true
+      - $ref: '#/components/parameters/IncludeCustomProfileFields'
       responses:
         '200':
           description: Success.
@@ -1288,14 +1277,7 @@ paths:
       parameters:
       - $ref: '#/components/parameters/UserId'
       - $ref: '#/components/parameters/ClientGravatar'
-      - name: include_custom_profile_fields
-        in: query
-        description: |
-          The client should pass true if it wants to include custom profile field data.
-        schema:
-          type: boolean
-          default: false
-        example: true
+      - $ref: '#/components/parameters/IncludeCustomProfileFields'
       responses:
         '200':
           description: Success.
@@ -3829,3 +3811,16 @@ components:
       schema:
         type: string
       example: 'octopus'
+    IncludeCustomProfileFields:
+      name: include_custom_profile_fields
+      in: query
+      description: |
+        Set to `true` if the client wants custom profile field data to be
+        included in the response.
+
+        **Changes**: New in Zulip 2.1.0.  Previous versions do no offer these
+        data via the API.
+      schema:
+        type: boolean
+        default: false
+      example: true

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -935,22 +935,7 @@ paths:
           type: string
         example: '1f419'
         required: false
-      - name: reaction_type
-        in: query
-        description: |
-          If the client is upvoting a reaction and wants to specifically add
-          a vote to an existing reaction, we recommend passing this parameter
-          using the value the server provided for the existing reaction.
-
-          **Changes**: In Zulip 2.2 (feature level 2), this become
-          optional for [custom emoji](/help/add-custom-emoji);
-          previously, this endpoint assumed `unicode_emoji` if this
-          parameter was not specified (as `realm_emoji` for custom
-          emoji).
-        schema:
-          type: string
-        example: 'unicode_emoji'
-        required: false
+      - $ref: '#/components/parameters/ReactionType'
       responses:
         '200':
           $ref: '#/components/responses/SimpleSuccess'
@@ -993,15 +978,7 @@ paths:
           type: string
         example: '1f419'
         required: false
-      - name: reaction_type
-        in: query
-        description: |
-          When removing a reaction with a [custom emoji](/help/add-custom-emoji),
-          set `reaction_type` to `realm_emoji`.
-        schema:
-          type: string
-        example: 'unicode_emoji'
-        required: false
+      - $ref: '#/components/parameters/ReactionType'
       responses:
         '200':
           $ref: '#/components/responses/SimpleSuccess'
@@ -3816,3 +3793,13 @@ components:
           type: string
         default: []
       example: ['ZOE@zulip.com']
+    ReactionType:
+      name: reaction_type
+      in: query
+      description: |
+        When removing a reaction with a [custom emoji](/help/add-custom-emoji),
+        set `reaction_type` to `realm_emoji`.
+      schema:
+        type: string
+      example: 'unicode_emoji'
+      required: false

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1917,21 +1917,7 @@ paths:
           type: boolean
           default: None
         example: false
-      - name: stream_post_policy
-        in: query
-        description: |
-          Policy for which users can post messages to the stream.
-
-          * 1 => Any user can post.
-          * 2 => Only administrators can post.
-          * 3 => Only new members can post.
-
-          **Changes**: New in Zulip 2.2 (feature level 1), replacing
-          the previous is_announcement_only boolean.
-        schema:
-          type: integer
-          default: 1
-        example: 1
+      - $ref: '#/components/parameters/StreamPostPolicy'
       - name: announce
         in: query
         description: |
@@ -3152,21 +3138,7 @@ paths:
           type: boolean
         example: true
         required: false
-      - name: stream_post_policy
-        in: query
-        description: |
-          Policy for which users can post messages to the stream.
-
-          * 1 => Any user can post.
-          * 2 => Only administrators can post.
-          * 3 => Only new members can post.
-
-          **Changes**: New in Zulip 2.2 (feature level 1), replacing
-          the previous `is_announcement_only` boolean.
-        schema:
-          type: integer
-        example: 2
-        required: false
+      - $ref: '#/components/parameters/StreamPostPolicy'
       - name: history_public_to_subscribers
         in: query
         description: |
@@ -3864,3 +3836,20 @@ components:
         type: integer
       example: 11
       required: true
+    StreamPostPolicy:
+      name: stream_post_policy
+      in: query
+      description: |
+        Policy for which users can post messages to the stream.
+
+        * 1 => Any user can post.
+        * 2 => Only administrators can post.
+        * 3 => Only new members can post.
+
+        **Changes**: New in Zulip 2.2, replacing the previous is_announcement_only
+        boolean.
+      schema:
+        type: integer
+        default: 1
+      example: 2
+      required: false

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1908,15 +1908,7 @@ paths:
           type: boolean
           default: true
         example: false
-      - name: history_public_to_subscribers
-        in: query
-        description: |
-          A boolean indicating if the history should be available to newly
-          subscribed members.
-        schema:
-          type: boolean
-          default: None
-        example: false
+      - $ref: '#/components/parameters/HistoryPublicToSubscribers'
       - $ref: '#/components/parameters/StreamPostPolicy'
       - name: announce
         in: query
@@ -3139,17 +3131,7 @@ paths:
         example: true
         required: false
       - $ref: '#/components/parameters/StreamPostPolicy'
-      - name: history_public_to_subscribers
-        in: query
-        description: |
-          Whether subscribers have access to full stream history, even before they joined
-          the stream.
-        schema:
-          type: boolean
-        example: true
-        required: false
-
-
+      - $ref: '#/components/parameters/HistoryPublicToSubscribers'
       responses:
         '200':
           description: Success.
@@ -3852,4 +3834,15 @@ components:
         type: integer
         default: 1
       example: 2
+      required: false
+    HistoryPublicToSubscribers:
+      name: history_public_to_subscribers
+      in: query
+      description: |
+        A boolean indicating if the history should be available to newly
+        subscribed members.
+      schema:
+        type: boolean
+        default: None
+      example: false
       required: false

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1772,18 +1772,7 @@ paths:
       # endpoints, and perhaps use this to provide links to implementations.
       operationId: zerver.views.streams.list_subscriptions_backend
       parameters:
-      - name: include_subscribers
-        in: query
-        description: |
-          Set to `true` if you would like each stream's info to include a list of
-          current subscribers to that stream. (This may be significantly slower in
-          organizations with thousands of users.)
-
-          **Changes**: New in Zulip 2.1.0.
-        schema:
-          type: boolean
-          default: false
-        example: true
+      - $ref: '#/components/parameters/IncludeSubscribers'
       responses:
         '200':
           description: Success.
@@ -2486,15 +2475,7 @@ paths:
           type: boolean
           default: false
         example: true
-      - name: include_subscribers
-        in: query
-        description: |
-          Set to `True` if you would like to receive events that include the
-          subscribers for each stream.
-        schema:
-          type: boolean
-          default: false
-        example: true
+      - $ref: '#/components/parameters/IncludeSubscribers'
       - name: client_capabilities
         in: query
         description: |
@@ -3846,3 +3827,16 @@ components:
         default: None
       example: false
       required: false
+    IncludeSubscribers:
+      name: include_subscribers
+      in: query
+      description: |
+        Set to `True` if you would like to receive events that include the
+        subscribers for each stream. (This may be significantly slower in
+        organizations with thousands of users.)
+
+        **Changes**: New in Zulip 2.1.0.
+      schema:
+        type: boolean
+        default: false
+      example: true

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -916,25 +916,7 @@ paths:
       - $ref: '#/components/parameters/MessageId'
       - $ref: '#/components/parameters/EmojiName'
         required: true
-      - name: emoji_code
-        in: query
-        description: |
-          An encoded version of the unicode codepoint.  For most
-          clients, you won't need this; it's used to handle a rare
-          corner case when upvoting a unicode emoji reaction added
-          previously by another user.
-
-          If the existing reaction was added when the Zulip
-          server was using a previous version of the emoji
-          data mapping from codepoints to human-readable
-          names, sending the `emoji_code` in the data for
-          the original reaction allows the Zulip server to
-          correctly consider your upvote as an upvote
-          rather than a reaction with a "diffenent" emoji.
-        schema:
-          type: string
-        example: '1f419'
-        required: false
+      - $ref: '#/components/parameters/EmojiCode'
       - $ref: '#/components/parameters/ReactionType'
       responses:
         '200':
@@ -963,21 +945,7 @@ paths:
       - $ref: '#/components/parameters/MessageId'
       - $ref: '#/components/parameters/EmojiName'
         required: false
-      - name: emoji_code
-        in: query
-        description: |
-          Alternative to emoji_name for expressing which emoji to remove. An
-          encoded version of the unicode codepoint for the emoji you'd like to
-          remove from the message.
-
-          Recommended over using `emoji_name` for Zulip apps
-          because this more robustly handles changes in the mapping
-          between user-facing names and aliases for emoji (which change from
-          time to time) and their unicode codepoints.
-        schema:
-          type: string
-        example: '1f419'
-        required: false
+      - $ref: '#/components/parameters/EmojiCode'
       - $ref: '#/components/parameters/ReactionType'
       responses:
         '200':
@@ -3802,4 +3770,23 @@ components:
       schema:
         type: string
       example: 'unicode_emoji'
+      required: false
+    EmojiCode:
+      name: emoji_code
+      in: query
+      description: |
+        An encoded version of the unicode codepoint.  For most
+        clients, you won't need this; it's used to handle a rare
+        corner case when upvoting a unicode emoji reaction added
+        previously by another user.
+        If the existing reaction was added when the Zulip
+        server was using a previous version of the emoji
+        data mapping from codepoints to human-readable
+        names, sending the `emoji_code` in the data for
+        the original reaction allows the Zulip server to
+        correctly consider your upvote as an upvote
+        rather than a reaction with a "diffenent" emoji.
+      schema:
+        type: string
+      example: '1f419'
       required: false

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1310,14 +1310,7 @@ paths:
 
         *This endpoint is new in Zulip Server 2.2.*
       parameters:
-      - name: user_id
-        in: path
-        description: |
-          The user id of the user.
-        schema:
-          type: integer
-        example: 11
-        required: true
+      - $ref: '#/components/parameters/UserId'
       - $ref: '#/components/parameters/ClientGravatar'
       - name: include_custom_profile_fields
         in: query
@@ -1401,14 +1394,7 @@ paths:
         [role](/help/roles-and-permissions), and [custom profile
         fields](/help/add-custom-profile-fields).
       parameters:
-      - name: user_id
-        in: path
-        description: |
-          The user id of the user.
-        schema:
-          type: integer
-        example: 12
-        required: true
+      - $ref: '#/components/parameters/UserId'
       - name: full_name
         in: query
         description: |
@@ -1481,14 +1467,7 @@ paths:
 
         `DELETE {{ api_url }}/v1/users/{user_id}`
       parameters:
-      - name: user_id
-        in: path
-        description: |
-          The user id of the user.
-        schema:
-          type: integer
-        example: 11
-        required: true
+      - $ref: '#/components/parameters/UserId'
       responses:
         '200':
           description: Success
@@ -3875,4 +3854,13 @@ components:
       schema:
         type: integer
       example: 42
+      required: true
+    UserId:
+      name: user_id
+      in: path
+      description: |
+        The user id of the user.
+      schema:
+        type: integer
+      example: 11
       required: true

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1830,18 +1830,7 @@ paths:
           type: boolean
           default: false
         example: true
-      - name: principals
-        in: query
-        description: |
-          A list of email addresses of the users that will be subscribed to the
-          streams specified in the `subscriptions` argument. If not provided, then
-          the requesting user/bot is subscribed.
-        schema:
-          type: array
-          items:
-            type: string
-          default: []
-        example: ['ZOE@zulip.com']
+      - $ref: '#/components/parameters/Principals'
       - name: authorization_errors_fatal
         in: query
         description: |
@@ -2039,17 +2028,7 @@ paths:
             type: string
         example: ['Verona', 'Denmark']
         required: true
-      - name: principals
-        in: query
-        description: |
-          A list of email addresses of the users that will be unsubscribed from
-          the streams specified in the `subscriptions` argument. If not provided,
-          then the requesting user/bot is unsubscribed.
-        schema:
-          type: array
-          items:
-            type: string
-        example: ['ZOE@zulip.com']
+      - $ref: '#/components/parameters/Principals'
       responses:
         '200':
           description: Success.
@@ -3824,3 +3803,16 @@ components:
         type: boolean
         default: false
       example: true
+    Principals:
+      name: principals
+      in: query
+      description: |
+        A list of email addresses of the users that will be subscribed/unsubscribed
+        to the streams specified in the `subscriptions` argument. If not provided, then
+        the requesting user/bot is subscribed.
+      schema:
+        type: array
+        items:
+          type: string
+        default: []
+      example: ['ZOE@zulip.com']


### PR DESCRIPTION
This PR deduplicate various common constructs, like `narrow`, to live in components and be shared between the documentation for multiple endpoints.