### PR TITLE
message-edit: Process user groups for mentioned user ids.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4404,10 +4404,16 @@ def do_update_message(user_profile: UserProfile, message: Message,
 
     if content is not None:
         assert rendered_content is not None
-        update_user_message_flags(message, ums)
 
         # mention_data is required if there's a content edit.
         assert mention_data is not None
+
+        # add data from group mentions to mentions_user_ids.
+        for group_id in message.mentions_user_group_ids:
+            members = mention_data.get_group_members(group_id)
+            message.mentions_user_ids.update(members)
+
+        update_user_message_flags(message, ums)
 
         # One could imagine checking realm.allow_edit_history here and
         # modifying the events based on that setting, but doing so


### PR DESCRIPTION
When editing a message where we mention a usergroup, we would remove
the 'mentioned' flag from messages, resulting in the message being
hidden from your mentions in the UI. This was reported by Greg Price in
https://chat.zulip.org/#narrow/stream/9-issues/topic/missing.20mention.

We add the same code that we use in do_send_messages to calculate the
updated mentions_user_ids. We add some tests alongside other user group
mention tests in test_bugdown.

