### PR TITLE
casper: Increase default timeout to avoid indeterministic CI failure.

### DIFF
--- a/frontend_tests/casper_tests/00-realm-creation.js
+++ b/frontend_tests/casper_tests/00-realm-creation.js
@@ -70,7 +70,7 @@ casper.then(function () {
     // The user is logged in to the newly created realm and the app is loaded
     casper.waitUntilVisible('#zfilt', function () {
         this.test.assertTitleMatch(/ - Zulip$/, "Successfully logged into Zulip webapp");
-    });
+    }, null, 20000);
 });
 
 common.then_log_out();


### PR DESCRIPTION
Test fails at default timeout value indeterministically
because we have to wait for the server to start and the
above tests to pass, which takes more than the Default Timeout
of this test.
Hence, 4 x Default timeout value is kept.
