### PR TITLE
Add support for sending custom email to only the administrators

### DIFF
--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -295,7 +295,8 @@ def send_custom_email(users: List[UserProfile], options: Dict[str, Any]) -> None
     inline_template(email_filename)
 
     # Finally, we send the actual emails.
-    for user_profile in users:
+    for user_profile in filter(lambda user:
+                               not options.get('admins_only') or user.is_realm_admin, users):
         context = {
             'realm_uri': user_profile.realm.uri,
             'realm_name': user_profile.realm.name,

--- a/zerver/management/commands/send_custom_email.py
+++ b/zerver/management/commands/send_custom_email.py
@@ -32,6 +32,9 @@ class Command(ZulipBaseCommand):
         parser.add_argument('--reply-to',
                             type=str,
                             help='Optional reply-to line for the email')
+        parser.add_argument('--admins-only',
+                            help='Send only to administrators or a realm',
+                            action='store_true')
 
         self.add_user_list_args(parser,
                                 help="Email addresses of user(s) to send emails to.",


### PR DESCRIPTION
https://github.com/zulip/zulip/issues/13413

- [x]  Add an option --admins-only to support sending an email to only the administrators of a realm (or server).


**Testing Plan:**
Added unit test, manually tested `./manage.py send_custom_email` with and without new `--admins-only` flag.
