### PR TITLE
base: Fix jinja2.exceptions.UndefinedError on Python ≥ 3.7

### DIFF
--- a/templates/zerver/base.html
+++ b/templates/zerver/base.html
@@ -34,7 +34,7 @@
         {% endblock %}
 
         {% set all_page_params = default_page_params.copy() %}
-        {% set _ = all_page_params.update(page_params) %}
+        {% set _ = all_page_params.update(page_params|default({})) %}
         <div hidden id="page-params" data-params='{{ all_page_params|tojson }}'></div>
     </body>
 


### PR DESCRIPTION
Python 3.7 changed `dict.update` to avoid swallowing exceptions when checking for the `keys` attribute (https://bugs.python.org/issue31572). This broke `{}.update(jinja2.Undefined())`.

Fix it with an explicit `default`.