### PR TITLE
compose.js: Fix compose box didn't collapse.

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -354,7 +354,6 @@ exports.send_message = function send_message(request) {
 };
 
 exports.enter_with_preview_open = function () {
-    exports.clear_preview_area();
     if (page_params.enter_sends) {
         // If enter_sends is enabled, we attempt to send the message
         exports.finish();
@@ -365,6 +364,7 @@ exports.enter_with_preview_open = function () {
 };
 
 exports.finish = function () {
+    exports.clear_preview_area();
     exports.clear_invites();
     exports.clear_private_stream_alert();
     notifications.clear_compose_notifications();


### PR DESCRIPTION
Fix a bug where the compose box didn't collapse when sending a message
from the preview area by hitting the send button. The bug ocurred because
the preview area wasn't being properly cleared when this flow was executed.
This was fixed by moving the clear_preview_area function call for a place
that will be reached by both the enter and button flow.

Fixes: #14889

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![giphy](https://user-images.githubusercontent.com/16260725/81871286-dfeb9480-954d-11ea-859b-8dd8b5d3177d.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
