### PR TITLE
requirements: Unpin libthumbor version in common.in

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -167,7 +167,7 @@ yamole
 
 # Needed for signing thumbnail requests so that they can be authenticated on the
 # other end.
-libthumbor==2.0.1
+libthumbor
 
 # Needed for string matching in AlertWordProcessor
 pyahocorasick


### PR DESCRIPTION
Versions should not be pinned in `*.in` unless specific circumstances merit an exception to this rule.  Every existing exception is commented.

(Cc @amanagr)