### PR TITLE
home: Fix furthest read time when user has multiple clients.

### DIFF
--- a/zerver/views/messages.py
+++ b/zerver/views/messages.py
@@ -1115,7 +1115,7 @@ def post_process_limited_query(rows: List[Any],
 
 def get_latest_update_message_flag_activity(user_profile: UserProfile) -> Optional[UserActivity]:
     return UserActivity.objects.filter(user_profile=user_profile,
-                                       query='update_message_flags').last()
+                                       query='update_message_flags').order_by("last_visit").last()
 
 # NOTE: If this function name is changed, add the new name to the
 # query in get_latest_update_message_flag_activity


### PR DESCRIPTION
The query to fetch the latest user activity was missing an
`.order_by('last_visit')`. This meant that the results were being
ordered by the `id`, which resulted in us getting `update_message_flags`
action performed on the client that the user installed last, instead of
being client agnostic and fetching the "global" last
`update_message_flags` action performed by the user.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Modified the test to use multiple clients. 
