### PR TITLE
billing: User FREE_TRIAL_DAYS instead of FREE_TRIAL_MONTHS

### DIFF
--- a/corporate/lib/stripe.py
+++ b/corporate/lib/stripe.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import Decimal
 from functools import wraps
 import logging
@@ -291,7 +291,7 @@ def compute_plan_parameters(
     if automanage_licenses:
         next_invoice_date = add_months(billing_cycle_anchor, 1)
     if free_trial:
-        period_end = add_months(billing_cycle_anchor, settings.FREE_TRIAL_MONTHS)
+        period_end = billing_cycle_anchor + timedelta(days=settings.FREE_TRIAL_DAYS)
         next_invoice_date = period_end
     return billing_cycle_anchor, next_invoice_date, period_end, price_per_license
 
@@ -302,7 +302,7 @@ def process_initial_upgrade(user: UserProfile, licenses: int, automanage_license
     realm = user.realm
     customer = update_or_create_stripe_customer(user, stripe_token=stripe_token)
     charge_automatically = stripe_token is not None
-    free_trial = settings.FREE_TRIAL_MONTHS not in (None, 0)
+    free_trial = settings.FREE_TRIAL_DAYS not in (None, 0)
 
     if get_current_plan_by_customer(customer) is not None:
         # Unlikely race condition from two people upgrading (clicking "Make payment")

--- a/corporate/views.py
+++ b/corporate/views.py
@@ -146,7 +146,7 @@ def initial_upgrade(request: HttpRequest) -> HttpResponse:
         'min_invoiced_licenses': max(seat_count, MIN_INVOICED_LICENSES),
         'default_invoice_days_until_due': DEFAULT_INVOICE_DAYS_UNTIL_DUE,
         'plan': "Zulip Standard",
-        "free_trial_months": settings.FREE_TRIAL_MONTHS,
+        "free_trial_days": settings.FREE_TRIAL_DAYS,
         'page_params': {
             'seat_count': seat_count,
             'annual_price': 8000,

--- a/templates/corporate/upgrade.html
+++ b/templates/corporate/upgrade.html
@@ -18,9 +18,9 @@
         <div class="page-content">
             <div class="main">
                 <h1>{% trans %}Upgrade to {{ plan }}{% endtrans %}</h1>
-                {% if free_trial_months %}
+                {% if free_trial_days %}
                 <div class="alert alert-info">
-                    Upgrade now to start your {{ free_trial_months }} month Free Trial of Zulip Standard.
+                    Upgrade now to start your {{ free_trial_days }} day Free Trial of Zulip Standard.
                 </div>
                 {% endif %}
 
@@ -44,7 +44,7 @@
                                 <input type="hidden" name="signed_seat_count" value="{{ signed_seat_count }}">
                                 <input type="hidden" name="salt" value="{{ salt }}">
                                 <input type="hidden" name="billing_modality" value="charge_automatically">
-                                {% if free_trial_months %}
+                                {% if free_trial_days %}
                                 <p>
                                     You won't be charged during the Free Trial. You can also downgrade back to Zulip Limited
                                     during the Free Trial.
@@ -94,7 +94,7 @@
 
                                 <div id="license-automatic-section">
                                     <p>
-                                        {% if free_trial_months %}
+                                        {% if free_trial_days %}
                                         After the Free Trial, you&rsquo;ll be charged
                                         <b>$<span id="charged_amount"></span></b> for <b>{{ seat_count }}</b>
                                         users.
@@ -116,7 +116,7 @@
                                 <div id="license-manual-section">
 
                                     <p>
-                                        {% if free_trial_months %}
+                                        {% if free_trial_days %}
                                         Enter the number of users you would like to pay for after the Free Trial.<br>
                                         You'll need to manually add licenses to add or invite
                                         additional users.
@@ -175,7 +175,7 @@
                                     </label>
                                 </div>
                                 <p>
-                                    {% if free_trial_months %}
+                                    {% if free_trial_days %}
                                     Enter the number of users you would like to pay for.<br>
                                     We'll email you an invoice after the Free Trial.
                                     Invoices can be paid by ACH transfer or credit card.

--- a/templates/zerver/plans.html
+++ b/templates/zerver/plans.html
@@ -87,16 +87,16 @@
                                     </a>
                                     {% elif realm_plan_type == 2 %}
                                     <a href="/upgrade" class="button green">
-                                        {% if free_trial_months %}
-                                        Start {{ free_trial_months }} month Free Trial
+                                        {% if free_trial_days %}
+                                        Start {{ free_trial_days }} day Free Trial
                                         {% else %}
                                         Buy Standard
                                         {% endif %}
                                     </a>
                                     {% else %}
                                     <a href="/upgrade" class="button green">
-                                        {% if free_trial_months %}
-                                        Start {{ free_trial_months }} month Free Trial
+                                        {% if free_trial_days %}
+                                        Start {{ free_trial_days }} day Free Trial
                                         {% else %}
                                         Buy Standard
                                         {% endif %}

--- a/zerver/views/portico.py
+++ b/zerver/views/portico.py
@@ -26,7 +26,7 @@ def apps_view(request: HttpRequest, _: str) -> HttpResponse:
 def plans_view(request: HttpRequest) -> HttpResponse:
     realm = get_realm_from_request(request)
     realm_plan_type = 0
-    free_trial_months = settings.FREE_TRIAL_MONTHS
+    free_trial_days = settings.FREE_TRIAL_DAYS
     if realm is not None:
         realm_plan_type = realm.plan_type
         if realm.plan_type == Realm.SELF_HOSTED and settings.PRODUCTION:
@@ -36,7 +36,7 @@ def plans_view(request: HttpRequest) -> HttpResponse:
     return TemplateResponse(
         request,
         "zerver/plans.html",
-        context={"realm_plan_type": realm_plan_type, 'free_trial_months': free_trial_months},
+        context={"realm_plan_type": realm_plan_type, 'free_trial_days': free_trial_days},
     )
 
 @add_google_analytics

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -363,7 +363,7 @@ ARCHIVED_DATA_VACUUMING_DELAY_DAYS = 7
 # are available to all realms.
 BILLING_ENABLED = False
 
-FREE_TRIAL_MONTHS = None
+FREE_TRIAL_DAYS = None
 
 # Automatically catch-up soft deactivated users when running the
 # `soft-deactivate-users` cron. Turn this off if the server has 10Ks of

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -155,7 +155,7 @@ THUMBNAIL_IMAGES = True
 SEARCH_PILLS_ENABLED = bool(os.getenv('SEARCH_PILLS_ENABLED', False))
 
 BILLING_ENABLED = True
-FREE_TRIAL_MONTHS = None
+FREE_TRIAL_DAYS = None
 
 # Test Custom TOS template rendering
 TERMS_OF_SERVICE = 'corporate/terms.md'


### PR DESCRIPTION
I have tested locally. 

No need to update fixtures since we are replacing `FREE_TRIAL_MONTHS=2` with `FREE_TRIAL_DAYS=60`. Both of these are equivalent in our test cases since our value of `self.now` is `2 Jan 2012`. [Adding 60 days](https://www.google.com/search?q=60+days+from+2012+january+2&oq=60+days+from+2012+january+2) to it gives `2 March 2020` which is what `add_months(self.now, 2)` gives as well.

I have also verified that the fixtures change when the value of `FREE_TRIAL_DAYS` is set to a value other than 60.
