### PR TITLE
unstar_topic : Adding support to unstar all messages in a topic.

### DIFF
--- a/static/js/message_flags.js
+++ b/static/js/message_flags.js
@@ -109,8 +109,13 @@ exports.toggle_starred_and_update_server = function (message) {
     }
 };
 
-exports.unstar_all_messages = function () {
-    const starred_msg_ids = starred_messages.get_starred_msg_ids();
+exports.unstar_messages = function (topic_name, stream_id) {
+    let starred_msg_ids;
+    if (topic_name && stream_id) {
+        starred_msg_ids = starred_messages.get_topic_starred_msg_ids(topic_name, stream_id);
+    } else {
+        starred_msg_ids = starred_messages.get_starred_msg_ids();
+    }
     channel.post({
         url: '/json/messages/flags',
         idempotent: true,

--- a/static/js/starred_messages.js
+++ b/static/js/starred_messages.js
@@ -34,6 +34,14 @@ exports.get_starred_msg_ids = function () {
     return Array.from(exports.ids);
 };
 
+exports.get_topic_starred_msg_ids = function (topic_name, stream_id) {
+    return Array.from(exports.ids).filter(function (id) {
+        const message = message_store.get(id);
+        return message.stream_id === stream_id &&
+        message.topic.toLowerCase() === topic_name.toLowerCase();
+    });
+};
+
 exports.rerender_ui = function () {
     let count = exports.count();
 

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -185,6 +185,8 @@ function build_topic_popover(opts) {
     const is_muted = muting.is_topic_muted(sub.stream_id, topic_name);
     const can_mute_topic = !is_muted;
     const can_unmute_topic = is_muted;
+    const starred_ids = starred_messages.get_topic_starred_msg_ids(topic_name, sub.stream_id);
+    const has_starred = starred_ids.length;
 
     const content = render_topic_sidebar_actions({
         stream_name: sub.name,
@@ -192,6 +194,7 @@ function build_topic_popover(opts) {
         topic_name: topic_name,
         can_mute_topic: can_mute_topic,
         can_unmute_topic: can_unmute_topic,
+        has_starred: has_starred,
         is_admin: sub.is_admin,
     });
 
@@ -362,18 +365,25 @@ exports.register_stream_handlers = function () {
     });
 
     // Unstar all messages
-    $('body').on('click', '#unstar_all_messages', function (e) {
+    $('body').on('click', '#unstar_all_messages, .sidebar-popover-unstar', function (e) {
         exports.hide_starred_messages_popover();
         e.preventDefault();
         e.stopPropagation();
         $(".left-sidebar-modal-holder").empty();
-        $(".left-sidebar-modal-holder").html(render_unstar_messages_modal());
+        const topic_name = $(".sidebar-popover-unstar").attr("data-topic-name");
+        const args = {
+            topic_name: topic_name,
+        };
+        $(".left-sidebar-modal-holder").html(render_unstar_messages_modal(args));
+        exports.hide_topic_popover();
         $("#unstar-messages-modal").modal("show");
     });
 
     $('body').on('click', '#do_unstar_messages_button', function (e) {
         $("#unstar-messages-modal").modal("hide");
-        message_flags.unstar_all_messages();
+        const topic_name = $(".sidebar-popover-unstar").attr("data-topic-name");
+        const stream_id = $(".sidebar-popover-unstar").attr("data-stream-id");
+        message_flags.unstar_messages(topic_name, Number(stream_id));
         e.stopPropagation();
     });
 

--- a/static/templates/topic_sidebar_actions.hbs
+++ b/static/templates/topic_sidebar_actions.hbs
@@ -24,6 +24,15 @@
         </a>
     </li>
     {{/if}}
+
+    {{#if has_starred}}
+    <li>
+        <a href="#" class="sidebar-popover-unstar" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
+            <i class="fa fa-star" aria-hidden="true"></i>
+            {{#tr this}}Unstar messages in <b>__topic_name__</b>{{/tr}}
+        </a>
+    </li>
+    {{/if}}
     <li>
         <a class="sidebar-popover-mark-topic-read" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
             <i class="fa fa-book" aria-hidden="true"></i>

--- a/static/templates/unstar_messages_modal.hbs
+++ b/static/templates/unstar_messages_modal.hbs
@@ -1,10 +1,18 @@
 <div id="unstar-messages-modal" class="modal new-style modal-bg hide fade" tabindex="-1" role="dialog" aria-labelledby="unstar_messages_modal_label" aria-hidden="true">
     <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+        {{#if topic_name}}
+        <h3 id="unstar_messages_modal_label">{{t "Unstar all messages in this topic" }}</h3>
+        {{else}}
         <h3 id="unstar_messages_modal_label">{{t "Unstar all messages" }}</h3>
+        {{/if}}
     </div>
     <div class="modal-body">
+        {{#if topic_name}}
+        <p>{{t "Would you like to unstar all starred messages in this topic?  This action cannot be undone." }}</p>
+        {{else}}
         <p>{{t "Would you like to unstar all starred messages?  This action cannot be undone." }}</p>
+        {{/if}}
     </div>
     <div class="modal-footer">
         <button type="button" class="button rounded" data-dismiss="modal">{{t "Cancel" }}</button>


### PR DESCRIPTION
Solves: https://github.com/zulip/zulip/issues/12194
Adding ability to unstar all messages in a topic.
Will show this option only if there are starred messages.
I'm using the existing "Are you sure" modal and am unstarring based on whether there's a topic name or not (all).
I'm also exempting starred_message.js from `avoid subject in JS code` lint checker because message has an attribute subject for the topic name.

![unstar](https://user-images.githubusercontent.com/42106909/80290418-76ecda00-8762-11ea-8541-0463ebc746fe.gif)
