### PR TITLE
user_name: Prevent users from setting forbidden format.

### DIFF
--- a/zerver/lib/users.py
+++ b/zerver/lib/users.py
@@ -19,6 +19,7 @@ from zerver.models import UserProfile, Service, Realm, \
 
 from zulip_bots.custom_exceptions import ConfigValidationError
 
+import re
 def check_full_name(full_name_raw: str) -> str:
     full_name = full_name_raw.strip()
     if len(full_name) > UserProfile.MAX_NAME_LENGTH:
@@ -29,6 +30,8 @@ def check_full_name(full_name_raw: str) -> str:
         if (unicodedata.category(character)[0] == 'C' or
                 character in UserProfile.NAME_INVALID_CHARS):
             raise JsonableError(_("Invalid characters in name!"))
+    if re.search(r"\|\d+$", full_name_raw):
+        raise JsonableError(_("Invalid format!"))
     return full_name
 
 # NOTE: We don't try to absolutely prevent 2 bots from having the same

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -299,6 +299,29 @@ class PermissionTest(ZulipTestCase):
         result = self.client_patch('/json/users/{}'.format(self.example_user('hamlet').id), req)
         self.assert_json_error(result, 'Name too short!')
 
+    def test_not_allowed_format(self) -> None:
+        # Name of format "Alice|999" breaks in markdown
+        new_name = 'iago|72'
+        self.login('iago')
+        req = dict(full_name=ujson.dumps(new_name))
+        result = self.client_patch('/json/users/{}'.format(self.example_user('hamlet').id), req)
+        self.assert_json_error(result, 'Invalid format!')
+
+    def test_allowed_format_complex(self) -> None:
+        # Adding characters after r'|d+' doesn't break markdown
+        new_name = 'Hello- 12iago|72k'
+        self.login('iago')
+        req = dict(full_name=ujson.dumps(new_name))
+        result = self.client_patch('/json/users/{}'.format(self.example_user('hamlet').id), req)
+        self.assert_json_success(result)
+
+    def test_not_allowed_format_complex(self) -> None:
+        new_name = 'Hello- 12iago|72'
+        self.login('iago')
+        req = dict(full_name=ujson.dumps(new_name))
+        result = self.client_patch('/json/users/{}'.format(self.example_user('hamlet').id), req)
+        self.assert_json_error(result, 'Invalid format!')
+
     def test_admin_cannot_set_full_name_with_invalid_characters(self) -> None:
         new_name = 'Opheli*'
         self.login('iago')


### PR DESCRIPTION
 https://github.com/zulip/zulip/issues/13923.

Preventing users from setting their usernames in the format "Alice|999".
EDIT: The regex finally decided upon and used is `r"\|\d+$"`.

![Screenshot from 2020-04-25 22-46-10](https://user-images.githubusercontent.com/42106909/80286143-56635680-8747-11ea-89db-5efd7e856084.png)
