### PR TITLE
integrations: Add Gogs webhooks for release events

### DIFF
--- a/zerver/lib/webhooks/git.py
+++ b/zerver/lib/webhooks/git.py
@@ -3,6 +3,7 @@ from typing import Optional, Any, Dict, List, Tuple
 from collections import defaultdict
 TOPIC_WITH_BRANCH_TEMPLATE = '{repo} / {branch}'
 TOPIC_WITH_PR_OR_ISSUE_INFO_TEMPLATE = '{repo} / {type} #{id} {title}'
+TOPIC_WITH_RELEASE_TEMPLATE = '{repo} / {tag} {title}'
 
 EMPTY_SHA = '0000000000000000000000000000000000000000'
 
@@ -51,6 +52,7 @@ PUSH_TAGS_MESSAGE_TEMPLATE = """{user_name} {action} tag {tag}"""
 TAG_WITH_URL_TEMPLATE = "[{tag_name}]({tag_url})"
 TAG_WITHOUT_URL_TEMPLATE = "{tag_name}"
 
+RELEASE_MESSAGE_TEMPLATE = "{user_name} {action} release [{release_name}]({url}) for tag {tagname}."
 
 def get_push_commits_event_message(user_name: str, compare_url: Optional[str],
                                    branch_name: str, commits_data: List[Dict[str, Any]],
@@ -274,6 +276,18 @@ def get_commits_content(commits_data: List[Dict[str, Any]], is_truncated: Option
             commits_number=''
         ).replace('  ', ' ')
     return commits_content.rstrip()
+
+def get_release_event_message(user_name: str, action: str,
+                              tagname: str, release_name: str, url: str) -> str:
+    content = RELEASE_MESSAGE_TEMPLATE.format(
+        user_name=user_name,
+        action=action,
+        tagname=tagname,
+        release_name=release_name,
+        url=url
+    )
+
+    return content
 
 def get_short_sha(sha: str) -> str:
     return sha[:7]

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -206,7 +206,7 @@ class GithubWebhookTest(WebhookTestCase):
         self.send_and_test_stream_message('team_add', self.EXPECTED_TOPIC_REPO_EVENTS, expected_message)
 
     def test_release_msg(self) -> None:
-        expected_message = "baxterthehacker published [release for tag 0.0.1](https://github.com/baxterthehacker/public-repo/releases/tag/0.0.1)."
+        expected_message = "baxterthehacker published release [None](https://github.com/baxterthehacker/public-repo/releases/tag/0.0.1) for tag 0.0.1."
         self.send_and_test_stream_message('release', self.EXPECTED_TOPIC_REPO_EVENTS, expected_message)
 
     def test_page_build_msg(self) -> None:

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -15,7 +15,8 @@ from zerver.lib.webhooks.git import CONTENT_MESSAGE_TEMPLATE, \
     TOPIC_WITH_BRANCH_TEMPLATE, TOPIC_WITH_PR_OR_ISSUE_INFO_TEMPLATE, \
     get_commits_comment_action_message, get_issue_event_message, \
     get_pull_request_event_message, get_push_commits_event_message, \
-    get_push_tag_event_message, get_setup_webhook_message
+    get_push_tag_event_message, get_setup_webhook_message, \
+    get_release_event_message
 from zerver.models import UserProfile
 
 fixture_to_headers = get_http_headers_from_filename("HTTP_X_GITHUB_EVENT")
@@ -235,12 +236,15 @@ def get_add_team_body(payload: Dict[str, Any]) -> str:
     )
 
 def get_release_body(payload: Dict[str, Any]) -> str:
-    return "{} {} [release for tag {}]({}).".format(
-        get_sender_name(payload),
-        payload['action'],
-        payload['release']['tag_name'],
-        payload['release']['html_url'],
-    )
+    data = {
+        'user_name': get_sender_name(payload),
+        'action': payload['action'],
+        'tagname': payload['release']['tag_name'],
+        'release_name': payload['release']['name'],
+        'url': payload['release']['html_url']
+    }
+
+    return get_release_event_message(**data)
 
 def get_page_build_body(payload: Dict[str, Any]) -> str:
     build = payload['build']

