### PR TITLE
feat(travis): display emoji for `Pending` status

### DIFF
--- a/zerver/webhooks/travis/view.py
+++ b/zerver/webhooks/travis/view.py
@@ -12,6 +12,7 @@ from zerver.models import UserProfile
 
 GOOD_STATUSES = ['Passed', 'Fixed']
 BAD_STATUSES = ['Failed', 'Broken', 'Still Failing', 'Errored', 'Canceled']
+PENDING_STATUSES = ['Pending']
 
 MESSAGE_TEMPLATE = (
     'Author: {}\n'
@@ -37,6 +38,8 @@ def api_travis_webhook(request: HttpRequest, user_profile: UserProfile,
         emoji = ':thumbs_up:'
     elif message_status in BAD_STATUSES:
         emoji = ':thumbs_down:'
+    elif message_status in PENDING_STATUSES:
+        emoji = ':arrows_counterclockwise:'
     else:
         emoji = "(No emoji specified for status '{}'.)".format(message_status)
 


### PR DESCRIPTION
* Encountered `No emoji specified for status 'Pending'` when using `on_start: always`:

```yaml
notifications:
  webhooks:
    ...
    on_start: always    # default: never
```

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
