### PR TITLE
puppet: Work around memcached SASL configuration path bug

### DIFF
--- a/puppet/zulip/manifests/systemd_daemon_reload.pp
+++ b/puppet/zulip/manifests/systemd_daemon_reload.pp
@@ -1,0 +1,5 @@
+class zulip::systemd_daemon_reload {
+  exec { 'sh -c "! command -v systemctl > /dev/null || systemctl daemon-reload"':
+    refreshonly => true,
+  }
+}


### PR DESCRIPTION
memcached 1.5.22 in Ubuntu 20.04 has a [bug](https://bugs.launchpad.net/ubuntu/+source/memcached/+bug/1878721) where it looks for its SASL configuration at `/etc/sasl2/memcached.conf/memcached.conf` instead of `/etc/sasl2/memcached.conf`.

**Testing Plan:** Tested on Ubuntu 18.04 and 20.04 production installations.