### PR TITLE
openapi: Create markdown extension for rendering endpoint descriptions.

### DIFF
--- a/templates/zerver/api/add-emoji-reaction.md
+++ b/templates/zerver/api/add-emoji-reaction.md
@@ -1,9 +1,6 @@
 # Add an emoji reaction
 
-Add an [emoji reaction](/help/emoji-reactions) to a message.
-
-`POST {{ api_url }}/v1/messages/{message_id}/reactions`
-
+{generate_api_description(/messages/{message_id}/reactions:post)}
 
 ## Usage examples
 

--- a/templates/zerver/api/add-linkifiers.md
+++ b/templates/zerver/api/add-linkifiers.md
@@ -1,10 +1,6 @@
 # Create linkifiers
 
-Configure [linkifiers](/help/add-a-custom-linkification-filter),
-regular expression patterns that are automatically linkified when they
-appear in messages and topics.
-
-`POST {{ api_url }}/v1/realm/filters`
+{generate_api_description(/realm/filters:post)}
 
 ## Usage examples
 

--- a/templates/zerver/api/add-subscriptions.md
+++ b/templates/zerver/api/add-subscriptions.md
@@ -1,12 +1,6 @@
 # Add subscriptions
 
-Subscribe one or more users to one or more streams.
-
-`POST {{ api_url }}/v1/users/me/subscriptions`
-
-If any of the specified streams do not exist, they are automatically
-created, and configured using the `invite_only` setting specified in
-the arguments (see below).
+{generate_api_description(/users/me/subscriptions:post)}
 
 ## Usage examples
 

--- a/templates/zerver/api/create-user-group.md
+++ b/templates/zerver/api/create-user-group.md
@@ -1,8 +1,6 @@
 # Create User Group
 
-Create a new [user group](/help/user-groups).
-
-`POST {{ api_url }}/v1/user_groups/create`
+{generate_api_description(/user_groups/create:post)}
 
 ## Usage examples
 

--- a/templates/zerver/api/create-user.md
+++ b/templates/zerver/api/create-user.md
@@ -2,9 +2,7 @@
 
 {!api-admin-only.md!}
 
-Create a new user account via the API.
-
-`POST {{ api_url }}/v1/users`
+{generate_api_description(/users:post)}
 
 ## Usage examples
 

--- a/templates/zerver/api/deactivate-user.md
+++ b/templates/zerver/api/deactivate-user.md
@@ -2,11 +2,7 @@
 
 {!api-admin-only.md!}
 
