### PR TITLE
upload: Include filename at the end of temporary access URLs.

### DIFF
--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -670,7 +670,9 @@ LOCAL_FILE_ACCESS_TOKEN_SALT = "local_file_"
 def generate_unauthed_file_access_url(path_id: str) -> str:
     signed_data = TimestampSigner(salt=LOCAL_FILE_ACCESS_TOKEN_SALT).sign(path_id)
     token = base64.b16encode(signed_data.encode('utf-8')).decode('utf-8')
-    return reverse('zerver.views.upload.serve_local_file_unauthed', args=[token, ])
+
+    filename = path_id.split('/')[-1]
+    return reverse('zerver.views.upload.serve_local_file_unauthed', args=[token, filename])
 
 def get_local_file_path_id_from_token(token: str) -> Optional[str]:
     signer = TimestampSigner(salt=LOCAL_FILE_ACCESS_TOKEN_SALT)

--- a/zerver/views/upload.py
+++ b/zerver/views/upload.py
@@ -82,10 +82,12 @@ def serve_file(request: HttpRequest, user_profile: UserProfile,
 
     return serve_s3(request, path_id, url_only)
 
-def serve_local_file_unauthed(request: HttpRequest, token: str) -> HttpResponse:
+def serve_local_file_unauthed(request: HttpRequest, token: str, filename: str) -> HttpResponse:
     path_id = get_local_file_path_id_from_token(token)
     if path_id is None:
         return json_error(_("Invalid token"))
+    if path_id.split('/')[-1] != filename:
+        return json_error(_("Invalid filename"))
 
     return serve_local(request, path_id, url_only=False)
 

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -593,7 +593,7 @@ urls += [
 # having to rewrite URLs, and is implemented using the
 # 'override_api_url_scheme' flag passed to rest_dispatch
 urls += [
-    url(r'^user_uploads/temporary/([0-9A-Za-z]+)$',
+    url(r'^user_uploads/temporary/([0-9A-Za-z]+)/([^/]+)$',
         zerver.views.upload.serve_local_file_unauthed,
         name='zerver.views.upload.serve_local_file_unauthed'),
     url(r'^user_uploads/(?P<realm_id_str>(\d*|unk))/(?P<filename>.*)$',


### PR DESCRIPTION
Requested in https://github.com/zulip/zulip/pull/14500#issuecomment-615332352