### PR TITLE
messages: Allow moving a topic to another stream.

### DIFF
--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -854,4 +854,27 @@ exports.handle_narrow_deactivated = function () {
     }
 };
 
+exports.move_topic_containing_message_to_stream =
+    function (message_id, new_stream_id, new_topic_name) {
+        const request = {
+            stream_id: new_stream_id,
+            propagate_mode: 'change_all',
+            topic: new_topic_name,
+        };
+        channel.patch({
+            url: '/json/messages/' + message_id,
+            data: request,
+            success: function () {
+
+            },
+            error: function (xhr) {
+                ui_report.error(i18n.t("Error moving the topic"), xhr,
+                                $("#home-error"));
+                // The fadeTo method used by ui_report.message doesn't work
+                // on this. Hence we fadeOut it here.
+                setTimeout(() => { $("#home-error").fadeOut('slow'); }, 4000);
+            },
+        });
+    };
+
 window.message_edit = exports;

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -4,6 +4,7 @@ const render_starred_messages_sidebar_actions = require('../templates/starred_me
 const render_stream_sidebar_actions = require('../templates/stream_sidebar_actions.hbs');
 const render_topic_sidebar_actions = require('../templates/topic_sidebar_actions.hbs');
 const render_unstar_messages_modal = require("../templates/unstar_messages_modal.hbs");
+const render_move_topic_to_stream = require("../templates/move_topic_to_stream.hbs");
 
 // We handle stream popovers and topic popovers in this
 // module.  Both are popped up from the left sidebar.
@@ -262,6 +263,21 @@ function build_starred_messages_popover(e) {
 
 }
 
+function build_move_topic_to_stream_popover(e, current_stream_id, topic_name) {
+    // TODO: Add support for keyboard-alphabet navigation. Some orgs have large no. of
+    // streams and scrolling can be a painful process in that case.
+    // NOTE: Private streams are also included in this list.
+    const available_streams = stream_data.subscribed_subs()
+        .filter(s => s.stream_id !== current_stream_id);
+    const args = { available_streams, topic_name, current_stream_id };
+
+    exports.hide_topic_popover();
+
+    $("#move-a-topic-modal-holder").html(render_move_topic_to_stream(args));
+    $('#move_topic_modal').modal('show');
+    e.stopPropagation();
+}
+
 exports.register_click_handlers = function () {
     $('#stream_filters').on('click', '.stream-sidebar-menu-icon', function (e) {
         e.stopPropagation();
@@ -499,6 +515,67 @@ exports.register_topic_handlers = function () {
         $('#delete_topic_modal').modal('show');
 
         e.stopPropagation();
+    });
+
+    $('body').on('click', '.sidebar-popover-move-topic-messages', function (e) {
+        const topic_row = $(e.currentTarget);
+        const stream_id = parseInt(topic_row.attr('data-stream-id'), 10);
+        const topic_name = topic_row.attr('data-topic-name');
+        build_move_topic_to_stream_popover(e, stream_id, topic_name);
+        e.stopPropagation();
+        e.preventDefault();
+    });
+
+    $('body').on('click', '#topic_stream_edit_form_error .send-status-close', function () {
+        $("#topic_stream_edit_form_error").hide();
+    });
+
+    $('body').on('click', '#do_move_topic_button', function (e) {
+        const params = $('#move_topic_form').serializeArray().reduce(function (obj, item) {
+            obj[item.name] = item.value;
+            return obj;
+        }, {});
+
+        // select_stream_id is stream selected by the user,
+        // We will send a request to the server to change the topic to
+        // this stream.
+        const {old_topic_name, select_stream_id} = params;
+        let {current_stream_id, new_topic_name} = params;
+        current_stream_id = parseInt(current_stream_id, 10);
+        // Get the latest message_id in the (old_topic_name, current_stream_id)
+        const data = {
+            anchor: 'newest',
+            num_before: 1,
+            num_after: 0,
+            narrow: JSON.stringify([{operator: "stream", operand: current_stream_id},
+                                    {operator: "topic", operand: old_topic_name}]),
+        };
+
+        channel.get({
+            url: '/json/messages',
+            data: data,
+            idempotent: true,
+            success: function (data) {
+                const message_id = data.messages[0].id;
+
+                if (old_topic_name.trim() === new_topic_name.trim()) {
+                    // We use `undefined` to tell the server that
+                    // there has been no change in the topic name.
+                    new_topic_name = undefined;
+                }
+
+                if (old_topic_name && select_stream_id) {
+                    message_edit.move_topic_containing_message_to_stream(
+                        message_id, select_stream_id, new_topic_name);
+                    $('#move_topic_modal').modal('hide');
+                }
+            },
+            error: function (xhr) {
+                $("#topic_stream_edit_form_error .error-msg").text(xhr.responseJSON.msg);
+                $("#topic_stream_edit_form_error").show();
+            },
+        });
+        e.preventDefault();
     });
 };
 

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -97,6 +97,11 @@ ul {
     &.remind_me_popover .remind_icon {
         text-align: center;
     }
+
+    &.topic-move_popover {
+        max-height: 200px;
+        overflow-y: auto;
+    }
 }
 
 .user_popover {
@@ -351,4 +356,9 @@ ul {
 .user_info_status_text {
     opacity: 0.8;
     padding: 2px 0px 3px 0px;
+}
+
+#topic_stream_edit_form_error {
+    background-color: hsla(0, 70%, 87%, 0.7);
+    color: hsl(0, 100%, 50%);
 }

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2562,6 +2562,10 @@ div.topic_edit_spinner .loading_indicator_spinner {
     opacity: 0.75;
 }
 
+select.inline_select_topic_edit {
+    margin: 0;
+}
+
 // Hide the up and down arrows in the Flatpickr datepicker year
 .flatpickr-months .numInputWrapper span {
     display: none;

--- a/static/templates/move_topic_to_stream.hbs
+++ b/static/templates/move_topic_to_stream.hbs
@@ -1,0 +1,31 @@
+<div id="move_topic_modal" class="modal modal-bg hide fade new-style" tabindex="-1" role="dialog" aria-labelledby="move_topic_modal_label" aria-hidden="true">
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+        <h3 id="move_topic_modal_label">{{t "Move a topic to stream" }} </h3>
+    </div>
+    <div class="modal-body">
+        <p>{{#tr this}}Do you want to move all messages in <strong>__topic_name__</strong> to another stream?{{/tr}}</p>
+        <form id="move_topic_form">
+            <div id="topic_stream_edit_form_error" class="alert">
+                <span class="send-status-close">&times;</span>
+                <span class="error-msg"></span>
+            </div>
+            <select name="select_stream_id" class="inline_select_topic_edit" id="select_stream_id">
+                <option value="">{{t "Select a stream" }}</option>
+                {{#each available_streams}}
+                <option value="{{ this.stream_id }}">#{{this.name}}</option>
+                {{/each}}
+            </select>
+            <input name="new_topic_name" type="text" class="inline_topic_edit" value="{{topic_name}}">
+            <input name="old_topic_name" type="hidden" class="inline_topic_edit" value="{{topic_name}}">
+            <input name="current_stream_id" type="hidden" value="{{current_stream_id}}">
+        </form>
+        <div class="topic_edit_spinner"></div>
+    </div>
+    <div class="modal-footer">
+        <button class="button" data-dismiss="modal">{{t "Cancel" }}</button>
+        <button class="button btn-danger rounded" id="do_move_topic_button">
+            {{t "Move topic" }}
+        </button>
+    </div>
+</div>

--- a/static/templates/topic_sidebar_actions.hbs
+++ b/static/templates/topic_sidebar_actions.hbs
@@ -40,4 +40,13 @@
     </li>
     {{/if}}
 
+    {{#if is_admin}}
+    <li>
+        <a class="sidebar-popover-move-topic-messages" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
+            <i class="fa fa-arrows" aria-hidden="true"></i>
+            {{#tr this}}Move <b>__topic_name__</b> to another stream.{{/tr}}
+        </a>
+    </li>
+    {{/if}}
+
 </ul>

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -173,5 +173,6 @@
     <div class='notifications top-right'></div>
     <div id="delete-topic-modal-holder"></div>
     <div class="left-sidebar-modal-holder"></div>
+    <div id="move-a-topic-modal-holder"></div>
 </div>
 {% endblock %}

--- a/templates/zerver/help/rename-a-topic.md
+++ b/templates/zerver/help/rename-a-topic.md
@@ -1,6 +1,8 @@
 # Rename a topic
 
-By default, any user can rename any topic.
+By default, any user can rename any topic within a stream, and
+organization administrators can additionally move topics from one
+stream to another.
 
 Organization administrators can
 [turn off community topic editing](/help/community-topic-edits), or turn off
@@ -8,7 +10,7 @@ message editing entirely. See the
 [guide to message and topic editing](/help/configure-message-editing-and-deletion)
 for the details on when topic editing is allowed.
 
-### Rename a topic
+## Rename a topic
 
 {start_tabs}
 
@@ -24,5 +26,28 @@ for the details on when topic editing is allowed.
    dropdown to the right.
 
 1. Click **Save**.
+
+{end_tabs}
+
+<br />
+
+## Move a topic to another stream
+
+{!admin-only.md!}
+
+Organization administrators can move a topic from one public stream to
+another.
+
+{start_tabs}
+
+{!stream-actions.md!}
+
+1. Select **Move <topic name\> to another stream**.
+
+1. Select the destination stream for the topic from the streams dropdown list.
+
+1. (Optional) Change the topic.
+
+1. Click **Move topic**.
 
 {end_tabs}


### PR DESCRIPTION
This initial implementation of moving a topic to another stream works
as follows:

* Added a method to get all topic's messages in a stream:
    get_topic_messages
* Refactored update_message_backend method to allow changing the
    recipient of a message and the message topic
* Created method notify_topic_moved_streams to create notifications
    messages whenever a messages is moved
* Added a new option in topic's options to change stream
* Added logic to update ui after a topic is moved
* Added tests to support the code
* Added documentation page for the feature

#13912 Followup. @timabbott I don't think I can push to that PR, so opened a new one.