### PR TITLE
uploads: Add support for ".jpe" file extension.

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-frontend/uploads.types
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/uploads.types
@@ -4,7 +4,7 @@ types {
     application/pdf                       pdf;
 
     image/gif                             gif;
-    image/jpeg                            jpeg jpg;
+    image/jpeg                            jpeg jpg jpe;
     image/png                             png;
     image/tiff                            tif tiff;
     image/webp                            webp;

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -667,7 +667,7 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
             return False
 
         # List from https://support.google.com/chromeos/bin/answer.py?hl=en&answer=183093
-        for ext in [".bmp", ".gif", ".jpg", "jpeg", ".png", ".webp"]:
+        for ext in [".bmp", ".gif", ".jpe", "jpeg", ".jpg", ".png", ".webp"]:
             if parsed_url.path.lower().endswith(ext):
                 return True
         return False


### PR DESCRIPTION
Currently, when the user uploads files with ".jpe" file extension, the markdown is converted to link but the image is not embedded. This PR adds the support for ".jpe" file extension.

Fixes #14863
