### PR TITLE
docs: Recommend contact page over email wherever possible

### DIFF
--- a/docs/production/requirements.md
+++ b/docs/production/requirements.md
@@ -209,11 +209,12 @@ installing Zulip with a dedicated database server.
 
   * Zulip 2.0 and later supports running multiple Tornado servers
     sharded by realm/organization, which is how we scale Zulip Cloud.
-    Contact us for help implementing the sharding policy.
+    [Contact us][contact-support] for help implementing the sharding policy.
 
 Scalability is an area of active development, so if you're unsure
 whether Zulip is a fit for your organization or need further advice
-[contact Zulip support](mailto:support@zulipchat.com).
+[contact Zulip support][contact-support].
 
 [s3-uploads]: ../production/upload-backends.html#s3-backend-configuration
 [streaming-replication]: ../production/export-and-import.html#postgres-streaming-replication
+[contact-support]: https://zulip.com/help/contact-support

--- a/templates/zerver/api/integrations-overview.md
+++ b/templates/zerver/api/integrations-overview.md
@@ -39,8 +39,8 @@ Zulip.
 
 We've put a lot of effort into making this as easy as possible, but all of
 the options below do require some comfort writing code. If you need an
-integration and don't have an engineer on staff, reach out to
-`support@zulipchat.com` and we'll see what we can do.
+integration and don't have an engineer on staff,
+[react out to us](/help/contact-support) and we'll see what we can do.
 
 ### Sending content into Zulip
 
