### PR TITLE
Navbar: Improve search_icon related styles.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1425,6 +1425,9 @@ div.focused_table {
             &:not(.stream) {
                 text-overflow: ellipsis;
             }
+            &:nth-last-child(2) {
+                flex-grow: 1;
+            }
             i {
                 margin-right: 3px;
             }
@@ -1519,8 +1522,8 @@ div.focused_table {
 
         .search_closed {
             flex: 0; // makes sure search icon is always visible
-            margin-left: auto; // aligns search icon to right end of box
             margin-right: 15px;
+
             cursor: pointer;
             font-size: 20px;
 

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1371,17 +1371,11 @@ div.focused_table {
     border-left: 1px solid hsl(0, 0%, 88%);
 }
 
-
 .search_icon {
     color: hsl(0, 0%, 80%);
     text-decoration: none;
-    width: 0;
-    height: 0;
-    padding-top: 12px;
-    padding-left: 50px;
     &:hover {
         color: hsl(0, 0%, 0%);
-        text-decoration: none;
     }
 }
 
@@ -1526,8 +1520,7 @@ div.focused_table {
         .search_closed {
             flex: 0; // makes sure search icon is always visible
             margin-left: auto; // aligns search icon to right end of box
-            margin-right: 40px;  // 27 = 15 (gets icon inside border) + 25 (margin against border)
-
+            margin-right: 15px;
             cursor: pointer;
             font-size: 20px;
 

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1371,6 +1371,20 @@ div.focused_table {
     border-left: 1px solid hsl(0, 0%, 88%);
 }
 
+
+.search_icon {
+    color: hsl(0, 0%, 80%);
+    text-decoration: none;
+    width: 0;
+    height: 0;
+    padding-top: 12px;
+    padding-left: 50px;
+    &:hover {
+        color: hsl(0, 0%, 0%);
+        text-decoration: none;
+    }
+}
+
 #tab_bar {
     width: 100%;
     z-index: 2;
@@ -1522,19 +1536,6 @@ div.focused_table {
                 padding: 5px 0px 0px 0px;
             }
         }
-    }
-}
-
-.search_icon {
-    color: hsl(0, 0%, 80%);
-    text-decoration: none;
-    width: 0;
-    height: 0;
-    padding-top: 12px;
-    padding-left: 50px;
-    &:hover {
-        color: hsl(0, 0%, 0%);
-        text-decoration: none;
     }
 }
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Made with support from Rohitt and Anders at: https://chat.zulip.org/#narrow/stream/101-design/topic/(from.20navbar.20redesign).20firefox.20search.20icon.20position.20breakage

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before:
![image](https://user-images.githubusercontent.com/33805964/79635792-a2832980-8190-11ea-9d78-23e3f29e85ad.png)
After:
![image](https://user-images.githubusercontent.com/33805964/79635816-c8103300-8190-11ea-9fe6-6010c03d2021.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
