### PR TITLE
Importing messages from different rooms into different streams

### DIFF
--- a/zerver/data_import/gitter.py
+++ b/zerver/data_import/gitter.py
@@ -24,19 +24,21 @@ realm_id = 0
 def gitter_workspace_to_realm(domain_name: str, gitter_data: GitterDataT,
                               realm_subdomain: str) -> Tuple[ZerverFieldsT,
                                                              List[ZerverFieldsT],
+                                                             Dict[str, int],
                                                              Dict[str, int]]:
     """
     Returns:
     1. realm, Converted Realm data
     2. avatars, which is list to map avatars to zulip avatar records.json
     3. user_map, which is a dictionary to map from gitter user id to zulip user id
+    4. stream_map, which is a dictionary to map from gitter rooms to zulip stream id
     """
     NOW = float(timezone_now().timestamp())
     zerver_realm: List[ZerverFieldsT] = build_zerver_realm(realm_id, realm_subdomain, NOW, 'Gitter')
     realm = build_realm(zerver_realm, realm_id, domain_name)
 
     zerver_userprofile, avatars, user_map = build_userprofile(int(NOW), domain_name, gitter_data)
-    zerver_stream, zerver_defaultstream = build_stream_and_defaultstream(int(NOW))
+    zerver_stream, zerver_defaultstream, stream_map = build_stream_map(int(NOW), gitter_data)
     zerver_recipient, zerver_subscription = build_recipient_and_subscription(
         zerver_userprofile, zerver_stream)
 
