### PR TITLE
org settings: Set message_retention_days to NULL for retain forever case.

### DIFF
--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -237,6 +237,9 @@ function set_message_retention_setting_dropdown() {
     $("#id_realm_message_retention_setting").val(value);
     change_element_block_display_property('id_realm_message_retention_days',
                                           value === "retain_for_period");
+    if (get_property_value('realm_message_retention_days') === settings_config.retain_message_forever) {
+        $("#id_realm_message_retention_days").val('');
+    }
 }
 
 function set_org_join_restrictions_dropdown() {
@@ -721,8 +724,8 @@ exports.build_page = function () {
             if (message_retention_setting_value === 'retain_forever') {
                 data.message_retention_days = JSON.stringify('forever');
             } else {
-                data.message_retention_days = exports.get_input_element_value(
-                    $('#id_realm_message_retention_days'));
+                data.message_retention_days = JSON.stringify(exports.get_input_element_value(
+                    $('#id_realm_message_retention_days')));
             }
         } else if (subsection === 'other_settings') {
             const code_block_language_value = exports.default_code_language_widget.value();

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -360,10 +360,8 @@ function discard_property_element_changes(elem) {
         exports.signup_notifications_stream_widget.render(property_value);
     } else if (property_name === 'realm_default_code_block_language') {
         exports.default_code_language_widget.render(property_value);
-    } else if (typeof property_value === 'boolean') {
-        elem.prop('checked', property_value);
-    } else if (typeof property_value === 'string' || typeof property_value === 'number') {
-        elem.val(property_value);
+    } else if (property_value !== undefined) {
+        exports.set_input_element_value(elem, property_value);
     } else {
         blueslip.error('Element refers to unknown property ' + property_name);
     }
@@ -485,6 +483,19 @@ exports.get_input_element_value = function (input_elem, input_type) {
         }
     }
     return;
+};
+
+exports.set_input_element_value = function (input_elem, value) {
+    const input_type = get_input_type(input_elem, typeof value);
+    if (input_type) {
+        if (input_type === 'boolean') {
+            return input_elem.prop('checked', value);
+        }
+        if (input_type === 'string' || input_type === 'number') {
+            return input_elem.val(value);
+        }
+    }
+    blueslip.error(`Failed to set value of property ${exports.extract_property_name(input_elem)}`);
 };
 
 exports.set_up = function () {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -463,10 +463,16 @@ exports.change_save_button_state = function ($element, state) {
     show_hide_element($element, is_show, 800);
 };
 
+function get_input_type(input_elem, input_type) {
+    if (["boolean", "string", "number"].includes(input_type)) {
+        return input_type;
+    }
+    return input_elem.data("setting-widget-type");
+}
+
 exports.get_input_element_value = function (input_elem, input_type) {
     input_elem = $(input_elem);
-    input_type = ["boolean", "string", "number"].includes(input_type)
-        || input_elem.data("setting-widget-type");
+    input_type = get_input_type(input_elem, input_type);
     if (input_type) {
         if (input_type === 'boolean') {
             return input_elem.prop('checked');

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -719,7 +719,7 @@ exports.build_page = function () {
         } else if (subsection === 'message_retention') {
             const message_retention_setting_value = $('#id_realm_message_retention_setting').val();
             if (message_retention_setting_value === 'retain_forever') {
-                data.message_retention_days = settings_config.retain_message_forever;
+                data.message_retention_days = JSON.stringify('forever');
             } else {
                 data.message_retention_days = exports.get_input_element_value(
                     $('#id_realm_message_retention_days'));

--- a/zerver/lib/retention.py
+++ b/zerver/lib/retention.py
@@ -28,7 +28,7 @@
 # deletions.
 import logging
 from datetime import timedelta
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from django.conf import settings
 from django.db import connection, transaction
@@ -37,6 +37,7 @@ from django.utils.timezone import now as timezone_now
 from psycopg2.sql import SQL, Composable, Identifier, Literal
 
 from zerver.lib.logging_util import log_to_file
+from zerver.lib.request import RequestVariableConversionError
 from zerver.models import (
     ArchivedAttachment,
     ArchivedReaction,
@@ -585,3 +586,12 @@ def clean_archived_data() -> None:
         count += len(transaction_block)
 
     logger.info("Deleted %s old ArchiveTransactions.", count)
+
+def parse_message_retention_days(value: Union[int, str],
+                                 special_values_map: Dict[str, Optional[int]]) -> Optional[int]:
+    if isinstance(value, str) and value in special_values_map.keys():
+        return special_values_map[value]
+    if isinstance(value, str) or value <= 0:
+        raise RequestVariableConversionError('message_retention_days', value)
+    assert isinstance(value, int)
+    return value

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -307,7 +307,9 @@ class Realm(models.Model):
         "Stream", related_name="+", null=True, blank=True, on_delete=CASCADE,
     )
 
-    RETAIN_MESSAGE_FOREVER = -1
+    MESSAGE_RETENTION_SPECIAL_VALUES_MAP = {
+        'forever': -1,
+    }
     # For old messages being automatically deleted
     message_retention_days: Optional[int] = models.IntegerField(null=True)
 
@@ -1475,6 +1477,10 @@ class Stream(models.Model):
     # Value NULL means "use retention policy of the realm".
     # Value -1 means "disable retention policy for this stream unconditionally".
     # Non-negative values have the natural meaning of "archive messages older than <value> days".
+    MESSAGE_RETENTION_SPECIAL_VALUES_MAP = {
+        'forever': -1,
+        'realm_default': None,
+    }
     message_retention_days: Optional[int] = models.IntegerField(null=True, default=None)
 
     # The very first message ID in the stream.  Used to help clients

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -629,7 +629,15 @@ class RealmTest(ZulipTestCase):
         self.assert_json_error(
             result, "Bad value for 'message_retention_days': -10")
 
-        req = dict(message_retention_days=ujson.dumps(Realm.RETAIN_MESSAGE_FOREVER))
+        req = dict(message_retention_days=ujson.dumps('invalid'))
+        result = self.client_patch('/json/realm', req)
+        self.assert_json_error(result, "Bad value for 'message_retention_days': invalid")
+
+        req = dict(message_retention_days=ujson.dumps(-1))
+        result = self.client_patch('/json/realm', req)
+        self.assert_json_error(result, "Bad value for 'message_retention_days': -1")
+
+        req = dict(message_retention_days=ujson.dumps('forever'))
         result = self.client_patch('/json/realm', req)
         self.assert_json_success(result)
 

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -938,6 +938,10 @@ class StreamAdminTest(ZulipTestCase):
                                    {'message_retention_days': ujson.dumps(-1)})
         self.assert_json_error(result, "Bad value for 'message_retention_days': -1")
 
+        result = self.client_patch(f'/json/streams/{stream.id}',
+                                   {'message_retention_days': ujson.dumps(0)})
+        self.assert_json_error(result, "Bad value for 'message_retention_days': 0")
+
     def test_change_stream_message_retention_days_requires_realm_owner(self) -> None:
         user_profile = self.example_user('iago')
         self.login_user(user_profile)

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -133,7 +133,7 @@ def parse_message_retention_days(value: Union[int, str]) -> Optional[int]:
         return -1
     if value == "realm_default":
         return None
-    if isinstance(value, str) or value < 0:
+    if isinstance(value, str) or value <= 0:
         raise RequestVariableConversionError('message_retention_days', value)
     assert isinstance(value, int)
     return value

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -52,8 +52,9 @@ from zerver.lib.actions import (
     internal_prep_stream_message,
 )
 from zerver.lib.exceptions import ErrorCode, JsonableError, OrganizationOwnerRequired
-from zerver.lib.request import REQ, RequestVariableConversionError, has_request_variables
+from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.response import json_error, json_success
+from zerver.lib.retention import parse_message_retention_days
 from zerver.lib.streams import (
     access_default_stream_group_by_id,
     access_stream_by_id,
@@ -127,16 +128,6 @@ def check_if_removing_someone_else(user_profile: UserProfile,
         return principals[0] != user_profile.id
     else:
         return principals[0] != user_profile.email
-
-def parse_message_retention_days(value: Union[int, str]) -> Optional[int]:
-    if value == "forever":
-        return -1
-    if value == "realm_default":
-        return None
-    if isinstance(value, str) or value <= 0:
-        raise RequestVariableConversionError('message_retention_days', value)
-    assert isinstance(value, int)
-    return value
 
 @require_realm_admin
 def deactivate_stream_backend(request: HttpRequest,
@@ -247,7 +238,8 @@ def update_stream_backend(
         if not user_profile.is_realm_owner:
             raise OrganizationOwnerRequired()
         user_profile.realm.ensure_not_on_limited_plan()
-        message_retention_days_value = parse_message_retention_days(message_retention_days)
+        message_retention_days_value = parse_message_retention_days(
+            message_retention_days, Stream.MESSAGE_RETENTION_SPECIAL_VALUES_MAP)
         do_change_stream_message_retention_days(stream, message_retention_days_value)
 
     if description is not None:
@@ -432,7 +424,8 @@ def add_subscriptions_backend(
         stream_dict_copy["invite_only"] = invite_only
         stream_dict_copy["stream_post_policy"] = stream_post_policy
         stream_dict_copy["history_public_to_subscribers"] = history_public_to_subscribers
-        stream_dict_copy["message_retention_days"] = parse_message_retention_days(message_retention_days)
+        stream_dict_copy["message_retention_days"] = parse_message_retention_days(
+            message_retention_days, Stream.MESSAGE_RETENTION_SPECIAL_VALUES_MAP)
         stream_dicts.append(stream_dict_copy)
 
     # Validation of the streams arguments, including enforcement of


### PR DESCRIPTION
Rather than saving Realm.RETAIN_MESSAGE_FOREVER to the database when we
want message retention forever, we will save it as NULL (None) in the
database as NULL implies "no realm-level message retention policy set".

In frontend `discard_property_element_changes()` couldn't handle the case
when the updated value of the setting is null, so fixed that too.

