### PR TITLE
(timestamp #2) Extract rendered_markdown.js to update dynamic elements.

### DIFF
--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -594,15 +594,6 @@ run_test('katex_throws_unexpected_exceptions', () => {
     markdown.apply_markdown(message);
 });
 
-run_test('misc_helpers', () => {
-    const elem = $('.user-mention');
-    markdown.set_name_in_mention_element(elem, 'Aaron');
-    assert.equal(elem.text(), '@Aaron');
-    elem.addClass('silent');
-    markdown.set_name_in_mention_element(elem, 'Aaron, but silent');
-    assert.equal(elem.text(), 'Aaron, but silent');
-});
-
 run_test('translate_emoticons_to_names', () => {
     // Simple test
     const test_text = 'Testing :)';

--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -1,6 +1,7 @@
 const rm = zrequire('rendered_markdown');
 zrequire('people');
 zrequire('user_groups');
+zrequire('stream_data');
 set_global('$', global.make_zjquery());
 
 set_global('rtl', {
@@ -36,6 +37,16 @@ const group_other = {
 user_groups.initialize({
     realm_user_groups: [group_me, group_other],
 });
+
+const stream = {
+    subscribed: true,
+    color: 'yellow',
+    name: 'test',
+    stream_id: 3,
+    is_muted: true,
+    invite_only: false,
+};
+stream_data.add_sub(stream);
 
 const $array = (array) => {
     const each = (func) => {
@@ -115,4 +126,28 @@ run_test('user-group-mention', () => {
     assert($group_me.hasClass('user-mention-me'));
     assert.equal($group_me.text(), `@${group_me.name}`);
     assert.equal($group_other.text(), `@${group_other.name}`);
+});
+
+run_test('stream-links', () => {
+    // Setup
+    const $content = get_content_element();
+    const $stream = $.create('a.stream');
+    $stream.set_find_results('.highlight', false);
+    $stream.attr('data-stream-id', stream.stream_id);
+    const $stream_topic = $.create('a.stream-topic');
+    $stream_topic.set_find_results('.highlight', false);
+    $stream_topic.attr('data-stream-id', stream.stream_id);
+    $stream_topic.text('#random>topic name');
+    $content.set_find_results('a.stream', $array([$stream]));
+    $content.set_find_results('a.stream-topic', $array([$stream_topic]));
+
+    // Initial asserts
+    assert.equal($stream.text(), 'never-been-set');
+    assert.equal($stream_topic.text(), '#random>topic name');
+
+    rm.update_elements($content);
+
+    // Final asserts
+    assert.equal($stream.text(), `#${stream.name}`);
+    assert.equal($stream_topic.text(), `#${stream.name} > topic name`);
 });

--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -1,7 +1,9 @@
 const rm = zrequire('rendered_markdown');
+set_global('moment', zrequire('moment', 'moment-timezone'));
 zrequire('people');
 zrequire('user_groups');
 zrequire('stream_data');
+zrequire('timerender');
 set_global('$', global.make_zjquery());
 
 set_global('rtl', {
@@ -66,6 +68,7 @@ const get_content_element = () => {
     $content.set_find_results('.user-group-mention', $array([]));
     $content.set_find_results('a.stream', $array([]));
     $content.set_find_results('a.stream-topic', $array([]));
+    $content.set_find_results('span.timestamp', $array([]));
     $content.set_find_results('.emoji', $array([]));
     return $content;
 };
@@ -150,6 +153,31 @@ run_test('stream-links', () => {
     // Final asserts
     assert.equal($stream.text(), `#${stream.name}`);
     assert.equal($stream_topic.text(), `#${stream.name} > topic name`);
+});
+
+run_test('timestamp', () => {
+    // Setup
+    const $content = get_content_element();
+    const $timestamp = $.create('timestamp(valid)');
+    $timestamp.attr('data-timestamp', 1);
+    const $timestamp_invalid = $.create('timestamp(invalid)');
+    $timestamp.addClass('timestamp');
+    $timestamp_invalid.addClass('timestamp');
+    $content.set_find_results('span.timestamp', $array([$timestamp, $timestamp_invalid]));
+
+    // Initial asserts
+    assert.equal($timestamp.text(), 'never-been-set');
+    assert.equal($timestamp_invalid.text(), 'never-been-set');
+
+    rm.update_elements($content);
+
+    // Final asserts
+    assert($timestamp.hasClass('timestamp'));
+    assert(!$timestamp_invalid.hasClass('timestamp'));
+    assert.equal($timestamp.text(), 'Thu, Jan 1 1970, 12:00 AM');
+    assert.equal($timestamp.attr('title'), "This time is in your timezone. Original text was 'never-been-set'.");
+    assert.equal($timestamp_invalid.text(), 'never-been-set');
+    assert.equal($timestamp_invalid.attr('title'), 'Could not parse timestamp.');
 });
 
 run_test('emoji', () => {

--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -151,3 +151,22 @@ run_test('stream-links', () => {
     assert.equal($stream.text(), `#${stream.name}`);
     assert.equal($stream_topic.text(), `#${stream.name} > topic name`);
 });
+
+run_test('emoji', () => {
+    // Setup
+    const $content = get_content_element();
+    const $emoji = $.create('.emoji');
+    $emoji.attr('title', 'tada');
+    let called = false;
+    $emoji.replaceWith = (f) => {
+        const text = f.call($emoji);
+        assert.equal(':tada:', text);
+        called = true;
+    };
+    $content.set_find_results('.emoji', $emoji);
+    page_params.emojiset = 'text';
+
+    rm.update_elements($content);
+
+    assert(called);
+});

--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -1,0 +1,11 @@
+const rm = zrequire('rendered_markdown');
+set_global('$', global.make_zjquery());
+
+run_test('misc_helpers', () => {
+    const elem = $.create('.user-mention');
+    rm.set_name_in_mention_element(elem, 'Aaron');
+    assert.equal(elem.text(), '@Aaron');
+    elem.addClass('silent');
+    rm.set_name_in_mention_element(elem, 'Aaron, but silent');
+    assert.equal(elem.text(), 'Aaron, but silent');
+});

--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -1,10 +1,40 @@
 const rm = zrequire('rendered_markdown');
 zrequire('people');
-zrequire('markdown');
+zrequire('user_groups');
 set_global('$', global.make_zjquery());
 
 set_global('rtl', {
     get_direction: () => 'ltr',
+});
+
+const iago = {
+    email: 'iago@zulip.com',
+    user_id: 30,
+    full_name: 'Iago',
+};
+
+const cordelia = {
+    email: 'cordelia@zulup.com',
+    user_id: 31,
+    full_name: 'Cordelia',
+};
+people.init();
+people.add(iago);
+people.add(cordelia);
+people.initialize_current_user(iago.user_id);
+
+const group_me = {
+    name: 'my user group',
+    id: 1,
+    members: [iago.user_id, cordelia.user_id],
+};
+const group_other = {
+    name: 'other user group',
+    id: 2,
+    members: [cordelia.user_id],
+};
+user_groups.initialize({
+    realm_user_groups: [group_me, group_other],
 });
 
 const $array = (array) => {
@@ -40,21 +70,6 @@ run_test('misc_helpers', () => {
 
 run_test('user-mention', () => {
     // Setup
-    const iago = {
-        email: 'iago@zulip.com',
-        user_id: 30,
-        full_name: 'Iago',
-    };
-
-    const cordelia = {
-        email: 'cordelia@zulup.com',
-        user_id: 31,
-        full_name: 'Cordelia',
-    };
-    people.init();
-    people.add(iago);
-    people.add(cordelia);
-    people.initialize_current_user(iago.user_id);
     const $content = get_content_element();
     const $iago = $.create('.user-mention(iago)');
     $iago.set_find_results('.highlight', false);
@@ -75,4 +90,29 @@ run_test('user-mention', () => {
     assert($iago.hasClass('user-mention-me'));
     assert.equal($iago.text(), `@${iago.full_name}`);
     assert.equal($cordelia.text(), `@${cordelia.full_name}`);
+});
+
+
+run_test('user-group-mention', () => {
+    // Setup
+    const $content = get_content_element();
+    const $group_me = $.create('.user-group-mention(me)');
+    $group_me.set_find_results('.highlight', false);
+    $group_me.attr('data-user-group-id', group_me.id);
+    const $group_other = $.create('.user-group-mention(other)');
+    $group_other.set_find_results('.highlight', false);
+    $group_other.attr('data-user-group-id', group_other.id);
+    $content.set_find_results('.user-group-mention', $array([$group_me, $group_other]));
+
+    // Initial asserts
+    assert(!$group_me.hasClass('user-mention-me'));
+    assert.equal($group_me.text(), 'never-been-set');
+    assert.equal($group_other.text(), 'never-been-set');
+
+    rm.update_elements($content);
+
+    // Final asserts
+    assert($group_me.hasClass('user-mention-me'));
+    assert.equal($group_me.text(), `@${group_me.name}`);
+    assert.equal($group_other.text(), `@${group_other.name}`);
 });

--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -1,5 +1,33 @@
 const rm = zrequire('rendered_markdown');
+zrequire('people');
+zrequire('markdown');
 set_global('$', global.make_zjquery());
+
+set_global('rtl', {
+    get_direction: () => 'ltr',
+});
+
+const $array = (array) => {
+    const each = (func) => {
+        array.forEach(e => {
+            func.call(e);
+        });
+    };
+    return {each};
+};
+
+set_global('page_params', { emojiset: 'apple' });
+
+const get_content_element = () => {
+    $.clear_all_elements();
+    const $content = $.create('.rendered_markdown');
+    $content.set_find_results('.user-mention', $array([]));
+    $content.set_find_results('.user-group-mention', $array([]));
+    $content.set_find_results('a.stream', $array([]));
+    $content.set_find_results('a.stream-topic', $array([]));
+    $content.set_find_results('.emoji', $array([]));
+    return $content;
+};
 
 run_test('misc_helpers', () => {
     const elem = $.create('.user-mention');
@@ -8,4 +36,43 @@ run_test('misc_helpers', () => {
     elem.addClass('silent');
     rm.set_name_in_mention_element(elem, 'Aaron, but silent');
     assert.equal(elem.text(), 'Aaron, but silent');
+});
+
+run_test('user-mention', () => {
+    // Setup
+    const iago = {
+        email: 'iago@zulip.com',
+        user_id: 30,
+        full_name: 'Iago',
+    };
+
+    const cordelia = {
+        email: 'cordelia@zulup.com',
+        user_id: 31,
+        full_name: 'Cordelia',
+    };
+    people.init();
+    people.add(iago);
+    people.add(cordelia);
+    people.initialize_current_user(iago.user_id);
+    const $content = get_content_element();
+    const $iago = $.create('.user-mention(iago)');
+    $iago.set_find_results('.highlight', false);
+    $iago.attr('data-user-id', iago.user_id);
+    const $cordelia = $.create('.user-mention(cordelia)');
+    $cordelia.set_find_results('.highlight', false);
+    $cordelia.attr('data-user-id', cordelia.user_id);
+    $content.set_find_results('.user-mention', $array([$iago, $cordelia]));
+
+    // Initial asserts
+    assert(!$iago.hasClass('user-mention-me'));
+    assert.equal($iago.text(), 'never-been-set');
+    assert.equal($cordelia.text(), 'never-been-set');
+
+    rm.update_elements($content);
+
+    // Final asserts
+    assert($iago.hasClass('user-mention-me'));
+    assert.equal($iago.text(), `@${iago.full_name}`);
+    assert.equal($cordelia.text(), `@${cordelia.full_name}`);
 });

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -167,7 +167,8 @@ page_params.realm_filters = [];
 page_params.starred_messages = [];
 page_params.presences = [];
 
-$('#tab_bar').append = () => {};
+const $tab_bar = $.create('#tab_bar');
+$tab_bar.append = () => {};
 upload.setup_upload = () => {};
 
 server_events.home_view_loaded = () => true;
@@ -186,6 +187,9 @@ count_stub.set_find_results('.value', value_stub);
 $(".top_left_starred_messages").set_find_results('.count', count_stub);
 
 $("#tab_list .stream").length = 0;
+
+// set find results doesn't work here since we call .empty() in the code.
+$tab_bar.find = () => false;
 
 compose.compute_show_video_chat_button = () => {};
 $("#below-compose-content .video_link").toggle = () => {};

--- a/frontend_tests/node_tests/zjquery.js
+++ b/frontend_tests/node_tests/zjquery.js
@@ -90,6 +90,10 @@ run_test('finding_related_objects', () => {
     update_message_emoji('foo.png');
     assert.equal(emoji.attr('src'), 'foo.png');
 
+    // Sometimes you want to deliberatly test paths that do not find an
+    // element. You can pass 'false' as the result for those cases.
+    emoji.set_find_results('.random', false);
+    assert.equal(emoji.find('.random').length, 0);
     /*
     An important thing to understand is that zjquery doesn't truly
     simulate DOM.  The way you make relationships work in zjquery

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -199,6 +199,12 @@ exports.make_new_elem = function (selector, opts) {
             if (child) {
                 return child;
             }
+            if (child === false) {
+                // This is deliberately set to simulate missing find results.
+                // Return an empty array, the most common check is
+                // if ($.find().length) { //success }
+                return [];
+            }
             if (opts.silent) {
                 return self;
             }

--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -27,6 +27,7 @@ import "../search_util.js";
 import "../keydown_util.js";
 import "../lightbox_canvas.js";
 import "../rtl.js";
+import "../rendered_markdown.js";
 import "../lazy_set.js";
 import "../fold_dict.ts";
 import "../scroll_util.js";

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -28,15 +28,6 @@ const backend_only_markdown_re = [
     /[^\s]*(?:twitter|youtube).com\/[^\s]*/,
 ];
 
-// Helper function to update a mentioned user's name.
-exports.set_name_in_mention_element = function (element, name) {
-    if ($(element).hasClass('silent')) {
-        $(element).text(name);
-    } else {
-        $(element).text("@" + name);
-    }
-};
-
 exports.translate_emoticons_to_names = (text) => {
     // Translates emoticons in a string to their colon syntax.
     let translated = text;

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -1,4 +1,5 @@
 const util = require("./util");
+const rendered_markdown = require('./rendered_markdown');
 const render_bookend = require('../templates/bookend.hbs');
 const render_message_group = require('../templates/message_group.hbs');
 const render_recipient_row = require('../templates/recipient_row.hbs');
@@ -18,41 +19,6 @@ function MessageListView(list, table_name, collapse_messages) {
     // Half-open interval of the indices that define the current render window
     this._render_win_start = 0;
     this._render_win_end = 0;
-}
-
-function get_user_id_for_mention_button(elem) {
-    const user_id_string = $(elem).attr('data-user-id');
-    // Handle legacy markdown that was rendered before we cut
-    // over to using data-user-id.
-    const email = $(elem).attr('data-user-email');
-
-    if (user_id_string === "*" || email === "*") {
-        return "*";
-    }
-
-    if (user_id_string) {
-        return parseInt(user_id_string, 10);
-    }
-
-    if (email) {
-        // Will return undefined if there's no match
-        const user = people.get_by_email(email);
-        if (user) {
-            return user.user_id;
-        }
-        return;
-    }
-    return;
-}
-
-function get_user_group_id_for_mention_button(elem) {
-    const user_group_id = $(elem).attr('data-user-group-id');
-
-    if (user_group_id) {
-        return parseInt(user_group_id, 10);
-    }
-
-    return;
 }
 
 function same_day(earlier_msg, later_msg) {
@@ -536,97 +502,7 @@ MessageListView.prototype = {
 
         const content = row.find('.message_content');
 
-        // Set the rtl class if the text has an rtl direction
-        if (rtl.get_direction(content.text()) === 'rtl') {
-            content.addClass('rtl');
-        }
-
-        content.find('.user-mention').each(function () {
-            const user_id = get_user_id_for_mention_button(this);
-            // We give special highlights to the mention buttons
-            // that refer to the current user.
-            if (user_id === "*" || people.is_my_user_id(user_id)) {
-                // Either a wildcard mention or us, so mark it.
-                $(this).addClass('user-mention-me');
-            }
-            if (user_id && user_id !== "*" && !$(this).find(".highlight").length) {
-                // If it's a mention of a specific user, edit the
-                // mention text to show the user's current name,
-                // assuming that you're not searching for text
-                // inside the highlight.
-                const person = people.get_by_user_id(user_id, true);
-                if (person !== undefined) {
-                    // Note that person might be undefined in some
-                    // unpleasant corner cases involving data import.
-                    markdown.set_name_in_mention_element(this, person.full_name);
-                }
-            }
-        });
-
-        content.find('.user-group-mention').each(function () {
-            const user_group_id = get_user_group_id_for_mention_button(this);
-            const user_group = user_groups.get_user_group_from_id(user_group_id, true);
-            if (user_group === undefined) {
-                // This is a user group the current user doesn't have
-                // data on.  This can happen when user groups are
-                // deleted.
-                blueslip.info("Rendered unexpected user group " + user_group_id);
-                return;
-            }
-
-            const my_user_id = people.my_current_user_id();
-            // Mark user group you're a member of.
-            if (user_groups.is_member_of(user_group_id, my_user_id)) {
-                $(this).addClass('user-mention-me');
-            }
-
-            if (user_group_id && !$(this).find(".highlight").length) {
-                // Edit the mention to show the current name for the
-                // user group, if its not in search.
-                $(this).text("@" + user_group.name);
-            }
-        });
-
-        content.find('a.stream').each(function () {
-            const stream_id = parseInt($(this).attr('data-stream-id'), 10);
-            if (stream_id && !$(this).find(".highlight").length) {
-                // Display the current name for stream if it is not
-                // being displayed in search highlight.
-                const stream_name = stream_data.maybe_get_stream_name(stream_id);
-                if (stream_name !== undefined) {
-                    // If the stream has been deleted,
-                    // stream_data.maybe_get_stream_name might return
-                    // undefined.  Otherwise, display the current stream name.
-                    $(this).text("#" + stream_name);
-                }
-            }
-        });
-
-        content.find('a.stream-topic').each(function () {
-            const stream_id = parseInt($(this).attr('data-stream-id'), 10);
-            if (stream_id && !$(this).find(".highlight").length) {
-                // Display the current name for stream if it is not
-                // being displayed in search highlight.
-                const text = $(this).text();
-                const topic = text.split('>', 2)[1];
-                const stream_name = stream_data.maybe_get_stream_name(stream_id);
-                if (stream_name !== undefined) {
-                    // If the stream has been deleted,
-                    // stream_data.maybe_get_stream_name might return
-                    // undefined.  Otherwise, display the current stream name.
-                    $(this).text("#" + stream_name + ' > ' + topic);
-                }
-            }
-        });
-
-        // Display emoji (including realm emoji) as text if
-        // page_params.emojiset is 'text'.
-        if (page_params.emojiset === 'text') {
-            content.find(".emoji").replaceWith(function () {
-                const text = $(this).attr("title");
-                return ":" + text + ":";
-            });
-        }
+        rendered_markdown.update_elements(content);
 
         const id = rows.id(row);
         message_edit.maybe_show_edit(row, id);

--- a/static/js/rendered_markdown.js
+++ b/static/js/rendered_markdown.js
@@ -33,6 +33,15 @@ function get_user_group_id_for_mention_button(elem) {
     return;
 }
 
+// Helper function to update a mentioned user's name.
+exports.set_name_in_mention_element = function (element, name) {
+    if ($(element).hasClass('silent')) {
+        $(element).text(name);
+    } else {
+        $(element).text("@" + name);
+    }
+};
+
 exports.update_elements = (content) => {
     // Set the rtl class if the text has an rtl direction
     if (rtl.get_direction(content.text()) === 'rtl') {
@@ -56,7 +65,7 @@ exports.update_elements = (content) => {
             if (person !== undefined) {
                 // Note that person might be undefined in some
                 // unpleasant corner cases involving data import.
-                markdown.set_name_in_mention_element(this, person.full_name);
+                exports.set_name_in_mention_element(this, person.full_name);
             }
         }
     });

--- a/static/js/rendered_markdown.js
+++ b/static/js/rendered_markdown.js
@@ -1,3 +1,14 @@
+/*
+    rendered_markdown
+
+    This module provies a single function 'update_elements' to
+    update any renamed users/streams/groups etc. and other
+    dynamic parts of our rendered messages.
+
+    Use this module wherever some markdown rendered content
+    is being displayed.
+*/
+
 function get_user_id_for_mention_button(elem) {
     const user_id_string = $(elem).attr('data-user-id');
     // Handle legacy markdown that was rendered before we cut

--- a/static/js/rendered_markdown.js
+++ b/static/js/rendered_markdown.js
@@ -1,0 +1,128 @@
+function get_user_id_for_mention_button(elem) {
+    const user_id_string = $(elem).attr('data-user-id');
+    // Handle legacy markdown that was rendered before we cut
+    // over to using data-user-id.
+    const email = $(elem).attr('data-user-email');
+
+    if (user_id_string === "*" || email === "*") {
+        return "*";
+    }
+
+    if (user_id_string) {
+        return parseInt(user_id_string, 10);
+    }
+
+    if (email) {
+        // Will return undefined if there's no match
+        const user = people.get_by_email(email);
+        if (user) {
+            return user.user_id;
+        }
+        return;
+    }
+    return;
+}
+
+function get_user_group_id_for_mention_button(elem) {
+    const user_group_id = $(elem).attr('data-user-group-id');
+
+    if (user_group_id) {
+        return parseInt(user_group_id, 10);
+    }
+
+    return;
+}
+
+exports.update_elements = (content) => {
+    // Set the rtl class if the text has an rtl direction
+    if (rtl.get_direction(content.text()) === 'rtl') {
+        content.addClass('rtl');
+    }
+
+    content.find('.user-mention').each(function () {
+        const user_id = get_user_id_for_mention_button(this);
+        // We give special highlights to the mention buttons
+        // that refer to the current user.
+        if (user_id === "*" || people.is_my_user_id(user_id)) {
+            // Either a wildcard mention or us, so mark it.
+            $(this).addClass('user-mention-me');
+        }
+        if (user_id && user_id !== "*" && !$(this).find(".highlight").length) {
+            // If it's a mention of a specific user, edit the
+            // mention text to show the user's current name,
+            // assuming that you're not searching for text
+            // inside the highlight.
+            const person = people.get_by_user_id(user_id, true);
+            if (person !== undefined) {
+                // Note that person might be undefined in some
+                // unpleasant corner cases involving data import.
+                markdown.set_name_in_mention_element(this, person.full_name);
+            }
+        }
+    });
+
+    content.find('.user-group-mention').each(function () {
+        const user_group_id = get_user_group_id_for_mention_button(this);
+        const user_group = user_groups.get_user_group_from_id(user_group_id, true);
+        if (user_group === undefined) {
+            // This is a user group the current user doesn't have
+            // data on.  This can happen when user groups are
+            // deleted.
+            blueslip.info("Rendered unexpected user group " + user_group_id);
+            return;
+        }
+
+        const my_user_id = people.my_current_user_id();
+        // Mark user group you're a member of.
+        if (user_groups.is_member_of(user_group_id, my_user_id)) {
+            $(this).addClass('user-mention-me');
+        }
+
+        if (user_group_id && !$(this).find(".highlight").length) {
+            // Edit the mention to show the current name for the
+            // user group, if its not in search.
+            $(this).text("@" + user_group.name);
+        }
+    });
+
+    content.find('a.stream').each(function () {
+        const stream_id = parseInt($(this).attr('data-stream-id'), 10);
+        if (stream_id && !$(this).find(".highlight").length) {
+            // Display the current name for stream if it is not
+            // being displayed in search highlight.
+            const stream_name = stream_data.maybe_get_stream_name(stream_id);
+            if (stream_name !== undefined) {
+                // If the stream has been deleted,
+                // stream_data.maybe_get_stream_name might return
+                // undefined.  Otherwise, display the current stream name.
+                $(this).text("#" + stream_name);
+            }
+        }
+    });
+
+    content.find('a.stream-topic').each(function () {
+        const stream_id = parseInt($(this).attr('data-stream-id'), 10);
+        if (stream_id && !$(this).find(".highlight").length) {
+            // Display the current name for stream if it is not
+            // being displayed in search highlight.
+            const text = $(this).text();
+            const topic = text.split('>', 2)[1];
+            const stream_name = stream_data.maybe_get_stream_name(stream_id);
+            if (stream_name !== undefined) {
+                // If the stream has been deleted,
+                // stream_data.maybe_get_stream_name might return
+                // undefined.  Otherwise, display the current stream name.
+                $(this).text("#" + stream_name + ' > ' + topic);
+            }
+        }
+    });
+
+    // Display emoji (including realm emoji) as text if
+    // page_params.emojiset is 'text'.
+    if (page_params.emojiset === 'text') {
+        content.find(".emoji").replaceWith(function () {
+            const text = $(this).attr("title");
+            return ":" + text + ":";
+        });
+    }
+};

--- a/static/js/rendered_markdown.js
+++ b/static/js/rendered_markdown.js
@@ -137,6 +137,22 @@ exports.update_elements = (content) => {
         }
     });
 
+    content.find('span.timestamp').each(function () {
+        // Populate each timestamp span with mentioned time
+        // in user's local timezone.
+        const timestamp = moment.unix($(this).attr('data-timestamp'));
+        if (timestamp.isValid() && $(this).attr('data-timestamp') !== null) {
+            const text = $(this).text();
+            const rendered_time = timerender.render_markdown_timestamp(timestamp,
+                                                                       null, text);
+            $(this).text(rendered_time.text);
+            $(this).attr('title', rendered_time.title);
+        } else {
+            $(this).removeClass('timestamp');
+            $(this).attr('title', 'Could not parse timestamp.');
+        }
+    });
+
     // Display emoji (including realm emoji) as text if
     // page_params.emojiset is 'text'.
     if (page_params.emojiset === 'text') {

--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -1,4 +1,5 @@
 const render_tab_bar = require('../templates/tab_bar.hbs');
+const rendered_markdown = require('./rendered_markdown');
 
 function get_sub_count(current_stream) {
     const sub_count = current_stream.subscriber_count;
@@ -60,6 +61,11 @@ function display_tab_bar(tab_bar_data) {
         exports.colorize_tab_bar();
     }
     tab_bar.removeClass('notdisplayed');
+    const content = tab_bar.find('span.rendered_markdown');
+    if (content) {
+        // Update syntax like stream names, emojis, mentions, timestamps.
+        rendered_markdown.update_elements(content);
+    }
 }
 
 function build_tab_bar(filter) {

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -164,6 +164,21 @@ exports.render_date = function (time, time_above, today) {
     return node;
 };
 
+// Renders the timestamp returned by the !time() markdown syntax.
+exports.render_markdown_timestamp = function (time, now, text) {
+    now = now || moment();
+    if (page_params.timezone) {
+        now = now.tz(page_params.timezone);
+        time = time.tz(page_params.timezone);
+    }
+    const timestring = time.format('ddd, MMM D YYYY, h:mm A');
+    const titlestring = "This time is in your timezone. Original text was '" + text + "'.";
+    return {
+        text: timestring,
+        title: titlestring,
+    };
+};
+
 // This isn't expected to be called externally except manually for
 // testing purposes.
 exports.update_timestamps = function () {

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -477,6 +477,11 @@ on a dark background, and don't change the dark labels dark either. */
         }
     }
 
+    .timestamp {
+        background: hsla(0, 0%, 0%, 0.2);
+        box-shadow: 0px 0px 0px 1px hsla(0, 0%, 0%, 0.4);
+    }
+
     .tip {
         color: inherit;
         background-color: hsla(46, 28%, 38%, 0.27);

--- a/static/styles/rendered_markdown.scss
+++ b/static/styles/rendered_markdown.scss
@@ -141,6 +141,19 @@
         vertical-align: text-bottom;
     }
 
+    /* Timestamps */
+    .timestamp {
+        background: hsl(0, 0%, 93%);
+        border-radius: 3px;
+        padding: 0 0.2em;
+        box-shadow: 0px 0px 0px 1px hsl(0, 0%, 80%);
+        white-space: nowrap;
+        margin-left: 2px;
+        margin-right: 2px;
+        display: inline-block;
+        margin-bottom: 1px;
+    }
+
     /* Highlighting for message edit history */
     .highlight_text_inserted {
         color: hsl(122, 72%, 30%);

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -101,6 +101,7 @@ EXEMPT_FILES = {
     'static/js/reload.js',
     'static/js/reload_state.js',
     'static/js/reminder.js',
+    'static/js/rendered_markdown.js',
     'static/js/resize.js',
     'static/js/rows.js',
     'static/js/scroll_bar.js',


### PR DESCRIPTION
Previously, we handled this code only in message_list_view.js.
Now we support rendering stream descriptions and some dynamic
elements can be rendered in them, so we extract this new module
and use it in both the places.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Manual testing. There are some issues like we don't actually render mentions in stream descriptions, but if we would, this code would pick them up and convert them.

