### PR TITLE
Upgrade libthumbor to latest release.

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -166,9 +166,8 @@ disposable-email-domains
 yamole
 
 # Needed for signing thumbnail requests so that they can be authenticated on the
-# other end.  Using a fork to eliminate a really slow pkgresources import:
-# https://github.com/thumbor/libthumbor/pull/37
-https://github.com/zulip/libthumbor/archive/60ed2431c07686a12f2770b2d852c5650f3ccfc6.zip#egg=libthumbor==1.3.2zulip
+# other end.
+libthumbor==2.0.1
 
 # Needed for string matching in AlertWordProcessor
 pyahocorasick

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -448,8 +448,9 @@ jsonschema==3.2.0 \
     --hash=sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163 \
     --hash=sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a \
     # via aws-sam-translator, cfn-lint
-https://github.com/zulip/libthumbor/archive/60ed2431c07686a12f2770b2d852c5650f3ccfc6.zip#egg=libthumbor==1.3.2zulip \
-    --hash=sha256:84e4a84b15ae13602c1560c58f5aef4faf33bb3ec568db987cce79371129baa8 \
+libthumbor==2.0.1 \
+    --hash=sha256:3c4e1a59c019d22f868d225315c06f97fad30fb5e78112d6a230b978e7d24e38 \
+    --hash=sha256:ed4fe5f27f8f90e7285b7e6dce99c1b67d43a140bf370e989080b43d80ce25f0 \
     # via -r requirements/common.in
 lp37==2.1.1 \
     --hash=sha256:a512cc0314c52c7b31e0aff4bc846867b2fd527ff6a2a626074639250713d73c \

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -294,8 +294,9 @@ jinja2==2.11.2 \
     --hash=sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0 \
     --hash=sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035 \
     # via -r requirements/common.in
-https://github.com/zulip/libthumbor/archive/60ed2431c07686a12f2770b2d852c5650f3ccfc6.zip#egg=libthumbor==1.3.2zulip \
-    --hash=sha256:84e4a84b15ae13602c1560c58f5aef4faf33bb3ec568db987cce79371129baa8 \
+libthumbor==2.0.1 \
+    --hash=sha256:3c4e1a59c019d22f868d225315c06f97fad30fb5e78112d6a230b978e7d24e38 \
+    --hash=sha256:ed4fe5f27f8f90e7285b7e6dce99c1b67d43a140bf370e989080b43d80ce25f0 \
     # via -r requirements/common.in
 lxml==4.5.0 \
     --hash=sha256:06d4e0bbb1d62e38ae6118406d7cdb4693a3fa34ee3762238bcb96c9e36a93cd \

--- a/version.py
+++ b/version.py
@@ -44,4 +44,4 @@ API_FEATURE_LEVEL = 1
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '79.2'
+PROVISION_VERSION = '79.3'


### PR DESCRIPTION
Branched out from #14278.

We need to drop Xenial CI suite and Travis before merging this.