### PR TITLE
Avoid running queries to db in a loop.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4308,11 +4308,11 @@ def update_to_dict_cache(changed_messages: List[Message]) -> List[int]:
     messages)."""
     items_for_remote_cache = {}
     message_ids = []
-    for changed_message in changed_messages:
-        message_ids.append(changed_message.id)
-        key = to_dict_cache_key_id(changed_message.id)
-        value = MessageDict.to_dict_uncached(changed_message)
-        items_for_remote_cache[key] = (value,)
+    changed_messages_to_dict = MessageDict.to_dict_uncached(changed_messages)
+    for msg_id, msg in changed_messages_to_dict.items():
+        message_ids.append(msg_id)
+        key = to_dict_cache_key_id(msg_id)
+        items_for_remote_cache[key] = (msg,)
 
     cache_set_many(items_for_remote_cache)
     return message_ids

--- a/zerver/lib/cache_helpers.py
+++ b/zerver/lib/cache_helpers.py
@@ -41,7 +41,7 @@ def message_cache_items(items_for_remote_cache: Dict[str, Tuple[bytes]],
     commented out for a while.
     '''
     key = to_dict_cache_key_id(message.id)
-    value = MessageDict.to_dict_uncached(message)
+    value = MessageDict.to_dict_uncached([message])[message.id]
     items_for_remote_cache[key] = (value,)
 
 def user_cache_items(items_for_remote_cache: Dict[str, Tuple[UserProfile]],

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -267,6 +267,14 @@ class MessageDict:
         dct = MessageDict.to_dict_uncached_helper(message)
         return stringify_message_dict(dct)
 
+    def sew_submessages_and_reactions_to_msgs(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        msg_ids = [msg['id'] for msg in messages]
+        submessages = SubMessage.get_raw_db_rows(msg_ids)
+        sew_messages_and_submessages(messages, submessages)
+
+        reactions = Reaction.get_raw_db_rows(msg_ids)
+        return sew_messages_and_reactions(messages, reactions)
+
     @staticmethod
     def to_dict_uncached_helper(message: Message) -> Dict[str, Any]:
         return MessageDict.build_message_dict(
@@ -310,12 +318,7 @@ class MessageDict:
             'sender__realm_id',
         ]
         messages = Message.objects.filter(id__in=needed_ids).values(*fields)
-
-        submessages = SubMessage.get_raw_db_rows(needed_ids)
-        sew_messages_and_submessages(messages, submessages)
-
-        reactions = Reaction.get_raw_db_rows(needed_ids)
-        return sew_messages_and_reactions(messages, reactions)
+        return MessageDict.sew_submessages_and_reactions_to_msgs(messages)
 
     @staticmethod
     def build_dict_from_raw_db_row(row: Dict[str, Any]) -> Dict[str, Any]:

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -1313,7 +1313,7 @@ class MessageDictTest(ZulipTestCase):
                 apply_markdown: bool,
                 client_gravatar: bool) -> Dict[str, Any]:
             msg = reload_message(msg_id)
-            unhydrated_dict = MessageDict.to_dict_uncached_helper(msg)
+            unhydrated_dict = MessageDict.to_dict_uncached_helper([msg])[0]
             # The next step mutates the dict in place
             # for performance reasons.
             MessageDict.post_process_dicts(
@@ -1492,7 +1492,7 @@ class MessageDictTest(ZulipTestCase):
             return Message.objects.get(id=msg_id)
 
         def assert_topic_links(links: List[str], msg: Message) -> None:
-            dct = MessageDict.to_dict_uncached_helper(msg)
+            dct = MessageDict.to_dict_uncached_helper([msg])[0]
             self.assertEqual(dct[TOPIC_LINKS], links)
 
         # Send messages before and after saving the realm filter from each user.
@@ -2687,10 +2687,10 @@ class EditMessageTest(ZulipTestCase):
 
         # Check number of queries performed
         with queries_captured() as queries:
-            for msg in messages:
-                MessageDict.to_dict_uncached(msg)
-        # 3 query for realm_id, reactions & submessage per message = 6
-        self.assertEqual(len(queries), 6)
+            MessageDict.to_dict_uncached(messages)
+        # 1 query for realm_id per message = 2
+        # 1 query each for reactions & submessage for all messages = 2
+        self.assertEqual(len(queries), 4)
 
     def test_save_message(self) -> None:
         """This is also tested by a client test, but here we can verify


### PR DESCRIPTION
Updated `to_dict_uncached_helper` to do bulk queries.
TODO: 
- [ ] eleminate this query: `Stream.objects.get(id=recipient_type_id).realm_id` in build_message_dict.
        # TODO: We could potentially avoid this database query in
        # common cases by optionally passing through the
        # stream_realm_id through the code path from do_send_messages
        # (where we've already fetched the data).  It would involve
        # somewhat messy plumbing, but would probably be worth it.