### PR TITLE
logging: Pass format arguments to unconventionally-named loggers too

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -153,8 +153,10 @@ def catch_stripe_errors(func: CallableT) -> CallableT:
         # https://stripe.com/docs/error-codes gives a more detailed set of error codes
         except stripe.error.StripeError as e:
             err = e.json_body.get('error', {})
-            billing_logger.error("Stripe error: %s %s %s %s" % (
-                e.http_status, err.get('type'), err.get('code'), err.get('param')))
+            billing_logger.error(
+                "Stripe error: %s %s %s %s",
+                e.http_status, err.get('type'), err.get('code'), err.get('param'),
+            )
             if isinstance(e, stripe.error.CardError):
                 # TODO: Look into i18n for this
                 raise StripeCardError('card error', err.get('message'))
@@ -285,7 +287,8 @@ def process_initial_upgrade(user: UserProfile, licenses: int, automanage_license
         # at exactly the same time. Doesn't fully resolve the race condition, but having
         # a check here reduces the likelihood.
         billing_logger.warning(
-            "Customer {} trying to upgrade, but has an active subscription".format(customer))
+            "Customer %s trying to upgrade, but has an active subscription", customer,
+        )
         raise BillingError('subscribing with existing subscription', BillingError.TRY_RELOADING)
 
     billing_cycle_anchor, next_invoice_date, period_end, price_per_license = compute_plan_parameters(
@@ -476,8 +479,10 @@ def get_discount_for_realm(realm: Realm) -> Optional[Decimal]:
 def do_change_plan_status(plan: CustomerPlan, status: int) -> None:
     plan.status = status
     plan.save(update_fields=['status'])
-    billing_logger.info('Change plan status: Customer.id: %s, CustomerPlan.id: %s, status: %s' % (
-        plan.customer.id, plan.id, status))
+    billing_logger.info(
+        'Change plan status: Customer.id: %s, CustomerPlan.id: %s, status: %s',
+        plan.customer.id, plan.id, status,
+    )
 
 def process_downgrade(plan: CustomerPlan) -> None:
     from zerver.lib.actions import do_change_plan_type

--- a/corporate/views.py
+++ b/corporate/views.py
@@ -99,10 +99,11 @@ def upgrade(request: HttpRequest, user: UserProfile,
     except BillingError as e:
         if not settings.TEST_SUITE:  # nocoverage
             billing_logger.warning(
-                ("BillingError during upgrade: %s. user=%s, realm=%s (%s), billing_modality=%s, "
-                 "schedule=%s, license_management=%s, licenses=%s, has stripe_token: %s")
-                % (e.description, user.id, user.realm.id, user.realm.string_id, billing_modality,
-                   schedule, license_management, licenses, stripe_token is not None))
+                "BillingError during upgrade: %s. user=%s, realm=%s (%s), billing_modality=%s, "
+                "schedule=%s, license_management=%s, licenses=%s, has stripe_token: %s",
+                e.description, user.id, user.realm.id, user.realm.string_id, billing_modality,
+                schedule, license_management, licenses, stripe_token is not None,
+            )
         return json_error(e.message, data={'error_description': e.description})
     except Exception as e:
         billing_logger.exception("Uncaught exception in billing: %s" % (e,))

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -618,7 +618,7 @@ class ZulipLDAPAuthBackend(ZulipLDAPAuthBackendBase):
             # django-auth-ldap authenticate().
             username = self.django_to_ldap_username(username)
         except ZulipLDAPExceptionNoMatchingLDAPUser as e:
-            ldap_logger.debug("{}: {}".format(self.__class__.__name__, e))
+            ldap_logger.debug("%s: %s", self.__class__.__name__, e)
             if return_data is not None:
                 return_data['no_matching_ldap_user'] = True
             return None


### PR DESCRIPTION
These were found by a more accurate version of the semgrep rule, which is unfortunately much slower:

```yaml
  - id: logging-format
    languages: [python]
    pattern-either:
      - pattern: logging.debug(... % ...)
      - pattern: logging.debug(... .format(...))
      - pattern: logging.info(... % ...)
      - pattern: logging.info(... .format(...))
      - pattern: logging.warning(... % ...)
      - pattern: logging.warning(... .format(...))
      - pattern: logging.error(... % ...)
      - pattern: logging.error(... .format(...))
      - pattern: logging.critical(... % ...)
      - pattern: logging.critical(... .format(...))
      - patterns:
          - pattern-inside: |
              $LOGGER = logging.getLogger(...)
              ...
          - pattern-either:
              - pattern: $LOGGER.debug(... % ...)
              - pattern: $LOGGER.debug(... .format(...))
              - pattern: $LOGGER.info(... % ...)
              - pattern: $LOGGER.info(... .format(...))
              - pattern: $LOGGER.warning(... % ...)
              - pattern: $LOGGER.warning(... .format(...))
              - pattern: $LOGGER.error(... % ...)
              - pattern: $LOGGER.error(... .format(...))
              - pattern: $LOGGER.critical(... % ...)
              - pattern: $LOGGER.critical(... .format(...))
    severity: ERROR
    message: "Pass format arguments to logging (https://docs.python.org/3/howto/logging.html#optimization)"
```