### PR TITLE
user-status: Do not show away users as active.

### DIFF
--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -249,6 +249,11 @@ run_test('level', () => {
 });
 
 run_test('user_last_seen_time_status', () => {
+    user_status.set_away(selma.user_id);
+    assert.equal(buddy_data.user_last_seen_time_status(selma.user_id),
+                 'translated: Unavailable');
+
+    user_status.revoke_away(selma.user_id);
     assert.equal(buddy_data.user_last_seen_time_status(selma.user_id),
                  'translated: Active now');
 

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -151,6 +151,10 @@ exports.my_user_status = function (user_id) {
 
 exports.user_last_seen_time_status = function (user_id) {
     const status = presence.get_status(user_id);
+    if (user_status.is_away(user_id)) {
+        return i18n.t("Unavailable");
+    }
+
     if (status === "active") {
         return i18n.t("Active now");
     }


### PR DESCRIPTION
We shouldn't show the last active information for users marked
as unavailable. In other parts of the UI, this isn't the case.
The user list renders them below active users and also uses a
different icon for them, however hovering on their name easily
revealed their last active information before this commit.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

This has been created after a bug report in https://chat.zulip.org/#narrow/stream/137-feedback/topic/disable.20presence.3F .
**Testing Plan:** <!-- How have you tested? -->

Manual + automated tests.