### PR TITLE
drafts: Rename open_modal -> open_overlay.

### DIFF
--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -320,7 +320,7 @@ run_test('format_drafts', () => {
         return '<draft table stub>';
     });
 
-    drafts.open_modal = noop;
+    drafts.open_overlay = noop;
     drafts.set_initial_element = noop;
     $("#drafts_table .draft-row").length = 0;
 

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -360,7 +360,7 @@ exports.launch = function () {
     // element in order for the CSS transition to take effect.
     $('#draft_overlay').css('opacity');
 
-    exports.open_modal();
+    exports.open_overlay();
     exports.set_initial_element(drafts);
     setup_event_handlers();
 };
@@ -485,7 +485,7 @@ exports.drafts_handle_events = function (e, event_key) {
     }
 };
 
-exports.open_modal = function () {
+exports.open_overlay = function () {
     overlays.open_overlay({
         name: 'drafts',
         overlay: $('#draft_overlay'),


### PR DESCRIPTION
We consider the drafts thing to be an overlay,
not a modal, so the old name was confusing.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
