### PR TITLE
nginx: Replace unanchored regexes in location directives

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-frontend/app
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/app
@@ -17,7 +17,7 @@ location /static/ {
 }
 
 # Send longpoll requests to Tornado
-location ~ /json/events {
+location /json/events {
     proxy_pass http://tornado;
     include /etc/nginx/zulip-include/proxy_longpolling;
 

--- a/puppet/zulip_ops/files/nginx/sites-available/loadbalancer
+++ b/puppet/zulip_ops/files/nginx/sites-available/loadbalancer
@@ -35,7 +35,12 @@ server {
     }
 
     # We don't need /api/v1/events/internal, because that doesn't go through the loadbalancer.
-    location ~ /json/events|/api/v1/events {
+    location /json/events {
+        proxy_pass https://staging;
+        include /etc/nginx/zulip-include/proxy_longpolling;
+    }
+
+    location /api/v1/events {
         proxy_pass https://staging;
         include /etc/nginx/zulip-include/proxy_longpolling;
     }
@@ -58,7 +63,12 @@ server {
         include /etc/nginx/zulip-include/proxy;
     }
 
-    location ~ /json/events|/api/v1/events {
+    location /json/events {
+        proxy_pass https://prod;
+        include /etc/nginx/zulip-include/proxy_longpolling;
+    }
+
+    location /api/v1/events {
         proxy_pass https://prod;
         include /etc/nginx/zulip-include/proxy_longpolling;
     }
@@ -81,7 +91,12 @@ server {
         include /etc/nginx/zulip-include/proxy;
     }
 
-    location ~ /json/events|/api/v1/events {
+    location /json/events {
+        proxy_pass https://prod;
+        include /etc/nginx/zulip-include/proxy_longpolling;
+    }
+
+    location /api/v1/events {
         proxy_pass https://prod;
         include /etc/nginx/zulip-include/proxy_longpolling;
     }
@@ -100,7 +115,12 @@ server {
         include /etc/nginx/zulip-include/proxy;
     }
 
-    location ~ /json/events|/api/v1/events {
+    location /json/events {
+        proxy_pass https://prod;
+        include /etc/nginx/zulip-include/proxy_longpolling;
+    }
+
+    location /api/v1/events {
         proxy_pass https://prod;
         include /etc/nginx/zulip-include/proxy_longpolling;
     }


### PR DESCRIPTION
We could anchor the regexes, but there’s no need for the power (and responsibility) of regexes here.

**Testing Plan:** https://andersk.zulipdev.org, https://andersk.zulipdev.org/not-the-root-url/json/events