### PR TITLE
stream: Allow non admins to set stream post policy when creating streams

### DIFF
--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -165,13 +165,8 @@ function create_stream() {
     data.invite_only = JSON.stringify(invite_only);
     data.history_public_to_subscribers = JSON.stringify(history_public_to_subscribers);
 
-    let stream_post_policy = parseInt($('#stream_creation_form input[name=stream-post-policy]:checked').val(), 10);
+    const stream_post_policy = parseInt($('#stream_creation_form input[name=stream-post-policy]:checked').val(), 10);
 
-    // Because the stream_post_policy field is hidden when non-administrators create streams,
-    // we need to set the default value here.
-    if (isNaN(stream_post_policy)) {
-        stream_post_policy = stream_data.stream_post_policy_values.everyone.code;
-    }
     data.stream_post_policy = JSON.stringify(stream_post_policy);
 
     const announce = stream_data.realm_has_notifications_stream() &&

--- a/static/templates/stream_types.hbs
+++ b/static/templates/stream_types.hbs
@@ -22,19 +22,17 @@
             {{t '<b>Private, protected history:</b> must be invited by a member; new members can only see messages sent after they join; hidden from non-administrator users' }}
         </label>
     </li>
-    {{#if is_admin}}
-        <h4>{{t 'Who can post to the stream?'}}
-            <a href="/help/stream-sending-policy" target="_blank">
-                <i class="fa fa-question-circle-o" aria-hidden="true"></i>
-            </a>
-        </h4>
-        {{#each stream_post_policy_values}}
-        <li>
-            <label class="radio">
-                <input type="radio" name="stream-post-policy" value="{{ this.code }}" {{#if (eq this.code ../stream_post_policy) }}checked{{/if}} />
-                {{ this.description }}
-            </label>
-        </li>
-        {{/each}}
-    {{/if}}
+    <h4>{{t 'Who can post to the stream?'}}
+        <a href="/help/stream-sending-policy" target="_blank">
+            <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+        </a>
+    </h4>
+    {{#each stream_post_policy_values}}
+    <li>
+        <label class="radio">
+            <input type="radio" name="stream-post-policy" value="{{ this.code }}" {{#if (eq this.code ../stream_post_policy) }}checked{{/if}} />
+            {{ this.description }}
+        </label>
+    </li>
+    {{/each}}
 </ul>

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -415,22 +415,10 @@ def list_to_streams(streams_raw: Iterable[Mapping[str, Any]],
     missing_stream_dicts: List[Mapping[str, Any]] = []
     existing_stream_map = bulk_get_streams(user_profile.realm, stream_set)
 
-    member_creating_announcement_only_stream = False
-
     for stream_dict in streams_raw:
         stream_name = stream_dict["name"]
         stream = existing_stream_map.get(stream_name.lower())
         if stream is None:
-            # Non admins cannot create STREAM_POST_POLICY_ADMINS streams.
-            if ((stream_dict.get("stream_post_policy", False) ==
-                 Stream.STREAM_POST_POLICY_ADMINS) and not user_profile.is_realm_admin):
-                member_creating_announcement_only_stream = True
-            # New members cannot create STREAM_POST_POLICY_RESTRICT_NEW_MEMBERS streams,
-            # unless they are admins who are also new members of the organization.
-            if ((stream_dict.get("stream_post_policy", False) ==
-                 Stream.STREAM_POST_POLICY_RESTRICT_NEW_MEMBERS) and user_profile.is_new_member):
-                if not user_profile.is_realm_admin:
-                    member_creating_announcement_only_stream = True
             missing_stream_dicts.append(stream_dict)
         else:
             existing_streams.append(stream)
@@ -446,8 +434,6 @@ def list_to_streams(streams_raw: Iterable[Mapping[str, Any]],
         elif not autocreate:
             raise JsonableError(_("Stream(s) (%s) do not exist") % ", ".join(
                 stream_dict["name"] for stream_dict in missing_stream_dicts))
-        elif member_creating_announcement_only_stream:
-            raise JsonableError(_('User cannot create a stream with these settings.'))
 
         # We already filtered out existing streams, so dup_streams
         # will normally be an empty list below, but we protect against somebody


### PR DESCRIPTION
This PR allows non admins to set stream post policy while creating
streams.

Restriction was there to prevent user from creating a stream in which
the user cannot post himself but this will be taken care of with
stream admin feature.

Removed the tests as there is no restrciction now for creation of streams and users can create streams with all stream_post_policy values.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
