### PR TITLE
queue_processors: Remove the slow_queries queue.

### DIFF
--- a/puppet/zulip/manifests/base.pp
+++ b/puppet/zulip/manifests/base.pp
@@ -82,7 +82,6 @@ class zulip::base {
     'missedmessage_mobile_notifications',
     'outgoing_webhooks',
     'signups',
-    'slow_queries',
     'user_activity',
     'user_activity_interval',
     'user_presence',

--- a/puppet/zulip_ops/files/nagios3/conf.d/services.cfg
+++ b/puppet/zulip_ops/files/nagios3/conf.d/services.cfg
@@ -463,7 +463,7 @@ define service {
 # The following queue workers batch-process events and thus can't be
 # monitored by checking for running consumers:
 #
-#     user_activity, slow_queries, missedmessage_emails
+#     user_activity, missedmessage_emails
 
 define service {
         use                             generic-service
@@ -496,15 +496,6 @@ define service {
         use                             generic-service
         service_description             Check outgoing webhooks queue processor
         check_command                   check_remote_arg_string!manage.py process_queue --queue_name=outgoing_webhooks!1:1!1:1
-        max_check_attempts              3
-        hostgroup_name                  frontends
-        contact_groups                  admins
-}
-
-define service {
-        use                             generic-service
-        service_description             Check slow_queries queue processor
-        check_command                   check_remote_arg_string!manage.py process_queue --queue_name=slow_queries!1:1!1:1
         max_check_attempts              3
         hostgroup_name                  frontends
         contact_groups                  admins

--- a/scripts/lib/check_rabbitmq_queue.py
+++ b/scripts/lib/check_rabbitmq_queue.py
@@ -22,7 +22,6 @@ normal_queues = [
     'missedmessage_mobile_notifications',
     'outgoing_webhooks',
     'signups',
-    'slow_queries',
     'user_activity',
     'user_activity_interval',
     'user_presence',
@@ -43,24 +42,20 @@ states = {
 MAX_SECONDS_TO_CLEAR_FOR_BURSTS: DefaultDict[str, int] = defaultdict(
     lambda: 120,
     digest_emails=600,
-    slow_queries=600,
 )
 MAX_SECONDS_TO_CLEAR_NORMAL: DefaultDict[str, int] = defaultdict(
     lambda: 30,
     digest_emails=1200,
-    slow_queries=120,
     missedmessage_mobile_notifications=120,
 )
 CRITICAL_SECONDS_TO_CLEAR_FOR_BURSTS: DefaultDict[str, int] = defaultdict(
     lambda: 240,
     digest_emails=1200,
-    slow_queries=1200,
 )
 CRITICAL_SECONDS_TO_CLEAR_NORMAL: DefaultDict[str, int] = defaultdict(
     lambda: 60,
     missedmessage_mobile_notifications=180,
     digest_emails=600,
-    slow_queries=600,
 )
 
 def analyze_queue_stats(queue_name: str, stats: Dict[str, Any],

--- a/tools/test-queue-worker-reload
+++ b/tools/test-queue-worker-reload
@@ -14,7 +14,7 @@ sanity_check.check_venv(__file__)
 
 # TODO: Convert this to use scripts/lib/queue_workers.py
 TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
-successful_worker_launch = '[process_queue] 17 queue worker threads were launched\n'
+successful_worker_launch = '[process_queue] 16 queue worker threads were launched\n'
 
 def check_worker_launch(run_dev: "subprocess.Popen[str]") -> bool:
     failed = False

--- a/zerver/tests/test_middleware.py
+++ b/zerver/tests/test_middleware.py
@@ -2,14 +2,11 @@ import time
 from typing import List
 
 from bs4 import BeautifulSoup
-from django.conf import settings
-from django.test import override_settings
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 from zerver.lib.realm_icon import get_realm_icon_url
-from zerver.lib.streams import create_stream_if_needed
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.middleware import is_slow_query, write_log_line
-from zerver.models import get_realm, get_system_bot
+from zerver.models import get_realm
 
 class SlowQueryTest(ZulipTestCase):
     SLOW_QUERY_TIME = 10
@@ -32,32 +29,21 @@ class SlowQueryTest(ZulipTestCase):
         self.assertFalse(is_slow_query(9, '/accounts/webathena_kerberos_login/'))
         self.assertTrue(is_slow_query(11, '/accounts/webathena_kerberos_login/'))
 
-    @override_settings(SLOW_QUERY_LOGS_STREAM="logs")
-    @patch('logging.info')
-    def test_slow_query_log(self, mock_logging_info: Mock) -> None:
-        error_bot = get_system_bot(settings.ERROR_BOT)
-        create_stream_if_needed(error_bot.realm, settings.SLOW_QUERY_LOGS_STREAM)
-
+    def test_slow_query_log(self) -> None:
         self.log_data['time_started'] = time.time() - self.SLOW_QUERY_TIME
-        write_log_line(self.log_data, path='/socket/open', method='SOCKET',
-                       remote_ip='123.456.789.012', requestor_for_logs='unknown', client_name='?')
-        last_message = self.get_last_message()
-        self.assertEqual(last_message.sender.email, "error-bot@zulip.com")
-        self.assertIn("logs", str(last_message.recipient))
-        self.assertEqual(last_message.topic_name(), "testserver: slow queries")
-        self.assertRegexpMatches(last_message.content,
-                                 r"123\.456\.789\.012 SOCKET  200 10\.\ds .*")
+        with patch("zerver.middleware.slow_query_logger") as mock_slow_query_logger, \
+                patch("zerver.middleware.logger") as mock_normal_logger:
 
-    @override_settings(ERROR_BOT=None)
-    @patch('logging.info')
-    @patch('zerver.lib.actions.internal_send_stream_message')
-    def test_slow_query_log_without_error_bot(self,
-                                              mock_internal_send_stream_message: Mock,
-                                              mock_logging_info: Mock) -> None:
-        self.log_data['time_started'] = time.time() - self.SLOW_QUERY_TIME
-        write_log_line(self.log_data, path='/socket/open', method='SOCKET',
-                       remote_ip='123.456.789.012', requestor_for_logs='unknown', client_name='?')
-        mock_internal_send_stream_message.assert_not_called()
+            write_log_line(self.log_data, path='/some/endpoint/', method='GET',
+                           remote_ip='123.456.789.012', requestor_for_logs='unknown', client_name='?')
+            mock_slow_query_logger.info.assert_called_once()
+            mock_normal_logger.info.assert_called_once()
+
+            logged_line = mock_slow_query_logger.info.call_args_list[0][0][0]
+            self.assertRegexpMatches(
+                logged_line,
+                r"123\.456\.789\.012 GET     200 10\.\ds .* \(unknown via \?\)"
+            )
 
 class OpenGraphTest(ZulipTestCase):
     def check_title_and_description(self, path: str, title: str,

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -86,7 +86,6 @@ ERROR_REPORTING = True
 BROWSER_ERROR_REPORTING = False
 LOGGING_SHOW_MODULE = False
 LOGGING_SHOW_PID = False
-SLOW_QUERY_LOGS_STREAM: Optional[str] = None
 
 # File uploads and avatars
 DEFAULT_AVATAR_URI = '/static/images/default-avatar.png'

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -56,7 +56,6 @@ EXTERNAL_URI_SCHEME = "http://"
 EMAIL_GATEWAY_PATTERN = "%s@" + EXTERNAL_HOST.split(':')[0]
 NOTIFICATION_BOT = "notification-bot@zulip.com"
 ERROR_BOT = "error-bot@zulip.com"
-# SLOW_QUERY_LOGS_STREAM = "errors"
 EMAIL_GATEWAY_BOT = "emailgateway@zulip.com"
 PHYSICAL_ADDRESS = "Zulip Headquarters, 123 Octo Stream, South Pacific Ocean"
 EXTRA_INSTALLED_APPS = ["zilencer", "analytics", "corporate"]

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -654,6 +654,7 @@ SERVER_LOG_PATH = zulip_path("/var/log/zulip/server.log")
 ERROR_FILE_LOG_PATH = zulip_path("/var/log/zulip/errors.log")
 MANAGEMENT_LOG_PATH = zulip_path("/var/log/zulip/manage.log")
 WORKER_LOG_PATH = zulip_path("/var/log/zulip/workers.log")
+SLOW_QUERIES_LOG_PATH = zulip_path("/var/log/zulip/slow_queries.log")
 JSON_PERSISTENT_QUEUE_FILENAME_PATTERN = zulip_path("/home/zulip/tornado/event_queues%s.json")
 EMAIL_LOG_PATH = zulip_path("/var/log/zulip/send_email.log")
 EMAIL_MIRROR_LOG_PATH = zulip_path("/var/log/zulip/email_mirror.log")
@@ -767,6 +768,12 @@ LOGGING: Dict[str, Any] = {
             'class': 'logging.handlers.WatchedFileHandler',
             'formatter': 'default',
             'filename': LDAP_LOG_PATH,
+        },
+        'slow_queries_file': {
+            'level': 'INFO',
+            'class': 'logging.handlers.WatchedFileHandler',
+            'formatter': 'default',
+            'filename': SLOW_QUERIES_LOG_PATH,
         },
     },
     'loggers': {
@@ -891,6 +898,10 @@ LOGGING: Dict[str, Any] = {
         'zulip.retention': {
             'handlers': ['file', 'errors_file'],
             'propagate': False,
+        },
+        'zulip.slow_queries': {
+            'level': 'INFO',
+            'handlers': ['slow_queries_file'],
         },
         'zulip.soft_deactivation': {
             'handlers': ['file', 'errors_file'],

--- a/zproject/test_settings.py
+++ b/zproject/test_settings.py
@@ -179,9 +179,6 @@ SOCIAL_AUTH_SUBDOMAIN = 'auth'
 TWO_FACTOR_AUTHENTICATION_ENABLED = False
 PUSH_NOTIFICATION_BOUNCER_URL = None
 
-# Disable messages from slow queries as they affect backend tests.
-SLOW_QUERY_LOGS_STREAM = None
-
 THUMBOR_URL = 'http://127.0.0.1:9995'
 THUMBNAIL_IMAGES = True
 THUMBOR_SERVES_CAMO = True


### PR DESCRIPTION
We get rid of the queue and replace it with a "zulip.slow_queries"
logger, which will log to /var/log/zulip/slow_queries.log for ease of
access to this information and propagate to the other logging handlers.