### PR TITLE
retention: Pass optional realm argument to move_messages_to_archive.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4600,7 +4600,7 @@ def do_delete_messages(realm: Realm, messages: Iterable[Message]) -> None:
             (event, message_id_to_notifiable_users.get(message.id, []))
         )
 
-    move_messages_to_archive(message_ids)
+    move_messages_to_archive(message_ids, realm=realm)
     for event, users_to_notify in events_and_users_to_notify:
         # TODO: Figure out some kind of bulk event that we could send just one of?
         send_event(realm, event, users_to_notify)

--- a/zerver/lib/retention.py
+++ b/zerver/lib/retention.py
@@ -380,7 +380,8 @@ def get_realms_and_streams_for_archiving() -> List[Tuple[Realm, List[Stream]]]:
     return [(realm_id_to_realm[realm_id], realm_id_to_streams_list[realm_id])
             for realm_id in realm_id_to_realm]
 
-def move_messages_to_archive(message_ids: List[int], chunk_size: int=MESSAGE_BATCH_SIZE) -> None:
+def move_messages_to_archive(message_ids: List[int], realm: Optional[Realm]=None,
+                             chunk_size: int=MESSAGE_BATCH_SIZE) -> None:
     query = SQL("""
     INSERT INTO zerver_archivedmessage ({dst_fields}, archive_transaction_id)
         SELECT {src_fields}, {archive_transaction_id}
@@ -394,6 +395,7 @@ def move_messages_to_archive(message_ids: List[int], chunk_size: int=MESSAGE_BAT
         query,
         type=ArchiveTransaction.MANUAL,
         message_ids=Literal(tuple(message_ids)),
+        realm=realm,
         chunk_size=chunk_size,
     )
 


### PR DESCRIPTION
This allows having the realm field of ArchiveTransaction set instead of
NULL when using move_messages_to_archive.

This will let us have fewer of these no-realm transactions and log lines
```
INFO     Archiving in ArchiveTransaction id: XXX, type: MANUAL, realm: None, timestamp: XXXX
```