### PR TITLE
Stream settings:Fix alignment of stream option buttons

### DIFF
--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -843,7 +843,6 @@ form#add_new_subscription {
         margin-top: -5px;
         margin-right: 5px;
         text-decoration: none;
-        line-height: 16px;
         vertical-align: middle;
     }
 


### PR DESCRIPTION
Stream options are not aligned properly. Buttons belonging to same
button-group should have an identical view(styling).

![bef](https://user-images.githubusercontent.com/23723464/81420564-c7563580-916d-11ea-9f10-a8566216a083.png)

![aft](https://user-images.githubusercontent.com/23723464/81420613-d6d57e80-916d-11ea-8dad-9ef13fd61450.png)

