### PR TITLE
droplet settings: Fix hostname-related settings.

### DIFF
--- a/tools/run-dev.py
+++ b/tools/run-dev.py
@@ -4,7 +4,6 @@ import argparse
 import os
 import pwd
 import signal
-import socket
 import subprocess
 import sys
 import traceback
@@ -79,8 +78,6 @@ if options.interface is None:
         # host.  The same argument applies to the remote development
         # servers using username "zulipdev".
         options.interface = None
-        if user_name == "zulipdev":
-            os.environ.setdefault("EXTERNAL_HOST", socket.gethostname() + ":9991")
     else:
         # Otherwise, only listen to requests on localhost for security.
         options.interface = "127.0.0.1"

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -12,13 +12,20 @@ from typing import Set
 DEPLOY_ROOT = os.path.realpath(os.path.dirname(os.path.dirname(__file__)))
 LOCAL_UPLOADS_DIR = os.path.join(DEPLOY_ROOT, 'var/uploads')
 
+def is_dev_droplet() -> bool:
+    # We assume dev droplets are the only places where
+    # users use zulipdev as the user.
+    user_id = os.getuid()
+    user_name = pwd.getpwuid(user_id).pw_name
+    return user_name == 'zulipdev'
+
+IS_DEV_DROPLET = is_dev_droplet()
+
 FORWARD_ADDRESS_CONFIG_FILE = "var/forward_address.ini"
 # Check if test_settings.py set EXTERNAL_HOST.
 external_host_env = os.getenv('EXTERNAL_HOST')
 if external_host_env is None:
-    user_id = os.getuid()
-    user_name = pwd.getpwuid(user_id).pw_name
-    if user_name == "zulipdev":
+    if IS_DEV_DROPLET:
         # For most of our droplets, we use the hostname (eg github_username.zulipdev.org) by default.
         hostname = os.uname()[1].lower()
         # Some of the droplets (eg droplets on 18.04) has the github_username as hostname.

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -71,6 +71,8 @@ CASPER_TESTS = False
 RUNNING_OPENAPI_CURL_TEST = False
 # This is overridden in test_settings.py for the test suites
 GENERATE_STRIPE_FIXTURES = False
+# This is overridden by dev_settings.py for droplets.
+IS_DEV_DROPLET = False
 
 # Google Compute Engine has an /etc/boto.cfg that is "nicely
 # configured" to work with GCE's storage service.  However, their
@@ -517,7 +519,7 @@ if CAMO_URI != '':
 # STATIC CONTENT AND MINIFICATION SETTINGS
 ########################################################################
 
-if PRODUCTION or os.getenv('EXTERNAL_HOST') is not None:
+if PRODUCTION or IS_DEV_DROPLET or os.getenv('EXTERNAL_HOST') is not None:
     STATIC_URL = urljoin(ROOT_DOMAIN_URI, '/static/')
 else:
     STATIC_URL = 'http://localhost:9991/static/'


### PR DESCRIPTION
We recently changed our droplet setup such that their
host names no longer include zulipdev.org.  This caused
a few things to break.

The particular symptom that this commit fixes is that
we were trying to server static assets from
showell:9991 instead of showell.zulipdev.org:9991,
which meant that you couldn't use the app locally.
(The server would start, but the site's pretty unusable
without static assets.)

Now we rely 100% on `dev_settings.py` to set
`EXTERNAL_HOST` for any droplet users who don't set
that var in their own environment.  That allows us to
remove some essentially duplicate code in `run-dev.py`.

We also set `IS_DEV_DROPLET` explicitly, so that other
code doesn't have to make inferences or duplicate
logic to detemine whether we're a droplet or not.

And then in `settings.py` we use `IS_DEV_DROPLET` to
know that we can use a prod-like method of calculating
`STATIC_URL`, instead of hard coding `localhost`.

We may want to iterate on this further--this was
sort of a quick fix to get droplets functional again.
It's possible we can re-configure droplets to have
folks get reasonable `EXTERNAL_HOST` settings in their
bash profiles, or something like that, although that
may have its own tradeoffs.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
