### PR TITLE
process_fts_updates: Use correct dbname and owner to access schema.

### DIFF
--- a/puppet/zulip/files/postgresql/process_fts_updates
+++ b/puppet/zulip/files/postgresql/process_fts_updates
@@ -105,7 +105,8 @@ if 'host' in pg_args:
         pg_args['sslmode'] = 'verify-full'
     pg_args['connect_timeout'] = '600'
 else:
-    pg_args['user'] = 'zulip'
+    pg_args['user'] = 'zulip_test'
+    pg_args['dbname'] = 'zulip_test'
 
 conn = None
 


### PR DESCRIPTION
Fixes #14756
The schema containing fts_updates
is owned by `zulip_test` and is in `zulip_test` db,
We were not using the correct db and user to connect when testing
hence, we were not able to find the Table.
