### PR TITLE
org settings: Enable message_retention_days in org settings UI. 

### DIFF
--- a/analytics/views.py
+++ b/analytics/views.py
@@ -31,7 +31,7 @@ from analytics.models import BaseCount, InstallationCount, \
     RealmCount, StreamCount, UserCount, last_successful_fill, installation_epoch
 from confirmation.models import Confirmation, confirmation_url, _properties
 from zerver.decorator import require_server_admin, require_server_admin_api, \
-    to_non_negative_int, to_utc_datetime, zulip_login_required, require_non_guest_user
+    to_utc_datetime, zulip_login_required, require_non_guest_user
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_success
@@ -41,6 +41,7 @@ from zerver.views.invite import get_invitee_emails_set
 from zerver.lib.subdomains import get_subdomain_from_hostname
 from zerver.lib.actions import do_change_plan_type, do_deactivate_realm, \
     do_send_realm_reactivation_email, do_scrub_realm
+from zerver.lib.validator import to_non_negative_int
 from confirmation.settings import STATUS_ACTIVE
 
 if settings.BILLING_ENABLED:

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -804,6 +804,8 @@ run_test('set_up', () => {
     };
     $("#id_realm_message_content_edit_limit_minutes").set_parent($.create('<stub edit limit parent>'));
     $("#id_realm_message_content_delete_limit_minutes").set_parent($.create('<stub delete limit parent>'));
+    $("#id_realm_message_retention_days").set_parent($.create('<stub retention period parent>'));
+    $("#id_realm_message_retention_setting").change = noop;
     $("#message_content_in_email_notifications_label").set_parent($.create('<stub in-content setting checkbox>'));
     $("#enable_digest_emails_label").set_parent($.create('<stub digest setting checkbox>'));
     $("#id_realm_digest_weekday").set_parent($.create('<stub digest weekday setting dropdown>'));

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -242,14 +242,14 @@ function test_submit_settings_form(submit_form) {
     invite_to_stream_policy_elem.val('1');
     invite_to_stream_policy_elem.attr("id", 'id_realm_invite_to_stream_policy');
     invite_to_stream_policy_elem.data = () => {
-        return "integer";
+        return "number";
     };
 
     const create_stream_policy_elem = $("#id_realm_create_stream_policy");
     create_stream_policy_elem.val('2');
     create_stream_policy_elem.attr("id", 'id_realm_create_stream_policy');
     create_stream_policy_elem.data = () => {
-        return "integer";
+        return "number";
     };
 
     const add_emoji_by_admins_only_elem = $("#id_realm_add_emoji_by_admins_only");
@@ -260,13 +260,13 @@ function test_submit_settings_form(submit_form) {
     bot_creation_policy_elem.val("1");
     bot_creation_policy_elem.attr('id', 'id_realm_bot_creation_policy');
     bot_creation_policy_elem.data = () => {
-        return "integer";
+        return "number";
     };
     const email_address_visibility_elem = $("#id_realm_email_address_visibility");
     email_address_visibility_elem.val("1");
     email_address_visibility_elem.attr('id', 'id_realm_email_address_visibility');
     email_address_visibility_elem.data = () => {
-        return "integer";
+        return "number";
     };
 
     let subsection_elem = $(`#org-${subsection}`);
@@ -302,13 +302,13 @@ function test_submit_settings_form(submit_form) {
     realm_default_language_elem.val("en");
     realm_default_language_elem.attr('id', 'id_realm_default_language');
     realm_default_language_elem.data = () => {
-        return "text";
+        return "string";
     };
     const realm_default_twenty_four_hour_time_elem = $("#id_realm_default_twenty_four_hour_time");
     realm_default_twenty_four_hour_time_elem.val('true');
     realm_default_twenty_four_hour_time_elem.attr('id', 'id_realm_default_twenty_four_hour_time');
     realm_default_twenty_four_hour_time_elem.data = () => {
-        return "bool";
+        return "boolean";
     };
 
     subsection_elem = $(`#org-${subsection}`);

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -75,7 +75,7 @@ exports.build_page = function () {
         realm_digest_weekday: page_params.realm_digest_weekday,
         show_email: settings_data.show_email(),
         development: page_params.development_environment,
-        plan_includes_wide_organization_logo: page_params.plan_includes_wide_organization_logo,
+        zulip_plan_is_not_limited: page_params.zulip_plan_is_not_limited,
         upgrade_text_for_wide_organization_logo:
             page_params.upgrade_text_for_wide_organization_logo,
         realm_default_external_accounts: page_params.realm_default_external_accounts,

--- a/static/js/settings_config.js
+++ b/static/js/settings_config.js
@@ -156,6 +156,7 @@ const time_limit_dropdown_values = new Map([
 exports.msg_edit_limit_dropdown_values = time_limit_dropdown_values;
 exports.msg_delete_limit_dropdown_values = time_limit_dropdown_values;
 
+exports.retain_message_forever = -1;
 
 // NOTIFICATIONS
 

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -458,7 +458,7 @@ exports.get_input_element_value = function (input_elem) {
             return parseInt(input_elem.val().trim(), 10);
         }
     }
-    return null;
+    return;
 };
 
 exports.set_up = function () {
@@ -744,7 +744,7 @@ exports.build_page = function () {
             input_elem = $(input_elem);
             if (check_property_changed(input_elem)) {
                 const input_value = exports.get_input_element_value(input_elem);
-                if (input_value !== null) {
+                if (input_value !== undefined) {
                     const property_name = input_elem.attr('id').replace("id_realm_", "");
                     data[property_name] = JSON.stringify(input_value);
                 }

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -983,7 +983,7 @@ exports.build_page = function () {
         });
     }
 
-    if (page_params.plan_includes_wide_organization_logo) {
+    if (page_params.zulip_plan_is_not_limited) {
         realm_logo.build_realm_logo_widget(upload_realm_logo, false);
         realm_logo.build_realm_logo_widget(upload_realm_logo, true);
     }

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -444,9 +444,10 @@ exports.change_save_button_state = function ($element, state) {
     show_hide_element($element, is_show, 800);
 };
 
-exports.get_input_element_value = function (input_elem) {
+exports.get_input_element_value = function (input_elem, input_type) {
     input_elem = $(input_elem);
-    const input_type = input_elem.data("setting-widget-type");
+    input_type = ["boolean", "string", "number"].includes(input_type)
+        || input_elem.data("setting-widget-type");
     if (input_type) {
         if (input_type === 'boolean') {
             return input_elem.prop('checked');
@@ -481,8 +482,8 @@ function get_auth_method_table_data() {
 function check_property_changed(elem) {
     elem = $(elem);
     const property_name = exports.extract_property_name(elem);
-    let changed_val;
     let current_val = get_property_value(property_name);
+    let changed_val;
 
     if (property_name === 'realm_authentication_methods') {
         current_val = sort_object_by_key(current_val);
@@ -495,13 +496,8 @@ function check_property_changed(elem) {
         changed_val = parseInt(exports.signup_notifications_stream_widget.value(), 10);
     } else if (property_name === 'realm_default_code_block_language') {
         changed_val = exports.default_code_language_widget.value();
-    } else if (typeof current_val === 'boolean') {
-        changed_val = elem.prop('checked');
-    } else if (typeof current_val === 'string') {
-        changed_val = elem.val().trim();
-    } else if (typeof current_val === 'number') {
-        current_val = current_val.toString();
-        changed_val = elem.val().trim();
+    } else if (current_val !== undefined) {
+        changed_val = exports.get_input_element_value(elem, typeof current_val);
     } else {
         blueslip.error('Element refers to unknown property ' + property_name);
     }

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -119,6 +119,14 @@ function get_property_value(property_name) {
         return "custom_limit";
     }
 
+    if (property_name === 'realm_message_retention_setting') {
+        if (page_params.realm_message_retention_days === null ||
+            page_params.realm_message_retention_days === settings_config.retain_message_forever) {
+            return "retain_forever";
+        }
+        return "retain_for_period";
+    }
+
     if (property_name === 'realm_msg_delete_limit_setting') {
         if (!page_params.realm_allow_message_deleting) {
             return "never";
@@ -231,6 +239,13 @@ function set_msg_delete_limit_dropdown() {
                                           value === "custom_limit");
 }
 
+function set_message_retention_setting_dropdown() {
+    const value = get_property_value("realm_message_retention_setting");
+    $("#id_realm_message_retention_setting").val(value);
+    change_element_block_display_property('id_realm_message_retention_days',
+                                          value === "retain_for_period");
+}
+
 function set_org_join_restrictions_dropdown() {
     const value = get_property_value("realm_org_join_restrictions");
     $("#id_realm_org_join_restrictions").val(value);
@@ -324,6 +339,8 @@ function update_dependent_subsettings(property_name) {
     } else if (property_name === 'realm_msg_edit_limit_setting' ||
                property_name === 'realm_message_content_edit_limit_minutes') {
         set_msg_edit_limit_dropdown();
+    } else if (property_name === 'realm_message_retention_days') {
+        set_message_retention_setting_dropdown();
     } else if (property_name === 'realm_msg_delete_limit_setting' ||
         property_name === 'realm_message_content_delete_limit_minutes') {
         set_msg_delete_limit_dropdown();
@@ -573,6 +590,7 @@ exports.build_page = function () {
     set_video_chat_provider_dropdown();
     set_msg_edit_limit_dropdown();
     set_msg_delete_limit_dropdown();
+    set_message_retention_setting_dropdown();
     set_org_join_restrictions_dropdown();
     set_message_content_in_email_notifications_visiblity();
     set_digest_emails_weekday_visibility();
@@ -668,19 +686,17 @@ exports.build_page = function () {
                 parseInt(exports.notifications_stream_widget.value(), 10));
             data.signup_notifications_stream_id = JSON.stringify(
                 parseInt(exports.signup_notifications_stream_widget.value(), 10));
-        } else if (subsection === 'other_settings') {
-            let new_message_retention_days = $("#id_realm_message_retention_days").val();
-
-            if (parseInt(new_message_retention_days, 10).toString() !== new_message_retention_days
-                && new_message_retention_days !== "") {
-                new_message_retention_days = "";
+        } else if (subsection === 'message_retention') {
+            const message_retention_setting_value = $('#id_realm_message_retention_setting').val();
+            if (message_retention_setting_value === 'retain_forever') {
+                data.message_retention_days = settings_config.retain_message_forever;
+            } else {
+                data.message_retention_days = exports.get_input_element_value(
+                    $('#id_realm_message_retention_days'));
             }
-
+        } else if (subsection === 'other_settings') {
             const code_block_language_value = exports.default_code_language_widget.value();
             data.default_code_block_language = JSON.stringify(code_block_language_value);
-
-            data.message_retention_days = new_message_retention_days !== "" ?
-                JSON.stringify(parseInt(new_message_retention_days, 10)) : null;
         } else if (subsection === 'other_permissions') {
             const add_emoji_permission = $("#id_realm_add_emoji_by_admins_only").val();
 
@@ -783,6 +799,12 @@ exports.build_page = function () {
         const msg_delete_limit_dropdown_value = e.target.value;
         change_element_block_display_property('id_realm_message_content_delete_limit_minutes',
                                               msg_delete_limit_dropdown_value === 'custom_limit');
+    });
+
+    $("#id_realm_message_retention_setting").change(function (e) {
+        const message_retention_setting_dropdown_value = e.target.value;
+        change_element_block_display_property('id_realm_message_retention_days',
+                                              message_retention_setting_dropdown_value === 'retain_for_period');
     });
 
     $("#id_realm_waiting_period_setting").change(function () {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -448,13 +448,13 @@ exports.get_input_element_value = function (input_elem) {
     input_elem = $(input_elem);
     const input_type = input_elem.data("setting-widget-type");
     if (input_type) {
-        if (input_type === 'bool') {
+        if (input_type === 'boolean') {
             return input_elem.prop('checked');
         }
-        if (input_type === 'text') {
+        if (input_type === 'string') {
             return input_elem.val().trim();
         }
-        if (input_type === 'integer') {
+        if (input_type === 'number') {
             return parseInt(input_elem.val().trim(), 10);
         }
     }

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -67,7 +67,7 @@
             </label>
 
             <div class="input-group {{#unless enable_sound_select}}control-label-disabled{{/unless}}">
-                <select name="notification_sound" id="notification_sound" data-setting-widget-type="text"
+                <select name="notification_sound" id="notification_sound" data-setting-widget-type="string"
                   {{#unless enable_sound_select}}
                   disabled
                   {{/unless}}>
@@ -83,7 +83,7 @@
             <div class="input-group">
                 <label for="desktop_icon_count_display" class="dropdown-title">{{ settings_label.desktop_icon_count_display }}</label>
                 <select name="desktop_icon_count_display" id="desktop_icon_count_display" class="prop-element"
-                  data-setting-widget-type="integer">
+                  data-setting-widget-type="number">
                     {{> dropdown_options_widget option_values=desktop_icon_count_display_values}}
                 </select>
             </div>

--- a/static/templates/settings/notification_settings_checkboxes.hbs
+++ b/static/templates/settings/notification_settings_checkboxes.hbs
@@ -2,7 +2,7 @@
     <label class="checkbox">
         <input type="checkbox" name="{{setting_name}}" id="{{prefix}}{{setting_name}}"
           {{#if is_disabled}}disabled="disabled"{{/if}}
-          {{#if is_checked}}checked="checked"{{/if}} data-setting-widget-type="bool"/>
+          {{#if is_checked}}checked="checked"{{/if}} data-setting-widget-type="boolean"/>
         <span></span>
     </label>
 </td>

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -84,7 +84,7 @@
                         <i class="fa fa-question-circle-o" aria-hidden="true"></i>
                     </a>
                 </label>
-                <select name="realm_email_address_visibility" class="setting-widget prop-element" id="id_realm_email_address_visibility" data-setting-widget-type="integer">
+                <select name="realm_email_address_visibility" class="setting-widget prop-element" id="id_realm_email_address_visibility" data-setting-widget-type="number">
                     {{> dropdown_options_widget option_values=email_address_visibility_values}}
                 </select>
             </div>
@@ -98,13 +98,13 @@
             <div class="m-10 inline-block organization-permissions-parent">
                 <div class="input-group">
                     <label for="realm_create_stream_policy" class="dropdown-title">{{t "Who can create streams" }}</label>
-                    <select name="realm_create_stream_policy" id="id_realm_create_stream_policy" class="prop-element" data-setting-widget-type="integer">
+                    <select name="realm_create_stream_policy" id="id_realm_create_stream_policy" class="prop-element" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=create_stream_policy_values}}
                     </select>
                 </div>
                 <div class="input-group">
                     <label for="realm_invite_to_stream_policy" class="dropdown-title">{{t "Who can add users to streams" }}</label>
-                    <select name="realm_invite_to_stream_policy" id="id_realm_invite_to_stream_policy" class="prop-element" data-setting-widget-type="integer">
+                    <select name="realm_invite_to_stream_policy" id="id_realm_invite_to_stream_policy" class="prop-element" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=invite_to_stream_policy_values}}
                     </select>
                 </div>
@@ -119,14 +119,14 @@
             <div class="m-10 inline-block organization-permissions-parent">
                 <div class="input-group">
                     <label for="realm_bot_creation_policy">{{t "Who can add bots" }}</label>
-                    <select name="realm_bot_creation_policy" class="setting-widget prop-element" id="id_realm_bot_creation_policy" data-setting-widget-type="integer">
+                    <select name="realm_bot_creation_policy" class="setting-widget prop-element" id="id_realm_bot_creation_policy" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=bot_creation_policy_values}}
                     </select>
                 </div>
 
                 <div class="input-group">
                     <label for="realm_user_group_edit_policy" class="dropdown-title">{{t "Who can create and manage user groups" }}</label>
-                    <select name="realm_user_group_edit_policy" id="id_realm_user_group_edit_policy" class="prop-element" data-setting-widget-type="integer">
+                    <select name="realm_user_group_edit_policy" id="id_realm_user_group_edit_policy" class="prop-element" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=user_group_edit_policy_values}}
                     </select>
                 </div>
@@ -145,7 +145,7 @@
                             <i class="fa fa-question-circle-o" aria-hidden="true"></i>
                         </a>
                     </label>
-                    <select name="realm_private_message_policy" class="setting-widget prop-element" id="id_realm_private_message_policy" data-setting-widget-type="integer">
+                    <select name="realm_private_message_policy" class="setting-widget prop-element" id="id_realm_private_message_policy" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=private_message_policy_values}}
                     </select>
                 </div>

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -45,7 +45,7 @@
                 </div>
                 {{!-- This setting is hidden unless `custom_days` --}}
                 <div class="dependent-block">
-                    <label for="aitin" class="inline-block">{{t "Waiting period (days)" }}:</label>
+                    <label for="id_realm_waiting_period_threshold" class="inline-block">{{t "Waiting period (days)" }}:</label>
                     <input type="text" id="id_realm_waiting_period_threshold"
                       name="realm_waiting_period_threshold"
                       class="admin-realm-time-limit-input prop-element"

--- a/static/templates/settings/organization_profile_admin.hbs
+++ b/static/templates/settings/organization_profile_admin.hbs
@@ -58,13 +58,7 @@
                     <i class="fa fa-question-circle-o" aria-hidden="true"></i>
                 </a>
             </h3>
-            <div>
-                {{#unless plan_includes_wide_organization_logo}}
-                <a href="/upgrade" class="upgrade-tip" target="_blank">
-                    {{upgrade_text_for_wide_organization_logo}}
-                </a>
-                {{/unless}}
-            </div>
+            {{> upgrade_tip_widget }}
         </div>
 
         <p>{{t "A wide image for the upper left corner of the app." }}</p>

--- a/static/templates/settings/organization_profile_admin.hbs
+++ b/static/templates/settings/organization_profile_admin.hbs
@@ -16,13 +16,13 @@
                 <div class="input-group admin-realm">
                     <label for="id_realm_name">{{t "Organization name" }}</label>
                     <input type="text" id="id_realm_name" name="realm_name" class="admin-realm-name setting-widget prop-element"
-                      autocomplete="off" data-setting-widget-type="text"
+                      autocomplete="off" data-setting-widget-type="string"
                       value="{{ realm_name }}" maxlength="40" />
                 </div>
                 <div class="input-group admin-realm">
                     <label for="realm_description">{{t "Organization description" }}</label>
                     <textarea id="id_realm_description" name="realm_description" class="admin-realm-description setting-widget prop-element"
-                      maxlength="1000" data-setting-widget-type="text">{{ realm_description }}</textarea>
+                      maxlength="1000" data-setting-widget-type="string">{{ realm_description }}</textarea>
                 </div>
             </div>
         </div>

--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -142,6 +142,39 @@
             </div>
         </div>
 
+        <div id="org-message-retention" class="org-subsection-parent">
+            <div class="subsection-header">
+                <h3>{{t "Message retention" }}</h3>
+                {{> settings_save_discard_widget section_name="message-retention" }}
+            </div>
+
+            {{> upgrade_tip_widget }}
+
+            <div class="inline-block organization-settings-parent">
+                <div class="input-group">
+                    <label for="id_realm_message_retention_setting" class="dropdown-title">{{t "Message retention period" }}</label>
+                    <select name="realm_message_retention_setting"
+                      id="id_realm_message_retention_setting" class="prop-element"
+                      {{#unless zulip_plan_is_not_limited}}disabled{{/unless}}>
+                        <option value="retain_forever">{{t 'Retain forever' }}</option>
+                        <option value="retain_for_period">{{t 'Retain for N days after posting' }}</option>
+                    </select>
+
+                    <div class="dependent-inline-block">
+                        <label for="id_realm_message_retention_days" class="inline-block realm-time-limit-label">
+                            {{t 'N' }}:
+                        </label>
+                        <input type="text" id="id_realm_message_retention_days" autocomplete="off"
+                          name="realm_message_retention_days"
+                          class="admin-realm-message-retention-days prop-element"
+                          value="{{ realm_message_retention_days }}"
+                          data-setting-widget-type="number"
+                          {{#unless zulip_plan_is_not_limited}}disabled{{/unless}}/>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <div id="org-other-settings" class="org-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "Other settings" }}</h3>
@@ -209,18 +242,6 @@
                   is_checked=realm_message_content_allowed_in_email_notifications
                   label=admin_settings_label.realm_message_content_allowed_in_email_notifications}}
 
-                {{#if false}}
-                <div class="input-group">
-                    <label for="realm_message_retention_days"
-                      id="id_realm_message_retention_days_label">
-                        {{t 'Messages retention period in days (blank means messages are retained forever)' }}
-                    </label>
-                    <input type="text" id="id_realm_message_retention_days"
-                      name="realm_message_retention_days"
-                      class="admin-realm-message-retention-days prop-element"
-                      value="{{ realm_message_retention_days }}"/>
-                </div>
-                {{/if}}
                 {{> settings_checkbox
                   setting_name="realm_mandatory_topics"
                   prefix="id_"

--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -90,7 +90,7 @@
                     <select name="realm_digest_weekday"
                       id="id_realm_digest_weekday"
                       class="setting-widget prop-element"
-                      data-setting-widget-type="integer">
+                      data-setting-widget-type="number">
                         <option value="0">{{t "Monday" }}</option>
                         <option value="1">{{t "Tuesday" }}</option>
                         <option value="2">{{t "Wednesday" }}</option>
@@ -125,7 +125,7 @@
             <div class="inline-block organization-settings-parent">
                 <div class="input-group">
                     <label for="realm_default_language" class="dropdown-title">{{t "Default language" }}</label>
-                    <select name="realm_default_language" class ="setting-widget prop-element" id="id_realm_default_language" data-setting-widget-type="text">
+                    <select name="realm_default_language" class ="setting-widget prop-element" id="id_realm_default_language" data-setting-widget-type="string">
                         {{#each language_list}}
                         <option value='{{this.code}}'>{{this.name}}</option>
                         {{/each}}
@@ -133,7 +133,7 @@
                 </div>
                 <div class="input-group">
                     <label for="realm_default_twenty_four_hour_time" class="dropdown-title">{{ admin_settings_label.realm_default_twenty_four_hour_time }}</label>
-                    <select name="realm_default_twenty_four_hour_time" class ="setting-widget prop-element" id="id_realm_default_twenty_four_hour_time" data-setting-widget-type="text">
+                    <select name="realm_default_twenty_four_hour_time" class ="setting-widget prop-element" id="id_realm_default_twenty_four_hour_time" data-setting-widget-type="string">
                         {{#each realm_default_twenty_four_hour_time_values}}
                         <option value='{{ this.value }}'>{{ this.description }}</option>
                         {{/each}}
@@ -152,7 +152,7 @@
                     <label for="realm_video_chat_provider" class="dropdown-title">
                         {{t 'Video chat provider' }}
                     </label>
-                    <select name="realm_video_chat_provider" class ="setting-widget prop-element" id="id_realm_video_chat_provider" data-setting-widget-type="integer">
+                    <select name="realm_video_chat_provider" class ="setting-widget prop-element" id="id_realm_video_chat_provider" data-setting-widget-type="number">
                         {{#each realm_available_video_chat_providers}}
                         <option value='{{this.id}}'>{{this.name}}</option>
                         {{/each}}
@@ -163,7 +163,7 @@
                           name="realm_google_hangouts_domain"
                           autocomplete="off"
                           class="admin-realm-google-hangouts-domain setting-widget prop-element"
-                          data-setting-widget-type="text"/>
+                          data-setting-widget-type="string"/>
                     </div>
                     <div id="zoom_help_text" class="zoom_credentials">
                         <p>
@@ -177,7 +177,7 @@
                           name="realm_zoom_user_id"
                           autocomplete="off"
                           class="admin-realm-zoom-field setting-widget prop-element"
-                          data-setting-widget-type="text"/>
+                          data-setting-widget-type="string"/>
                     </div>
                     <div id="zoom_api_key" class="zoom_credentials">
                         <label>{{t 'Zoom API key (required)' }}:</label>
@@ -185,7 +185,7 @@
                           name="realm_zoom_api_key"
                           autocomplete="off"
                           class="admin-realm-zoom-field setting-widget prop-element"
-                          data-setting-widget-type="text"/>
+                          data-setting-widget-type="string"/>
                     </div>
                     <div id="zoom_api_secret" class="zoom_credentials">
                         <label>{{t 'Zoom API secret (required if changed)' }}:</label>
@@ -193,7 +193,7 @@
                           name="realm_zoom_api_secret"
                           autocomplete="off"
                           class="admin-realm-zoom-field setting-widget prop-element"
-                          data-setting-widget-type="text"/>
+                          data-setting-widget-type="string"/>
                     </div>
                 </div>
 

--- a/static/templates/settings/realm-logo-widget.hbs
+++ b/static/templates/settings/realm-logo-widget.hbs
@@ -7,7 +7,7 @@
     {{#if is_admin}}
     <div class="inline-block avatar-controls">
         <div class="realm-logo-file-input-error alert text-error"></div>
-        {{#if plan_includes_wide_organization_logo}}
+        {{#if zulip_plan_is_not_limited}}
         <button class="realm-logo-upload-button button rounded sea-green w-200 block input-size {{theme_mode}}-settings">
             <span class="upload-logo-button-text">{{t 'Upload new logo' }}</span>
             <span class="upload-logo-spinner"></span>

--- a/static/templates/settings/settings_checkbox.hbs
+++ b/static/templates/settings/settings_checkbox.hbs
@@ -1,7 +1,7 @@
 {{#unless (eq render_only false)}}
 <div class="input-group {{#if is_nested}}disableable{{/if}}">
     <label class="checkbox">
-        <input type="checkbox" class="inline-block setting-widget prop-element" name="{{setting_name}}" data-setting-widget-type="bool"
+        <input type="checkbox" class="inline-block setting-widget prop-element" name="{{setting_name}}" data-setting-widget-type="boolean"
           id="{{prefix}}{{setting_name}}" {{#if is_checked}}checked="checked"{{/if}} />
         <span></span>
     </label>

--- a/static/templates/settings/upgrade_tip_widget.hbs
+++ b/static/templates/settings/upgrade_tip_widget.hbs
@@ -1,0 +1,7 @@
+<div>
+    {{#unless plan_includes_wide_organization_logo}}
+    <a href="/upgrade" class="upgrade-tip" target="_blank">
+        {{upgrade_text_for_wide_organization_logo}}
+    </a>
+    {{/unless}}
+</div>

--- a/static/templates/settings/upgrade_tip_widget.hbs
+++ b/static/templates/settings/upgrade_tip_widget.hbs
@@ -1,5 +1,5 @@
 <div>
-    {{#unless plan_includes_wide_organization_logo}}
+    {{#unless zulip_plan_is_not_limited}}
     <a href="/upgrade" class="upgrade-tip" target="_blank">
         {{upgrade_text_for_wide_organization_logo}}
     </a>

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -26,7 +26,6 @@ from zerver.lib.exceptions import JsonableError, ErrorCode, \
     InvalidJSONError, InvalidAPIKeyError, InvalidAPIKeyFormatError, \
     OrganizationAdministratorRequired
 from zerver.lib.types import ViewFuncT
-from zerver.lib.validator import to_non_negative_int
 
 from zerver.lib.rate_limiter import RateLimitedUser
 from zerver.lib.request import REQ, has_request_variables
@@ -715,13 +714,6 @@ def internal_notify_view(is_tornado_view: bool) -> Callable[[ViewFuncT], ViewFun
             return view_func(request, *args, **kwargs)
         return _wrapped_func_arguments
     return _wrapped_view_func
-
-
-def to_not_negative_int_or_none(s: str) -> Optional[int]:
-    if s:
-        return to_non_negative_int(s)
-    return None
-
 
 def to_utc_datetime(timestamp: str) -> datetime.datetime:
     return timestamp_to_datetime(float(timestamp))

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -167,7 +167,7 @@ def fetch_initial_state_data(user_profile: UserProfile,
         state['realm_push_notifications_enabled'] = push_notifications_enabled()
         state['realm_upload_quota'] = realm.upload_quota_bytes()
         state['realm_plan_type'] = realm.plan_type
-        state['plan_includes_wide_organization_logo'] = realm.plan_type != Realm.LIMITED
+        state['zulip_plan_is_not_limited'] = realm.plan_type != Realm.LIMITED
         state['upgrade_text_for_wide_organization_logo'] = str(Realm.UPGRADE_TEXT_STANDARD)
         state['realm_default_external_accounts'] = DEFAULT_EXTERNAL_ACCOUNTS
 
@@ -526,7 +526,7 @@ def apply_event(state: Dict[str, Any],
 
             if event['property'] == 'plan_type':
                 # Then there are some extra fields that also need to be set.
-                state['plan_includes_wide_organization_logo'] = event['value'] != Realm.LIMITED
+                state['zulip_plan_is_not_limited'] = event['value'] != Realm.LIMITED
                 state['realm_upload_quota'] = event['extra_data']['upload_quota']
 
             policy_permission_dict = {'create_stream_policy': 'can_create_streams',

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -418,6 +418,17 @@ def to_non_negative_int(s: str, max_int_size: int=2**32-1) -> int:
         raise ValueError('%s is too large (max %s)' % (x, max_int_size))
     return x
 
+def to_positive_or_allowed_int(allowed_integer: int) -> Callable[[str], int]:
+    @set_type_structure('int')
+    def convertor(s: str) -> int:
+        x = int(s)
+        if x is allowed_integer:
+            return x
+        if x == 0:
+            raise ValueError("argument is 0")
+        return to_non_negative_int(s)
+    return convertor
+
 @set_type_structure('any(List[int], str)]')
 def check_string_or_int_list(var_name: str, val: object) -> Optional[str]:
     if isinstance(val, str):

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -264,6 +264,7 @@ class Realm(models.Model):
         "Stream", related_name="+", null=True, blank=True, on_delete=CASCADE
     )
 
+    RETAIN_MESSAGE_FOREVER = -1
     # For old messages being automatically deleted
     message_retention_days: Optional[int] = models.IntegerField(null=True)
 

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -37,7 +37,7 @@ from zerver.decorator import (
     authenticate_notify, cachify,
     get_client_name, internal_notify_view, is_local_addr,
     rate_limit, validate_api_key,
-    return_success_on_head_request, to_not_negative_int_or_none,
+    return_success_on_head_request,
     zulip_login_required
 )
 from zerver.lib.cache import ignore_unhashable_lru_cache, dict_to_items_tuple, items_tuple_to_dict
@@ -45,7 +45,8 @@ from zerver.lib.validator import (
     check_string, check_dict, check_dict_only, check_bool, check_float, check_int, check_list, Validator,
     check_variable_type, equals, check_none_or, check_url, check_short_string,
     check_string_fixed_length, check_capped_string, check_color, to_non_negative_int,
-    check_string_or_int_list, check_string_or_int, check_int_in, check_string_in
+    check_string_or_int_list, check_string_or_int, check_int_in, check_string_in,
+    to_positive_or_allowed_int
 )
 from zerver.models import \
     get_realm, get_user, UserProfile, Realm
@@ -773,11 +774,13 @@ class ValidatorTestCase(TestCase):
         with self.assertRaisesRegex(ValueError, re.escape('%s is too large (max %s)' % (2**32, 2**32-1))):
             self.assertEqual(to_non_negative_int(str(2**32)))
 
-    def test_check_to_not_negative_int_or_none(self) -> None:
-        self.assertEqual(to_not_negative_int_or_none('5'), 5)
-        self.assertEqual(to_not_negative_int_or_none(None), None)
+    def test_to_positive_or_allowed_int(self) -> None:
+        self.assertEqual(to_positive_or_allowed_int(-1)('5'), 5)
+        self.assertEqual(to_positive_or_allowed_int(-1)('-1'), -1)
+        with self.assertRaisesRegex(ValueError, 'argument is negative'):
+            to_positive_or_allowed_int(-1)('-5')
         with self.assertRaises(ValueError):
-            to_not_negative_int_or_none('-5')
+            to_positive_or_allowed_int(-1)('0')
 
     def test_check_float(self) -> None:
         x: Any = 5.5

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1990,7 +1990,7 @@ class EventsRegisterTest(ZulipTestCase):
 
         state_data = fetch_initial_state_data(self.user_profile, None, "", False)
         self.assertEqual(state_data['realm_plan_type'], Realm.SELF_HOSTED)
-        self.assertEqual(state_data['plan_includes_wide_organization_logo'], True)
+        self.assertEqual(state_data['zulip_plan_is_not_limited'], True)
 
         schema_checker = self.check_events_dict([
             ('type', equals('realm')),
@@ -2007,7 +2007,7 @@ class EventsRegisterTest(ZulipTestCase):
 
         state_data = fetch_initial_state_data(self.user_profile, None, "", False)
         self.assertEqual(state_data['realm_plan_type'], Realm.LIMITED)
-        self.assertEqual(state_data['plan_includes_wide_organization_logo'], False)
+        self.assertEqual(state_data['zulip_plan_is_not_limited'], False)
 
     def test_realm_emoji_events(self) -> None:
         schema_checker = self.check_events_dict([

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -115,7 +115,6 @@ class HomeTest(ZulipTestCase):
             "notification_sound",
             "password_min_guesses",
             "password_min_length",
-            "plan_includes_wide_organization_logo",
             "pm_content_in_desktop_notifications",
             "pointer",
             "poll_timeout",
@@ -226,6 +225,7 @@ class HomeTest(ZulipTestCase):
             "webpack_public_path",
             "wildcard_mentions_notify",
             "zulip_feature_level",
+            "zulip_plan_is_not_limited",
             "zulip_version",
         ]
 

--- a/zerver/tornado/views.py
+++ b/zerver/tornado/views.py
@@ -5,10 +5,11 @@ import ujson
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
 
-from zerver.decorator import REQ, to_non_negative_int, \
-    has_request_variables, internal_notify_view, process_client
+from zerver.decorator import REQ, has_request_variables, internal_notify_view, \
+    process_client
 from zerver.lib.response import json_error, json_success
-from zerver.lib.validator import check_bool, check_int, check_list, check_string
+from zerver.lib.validator import check_bool, check_int, check_list, check_string, \
+    to_non_negative_int
 from zerver.models import Client, UserProfile, get_client, get_user_profile_by_id
 from zerver.tornado.event_queue import fetch_events, \
     get_client_descriptor, process_notification

--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -9,8 +9,7 @@ from typing import Dict, List, Set, Any, Iterable, \
     Optional, Tuple, Union, Sequence, cast
 from zerver.lib.exceptions import JsonableError, ErrorCode
 from zerver.lib.html_diff import highlight_html_differences
-from zerver.decorator import has_request_variables, \
-    REQ, to_non_negative_int
+from zerver.decorator import has_request_variables, REQ
 from django.utils.html import escape as escape_html
 from zerver.lib import bugdown
 from zerver.lib.zcommand import process_zcommands
@@ -50,7 +49,7 @@ from zerver.lib.utils import statsd
 from zerver.lib.validator import \
     check_list, check_int, check_dict, check_string, check_bool, \
     check_string_or_int_list, check_string_or_int, check_string_in, \
-    check_required_string
+    check_required_string, to_non_negative_int
 from zerver.lib.zephyr import compute_mit_user_fullname
 from zerver.models import Message, UserProfile, Stream, Subscription, Client,\
     Realm, RealmDomain, Recipient, UserMessage, \

--- a/zerver/views/pointer.py
+++ b/zerver/views/pointer.py
@@ -1,10 +1,10 @@
 from django.http import HttpRequest, HttpResponse
 from django.utils.translation import ugettext as _
 
-from zerver.decorator import to_non_negative_int
 from zerver.lib.actions import do_update_pointer
 from zerver.lib.request import has_request_variables, JsonableError, REQ
 from zerver.lib.response import json_success
+from zerver.lib.validator import to_non_negative_int
 from zerver.models import UserProfile, get_usermessage_by_message_id
 
 def get_pointer_backend(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext as _
 from django.core.exceptions import ValidationError
 from django.views.decorators.http import require_safe
 
-from zerver.decorator import require_realm_admin, to_non_negative_int, to_not_negative_int_or_none
+from zerver.decorator import require_realm_admin
 from zerver.lib.actions import (
     do_set_realm_message_editing,
     do_set_realm_message_deleting,
@@ -19,7 +19,8 @@ from zerver.lib.actions import (
 from zerver.lib.i18n import get_available_language_codes
 from zerver.lib.request import has_request_variables, REQ, JsonableError
 from zerver.lib.response import json_success, json_error
-from zerver.lib.validator import check_string, check_dict, check_bool, check_int, check_int_in
+from zerver.lib.validator import check_string, check_dict, check_bool, check_int, \
+    check_int_in, to_positive_or_allowed_int, to_non_negative_int
 from zerver.lib.streams import access_stream_by_id
 from zerver.lib.domains import validate_domain
 from zerver.lib.video_calls import request_zoom_video_call_url
@@ -55,7 +56,8 @@ def update_realm(
         authentication_methods: Optional[Dict[Any, Any]]=REQ(validator=check_dict([]), default=None),
         notifications_stream_id: Optional[int]=REQ(validator=check_int, default=None),
         signup_notifications_stream_id: Optional[int]=REQ(validator=check_int, default=None),
-        message_retention_days: Optional[int]=REQ(converter=to_not_negative_int_or_none, default=None),
+        message_retention_days: Optional[int] = REQ(converter=to_positive_or_allowed_int(
+            Realm.RETAIN_MESSAGE_FOREVER), default=None),
         send_welcome_emails: Optional[bool]=REQ(validator=check_bool, default=None),
         digest_emails_enabled: Optional[bool]=REQ(validator=check_bool, default=None),
         message_content_allowed_in_email_notifications: Optional[bool]=REQ(

--- a/zerver/views/report.py
+++ b/zerver/views/report.py
@@ -6,8 +6,7 @@ from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
-from zerver.decorator import human_users_only, \
-    to_non_negative_int
+from zerver.decorator import human_users_only
 from zerver.lib.bugdown import privacy_clean_markdown
 from zerver.lib.request import has_request_variables, REQ
 from zerver.lib.response import json_success
@@ -15,7 +14,7 @@ from zerver.lib.queue import queue_json_publish
 from zerver.lib.storage import static_path
 from zerver.lib.unminify import SourceMap
 from zerver.lib.utils import statsd, statsd_key
-from zerver.lib.validator import check_bool, check_dict
+from zerver.lib.validator import check_bool, check_dict, to_non_negative_int
 from zerver.models import UserProfile
 
 import subprocess

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -9,7 +9,7 @@ from django.http import HttpRequest, HttpResponse
 from zerver.lib.exceptions import JsonableError, ErrorCode
 from zerver.lib.request import REQ, has_request_variables
 from zerver.decorator import authenticated_json_post_view, \
-    require_realm_admin, to_non_negative_int, require_non_guest_user
+    require_realm_admin, require_non_guest_user
 from zerver.lib.actions import bulk_remove_subscriptions, \
     do_change_subscription_property, internal_prep_private_message, \
     internal_prep_stream_message, \
@@ -28,7 +28,7 @@ from zerver.lib.streams import access_stream_by_id, access_stream_by_name, \
 from zerver.lib.topic import get_topic_history_for_stream, messages_for_topic
 from zerver.lib.validator import check_string, check_int, check_list, check_dict, \
     check_bool, check_variable_type, check_capped_string, check_color, check_dict_only, \
-    check_int_in
+    check_int_in, to_non_negative_int
 from zerver.models import UserProfile, Stream, Realm, UserMessage, \
     get_system_bot, get_active_user
 


### PR DESCRIPTION
Since production testing of `message_retention_days` is finished, we can
enable this feature in the organization settings page. We already had this
setting in frontend but it was bit rotten and not rendered in templates.

Here we replaced our past text-input based setting with a
dropdown-with-text-input setting approach which is more consistent with our
existing UI.

Along with frontend changes, we also incorporated a backend change to
handle making retention period forever. This change introduces a new
convertor `to_positive_or_allowed_int` which only allows positive integers
and an allowed value for settings like `message_retention_days` which can
be a positive integer or has the value `Realm.RETAIN_MESSAGE_FOREVER` when
we change the setting to retain message forever.

This change made `to_not_negative_int_or_none` redundant so removed it as
well.

Fixes: #14854

GIF: For non-limited Zulip plan
![Peek 2020-05-08 17-59](https://user-images.githubusercontent.com/40331304/81405866-214b0100-9156-11ea-8ad5-625295027a81.gif)
For Limited Zulip plan
![Peek 2020-05-08 18-00](https://user-images.githubusercontent.com/40331304/81405879-29a33c00-9156-11ea-95ec-ecec837c8283.gif)
