### PR TITLE
Blueslip Refactor

### DIFF
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -159,7 +159,6 @@ run_test('get_status', () => {
 run_test('reload_defaults', () => {
     blueslip.expect('warn', 'get_filter_text() is called before initialization');
     assert.equal(activity.get_filter_text(), '');
-    blueslip.reset();
 });
 
 run_test('sort_users', () => {

--- a/frontend_tests/node_tests/channel.js
+++ b/frontend_tests/node_tests/channel.js
@@ -254,6 +254,7 @@ run_test('retry', () => {
                 f();
             });
 
+            blueslip.expect('log', 'Retrying idempotent[object Object]');
             test_with_mock_ajax({
                 run_code: function () {
                     options.simulate_success();
@@ -263,8 +264,6 @@ run_test('retry', () => {
                     assert.equal(options.data, 42);
                 },
             });
-
-            assert.equal(blueslip.get_test_logs('log')[0].message, 'Retrying idempotent[object Object]');
             blueslip.reset();
         },
     });

--- a/frontend_tests/node_tests/channel.js
+++ b/frontend_tests/node_tests/channel.js
@@ -234,7 +234,6 @@ run_test('unexpected_403_response', () => {
         check_ajax_options: function (options) {
             blueslip.expect('error', 'Unexpected 403 response from server');
             options.simulate_error();
-            blueslip.reset();
         },
     });
 });
@@ -264,7 +263,6 @@ run_test('retry', () => {
                     assert.equal(options.data, 42);
                 },
             });
-            blueslip.reset();
         },
     });
 });
