### PR TITLE
db tools: Simplify args for postgres-init-dev-db.

### DIFF
--- a/tools/setup/postgres-init-dev-db
+++ b/tools/setup/postgres-init-dev-db
@@ -1,6 +1,31 @@
 #!/usr/bin/env bash
-set -x
 set -e
+
+if [[ $# == 0 ]]; then
+    MODE=dev
+elif [[ $# == 1 ]]; then
+    MODE=$1
+else
+    echo "Too many arguments"
+    exit 1
+fi
+
+if [[ "$MODE" == "dev" ]]; then
+    USERNAME=zulip
+    DBNAME=zulip
+    STATUS_FILE_NAME=migration_status_dev
+elif [[ "$MODE" == "test" ]]; then
+    USERNAME=zulip_test
+    DBNAME=zulip_test
+    STATUS_FILE_NAME=migration_status_test
+else
+    echo "Usage Instructions"
+    echo "Run with either no arguments (sets up devel db for local deploy--zulip with user zulip)"
+    echo "or specify 'test'"
+    exit 1
+fi
+
+set -x
 
 POSTGRES_USER="postgres"
 if [ "$(uname)" = "OpenBSD" ]; then
@@ -20,25 +45,8 @@ fi
 
 VAGRANTUSERNAME=$(whoami)
 
-if [[ $# == 0 ]]; then
-    USERNAME=zulip
-    PASSWORD=$("$(dirname "$0")/../../scripts/get-django-setting" LOCAL_DATABASE_PASSWORD)
-    DBNAME=zulip
-    SEARCH_PATH="$USERNAME",public
-    STATUS_FILE_NAME="migration_status_dev"
-elif [[ $# == 5 ]]; then
-    USERNAME=$1
-    PASSWORD=$2
-    DBNAME=$3
-    SEARCH_PATH=$4
-    STATUS_FILE_NAME=$5
-else
-    echo "Usage Instructions"
-    echo "Run with either no arguments (sets up devel db for local deploy--zulip with user zulip)"
-    echo "or specify <db-username> <password> <db-name> <user-schema-search-path> <migration-status-path>"
-    exit
-fi
-
+SEARCH_PATH=zulip,public
+PASSWORD=$("$(dirname "$0")/../../scripts/get-django-setting" LOCAL_DATABASE_PASSWORD)
 DBNAME_BASE=${DBNAME}_base
 
 if ! pg_isready -U "$POSTGRES_USER" -q; then

--- a/tools/setup/postgres-init-test-db
+++ b/tools/setup/postgres-init-test-db
@@ -2,4 +2,4 @@
 set -x
 set -e
 
-"$(dirname "$0")/postgres-init-dev-db" zulip_test "$("$(dirname "$0")/../../scripts/get-django-setting" LOCAL_DATABASE_PASSWORD)" zulip_test zulip,public migration_status_test
+"$(dirname "$0")/postgres-init-dev-db" test


### PR DESCRIPTION
We now just have two modes for setting up a dev/test
database.  This makes it easy to see these things
side-by-side, when you're trying to understand how
the two different databases get built:

    # dev:
        USERNAME=zulip
        DBNAME=zulip
        STATUS_FILE_NAME=migration_status_dev

    # test:
        USERNAME=zulip_test
        DBNAME=zulip_test
        STATUS_FILE_NAME=migration_status_test

And then we make it more explicit the things that
are common between dev and test (which are
important things to understand when troubleshooting
provision-related glitches):

    SEARCH_PATH=zulip,public
    PASSWORD=$("$(dirname "$0")/../../scripts/get-django-setting" LOCAL_DATABASE_PASSWORD)
    DBNAME_BASE=${DBNAME}_base

We lose some "generality" here, but passing in arbitrary
combinations of username/dbname/status_file to the script
would cause chaos for our digest checks, and all the different
template/base databases could cause confusion too.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
