### PR TITLE
Adds usage of i18next's pluralization functionality (issue #1286)

### DIFF
--- a/docs/translating/internationalization.md
+++ b/docs/translating/internationalization.md
@@ -221,6 +221,9 @@ i18n.t('keyWithCount', {count: 5}); // output: '5 items'
 i18n.t('keyWithCount', {count: 100}); // output: '100 items'
 ```
 
+For examples of tested usages of plurals with different language codes and
+translation data, refer to `frontend_tests/node_tests/i18n.js`.
+
 For further reading on plurals, read the [official] documentation.
 
 By default, all text is escaped by i18next. To unescape a text you can use

--- a/frontend_tests/node_tests/i18n.js
+++ b/frontend_tests/node_tests/i18n.js
@@ -60,3 +60,84 @@ run_test('tr_tag', () => {
     const html = require('../../static/templates/settings_tab.hbs')(args);
     assert(html.indexOf('Some French text') > 0);
 });
+
+
+
+/* =================== PLURALIZATION =================== */
+
+// Plurals for three language codes are tested here
+// with the i18next library: 'en', 'fr', and 'ar'
+
+// Test for 'en' language code plural translations
+run_test('en_pluralization_test', () => {
+    // i18n 'en' setup: stubbing resource file's translation data and changing language
+    i18n.addResourceBundle('en', 'translation', {
+        key: 'hello world',
+        interpolate: 'value is __val__',
+        child: '__count__ child',
+        child_plural: '__count__ children',
+        'Users can now edit topics for all their messages, and the content of messages which are less than __count__ minutes old.': 'Users can now edit topics for all their messages, and the content of messages which are less than __count__ minute old.',
+        'Users can now edit topics for all their messages, and the content of messages which are less than __count__ minutes old._plural': 'Users can now edit topics for all their messages, and the content of messages which are less than __count__ minutes old.',
+    });
+    i18n.changeLanguage('en');
+    assert.equal(i18n.language, 'en');
+
+    // testing translations
+    assert.equal(i18n.t('key'), 'hello world'); // basic test
+    assert.equal(i18n.t('interpolate', {val: 10}), 'value is 10'); // basic test
+    assert.equal(i18n.t('child', {count: 0}), '0 children');
+    assert.equal(i18n.t('child', {count: 1}), '1 child');
+    assert.equal(i18n.t('child', {count: 2}), '2 children');
+    assert.equal(i18n.t('child', {count: 100}), '100 children');
+
+    // testing the proposed key in https://github.com/zulip/zulip/issues/1286
+    assert.equal(i18n.t('Users can now edit topics for all their messages, and the content of messages which are less than __count__ minutes old.', {count: 0}), 'Users can now edit topics for all their messages, and the content of messages which are less than 0 minutes old.'); // plural 'minutes' used for count of 0
+    assert.equal(i18n.t('Users can now edit topics for all their messages, and the content of messages which are less than __count__ minutes old.', {count: 1}), 'Users can now edit topics for all their messages, and the content of messages which are less than 1 minute old.'); // singular 'minute' used for count of 1
+    assert.equal(i18n.t('Users can now edit topics for all their messages, and the content of messages which are less than __count__ minutes old.', {count: 2}), 'Users can now edit topics for all their messages, and the content of messages which are less than 2 minutes old.');
+    assert.equal(i18n.t('Users can now edit topics for all their messages, and the content of messages which are less than __count__ minutes old.', {count: 100}), 'Users can now edit topics for all their messages, and the content of messages which are less than 100 minutes old.');
+});
+
+
+// Test for 'fr' language code plural translations
+run_test('fr_pluralization_test', () => {
+    // i18n 'fr' setup: stubbing resource file's translation data and changing language
+    i18n.addResourceBundle('fr', 'translation', {
+        enfant: '__count__ enfant',
+        enfant_plural: '__count__ enfants',
+    });
+    i18n.changeLanguage('fr');
+    assert.equal(i18n.language, 'fr');
+
+    // testing translations
+    assert.equal(i18n.t('enfant', {count: 0}), '0 enfant'); // 'fr' uses singular key for a count of 0, unlike 'en'
+    assert.equal(i18n.t('enfant', {count: 1}), '1 enfant');
+    assert.equal(i18n.t('enfant', {count: 2}), '2 enfants');
+    assert.equal(i18n.t('enfant', {count: 10}), '10 enfants');
+});
+
+
+// Test for 'ar' language code plural translations
+run_test('ar_pluralization_test', () => {
+    // i18n 'en' setup: stubbing resource file's translation data and changing language
+    i18n.addResourceBundle('ar', 'translation', {
+        key_0: 'zero',
+        key_1: 'singular',
+        key_2: 'two',
+        key_3: 'few',
+        key_4: 'many',
+        key_5: 'other',
+    });
+    i18n.changeLanguage('ar');
+    assert.equal(i18n.language, 'ar');
+
+    // testing translations
+    assert.equal(i18n.t('key', {count: 0}), 'zero');
+    assert.equal(i18n.t('key', {count: 1}), 'singular');
+    assert.equal(i18n.t('key', {count: 2}), 'two');
+    assert.equal(i18n.t('key', {count: 3}), 'few');
+    assert.equal(i18n.t('key', {count: 4}), 'few');
+    assert.equal(i18n.t('key', {count: 5}), 'few');
+    assert.equal(i18n.t('key', {count: 11}), 'many');
+    assert.equal(i18n.t('key', {count: 99}), 'many');
+    assert.equal(i18n.t('key', {count: 100}), 'other');
+});


### PR DESCRIPTION
Issue #1286: Modified i18n.js node test to work with i18next's pluralization functionality and updated the internationalization docs.

Testing: Added code in the i18n.js front-end node test, which is passing.

Collaborated with @rohanpra.