### PR TITLE
navbar: Use direct child selector to target spans.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1433,7 +1433,7 @@ div.focused_table {
         .hidden {
             display: none;
         }
-        span {
+        & > span {
             white-space: nowrap;
             list-style-type: none;
             display: inline-block;


### PR DESCRIPTION
The navbar uses rendered markdown and rendered html within the narrow
description, this inserts eg katex--html and allows rendering of
inline math formulae. Unfortunately, in the previous SCSS file, this
fact was overlooked and a generic "span" selector was used with would
target all spans within the parent element, direct descendants or
otherwise, which caused the side effect of applying padding and margin
to inner katex elements which broke appearance.

This commit replaces the "span" selector with "& > span" so that only
spans which are the direct children to the parent element are selected
and katex--html is rendered correctly.

Fixes: #14947.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
AFTER:
![image](https://user-images.githubusercontent.com/33805964/82173006-8981ab80-98e9-11ea-823e-6a9a47fde185.png)
![image](https://user-images.githubusercontent.com/33805964/82173324-6acfe480-98ea-11ea-9be0-d1d4c1bcf751.png)


TODO: we'll probably want to write some javascript to handle cases like the following image... css solution seems difficult, since it's font-size related.
![image](https://user-images.githubusercontent.com/33805964/82173371-a10d6400-98ea-11ea-9c11-10d7aa33b07e.png)

bellow is one terrible way of doing it: (possibly we can get rid of the loop via em units...)
```javascript
    let katex = $(".narrow_description > .katex");
    let katex_height = katex.css("height").slice(0,-2);
    while (katex_height > 20) {
        let font_size = katex.css("font-size").slice(0,-2);
        katex.css("font-size", font_size - 0.05 + "px");
        katex_height = katex.css("height").slice(0,-2);
    }
```
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
