### PR TITLE
actions: Merge do_change_is_admin and do_change_is_guest.

### DIFF
--- a/analytics/management/commands/populate_analytics_db.py
+++ b/analytics/management/commands/populate_analytics_db.py
@@ -11,10 +11,11 @@ from analytics.lib.fixtures import generate_time_series_data
 from analytics.lib.time_utils import time_range
 from analytics.models import BaseCount, FillState, InstallationCount, \
     RealmCount, StreamCount, UserCount
-from zerver.lib.actions import STREAM_ASSIGNMENT_COLORS, do_change_is_admin
+from zerver.lib.actions import STREAM_ASSIGNMENT_COLORS, do_change_user_role
 from zerver.lib.create_user import create_user
 from zerver.lib.timestamp import floor_to_day
-from zerver.models import Client, Realm, Recipient, Stream, Subscription
+from zerver.models import Client, Realm, Recipient, Stream, Subscription, \
+    UserProfile
 
 
 class Command(BaseCommand):
@@ -59,7 +60,7 @@ class Command(BaseCommand):
             shylock = create_user('shylock@analytics.ds', 'Shylock', realm,
                                   full_name='Shylock', short_name='shylock',
                                   is_realm_admin=True)
-        do_change_is_admin(shylock, True)
+        do_change_user_role(shylock, UserProfile.ROLE_REALM_ADMINISTRATOR)
         stream = Stream.objects.create(
             name='all', realm=realm, date_created=installation_time)
         recipient = Recipient.objects.create(type_id=stream.id, type=Recipient.STREAM)

--- a/zerver/lib/server_initialization.py
+++ b/zerver/lib/server_initialization.py
@@ -10,7 +10,7 @@ def server_initialized() -> bool:
     return Realm.objects.exists()
 
 def create_internal_realm() -> None:
-    from zerver.lib.actions import do_change_is_admin
+    from zerver.lib.actions import do_change_is_api_super_user
 
     realm = Realm.objects.create(string_id=settings.SYSTEM_BOT_REALM)
 
@@ -33,7 +33,7 @@ def create_internal_realm() -> None:
 
     # Initialize the email gateway bot as an API Super User
     email_gateway_bot = get_system_bot(settings.EMAIL_GATEWAY_BOT)
