### PR TITLE
minor: Navbar CSS fixes

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1492,10 +1492,11 @@ div.focused_table {
             .fa.fa-user-o {
                 margin-left: 0px;
             }
-            &::before {
+
+            &::before,
+            &::after {
                 content: "";
                 position: absolute;
-                left: -5px;
                 top: 25%;
                 width: 1px;
                 height: 50%;
@@ -1504,17 +1505,13 @@ div.focused_table {
                     top: 10%;
                 }
             }
+
+            &::before {
+                left: -5px;
+            }
+
             &::after {
-                content: "";
-                position: absolute;
                 right: -5px;
-                top: 25%;
-                width: 1px;
-                height: 50%;
-                background: hsl(0, 0%, 88%);
-                @media (max-width: 500px) {
-                    top: 10%;
-                }
             }
         }
 

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1495,14 +1495,13 @@ div.focused_table {
 
             &::before,
             &::after {
-                content: "";
+                content: "|";
                 position: absolute;
                 top: 25%;
-                width: 1px;
                 height: 50%;
-                background: hsl(0, 0%, 88%);
+                color: hsl(0, 0%, 88%);
                 @media (max-width: 500px) {
-                    top: 10%;
+                    top: 12%;
                 }
             }
 

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1500,8 +1500,9 @@ div.focused_table {
                 top: 25%;
                 height: 50%;
                 color: hsl(0, 0%, 88%);
+                font-size: 20px;
                 @media (max-width: 500px) {
-                    top: 12%;
+                    top: 10%;
                 }
             }
 


### PR DESCRIPTION
From https://chat.zulip.org/#narrow/stream/101-design/topic/navbar.20redesign/near/873312

![image](https://user-images.githubusercontent.com/8033238/81537379-b7676d00-938a-11ea-98c5-2c9e6bd0446e.png)

The separators now look identical. I'm still curious what causes the initial breakage and couldn't reproduce it in a smaller jsfiddle.