### PR TITLE
Allow for files to be dropped anywhere and attached to message box issue 14579 

### DIFF
--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -46,6 +46,7 @@ run_test('get_item', () => {
     assert.equal(upload.get_item("file_input_identifier", {mode: "compose"}), "#file_input");
     assert.equal(upload.get_item("source", {mode: "compose"}), "compose-file-input");
     assert.equal(upload.get_item("drag_drop_container", {mode: "compose"}), $('#compose'));
+    assert.equal(upload.get_item("drag_drop_container_img", {mode: "compose"}), $("#main_div"));
 
     assert.equal(upload.get_item("textarea", {mode: "edit", row: 1}), $('#message_edit_content_1'));
 
@@ -67,6 +68,7 @@ run_test('get_item', () => {
     assert.equal(upload.get_item("file_input_identifier", {mode: "edit", row: 123}), "#message_edit_file_input_123");
     assert.equal(upload.get_item("source", {mode: "edit", row: 123}), "message-edit-file-input");
     assert.equal(upload.get_item("drag_drop_container", {mode: "edit", row: 1}), $("#message_edit_form"));
+    assert.equal(upload.get_item("drag_drop_container_img", {mode: "edit", row: 1}), $("#main_div"));
 
     assert.throws(
         () => {
@@ -371,6 +373,43 @@ run_test('file_drop', () => {
         },
     };
     const drop_handler = $("#compose").get_on_handler("drop");
+    let upload_files_called = false;
+    upload.upload_files = () => {upload_files_called = true;};
+    drop_handler(drop_event);
+    assert.equal(prevent_default_counter, 3);
+    assert.equal(upload_files_called, true);
+
+});
+
+run_test('universal_file_drop', () => {
+    set_global('$', global.make_zjquery());
+    upload.setup_upload({mode: "compose"});
+    let prevent_default_counter = 0;
+    const drag_event = {
+        preventDefault: () => {
+            prevent_default_counter += 1;
+        },
+    };
+    const dragover_handler = $("#main_div").get_on_handler("dragover");
+    dragover_handler(drag_event);
+    assert.equal(prevent_default_counter, 1);
+
+    const dragenter_handler = $("#main_div").get_on_handler("dragenter");
+    dragenter_handler(drag_event);
+    assert.equal(prevent_default_counter, 2);
+
+    const files = ["file1", "file2"];
+    const drop_event = {
+        preventDefault: () => {
+            prevent_default_counter += 1;
+        },
+        originalEvent: {
+            dataTransfer: {
+                files: files,
+            },
+        },
+    };
+    const drop_handler = $("#main_div").get_on_handler("drop");
     let upload_files_called = false;
     upload.upload_files = () => {upload_files_called = true;};
     drop_handler(drop_event);

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -45,6 +45,8 @@ exports.get_item = function (key, config) {
             return "compose-file-input";
         case "drag_drop_container":
             return $("#compose");
+        case "drag_drop_container_img":
+            return $("#main_div");
         default:
             throw Error(`Invalid key name for mode "${config.mode}"`);
         }
@@ -71,6 +73,8 @@ exports.get_item = function (key, config) {
             return "message-edit-file-input";
         case "drag_drop_container":
             return $("#message_edit_form");
+        case "drag_drop_container_img":
+            return $("#main_div");
         default:
             throw Error(`Invalid key name for mode "${config.mode}"`);
         }
@@ -201,6 +205,16 @@ exports.setup_upload = function (config) {
             files.push(file);
         }
         exports.upload_files(uppy, config, files);
+    });
+
+    const drag_drop_container_img = exports.get_item("drag_drop_container_img", config);
+    drag_drop_container_img.on("dragover", (event) => event.preventDefault());
+    drag_drop_container_img.on("dragenter", (event) => event.preventDefault());
+
+    drag_drop_container_img.on("drop", (event) => {
+        event.preventDefault();
+        const img = event.originalEvent.dataTransfer.files;
+        exports.upload_files(uppy, config, img);
     });
 
     uppy.on('upload-success', (file, response) => {


### PR DESCRIPTION
Fixes #14579 

Tested with ./tools/lint with no errors and manually by dragging and dropping files to messages in development environment

![ezgif com-gif-maker](https://user-images.githubusercontent.com/38227182/80935119-29432380-8d99-11ea-98e3-b757d533ac31.gif)

