### PR TITLE
tests-backend: Bring stream_recipient.py to 100 percent coverage.

### DIFF
--- a/tools/test-backend
+++ b/tools/test-backend
@@ -95,7 +95,6 @@ not_yet_fully_covered = {path for target in [
     'zerver/lib/queue.py',
     'zerver/lib/sqlalchemy_utils.py',
     'zerver/lib/storage.py',
-    'zerver/lib/stream_recipient.py',
     'zerver/lib/timeout.py',
     'zerver/lib/unminify.py',
     'zerver/lib/utils.py',

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -26,6 +26,7 @@ from zerver.lib.actions import (
     do_set_realm_property,
     extract_private_recipients,
     extract_stream_indicator,
+    gather_subscriptions_helper,
     get_active_presence_idle_user_ids,
     get_client,
     get_last_message_id,
@@ -93,8 +94,6 @@ from zerver.lib.soft_deactivation import (
     do_soft_deactivate_users,
     reactivate_user_if_soft_deactivated,
 )
-
-from zerver.lib.stream_recipient import StreamRecipientMap
 
 from zerver.models import (
     MAX_MESSAGE_LENGTH, MAX_TOPIC_NAME_LENGTH,
@@ -5223,11 +5222,15 @@ class NoRecipientIDsTest(ZulipTestCase):
         # and checks that having no recipient ids
         # returns nothing.
 
-        empty_stream_recipient = StreamRecipientMap()
-        empty_stream_recipient.populate_for_recipient_ids([])
+        user_profile = self.example_user('cordelia')
+        # self.login_user(user_profile)
 
-        # Checks that the dictionary mapping recipients to streams is empty
+        Subscription.objects.all().delete()
+
+        subs = gather_subscriptions_helper(user_profile)
+
+        # Checks that gather_subscriptions_helper will not return anything
         # since there will not be any recipients.
         # recip_to_stream will be empty because _process_query() will not have
         # run due to the return statement prior to the query execution.
-        self.assertEqual(empty_stream_recipient.recipient_to_stream_id_dict(), {})
+        self.assertEqual(len(subs[0]), 0)

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -5225,7 +5225,7 @@ class NoRecipientIDsTest(ZulipTestCase):
         user_profile = self.example_user('cordelia')
         # self.login_user(user_profile)
 
-        Subscription.objects.all().delete()
+        Subscription.objects.filter(user_profile=user_profile, recipient__type=Recipient.STREAM).delete()
 
         subs = gather_subscriptions_helper(user_profile)
 

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -94,6 +94,8 @@ from zerver.lib.soft_deactivation import (
     reactivate_user_if_soft_deactivated,
 )
 
+from zerver.lib.stream_recipient import StreamRecipientMap
+
 from zerver.models import (
     MAX_MESSAGE_LENGTH, MAX_TOPIC_NAME_LENGTH,
     Message, Realm, Recipient, Stream, UserMessage, UserProfile, Attachment,
@@ -5214,3 +5216,18 @@ class TestBulkGetHuddleUserIds(ZulipTestCase):
 
     def test_bulk_get_huddle_user_ids_empty_list(self) -> None:
         self.assertEqual(bulk_get_huddle_user_ids([]), {})
+
+class NoRecipientIDsTest(ZulipTestCase):
+    def test_no_recipient_ids(self) -> None:
+        # Takes code coverage for stream_recipients.py to 100%
+        # and checks that having no recipient ids
+        # returns nothing.
+
+        empty_stream_recipient = StreamRecipientMap()
+        empty_stream_recipient.populate_for_recipient_ids([])
+
+        # Checks that the dictionary mapping recipients to streams is empty
+        # since there will not be any recipients.
+        # recip_to_stream will be empty because _process_query() will not have
+        # run due to the return statement prior to the query execution.
+        self.assertEqual(empty_stream_recipient.recipient_to_stream_id_dict(), {})


### PR DESCRIPTION
https://github.com/zulip/zulip/issues/7089
Increasing coverage to 100% for specifically stream_recipient.py.

At first, I attempted to create a far more comprehensive test. However, the functionality did not work as intended. This test is simple and checks a specific, rare corner case where the list of recipient ids passed into populate_for_recipient_ids() is empty, causing the function to return without processing the query. It ensures that the map from recipient id to stream id is empty.