### PR TITLE
stream-subscribe: Rename 'Add streams' to 'Subscribe to new streams'

### DIFF
--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -75,7 +75,7 @@
                 <ul id="stream_filters" class="filters"></ul>
                 {% if show_add_streams %}
                 <div id="add-stream-link">
-                    <a href="#streams/all"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{ _('Add streams') }}</a>
+                    <a href="#streams/all"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{ _('Subscribe to new streams') }}</a>
                 </div>
                 {% endif %}
             </div>


### PR DESCRIPTION
'Add streams' button confuses for a user with 'Create a new stream'.
So rename it to 'Subscribe to new streams'.

Fixes: #14880

![Screenshot from 2020-05-20 19-58-12](https://user-images.githubusercontent.com/23723464/82458486-594a3080-9ad4-11ea-9054-2919f503af77.png)
