### PR TITLE
dropdown-menu: Remove caret-down icon.

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -358,13 +358,21 @@ on a dark background, and don't change the dark labels dark either. */
 
     #streamlist-toggle,
     #userlist-toggle {
-        border-color: hsla(199, 33%, 46%, 0.2);
+        color: inherit;
+        border-color: hsla(0, 0%, 0%, 0.6);
     }
 
-    #streamlist-toggle-button,
-    #userlist-toggle-button {
+    #streamlist-toggle-button {
         color: inherit;
         background-color: inherit;
+    }
+
+    #userlist-toggle-button {
+        color: hsl(221, 9%, 54%);
+
+        &:hover {
+            color: inherit;
+        }
     }
 
     li.active-filter,

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -151,18 +151,21 @@
     right: 0px;
     text-align: center;
     vertical-align: middle;
-    border-left: 2px solid hsl(204, 20%, 74%);
+    border-left: 1px solid hsl(0, 0%, 88%);
 }
 
 #userlist-toggle-button {
     text-decoration: none;
-    background-color: hsl(0, 0%, 89%);
-    color: hsl(0, 0%, 52%);
+    color: hsl(0, 0%, 60%);
     display: block;
     width: 45px;
     height: 19px;
     padding-top: 12px;
     padding-bottom: 9px;
+
+    &:hover {
+        color: inherit;
+    }
 }
 
 #userlist-header {

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -159,7 +159,7 @@
     background-color: hsl(0, 0%, 89%);
     color: hsl(0, 0%, 52%);
     display: block;
-    width: 40px;
+    width: 45px;
     height: 19px;
     padding-top: 12px;
     padding-bottom: 9px;

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -546,6 +546,10 @@ li.actual-dropdown-menu i {
     margin-right: 3px;
 }
 
+.settings-dropdown-cog {
+    padding-right: 14px;
+}
+
 .message_area_padder {
     /* The height of the header and the tabbar plus a small gap */
     margin-top: 57px;
@@ -1829,7 +1833,7 @@ div.focused_table {
         width: 0px;
         height: 0px;
         top: -7px;
-        right: 10px;
+        right: 14px;
         display: inline-block;
         border-right: 7px solid transparent;
         border-bottom: 7px solid hsl(0, 0%, 67%);
@@ -2175,12 +2179,6 @@ div.topic_edit_spinner .loading_indicator_spinner {
     top: 1px;
 }
 
-.settings-dropdown-caret {
-    margin-left: 8px;
-    margin-right: 8px;
-    font-size: 14px;
-}
-
 #notifications-area {
     position: fixed;
     z-index: 10;
@@ -2510,6 +2508,14 @@ select.inline_select_topic_edit {
         &::after {
             right: 10px;
         }
+    }
+
+    .nav .dropdown-menu::after {
+        right: 21px;
+    }
+
+    .settings-dropdown-cog {
+        padding-right: 21px;
     }
 
     .column-middle {

--- a/templates/zerver/app/navbar.html
+++ b/templates/zerver/app/navbar.html
@@ -53,7 +53,7 @@
                 <ul class="nav" role="navigation">
                     <li class="dropdown actual-dropdown-menu" id="gear-menu">
                         <a id="settings-dropdown" href="#" role="button" class="dropdown-toggle" data-target="nada" data-toggle="dropdown" title="{{ _('Menu') }} (g)">
-                            <i class="fa fa-cog" aria-hidden="true"></i><i class="fa fa-caret-down settings-dropdown-caret" aria-hidden="true"></i>
+                            <i class="fa fa-cog settings-dropdown-cog" aria-hidden="true"></i>
                         </a>
                         <ul class="dropdown-menu" role="menu" aria-labelledby="settings-dropdown">
                             {#


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
A revival of #6657.  See [this discussion on czo](https://chat.zulip.org/#narrow/stream/2-general/topic/menu.20icon/near/869229).


**Testing Plan:** <!-- How have you tested? -->
`tools/run-dev.py`

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<img width="250" alt="Screen Shot 2020-05-10 at 9 02 51 AM" src="https://user-images.githubusercontent.com/39782863/81508050-501fbf00-929d-11ea-8c6e-03b73429e25f.png">

---

<img width="250" alt="Screen Shot 2020-05-10 at 9 02 43 AM" src="https://user-images.githubusercontent.com/39782863/81508056-5877fa00-929d-11ea-94e9-3e70d41a8c60.png">

---

__Demo of current behavior with narrow window:__
![demo](https://user-images.githubusercontent.com/39782863/81514825-c8ea3f80-92cc-11ea-898c-a5d4d71923ec.gif)
