### PR TITLE
api: Remove email field from realm_user and realm_bot events.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -10,6 +10,13 @@ below features are supported.
 
 ## Changes in Zulip 2.2
 
+**Feature level 7**
+* [`GET /events`](/api/get-events-from-queue): `realm_user` and
+  `realm_bot` events no longer contain an `email` field to identify
+  the user; use the `user_id` field instead.  Previously, some (but
+  not all) events of these types contained an `email` key in addition to
+  to `user_id`) for identifying the modified user.
+
 **Feature level 6**
 * [`GET /events`](/api/get-events-from-queue): `realm_user` events to
   update a user's avatar now include the `avatar_version` field, which

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -467,18 +467,18 @@ def apply_event(state: Dict[str, Any],
             state['realm_bots'].append(event['bot'])
 
         if event['op'] == 'remove':
-            email = event['bot']['email']
+            user_id = event['bot']['user_id']
             for bot in state['realm_bots']:
-                if bot['email'] == email:
+                if bot['user_id'] == user_id:
                     bot['is_active'] = False
 
         if event['op'] == 'delete':
             state['realm_bots'] = [item for item
-                                   in state['realm_bots'] if item['email'] != event['bot']['email']]
+                                   in state['realm_bots'] if item['user_id'] != event['bot']['user_id']]
 
         if event['op'] == 'update':
             for bot in state['realm_bots']:
-                if bot['email'] == event['bot']['email']:
+                if bot['user_id'] == event['bot']['user_id']:
                     if 'owner_id' in event['bot']:
                         bot_owner_id = event['bot']['owner_id']
                         bot['owner_id'] = bot_owner_id

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -474,7 +474,6 @@ class EventsRegisterTest(ZulipTestCase):
             ('type', equals('realm_bot')),
             ('op', equals('update')),
             ('bot', check_dict_only([
-                ('email', check_string),
                 ('user_id', check_int),
                 (field_name, check),
             ])),
@@ -1532,12 +1531,11 @@ class EventsRegisterTest(ZulipTestCase):
             ('type', equals('realm_user')),
             ('op', equals('update')),
             ('person', check_dict_only([
-                ('email', check_string),
-                ('user_id', check_int),
                 ('avatar_url', check_string),
                 ('avatar_url_medium', check_string),
                 ('avatar_version', check_int),
                 ('avatar_source', check_string),
+                ('user_id', check_int),
             ])),
         ])
         events = self.do_test(
@@ -1554,7 +1552,6 @@ class EventsRegisterTest(ZulipTestCase):
                 ('avatar_url', check_none_or(check_string)),
                 ('avatar_url_medium', check_none_or(check_string)),
                 ('avatar_version', check_int),
-                ('email', check_string),
                 ('user_id', check_int),
             ])),
         ])
@@ -1569,7 +1566,6 @@ class EventsRegisterTest(ZulipTestCase):
             ('type', equals('realm_user')),
             ('op', equals('update')),
             ('person', check_dict_only([
-                ('email', check_string),
                 ('full_name', check_string),
                 ('user_id', check_int),
             ])),
@@ -1591,12 +1587,11 @@ class EventsRegisterTest(ZulipTestCase):
             ('type', equals('realm_user')),
             ('op', equals('update')),
             ('person', check_dict_only([
-                ('email', check_string),
-                ('user_id', check_int),
                 ('avatar_source', check_string),
                 ('avatar_url', check_string),
                 ('avatar_url_medium', check_string),
                 ('avatar_version', check_int),
+                ('user_id', check_int),
             ])),
         ])
         do_set_realm_property(self.user_profile.realm, "email_address_visibility",
@@ -1836,7 +1831,6 @@ class EventsRegisterTest(ZulipTestCase):
             ('type', equals('realm_user')),
             ('op', equals('update')),
             ('person', check_dict_only([
-                ('email', check_string),
                 ('is_admin', check_bool),
                 ('user_id', check_int),
             ])),
@@ -1907,7 +1901,6 @@ class EventsRegisterTest(ZulipTestCase):
                 ('type', equals('realm_user')),
                 ('op', equals('update')),
                 ('person', check_dict_only([
-                    ('email', check_string),
                     ('user_id', check_int),
                     ('timezone', check_string),
                 ])),
@@ -2259,7 +2252,6 @@ class EventsRegisterTest(ZulipTestCase):
             ('type', equals('realm_bot')),
             ('op', equals('update')),
             ('bot', check_dict_only([
-                ('email', check_string),
                 ('user_id', check_int),
                 ('owner_id', check_int),
             ])),
@@ -2278,7 +2270,6 @@ class EventsRegisterTest(ZulipTestCase):
             ('type', equals('realm_bot')),
             ('op', equals('delete')),
             ('bot', check_dict_only([
-                ('email', check_string),
                 ('user_id', check_int),
             ])),
         ])
