### PR TITLE
Alert words: Fix content overflow out of alert item box

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -587,6 +587,7 @@ input[type=checkbox].inline-block {
 
 .remove-alert-word {
     margin-top: 1px;
+    height: 35px;
 }
 
 @media (max-width: 480px) {

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -575,10 +575,14 @@ input[type=checkbox].inline-block {
 }
 
 .alert-word-information-box {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
     position: relative;
-    padding: 7px;
     margin: 2px;
     width: 50%;
+    padding: 0px 5px 0px 10px;
 }
 
 .green-bg {
@@ -586,7 +590,6 @@ input[type=checkbox].inline-block {
 }
 
 .remove-alert-word {
-    margin-top: 1px;
     height: 35px;
 }
 
@@ -1057,15 +1060,9 @@ input[type=checkbox].inline-block {
     margin-top: 8px;
 }
 
-#alert_words_list .edit-alert-word-buttons,
-#attachments_list .edit-attachment-buttons {
-    position: absolute;
-    right: 20px;
-    top: 0px;
-}
-
 #alert_words_list .alert_word_listing .value {
     display: block;
+    margin-right: 15px;
     white-space: pre-wrap;
     word-wrap: break-word;
     word-break: break-all;

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -583,6 +583,9 @@ input[type=checkbox].inline-block {
     margin: 2px;
     width: 50%;
     padding: 0px 5px 0px 10px;
+    @media (max-width: 600px) {
+        width: 96%;
+    }
 }
 
 .green-bg {


### PR DESCRIPTION
The Delete icon on alert word list overflows out of the alert word card.
So fix it with appropriate height property.

![befor](https://user-images.githubusercontent.com/23723464/81439390-ef549180-918b-11ea-9fe5-9a76e0ca109c.png)
![aftr](https://user-images.githubusercontent.com/23723464/81439384-ee236480-918b-11ea-81b2-32444be82bac.png)

fixes: #14910
