### PR TITLE
bugfix: Fix codecov broken backend coverage upload.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,11 +95,20 @@ aliases:
     run:
      name: upload coverage report
      command: |
+       # codecov requires `.coverage` file to be stored in pwd for
+       # uploading coverage results.
+       mv /home/circleci/zulip/var/.coverage /home/circleci/zulip/.coverage
+
        . /srv/zulip-py3-venv/bin/activate
-       # codecov version is fixed here, since future versions of it
-       # use "find" for locating files which is buggy on some platforms.
-       # See https://github.com/codecov/codecov-python/issues/250
-       pip install codecov==2.0.15 && codecov \
+       # TODO: Check that the next release of codecov doesn't
+       # throw find error.
+       # codecov==2.0.16 introduced a bug which uses "find"
+       # for locating files which is buggy on some platforms.
+       # It was fixed via https://github.com/codecov/codecov-python/pull/217
+       # and should get automatically fixed here once it's released.
+       # We cannot pin the version here because we need the latest version for uploading files.
+       # see https://community.codecov.io/t/http-400-while-uploading-to-s3-with-python-codecov-from-travis/1428/7
+       pip install codecov && codecov \
          || echo "Error in uploading coverage reports to codecov.io."
 
   - &build_production

--- a/tools/ci/backend
+++ b/tools/ci/backend
@@ -12,7 +12,7 @@ set -x
 # docker setup means the auto-detection logic sees the ~36 processes
 # the Docker host has, not the ~2 processes of resources we're
 # allocated.
-./tools/test-backend --coverage --include-webhooks --parallel=6
+./tools/test-backend --coverage --include-webhooks --no-cov-cleanup --parallel=6
 
 # We run mypy after the backend tests so we get output from the
 # backend tests, which tend to uncover more serious problems, first.

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -216,6 +216,10 @@ def main() -> None:
     parser.add_argument('--verbose-coverage', dest='verbose_coverage',
                         action="store_true",
                         default=False, help='Enable verbose print of coverage report.')
+    parser.add_argument('--no-cov-cleanup', dest='no_cov_cleanup',
+                        action='store_true',
+                        default=False,
+                        help="Do not clean generated coverage files.")
 
     parser.add_argument('--parallel', dest='processes',
                         type=int,
@@ -354,10 +358,12 @@ def main() -> None:
     assert_provisioning_status_ok(options.force)
 
     if options.coverage:
-        import atexit
         import coverage
-        cov = coverage.Coverage(config_file="tools/coveragerc", concurrency='multiprocessing')
-        atexit.register(lambda: cov.erase())  # Ensure the data file gets cleaned up at the end.
+        cov = coverage.Coverage(data_suffix="", config_file="tools/coveragerc", concurrency='multiprocessing')
+        # Do not clean .coverage file in CircleCi job so that coverage data can be uploaded.
+        if not options.no_cov_cleanup:
+            import atexit
+            atexit.register(lambda: cov.erase())  # Ensure the data file gets cleaned up at the end.
         cov.start()
     if options.profile:
         import cProfile
@@ -407,7 +413,6 @@ def main() -> None:
         cov.stop()
         cov.save()
         cov.combine()
-        cov.data_suffix = False  # Disable suffix so that filename is .coverage
         cov.save()
         if options.verbose_coverage:
             print("Printing coverage data")


### PR DESCRIPTION
Looks like @mateuszmandera 's #13946 introduces this issue. The commits before this have backend coverage. Also, there appears to be some problem with suffix of the file, which should be blank.

Also, removes the find error we see:
```
find: unknown predicate `-not -path './bower_components/**' -not -path './node_modules/**' -not -path './vendor/**''
 
    Error running `['find', '/home/circleci/zulip', "-not -path './bower_components/**' -not -path './node_modules/**' -not -path './vendor/**'", '-type', 'f', '-name', '*.gcno', '', '-exec', 'gcov', '-pb', '', '{}', '+']`: Command '['find', '/home/circleci/zulip', "-not -path './bower_components/**' -not -path './node_modules/**' -not -path './vendor/**'", '-type', 'f', '-name', '*.gcno', '', '-exec', 'gcov', '-pb', '', '{}', '+']' returned non-zero exit status 1.
 
```