### PR TITLE
subs.js: Change how to check if the subscribed tab is active.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -104,15 +104,12 @@ exports.toggle_pin_to_top_stream = function (sub) {
     stream_edit.set_stream_property(sub, 'pin_to_top', !sub.pin_to_top);
 };
 
+let subscribed_only = true;
+
 exports.is_subscribed_stream_tab_active = function () {
     // Returns true if "Subscribed" tab in stream settings is open
     // otherwise false.
-    const tab = $(`#subscriptions_table .search-container .tab-switcher
-                  .first[data-tab-key=subscribed]`).expectOne();
-    if (tab.hasClass("selected")) {
-        return true;
-    }
-    return false;
+    return subscribed_only;
 };
 
 exports.update_stream_name = function (sub, new_name) {
@@ -455,7 +452,6 @@ exports.filter_table = function (query) {
     ui.get_scroll_element($(".streams-list")).scrollTop(streams_list_scrolltop);
 };
 
-let subscribed_only = true;
 let sort_order = "by-stream-name";
 
 exports.get_search_params = function () {


### PR DESCRIPTION
Before we used a selector to check whether the "Subscribed" tab
is active or not. The problem is that if a new sibling of the tab
switcher is inserted in the DOM and uses the same classes as the
"Subscribed" and "All Streams" button do, the selector can get
the sibling element instead the tab button.
To avoid that, we are using a variable that tracks the current
active tab instead of using the selector.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
