### PR TITLE
auth: Log when a user tries to login with deactivated account.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -886,11 +886,14 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase):
         # We expect to go through the "choose email" screen here,
         # because there won't be an existing user account we can
         # auto-select for the user.
-        result = self.social_auth_test(account_data_dict,
-                                       expect_choose_email_screen=True,
-                                       subdomain='zulip')
-        self.assertEqual(result.status_code, 302)
-        self.assertEqual(result.url, "/login/?is_deactivated=true")
+        with mock.patch('zproject.backends.logging.info') as m:
+            result = self.social_auth_test(account_data_dict,
+                                           expect_choose_email_screen=True,
+                                           subdomain='zulip')
+            self.assertEqual(result.status_code, 302)
+            self.assertEqual(result.url, "/login/?is_deactivated=true")
+            m.assert_called_with("Failed login attempt for deactivated account: %s@%s",
+                                 user_profile.id, 'zulip')
         # TODO: verify whether we provide a clear error message
 
     def test_social_auth_invalid_realm(self) -> None:

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -143,6 +143,7 @@ def is_user_active(user_profile: UserProfile, return_data: Optional[Dict[str, An
                 # Record whether it's a mirror dummy account
                 return_data['is_mirror_dummy'] = True
             return_data['inactive_user'] = True
+            return_data['inactive_user_id'] = user_profile.id
         return False
     if user_profile.realm.deactivated:
         if return_data is not None:
@@ -1055,6 +1056,7 @@ def social_associate_user_helper(backend: BaseAuth, return_data: Dict[str, Any],
         return_data["invalid_realm"] = True
         return None
     return_data["realm_id"] = realm.id
+    return_data["realm_string_id"] = realm.string_id
 
     if not auth_enabled_helper([backend.auth_backend_name], realm):
         return_data["auth_backend_disabled"] = True
@@ -1224,6 +1226,8 @@ def social_auth_finish(backend: Any,
         return HttpResponseRedirect(reverse('zerver.views.registration.find_account'))
 
     if inactive_user:
+        logging.info("Failed login attempt for deactivated account: %s@%s",
+                     return_data['inactive_user_id'], return_data['realm_string_id'])
         return redirect_deactivated_user_to_login()
 
     if auth_backend_disabled or inactive_realm or no_verified_email or email_not_associated:


### PR DESCRIPTION
Helps to see if users are often trying to login with deactived
accounts.
A use case: Trackdown whether any deactivated bot users are still
trying to access the API.

This implementation adds a new key `inactive_user_id`
to `return_data` in the function `is_user_active` which
check if a `user_profile` is active. This reduces the effort
of getting `user_id` just before logging.

Modified tests for line coverage.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Ran automated tests and modified tests to cover this logging
