### PR TITLE
navbar: Fix handling of links in click handler.

### DIFF
--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -78,18 +78,13 @@ function build_tab_bar(filter) {
         });
 
         $("#tab_list span:nth-last-child(2)").on("click", function (e) {
-            exports.open_search_bar_and_close_narrow_description();
-            search.initiate_search();
-            e.preventDefault();
-            e.stopPropagation();
-        });
-
-        // Hacky way of protecting the behaviour of links via preventDefault
-        // and stopPropagation
-        $(".narrow_description > a").on("click", function (e) {
-            window.location.href = e.target.href;
-            e.preventDefault();
-            e.stopPropagation();
+            // Let links behave normally, ie, do nothing if <a>
+            if (e.target.tagName.toLowerCase() === 'span') {
+                exports.open_search_bar_and_close_narrow_description();
+                search.initiate_search();
+                e.preventDefault();
+                e.stopPropagation();
+            }
         });
 
         const color = $(".search_closed").css("color");


### PR DESCRIPTION

This commits improves how we handle <a> tags within the navbar
description. The code previously overlaid click regions on top of each
other, which was messy. It is cleaner if we just check if the click
was on an <a> tag or not.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
related to feedback on PR #14707, specifically this comment: https://github.com/zulip/zulip/pull/14707#discussion_r414170907.

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![cleaner navbar link handling](https://user-images.githubusercontent.com/33805964/81514889-1a3b1300-934f-11ea-9432-2047ba230806.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
