### PR TITLE
presence: Optimize performance of mobile_query.

### DIFF
--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -3690,7 +3690,7 @@ class FetchQueriesTest(ZulipTestCase):
                     client_gravatar=False,
                 )
 
-        self.assert_length(queries, 32)
+        self.assert_length(queries, 30)
 
         expected_counts = dict(
             alert_words=1,
@@ -3701,7 +3701,7 @@ class FetchQueriesTest(ZulipTestCase):
             message=1,
             muted_topics=1,
             pointer=0,
-            presence=3,
+            presence=1,
             realm=0,
             realm_bot=1,
             realm_domains=1,

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -251,7 +251,7 @@ class HomeTest(ZulipTestCase):
         self.assertEqual(set(result["Cache-Control"].split(", ")),
                          {"must-revalidate", "no-store", "no-cache"})
 
-        self.assert_length(queries, 44)
+        self.assert_length(queries, 42)
         self.assert_length(cache_mock.call_args_list, 5)
 
         html = result.content.decode('utf-8')
@@ -317,7 +317,7 @@ class HomeTest(ZulipTestCase):
                 result = self._get_home_page()
                 self.assertEqual(result.status_code, 200)
                 self.assert_length(cache_mock.call_args_list, 6)
-            self.assert_length(queries, 42)
+            self.assert_length(queries, 40)
 
     @slow("Creates and subscribes 10 users in a loop.  Should use bulk queries.")
     def test_num_queries_with_streams(self) -> None:
@@ -349,7 +349,7 @@ class HomeTest(ZulipTestCase):
         with queries_captured() as queries2:
             result = self._get_home_page()
 
-        self.assert_length(queries2, 39)
+        self.assert_length(queries2, 37)
 
         # Do a sanity check that our new streams were in the payload.
         html = result.content.decode('utf-8')


### PR DESCRIPTION
I'm not sure exactly what series of history got us here, but we were
fetching the mobile_user_ids data for all users in the organization,
regardless of whether they were recently active (and thus relevant for
the main presence data set).  And doing so in a sloppy fashion
(sending every user ID over the wire, rather than just having the
database join on Realm).

Fixing this saves a factor of 4-5 on the total runtime of a presence
request on organizations with 10Ks of users like chat.zulip.org; more
like 25% in an organization with 150.  Since large organizations are
very heavily weighted in the overall cost of presence, this is a huge
win.

Fixes part of #13734.

Tested on chat.zulip.org in a manage.py shell.