### PR TITLE
message_edit: Always empty edit form before appending to it.

### DIFF
--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -304,6 +304,9 @@ exports.MessageList.prototype = {
     },
 
     show_edit_message: function MessageList_show_edit_message(row, edit_obj) {
+        if (row.find(".message_edit_form form").length !== 0) {
+            return;
+        }
         row.find(".message_edit_form").append(edit_obj.form);
         row.find(".message_content, .status-message, .message_controls").hide();
         row.find(".message_edit").css("display", "block");


### PR DESCRIPTION
Prior to commit 8b7e70ac2711372a0315b01179697ec644b33347 this system
would simply just .hide() forms when they were closed and
.empty().append() them when a new edit form was made. This was not a
very clean way of handling the action of canceling an edit, so
8b7e70ac2711372a0315b01179697ec644b33347 introduced a change that had
the "show_edit" function append the form and the hide function delete
the form. However, we overlooked the fact that the user could use
history to navigate away and back to the form and use "e" or "left
arrow key" to successfully append another form to element and get to
an ugly broken state.

This commit does not revert 8b7e70ac2711372a0315b01179697ec644b33347
as it is still accurate to .empty() when hiding the form, but we also
.empty().append() when showing the form, to avoid bugs like the above.
Fixes: #15045.


<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![always remove form before appending](https://user-images.githubusercontent.com/33805964/82553555-e5fef800-9b81-11ea-85e8-001f98cc1aaa.gif)

AS THE GIF SHOWS AT THE END: the current commit might not be an ideal fix, because if you're editing the form and click outside the form and use "e" or "left arrow" you're likely to delete whatever text you'd placed in the form... Should we change that?
Would it be an improvement if (instead of what this commit currently is) we modify the "show edit message" to check and early exit if there's already an edit form present?

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->