### PR TITLE
todo widget: Downgrade error to warning.

### DIFF
--- a/static/js/todo_widget.js
+++ b/static/js/todo_widget.js
@@ -104,7 +104,7 @@ exports.task_data_holder = function () {
                 const item = task_map.get(key);
 
                 if (item === undefined) {
-                    blueslip.error('unknown key for tasks: ' + key);
+                    blueslip.warn('Do we have legacy data? unknown key for tasks: ' + key);
                     return;
                 }
 


### PR DESCRIPTION
We were creating errors for task keys that were
from older versions of the widget.  We don't migrate
data for the widgets yet (they're all still considered
to be somewhat beta); instead, we just drop bad data
on the floor.

Rohitt and I re-tested the widget on czo pretty
extensively to verify that these errors don't show
up for newly created widgets.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
