### PR TITLE
notifications: Add test link; clean deprecated APIs; prepare to remove desktop app injected JS

### DIFF
--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -868,14 +868,14 @@ run_test('electron_bridge', () => {
     assert.equal(activity.compute_active_status(), activity.ACTIVE);
 
     window.electron_bridge = {
-        idle_on_system: true,
+        get_idle_on_system: () => true,
     };
     assert.equal(activity.compute_active_status(), activity.IDLE);
     activity.client_is_active = false;
     assert.equal(activity.compute_active_status(), activity.IDLE);
 
     window.electron_bridge = {
-        idle_on_system: false,
+        get_idle_on_system: () => false,
     };
     assert.equal(activity.compute_active_status(), activity.ACTIVE);
     activity.client_is_active = true;

--- a/frontend_tests/node_tests/notifications.js
+++ b/frontend_tests/node_tests/notifications.js
@@ -254,23 +254,24 @@ run_test('basic_notifications', () => {
     let last_shown_message_id = null;
 
     // Notifications API stub
-    notifications.set_notification_api({
-        createNotification: function createNotification(icon, title, content, tag) {
-            const notification_object = {icon: icon, body: content, tag: tag};
+    class StubNotification {
+        constructor(title, { icon, body, tag }) {
+            this.icon = icon;
+            this.body = body;
+            this.tag = tag;
             // properties for testing.
-            notification_object.tests = {
+            this.tests = {
                 shown: false,
             };
-            notification_object.show = function () {
-                last_shown_message_id = this.tag;
-            };
-            notification_object.close = function () {
-                last_closed_message_id = this.tag;
-            };
-            notification_object.cancel = function () { notification_object.close(); };
-            return notification_object;
-        },
-    });
+            last_shown_message_id = this.tag;
+        }
+
+        close() {
+            last_closed_message_id = this.tag;
+        }
+    }
+
+    notifications.set_notification_api(StubNotification);
 
     const message_1 = {
         id: 1000,

--- a/frontend_tests/node_tests/notifications.js
+++ b/frontend_tests/node_tests/notifications.js
@@ -266,6 +266,8 @@ run_test('basic_notifications', () => {
             last_shown_message_id = this.tag;
         }
 
+        addEventListener() {}
+
         close() {
             last_closed_message_id = this.tag;
         }

--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -272,11 +272,11 @@ exports.compute_active_status = function () {
     // * For the electron desktop app, we also know whether the
     //   user is active or idle elsewhere on their system.
     //
-    // The check for `idle_on_system === undefined` is feature
+    // The check for `get_idle_on_system === undefined` is feature
     // detection; older desktop app releases never set that property.
     if (window.electron_bridge !== undefined
-            && window.electron_bridge.idle_on_system !== undefined) {
-        if (window.electron_bridge.idle_on_system) {
+            && window.electron_bridge.get_idle_on_system !== undefined) {
+        if (window.electron_bridge.get_idle_on_system()) {
             return exports.IDLE;
         }
         return exports.ACTIVE;

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -91,12 +91,12 @@ function update_notification_sound_source() {
 }
 
 exports.permission_state = function () {
-    if (window.Notification === undefined) {
+    if (NotificationAPI === undefined) {
         // act like notifications are blocked if they do not have access to
         // the notification API.
         return "denied";
     }
-    return window.Notification.permission;
+    return NotificationAPI.permission;
 };
 
 let new_message_count = 0;

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -373,8 +373,7 @@ function process_notification(notification) {
         ];
     }
 
-    // Firefox on Ubuntu claims to do webkitNotifications but its notifications are terrible
-    if (notification.desktop_notify && /webkit/i.test(navigator.userAgent)) {
+    if (notification.desktop_notify) {
         const icon_url = people.small_avatar_url(message);
         notification_object = new NotificationAPI(title, {
             icon: icon_url,
@@ -396,28 +395,6 @@ function process_notification(notification) {
         notification_object.onclose = function () {
             notice_memory.delete(key);
         };
-    } else if (notification.desktop_notify && typeof Notification !== "undefined" && /mozilla/i.test(navigator.userAgent)) {
-        Notification.requestPermission(function (perm) {
-            if (perm === 'granted') {
-                notification_object = new Notification(title, {
-                    body: content,
-                    iconUrl: people.small_avatar_url(message),
-                    tag: message.id,
-                });
-                notification_object.onclick = function () {
-                    if (message.type === "test-notification") {
-                        return;
-                    }
-
-                    // We don't need to bring the browser window into focus explicitly
-                    // by calling `window.focus()` as well as don't need to clear the
-                    // notification since it is the default behavior in Firefox.
-                    narrow.by_topic(message.id, {trigger: 'notification'});
-                };
-            } else {
-                in_browser_notify(message, title, content, raw_operators, opts);
-            }
-        });
     } else {
         in_browser_notify(message, title, content, raw_operators, opts);
     }

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -25,13 +25,6 @@ if (window.Notification) {
     NotificationAPI = window.Notification;
 }
 
-function cancel_notification_object(notification_object) {
-    // We must remove the .onclose so that it does not trigger on .cancel
-    notification_object.onclose = function () {};
-    notification_object.onclick = function () {};
-    notification_object.close();
-}
-
 exports.get_notifications = function () {
     return notice_memory;
 };
@@ -49,7 +42,7 @@ exports.initialize = function () {
         window_has_focus = true;
 
         for (const notice_mem_entry of notice_memory.values()) {
-            cancel_notification_object(notice_mem_entry.obj);
+            notice_mem_entry.obj.close();
         }
         notice_memory.clear();
 
@@ -351,7 +344,7 @@ function process_notification(notification) {
         msg_count = notice_memory.get(key).msg_count + 1;
         title = msg_count + " messages from " + title;
         notification_object = notice_memory.get(key).obj;
-        cancel_notification_object(notification_object);
+        notification_object.close();
     }
 
     if (message.type === "private") {
@@ -435,7 +428,7 @@ exports.process_notification = process_notification;
 exports.close_notification = function (message) {
     for (const [key, notice_mem_entry] of notice_memory) {
         if (notice_mem_entry.message_id === message.id) {
-            cancel_notification_object(notice_mem_entry.obj);
+            notice_mem_entry.obj.close();
             notice_memory.delete(key);
         }
     }

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -271,7 +271,9 @@ if (window.electron_bridge !== undefined) {
     // is often referred to as inline reply feature. This is done so desktop app doesn't
     // have to depend on channel.post for setting crsf_token and narrow.by_topic
     // to narrow to the message being sent.
-    window.electron_bridge.send_notification_reply_message_supported = true;
+    if (window.electron_bridge.set_send_notification_reply_message_supported !== undefined) {
+        window.electron_bridge.set_send_notification_reply_message_supported(true);
+    }
     window.electron_bridge.on_event('send_notification_reply_message', function (message_id, reply) {
         const message = message_store.get(message_id);
         const data = {

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -385,16 +385,16 @@ function process_notification(notification) {
             msg_count: msg_count,
             message_id: message.id,
         });
-        notification_object.onclick = function () {
+        notification_object.addEventListener("click", () => {
             notification_object.close();
             if (message.type !== "test-notification") {
                 narrow.by_topic(message.id, {trigger: 'notification'});
             }
             window.focus();
-        };
-        notification_object.onclose = function () {
+        });
+        notification_object.addEventListener("close", () => {
             notice_memory.delete(key);
-        };
+        });
     } else {
         in_browser_notify(message, title, content, raw_operators, opts);
     }

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -103,6 +103,12 @@ exports.set_up = function () {
 
     update_desktop_icon_count_display();
 
+    $("#send_test_notification").click(() => {
+        notifications.send_test_notification(
+            i18n.t("This is what a Zulip notification looks like.")
+        );
+    });
+
     $("#play_notification_sound").click(function () {
         $("#notifications-area").find("audio")[0].play();
     });

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -53,6 +53,8 @@
 
             <h5>{{t "Desktop" }}</h5>
 
+            <p><a id="send_test_notification">{{t "Send test notification" }}</a></p>
+
             {{#each notification_settings.desktop_notification_settings}}
             {{> settings_checkbox
               setting_name=this


### PR DESCRIPTION
* electron_bridge: Use getter and setter interface to mutable properties.

  This exists in all versions of the desktop app that we still support, and will eventually let us delete a bit of annoying compatibility code from the desktop app’s injected JavaScript.

* notifications: Add link for sending a test notification.

* notifications: Remove long-gone `webkitNotifications` draft API.

* notifications: Remove `cancel_notification_object` wrapper.

  Running the `close` handler won’t break anything; it’s safe to delete from a `Map` while iterating through it.

* notifications: Remove weird Firefox code.

  Firefox’s notifications are fine, and `iconUrl` isn’t a thing.

* notifications: Use `addEventListener` to register handlers.

* notifications: Use `notifications_api` for `permission_state`.

* notifications: Use `electron_bridge.new_notification` when available.

  This will eventually let us delete a bit of annoying compatibility code from the desktop app’s injected JavaScript.

**Testing Plan:** Dev server.
