### PR TITLE
nginx: Listen for ACME challenges on port 80 too

### DIFF
--- a/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
+++ b/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
@@ -3,7 +3,12 @@
 server {
     listen 80;
     listen [::]:80;
-    return 301 https://$host$request_uri;
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+
+    include /etc/nginx/zulip-include/certbot;
 }
 <% end -%>
 


### PR DESCRIPTION
This should make Certbot renewals more reliable.

**Testing Plan:** http://andersk.zulipdev.org/.well-known/acme-challenge/ no longer redirects to HTTPS.