### PR TITLE
increase navbar search icon alignment and trigger area.

### DIFF
--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -190,6 +190,8 @@ $("#tab_list .stream").length = 0;
 compose.compute_show_video_chat_button = () => {};
 $("#below-compose-content .video_link").toggle = () => {};
 
+$(".narrow_description > a").hover = () => {};
+
 run_test('initialize_everything', () => {
     ui_init.initialize_everything();
 });

--- a/static/js/setup.js
+++ b/static/js/setup.js
@@ -36,7 +36,7 @@ $(function () {
             // We got logged out somehow, perhaps from another window or a session timeout.
             // We could display an error message, but jumping right to the login page seems
             // smoother and conveys the same information.
-            window.location.replace(page_params.login_page);
+            window.location.href = page_params.login_page;
         }
     });
 

--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -69,12 +69,44 @@ function build_tab_bar(filter) {
     } else {
         const tab_bar_data = make_tab_data(filter);
         display_tab_bar(tab_bar_data);
+
         $(".search_closed").on("click", function (e) {
             exports.open_search_bar_and_close_narrow_description();
             search.initiate_search();
             e.preventDefault();
             e.stopPropagation();
         });
+
+        $("#tab_list span:nth-last-child(2)").on("click", function (e) {
+            exports.open_search_bar_and_close_narrow_description();
+            search.initiate_search();
+            e.preventDefault();
+            e.stopPropagation();
+        });
+
+        // Hacky way of protecting the behaviour of links via preventDefault
+        // and stopPropagation
+        $(".narrow_description > a").on("click", function (e) {
+            window.location.href = e.target.href;
+            e.preventDefault();
+            e.stopPropagation();
+        });
+
+        const color = $(".search_closed").css("color");
+        const night_mode_color = $(".nightmode .closed_icon").css("color");
+
+        // make sure that hover plays nicely with whether search is being
+        // opened or not.
+        $(".narrow_description > a").hover(function () {
+            if (night_mode_color) {
+                $(".search_closed").css("color", night_mode_color);
+            } else {
+                $(".search_closed").css("color", color);
+            }
+        }, function () {
+            $(".search_closed").css("color", "");
+        });
+
         exports.close_search_bar_and_open_narrow_description();
     }
 }

--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -38,6 +38,13 @@ function make_tab_data(filter) {
             tab_data.formatted_sub_count = '0';
             tab_data.rendered_narrow_description = "This stream does not exist or is private.";
         }
+        if (tab_data.rendered_narrow_description === "") {
+            if (page_params.is_admin) {
+                tab_data.rendered_narrow_description = "<a href=" + tab_data.stream_settings_link + ">(no description)</a>";
+            } else {
+                tab_data.rendered_narrow_description = "(no description)";
+            }
+        }
     }
     return tab_data;
 }

--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -90,7 +90,7 @@ exports.exit_search = function () {
         $("#search_query").val(search_string);
     } else {
         // for "searching narrows", we redirect
-        window.location.replace(filter.generate_redirect_url());
+        window.location.href = filter.generate_redirect_url();
     }
 };
 

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -232,6 +232,10 @@ on a dark background, and don't change the dark labels dark either. */
         background: hsla(0, 0%, 100%, 0.5);
     }
 
+    #tab_bar #tab_list span:nth-last-child(2):hover + .search_closed {
+        color: hsl(0, 0%, 100%);
+    }
+
     #searchbox_legacy {
         #tab_bar #tab_list .sub_count,
         #tab_bar #tab_list .narrow_description {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1531,7 +1531,7 @@ div.focused_table {
             cursor: pointer;
             font-size: 20px;
 
-            padding: 12px 0px 0px 0px;
+            padding: 10px 0px 0px 0px;
             @media (max-width: 500px) {
                 padding: 5px 0px 0px 0px;
             }

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1432,6 +1432,17 @@ div.focused_table {
             &:nth-last-child(2) {
                 flex-grow: 1;
             }
+
+            // We extend the clickable area for the search_closed icon over the
+            // 2nd last navbar element for better design (user convenience) this
+            // selector makes it so mousing over that element also gives the user
+            // a visual cue about the results of clicking the element
+            &:nth-last-child(2) {
+                cursor: pointer;
+                &:hover + .search_closed {
+                    color: hsl(0, 0%, 0%);
+                }
+            }
             i {
                 margin-right: 3px;
             }
@@ -1522,18 +1533,21 @@ div.focused_table {
                 padding: 7px 0;
                 padding-left: 2px;
             }
+
+            & > a {
+                padding: 12px 0px;
+            }
         }
 
         .search_closed {
             flex: 0; // makes sure search icon is always visible
-            margin-right: 15px;
 
             cursor: pointer;
             font-size: 20px;
 
-            padding: 10px 0px 0px 0px;
+            padding: 10px 15px 0px 0px;
             @media (max-width: 500px) {
-                padding: 5px 0px 0px 0px;
+                padding: 5px 15px 0px 0px;
             }
         }
     }


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
aligns the search icon and increases the trigger area for search

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![navbar expanded search trigger area](https://user-images.githubusercontent.com/33805964/80028454-bb7a3a80-8502-11ea-9fc7-9c3ed46952c1.gif)
![navbar expanded search trigger area day mode](https://user-images.githubusercontent.com/33805964/80028459-bddc9480-8502-11ea-958f-b9dd8a63d200.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
