### PR TITLE
org settings: Fix limited plan realm can change message_retention_days.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5826,3 +5826,7 @@ def get_topic_messages(user_profile: UserProfile, stream: Stream,
         message__recipient=stream.recipient
     ).order_by("id")
     return [um.message for um in filter_by_topic_name_via_message(query, topic_name)]
+
+def check_realm_has_non_limited_plan(realm: Realm) -> None:
+    if realm.plan_type == Realm.LIMITED:
+        raise JsonableError(_("Feature unavailable on your current plan."))

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -15,6 +15,7 @@ from zerver.lib.actions import (
     do_set_realm_property,
     do_deactivate_realm,
     do_reactivate_realm,
+    check_realm_has_non_limited_plan,
 )
 from zerver.lib.i18n import get_available_language_codes
 from zerver.lib.request import has_request_variables, REQ, JsonableError
@@ -126,6 +127,9 @@ def update_realm(
                 not request_zoom_video_call_url(zoom_user_id, zoom_api_key, zoom_api_secret)):
             return json_error(_('Invalid credentials for the %(third_party_service)s API.') % dict(
                 third_party_service="Zoom"))
+
+    if message_retention_days is not None:
+        check_realm_has_non_limited_plan(realm)
 
     # The user of `locals()` here is a bit of a code smell, but it's
     # restricted to the elements present in realm.property_types.

--- a/zerver/views/realm_logo.py
+++ b/zerver/views/realm_logo.py
@@ -6,20 +6,19 @@ from django.http import HttpResponse, HttpRequest
 from zerver.lib.validator import check_bool
 from zerver.lib.request import REQ, has_request_variables
 from zerver.decorator import require_realm_admin
-from zerver.lib.actions import do_change_logo_source
+from zerver.lib.actions import do_change_logo_source, check_realm_has_non_limited_plan
 from zerver.lib.realm_logo import get_realm_logo_url
 from zerver.lib.response import json_error, json_success
 from zerver.lib.upload import upload_logo_image
 from zerver.lib.url_encoding import add_query_arg_to_redirect_url
-from zerver.models import Realm, UserProfile
+from zerver.models import UserProfile
 
 
 @require_realm_admin
 @has_request_variables
 def upload_logo(request: HttpRequest, user_profile: UserProfile,
                 night: bool=REQ(validator=check_bool)) -> HttpResponse:
-    if user_profile.realm.plan_type == Realm.LIMITED:
-        return json_error(_("Feature unavailable on your current plan."))
+    check_realm_has_non_limited_plan(user_profile.realm)
 
     if len(request.FILES) != 1:
         return json_error(_("You must upload exactly one logo."))


### PR DESCRIPTION
These changes should be included in bd9b74436c6f24425a284c1a366f355d3d7bdb6f,
as it makes sure that Zulip limited plan realm won't be able to change the
`message_retention_days` setting.
