### PR TITLE
Added notification for user profile display

### DIFF
--- a/static/templates/me_message.hbs
+++ b/static/templates/me_message.hbs
@@ -1,3 +1,10 @@
+{{!--
+This code contains modifications by another contributor: see Issue #13575.
+Although the mouse hover and shortcut work, there is an issue with the user profile.
+The shorcut description now replaces the user's avatar when the shortcut is used.
+--}}
+
+
 <span class="message_sender no-select">
     <span class="sender_info_hover">
         {{> message_avatar}}

--- a/static/templates/me_message.hbs
+++ b/static/templates/me_message.hbs
@@ -6,12 +6,12 @@ The shorcut description now replaces the user's avatar when the shortcut is used
 
 
 <span class="message_sender no-select">
-    <span class="sender_info_hover">
+    <span class="sender_info_hover" title="{{t 'User profile' }} (u)">
         {{> message_avatar}}
     </span>
 
     <span class="sender-status">
-        <span class="sender_info_hover sender_name-in-status auto-select" role="button" tabindex="0">{{msg/sender_full_name}}</span>
+        <span class="sender_info_hover sender_name-in-status auto-select" title="{{t 'User profile' }} (u)" role="button" tabindex="0">{{msg/sender_full_name}}</span>
         {{#if sender_is_bot}}
         <i class="zulip-icon bot" aria-label="{{t 'Bot' }}"></i>
         {{/if}}

--- a/static/templates/me_message.hbs
+++ b/static/templates/me_message.hbs
@@ -1,17 +1,10 @@
-{{!--
-This code contains modifications by another contributor: see Issue #13575.
-Although the mouse hover and shortcut work, there is an issue with the user profile.
-The shorcut description now replaces the user's avatar when the shortcut is used.
---}}
-
-
 <span class="message_sender no-select">
-    <span class="sender_info_hover" title="{{t 'User profile' }} (u)">
+    <span class="sender_info_hover">
         {{> message_avatar}}
     </span>
 
     <span class="sender-status">
-        <span class="sender_info_hover sender_name-in-status auto-select" title="{{t 'User profile' }} (u)" role="button" tabindex="0">{{msg/sender_full_name}}</span>
+        <span class="sender_info_hover sender_name-in-status auto-select" role="button" tabindex="0">{{msg/sender_full_name}}</span>
         {{#if sender_is_bot}}
         <i class="zulip-icon bot" aria-label="{{t 'Bot' }}"></i>
         {{/if}}

--- a/static/templates/message_body.hbs
+++ b/static/templates/message_body.hbs
@@ -1,22 +1,15 @@
-{{!--
-This code contains modifications by another contributor: see Issue #13575.
-Although the mouse hover and shortcut works, there is now an issue with the user profile.
-The shorcut description now replaces the user's avatar.
---}}
-
-
 <div class="message_top_line">
     {{#unless status_message}}
-    <span class="message_sender sender_info_hover no-select"  title="{{t 'User profile' }} (u)">
+    <span class="message_sender sender_info_hover no-select" >
         {{#if include_sender}}
-
+            <span title="{{t 'View user profile' }} (u)">
             {{> message_avatar}}
 
             <span class="sender_name auto-select" role="button" tabindex="0">{{msg/sender_full_name}}</span>
             {{#if sender_is_bot}}
             <i class="zulip-icon bot" aria-label="{{t 'Bot' }}"></i>
             {{/if}}
-
+          </span>
         {{/if}}
     </span>
     {{/unless}}

--- a/static/templates/message_body.hbs
+++ b/static/templates/message_body.hbs
@@ -1,6 +1,13 @@
+{{!--
+This code contains modifications by another contributor: see Issue #13575.
+Although the mouse hover and shortcut works, there is now an issue with the user profile.
+The shorcut description now replaces the user's avatar.
+--}}
+
+
 <div class="message_top_line">
     {{#unless status_message}}
-    <span class="message_sender sender_info_hover no-select">
+    <span class="message_sender sender_info_hover no-select"  title="{{t 'User profile' }} (u)">
         {{#if include_sender}}
 
             {{> message_avatar}}


### PR DESCRIPTION
Modified message_body.hbs file to display user profile (u) shortcut by adding span tag with title only under the span class message_sender sender_info_hover no-select . Issues mentioned in https://github.com/zulip/zulip/pull/12778/files#r303213836 and https://github.com/zulip/zulip/pull/12778/files#r303213844 do not occur because we did not modify the me_message.hbs file. Adding the title to sender_info_hover of this file breaks the me message popover -- i.e. the title replaces the user's avatar.
Fixes: #12769, #13575, and #14225