### PR TITLE
styles: Fix code block styling for Python-Markdown upgrade

### DIFF
--- a/static/styles/rendered_markdown.scss
+++ b/static/styles/rendered_markdown.scss
@@ -423,6 +423,11 @@ pre {
     padding-right: 7px;
 }
 
+.rendered_markdown pre code {
+    font-size: inherit;
+    padding: 0;
+}
+
 /* Ensure the horizontal scrollbar is visible on Mac */
 pre::-webkit-scrollbar {
     height: 8px;


### PR DESCRIPTION
It seems Python-Markdown now wraps code blocks in `<pre><code>`, not just `<pre>`.

Broken:

![before](https://user-images.githubusercontent.com/26471/79677107-7bcdee80-81a2-11ea-9689-492a7662a484.png)

Fixed:

![after](https://user-images.githubusercontent.com/26471/79677108-7d97b200-81a2-11ea-9e46-6bbff053f08d.png)