### PR TITLE
migrations: Mark RunPython statements elidable.

### DIFF
--- a/zerver/migrations/0001_initial.py
+++ b/zerver/migrations/0001_initial.py
@@ -570,6 +570,7 @@ CREATE TRIGGER zerver_message_update_search_tsvector_async
         ),
         migrations.RunPython(
             code=migrate_existing_attachment_data,
+            elidable=True,
         ),
         migrations.AddField(
             model_name='subscription',

--- a/zerver/migrations/0029_realm_subdomain.py
+++ b/zerver/migrations/0029_realm_subdomain.py
@@ -29,5 +29,5 @@ class Migration(migrations.Migration):
             name='subdomain',
             field=models.CharField(max_length=40, unique=True, null=True),
         ),
-        migrations.RunPython(set_subdomain_of_default_realm)
+        migrations.RunPython(set_subdomain_of_default_realm, elidable=True)
     ]

--- a/zerver/migrations/0032_verify_all_medium_avatar_images.py
+++ b/zerver/migrations/0032_verify_all_medium_avatar_images.py
@@ -37,5 +37,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(verify_medium_avatar_image)
+        migrations.RunPython(verify_medium_avatar_image, elidable=True)
     ]

--- a/zerver/migrations/0033_migrate_domain_to_realmalias.py
+++ b/zerver/migrations/0033_migrate_domain_to_realmalias.py
@@ -19,5 +19,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(add_domain_to_realm_alias_if_needed)
+        migrations.RunPython(add_domain_to_realm_alias_if_needed, elidable=True)
     ]

--- a/zerver/migrations/0037_disallow_null_string_id.py
+++ b/zerver/migrations/0037_disallow_null_string_id.py
@@ -31,7 +31,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(set_string_id_using_domain),
+        migrations.RunPython(set_string_id_using_domain, elidable=True),
 
         migrations.AlterField(
             model_name='realm',

--- a/zerver/migrations/0041_create_attachments_for_old_messages.py
+++ b/zerver/migrations/0041_create_attachments_for_old_messages.py
@@ -50,5 +50,5 @@ class Migration(migrations.Migration):
             name='file_name',
             field=models.TextField(db_index=True),
         ),
-        migrations.RunPython(check_and_create_attachments)
+        migrations.RunPython(check_and_create_attachments, elidable=True)
     ]

--- a/zerver/migrations/0057_realmauditlog.py
+++ b/zerver/migrations/0057_realmauditlog.py
@@ -58,6 +58,6 @@ class Migration(migrations.Migration):
         ),
 
         migrations.RunPython(backfill_user_activations_and_deactivations,
-                             reverse_code=reverse_code),
+                             reverse_code=reverse_code, elidable=True),
 
     ]

--- a/zerver/migrations/0074_fix_duplicate_attachments.py
+++ b/zerver/migrations/0074_fix_duplicate_attachments.py
@@ -41,5 +41,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(fix_duplicate_attachments)
+        migrations.RunPython(fix_duplicate_attachments, elidable=True)
     ]

--- a/zerver/migrations/0079_remove_old_scheduled_jobs.py
+++ b/zerver/migrations/0079_remove_old_scheduled_jobs.py
@@ -20,5 +20,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(delete_old_scheduled_jobs),
+        migrations.RunPython(delete_old_scheduled_jobs, elidable=True),
     ]

--- a/zerver/migrations/0081_make_emoji_lowercase.py
+++ b/zerver/migrations/0081_make_emoji_lowercase.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
             e.save()
 
     operations = [
-        migrations.RunPython(emoji_to_lowercase),
+        migrations.RunPython(emoji_to_lowercase, elidable=True),
         migrations.AlterField(
             model_name='realmemoji',
             name='name',

--- a/zerver/migrations/0085_fix_bots_with_none_bot_type.py
+++ b/zerver/migrations/0085_fix_bots_with_none_bot_type.py
@@ -18,5 +18,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(fix_bot_type),
+        migrations.RunPython(fix_bot_type, elidable=True),
     ]

--- a/zerver/migrations/0087_remove_old_scheduled_jobs.py
+++ b/zerver/migrations/0087_remove_old_scheduled_jobs.py
@@ -20,5 +20,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(delete_old_scheduled_jobs),
+        migrations.RunPython(delete_old_scheduled_jobs, elidable=True),
     ]

