### PR TITLE
Create venv using only conda.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,21 +71,24 @@ aliases:
     run:
       name: run backend tests
       command: |
-        . /srv/zulip-py3-venv/bin/activate
+        source /opt/conda/etc/profile.d/conda.sh
+        conda activate /srv/zulip-py3-venv
         mispipe ./tools/ci/backend ts
 
   - &run_frontend_tests
     run:
       name: run frontend tests
       command: |
-        . /srv/zulip-py3-venv/bin/activate
+        source /opt/conda/etc/profile.d/conda.sh
+        conda activate /srv/zulip-py3-venv
         mispipe ./tools/ci/frontend ts
 
   - &upload_coverage_report
     run:
      name: upload coverage report
      command: |
-       . /srv/zulip-py3-venv/bin/activate
+       source /opt/conda/etc/profile.d/conda.sh
+       conda activate /srv/zulip-py3-venv
        pip install codecov && codecov \
          || echo "Error in uploading coverage reports to codecov.io."
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -396,7 +396,7 @@ importlib-metadata==1.6.0 \
 importlib-resources==1.0.2 \
     --hash=sha256:6e2783b2538bd5a14678284a3962b0660c715e5a0f10243fd5e00a4b5974f50b \
     --hash=sha256:d3279fd0f6f847cced9f7acc19bd3e5df54d34f93a2e7bb5f238f81545787078 \
-    # via -r requirements/dev.in, cfn-lint
+    # via -r requirements/dev.in
 incremental==17.5.0 \
     --hash=sha256:717e12246dddf231a349175f48d74d93e2897244939173b01974ab6661406b9f \
     --hash=sha256:7b751696aaf36eebfab537e458929e194460051ccad279c72b755a167eebd4b3 \
@@ -1021,9 +1021,6 @@ urllib3==1.25.9 \
     --hash=sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527 \
     --hash=sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115 \
     # via botocore, requests
-uwsgi==2.0.18 \
-    --hash=sha256:4972ac538800fb2d421027f49b4a1869b66048839507ccf0aa2fda792d99f583 \
-    # via -r requirements/prod.in
 virtualenv-clone==0.5.4 \
     --hash=sha256:07e74418b7cc64f4fda987bf5bc71ebd59af27a7bc9e8a8ee9fd54b1f2390a27 \
     --hash=sha256:665e48dd54c84b98b71a657acb49104c54e7652bce9c1c4f6c6976ed4c827a29 \

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -2,5 +2,3 @@
 # /tools/update-locked-requirements to update requirements/prod.txt.
 # See requirements/README.md for more detail.
 -r common.in
-# Used for running the Zulip production Django server
-uWSGI

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -656,9 +656,6 @@ urllib3==1.25.9 \
     --hash=sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527 \
     --hash=sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115 \
     # via requests
-uwsgi==2.0.18 \
-    --hash=sha256:4972ac538800fb2d421027f49b4a1869b66048839507ccf0aa2fda792d99f583 \
-    # via -r requirements/prod.in
 virtualenv-clone==0.5.4 \
     --hash=sha256:07e74418b7cc64f4fda987bf5bc71ebd59af27a7bc9e8a8ee9fd54b1f2390a27 \
     --hash=sha256:665e48dd54c84b98b71a657acb49104c54e7652bce9c1c4f6c6976ed4c827a29 \

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -235,6 +235,19 @@ case " $os_id $os_id_like " in
         ;;
 esac
 
+# Install conda
+case " $os_id $os_id_like " in
+    *' debian '*)
+        sudo "$ZULIP_PATH"/scripts/setup/install-conda-debian
+        ;;
+    *' rhel '*)
+        sudo "$ZULIP_PATH"/scripts/setup/install-conda-rhel
+        ;;
+esac
+
+# Add conda to path
+source /opt/conda/etc/profile.d/conda.sh
+
 if [ -n "$USE_CERTBOT" ]; then
     "$ZULIP_PATH"/scripts/setup/setup-certbot \
         --no-zulip-conf --method=standalone \

--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -324,7 +324,11 @@ def do_setup_virtualenv(venv_path: str, requirements_file: str, python2: bool) -
     if not try_to_copy_venv(venv_path, new_packages):
         # Create new virtualenv.
         run_as_root(["mkdir", "-p", venv_path])
-        run_as_root(["virtualenv", "-p", "python2.7" if python2 else "python3", venv_path])
+        if python2:
+            run_as_root(["virtualenv", "-p", "python2.7", venv_path])
+        else:
+            run_as_root(["chmod", "-R", "a+rwX", venv_path])
+            run(["conda", "create", "-y", "--prefix", venv_path, "python=3.7"])
         run_as_root(["chown", "-R",
                      "{}:{}".format(os.getuid(), os.getgid()), venv_path])
         create_log_entry(get_logfile_name(venv_path), "", set(), new_packages)

--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -328,7 +328,8 @@ def do_setup_virtualenv(venv_path: str, requirements_file: str, python2: bool) -
             run_as_root(["virtualenv", "-p", "python2.7", venv_path])
         else:
             run_as_root(["chmod", "-R", "a+rwX", venv_path])
