### PR TITLE
install-{sgrep,shellcheck}: Check that we detect the version correctly

### DIFF
--- a/tools/setup/install-sgrep
+++ b/tools/setup/install-sgrep
@@ -6,8 +6,11 @@ tarball=sgrep-$version-ubuntu-16.04.tgz
 sha256=9e57323fd0eb9133b7ff301a6be8361c073c3bfe6e6959ca1b622e5abc176e03
 tarball_url=https://github.com/returntocorp/sgrep/releases/download/v$version/$tarball
 
-if ! out="$(sgrep-lint --version 2>/dev/null)" || [[ "$out" != "$version" ]]
-then
+check_version () {
+    out="$(sgrep-lint --version 2>/dev/null)" && [ "$out" = "$version" ]
+}
+
+if ! check_version; then
     tmpdir="$(mktemp -d)"
     trap 'rm -r "$tmpdir"' EXIT
     cd "$tmpdir"
@@ -16,4 +19,5 @@ then
     tar -xzf "$tarball" -C /usr/local/lib/
     ln -sf /usr/local/lib/sgrep-lint-files/sgrep-lint /usr/local/bin/sgrep-lint
     ln -sf /usr/local/lib/sgrep-lint-files/sgrep /usr/local/bin/sgrep
+    check_version
 fi

--- a/tools/setup/install-shellcheck
+++ b/tools/setup/install-shellcheck
@@ -5,13 +5,18 @@ version=0.7.0
 tarball="shellcheck-v$version.linux.x86_64.tar.xz"
 sha256=39c501aaca6aae3f3c7fc125b3c3af779ddbe4e67e4ebdc44c2ae5cba76c847f
 
-if ! out="$(shellcheck --version 2>/dev/null)" || [[ "$out" != *"
+check_version () {
+    out="$(shellcheck --version 2>/dev/null)" && [[ "$out" = *"
 version: $version
-"* ]]; then
+"* ]]
+}
+
+if ! check_version; then
     tmpdir="$(mktemp -d)"
     trap 'rm -r "$tmpdir"' EXIT
     cd "$tmpdir"
     wget -nv "https://storage.googleapis.com/shellcheck/$tarball"
     sha256sum -c <<< "$sha256 $tarball"
     tar -xJf "$tarball" --no-same-owner --strip-components=1 -C /usr/local/bin "shellcheck-v$version/shellcheck"
+    check_version
 fi


### PR DESCRIPTION
The new release of sgrep (now semgrep) has a bug (returntocorp/semgrep#536) where it outputs the wrong version number, which would cause `install-sgrep` to re-download it every time. This makes sure we don’t do that.