### PR TITLE
semgrep: Use pattern-where-python operator to filter patterns.

### DIFF
--- a/tools/lint
+++ b/tools/lint
@@ -89,7 +89,10 @@ def run() -> None:
                                   description="Checks commit messages for common formatting errors."
                                   "(config: .gitlint)")
 
-    semgrep_command = ["semgrep", "--config=./tools/semgrep.yml", "--error"]
+    semgrep_command = ["semgrep", "--config=./tools/semgrep.yml", "--error",
+                       # Its use allows for arbitrary Python code execution. Hence, we should
+                       # be careful with what python snippet we run in `pattern-where-python`.
+                       "--dangerously-allow-arbitrary-code-execution-from-rules"]
     linter_config.external_linter('semgrep-py', [*semgrep_command, "--lang=python"], ['py'],
                                   fix_arg='--autofix',
                                   description="Syntactic Grep (semgrep) Code Search Tool "

--- a/tools/semgrep.yml
+++ b/tools/semgrep.yml
@@ -52,27 +52,13 @@ rules:
 
   - id: logging-format
     languages: [python]
-    pattern-either:
-      - pattern: logging.debug(... % ...)
-      - pattern: logging.debug(... .format(...))
-      - pattern: logger.debug(... % ...)
-      - pattern: logger.debug(... .format(...))
-      - pattern: logging.info(... % ...)
-      - pattern: logging.info(... .format(...))
-      - pattern: logger.info(... % ...)
-      - pattern: logger.info(... .format(...))
-      - pattern: logging.warning(... % ...)
-      - pattern: logging.warning(... .format(...))
-      - pattern: logger.warning(... % ...)
-      - pattern: logger.warning(... .format(...))
-      - pattern: logging.error(... % ...)
-      - pattern: logging.error(... .format(...))
-      - pattern: logger.error(... % ...)
-      - pattern: logger.error(... .format(...))
-      - pattern: logging.critical(... % ...)
-      - pattern: logging.critical(... .format(...))
-      - pattern: logger.critical(... % ...)
-      - pattern: logger.critical(... .format(...))
+    patterns:
+      - pattern-either:
+          - pattern: logging.$Y(... % ...)
+          - pattern: logging.$Y(... .format(...))
+          - pattern: logger.$Y(... % ...)
+          - pattern: logger.$Y(... .format(...))
+      - pattern-where-python: "vars['$Y'] in ['debug', 'info', 'warning', 'error', 'critical']"
     severity: ERROR
     message: "Pass format arguments to logging (https://docs.python.org/3/howto/logging.html#optimization)"
 


### PR DESCRIPTION
See https://github.com/returntocorp/semgrep/blob/experimental/docs/config/advanced.md#pattern-where-python for usage.

This helps us minimize duplication of similar patterns.
