### PR TITLE
User interface for profile display

### DIFF
--- a/static/templates/me_message.hbs
+++ b/static/templates/me_message.hbs
@@ -1,14 +1,17 @@
 <span class="message_sender no-select">
     <span class="sender_info_hover">
-        {{> message_avatar}}
+        <span title="{{t 'View user profile' }} (u)">
+            {{> message_avatar}}
+        </span>
     </span>
 
     <span class="sender-status">
-        <span class="sender_info_hover sender_name-in-status auto-select" role="button" tabindex="0">{{msg/sender_full_name}}</span>
+        <span title="{{t 'View user profile' }} (u)" >
+            <span class="sender_info_hover sender_name-in-status auto-select" role="button" tabindex="0">{{msg/sender_full_name}}</span>
+        </span>
         {{#if sender_is_bot}}
         <i class="zulip-icon bot" aria-label="{{t 'Bot' }}"></i>
         {{/if}}
-
         <span class="rendered_markdown status-message auto-select">{{rendered_markdown status_message}}</span>
 
         {{#if edited_status_msg}}

--- a/static/templates/message_body.hbs
+++ b/static/templates/message_body.hbs
@@ -2,14 +2,13 @@
     {{#unless status_message}}
     <span class="message_sender sender_info_hover no-select">
         {{#if include_sender}}
-
+        <span title="{{t 'View user profile' }} (u)">
             {{> message_avatar}}
-
             <span class="sender_name auto-select" role="button" tabindex="0">{{msg/sender_full_name}}</span>
             {{#if sender_is_bot}}
             <i class="zulip-icon bot" aria-label="{{t 'Bot' }}"></i>
             {{/if}}
-
+        </span>
         {{/if}}
     </span>
     {{/unless}}


### PR DESCRIPTION
Modified message_body.hbs file to display user profile (u) shortcut by adding span tag with title only under the span class message_sender sender_info_hover no-select . Issues mentioned in https://github.com/zulip/zulip/pull/12778/files#r303213836 and https://github.com/zulip/zulip/pull/12778/files#r303213844 do not occur because we did not modify the me_message.hbs file. Adding the title to sender_info_hover of this file breaks the me message popover -- i.e. the title replaces the user's avatar.
Fixes: #12769, REPEAT. Our previous submission was empty and this actually contains files