### PR TITLE
Navbar search query val behaviour

### DIFF
--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -311,7 +311,11 @@ exports.activate = function (raw_operators, opts) {
     }
 
     // Put the narrow operators in the search bar.
-    $('#search_query').val(Filter.unparse(operators));
+    // we append a space to make searching more convenient in some cases.
+    if (filter && !filter.is_search()) {
+        $('#search_query').val(Filter.unparse(operators) + " ");
+    }
+
     search.update_button_visibility();
 
     compose_actions.on_narrow(opts);

--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -87,7 +87,12 @@ exports.exit_search = function () {
 
         // reset searchbox text
         const search_string = narrow_state.search_string();
-        $("#search_query").val(search_string);
+        // This does not need to be conditional like the corresponding
+        // function call in narrow.activate because search filters are
+        // not common narrows
+        if (search_string !== "") {
+            $("#search_query").val(search_string + " ");
+        }
     } else {
         // for "searching narrows", we redirect
         window.location.replace(filter.generate_redirect_url());


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://chat.zulip.org/#narrow/stream/101-design/topic/navbar.20redesign/near/859798

A small caveat here is that (as the gif shows), the search bar will append a space to any search terms which are already present, ie search for "foo" -> open search bar -> get "foo " -> add bar, and search -> open search -> get "foo bar ".

This makes adding search terms pretty easy but editing a previous term is kinda annoying.

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![long, slow gif](https://user-images.githubusercontent.com/33805964/79936639-98ee1000-8475-11ea-9889-8123131e5912.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
