### PR TITLE
bugdown: Support hanging_lists preprocessor for indented lists.

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -1506,7 +1506,7 @@ class BugdownListPreprocessor(markdown.preprocessors.Preprocessor):
         directly after a line of text, and inserts a newline between
         to satisfy Markdown"""
 
-    LI_RE = re.compile(r'^[ ]{0,3}([*+-]|\d\.)[ ]+(.*)', re.MULTILINE)
+    LI_RE = re.compile(r'^[ ]*([*+-]|\d\.)[ ]+(.*)', re.MULTILINE)
 
     def run(self, lines: List[str]) -> List[str]:
         """ Insert a newline between a paragraph and ulist if missing """

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -183,6 +183,16 @@
       "text_content": "Some text with a list:\n\nOne item\nTwo items\nThree items\n"
     },
     {
+      "name": "list_complexly_nested",
+      "input": "This is a heavily nested OL\n1. level-1\n  2. level-2\n    3. level-3\n    3. level-3a\n  2. level-2a\n2. level-1a\n",
+      "expected_output": "<p>This is a heavily nested OL</p>\n<ol>\n<li>level-1<ol start=\"2\">\n<li>level-2<ol start=\"3\">\n<li>level-3</li>\n<li>level-3a</li>\n</ol>\n</li>\n<li>level-2a</li>\n</ol>\n</li>\n<li>level-1a</li>\n</ol>"
+    },
+    {
+      "name": "list_codeblock_interference",
+      "input": "para:\n\n    1. list-1\n    2. list-2\n      1. list-2a\n    3. list-3\n",
+      "expected_output": "<p>para:</p>\n<div class=\"codehilite\"><pre><span></span><code>1. list-1\n2. list-2\n  1. list-2a\n3. list-3\n</code></pre></div>"
+    },
+    {
       "name": "ulist_mixed_bullets",
       "input": "Combine four lists:\n\n* One\n- Two\n+ Three\n- Four\n- Five",
       "expected_output": "<p>Combine four lists:</p>\n<ul>\n<li>One</li>\n<li>Two</li>\n<li>Three</li>\n<li>Four</li>\n<li>Five</li>\n</ul>",


### PR DESCRIPTION
Previously, hanging_lists preprocessor didn't consider anything
indented at 4 or above spaces to be a list. This meant that when
we had a list like:

1. 1
  2. 2
    3. 3
  2. 2a
1. 1a

We would insert a newline between 3. 3 and 2. 2a. This resulted
in the block processor breaeking down 1 list into 2 blocks, which
messed up the nesting and indentation for the second block.

Discussion at:
https://chat.zulip.org/#narrow/stream/9-issues/topic/List.20rendering.20(ul.2Fol)
**Testing Plan:** <!-- How have you tested? -->
Manual + automated tests

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
