### PR TITLE
retention: Optimize fetching of realm and streams with retention policy.

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1399,7 +1399,10 @@ class Stream(models.Model):
         max_length=32, default=generate_email_token_for_stream, unique=True
     )
 
-    # For old messages being automatically deleted
+    # For old messages being automatically deleted.
+    # Value NULL means "use retention policy of the realm".
+    # Value -1 means "disable retention policy for this stream unconditionally".
+    # Non-negative values have the natural meaning of "archive messages older than <value> days".
     message_retention_days: Optional[int] = models.IntegerField(null=True, default=None)
 
     # The very first message ID in the stream.  Used to help clients


### PR DESCRIPTION
In my test setup this gives massive performance improvement to noop runs, with 25000 realms, with 100 of those having any retention policies - so something like I think we could expect on zulipchat.
Before the change, it was 2-3 minutes per noop run. With this commit applied that becomes 2.1-2.2 seconds.

Set up running this sloppy snippet in the django shell in dev environment:
```
for i in range(0, 25000):
    Realm.objects.create(
        string_id=f"zulip{i}", name="Zulip Dev", emails_restricted_to_domains=False,
        email_address_visibility=Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS,
        description="The Zulip development environment default organization."
        "  It's great for testing!",
        invite_required=False, org_type=Realm.CORPORATE)
    
for realm in Realm.objects.order_by("-id")[:100]:
    print(f"doing realm {realm.id}")
    realm.message_retention_days = 1000000
    realm.save()
```

I think this should be a relatively safe change, because all that bugs can do is cause some streams/realms not to get archiving run on them - or for the archiving to be called on too many streams/realms, but logic deciding which messages to delete is elsewhere and it reads the retention policy from those objects - so it won't accidentally nuke some stream or realm.