### PR TITLE
ci: Correct notify_failure_status in circleci config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,9 +147,9 @@ aliases:
       branches:
         only: master
       command: |
-        if [[ "$CIRCLE_REPOSITORY_URL" == 'git@github.com:zulip/zulip.git' ]]; then
+        if [[ "$CIRCLE_REPOSITORY_URL" == "git@github.com:zulip/zulip.git" ]]; then
           curl  -H "Content-Type: application/json" \
-          -X POST -i 'https://chat.zulip.org/api/v1/external/circleci?api_key=$ZULIP_BOT_KEY&stream=automated%20testing&topic=master%20failing' \
+          -X POST -i 'https://chat.zulip.org/api/v1/external/circleci?api_key='"$ZULIP_BOT_KEY"'&stream=automated%20testing&topic=master%20failing' \
           -d '{"payload": { "branch": "'"$CIRCLE_BRANCH"'", "reponame": "'"$CIRCLE_PROJECT_REPONAME"'", "status": "failed", "build_url": "'"$CIRCLE_BUILD_URL"'", "username": "'"$CIRCLE_USERNAME"'"}}'
         fi
 


### PR DESCRIPTION
Steps to add ZULIP_BOT_KEY in environment 
[Link](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-context)

@timabbott Just changes in this [PR](https://github.com/zulip/zulip/pull/14940) has to be merged in czo otherwise we will get KeyError for ['previous']




