### PR TITLE
design: Make copy text button clickable again.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -390,6 +390,10 @@ li,
     left: -5px;
     margin-top: -24px;
     display: block;
+    /* The z-index here ensures that the copy-message
+    icon is clickable and is needed because of reduced
+    opacity of readonly textarea */
+    z-index: 2;
 }
 
 #clipboard_image {


### PR DESCRIPTION
Due to added opacity of 0.5 through the readonly property, the button
for copy and close was not clickable. Increasing z-index of the button
solves it.