### PR TITLE
subs: Update hash on deactivating a stream.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -255,7 +255,7 @@ exports.remove_stream = function (stream_id) {
     row.remove();
     const sub = stream_data.get_sub_by_id(stream_id);
     if (stream_edit.is_sub_settings_active(sub)) {
-        exports.show_subs_pane.nothing_selected();
+        stream_edit.open_edit_panel_empty();
     }
 };
 


### PR DESCRIPTION
This commit updates the hash on deactivating the stream.
I have used 'open_edit_panel_empty` which resets the hash instead of only using `nothing selected`.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
