### PR TITLE
Tornado sharding for normal zulip installations

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-frontend/app
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/app
@@ -18,7 +18,7 @@ location /static/ {
 
 # Send longpoll requests to Tornado
 location /json/events {
-    proxy_pass http://tornado;
+    proxy_pass $tornado_server;
     include /etc/nginx/zulip-include/proxy_longpolling;
 
     proxy_set_header X-Real-IP       $remote_addr;
@@ -32,12 +32,11 @@ location /api/v1/events {
         return 204;
     }
 
-    proxy_pass http://tornado;
+    proxy_pass $tornado_server;
     include /etc/nginx/zulip-include/proxy_longpolling;
 
     proxy_set_header X-Real-IP       $remote_addr;
 }
-
 
 # Send everything else to Django via uWSGI
 location / {

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -5,6 +5,7 @@ class zulip::app_frontend_base {
   include zulip::nginx
   include zulip::sasl_modules
   include zulip::supervisor
+  include zulip::sharding
 
   if $::osfamily == 'debian' {
     $web_packages = [

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -30,14 +30,6 @@ class zulip::app_frontend_base {
     source  => 'puppet:///modules/zulip/nginx/zulip-include-frontend/app',
     notify  => Service['nginx'],
   }
-  file { '/etc/nginx/zulip-include/upstreams':
-    require => Package[$zulip::common::nginx],
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    source  => 'puppet:///modules/zulip/nginx/zulip-include-frontend/upstreams',
-    notify  => Service['nginx'],
-  }
   file { '/etc/nginx/zulip-include/uploads.types':
     require => Package[$zulip::common::nginx],
     owner   => 'root',
@@ -70,10 +62,19 @@ class zulip::app_frontend_base {
   # Realm level.
   $tornado_processes = Integer(zulipconf('application_server', 'tornado_processes', 1))
   if $tornado_processes > 1 {
-    $tornado_ports = range(9800, 9800 + $tornado_processes)
+    $tornado_ports = range(9800, 9800 + $tornado_processes - 1)
     $tornado_multiprocess = true
   } else {
     $tornado_multiprocess = false
+  }
+
+  file { '/etc/nginx/zulip-include/upstreams':
+    require => Package[$zulip::common::nginx],
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('zulip/nginx/upstreams.conf.template.erb'),
+    notify  => Service['nginx'],
   }
 
   # This determines whether we run queue processors multithreaded or

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -5,7 +5,7 @@ class zulip::app_frontend_base {
   include zulip::nginx
   include zulip::sasl_modules
   include zulip::supervisor
-  include zulip::sharding
+  include zulip::tornado_sharding
 
   if $::osfamily == 'debian' {
     $web_packages = [

--- a/puppet/zulip/manifests/sharding.pp
+++ b/puppet/zulip/manifests/sharding.pp
@@ -1,0 +1,45 @@
+class zulip::sharding {
+  include zulip::base
+  include zulip::common
+  include zulip::nginx
+
+  # These two execs below are rather ugly logic to have in puppet,
+  # but the advantage is that if the format of the config file generated
+  # by the sharding script changes, they will automatically get re-generated
+  # by puppet apply in the process of upgrading zulip, without requiring
+  # the administrator to think about this step.
+  exec { 'sharding_script':
+    subscribe => File['/etc/zulip/zulip.conf'],
+    command   => '/home/zulip/deployments/current/scripts/lib/sharding.py',
+    onlyif    => 'test -f /home/zulip/deployments/current/scripts/lib/sharding.py\
+  -a ! -f /home/zulip/deployments/next/scripts/lib/sharding.py',
+  }
+  exec { 'sharding_script_next':
+    subscribe => File['/etc/zulip/zulip.conf'],
+    command   => '/home/zulip/deployments/next/scripts/lib/sharding.py',
+    onlyif    => 'test -f /home/zulip/deployments/next/scripts/lib/sharding.py',
+  }
+  # The file entries below serve only to initialize the sharding config files
+  # with the correct default content for the "only one shard" setup. For this
+  # reason they use "replace => false", because the files are managed by
+  # the sharding script afterwards and puppet shouldn't overwrite them.
+  file { '/etc/zulip/nginx_sharding.conf':
+    ensure  => file,
+    require => User['zulip'],
+    owner   => 'zulip',
+    group   => 'zulip',
+    mode    => '0640',
+    notify  => Service['nginx'],
+    content => "set \$tornado_server http://tornado;\n",
+    replace => false,
+  }
+  file { '/etc/zulip/sharding.json':
+    ensure  => file,
+    require => User['zulip'],
+    owner   => 'zulip',
+    group   => 'zulip',
+    mode    => '0640',
+    content => "{}\n",
+    replace => false,
+  }
+}

--- a/puppet/zulip/manifests/sharding.pp
+++ b/puppet/zulip/manifests/sharding.pp
@@ -3,21 +3,10 @@ class zulip::sharding {
   include zulip::common
   include zulip::nginx
 
-  # These two execs below are rather ugly logic to have in puppet,
-  # but the advantage is that if the format of the config file generated
-  # by the sharding script changes, they will automatically get re-generated
-  # by puppet apply in the process of upgrading zulip, without requiring
-  # the administrator to think about this step.
+  $sharding_script = "${::zulip_scripts_path}/lib/sharding.py"
   exec { 'sharding_script':
     subscribe => File['/etc/zulip/zulip.conf'],
-    command   => '/home/zulip/deployments/current/scripts/lib/sharding.py',
-    onlyif    => 'test -f /home/zulip/deployments/current/scripts/lib/sharding.py\
-  -a ! -f /home/zulip/deployments/next/scripts/lib/sharding.py',
-  }
-  exec { 'sharding_script_next':
-    subscribe => File['/etc/zulip/zulip.conf'],
-    command   => '/home/zulip/deployments/next/scripts/lib/sharding.py',
-    onlyif    => 'test -f /home/zulip/deployments/next/scripts/lib/sharding.py',
+    command   => "bash -c '${sharding_script}'"
   }
   # The file entries below serve only to initialize the sharding config files
   # with the correct default content for the "only one shard" setup. For this

--- a/puppet/zulip/manifests/tornado_sharding.pp
+++ b/puppet/zulip/manifests/tornado_sharding.pp
@@ -14,9 +14,8 @@ class zulip::tornado_sharding {
   # the sharding script afterwards and puppet shouldn't overwrite them.
   file { '/etc/zulip/nginx_sharding.conf':
     ensure  => file,
-    require => User['zulip'],
-    owner   => 'zulip',
-    group   => 'zulip',
+    owner   => 'root',
+    group   => 'root',
     mode    => '0640',
     notify  => Service['nginx'],
     content => "set \$tornado_server http://tornado;\n",

--- a/puppet/zulip/manifests/tornado_sharding.pp
+++ b/puppet/zulip/manifests/tornado_sharding.pp
@@ -1,4 +1,4 @@
-class zulip::sharding {
+class zulip::tornado_sharding {
   include zulip::base
   include zulip::common
   include zulip::nginx

--- a/puppet/zulip/templates/nginx/upstreams.conf.template.erb
+++ b/puppet/zulip/templates/nginx/upstreams.conf.template.erb
@@ -2,10 +2,19 @@ upstream django {
     server unix:/home/zulip/deployments/uwsgi-socket;
 }
 
+<% if @tornado_multiprocess -%>
+<% @tornado_ports.each do |port| -%>
+upstream tornado<%= port %> {
+    server 127.0.0.1:<%= port %>;
+    keepalive 10000;
+}
+<% end -%>
+<% else -%>
 upstream tornado {
     server 127.0.0.1:9993;
     keepalive 10000;
 }
+<% end -%>
 
 upstream localhost_sso {
     server 127.0.0.1:8888;

--- a/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
+++ b/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
@@ -40,6 +40,7 @@ server {
         alias /home/zulip/local-static;
     }
 
+    include /etc/zulip/nginx_sharding.conf;
     include /etc/nginx/zulip-include/certbot;
     include /etc/nginx/zulip-include/app;
 }

--- a/puppet/zulip_ops/files/nginx/sites-available/zulip
+++ b/puppet/zulip_ops/files/nginx/sites-available/zulip
@@ -12,5 +12,6 @@ server {
 
     server_name zulipchat.com *.zulipchat.com;
 
+    include /etc/zulip/nginx_sharding.conf;
     include /etc/nginx/zulip-include/app;
 }

--- a/puppet/zulip_ops/files/nginx/sites-available/zulip-staging
+++ b/puppet/zulip_ops/files/nginx/sites-available/zulip-staging
@@ -15,5 +15,6 @@ server {
 
     server_name staging.zulip.com;
 
+    include /etc/zulip/nginx_sharding.conf;
     include /etc/nginx/zulip-include/app;
 }

--- a/scripts/lib/sharding.py
+++ b/scripts/lib/sharding.py
@@ -48,7 +48,7 @@ with open('/etc/zulip/nginx_sharding.conf.tmp', 'w') as nginx_sharding_conf_f, \
                 host = shard
             else:
                 host = "{}.{}".format(shard, external_host)
-            assert host not in shard_map
+            assert host not in shard_map, "host %s duplicated" % (host,)
             shard_map[host] = int(port)
             write_realm_nginx_config_line(nginx_sharding_conf_f, host, port)
         nginx_sharding_conf_f.write('\n')

--- a/scripts/lib/sharding.py
+++ b/scripts/lib/sharding.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import subprocess
+import sys
+from typing import Any, Dict
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(BASE_DIR)
+from scripts.lib.setup_path import setup_path
+
+setup_path()
+
+from scripts.lib.zulip_tools import get_config_file
+
+def print_shard(f: Any, host: str, port: str) -> None:
+    f.write("""if ($host = '%s') {
+    set $tornado_server http://tornado%s;
+}\n""" % (host, port))
+
+# Basic system to do Tornado sharding.  Writes two output files:
+# * /etc/zulip/nginx_sharding.conf; nginx needs to be reloaded after changing.
+# * /etc/zulip/sharding.json; supervisor Django process needs to be reloaded
+# after changing.  TODO: We can probably make this live-reload by statting the file.
+#
+# TODO: Restructure this to automatically generate a sharding layout.
+with open('/etc/zulip/nginx_sharding.conf', 'w') as nginx_sharding_conf_f, \
+        open('/etc/zulip/sharding.json', 'w') as sharding_json_f:
+
+    config_file = get_config_file()
+    if not config_file.has_section("tornado_sharding"):
+        nginx_sharding_conf_f.write("set $tornado_server http://tornado;\n")
+        sharding_json_f.write('{}\n')
+        sys.exit(0)
+
+    nginx_sharding_conf_f.write("set $tornado_server http://tornado9800;\n")
+    shard_map: Dict[str, int] = {}
+    external_host = subprocess.check_output([os.path.join(BASE_DIR, 'scripts/get-django-setting'),
+                                             'EXTERNAL_HOST'],
+                                            universal_newlines=True).strip()
+    for port in config_file["tornado_sharding"]:
+        shards = config_file["tornado_sharding"][port].strip().split(' ')
+
+        for shard in shards:
+            if '.' in shard:
+                host = shard
+            else:
+                host = "{}.{}".format(shard, external_host)
+            assert host not in shard_map
+            shard_map[host] = int(port)
+            print_shard(nginx_sharding_conf_f, host, port)
+            if shard in ['zephyr', 'recurse']:
+                print_shard(nginx_sharding_conf_f, shard + ".zulipstaging.com", port)
+        nginx_sharding_conf_f.write('\n')
+
+    sharding_json_f.write(json.dumps(shard_map) + '\n')

--- a/scripts/refresh-sharding-and-restart
+++ b/scripts/refresh-sharding-and-restart
@@ -4,6 +4,10 @@ set -e
 
 "$(dirname "$0")/zulip-puppet-apply" -f
 # The step above should have generated the config files, now we need to move them into place:
+chown root:root /etc/zulip/nginx_sharding.conf.tmp
+chmod 640 /etc/zulip/nginx_sharding.conf.tmp
+chown zulip:zulip /etc/zulip/sharding.json.tmp
+chmod 640 /etc/zulip/sharding.json.tmp
 mv /etc/zulip/nginx_sharding.conf.tmp /etc/zulip/nginx_sharding.conf
 mv /etc/zulip/sharding.json.tmp /etc/zulip/sharding.json
 

--- a/scripts/refresh-sharding-and-restart
+++ b/scripts/refresh-sharding-and-restart
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -e
+
+args="$(getopt -o '' -l adjusted-only,shards-added,shards-removed -n "$0" -- "$@")"
+eval "set -- $args"
+while true; do
+    case "$1" in
+        --adjusted-only) ADJUSTED_ONLY=1; shift;;
+        --shards-added) SHARDS_ADDED=1; shift;;
+        --shards-removed) SHARDS_REMOVED=1; shift;;
+        --) shift; break;;
+    esac
+done
+
+if [ -z "$ADJUSTED_ONLY" ] && [ -z "$SHARDS_ADDED" ] && [ -z "$SHARDS_REMOVED" ]; then
+    echo "You need to specify a valid option."
+    exit 1
+fi
+
+"$(dirname "$0")/zulip-puppet-apply" -f
+
+# In the ordering of operationss below the crucial detail
+# is that zulip-django and zulip-workers:* need to be restarted
+# before reloading nginx. Django has an in-memory map of which realm
+# belongs to which shard. Reloading nginx will cause users' tornado
+# requests to be routed according to the new sharding scheme. If that happens
+# before Django is restarted, updating its realm->shard map, users on realms,
+# whose shard has changed, will have their tornado requests handled by the new
+# tornado process, while Django will still use the old process for its internal
+# communication with tornado when servicing the user's requests.
+# That's a bad state that leads to clients getting into reload loops
+# ending in crashing on 500 response while Django is restarting.
+# For this reason it's important to reload nginx only after Django.
+if [ -n "$ADJUSTED_ONLY" ]; then
+    # The number of tornado workers hasn't changed, so we don't need
+    # to touch zulip-tornado:*.
+    supervisorctl restart zulip-django zulip-workers:*
+    service nginx reload
+elif [ -n "$SHARDS_ADDED" ]; then
+    # An additional tornado process is needed, so first
+    # we restart zulip-tornado:* to have the process ready to accept requests.
+    # TODO: This can be significantly improved, because we can simply start
+    # the new tornado process without restarting the existing ones.
+    supervisorctl restart zulip-tornado:*
+    supervisorctl restart zulip-django zulip-workers:*
+    service nginx reload
+elif [ -n "$SHARDS_REMOVED" ]; then
+    supervisorctl restart zulip-django zulip-workers:*
+    service nginx reload
+    # All the necessary tornado processes are running, we actually only have
+    # to reduce their amount, so this can be done in the last step.
+    # TODO: Don't restart all processes, only stop the ones that aren't needed anymore.
+    supervisorctl restart zulip-tornado:*
+fi
+

--- a/scripts/refresh-sharding-and-restart
+++ b/scripts/refresh-sharding-and-restart
@@ -2,23 +2,10 @@
 
 set -e
 
-args="$(getopt -o '' -l adjusted-only,shards-added,shards-removed -n "$0" -- "$@")"
-eval "set -- $args"
-while true; do
-    case "$1" in
-        --adjusted-only) ADJUSTED_ONLY=1; shift;;
-        --shards-added) SHARDS_ADDED=1; shift;;
-        --shards-removed) SHARDS_REMOVED=1; shift;;
-        --) shift; break;;
-    esac
-done
-
-if [ -z "$ADJUSTED_ONLY" ] && [ -z "$SHARDS_ADDED" ] && [ -z "$SHARDS_REMOVED" ]; then
-    echo "You need to specify a valid option."
-    exit 1
-fi
-
 "$(dirname "$0")/zulip-puppet-apply" -f
+# The step above should have generated the config files, now we need to move them into place:
+mv /etc/zulip/nginx_sharding.conf.tmp /etc/zulip/nginx_sharding.conf
+mv /etc/zulip/sharding.json.tmp /etc/zulip/sharding.json
 
 # In the ordering of operationss below the crucial detail
 # is that zulip-django and zulip-workers:* need to be restarted
@@ -32,25 +19,6 @@ fi
 # That's a bad state that leads to clients getting into reload loops
 # ending in crashing on 500 response while Django is restarting.
 # For this reason it's important to reload nginx only after Django.
-if [ -n "$ADJUSTED_ONLY" ]; then
-    # The number of tornado workers hasn't changed, so we don't need
-    # to touch zulip-tornado:*.
-    supervisorctl restart zulip-django zulip-workers:*
-    service nginx reload
-elif [ -n "$SHARDS_ADDED" ]; then
-    # An additional tornado process is needed, so first
-    # we restart zulip-tornado:* to have the process ready to accept requests.
-    # TODO: This can be significantly improved, because we can simply start
-    # the new tornado process without restarting the existing ones.
-    supervisorctl restart zulip-tornado:*
-    supervisorctl restart zulip-django zulip-workers:*
-    service nginx reload
-elif [ -n "$SHARDS_REMOVED" ]; then
-    supervisorctl restart zulip-django zulip-workers:*
-    service nginx reload
-    # All the necessary tornado processes are running, we actually only have
-    # to reduce their amount, so this can be done in the last step.
-    # TODO: Don't restart all processes, only stop the ones that aren't needed anymore.
-    supervisorctl restart zulip-tornado:*
-fi
-
+supervisorctl restart zulip-django
+supervisorctl restart zulip-workers:*
+service nginx reload

--- a/zerver/tornado/sharding.py
+++ b/zerver/tornado/sharding.py
@@ -1,13 +1,19 @@
 from django.conf import settings
 
 from zerver.models import Realm
+import json
+import os
+shard_map = {}
+if os.path.exists("/etc/zulip/sharding.json"):
+    with open("/etc/zulip/sharding.json") as f:
+        shard_map = json.loads(f.read())
 
 def get_tornado_port(realm: Realm) -> int:
     if settings.TORNADO_SERVER is None:
         return 9993
     if settings.TORNADO_PROCESSES == 1:
         return int(settings.TORNADO_SERVER.split(":")[-1])
-    return 9993
+    return shard_map.get(realm.host, 9800)
 
 def get_tornado_uri(realm: Realm) -> str:
     if settings.TORNADO_PROCESSES == 1:


### PR DESCRIPTION
With this, sharding-style config files will be present on all installations, but if the server doesn't configure sharding in `zulip.conf`, the behavior will stay the same as before - tornado on port `9993`.

The procedure to change sharding is:
1. Edit `zulip.conf`
2. Run ` /home/zulip/deployments/current/scripts/refresh-sharding-and-restart` as root with one of the self-explanatory flags ``--adjusted-only``,`--shards-added`,`--shards-removed`. This will apply the changes to appropriate config files and restart the necessary processes.

An important thing still missing is that the `/home/zulip/deployments/current/scripts/refresh-sharding-and-restart` script should be made smarter and not restart all of `zulip-tornado:*` - since we only need to either start up more processes or stop some processes, but the other ones shouldn't be touched.