### PR TITLE
stream_edit: Remove unnacessary conditionals.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -636,12 +636,8 @@ exports.initialize = function () {
     // checkmark in the subscriber list.
     $("#subscriptions_table").on("click", ".sub_unsub_button", function (e) {
         const sub = get_sub_for_target(e.target);
-        let stream_row;
-        if ($(e.currentTarget).is(":button")) {
-            stream_row = $("#subscriptions_table div.stream-row[data-stream-id='" + sub.stream_id + "']");
-        } else {
-            stream_row = $(e.currentTarget).parent();
-        }
+        // Makes sure we take the correct stream_row.
+        const stream_row = $("#subscriptions_table div.stream-row[data-stream-id='" + sub.stream_id + "']");
         subs.sub_or_unsub(sub, stream_row);
 
         if (!sub.subscribed) {


### PR DESCRIPTION
The condition was removed because in either case we
want to have the stream_row and not the sub/unsub
button, so we can always get the stream_row directly.