### PR TITLE
Draft UI redesign

### DIFF
--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -1,6 +1,11 @@
 const util = require("./util");
 const render_draft_table_body = require('../templates/draft_table_body.hbs');
 
+function set_count(count) {
+    const text = "Drafts (" + count.toString() + ")";
+    $(".compose_drafts_button").text(i18n.t(text));
+}
+
 const draft_model = (function () {
     const exports = {};
 
@@ -24,6 +29,7 @@ const draft_model = (function () {
 
     function save(drafts) {
         ls.set(KEY, drafts);
+        set_count(Object.keys(drafts).length);
     }
 
     exports.addDraft = function (draft) {
@@ -510,6 +516,8 @@ exports.initialize = function () {
     window.addEventListener("beforeunload", function () {
         exports.update_draft();
     });
+
+    set_count(Object.keys(draft_model.get()).length);
 
     $("#compose-textarea").focusout(exports.update_draft);
 

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -141,6 +141,7 @@ exports.update_draft = function () {
         // just update the existing draft.
         draft_model.editDraft(draft_id, draft);
         draft_notify();
+        notifications.notify_drafts();
         return;
     }
 
@@ -149,6 +150,7 @@ exports.update_draft = function () {
     const new_draft_id = draft_model.addDraft(draft);
     $("#compose-textarea").data("draft-id", new_draft_id);
     draft_notify();
+    notifications.notify_drafts();
 };
 
 exports.delete_draft_after_send = function () {

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -117,11 +117,6 @@ exports.restore_message = function (draft) {
     return compose_args;
 };
 
-function draft_notify() {
-    $(".alert-draft").css("display", "inline-block");
-    $(".alert-draft").delay(1000).fadeOut(500);
-}
-
 exports.update_draft = function () {
     const draft = exports.snapshot_message();
 
@@ -140,7 +135,6 @@ exports.update_draft = function () {
         // We don't save multiple drafts of the same message;
         // just update the existing draft.
         draft_model.editDraft(draft_id, draft);
-        draft_notify();
         notifications.notify_drafts();
         return;
     }
@@ -149,7 +143,6 @@ exports.update_draft = function () {
     // one.
     const new_draft_id = draft_model.addDraft(draft);
     $("#compose-textarea").data("draft-id", new_draft_id);
-    draft_notify();
     notifications.notify_drafts();
 };
 

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -739,7 +739,7 @@ exports.register_click_handlers = function () {
         e.stopPropagation();
         e.preventDefault();
     });
-    $('#out-of-view-notification').on('click', '.out-of-view-notification-close', function (e) {
+    $('#out-of-view-notification').on('click', '.compose-notification-close', function (e) {
         exports.clear_compose_notifications();
         e.stopPropagation();
         e.preventDefault();

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -262,6 +262,7 @@ exports.notify_above_composebox = function (note, link_class, link_msg_id, link_
         link_text: link_text,
     }));
     exports.clear_compose_notifications();
+    exports.clear_draft_notifications();
     $('#out-of-view-notification').append(notification_html);
     $('#out-of-view-notification').show();
 };
@@ -709,6 +710,12 @@ exports.clear_compose_notifications = function () {
     $('#out-of-view-notification').hide();
 };
 
+exports.clear_draft_notifications = function () {
+    $('#compose-notifications').empty();
+    $('#compose-notifications').stop(true, true);
+    $('#compose-notifications').hide();
+};
+
 exports.reify_message_id = function (opts) {
     const old_id = opts.old_id;
     const new_id = opts.new_id;
@@ -744,6 +751,12 @@ exports.register_click_handlers = function () {
         e.stopPropagation();
         e.preventDefault();
     });
+
+    $('#compose-notifications').on('click', '.compose-notification-close', function (e) {
+        exports.clear_draft_notifications();
+        e.stopPropagation();
+        e.preventDefault();
+    });
 };
 
 exports.handle_global_notification_updates = function (notification_name, setting) {
@@ -765,4 +778,20 @@ exports.handle_global_notification_updates = function (notification_name, settin
     }
 };
 
+exports.notify_drafts = function () {
+    const draft_msg = i18n.t("Your message has been saved in drafts.");
+    const notification_html = $(render_compose_notification({
+        note: draft_msg,
+        link_class: "",
+        link_msg_id: null,
+        link_text: "",
+    }));
+
+    exports.clear_compose_notifications();
+    exports.clear_draft_notifications();
+    $('#compose-notifications').addClass("draft-notification");
+    $('#compose-notifications').append(notification_html);
+    $('#compose-notifications').show();
+    $('#compose-notifications').delay(1000).fadeOut();
+};
 window.notifications = exports;

--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -282,7 +282,8 @@ div[id^="message-edit-send-status"],
     filter: alpha(opacity=40);
 }
 
-#out-of-view-notification {
+#out-of-view-notification,
+.draft-notification {
     position: relative;
     margin-bottom: 6px;
 
@@ -301,6 +302,29 @@ div[id^="message-edit-send-status"],
         opacity: .2;
         filter: alpha(opacity=20);
     }
+}
+.draft-notification {
+    position: relative;
+    margin-bottom: 10px;
+    left: 5px;
+    padding-right: 50px;
+    padding-left: 50px;
+
+    .close {
+        position: absolute;
+        top: auto;
+        right: 0px;
+    }
+
+    .compose-notifications-content {
+        padding-top: 0px;
+    }
+}
+
+#compose-notifications {
+    position: relative;
+    bottom: 0px;
+    height: 25px;
 }
 
 .compose-notifications-content {

--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -291,15 +291,6 @@ div[id^="message-edit-send-status"],
     border-radius: 4px;
 }
 
-.compose-notifications-content {
-    padding: 4px 22px 4px 22px;
-    text-align: center;
-}
-
-.composition-area {
-    position: relative;
-}
-
 #out-of-view-notification .close {
     position: absolute;
     right: 8px;
@@ -310,6 +301,15 @@ div[id^="message-edit-send-status"],
     text-shadow: 0 1px 0 hsl(0, 0%, 100%);
     opacity: .2;
     filter: alpha(opacity=20);
+}
+
+.compose-notifications-content {
+    padding: 4px 22px 4px 22px;
+    text-align: center;
+}
+
+.composition-area {
+    position: relative;
 }
 
 textarea.new_message_textarea {

--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -289,18 +289,18 @@ div[id^="message-edit-send-status"],
     background-color: hsla(152, 51%, 63%, 0.25);
     border: 1px solid hsla(0, 0%, 0%, 0.1);
     border-radius: 4px;
-}
 
-#out-of-view-notification .close {
-    position: absolute;
-    right: 8px;
-    top: 4px;
-    font-size: 17px;
-    font-weight: bold;
-    color: hsl(0, 0%, 0%);
-    text-shadow: 0 1px 0 hsl(0, 0%, 100%);
-    opacity: .2;
-    filter: alpha(opacity=20);
+    .close {
+        position: absolute;
+        right: 8px;
+        top: 4px;
+        font-size: 17px;
+        font-weight: bold;
+        color: hsl(0, 0%, 0%);
+        text-shadow: 0 1px 0 hsl(0, 0%, 100%);
+        opacity: .2;
+        filter: alpha(opacity=20);
+    }
 }
 
 .compose-notifications-content {

--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -25,14 +25,6 @@
             float: left;
         }
 
-        .alert-draft {
-            font-size: 14px;
-            color: hsl(170, 48%, 54%);
-            padding: 3px 12px;
-            font-weight: 400;
-            display: none;
-        }
-
         @media (max-width: 550px) {
             .compose_stream_button,
             .compose_private_button {

--- a/static/templates/compose_notification.hbs
+++ b/static/templates/compose_notification.hbs
@@ -1,5 +1,5 @@
 {{! Content of sent-message notifications }}
 <div class="compose-notifications-content">
     {{note}} {{#if link_class}}<a href="#" class="{{link_class}}" data-message-id="{{link_msg_id}}">{{link_text}}</a>{{/if}}
-    <button type="button" class="out-of-view-notification-close close">&times;</button>
+    <button type="button" class="compose-notification-close close">&times;</button>
 </div>

--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -12,7 +12,6 @@
                     <a class="drafts-link no-underline button small rounded compose_drafts_button" href="#drafts" title="{{ _('Drafts') }} (d)">
                         {{ _('Drafts') }}
                     </a>
-                    <span class="alert-draft pull-left">{{ _('Saved as draft') }}</span>
                 </span>
                 <span class="new_message_button">
                     <button type="button" class="button small rounded compose_mobile_button"


### PR DESCRIPTION
 Solves part 1 and 2 of https://github.com/zulip/zulip/issues/5591.


1. Draft Count.
![draft_count](https://user-images.githubusercontent.com/42106909/80285263-434d8800-8741-11ea-9594-1c6abda4446a.gif)

2. Notification for saving draft (goes away in 5 sec).
![Screenshot from 2020-04-25 20-18-32](https://user-images.githubusercontent.com/42106909/80285271-48aad280-8741-11ea-93ad-4a85b0041ace.png)