### PR TITLE
composebox_typeahead: Properly populate stream topic data for message edits.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -620,6 +620,9 @@ run_test('initialize', () => {
         assert.deepEqual(actual_value, expected_value);
 
         subject_typeahead_called = true;
+
+        // Unset the stream name.
+        $('#stream_message_recipient_stream').val('');
     };
 
     let pm_recipient_typeahead_called = false;
@@ -631,8 +634,8 @@ run_test('initialize', () => {
 
         // This should match the users added at the beginning of this test file.
         let actual_value = options.source('');
-        let expected_value = [alice, hamlet, othello, cordelia, lear,
-                              twin1, twin2, gael, hal, harry,
+        let expected_value = [alice, cordelia, hal, gael, harry,
+                              hamlet, lear, twin1, twin2, othello,
                               hamletcharacters, backend, call_center];
         assert.deepEqual(actual_value, expected_value);
 
@@ -715,7 +718,7 @@ run_test('initialize', () => {
         // A literal match at the beginning of an element puts it at the top.
         query = 'co';  // Matches everything ("x@zulip.COm")
         actual_value = sorter(query, [othello, deactivated_user, cordelia]);
-        expected_value = [cordelia, othello, deactivated_user];
+        expected_value = [cordelia, deactivated_user, othello];
         assert.deepEqual(actual_value, expected_value);
 
         query = 'non-existing-user';

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -806,6 +806,7 @@ run_test('initialize', () => {
             caret_called = true;
             return 7;
         };
+        fake_this.$element.closest = () => [];
         fake_this.options = options;
         let actual_value = options.source.call(fake_this, 'test #s');
         assert.deepEqual(

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -406,11 +406,12 @@ exports.slash_commands = [
     },
 ];
 
-exports.filter_and_sort_mentions = function (is_silent, query) {
-    const opts = {
+exports.filter_and_sort_mentions = function (is_silent, query, opts) {
+    opts = {
         want_broadcast: !is_silent,
         want_groups: !is_silent,
         filter_pills: false,
+        ...opts,
     };
     return exports.get_person_suggestions(query, opts);
 };
@@ -501,11 +502,28 @@ exports.get_person_suggestions = function (query, opts) {
     return typeahead_helper.sort_recipients(
         filtered_persons,
         query,
-        compose_state.stream_name(),
-        compose_state.topic(),
+        opts.stream,
+        opts.topic,
         filtered_groups,
         exports.max_num_items
     );
+};
+
+exports.get_stream_topic_data = (hacky_this) => {
+    const opts = {};
+    const message_row = hacky_this.$element.closest(".message_row");
+    if (message_row.length === 1) {
+        // we are editting a message so we try to use it's keys.
+        const msg = message_store.get(rows.id(message_row));
+        if (msg.type === 'stream') {
+            opts.stream = msg.stream;
+            opts.topic = msg.topic;
+        }
+    } else {
+        opts.stream = compose_state.stream_name();
+        opts.topic = compose_state.topic();
+    }
+    return opts;
 };
 
 exports.get_sorted_filtered_items = function (query) {
@@ -545,9 +563,11 @@ exports.get_sorted_filtered_items = function (query) {
     const completing = hacky_this.completing;
     const token = hacky_this.token;
 
+    const opts = exports.get_stream_topic_data(hacky_this);
+
     if (completing === 'mention' || completing === 'silent_mention') {
         return exports.filter_and_sort_mentions(
-            big_results.is_silent, token);
+            big_results.is_silent, token, opts);
     }
 
     return exports.filter_and_sort_candidates(completing, big_results, token);


### PR DESCRIPTION
Previously, we would always pick up the stream and topic name from
compose_state. This would work for message edits as well when the
composebox was open.

Now, if we are in a message edit, we get the stream and topic of the
message being edited before falling back on trying to populate using
the composebox state.

Fixes #14545.