### PR TITLE
python: Fixes from autopep8

### DIFF
--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -1003,12 +1003,12 @@ class TestDoIncrementLoggingStat(AnalyticsTestCase):
         self.current_property = 'test'
         self.assertTableState(RealmCount, ['value', 'subgroup', 'end_time'],
                               [[1, 'subgroup1', self.TIME_ZERO], [1, 'subgroup2', self.TIME_ZERO],
-                              [1, 'subgroup1', self.TIME_LAST_HOUR]])
+                               [1, 'subgroup1', self.TIME_LAST_HOUR]])
         # This should trigger the get part of get_or_create
         do_increment_logging_stat(self.default_realm, stat, 'subgroup1', self.TIME_ZERO)
         self.assertTableState(RealmCount, ['value', 'subgroup', 'end_time'],
                               [[2, 'subgroup1', self.TIME_ZERO], [1, 'subgroup2', self.TIME_ZERO],
-                              [1, 'subgroup1', self.TIME_LAST_HOUR]])
+                               [1, 'subgroup1', self.TIME_LAST_HOUR]])
 
     def test_increment(self) -> None:
         stat = LoggingCountStat('test', RealmCount, CountStat.DAY)

--- a/analytics/tests/test_views.py
+++ b/analytics/tests/test_views.py
@@ -508,7 +508,7 @@ class TestSupportEndpoint(ZulipTestCase):
         stream_ids = [self.get_stream_id("Denmark")]
         invitee_emails = [self.nonreg_email("test1")]
         self.client_post("/json/invites", {"invitee_emails": invitee_emails,
-                         "stream_ids": ujson.dumps(stream_ids), "invite_as": 1})
+                                           "stream_ids": ujson.dumps(stream_ids), "invite_as": 1})
         result = self.client_get("/activity/support", {"q": self.nonreg_email("test1")})
         check_preregistration_user_query_result(result, self.nonreg_email("test1"), invite=True)
         check_zulip_realm_query_result(result)

--- a/scripts/lib/check_rabbitmq_queue.py
+++ b/scripts/lib/check_rabbitmq_queue.py
@@ -181,7 +181,7 @@ def check_rabbitmq_queues() -> None:
             queues_with_consumers.append(queue_name)
 
     queue_stats_dir = subprocess.check_output([os.path.join(ZULIP_PATH, 'scripts/get-django-setting'),
-                                              'QUEUE_STATS_DIR'],
+                                               'QUEUE_STATS_DIR'],
                                               universal_newlines=True).strip()
     queue_stats = dict()  # type: Dict[str, Dict[str, Any]]
     queues_to_check = set(normal_queues).intersection(set(queues_with_consumers))

--- a/scripts/setup/inline_email_css.py
+++ b/scripts/setup/inline_email_css.py
@@ -25,7 +25,7 @@ def configure_cssutils() -> None:
                                                           r'visible|painted|fill|stroke|all|inherit')
 
     profile.addProfiles([(Profiles.CSS_LEVEL_2, properties[Profiles.CSS_LEVEL_2],
-                         macros[Profiles.CSS_LEVEL_2])])
+                          macros[Profiles.CSS_LEVEL_2])])
 configure_cssutils()
 
 def inline_template(template_source_name: str) -> None:

--- a/zerver/data_import/hipchat_user.py
+++ b/zerver/data_import/hipchat_user.py
@@ -21,6 +21,7 @@ class UserHandler:
     We also sometimes need to build mirror
     users on the fly.
     '''
+
     def __init__(self) -> None:
         self.id_to_user_map = dict()  # type: Dict[int, Dict[str, Any]]
         self.name_to_mirror_user_map = dict()  # type: Dict[str, Dict[str, Any]]

--- a/zerver/data_import/mattermost_user.py
+++ b/zerver/data_import/mattermost_user.py
@@ -9,6 +9,7 @@ class UserHandler:
     The class helps us do things like map ids
     to names for mentions.
     '''
