### PR TITLE
api_code_examples: Fix buggy rendering of print statement in python examples.

### DIFF
--- a/zerver/lib/bugdown/api_code_examples.py
+++ b/zerver/lib/bugdown/api_code_examples.py
@@ -99,7 +99,7 @@ def render_python_code_example(function: str, admin_config: Optional[bool]=False
         # Remove one level of indentation and strip newlines
         code_example.append(line[4:].rstrip())
 
-    code_example.append('    print(result)')
+    code_example.append('print(result)')
     code_example.append('\n')
     code_example.append('```')
 


### PR DESCRIPTION
This fixes the buggy rendering of the print statement in the
python code examples.
Introduced in 18b577f .

![Screenshot_20200430_055954](https://user-images.githubusercontent.com/12623921/80659932-f6064900-8aa7-11ea-8371-8d527ac447f3.png)

