### PR TITLE
debug: Enable jquery-migrate plugin in development

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "difflib": "^0.2.4",
     "eslint": "^7.2.0",
     "eslint-plugin-empty-returns": "^1.0.2",
+    "jquery-migrate": "^3.3.0",
     "jsdom": "^16.1.0",
     "nyc": "^15.0.0",
     "phantomjs-prebuilt": "^2.1.16",

--- a/static/js/debug.js
+++ b/static/js/debug.js
@@ -11,6 +11,9 @@
     The file may still be accessible under other circumstances, so do
     not put sensitive information here. */
 
+import "jquery/dist/jquery.js";
+import "jquery-migrate";
+
 /*
       debug.print_elapsed_time("foo", foo)
 

--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -247,7 +247,7 @@ export default (env?: string): webpack.Configuration[] => {
     if (!production) {
         // Out JS debugging tools
         for (const paths of Object.values(assets)) {
-            paths.push('./static/js/debug.js');
+            paths.unshift('./static/js/debug.js');
         }
         config.devServer = {
             clientLogLevel: "error",

--- a/version.py
+++ b/version.py
@@ -44,4 +44,4 @@ API_FEATURE_LEVEL = 12
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '86.6'
+PROVISION_VERSION = '86.7'

--- a/yarn.lock
+++ b/yarn.lock
@@ -6986,6 +6986,11 @@ jquery-caret-plugin@^1.5.2:
   resolved "https://registry.yarnpkg.com/jquery-caret-plugin/-/jquery-caret-plugin-1.5.3.tgz#0c5513236883959bbef8da48ecc2307e8eb47516"
   integrity sha1-DFUTI2iDlZu++NpI7MIwfo60dRY=
 
+jquery-migrate@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/jquery-migrate/-/jquery-migrate-3.3.0.tgz#a8414c2be293460abe970a7a6beeb9c49fd7e5ad"
+  integrity sha512-9YhxHLmZZW3neoTw+MAbHV7geQYbnj4dnLuLphjbhDv/QKfxXNQ/pFoUjEsHNZnLH+k8pe+RFFBbORtwC2wzvA==
+
 jquery-validation@^1.19.0:
   version "1.19.2"
   resolved "https://registry.yarnpkg.com/jquery-validation/-/jquery-validation-1.19.2.tgz#c602831b0d8c5881400af424e872757ce241eff9"


### PR DESCRIPTION
This [plugin](https://github.com/jquery/jquery-migrate) warns us about our use of [deprecated jQuery features](https://github.com/jquery/jquery-migrate/blob/master/warnings.md) in the console. It turns out we have a lot of them.

```
JQMIGRATE: jQuery.fn.keydown() event shorthand is deprecated
JQMIGRATE: jQuery.fn.keypress() event shorthand is deprecated
JQMIGRATE: jQuery.fn.click() event shorthand is deprecated
JQMIGRATE: jQuery.fn.resize() event shorthand is deprecated
JQMIGRATE: jQuery.fn.bind() is deprecated
JQMIGRATE: jQuery.fn.scroll() event shorthand is deprecated
JQMIGRATE: jQuery.fn.focus() event shorthand is deprecated
JQMIGRATE: jQuery.fn.keyup() event shorthand is deprecated
JQMIGRATE: jQuery.fn.blur() event shorthand is deprecated
JQMIGRATE: jQuery.fn.focusout() event shorthand is deprecated
JQMIGRATE: jQuery.fn.change() event shorthand is deprecated
JQMIGRATE: jQuery.fn.hover() is deprecated
JQMIGRATE: jQuery.isArray is deprecated; use Array.isArray
JQMIGRATE: jQuery.fn.delegate() is deprecated
JQMIGRATE: jQuery.fn.removeAttr no longer sets boolean properties: disabled
```

Although the warnings are deduplicated, they’re still pretty spammy since each one comes with a traceback. So maybe we should make a pass at fixing them before merging this.