### PR TITLE
message_header_colorblock's height fixes

### DIFF
--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -67,7 +67,7 @@
 .compose_table {
     .message_header_colorblock {
         /* box-shadow: 0px 2px 3px hsl(0, 0%, 80%); */
-        box-shadow: inset 0px 2px 1px -2px hsl(0, 0%, 20%), inset 2px 0px 1px -2px hsl(0, 0%, 20%);
+        box-shadow: 0px 2px 1px -2px hsl(0, 0%, 20%) inset, 2px 0px 1px -2px hsl(0, 0%, 20%) inset, 0px -2px 1px -2px hsl(0, 0%, 20%) inset;
         width: 10px;
 
         &,


### PR DESCRIPTION

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #14996 

**Testing Plan:** <!-- How have you tested? -->
./tools/lint

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot from 2020-05-22 23-35-29](https://user-images.githubusercontent.com/44861163/82698441-6576ef00-9c88-11ea-8b55-27a23f249d34.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
