### PR TITLE
typeaheads: Show tip text for silent mentions.

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -917,6 +917,9 @@ function get_header_text() {
     case 'stream':
         tip_text = i18n.t('Press > for list of topics');
         break;
+    case 'silent_mention':
+        tip_text = i18n.t('User will not be notified');
+        break;
     default:
         return false;
     }


### PR DESCRIPTION
This addition is prompted by the feedback and discussion at
https://chat.zulip.org/#narrow/stream/137-feedback/topic/silent.20mention.

