### PR TITLE
wip navbar: Add proper live update.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -144,7 +144,12 @@ exports.update_stream_name = function (sub, new_name) {
     // Update navbar stream name if needed
     const filter = narrow_state.filter();
     if (filter && filter.operands("stream")[0] === old_name) {
-        tab_bar.update_stream_name(new_name);
+        narrow.activate(
+            [
+                {operator: "stream", operand: new_name},
+            ]
+        );
+        tab_bar.update_stream_name();
     }
 };
 

--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -131,10 +131,10 @@ exports.exit_search = function () {
     }
 };
 
-exports.update_stream_name = function (new_name) {
+exports.update_stream_name = function () {
     const stream_name = $(".stream a");
     if (stream_name !== undefined) {
-        stream_name.text(new_name);
+        this.initialize();
     }
 };
 
@@ -145,6 +145,10 @@ exports.update_stream_description = function () {
 
     // TODO: Do similar rerenders for stream privacy or subscriber
     // count changes.
+    const stream_name = $(".stream a");
+    if (stream_name !== undefined) {
+        this.initialize();
+    }
     return;
 };
 


### PR DESCRIPTION
Previously changing stream names & descriptions did not update
the navbar to display these updated changes. This commit fixes
this by re-initializing and rerendering the navbar. This has been
made possible by updating the narrow to the new data, when an
in-narrow stream is updated. The navbar initialize function is then
called, when stream name or description changes to rerender the navbar
with the new data. Since the navbar gets its data from the current
narrow object. This approach works.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/14728

**Testing Plan:** <!-- How have you tested? -->
Used the stream subscriptions overlay to modify stream names &
descriptions and checked if the navbar was updated.