### PR TITLE
actions: Implement do_delete_user.

### DIFF
--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -72,9 +72,14 @@ def create_user_profile(realm: Realm, email: str, password: Optional[str],
                         is_mirror_dummy: bool, tos_version: Optional[str],
                         timezone: Optional[str],
                         tutorial_status: str = UserProfile.TUTORIAL_WAITING,
-                        enter_sends: bool = False) -> UserProfile:
+                        enter_sends: bool = False,
+                        force_id: Optional[int] = None) -> UserProfile:
     now = timezone_now()
     email = UserManager.normalize_email(email)
+
+    extra_kwargs = {}
+    if force_id is not None:
+        extra_kwargs['id'] = force_id
 
     user_profile = UserProfile(is_staff=False, is_active=active,
                                full_name=full_name,
@@ -87,7 +92,8 @@ def create_user_profile(realm: Realm, email: str, password: Optional[str],
                                onboarding_steps=orjson.dumps([]).decode(),
                                default_language=realm.default_language,
                                twenty_four_hour_time=realm.default_twenty_four_hour_time,
-                               delivery_email=email)
+                               delivery_email=email,
+                               **extra_kwargs)
     if bot_type or not active:
         password = None
     if user_profile.email_address_is_realm_public():
@@ -112,7 +118,8 @@ def create_user(email: str,
                 default_sending_stream: Optional[Stream] = None,
                 default_events_register_stream: Optional[Stream] = None,
                 default_all_public_streams: Optional[bool] = None,
-                source_profile: Optional[UserProfile] = None) -> UserProfile:
+                source_profile: Optional[UserProfile] = None,
+                force_id: Optional[int] = None) -> UserProfile:
     user_profile = create_user_profile(
         realm,
         email,
@@ -123,7 +130,8 @@ def create_user(email: str,
         bot_owner,
         is_mirror_dummy,
         tos_version,
-        timezone
+        timezone,
+        force_id=force_id
     )
     user_profile.avatar_source = avatar_source
     user_profile.timezone = timezone


### PR DESCRIPTION
This is a simple implementation of do_delete_user. There's a TODO for whether we want to do anything special in the zephyr realm case? (do_deactivate_user has a special treatment here).

Do we want to actually be deleting all messages here? (it happens through CASCADE). If so, do we want to do something more fancy here, such as calling `do_delete_messages` first as that function sends events about the deletion to clients?

Last question - what domain should the dummy email addresses use? With @zulip.com the problem is that hypothetically we could register with those emails to claim the accounts on self-hosted deployments, which is definitely not a good thing. Should we use `@{settings.EXTERNAL_HOST}`?

I still have to write automated tests, once we know what exactly this function should be doing.