### PR TITLE
home: Use last update_message_flags activity instead of pointer.

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -2332,6 +2332,9 @@ class UserActivity(models.Model):
     class Meta:
         unique_together = ("user_profile", "client", "query")
 
+def get_latest_update_message_flag_activity(user_profile: UserProfile) -> Optional[UserActivity]:
+    return UserActivity.objects.filter(user_profile=user_profile, query='update_message_flags').last()
+
 class UserActivityInterval(models.Model):
     MIN_INTERVAL_LENGTH = datetime.timedelta(minutes=15)
 

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -827,10 +827,10 @@ class HomeTest(ZulipTestCase):
             self._sanity_check(result)
 
     def send_test_message(self, content: str, sender_name: str='iago',
-                          stream_name: str='Denmark', topic_name: str='foo') -> None:
+                          stream_name: str='Denmark', topic_name: str='foo') -> int:
         sender = self.example_user(sender_name)
-        self.send_stream_message(sender, stream_name,
-                                 content=content, topic_name=topic_name)
+        return self.send_stream_message(sender, stream_name,
+                                        content=content, topic_name=topic_name)
 
     def soft_activate_and_get_unread_count(self, stream: str='Denmark', topic: str='foo') -> int:
         stream_narrow = self._get_home_page(stream=stream, topic=topic)

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -11,9 +11,8 @@ from zerver.context_processors import latest_info_context
 from zerver.decorator import zulip_login_required
 from zerver.forms import ToSForm
 from zerver.models import Message, Stream, UserProfile, \
-    Realm, UserMessage, \
-    PreregistrationUser, \
-    get_usermessage_by_message_id
+    Realm, PreregistrationUser, \
+    get_latest_update_message_flag_activity
 from zerver.lib.events import do_events_register
 from zerver.lib.actions import do_change_tos_version, \
     realm_user_count
@@ -105,24 +104,15 @@ def update_last_reminder(user_profile: Optional[UserProfile]) -> None:
         user_profile.last_reminder = None
         user_profile.save(update_fields=["last_reminder"])
 
-def sent_time_in_epoch_seconds(user_message: Optional[UserMessage]) -> Optional[float]:
-    if user_message is None:
-        return None
-    # We have USE_TZ = True, so our datetime objects are timezone-aware.
-    # Return the epoch seconds in UTC.
-    return calendar.timegm(user_message.message.date_sent.utctimetuple())
-
 def get_furthest_read_time(user_profile: Optional[UserProfile]) -> Optional[float]:
-    if user_profile is None:  # nocoverage
+    if user_profile is None:
         furthest_read_time: Optional[float] = time.time()
-    elif user_profile.pointer == -1:
-        furthest_read_time = None
     else:
-        latest_read = get_usermessage_by_message_id(user_profile, user_profile.pointer)
-        if latest_read is None:
-            # Don't completely fail if your saved pointer ID is invalid
-            logging.warning("User %s has invalid pointer %s", user_profile.id, user_profile.pointer)
-        furthest_read_time = sent_time_in_epoch_seconds(latest_read)
+        user_activity = get_latest_update_message_flag_activity(user_profile)
+        if user_activity is None:
+            furthest_read_time = None
+        else:
+            furthest_read_time = calendar.timegm(user_activity.last_visit.utctimetuple())
     return furthest_read_time
 
 def get_bot_types(user_profile: Optional[UserProfile]) -> List[Dict[str, object]]:

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -1114,6 +1114,8 @@ def post_process_limited_query(rows: List[Any],
         history_limited=history_limited,
     )
 
+# NOTE: If this function name is changed ,change the query in
+# zerver.models.get_latest_update_message_flag_activity
 @has_request_variables
 def update_message_flags(request: HttpRequest, user_profile: UserProfile,
                          messages: List[int]=REQ(validator=check_list(check_int)),


### PR DESCRIPTION
The pointer doesn't get updated when a user is only reading messages in
narrowed views. But, we use the pointer position to determine the
furthest read time, which causes the bankruptcy banner to show up even
for users who have been actively reading and sending messages.

This commit switches to using the time of the last update_message_flags
activity by a user to determine the time of last activity.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
