### PR TITLE
ci: Fix i18n test failure.

### DIFF
--- a/zerver/tests/test_i18n.py
+++ b/zerver/tests/test_i18n.py
@@ -44,7 +44,7 @@ class EmailTranslationTestCase(ZulipTestCase):
         # Also remove the "nocoverage" from check_translation above.
         # check_translation("Viele Grüße", "patch", "/json/settings", {"email": "hamlets-new@zulip.com"})
         check_translation("Incrível!", "post", "/accounts/home/", {"email": "new-email@zulip.com"}, HTTP_ACCEPT_LANGUAGE="pt")
-        check_translation("Danke, dass du", "post", '/accounts/find/', {'emails': hamlet.delivery_email})
+        check_translation("Danke, dass Du", "post", '/accounts/find/', {'emails': hamlet.delivery_email})
         check_translation("Hallo", "post", "/json/invites",  {"invitee_emails": "new-email@zulip.com",
                                                               "stream_ids": ujson.dumps([stream.id])})
 


### PR DESCRIPTION
Idk how master's CI is passing, but this commit f9a61aa645ecb9509a3e2e6b42f204713bb278cb introduces the failure.


following is the failure is see locally without this commit
```
❯ ./tools/test-backend --coverage EmailTranslationTestCase
-- Running tests in serial mode.
Destroying test database for alias 'default'...
Using existing clone for alias 'default'...
Running zerver.tests.test_i18n.EmailTranslationTestCase.test_email_translation

======================================================================
FAIL: test_email_translation (zerver.tests.test_i18n.EmailTranslationTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/aman/zulip/zerver/tests/test_i18n.py", line 47, in test_email_translation
    check_translation("Danke, dass du", "post", '/accounts/find/', {'emails': hamlet.delivery_email})
  File "/home/aman/zulip/zerver/tests/test_i18n.py", line 28, in check_translation
    self.assertIn(phrase, email_message.body)
AssertionError: 'Danke, dass du' not found in 'Hi King Hamlet,\n\nDu kannst Dich bei deiner Zulip-Organisation\nZulip Dev unter folgendem Link anmelden:\n    http://zulip.testserver\n\nDie mit Deinem Account verbundene E-Mail-Adresse ist hamlet@zulip.com.\n\nFalls Du Probleme hast Dich anzumelden, kontaktiere bitte Zulip, indem Du auf diese Mail antwortest.\n\nDanke, dass Du Zulip benutzt!'

----------------------------------------------------------------------
Ran 1 test in 0.335s

FAILED (failures=1)
Destroying test database for alias 'default'...
HTML report saved; visit at http://127.0.0.1:9991/coverage/index.html

```