### PR TITLE
i18n: Add translation tag to email templates.

### DIFF
--- a/templates/zerver/emails/missed_message.source.html
+++ b/templates/zerver/emails/missed_message.source.html
@@ -14,9 +14,9 @@
     {% else %}
     <div class="missed_message">
     {% if message_content_disabled_by_realm %}
-    This email does not include message content because your organization has disabled <a class="content_disabled_help_link" href="{{ realm_uri }}/help/hide-message-content-in-emails">message content appearing in email notifications</a>.
+    {% trans help_url=realm_uri + "/help/hide-message-content-in-emails" %}This email does not include message content because your organization has disabled <a class="content_disabled_help_link" href="{{ help_url }}">message content appearing in email notifications</a>.{% endtrans %}
     {% elif message_content_disabled_by_user %}
-    This email does not include message content because you have disabled <a class="content_disabled_help_link" href="{{ realm_uri }}/help/pm-mention-alert-notifications">message content appearing in email notifications</a>.
+    {% trans alert_notif_url=realm_uri + "/help/pm-mention-alert-notifications" %}This email does not include message content because you have disabled <a class="content_disabled_help_link" href="{{ alert_notif_url }}">message content appearing in email notifications</a>.{% endtrans %}
     {% endif %}
     </div>
     {% endif %}
@@ -26,19 +26,20 @@
 <div class="email-preferences">
     &mdash;<br>
     {% if mention %}
-    You are receiving this because you were mentioned in {{ realm_name }}.<br>
+    {% trans %}You are receiving this because you were mentioned in {{ realm_name }}.{% endtrans %}<br>
     {% elif stream_email_notify %}
-    You are receiving this because you have email notifications enabled for this stream.<br>
+    {% trans %}You are receiving this because you have email notifications enabled for this stream.{% endtrans %}<br>
     {% endif %}
     {% if reply_to_zulip %}
-    Reply to this email directly, <a href="{{ narrow_url }}">view it in Zulip</a>, or <a href="{{ realm_uri }}/#settings/notifications">manage email preferences</a>.
+    {% trans notif_url=realm_uri + "/#settings/notifications" %}Reply to this email directly, <a href="{{ narrow_url }}">view it in Zulip</a>, or <a href="{{ notif_url }}">manage email preferences</a>.{% endtrans %}
     {% elif not show_message_content %}
-    <a href="{{ narrow_url }}">View or reply in Zulip</a>, or <a href="{{ realm_uri }}/#settings/notifications">manage email preferences</a>.<br>
+    {% trans notif_url=realm_uri + "/#settings/notifications" %}<a href="{{ narrow_url }}">View or reply in Zulip</a>, or <a href="{{ notif_url }}">manage email preferences</a>.{% endtrans %} <br>
     {% else %}
-    <a href="{{ narrow_url }}">Reply in Zulip</a>, or <a href="{{ realm_uri }}/#settings/notifications">manage email preferences</a>.<br>
+    {% trans notif_url=realm_uri + "/#settings/notifications" %}<a href="{{ narrow_url }}">Reply in Zulip</a>, or <a href="{{ notif_url }}">manage email preferences</a>.{% endtrans %} <br>
     <br>
-    Do not reply to this email. This Zulip server is not
-    configured to accept incoming emails (<a href="https://zulip.readthedocs.io/en/latest/production/email-gateway.html">help</a>).
+    {% trans url="https://zulip.readthedocs.io/en/latest/production/email-gateway.html" %}
+    Do not reply to this email. This Zulip server is not configured to accept incoming emails (<a href="{{ url }}">help</a>).
+    {% endtrans %}
 
     {% endif %}
 </div>

--- a/templates/zerver/emails/missed_message.subject.txt
+++ b/templates/zerver/emails/missed_message.subject.txt
@@ -1,10 +1,10 @@
 {% if show_message_content %}
-    {% if group_pm %} Group PMs with {{ huddle_display_name }}
-    {% elif private_message %} PMs with {{ sender_str }}
+    {% if group_pm %} {% trans %}Group PMs with {{ huddle_display_name }}{% endtrans %}
+    {% elif private_message %} {% trans %}PMs with {{ sender_str }}{% endtrans %}
     {% elif stream_email_notify or mention %} #{{ stream_header }}
     {% endif %}
 {% else %}
-    New missed messages
+    {% trans %}New missed messages{% endtrans %}
 {% endif %}
 {% if realm_name_in_notifications %} [{{ realm_str }}]
 {% endif %}

--- a/templates/zerver/emails/missed_message.txt
+++ b/templates/zerver/emails/missed_message.txt
@@ -29,12 +29,15 @@ See {{ alert_notif_url }} for more details.
 
 {% if reply_to_zulip  %}
 {% trans %}Reply to this email directly, or view it in Zulip:{% endtrans %}
