### PR TITLE
ci: bugfix: Don't restore emoji cache on prod.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,10 +287,8 @@ jobs:
       - *do_bionic_hack
       - *production_extract_tarball
       - *restore_cache_package_json
-      - *restore_emoji_cache
       - *install_production
       - *save_cache_package_json
-      - *save_emoji_cache
 
   "focal-production-install-python3.8":
     docker:
@@ -310,10 +308,8 @@ jobs:
       - *do_bionic_hack
       - *production_extract_tarball
       - *restore_cache_package_json
-      - *restore_emoji_cache
       - *install_production
       - *save_cache_package_json
-      - *save_emoji_cache
 
 workflows:
   version: 2


### PR DESCRIPTION
The emoji cache files are not available on production jobs. Also,
copying the files, creating and restoring caches doesn't add
much optimization over just rebuilding the caches here.

@timabbott This was a mistake on my part.