### PR TITLE
user-popover: Replace bullhorn icon with paper-plane.

### DIFF
--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -137,7 +137,7 @@
     </li>
     <li>
         <a href="{{ sent_by_uri }}" class="narrow_to_messages_sent">
-            <i class="fa fa-bullhorn" aria-hidden="true"></i> {{#tr this}}View messages sent{{/tr}}
+            <i class="fa fa-paper-plane" aria-hidden="true"></i> {{#tr this}}View messages sent{{/tr}}
         </a>
     </li>
 </ul>


### PR DESCRIPTION

![Screenshot from 2020-04-22 22-29-10](https://user-images.githubusercontent.com/32801674/80010915-c0ca8b80-84e8-11ea-86b6-77339284751a.png)

