### PR TITLE
user settings: Correct overflow behaviour of custom user field.

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1959,7 +1959,6 @@ input[type=text]#settings_search {
 
 .custom_user_field .pill-container {
     padding: 2px 6px;
-    height: 24px;
     background-color: hsl(0, 0%, 100%);
 }
 


### PR DESCRIPTION
The height of the input box was explicitly fixed, causing content to overflow.
Screenshot:
![Screenshot from 2020-05-01 00-44-50](https://user-images.githubusercontent.com/47082523/80750398-a24a3d00-8b45-11ea-975d-0866524a3c9b.png)
![Screenshot from 2020-05-01 00-50-18](https://user-images.githubusercontent.com/47082523/80750484-cc9bfa80-8b45-11ea-917a-1cad9e911f90.png)



Fixes: #14816

