### PR TITLE
message_edit: Add support for changing stream of a message.

### DIFF
--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -190,14 +190,20 @@ exports.edit_locally = function (message, request) {
     const raw_content = request.raw_content;
     const message_content_edited = raw_content !== undefined && message.raw_content !== raw_content;
 
-    if (request.new_topic !== undefined) {
+    if (request.new_topic !== undefined || request.new_stream_id !== undefined) {
+        const new_stream_id = request.new_stream_id;
         const new_topic = request.new_topic;
         stream_topic_history.remove_message({
             stream_id: message.stream_id,
             topic_name: message.topic,
         });
 
-        message.topic = new_topic;
+        if (new_stream_id !== undefined) {
+            message.stream_id = new_stream_id;
+        }
+        if (new_topic !== undefined) {
+            message.topic = new_topic;
+        }
 
         stream_topic_history.add_message({
             stream_id: message.stream_id,

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1249,6 +1249,17 @@ div.focused_table {
     margin-bottom: 5px;
 }
 
+.select_edit_stream {
+    margin-bottom: 5px !important;
+}
+
+.edit-controls .fa-angle-right {
+    font-size: 0.9em;
+    -webkit-text-stroke: 0.05em;
+    position: relative;
+    margin: 0px 5px;
+}
+
 #inline_topic_edit.header-v {
     height: 18px;
     display: inline-block;
@@ -1265,6 +1276,7 @@ div.focused_table {
 #message_edit_topic:focus {
     outline: none;
 }
+
 
 .message_edit_topic_propagate {
     display: inline-block;

--- a/static/templates/message_edit_form.hbs
+++ b/static/templates/message_edit_form.hbs
@@ -8,6 +8,13 @@
     {{#if is_stream}}
     <div class="control-group no-margin">
         <div class="controls edit-controls">
+            <select class="select_edit_stream" id="select_stream_id_{{ message_id }}" {{#unless show_edit_stream}}style="display:none"{{/unless}}>
+                <option value="{{ stream_id }}" selected='selected'>#{{ stream_name }}</option>
+                {{#each available_streams}}
+                <option value="{{ this.stream_id }}">#{{this.name}}</option>
+                {{/each}}
+            </select>
+            <i class="fa fa-angle-right" aria-hidden="true" {{#unless show_edit_stream}}style="display:none"{{/unless}}></i>
             <input type="text" placeholder="{{topic}}" value="{{topic}}" class="message_edit_topic" id="message_edit_topic" />
             <select class='message_edit_topic_propagate' style='display:none;'>
                 <option selected="selected" value="change_later"> {{t "Change later messages to this topic" }}</option>

--- a/templates/zerver/help/rename-a-topic.md
+++ b/templates/zerver/help/rename-a-topic.md
@@ -51,3 +51,36 @@ another.
 1. Click **Move topic**.
 
 {end_tabs}
+
+## Move message(s) in a topic to another stream
+
+{!admin-only.md!}
+
+Organization administrators can move messages from one public stream to
+another.
+
+{start_tabs}
+
+{!message-actions-menu.md!}
+
+1. Select the first option. It may be called **View source / Edit topic**,
+   or simply **Edit**. If it's called **View source**, then you are not
+   allowed to edit the stream of that message.
+
+1. Select the destination stream for the message from the streams dropdown list.
+
+1. (Optional) Change the topic.
+
+1. A dropdown with three options will appear to the right:
+**Change only this message topic**, **Change later messages to this topic**, and
+**Change previous and following messages to this topic**. Pick the appropriate
+option.
+
+1. Click **Save**.
+
+
+!!! warn ""
+    **Note**: You cannot edit content of a message while changing its stream.
+
+
+{end_tabs}


### PR DESCRIPTION
* This feature is currently only visible to admins.
* Locally echoed messages are also updated.
* Add UI for editing stream if user is admin.
* Show propagate mode selector if either stream or topic changed.
* Add Help doc for using this feature.

Followup from #14844 