### PR TITLE
home: Don't use pointer to compute furthest_read_time.

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1966,6 +1966,10 @@ def get_usermessage_by_message_id(user_profile: UserProfile, message_id: int) ->
     except UserMessage.DoesNotExist:
         return None
 
+def get_latest_read_usermessage(user_profile: UserProfile) -> Optional[UserMessage]:
+    return UserMessage.objects.select_related().filter(user_profile=user_profile,
+                                                       flags=UserMessage.flags.read).last()
+
 class ArchivedUserMessage(AbstractUserMessage):
     """Used as a temporary holding place for deleted UserMessages objects
     before they are permanently deleted.  This is an important part of

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -13,7 +13,7 @@ from zerver.forms import ToSForm
 from zerver.models import Message, Stream, UserProfile, \
     Realm, UserMessage, \
     PreregistrationUser, \
-    get_usermessage_by_message_id
+    get_latest_read_usermessage
 from zerver.lib.events import do_events_register
 from zerver.lib.actions import do_change_tos_version, \
     realm_user_count
@@ -224,10 +224,7 @@ def home_real(request: HttpRequest) -> HttpResponse:
             user_profile.last_pointer_updater = request.session.session_key
         furthest_read_time = None
     else:
-        latest_read = get_usermessage_by_message_id(user_profile, user_profile.pointer)
-        if latest_read is None:
-            # Don't completely fail if your saved pointer ID is invalid
-            logging.warning("User %s has invalid pointer %s" % (user_profile.id, user_profile.pointer))
+        latest_read = get_latest_read_usermessage(user_profile)
         furthest_read_time = sent_time_in_epoch_seconds(latest_read)
 
     # We pick a language for the user as follows:


### PR DESCRIPTION
When a user is reading messages only in stream or topic narrows, the pointer
can be left far behind. Using this to compute the furthest_read_time causes
the banckruptcy banner to be shown even when a user has been actively
reading messages. This commit switches to using the sent time on the last
message that the user has read to compute the furthest read time.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->

Haven't really tested the unread banner itself, but added a unit test for an edge case to verify that the home page loads. 

