### PR TITLE
Various search pills related bugfixes.

### DIFF
--- a/frontend_tests/node_tests/input_pill.js
+++ b/frontend_tests/node_tests/input_pill.js
@@ -207,6 +207,14 @@ run_test('paste to input', () => {
         items.blue,
         items.yellow,
     ]);
+
+    let entered = false;
+    widget.createPillonPaste(function () {
+        entered = true;
+    });
+
+    paste_handler(e);
+    assert(entered);
 });
 
 run_test('arrows on pills', () => {

--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -12,7 +12,7 @@ const return_true = () => true;
 const return_false = () => false;
 
 set_global('$', global.make_zjquery());
-set_global('narrow_state', {});
+set_global('narrow_state', {filter: return_false});
 set_global('search_suggestion', {});
 set_global('ui_util', {
     change_tab_to: noop,
@@ -283,7 +283,7 @@ run_test('initizalize', () => {
 
 run_test('initiate_search', () => {
     let is_searchbox_focused = false;
-    $('#search_query').focus = () => {
+    $('#search_arrows').focus = () => {
         is_searchbox_focused = true;
     };
     search.initiate_search();

--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -20,6 +20,7 @@ set_global('ui_util', {
 set_global('narrow', {});
 
 search_pill.append_search_string = noop;
+search_pill.get_search_string_for_current_filter = noop;
 
 global.patch_builtin('setTimeout', func => func());
 
@@ -139,7 +140,7 @@ run_test('initizalize', () => {
                     assert.deepEqual(options, {trigger: 'search'});
                 };
                 search_pill.get_search_string_for_current_filter = () => {
-                    return '';
+                    return search_box_val;
                 };
             };
 
@@ -150,7 +151,7 @@ run_test('initizalize', () => {
             }];
             _setup('ver');
             opts.updater('ver');
-            assert(is_blurred);
+            assert(!is_blurred);
             assert(is_append_search_string_called);
 
             operators = [{
@@ -160,7 +161,7 @@ run_test('initizalize', () => {
             }];
             _setup('stream:Verona');
             opts.updater('stream:Verona');
-            assert(is_blurred);
+            assert(!is_blurred);
             assert(is_append_search_string_called);
 
             search.is_using_input_method = true;
@@ -206,7 +207,7 @@ run_test('initizalize', () => {
                 assert.deepEqual(options, {trigger: 'search'});
             };
             search_pill.get_search_string_for_current_filter = () => {
-                return '';
+                return search_box_val;
             };
         };
 

--- a/static/js/input_pill.js
+++ b/static/js/input_pill.js
@@ -225,6 +225,13 @@ exports.create = function (opts) {
         items: function () {
             return store.pills.map(pill => pill.item);
         },
+
+        createPillonPaste: function () {
+            if (typeof store.createPillonPaste === "function") {
+                return store.createPillonPaste();
+            }
+            return true;
+        },
     };
 
     (function events() {
@@ -331,7 +338,9 @@ exports.create = function (opts) {
             // insert text manually
             document.execCommand("insertText", false, text);
 
-            funcs.insertManyPills(store.$input.text().trim());
+            if (funcs.createPillonPaste()) {
+                funcs.insertManyPills(store.$input.text().trim());
+            }
         });
 
         // when the "×" is clicked on a pill, it should delete that pill and then
@@ -373,6 +382,10 @@ exports.create = function (opts) {
 
         onPillRemove: function (callback) {
             store.removePillFunction = callback;
+        },
+
+        createPillonPaste: function (callback) {
+            store.createPillonPaste = callback;
         },
 
         clear: funcs.removeAllPills.bind(funcs),

--- a/static/js/input_pill.js
+++ b/static/js/input_pill.js
@@ -47,7 +47,7 @@ exports.create = function (opts) {
     const funcs = {
         // return the value of the contenteditable input form.
         value: function (input_elem) {
-            return input_elem.innerText.trim();
+            return input_elem.innerText;
         },
 
         // clear the value of the input form.
@@ -239,7 +239,7 @@ exports.create = function (opts) {
 
                 // if there is input, grab the input, make a pill from it,
                 // and append the pill, then clear the input.
-                const value = funcs.value(e.target);
+                const value = funcs.value(e.target).trim();
                 if (value.length > 0) {
                     // append the pill and by proxy create the pill object.
                     const ret = funcs.appendPill(value);

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -149,7 +149,17 @@ exports.initialize = function () {
             // operators.  (The reason the other actions don't call
             // this codepath is that they first all blur the box to
             // indicate that they've done what they need to do)
-            narrow.activate(Filter.parse(search_query_box.val()), {trigger: 'search'});
+
+            let operators = Filter.parse(search_query_box.val());
+            if (page_params.search_pills_enabled) {
+                // Pill is already added during keydown event of input pills.
+                // Thus we can't call narrow_or_search_for_term as the
+                // search_query_box has empty value.
+                const base_query = search_pill.get_search_string_for_current_filter(
+                    search_pill_widget.widget);
+                operators = Filter.parse(base_query);
+            }
+            narrow.activate(operators, {trigger: 'search'});
             search_query_box.blur();
             update_buttons_with_focus(false);
         }

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -177,9 +177,11 @@ exports.initialize = function () {
         // while we want to add box-shadow to `#searchbox`. This could have been done
         // with `:focus-within` CSS selector, but it is not supported in IE or Opera.
         searchbox.on('focusin', function () {
+            tab_bar.open_search_bar_and_close_narrow_description();
             searchbox.css({"box-shadow": "inset 0px 0px 0px 2px hsl(204, 20%, 74%)"});
         });
         searchbox.on('focusout', function () {
+            tab_bar.close_search_bar_and_open_narrow_description();
             searchbox.css({"box-shadow": "unset"});
         });
     }

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -192,7 +192,7 @@ exports.focus_search = function () {
 
 exports.initiate_search = function () {
     if (page_params.search_pills_enabled) {
-        $('#search_query').focus();
+        $('#search_arrows').focus();
     } else {
         tab_bar.open_search_bar_and_close_narrow_description();
         $('#search_query').typeahead('lookup').select();

--- a/static/js/search_pill_widget.js
+++ b/static/js/search_pill_widget.js
@@ -8,6 +8,10 @@ exports.initialize = function () {
     exports.widget.onPillRemove(function () {
         search.narrow_or_search_for_term();
     });
+
+    exports.widget.createPillonPaste(function () {
+        return false;
+    });
 };
 
 window.search_pill_widget = exports;

--- a/static/js/search_pill_widget.js
+++ b/static/js/search_pill_widget.js
@@ -6,9 +6,7 @@ exports.initialize = function () {
     exports.widget = search_pill.create_pills(container);
 
     exports.widget.onPillRemove(function () {
-        const base_query = search_pill.get_search_string_for_current_filter(exports.widget);
-        const operators = Filter.parse(base_query);
-        narrow.activate(operators, {trigger: 'search'});
+        search.narrow_or_search_for_term();
     });
 };
 

--- a/static/js/stream_color.js
+++ b/static/js/stream_color.js
@@ -72,9 +72,7 @@ exports.update_stream_color = function (sub, color, opts) {
         update_historical_message_color(sub.name, color);
     }
     update_stream_sidebar_swatch_color(stream_id, color);
-    if (!page_params.search_pills_enabled) {
-        tab_bar.colorize_tab_bar();
-    }
+    tab_bar.colorize_tab_bar();
 };
 
 function picker_do_change_color(color) {

--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -166,8 +166,11 @@ exports.open_search_bar_and_close_narrow_description = function () {
 };
 
 exports.close_search_bar_and_open_narrow_description = function () {
-    $(".navbar-search").removeClass("expanded");
-    $("#tab_list").removeClass("hidden");
+    const filter = narrow_state.filter();
+    if (!(filter && !filter.is_common_narrow())) {
+        $(".navbar-search").removeClass("expanded");
+        $("#tab_list").removeClass("hidden");
+    }
 };
 
 window.tab_bar = exports;

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -445,9 +445,7 @@ exports.initialize_everything = function () {
     overlays.initialize();
     invite.initialize();
     timerender.initialize();
-    if (!page_params.search_pills_enabled) {
-        tab_bar.initialize();
-    }
+    tab_bar.initialize();
     server_events.initialize();
     user_status.initialize(user_status_params);
     compose_pm_pill.initialize();

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1577,25 +1577,41 @@ div.focused_table {
 }
 
 #searchbox {
-    display: flex;
     width: 100%;
     height: 40px;
 
-    .navbar-search {
-        margin-top: 0px;
-        width: calc(100% - 66px);
-        float: none;
+    .navbar-search:not(.expanded) {
+        display: none;
+    }
+
+    .navbar-search.expanded {
         overflow: hidden;
-        height: 100%;
+        margin-top: 0px;
+        right: 2;
+        width: calc(100% - 2px);
+        position: absolute;
+        .search_button {
+            display: inline;
+            margin-right: 16px;
+        }
     }
 
     .input-append {
-        height: 100%;
-        align-items: center;
-        display: flex;
-        flex-wrap: nowrap;
         position: relative;
-        width: calc(100% - 28px);
+        width: 100%;
+
+        .fa-search {
+            padding: 0px;
+            font-size: 20px;
+            position: absolute;
+            left: 10px;
+            top: 10px;
+            z-index: 5;
+        }
+
+        .fa-search:not(.deactivated) {
+            cursor: pointer;
+        }
     }
 
     #search_query {
@@ -1612,18 +1628,26 @@ div.focused_table {
         line-height: 40px;
     }
 
+    #search_query:focus {
+        box-shadow: inset 0px 0px 0px 2px hsl(204, 20%, 74%);
+    }
+
     .search_button,
     .search_button[disabled]:hover {
-        position: relative;
+        position: absolute;
+        right: 2px;
+        top: 6px;
         background: none;
-        height: 40px;
+        border-radius: 0px;
+        border: none;
+        height: 30px;
+        text-align: center;
         padding: 4px;
         color: hsl(0, 0%, 80%);
         font-size: 18px;
         box-shadow: none;
         text-shadow: none;
         z-index: 5;
-        float: right;
     }
 
     .search_button:hover {
@@ -1658,8 +1682,6 @@ div.focused_table {
     #search_arrows {
         font-size: 90%;
         letter-spacing: normal;
-        border: none;
-        background-color: inherit;
     }
 
     @media (min-width: 500px) {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1576,7 +1576,8 @@ div.focused_table {
     }
 }
 
-#searchbox {
+#searchbox,
+#searchbox_legacy {
     width: 100%;
     height: 40px;
 
@@ -1628,14 +1629,14 @@ div.focused_table {
         line-height: 40px;
     }
 
-    #search_query:focus {
+    #search_arrows:focus {
         box-shadow: inset 0px 0px 0px 2px hsl(204, 20%, 74%);
     }
 
     .search_button,
     .search_button[disabled]:hover {
         position: absolute;
-        right: 2px;
+        right: 20px;
         top: 6px;
         background: none;
         border-radius: 0px;
@@ -1659,6 +1660,7 @@ div.focused_table {
     }
 
     .search_icon {
+        position: absolute;
         display: table;
         height: 100%;
         color: hsl(0, 0%, 80%);
@@ -1666,12 +1668,7 @@ div.focused_table {
         padding: 0 10px;
         font-size: 20px;
         z-index: 5;
-        float: left;
-
-        i {
-            display: table-cell;
-            vertical-align: middle;
-        }
+        left: 0px;
     }
 
     .search_icon:hover {
@@ -1680,8 +1677,14 @@ div.focused_table {
     }
 
     #search_arrows {
+        padding-left: 30px;
         font-size: 90%;
         letter-spacing: normal;
+    }
+
+    .pill-container {
+        border: none;
+        padding: 0px;
     }
 
     @media (min-width: 500px) {
@@ -1698,103 +1701,6 @@ div.focused_table {
                 top: 0;
             }
         }
-    }
-}
-
-#searchbox_legacy {
-    width: 100%;
-    height: 40px;
-
-    .navbar-search:not(.expanded) {
-        display: none;
-    }
-
-    .navbar-search.expanded {
-        overflow: hidden;
-        margin-top: 0px;
-        right: 2;
-        width: calc(100% - 2px);
-        position: absolute;
-        .search_button {
-            display: inline;
-            margin-right: 16px;
-        }
-    }
-
-    .input-append {
-        position: relative;
-        width: 100%;
-
-        .fa-search {
-            padding: 0px;
-            font-size: 20px;
-            position: absolute;
-            left: 10px;
-            top: 10px;
-            z-index: 5;
-        }
-
-        .fa-search:not(.deactivated) {
-            cursor: pointer;
-        }
-    }
-
-    #search_query {
-        width: 100%;
-        font-size: 16px;
-        height: 40px;
-        padding: 0px;
-        padding-left: 35px;
-        padding-right: 40px;
-        border: none;
-        border-radius: 0px;
-        font-family: 'Source Sans Pro';
-        font-weight: 300;
-        line-height: 27px;
-    }
-
-    #search_query:focus {
-        box-shadow: inset 0px 0px 0px 2px hsl(204, 20%, 74%);
-    }
-
-    .search_button,
-    .search_button[disabled]:hover {
-        position: absolute;
-        right: 2px;
-        top: 6px;
-        background: none;
-        border-radius: 0px;
-        border: none;
-        height: 30px;
-        text-align: center;
-        padding: 4px;
-        color: hsl(0, 0%, 80%);
-        font-size: 18px;
-        box-shadow: none;
-        text-shadow: none;
-        z-index: 5;
-    }
-
-    .search_button:hover {
-        color: hsl(0, 0%, 0%);
-    }
-
-    .search_button[disabled] {
-        visibility: hidden;
-    }
-
-    #search_arrows {
-        /* Bootstrap wants font-size: 0 to eliminate space between
-       the buttons.  We need to inherit the font size, so we
-       remove the button gap by adjusting "letter" spacing. */
-        font-size: 90%;
-        letter-spacing: -.3em;
-    }
-
-    #search_arrows input {
-        /* Chrome and Firefox do this already via default browser stylesheet;
-       but Opera needs this to avoid smushed letters in the search box. */
-        letter-spacing: normal;
     }
 }
 
@@ -2667,7 +2573,8 @@ select.inline_select_topic_edit {
     }
 
     .top-navbar-container,
-    #searchbox_legacy .navbar-search.expanded {
+    #searchbox_legacy .navbar-search.expanded,
+    #searchbox .navbar-search.expanded {
         width: calc(100% - 91px);
     }
 
@@ -2680,7 +2587,8 @@ select.inline_select_topic_edit {
             right: 72px;
         }
         .top-navbar-border,
-        #searchbox_legacy .navbar-search.expanded {
+        #searchbox_legacy .navbar-search.expanded,
+        #searchbox .navbar-search.expanded {
             width: calc(100% - 50px);
         }
     }
@@ -2759,7 +2667,8 @@ select.inline_select_topic_edit {
     // todo: Figure out why this has to be different
     // from above at this width and resolve it
     // #searchbox_legacy .navbar-search.expanded,
-    #searchbox_legacy .navbar-search.expanded {
+    #searchbox_legacy .navbar-search.expanded,
+    #searchbox .navbar-search.expanded {
         width: calc(100% - 131px);
     }
 
@@ -2774,7 +2683,8 @@ select.inline_select_topic_edit {
         .top-navbar-border {
             width: calc(100% - 75px);
         }
-        #searchbox_legacy .navbar-search.expanded {
+        #searchbox_legacy .navbar-search.expanded,
+        #searchbox .navbar-search.expanded {
             width: calc(100% - 90px);
         }
     }

--- a/templates/zerver/app/navbar.html
+++ b/templates/zerver/app/navbar.html
@@ -17,15 +17,14 @@
                     <div id="searchbox">
                         <div id="tab_bar" class="notdisplayed">
                         </div>
-                        <span class="search_icon" ><i class="fa fa-search" aria-hidden="true"></i></span>
                         <form id="searchbox_form" class="form-search navbar-search">
                             <div id="search_arrows" class="pill-container input-append">
+                                <span class="search_icon search_open" ><i class="fa fa-search" aria-hidden="true"></i></span>
                                 <div contenteditable="true" class="input search-query input-block-level" id="search_query" type="text" placeholder="{{ _('Search') }}"
                                   autocomplete="off" aria-label="{{ _('Search') }}" title="{{ _('Search') }} (/)"> </div>
+                                <button class="btn search_button" type="button" id="search_exit" aria-label="{{ _('Exit search') }}"><i class="fa fa-remove" aria-hidden="true"></i></button>
                             </div>
                         </form>
-                        {# Start the button off disabled since there is no active search #}
-                        <button class="btn search_button" type="button" id="search_exit" disabled="disabled" aria-label="{{ _('Exit search') }}"><i class="fa fa-remove" aria-hidden="true"></i></button>
                     </div>
                     {% else %}
                     <div id="searchbox_legacy">
@@ -33,10 +32,10 @@
                         </div>
                         <form id="searchbox_form" class="form-search navbar-search">
                             <div id="search_arrows" class="input-append">
+                                <span class="search_icon search_open" ><i class="fa fa-search" aria-hidden="true"></i></span>
                                 <input class="search-query input-block-level" id="search_query" type="text" placeholder="{{ _('Search') }}"
                                   autocomplete="off" aria-label="{{ _('Search') }}" title="{{ _('Search') }} (/)"/>
                                 <button class="btn search_button" type="button" id="search_exit" aria-label="{{ _('Exit search') }}"><i class="fa fa-remove" aria-hidden="true"></i></button>
-                                <span class="search_icon search_open" ><i class="fa fa-search" aria-hidden="true"></i></span>
                             </div>
                         </form>
                     </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This is a WIP PR related to #10026 

some more bugs i notice are:-
- [ ] If the width of the search pills overflows the searchbox, only way to refocus the searchbox for typing is to go to the end by using the right key on the pills.
- [ ] multiple pasted pills get combined as one.
- [ ] on reloading the page the pills having "search" operator get combined as one. (not sure if bug)