### PR TITLE
docs: Remove unnecessary double-backticks in indented line

### DIFF
--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -16,7 +16,7 @@ You can run them all at once with
 
 You can set this up as a local Git commit hook with
 
-    ``tools/setup-git-repo``
+    tools/setup-git-repo
 
 The Vagrant setup process runs this for you.
 


### PR DESCRIPTION
These came in during the conversion from rST in 337155f280.

**Testing Plan:** Generated the docs via `./tools/build-docs` and looked at it.  `grep` found no other similar occurrences.