### PR TITLE
stream settings: Close colorpicker when settings overlay is closed.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -935,6 +935,11 @@ exports.initialize = function () {
         });
     }());
 
+    $("#subscriptions_table").on("click", ".exit, #subscription_overlay", function () {
+        const colorpicker = $(" .colorpicker");
+        colorpicker.spectrum('hide');
+    });
+
 };
 
 window.subs = exports;


### PR DESCRIPTION
This commit adds code in overlays.js to close the opened colorpicker
when stream settings overlay is closed.

Fixes #14780.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Peek 2020-05-08 04-14](https://user-images.githubusercontent.com/35494118/81351927-f07db400-90e2-11ea-9e08-9101a45658b1.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
