### PR TITLE
Custom profile fields color

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -104,11 +104,10 @@ function update_custom_profile_field(field, method) {
         field_id = field.id;
     }
 
-    const spinner = $('.custom_user_field[data-field-id="' + field_id +
+    const spinner_element = $('.custom_user_field[data-field-id="' + field_id +
         '"] .custom-field-status').expectOne();
-    loading.make_indicator(spinner, {text: 'Saving ...'});
     settings_ui.do_settings_change(method, "/json/users/me/profile_data",
-                                   {data: JSON.stringify([field])}, spinner);
+                                   {data: JSON.stringify([field])}, spinner_element);
 }
 
 function update_user_custom_profile_fields(fields, method) {

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -640,7 +640,7 @@ input[type=checkbox].inline-block {
         border: 1px solid hsl(156, 30%, 50%);
     }
 
-    .alert-error {
+    &.alert-error {
         color: hsl(2, 46%, 68%);
         border-color: hsl(2, 46%, 68%);
     }


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://chat.zulip.org/#narrow/stream/6-frontend/topic/settings.20-.20custom.20profile.20fields
Make the error message displayed red in colour.
**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/20909078/80756177-b430dd80-8b4f-11ea-81a0-6602772101bd.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->