### PR TITLE
realm_logo: Fix incorrect display of realm logo delete button.

### DIFF
--- a/static/js/realm_logo.js
+++ b/static/js/realm_logo.js
@@ -1,7 +1,10 @@
 exports.build_realm_logo_widget = function (upload_function, is_night) {
     let logo_section_id = '#day-logo-section';
+    let logo_source = page_params.realm_logo_source;
+
     if (is_night) {
         logo_section_id = '#night-logo-section';
+        logo_source = page_params.realm_night_logo_source;
     }
 
     const delete_button_elem = $(logo_section_id + " .realm-logo-delete-button");
@@ -17,7 +20,7 @@ exports.build_realm_logo_widget = function (upload_function, is_night) {
         return;
     }
 
-    if (page_params.realm_logo_source === 'D') {
+    if (logo_source === 'D') {
         delete_button_elem.hide();
     } else {
         delete_button_elem.show();


### PR DESCRIPTION
This commit fixes the bug of incorrectly showing/hiding the
realm logo delete button by using realm_night_logo_source for
checking the source of night mode logo instead of previously
used realm_logo_source for both day and night logos.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
