### PR TITLE
api/get-presence: Add user ID support to endpoint.

### DIFF
--- a/templates/zerver/api/get-user-presence.md
+++ b/templates/zerver/api/get-user-presence.md
@@ -1,32 +1,32 @@
 # Get user presence
 
-{generate_api_description(/users/{email}/presence:get)}
+{generate_api_description(/users/{email_or_id}/presence:get)}
 
 ## Usage examples
 
 {start_tabs}
 {tab|python}
 
-{generate_code_example(python)|/users/{email}/presence:get|example}
+{generate_code_example(python)|/users/{email_or_id}/presence:get|example}
 
 {tab|curl}
 
-{generate_code_example(curl)|/users/{email}/presence:get|example}
+{generate_code_example(curl)|/users/{email_or_id}/presence:get|example}
 
 {end_tabs}
 
 ## Parameters
 
-{generate_api_arguments_table|zulip.yaml|/users/{email}/presence:get}
+{generate_api_arguments_table|zulip.yaml|/users/{email_or_id}/presence:get}
 
 ## Response
 
 #### Return values
 
-{generate_return_values_table|zulip.yaml|/users/{email}/presence:get}
+{generate_return_values_table|zulip.yaml|/users/{email_or_id}/presence:get}
 
 #### Example response
 
 A typical successful JSON response may look like:
 
-{generate_code_example|/users/{email}/presence:get|fixture(200)}
+{generate_code_example|/users/{email_or_id}/presence:get|fixture(200)}

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -2347,6 +2347,7 @@ def get_user_profile_by_id_in_realm(uid: int, realm: Realm) -> UserProfile:
     return UserProfile.objects.select_related().get(id=uid, realm=realm)
 
 def get_active_user_profile_by_id_in_realm(uid: int, realm: Realm) -> UserProfile:
+    """Variant of get_user_profile_by_id_in_realm that excludes deactivated users."""
     user_profile = get_user_profile_by_id_in_realm(uid, realm)
     if not user_profile.is_active:
         raise UserProfile.DoesNotExist()

--- a/zerver/openapi/curl_param_value_generators.py
+++ b/zerver/openapi/curl_param_value_generators.py
@@ -171,7 +171,7 @@ def delete_event_queue() -> Dict[str, object]:
         "last_event_id": response["last_event_id"],
     }
 
-@openapi_param_value_generator(["/users/{email}/presence:get"])
+@openapi_param_value_generator(["/users/{email_or_id}/presence:get"])
 def get_user_presence() -> Dict[str, object]:
     iago = helpers.example_user("iago")
     client = Client.objects.create(name="curl-test-client-3")

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -62,11 +62,16 @@ class OpenAPISpec():
         # such as email they must be substituted with proper regex.
 
         email_regex = r'([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5})'
+        email_or_id_regex = r'(([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5}))|([0-9]*)'
         self.regex_dict = {}
         for key in self.data['paths']:
             if '{' not in key:
                 continue
             regex_key = '^' + key + '$'
+            # Email or Id arguments include email and
+            # end with id so find and replace them with
+            # email_or_id_regex
+            regex_key = re.sub(r'{[^}]*email[^}]*id}', email_or_id_regex, regex_key)
             # Numeric arguments have id at their end
             # so find such arguments and replace them with numeric
             # regex

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -122,7 +122,7 @@ def test_authorization_errors_fatal(client: Client, nonadmin_client: Client) -> 
     validate_against_openapi_schema(result, '/users/me/subscriptions', 'post',
                                     '400_1')
 
-@openapi_test_function("/users/{email}/presence:get")
+@openapi_test_function("/users/{email_or_id}/presence:get")
 def get_user_presence(client: Client) -> None:
 
     # {code_example|start}
@@ -130,7 +130,7 @@ def get_user_presence(client: Client) -> None:
     result = client.get_user_presence('iago@zulip.com')
     # {code_example|end}
 
-    validate_against_openapi_schema(result, '/users/{email}/presence', 'get', '200')
+    validate_against_openapi_schema(result, '/users/{email_or_id}/presence', 'get', '200')
 
 @openapi_test_function("/users/me/presence:post")
 def update_presence(client: Client) -> None:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1798,7 +1798,7 @@ paths:
                       "result": "success",
                     }
 
-  /users/{email}/presence:
+  /users/{email_or_id}/presence:
     get:
       operationId: get_user_presence
       tags: ["users"]
@@ -1811,16 +1811,16 @@ paths:
         presence endpoint, which returns data for all active users in the
         organization, instead.
 
-        `GET {{ api_url }}/v1/users/{email}/presence`
+        `GET {{ api_url }}/v1/users/{email_or_id}/presence`
 
         See
         [Zulip's developer documentation](https://zulip.readthedocs.io/en/latest/subsystems/presence.html)
         for details on the data model for presence in Zulip.
       parameters:
-      - name: email
+      - name: email_or_id
         in: path
         description: |
-          The email address of the user whose presence you want to fetch.
+          The email address or id of the user whose presence you want to fetch.
         schema:
           type: string
         example: iago@zulip.com

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -1062,7 +1062,7 @@ class OpenAPIRegexTest(ZulipTestCase):
         assert(match_against_openapi_regex('/users/23/subscriptions/21') ==
                '/users/{user_id}/subscriptions/{stream_id}')
         assert(match_against_openapi_regex('/users/iago@zulip.com/presence') ==
-               '/users/{email}/presence')
+               '/users/{email_or_id}/presence')
         assert(match_against_openapi_regex('/messages/23') ==
                '/messages/{message_id}')
         assert(match_against_openapi_regex('/realm/emoji/realm_emoji_1') ==

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -149,7 +149,7 @@ v1_api_and_json_patterns = [
           'POST': 'zerver.views.users.create_user_backend'}),
     path('users/<int:user_id>/reactivate', rest_dispatch,
          {'POST': 'zerver.views.users.reactivate_user_backend'}),
-    re_path(r'^users/(?!me/)(?P<email>[^/]*)/presence$', rest_dispatch,
+    re_path(r'^users/(?!me/)(?P<email_or_id>[^/]*)/presence$', rest_dispatch,
             {'GET': 'zerver.views.presence.get_presence_backend'}),
     path('users/<int:user_id>', rest_dispatch,
          {'GET': 'zerver.views.users.get_members_backend',


### PR DESCRIPTION
Modifies get_user_presence endpoint to support both email addresses and
user IDs.

Tested the fix manually, ran the following test suites and made fixes
accordingly-
/tools/lint
/tools/test-backend
/tools/test-migrations
/tools/test-help-documentation
/tools/test-api

Fixes #14304

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
