### PR TITLE
Improving gitlab pipeline event notifications

### DIFF
--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -491,7 +491,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_pipeline_succeeded_event_message(self) -> None:
         expected_topic = "my-awesome-project / master"
-        expected_message = "Pipeline changed status to success with build(s):\n* job_name2 - success\n* job_name - success."
+        expected_message = "[Pipeline](https://gitlab.com/TomaszKolek/my-awesome-project/pipelines/4414206) changed status to success with build(s):\n* [job_name2](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541113) - success\n* [job_name](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541112) - success."
 
         self.send_and_test_stream_message(
             'pipeline_hook__pipeline_succeeded',
@@ -501,7 +501,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_pipeline_started_event_message(self) -> None:
         expected_topic = "my-awesome-project / master"
-        expected_message = "Pipeline started with build(s):\n* job_name - running\n* job_name2 - pending."
+        expected_message = "[Pipeline](https://gitlab.com/TomaszKolek/my-awesome-project/pipelines/4414206) started with build(s):\n* [job_name](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541112) - running\n* [job_name2](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541113) - pending."
 
         self.send_and_test_stream_message(
             'pipeline_hook__pipeline_started',
@@ -511,7 +511,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_pipeline_pending_event_message(self) -> None:
         expected_topic = "my-awesome-project / master"
-        expected_message = "Pipeline was created with build(s):\n* job_name2 - pending\n* job_name - created."
+        expected_message = "[Pipeline](https://gitlab.com/TomaszKolek/my-awesome-project/pipelines/4414206) was created with build(s):\n* [job_name2](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541113) - pending\n* [job_name](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541112) - created."
 
         self.send_and_test_stream_message(
             'pipeline_hook__pipeline_pending',

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -253,10 +253,15 @@ def get_pipeline_event_body(payload: Dict[str, Any]) -> str:
     else:
         action = 'changed status to {}'.format(pipeline_status)
 
+    pipeline_url = '{}/pipelines/{}'.format(
+        get_project_homepage(payload),
+        payload['object_attributes'].get('id')
+    )
+
     builds_status = ""
     for build in payload['builds']:
         builds_status += "* {} - {}\n".format(build.get('name'), build.get('status'))
-    return "Pipeline {} with build(s):\n{}.".format(action, builds_status[:-1])
+    return "[Pipeline]({}) {} with build(s):\n{}.".format(pipeline_url, action, builds_status[:-1])
 
 def get_repo_name(payload: Dict[str, Any]) -> str:
     return payload['project']['name']

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -253,14 +253,23 @@ def get_pipeline_event_body(payload: Dict[str, Any]) -> str:
     else:
         action = 'changed status to {}'.format(pipeline_status)
 
+    project_homepage = get_project_homepage(payload)
     pipeline_url = '{}/pipelines/{}'.format(
-        get_project_homepage(payload),
+        project_homepage,
         payload['object_attributes'].get('id')
     )
 
     builds_status = ""
     for build in payload['builds']:
-        builds_status += "* {} - {}\n".format(build.get('name'), build.get('status'))
+        build_url = '{}/-/jobs/{}'.format(
+            project_homepage,
+            build.get('id')
+        )
+        builds_status += "* [{}]({}) - {}\n".format(
+            build.get('name'),
+            build_url,
+            build.get('status')
+        )
     return "[Pipeline]({}) {} with build(s):\n{}.".format(pipeline_url, action, builds_status[:-1])
 
 def get_repo_name(payload: Dict[str, Any]) -> str:


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
To improve the notification a user gets when a pipeline event occurs by giving direct links to the pipeline website and to each job log. 
Instead of 
```markdown
Pipeline changed status to success with build(s):
* job_name2 - success
* job_name - success.
```
it is now going to be
```markdown
[Pipeline](https://gitlab.com/TomaszKolek/my-awesome-project/pipelines/4414206) changed status to success with build(s):
* [job_name2](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541113) - success
* [job_name](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541112) - success.
```
where

> [Pipeline](https://gitlab.com/TomaszKolek/my-awesome-project/pipelines/4414206) changed status to success with build(s):
> * [job_name2](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541113) - success
> * [job_name](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541112) - success.

pipeline and jobs will be linkified to the corresponding pipeline overview and job logs on the corresponding gitlab instance.
The is  extremly usefull in the case of failing jobs in which case you might want to access the job logs directly.

**Testing Plan:** <!-- How have you tested? -->
Not tested in the wild yet, but unittest failed as expectedand were updated appropriately.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
No UI changes.