### PR TITLE
Use cacheLoader more consistently in webpack compilation

### DIFF
--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -109,15 +109,22 @@ export default (env?: string): webpack.Configuration[] => {
                 },
                 {
                     test: /\.hbs$/,
-                    loader: 'handlebars-loader',
-                    options: {
-                        // Tell webpack not to explicitly require these.
-                        knownHelpers: ['if', 'unless', 'each', 'with',
-                            // The ones below are defined in static/js/templates.js
-                            'plural', 'eq', 'and', 'or', 'not',
-                            't', 'tr', 'rendered_markdown'],
-                        preventIndent: true,
-                    },
+                    use: [
+                        cacheLoader,
+                        {
+                            loader: 'handlebars-loader',
+                            options: {
+                                // Tell webpack not to explicitly require these.
+                                knownHelpers: [
+                                    'if', 'unless', 'each', 'with',
+                                    // The ones below are defined in static/js/templates.js
+                                    'plural', 'eq', 'and', 'or', 'not',
+                                    't', 'tr', 'rendered_markdown',
+                                ],
+                                preventIndent: true,
+                            },
+                        },
+                    ],
                 },
                 // load fonts and files
                 {

--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -50,7 +50,7 @@ export default (env?: string): webpack.Configuration[] => {
                         resolve(__dirname, '../static/shared/js'),
                         resolve(__dirname, '../static/js'),
                     ],
-                    loader: 'babel-loader',
+                    use: [cacheLoader, 'babel-loader'],
                 },
                 // Uses script-loader on minified files so we don't change global variables in them.
                 // Also has the effect of making processing these files fast


### PR DESCRIPTION
This branch reduces the noop time until `webpack` compilation has finished from about ~12s to ~7s for me, measured starting from the start of `run-dev.py`. 

I don't understand why the time isn't like 0.2s in this more fully cached case.  

Timed using:
`echo start | ts '%.s'; run-dev.py | ts '%.s'`

```
(zulip-py3-venv) tabbott@coset:~/zulip$ echo start | ts '%.s'; run-dev.py | ts '%.s'
1588275018.731378 start
2020-04-30 19:30:20,010 INFO: process_fts_updates starting
2020-04-30 19:30:20,134 INFO: Not in recovery; listening for FTS updates
2020-04-30 19:30:20,136 INFO: Processed 0 rows catching up
2020-04-30 12:30:20 thumbor:WARNING Error importing bounding_box filter, trimming won't work
1588275021.249395 ℹ ｢wds｣: Project is running at http://127.0.0.1:9994/
1588275021.249603 ℹ ｢wds｣: webpack output is served from /webpack/
1588275021.249636 ℹ ｢wds｣: Content not from webpack is served from /home/tabbott/zulip
2020-04-30 19:30:21.291 INFO [django.utils.autoreload] Watching for file changes with StatReloader
1588275021.519841 Validating Django models.py...
1588275021.544132 System check identified no issues (1 silenced).
1588275021.544182 
1588275021.544197 Django version 2.2.12
1588275021.544210 Tornado server is running at http://127.0.0.1:9993/
1588275021.544223 Quit the server with CTRL-C.
2020-04-30 19:30:21.545 INFO [:9993] Tornado 9993 loaded 0 event queues in 0.000s
2020-04-30 19:30:22.759 INFO [django.utils.autoreload] Watching for file changes with StatReloader
2020-04-30 19:30:22.866 INFO [process_queue] 17 queue worker threads were launched
1588275025.586076 ℹ ｢wdm｣: Compiled successfully.
```
