### PR TITLE
auth: Use the clipboard instead of zulip:// for desktop auth flow

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -145,6 +145,9 @@ py3dns
 social-auth-app-django
 social-auth-core[azuread,saml]
 
+# For encrypting a login token to the desktop app
+cryptography
+
 # Needed for messages' rendered content parsing in push notifications.
 lxml
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -230,7 +230,7 @@ cryptography==2.9 \
     --hash=sha256:d1bf5a1a0d60c7f9a78e448adcb99aa101f3f9588b16708044638881be15d6bc \
     --hash=sha256:ed1d0760c7e46436ec90834d6f10477ff09475c692ed1695329d324b2c5cd547 \
     --hash=sha256:ef9a55013676907df6c9d7dd943eb1770d014f68beaa7e73250fb43c759f4585 \
-    # via apns2, moto, pyopenssl, requests, scrapy, service-identity, social-auth-core, sshpubkeys
+    # via -r requirements/common.in, apns2, moto, pyopenssl, requests, scrapy, service-identity, social-auth-core, sshpubkeys
 cssselect2==0.3.0 \
     --hash=sha256:5c2716f06b5de93f701d5755a9666f2ee22cbcd8b4da8adddfc30095ffea3abc \
     --hash=sha256:97d7d4234f846f9996d838964d38e13b45541c18143bc55cf00e4bc1281ace76 \

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -143,7 +143,7 @@ cryptography==2.9 \
     --hash=sha256:d1bf5a1a0d60c7f9a78e448adcb99aa101f3f9588b16708044638881be15d6bc \
     --hash=sha256:ed1d0760c7e46436ec90834d6f10477ff09475c692ed1695329d324b2c5cd547 \
     --hash=sha256:ef9a55013676907df6c9d7dd943eb1770d014f68beaa7e73250fb43c759f4585 \
-    # via apns2, pyopenssl, requests, social-auth-core
+    # via -r requirements/common.in, apns2, pyopenssl, requests, social-auth-core
 cssselect==1.1.0 \
     --hash=sha256:f612ee47b749c877ebae5bb77035d8f4202c6ad0f0fc1271b3c18ad6c4468ecf \
     --hash=sha256:f95f8dedd925fd8f54edb3d2dfb44c190d9d18512377d3c1e2388d16126879bc \

--- a/static/js/portico/desktop-login.js
+++ b/static/js/portico/desktop-login.js
@@ -1,0 +1,64 @@
+document.querySelector("#form").addEventListener("submit", () => {
+    document.querySelector("#bad-token").hidden = false;
+});
+document.querySelector("#token").focus();
+
+async function decrypt_manual() {
+    const key = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, true, [
+        "decrypt",
+    ]);
+    return {
+        key: new Uint8Array(await crypto.subtle.exportKey("raw", key)),
+        pasted: new Promise((resolve) => {
+            const tokenElement = document.querySelector("#token");
+            tokenElement.addEventListener("input", async () => {
+                document.querySelector("#bad-token").hidden = true;
+                document.querySelector("#submit").disabled = tokenElement.value === "";
+                try {
+                    const data = new Uint8Array(
+                        tokenElement.value.match(/../g).map((b) => parseInt(b, 16))
+                    );
+                    const iv = data.slice(0, 12);
+                    const ciphertext = data.slice(12);
+                    const plaintext = await crypto.subtle.decrypt(
+                        { name: "AES-GCM", iv },
+                        key,
+                        ciphertext
+                    );
+                    resolve(new TextDecoder().decode(plaintext));
+                } catch {
+                    // Ignore all parsing and decryption failures.
+                }
+            });
+        }),
+    };
+}
+
+(async () => {
+    // Sufficiently new versions of the desktop app provide the
+    // electron_bridge.decrypt_clipboard API, which returns AES-GCM encryption
+    // key and a promise; as soon as something encrypted to that key is copied
+    // to the clipboard, the app decrypts it and resolves the promise to the
+    // plaintext.  This lets us skip the manual paste step.
+    const { key, pasted } =
+        window.electron_bridge && window.electron_bridge.decrypt_clipboard
+            ? window.electron_bridge.decrypt_clipboard(1)
+            : await decrypt_manual();
+
+    console.log(key);
+    const keyHex = Array.from(key, (b) => b.toString(16).padStart(2, "0")).join("");
+    window.open(
+        new URL(
+            (window.location.search ? window.location.search + "&" : "?") +
+                "desktop_flow_otp=" +
+                encodeURIComponent(keyHex),
+            window.location.href
+        ),
+        "_blank"
+    );
+
+    const token = await pasted;
+    document.querySelector("#form").hidden = true;
+    document.querySelector("#done").hidden = false;
+    window.location.href = "/accounts/login/subdomain/" + encodeURIComponent(token);
+})();

