### PR TITLE
node test: Remove unnecessary zrequires.

### DIFF
--- a/frontend_tests/node_tests/muting.js
+++ b/frontend_tests/node_tests/muting.js
@@ -2,7 +2,6 @@
 zrequire('timerender');
 zrequire('muting');
 zrequire('stream_data');
-set_global('i18n', global.stub_i18n);
 set_global('XDate', zrequire('XDate', 'xdate'));
 set_global('page_params', {});
 

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -1,5 +1,3 @@
-
-zrequire('timerender');
 zrequire('muting');
 zrequire('people');
 zrequire('stream_data');
@@ -12,9 +10,6 @@ zrequire('settings_notifications');
 
 const FoldDict = zrequire('fold_dict').FoldDict;
 
-set_global('i18n', global.stub_i18n);
-set_global('XDate', zrequire('XDate', 'xdate'));
-set_global('page_params', {});
 set_global('narrow_state', {});
 set_global('current_msg_list', {});
 set_global('home_msg_list', {});


### PR DESCRIPTION
Some extraneous zrequires were added in
3bc818b9f7a8a6e15881d5aeedc9917a9d64d66d

This is not a huge deal, but it makes it
appear as if data modules are dependent
on things that they don't really care
about.  The tests should provide a bit
of signal on how "deep" an object's
dependencies go.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