-            run(["conda", "create", "-y", "--prefix", venv_path, "python=3.7"])
+            run(["conda", "config", "--append", "channels", "conda-forge"])
+            run(["conda", "create", "-y", "--prefix", venv_path, "python=3.7", "uwsgi"])
         run_as_root(["chown", "-R",
                      "{}:{}".format(os.getuid(), os.getgid()), venv_path])
         create_log_entry(get_logfile_name(venv_path), "", set(), new_packages)

--- a/scripts/setup/install-conda-debian
+++ b/scripts/setup/install-conda-debian
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Use this script to install conda package manager.
+set -e
+set -x
+
+# Using instructions from https://docs.conda.io/projects/conda/en/latest/user-guide/install/rpm-debian.html
+
+cd "$(mktemp -d)"
+
+# Install conda public GPG key to trusted store
+curl https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc | gpg --dearmor > conda.gpg
+install -o root -g root -m 644 conda.gpg /usr/share/keyrings/conda-archive-keyring.gpg
+
+# Check whether fingerprint is correct (will output an error message otherwise)
+gpg --keyring /usr/share/keyrings/conda-archive-keyring.gpg --no-default-keyring --fingerprint 34161F5BF5EB1D4BFBBB8F0A8AEB4F8B29D82806
+
+# Add conda Debian repo
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/conda-archive-keyring.gpg] https://repo.anaconda.com/pkgs/misc/debrepo/conda stable main" > /etc/apt/sources.list.d/conda.list
+
+# Install!
+apt-get update
+
+# NOTE: Pin conda version?
+apt-get -y install conda

--- a/scripts/setup/install-conda-rhel
+++ b/scripts/setup/install-conda-rhel
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Use this script to install conda package manager.
+set -e
+set -x
+
+# Using instructions from https://docs.conda.io/projects/conda/en/latest/user-guide/install/rpm-debian.html
+
+# Import conda GPG public key
+rpm --import https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc
+
+# Add the Anaconda repository
+cat <<EOF > /etc/yum.repos.d/conda.repo
+[conda]
+name=Conda
+baseurl=https://repo.anaconda.com/pkgs/misc/rpmrepo/conda
+enabled=1
+gpgcheck=1
+gpgkey=https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc
+EOF
+
+# Install it!
+# NOTE: Pin conda version?
+yum install -y conda

--- a/tools/ci/activate-venv
+++ b/tools/ci/activate-venv
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
-source /srv/zulip-py3-venv/bin/activate
+source /opt/conda/etc/profile.d/conda.sh
+conda activate /srv/zulip-py3-venv
 echo "Using $VIRTUAL_ENV"

--- a/tools/provision
+++ b/tools/provision
@@ -59,11 +59,15 @@ if [ "$failed" -ne 0 ]; then
     exit "$failed"
 elif [ "$VIRTUAL_ENV" != "/srv/zulip-py3-venv" ] && [ -z "${CIRCLECI}${SKIP_VENV_SHELL_WARNING}" ]; then
     echo -e "$WARNING"
-    echo "WARNING: This shell does not have the Zulip Python 3 virtualenv activated."
+    echo "WARNING: This shell does not have the Zulip Python 3 conda venv activated."
     echo "Zulip commands will fail until you activate the virtualenv."
     echo
     echo "To update the shell, run:"
-    echo "    source /srv/zulip-py3-venv/bin/activate"
+    # TODO: Add to .zprofile
+    echo "    source /opt/conda/etc/profile.d/conda.sh"
+    # TODO: Give venv a shorter name using
+    # conda config --set env_prompt '({name})'
+    echo "    conda activate /srv/zulip-py3-venv"
     # shellcheck disable=SC2016
     echo 'or just close this shell and start a new one (with Vagrant, `vagrant ssh`).'
     echo -en "$ENDC"

--- a/tools/provision
+++ b/tools/provision
@@ -22,6 +22,25 @@ LOG_PATH="../var/log/provision.log"
 
 echo "PROVISIONING STARTING." >> $LOG_PATH
 
+# Check for a supported OS release.
+if [ -f /etc/os-release ]; then
+    os_info="$(. /etc/os-release; printf '%s\n' "$ID" "$ID_LIKE")"
+    { read -r os_id; read -r os_id_like || true; } <<< "$os_info"
+fi
+
+# Install conda
+case " $os_id $os_id_like " in
+    *' debian '*)
+        sudo "$PARENT_PATH"/../scripts/setup/install-conda-debian
+        ;;
+    *' rhel '*)
+        sudo "$PARENT_PATH"/../scripts/setup/install-conda-rhel
+        ;;
+esac
+
+# Add conda to path
+source /opt/conda/etc/profile.d/conda.sh
+
 # PYTHONUNBUFFERED is important to ensure that tracebacks don't get
 # lost far above where they should be in the output.
 export PYTHONUNBUFFERED=1

--- a/version.py
+++ b/version.py
@@ -44,4 +44,4 @@ API_FEATURE_LEVEL = 1
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '79.3'
+PROVISION_VERSION = '80.0'


### PR DESCRIPTION
@timabbott @andersk this is how it will look like if we move to a conda only venv. The python 2 venv we create for thumbor will also be dropped soon. I tested installing via this branch on fresh Ubuntu 18 remote server and it works smoothly. If you like this direction, I will proceed further.