### PR TITLE
docs: Fix recent regression with server-settings.

### DIFF
--- a/templates/zerver/api/server-settings.md
+++ b/templates/zerver/api/server-settings.md
@@ -36,6 +36,7 @@
 
     **Changes**.  New in Zulip 2.2.  We recommend using an implied value
     of 0 for Zulip servers that do not send this field.
+
 * `push_notifications_enabled`: whether mobile/push notifications are enabled.
 * `is_incompatible`: whether the Zulip client that has sent a request to
   this endpoint is deemed incompatible with the server.


### PR DESCRIPTION
We just needed a blank line after the "Changes"
paragraph.  Otherwise, the list formatting gets
all messed up.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