--- a/zerver/webhooks/gogs/fixtures/release__published.json
+++ b/zerver/webhooks/gogs/fixtures/release__published.json
@@ -1,0 +1,60 @@
+{
+    "action": "published",
+    "release": {
+        "id": 620,
+        "tag_name": "v1.4",
+        "target_commitish": "master",
+        "name": "Title",
+        "body": "Content",
+        "draft": false,
+        "prerelease": false,
+        "author": {
+        "id": 54021,
+        "username": "cestrell",
+        "login": "cestrell",
+        "full_name": "",
+        "email": "cestrell@umich.edu",
+        "avatar_url": "https://secure.gravatar.com/avatar/9d38a3e0dfca4e5784288da94c98ff34?d=identicon"
+        },
+        "created_at": "2020-05-11T04:47:11Z"
+    },
+    "repository": {
+        "id": 26908,
+        "owner": {
+        "id": 54021,
+        "username": "cestrell",
+        "login": "cestrell",
+        "full_name": "",
+        "email": "cestrell@umich.edu",
+        "avatar_url": "https://secure.gravatar.com/avatar/9d38a3e0dfca4e5784288da94c98ff34?d=identicon"
+        },
+        "name": "zulip_test",
+        "full_name": "cestrell/zulip_test",
+        "description": "",
+        "private": false,
+        "fork": false,
+        "parent": null,
+        "empty": false,
+        "mirror": false,
+        "size": 16384,
+        "html_url": "https://try.gogs.io/cestrell/zulip_test",
+        "ssh_url": "git@try.gogs.io:cestrell/zulip_test.git",
+        "clone_url": "https://try.gogs.io/cestrell/zulip_test.git",
+        "website": "",
+        "stars_count": 0,
+        "forks_count": 0,
+        "watchers_count": 1,
+        "open_issues_count": 0,
+        "default_branch": "master",
+        "created_at": "2020-04-25T16:02:30Z",
+        "updated_at": "2020-04-25T16:15:49Z"
+    },
+    "sender": {
+        "id": 54021,
+        "username": "cestrell",
+        "login": "cestrell",
+        "full_name": "",
+        "email": "cestrell@umich.edu",
+        "avatar_url": "https://secure.gravatar.com/avatar/9d38a3e0dfca4e5784288da94c98ff34?d=identicon"
+    }
+}

--- a/zerver/webhooks/gogs/tests.py
+++ b/zerver/webhooks/gogs/tests.py
@@ -137,6 +137,11 @@ class GogsHookTests(WebhookTestCase):
         expected_message = """kostekIV edited a [comment](https://try.gogs.io/kostekIV/test/issues/3#issuecomment-3634) on [Issue #3](https://try.gogs.io/kostekIV/test/issues/3):\n\n~~~ quote\nedit comment\n~~~"""
         self.send_and_test_stream_message('issue_comment__edited', expected_topic, expected_message)
 
+    def test_release_published(self) -> None:
+        expected_topic = "zulip_test / v1.4 Title"
+        expected_message = """cestrell published release [Title](https://try.gogs.io/cestrell/zulip_test) for tag v1.4."""
+        self.send_and_test_stream_message('release__published', expected_topic, expected_message)
+
     @patch('zerver.webhooks.gogs.view.check_send_webhook_message')
     def test_push_filtered_by_branches_ignore(self, check_send_webhook_message_mock: MagicMock) -> None:
         self.url = self.build_webhook_url(branches='changes,development')


### PR DESCRIPTION
This extends Gogs integrations in order to support published release events. It seems that the release event is only triggered when a release is published, since webhooks.site did not intercept any request details when editing, deleting, or publishing as a prerelease. Not sure if they can be triggered in a different way and I overlooked it.

Addresses #14746 

Tested on my local Ubuntu development server running on WSL2 using 
```tools/test-backend zerver/webhooks/gogs/```