@@ -65,4 +65,4 @@ integration and don't have an engineer on staff, reach out to
   but not all of the endpoints are documented on this site; if you need
   something that isn't there check out Zulip's
   [REST endpoints](https://github.com/zulip/zulip/tree/master/zproject/urls.py)
-  or email `support@zulipchat.com` and we'll help you out.
+  or [contact us](/help/contact-support) and we'll help you out.

--- a/templates/zerver/atlassian.md
+++ b/templates/zerver/atlassian.md
@@ -47,8 +47,9 @@ Instructions for integrating with [JIRA](/integrations/doc/jira),
 [OpsGenie](/integrations/doc/opsgenie) are linked.
 
 We recommend integrating via [Zapier](/integrations/doc/zapier) for
-Confluence, Bamboo, Fisheye, Crucible, Crowd, and Sourcetree. Email
-<support@zulipchat.com> if you get stuck and we’d be happy to help you out.
+Confluence, Bamboo, Fisheye, Crucible, Crowd, and Sourcetree.
+[Contact us](/help/contact-support) if you get stuck and we’d be happy to help
+you out.
 
 ## Read our guides.
 

--- a/templates/zerver/for/open-source.md
+++ b/templates/zerver/for/open-source.md
@@ -217,5 +217,4 @@ So if there’s something we could improve to make Zulip the obvious
 choice either for you or your community, [open an
 issue](https://github.com/zulip/zulip/issues), [submit a
 patch](https://zulip.readthedocs.io/en/latest/development/overview.html),
-[email us](mailto:support@zulipchat.com), or chat with us directly at
-[chat.zulip.org](https://chat.zulip.org).
+or [contact us](/help/contact-support).

--- a/templates/zerver/help/add-a-custom-linkification-filter.md
+++ b/templates/zerver/help/add-a-custom-linkification-filter.md
@@ -49,6 +49,6 @@ Generic GitHub `org/repo#ID` format:
 * Automatically links to: `https://github.com/zulip/zulip/issues/2468`
 
 Linkifiers can be very useful, but also complicated to set up. If you have
-any trouble setting these up, please email support@zulipchat.com with a few
-examples of "Original text" and "Automatically links to" and we'll be happy
-to help you out.
+any trouble setting these up, please [contact us](/help/contact-support) with
+a few examples of "Original text" and "Automatically links to" and we'll be
+happy to help you out.

--- a/templates/zerver/help/add-custom-emoji.md
+++ b/templates/zerver/help/add-custom-emoji.md
@@ -29,8 +29,8 @@ are treated the same as spaces.
 ### Bulk add emoji
 
 We expose a [REST API endpoint](/api/upload-custom-emoji) for bulk uploading
-emoji. Using REST API endpoints requires some technical expertise; email
-support@zulipchat.com if you get stuck.
+emoji. Using REST API endpoints requires some technical expertise;
+[contact us](/help/contact-support) if you get stuck.
 
 ## Replace a default emoji
 

--- a/templates/zerver/help/bots-and-integrations.md
+++ b/templates/zerver/help/bots-and-integrations.md
@@ -63,8 +63,8 @@ A few more details:
   (e.g. write messages that come from you, rather than from a look-a-like),
   you'll need to use your **personal API key**.
 
-* **API super bot**: You cannot create this from the web interface. Contact
-  `support@zulipchat.com` if you'd like information on how to set this up.
+* **API super bot**: You cannot create this from the web interface.
+  [Contact us](/help/contact-support) if you'd like information on how to set this up.
 
 ## Adding bots
 

--- a/templates/zerver/help/emoji-and-emoticons.md
+++ b/templates/zerver/help/emoji-and-emoticons.md
@@ -52,8 +52,8 @@ The list of supported emoticons is available
 
 ### Paste from another site
 
-Copying and pasting emoji from other sites generally works. Email us at
-support@zulipchat.com if you find a site where it doesn't!
+Copying and pasting emoji from other sites generally works.
+[Contact us](/help/contact-support) if you find a site where it doesn't!
 
 ## Change your emoji set
 

--- a/templates/zerver/help/getting-your-organization-started-with-zulip.md
+++ b/templates/zerver/help/getting-your-organization-started-with-zulip.md
@@ -85,10 +85,8 @@ expert teaching other users how to use Zulip.
 
 * Bonus: learn [Markdown message formatting](/help/format-your-message-using-markdown).
 
-* If anything is confusing or feels missing, tweet `@zulip`, ask on the
-  [Zulip community server](https://chat.zulip.org), or email
-  [support@zulipchat.com](mailto:support@zulipchat.com). We love hearing
-  from new administrators!
+* If anything is confusing or feels missing, tweet `@zulip`, or
+  [contact us](/help/contact-support). We love hearing from new administrators!
 
 ## Invite users and onboard your community
 

--- a/templates/zerver/help/import-from-hipchat.md
+++ b/templates/zerver/help/import-from-hipchat.md
@@ -6,8 +6,7 @@ including users, rooms, messages, avatars, and custom emoji.
 This tool has been used to import HipChat teams with thousands of
 members, thousands of streams and millions of messages. If you're
 planning on doing an import much larger than that, or run into
-performance issues when importing, email us at support@zulipchat.com
-for help.
+performance issues when importing, [contact us](/help/contact-support).
 
 **Note:** You can only import a HipChat or Stride group as a new Zulip
 organization. In particular, you cannot use this tool to import data

--- a/templates/zerver/help/import-from-mattermost.md
+++ b/templates/zerver/help/import-from-mattermost.md
@@ -12,7 +12,7 @@ into an existing Zulip organization.
 
 First, export your data from Mattermost.
 The instructions below correspond to various common ways Mattermost is installed; if
-yours isn't covered contact support@zulipchat.com and we'll help you out.
+yours isn't covered, [contact us](/help/contact-support) and we'll help you out.
 
 Replace `<username>` and `<server_ip>` with the appropriate values below.
 

--- a/templates/zerver/help/import-from-slack.md
+++ b/templates/zerver/help/import-from-slack.md
@@ -6,8 +6,8 @@ emoji, and emoji reactions.
 
 This tool has been used to import Slack workspaces with 10,000 members
 and millions of messages. If you're planning on doing an import much
-larger than that, or run into performance issues when importing, email
-us at support@zulipchat.com for help.
+larger than that, or run into performance issues when importing,
+[contact us](/help/contact-support) for help.
 
 **Note:** You can only import a Slack workspace as a new Zulip
 organization. In particular, you cannot use this tool to import from Slack


### PR DESCRIPTION
Followup of https://github.com/zulip/zulip/pull/14855

This is ready for a review.


The following occurrences of `support@zulipchat.com` were skipped

```
docs/production/mobile-push-notifications.md:   email support@zulipchat.com with the output of this command.
docs/production/mobile-push-notifications.md:support@zulipchat.com.
docs/production/mobile-push-notifications.md:1. First, contact support@zulipchat.com with the `zulip_org_id` and
templates/corporate/billing.html:                        Contact <a href="mailto:support@zulipchat.com">support@zulipchat.com</a>
templates/corporate/billing.html:                        Contact <a href="mailto:support@zulipchat.com">support@zulipchat.com</a> for billing history.
templates/corporate/upgrade.html:                        Contact <a href="mailto:support@zulipchat.com">support@zulipchat.com</a>
templates/zerver/atlassian.md:pricing, or email <support@zulipchat.com> for on-premise support
templates/zerver/faq.html:                    support@zulipchat.com and we’ll get you started!
templates/zerver/for/mystery-hunt.md:support@zulipchat.com to tell us you’re a mystery hunt team.
templates/zerver/for/open-source.md:support@zulipchat.com.
templates/zerver/help/configure-authentication-methods.md:Cloud but requires contacting support@zulipchat.com to configure it.
templates/zerver/help/export-your-organization.md:1. Email support@zulipchat.com with your zulipchat.com subdomain, asking for
templates/zerver/help/export-your-organization.md:To start this export, email support@zulipchat.com with your zulipchat.com
templates/zerver/help/gdpr-compliance.md:Contact [support@zulipchat.com](mailto:support@zulipchat.com) for
templates/zerver/help/gdpr-compliance.md:recommend contacting support@zulipchat.com; our paid support contracts
templates/zerver/help/import-from-gitter.md:Email support@zulipchat.com with `gitter_data.zip` and your desired
templates/zerver/help/import-from-hipchat.md:Email support@zulipchat.com with your exported archive and your desired Zulip
templates/zerver/help/import-from-mattermost.md:Email support@zulipchat.com with your exported archive,
templates/zerver/help/import-from-slack.md:Email support@zulipchat.com with `slack_data.zip`, the Slack API token
templates/zerver/help/message-retention-policy.md:Standard hosting.  Contact support@zulipchat.com if you're on one of
zerver/forms.py:                       '<a href="mailto:support@zulipchat.com">contact us</a>.'
```