+
     def __init__(self) -> None:
         self.id_to_user_map = dict()  # type: Dict[int, Dict[str, Any]]
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1530,6 +1530,7 @@ class UserMessageLite:
     is optimized for the simple use case of inserting a bunch of
     rows into zerver_usermessage.
     '''
+
     def __init__(self, user_profile_id: int, message_id: int, flags: int) -> None:
         self.user_profile_id = user_profile_id
         self.message_id = message_id
@@ -4002,7 +4003,7 @@ def do_update_pointer(user_profile: UserProfile, client: Client,
         UserMessage.objects.filter(user_profile=user_profile,
                                    message__id__gt=prev_pointer,
                                    message__id__lte=pointer).extra(where=[UserMessage.where_unread()]) \
-                           .update(flags=F('flags').bitor(UserMessage.flags.read))
+            .update(flags=F('flags').bitor(UserMessage.flags.read))
         do_clear_mobile_push_notifications_for_ids(user_profile, app_message_ids)
 
     event = dict(type='pointer', pointer=pointer)
@@ -4531,7 +4532,7 @@ def do_update_message(user_profile: UserProfile, message: Message,
     send_event(user_profile.realm, event, users_to_be_notified)
 
     if (len(changed_messages) > 0 and new_stream is not None and
-       stream_being_edited is not None):
+            stream_being_edited is not None):
         # Notify users that the topic was moved.
         notify_topic_moved_streams(user_profile, stream_being_edited, orig_topic_name,
                                    new_stream, topic_name)

--- a/zerver/lib/bot_storage.py
+++ b/zerver/lib/bot_storage.py
@@ -30,9 +30,9 @@ def set_bot_storage(bot_profile: UserProfile, entries: List[Tuple[str, str]]) ->
     storage_size_limit = settings.USER_STATE_SIZE_LIMIT
     storage_size_difference = 0
     for key, value in entries:
-        if type(key) is not str:
+        if not isinstance(key, str):
             raise StateError("Key type is {}, but should be str.".format(type(key)))
-        if type(value) is not str:
+        if not isinstance(value, str):
             raise StateError("Value type is {}, but should be str.".format(type(value)))
         storage_size_difference += (len(key) + len(value)) - get_bot_storage_size(bot_profile, key)
     new_storage_size = get_bot_storage_size(bot_profile) + storage_size_difference

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -502,6 +502,7 @@ class InlineHttpsProcessor(markdown.treeprocessors.Treeprocessor):
 
 class BacktickPattern(markdown.inlinepatterns.Pattern):
     """ Return a `<code>` element containing the matching text. """
+
     def __init__(self, pattern: str) -> None:
         markdown.inlinepatterns.Pattern.__init__(self, pattern)
         self.ESCAPED_BSLASH = '%s%s%s' % (markdown.util.STX, ord('\\'), markdown.util.ETX)
@@ -1276,6 +1277,7 @@ def unicode_emoji_to_codepoint(unicode_emoji: str) -> str:
 
 class EmoticonTranslation(markdown.inlinepatterns.Pattern):
     """ Translates emoticons like `:)` into emoji like `:smile:`. """
+
     def handleMatch(self, match: Match[str]) -> Optional[Element]:
         db_data = self.markdown.zulip_db_data
         if db_data is None or not db_data['translate_emoticons']:

--- a/zerver/lib/bugdown/api_code_examples.py
+++ b/zerver/lib/bugdown/api_code_examples.py
@@ -147,7 +147,7 @@ cURL example.""".format(endpoint, method, param_name)
         return ordered_ex_val_str  # nocoverage
     else:
         example_value = param.get("example", DEFAULT_EXAMPLE[param_type])
-        if type(example_value) == bool:
+        if isinstance(example_value, bool):
             example_value = str(example_value).lower()
         if param["schema"].get("format", "") == "json":
             example_value = json.dumps(example_value)

--- a/zerver/lib/bugdown/include.py
+++ b/zerver/lib/bugdown/include.py
@@ -26,6 +26,7 @@ class IncludeCustomPreprocessor(IncludePreprocessor):
     JsonableError exception. The rest of the functionality is identical
     to the original markdown_include extension.
     """
+
     def run(self, lines: List[str]) -> List[str]:
         done = False
         while not done:

--- a/zerver/lib/stream_recipient.py
+++ b/zerver/lib/stream_recipient.py
@@ -16,6 +16,7 @@ class StreamRecipientMap:
     Note that this class uses raw SQL, because we want to highly
     optimize page loads.
     '''
+
     def __init__(self) -> None:
         self.recip_to_stream = dict()  # type: Dict[int, int]
         self.stream_to_recip = dict()  # type: Dict[int, int]

