### PR TITLE
dropdown_list_widget: Fix Zulipchat error and add tests.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -1221,7 +1221,6 @@ with_overrides(function (override) {
         assert_same(args.stream_id, 42);
 
         override('stream_list.remove_sidebar_row', noop);
-        override('settings_org.render_notifications_stream_ui', noop);
         page_params.realm_notifications_stream_id = 42;
         dispatch(event);
         assert_same(page_params.realm_notifications_stream_id, -1);

--- a/frontend_tests/node_tests/dropdown_list_widget.js
+++ b/frontend_tests/node_tests/dropdown_list_widget.js
@@ -1,0 +1,47 @@
+zrequire('dropdown_list_widget');
+zrequire('scroll_util');
+set_global('$', global.make_zjquery());
+
+const noop = () => {};
+const _list_render = {
+    create: () => {
+        return { init: noop };
+    },
+};
+set_global('list_render', _list_render);
+
+run_test('basic_functions', () => {
+    let updated_value;
+    const opts = {
+        setting_name: 'my_setting',
+        data: ['one', 'two', 'three'].map(x => ({name: x, value: x})),
+        value: 'one',
+        on_update: (val) => { updated_value = val; },
+        default_text: i18n.t("not set"),
+        render_text: (text) => `rendered: ${text}`,
+    };
+
+    const input_group = $(".input_group");
+    const reset_button = $('.dropdown_list_reset_button');
+    input_group.set_find_results('.dropdown_list_reset_button', reset_button);
+    $("#my_setting_widget #my_setting_name").closest = () => input_group;
+    const $widget = $("#my_setting_widget #my_setting_name");
+
+    const widget = dropdown_list_widget(opts);
+
+    assert.equal(widget.value(), 'one');
+    assert.equal(updated_value, undefined);  // We haven't 'updated' the widget yet.
+    assert(reset_button.visible());
+
+    widget.update('two');
+    assert.equal($widget.text(), 'rendered: two');
+    assert.equal(widget.value(), 'two');
+    assert.equal(updated_value, 'two');
+    assert(reset_button.visible());
+
+    widget.update(null);
+    assert.equal($widget.text(), 'translated: not set');
+    assert.equal(widget.value(), '');
+    assert.equal(updated_value, null);
+    assert(!reset_button.visible());
+});

--- a/frontend_tests/node_tests/zjquery.js
+++ b/frontend_tests/node_tests/zjquery.js
@@ -54,6 +54,10 @@ run_test('basics', () => {
     assert.equal(widget.attr('data-department-id'), 77);
     assert.equal(widget.data('department-id'), 77);
 
+    widget.data('department-name', 'hr');
+    assert.equal(widget.attr('data-department-name'), 'hr');
+    assert.equal(widget.data('department-name'), 'hr');
+
     widget.html('<b>hello</b>');
     assert.equal(widget.html(), '<b>hello</b>');
 

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -165,7 +165,7 @@ exports.make_new_elem = function (selector, opts) {
                 if (data_val === undefined) {
                     return;
                 }
-                return JSON.parse(data_val);
+                return data_val;
             }
             attrs.set('data-' + name, val);
             return self;

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -286,13 +286,11 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
                 stream_data.remove_default_stream(stream.stream_id);
                 if (page_params.realm_notifications_stream_id === stream.stream_id) {
                     page_params.realm_notifications_stream_id = -1;
-                    settings_org.render_notifications_stream_ui(
-                        page_params.realm_notifications_stream_id, 'notifications');
+                    settings_org.sync_realm_settings('notifications_stream_id');
                 }
                 if (page_params.realm_signup_notifications_stream_id === stream.stream_id) {
                     page_params.realm_signup_notifications_stream_id = -1;
-                    settings_org.render_notifications_stream_ui(
-                        page_params.realm_signup_notifications_stream_id, 'signup_notifications');
+                    settings_org.sync_realm_settings('signup_notifications_stream_id');
                 }
             }
         }


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This is for a traceback from zulipchat.com. We missed renaming a function call when we first added the widgets.


Sidenote: I'm wondering if there was any way this could have been avoided in the first place. I must have missed converting all the calls to this function, that's human error and I should have been more careful, but the tests were passing because we had set `setting_org.old_function_name = noop` in the tests for dispatch.

Also of note is that this didn't come up in manual testing either. There may be other similar bugs lurking around like this.

Maybe we should come up with a way to confirm that when we set something to noop, that was originally a function in the original module.

**Testing Plan:** <!-- How have you tested? -->
Automated tests.
