### PR TITLE
Support remote HTTP proxy authentication

### DIFF
--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -431,6 +431,24 @@ the bottom of the problem:
   this file (feel free to anonymize any email addresses to
   `username@example.com`) in your report.
 
+## Authenticating Proxy SSO
+
+You can configure Zulip to let an HTTP reverse proxy handle authentication and send
+through the authenticated username in an HTTP header. It is recommended to configure
+an optional header with a shared secret between the proxy and Zulip.
+
+### Setup instructions for Authenticating Proxy SSO
+
+In `/etc/zulip/settings.py`, configure these settings settings:
+
+1. `AUTHENTICATION_BACKENDS`: `'zproject.backends.ZulipRemoteUserBackend'`.
+2. `REMOTE_USER_AUTH_USER_HEADER`: the name of the HTTP header that will contain the username.
+3. (Optional) `REMOTE_USER_AUTH_SECRET_HEADER`: the name of the HTTP header that will contain the shared secret.
+   * Add the shared secret to `/etc/zulip/zulip-secrets.conf` by setting
+     `remote_sso_secret`. This should be a long random string.
+4. (Optional) `REMOTE_USER_AUTH_DOMAIN`: see documentation in `settings.py`.
+
+
 ## Apache-based SSO with `REMOTE_USER`
 
 If you have any existing SSO solution where a preferred way to deploy
@@ -445,7 +463,7 @@ straightforward way to deploy that SSO solution with Zulip.
    * `AUTHENTICATION_BACKENDS`: `'zproject.backends.ZulipRemoteUserBackend'`,
      and no other entries.
 
-   * `SSO_APPEND_DOMAIN`: see documentation in `settings.py`.
+   * `REMOTE_USER_AUTH_DOMAIN`: see documentation in `settings.py`.
 
    Make sure that you've restarted the Zulip server since making this
    configuration change.

--- a/templates/zerver/config_error.html
+++ b/templates/zerver/config_error.html
@@ -95,6 +95,21 @@
                         The REMOTE_USER header is not set.
                     </p>
                     {% endif %}
+                    {% if error_name == "remoteuser_error_remote_user_http_header_missing" %}
+                    <p>
+                        The HTTP user header {{ header_name }} is not set.
+                    </p>
+                    {% endif %}
+                    {% if error_name == "remoteuser_error_remote_user_http_secret_missing" %}
+                    <p>
+                        The HTTP secret header {{ header_name }} is not set.
+                    </p>
+                    {% endif %}
+                    {% if error_name == "remoteuser_error_remote_user_http_secret_incorrect" %}
+                    <p>
+                        The HTTP header secret in {{ header_name }} is incorrect.
+                    </p>
+                    {% endif %}
                     <p>After making your changes, remember to restart
                     the Zulip server.</p>
                 </div>

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1303,8 +1303,8 @@ def receives_stream_notifications(user_profile: UserProfile) -> bool:
             not user_profile.is_bot)
 
 def remote_user_to_email(remote_user: str) -> str:
-    if settings.SSO_APPEND_DOMAIN is not None:
-        remote_user += "@" + settings.SSO_APPEND_DOMAIN
+    if settings.REMOTE_USER_AUTH_DOMAIN is not None:
+        remote_user += "@" + settings.REMOTE_USER_AUTH_DOMAIN
     return remote_user
 
 # Make sure we flush the UserProfile object from our remote cache

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -43,6 +43,7 @@ from .configured_settings import (
     REMOTE_POSTGRES_HOST,
     REMOTE_POSTGRES_PORT,
     REMOTE_POSTGRES_SSLMODE,
+    REMOTE_USER_AUTH_DOMAIN,
     SENDFILE_BACKEND,
     SOCIAL_AUTH_APPLE_SERVICES_ID,
     SOCIAL_AUTH_GITHUB_KEY,
@@ -51,6 +52,7 @@ from .configured_settings import (
     SOCIAL_AUTH_GOOGLE_KEY,
     SOCIAL_AUTH_SAML_ENABLED_IDPS,
     SOCIAL_AUTH_SAML_SECURITY_CONFIG,
+    SSO_APPEND_DOMAIN,
     STATSD_HOST,
     USING_PGROONGA,
     ZULIP_ADMINISTRATOR,
@@ -962,6 +964,10 @@ POLL_TIMEOUT = 90 * 1000
 ########################################################################
 
 USING_APACHE_SSO = ('zproject.backends.ZulipRemoteUserBackend' in AUTHENTICATION_BACKENDS)
+
+# Backwards compatibility with previous SSO variable.
+if SSO_APPEND_DOMAIN and not REMOTE_USER_AUTH_DOMAIN:
+    REMOTE_USER_AUTH_DOMAIN = SSO_APPEND_DOMAIN
 
 ONLY_LDAP = False
 if len(AUTHENTICATION_BACKENDS) == 1 and (AUTHENTICATION_BACKENDS[0] ==

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -83,6 +83,10 @@ SOCIAL_AUTH_APPLE_EMAIL_AS_USERNAME = True
 
 # Other auth
 SSO_APPEND_DOMAIN: Optional[str] = None
+REMOTE_USER_AUTH_DOMAIN: Optional[str] = None
+REMOTE_USER_AUTH_USER_HEADER: Optional[str] = None
+REMOTE_USER_AUTH_SECRET_HEADER: Optional[str] = None
+REMOTE_USER_AUTH_SECRET = get_secret('remote_sso_secret')
 
 VIDEO_ZOOM_CLIENT_ID = get_secret('video_zoom_client_id', development_only=True)
 VIDEO_ZOOM_CLIENT_SECRET = get_secret('video_zoom_client_secret')

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -309,13 +309,26 @@ SOCIAL_AUTH_SAML_SUPPORT_CONTACT = {
 #SOCIAL_AUTH_AZUREAD_OAUTH2_KEY = ''
 
 ########
-# SSO via REMOTE_USER.
+# SSO via REMOTE_USER and Authenticating Proxy SSO
 #
 # If you are using the ZulipRemoteUserBackend authentication backend,
 # set this to your domain (e.g. if REMOTE_USER is "username" and the
 # corresponding email address is "username@example.com", set
-# SSO_APPEND_DOMAIN = "example.com")
-SSO_APPEND_DOMAIN = None  # type: Optional[str]
+# REMOTE_USER_AUTH_DOMAIN = "example.com")
+REMOTE_USER_AUTH_DOMAIN = None  # type: Optional[str]
+
+########
+# Authenticating Proxy SSO
+#
+# If you are using a remote HTTP proxy for authentication then set REMOTE_USER_AUTH_USER_HEADER
+# to the name of the HTTP header that will contain the username.
+# REMOTE_USER_AUTH_USER_HEADER = "X-Remote-User"
+
+# It is recommened to configure a shared secret between the proxy and Zulip.
+# The name of the HTTP header containing the shared secret between
+# the authenticating proxy and Zulip. If this is set you must also define
+# remote_sso_secret with the shared secret in your zulip-secrets.conf
+# REMOTE_USER_AUTH_SECRET_HEADER = "X-Remote-Secret"
 
 ################
 # Miscellaneous settings.


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR adds the ability to authenticate users based on an HTTP header (`SSO_HTTP_USER_HEADER`). This differs from the existing Apache SSO in that it allows remote proxies to send the authenticated user header. The PR also allows specifying an optional header (`SSO_HTTP_SECRET_HEADER`) that will contain a shared secret between the authenticating proxy and Zulip.

**Testing Plan:** <!-- How have you tested? -->
I've added tests that cover authenticating successfully with a custom `SSO_HTTP_USER_HEADER` with and without a shared secret. There are also tests for failure cases where the headers are not present, or the shared secret is invalid.

Manual testing can be conducted by setting:
```python
AUTHENTICATION_BACKENDS = ('zproject.backends.ZulipRemoteUserBackend',)
SSO_HTTP_USER_HEADER = "X-Remote-User"
SSO_HTTP_SECRET_HEADER = "X-Remote-Secret"
```
and setting `remote_sso_secret = secretval` in `dev-secrets.conf`.

And submitting curl requests
```bash
# Success
curl "http://localhost:9991/accounts/login/sso/?next=" -H "X-Remote-User: iago@zulip.com" -H "X-Remote-Secret: secretval" -v

# Redirect to missing HTTP user header
curl "http://localhost:9991/accounts/login/sso/?next=" -H "X-Remote-Secret: secretval" -v

# Redirect to incorrect shared secret
curl "http://localhost:9991/accounts/login/sso/?next=" -H "X-Remote-User: iago@zulip.com" -H "X-Remote-Secret: wrong" -v

# Redirect to missing shared secret header
curl "http://localhost:9991/accounts/login/sso/?next=" -H "X-Remote-User: iago@zulip.com" -v

```
**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Various failure messages:
<img width="789" alt="Screen Shot 2020-05-14 at 14 17 21" src="https://user-images.githubusercontent.com/939704/81939080-c732bb80-95ed-11ea-9283-63bf6d78d904.png">
<img width="801" alt="Screen Shot 2020-05-14 at 14 17 55" src="https://user-images.githubusercontent.com/939704/81939076-c6018e80-95ed-11ea-8af2-871dcdf5576e.png">
<img width="817" alt="Screen Shot 2020-05-14 at 14 17 38" src="https://user-images.githubusercontent.com/939704/81939078-c69a2500-95ed-11ea-8310-6d7ca103c493.png">




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