-    do_change_is_admin(email_gateway_bot, True, permission="api_super_user")
+    do_change_is_api_super_user(email_gateway_bot, True)
 
 def create_users(realm: Realm, name_list: Iterable[Tuple[str, str]],
                  tos_version: Optional[str]=None,

--- a/zerver/management/commands/knight.py
+++ b/zerver/management/commands/knight.py
@@ -3,8 +3,9 @@ from typing import Any
 
 from django.core.management.base import CommandError
 
-from zerver.lib.actions import do_change_is_admin
+from zerver.lib.actions import do_change_user_role, do_change_is_api_super_user
 from zerver.lib.management import ZulipBaseCommand
+from zerver.models import UserProfile
 
 
 class Command(ZulipBaseCommand):
@@ -46,7 +47,10 @@ ONLY perform this on customer request from an authorized person.
                 raise CommandError("User already has permission for this realm.")
             else:
                 if options['ack']:
-                    do_change_is_admin(user, True, permission=options['permission'])
+                    if options['permission'] == "api_super_user":
+                        do_change_is_api_super_user(user, True)
+                    elif options['permission'] == "administer":
+                        do_change_user_role(user, UserProfile.ROLE_REALM_ADMINISTRATOR)
                     print("Done!")
                 else:
                     print("Would have granted %s %s rights for %s" % (
@@ -55,7 +59,10 @@ ONLY perform this on customer request from an authorized person.
             if (user.is_realm_admin and options['permission'] == "administer" or
                     user.is_api_super_user and options['permission'] == "api_super_user"):
                 if options['ack']:
-                    do_change_is_admin(user, False, permission=options['permission'])
+                    if options['permission'] == "api_super_user":
+                        do_change_is_api_super_user(user, False)
+                    elif options['permission'] == "administer":
+                        do_change_user_role(user, UserProfile.ROLE_MEMBER)
                     print("Done!")
                 else:
                     print("Would have removed %s's %s rights on %s" % (email, options['permission'],

--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -5,7 +5,7 @@ from zerver.lib.actions import do_create_user, do_deactivate_user, \
     do_change_user_delivery_email, do_change_avatar_fields, do_change_bot_owner, \
     do_regenerate_api_key, do_change_tos_version, \
     bulk_add_subscriptions, bulk_remove_subscriptions, get_streams_traffic, \
-    do_change_is_admin, do_change_is_guest, do_deactivate_realm, do_reactivate_realm
+    do_change_user_role, do_deactivate_realm, do_reactivate_realm
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.models import RealmAuditLog, get_client, get_realm, UserProfile
 from analytics.models import StreamCount
@@ -53,10 +53,10 @@ class TestRealmAuditLog(ZulipTestCase):
         realm = get_realm('zulip')
         now = timezone_now()
         user_profile = self.example_user("hamlet")
-        do_change_is_admin(user_profile, True)
-        do_change_is_admin(user_profile, False)
-        do_change_is_guest(user_profile, True)
-        do_change_is_guest(user_profile, False)
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
+        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER)
+        do_change_user_role(user_profile, UserProfile.ROLE_GUEST)
+        do_change_user_role(user_profile, UserProfile.ROLE_MEMBER)
         for event in RealmAuditLog.objects.filter(
                 event_type=RealmAuditLog.USER_ROLE_CHANGED,
                 realm=realm, modified_user=user_profile,

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -13,7 +13,7 @@ from typing import List, Optional
 
 from zerver.lib.email_notifications import fix_emojis, handle_missedmessage_emails, \
     enqueue_welcome_emails, relative_to_full_url
-from zerver.lib.actions import do_change_notification_settings, do_change_is_admin
+from zerver.lib.actions import do_change_notification_settings, do_change_user_role
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.send_email import FromAddress, send_custom_email
 from zerver.models import (
@@ -91,7 +91,7 @@ class TestCustomEmails(ZulipTestCase):
 
     def test_send_custom_email_admins_only(self) -> None:
         admin_user = self.example_user('hamlet')
-        do_change_is_admin(admin_user, True)
+        do_change_user_role(admin_user, UserProfile.ROLE_REALM_ADMINISTRATOR)
 
         non_admin_user = self.example_user('cordelia')
 

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -15,7 +15,7 @@ from zerver.lib.actions import (
     check_send_stream_message,
     create_mirror_user_if_needed,
     do_add_alert_words,
-    do_change_is_admin,
+    do_change_is_api_super_user,
     do_change_stream_invite_only,
     do_change_stream_post_policy,
     do_claim_attachments,
@@ -1167,7 +1167,7 @@ class StreamMessagesTest(ZulipTestCase):
         user = self.mit_user('starnine')
         self.subscribe(user, 'Verona')
 
-        do_change_is_admin(user, True, 'api_super_user')
+        do_change_is_api_super_user(user, True)
         result = self.api_post(user, "/api/v1/messages", {"type": "stream",
                                                           "to": "Verona",
                                                           "sender": self.mit_email("sipbtest"),
@@ -1178,7 +1178,7 @@ class StreamMessagesTest(ZulipTestCase):
                                subdomain="zephyr")
         self.assert_json_success(result)
 
-        do_change_is_admin(user, False, 'api_super_user')
+        do_change_is_api_super_user(user, False)
         result = self.api_post(user, "/api/v1/messages", {"type": "stream",
                                                           "to": "Verona",
                                                           "sender": self.mit_email("sipbtest"),

--- a/zerver/tests/test_realm_domains.py
+++ b/zerver/tests/test_realm_domains.py
@@ -1,13 +1,13 @@
 from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
 
-from zerver.lib.actions import do_change_is_admin, \
+from zerver.lib.actions import do_change_user_role, \
     do_change_realm_domain, do_create_realm, \
     do_remove_realm_domain, do_set_realm_property
 from zerver.lib.email_validation import email_allowed_for_realm
 from zerver.lib.domains import validate_domain
 from zerver.lib.test_classes import ZulipTestCase
-from zerver.models import get_realm, \
+from zerver.models import get_realm, UserProfile, \
     RealmDomain, DomainNotAllowedForRealmError
 
 import ujson
@@ -59,7 +59,7 @@ class RealmDomainTest(ZulipTestCase):
         mit_user_profile = self.mit_user("sipbtest")
         self.login_user(mit_user_profile)
 
-        do_change_is_admin(mit_user_profile, True)
+        do_change_user_role(mit_user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
 
         result = self.client_post("/json/realm/domains", info=data,
                                   HTTP_HOST=mit_user_profile.realm.host)

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -35,7 +35,7 @@ from zerver.models import (
     Stream, Subscription, flush_per_request_caches, get_system_bot,
 )
 from zerver.lib.actions import (
-    do_change_is_admin,
+    do_change_user_role,
     get_stream,
     do_create_default_stream_group,
     do_add_default_stream,
@@ -3718,7 +3718,7 @@ class DeactivateUserTest(ZulipTestCase):
     def test_do_not_deactivate_final_admin(self) -> None:
         user = self.example_user('iago')
         user_2 = self.example_user('desdemona')
-        do_change_is_admin(user_2, False)
+        do_change_user_role(user_2, UserProfile.ROLE_MEMBER)
         self.assertFalse(user_2.is_realm_admin)
         self.login_user(user)
         self.assertTrue(user.is_active)
@@ -3727,15 +3727,15 @@ class DeactivateUserTest(ZulipTestCase):
         user = self.example_user('iago')
         self.assertTrue(user.is_active)
         self.assertTrue(user.is_realm_admin)
-        do_change_is_admin(user_2, True)
+        do_change_user_role(user_2, UserProfile.ROLE_REALM_ADMINISTRATOR)
         self.assertTrue(user_2.is_realm_admin)
         result = self.client_delete('/json/users/me')
         self.assert_json_success(result)
-        do_change_is_admin(user, True)
+        do_change_user_role(user, UserProfile.ROLE_REALM_ADMINISTRATOR)
 
     def test_do_not_deactivate_final_user(self) -> None:
         realm = get_realm('zulip')
-        do_change_is_admin(self.example_user("desdemona"), False)
+        do_change_user_role(self.example_user("desdemona"), UserProfile.ROLE_MEMBER)
         UserProfile.objects.filter(realm=realm).exclude(
             role=UserProfile.ROLE_REALM_ADMINISTRATOR).update(is_active=False)
         user = self.example_user("iago")

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -16,7 +16,7 @@ from django.utils.timezone import timedelta as timezone_timedelta
 import pylibmc
 
 from zerver.lib.actions import STREAM_ASSIGNMENT_COLORS, check_add_realm_emoji, \
-    do_change_is_admin, do_send_messages, do_update_user_custom_profile_data_if_changed, \
+    do_change_user_role, do_send_messages, do_update_user_custom_profile_data_if_changed, \
     try_add_realm_custom_profile_field, try_add_realm_default_custom_profile_field
 from zerver.lib.bulk_create import bulk_create_streams
 from zerver.lib.cache import cache_set
@@ -278,12 +278,12 @@ class Command(BaseCommand):
             create_users(zulip_realm, names, tos_version=settings.TOS_VERSION)
 
             iago = get_user_by_delivery_email("iago@zulip.com", zulip_realm)
-            do_change_is_admin(iago, True)
+            do_change_user_role(iago, UserProfile.ROLE_REALM_ADMINISTRATOR)
             iago.is_staff = True
             iago.save(update_fields=['is_staff'])
 
             desdemona = get_user_by_delivery_email("desdemona@zulip.com", zulip_realm)
-            do_change_is_admin(desdemona, True)
+            do_change_user_role(desdemona, UserProfile.ROLE_REALM_ADMINISTRATOR)
 
             guest_user = get_user_by_delivery_email("polonius@zulip.com", zulip_realm)
             guest_user.role = UserProfile.ROLE_GUEST


### PR DESCRIPTION
This commit merges do_change_is_admin and do_change_is_guest to a
single function do_change_user_role which will be used for changing
role of users.

do_change_is_api_super_user is added as a separate function for
changing is_api_super_user field of UserProfile.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
