### PR TITLE
ci: Add test to check for untracked files.

### DIFF
--- a/tools/ci/backend
+++ b/tools/ci/backend
@@ -38,3 +38,12 @@ set -x
 # NB: Everything here should be in `tools/test-all`.  If there's a
 # reason not to run it there, it should be there as a comment
 # explaining why.
+
+# This test is run to check if some untracked files have been created after 
+# running all the checks.
+untracked="$(git ls-files --exclude-standard --others)"
+if [ -n "$untracked" ]; then
+  printf >&2 "Error: untracked files:\n%s\n" "$untracked"
+  exit 1
+fi
+


### PR DESCRIPTION
Runs a test at the end of tools/ci/backend to check if any untracked
files have been created in ci tests. Exits with error code 1 if
untracked files found, otherwise exits successfully.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->

Triedn running ./tools/ci/backend with some untracked files present. Caused the program to exit, with code 1

Fixes #14691 