--- a/static/js/portico/desktop-redirect.js
+++ b/static/js/portico/desktop-redirect.js
@@ -1,0 +1,3 @@
+const ClipboardJS = require("clipboard");
+new ClipboardJS("#copy");
+document.querySelector("#copy").focus();

--- a/templates/zerver/desktop_login.html
+++ b/templates/zerver/desktop_login.html
@@ -1,0 +1,27 @@
+{% extends "zerver/portico.html" %}
+{% set entrypoint = "desktop-login" %}
+
+{% block portico_content %}
+<div class="flex">
+    <div class="desktop-redirect-box">
+        <h1>{% trans %}Finish desktop login{% endtrans %}</h1>
+
+        <div class="white-box">
+            <p>{% trans %}Use your web browser to finish logging in, then come back here to paste in your login token.{% endtrans %}</p>
+
+            <form id="form" action="blob:">
+                <input id="token" placeholder="{% trans %}Paste token here{% endtrans %}" />
+                <button id="submit" disabled class="btn btn-primary">{% trans %}Finish{% endtrans %}</button>
+            </form>
+
+            <p id="bad-token" hidden>
+                {% trans %}Incorrect token.{% endtrans %}
+            </p>
+
+            <p id="done" hidden>
+                {% trans %}Token accepted.  Logging you in…{% endtrans %}
+            </p>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/zerver/desktop_redirect.html
+++ b/templates/zerver/desktop_redirect.html
@@ -1,18 +1,17 @@
 {% extends "zerver/portico.html" %}
-
-{% block customhead %}
-<meta http-equiv="Refresh" content="2; {{ desktop_url }}">
-{% endblock %}
+{% set entrypoint = "desktop-redirect" %}
 
 {% block content %}
 <div class="flex">
     <div class="desktop-redirect-box">
         <img class="avatar desktop-redirect-image" src="{{ realm_icon_url }}" alt=""/><br>
-        Redirecting to your Zulip app...
-        <div class="desktop-redirect-links">
-            <a id="desktop-redirect-link" href="{{ desktop_url }}">If you weren't redirected, click here.</a><br>
-            <a href="{{ browser_url }}">Or, continue in your browser.</a>
-        </div>
+        <p>{% trans %}Copy this login token and return to your Zulip app to finish logging in:{% endtrans %}</p>
+        <p>
+            <input id="desktop-data" value="{{ desktop_data }}" readonly />
+            <button id="copy" tabindex="0" class="btn btn-primary" data-clipboard-target="#desktop-data">{% trans %}Copy{% endtrans %}</button>
+        </p>
+        <p>{% trans %}You may then close this window.{% endtrans %}</p>
+        <p><a href="{{ browser_url }}">{% trans %}Or, continue in your browser.{% endtrans %}</a></p>
     </div>
 </div>
 {% endblock %}

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -101,6 +101,14 @@
         "./static/js/bundles/portico.js",
         "./static/js/portico/dev-login.js"
     ],
+    "desktop-login": [
+        "./static/js/bundles/portico.js",
+        "./static/js/portico/desktop-login.js"
+    ],
+    "desktop-redirect": [
+        "./static/js/bundles/portico.js",
+        "./static/js/portico/desktop-redirect.js"
+    ],
     "integrations-dev-panel": [
         "./static/js/bundles/portico.js",
         "./static/js/portico/integrations_dev_panel.js",


### PR DESCRIPTION
This gives a smoother UX with zulip/zulip-desktop#943, but it’s no longer a hard requirement.

I’ve tested this with the dev server.