--- a/zerver/migrations/0093_subscription_event_log_backfill.py
+++ b/zerver/migrations/0093_subscription_event_log_backfill.py
@@ -61,5 +61,5 @@ class Migration(migrations.Migration):
             field=models.IntegerField(null=True),
         ),
         migrations.RunPython(backfill_subscription_log_events,
-                             reverse_code=reverse_code),
+                             reverse_code=reverse_code, elidable=True),
     ]

--- a/zerver/migrations/0097_reactions_emoji_code.py
+++ b/zerver/migrations/0097_reactions_emoji_code.py
@@ -45,5 +45,6 @@ class Migration(migrations.Migration):
             field=models.CharField(choices=[('unicode_emoji', 'Unicode emoji'), ('realm_emoji', 'Custom emoji'), ('zulip_extra_emoji', 'Zulip extra emoji')], default='unicode_emoji', max_length=30),
         ),
         migrations.RunPython(populate_new_fields,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0102_convert_muted_topic.py
+++ b/zerver/migrations/0102_convert_muted_topic.py
@@ -71,5 +71,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(convert_muted_topics),
+        migrations.RunPython(convert_muted_topics, elidable=True),
     ]

--- a/zerver/migrations/0104_fix_unreads.py
+++ b/zerver/migrations/0104_fix_unreads.py
@@ -19,5 +19,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(fix_unreads),
+        migrations.RunPython(fix_unreads, elidable=True),
     ]

--- a/zerver/migrations/0108_fix_default_string_id.py
+++ b/zerver/migrations/0108_fix_default_string_id.py
@@ -26,5 +26,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(fix_realm_string_ids,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0109_mark_tutorial_status_finished.py
+++ b/zerver/migrations/0109_mark_tutorial_status_finished.py
@@ -14,5 +14,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(set_tutorial_status_to_finished)
+        migrations.RunPython(set_tutorial_status_to_finished, elidable=True)
     ]

--- a/zerver/migrations/0110_stream_is_in_zephyr_realm.py
+++ b/zerver/migrations/0110_stream_is_in_zephyr_realm.py
@@ -32,5 +32,6 @@ class Migration(migrations.Migration):
             field=models.BooleanField(default=False),
         ),
         migrations.RunPython(populate_is_zephyr,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0121_realm_signup_notifications_stream.py
+++ b/zerver/migrations/0121_realm_signup_notifications_stream.py
@@ -27,5 +27,6 @@ class Migration(migrations.Migration):
             field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='+', to='zerver.Stream'),
         ),
         migrations.RunPython(set_initial_value_for_signup_notifications_stream,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0126_prereg_remove_users_without_realm.py
+++ b/zerver/migrations/0126_prereg_remove_users_without_realm.py
@@ -18,5 +18,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(remove_prereg_users_without_realm,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0128_scheduledemail_realm.py
+++ b/zerver/migrations/0128_scheduledemail_realm.py
@@ -39,7 +39,8 @@ class Migration(migrations.Migration):
 
         # Sets realm for existing ScheduledEmails
         migrations.RunPython(set_realm_for_existing_scheduledemails,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
 
         # Require ScheduledEmail.realm to be non-null
         migrations.AlterField(

--- a/zerver/migrations/0130_text_choice_in_emojiset.py
+++ b/zerver/migrations/0130_text_choice_in_emojiset.py
@@ -33,7 +33,7 @@ class Migration(migrations.Migration):
             name='emojiset',
             field=models.CharField(choices=[('google', 'Google'), ('apple', 'Apple'), ('twitter', 'Twitter'), ('emojione', 'EmojiOne'), ('text', 'Plain text')], default='google', max_length=20),
         ),
-        migrations.RunPython(change_emojiset, reverse_change_emojiset),
+        migrations.RunPython(change_emojiset, reverse_change_emojiset, elidable=True),
         migrations.RemoveField(
             model_name='userprofile',
             name='emoji_alt_code',

--- a/zerver/migrations/0139_fill_last_message_id_in_subscription_logs.py
+++ b/zerver/migrations/0139_fill_last_message_id_in_subscription_logs.py
@@ -18,5 +18,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(backfill_last_message_id,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0143_realm_bot_creation_policy.py
+++ b/zerver/migrations/0143_realm_bot_creation_policy.py
@@ -40,5 +40,6 @@ class Migration(migrations.Migration):
             field=models.PositiveSmallIntegerField(default=BOT_CREATION_EVERYONE),
         ),
         migrations.RunPython(set_initial_value_for_bot_creation_policy,
-                             reverse_code=reverse_code),
+                             reverse_code=reverse_code,
+                             elidable=True),
     ]

--- a/zerver/migrations/0145_reactions_realm_emoji_name_to_id.py
+++ b/zerver/migrations/0145_reactions_realm_emoji_name_to_id.py
@@ -45,5 +45,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(realm_emoji_name_to_id,
-                             reverse_code=reversal),
+                             reverse_code=reversal,
+                             elidable=True),
     ]

