### PR TITLE
stream_settings: Don't remove stream_row if in "All Streams" tab.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -107,7 +107,9 @@ exports.toggle_pin_to_top_stream = function (sub) {
 exports.is_subscribed_stream_tab_active = function () {
     // Returns true if "Subscribed" tab in stream settings is open
     // otherwise false.
-    if ($("#subscriptions_table .search-container .tab-switcher .first").hasClass("selected")) {
+    const tab = $(`#subscriptions_table .search-container .tab-switcher
+                  .first[data-tab-key=subscribed]`).expectOne();
+    if (tab.hasClass("selected")) {
         return true;
     }
     return false;


### PR DESCRIPTION
If you were on the "All Streams" tab and unsubscribed to a private
stream, that stream row would momentarily disappear. If you
click again on the "All Streams" button, it would appear again.

To fix this, we added a condition so the "notdisplayed" CSS
class isn't added if the user is on the "All Streams" tab.

**Testing Plan:** <!-- How have you tested? -->
Manual testing.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![](https://media.giphy.com/media/kdL1W6g24Z33tHb5WB/giphy.gif)
