### PR TITLE
auth: Gracefully handle bad http responses from IdP in social auth.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -19,6 +19,7 @@ import mock
 import re
 import datetime
 import time
+import requests
 
 from zerver.lib.actions import (
     do_create_user,
@@ -1350,6 +1351,12 @@ class SocialAuthBase(DesktopFlowTestingLib, ZulipTestCase):
     def test_social_auth_complete(self) -> None:
         with mock.patch('social_core.backends.oauth.BaseOAuth2.process_error',
                         side_effect=AuthFailed('Not found')):
+            result = self.client_get(reverse('social:complete', args=[self.backend.name]))
+            self.assertEqual(result.status_code, 302)
+            self.assertIn('login', result.url)
+
+        with mock.patch('social_core.backends.oauth.BaseOAuth2.auth_complete',
+                        side_effect=requests.exceptions.HTTPError):
             result = self.client_get(reverse('social:complete', args=[self.backend.name]))
             self.assertEqual(result.status_code, 302)
             self.assertIn('login', result.url)

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -1338,10 +1338,11 @@ class SocialAuthMixin(ZulipAuthMixin, ExternalAuthMethod):
         try:
             # Call the auth_complete method of social_core.backends.oauth.BaseOAuth2
             return super().auth_complete(*args, **kwargs)  # type: ignore[misc] # monkey-patching
-        except AuthFailed as e:
+        except (AuthFailed, HTTPError) as e:
             # When a user's social authentication fails (e.g. because
             # they did something funny with reloading in the middle of
-            # the flow), don't throw a 500, just send them back to the
+            # the flow or the IdP is unreliable and returns a bad http response),
+            # don't throw a 500, just send them back to the
             # login page and record the event at the info log level.
             logging.info(str(e))
             return None


### PR DESCRIPTION
If the IdP authentication API is flaky for some reason, it can return
bad http responses, which will raise HTTPError inside
python-social-auth. We don't want to generate a traceback
in those cases, but simply log the exception and fail gracefully.