### PR TITLE
message list: Render new messages only after "newest" is found.

### DIFF
--- a/frontend_tests/node_tests/fetch_status.js
+++ b/frontend_tests/node_tests/fetch_status.js
@@ -70,7 +70,7 @@ run_test('basics', () => {
         found_newest: true,
         history_limited: true,
     };
-    fetch_status.finish_newer_batch(data);
+    fetch_status.finish_newer_batch([], data);
     fetch_status.finish_older_batch(data);
 
     has_found_oldest();
@@ -94,7 +94,7 @@ run_test('basics', () => {
         found_newest: false,
         history_limited: false,
     };
-    fetch_status.finish_newer_batch(data);
+    fetch_status.finish_newer_batch([], data);
     fetch_status.finish_older_batch(data);
 
     can_load_older();
@@ -147,7 +147,7 @@ run_test('basics', () => {
     can_load_older();
     blocked_newer();
 
-    fetch_status.finish_newer_batch({
+    fetch_status.finish_newer_batch([], {
         update_loading_indicator: true,
         found_newest: false,
     });
@@ -160,7 +160,7 @@ run_test('basics', () => {
     can_load_older();
     blocked_newer();
 
-    fetch_status.finish_newer_batch({
+    fetch_status.finish_newer_batch([], {
         update_loading_indicator: true,
         found_newest: true,
     });

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -345,6 +345,23 @@ run_test('loading_newer', () => {
         });
 
         assert.equal(msg_list.data.fetch_status.can_load_newer_messages(), true);
+
+        // The server successfully responded with messages having id's from 500-599.
+        // We test for the case that this was the last batch of messages for the narrow
+        // so no more fetching should occur.
+        // And also while fetching for the above condition the server received a new message
+        // event, updating the last message's id for that narrow to 600 from 599.
+        data.resp.found_newest = true;
+        msg_list.data.fetch_status.update_expected_max_message_id([{id: 600}]);
+
+        test_happy_path({
+            msg_list: msg_list,
+            data: data,
+        });
+
+        // To handle this special case we should allow another fetch to occur,
+        // since the last message event's data had been discarded.
+        assert.equal(msg_list.data.fetch_status.can_load_newer_messages(), true);
     }());
 
     (function test_home() {

--- a/static/js/fetch_status.js
+++ b/static/js/fetch_status.js
@@ -7,6 +7,15 @@ const FetchStatus = function () {
     let found_oldest = false;
     let found_newest = false;
     let history_limited = false;
+    let expected_max_message_id = 0;
+
+    function max_id_for_messages(messages) {
+        let max_id = 0;
+        for (const msg of messages) {
+            max_id = Math.max(max_id, msg.id);
+        }
+        return max_id;
+    }
 
     self.start_older_batch = function (opts) {
         loading_older = true;
@@ -43,7 +52,11 @@ const FetchStatus = function () {
         }
     };
 
-    self.finish_newer_batch = function (opts) {
+    self.finish_newer_batch = function (messages, opts) {
+        const found_max_message_id = max_id_for_messages(messages);
+        if (opts.found_newest && expected_max_message_id > found_max_message_id) {
+            opts.found_newest = false;
+        }
         loading_newer = false;
         found_newest = opts.found_newest;
         if (opts.update_loading_indicator) {
@@ -57,6 +70,11 @@ const FetchStatus = function () {
 
     self.has_found_newest = function () {
         return found_newest;
+    };
+
+    self.update_expected_max_message_id = function (messages) {
+        expected_max_message_id = Math.max(expected_max_message_id,
+                                           max_id_for_messages(messages));
     };
 
     return self;

--- a/static/js/fetch_status.js
+++ b/static/js/fetch_status.js
@@ -54,13 +54,32 @@ const FetchStatus = function () {
 
     self.finish_newer_batch = function (messages, opts) {
         const found_max_message_id = max_id_for_messages(messages);
-        if (opts.found_newest && expected_max_message_id > found_max_message_id) {
-            opts.found_newest = false;
-        }
         loading_newer = false;
         found_newest = opts.found_newest;
         if (opts.update_loading_indicator) {
             message_scroll.hide_loading_newer();
+        }
+        if (found_newest && expected_max_message_id > found_max_message_id) {
+            // We may not have inserted the newly received messages into their
+            // respective message_list's but we keep track of the last message
+            // that should have been added.
+            // These messages are loaded into their respective message_lists,
+            // through a fetch instead.
+            //
+            // However there maybe a situation where we discard the newly received
+            // messages just after the server responds with the last batch of
+            // messages, that has not been updated with these new messages.
+            // Thus we refuse to acknowledge the server received `found_newest`
+            // and explicitly fetch the newer messages.
+            //
+            //
+            // Note: We reset our tracked last message id to act as a circuit-breaker.
+            // And if the race condition mentioned above occurs while we're handling
+            // this race condition, `expected_max_message_id` gets updated again.
+            // Thus it can again enter this block as the reset value is updated again.
+            found_newest = false;
+            expected_max_message_id = 0;
+            return true;
         }
     };
 

--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -83,7 +83,7 @@ function get_messages_success(data, opts) {
     }
 
     if (opts.num_after > 0) {
-        opts.msg_list.data.fetch_status.finish_newer_batch({
+        opts.msg_list.data.fetch_status.finish_newer_batch(data.messages, {
             update_loading_indicator: update_loading_indicator,
             found_newest: data.found_newest,
         });
@@ -92,7 +92,7 @@ function get_messages_success(data, opts) {
             // the fetch_status data structure for message_list.all,
             // which is never rendered (and just used for
             // prepopulating narrowed views).
-            message_list.all.data.fetch_status.finish_newer_batch({
+            message_list.all.data.fetch_status.finish_newer_batch(data.messages, {
                 update_loading_indicator: false,
                 found_newest: data.found_newest,
             });

--- a/static/js/message_util.js
+++ b/static/js/message_util.js
@@ -19,7 +19,16 @@ function add_messages(messages, msg_list, opts) {
 exports.add_old_messages = function (messages, msg_list) {
     return add_messages(messages, msg_list, {messages_are_new: false});
 };
+
 exports.add_new_messages = function (messages, msg_list) {
+    if (!msg_list.data.fetch_status.has_found_newest()) {
+        // We don't render newly received messages for the message list,
+        // if we haven't found the latest messages to be displayed in the
+        // narrow. Otherwise the new message would be rendered just after
+        // the previously fetched messages when that's inaccurate.
+        msg_list.data.fetch_status.update_expected_max_message_id(messages);
+        return;
+    }
     return add_messages(messages, msg_list, {messages_are_new: true});
 };
 


### PR DESCRIPTION
Fixes #14017

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Tested manually as follows:-

1. set 5 secs delay for [get messages](https://github.com/zulip/zulip/blob/master/zerver/views/messages.py#L804).
2. Also set 10 seconds delay if `query_info['found_newest']` = True in [same view function](https://github.com/zulip/zulip/blob/master/zerver/views/messages.py#L969)
3.  set timeout duration to 500000 in [sent messages](https://github.com/zulip/zulip/blob/master/static/js/sent_messages.js#L113). (not sure if necessary, was getting blueslip warnings about event loop restarting)
4. `./manage.py populate_db -n10000`
5. `./manage.py mark_all_messages_unread`
6. Go to private message narrow
7. send a message to that narrow when all the messages haven't been fetched.
Previously the new message would get temporarily displayed.
Now the new message isn't rendered but is processed. (such as unread count increases)
8. send another message when last batch is being fetched.
This message gets stored in `_newest_items` and after the fetch is complete and the new if condition in `message_list.js` is satisfied, the new message(`_newest_items`) is rendered after the fetched messages(`bottom_messages`).

I also tested the last point by discarding the new message event if "newest" has not been found by the current message list.
Then if a new message is sent while fetching the last batch for that narrow then the message is missing. (as mentioned in the issue)