--- a/zerver/lib/stream_topic.py
+++ b/zerver/lib/stream_topic.py
@@ -16,6 +16,7 @@ class StreamTopicTarget:
     places where we are are still using `topic_name` as
     a key into tables.
     '''
+
     def __init__(self, stream_id: int, topic_name: str) -> None:
         self.stream_id = stream_id
         self.topic_name = topic_name

--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -151,6 +151,7 @@ class TextTestResult(runner.TextTestResult):
     This class has unpythonic function names because base class follows
     this style.
     """
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.failed_tests = []  # type: List[str]
@@ -192,6 +193,7 @@ class RemoteTestResult(django_runner.RemoteTestResult):
     The class follows the unpythonic style of function names of the
     base class.
     """
+
     def addInfo(self, test: TestCase, msg: str) -> None:
         self.events.append(('addInfo', self.test_index, msg))
 
@@ -598,6 +600,7 @@ class SubSuiteList(List[Tuple[Type[TestSuite], List[str]]]):
     This class allows us to avoid changing the main logic of
     ParallelTestSuite and still make it serializable.
     """
+
     def __init__(self, suites: List[TestSuite]) -> None:
         serialized_suites = [serialize_suite(s) for s in suites]
         super().__init__(serialized_suites)

--- a/zerver/lib/topic_mutes.py
+++ b/zerver/lib/topic_mutes.py
@@ -35,7 +35,6 @@ def get_topic_mutes(user_profile: UserProfile) -> List[List[Union[str, float]]]:
 
 def set_topic_mutes(user_profile: UserProfile, muted_topics: List[List[str]],
                     date_muted: Optional[datetime.datetime]=None) -> None:
-
     '''
     This is only used in tests.
     '''

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -425,6 +425,7 @@ class SetRemoteAddrFromForwardedFor(MiddlewareMixin):
     is set in the request, then it has properly been set by NGINX.
     Therefore HTTP_X_FORWARDED_FOR's value is trusted.
     """
+
     def process_request(self, request: HttpRequest) -> None:
         try:
             real_ip = request.META['HTTP_X_FORWARDED_FOR']
@@ -465,6 +466,7 @@ class ZulipCommonMiddleware(CommonMiddleware):
     for non-API endpoints things like /login.  But doing that
     transition will require more careful testing.
     """
+
     def should_redirect_with_slash(self, request: HttpRequest) -> bool:
         if settings.RUNNING_INSIDE_TORNADO:
             return False

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -17,6 +17,7 @@ from zerver.tornado.views import get_events, cleanup_event_queue
 class MissedMessageNotificationsTest(ZulipTestCase):
     """Tests the logic for when missed-message notifications
     should be triggered, based on user settings"""
+
     def check_will_notify(self, *args: Any, **kwargs: Any) -> Tuple[str, str]:
         email_notice = None
         mobile_notice = None

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -689,6 +689,7 @@ class ImportExportTest(ZulipTestCase):
     """
     Tests for import_realm
     """
+
     def test_import_realm(self) -> None:
 
         original_realm = Realm.objects.get(string_id='zulip')

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -4036,6 +4036,7 @@ class MessageAccessTests(ZulipTestCase):
 
 class MessageHasKeywordsTest(ZulipTestCase):
     '''Test for keywords like has_link, has_image, has_attachment.'''
+
     def setup_dummy_attachments(self, user_profile: UserProfile) -> List[str]:
         sample_size = 10
         realm_id = user_profile.realm_id

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -354,7 +354,7 @@ so maybe we shouldn't mark it as intentionally undocumented in the urls.
         needs to be mapped to list."""
 
         if sys.version_info < (3, 7):  # nocoverage  # python 3.5-3.6
-            if sys.version_info < (3, 6) and type(t) is type(Union):  # python 3.5 has special consideration for Union
+            if sys.version_info < (3, 6) and isinstance(t, type(Union)):  # python 3.5 has special consideration for Union
                 origin = Union
             else:
                 origin = getattr(t, "__origin__", None)

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -41,6 +41,7 @@ class OpenAPIToolsTest(ZulipTestCase):
     These tools are mostly dedicated to fetching parts of the -already parsed-
     specification, and comparing them to objects returned by our REST API.
     """
+
     def test_get_openapi_fixture(self) -> None:
         actual = get_openapi_fixture(TEST_ENDPOINT, TEST_METHOD,
                                      TEST_RESPONSE_BAD_REQ)

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -424,6 +424,7 @@ class ReactionEventTest(ZulipTestCase):
 class EmojiReactionBase(ZulipTestCase):
     """Reusable testing functions for emoji reactions tests.  Be careful when
     changing this: It's used in test_retention.py as well."""
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.reaction_type = 'realm_emoji'
         super().__init__(*args, **kwargs)

--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -327,7 +327,7 @@ class TestArchiveMessagesGeneral(ArchiveMessagesTestingBase):
         self.assertEqual(ArchivedAttachment.objects.count(), 3)
         self.assertEqual(
             list(ArchivedAttachment.objects.distinct('messages__id').values_list('messages__id',
-                 flat=True)),
+                                                                                 flat=True)),
             [msgs_ids['expired_message_id']]
         )
         self.assertEqual(Attachment.objects.count(), 3)

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -775,7 +775,6 @@ ClientInfo = TypedDict('ClientInfo', {
 
 def get_client_info_for_message_event(event_template: Mapping[str, Any],
                                       users: Iterable[Mapping[str, Any]]) -> Dict[str, ClientInfo]:
-
     '''
     Return client info for all the clients interested in a message.
     This basically includes clients for users who are recipients

