### PR TITLE
slack-import: Downgrade Slack legacy-token check failure to warning.

### DIFF
--- a/templates/zerver/help/import-from-slack.md
+++ b/templates/zerver/help/import-from-slack.md
@@ -17,29 +17,44 @@ into an existing Zulip organization.
 
 First, export your data from Slack.
 
-### Export your Slack data
+!!! warn ""
+    **Note:** Only Slack owners and admins can export data from Slack.
+    See Slack's
+    [guide to data exports](https://get.slack.help/hc/en-us/articles/201658943-Export-data-and-message-history)
+    for more information.
+
+#### Get a Slack API token.
+
+It will be a long string starting with `xoxb-`.  It is required to
+fetch data that Slack doesn't include in their data exports, like
+email addresses.
+
 
 {start_tabs}
 
-1. [Generate a Slack Legacy API
-   token](https://api.slack.com/custom-integrations/legacy-tokens).
-   It will be a long string starting with `xoxp-`.  It is required to
-   fetch data that Slack doesn't include in their data exports, like
-   email addresses.
+1. [Create a new Slack app](https://api.slack.com/apps).
 
-2. [Export your Slack data](https://my.slack.com/services/export). You will
-   receive a zip file `slack_data.zip`.
+2. [Add OAuth scopes](https://api.slack.com/authentication/basics#scopes)
+   to your app. We need the following 'bot token scopes':
+    - `emoji:read`
+    - `users:read`
+    - `users:read.email`
+    - `team:read`
 
-    !!! warn ""
-        **Note:** Only Slack owners and admins can export data from Slack.
-        See Slack's
-        [guide to data exports](https://get.slack.help/hc/en-us/articles/201658943-Export-data-and-message-history)
-        for more information.
-
-    This step will also generate a different token starting with
-    `xoxe-`; you don't need it.
+3. [Install the app](https://api.slack.com/authentication/basics#installing)
+  to your workspace. You will get an API token that you can now use to fetch
+      data from your slack workspace.
 
 {end_tabs}
+
+### Export your Slack data
+
+Now, [Export your Slack data](https://my.slack.com/services/export). You will
+receive a zip file `slack_data.zip`.
+
+
+This step will also generate a different token starting with
+`xoxe-`; you don't need it.
 
 ### Import into zulipchat.com
 

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -1033,6 +1033,8 @@ def do_convert_data(slack_zip_file: str, output_dir: str, token: str, threads: i
     realm_id = 0
     domain_name = settings.EXTERNAL_HOST
 
+    log_token_warning(token)
+
     slack_data_dir = slack_zip_file.replace('.zip', '')
     if not os.path.exists(slack_data_dir):
         os.makedirs(slack_data_dir)
@@ -1100,15 +1102,16 @@ def get_data_file(path: str) -> Any:
         data = ujson.load(fp)
         return data
 
+def log_token_warning(token: str) -> None:
+    if not token.startswith("xoxp-"):
+        logging.info('Not a Slack legacy token.\n'
+                     '  This token might not have all the needed scopes. We need the following scopes:\n'
+                     '  - emoji:read\n  - users:read\n  - users:read.email\n  - team:read')
+
+
 def get_slack_api_data(slack_api_url: str, get_param: str, **kwargs: Any) -> Any:
     if not kwargs.get("token"):
         raise AssertionError("Slack token missing in kwargs")
-    token = kwargs["token"]
-    if not token.startswith("xoxp-"):
-        raise Exception('Invalid Slack legacy token.\n'
-                        '  You must pass a Slack "legacy token" starting with "xoxp-".\n'
-                        '  Create one at https://api.slack.com/custom-integrations/legacy-tokens')
-
     data = requests.get("{}?{}".format(slack_api_url, urlencode(kwargs)))
 
     if data.status_code == requests.codes.ok:

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -96,11 +96,6 @@ class SlackImporter(ZulipTestCase):
             get_slack_api_data(slack_user_list_url, "members", token=token)
         self.assertEqual(invalid.exception.args, ('Error accessing Slack API: invalid_auth',),)
 
-        token = 'xoxe-invalid-token'
-        with self.assertRaises(Exception) as invalid:
-            get_slack_api_data(slack_user_list_url, "members", token=token)
-        self.assertTrue(invalid.exception.args[0].startswith("Invalid Slack legacy token.\n"))
-
         with self.assertRaises(Exception) as invalid:
             get_slack_api_data(slack_user_list_url, "members")
         self.assertEqual(invalid.exception.args, ('Slack token missing in kwargs',),)


### PR DESCRIPTION
Slack has disabled creation of legacy tokens, which means we have to use other
tokens for importing the data. Thus, we shouldn't throw an error if the token
doesn't match the legacy token format.

Since we do not have any other validation for those tokens yet, we log a warning
but still try to continue with the import assuming that the token has the right
scopes.

See https://api.slack.com/changelog/2020-02-legacy-test-token-creation-to-retire.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Tested export with a small slack org, we have it working again properly.

![image](https://user-images.githubusercontent.com/8033238/81607044-a69e1200-93f1-11ea-8013-709bd3b0183e.png)

Updated docs. ^