@@ -2326,7 +2317,6 @@ class EventsRegisterTest(ZulipTestCase):
             ('type', equals('realm_bot')),
             ('op', equals('update')),
             ('bot', check_dict_only([
-                ('email', check_string),
                 ('user_id', check_int),
                 ('services', check_list(check_dict_only([
                     ('base_url', check_url),
@@ -2352,7 +2342,6 @@ class EventsRegisterTest(ZulipTestCase):
             ('type', equals('realm_bot')),
             ('op', equals('remove')),
             ('bot', check_dict_only([
-                ('email', check_string),
                 ('full_name', check_string),
                 ('user_id', check_int),
             ])),

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -157,7 +157,7 @@ class PermissionTest(ZulipTestCase):
         admin_users = realm.get_human_admin_users()
         self.assertTrue(othello in admin_users)
         person = events[0]['event']['person']
-        self.assertEqual(person['email'], othello.email)
+        self.assertEqual(person['user_id'], othello.id)
         self.assertEqual(person['is_admin'], True)
 
         # Taketh away
@@ -169,7 +169,7 @@ class PermissionTest(ZulipTestCase):
         admin_users = realm.get_human_admin_users()
         self.assertFalse(othello in admin_users)
         person = events[0]['event']['person']
-        self.assertEqual(person['email'], othello.email)
+        self.assertEqual(person['user_id'], othello.id)
         self.assertEqual(person['is_admin'], False)
 
         # Cannot take away from last admin
@@ -182,7 +182,7 @@ class PermissionTest(ZulipTestCase):
         admin_users = realm.get_human_admin_users()
         self.assertFalse(hamlet in admin_users)
         person = events[0]['event']['person']
-        self.assertEqual(person['email'], hamlet.email)
+        self.assertEqual(person['user_id'], hamlet.id)
         self.assertEqual(person['is_admin'], False)
         with tornado_redirected_to_list([]):
             result = self.client_patch('/json/users/{}'.format(iago.id), req)
@@ -383,7 +383,7 @@ class PermissionTest(ZulipTestCase):
         self.assertTrue(hamlet.is_guest)
         self.assertFalse(hamlet.can_access_all_realm_members())
         person = events[0]['event']['person']
-        self.assertEqual(person['email'], hamlet.email)
+        self.assertEqual(person['user_id'], hamlet.id)
         self.assertTrue(person['is_guest'])
 
     def test_change_guest_to_regular_member(self) -> None:
@@ -401,7 +401,7 @@ class PermissionTest(ZulipTestCase):
         polonius = self.example_user("polonius")
         self.assertFalse(polonius.is_guest)
         person = events[0]['event']['person']
-        self.assertEqual(person['email'], polonius.email)
+        self.assertEqual(person['user_id'], polonius.id)
         self.assertFalse(person['is_guest'])
 
     def test_change_admin_to_guest(self) -> None:
@@ -431,11 +431,11 @@ class PermissionTest(ZulipTestCase):
         self.assertFalse(hamlet.is_realm_admin)
 
         person = events[0]['event']['person']
-        self.assertEqual(person['email'], hamlet.email)
+        self.assertEqual(person['user_id'], hamlet.id)
         self.assertFalse(person['is_admin'])
 
         person = events[1]['event']['person']
-        self.assertEqual(person['email'], hamlet.email)
+        self.assertEqual(person['user_id'], hamlet.id)
         self.assertTrue(person['is_guest'])
 
     def test_change_guest_to_admin(self) -> None:
@@ -464,7 +464,7 @@ class PermissionTest(ZulipTestCase):
         self.assertTrue(polonius.is_realm_admin)
 
         person = events[0]['event']['person']
-        self.assertEqual(person['email'], polonius.email)
+        self.assertEqual(person['user_id'], polonius.id)
         self.assertTrue(person['is_admin'])
 
     def test_admin_user_can_change_profile_data(self) -> None:


### PR DESCRIPTION
The `email` field for identifying the user being modified in these
events was not used by either the webapp or other official Zulip
clients.  Instead, it was legacy data from before we switched years
ago to sending user_id fields as the correct way to uniquely identify
a user.
