### PR TITLE
Minor Updates to the Stripe Integration

### DIFF
--- a/zerver/webhooks/stripe/fixtures/pseudo_refund_event.json
+++ b/zerver/webhooks/stripe/fixtures/pseudo_refund_event.json
@@ -1,0 +1,32 @@
+{
+    "id": "evt_abcde12345ABCDE",
+    "object": "event",
+    "api_version": "2018-05-21",
+    "created": 1581391347,
+    "data": {
+        "object": {
+            "id": "pyr_abcde12345ABCDF",
+            "object": "refund",
+            "amount": 1234,
+            "balance_transaction": null,
+            "charge": "py_abcde12345ABCDG",
+            "created": 1589212391,
+            "currency": "eur",
+            "metadata": {},
+            "payment_intent": "pi_abcd1234ABCDH",
+            "reason": null,
+            "receipt_number": null,
+            "source_transfer_reversal": null,
+            "status": "succeeded",
+            "transfer_reversal": null
+        },
+        "previous_attributes": {}
+    },
+    "livemode": true,
+    "pending_webhooks": 1,
+    "request": {
+        "id": null,
+        "idempotency_key": null
+    },
+    "type": "charge.refund.updated"
+}

--- a/zerver/webhooks/stripe/fixtures/refund_event.json
+++ b/zerver/webhooks/stripe/fixtures/refund_event.json
@@ -1,0 +1,38 @@
+{
+    "id": "evt_1Gib6dHLwdCOCoR7mbMhSVu0",
+    "object": "event",
+    "api_version": "2020-03-02",
+    "created": 1589439827,
+    "data": {
+        "object": {
+            "id": "re_1Gib6ZHLwdCOCoR7VrzCnXlj",
+            "object": "refund",
+            "amount": 30000000,
+            "balance_transaction": "txn_1Gib6ZHLwdCOCoR71Gd83huz",
+            "charge": "ch_1Gib61HLwdCOCoR71rnkccye",
+            "created": 1589439823,
+            "currency": "inr",
+            "failure_balance_transaction": "txn_1Gib6dHLwdCOCoR7VQXTaZVj",
+            "failure_reason": "expired_or_canceled_card",
+            "metadata": {},
+            "payment_intent": "pi_1Gib60HLwdCOCoR7KJbTO3U7",
+            "reason": null,
+            "receipt_number": null,
+            "source_transfer_reversal": null,
+            "status": "failed",
+            "transfer_reversal": null
+        },
+        "previous_attributes": {
+            "failure_balance_transaction": null,
+            "failure_reason": null,
+            "status": "succeeded"
+        }
+    },
+    "livemode": false,
+    "pending_webhooks": 1,
+    "request": {
+        "id": null,
+        "idempotency_key": null
+    },
+    "type": "charge.refund.updated"
+}

--- a/zerver/webhooks/stripe/tests.py
+++ b/zerver/webhooks/stripe/tests.py
@@ -143,6 +143,11 @@ Billing method: send invoice"""
         expected_message = "A [refund](https://dashboard.stripe.com/refunds/re_1Gib6ZHLwdCOCoR7VrzCnXlj) for a [charge](https://dashboard.stripe.com/charges/ch_1Gib61HLwdCOCoR71rnkccye) of 30000000 INR was updated."
         self.send_and_test_stream_message('refund_event', expected_topic, expected_message)
 
+    def test_pseudo_refund_event(self) -> None:
+        expected_topic = "refunds"
+        expected_message = "A [refund](https://dashboard.stripe.com/refunds/pyr_abcde12345ABCDF) for a [payment](https://dashboard.stripe.com/payments/py_abcde12345ABCDG) of 1234 EUR was updated."
+        self.send_and_test_stream_message('pseudo_refund_event', expected_topic, expected_message)
+
     @patch('zerver.webhooks.stripe.view.check_send_webhook_message')
     def test_account_updated_without_previous_attributes_ignore(
             self, check_send_webhook_message_mock: MagicMock) -> None:

--- a/zerver/webhooks/stripe/tests.py
+++ b/zerver/webhooks/stripe/tests.py
@@ -138,6 +138,11 @@ Billing method: send invoice"""
             content_type="application/x-www-form-urlencoded"
         )
 
+    def test_refund_event(self) -> None:
+        expected_topic = "refunds"
+        expected_message = "A [refund](https://dashboard.stripe.com/refunds/re_1Gib6ZHLwdCOCoR7VrzCnXlj) for a [charge](https://dashboard.stripe.com/charges/ch_1Gib61HLwdCOCoR71rnkccye) of 30000000 INR was updated."
+        self.send_and_test_stream_message('refund_event', expected_topic, expected_message)
+
     @patch('zerver.webhooks.stripe.view.check_send_webhook_message')
     def test_account_updated_without_previous_attributes_ignore(
             self, check_send_webhook_message_mock: MagicMock) -> None:

--- a/zerver/webhooks/stripe/view.py
+++ b/zerver/webhooks/stripe/view.py
@@ -97,11 +97,14 @@ def topic_and_body(payload: Dict[str, Any]) -> Tuple[str, str]:
             topic = 'disputes'
             body = default_body() + '. Current status: {status}.'.format(
                 status=object_['status'].replace('_', ' '))
-        if resource == 'refund':  # nocoverage
+        if resource == 'refund':
             topic = 'refunds'
-            body = 'A {resource} for a {charge} of {amount} was updated.'.format(
+            body = 'A {resource} for a {charge} of {amount} {currency} was updated.'.format(
                 resource=linkified_id(object_['id'], lower=True),
-                charge=linkified_id(object_['charge'], lower=True), amount=object_['amount'])
+                charge=linkified_id(object_['charge'], lower=True),
+                amount=object_['amount'],
+                currency=object_['currency'].upper()
+            )
     if category == 'checkout_beta':  # nocoverage
         # Not sure what this is
         raise NotImplementedEventType()

--- a/zerver/webhooks/stripe/view.py
+++ b/zerver/webhooks/stripe/view.py
@@ -242,6 +242,7 @@ def linkified_id(object_id: str, lower: bool=False) -> str:
 
         # Undocumented :|
         'py': ('Payment', 'payments'),
+        'pyr': ('Refund', 'refunds'),  # Psuedo refunds. Not fully tested.
 
         # Connect, Fraud, Orders, etc not implemented
     }


### PR DESCRIPTION
The first commit adds test coverage for the `charge.refund.updated` event and changes the message a bit to consider the currency and not just the amount. The second commit adds support for events involving refunds with `pyr_` IDs. Due to lack of documentation and inability to reproduce the event, I admit that I feel quite under-confident about this change.

@timabbott pinging for review.