### PR TITLE
nginx: Tweak nginx settings to customize 5xx page.

### DIFF
--- a/puppet/zulip/templates/nginx.conf.template.erb
+++ b/puppet/zulip/templates/nginx.conf.template.erb
@@ -13,6 +13,7 @@ events {
 }
 
 http {
+    ssi on;
     sendfile on;
     tcp_nopush on;
     tcp_nodelay on;
@@ -61,4 +62,11 @@ http {
 
     include /etc/nginx/conf.d/*.conf;
     include /etc/nginx/sites-enabled/*;
+
+    map $status $status_text {
+        502 'Bad Gateway';
+        503 'Service Unavailable';
+        504 'Gateway Timeout';
+        default 'Something is wrong';
+    }
 }

--- a/static/html/5xx.html
+++ b/static/html/5xx.html
@@ -5,14 +5,13 @@
         <title>Zulip - 500 internal server error</title>
         <base href="/static/webpack-bundles/">
 
+        <!--# if expr="$status = 502" -->
         <meta http-equiv="refresh" content="60;URL='/'">
+        <!--# endif -->
 
     </head>
 
     <body class="error_page">
-        <!-- TODO: Make nginx 5xx error page customizable -->
-        <!-- This is tricky because it's not served by Django, -->
-        <!-- so we can't use variables -->
         <div class="header" style="background-color: #c9e9e0;">
             <div class="header-main" id="top_navbar">
                 <div class="float-left">
@@ -36,7 +35,7 @@
                 <img src="/static/images/500art.svg" alt=""/>
                 <div class="errorbox">
                     <div class="errorcontent">
-                        <h1 class="lead">Internal server error</h1>
+                        <h1 class="lead"><!--# echo var="status" default="" --> <!--# echo var="status_text" default="Something went wrong." --></h1>
                         <p>This Zulip server is currently experiencing some technical difficulties. Sorry about that!</p>
                         <p>The page will reload automatically soon after service is restored.</p>
                     </div>

--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -214,6 +214,7 @@ export default (env?: string): webpack.Configuration[] => {
                 filename: "5xx.html",
                 template: "static/html/5xx.html",
                 chunks: ["error-styles"],
+                removeComments: false,
             }),
         ],
     };


### PR DESCRIPTION
Tweaked the `nginx.conf` to map error status with their error message and
enabled ssi (server side include) to pass variables to the resulting page.
Included the imports into the `5xx.html` to print error code and it's
message. Tweaked the webpack config to preserve comment in the error page
to preserve the ssi.

Fixes #14611.

**Testing Plan:** <!-- How have you tested? -->
Manually add a location in `puppet/zulip/files/nginx/zulip-include-frontend/app`
to return either 502/503/504 error.
Eg:- 
```
location /test-path.html {
    return 502;
}
```

Or visit my test instance [here](https://majordwarf.zulipdev.org/502/).

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/23737560/79893396-a37eba00-8421-11ea-870c-2e11f97d6d91.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
