### PR TITLE
api: Refactor get_members_backend to return a single bot's data.

### DIFF
--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1415,6 +1415,11 @@ class GetProfileTest(ZulipTestCase):
         result = self.client_get('/json/users/{}?'.format(30))
         self.assert_json_error(result, "No such user")
 
+        bot = self.example_user("default_bot")
+        result = ujson.loads(self.client_get('/json/users/{}'.format(bot.id)).content)
+        self.assertEqual(result['user']['email'], bot.email)
+        self.assertTrue(result['user']['is_bot'])
+
     def test_api_get_empty_profile(self) -> None:
         """
         Ensure GET /users/me returns a max message id and returns successfully

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -415,7 +415,7 @@ def get_members_backend(request: HttpRequest, user_profile: UserProfile, user_id
     target_user = None
     if user_id is not None:
         target_user = access_user_by_id(user_profile, user_id, allow_deactivated=True,
-                                        read_only=True)
+                                        allow_bots=True, read_only=True)
 
     members = get_raw_user_data(realm, user_profile, client_gravatar=client_gravatar,
                                 target_user=target_user,


### PR DESCRIPTION
This makes `get_members_backend` in zerver/views/users.py to
return a single bot's data too.
