### PR TITLE
Recent topic UI

### DIFF
--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -100,6 +100,7 @@ zrequire('recent_senders');
 zrequire('unread');
 zrequire('stream_topic_history');
 zrequire('recent_topics');
+zrequire('overlays');
 
 // And finally require the module that we will test directly:
 zrequire('message_store');

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -178,7 +178,7 @@ run_test('basic_chars', () => {
 
     // Unmapped keys should immediately return false, without
     // calling any functions outside of hotkey.js.
-    assert_unmapped('abfhlmotyz');
+    assert_unmapped('abfhlmoyz');
     assert_unmapped('BEFHILNOQTUWXYZ');
 
     // We have to skip some checks due to the way the code is
@@ -204,7 +204,7 @@ run_test('basic_chars', () => {
     hotkey.processing_text = return_true;
 
     function test_normal_typing() {
-        assert_unmapped('abcdefghijklmnopqrstuvwxyz');
+        assert_unmapped('abcdefghijklmnopqrsuvwxyz');
         assert_unmapped(' ');
         assert_unmapped('[]\\.,;');
         assert_unmapped('ABCDEFGHIJKLMNOPQRSTUVWXYZ');
@@ -230,6 +230,7 @@ run_test('basic_chars', () => {
     overlays.streams_open = return_false;
     overlays.lightbox_open = return_false;
     overlays.drafts_open = return_false;
+    overlays.recent_topics = return_false;
 
     page_params.can_create_streams = true;
     overlays.streams_open = return_true;
@@ -263,6 +264,16 @@ run_test('basic_chars', () => {
     test_normal_typing();
     overlays.is_active = return_false;
     assert_mapping('d', 'drafts.launch');
+
+
+    // Test opening and closing of Recent Topics
+    overlays.is_active = return_true;
+    overlays.recent_topics_open = return_true;
+    assert_mapping('t', 'overlays.close_overlay');
+    overlays.recent_topics_open = return_false;
+    test_normal_typing();
+    overlays.is_active = return_false;
+    assert_mapping('t', 'hashchange.go_to_location');
 
     // Next, test keys that only work on a selected message.
     const message_view_only_keys = '@+>RjJkKsSuvi:GM';

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -11,9 +11,11 @@ zrequire('FetchStatus', 'js/fetch_status');
 zrequire('Filter', 'js/filter');
 zrequire('MessageListData', 'js/message_list_data');
 zrequire('message_list');
-zrequire('recent_topics');
 zrequire('people');
 
+set_global('recent_topics', {
+    process_messages: noop,
+});
 set_global('page_params', {
     have_initial_messages: true,
     pointer: 444,

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -609,6 +609,26 @@ run_test('message_methods', () => {
 
     assert.equal(people.small_avatar_url_for_person(maria),
                  'https://secure.gravatar.com/avatar/md5-athens@example.com?d=identicon&s=50');
+
+    assert.deepEqual(people.sender_info_with_small_avatar_urls_for_sender_ids([30]), [
+        {
+            avatar_url_small: 'https://secure.gravatar.com/avatar/md5-me@example.com?d=identicon&s=50',
+            email: 'me@example.com',
+            full_name: 'Me the Third',
+            is_admin: false,
+            is_bot: false,
+            is_guest: false,
+            profile_data: {
+                3: {
+                    rendered_value: '<p>Field value</p>',
+                    value: 'Field value',
+                },
+            },
+            timezone: 'US/Pacific',
+            user_id: 30,
+        },
+    ]);
+
     let message = {
         type: 'private',
         display_recipient: [

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -1,6 +1,15 @@
 let rt = zrequire('recent_topics');
 zrequire('message_util');
 
+set_global('$', global.make_zjquery());
+set_global('hashchange', {
+    exit_overlay: () => {},
+});
+set_global('overlays', {
+    open_overlay: (opts) => {
+        overlays.close_callback = opts.on_close;
+    },
+});
 set_global('people', {
     is_my_user_id: function (id) {
         return id === 1;
@@ -292,4 +301,14 @@ run_test('test_topic_edit', () => {
 
     assert.equal(all_topics.get(stream2 + ":" + topic1), undefined);
     verify_topic_data(all_topics, stream3, topic9, messages[0].id, true, 0);
+});
+
+run_test("test_recent_topics_launch", () => {
+
+    global.stub_templates(function (template_name) {
+        assert.equal(template_name, 'recent_topics_table');
+        return '<recent_topics table stub>';
+    });
+    rt.launch();
+    overlays.close_callback();
 });

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -187,6 +187,30 @@ messages[9] = {
     type: 'stream',
 };
 
+function generate_topic_data(topic_info_array) {
+    // Since most of the fields are common, this function helps generate fixtures
+    // with non common fields.
+    const data = [];
+    for (const [stream_id, topic, unread_count, hidden] of topic_info_array) {
+        data.push({
+            count_senders: 0,
+            hidden: hidden,
+            last_msg_time: 'Just now',
+            senders: [
+                1,
+                2,
+            ],
+            stream: 'stream' + stream_id,
+            stream_id: stream_id,
+            stream_url: 'https://www.example.com',
+            topic: topic,
+            topic_url: 'https://www.example.com',
+            unread_count: unread_count,
+        });
+    }
+    return data;
+}
+
 function verify_topic_data(all_topics, stream, topic, last_msg_id,
                            participated) {
     const topic_data = all_topics.get(stream + ':' + topic);
@@ -201,92 +225,16 @@ run_test("test_recent_topics_launch", () => {
     const expected = {
         filter_participated: false,
         filter_unread: false,
-        recent_topics: [
-            {
-                stream_id: 1,
-                stream: 'stream1',
-                topic: 'topic-7',
-                unread_count: 1,
-                last_msg_time: 'Just now',
-                stream_url: 'https://www.example.com',
-                topic_url: 'https://www.example.com',
-                hidden: true,
-                senders: [1, 2],
-                count_senders: 0,
-            },
-            {
-                stream_id: 1,
-                stream: 'stream1',
-                topic: 'topic-6',
-                unread_count: 1,
-                last_msg_time: 'Just now',
-                stream_url: 'https://www.example.com',
-                topic_url: 'https://www.example.com',
-                hidden: false,
-                senders: [1, 2],
-                count_senders: 0,
-            },
-            {
-                stream_id: 1,
-                stream: 'stream1',
-                topic: 'topic-5',
-                unread_count: 1,
-                last_msg_time: 'Just now',
-                stream_url: 'https://www.example.com',
-                topic_url: 'https://www.example.com',
-                hidden: false,
-                senders: [1, 2],
-                count_senders: 0,
-            },
-            {
-                stream_id: 1,
-                stream: 'stream1',
-                topic: 'topic-4',
-                unread_count: 1,
-                last_msg_time: 'Just now',
-                stream_url: 'https://www.example.com',
-                topic_url: 'https://www.example.com',
-                hidden: false,
-                senders: [1, 2],
-                count_senders: 0,
-            },
-            {
-                stream_id: 1,
-                stream: 'stream1',
-                topic: 'topic-3',
-                unread_count: 1,
-                last_msg_time: 'Just now',
-                stream_url: 'https://www.example.com',
-                topic_url: 'https://www.example.com',
-                hidden: false,
-                senders: [1, 2],
-                count_senders: 0,
-            },
-            {
-                stream_id: 1,
-                stream: 'stream1',
-                topic: 'topic-2',
-                unread_count: 1,
-                last_msg_time: 'Just now',
-                stream_url: 'https://www.example.com',
-                topic_url: 'https://www.example.com',
-                hidden: false,
-                senders: [1, 2],
-                count_senders: 0,
-            },
-            {
-                stream_id: 1,
-                stream: 'stream1',
-                topic: 'topic-1',
-                unread_count: 0,
-                last_msg_time: 'Just now',
-                stream_url: 'https://www.example.com',
-                topic_url: 'https://www.example.com',
-                hidden: false,
-                senders: [1, 2],
-                count_senders: 0,
-            },
-        ],
+        recent_topics: generate_topic_data([
+            // stream_id, topic, unread_count, hidden
+            [1, 'topic-7', 1, true],
+            [1, 'topic-6', 1, false],
+            [1, 'topic-5', 1, false],
+            [1, 'topic-4', 1, false],
+            [1, 'topic-3', 1, false],
+            [1, 'topic-2', 1, false],
+            [1, 'topic-1', 0, false],
+        ]),
     };
 
     global.stub_templates(function (template_name, data) {
@@ -308,18 +256,7 @@ run_test("test_recent_topics_launch", () => {
 run_test('test_filter_all', () => {
     // Just tests inplace rerender of a message
     // in All topics filter.
-    let expected = {
-        count_senders: 0,
-        hidden: false,
-        last_msg_time: 'Just now',
-        senders: [1, 2],
-        stream: 'stream1',
-        stream_id: 1,
-        stream_url: 'https://www.example.com',
-        topic: 'topic-1',
-        topic_url: 'https://www.example.com',
-        unread_count: 0,
-    };
+    let expected = generate_topic_data([[1, 'topic-1', 0, false]])[0];
 
     global.stub_templates(function (template_name, data) {
         assert.equal(template_name, 'recent_topic_row');
@@ -331,18 +268,7 @@ run_test('test_filter_all', () => {
     const rt = zrequire('recent_topics');
     rt.process_messages([messages[0]]);
 
-    expected = {
-        stream_id: 1,
-        stream: 'stream1',
-        topic: 'topic-7',
-        unread_count: 1,
-        last_msg_time: 'Just now',
-        stream_url: 'https://www.example.com',
-        topic_url: 'https://www.example.com',
-        hidden: true,
-        senders: [1, 2],
-        count_senders: 0,
-    };
+    expected = generate_topic_data([[1, 'topic-7', 1, true]])[0];
 
     // topic is muted (=== hidden)
     rt.process_messages([messages[9]]);
@@ -353,92 +279,16 @@ run_test('test_filter_unread', () => {
     const expected =   {
         filter_participated: false,
         filter_unread: true,
-        recent_topics: [
-            {
-                count_senders: 0,
-                hidden: true,
-                last_msg_time: 'Just now',
-                senders: [1, 2],
-                stream: 'stream1',
-                stream_id: 1,
-                stream_url: 'https://www.example.com',
-                topic: 'topic-7',
-                topic_url: 'https://www.example.com',
-                unread_count: 1,
-            },
-            {
-                count_senders: 0,
-                hidden: false,
-                last_msg_time: 'Just now',
-                senders: [1, 2],
-                stream: 'stream1',
-                stream_id: 1,
-                stream_url: 'https://www.example.com',
-                topic: 'topic-6',
-                topic_url: 'https://www.example.com',
-                unread_count: 1,
-            },
-            {
-                count_senders: 0,
-                hidden: false,
-                last_msg_time: 'Just now',
-                senders: [1, 2],
-                stream: 'stream1',
-                stream_id: 1,
-                stream_url: 'https://www.example.com',
-                topic: 'topic-5',
-                topic_url: 'https://www.example.com',
-                unread_count: 1,
-            },
-            {
-                count_senders: 0,
-                hidden: false,
-                last_msg_time: 'Just now',
-                senders: [1, 2],
-                stream: 'stream1',
-                stream_id: 1,
-                stream_url: 'https://www.example.com',
-                topic: 'topic-4',
-                topic_url: 'https://www.example.com',
-                unread_count: 1,
-            },
-            {
-                count_senders: 0,
-                hidden: false,
-                last_msg_time: 'Just now',
-                senders: [1, 2],
-                stream: 'stream1',
-                stream_id: 1,
-                stream_url: 'https://www.example.com',
-                topic: 'topic-3',
-                topic_url: 'https://www.example.com',
-                unread_count: 1,
-            },
-            {
-                count_senders: 0,
-                hidden: false,
-                last_msg_time: 'Just now',
-                senders: [1, 2],
-                stream: 'stream1',
-                stream_id: 1,
-                stream_url: 'https://www.example.com',
-                topic: 'topic-2',
-                topic_url: 'https://www.example.com',
-                unread_count: 1,
-            },
-            {
-                count_senders: 0,
-                hidden: true,  // This is the only thing we are testing here
-                last_msg_time: 'Just now',
-                senders: [1, 2],
-                stream: 'stream1',
-                stream_id: 1,
-                stream_url: 'https://www.example.com',
-                topic: 'topic-1',
-                topic_url: 'https://www.example.com',
-                unread_count: 0,
-            },
-        ],
+        recent_topics: generate_topic_data([
+            // stream_id, topic, unread_count, hidden
+            [1, 'topic-7', 1, true],
+            [1, 'topic-6', 1, false],
+            [1, 'topic-5', 1, false],
+            [1, 'topic-4', 1, false],
+            [1, 'topic-3', 1, false],
+            [1, 'topic-2', 1, false],
+            [1, 'topic-1', 0, true],
+        ]),
     };
 
     const rt = zrequire('recent_topics');
@@ -470,92 +320,16 @@ run_test('test_filter_participated', () => {
     const expected =   {
         filter_participated: true,
         filter_unread: false,
-        recent_topics: [
-            {
-                count_senders: 0,
-                hidden: true,
-                last_msg_time: 'Just now',
-                senders: [1, 2],
-                stream: 'stream1',
-                stream_id: 1,
-                stream_url: 'https://www.example.com',
-                topic: 'topic-7',
-                topic_url: 'https://www.example.com',
-                unread_count: 1,
-            },
-            {
-                count_senders: 0,
-                hidden: false,
-                last_msg_time: 'Just now',
-                senders: [1, 2],
-                stream: 'stream1',
-                stream_id: 1,
-                stream_url: 'https://www.example.com',
-                topic: 'topic-6',
-                topic_url: 'https://www.example.com',
-                unread_count: 1,
-            },
-            {
-                count_senders: 0,
-                hidden: false,
-                last_msg_time: 'Just now',
-                senders: [1, 2],
-                stream: 'stream1',
-                stream_id: 1,
-                stream_url: 'https://www.example.com',
-                topic: 'topic-5',
-                topic_url: 'https://www.example.com',
-                unread_count: 1,
-            },
-            {
-                count_senders: 0,
-                hidden: true,
-                last_msg_time: 'Just now',
-                senders: [1, 2],
-                stream: 'stream1',
-                stream_id: 1,
-                stream_url: 'https://www.example.com',
-                topic: 'topic-4',
-                topic_url: 'https://www.example.com',
-                unread_count: 1,
-            },
-            {
-                count_senders: 0,
-                hidden: true,
-                last_msg_time: 'Just now',
-                senders: [1, 2],
-                stream: 'stream1',
-                stream_id: 1,
-                stream_url: 'https://www.example.com',
-                topic: 'topic-3',
-                topic_url: 'https://www.example.com',
-                unread_count: 1,
-            },
-            {
-                count_senders: 0,
-                hidden: false,
-                last_msg_time: 'Just now',
-                senders: [1, 2],
-                stream: 'stream1',
-                stream_id: 1,
-                stream_url: 'https://www.example.com',
-                topic: 'topic-2',
-                topic_url: 'https://www.example.com',
-                unread_count: 1,
-            },
-            {
-                count_senders: 0,
-                hidden: false,
-                last_msg_time: 'Just now',
-                senders: [1, 2],
-                stream: 'stream1',
-                stream_id: 1,
-                stream_url: 'https://www.example.com',
-                topic: 'topic-1',
-                topic_url: 'https://www.example.com',
-                unread_count: 0,
-            },
-        ],
+        recent_topics: generate_topic_data([
+            // stream_id, topic, unread_count, hidden
+            [1, 'topic-7', 1, true],
+            [1, 'topic-6', 1, false],
+            [1, 'topic-5', 1, false],
+            [1, 'topic-4', 1, true],
+            [1, 'topic-3', 1, true],
+            [1, 'topic-2', 1, false],
+            [1, 'topic-1', 0, false],
+        ]),
     };
 
     const rt = zrequire('recent_topics');

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -6,6 +6,15 @@ set_global('$', global.make_zjquery({
 set_global('hashchange', {
     exit_overlay: () => {},
 });
+set_global('stream_data', {
+    get_sub: () => {
+        return {
+            color: "",
+            invite_only: false,
+            is_web_public: true,
+        };
+    },
+});
 set_global('overlays', {
     open_overlay: (opts) => {
         overlays.close_callback = opts.on_close;
@@ -195,12 +204,15 @@ function generate_topic_data(topic_info_array) {
         data.push({
             count_senders: 0,
             hidden: hidden,
+            invite_only: false,
+            is_web_public: true,
             last_msg_time: 'Just now',
             senders: [
                 1,
                 2,
             ],
             stream: 'stream' + stream_id,
+            stream_color: '',
             stream_id: stream_id,
             stream_url: 'https://www.example.com',
             topic: topic,

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -108,7 +108,6 @@ messages[2] = {
     topic: topic2,
     sender_id: sender2,
     type: 'stream',
-    starred: true,
 };
 
 messages[3] = {
@@ -127,7 +126,6 @@ messages[4] = {
     topic: topic4,
     sender_id: sender2,
     type: 'stream',
-    starred: true,
 };
 
 messages[5] = {
@@ -176,11 +174,10 @@ messages[9] = {
 };
 
 function verify_topic_data(all_topics, stream, topic, last_msg_id,
-                           participated, starred_count) {
+                           participated) {
     const topic_data = all_topics.get(stream + ':' + topic);
     assert.equal(topic_data.last_msg_id, last_msg_id);
     assert.equal(topic_data.participated, participated);
-    assert.equal(topic_data.starred.size, starred_count);
 }
 
 run_test("test_recent_topics_launch", () => {
@@ -305,34 +302,14 @@ run_test('basic assertions', () => {
     assert.equal(Array.from(all_topics.keys()).toString(),
                  '1:topic-7,1:topic-6,1:topic-5,1:topic-4,1:topic-3,1:topic-2,1:topic-1');
 
-    // participated but not starred
-    verify_topic_data(all_topics, stream1, topic1, messages[0].id, true, 0);
-
-    // starred and participated
-    verify_topic_data(all_topics, stream1, topic2, messages[2].id, true, 1);
+    // participated
+    verify_topic_data(all_topics, stream1, topic1, messages[0].id, true);
 
     // No message was sent by us.
-    verify_topic_data(all_topics, stream1, topic3, messages[3].id, false, 0);
+    verify_topic_data(all_topics, stream1, topic3, messages[3].id, false);
 
-    // Not participated but starred
-    verify_topic_data(all_topics, stream1, topic4, messages[4].id, false, 1);
-
-    // topic1 now starred
-    rt.process_message({
-        stream_id: stream1,
-        id: id += 1,
-        topic: topic1,
-        sender_id: sender1,
-        type: 'stream',
-        starred: true,
-    });
-
-    all_topics = rt.get();
-
-    assert.equal(Array.from(all_topics.keys()).toString(),
-                 '1:topic-1,1:topic-7,1:topic-6,1:topic-5,1:topic-4,1:topic-3,1:topic-2');
-
-    verify_topic_data(all_topics, stream1, topic1, id, true, 1);
+    // Not participated
+    verify_topic_data(all_topics, stream1, topic4, messages[4].id, false);
 
     // topic3 now participated
     rt.process_message({
@@ -345,8 +322,8 @@ run_test('basic assertions', () => {
 
     all_topics = rt.get();
     assert.equal(Array.from(all_topics.keys()).toString(),
-                 '1:topic-3,1:topic-1,1:topic-7,1:topic-6,1:topic-5,1:topic-4,1:topic-2');
-    verify_topic_data(all_topics, stream1, topic3, id, true, 0);
+                 '1:topic-3,1:topic-7,1:topic-6,1:topic-5,1:topic-4,1:topic-2,1:topic-1');
+    verify_topic_data(all_topics, stream1, topic3, id, true);
 
     // Send new message to topic7 (muted)
     // The topic will be hidden when displayed
@@ -360,7 +337,7 @@ run_test('basic assertions', () => {
 
     all_topics = rt.get();
     assert.equal(Array.from(all_topics.keys()).toString(),
-                 '1:topic-7,1:topic-3,1:topic-1,1:topic-6,1:topic-5,1:topic-4,1:topic-2');
+                 '1:topic-7,1:topic-3,1:topic-6,1:topic-5,1:topic-4,1:topic-2,1:topic-1');
 
     // unmute topic7
     assert.equal(rt.update_topic_is_muted(stream1, topic7, false), true);
@@ -382,7 +359,7 @@ run_test('test_topic_edit', () => {
                  '1:topic-7,1:topic-6,1:topic-5,1:topic-4,1:topic-3,1:topic-2,1:topic-1');
 
     ////////////////// test change topic //////////////////
-    verify_topic_data(all_topics, stream1, topic6, messages[8].id, true, 0);
+    verify_topic_data(all_topics, stream1, topic6, messages[8].id, true);
     assert.equal(all_topics.get(stream1 + ":" + topic8), undefined);
 
     // change topic of topic6 to topic8
@@ -391,11 +368,11 @@ run_test('test_topic_edit', () => {
     rt.process_topic_edit(stream1, topic6, topic8);
     all_topics = rt.get();
 
-    verify_topic_data(all_topics, stream1, topic8, messages[8].id, true, 0);
+    verify_topic_data(all_topics, stream1, topic8, messages[8].id, true);
     assert.equal(all_topics.get(stream1 + ":" + topic6), undefined);
 
     ////////////////// test stream change //////////////////
-    verify_topic_data(all_topics, stream1, topic1, messages[0].id, true, 0);
+    verify_topic_data(all_topics, stream1, topic1, messages[0].id, true);
     assert.equal(all_topics.get(stream2 + ":" + topic1), undefined);
 
     messages[0].stream_id = stream2;
@@ -403,10 +380,10 @@ run_test('test_topic_edit', () => {
     all_topics = rt.get();
 
     assert.equal(all_topics.get(stream1 + ":" + topic1), undefined);
-    verify_topic_data(all_topics, stream2, topic1, messages[0].id, true, 0);
+    verify_topic_data(all_topics, stream2, topic1, messages[0].id, true);
 
     ////////////////// test stream & topic change //////////////////
-    verify_topic_data(all_topics, stream2, topic1, messages[0].id, true, 0);
+    verify_topic_data(all_topics, stream2, topic1, messages[0].id, true);
     assert.equal(all_topics.get(stream3 + ":" + topic9), undefined);
 
     messages[0].stream_id = stream3;
@@ -415,5 +392,5 @@ run_test('test_topic_edit', () => {
     all_topics = rt.get();
 
     assert.equal(all_topics.get(stream2 + ":" + topic1), undefined);
-    verify_topic_data(all_topics, stream3, topic9, messages[0].id, true, 0);
+    verify_topic_data(all_topics, stream3, topic9, messages[0].id, true);
 });

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -14,6 +14,11 @@ set_global('stream_data', {
             is_web_public: true,
         };
     },
+    is_muted: () => {
+        // We only test via muted topics for now.
+        // TODO: Make muted streams and test them.
+        return false;
+    },
 });
 set_global('overlays', {
     open_overlay: (opts) => {
@@ -257,6 +262,7 @@ function generate_topic_data(topic_info_array) {
             topic_url: 'https://www.example.com',
             unread_count: unread_count,
             muted: muted,
+            topic_muted: muted,
             participated: participated,
         });
     }
@@ -279,6 +285,7 @@ run_test("test_recent_topics_launch", () => {
     const expected = {
         filter_participated: false,
         filter_unread: false,
+        filter_muted: false,
         recent_topics: generate_topic_data([
             // stream_id, topic, unread_count, muted, participated
             [1, 'topic-7', 1, true, true],
@@ -337,6 +344,7 @@ run_test('test_filter_unread', () => {
     let expected =   {
         filter_participated: false,
         filter_unread: true,
+        filter_muted: false,
         recent_topics: generate_topic_data([
             // stream_id, topic, unread_count,  muted, participated
             [1, 'topic-7', 1, true, true],
@@ -436,12 +444,15 @@ run_test('test_filter_participated', () => {
     rt.set_filter('all');
 });
 
+// TODO: Add tests for filter_muted.
+
 run_test('test_search_keyword', () => {
     // TODO: Test search mechanism properly.
     // This is only intended to pass coverage currently.
     const expected =   {
         filter_participated: false,
         filter_unread: false,
+        filter_muted: false,
         recent_topics: generate_topic_data([
             // stream_id, topic, unread_count,  muted, participated
             [1, 'topic-7', 1, true, true],
@@ -548,14 +559,12 @@ run_test('basic assertions', () => {
     assert.equal(Array.from(all_topics.keys()).toString(),
                  '1:topic-7,1:topic-3,1:topic-6,1:topic-5,1:topic-4,1:topic-2,1:topic-1');
 
-    // unmute topic7
-    assert.equal(rt.update_topic_is_muted(stream1, topic7, false), true);
-
-    // mute topic7
-    assert.equal(rt.update_topic_is_muted(stream1, topic7, true), true);
-
+    // update_topic_is_muted now relies on external libraries completely
+    // so we don't need to check anythere here.
+    generate_topic_data([[1, topic1, 0, false, true]]);
+    assert.equal(rt.update_topic_is_muted(stream1, topic1), true);
     // a topic gets muted which we are not tracking
-    assert.equal(rt.update_topic_is_muted(stream1, "topic-10", true), false);
+    assert.equal(rt.update_topic_is_muted(stream1, "topic-10"), false);
 });
 
 run_test('test_reify_local_echo_message', () => {

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -439,6 +439,46 @@ run_test('basic assertions', () => {
     assert.equal(rt.update_topic_is_muted(stream1, "topic-10", true), false);
 });
 
+run_test('test_reify_local_echo_message', () => {
+    const rt = zrequire('recent_topics');
+    rt.process_messages(messages);
+
+    rt.process_message({
+        stream_id: stream1,
+        id: 1000.01,
+        topic: topic7,
+        sender_id: sender1,
+        type: 'stream',
+    }, false);
+
+    assert.equal(rt.reify_message_id_if_available({
+        old_id: 1000.01,
+        new_id: 1001,
+    }), true);
+
+    rt.process_message({
+        stream_id: stream1,
+        id: 1001.01,
+        topic: topic7,
+        sender_id: sender1,
+        type: 'stream',
+    }, false);
+
+    // A new message arrived in the same topic before we could reify the message_id
+    rt.process_message({
+        stream_id: stream1,
+        id: 1003,
+        topic: topic7,
+        sender_id: sender1,
+        type: 'stream',
+    }, false);
+
+    assert.equal(rt.reify_message_id_if_available({
+        old_id: 1000.01,
+        new_id: 1001,
+    }), false);
+});
+
 run_test('test_topic_edit', () => {
     // NOTE: This test should always run in the end as it modified the messages data.
     const rt = zrequire('recent_topics');

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -1,6 +1,8 @@
 zrequire('message_util');
 
-set_global('$', global.make_zjquery());
+set_global('$', global.make_zjquery({
+    silent: true,
+}));
 set_global('hashchange', {
     exit_overlay: () => {},
 });
@@ -25,7 +27,13 @@ set_global('timerender', {
 });
 set_global('unread', {
     unread_topic_counter: {
-        get: () => { return 1; },
+        get: (stream_id, topic) => {
+            if (stream_id === 1 && topic === "topic-1") {
+                // Only stream1, topic-1 is read.
+                return 0;
+            }
+            return 1;
+        },
     },
 });
 set_global('hash_util', {
@@ -47,8 +55,8 @@ const stream1 = 1;
 const stream2 = 2;
 const stream3 = 3;
 
-// Topics in the stream
-const topic1 = "topic-1";  // No Other sender
+// Topics in the stream, all unread except topic1 & stream1.
+const topic1 = "topic-1";  // No Other sender & read.
 const topic2 = "topic-2";  // Other sender
 const topic3 = "topic-3";  // User not present
 const topic4 = "topic-4";  // User not present
@@ -268,7 +276,7 @@ run_test("test_recent_topics_launch", () => {
                 stream_id: 1,
                 stream: 'stream1',
                 topic: 'topic-1',
-                unread_count: 1,
+                unread_count: 0,
                 last_msg_time: 'Just now',
                 stream_url: 'https://www.example.com',
                 topic_url: 'https://www.example.com',
@@ -293,6 +301,274 @@ run_test("test_recent_topics_launch", () => {
 
     // incorrect topic_key
     assert.equal(rt.inplace_rerender('stream_unknown:topic_unknown'), false);
+});
+
+run_test('test_filter_all', () => {
+    // Just tests inplace rerender of a message
+    // in All topics filter.
+    let expected = {
+        count_senders: 0,
+        hidden: false,
+        last_msg_time: 'Just now',
+        senders: [1, 2],
+        stream: 'stream1',
+        stream_id: 1,
+        stream_url: 'https://www.example.com',
+        topic: 'topic-1',
+        topic_url: 'https://www.example.com',
+        unread_count: 0,
+    };
+
+    global.stub_templates(function (template_name, data) {
+        assert.equal(template_name, 'recent_topic_row');
+        assert.deepEqual(data, expected);
+        return '<recent_topics row stub>';
+    });
+
+    // topic is not muted
+    const rt = zrequire('recent_topics');
+    rt.process_messages([messages[0]]);
+
+    expected = {
+        stream_id: 1,
+        stream: 'stream1',
+        topic: 'topic-7',
+        unread_count: 1,
+        last_msg_time: 'Just now',
+        stream_url: 'https://www.example.com',
+        topic_url: 'https://www.example.com',
+        hidden: true,
+        senders: [1, 2],
+        count_senders: 0,
+    };
+
+    // topic is muted (=== hidden)
+    rt.process_messages([messages[9]]);
+});
+
+run_test('test_filter_unread', () => {
+    // Tests rerender of all topics when filter changes to "unread".
+    const expected =   {
+        recent_topics: [
+            {
+                count_senders: 0,
+                hidden: true,
+                last_msg_time: 'Just now',
+                senders: [1, 2],
+                stream: 'stream1',
+                stream_id: 1,
+                stream_url: 'https://www.example.com',
+                topic: 'topic-7',
+                topic_url: 'https://www.example.com',
+                unread_count: 1,
+            },
+            {
+                count_senders: 0,
+                hidden: false,
+                last_msg_time: 'Just now',
+                senders: [1, 2],
+                stream: 'stream1',
+                stream_id: 1,
+                stream_url: 'https://www.example.com',
+                topic: 'topic-6',
+                topic_url: 'https://www.example.com',
+                unread_count: 1,
+            },
+            {
+                count_senders: 0,
+                hidden: false,
+                last_msg_time: 'Just now',
+                senders: [1, 2],
+                stream: 'stream1',
+                stream_id: 1,
+                stream_url: 'https://www.example.com',
+                topic: 'topic-5',
+                topic_url: 'https://www.example.com',
+                unread_count: 1,
+            },
+            {
+                count_senders: 0,
+                hidden: false,
+                last_msg_time: 'Just now',
+                senders: [1, 2],
+                stream: 'stream1',
+                stream_id: 1,
+                stream_url: 'https://www.example.com',
+                topic: 'topic-4',
+                topic_url: 'https://www.example.com',
+                unread_count: 1,
+            },
+            {
+                count_senders: 0,
+                hidden: false,
+                last_msg_time: 'Just now',
+                senders: [1, 2],
+                stream: 'stream1',
+                stream_id: 1,
+                stream_url: 'https://www.example.com',
+                topic: 'topic-3',
+                topic_url: 'https://www.example.com',
+                unread_count: 1,
+            },
+            {
+                count_senders: 0,
+                hidden: false,
+                last_msg_time: 'Just now',
+                senders: [1, 2],
+                stream: 'stream1',
+                stream_id: 1,
+                stream_url: 'https://www.example.com',
+                topic: 'topic-2',
+                topic_url: 'https://www.example.com',
+                unread_count: 1,
+            },
+            {
+                count_senders: 0,
+                hidden: true,  // This is the only thing we are testing here
+                last_msg_time: 'Just now',
+                senders: [1, 2],
+                stream: 'stream1',
+                stream_id: 1,
+                stream_url: 'https://www.example.com',
+                topic: 'topic-1',
+                topic_url: 'https://www.example.com',
+                unread_count: 0,
+            },
+        ],
+    };
+
+    const rt = zrequire('recent_topics');
+
+    global.stub_templates(function () {
+        return '<recent_topics table stub>';
+    });
+    rt.process_messages(messages);
+
+    $('#recent_topics_filter_buttons').removeClass('btn-recent-selected');
+    global.stub_templates(function (template_name, data) {
+        assert.equal(template_name, 'recent_topics_table');
+        assert.deepEqual(data, expected);
+        return '<recent_topics table stub>';
+    });
+    rt.set_filter('unread');
+
+    // Unselect "unread" filter by clicking twice.
+    expected.recent_topics[6].hidden = false;
+    rt.set_filter('unread');
+
+    // Now clicking "all" filter should have no change to expected data.
+    rt.set_filter('all');
+});
+
+run_test('test_filter_participated', () => {
+    // Tests rerender of all topics when filter changes to "unread".
+    const expected =   {
+        recent_topics: [
+            {
+                count_senders: 0,
+                hidden: true,
+                last_msg_time: 'Just now',
+                senders: [1, 2],
+                stream: 'stream1',
+                stream_id: 1,
+                stream_url: 'https://www.example.com',
+                topic: 'topic-7',
+                topic_url: 'https://www.example.com',
+                unread_count: 1,
+            },
+            {
+                count_senders: 0,
+                hidden: false,
+                last_msg_time: 'Just now',
+                senders: [1, 2],
+                stream: 'stream1',
+                stream_id: 1,
+                stream_url: 'https://www.example.com',
+                topic: 'topic-6',
+                topic_url: 'https://www.example.com',
+                unread_count: 1,
+            },
+            {
+                count_senders: 0,
+                hidden: false,
+                last_msg_time: 'Just now',
+                senders: [1, 2],
+                stream: 'stream1',
+                stream_id: 1,
+                stream_url: 'https://www.example.com',
+                topic: 'topic-5',
+                topic_url: 'https://www.example.com',
+                unread_count: 1,
+            },
+            {
+                count_senders: 0,
+                hidden: true,
+                last_msg_time: 'Just now',
+                senders: [1, 2],
+                stream: 'stream1',
+                stream_id: 1,
+                stream_url: 'https://www.example.com',
+                topic: 'topic-4',
+                topic_url: 'https://www.example.com',
+                unread_count: 1,
+            },
+            {
+                count_senders: 0,
+                hidden: true,
+                last_msg_time: 'Just now',
+                senders: [1, 2],
+                stream: 'stream1',
+                stream_id: 1,
+                stream_url: 'https://www.example.com',
+                topic: 'topic-3',
+                topic_url: 'https://www.example.com',
+                unread_count: 1,
+            },
+            {
+                count_senders: 0,
+                hidden: false,
+                last_msg_time: 'Just now',
+                senders: [1, 2],
+                stream: 'stream1',
+                stream_id: 1,
+                stream_url: 'https://www.example.com',
+                topic: 'topic-2',
+                topic_url: 'https://www.example.com',
+                unread_count: 1,
+            },
+            {
+                count_senders: 0,
+                hidden: false,
+                last_msg_time: 'Just now',
+                senders: [1, 2],
+                stream: 'stream1',
+                stream_id: 1,
+                stream_url: 'https://www.example.com',
+                topic: 'topic-1',
+                topic_url: 'https://www.example.com',
+                unread_count: 0,
+            },
+        ],
+    };
+
+    const rt = zrequire('recent_topics');
+
+    global.stub_templates(function () {
+        return '<recent_topics table stub>';
+    });
+    rt.process_messages(messages);
+
+    $('#recent_topics_filter_buttons').removeClass('btn-recent-selected');
+    global.stub_templates(function (template_name, data) {
+        assert.equal(template_name, 'recent_topics_table');
+        assert.deepEqual(data, expected);
+        return '<recent_topics table stub>';
+    });
+    rt.set_filter('participated');
+
+    expected.recent_topics[3].hidden = false;
+    expected.recent_topics[4].hidden = false;
+    rt.set_filter('all');
 });
 
 // template rendering is tested in test_recent_topics_launch.

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -13,6 +13,9 @@ set_global('people', {
     is_my_user_id: function (id) {
         return id === 1;
     },
+    sender_info_with_small_avatar_urls_for_sender_ids: (ids) => {
+        return ids;
+    },
 });
 set_global('XDate', zrequire('XDate', 'xdate'));
 set_global('timerender', {
@@ -32,6 +35,9 @@ set_global('hash_util', {
     by_stream_topic_uri: () => {
         return "https://www.example.com";
     },
+});
+set_global('recent_senders', {
+    get_topic_recent_senders: () => { return [1, 2]; },
 });
 
 // Custom Data
@@ -195,6 +201,8 @@ run_test("test_recent_topics_launch", () => {
                 stream_url: 'https://www.example.com',
                 topic_url: 'https://www.example.com',
                 hidden: true,
+                senders: [1, 2],
+                count_senders: 0,
             },
             {
                 stream_id: 1,
@@ -205,6 +213,8 @@ run_test("test_recent_topics_launch", () => {
                 stream_url: 'https://www.example.com',
                 topic_url: 'https://www.example.com',
                 hidden: false,
+                senders: [1, 2],
+                count_senders: 0,
             },
             {
                 stream_id: 1,
@@ -215,6 +225,8 @@ run_test("test_recent_topics_launch", () => {
                 stream_url: 'https://www.example.com',
                 topic_url: 'https://www.example.com',
                 hidden: false,
+                senders: [1, 2],
+                count_senders: 0,
             },
             {
                 stream_id: 1,
@@ -225,6 +237,8 @@ run_test("test_recent_topics_launch", () => {
                 stream_url: 'https://www.example.com',
                 topic_url: 'https://www.example.com',
                 hidden: false,
+                senders: [1, 2],
+                count_senders: 0,
             },
             {
                 stream_id: 1,
@@ -235,6 +249,8 @@ run_test("test_recent_topics_launch", () => {
                 stream_url: 'https://www.example.com',
                 topic_url: 'https://www.example.com',
                 hidden: false,
+                senders: [1, 2],
+                count_senders: 0,
             },
             {
                 stream_id: 1,
@@ -245,6 +261,8 @@ run_test("test_recent_topics_launch", () => {
                 stream_url: 'https://www.example.com',
                 topic_url: 'https://www.example.com',
                 hidden: false,
+                senders: [1, 2],
+                count_senders: 0,
             },
             {
                 stream_id: 1,
@@ -255,6 +273,8 @@ run_test("test_recent_topics_launch", () => {
                 stream_url: 'https://www.example.com',
                 topic_url: 'https://www.example.com',
                 hidden: false,
+                senders: [1, 2],
+                count_senders: 0,
             },
         ],
     };

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -317,6 +317,7 @@ run_test("test_recent_topics_launch", () => {
     rt.process_messages(messages);
 
     rt.launch();
+    assert.equal($("#recent_topics_search").is(":focus"), true);
     overlays.close_callback();
 
     // incorrect topic_key

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -199,6 +199,8 @@ run_test("test_recent_topics_launch", () => {
     // since they are generated in external libraries
     // and are not to be tested here.
     const expected = {
+        filter_participated: false,
+        filter_unread: false,
         recent_topics: [
             {
                 stream_id: 1,
@@ -349,6 +351,8 @@ run_test('test_filter_all', () => {
 run_test('test_filter_unread', () => {
     // Tests rerender of all topics when filter changes to "unread".
     const expected =   {
+        filter_participated: false,
+        filter_unread: true,
         recent_topics: [
             {
                 count_senders: 0,
@@ -453,6 +457,7 @@ run_test('test_filter_unread', () => {
     rt.set_filter('unread');
 
     // Unselect "unread" filter by clicking twice.
+    expected.filter_unread = false;
     expected.recent_topics[6].hidden = false;
     rt.set_filter('unread');
 
@@ -463,6 +468,8 @@ run_test('test_filter_unread', () => {
 run_test('test_filter_participated', () => {
     // Tests rerender of all topics when filter changes to "unread".
     const expected =   {
+        filter_participated: true,
+        filter_unread: false,
         recent_topics: [
             {
                 count_senders: 0,
@@ -568,6 +575,7 @@ run_test('test_filter_participated', () => {
 
     expected.recent_topics[3].hidden = false;
     expected.recent_topics[4].hidden = false;
+    expected.filter_participated = false;
     rt.set_filter('all');
 });
 

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -1,4 +1,3 @@
-let rt = zrequire('recent_topics');
 zrequire('message_util');
 
 set_global('$', global.make_zjquery());
@@ -13,6 +12,25 @@ set_global('overlays', {
 set_global('people', {
     is_my_user_id: function (id) {
         return id === 1;
+    },
+});
+set_global('XDate', zrequire('XDate', 'xdate'));
+set_global('timerender', {
+    last_seen_status_from_date: () => {
+        return "Just now";
+    },
+});
+set_global('unread', {
+    unread_topic_counter: {
+        get: () => { return 1; },
+    },
+});
+set_global('hash_util', {
+    by_stream_uri: () => {
+        return "https://www.example.com";
+    },
+    by_stream_topic_uri: () => {
+        return "https://www.example.com";
     },
 });
 
@@ -57,11 +75,17 @@ set_global('message_list', {
         },
     },
 });
+set_global('message_store', {
+    get: (msg_id) => {
+        return messages[msg_id - 1];
+    },
+});
 
 let id = 0;
 
 messages[0] = {
     stream_id: stream1,
+    stream: 'stream1',
     id: id += 1,
     topic: topic1,
     sender_id: sender1,
@@ -70,6 +94,7 @@ messages[0] = {
 
 messages[1] = {
     stream_id: stream1,
+    stream: 'stream1',
     id: id += 1,
     topic: topic2,
     sender_id: sender1,
@@ -78,6 +103,7 @@ messages[1] = {
 
 messages[2] = {
     stream_id: stream1,
+    stream: 'stream1',
     id: id += 1,
     topic: topic2,
     sender_id: sender2,
@@ -87,6 +113,7 @@ messages[2] = {
 
 messages[3] = {
     stream_id: stream1,
+    stream: 'stream1',
     id: id += 1,
     topic: topic3,
     sender_id: sender2,
@@ -95,6 +122,7 @@ messages[3] = {
 
 messages[4] = {
     stream_id: stream1,
+    stream: 'stream1',
     id: id += 1,
     topic: topic4,
     sender_id: sender2,
@@ -104,6 +132,7 @@ messages[4] = {
 
 messages[5] = {
     stream_id: stream1,
+    stream: 'stream1',
     id: id += 1,
     topic: topic5,
     sender_id: sender1,
@@ -112,6 +141,7 @@ messages[5] = {
 
 messages[6] = {
     stream_id: stream1,
+    stream: 'stream1',
     id: id += 1,
     topic: topic5,
     sender_id: sender2,
@@ -120,6 +150,7 @@ messages[6] = {
 
 messages[7] = {
     stream_id: stream1,
+    stream: 'stream1',
     id: id += 1,
     topic: topic6,
     sender_id: sender1,
@@ -128,6 +159,7 @@ messages[7] = {
 
 messages[8] = {
     stream_id: stream1,
+    stream: 'stream1',
     id: id += 1,
     topic: topic6,
     sender_id: sender2,
@@ -136,6 +168,7 @@ messages[8] = {
 
 messages[9] = {
     stream_id: stream1,
+    stream: 'stream1',
     id: id += 1,
     topic: topic7,
     sender_id: sender1,
@@ -143,22 +176,120 @@ messages[9] = {
 };
 
 function verify_topic_data(all_topics, stream, topic, last_msg_id,
-                           participated, starred_count, is_muted) {
-    // default is_muted to false since most of the test cases will
-    // be not muted
-    is_muted = is_muted || false;
+                           participated, starred_count) {
     const topic_data = all_topics.get(stream + ':' + topic);
     assert.equal(topic_data.last_msg_id, last_msg_id);
     assert.equal(topic_data.participated, participated);
     assert.equal(topic_data.starred.size, starred_count);
-    assert.equal(topic_data.muted, is_muted);
 }
 
-run_test('basic assertions', () => {
+run_test("test_recent_topics_launch", () => {
+    // Note: unread count and urls are fake,
+    // since they are generated in external libraries
+    // and are not to be tested here.
+    const expected = {
+        recent_topics: [
+            {
+                stream_id: 1,
+                stream: 'stream1',
+                topic: 'topic-7',
+                unread_count: 1,
+                last_msg_time: 'Just now',
+                stream_url: 'https://www.example.com',
+                topic_url: 'https://www.example.com',
+                hidden: true,
+            },
+            {
+                stream_id: 1,
+                stream: 'stream1',
+                topic: 'topic-6',
+                unread_count: 1,
+                last_msg_time: 'Just now',
+                stream_url: 'https://www.example.com',
+                topic_url: 'https://www.example.com',
+                hidden: false,
+            },
+            {
+                stream_id: 1,
+                stream: 'stream1',
+                topic: 'topic-5',
+                unread_count: 1,
+                last_msg_time: 'Just now',
+                stream_url: 'https://www.example.com',
+                topic_url: 'https://www.example.com',
+                hidden: false,
+            },
+            {
+                stream_id: 1,
+                stream: 'stream1',
+                topic: 'topic-4',
+                unread_count: 1,
+                last_msg_time: 'Just now',
+                stream_url: 'https://www.example.com',
+                topic_url: 'https://www.example.com',
+                hidden: false,
+            },
+            {
+                stream_id: 1,
+                stream: 'stream1',
+                topic: 'topic-3',
+                unread_count: 1,
+                last_msg_time: 'Just now',
+                stream_url: 'https://www.example.com',
+                topic_url: 'https://www.example.com',
+                hidden: false,
+            },
+            {
+                stream_id: 1,
+                stream: 'stream1',
+                topic: 'topic-2',
+                unread_count: 1,
+                last_msg_time: 'Just now',
+                stream_url: 'https://www.example.com',
+                topic_url: 'https://www.example.com',
+                hidden: false,
+            },
+            {
+                stream_id: 1,
+                stream: 'stream1',
+                topic: 'topic-1',
+                unread_count: 1,
+                last_msg_time: 'Just now',
+                stream_url: 'https://www.example.com',
+                topic_url: 'https://www.example.com',
+                hidden: false,
+            },
+        ],
+    };
 
+    global.stub_templates(function (template_name, data) {
+        assert.equal(template_name, 'recent_topics_table');
+        assert.deepEqual(data, expected);
+        return '<recent_topics table stub>';
+    });
+
+    const rt = zrequire('recent_topics');
+    rt.process_messages(messages);
+
+    rt.launch();
+    overlays.close_callback();
+
+    // incorrect topic_key
+    assert.equal(rt.inplace_rerender('stream_unknown:topic_unknown'), false);
+});
+
+// template rendering is tested in test_recent_topics_launch.
+global.stub_templates(function () {
+    return '<recent_topics table stub>';
+});
+
+run_test('basic assertions', () => {
+    const rt = zrequire('recent_topics');
     rt.process_messages(messages);
     let all_topics = rt.get();
 
+    // update a message
+    rt.process_messages([messages[9]]);
     // Check for expected lengths.
     // total 7 topics, 1 muted
     assert.equal(all_topics.size, 7);
@@ -218,6 +349,7 @@ run_test('basic assertions', () => {
     verify_topic_data(all_topics, stream1, topic3, id, true, 0);
 
     // Send new message to topic7 (muted)
+    // The topic will be hidden when displayed
     rt.process_message({
         stream_id: stream1,
         id: id += 1,
@@ -229,24 +361,20 @@ run_test('basic assertions', () => {
     all_topics = rt.get();
     assert.equal(Array.from(all_topics.keys()).toString(),
                  '1:topic-7,1:topic-3,1:topic-1,1:topic-6,1:topic-5,1:topic-4,1:topic-2');
-    verify_topic_data(all_topics, stream1, topic7, id, true, 0, true);
 
     // unmute topic7
-    rt.update_topic_is_muted(stream1, topic7, false);
-    all_topics = rt.get();
-    verify_topic_data(all_topics, stream1, topic7, id, true, 0, false);
+    assert.equal(rt.update_topic_is_muted(stream1, topic7, false), true);
 
     // mute topic7
-    rt.update_topic_is_muted(stream1, topic7, true);
-    all_topics = rt.get();
-    verify_topic_data(all_topics, stream1, topic7, id, true, 0, true);
+    assert.equal(rt.update_topic_is_muted(stream1, topic7, true), true);
 
     // a topic gets muted which we are not tracking
     assert.equal(rt.update_topic_is_muted(stream1, "topic-10", true), false);
 });
 
 run_test('test_topic_edit', () => {
-    rt = zrequire('recent_topics');
+    // NOTE: This test should always run in the end as it modified the messages data.
+    const rt = zrequire('recent_topics');
     rt.process_messages(messages);
 
     let all_topics = rt.get();
@@ -265,19 +393,6 @@ run_test('test_topic_edit', () => {
 
     verify_topic_data(all_topics, stream1, topic8, messages[8].id, true, 0);
     assert.equal(all_topics.get(stream1 + ":" + topic6), undefined);
-
-    ////////////////// test change topic to muted topic //////////////////
-    verify_topic_data(all_topics, stream1, topic8, messages[8].id, true, 0);
-    verify_topic_data(all_topics, stream1, topic7, messages[9].id, true, 0, true);
-
-    // change topic of topic8 to topic7
-    messages[7].topic = topic7;
-    messages[8].topic = topic7;
-    rt.process_topic_edit(stream1, topic8, topic7);
-    all_topics = rt.get();
-
-    assert.equal(all_topics.get(stream1 + ":" + topic8), undefined);
-    verify_topic_data(all_topics, stream1, topic7, messages[9].id, true, 0, true);
 
     ////////////////// test stream change //////////////////
     verify_topic_data(all_topics, stream1, topic1, messages[0].id, true, 0);
@@ -301,14 +416,4 @@ run_test('test_topic_edit', () => {
 
     assert.equal(all_topics.get(stream2 + ":" + topic1), undefined);
     verify_topic_data(all_topics, stream3, topic9, messages[0].id, true, 0);
-});
-
-run_test("test_recent_topics_launch", () => {
-
-    global.stub_templates(function (template_name) {
-        assert.equal(template_name, 'recent_topics_table');
-        return '<recent_topics table stub>';
-    });
-    rt.launch();
-    overlays.close_callback();
 });

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -283,8 +283,8 @@ run_test("test_recent_topics_launch", () => {
     // since they are generated in external libraries
     // and are not to be tested here.
     const expected = {
-        filter_participated: false,
-        filter_unread: false,
+        filter_participated: true,
+        filter_unread: true,
         filter_muted: false,
         recent_topics: generate_topic_data([
             // stream_id, topic, unread_count, muted, participated
@@ -364,7 +364,6 @@ run_test('test_filter_unread', () => {
     });
     rt.process_messages(messages);
 
-    $('#recent_topics_filter_buttons').removeClass('btn-recent-selected');
     global.stub_templates(function (template_name, data) {
         if (template_name === 'recent_topics_table') {
             assert.deepEqual(data, expected);
@@ -375,7 +374,8 @@ run_test('test_filter_unread', () => {
         return '<recent_topics table stub>';
     });
 
-    rt.set_filter('unread');
+    // This will deselect participated and leave only unread selected.
+    rt.set_filter('participated');
     rt.update_filters_view();
     expected = generate_topic_data([[1, 'topic-1', 0, false, true]])[0];
 
@@ -419,7 +419,6 @@ run_test('test_filter_participated', () => {
     });
     rt.process_messages(messages);
 
-    $('#recent_topics_filter_buttons').removeClass('btn-recent-selected');
     global.stub_templates(function (template_name, data) {
         if (template_name === 'recent_topics_table') {
             assert.deepEqual(data, expected);
@@ -429,7 +428,7 @@ run_test('test_filter_participated', () => {
         }
         return '<recent_topics table stub>';
     });
-    rt.set_filter('participated');
+    rt.set_filter('unread');
     rt.update_filters_view();
     expected = generate_topic_data([[1, 'topic-4', 1, false, false]])[0];
 
@@ -450,8 +449,8 @@ run_test('test_search_keyword', () => {
     // TODO: Test search mechanism properly.
     // This is only intended to pass coverage currently.
     const expected =   {
-        filter_participated: false,
-        filter_unread: false,
+        filter_participated: true,
+        filter_unread: true,
         filter_muted: false,
         recent_topics: generate_topic_data([
             // stream_id, topic, unread_count,  muted, participated

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -528,10 +528,20 @@ exports.make_zjquery = function (opts) {
         };
     };
 
+    fn.after = function (s) {
+        return s;
+    };
+    fn.before = function (s) {
+        return s;
+    };
+
     zjquery.fn = fn;
 
     zjquery.clear_all_elements = function () {
         elems.clear();
+    };
+    zjquery.escapeSelector = function (s) {
+        return s;
     };
 
     return zjquery;

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -365,6 +365,9 @@ exports.make_new_elem = function (selector, opts) {
         visible: function () {
             return shown;
         },
+        slice: function () {
+            return self;
+        },
     };
 
     if (selector[0] === '<') {

--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -223,6 +223,7 @@ import "../../styles/left-sidebar.scss";
 import "../../styles/right-sidebar.scss";
 import "../../styles/lightbox.scss";
 import "../../styles/popovers.scss";
+import "../../styles/recent_topics.scss";
 import "../../styles/typing_notifications.scss";
 import "../../styles/hotspots.scss";
 import "../../styles/night_mode.scss";

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -358,25 +358,12 @@ exports.initialize = function () {
     $('body').on('click', '.btn-recent-filters', function (e) {
         e.stopPropagation();
         recent_topics.set_filter(e.currentTarget.dataset.filter);
+        recent_topics.update_filters_view();
     });
 
     // Search for all table rows (this combines stream & topic names)
     $('body').on('keyup', '#recent_topics_search', _.debounce(function () {
-        // take all rows and slice off the header.
-        const $rows = $('.recent_topics_table tr').slice(1);
-        // split the search text around whitespace(s).
-        // eg: "Denamark recent" -> ["Denamrk", "recent"]
-        const search_keywords = $.trim($(this).val()).split(/\s+/);
-        // turn the search keywords into word boundry groups
-        // eg: ["Denamrk", "recent"] -> "^(?=.*\bDenmark\b)(?=.*\brecent\b).*$"
-        const val = '^(?=.*\\b' + search_keywords.join('\\b)(?=.*\\b') + ').*$';
-        const reg = RegExp(val, 'i'); // i for ignorecase
-        let text;
-
-        $rows.show().filter(function () {
-            text = $(this).text().replace(/\s+/g, ' ');
-            return !reg.test(text);
-        }).hide();
+        recent_topics.update_filters_view();
     // Wait for user to go idle before initiating search.
     }, 300));
 

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -346,6 +346,15 @@ exports.initialize = function () {
         muting_ui.mute(stream_id, topic);
     });
 
+    // RECENT TOPICS
+
+    $('body').on('click', '.on_hover_topic_read', function (e) {
+        e.stopPropagation();
+        const stream_id = parseInt($(e.currentTarget).attr('data-stream-id'), 10);
+        const topic = $(e.currentTarget).attr('data-topic-name');
+        unread_ops.mark_topic_as_read(stream_id, topic);
+    });
+
     // RECIPIENT BARS
 
     function get_row_id_for_narrowing(narrow_link_elem) {

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -367,6 +367,12 @@ exports.initialize = function () {
     // Wait for user to go idle before initiating search.
     }, 300));
 
+    $('body').on('click', '#recent_topics_search_clear', function (e) {
+        e.stopPropagation();
+        $('#recent_topics_search').val("");
+        recent_topics.update_filters_view();
+    });
+
     // RECIPIENT BARS
 
     function get_row_id_for_narrowing(narrow_link_elem) {

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -355,6 +355,31 @@ exports.initialize = function () {
         unread_ops.mark_topic_as_read(stream_id, topic);
     });
 
+    $('body').on('click', '.btn-recent-filters', function (e) {
+        e.stopPropagation();
+        recent_topics.set_filter(e.currentTarget.dataset.filter);
+    });
+
+    // Search for all table rows (this combines stream & topic names)
+    $('body').on('keyup', '#recent_topics_search', _.debounce(function () {
+        // take all rows and slice off the header.
+        const $rows = $('.recent_topics_table tr').slice(1);
+        // split the search text around whitespace(s).
+        // eg: "Denamark recent" -> ["Denamrk", "recent"]
+        const search_keywords = $.trim($(this).val()).split(/\s+/);
+        // turn the search keywords into word boundry groups
+        // eg: ["Denamrk", "recent"] -> "^(?=.*\bDenmark\b)(?=.*\brecent\b).*$"
+        const val = '^(?=.*\\b' + search_keywords.join('\\b)(?=.*\\b') + ').*$';
+        const reg = RegExp(val, 'i'); // i for ignorecase
+        let text;
+
+        $rows.show().filter(function () {
+            text = $(this).text().replace(/\s+/g, ' ');
+            return !reg.test(text);
+        }).hide();
+    // Wait for user to go idle before initiating search.
+    }, 300));
+
     // RECIPIENT BARS
 
     function get_row_id_for_narrowing(narrow_link_elem) {

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -346,6 +346,13 @@ exports.initialize = function () {
         muting_ui.mute(stream_id, topic);
     });
 
+    $('body').on('click', '.on_hover_topic_unmute', function (e) {
+        e.stopPropagation();
+        const stream_id = parseInt($(e.currentTarget).attr('data-stream-id'), 10);
+        const topic = $(e.currentTarget).attr('data-topic-name');
+        muting_ui.unmute(stream_id, topic);
+    });
+
     // RECENT TOPICS
 
     $('body').on('click', '.on_hover_topic_read', function (e) {

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -602,6 +602,11 @@ exports.initialize = function () {
         compose_actions.cancel();
     });
 
+    $("#recent_topics_icon").click(function (e) {
+        e.stopPropagation();
+        hashchange.go_to_location('recent_topics');
+    });
+
     $("#streams_inline_cog").click(function (e) {
         e.stopPropagation();
         hashchange.go_to_location('streams/subscribed');

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -272,6 +272,7 @@ exports.reify_message_id = function (local_id, server_id) {
 
     message_store.reify_message_id(opts);
     notifications.reify_message_id(opts);
+    recent_topics.reify_message_id_if_available(opts);
 };
 
 exports.process_from_server = function (messages) {

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -63,7 +63,7 @@ const state = {
 
 function is_overlay_hash(hash) {
     // Hash changes within this list are overlays and should not unnarrow (etc.)
-    const overlay_list = ["streams", "drafts", "settings", "organization", "invite"];
+    const overlay_list = ["streams", "drafts", "settings", "organization", "invite", "recent_topics"];
     const main_hash = hash_util.get_hash_category(hash);
 
     return overlay_list.includes(main_hash);
@@ -122,6 +122,7 @@ function do_hashchange_normal(from_reload) {
     case "#streams":
     case "#organization":
     case "#settings":
+    case "#recent_topics":
         blueslip.error('overlay logic skipped for: ' + hash);
         break;
     }
@@ -223,6 +224,11 @@ function do_hashchange_overlay(old_hash) {
 
     if (base === "invite") {
         invite.launch();
+        return;
+    }
+
+    if (base === 'recent_topics') {
+        recent_topics.launch();
         return;
     }
 }

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -104,6 +104,7 @@ const keypress_mappings = {
     113: {name: 'query_streams', message_view_only: true}, // 'q'
     114: {name: 'reply_message', message_view_only: true}, // 'r'
     115: {name: 'narrow_by_recipient', message_view_only: true}, // 's'
+    116: {name: 'open_recent_topics', message_view_only: true}, // 't'
     117: {name: 'show_sender_info', message_view_only: true}, // 'u'
     118: {name: 'show_lightbox', message_view_only: true}, // 'v'
     119: {name: 'query_users', message_view_only: true}, // 'w'
@@ -462,6 +463,10 @@ exports.process_hotkey = function (e, hotkey) {
             overlays.close_overlay('drafts');
             return true;
         }
+        if (event_name === 'open_recent_topics' && overlays.recent_topics_open()) {
+            overlays.close_overlay('recent_topics');
+            return true;
+        }
         return false;
     }
 
@@ -663,6 +668,9 @@ exports.process_hotkey = function (e, hotkey) {
         return true;
     case 'copy_with_c':
         copy_and_paste.copy_handler();
+        return true;
+    case 'open_recent_topics':
+        hashchange.go_to_location('recent_topics');
         return true;
     }
 

--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -112,7 +112,7 @@ exports.mute = function (stream_id, topic) {
         title_text: i18n.t("Topic muted"),
         undo_button_text: i18n.t("Unmute"),
     });
-    recent_topics.update_topic_is_muted(stream_id, topic, true);
+    recent_topics.update_topic_is_muted(stream_id, topic);
 };
 
 exports.unmute = function (stream_id, topic) {
@@ -125,7 +125,7 @@ exports.unmute = function (stream_id, topic) {
     exports.rerender();
     exports.persist_unmute(stream_id, topic);
     feedback_widget.dismiss();
-    recent_topics.update_topic_is_muted(stream_id, topic, false);
+    recent_topics.update_topic_is_muted(stream_id, topic);
 };
 
 exports.toggle_mute = function (message) {

--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -36,6 +36,10 @@ exports.drafts_open = function () {
     return open_overlay_name === 'drafts';
 };
 
+exports.recent_topics_open = function () {
+    return open_overlay_name === 'recent_topics';
+};
+
 // To address bugs where mouse might apply to the streams/settings
 // overlays underneath an open modal within those settings UI, we add
 // this inline style to '.overlay.show', overriding the

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -605,6 +605,16 @@ exports.small_avatar_url_for_person = function (person) {
     return gravatar_url_for_email(person.email);
 };
 
+exports.sender_info_with_small_avatar_urls_for_sender_ids = function (sender_ids) {
+    const senders_info = [];
+    for (const id of sender_ids) {
+        const sender = {...exports.get_by_user_id(id)};
+        sender.avatar_url_small = exports.small_avatar_url_for_person(sender);
+        senders_info.push(sender);
+    }
+    return senders_info;
+};
+
 exports.small_avatar_url = function (message) {
     // Try to call this function in all places where we need 25px
     // avatar images, so that the browser can help

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -27,7 +27,6 @@ exports.process_message = function (msg, do_inplace_rerender) {
     if (!topics.has(key)) {
         topics.set(key, {
             last_msg_id: -1,
-            starred: new Set(),
             participated: false,
         });
     }
@@ -36,9 +35,6 @@ exports.process_message = function (msg, do_inplace_rerender) {
     const topic_data = topics.get(key);
     if (topic_data.last_msg_id < msg.id) {
         topic_data.last_msg_id = msg.id;
-    }
-    if (msg.starred) {
-        topic_data.starred.add(msg.id);
     }
     topic_data.participated = is_ours || topic_data.participated;
 

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -323,6 +323,7 @@ exports.launch = function () {
         },
     });
     recent_topics.complete_rerender();
+    $("#recent_topics_search").focus();
 };
 
 window.recent_topics = exports;

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -1,6 +1,9 @@
 const render_recent_topics_body = require('../templates/recent_topics_table.hbs');
 const render_recent_topic_row = require('../templates/recent_topic_row.hbs');
 const topics = new Map(); // Key is stream-id:topic.
+// Sets the number of avatars to display.
+// Rest of the avatars, if present, are displayed as {+x}
+const MAX_AVATAR = 4;
 
 exports.process_messages = function (messages) {
     // Since a complete re-render is expensive, we
@@ -77,6 +80,12 @@ function format_topic(topic_data) {
     const last_msg_time = timerender.last_seen_status_from_date(time);
     const unread_count = unread.unread_topic_counter.get(stream_id, topic);
     const hidden = muting.is_topic_muted(stream_id, topic);
+
+    // Display in most recent sender first order
+    const all_senders = recent_senders.get_topic_recent_senders(stream_id, topic);
+    const senders = all_senders.slice(-MAX_AVATAR);
+    const senders_info = people.sender_info_with_small_avatar_urls_for_sender_ids(senders);
+
     return {
         stream_id: stream_id,
         stream: stream,
@@ -86,6 +95,8 @@ function format_topic(topic_data) {
         stream_url: hash_util.by_stream_uri(stream_id),
         topic_url: hash_util.by_stream_topic_uri(stream_id, topic),
         hidden: hidden,
+        senders: senders_info,
+        count_senders: Math.max(0, all_senders.length - MAX_AVATAR),
     };
 }
 

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -249,6 +249,29 @@ exports.update_filters_view = function () {
     topics_widget.hard_redraw();
 };
 
+
+function stream_sort(a, b) {
+    const a_stream = message_store.get(a.last_msg_id).stream;
+    const b_stream = message_store.get(b.last_msg_id).stream;
+    if (a_stream > b_stream) {
+        return 1;
+    } else if (a_stream === b_stream) {
+        return 0;
+    }
+    return -1;
+}
+
+function topic_sort(a, b) {
+    const a_topic = message_store.get(a.last_msg_id).topic;
+    const b_topic = message_store.get(b.last_msg_id).topic;
+    if (a_topic > b_topic) {
+        return 1;
+    } else if (a_topic === b_topic) {
+        return 0;
+    }
+    return -1;
+}
+
 exports.complete_rerender = function () {
     if (!overlays.recent_topics_open()) {
         return false;
@@ -272,6 +295,7 @@ exports.complete_rerender = function () {
 
     topics_widget = list_render.create(container, mapped_topic_values, {
         name: "recent_topics_table",
+        parent_container: $("#recent_topics_table"),
         modifier: function (item) {
             return render_recent_topic_row(format_topic(item));
         },
@@ -281,6 +305,10 @@ exports.complete_rerender = function () {
             predicate: function (topic_data) {
                 return !is_topic_hidden(topic_data);
             },
+        },
+        sort_fields: {
+            stream_sort: stream_sort,
+            topic_sort: topic_sort,
         },
         html_selector: get_topic_row,
     });

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -152,6 +152,11 @@ exports.update_topic_is_muted = function (stream_id, topic, is_muted) {
     return true;
 };
 
+exports.update_topic_unread_count = function (message) {
+    const topic_key = message.stream_id + ":" + message.topic;
+    exports.inplace_rerender(topic_key);
+};
+
 exports.complete_rerender = function () {
     // NOTE: This function is grows expensive with
     // number of topics. Only call when necessary.

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -38,6 +38,10 @@ exports.process_message = function (msg, do_inplace_rerender) {
     const is_ours = people.is_my_user_id(msg.sender_id);
     const topic_data = topics.get(key);
     if (topic_data.last_msg_id < msg.id) {
+        // NOTE: This also stores locally echoed msg_id which
+        // has not been successfully received from the server.
+        // We store it now and reify it when response is available
+        // from server.
         topic_data.last_msg_id = msg.id;
     }
     topic_data.participated = is_ours || topic_data.participated;
@@ -46,6 +50,16 @@ exports.process_message = function (msg, do_inplace_rerender) {
         exports.inplace_rerender(key);
     }
     return true;
+};
+
+exports.reify_message_id_if_available = function (opts) {
+    for (const [, value] of topics.entries()) {
+        if (value.last_msg_id === opts.old_id) {
+            value.last_msg_id = opts.new_id;
+            return true;
+        }
+    }
+    return false;
 };
 
 function get_sorted_topics() {

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -59,18 +59,6 @@ exports.get = function () {
     return get_sorted_topics();
 };
 
-exports.process_topic_edit = function (old_stream_id, old_topic, new_topic, new_stream_id) {
-    // See `recent_senders.process_topic_edit` for
-    // logic behind this and important notes on use of this function.
-    topics.delete(old_stream_id + ':' + old_topic);
-
-    const old_topic_msgs = message_util.get_messages_in_topic(old_stream_id, old_topic);
-    exports.process_messages(old_topic_msgs);
-
-    new_stream_id = new_stream_id || old_stream_id;
-    const new_topic_msgs = message_util.get_messages_in_topic(new_stream_id, new_topic);
-    exports.process_messages(new_topic_msgs);
-};
 
 function format_topic(topic_data) {
     const last_msg = message_store.get(topic_data.last_msg_id);
@@ -127,6 +115,20 @@ function get_topic_row(topic_key) {
     // topic_key = stream_id + ":" + topic
     return $("#" + $.escapeSelector("recent_topic:" + topic_key));
 }
+
+exports.process_topic_edit = function (old_stream_id, old_topic, new_topic, new_stream_id) {
+    // See `recent_senders.process_topic_edit` for
+    // logic behind this and important notes on use of this function.
+    topics.delete(old_stream_id + ':' + old_topic);
+    get_topic_row(old_stream_id + ':' + old_topic).remove();
+
+    const old_topic_msgs = message_util.get_messages_in_topic(old_stream_id, old_topic);
+    exports.process_messages(old_topic_msgs);
+
+    new_stream_id = new_stream_id || old_stream_id;
+    const new_topic_msgs = message_util.get_messages_in_topic(new_stream_id, new_topic);
+    exports.process_messages(new_topic_msgs);
+};
 
 exports.inplace_rerender = function (topic_key) {
     // We remove topic from the UI and reinsert it.

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -1,13 +1,24 @@
 const render_recent_topics_body = require('../templates/recent_topics_table.hbs');
+const render_recent_topic_row = require('../templates/recent_topic_row.hbs');
 const topics = new Map(); // Key is stream-id:topic.
 
 exports.process_messages = function (messages) {
+    // Since a complete re-render is expensive, we
+    // only do it if there are more than 5 messages
+    // to process.
+    let do_inplace_rerender = true;
+    if (messages.length > 5) {
+        do_inplace_rerender = false;
+    }
     for (const msg of messages) {
-        exports.process_message(msg);
+        exports.process_message(msg, do_inplace_rerender);
+    }
+    if (!do_inplace_rerender) {
+        exports.complete_rerender();
     }
 };
 
-exports.process_message = function (msg) {
+exports.process_message = function (msg, do_inplace_rerender) {
     if (msg.type !== 'stream') {
         return false;
     }
@@ -18,7 +29,6 @@ exports.process_message = function (msg) {
             last_msg_id: -1,
             starred: new Set(),
             participated: false,
-            muted: false,
         });
     }
     // Update topic data
@@ -31,17 +41,11 @@ exports.process_message = function (msg) {
         topic_data.starred.add(msg.id);
     }
     topic_data.participated = is_ours || topic_data.participated;
-    topic_data.muted = topic_data.muted || muting.is_topic_muted(msg.stream_id, msg.topic);
-    return true;
-};
 
-exports.update_topic_is_muted = function (stream_id, topic, is_muted) {
-    const key = stream_id + ":" + topic;
-    if (!topics.has(key)) {
-        return false;
+    if (do_inplace_rerender) {
+        exports.inplace_rerender(key);
     }
-    const topic_data = topics.get(stream_id + ":" + topic);
-    topic_data.muted = is_muted;
+    return true;
 };
 
 function get_sorted_topics() {
@@ -68,10 +72,101 @@ exports.process_topic_edit = function (old_stream_id, old_topic, new_topic, new_
     exports.process_messages(new_topic_msgs);
 };
 
-exports.launch = function () {
-    const rendered_body = render_recent_topics_body();
-    $('#recent_topics_table').html(rendered_body);
+function format_topic(topic_data) {
+    const last_msg = message_store.get(topic_data.last_msg_id);
+    const stream = last_msg.stream;
+    const stream_id = last_msg.stream_id;
+    const topic = last_msg.topic;
+    const time = new XDate(last_msg.timestamp * 1000);
+    const last_msg_time = timerender.last_seen_status_from_date(time);
+    const unread_count = unread.unread_topic_counter.get(stream_id, topic);
+    const hidden = muting.is_topic_muted(stream_id, topic);
+    return {
+        stream_id: stream_id,
+        stream: stream,
+        topic: topic,
+        unread_count: unread_count,
+        last_msg_time: last_msg_time,
+        stream_url: hash_util.by_stream_uri(stream_id),
+        topic_url: hash_util.by_stream_topic_uri(stream_id, topic),
+        hidden: hidden,
+    };
+}
 
+function format_all_topics() {
+    const topics_array = [];
+    for (const [, value] of exports.get()) {
+        topics_array.push(format_topic(value));
+    }
+    return topics_array;
+}
+
+function get_topic_row(topic_key) {
+    // topic_key = stream_id + ":" + topic
+    return $("#" + $.escapeSelector("recent_topic:" + topic_key));
+}
+
+exports.inplace_rerender = function (topic_key) {
+    // We remove topic from the UI and reinsert it.
+    // This makes sure we maintain the correct order
+    // of topics.
+    const topic_data = topics.get(topic_key);
+    if (topic_data === undefined) {
+        return false;
+    }
+    const formatted_values = format_topic(topic_data);
+    const topic_row = get_topic_row(topic_key);
+    topic_row.remove();
+
+    const rendered_row = render_recent_topic_row(formatted_values);
+
+    const sorted_topic_keys = Array.from(get_sorted_topics().keys());
+    const topic_index = sorted_topic_keys.findIndex(
+        function (key) {
+            if (key === topic_key) {
+                return true;
+            }
+            return false;
+        }
+    );
+
+    if (topic_index === 0) {
+        // Note: In this function length of sorted_topic_keys is always >= 2,
+        // since it is called after a complete_rerender has taken place.
+        // A complete_rerender only takes place after there is a topic to
+        // display. So, this can at min be the second topic we are dealing with.
+        get_topic_row(sorted_topic_keys[1]).before(rendered_row);
+    }
+    get_topic_row(sorted_topic_keys[topic_index - 1]).after(rendered_row);
+};
+
+exports.update_topic_is_muted = function (stream_id, topic, is_muted) {
+    const key = stream_id + ":" + topic;
+    if (!topics.has(key)) {
+        // we receive mute request for a topic we are
+        // not tracking currently
+        return false;
+    }
+
+    if (is_muted) {
+        get_topic_row(key).hide();
+    } else {
+        get_topic_row(key).show();
+    }
+    return true;
+};
+
+exports.complete_rerender = function () {
+    // NOTE: This function is grows expensive with
+    // number of topics. Only call when necessary.
+    // This functions takes around 1ms per topic to process.
+    const rendered_body = render_recent_topics_body({
+        recent_topics: format_all_topics(),
+    });
+    $('#recent_topics_table').html(rendered_body);
+};
+
+exports.launch = function () {
     overlays.open_overlay({
         name: 'recent_topics',
         overlay: $('#recent_topics_overlay'),

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -76,6 +76,7 @@ function format_topic(topic_data) {
     const last_msg = message_store.get(topic_data.last_msg_id);
     const stream = last_msg.stream;
     const stream_id = last_msg.stream_id;
+    const stream_info = stream_data.get_sub(stream);
     const topic = last_msg.topic;
     const time = new XDate(last_msg.timestamp * 1000);
     const last_msg_time = timerender.last_seen_status_from_date(time);
@@ -96,12 +97,17 @@ function format_topic(topic_data) {
     const senders_info = people.sender_info_with_small_avatar_urls_for_sender_ids(senders);
 
     return {
+        // stream info
         stream_id: stream_id,
         stream: stream,
+        stream_color: stream_info.color,
+        invite_only: stream_info.invite_only,
+        is_web_public: stream_info.is_web_public,
+        stream_url: hash_util.by_stream_uri(stream_id),
+
         topic: topic,
         unread_count: unread_count,
         last_msg_time: last_msg_time,
-        stream_url: hash_util.by_stream_uri(stream_id),
         topic_url: hash_util.by_stream_topic_uri(stream_id, topic),
         hidden: hidden,
         senders: senders_info,

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -197,6 +197,8 @@ exports.complete_rerender = function () {
     // This functions takes around 1ms per topic to process.
     const rendered_body = render_recent_topics_body({
         recent_topics: format_all_topics(),
+        filter_participated: filters.has('participated'),
+        filter_unread: filters.has('unread'),
     });
     $('#recent_topics_table').html(rendered_body);
 

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -18,7 +18,7 @@ exports.process_messages = function (messages) {
     for (const msg of messages) {
         exports.process_message(msg, do_inplace_rerender);
     }
-    if (!do_inplace_rerender) {
+    if (!do_inplace_rerender && overlays.recent_topics_open()) {
         exports.complete_rerender();
     }
 };
@@ -47,7 +47,7 @@ exports.process_message = function (msg, do_inplace_rerender) {
     }
     topic_data.participated = is_ours || topic_data.participated;
 
-    if (do_inplace_rerender) {
+    if (do_inplace_rerender && overlays.recent_topics_open()) {
         exports.inplace_rerender(key);
     }
     return true;
@@ -213,8 +213,10 @@ exports.update_topic_is_muted = function (stream_id, topic, is_muted) {
 };
 
 exports.update_topic_unread_count = function (message) {
-    const topic_key = message.stream_id + ":" + message.topic;
-    exports.inplace_rerender(topic_key);
+    if (overlays.recent_topics_open()) {
+        const topic_key = message.stream_id + ":" + message.topic;
+        exports.inplace_rerender(topic_key);
+    }
 };
 
 exports.set_filter = function (filter) {
@@ -297,10 +299,11 @@ exports.complete_rerender = function () {
         filter_unread: filters.has('unread'),
     });
     $('#recent_topics_table').html(rendered_body);
-    show_selected_filters();
+    exports.update_filters_view();
 };
 
 exports.launch = function () {
+    recent_topics.complete_rerender();
     overlays.open_overlay({
         name: 'recent_topics',
         overlay: $('#recent_topics_overlay'),

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -1,3 +1,4 @@
+const render_recent_topics_body = require('../templates/recent_topics_table.hbs');
 const topics = new Map(); // Key is stream-id:topic.
 
 exports.process_messages = function (messages) {
@@ -65,6 +66,19 @@ exports.process_topic_edit = function (old_stream_id, old_topic, new_topic, new_
     new_stream_id = new_stream_id || old_stream_id;
     const new_topic_msgs = message_util.get_messages_in_topic(new_stream_id, new_topic);
     exports.process_messages(new_topic_msgs);
+};
+
+exports.launch = function () {
+    const rendered_body = render_recent_topics_body();
+    $('#recent_topics_table').html(rendered_body);
+
+    overlays.open_overlay({
+        name: 'recent_topics',
+        overlay: $('#recent_topics_overlay'),
+        on_close: function () {
+            hashchange.exit_overlay();
+        },
+    });
 };
 
 window.recent_topics = exports;

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -5,7 +5,8 @@ const topics = new Map(); // Key is stream-id:topic.
 // Sets the number of avatars to display.
 // Rest of the avatars, if present, are displayed as {+x}
 const MAX_AVATAR = 4;
-let filters = new Set();
+// This variable can be used to set default filters.
+let filters = new Set(['unread', 'participated']);
 
 exports.process_messages = function (messages) {
     // Since a complete re-render is expensive, we

--- a/static/js/unread_ops.js
+++ b/static/js/unread_ops.js
@@ -15,6 +15,7 @@ function process_newly_read_message(message, options) {
         message_list.narrowed.show_message_as_read(message, options);
     }
     notifications.close_notification(message);
+    recent_topics.update_topic_unread_count(message);
 }
 
 exports.process_read_messages_event = function (message_ids) {

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -54,7 +54,8 @@ li.show-more-topics {
 }
 
 #streams_inline_cog,
-#streams_filter_icon {
+#streams_filter_icon,
+#recent_topics_icon {
     float: right;
     opacity: 0.50;
     font-size: 13px;

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -397,6 +397,7 @@ on a dark background, and don't change the dark labels dark either. */
 
     thead,
     .drafts-container .drafts-header,
+    .recent_topics_container .recent_topics_header,
     .nav > li > a:hover,
     .subscriptions-container .subscriptions-header,
     .grey-box,

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -415,6 +415,11 @@ on a dark background, and don't change the dark labels dark either. */
         background-color: hsla(0, 0%, 0%, 0.2);
     }
 
+    .table-hover tbody tr:hover td,
+    .table-hover tbody tr:hover th {
+        background-color: hsla(0, 0%, 0%, 0.5);
+    }
+
     .table-striped tbody tr:nth-child(odd) td {
         background-color: hsl(212, 28%, 18%);
     }

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -395,6 +395,17 @@ on a dark background, and don't change the dark labels dark either. */
         background-color: hsla(0, 0%, 0%, 0.2);
     }
 
+
+    .btn-recent-filters {
+        background-color: hsl(0, 0%, 26%);
+        border-color: hsl(0, 0%, 0%);
+        color: hsl(0, 0%, 100%);
+    }
+
+    .btn-recent-selected {
+        background-color: hsl(0, 0%, 0%) !important;
+    }
+
     thead,
     .drafts-container .drafts-header,
     .recent_topics_container .recent_topics_header,

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -395,6 +395,10 @@ on a dark background, and don't change the dark labels dark either. */
         background-color: hsla(0, 0%, 0%, 0.2);
     }
 
+    .recent_topic_unread_count {
+        background-color: hsl(0, 0%, 15%) !important;
+        color: hsl(0, 0%, 100%);
+    }
 
     .btn-recent-filters {
         background-color: hsl(0, 0%, 26%);

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -401,13 +401,25 @@ on a dark background, and don't change the dark labels dark either. */
     }
 
     .btn-recent-filters {
-        background-color: hsl(0, 0%, 26%);
+        background-color: hsl(211, 29%, 14%);
         border-color: hsl(0, 0%, 0%);
         color: hsl(0, 0%, 100%);
     }
 
-    .btn-recent-selected {
+    .btn-recent-selected,
+    .recent_topics_table thead th {
         background-color: hsl(0, 0%, 0%) !important;
+        &:hover {
+            background-color: hsl(211, 29%, 14%) !important;
+        }
+    }
+
+    .recent_topics_table td a {
+        color: hsl(206, 89%, 74%);
+        text-decoration: none;
+        &:hover {
+            color: hsl(208, 64%, 52%);
+        }
     }
 
     thead,

--- a/static/styles/recent_topics.scss
+++ b/static/styles/recent_topics.scss
@@ -57,6 +57,14 @@
         padding: 15px;
         overflow: hidden !important;
 
+        a {
+            color: hsl(205, 47%, 42%);
+            text-decoration: none;
+            &:hover {
+                color: hsl(214, 40%, 58%);
+            }
+        }
+
         .required-text:empty::after {
             content: attr(data-empty);
             display: block;
@@ -79,10 +87,10 @@
             overflow-y: auto;
             max-height: 100%;
         }
-        .tableFixHead thead th {
-            position: sticky;
-            top: 0;
-            z-index: 1000;
+
+        .tableFixHead table {
+            // To keep border properties to the thead th.
+            border-collapse: separate;
         }
 
         #recent_topics_filter_buttons {
@@ -158,10 +166,13 @@
         }
 
         thead th {
-            background-color: inherit;
+            background-color: hsl(0, 0%, 100%);
             color: inherit;
             border-top: 1px solid hsla(0, 0%, 0%, 0.2) !important;
             border-bottom: 1px solid hsla(0, 0%, 0%, 0.2) !important;
+            position: sticky;
+            top: 0;
+            z-index: 1000;
 
             &.active::after,
             &[data-sort]:hover::after {
@@ -185,7 +196,7 @@
 
             &[data-sort]:hover {
                 cursor: pointer;
-                background-color: hsla(0, 0%, 0%, 0.05);
+                background-color: hsla(0, 0%, 95%);
                 transition: background-color 100ms ease-in-out;
 
                 &:not(.active)::after {

--- a/static/styles/recent_topics.scss
+++ b/static/styles/recent_topics.scss
@@ -57,6 +57,27 @@
         padding: 15px;
         overflow: auto;
 
+        #recent_topics_filter_buttons {
+            margin: 0 10px 0 10px;
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: flex-start;
+        }
+
+        #recent_topics_search {
+            margin: 0 0 10px 0px;
+            flex-grow: 1;
+        }
+
+        .btn-recent-filters {
+            border-radius: 40px;
+            margin: 0 5px 10px 0;
+        }
+
+        .btn-recent-selected {
+            background-color: hsl(0, 11%, 93%);
+        }
+
         thead {
             background-color: hsl(0, 0%, 27%);
             color: hsl(0, 0%, 100%);

--- a/static/styles/recent_topics.scss
+++ b/static/styles/recent_topics.scss
@@ -55,7 +55,21 @@
     .recent_topics_table {
         margin: 0px;
         padding: 15px;
-        overflow: auto;
+        overflow: hidden !important;
+
+        .tableFixHead {
+            padding: 10px;
+            padding-top: 0px !important;
+            overflow-y: auto;
+            max-height: 100%;
+        }
+        .tableFixHead thead th {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background-color: hsl(0, 0%, 27%);
+            color: hsl(0, 0%, 100%);
+        }
 
         #recent_topics_filter_buttons {
             margin: 0 10px 0 10px;
@@ -76,11 +90,6 @@
 
         .btn-recent-selected {
             background-color: hsl(0, 11%, 93%);
-        }
-
-        thead {
-            background-color: hsl(0, 0%, 27%);
-            color: hsl(0, 0%, 100%);
         }
 
         .recent_topic_unread_count {

--- a/static/styles/recent_topics.scss
+++ b/static/styles/recent_topics.scss
@@ -102,11 +102,11 @@
         }
 
         .recent_topic_unread_count {
-            text-align: center;
-            // width is kept less than width of
-            // header text "Unread" so, that final width
-            // is set to header's width.
-            width: 1px;
+            background-color: hsl(0, 0%, 89%);
+            float: right;
+            padding: 0.5px;
+            margin-right: 10px;
+            border-radius: 5px;
         }
 
         .recent_avatars {

--- a/static/styles/recent_topics.scss
+++ b/static/styles/recent_topics.scss
@@ -1,0 +1,60 @@
+.recent_topics_container {
+    position: relative;
+    height: 95%;
+    width: 70%;
+    max-width: 1200px;
+    max-height: 1000px;
+    padding: 0px;
+    border-radius: 4px;
+    background-color: hsl(0, 0%, 100%);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+
+    @media (max-width: 1130px) {
+        max-width: 90%;
+    }
+
+    @media (max-width: 700px) {
+        height: 95%;
+        max-width: none;
+        width: 90%;
+    }
+
+    .recent_topics_header {
+        padding-top: 4px;
+        padding-bottom: 8px;
+        text-align: center;
+        border-bottom: 1px solid hsl(0, 0%, 87%);
+
+        h1 {
+            margin: 0;
+            font-size: 1.1em;
+            text-transform: uppercase;
+        }
+
+        .exit {
+            font-weight: 400;
+            position: absolute;
+            top: 10px;
+            right: 10px;
+            color: hsl(0, 0%, 67%);
+            cursor: pointer;
+
+            .exit-sign {
+                position: relative;
+                top: 3px;
+                margin-left: 3px;
+                font-size: 1.5rem;
+                font-weight: 600;
+                cursor: pointer;
+            }
+        }
+    }
+
+    .recent_topics_table {
+        margin: 0px;
+        padding: 15px;
+        overflow: auto;
+    }
+}

--- a/static/styles/recent_topics.scss
+++ b/static/styles/recent_topics.scss
@@ -92,6 +92,10 @@
             flex-grow: 1;
         }
 
+        #recent_topics_search_clear {
+            margin-top: -10px !important;
+        }
+
         .btn-recent-filters {
             border-radius: 40px;
             margin: 0 5px 10px 0;

--- a/static/styles/recent_topics.scss
+++ b/static/styles/recent_topics.scss
@@ -57,6 +57,11 @@
         padding: 15px;
         overflow: hidden !important;
 
+        .fa-check-square-o,
+        .fa-square-o {
+            padding: 0 2px 0 2px;
+        }
+
         .tableFixHead {
             padding: 10px;
             padding-top: 0px !important;

--- a/static/styles/recent_topics.scss
+++ b/static/styles/recent_topics.scss
@@ -69,5 +69,44 @@
             // is set to header's width.
             width: 1px;
         }
+
+        .recent_avatars {
+            display: inline-flex; /* Causes LI items to display in row. */
+            list-style-type: none;
+            margin: auto; /* Centers vertically / horizontally in flex container. */
+            height: 15px !important;
+
+            /*
+                By using the row-reverse layout, the visual ordering will be opposite of
+                the DOM ordering. This will allows us to stack the items in the opposite
+                direction of the natural stacking order without having to mess with the
+                zIndex value. The MAJOR DOWNSIDE is that the HTML itself now reads
+                backwards, which super janky.
+            */
+            flex-direction: row-reverse;
+        }
+
+        .recent_avatars_item {
+            height: 18px;
+            margin: 0px 0px 0px 0px;
+            padding: 0px 0px 0px 0px;
+            position: relative;
+            min-width: 18px;
+        }
+
+        .recent_avatars_img,
+        .recent_avatars_others {
+            border: 1px solid hsl(221.1, 23.5%, 15.9%);
+            border-left: 0 !important;
+            border-radius: 6px;
+            color: hsl(0, 0%, 100%);
+            display: block;
+            height: 18px;
+            text-align: center;
+        }
+
+        .recent_avatars_others {
+            background-color: hsl(205.2, 76.5%, 50%);
+        }
     }
 }

--- a/static/styles/recent_topics.scss
+++ b/static/styles/recent_topics.scss
@@ -76,8 +76,6 @@
             position: sticky;
             top: 0;
             z-index: 1000;
-            background-color: hsl(0, 0%, 27%);
-            color: hsl(0, 0%, 100%);
         }
 
         #recent_topics_filter_buttons {
@@ -150,6 +148,43 @@
 
         .recent_avatars_others {
             background-color: hsl(205.2, 76.5%, 50%);
+        }
+
+        thead th {
+            background-color: inherit;
+            color: inherit;
+            border-top: 1px solid hsla(0, 0%, 0%, 0.2) !important;
+            border-bottom: 1px solid hsla(0, 0%, 0%, 0.2) !important;
+
+            &.active::after,
+            &[data-sort]:hover::after {
+                content: " \f0d8";
+                white-space: pre;
+                display: inline-block;
+                position: absolute;
+                padding-top: 3px;
+                font: normal normal normal 12px/1 FontAwesome;
+                font-size: inherit;
+            }
+
+            &.active {
+                opacity: 1;
+                transition: opacity 100ms ease-out;
+
+                &.descend::after {
+                    content: " \f0d7";
+                }
+            }
+
+            &[data-sort]:hover {
+                cursor: pointer;
+                background-color: hsla(0, 0%, 0%, 0.05);
+                transition: background-color 100ms ease-in-out;
+
+                &:not(.active)::after {
+                    opacity: 0.3;
+                }
+            }
         }
     }
 }

--- a/static/styles/recent_topics.scss
+++ b/static/styles/recent_topics.scss
@@ -62,6 +62,10 @@
             padding: 0 2px 0 2px;
         }
 
+        .fa-lock {
+            padding-right: 3px;
+        }
+
         .tableFixHead {
             padding: 10px;
             padding-top: 0px !important;

--- a/static/styles/recent_topics.scss
+++ b/static/styles/recent_topics.scss
@@ -56,5 +56,18 @@
         margin: 0px;
         padding: 15px;
         overflow: auto;
+
+        thead {
+            background-color: hsl(0, 0%, 27%);
+            color: hsl(0, 0%, 100%);
+        }
+
+        .recent_topic_unread_count {
+            text-align: center;
+            // width is kept less than width of
+            // header text "Unread" so, that final width
+            // is set to header's width.
+            width: 1px;
+        }
     }
 }

--- a/static/styles/recent_topics.scss
+++ b/static/styles/recent_topics.scss
@@ -57,6 +57,13 @@
         padding: 15px;
         overflow: hidden !important;
 
+        .required-text:empty::after {
+            content: attr(data-empty);
+            display: block;
+            font-style: italic;
+            color: hsl(0, 0%, 67%);
+        }
+
         .fa-check-square-o,
         .fa-square-o {
             padding: 0 2px 0 2px;

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1133,7 +1133,8 @@ td.pointer {
 }
 
 .on_hover_topic_edit,
-.on_hover_topic_mute {
+.on_hover_topic_mute,
+.on_hover_topic_read {
     opacity: 0.2;
 }
 
@@ -1143,7 +1144,8 @@ td.pointer {
 
 .on_hover_topic_edit,
 .always_visible_topic_edit,
-.on_hover_topic_mute {
+.on_hover_topic_mute,
+.on_hover_topic_read {
     &:hover {
         cursor: pointer;
         opacity: 1.0;

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1145,6 +1145,7 @@ td.pointer {
 .on_hover_topic_edit,
 .always_visible_topic_edit,
 .on_hover_topic_mute,
+.on_hover_topic_unmute,
 .on_hover_topic_read {
     &:hover {
         cursor: pointer;

--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -10,7 +10,11 @@
         {{#if unread_count}}<span class="recent_topic_unread_count">+{{unread_count}}</span>{{/if}}
     </td>
     <td class="recent_topic_actions">
+        {{#if topic_muted}}
+        <i class="fa fa-bell-slash on_hover_topic_unmute recipient_bar_icon" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Unmute topic' }}" role="button" tabindex="0" aria-label="{{t 'Mute topic' }}"></i>
+        {{else}}
         <i class="fa fa-bell-slash on_hover_topic_mute recipient_bar_icon" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Mute topic' }}" role="button" tabindex="0" aria-label="{{t 'Mute topic' }}"></i>
+        {{/if}}
         <i class="fa fa-check-circle on_hover_topic_read recipient_bar_icon" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}"></i>
     </td>
     <td class='recent_topic_users'>

--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -7,6 +7,9 @@
         {{/if}}
     </td>
     <td class="recent_topic_stream">
+        <span id="stream_sidebar_privacy_swatch_{{stream_id}}" class="stream-privacy filter-icon" style="color: {{stream_color}}">
+            {{> stream_privacy }}
+        </span>
         <a href="{{stream_url}}">{{stream}}</a>
     </td>
     <td class="recent_topic_name">

--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -1,4 +1,4 @@
-<tr id="recent_topic:{{stream_id}}:{{topic}}" {{#if hidden}}style="display:none;"{{/if}}>
+<tr id="recent_topic:{{stream_id}}:{{topic}}" data-unread-count="{{unread_count}}" data-muted="{{muted}}" data-participated="{{participated}}">
     <td class="recent_topic_stream">
         <span id="stream_sidebar_privacy_swatch_{{stream_id}}" class="stream-privacy filter-icon" style="color: {{stream_color}}">
             {{> stream_privacy }}

--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -1,0 +1,23 @@
+<tr id="recent_topic:{{stream_id}}:{{topic}}" {{#if hidden}}style="display:none;"{{/if}}>
+    <td class="recent_topic_unread_count">
+        {{#if unread_count}}
+        {{unread_count}}
+        {{else}}
+        <i class="fa fa-check-circle" title="{{t 'All messages read' }}" aria-hidden="true"></i>
+        {{/if}}
+    </td>
+    <td class="recent_topic_stream">
+        <a href="{{stream_url}}">{{stream}}</a>
+    </td>
+    <td class="recent_topic_name">
+        <a href="{{topic_url}}">{{topic}}</a>
+    </td>
+    <td class="recent_topic_actions">
+        <i class="fa fa-bell-slash on_hover_topic_mute recipient_bar_icon" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Mute topic' }}" role="button" tabindex="0" aria-label="{{t 'Mute topic' }}"></i>
+    </td>
+    <td class='recent_topic_users'>
+    </td>
+    <td class="recent_topic_timestamp">
+        {{ last_msg_time }}
+    </td>
+</tr>

--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -14,6 +14,7 @@
     </td>
     <td class="recent_topic_actions">
         <i class="fa fa-bell-slash on_hover_topic_mute recipient_bar_icon" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Mute topic' }}" role="button" tabindex="0" aria-label="{{t 'Mute topic' }}"></i>
+        <i class="fa fa-check-circle on_hover_topic_read recipient_bar_icon" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}"></i>
     </td>
     <td class='recent_topic_users'>
     </td>

--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -17,6 +17,18 @@
         <i class="fa fa-check-circle on_hover_topic_read recipient_bar_icon" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Mark as read' }}" role="button" tabindex="0" aria-label="{{t 'Mark as read' }}"></i>
     </td>
     <td class='recent_topic_users'>
+        <ul class="recent_avatars">
+            {{#if count_senders}}
+            <li class="recent_avatars_item">
+                <span class="recent_avatars_others">+{{count_senders}}</span>
+            </li>
+            {{/if}}
+            {{#each senders}}
+            <li class="recent_avatars_item" title="{{this.full_name}}">
+                <img src="{{this.avatar_url_small}}" class="recent_avatars_img" />
+            </li>
+            {{/each}}
+        </ul>
     </td>
     <td class="recent_topic_timestamp">
         {{ last_msg_time }}

--- a/static/templates/recent_topic_row.hbs
+++ b/static/templates/recent_topic_row.hbs
@@ -1,11 +1,4 @@
 <tr id="recent_topic:{{stream_id}}:{{topic}}" {{#if hidden}}style="display:none;"{{/if}}>
-    <td class="recent_topic_unread_count">
-        {{#if unread_count}}
-        {{unread_count}}
-        {{else}}
-        <i class="fa fa-check-circle" title="{{t 'All messages read' }}" aria-hidden="true"></i>
-        {{/if}}
-    </td>
     <td class="recent_topic_stream">
         <span id="stream_sidebar_privacy_swatch_{{stream_id}}" class="stream-privacy filter-icon" style="color: {{stream_color}}">
             {{> stream_privacy }}
@@ -14,6 +7,7 @@
     </td>
     <td class="recent_topic_name">
         <a href="{{topic_url}}">{{topic}}</a>
+        {{#if unread_count}}<span class="recent_topic_unread_count">+{{unread_count}}</span>{{/if}}
     </td>
     <td class="recent_topic_actions">
         <i class="fa fa-bell-slash on_hover_topic_mute recipient_bar_icon" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Mute topic' }}" role="button" tabindex="0" aria-label="{{t 'Mute topic' }}"></i>

--- a/static/templates/recent_topics_filters.hbs
+++ b/static/templates/recent_topics_filters.hbs
@@ -1,0 +1,17 @@
+<button data-filter="all" type="button" class="btn btn-default btn-recent-filters">{{t 'All' }}</button>
+<button data-filter="unread" type="button" class="btn btn-default btn-recent-filters">
+    {{#if filter_unread}}
+    <i class="fa fa-check-square-o"></i>
+    {{else}}
+    <i class="fa fa-square-o"></i>
+    {{/if}}
+    {{t 'Unread' }}
+</button>
+<button data-filter="participated" type="button" class="btn btn-default btn-recent-filters">
+    {{#if filter_participated}}
+    <i class="fa fa-check-square-o"></i>
+    {{else}}
+    <i class="fa fa-square-o"></i>
+    {{/if}}
+    {{t 'Participated' }}
+</button>

--- a/static/templates/recent_topics_filters.hbs
+++ b/static/templates/recent_topics_filters.hbs
@@ -15,3 +15,11 @@
     {{/if}}
     {{t 'Participated' }}
 </button>
+<button data-filter="muted" type="button" class="btn btn-default btn-recent-filters">
+    {{#if filter_muted }}
+    <i class="fa fa-check-square-o"></i>
+    {{else}}
+    <i class="fa fa-square-o"></i>
+    {{/if}}
+    {{t 'Muted' }}
+</button>

--- a/static/templates/recent_topics_table.hbs
+++ b/static/templates/recent_topics_table.hbs
@@ -1,0 +1,2 @@
+<table>
+</table>

--- a/static/templates/recent_topics_table.hbs
+++ b/static/templates/recent_topics_table.hbs
@@ -2,7 +2,7 @@
     <div id="recent_filters_group">
         {{> recent_topics_filters}}
     </div>
-    <input type="text" id="recent_topics_search" placeholder="{{t 'Search stream / topic' }}">
+    <input type="text" id="recent_topics_search" value="{{ search_val }}" placeholder="{{t 'Search stream / topic' }}">
     <button type="button" class="btn clear_search_button" id="recent_topics_search_clear">
         <i class="fa fa-remove" aria-hidden="true"></i>
     </button>
@@ -18,8 +18,7 @@
                 <th>{{t 'Last message' }}</th>
             </tr>
         </thead>
-        {{#each recent_topics}}
-        {{> recent_topic_row}}
-        {{/each}}
+        <tbody>
+        </tbody>
     </table>
 </div>

--- a/static/templates/recent_topics_table.hbs
+++ b/static/templates/recent_topics_table.hbs
@@ -1,2 +1,15 @@
-<table>
+<table class="table table-responsive table-hover">
+    <thead>
+        <tr>
+            <th>{{t 'Unread' }}</th>
+            <th>{{t 'Stream' }}</th>
+            <th>{{t 'Topic' }}</th>
+            <th>{{t 'Actions' }}</th>
+            <th>{{t 'Participants' }}</th>
+            <th>{{t 'Last message' }}</th>
+        </tr>
+    </thead>
+    {{#each recent_topics}}
+    {{> recent_topic_row}}
+    {{/each}}
 </table>

--- a/static/templates/recent_topics_table.hbs
+++ b/static/templates/recent_topics_table.hbs
@@ -1,3 +1,9 @@
+<div id="recent_topics_filter_buttons" class="btn-group" role="group">
+    <button data-filter="all" type="button" class="btn btn-default btn-recent-filters">{{t 'All' }}</button>
+    <button data-filter="unread" type="button" class="btn btn-default btn-recent-filters">{{t 'Unread' }}</button>
+    <button data-filter="participated" type="button" class="btn btn-default btn-recent-filters">{{t 'Participated' }}</button>
+    <input type="text" id="recent_topics_search" placeholder="{{t 'Search stream / topic' }}">
+</div>
 <table class="table table-responsive table-hover">
     <thead>
         <tr>

--- a/static/templates/recent_topics_table.hbs
+++ b/static/templates/recent_topics_table.hbs
@@ -18,7 +18,6 @@
                 <th data-sort="numeric" data-sort-prop="last_msg_id" class="active descend">{{t 'Last message' }}</th>
             </tr>
         </thead>
-        <tbody>
-        </tbody>
+        <tbody class="required-text" data-empty="{{t 'No topics match your current filter.' }}"></tbody>
     </table>
 </div>

--- a/static/templates/recent_topics_table.hbs
+++ b/static/templates/recent_topics_table.hbs
@@ -22,7 +22,6 @@
     <table class="table table-responsive table-hover">
         <thead>
             <tr>
-                <th>{{t 'Unread' }}</th>
                 <th>{{t 'Stream' }}</th>
                 <th>{{t 'Topic' }}</th>
                 <th>{{t 'Actions' }}</th>

--- a/static/templates/recent_topics_table.hbs
+++ b/static/templates/recent_topics_table.hbs
@@ -3,6 +3,9 @@
         {{> recent_topics_filters}}
     </div>
     <input type="text" id="recent_topics_search" placeholder="{{t 'Search stream / topic' }}">
+    <button type="button" class="btn clear_search_button" id="recent_topics_search_clear">
+        <i class="fa fa-remove" aria-hidden="true"></i>
+    </button>
 </div>
 <div class="tableFixHead">
     <table class="table table-responsive table-hover">

--- a/static/templates/recent_topics_table.hbs
+++ b/static/templates/recent_topics_table.hbs
@@ -1,7 +1,21 @@
 <div id="recent_topics_filter_buttons" class="btn-group" role="group">
     <button data-filter="all" type="button" class="btn btn-default btn-recent-filters">{{t 'All' }}</button>
-    <button data-filter="unread" type="button" class="btn btn-default btn-recent-filters">{{t 'Unread' }}</button>
-    <button data-filter="participated" type="button" class="btn btn-default btn-recent-filters">{{t 'Participated' }}</button>
+    <button data-filter="unread" type="button" class="btn btn-default btn-recent-filters">
+        {{#if filter_unread}}
+        <i class="fa fa-check-square-o"></i>
+        {{else}}
+        <i class="fa fa-square-o"></i>
+        {{/if}}
+        {{t 'Unread' }}
+    </button>
+    <button data-filter="participated" type="button" class="btn btn-default btn-recent-filters">
+        {{#if filter_participated}}
+        <i class="fa fa-check-square-o"></i>
+        {{else}}
+        <i class="fa fa-square-o"></i>
+        {{/if}}
+        {{t 'Participated' }}
+    </button>
     <input type="text" id="recent_topics_search" placeholder="{{t 'Search stream / topic' }}">
 </div>
 <div class="tableFixHead">

--- a/static/templates/recent_topics_table.hbs
+++ b/static/templates/recent_topics_table.hbs
@@ -1,21 +1,7 @@
 <div id="recent_topics_filter_buttons" class="btn-group" role="group">
-    <button data-filter="all" type="button" class="btn btn-default btn-recent-filters">{{t 'All' }}</button>
-    <button data-filter="unread" type="button" class="btn btn-default btn-recent-filters">
-        {{#if filter_unread}}
-        <i class="fa fa-check-square-o"></i>
-        {{else}}
-        <i class="fa fa-square-o"></i>
-        {{/if}}
-        {{t 'Unread' }}
-    </button>
-    <button data-filter="participated" type="button" class="btn btn-default btn-recent-filters">
-        {{#if filter_participated}}
-        <i class="fa fa-check-square-o"></i>
-        {{else}}
-        <i class="fa fa-square-o"></i>
-        {{/if}}
-        {{t 'Participated' }}
-    </button>
+    <div id="recent_filters_group">
+        {{> recent_topics_filters}}
+    </div>
     <input type="text" id="recent_topics_search" placeholder="{{t 'Search stream / topic' }}">
 </div>
 <div class="tableFixHead">

--- a/static/templates/recent_topics_table.hbs
+++ b/static/templates/recent_topics_table.hbs
@@ -11,11 +11,11 @@
     <table class="table table-responsive table-hover">
         <thead>
             <tr>
-                <th>{{t 'Stream' }}</th>
-                <th>{{t 'Topic' }}</th>
+                <th data-sort="stream_sort">{{t 'Stream' }}</th>
+                <th data-sort="topic_sort">{{t 'Topic' }}</th>
                 <th>{{t 'Actions' }}</th>
                 <th>{{t 'Participants' }}</th>
-                <th>{{t 'Last message' }}</th>
+                <th data-sort="numeric" data-sort-prop="last_msg_id" class="active descend">{{t 'Last message' }}</th>
             </tr>
         </thead>
         <tbody>

--- a/static/templates/recent_topics_table.hbs
+++ b/static/templates/recent_topics_table.hbs
@@ -4,18 +4,20 @@
     <button data-filter="participated" type="button" class="btn btn-default btn-recent-filters">{{t 'Participated' }}</button>
     <input type="text" id="recent_topics_search" placeholder="{{t 'Search stream / topic' }}">
 </div>
-<table class="table table-responsive table-hover">
-    <thead>
-        <tr>
-            <th>{{t 'Unread' }}</th>
-            <th>{{t 'Stream' }}</th>
-            <th>{{t 'Topic' }}</th>
-            <th>{{t 'Actions' }}</th>
-            <th>{{t 'Participants' }}</th>
-            <th>{{t 'Last message' }}</th>
-        </tr>
-    </thead>
-    {{#each recent_topics}}
-    {{> recent_topic_row}}
-    {{/each}}
-</table>
+<div class="tableFixHead">
+    <table class="table table-responsive table-hover">
+        <thead>
+            <tr>
+                <th>{{t 'Unread' }}</th>
+                <th>{{t 'Stream' }}</th>
+                <th>{{t 'Topic' }}</th>
+                <th>{{t 'Actions' }}</th>
+                <th>{{t 'Participants' }}</th>
+                <th>{{t 'Last message' }}</th>
+            </tr>
+        </thead>
+        {{#each recent_topics}}
+        {{> recent_topic_row}}
+        {{/each}}
+    </table>
+</div>

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -45,6 +45,7 @@
 {% include "zerver/app/lightbox_overlay.html" %}
 {% include "zerver/app/subscriptions.html" %}
 {% include "zerver/app/drafts.html" %}
+{% include "zerver/app/recent_topics.html" %}
 <div id="settings_overlay_container" class="overlay" data-overlay="settings" aria-hidden="true">
     {% include "zerver/app/settings_overlay.html" %}
 </div>

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -60,6 +60,7 @@
         <div id="streams_list" class="zoom-out">
             <div id="streams_header" class="zoom-in-hide"><h4 class="sidebar-title" data-toggle="tooltip" title="{{ _('Filter streams') }}">{{ _('STREAMS') }}</h4>
                 <i id="streams_inline_cog" class='fa fa-cog' aria-hidden="true" data-toggle="tooltip" title="{{ _('Subscribe, add, or configure streams') }}"></i>
+                <i id="recent_topics_icon" class='fa fa-clock-o' aria-hidden="true" data-toggle="tooltip" title="{{ _('Recent topics') }} (t)"></i>
                 <i id="streams_filter_icon" class='fa fa-search' aria-hidden="true" data-toggle="tooltip" title="{{ _('Filter streams') }} (q)"></i>
                 <div class="input-append notdisplayed stream_search_section">
                     <input class="stream-list-filter" type="text" autocomplete="off" placeholder="{{ _('Search streams') }}" />

--- a/templates/zerver/app/recent_topics.html
+++ b/templates/zerver/app/recent_topics.html
@@ -1,0 +1,17 @@
+<div id="recent_topics_overlay" class="overlay new-style" data-overlay="recent_topics">
+    <div class="flex overlay-content">
+        <div class="recent_topics_container modal-bg">
+            <div class="recent_topics_header">
+                <h1>{% trans %}Recent topics (beta){% endtrans %}</h1>
+                <div class="exit">
+                    <span class="exit-sign">&times;</span>
+                </div>
+                <div class="recent-hotkey-reminder">
+                    {% trans %}Pro tip: You can use 't' to view recent topics.{% endtrans %}
+                </div>
+            </div>
+            <div class="recent_topics_table" id="recent_topics_table">
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Events:
- [x] Topic Mute Updates
- [ ] Stream Mute Updates https://chat.zulip.org/#narrow/stream/6-frontend/topic/.236605.20%28Recent.20Topics%29/near/854026
- [x] Topic Edits
- [x] Stream Edits
- [ ] Stream Deletion

 * Should deleted streams be displayed in recent topics?  They are currently displayed as 
`DEACTIVATED:"Stream Name"`, we can work with the formatting to display it as
 `Stream Name (Deleted)`


Features:
- [x] Keyboard Navigation 
- [x] Mute/Unmute Topic 
- [x] Mark Topic as read
- [x] Display recent users
- [x] Open via hotkey
- [x] Show only starred topics
- [x] Add search bar for searching topics


Other UI things todo:
- [x] Only update components that are required
- [x] Make headers fixed


Followup things to do:
- [ ] We should use sortable.js to make the columns sortable by clicking the headings.
- [ ] Starred messages (problem: All message that are starred might not be initially loaded)
- [ ] Visited Topics (track data of visited topics - https://chat.zulip.org/#narrow/stream/101-design/topic/recent.20topics.20use.20cases)
- [ ] Add a keybind for cycling through recent topics. User should be able to specify which combination of filters to cycle through.
- [ ] follow/unfollow a stream+topic pair for notifications (#14555 adds backend for this)
- [ ] Add announcement section
- [ ] Mark topic as unread "Action" button

Current Discussion Link - https://chat.zulip.org/#narrow/stream/6-frontend/topic/.236605.20(Recent.20Topics)
Relevant issues: #6605, #4271 and #12309 (this issue should require a different PR however).
Started with rebase of #7714.

Thanks @aero31aero for helping me get started with this 👍 