### PR TITLE
message edit: Removed unused message_edit_forms from DOM

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -472,6 +472,8 @@ exports.end = function (row) {
     // We have to blur out text fields, or else hotkeys.js
     // thinks we are still editing.
     row.find(".message_edit").blur();
+    // Clear the message_edit_form to prevent an accumulations of unneeded forms in DOM
+    row.find(".message_edit_form").empty();
 };
 
 exports.save = function (row, from_topic_edited_only) {


### PR DESCRIPTION
We now handle the removal of the message_edit_form within message_edit.end() 
When a user edits a particular message and chooses to either close or save the edit -- message_edit.end() will immediately clear the message_edit_form from the DOM 

This is a fix to the request, found in  #14151, for the cleanup of unnecessary message_edit_forms found in the DOM