--- a/zerver/webhooks/insping/view.py
+++ b/zerver/webhooks/insping/view.py
@@ -31,7 +31,7 @@ def api_insping_webhook(
     timestamp = data['request_start_time']
 
     time_formatted = time.strftime("%c", time.strptime(timestamp,
-                                   "%Y-%m-%dT%H:%M:%S.%f+00:00"))
+                                                       "%Y-%m-%dT%H:%M:%S.%f+00:00"))
 
     body = MESSAGE_TEMPLATE.format(
         state=state_name, url=url_tested,

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -1087,7 +1087,7 @@ def social_auth_associate_user(
     user_profile = social_associate_user_helper(
         backend, return_data, *args, **kwargs)
 
-    if type(user_profile) == HttpResponse:
+    if isinstance(user_profile, HttpResponse):
         return user_profile
     else:
         return {'user_profile': user_profile,

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -235,6 +235,7 @@ class ZulipAuthMixin:
     from memcached before checking the database (avoiding a database
     query in most cases).
     """
+
     def get_user(self, user_profile_id: int) -> Optional[UserProfile]:
         """Override the Django method for getting a UserProfile object from
         the user_profile_id,."""
@@ -380,6 +381,7 @@ class ZulipLDAPAuthBackendBase(ZulipAuthMixin, LDAPBackend):
     library.  It's not a lot of code, and searching around in that
     file makes the flow for LDAP authentication clear.
     """
+
     def __init__(self) -> None:
         # Used to initialize a fake LDAP directly for both manual
         # and automated testing in a development environment where
@@ -720,6 +722,7 @@ class ZulipLDAPUser(_LDAPUser):
     UserProfile. The realm attribute serves to uniquely identify the UserProfile
     in case the ldap user is registered to multiple realms.
     """
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.realm = kwargs['realm']  # type: Realm
         del kwargs['realm']
@@ -733,6 +736,7 @@ class ZulipLDAPUserPopulator(ZulipLDAPAuthBackendBase):
     registration for organizations that use a different SSO solution
     for managing login (often via RemoteUserBackend).
     """
+
     def authenticate(self, request: Optional[HttpRequest]=None, *,
                      username: str, password: str, realm: Realm,
                      return_data: Optional[Dict[str, Any]]=None) -> Optional[UserProfile]:
@@ -852,6 +856,7 @@ def query_ldap(email: str) -> List[str]:
 class DevAuthBackend(ZulipAuthMixin):
     """Allow logging in as any user without a password.  This is used for
     convenience when developing Zulip, and is disabled in production."""
+
     def authenticate(self, request: Optional[HttpRequest]=None, *,
                      dev_auth_username: str, realm: Realm,
                      return_data: Optional[Dict[str, Any]]=None) -> Optional[UserProfile]:


### PR DESCRIPTION
Having autopep8 fixes applied will make it easier to use other automatic refactoring tools that need to be followed by whitespace fixes, since I can now deal with many of those by running autopep8 again. This isn’t as good as Black (e.g. it can’t deal with line length limits), but it’s better than nothing and the diff is pretty small.

I’m not proposing it as a linter because it’s pretty slow.

* python: Whitespace fixes from autopep8.
  
  Generated by `autopep8`, with the `setup.cfg` configuration from #14532. I’m not sure why pycodestyle didn’t already flag these.

* python: Convert `type` checks to `isinstance` checks.
  
  Generated by `autopep8 --aggressive`, with the `setup.cfg` configuration from #14532.  In general, an `isinstance` check may not be equivalent to a `type` check because it includes subtypes; however, that’s usually what you want.