@@ -281,7 +279,6 @@ run_test('too_many_pending', () => {
     _.times(50, function () {
         channel.post({});
     });
-    blueslip.reset();
 });
 
 run_test('xhr_error_message', () => {

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1299,7 +1299,6 @@ run_test('on_events', () => {
         assert(!helper.container_was_removed());
         assert(!$("#compose_invite_users").visible());
         assert.equal($('#compose-error-msg').html(), "Stream no longer exists: no-stream");
-        blueslip.reset();
 
         // !sub will result in true here and we check the success code path.
         stream_data.add_sub(subscription);

--- a/frontend_tests/node_tests/emoji.js
+++ b/frontend_tests/node_tests/emoji.js
@@ -46,7 +46,6 @@ run_test('get_canonical_name', () => {
 
     blueslip.expect('error', 'Invalid emoji name: non_existent');
     emoji.get_canonical_name('non_existent');
-    blueslip.reset();
 });
 
 function set_up_spain_realm_emoji_for_test() {

--- a/frontend_tests/node_tests/fold_dict.js
+++ b/frontend_tests/node_tests/fold_dict.js
@@ -88,7 +88,5 @@ run_test('undefined_keys', () => {
 
     assert.equal(d.has(undefined), false);
     assert.strictEqual(d.get(undefined), undefined);
-
-    blueslip.reset();
 });
 

--- a/frontend_tests/node_tests/fold_dict.js
+++ b/frontend_tests/node_tests/fold_dict.js
@@ -82,13 +82,12 @@ run_test('clear', () => {
 });
 
 run_test('undefined_keys', () => {
-    blueslip.expect('error', 'Tried to call a FoldDict method with an undefined key.');
+    blueslip.expect('error', 'Tried to call a FoldDict method with an undefined key.', 2);
 
     const d = new FoldDict();
 
     assert.equal(d.has(undefined), false);
     assert.strictEqual(d.get(undefined), undefined);
-    assert.equal(blueslip.get_test_logs('error').length, 2);
 
     blueslip.reset();
 });

--- a/frontend_tests/node_tests/hashchange.js
+++ b/frontend_tests/node_tests/hashchange.js
@@ -300,7 +300,6 @@ run_test('save_narrow', () => {
 
     blueslip.expect('warn', 'browser does not support pushState');
     hashchange.save_narrow(operators);
-    blueslip.reset();
 
     helper.assert_events([
         'message_viewport.stop_auto_scrolling',

--- a/frontend_tests/node_tests/input_pill.js
+++ b/frontend_tests/node_tests/input_pill.js
@@ -51,7 +51,6 @@ run_test('basics', () => {
 
     blueslip.expect('error', 'Pill needs container.');
     input_pill.create(config);
-    blueslip.reset();
 
     const pill_input = $.create('pill_input');
     const container = $.create('container');
@@ -60,12 +59,10 @@ run_test('basics', () => {
     blueslip.expect('error', 'Pill needs create_item_from_text');
     config.container = container;
     input_pill.create(config);
-    blueslip.reset();
 
     blueslip.expect('error', 'Pill needs get_text_from_item');
     config.create_item_from_text = noop;
     input_pill.create(config);
-    blueslip.reset();
 
     config.get_text_from_item = noop;
     const widget = input_pill.create(config);

--- a/frontend_tests/node_tests/lazy_set.js
+++ b/frontend_tests/node_tests/lazy_set.js
@@ -19,5 +19,4 @@ run_test('conversions', () => {
     const ls = new LazySet([1, 2]);
     ls.add('3');
     assert(ls.has('3'));
-    blueslip.reset();
 });

--- a/frontend_tests/node_tests/lazy_set.js
+++ b/frontend_tests/node_tests/lazy_set.js
@@ -15,8 +15,9 @@ run_test('map', () => {
 });
 
 run_test('conversions', () => {
-    blueslip.expect('error', 'not a number');
+    blueslip.expect('error', 'not a number', 2);
     const ls = new LazySet([1, 2]);
     ls.add('3');
     assert(ls.has('3'));
+    blueslip.reset();
 });

--- a/frontend_tests/node_tests/list_cursor.js
+++ b/frontend_tests/node_tests/list_cursor.js
@@ -43,7 +43,6 @@ run_test('misc errors', () => {
     blueslip.expect('error', 'Cannot highlight key for list_cursor: nada');
     cursor.go_to('nada');
 
-    blueslip.reset();
     cursor.prev();
     cursor.next();
 });
@@ -68,7 +67,6 @@ run_test('single item list', () => {
 
     // Test prev/next, which should just silently do nothing.
     // (Our basic_conf() has prev_key and next_key return undefined.)
-    blueslip.reset();
     cursor.prev();
     cursor.next();
 

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -583,7 +583,6 @@ run_test('python_to_js_filter', () => {
     actual_value = marked.InlineLexer.rules.zulip.realm_filters;
     expected_value = [];
     assert.deepEqual(actual_value, expected_value);
-    blueslip.reset();
 });
 
 run_test('katex_throws_unexpected_exceptions', () => {
@@ -591,7 +590,6 @@ run_test('katex_throws_unexpected_exceptions', () => {
     blueslip.expect('error', 'Error: some-exception');
     const message = { raw_content: '$$a$$' };
     markdown.apply_markdown(message);
-    blueslip.reset();
 });
 
 run_test('misc_helpers', () => {

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -101,7 +101,6 @@ run_test('add_message_metadata', () => {
 
     blueslip.expect('error', 'message_store got non-number: 2067');
     retrieved_message = message_store.get('2067');
-    blueslip.reset();
     assert.equal(retrieved_message, message);
 
     // access cached previous message, and test match subject/content
@@ -196,8 +195,6 @@ run_test('errors', () => {
 
     const names = message_store.get_pm_full_names(message);
     assert.equal(names, '?');
-
-    blueslip.reset();
 
     message = {
         type: 'stream',
@@ -304,5 +301,4 @@ run_test('message_id_change', () => {
 run_test('errors', () => {
     blueslip.expect('error', 'message_store.get got bad value: undefined');
     message_store.get(undefined);
-    blueslip.reset();
 });

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -186,18 +186,16 @@ run_test('errors', () => {
         display_recipient: [{id: 92714}],
     };
 
-    blueslip.expect('error', 'Unknown user_id in get_by_user_id: 92714');
-    blueslip.expect('error', 'Unknown user id 92714'); // From person.js
+    blueslip.expect('error', 'Unknown user_id in get_by_user_id: 92714', 2);
+    blueslip.expect('error', 'Unknown user id 92714', 2); // From person.js
 
     // Expect each to throw two blueslip errors
     // One from message_store.js, one from person.js
     const emails = message_store.get_pm_emails(message);
     assert.equal(emails, '?');
-    assert.equal(blueslip.get_test_logs('error').length, 2);
 
     const names = message_store.get_pm_full_names(message);
     assert.equal(names, '?');
-    assert.equal(blueslip.get_test_logs('error').length, 4);
 
     blueslip.reset();
 

--- a/frontend_tests/node_tests/muting.js
+++ b/frontend_tests/node_tests/muting.js
@@ -77,7 +77,6 @@ run_test('get_and_set_muted_topics', () => {
     ];
     muting.initialize();
 
-    blueslip.reset();
 
     assert.deepEqual(muting.get_muted_topics().sort(), [
         [design.stream_id, 'typography'],

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -155,7 +155,6 @@ run_test('basics', () => {
     // Invalid user ID returns false and warns.
     blueslip.expect('warn', 'Unexpectedly invalid user_id in user popover query: 123412');
     assert.equal(people.is_active_user_for_popover(123412), false);
-    blueslip.reset();
 
     // We can still get their info for non-realm needs.
     person = people.get_by_email(email);
@@ -807,7 +806,6 @@ run_test('updates', () => {
                     'FOO@example.com new email = bar@example.com');
     person = people.get_by_email(old_email);
     assert.equal(person.user_id, user_id);
-    blueslip.reset();
 });
 
 initialize();
@@ -912,7 +910,6 @@ run_test('track_duplicate_full_names', () => {
 
     blueslip.expect('warn', 'get_mention_syntax called without user_id.');
     assert.equal(people.get_mention_syntax('Stephen King'), '@**Stephen King**');
-    blueslip.reset();
     assert.equal(people.get_mention_syntax('Stephen King', 601), '@**Stephen King|601**');
     assert.equal(people.get_mention_syntax('Stephen King', 602), '@**Stephen King|602**');
     assert.equal(people.get_mention_syntax('Maria Athens', 603), '@**Maria Athens**');
@@ -1058,5 +1055,4 @@ run_test('emails_strings_to_user_ids_array', function () {
     blueslip.expect('warn', 'Unknown emails: dummyuser@example.com');
     user_ids = people.emails_strings_to_user_ids_array('dummyuser@example.com');
     assert.equal(user_ids, undefined);
-    blueslip.reset();
 });

--- a/frontend_tests/node_tests/people_errors.js
+++ b/frontend_tests/node_tests/people_errors.js
@@ -81,12 +81,11 @@ run_test('blueslip', () => {
         display_recipient: [],
         sender_id: me.user_id,
     };
-    blueslip.expect('error', 'Empty recipient list in message');
+    blueslip.expect('error', 'Empty recipient list in message', 4);
     people.pm_with_user_ids(message);
     people.group_pm_with_user_ids(message);
     people.all_user_ids_in_pm(message);
     assert.equal(people.pm_perma_link(message), undefined);
-    assert.equal(blueslip.get_test_logs('error').length, 4);
     blueslip.reset();
 
     const charles = {

--- a/frontend_tests/node_tests/people_errors.js
+++ b/frontend_tests/node_tests/people_errors.js
@@ -22,9 +22,9 @@ run_test('report_late_add', () => {
     people.report_late_add(55, 'foo@example.com');
     blueslip.reset();
 
+    blueslip.expect('log', 'Added user late: user_id=55 email=foo@example.com');
     reload_state.is_in_progress = return_true;
     people.report_late_add(55, 'foo@example.com');
-    assert.equal(blueslip.get_test_logs('log')[0].message, 'Added user late: user_id=55 email=foo@example.com');
     blueslip.reset();
 });
 
@@ -36,7 +36,7 @@ run_test('is_my_user_id', () => {
     blueslip.expect('error', 'user_id is a string in my_user_id: 30');
     assert.equal(people.is_my_user_id(me.user_id.toString()), true);
 
-    assert.equal(blueslip.get_test_logs('error').length, 2);
+    blueslip.reset();
 });
 
 run_test('blueslip', () => {

--- a/frontend_tests/node_tests/people_errors.js
+++ b/frontend_tests/node_tests/people_errors.js
@@ -20,23 +20,18 @@ people.initialize_current_user(me.user_id);
 run_test('report_late_add', () => {
     blueslip.expect('error', 'Added user late: user_id=55 email=foo@example.com');
     people.report_late_add(55, 'foo@example.com');
-    blueslip.reset();
 
     blueslip.expect('log', 'Added user late: user_id=55 email=foo@example.com');
     reload_state.is_in_progress = return_true;
     people.report_late_add(55, 'foo@example.com');
-    blueslip.reset();
 });
 
 run_test('is_my_user_id', () => {
-    blueslip.reset();
     blueslip.expect('error', 'user_id is a string in my_user_id: 999');
     assert.equal(people.is_my_user_id('999'), false);
 
     blueslip.expect('error', 'user_id is a string in my_user_id: 30');
     assert.equal(people.is_my_user_id(me.user_id.toString()), true);
-
-    blueslip.reset();
 });
 
 run_test('blueslip', () => {
@@ -44,15 +39,12 @@ run_test('blueslip', () => {
 
     blueslip.expect('debug', 'User email operand unknown: ' + unknown_email);
     people.id_matches_email_operand(42, unknown_email);
-    blueslip.reset();
 
     blueslip.expect('error', 'Unknown user_id: 9999');
     people.get_actual_name_from_user_id(9999);
-    blueslip.reset();
 
     blueslip.expect('error', 'Unknown email for get_user_id: ' + unknown_email);
     people.get_user_id(unknown_email);
-    blueslip.reset();
 
     blueslip.expect('warn', 'No user_id provided for person@example.com');
     const person = {
@@ -61,20 +53,16 @@ run_test('blueslip', () => {
         full_name: 'Person Person',
     };
     people.add(person);
-    blueslip.reset();
 
     blueslip.expect('error', 'No user_id found for person@example.com');
     const user_id = people.get_user_id('person@example.com');
     assert.equal(user_id, undefined);
-    blueslip.reset();
 
     blueslip.expect('warn', 'Unknown user ids: 1,2');
     people.user_ids_string_to_emails_string('1,2');
-    blueslip.reset();
 
     blueslip.expect('warn', 'Unknown emails: ' + unknown_email);
     people.email_list_to_user_ids_string([unknown_email]);
-    blueslip.reset();
 
     let message = {
         type: 'private',
@@ -86,7 +74,6 @@ run_test('blueslip', () => {
     people.group_pm_with_user_ids(message);
     people.all_user_ids_in_pm(message);
     assert.equal(people.pm_perma_link(message), undefined);
-    blueslip.reset();
 
     const charles = {
         email: 'charles@example.com',
@@ -114,14 +101,12 @@ run_test('blueslip', () => {
     blueslip.expect('error', 'Unknown user id in message: 42');
     const reply_to = people.pm_reply_to(message);
     assert(reply_to.includes('?'));
-    blueslip.reset();
 
     people.pm_with_user_ids = function () { return [42]; };
     people.get_by_user_id = function () { return; };
     blueslip.expect('error', 'Unknown people in message');
     const uri = people.pm_with_url({});
     assert.equal(uri.indexOf('unk'), uri.length - 3);
-    blueslip.reset();
 
     blueslip.expect('error', 'Undefined field id');
     assert.equal(people.my_custom_profile_data(undefined), undefined);

--- a/frontend_tests/node_tests/poll_widget.js
+++ b/frontend_tests/node_tests/poll_widget.js
@@ -92,7 +92,6 @@ run_test('poll_data_holder my question', () => {
     blueslip.expect('warn', `unknown key for poll: ${invalid_vote_event.key}`);
     data_holder.handle_event(sender_id, invalid_vote_event);
     data = data_holder.get_widget_data();
-    blueslip.reset();
 
     const option_outbound_event = data_holder.handle.new_option.outbound('new option');
     assert.deepEqual(option_outbound_event, {

--- a/frontend_tests/node_tests/presence.js
+++ b/frontend_tests/node_tests/presence.js
@@ -68,7 +68,6 @@ run_test('unknown user', () => {
 
     blueslip.expect('error', 'Unknown user ID in presence data: 999');
     presence.set_info(presences, now);
-    blueslip.reset();
 
     // If the server is suspected to be offline or reloading,
     // then we suppress errors.  The use case here is that we

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -136,7 +136,6 @@ run_test('basics', () => {
     blueslip.expect('warn', 'Unknown user_id 8888 in reaction for message 1001');
     blueslip.expect('warn', 'Unknown user_id 9999 in reaction for message 1001');
     const result = reactions.get_message_reactions(message);
-    blueslip.reset();
     assert(reactions.current_user_has_reacted_to_emoji(message, 'unicode_emoji,263a'));
     assert(!reactions.current_user_has_reacted_to_emoji(message, 'bogus'));
 
@@ -209,7 +208,6 @@ run_test('sending', () => {
         blueslip.expect('warn', 'XHR Error Message.');
         global.channel.xhr_error_message = function () {return 'XHR Error Message.';};
         args.error();
-        blueslip.reset();
     });
     emoji_name = 'alien'; // not set yet
     global.with_stub(function (stub) {
@@ -257,7 +255,6 @@ run_test('sending', () => {
     emoji_name = 'unknown-emoji';   // Test sending an emoji unknown to frontend.
     blueslip.expect('warn', 'Bad emoji name: ' + emoji_name);
     reactions.toggle_emoji_reaction(message_id, emoji_name);
-    blueslip.reset();
     reactions.add_reaction = orig_add_reaction;
     reactions.remove_reaction = orig_remove_reaction;
 });
@@ -639,7 +636,6 @@ run_test('error_handling', () => {
     reactions.current_user_has_reacted_to_emoji = function () { return true; };
     reactions.toggle_emoji_reaction(55, bogus_event.emoji_name);
     reactions.current_user_has_reacted_to_emoji = original_func;
-    blueslip.reset();
 
     reactions.add_reaction(bogus_event);
 
@@ -763,7 +759,6 @@ run_test('duplicates', () => {
         ],
     };
 
-    blueslip.reset();
     blueslip.expect(
         'error',
         'server sent duplicate reactions for user 5 (key=unicode_emoji,263a)');
@@ -772,13 +767,11 @@ run_test('duplicates', () => {
 
 run_test('process_reaction_click errors', () => {
     global.message_store.get = () => undefined;
-    blueslip.reset();
     blueslip.expect('error', 'reactions: Bad message id: 55');
     blueslip.expect('error', 'message_id for reaction click is unknown: 55');
     reactions.process_reaction_click(55, 'whatever');
 
     global.message_store.get = () => message;
-    blueslip.reset();
     blueslip.expect('error', 'Data integrity problem for reaction bad-local-id (message some-msg-id)');
     reactions.process_reaction_click('some-msg-id', 'bad-local-id');
 });

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -136,7 +136,6 @@ run_test('basics', () => {
     blueslip.expect('warn', 'Unknown user_id 8888 in reaction for message 1001');
     blueslip.expect('warn', 'Unknown user_id 9999 in reaction for message 1001');
     const result = reactions.get_message_reactions(message);
-    assert.equal(blueslip.get_test_logs('warn').length, 2);
     blueslip.reset();
     assert(reactions.current_user_has_reacted_to_emoji(message, 'unicode_emoji,263a'));
     assert(!reactions.current_user_has_reacted_to_emoji(message, 'bogus'));

--- a/frontend_tests/node_tests/scroll_util.js
+++ b/frontend_tests/node_tests/scroll_util.js
@@ -110,6 +110,4 @@ run_test('get_list_scrolling_container error', () => {
     );
 
     scroll_util.get_list_scrolling_container(body);
-
-    blueslip.reset();
 });

--- a/frontend_tests/node_tests/server_events.js
+++ b/frontend_tests/node_tests/server_events.js
@@ -112,7 +112,6 @@ run_test('event_dispatch_error', () => {
     assert.equal(logs[0].more_info.event.op, 'update');
     assert.equal(logs[0].more_info.event.id, 1);
     assert.equal(logs[0].more_info.other, undefined);
-    blueslip.reset();
 });
 
 run_test('event_new_message_error', () => {
@@ -130,7 +129,6 @@ run_test('event_new_message_error', () => {
     const logs = blueslip.get_test_logs('error');
     assert.equal(logs.length, 1);
     assert.equal(logs[0].more_info, undefined);
-    blueslip.reset();
 });
 
 run_test('event_edit_message_error', () => {
@@ -146,5 +144,4 @@ run_test('event_edit_message_error', () => {
     const logs = blueslip.get_test_logs('error');
     assert.equal(logs.length, 1);
     assert.equal(logs[0].more_info, undefined);
-    blueslip.reset();
 });

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -320,7 +320,6 @@ run_test('populate_user_groups', () => {
     assert(user_groups_list_append_called);
     assert(get_by_user_id_called);
     assert(input_typeahead_called);
-    blueslip.reset();
     test_create_item(create_item_handler);
 
     // Tests for settings_user_groups.set_up workflow.

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -292,7 +292,7 @@ run_test('subscribers', () => {
 
     blueslip.expect(
         'warn',
-        'We got a is_user_subscribed call for a non-existent or inaccessible stream.');
+        'We got a is_user_subscribed call for a non-existent or inaccessible stream.', 2);
     sub.invite_only = true;
     stream_data.update_calculated_fields(sub);
     assert.equal(stream_data.is_user_subscribed('Rome', brutus.user_id), undefined);

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -310,7 +310,6 @@ run_test('subscribers', () => {
     blueslip.expect('error', 'We tried to add invalid subscriber: 9999999');
     ok = stream_data.add_subscriber('Rome', 9999999);
     assert(!ok);
-    blueslip.reset();
 });
 
 run_test('is_active', () => {
@@ -588,7 +587,6 @@ run_test('delete_sub', () => {
 
     blueslip.expect('warn', 'Failed to delete stream 99999');
     stream_data.delete_sub(99999);
-    blueslip.reset();
 });
 
 run_test('get_subscriber_count', () => {
@@ -601,7 +599,6 @@ run_test('get_subscriber_count', () => {
 
     blueslip.expect('warn', 'We got a get_subscriber_count count call for a non-existent stream.');
     assert.equal(stream_data.get_subscriber_count('India'), undefined);
-    blueslip.reset();
 
     stream_data.add_sub(india);
     assert.equal(stream_data.get_subscriber_count('India'), 0);

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -260,7 +260,6 @@ run_test('subscribers', () => {
     blueslip.expect('warn', 'We got a remove_subscriber call for a non-existent stream ' + bad_stream);
     ok = stream_data.remove_subscriber(bad_stream, brutus.user_id);
     assert(!ok);
-    assert.equal(blueslip.get_test_logs('warn').length, 2);
 
     // verify that removing an already-removed subscriber is a noop
     blueslip.expect('warn', 'We tried to remove invalid subscriber: 104');
@@ -311,7 +310,6 @@ run_test('subscribers', () => {
     blueslip.expect('error', 'We tried to add invalid subscriber: 9999999');
     ok = stream_data.add_subscriber('Rome', 9999999);
     assert(!ok);
-    assert.equal(blueslip.get_test_logs('error').length, 2);
     blueslip.reset();
 });
 

--- a/frontend_tests/node_tests/topic_generator.js
+++ b/frontend_tests/node_tests/topic_generator.js
@@ -180,7 +180,6 @@ run_test('fchain', () => {
     ints = tg.list_generator([29, 43]);
     gen = tg.fchain(ints, undef);
     gen.next();
-    blueslip.reset();
 });
 
 run_test('streams', () => {

--- a/frontend_tests/node_tests/transmit.js
+++ b/frontend_tests/node_tests/transmit.js
@@ -184,5 +184,4 @@ run_test('reply_message_errors', () => {
         message: bogus_message,
     });
 
-    blueslip.reset();
 });

--- a/frontend_tests/node_tests/user_events.js
+++ b/frontend_tests/node_tests/user_events.js
@@ -151,7 +151,6 @@ run_test('updates', () => {
     blueslip.expect('error', 'Got update_person event for unexpected user 29');
     blueslip.expect('error', 'Unknown user_id in get_by_user_id: 29');
     assert(!user_events.update_person({user_id: 29, full_name: 'Sir Isaac Newton'}));
-    blueslip.reset();
 
     me.profile_data = {};
     user_events.update_person({user_id: me.user_id, custom_profile_field: {id: 3, value: 'Value', rendered_value: '<p>Value</p>'}});

--- a/frontend_tests/node_tests/user_events.js
+++ b/frontend_tests/node_tests/user_events.js
@@ -151,7 +151,6 @@ run_test('updates', () => {
     blueslip.expect('error', 'Got update_person event for unexpected user 29');
     blueslip.expect('error', 'Unknown user_id in get_by_user_id: 29');
     assert(!user_events.update_person({user_id: 29, full_name: 'Sir Isaac Newton'}));
-    assert.equal(blueslip.get_test_logs('error').length, 2);
     blueslip.reset();
 
     me.profile_data = {};

--- a/frontend_tests/node_tests/user_groups.js
+++ b/frontend_tests/node_tests/user_groups.js
@@ -49,13 +49,11 @@ run_test('user_groups', () => {
 
     blueslip.expect('error', 'Unknown group_id in get_user_group_from_id: ' + all.id);
     assert.equal(user_groups.get_user_group_from_id(all.id), undefined);
-    blueslip.reset();
 
     user_groups.remove(students);
 
     blueslip.expect('error', 'Unknown group_id in get_user_group_from_id: ' + students.id);
     assert.equal(user_groups.get_user_group_from_id(students.id), undefined);
-    blueslip.reset();
 
     assert.equal(user_groups.get_user_group_from_name(all.name), undefined);
     assert.equal(user_groups.get_user_group_from_name(admins.name).id, 1);
@@ -89,5 +87,4 @@ run_test('user_groups', () => {
 
     blueslip.expect('error', 'Could not find user group with ID -1');
     assert.equal(user_groups.is_member_of(-1, 15), false);
-    blueslip.reset();
 });

--- a/frontend_tests/node_tests/user_status.js
+++ b/frontend_tests/node_tests/user_status.js
@@ -72,7 +72,7 @@ run_test('server', () => {
 });
 
 run_test('defensive checks', () => {
-    blueslip.expect('error', 'need ints for user_id');
+    blueslip.expect('error', 'need ints for user_id', 2);
     user_status.set_away('string');
     user_status.revoke_away('string');
 });

--- a/frontend_tests/node_tests/widgetize.js
+++ b/frontend_tests/node_tests/widgetize.js
@@ -136,7 +136,6 @@ run_test('activate', () => {
     assert(!is_widget_activated);
     assert(!is_event_handled);
     assert.equal(blueslip.get_test_logs('warn')[0].more_info, 'invalid_widget');
-    blueslip.reset();
 
     /* Testing widgetize.handle_events */
     const post_activate_event = {

--- a/frontend_tests/node_tests/zblueslip.js
+++ b/frontend_tests/node_tests/zblueslip.js
@@ -34,7 +34,7 @@ run_test('basics', () => {
     // zblueslip logs all the calls made to it, and they can be used in asserts like:
 
     // Now, let's add our error to the list of expected errors.
-    blueslip.expect('error', 'world');
+    blueslip.expect('error', 'world', 2);
     // This time, blueslip will just log the error, which is
     // being verified by the assert call on the length of the log.
     // We can also check for which specific error was logged, but since
@@ -42,13 +42,18 @@ run_test('basics', () => {
     // only that error could have been logged, and others would raise
     // an error, aborting the test.
     throw_an_error();
+    // The following check is redundant; blueslip.reset() already asserts that
+    // we got the expected number of errors.
     assert.equal(blueslip.get_test_logs('error').length, 2);
 
     // Let's clear the array of valid errors as well as the log. Now, all errors
     // should be thrown directly by blueslip.
     blueslip.reset();
     assert.throws(throw_an_error);
-    blueslip.reset();
+    // This call to blueslip.reset() would complain.
+    assert.throws(() => {
+        blueslip.reset();
+    });
 
     // Let's repeat the above procedue with warnings. Unlike errors,
     // warnings shouldn't stop the code execution, and thus, the
@@ -59,7 +64,14 @@ run_test('basics', () => {
     }
 
     assert.throws(throw_a_warning);
-    blueslip.reset();
+    // Again, we do not expect this particular warning so blueslip.reset should complain.
+    assert.throws(() => {
+        blueslip.reset();
+    });
+
+    // Let's reset blueslip regardless of errors. This is only for demonstration
+    // purposes here; do not reset blueslip like this in actual tests.
+    blueslip.reset(true);
 
     // Now, let's add our warning to the list of expected warnings.
     // This time, we shouldn't throw an error. However, to confirm that we
@@ -67,4 +79,12 @@ run_test('basics', () => {
     blueslip.expect('warn', 'world');
     throw_a_warning();
     blueslip.reset();
+
+    // However, we detect when we have more or less of the expected errors/warnings.
+    blueslip.expect('warn', 'world');
+    assert.throws(() => {
+        blueslip.reset();
+    });
+    // Again, forcefully reset blueslip.
+    blueslip.reset(true);
 });

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -101,6 +101,8 @@ global.run_test = (label, f) => {
         console.info('        test: ' + label);
     }
     f();
+    // defensively reset blueslip after each test.
+    blueslip.reset();
 };
 
 try {

--- a/frontend_tests/zjsunit/zblueslip.js
+++ b/frontend_tests/zjsunit/zblueslip.js
@@ -20,12 +20,10 @@ exports.make_zblueslip = function () {
     // Store valid test data for options.
     lib.test_data = {};
     lib.test_logs = {};
-    lib.seen_messages = {};
 
     for (const name of names) {
         lib.test_data[name] = [];
         lib.test_logs[name] = [];
-        lib.seen_messages[name] = new Set();
     }
 
     lib.expect = (name, message, count = 1) => {
@@ -62,9 +60,6 @@ exports.make_zblueslip = function () {
                 } else if (obj.count < 0) {
                     throw Error(`We saw ${obj.expected_count - obj.count} (expected ${obj.expected_count}) of '${name}': ${message}`);
                 }
-                if (!lib.seen_messages[name].has(message)) {
-                    throw Error('Never saw: ' + message);
-                }
             }
         }
     };
@@ -77,7 +72,6 @@ exports.make_zblueslip = function () {
         for (const name of names) {
             lib.test_data[name] = [];
             lib.test_logs[name] = [];
-            lib.seen_messages[name].clear();
         }
     };
 
@@ -90,7 +84,6 @@ exports.make_zblueslip = function () {
         if (!opts[name]) {
             // should just log the message.
             lib[name] = function (message, more_info, stack) {
-                lib.seen_messages[name].add(message);
                 lib.test_logs[name].push({message, more_info, stack});
             };
             continue;
@@ -105,7 +98,6 @@ exports.make_zblueslip = function () {
                     throw Error('message should be string: ' + message);
                 }
             }
-            lib.seen_messages[name].add(message);
             lib.test_logs[name].push({message, more_info, stack});
             const matched_error_message = lib.test_data[name].find(x => x.message === message);
             const exact_match_fail = !matched_error_message;

--- a/frontend_tests/zjsunit/zblueslip.js
+++ b/frontend_tests/zjsunit/zblueslip.js
@@ -37,7 +37,7 @@ exports.make_zblueslip = function () {
         lib.test_data[name].push(obj);
     };
 
-    lib.check_seen_messages = () => {
+    const check_seen_messages = () => {
         for (const name of names) {
             for (const obj of lib.test_logs[name]) {
                 const message = obj.message;
@@ -66,7 +66,7 @@ exports.make_zblueslip = function () {
 
     lib.reset = (skip_checks = false) => {
         if (!skip_checks) {
-            lib.check_seen_messages();
+            check_seen_messages();
         }
 
         for (const name of names) {


### PR DESCRIPTION
We essentially simplify the interface of zblueslip for some more complex tests as well:

```js
run_test('test', () => {
    // Expecting 3 errors and 1 warning.
    blueslip.expect('error', 'sample error message', 3);
    blueslip.expect('warn', 'sample warning message');
    warn();
    err();
    err();
    err();
});
```