### PR TITLE
settings_org: Improve failure response of save_discard_widget.

### DIFF
--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -481,6 +481,7 @@ exports.change_save_button_state = function ($element, state) {
     }
 
     const $saveBtn = $element.find('.save-button');
+    const $failBtn = $element.find('.fail-button');
     const $textEl = $saveBtn.find('.icon-button-text');
 
     if (state !== "saving") {
@@ -489,6 +490,13 @@ exports.change_save_button_state = function ($element, state) {
 
     if (state === "discarded") {
         show_hide_element($element, false, 0);
+        return;
+    }
+
+    if (state === "failed") {
+        $failBtn.show();
+        $saveBtn.hide();
+        get_subsection_property_elements($element).forEach(discard_property_element_changes);
         return;
     }
 
@@ -501,6 +509,7 @@ exports.change_save_button_state = function ($element, state) {
         is_show = true;
 
         $element.find('.discard-button').show();
+        $failBtn.hide();
     } else if (state === "saved") {
         button_text = i18n.t("Save changes");
         data_status = "";
@@ -512,10 +521,6 @@ exports.change_save_button_state = function ($element, state) {
 
         $element.find('.discard-button').hide();
         $saveBtn.addClass('saving');
-    } else if (state === "failed") {
-        button_text = i18n.t("Save changes");
-        data_status = "failed";
-        is_show = true;
     } else if (state === 'succeeded') {
         button_text = i18n.t("Saved");
         data_status = "saved";
@@ -767,7 +772,7 @@ exports.build_page = function () {
     exports.save_organization_settings = function (data, save_button) {
         const subsection_parent = save_button.closest('.org-subsection-parent');
         const save_btn_container = subsection_parent.find('.save-button-controls');
-        const failed_alert_elem = subsection_parent.find('.subsection-failed-status p');
+        const failed_alert_elem = subsection_parent.find('.subsection-changes-fail .icon-button-text');
         exports.change_save_button_state(save_btn_container, "saving");
         channel.patch({
             url: "/json/realm",
@@ -778,7 +783,6 @@ exports.build_page = function () {
             },
             error: function (xhr) {
                 exports.change_save_button_state(save_btn_container, "failed");
-                save_button.hide();
                 ui_report.error(i18n.t("Save failed"), xhr, failed_alert_elem);
             },
         });
@@ -906,6 +910,12 @@ exports.build_page = function () {
 
         return data;
     }
+
+    $(".organization").on("click", ".subsection-header .subsection-changes-fail .button", function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        $(e.currentTarget).hide();
+    });
 
     $(".organization").on("click", ".subsection-header .subsection-changes-save .button", function (e) {
         e.preventDefault();

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -522,6 +522,33 @@ input[type=checkbox] + .inline-block {
     display: none;
 }
 
+#settings_page .icon-button.fail-button {
+    background-color: hsl(2, 46%, 68%);
+    border-color: hsl(2, 46%, 68%);
+}
+
+#settings_page .fail-button {
+    color: hsl(0, 0%, 100%);
+}
+
+#settings_page .fail-button:hover {
+    color: hsl(0, 0%, 100%);
+}
+
+#settings_page .fail-button.icon-button:hover .icon-button-icon {
+    color: hsl(0, 0%, 100%);
+}
+
+#settings_page .fail-button .icon-button-text.alert-error {
+    color: hsl(0, 0%, 100%);
+    background-color: hsl(2, 46%, 68%);
+    border-color: hsl(2, 46%, 68%);
+}
+
+#settings_page .fail-button .icon-button-text.show {
+    display: inline;
+}
+
 #google_hangouts_domain,
 #zoom_help_text,
 .organization-settings-parent div:first-of-type {

--- a/static/templates/settings/settings_save_discard_widget.hbs
+++ b/static/templates/settings/settings_save_discard_widget.hbs
@@ -16,5 +16,12 @@
             </span>
         </div>
     </div>
-    <div class="inline-block subsection-failed-status"><p class="hide"></p></div>
+    <div class="inline-block subsection-changes-fail">
+        <div class="icon-button button fail-button" type="button" id="org-fail-{{section_name}}">
+            <span class="fa fa-times icon-button-icon"></span>
+            <span class="icon-button-text">
+                {{t 'Failed' }}
+            </span>
+        </div>
+    </div>
 </div>


### PR DESCRIPTION
Previously, on receiving a failure response from the backend, the
changes sent with the request were not rolled back in the UI which
caused buggy behaviour. Styling of the failure case was not consistent
with styling of the other parts of the save_discard_widget. This commit
fixes this issue by updating the UI to previous changes, in case of
failure. And provides a much cleaner failure message, which can be
dismissed by clicking on it. This has been done by creating a new div
element to handle failures in the settings_save_discard_widget template
file. The styling of this element has been done by adding appropriate
CSS. settings_org.js has been updated to incorporate this new failure
div.

**GIFs or Screenshots:**
![failfix](https://user-images.githubusercontent.com/20909078/79887785-10da1d00-8419-11ea-8dfd-d2b100d9a3b6.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