--- a/zerver/migrations/0149_realm_emoji_drop_unique_constraint.py
+++ b/zerver/migrations/0149_realm_emoji_drop_unique_constraint.py
@@ -106,5 +106,6 @@ class Migration(migrations.Migration):
         ),
         migrations.RunPython(
             migrate_realm_emoji_image_files,
-            reverse_code=reversal),
+            reverse_code=reversal,
+            elidable=True),
     ]

--- a/zerver/migrations/0154_fix_invalid_bot_owner.py
+++ b/zerver/migrations/0154_fix_invalid_bot_owner.py
@@ -19,5 +19,6 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RunPython(
             migrate_fix_invalid_bot_owner_values,
-            reverse_code=migrations.RunPython.noop),
+            reverse_code=migrations.RunPython.noop,
+            elidable=True),
     ]

--- a/zerver/migrations/0164_stream_history_public_to_subscribers.py
+++ b/zerver/migrations/0164_stream_history_public_to_subscribers.py
@@ -35,5 +35,6 @@ class Migration(migrations.Migration):
             field=models.BooleanField(default=False),
         ),
         migrations.RunPython(set_initial_value_for_history_public_to_subscribers,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0167_custom_profile_fields_sort_order.py
+++ b/zerver/migrations/0167_custom_profile_fields_sort_order.py
@@ -23,5 +23,6 @@ class Migration(migrations.Migration):
             field=models.IntegerField(default=0),
         ),
         migrations.RunPython(migrate_set_order_value,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0174_userprofile_delivery_email.py
+++ b/zerver/migrations/0174_userprofile_delivery_email.py
@@ -26,5 +26,6 @@ class Migration(migrations.Migration):
             preserve_default=False,
         ),
         migrations.RunPython(copy_email_field,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0175_change_realm_audit_log_event_type_tense.py
+++ b/zerver/migrations/0175_change_realm_audit_log_event_type_tense.py
@@ -17,5 +17,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(change_realm_audit_log_event_type_tense,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0177_user_message_add_and_index_is_private_flag.py
+++ b/zerver/migrations/0177_user_message_add_and_index_is_private_flag.py
@@ -72,5 +72,6 @@ class Migration(migrations.Migration):
             reverse_sql='DROP INDEX zerver_usermessage_is_private_message_id;'
         ),
         migrations.RunPython(reset_is_private_flag,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0181_userprofile_change_emojiset.py
+++ b/zerver/migrations/0181_userprofile_change_emojiset.py
@@ -16,7 +16,8 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RunPython(
             change_emojiset_choice,
-            reverse_code=migrations.RunPython.noop),
+            reverse_code=migrations.RunPython.noop,
+            elidable=True),
         migrations.AlterField(
             model_name='userprofile',
             name='emojiset',

--- a/zerver/migrations/0182_set_initial_value_is_private_flag.py
+++ b/zerver/migrations/0182_set_initial_value_is_private_flag.py
@@ -48,5 +48,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(set_initial_value_of_is_private_flag,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0189_userprofile_add_some_emojisets.py
+++ b/zerver/migrations/0189_userprofile_add_some_emojisets.py
@@ -23,5 +23,6 @@ class Migration(migrations.Migration):
         ),
         migrations.RunPython(
             change_emojiset_choice,
-            reverse_code=migrations.RunPython.noop),
+            reverse_code=migrations.RunPython.noop,
+            elidable=True),
     ]

--- a/zerver/migrations/0198_preregistrationuser_invited_as.py
+++ b/zerver/migrations/0198_preregistrationuser_invited_as.py
@@ -37,6 +37,7 @@ class Migration(migrations.Migration):
         ),
         migrations.RunPython(
             set_initial_value_for_invited_as,
-            reverse_code=reverse_code
+            reverse_code=reverse_code,
+            elidable=True
         ),
     ]

