### PR TITLE
browser_support: Drop support for Internet Explorer.

### DIFF
--- a/static/styles/portico/portico.scss
+++ b/static/styles/portico/portico.scss
@@ -1753,3 +1753,7 @@ input.new-organization-button {
 .desktop-redirect-image {
     margin-bottom: 20px;
 }
+
+.unsupported_browser_page {
+    padding-bottom: 80px;
+}

--- a/templates/zerver/unsupported_browser.html
+++ b/templates/zerver/unsupported_browser.html
@@ -1,0 +1,37 @@
+{% extends "zerver/portico.html" %}
+
+{% block portico_content %}
+
+<div class="error_page unsupported_browser_page">
+    <div class="container">
+        <div class="row-fluid">
+            <img src="/static/images/400art.svg" alt=""/>
+            <div class="errorbox config-error">
+                <div class="errorcontent">
+                    <h1 class="lead">{{ _('Unsupported browser') }}</h1>
+                    <p>
+                        {% trans %}
+                        {{ browser_name }} is not supported by Zulip.
+                        {% endtrans %}
+                    </p>
+                    <p>
+                        {% trans %}
+                        Zulip supports modern browsers like Firefox,
+                        Chrome, and Edge.
+                        {% endtrans %}
+                    </p>
+                    <p>
+                        {% trans %}
+                        You can also use
+                        the <a href="https://zulipchat.com/apps">Zulip
+                        desktop app</a>.
+                        {% endtrans %}
+                    </p>
+                </div>
+
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -401,6 +401,22 @@ class HomeTest(ZulipTestCase):
         html = result.content.decode('utf-8')
         self.assertIn('You are using old version of the Zulip desktop', html)
 
+    def test_unsupported_browser(self) -> None:
+        user = self.example_user('hamlet')
+        self.login_user(user)
+
+        # currently we don't support IE, so some of IE's user agents are added.
+        unsupported_user_agents = [
+            "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2)",
+            "Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko",
+            "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0)"
+        ]
+        for user_agent in unsupported_user_agents:
+            result = self.client_get('/',
+                                     HTTP_USER_AGENT=user_agent)
+            html = result.content.decode('utf-8')
+            self.assertIn('Internet Explorer is not supported by Zulip.', html)
+
     def test_terms_of_service_first_time_template(self) -> None:
         user = self.example_user('hamlet')
         self.login_user(user)

--- a/zerver/views/compatibility.py
+++ b/zerver/views/compatibility.py
@@ -6,6 +6,7 @@ from django.utils.translation import ugettext as _
 
 from zerver.lib.response import json_error, json_success
 from zerver.lib.user_agent import parse_user_agent
+from zerver.signals import get_device_browser
 from version import DESKTOP_MINIMUM_VERSION, DESKTOP_WARNING_VERSION
 
 def pop_numerals(ver: str) -> Tuple[List[int], str]:
@@ -115,3 +116,9 @@ def is_outdated_desktop_app(user_agent_str: str) -> Tuple[bool, bool, bool]:
         return (True, False, False)
 
     return (False, False, False)
+
+def is_unsupported_browser(user_agent: str) -> Tuple[bool, Optional[str]]:
+    browser_name = get_device_browser(user_agent)
+    if browser_name == "Internet Explorer":
+        return (True, browser_name)
+    return (False, browser_name)


### PR DESCRIPTION
Internet Explorer does not support `position: sticky` which improves
floating recipient bar behavior during scrolling added with PR#9911.
IE also does not support some features that modern browsers support
hence may not super well.
This commit adds an error page that'll be displayed when a user logs
in from Internet Explorer. Also, a test is added.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Tested manually with an extension that changes user agent to that of IE11 on firefox. Could not test on actual IE11. But there shouldn't be any problem I think.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
this is how it looks now.
![browser_error](https://user-images.githubusercontent.com/44665669/79754073-8ddf9680-8334-11ea-9892-dbe23561e723.png)

Might have to change the error message, if it's not OK.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
