### PR TITLE
invite emails: Ensure user-controlled input is always in links.

### DIFF
--- a/templates/zerver/emails/invitation.source.html
+++ b/templates/zerver/emails/invitation.source.html
@@ -8,7 +8,7 @@
 <p>{{ _("Hi there,") }}</p>
 
 <p>
-    {% trans %}<a href="mailto:{{ referrer_email }}">{{ referrer_full_name }} ({{ referrer_email }}</a>) wants you to join them on Zulip &mdash; the team communication tool designed for productivity.{% endtrans %}
+    {% trans %}<a href="mailto:{{ referrer_email }}">{{ referrer_full_name }} ({{ referrer_email }})</a> wants you to join them on Zulip &mdash; the team communication tool designed for productivity.{% endtrans %}
 </p>
 <p>
     {{ _("To get started, click the button below.") }}

--- a/templates/zerver/emails/invitation.source.html
+++ b/templates/zerver/emails/invitation.source.html
@@ -8,7 +8,7 @@
 <p>{{ _("Hi there,") }}</p>
 
 <p>
-    {% trans %}{{ referrer_full_name }} (<a href="mailto:{{ referrer_email }}">{{ referrer_email }}</a>) wants you to join them on Zulip &mdash; the team communication tool designed for productivity.{% endtrans %}
+    {% trans %}<a href="mailto:{{ referrer_email }}">{{ referrer_full_name }} ({{ referrer_email }}</a>) wants you to join them on Zulip &mdash; the team communication tool designed for productivity.{% endtrans %}
 </p>
 <p>
     {{ _("To get started, click the button below.") }}

--- a/templates/zerver/emails/invitation_reminder.source.html
+++ b/templates/zerver/emails/invitation_reminder.source.html
@@ -7,7 +7,7 @@
 {% block content %}
 <p>{{ _("Hi again,") }}</p>
 
-<p>{% trans %}This is a friendly reminder that <a href="mailto:{{ referrer_email }}">{{ referrer_name }} ({{ referrer_email }}</a>) wants you to join them on Zulip &mdash; the team communication tool designed for productivity.{% endtrans %}</p>
+<p>{% trans %}This is a friendly reminder that <a href="mailto:{{ referrer_email }}">{{ referrer_name }} ({{ referrer_email }})</a> wants you to join them on Zulip &mdash; the team communication tool designed for productivity.{% endtrans %}</p>
 
 <p>
     {{ _("To get started, click the button below.") }}

--- a/templates/zerver/emails/invitation_reminder.source.html
+++ b/templates/zerver/emails/invitation_reminder.source.html
@@ -7,7 +7,7 @@
 {% block content %}
 <p>{{ _("Hi again,") }}</p>
 
-<p>{% trans %}This is a friendly reminder that {{ referrer_name }} (<a href="mailto:{{ referrer_email }}">{{ referrer_email }}</a>) wants you to join them on Zulip &mdash; the team communication tool designed for productivity.{% endtrans %}</p>
+<p>{% trans %}This is a friendly reminder that <a href="mailto:{{ referrer_email }}">{{ referrer_name }} ({{ referrer_email }}</a>) wants you to join them on Zulip &mdash; the team communication tool designed for productivity.{% endtrans %}</p>
 
 <p>
     {{ _("To get started, click the button below.") }}
@@ -19,6 +19,10 @@
 </p>
 
 <p>
-    {% trans %}This invitation expires in two days. If the invitation expires, you'll need to ask {{ referrer_name }} for another one.{% endtrans %}
+    {% trans %}
+    This invitation expires in two days. If the invitation expires,
+    you'll need to ask <a href="mailto:{{ referrer_email }}">{{ referrer_name }}</a>
+    for another one.
+    {% endtrans %}
 </p>
 {% endblock %}

--- a/version.py
+++ b/version.py
@@ -44,4 +44,4 @@ API_FEATURE_LEVEL = 3
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '82.0'
+PROVISION_VERSION = '82.1'


### PR DESCRIPTION
Popular email clients like Gmail will automatically linkify link-like
content present in an HTML email they receive, even if it doesn't have
links in it.  This made it possible to include what in Gmail will be a
user-controlled link in invitation emails that Zulip sends, which a
spammer/phisher could try to take advantage of to send really bad spam
(the limitation of having the rest of the invitation email HTML there
makes it hard to do something compelling here).

We close this opportunity by structuring our emails to always show the
user's name inside an existing link, so that Gmail won't do new
linkification, and add a test to help ensure we don't remove this
structure in a future design change.

@andersk @hackerkid FYI.  