--- a/zerver/migrations/0206_stream_rendered_description.py
+++ b/zerver/migrations/0206_stream_rendered_description.py
@@ -26,5 +26,6 @@ class Migration(migrations.Migration):
             field=models.TextField(default=''),
         ),
         migrations.RunPython(render_all_stream_descriptions,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0209_user_profile_no_empty_password.py
+++ b/zerver/migrations/0209_user_profile_no_empty_password.py
@@ -225,5 +225,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(ensure_no_empty_passwords,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0210_stream_first_message_id.py
+++ b/zerver/migrations/0210_stream_first_message_id.py
@@ -26,5 +26,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(backfill_first_message_id,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0211_add_users_field_to_scheduled_email.py
+++ b/zerver/migrations/0211_add_users_field_to_scheduled_email.py
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
             name='users',
             field=models.ManyToManyField(to=settings.AUTH_USER_MODEL),
         ),
-        migrations.RunPython(set_users_for_existing_scheduledemails, reverse_code=migrations.RunPython.noop),
+        migrations.RunPython(set_users_for_existing_scheduledemails, reverse_code=migrations.RunPython.noop, elidable=True),
         migrations.RemoveField(
             model_name='scheduledemail',
             name='user',

--- a/zerver/migrations/0214_realm_invite_to_stream_policy.py
+++ b/zerver/migrations/0214_realm_invite_to_stream_policy.py
@@ -25,5 +25,6 @@ class Migration(migrations.Migration):
             field=models.PositiveSmallIntegerField(default=INVITE_TO_STREAM_POLICY_MEMBERS),
         ),
         migrations.RunPython(handle_waiting_period,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0217_migrate_create_stream_policy.py
+++ b/zerver/migrations/0217_migrate_create_stream_policy.py
@@ -27,5 +27,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(upgrade_create_stream_policy,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0219_toggle_realm_digest_emails_enabled_default.py
+++ b/zerver/migrations/0219_toggle_realm_digest_emails_enabled_default.py
@@ -23,5 +23,6 @@ class Migration(migrations.Migration):
             field=models.BooleanField(default=False),
         ),
         migrations.RunPython(disable_realm_digest_emails_enabled,
-                             reverse_code=migrations.RunPython.noop)
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True)
     ]

--- a/zerver/migrations/0221_subscription_notifications_data_migration.py
+++ b/zerver/migrations/0221_subscription_notifications_data_migration.py
@@ -51,5 +51,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(update_notification_settings,
-                             reverse_notification_settings),
+                             reverse_notification_settings,
+                             elidable=True),
     ]

--- a/zerver/migrations/0223_rename_to_is_muted.py
+++ b/zerver/migrations/0223_rename_to_is_muted.py
@@ -35,7 +35,8 @@ class Migration(migrations.Migration):
         ),
         migrations.RunPython(
             set_initial_value_for_is_muted,
-            reverse_code=reverse_code
+            reverse_code=reverse_code,
+            elidable=True
         ),
         migrations.RemoveField(
             model_name='subscription',

--- a/zerver/migrations/0224_alter_field_realm_video_chat_provider.py
+++ b/zerver/migrations/0224_alter_field_realm_video_chat_provider.py
@@ -69,7 +69,8 @@ class Migration(migrations.Migration):
             field=models.PositiveSmallIntegerField(default=VIDEO_CHAT_PROVIDERS['jitsi_meet']['id']),
         ),
         migrations.RunPython(update_existing_video_chat_provider_values,
-                             reverse_code=reverse_code),
+                             reverse_code=reverse_code,
+                             elidable=True),
         migrations.RemoveField(
             model_name='realm',
             name='video_chat_provider_old',

--- a/zerver/migrations/0227_inline_url_embed_preview_default_off.py
+++ b/zerver/migrations/0227_inline_url_embed_preview_default_off.py
@@ -24,6 +24,7 @@ class Migration(migrations.Migration):
             field=models.BooleanField(default=False),
         ),
         migrations.RunPython(disable_realm_inline_url_embed_preview,
-                             reverse_code=migrations.RunPython.noop)
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True)
 
     ]

--- a/zerver/migrations/0236_remove_illegal_characters_email_full.py
+++ b/zerver/migrations/0236_remove_illegal_characters_email_full.py
@@ -26,5 +26,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(remove_name_illegal_chars)
+        migrations.RunPython(remove_name_illegal_chars, elidable=True)
     ]