@@ -46,7 +48,7 @@ def gitter_workspace_to_realm(domain_name: str, gitter_data: GitterDataT,
     realm['zerver_recipient'] = zerver_recipient
     realm['zerver_subscription'] = zerver_subscription
 
-    return realm, avatars, user_map
+    return realm, avatars, user_map, stream_map
 
 def build_userprofile(timestamp: Any, domain_name: str,
                       gitter_data: GitterDataT) -> Tuple[List[ZerverFieldsT],
@@ -98,26 +100,46 @@ def get_user_email(user_data: ZerverFieldsT, domain_name: str) -> str:
     email = ("%s@users.noreply.github.com" % (user_data['username'],))
     return email
 
-def build_stream_and_defaultstream(timestamp: Any) -> Tuple[List[ZerverFieldsT],
-                                                            List[ZerverFieldsT]]:
+def build_stream_map(timestamp: Any,
+                     gitter_data: GitterDataT) -> Tuple[List[ZerverFieldsT],
+                                                        List[ZerverFieldsT],
+                                                        Dict[str, int]]:
+    """
+    Returns:
+    1. stream, which is the list of streams
+    2. defaultstreams, which is the list of default streams
+    3. stream_map, which is a dictionary to map from gitter rooms to zulip stream id
+    """
     logging.info('######### IMPORTING STREAM STARTED #########\n')
-    # We have only one stream for gitter export
-    stream_name = 'from gitter'
-    stream_description = "Imported from gitter"
     stream_id = 0
-    stream = build_stream(timestamp, realm_id, stream_name, stream_description,
-                          stream_id)
+    stream: List[ZerverFieldsT] = []
 
+    # Default stream when no "room" field is present
+    stream.append(build_stream(timestamp, realm_id, 'from gitter',
+                               "Imported from gitter", stream_id))
     defaultstream = build_defaultstream(realm_id=realm_id, stream_id=stream_id,
                                         defaultstream_id=0)
+    stream_id += 1
+
+    # Gathering streams from gitter_data
+    stream_map: Dict[str, int] = {}
+    for data in gitter_data:
+        if 'room' in data and data['room'] not in stream_map:
+            stream.append(build_stream(timestamp, realm_id, data['room'],
+                                       f'Gitter room {data["room"]}', stream_id))
+            stream_map[data['room']] = stream_id
+            stream_id += 1
     logging.info('######### IMPORTING STREAMS FINISHED #########\n')
-    return [stream], [defaultstream]
+
+    return stream, [defaultstream], stream_map
 
 def build_recipient_and_subscription(
     zerver_userprofile: List[ZerverFieldsT],
     zerver_stream: List[ZerverFieldsT]) -> Tuple[List[ZerverFieldsT],
                                                  List[ZerverFieldsT]]:
     """
+    Assumes that there is at least one stream with 'stream_id' = 0,
+      and that this stream is the only defaultstream, with 'defaultstream_id' = 0
     Returns:
     1. zerver_recipient, which is a list of mapped recipient
     2. zerver_subscription, which is a list of mapped subscription
@@ -128,23 +150,23 @@ def build_recipient_and_subscription(
 
     # For stream
 
-    # We have only one recipient, because we have only one stream
-    # Hence 'recipient_id'=0 corresponds to 'stream_id'=0
-    recipient = build_recipient(0, recipient_id, Recipient.STREAM)
-    zerver_recipient.append(recipient)
+    # Initial recipients correspond to intitial streams
+    # We enumerate all streams, and build a recipient for each
+    # Hence 'recipient_id'=n corresponds to 'stream_id'=n
+    for stream in zerver_stream:
+        zerver_recipient.append(build_recipient(recipient_id, recipient_id, Recipient.STREAM))
+        recipient_id += 1
 
+    # There is only one default stream to subscribe users to.
+    # which corresponds to 'recipient_id' = 'stream_id' = 0
     for user in zerver_userprofile:
-        subscription = build_subscription(recipient_id, user['id'], subscription_id)
-        zerver_subscription.append(subscription)
+        zerver_subscription.append(build_subscription(0, user['id'], subscription_id))
         subscription_id += 1
-    recipient_id += 1
 
     # For users
     for user in zerver_userprofile:
-        recipient = build_recipient(user['id'], recipient_id, Recipient.PERSONAL)
-        subscription = build_subscription(recipient_id, user['id'], subscription_id)
-        zerver_recipient.append(recipient)
-        zerver_subscription.append(subscription)
+        zerver_recipient.append(build_recipient(user['id'], recipient_id, Recipient.PERSONAL))
+        zerver_subscription.append(build_subscription(recipient_id, user['id'], subscription_id))
         recipient_id += 1
         subscription_id += 1
 
@@ -153,6 +175,7 @@ def build_recipient_and_subscription(
 def convert_gitter_workspace_messages(gitter_data: GitterDataT, output_dir: str,
                                       subscriber_map: Dict[int, Set[int]],
                                       user_map: Dict[str, int],
+                                      stream_map: Dict[str, int],
                                       user_short_name_to_full_name: Dict[str, str],
                                       chunk_size: int=MESSAGE_BATCH_CHUNK_SIZE) -> None:
     """
@@ -160,7 +183,6 @@ def convert_gitter_workspace_messages(gitter_data: GitterDataT, output_dir: str,
     """
     logging.info('######### IMPORTING MESSAGES STARTED #########\n')
     message_id = 0
-    recipient_id = 0  # Corresponding to stream "gitter"
 
     low_index = 0
     upper_index = low_index + chunk_size
@@ -178,9 +200,9 @@ def convert_gitter_workspace_messages(gitter_data: GitterDataT, output_dir: str,
             mentioned_user_ids = get_usermentions(message, user_map,
                                                   user_short_name_to_full_name)
             rendered_content = None
-            topic_name = 'imported from gitter'
+            topic_name = 'imported from gitter' + (f' room {message["room"]}' if 'room' in message else '')
             user_id = user_map[message['fromUser']['id']]
-
+            recipient_id = stream_map[message['room']] if 'room' in message else 0
             zulip_message = build_message(topic_name, float(message_time), message_id, message['text'],
                                           rendered_content, user_id, recipient_id)
             zerver_message.append(zulip_message)
@@ -241,7 +263,7 @@ def do_convert_data(gitter_data_file: str, output_dir: str, threads: int=6) -> N
     with open(gitter_data_file) as fp:
         gitter_data = ujson.load(fp)
 
-    realm, avatar_list, user_map = gitter_workspace_to_realm(
+    realm, avatar_list, user_map, stream_map = gitter_workspace_to_realm(
         domain_name, gitter_data, realm_subdomain)
 
     subscriber_map = make_subscriber_map(
@@ -254,7 +276,7 @@ def do_convert_data(gitter_data_file: str, output_dir: str, threads: int=6) -> N
         user_short_name_to_full_name[userprofile['short_name']] = userprofile['full_name']
 
     convert_gitter_workspace_messages(
-        gitter_data, output_dir, subscriber_map, user_map,
+        gitter_data, output_dir, subscriber_map, user_map, stream_map,
         user_short_name_to_full_name)
 
     avatar_folder = os.path.join(output_dir, 'avatars')


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Features:**
Improving `./manage.py convert_gitter_data`
- If messages have been post-processed to add a 'room' field,  we create as many streams as existing rooms.
- Messages with a 'room' field go to the corresponding stream.
- This modification is backward compatible. I.e.
  + messages that have no 'room' field go to the default stream/topic
  + messages that do, go to a specific stream

**Implementation:**
- adding a map `stream_map` to map room names to stream ids
- create as many streams as room field messages + 1 default stream

**Testing Plan:** <!-- How have you tested? -->
I tested it using https://github.com/minrk/archive-gitter/pull/5 and several gitter channels from the coq gitter organization.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
No UI change

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
