### PR TITLE
Change markdown rendering function to 'markdown' library

### DIFF
--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -273,13 +273,15 @@ def send_custom_email(users: List[UserProfile], options: Dict[str, Any]) -> None
     subject_path = "templates/%s.subject.txt" % (email_id,)
     os.makedirs(os.path.dirname(html_source_template_path), exist_ok=True)
 
+    plain_text_template = parsed_email_template.get_payload()
+
     # First, we render the markdown input file just like our
     # user-facing docs with render_markdown_path.
     with open(plain_text_template_path, "w") as f:
-        f.write(parsed_email_template.get_payload())
+        f.write(plain_text_template)
 
-    from zerver.templatetags.app_filters import render_markdown_path
-    rendered_input = render_markdown_path(plain_text_template_path.replace("templates/", ""))
+    from markdown import markdown
+    rendered_input = markdown(plain_text_template)
 
     # And then extend it with our standard email headers.
     with open(html_source_template_path, "w") as f:

--- a/zerver/tests/fixtures/email/custom_emails/email_base_markdown_realm.source.html
+++ b/zerver/tests/fixtures/email/custom_emails/email_base_markdown_realm.source.html
@@ -1,0 +1,4 @@
+From: TestFrom
+Subject: Test Subject
+
+[{{ realm_name }}]({{ realm_uri }})

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -103,6 +103,17 @@ class TestCustomEmails(ZulipTestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn(admin_user.delivery_email, mail.outbox[0].to[0])
 
+    def test_send_custom_email_markdown_realm(self) -> None:
+        hamlet = self.example_user('hamlet')
+        markdown_template_path = "zerver/tests/fixtures/email/custom_emails/email_base_markdown_realm.source.html"
+        send_custom_email([hamlet], {
+            "markdown_template_path": markdown_template_path,
+        })
+        msg = mail.outbox[0]
+        html_msg = msg.alternatives[0][0]
+        self.assertIn('<a href="%s"' % hamlet.realm.uri, html_msg)
+        self.assertIn('%s</a>' % hamlet.realm.name, html_msg)
+        self.assertEqual('[%s](%s)' % (hamlet.realm.name, hamlet.realm.uri), msg.body)
 
 class TestFollowupEmails(ZulipTestCase):
     def test_day1_email_context(self) -> None:


### PR DESCRIPTION
https://github.com/zulip/zulip/issues/13413

* [x]  I can only reproduce this in production, but if the file contains a markdown-format link to a piece of Jinja2 code (e.g. [{{ realm_name }}]({{ realm_uri }}), that link link seems to be lost in the `render_markdown_path` translation.  We should figure out why that's not working properly.  The actual issue here is likely that we're doing Jinja2 translation twice -- once inside `render_markdown_path` and again in the email template code; the fix might be to use something simpler than `render_markdown_path` for markdown rendering (e.g. just `markdown.Markdown`).


Previously, 'render_markdown_path' function was doing JINJA2 substition, but we didn't pass any context, so all variables in template were lost. That's why we changed this to markdown.markdown function.

**Testing Plan:** :
Manually tested on production environment. Seems to work with `[{{ realm_name }}]({{ realm_uri }}`, in HTML proper `<a>` tag with links was created.

Btw, I know that docker-zulip is still in beta, but works very great!
