### PR TITLE
upgrade-zulip-from-git: Provide useful error messages when `update-prod-static` fails 

### DIFF
--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -125,9 +125,17 @@ elif args.from_git:
     # update-prod-static with the git upgrade process.  But it'll fail
     # safely; this seems like a worthwhile tradeoff to minimize downtime.
     logging.info("Building static assets...")
-    subprocess.check_call(["./tools/update-prod-static", "--authors-not-required", "--prev-deploy",
-                           os.path.join(DEPLOYMENTS_DIR, 'current')],
-                          preexec_fn=su_to_zulip)
+    try:
+        subprocess.check_call(["./tools/update-prod-static", "--authors-not-required", "--prev-deploy",
+                               os.path.join(DEPLOYMENTS_DIR, 'current')],
+                              preexec_fn=su_to_zulip)
+    except subprocess.CalledProcessError:
+        # Print proper error output in-case update-prod-static fails.
+        log_file_path = "/home/zulip/deployments/next/var/log/update-prod-static.log"
+        logging.error("Building static assets failed.")
+        logging.info("Complete error message can be found at " + log_file_path)
+        sys.exit(1)
+
     logging.info("Caching zulip git version...")
     subprocess.check_call(["./tools/cache-zulip-git-version"], preexec_fn=su_to_zulip)
 else:

--- a/tools/update-prod-static
+++ b/tools/update-prod-static
@@ -34,42 +34,40 @@ os.chdir(settings.DEPLOY_ROOT)
 
 # Redirect child processes' output to a log file (most recent run only).
 os.makedirs("var/log", exist_ok=True)
-fp = open('var/log/update-prod-static.log', 'w')
+with open('var/log/update-prod-static.log', 'w') as fp:
 
-# Install node packages
-setup_node_modules(production=True, stdout=fp, stderr=fp)
+    # Install node packages
+    setup_node_modules(production=True, stdout=fp, stderr=fp)
 
-# Build emoji
-run(['./tools/setup/emoji/build_emoji'], stdout=fp, stderr=fp)
+    # Build emoji
+    run(['./tools/setup/emoji/build_emoji'], stdout=fp, stderr=fp)
 
-# Inline CSS in emails
-run(['./scripts/setup/inline_email_css.py'], stdout=fp, stderr=fp)
+    # Inline CSS in emails
+    run(['./scripts/setup/inline_email_css.py'], stdout=fp, stderr=fp)
 
-# Copy over static files from the zulip_bots package
-run(['./tools/setup/generate_zulip_bots_static_files.py'], stdout=fp, stderr=fp)
+    # Copy over static files from the zulip_bots package
+    run(['./tools/setup/generate_zulip_bots_static_files.py'], stdout=fp, stderr=fp)
 
-# Build pygment data
-run(['./tools/setup/build_pygments_data'], stdout=fp, stderr=fp)
+    # Build pygment data
+    run(['./tools/setup/build_pygments_data'], stdout=fp, stderr=fp)
 
-# Create webpack bundle
-run(['./tools/webpack'], stdout=fp, stderr=fp)
+    # Create webpack bundle
+    run(['./tools/webpack'], stdout=fp, stderr=fp)
 
-# Collect the files that we're going to serve; this creates prod-static/serve.
-run([
-    './manage.py', 'collectstatic', '--no-default-ignore',
-    '--noinput',
-    '-i', 'assets',
-    '-i', 'emoji-styles',
-    '-i', 'html',
-    '-i', 'js',
-    '-i', 'styles',
-    '-i', 'templates',
-], stdout=fp, stderr=fp)
+    # Collect the files that we're going to serve; this creates prod-static/serve.
+    run([
+        './manage.py', 'collectstatic', '--no-default-ignore',
+        '--noinput',
+        '-i', 'assets',
+        '-i', 'emoji-styles',
+        '-i', 'html',
+        '-i', 'js',
+        '-i', 'styles',
+        '-i', 'templates',
+    ], stdout=fp, stderr=fp)
 
-# Compile translation strings to generate `.mo` files.
-run(['./manage.py', 'compilemessages'], stdout=fp, stderr=fp)
+    # Compile translation strings to generate `.mo` files.
+    run(['./manage.py', 'compilemessages'], stdout=fp, stderr=fp)
 
-# Needed if PRODUCTION
-os.makedirs('prod-static', exist_ok=True)
-
-fp.close()
+    # Needed if PRODUCTION
+    os.makedirs('prod-static', exist_ok=True)


### PR DESCRIPTION
This just prints the path to the prod static log file. 