### PR TITLE
dependencies: Patch spectrum-colorpicker for jQuery 3.5 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "sortablejs": "^1.9.0",
     "sorttable": "^1.0.2",
     "source-sans-pro": "^3.6.0",
-    "spectrum-colorpicker": "^1.8.0",
+    "spectrum-colorpicker": "https://github.com/andersk/spectrum.git#44dbe543919befc33e9160bf79f1395e8b9f6eb4",
     "stacktrace-gps": "^3.0.4",
     "style-loader": "^1.0.0",
     "terser-webpack-plugin": "^2.1.0",

--- a/version.py
+++ b/version.py
@@ -34,4 +34,4 @@ DESKTOP_WARNING_VERSION = "5.0.0"
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '79.0'
+PROVISION_VERSION = '79.1'

--- a/yarn.lock
+++ b/yarn.lock
@@ -10967,10 +10967,9 @@ specificity@^0.4.1:
   resolved "https://registry.yarnpkg.com/specificity/-/specificity-0.4.1.tgz#aab5e645012db08ba182e151165738d00887b019"
   integrity sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==
 
-spectrum-colorpicker@^1.8.0:
+"spectrum-colorpicker@https://github.com/andersk/spectrum.git#44dbe543919befc33e9160bf79f1395e8b9f6eb4":
   version "1.8.0"
-  resolved "https://registry.yarnpkg.com/spectrum-colorpicker/-/spectrum-colorpicker-1.8.0.tgz#b926cf5002c0a77860b5f8351e1c093c65200107"
-  integrity sha1-uSbPUALAp3hgtfg1HhwJPGUgAQc=
+  resolved "https://github.com/andersk/spectrum.git#44dbe543919befc33e9160bf79f1395e8b9f6eb4"
 
 split-polygon@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
See bgrins/spectrum#556.

**Testing Plan:** Dev server.