--- a/zerver/migrations/0237_rename_zulip_realm_to_zulipinternal.py
+++ b/zerver/migrations/0237_rename_zulip_realm_to_zulipinternal.py
@@ -39,5 +39,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(rename_zulip_realm_to_zulipinternal)
+        migrations.RunPython(rename_zulip_realm_to_zulipinternal, elidable=True)
     ]

--- a/zerver/migrations/0239_usermessage_copy_id_to_bigint_id.py
+++ b/zerver/migrations/0239_usermessage_copy_id_to_bigint_id.py
@@ -67,7 +67,7 @@ class Migration(migrations.Migration):
         FOR EACH ROW
         EXECUTE PROCEDURE zerver_usermessage_bigint_id_to_id_trigger_function();
         """),
-        migrations.RunPython(copy_id_to_bigid),
+        migrations.RunPython(copy_id_to_bigid, elidable=True),
         migrations.RunSQL("""
         CREATE UNIQUE INDEX CONCURRENTLY zerver_usermessage_bigint_id_idx ON zerver_usermessage (bigint_id);
         """)

--- a/zerver/migrations/0242_fix_bot_email_property.py
+++ b/zerver/migrations/0242_fix_bot_email_property.py
@@ -20,5 +20,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(fix_bot_email_property,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0244_message_copy_pub_date_to_date_sent.py
+++ b/zerver/migrations/0244_message_copy_pub_date_to_date_sent.py
@@ -64,7 +64,7 @@ class Migration(migrations.Migration):
         FOR EACH ROW
         EXECUTE PROCEDURE zerver_message_date_sent_to_pub_date_trigger_function();
         """),
-        migrations.RunPython(copy_pub_date_to_date_sent),
+        migrations.RunPython(copy_pub_date_to_date_sent, elidable=True),
         # The name for the index was chosen to match the name of the index Django would create
         # in a normal migration with AlterField of date_sent to have db_index=True:
         migrations.RunSQL("""

--- a/zerver/migrations/0247_realmauditlog_event_type_to_int.py
+++ b/zerver/migrations/0247_realmauditlog_event_type_to_int.py
@@ -104,7 +104,8 @@ class Migration(migrations.Migration):
             field=models.CharField(max_length=40, null=True),
         ),
         migrations.RunPython(update_existing_event_type_values,
-                             reverse_code=reverse_code),
+                             reverse_code=reverse_code,
+                             elidable=True),
         migrations.RemoveField(
             model_name='realmauditlog',
             name='event_type',

--- a/zerver/migrations/0248_userprofile_role_start.py
+++ b/zerver/migrations/0248_userprofile_role_start.py
@@ -44,5 +44,5 @@ class Migration(migrations.Migration):
             field=models.PositiveSmallIntegerField(null=True),
         ),
 
-        migrations.RunPython(update_role, reverse_code=reverse_code),
+        migrations.RunPython(update_role, reverse_code=reverse_code, elidable=True),
     ]

--- a/zerver/migrations/0257_fix_has_link_attribute.py
+++ b/zerver/migrations/0257_fix_has_link_attribute.py
@@ -88,5 +88,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(fix_has_link,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0260_missed_message_addresses_from_redis_to_db.py
+++ b/zerver/migrations/0260_missed_message_addresses_from_redis_to_db.py
@@ -91,5 +91,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(move_missed_message_addresses_to_database, reverse_code=migrations.RunPython.noop),
+        migrations.RunPython(move_missed_message_addresses_to_database,
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0264_migrate_is_announcement_only.py
+++ b/zerver/migrations/0264_migrate_is_announcement_only.py
@@ -22,5 +22,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(upgrade_stream_post_policy,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0273_migrate_old_bot_messages.py
+++ b/zerver/migrations/0273_migrate_old_bot_messages.py
@@ -84,5 +84,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(fix_messages,
-                             reverse_code=migrations.RunPython.noop),
+                             reverse_code=migrations.RunPython.noop,
+                             elidable=True),
     ]

--- a/zerver/migrations/0277_migrate_alert_word.py
+++ b/zerver/migrations/0277_migrate_alert_word.py
@@ -46,5 +46,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(move_to_seperate_table, move_back_to_user_profile)
+        migrations.RunPython(move_to_seperate_table, move_back_to_user_profile, elidable=True)
     ]


### PR DESCRIPTION
This will make django automatically remove them when we run
squashmigrations. There are still some RunSQL statements which
we will have to take care of manually.