### PR TITLE
node tests: Add test_realm_boolean test for default_twenty_four_hour_time.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -982,6 +982,9 @@ with_overrides(function (override) {
     event = event_fixtures.realm__update__disallow_disposable_email_addresses;
     test_realm_boolean(event, 'realm_disallow_disposable_email_addresses');
 
+    event = event_fixtures.realm__update_default_twenty_four_hour_time;
+    test_realm_boolean(event, 'realm_default_twenty_four_hour_time');
+
     event = event_fixtures.realm__update__email_addresses_visibility;
     override('stream_ui_updates.update_subscribers_list', noop);
     dispatch(event);


### PR DESCRIPTION
This is a followup from this [comment](https://github.com/zulip/zulip/pull/14445#issuecomment-608166487)
Adds missing test.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
