### PR TITLE
Remove redundant stream

### DIFF
--- a/frontend_tests/casper_tests/03-narrow.js
+++ b/frontend_tests/casper_tests/03-narrow.js
@@ -70,9 +70,9 @@ function expect_stream() {
     casper.then(function () {
         casper.waitUntilVisible('#zfilt', function () {
             common.expected_messages('zfilt', [
-                'Verona > frontend test',
-                'Verona > other subject',
-                'Verona > frontend test',
+                '> frontend test',
+                '> other subject',
+                '> frontend test',
             ], [
                 '<p>test message A</p>',
                 '<p>test message B</p>',
@@ -87,7 +87,7 @@ function expect_stream_subject() {
     casper.then(function () {
         casper.waitUntilVisible('#zfilt', function () {
             common.expected_messages('zfilt', [
-                'Verona > frontend test',
+                '> frontend test',
             ], [
                 '<p>test message A</p>',
                 '<p>test message B</p>',

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -651,11 +651,13 @@ MessageListView.prototype = {
         const message_groups = opts.message_groups;
         const use_match_properties = opts.use_match_properties;
         const table_name = opts.table_name;
+        const stream_operands = opts.stream_operands;
 
         return $(render_message_group({
             message_groups: message_groups,
             use_match_properties: use_match_properties,
             table_name: table_name,
+            narrow_is_stream: stream_operands,
         }));
     },
 
@@ -672,6 +674,10 @@ MessageListView.prototype = {
         }
 
         const list = self.list; // for convenience
+
+        const msg_filter = list.data.filter;
+        const stream_operands = msg_filter.operands("stream");
+
         const table_name = self.table_name;
         const table = rows.get_table(table_name);
         let orig_scrolltop_offset;
@@ -736,6 +742,7 @@ MessageListView.prototype = {
                 message_groups: message_actions.prepend_groups,
                 use_match_properties: self.list.is_search(),
                 table_name: self.table_name,
+                stream_operands: stream_operands,
             });
 
             dom_messages = rendered_groups.find('.message_row');
@@ -763,6 +770,7 @@ MessageListView.prototype = {
                     message_groups: [message_group],
                     use_match_properties: self.list.is_search(),
                     table_name: self.table_name,
+                    stream_operands: stream_operands,
                 });
 
                 dom_messages = rendered_groups.find('.message_row');
@@ -813,6 +821,7 @@ MessageListView.prototype = {
                 message_groups: message_actions.append_groups,
                 use_match_properties: self.list.is_search(),
                 table_name: self.table_name,
+                stream_operands: stream_operands,
             });
 
             dom_messages = rendered_groups.find('.message_row');
@@ -1188,7 +1197,9 @@ MessageListView.prototype = {
         // where we constructed an artificial message group for this
         // rerendering rather than looking up the original version.
         populate_group_from_message_container(group, group.message_containers[0]);
-
+        const msg_filter = this.list.data.filter;
+        const stream_operands = msg_filter.operands("stream");
+        group.narrow_is_stream = stream_operands;
         const rendered_recipient_row = $(render_recipient_row(group));
 
         header.replaceWith(rendered_recipient_row);

--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -47,8 +47,8 @@ exports.colorize_tab_bar = function () {
     if (filter === undefined || !filter.has_operator('stream')) {return;}
     const color_for_stream = stream_data.get_color(filter.operands("stream")[0]);
     const stream_light = colorspace.getHexColor(colorspace.getDecimalColor(color_for_stream));
-    $("#tab_list .fa-hashtag").css('color', stream_light);
-    $("#tab_list .fa-lock").css('color', stream_light);
+    $("#tab_list .stream").css('background-color', stream_light);
+    $("#tab_list .stream").css('color', "white");
 };
 
 function display_tab_bar(tab_bar_data) {

--- a/static/templates/message_group.hbs
+++ b/static/templates/message_group.hbs
@@ -12,7 +12,7 @@
         {{/if}}
 
         <div class="recipient_row" id="{{message_group_id}}">
-            {{> recipient_row use_match_properties=../use_match_properties}}
+            {{> recipient_row use_match_properties=../use_match_properties narrow_is_stream=../narrow_is_stream}}
             {{#each message_containers}}
                 {{#with this}}
                 {{> single_message use_match_properties=../../use_match_properties table_name=../../table_name}}

--- a/static/templates/recipient_row.hbs
+++ b/static/templates/recipient_row.hbs
@@ -11,7 +11,12 @@
                 {{#if invite_only}}
                 <i class="fa fa-lock invite-stream-icon" title="{{t 'This is a private stream' }}" aria-label="{{t 'This is a private stream' }}"></i>
                 {{/if}}
-                {{display_recipient}}</a>
+                {{#unless narrow_is_stream}}
+                    {{display_recipient}}
+                {{else}}
+                    &nbsp
+                {{/unless}}
+            </a>
 
             {{! hidden narrow icon for copy-pasting }}
             <span class="copy-paste-text">&gt;</span>


### PR DESCRIPTION
Issue: 
https://github.com/zulip/zulip/issues/14748


Reference:
https://chat.zulip.org/#narrow/stream/101-design/topic/remove.20redundant.20streams

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/20909078/80859083-995b8780-8c7b-11ea-9065-912c6aed3096.png)