### PR TITLE
[WIP] zerver/messages.py: Add has:reactions filter to messages search

### DIFF
--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -509,6 +509,13 @@ function get_has_filter_suggestions(last, operators) {
                 {operator: 'has', operand: 'attachment'},
             ],
         },
+        {
+            search_string: 'has:reaction',
+            description: 'messages with one or more reaction',
+            invalid: [
+                {operator: 'has', operand: 'reaction'},
+            ],
+        },
     ];
     return get_special_filter_suggestions(last, operators, suggestions);
 }

--- a/templates/zerver/app/search_operators.html
+++ b/templates/zerver/app/search_operators.html
@@ -77,6 +77,10 @@
                 <td class="definition">{{ _('Narrow to messages containing uploads.') }}</td>
             </tr>
             <tr>
+                <td class="operator">has:reaction</td>
+                <td class="definition">{{ _('Narrow to messages containing reactions.') }}</td>
+            </tr>
+            <tr>
                 <td class="operator"><span class="operator_value">keyword</span></td>
                 <td class="definition">{% trans %}Search for <span class="operator_value"> keyword </span> in the topic or message content {% endtrans %}</td>
             </tr>

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -4219,6 +4219,13 @@ class MessageHasKeywordsTest(ZulipTestCase):
             self.assertFalse(m.called)
             m.reset_mock()
 
+    def test_has_reaction(self) -> None:
+        self.login('hamlet')
+        with queries_captured() as queries:
+            result = self.client_get(
+                '/json/messages?anchor=newest&num_before=1&num_after=1&narrow=%5B%7B"negated"%3Afalse%2C"operator"%3A"has"%2C"operand"%3A"reaction"%7D%5D&client_gravatar=true')
+        self.assert_json_success(result)
+
 class MissedMessageTest(ZulipTestCase):
     def test_presence_idle_user_ids(self) -> None:
         UserPresence.objects.all().delete()

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -172,11 +172,15 @@ class NarrowBuilder:
         return method(query, operand, maybe_negate)
 
     def by_has(self, query: Query, operand: str, maybe_negate: ConditionTransform) -> Query:
-        if operand not in ['attachment', 'image', 'link']:
-            raise BadNarrowOperator("unknown 'has' operand " + operand)
-        col_name = 'has_' + operand
-        cond = column(col_name)
-        return query.where(maybe_negate(cond))
+        if operand in ['attachment', 'image', 'link']:
+            col_name = 'has_' + operand
+            cond = column(col_name)
+            return query.where(maybe_negate(cond))
+        elif operand == 'reaction':
+            message_id = column('message_id')
+            Reaction = table('zerver_reaction')
+            return query.where(message_id.in_(select([message_id]).select_from(Reaction)))
+        raise BadNarrowOperator("unknown 'has' operand " + operand)
 
     def by_in(self, query: Query, operand: str, maybe_negate: ConditionTransform) -> Query:
         if operand == 'home':


### PR DESCRIPTION

https://github.com/zulip/zulip/issues/14578

**Testing Plan:**
Run backend tests for zerver
Test speed on query; optimize by adding has_reaction to messages table

Adds support for has:reaction search filter
**GIFs or Screenshots:** 
![feature_demo_gif](https://user-images.githubusercontent.com/22668900/80033465-ca3cff00-84ba-11ea-89ec-2b26a773ca4e.gif)

![image](https://user-images.githubusercontent.com/22668900/80033573-f5275300-84ba-11ea-9a17-436aae9da631.png)

