### PR TITLE
typeahead: Show only active users in mention typeaheads.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -1512,4 +1512,14 @@ run_test('message people', () => {
 
     results = ct.get_person_suggestions('Ha', opts);
     assert.deepEqual(results, [harry, hamletcharacters]);
+
+    message_store.user_ids = () => [hamlet.user_id, harry.user_id, hal.user_id];
+
+    results = ct.get_person_suggestions('Ha', opts);
+    assert.deepEqual(results, [harry, hamletcharacters]);
+
+    people.deactivate(harry);
+    results = ct.get_person_suggestions('Ha', opts);
+    // harry is excluded since it has been deactivated.
+    assert.deepEqual(results, [hamletcharacters, hal]);
 });

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -1060,3 +1060,38 @@ run_test('emails_strings_to_user_ids_array', function () {
     assert.equal(user_ids, undefined);
     blueslip.reset();
 });
+
+run_test('get_active_message_people', function () {
+    const steven = {
+        email: 'steven@example.com',
+        user_id: 1,
+        full_name: 'Steven',
+    };
+
+    const maria = {
+        email: 'maria@example.com',
+        user_id: 2,
+        full_name: 'Maria',
+    };
+
+    const alice = {
+        email: 'alice@example.com',
+        user_id: 3,
+        full_name: 'Alice',
+    };
+
+    message_store.user_ids = () => {
+        return [1, 2, 3];
+    };
+
+    people.add(steven);
+    people.add(maria);
+    people.add(alice);
+
+    let active_message_people = people.get_active_message_people();
+    assert.deepEqual(active_message_people, [steven, maria, alice]);
+
+    people.deactivate(alice);
+    active_message_people = people.get_active_message_people();
+    assert.deepEqual(active_message_people, [steven, maria]);
+});

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -485,7 +485,7 @@ exports.get_person_suggestions = function (query, opts) {
     const cutoff_length = exports.max_num_items;
 
     const filtered_message_persons = filter_persons(
-        people.get_message_people()
+        people.get_active_message_people()
     );
 
     let filtered_persons;

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -790,6 +790,14 @@ exports.get_message_people = function () {
     return message_people;
 };
 
+exports.get_active_message_people = function () {
+    const message_people = exports.get_message_people();
+    const active_message_people = message_people.filter(function (item) {
+        return active_user_dict.has(item.user_id);
+    });
+    return active_message_people;
+};
+
 exports.get_people_for_search_bar = function (query) {
     const pred = exports.build_person_matcher(query);
 


### PR DESCRIPTION
This PR changes mention typeaheads to show only active users and exclude deactivated users.

Fixes #14310

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->Added required test and manually tested.


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
