### PR TITLE
regression: Add minimum height to custom user field textbox.

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1959,6 +1959,8 @@ input[type=text]#settings_search {
 
 .custom_user_field .pill-container {
     padding: 2px 6px;
+    min-height: 24px;
+    max-width: 206px;
     background-color: hsl(0, 0%, 100%);
 }
 


### PR DESCRIPTION
Also, if the width of the textbox increased too much, the avatar icon
would move below. Fixed by setting max-width that matches the width of
the other textboxes.

Earlier:
![Screenshot from 2020-05-01 13-48-03](https://user-images.githubusercontent.com/47082523/80792599-6dc09a80-8bb2-11ea-97bd-e12e997344c9.png)
Fixed:
![Screenshot from 2020-05-01 13-49-20](https://user-images.githubusercontent.com/47082523/80792653-9c3e7580-8bb2-11ea-81c8-d51a8e5b654f.png)