+
 {{ narrow_url }}
 {% elif not show_message_content %}
 {% trans %}View or reply in Zulip:{% endtrans %}
+
 {{ narrow_url }}
 {% else %}
 {% trans %}Reply in Zulip:{% endtrans %}
+
 {{ narrow_url }}
 
 {% trans %}
@@ -45,4 +48,5 @@ https://zulip.readthedocs.io/en/latest/production/email-gateway.html
 {% endif %}
 
 {% trans %}Manage email preferences: {% endtrans %}
+
 {{ realm_uri }}/#settings/notifications

--- a/templates/zerver/emails/missed_message.txt
+++ b/templates/zerver/emails/missed_message.txt
@@ -8,35 +8,41 @@
 {% endfor %}
 {% else %}
 {% if message_content_disabled_by_realm %}
+{% trans hide_content_url=realm_uri + "/help/hide-message-content-in-emails" %}
 This email does not include message content because your organization has disabled message content appearing in email notifications.
-See {{ realm_uri }}/help/hide-message-content-in-emails for more details.
+See {{ hide_content_url }} for more details.
+{% endtrans %}
 {% elif message_content_disabled_by_user %}
+{% trans alert_notif_url=realm_uri + "/help/pm-mention-alert-notifications" %}
 This email does not include message content because you have disabled message content appearing in email notifications.
-See {{ realm_uri }}/help/pm-mention-alert-notifications for more details.
+See {{ alert_notif_url }} for more details.
+{% endtrans %}
 {% endif %}
 {% endif %}
 
 --
 {% if mention %}
-You are receiving this because you were mentioned in {{ realm_name }}.
+{% trans %}You are receiving this because you were mentioned in {{ realm_name }}.{% endtrans %}
 {% elif stream_email_notify %}
-You are receiving this because you have email notifications enabled for this stream.
+{% trans %}You are receiving this because you have email notifications enabled for this stream.{% endtrans %}
 {% endif %}
 
 {% if reply_to_zulip  %}
-Reply to this email directly, or view it in Zulip:
+{% trans %}Reply to this email directly, or view it in Zulip:{% endtrans %}
 {{ narrow_url }}
 {% elif not show_message_content %}
-View or reply in Zulip:
+{% trans %}View or reply in Zulip:{% endtrans %}
 {{ narrow_url }}
 {% else %}
-Reply in Zulip:
+{% trans %}Reply in Zulip:{% endtrans %}
 {{ narrow_url }}
 
+{% trans %}
 Do not reply to this email. This Zulip server is not configured to accept
 incoming emails. Help:
+{% endtrans %}
 https://zulip.readthedocs.io/en/latest/production/email-gateway.html
 {% endif %}
 
-Manage email preferences:
+{% trans %}Manage email preferences: {% endtrans %}
 {{ realm_uri }}/#settings/notifications

--- a/templates/zerver/emails/realm_reactivation.subject.txt
+++ b/templates/zerver/emails/realm_reactivation.subject.txt
@@ -1,1 +1,1 @@
-Reactivate your Zulip organization
+{% trans %}Reactivate your Zulip organization{% endtrans %}


### PR DESCRIPTION
Some of the email templates were missing translation tags. Added them.

Fixes: #14398

Tested by temporarily adding the german translations in the `django.po` files. Most of the strings to which the tags have been added here require additional translations.

**The list of strings requiring translation is:**
(left the HTML tags in some so it would be easier to just copy-paste the entire thing)
* Reactivate your Zulip organization
* New streams
* Click here to log in to Zulip and catch up.
* Manage email preferences
* Unsubscribe from digest emails
* Zulip digest for
* Group PMs with
* PMs with
* New missed messages
* This email does not include message content because your organization has disabled
* This email does not include message content because you have disabled
* You are receiving this because you were mentioned in
* You are receiving this because you have email notifications enabled for this stream.
* Do not reply to this email. This Zulip server is not configured to accept incoming emails 

* `More message{{ convo.count|pluralize }} by`

* `Reply to this email directly, <a href="{{ narrow_url }}">view it in Zulip</a>, or <a href="{{ realm_uri }}/#settings/notifications">manage email preferences</a>.`

* `<a href="{{ narrow_url }}">View or reply in Zulip</a>, or <a href="{{ realm_uri }}/#settings/notifications">manage email preferences</a>.<br>`

* `<a href="{{ narrow_url }}">Reply in Zulip{</a>, or <a href="{{ realm_uri }}/#settings/notifications">manage email preferences</a>.<br>`