### PR TITLE
styles: Size full-viewport fixed elements as 100%, not 100vw × 100vh

### DIFF
--- a/static/styles/app_components.scss
+++ b/static/styles/app_components.scss
@@ -268,8 +268,8 @@
     position: fixed;
     top: 0;
     left: 0;
-    width: 100vw;
-    height: 100vh;
+    width: 100%;
+    height: 100%;
     overflow: auto;
     -webkit-overflow-scrolling: touch;
 

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -296,8 +296,8 @@ ul {
         top: 0px !important;
         left: 0px !important;
         margin: 0 !important;
-        width: 100vw;
-        height: 100vh;
+        width: 100%;
+        height: 100%;
 
         background-color: hsla(0, 0%, 0%, 0.7);
         border-radius: 0px;

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -362,8 +362,8 @@ form#add_new_subscription {
     position: fixed;
     top: 0;
     left: 0;
-    width: 100vw;
-    height: 100vh;
+    width: 100%;
+    height: 100%;
     background-color: hsla(0, 0%, 8%, 0.7);
     color: hsl(0, 0%, 27%);
 }


### PR DESCRIPTION
Mobile Chrome includes the height of the address bar in its calculation of 100vh, which was causing a corresponding part of our content to be pushed off the bottom of the screen.

Fixes #11324.

**Testing Plan:** Dev server in mobile Chrome.