### PR TITLE
message_events: Fix live update of message edit history.

### DIFF
--- a/frontend_tests/node_tests/message_events.js
+++ b/frontend_tests/node_tests/message_events.js
@@ -7,6 +7,7 @@ zrequire('stream_data');
 zrequire('stream_topic_history');
 zrequire('unread');
 
+set_global('$', global.make_zjquery());
 set_global('alert_words', {});
 set_global('condense', {});
 set_global('current_msg_list', {});

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -768,9 +768,7 @@ exports.edit_last_sent_message = function () {
     });
 };
 
-exports.show_history = function (message) {
-    $('#message-history').html('');
-    $('#message-edit-history').modal("show");
+exports.get_and_render_message_history = function (message) {
     channel.get({
         url: "/json/messages/" + message.id + "/history",
         data: {message_id: JSON.stringify(message.id)},
@@ -816,7 +814,7 @@ exports.show_history = function (message) {
 
                 content_edit_history.push(item);
             }
-
+            $('#message-history').attr('data-message-id', message.id);
             $('#message-history').html(render_message_edit_history({
                 edited_messages: content_edit_history,
             }));
@@ -826,6 +824,12 @@ exports.show_history = function (message) {
                             $("#message-history-error"));
         },
     });
+};
+
+exports.show_history = function (message) {
+    $('#message-history').html('');
+    $('#message-edit-history').modal("show");
+    exports.get_and_render_message_history(message);
 };
 
 function hide_delete_btn_show_spinner(deleting) {

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -319,6 +319,10 @@ exports.update_messages = function update_messages(events) {
             recent_senders.process_topic_edit(...args);
             recent_topics.process_topic_edit(...args);
         }
+
+        if ($('#message-edit-history').hasClass('in') && msg.id === parseInt($('#message-history').attr('data-message-id'), 10)) {
+            message_edit.get_and_render_message_history(msg);
+        }
     }
 
     // If a topic was edited, we re-render the whole view to get any


### PR DESCRIPTION
This PR adds code to live update the message edit histroy.
Message edit histroy is fetched and rendered again if the edit
histroy modal is open.

Fixes #15051.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


<!-- How have you tested? -->


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
