### PR TITLE
invitation: Make Member see invitations sent by him/her.

### DIFF
--- a/static/js/settings_invites.js
+++ b/static/js/settings_invites.js
@@ -50,6 +50,7 @@ function populate_invites(invites_data) {
         name: 'admin_invites_list',
         modifier: function (item) {
             item.invited_absolute_time = timerender.absolute_time(item.invited * 1000);
+            item.is_admin = page_params.is_admin;
             return render_admin_invites_list({ invite: item });
         },
         filter: {

--- a/static/templates/admin_invites_list.hbs
+++ b/static/templates/admin_invites_list.hbs
@@ -7,9 +7,11 @@
         <span class="email">{{email}}</span>
         {{/if}}
     </td>
+    {{#if is_admin}}
     <td>
         <span class="referred_by">{{ref}}</span>
     </td>
+    {{/if}}
     <td>
         <span class="invited_at">{{invited_absolute_time}}</span>
     </td>

--- a/static/templates/settings/invites_list_admin.hbs
+++ b/static/templates/settings/invites_list_admin.hbs
@@ -1,4 +1,7 @@
 <div id="admin-invites-list" class="settings-section" data-name="invites-list-admin">
+    {{#unless is_admin }}
+    <div class="tip">{{t "Members can only view or manage invitations that you yourself sent." }}</div>
+    {{/unless}}
     <a class="invite-user-link" href="#invite"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{t "Invite more users" }}</a>
     <div>
         <h3 class="inline-block">{{t "Invites" }}</h3>
@@ -11,7 +14,9 @@
         <table class="table table-condensed table-striped">
             <thead>
                 <th class="active" data-sort="invitee">{{t "Invitee" }}</th>
+                {{#if is_admin }}
                 <th data-sort="alphabetic" data-sort-prop="ref">{{t "Invited by" }}</th>
+                {{/if}}
                 <th data-sort="numeric" data-sort-prop="invited">{{t "Invited at" }}</th>
                 <th data-sort="numeric" data-sort-prop="invited_as">{{t "Invited as" }}</th>
                 <th class="actions">{{t "Actions" }}</th>

--- a/templates/zerver/app/settings_overlay.html
+++ b/templates/zerver/app/settings_overlay.html
@@ -140,11 +140,13 @@
                     <div class="text">{{ _('Custom profile fields') }}</div>
                 </li>
                 {% endif %}
-                {% if is_admin %}
+                {% if not guest %}
                 <li tabindex="0" data-section="invites-list-admin">
                     <i class="icon fa fa-user-plus" aria-hidden="true"></i>
                     <div class="text">{{ _('Invitations') }}</div>
                 </li>
+                {% endif %}
+                {% if is_admin %}
                 <li tabindex="0" data-section="data-exports-admin">
                     <i class="icon fa fa-database" aria-hidden="true"></i>
                     <div class="text">{{ _('Data exports') }}</div>

--- a/templates/zerver/app/settings_overlay.html
+++ b/templates/zerver/app/settings_overlay.html
@@ -142,7 +142,7 @@
                 {% endif %}
                 {% if is_admin %}
                 <li tabindex="0" data-section="invites-list-admin">
-                    <i class="icon fa fa-user" aria-hidden="true"></i>
+                    <i class="icon fa fa-user-plus" aria-hidden="true"></i>
                     <div class="text">{{ _('Invitations') }}</div>
                 </li>
                 <li tabindex="0" data-section="data-exports-admin">

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5102,8 +5102,9 @@ def do_get_user_invites(user_profile: UserProfile) -> List[Dict[str, Any]]:
 
     lowest_datetime = timezone_now() - datetime.timedelta(days=days_to_activate)
     prereg_users = PreregistrationUser.objects.exclude(status=active_value).filter(
-        invited_at__gte=lowest_datetime,
-        referred_by__realm=user_profile.realm)
+        invited_at__gte=lowest_datetime)
+    if not user_profile.is_realm_admin:
+        prereg_users = prereg_users.filter(referred_by=user_profile)
 
     invites = []
 

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -46,6 +46,7 @@ from zerver.lib.send_email import send_future_email, FromAddress, \
     deliver_email
 from zerver.lib.initial_password import initial_password
 from zerver.lib.actions import (
+    do_get_user_invites,
     do_deactivate_realm,
     do_deactivate_user,
     do_set_realm_property,
@@ -1469,6 +1470,23 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
                                          "or been deactivated."], result)
 
 class InvitationsTestCase(InviteUserBase):
+    def test_do_get_user_invites(self) -> None:
+        self.login('iago')
+        user_profile = self.example_user("iago")
+        hamlet = self.example_user('hamlet')
+        othello = self.example_user('othello')
+        prereg_user_one = PreregistrationUser(email="TestOne@zulip.com", referred_by=user_profile)
+        prereg_user_one.save()
+        prereg_user_two = PreregistrationUser(email="TestTwo@zulip.com", referred_by=user_profile)
+        prereg_user_two.save()
+        prereg_user_three = PreregistrationUser(email="TestThree@zulip.com", referred_by=hamlet)
+        prereg_user_three.save()
+        prereg_user_four = PreregistrationUser(email="TestFour@zulip.com", referred_by=othello)
+        prereg_user_four.save()
+        self.assertEqual(len(do_get_user_invites(user_profile)), 4)
+        self.assertEqual(len(do_get_user_invites(hamlet)), 1)
+        self.assertEqual(len(do_get_user_invites(othello)), 1)
+
     def test_successful_get_open_invitations(self) -> None:
         """
         A GET call to /json/invites returns all unexpired invitations.
@@ -1537,6 +1555,39 @@ class InvitationsTestCase(InviteUserBase):
                           lambda: ScheduledEmail.objects.get(address__iexact=invitee,
                                                              type=ScheduledEmail.INVITATION_REMINDER))
 
+    def test_successful_member_delete_invitation(self) -> None:
+        """
+        A DELETE call from member account to /json/invites/<ID> should delete the invite and
+        any scheduled invitation reminder emails.
+        """
+        self.login('hamlet')
+        user_profile = self.example_user('hamlet')
+        invitee = "DeleteMe@zulip.com"
+        self.assert_json_success(self.invite(invitee, ['Denmark']))
+        # Verify hamlet has only one invitation (Members can delete invitations only sent by him).
+        invitation = PreregistrationUser.objects.filter(referred_by=user_profile)
+        self.assertEqual(len(invitation), 1)
+        prereg_user = PreregistrationUser.objects.get(email=invitee)
+        # Verify that the scheduled email exists.
+        ScheduledEmail.objects.get(address__iexact=invitee,
+                                   type=ScheduledEmail.INVITATION_REMINDER)
+
+        result = self.client_delete('/json/invites/' + str(prereg_user.id))
+        self.assertEqual(result.status_code, 200)
+        error_result = self.client_delete('/json/invites/' + str(prereg_user.id))
+        self.assert_json_error(error_result, "No such invitation")
+
+        self.assertRaises(ScheduledEmail.DoesNotExist,
+                          lambda: ScheduledEmail.objects.get(address__iexact=invitee,
+                                                             type=ScheduledEmail.INVITATION_REMINDER))
+        self.logout()
+        self.login("othello")
+        prereg_user_one = PreregistrationUser(email=invitee, referred_by=user_profile)
+        prereg_user_one.save()
+        prereg_user = PreregistrationUser.objects.get(email=invitee)
+        error_result = self.client_delete('/json/invites/' + str(prereg_user.id))
+        self.assert_json_error(error_result, "Must be an organization administrator")
+
     def test_delete_multiuse_invite(self) -> None:
         """
         A DELETE call to /json/invites/multiuse<ID> should delete the
@@ -1598,6 +1649,56 @@ class InvitationsTestCase(InviteUserBase):
         self.assert_json_error(error_result, "No such invitation")
 
         self.check_sent_emails([invitee], custom_from_name="Zulip")
+
+    def test_successful_member_resend_invitation(self) -> None:
+        """
+        A POST call from member account to /json/invites/<ID>/resend should send an invitation
+        reminder email and delete any scheduled invitation reminder email.
+        """
+        self.login('hamlet')
+        user_profile = self.example_user('hamlet')
+        invitee = "resend_me@zulip.com"
+        self.assert_json_success(self.invite(invitee, ['Denmark']))
+        # Verify hamlet has only one invitation (Member can resend invitations only sent by him).
+        invitation = PreregistrationUser.objects.filter(referred_by=user_profile)
+        self.assertEqual(len(invitation), 1)
+        prereg_user = PreregistrationUser.objects.get(email=invitee)
+
+        # Verify and then clear from the outbox the original invite email
+        self.check_sent_emails([invitee], custom_from_name="Zulip")
+        from django.core.mail import outbox
+        outbox.pop()
+
+        # Verify that the scheduled email exists.
+        scheduledemail_filter = ScheduledEmail.objects.filter(
+            address__iexact=invitee, type=ScheduledEmail.INVITATION_REMINDER)
+        self.assertEqual(scheduledemail_filter.count(), 1)
+        original_timestamp = scheduledemail_filter.values_list('scheduled_timestamp', flat=True)
+
+        # Resend invite
+        result = self.client_post('/json/invites/' + str(prereg_user.id) + '/resend')
+        self.assertEqual(ScheduledEmail.objects.filter(
+            address__iexact=invitee, type=ScheduledEmail.INVITATION_REMINDER).count(), 1)
+
+        # Check that we have exactly one scheduled email, and that it is different
+        self.assertEqual(scheduledemail_filter.count(), 1)
+        self.assertNotEqual(original_timestamp,
+                            scheduledemail_filter.values_list('scheduled_timestamp', flat=True))
+
+        self.assertEqual(result.status_code, 200)
+        error_result = self.client_post('/json/invites/' + str(9999) + '/resend')
+        self.assert_json_error(error_result, "No such invitation")
+
+        self.check_sent_emails([invitee], custom_from_name="Zulip")
+
+        self.logout()
+        self.login("othello")
+        invitee = "TestOne@zulip.com"
+        prereg_user_one = PreregistrationUser(email=invitee, referred_by=user_profile)
+        prereg_user_one.save()
+        prereg_user = PreregistrationUser.objects.get(email=invitee)
+        error_result = self.client_post('/json/invites/' + str(prereg_user.id) + '/resend')
+        self.assert_json_error(error_result, "Must be an organization administrator")
 
     def test_accessing_invites_in_another_realm(self) -> None:
         inviter = UserProfile.objects.exclude(realm=get_realm('zulip')).first()


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Member of the Org can able see list of invitations sent by him/her.
given permission for the member to revoke or resend the invitations
sent by him/her
fixes #14007

**Testing Plan:** <!-- How have you tested? -->
Tested Manually in browser

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
**ADMIN VIEW**
![inviitation_admin](https://user-images.githubusercontent.com/45326319/80287809-20c36b00-8751-11ea-94c4-5571b6d391e4.png)
**MEMBER VIEW**
![invitation_member](https://user-images.githubusercontent.com/45326319/80287816-2de05a00-8751-11ea-8974-cc6afa524771.png)




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