-[Deactivates a
-user](https://zulipchat.com/help/deactivate-or-reactivate-a-user)
-given their user ID.
-
-`DELETE {{ api_url }}/v1/users/{user_id}`
+{generate_api_description(/users/{user_id}:delete)}
 
 ## Usage examples
 

--- a/templates/zerver/api/delete-message.md
+++ b/templates/zerver/api/delete-message.md
@@ -1,12 +1,6 @@
 # Delete a message
 
-Permanently delete a message.
-
-`DELETE {{ api_url }}/v1/messages/{msg_id}`
-
-This API corresponds to the
-[delete a message completely][delete-completely] feature documented in
-the Zulip Help Center.
+{generate_api_description(/messages/{message_id}:delete)}
 
 [delete-completely]: /help/edit-or-delete-a-message#delete-a-message-completely
 

--- a/templates/zerver/api/delete-queue.md
+++ b/templates/zerver/api/delete-queue.md
@@ -1,8 +1,6 @@
 # Delete a queue
 
-Delete a previously registered queue.
-
-`DELETE {{ api_url }}/v1/events`
+{generate_api_description(/events:delete)}
 
 ## Usage examples
 

--- a/templates/zerver/api/delete-stream.md
+++ b/templates/zerver/api/delete-stream.md
@@ -1,8 +1,6 @@
 # Delete stream
 
-[Delete the stream](/help/delete-a-stream) with the ID `stream_id`.
-
-`DELETE {{ api_url }}/v1/streams/{stream_id}`
+{generate_api_description(/streams/{stream_id}:delete)}
 
 ## Usage examples
 

--- a/templates/zerver/api/delete-user-group.md
+++ b/templates/zerver/api/delete-user-group.md
@@ -1,8 +1,6 @@
 # Delete a user group
 
-Delete a [user group](/help/user-groups).
-
-`DELETE {{ api_url }}/v1/user_groups/{group_id}`
+{generate_api_description(/user_groups/{group_id}:delete)}
 
 ## Usage examples
 

--- a/templates/zerver/api/dev-fetch-api-key.md
+++ b/templates/zerver/api/dev-fetch-api-key.md
@@ -1,16 +1,6 @@
 # Fetch a development API key
 
-For easy testing of mobile apps and other clients and against Zulip
-development servers, we support fetching a Zulip API key for any user
-on the development server without authentication (so that they can
-implement analogues of the one-click login process available for Zulip
-development servers on the web).
-
-**Note:** This endpoint is only available on Zulip development
-servers; for obvious security reasons it will always return an error
-in a Zulip production server.
-
-`POST {{ api_url }}/v1/dev_fetch_api_key`
+{generate_api_description(/dev_fetch_api_key:post)}
 
 ## Usage examples
 

--- a/templates/zerver/api/get-all-streams.md
+++ b/templates/zerver/api/get-all-streams.md
@@ -1,8 +1,6 @@
 # Get all streams
 
-Get all streams that the user has access to.
-
-`GET {{ api_url }}/v1/streams`
+{generate_api_description(/streams:get)}
 
 ## Usage examples
 

--- a/templates/zerver/api/get-all-users.md
+++ b/templates/zerver/api/get-all-users.md
@@ -1,9 +1,6 @@
 # Get all users
 
-Retrieve details on all users in the organization.  Optionally
-includes values of [custom profile field](/help/add-custom-profile-fields).
-
-`GET {{ api_url }}/v1/users`
+{generate_api_description(/users:get)}
 
 You can also [fetch details on a single user](/api/get-user).
 

--- a/templates/zerver/api/get-events-from-queue.md
+++ b/templates/zerver/api/get-events-from-queue.md
@@ -1,9 +1,6 @@
 # Get events from an event queue
 
-`GET {{ api_url }}/v1/events`
-
-This endpoint allows you to receive new events from
-[a registered event queue](/api/register-queue).
+{generate_api_description(/events:get)}
 
 ## Usage examples
 

--- a/templates/zerver/api/get-message-history.md
+++ b/templates/zerver/api/get-message-history.md
@@ -1,13 +1,6 @@
 # Get a message's edit history
 
-Fetch the message edit history of a previously edited message.
-
-`GET {{ api_url }}/v1/messages/{message_id}/history`
-
-Note that edit history may be disabled in some organizations; see the
-[Zulip Help Center documentation on editing messages][edit-settings].
-
-[edit-settings]: /help/view-a-messages-edit-history
+{generate_api_description(/messages/{message_id}/history:get)}
 
 ## Usage examples
 

--- a/templates/zerver/api/get-messages.md
+++ b/templates/zerver/api/get-messages.md
@@ -1,33 +1,6 @@
 # Get messages
 
-Fetch message history from a Zulip server.
-
-`GET {{ api_url }}/v1/messages`
-
-This `GET /api/v1/messages` endpoint is the primary way to fetch
-message history from a Zulip server.  It is useful both for Zulip
-clients (e.g. the web, desktop, mobile, and terminal clients) as well
-as bots, API clients, backup scripts, etc.
-
-By specifying a [narrow filter](/api/construct-narrow), you can use
-this endpoint to fetch the messages matching any search query that is
-supported by Zulip's powerful full-text search backend.
-
-When a narrow is not specified, it can be used to fetch a user's
-message history (We recommend paginating to 1000 messages at a time).
-
-In either case, you specify an `anchor` message (or ask the server to
-calculate the first unread message for you and use that as the
-anchor), as well as a number of messages before and after the anchor
-message.  The server returns those messages, sorted by message ID, as
-well as some metadata that makes it easy for a client to determine
-whether there are more messages matching the query that were not
-returned due to the `num_before` and `num_after` limits.
-
-We recommend using `num_before <= 1000` and `num_after <= 1000` to
-avoid generating very large HTTP responses. A maximum of 5000 messages
-can be obtained per request; attempting to exceed this will result in an
-error.
+{generate_api_description(/messages:get)}
 
 ## Usage examples
 

--- a/templates/zerver/api/get-org-emoji.md
+++ b/templates/zerver/api/get-org-emoji.md
@@ -1,8 +1,6 @@
 # Get all custom emoji
 
-Get all the custom emoji in the user's organization.
-
-`GET {{ api_url }}/v1/realm/emoji`
+{generate_api_description(/realm/emoji:get)}
 
 ## Usage examples
 

--- a/templates/zerver/api/get-presence.md
+++ b/templates/zerver/api/get-presence.md
@@ -1,18 +1,6 @@
 # Get user presence
 
-Get the presence status for a specific user.
-
-This endpoint is most useful for embedding data about a user's
-presence status in other sites (E.g. an employee directory).  Full
-Zulip clients like mobile/desktop apps will want to use the main
-presence endpoint, which returns data for all active users in the
-organization, instead.
-
-`GET {{ api_url }}/v1/users/{email}/presence`
-
-See
-[Zulip's developer documentation](https://zulip.readthedocs.io/en/latest/subsystems/presence.html)
-for details on the data model for presence in Zulip.
+{generate_api_description(/users/{email}/presence:get)}
 
 ## Usage examples
 

--- a/templates/zerver/api/get-profile.md
+++ b/templates/zerver/api/get-profile.md
@@ -1,8 +1,6 @@
 # Get profile
 
-Get basic data about the user/bot that requests this endpoint.
-
-`GET {{ api_url }}/v1/users/me`
+{generate_api_description(/users/me:get)}
 
 ## Usage examples
 

--- a/templates/zerver/api/get-raw-message.md
+++ b/templates/zerver/api/get-raw-message.md
@@ -1,13 +1,6 @@
 # Get a raw message
 
-Get the raw content of a message.
-
-`GET {{ api_url }}/v1/messages/{msg_id}`
-
-This is a rarely-used endpoint relevant for clients that primarily
-work with HTML-rendered messages but might need to occasionally fetch
-the message's raw markdown (e.g. for pre-filling a message-editing
-UI).
+{generate_api_description(/messages/{message_id}:get)}
 
 ## Usage examples
 

--- a/templates/zerver/api/get-stream-id.md
+++ b/templates/zerver/api/get-stream-id.md
@@ -1,8 +1,6 @@
 # Get stream ID
 
-Get the unique ID of a given stream.
-
-`GET {{ api_url }}/v1/get_stream_id`
+{generate_api_description(/get_stream_id:get)}
 
 ## Usage examples
 

--- a/templates/zerver/api/get-stream-topics.md
+++ b/templates/zerver/api/get-stream-topics.md
@@ -1,8 +1,6 @@
 # Get topics in a stream
 
-Get all the topics in a specific stream
-
-`GET {{ api_url }}/v1/users/me/{stream_id}/topics`
+{generate_api_description(/users/me/{stream_id}/topics:get)}
 
 ## Usage examples
 

--- a/templates/zerver/api/get-subscribed-streams.md
+++ b/templates/zerver/api/get-subscribed-streams.md
@@ -1,8 +1,6 @@
 # Get subscribed streams
 
-Get all streams that the user is subscribed to.
-
-`GET {{ api_url }}/v1/users/me/subscriptions`
+{generate_api_description(/users/me/subscriptions:get)}
 
 ## Usage examples
 

--- a/templates/zerver/api/get-user-groups.md
+++ b/templates/zerver/api/get-user-groups.md
@@ -2,9 +2,7 @@
 
 {!api-members-only.md!}
 
-Fetches all of the user groups in the organization.
-
-`GET {{ api_url }}/v1/user_groups`
+{generate_api_description(/user_groups:get)}
 
 ## Usage examples
 

--- a/templates/zerver/api/get-user.md
+++ b/templates/zerver/api/get-user.md
@@ -1,12 +1,6 @@
 # Get a user
 
-Fetch details for a single user in the organization.
-
-`GET {{ api_url }}/v1/users/{user_id}`
-
-You can also fetch details on [all users in the organization](/api/get-all-users).
-
-*This endpoint is new in Zulip Server 2.2.*
+{generate_api_description(/users/{user_id}:get)}
 
 ## Usage examples
 

--- a/templates/zerver/api/list-linkifiers.md
+++ b/templates/zerver/api/list-linkifiers.md
@@ -1,11 +1,6 @@
 # List linkifiers
 
-List all of an organization's configured
-[linkifiers](/help/add-a-custom-linkification-filter), regular
-expression patterns that are automatically linkified when they appear
-in messages and topics.
-
-`GET {{ api_url }}/v1/realm/filters`
+{generate_api_description(/realm/filters:get)}
 
 ## Usage examples
 

--- a/templates/zerver/api/mark-as-read-bulk.md
+++ b/templates/zerver/api/mark-as-read-bulk.md
@@ -1,8 +1,6 @@
 # Mark all messages as read
 
-Marks all of the current user's unread messages as read.
-
-`POST {{ api_url }}/v1/mark_all_as_read`
+{generate_api_description(/mark_all_as_read:post)}
 
 ## Usage examples
 

--- a/templates/zerver/api/mute-topics.md
+++ b/templates/zerver/api/mute-topics.md
@@ -1,10 +1,6 @@
 # Topic muting
 
-This endpoint mutes/unmutes a topic within a stream that the current
-user is subscribed to.  Muted topics are displayed faded in the Zulip
-UI, and are not included in the user's unread count totals.
-
-`PATCH {{ api_url }}/v1/users/me/subscriptions/muted_topics`
+{generate_api_description(/users/me/subscriptions/muted_topics:patch)}
 
 ## Usage examples
 

--- a/templates/zerver/api/remove-emoji-reaction.md
+++ b/templates/zerver/api/remove-emoji-reaction.md
@@ -1,9 +1,6 @@
 # Remove an emoji reaction
 
-Remove an [emoji reaction](/help/emoji-reactions) from a message.
-
-`DELETE {{ api_url }}/v1/messages/{message_id}/reactions`
-
+{generate_api_description(/messages/{message_id}/reactions:delete)}
 
 ## Usage examples
 

--- a/templates/zerver/api/remove-linkifiers.md
+++ b/templates/zerver/api/remove-linkifiers.md
@@ -1,10 +1,6 @@
 # Remove linkifiers
 
-Remove [linkifiers](/help/add-a-custom-linkification-filter), regular
-expression patterns that are automatically linkified when they appear
-in messages and topics.
-
-`DELETE {{ api_url }}/v1/realm/filters/{filter_id}`
+{generate_api_description(/realm/filters/{filter_id}:delete)}
 
 ## Usage examples
 

--- a/templates/zerver/api/remove-subscriptions.md
+++ b/templates/zerver/api/remove-subscriptions.md
@@ -1,8 +1,6 @@
 # Remove subscriptions
 
-Unsubscribe yourself or other users from one or more streams.
-
-`DELETE {{ api_url }}/v1/users/me/subscriptions`
+{generate_api_description(/users/me/subscriptions:delete)}
 
 ## Usage examples
 

--- a/templates/zerver/api/render-message.md
+++ b/templates/zerver/api/render-message.md
@@ -1,8 +1,6 @@
 # Render message
 
-Render a message to HTML.
-
-`POST {{ api_url }}/v1/messages/render`
+{generate_api_description(/messages/render:post)}
 
 ## Usage examples
 

--- a/templates/zerver/api/send-message.md
+++ b/templates/zerver/api/send-message.md
@@ -1,8 +1,6 @@
 # Send a message
 
-Send a stream or a private message.
-
-`POST {{ api_url }}/v1/messages`
+{generate_api_description(/messages:post)}
 
 ## Usage examples
 

--- a/templates/zerver/api/server-settings.md
+++ b/templates/zerver/api/server-settings.md
@@ -1,16 +1,6 @@
 # Get global settings
 
-Fetch global settings for a Zulip server.
-
-`GET {{ api_url }}/v1/server_settings`
-
-**Note:** this endpoint does not require any authentication at all, and you can use it to check:
-
-* If this is a Zulip server, and if so, what version of Zulip it's running.
-* What a Zulip client (e.g. a mobile app or
-  [zulip-terminal](https://github.com/zulip/zulip-terminal/)) needs to
-  know in order to display a login prompt for the server (e.g. what
-  authentication methods are available).
+{generate_api_description(/server_settings:get)}
 
 ## Usage examples
 

--- a/templates/zerver/api/typing.md
+++ b/templates/zerver/api/typing.md
@@ -1,11 +1,6 @@
 # Set "typing" status
 
-Send an event indicating that the user has started or stopped typing
-on their client.  See
-[the typing notification docs](https://zulip.readthedocs.io/en/latest/subsystems/typing-indicators.html)
-for details on Zulip's typing notifications protocol.
-
-`POST {{ api_url }}/v1/typing`
+{generate_api_description(/typing:post)}
 
 ## Usage examples
 

--- a/templates/zerver/api/update-message-flags.md
+++ b/templates/zerver/api/update-message-flags.md
@@ -1,12 +1,6 @@
 # Update a message's flags
 
-Add or remove flags in a list of messages.
-
-`POST {{ api_url }}/v1/messages/flags`
-
-For updating the `read` flag on common collections of messages, see also
-the
-[special endpoints for marking message as read in bulk](/api/mark-as-read-bulk).
+{generate_api_description(/messages/flags:post)}
 
 ## Usage examples
 

--- a/templates/zerver/api/update-message.md
+++ b/templates/zerver/api/update-message.md
@@ -1,11 +1,6 @@
 # Update a message
 
-Edit/update the content or topic of a message.
-
-`PATCH {{ api_url }}/v1/messages/{msg_id}`
-
-`{msg_id}` in the above URL should be replaced with the ID of the
-message you wish you update.
+{generate_api_description(/messages/{message_id}:patch)}
 
 ## Usage examples
 

--- a/templates/zerver/api/update-notification-settings.md
+++ b/templates/zerver/api/update-notification-settings.md
@@ -1,10 +1,6 @@
 # Update notification settings
 
-This endpoint is used to edit the user's global notification settings.
-See [this endpoint](/api/update-subscription-properties) for
-per-stream notification settings.
-
-`PATCH {{ api_url }}/v1/settings/notifications`
+{generate_api_description(/settings/notifications:patch)}
 
 ## Usage examples
 

--- a/templates/zerver/api/update-stream.md
+++ b/templates/zerver/api/update-stream.md
@@ -1,15 +1,6 @@
 # Update stream
 
-Configure the stream with the ID `stream_id`.  This endpoint supports
-an organization administrator editing any property of a stream,
-including:
-
-* Stream [name](/help/rename-a-stream) and [description](/help/change-the-stream-description)
-* Stream [permissions](/help/stream-permissions), including
-  [privacy](/help/change-the-privacy-of-a-stream) and [who can
-  send](/help/stream-sending-policy).
-
-`PATCH {{ api_url }}/v1/streams/{stream_id}`
+{generate_api_description(/streams/{stream_id}:patch)}
 
 ## Usage examples
 

--- a/templates/zerver/api/update-subscription-properties.md
+++ b/templates/zerver/api/update-subscription-properties.md
@@ -1,10 +1,6 @@
 # Update subscription properties
 
-This endpoint is used to update the user's personal settings for the
-streams they are subscribed to, including muting, color, pinning, and
-per-stream notification settings.
-
-`POST {{ api_url }}/v1/users/me/subscriptions/properties`
+{generate_api_description(/users/me/subscriptions/properties:post)}
 
 ## Usage examples
 

--- a/templates/zerver/api/update-user-group.md
+++ b/templates/zerver/api/update-user-group.md
@@ -1,8 +1,6 @@
 # Update User Group
 
-Update the name or description of a [user group](/help/user-groups).
-
-`PATCH {{ api_url }}/v1/user_groups/{group_id}`
+{generate_api_description(/user_groups/{group_id}:patch)}
 
 ## Usage examples
 

--- a/templates/zerver/api/update-user.md
+++ b/templates/zerver/api/update-user.md
@@ -2,14 +2,7 @@
 
 {!api-admin-only.md!}
 
-Administrative endpoint to update the details of another user in the organization.
-
-`PATCH {{ api_url }}/v1/users/{user_id}`
-
-Supports everything an administrator can do to edit details of another
-user's account, including editing full name,
-[role](/help/roles-and-permissions), and [custom profile
-fields](/help/add-custom-profile-fields).
+{generate_api_description(/users/{user_id}:patch)}
 
 ## Usage examples
 

--- a/templates/zerver/api/upload-custom-emoji.md
+++ b/templates/zerver/api/upload-custom-emoji.md
@@ -1,10 +1,6 @@
 # Upload a custom emoji
 
-This endpoint is used to upload a custom emoji for use in the user's
-organization.  Access to this endpoint depends on the
-[organization's configuration](https://zulipchat.com/help/only-allow-admins-to-add-emoji).
-
- `POST {{ api_url }}/v1/realm/emoji/{emoji_name}`
+{generate_api_description(/realm/emoji/{emoji_name}:post)}
 
 ## Usage examples
 

--- a/templates/zerver/api/upload-file.md
+++ b/templates/zerver/api/upload-file.md
@@ -1,17 +1,6 @@
 # Upload a file
 
-Upload a single file and get the corresponding URI.
-
-`POST {{ api_url }}/v1/user_uploads`
-
-Initially, only you will be able to access the link.  To share the
-uploaded file, you'll need to [send a message][send-message]
-containing the resulting link.  Users who can already access the link
-can reshare it with other users by sending additional Zulip messages
-containing the link.
-
-[uploaded-files]: /help/manage-your-uploaded-files
-[send-message]: /api/send-message
+{generate_api_description(/user_uploads:post)}
 
 ## Usage examples
 

--- a/zerver/lib/bugdown/api_description.py
+++ b/zerver/lib/bugdown/api_description.py
@@ -1,0 +1,63 @@
+import re
+from markdown.extensions import Extension
+from markdown.preprocessors import Preprocessor
+from typing import Any, Dict, Optional, List
+import markdown
+
+from zerver.openapi.openapi import get_openapi_description
+
+MACRO_REGEXP = re.compile(r'\{generate_api_description(\(\s*(.+?)\s*\))}')
+
+class APIDescriptionGenerator(Extension):
+    def __init__(self, api_url: Optional[str]) -> None:
+        self.config = {
+            'api_url': [
+                api_url,
+                'API URL to use when rendering api links'
+            ]
+        }
+
+    def extendMarkdown(self, md: markdown.Markdown, md_globals: Dict[str, Any]) -> None:
+        md.preprocessors.add(
+            'generate_api_description', APIDescriptionPreprocessor(md, self.getConfigs()), '_begin'
+        )
+
+class APIDescriptionPreprocessor(Preprocessor):
+    def __init__(self, md: markdown.Markdown, config: Dict[str, Any]) -> None:
+        super().__init__(md)
+        self.api_url = config['api_url']
+
+    def run(self, lines: List[str]) -> List[str]:
+        done = False
+        while not done:
+            for line in lines:
+                loc = lines.index(line)
+                match = MACRO_REGEXP.search(line)
+
+                if match:
+                    function = match.group(2)
+                    text = self.render_description(function)
+                    # The line that contains the directive to include the macro
+                    # may be preceded or followed by text or tags, in that case
+                    # we need to make sure that any preceding or following text
+                    # stays the same.
+                    line_split = MACRO_REGEXP.split(line, maxsplit=0)
+                    preceding = line_split[0]
+                    following = line_split[-1]
+                    text = [preceding] + text + [following]
+                    lines = lines[:loc] + text + lines[loc+1:]
+                    break
+            else:
+                done = True
+        return lines
+
+    def render_description(self, function: str) -> List[str]:
+        description: List[str] = []
+        path, method = function.rsplit(':', 1)
+        description_dict = get_openapi_description(path, method)
+        description_dict = description_dict.replace('{{api_url}}', self.api_url)
+        description.extend(description_dict.splitlines())
+        return description
+
+def makeExtension(*args: Any, **kwargs: str) -> APIDescriptionGenerator:
+    return APIDescriptionGenerator(*args, **kwargs)

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -79,6 +79,12 @@ def get_openapi_fixture(endpoint: str, method: str,
         response = '200'
     return (get_schema(endpoint, method, response)['example'])
 
+def get_openapi_description(endpoint: str, method: str) -> str:
+    """Fetch a description from the full spec object.
+    """
+    description = openapi_spec.spec()['paths'][endpoint][method.lower()]['description']
+    return description
+
 def get_openapi_paths() -> Set[str]:
     return set(openapi_spec.spec()['paths'].keys())
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -60,9 +60,17 @@ paths:
   /dev_fetch_api_key:
     post:
       description: |
-        Gather a token bound to a user account, to identify and authenticate
-        them when making operations with the API. This token must be used as the
-        password in the rest of the endpoints that require Basic authentication.
+        For easy testing of mobile apps and other clients and against Zulip
+        development servers, we support fetching a Zulip API key for any user
+        on the development server without authentication (so that they can
+        implement analogues of the one-click login process available for Zulip
+        development servers on the web).
+
+        **Note:** This endpoint is only available on Zulip development
+        servers; for obvious security reasons it will always return an error
+        in a Zulip production server.
+
+        `POST {{ api_url }}/v1/dev_fetch_api_key`
       parameters:
       - name: username
         in: query
@@ -83,7 +91,10 @@ paths:
   /events:
     get:
       description: |
-        Receive new events from [a registered event queue](/api/register-queue).
+        `GET {{ api_url }}/v1/events`
+
+        This endpoint allows you to receive new events from
+        [a registered event queue](/api/register-queue).
       parameters:
       - $ref: '#/components/parameters/QueueId'
       - name: last_event_id
@@ -195,6 +206,8 @@ paths:
     delete:
       description: |
         Delete a previously registered queue.
+
+        `DELETE {{ api_url }}/v1/events`
       parameters:
       - $ref: '#/components/parameters/QueueId'
       responses:
@@ -214,6 +227,8 @@ paths:
     get:
       description: |
         Get the unique ID of a given stream.
+
+        `GET {{ api_url }}/v1/get_stream_id`
       parameters:
       - $ref: '#/components/parameters/Stream'
         required: true
@@ -252,8 +267,9 @@ paths:
   /mark_all_as_read:
     post:
       description: |
-        Mark all the user's unread messages as read. This is often called
-        "bankruptcy" in Zulip.
+        Marks all of the current user's unread messages as read.
+
+        `POST {{ api_url }}/v1/mark_all_as_read`
       responses:
         '200':
           description: Success.
@@ -300,7 +316,34 @@ paths:
   /messages:
     get:
       description: |
-        Fetch messages that match a specific narrow.
+        Fetch message history from a Zulip server.
+
+        `GET {{ api_url }}/v1/messages`
+
+        This `GET /api/v1/messages` endpoint is the primary way to fetch
+        message history from a Zulip server.  It is useful both for Zulip
+        clients (e.g. the web, desktop, mobile, and terminal clients) as well
+        as bots, API clients, backup scripts, etc.
+
+        By specifying a [narrow filter](/api/construct-narrow), you can use
+        this endpoint to fetch the messages matching any search query that is
+        supported by Zulip's powerful full-text search backend.
+
+        When a narrow is not specified, it can be used to fetch a user's
+        message history (We recommend paginating to 1000 messages at a time).
+
+        In either case, you specify an `anchor` message (or ask the server to
+        calculate the first unread message for you and use that as the
+        anchor), as well as a number of messages before and after the anchor
+        message.  The server returns those messages, sorted by message ID, as
+        well as some metadata that makes it easy for a client to determine
+        whether there are more messages matching the query that were not
+        returned due to the `num_before` and `num_after` limits.
+
+        We recommend using `num_before <= 1000` and `num_after <= 1000` to
+        avoid generating very large HTTP responses. A maximum of 5000 messages
+        can be obtained per request; attempting to exceed this will result in an
+        error.
       parameters:
       - name: anchor
         in: query
@@ -509,7 +552,9 @@ paths:
                     }
     post:
       description: |
-        Send a message.
+        Send a stream or a private message.
+
+        `POST {{ api_url }}/v1/messages`
       parameters:
       - name: type
         in: query
@@ -575,6 +620,13 @@ paths:
     get:
       description: |
         Get the raw content of a message.
+
+        `GET {{ api_url }}/v1/messages/{msg_id}`
+
+        This is a rarely-used endpoint relevant for clients that primarily
+        work with HTML-rendered messages but might need to occasionally fetch
+        the message's raw markdown (e.g. for pre-filling a message-editing
+        UI).
       parameters:
       - $ref: '#/components/parameters/MessageId'
       responses:
@@ -604,7 +656,12 @@ paths:
                 $ref: '#/components/schemas/InvalidMessageError'
     patch:
       description: |
-        Edit a message that has already been sent.
+        Edit/update the content or topic of a message.
+
+        `PATCH {{ api_url }}/v1/messages/{msg_id}`
+
+        `{msg_id}` in the above URL should be replaced with the ID of the
+        message you wish you update.
       parameters:
       - $ref: '#/components/parameters/MessageId'
       - $ref: '#/components/parameters/Topic'
@@ -654,7 +711,13 @@ paths:
                     }
     delete:
       description: |
-        Delete a message.
+        Permanently delete a message.
+
+        `DELETE {{ api_url }}/v1/messages/{msg_id}`
+
+        This API corresponds to the
+        [delete a message completely][delete-completely] feature documented in
+        the Zulip Help Center.
       parameters:
       - $ref: '#/components/parameters/MessageId'
       responses:
@@ -682,7 +745,14 @@ paths:
   /messages/{message_id}/history:
     get:
       description: |
-        Get the different versions of a previously edited message.
+        Fetch the message edit history of a previously edited message.
+
+        `GET {{ api_url }}/v1/messages/{message_id}/history`
+
+        Note that edit history may be disabled in some organizations; see the
+        [Zulip Help Center documentation on editing messages][edit-settings].
+
+        [edit-settings]: /help/view-a-messages-edit-history
       parameters:
       - $ref: '#/components/parameters/MessageId'
       responses:
@@ -737,6 +807,12 @@ paths:
     post:
       description: |
         Add or remove flags in a list of messages.
+
+        `POST {{ api_url }}/v1/messages/flags`
+
+        For updating the `read` flag on common collections of messages, see also
+        the
+        [special endpoints for marking message as read in bulk](/api/mark-as-read-bulk).
       parameters:
       - name: messages
         in: query
@@ -794,6 +870,8 @@ paths:
     post:
       description: |
         Render a message to HTML.
+
+        `POST {{ api_url }}/v1/messages/render`
       parameters:
       - $ref: '#/components/parameters/Content'
       responses:
@@ -884,7 +962,9 @@ paths:
 
     delete:
       description: |
-        Delete an emoji reaction from a message.
+        Remove an [emoji reaction](/help/emoji-reactions) from a message.
+
+        `DELETE {{ api_url }}/v1/messages/{message_id}/reactions`
       parameters:
       - $ref: '#/components/parameters/MessageId'
       - name: emoji_name
@@ -946,6 +1026,17 @@ paths:
     post:
       description: |
         Upload a single file and get the corresponding URI.
+
+        `POST {{ api_url }}/v1/user_uploads`
+
+        Initially, only you will be able to access the link.  To share the
+        uploaded file, you'll need to [send a message][send-message]
+        containing the resulting link.  Users who can already access the link
+        can reshare it with other users by sending additional Zulip messages
+        containing the link.
+
+        [uploaded-files]: /help/manage-your-uploaded-files
+        [send-message]: /api/send-message
       requestBody:
         content:
           multipart/form-data:
@@ -1019,7 +1110,10 @@ paths:
   /users:
     get:
       description: |
-        Retrieve all users in a realm.
+        Retrieve details on all users in the organization.  Optionally
+        includes values of [custom profile field](/help/add-custom-profile-fields).
+
+        `GET {{ api_url }}/v1/users`
       parameters:
       - $ref: '#/components/parameters/ClientGravatar'
       - name: include_custom_profile_fields
@@ -1129,7 +1223,9 @@ paths:
                     }
     post:
       description: |
-        Create a new user in a realm.
+        Create a new user account via the API.
+
+        `POST {{ api_url }}/v1/users`
       parameters:
       - name: email
         in: query
@@ -1186,7 +1282,13 @@ paths:
   /users/{user_id}:
     get:
       description: |
-        Retrieve a user in a realm.
+        Fetch details for a single user in the organization.
+
+        `GET {{ api_url }}/v1/users/{user_id}`
+
+        You can also fetch details on [all users in the organization](/api/get-all-users).
+
+        *This endpoint is new in Zulip Server 2.2.*
       parameters:
       - name: user_id
         in: path
@@ -1270,7 +1372,14 @@ paths:
 
     patch:
       description: |
-        Update the user.
+        Administrative endpoint to update the details of another user in the organization.
+
+        `PATCH {{ api_url }}/v1/users/{user_id}`
+
+        Supports everything an administrator can do to edit details of another
+        user's account, including editing full name,
+        [role](/help/roles-and-permissions), and [custom profile
+        fields](/help/add-custom-profile-fields).
       parameters:
       - name: user_id
         in: path
@@ -1346,7 +1455,11 @@ paths:
 
     delete:
       description: |
-        Delete the user with the passed 'user_id' from the realm.
+        [Deactivates a
+        user](https://zulipchat.com/help/deactivate-or-reactivate-a-user)
+        given their user ID.
+
+        `DELETE {{ api_url }}/v1/users/{user_id}`
       parameters:
       - name: user_id
         in: path
@@ -1386,6 +1499,18 @@ paths:
     get:
       description: |
         Get the presence status for a specific user.
+
+        This endpoint is most useful for embedding data about a user's
+        presence status in other sites (E.g. an employee directory).  Full
+        Zulip clients like mobile/desktop apps will want to use the main
+        presence endpoint, which returns data for all active users in the
+        organization, instead.
+
+        `GET {{ api_url }}/v1/users/{email}/presence`
+
+        See
+        [Zulip's developer documentation](https://zulip.readthedocs.io/en/latest/subsystems/presence.html)
+        for details on the data model for presence in Zulip.
       parameters:
       - name: email
         in: path
@@ -1431,7 +1556,9 @@ paths:
   /users/me:
     get:
       description: |
-        Get the requesting user's profile data from the backend.
+        Get basic data about the user/bot that requests this endpoint.
+
+        `GET {{ api_url }}/v1/users/me`
       responses:
         '200':
           description: Success
@@ -1576,7 +1703,9 @@ paths:
   /users/me/{stream_id}/topics:
     get:
       description: |
-        Get all the topics in a specific stream.
+        Get all the topics in a specific stream
+
+        `GET {{ api_url }}/v1/users/me/{stream_id}/topics`
       parameters:
       - $ref: '#/components/parameters/StreamIdInPath'
       responses:
@@ -1636,7 +1765,9 @@ paths:
   /users/me/subscriptions:
     get:
       description: |
-        Get information on every stream the user is subscribed to.
+        Get all streams that the user is subscribed to.
+
+        `GET {{ api_url }}/v1/users/me/subscriptions`
       # operationId can be used to record which view function
       # corresponds to an endpoint.  TODO: Add these for more
       # endpoints, and perhaps use this to provide links to implementations.
@@ -1719,6 +1850,12 @@ paths:
     post:
       description: |
         Subscribe one or more users to one or more streams.
+
+        `POST {{ api_url }}/v1/users/me/subscriptions`
+
+        If any of the specified streams do not exist, they are automatically
+        created, and configured using the `invite_only` setting specified in
+        the arguments (see below).
       parameters:
       - name: subscriptions
         in: query
@@ -1964,6 +2101,8 @@ paths:
     delete:
       description: |
         Unsubscribe yourself or other users from one or more streams.
+
+        `DELETE {{ api_url }}/v1/users/me/subscriptions`
       parameters:
       - name: subscriptions
         in: query
@@ -2028,7 +2167,12 @@ paths:
   /users/me/subscriptions/muted_topics:
     patch:
       description: |
-        Toggle muting for a specific topic the user is subscribed to.
+        This endpoint mutes/unmutes a topic within a stream that the current
+        user is subscribed to.  Muted topics are displayed faded in the Zulip
+        UI, and are not included in the user's unread count totals.
+
+        `PATCH {{ api_url }}/v1/users/me/subscriptions/muted_topics`
+
       parameters:
       - $ref: '#/components/parameters/Stream'
         required: false
@@ -2084,7 +2228,11 @@ paths:
   /realm/emoji/{emoji_name}:
     post:
       description: |
-        Upload a single emoji file.
+        This endpoint is used to upload a custom emoji for use in the user's
+        organization.  Access to this endpoint depends on the
+        [organization's configuration](https://zulipchat.com/help/only-allow-admins-to-add-emoji).
+
+        `POST {{ api_url }}/v1/realm/emoji/{emoji_name}`
       parameters:
       - name: emoji_name
         required: true
@@ -2114,7 +2262,9 @@ paths:
   /realm/emoji:
     get:
       description: |
-        Get all the custom emoji in the user's realm.
+        Get all the custom emoji in the user's organization.
+
+        `GET {{ api_url }}/v1/realm/emoji`
       responses:
         '200':
           description: Success.
@@ -2150,8 +2300,11 @@ paths:
   /users/me/subscriptions/properties:
     post:
       description: |
-        Make bulk modifications of the subscription properties on one or more
-        streams the user is subscribed to.
+        This endpoint is used to update the user's personal settings for the
+        streams they are subscribed to, including muting, color, pinning, and
+        per-stream notification settings.
+
+        `POST {{ api_url }}/v1/users/me/subscriptions/properties`
       parameters:
       - name: subscription_data
         in: query
@@ -2201,7 +2354,12 @@ paths:
   /realm/filters:
     get:
       description: |
-        Fetch all the filters set up for the user's organization.
+        List all of an organization's configured
+        [linkifiers](/help/add-a-custom-linkification-filter), regular
+        expression patterns that are automatically linkified when they appear
+        in messages and topics.
+
+        `GET {{ api_url }}/v1/realm/filters`
       responses:
         '200':
           description: Success.
@@ -2241,8 +2399,11 @@ paths:
                     }
     post:
       description: |
-        Establish patterns in the messages that should be automatically
-        linkified.
+        Configure [linkifiers](/help/add-a-custom-linkification-filter),
+        regular expression patterns that are automatically linkified when they
+        appear in messages and topics.
+
+        `POST {{ api_url }}/v1/realm/filters`
       parameters:
       - name: pattern
         in: query
@@ -2286,7 +2447,11 @@ paths:
   /realm/filters/{filter_id}:
     delete:
       description: |
-        Remove an organization filter.
+        Remove [linkifiers](/help/add-a-custom-linkification-filter), regular
+        expression patterns that are automatically linkified when they appear
+        in messages and topics.
+
+        `DELETE {{ api_url }}/v1/realm/filters/{filter_id}`
       parameters:
       - name: filter_id
         in: path
@@ -2425,7 +2590,17 @@ paths:
   /server_settings:
     get:
       description: |
-        Fetch global settings for the Zulip server.
+        Fetch global settings for a Zulip server.
+
+        `GET {{ api_url }}/v1/server_settings`
+
+        **Note:** this endpoint does not require any authentication at all, and you can use it to check:
+
+        * If this is a Zulip server, and if so, what version of Zulip it's running.
+        * What a Zulip client (e.g. a mobile app or
+        [zulip-terminal](https://github.com/zulip/zulip-terminal/)) needs to
+        know in order to display a login prompt for the server (e.g. what
+        authentication methods are available).
       responses:
         '200':
           description: Success.
@@ -2550,7 +2725,11 @@ paths:
   /settings/notifications:
     patch:
       description: |
-        Modify the user's preferences for notifications.
+        This endpoint is used to edit the user's global notification settings.
+        See [this endpoint](/api/update-subscription-properties) for
+        per-stream notification settings.
+
+        `PATCH {{ api_url }}/v1/settings/notifications`
       parameters:
       - name: enable_stream_desktop_notifications
         in: query
@@ -2754,6 +2933,8 @@ paths:
     get:
       description: |
         Get all streams that the user has access to.
+
+        `GET {{ api_url }}/v1/streams`
       parameters:
       - name: include_public
         in: query
@@ -2872,7 +3053,9 @@ paths:
   /streams/{stream_id}:
     delete:
       description: |
-        Delete the stream with the given ID.
+        [Delete the stream](/help/delete-a-stream) with the ID `stream_id`.
+
+        `DELETE {{ api_url }}/v1/streams/{stream_id}`
       operationId: zerver.views.streams.deactivate_stream_backend
       parameters:
       - $ref: '#/components/parameters/StreamIdInPath'
@@ -2907,7 +3090,16 @@ paths:
                     }
     patch:
       description: |
-        Update the stream with the given ID.
+        Configure the stream with the ID `stream_id`.  This endpoint supports
+        an organization administrator editing any property of a stream,
+        including:
+
+        * Stream [name](/help/rename-a-stream) and [description](/help/change-the-stream-description)
+        * Stream [permissions](/help/stream-permissions), including
+        [privacy](/help/change-the-privacy-of-a-stream) and [who can
+        send](/help/stream-sending-policy).
+
+        `PATCH {{ api_url }}/v1/streams/{stream_id}`
       operationId: zerver.views.streams.update_stream_backend
       parameters:
       - $ref: '#/components/parameters/StreamIdInPath'
@@ -3002,8 +3194,12 @@ paths:
   /typing:
     post:
       description: |
-        Send an event indicating that the user has started or stopped typing on
-        their client.
+        Send an event indicating that the user has started or stopped typing
+        on their client.  See
+        [the typing notification docs](https://zulip.readthedocs.io/en/latest/subsystems/typing-indicators.html)
+        for details on Zulip's typing notifications protocol.
+
+        `POST {{ api_url }}/v1/typing`
       parameters:
       - name: op
         in: query
@@ -3044,7 +3240,9 @@ paths:
   /user_groups/create:
     post:
       description: |
-        Create a user group.
+        Create a new [user group](/help/user-groups).
+
+        `POST {{ api_url }}/v1/user_groups/create`
       parameters:
       - name: name
         in: query
@@ -3102,7 +3300,9 @@ paths:
   /user_groups/{group_id}:
     patch:
       description: |
-        Update the user group.
+        Update the name or description of a [user group](/help/user-groups).
+
+        `PATCH {{ api_url }}/v1/user_groups/{group_id}`
       parameters:
       - $ref: '#/components/parameters/GroupId'
       - name: name
@@ -3140,7 +3340,9 @@ paths:
                     }
     delete:
       description: |
-        Delete the user group.
+        Delete a [user group](/help/user-groups).
+
+        `DELETE {{ api_url }}/v1/user_groups/{group_id}`
       parameters:
       - $ref: '#/components/parameters/GroupId'
       responses:
@@ -3174,7 +3376,9 @@ paths:
   /user_groups:
     get:
       description: |
-        Get all user groups of the realm.
+        Fetches all of the user groups in the organization.
+
+        `GET {{ api_url }}/v1/user_groups`
       responses:
         '200':
           description: Success.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -818,7 +818,9 @@ paths:
   /messages/{message_id}/reactions:
     post:
       description: |
-        Add an emoji reaction to a message.
+        Add an [emoji reaction](/help/emoji-reactions) to a message.
+
+        `POST {{ api_url }}/v1/messages/{message_id}/reactions`
       parameters:
       - $ref: '#/components/parameters/MessageId'
       - name: emoji_name

--- a/zerver/templatetags/app_filters.py
+++ b/zerver/templatetags/app_filters.py
@@ -12,6 +12,7 @@ from jinja2.exceptions import TemplateNotFound
 import zerver.lib.bugdown.fenced_code
 import zerver.lib.bugdown.api_arguments_table_generator
 import zerver.lib.bugdown.api_code_examples
+import zerver.lib.bugdown.api_description
 import zerver.lib.bugdown.nested_code_blocks
 import zerver.lib.bugdown.tabbed_sections
 import zerver.lib.bugdown.help_settings_links
@@ -124,6 +125,9 @@ def render_markdown_path(markdown_file_path: str,
         # TODO: Convert this to something more efficient involving
         # passing the API URL as a direct parameter.
         extensions = extensions + [zerver.lib.bugdown.api_code_examples.makeExtension(
+            api_url=context["api_url"],
+        )]
+        extensions = extensions + [zerver.lib.bugdown.api_description.makeExtension(
             api_url=context["api_url"],
         )]
     if not any(doc in markdown_file_path for doc in docs_without_macros):


### PR DESCRIPTION
Add function in openapi.py to access endpoint descriptions written
in zulip.yaml. Use this function for creating a markdown extension
for rendering endpoint descriptions written in zulip.yaml.