### PR TITLE
help: Add article for how to get support.

### DIFF
--- a/templates/zerver/app/navbar.html
+++ b/templates/zerver/app/navbar.html
@@ -100,6 +100,13 @@
                                     <i class="fa fa-search" aria-hidden="true"></i> {{ _('Search operators') }}
                                 </a>
                             </li>
+                            {% if corporate_enabled %}
+                            <li role="presentation">
+                                <a href="/help/contact-support" target="_blank" role="menuitem">
+                                    <i class="fa fa-envelope" aria-hidden="true"></i> {{ _('Contact support') }}
+                                </a>
+                            </li>
+                            {% endif %}
                             <li class="divider" role="presentation"></li>
                             <li role="presentation">
                                 <a href="{{ apps_page_url }}" target="_blank" role="menuitem">

--- a/templates/zerver/footer.html
+++ b/templates/zerver/footer.html
@@ -14,9 +14,10 @@
         <ul>
             <li><a href="https://zulip.readthedocs.io/en/latest/contributing/chat-zulip-org.html">{{ _("Community chat") }}</a></li>
             <li><a href="/help/">{{ _("Help center") }}</a></li>
-            <li><a href="https://zulip.readthedocs.io/en/latest/">{{ _("Documentation") }}</a></li>
-            <li><a href="https://twitter.com/zulip/">Twitter</a> and <a href="https://blog.zulip.org">Blog</a></li>
-            <li><a href="https://github.com/zulip/zulip/">GitHub</a></li>
+            <li><a href="https://twitter.com/zulip/">Twitter</a> & <a href="https://blog.zulip.org">Blog</a></li>
+            <li><a href="https://github.com/zulip/zulip/">GitHub</a>
+            & <a href="https://zulip.readthedocs.io/en/latest/">ReadTheDocs</a></li>
+            <li><a href="{{ root_domain_uri }}/help/contact-support">{{ _("Support") }}</a></li>
         </ul>
     </section>
     <section>

--- a/templates/zerver/help/contact-support.md
+++ b/templates/zerver/help/contact-support.md
@@ -1,0 +1,27 @@
+# Contact support
+
+Support for Zulip is available through three channels:
+
+* [chat.zulip.org][chat-zulip-org], the Zulip development community.
+  Depending on the time of day/week of your query and the complexity
+  of your question, you may get useful responses immediately or up to
+  a couple days later, but the magic of Zulip means it's easy for us
+  for to reply to every thread.  Please read the community conventions
+  (linked above) and choose a topic when starting a conversation.
+* We aim to reply to [email support](mailto:support@zulipchat.com)
+  questions within a business day.  Simple queries or requests for
+  data imports generally receive faster replies.
+* GitHub [server](https://github.com/zulip/zulip/issues/new), web
+  [frontend](https://github.com/zulip/zulip/issues/new), [mobile
+  app](https://github.com/zulip/zulip-mobile/issues/new), [desktop
+  app](https://github.com/zulip/zulip-desktop/issues/new).  If you
+  aren't able to provide a clear bug report or are otherwise
+  uncertain, it can be helpful to discuss in chat.zulip.org first to
+  help create a better GitHub issue.
+* We don't offer phone support except as part of enterprise contracts.
+
+We love hearing feedback!  Please reach out if you have feedback,
+questions, or just want to brainstorm how to make Zulip work for your
+organization.
+
+[chat-zulip-org]: https://zulip.readthedocs.io/en/latest/contributing/chat-zulip-org.html

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -162,3 +162,6 @@
 * [Change the privacy of a stream](/help/change-the-privacy-of-a-stream)
 * [Add or remove users from a stream](/help/add-or-remove-users-from-a-stream)
 * [Stream posting policy](/help/stream-sending-policy)
+
+## Support
+* [Contact support](/help/contact-support)

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -349,6 +349,7 @@ def home_real(request: HttpRequest) -> HttpResponse:
                                'show_invites': show_invites,
                                'show_add_streams': show_add_streams,
                                'show_billing': show_billing,
+                               'corporate_enabled': settings.CORPORATE_ENABLED,
                                'show_plans': show_plans,
                                'is_admin': is_realm_admin,
                                'is_guest': is_guest,


### PR DESCRIPTION
There's a few things we should tweak here, but it's definitely better
to have this page than not.

Fixes #10033.

@hackerkid would you be up for adding a commit here after doing some grepping to add links to this page wherever we currently ask folks to "contact support"?  I think the only exception to this is the Slack import stuff, where it really needs to be the email channel (though we should move that to a web form soon anyway).  

We'll want to polish this page more.
