### PR TITLE
circleci: Build production tarball and install it in different jobs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,14 +99,20 @@ aliases:
 
         mispipe ./tools/ci/setup-production ts
 
-  - &install_production
+  - &production_extract_tarball
     run:
-     name: install production
+     name: production extract tarball
      command: |
       sudo apt-get update
       # Install moreutils so we can use `ts` and `mispipe` in the following.
       sudo apt-get install -y moreutils
 
+      mispipe /tmp/production-extract-tarball ts
+
+  - &install_production
+    run:
+     name: install production
+     command: |
       sudo service rabbitmq-server restart
       mispipe /tmp/production ts
 
@@ -245,6 +251,7 @@ jobs:
             - success-http-headers.txt
             - production-helper
             - production
+            - production-extract-tarball
 
   "bionic-production-install-python3.6":
     docker:
@@ -262,6 +269,7 @@ jobs:
 
       - *create_cache_directories
       - *do_bionic_hack
+      - *production_extract_tarball
       - *restore_cache_package_json
       - *install_production
       - *save_cache_package_json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,8 +262,9 @@ jobs:
 
       - *create_cache_directories
       - *do_bionic_hack
-      - *install_production
       - *restore_cache_package_json
+      - *install_production
+      - *save_cache_package_json
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ aliases:
       sudo apt-get install -y moreutils
 
       sudo service rabbitmq-server restart
-      mispipe ./tools/ci/production ts
+      mispipe /tmp/production ts
 
   - &check_xenial_provision_error
     run:
@@ -243,6 +243,8 @@ jobs:
           paths:
             - zulip-server-test.tar.gz
             - success-http-headers.txt
+            - production-helper
+            - production
 
   "bionic-production-install-python3.6":
     docker:
@@ -253,8 +255,6 @@ jobs:
     working_directory: ~/zulip
 
     steps:
-      # required to run production-helper script.
-      - checkout
       # Contains the built tarball from bionic-production-build-python3.6 job
       - attach_workspace:
           # Must be absolute path or relative path from working_directory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
     docker:
       # This is built from tools/circleci/images/bionic/Dockerfile .
       # Bionic ships with Python 3.6.
-      - image: gregprice/circleci:bionic-python-1.test
+      - image: amanagr/circleci:bionic-python-2.test
 
     working_directory: ~/zulip
 
@@ -221,7 +221,7 @@ jobs:
     docker:
         # This is built from tools/circleci/images/bionic/Dockerfile .
         # Bionic ships with Python 3.6.
-        - image: gregprice/circleci:bionic-python-1.test
+        - image: amanagr/circleci:bionic-python-2.test
 
     working_directory: ~/zulip
 
@@ -257,7 +257,7 @@ jobs:
     docker:
         # This is built from tools/circleci/images/bionic/Dockerfile .
         # Bionic ships with Python 3.6.
-        - image: gregprice/circleci:bionic-python-1.test
+        - image: amanagr/circleci:bionic-python-2.test
 
     working_directory: ~/zulip
 

--- a/tools/ci/production
+++ b/tools/ci/production
@@ -2,4 +2,4 @@
 set -e
 set -x
 
-sudo ./tools/ci/production-helper
+sudo /tmp/production-helper

--- a/tools/ci/production-extract-tarball
+++ b/tools/ci/production-extract-tarball
@@ -3,5 +3,5 @@
 set -e
 set -x
 
-ZULIP_PATH=$(mktemp -d)
+ZULIP_PATH=~/zulip
 tar -xf /tmp/zulip-server-test.tar.gz -C "$ZULIP_PATH" --strip-components=1

--- a/tools/ci/production-extract-tarball
+++ b/tools/ci/production-extract-tarball
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+ZULIP_PATH=$(mktemp -d)
+tar -xf /tmp/zulip-server-test.tar.gz -C "$ZULIP_PATH" --strip-components=1

--- a/tools/ci/production-helper
+++ b/tools/ci/production-helper
@@ -5,7 +5,7 @@
 set -e
 set -x
 
-ZULIP_PATH=$(mktemp -d)
+ZULIP_PATH=~/zulip
 
 # Do an apt upgrade to start with an up-to-date machine
 APT_OPTIONS=(-o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold')

--- a/tools/ci/production-helper
+++ b/tools/ci/production-helper
@@ -6,7 +6,6 @@ set -e
 set -x
 
 ZULIP_PATH=$(mktemp -d)
-tar -xf /tmp/zulip-server-test.tar.gz -C "$ZULIP_PATH" --strip-components=1
 
 # Do an apt upgrade to start with an up-to-date machine
 APT_OPTIONS=(-o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold')

--- a/tools/ci/setup-production
+++ b/tools/ci/setup-production
@@ -32,3 +32,4 @@ mv /tmp/tmp.*/zulip-server-test.tar.gz /tmp/
 cp -a tools/ci/success-http-headers.txt /tmp/success-http-headers.txt
 cp -a tools/ci/production /tmp/production
 cp -a tools/ci/production-helper /tmp/production-helper
+cp -a tools/ci/production-extract-tarball /tmp/production-extract-tarball

--- a/tools/ci/setup-production
+++ b/tools/ci/setup-production
@@ -30,3 +30,5 @@ fi
 
 mv /tmp/tmp.*/zulip-server-test.tar.gz /tmp/
 cp -a tools/ci/success-http-headers.txt /tmp/success-http-headers.txt
+cp -a tools/ci/production /tmp/production
+cp -a tools/ci/production-helper /tmp/production-helper


### PR DESCRIPTION
This separates the production installer tarball build process from install process and avoids any leakages that could happen between the production install and dev provision installations. 