### PR TITLE
click_handlers: Remove click handler for closing stream settings.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -423,12 +423,6 @@ exports.initialize = function () {
         $(".tooltip").remove();
     });
 
-    $("#subscriptions_table").on("click", ".exit, #subscription_overlay", function (e) {
-        if ($(e.target).is(".exit, .exit-sign, #subscription_overlay, #subscription_overlay > .flex")) {
-            subs.close();
-        }
-    });
-
     function do_render_buddy_list_tooltip(elem, title_data) {
         elem.tooltip({
             template: render_buddy_list_tooltip(),

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -674,17 +674,15 @@ exports.launch = function (section) {
         overlays.open_overlay({
             name: 'subscriptions',
             overlay: $("#subscription_overlay"),
-            on_close: exports.close,
+            on_close: function () {
+                hashchange.exit_overlay();
+            },
         });
         exports.change_state(section);
     });
     if (!exports.get_active_data().id) {
         $('#search_stream_name').focus();
     }
-};
-
-exports.close = function () {
-    hashchange.exit_overlay();
 };
 
 exports.switch_rows = function (event) {


### PR DESCRIPTION
The click handler for closing stream settings in click_handlers.js
is removed as overlays.js contains common logic for closing all
overlays.

Link to conversation - [here](https://chat.zulip.org/#narrow/stream/6-frontend/topic/closing.20streams.20settings.20click.20handler)
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? --> This has been tested manually and removing the redundant code keeps the behaviour as expected.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
