### PR TITLE
bots: Remove `owner` (email) from bot-related payloads.

### DIFF
--- a/version.py
+++ b/version.py
@@ -29,7 +29,7 @@ DESKTOP_WARNING_VERSION = "5.2.0"
 #
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md.
-API_FEATURE_LEVEL = 4
+API_FEATURE_LEVEL = 5
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -476,7 +476,6 @@ def created_bot_event(user_profile: UserProfile) -> Dict[str, Any]:
     # The default bots don't have an owner. So don't
     # set the owner key while reactivating them.
     if user_profile.bot_owner is not None:
-        bot['owner'] = user_profile.bot_owner.email
         bot['owner_id'] = user_profile.bot_owner.id
 
     return dict(type="realm_bot", op="add", bot=bot)
@@ -5733,7 +5732,6 @@ def get_owned_bot_dicts(user_profile: UserProfile,
              'default_sending_stream': botdict['default_sending_stream__name'],
              'default_events_register_stream': botdict['default_events_register_stream__name'],
              'default_all_public_streams': botdict['default_all_public_streams'],
-             'owner': botdict['bot_owner__email'],  # TODO: eliminate
              'owner_id': botdict['bot_owner__id'],
              'avatar_url': avatar_url_from_dict(botdict),
              'services': services_by_ids[botdict['id']],

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -465,7 +465,6 @@ bot_dict_fields: List[str] = [
     'avatar_source',
     'avatar_version',
     'bot_owner__id',
-    'bot_owner__email',  # TODO: eliminate
     'bot_type',
     'default_all_public_streams',
     'default_events_register_stream__name',

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -54,7 +54,7 @@ from zerver.lib.user_status import get_user_info_dict
 from zerver.tornado.event_queue import request_event_queue, get_user_events
 from zerver.models import (
     Client, Message, Realm, UserProfile, UserMessage,
-    get_user_profile_by_id, realm_filters_for_realm,
+    realm_filters_for_realm,
     custom_profile_fields_for_realm, get_realm_domains,
     get_default_stream_groups, CustomProfileField, Stream
 )
@@ -482,10 +482,6 @@ def apply_event(state: Dict[str, Any],
                     if 'owner_id' in event['bot']:
                         bot_owner_id = event['bot']['owner_id']
                         bot['owner_id'] = bot_owner_id
-
-                        # TODO: eliminate `owner` field.
-                        bot_owner = get_user_profile_by_id(bot_owner_id)
-                        bot['owner'] = bot_owner.email
                     else:
                         bot.update(event['bot'])
 

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -182,7 +182,6 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
                     default_all_public_streams=False,
                     services=[],
                     owner_id=hamlet.id,
-                    owner=hamlet.email,
                 ),
             ),
             event['event']
@@ -315,11 +314,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
                          default_events_register_stream=None,
                          default_all_public_streams=False,
                          services=[],
-                         owner_id=user.id,
-                         # Important: This is the product-facing
-                         # email, not the delivery email, for this
-                         # user.  TODO: Migrate this to an integer ID.
-                         owner=user.email)
+                         owner_id=user.id)
             ),
             event['event']
         )
@@ -420,7 +415,6 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
                     default_all_public_streams=False,
                     services=[],
                     owner_id=user_profile.id,
-                    owner=user_profile.email,
                 ),
             ),
             event['event']
@@ -496,7 +490,6 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
                     default_all_public_streams=False,
                     services=[],
                     owner_id=user_profile.id,
-                    owner=user_profile.email,
                 ),
             ),
             event['event']

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2109,7 +2109,6 @@ class EventsRegisterTest(ZulipTestCase):
                     ('default_events_register_stream', check_none_or(check_string)),
                     ('default_all_public_streams', check_bool),
                     ('avatar_url', check_string),
-                    ('owner', check_string),
                     ('owner_id', check_int),
                     ('services', check_services),
                 ])),
@@ -2303,7 +2302,6 @@ class EventsRegisterTest(ZulipTestCase):
                 ('default_events_register_stream', check_none_or(check_string)),
                 ('default_all_public_streams', check_bool),
                 ('avatar_url', check_string),
-                ('owner', check_string),
                 ('owner_id', check_int),
                 ('services', check_services),
             ])),
@@ -2375,7 +2373,6 @@ class EventsRegisterTest(ZulipTestCase):
                 ('default_events_register_stream', check_none_or(check_string)),
                 ('default_all_public_streams', check_bool),
                 ('avatar_url', check_string),
-                ('owner', check_none_or(check_string)),
                 ('owner_id', check_none_or(check_int)),
                 ('services', check_list(check_dict_only([
                     ('base_url', check_url),

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -278,7 +278,6 @@ class HomeTest(ZulipTestCase):
             'email',
             'full_name',
             'is_active',
-            'owner',
             'owner_id',
             'services',
             'user_id',
@@ -568,7 +567,7 @@ class HomeTest(ZulipTestCase):
                 if field == 'realm_bots':
                     self.assertNotIn('is_bot', rec)
                     self.assertIn('is_active', rec)
-                    self.assertIn('owner', rec)
+                    self.assertIn('owner_id', rec)
                 else:
                     self.assertIn('is_bot', rec)
                     self.assertNotIn('is_active', rec)


### PR DESCRIPTION
We remove the `owner` field from `page_params/realm_bots`
and bot-related events.

In the recent commit 155f6da8ba7af44e002f4f967b4015245c0dad1b
we added `owner_id`, which we now use everywhere we need
bot owners for.

We also bump the `API_FEATURE_LEVEL` to 5 here.  We
had already documented this in the prior commit to
add `owner_id`.

Note that we don't have to worry about mobile/ZT clients
here--we only deal with bot data in the webapp.
