### PR TITLE
GitHub Webhook: Support team/edited and more verbose logging for pull_request events

### DIFF
--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -569,7 +569,8 @@ def get_event(request: HttpRequest, payload: Dict[str, Any], branches: Optional[
     elif event in IGNORED_EVENTS:
         return None
 
-    raise UnexpectedWebhookEventType('GitHub', event)
+    complete_event = "{}:{}".format(event, payload.get("action", "???"))  # nocoverage
+    raise UnexpectedWebhookEventType('GitHub', complete_event)
 
 def get_body_function_based_on_type(type: str) -> Any:
     return EVENT_FUNCTION_MAPPER.get(type)


### PR DESCRIPTION
A simple follow up from PR #14954.

@timabbott pinging for review.