### PR TITLE
.editorconfig: Add .scss, .hbs; drop weirder rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{sh,py,pyi,js,ts,json,yml,xml,css,md,markdown,handlebars,html}]
+[*.{sh,py,pyi,js,ts,json,xml,css,scss,hbs,html}]
 indent_style = space
 indent_size = 4
 
@@ -16,10 +16,6 @@ max_line_length = 110
 [*.{js,ts}]
 max_line_length = 100
 
-[*.{svg,rb,pp,pl}]
+[*.{svg,rb,pp}]
 indent_style = space
 indent_size = 2
-
-[*.cfg]
-indent_style = space
-indent_size = 8


### PR DESCRIPTION
For example, nobody uses 4 space indents for `.yml`.