### PR TITLE
version: Update for Zulip Desktop v5.1.0 release

### DIFF
--- a/version.py
+++ b/version.py
@@ -12,7 +12,7 @@ if os.path.exists(zulip_git_version_file):
 LATEST_MAJOR_VERSION = "2.1"
 LATEST_RELEASE_VERSION = "2.1.4"
 LATEST_RELEASE_ANNOUNCEMENT = "https://blog.zulip.org/2019/12/13/zulip-2-1-released/"
-LATEST_DESKTOP_VERSION = "5.0.0"
+LATEST_DESKTOP_VERSION = "5.1.0"
 
 # Versions of the desktop app below DESKTOP_MINIMUM_VERSION will be
 # prevented from connecting to the Zulip server.  Versions above


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
The [zulipchat.com/apps/](https://zulipchat.com/apps/) page is not updated for Zulip Desktop v5.1.0 release
This commit only updates the above mentioned page's links

cc: @akashnimare 