### PR TITLE
stream settings: Move the "Saving" widget to "Personal settings" block.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -311,7 +311,7 @@ function stream_is_muted_clicked(e) {
     const sub_settings = exports.settings_for_sub(sub);
     const notification_checkboxes = sub_settings.find(".sub_notification_setting");
 
-    subs.toggle_home(sub);
+    subs.toggle_home(sub, `#stream_change_property_status${sub.stream_id}`);
 
     if (!sub.is_muted) {
         sub_settings.find(".mute-note").addClass("hide-mute-note");

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -95,9 +95,9 @@ exports.active_stream = function () {
     }
 };
 
-exports.toggle_home = function (sub) {
+exports.toggle_home = function (sub, status_element) {
     stream_muting.update_is_muted(sub, !sub.is_muted);
-    stream_edit.set_stream_property(sub, 'is_muted', sub.is_muted);
+    stream_edit.set_stream_property(sub, 'is_muted', sub.is_muted, status_element);
 };
 
 exports.toggle_pin_to_top_stream = function (sub) {

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -995,9 +995,13 @@ form#add_new_subscription {
         }
     }
 
+    #personal_settings_label_container {
+        margin-bottom: 5px;
+    }
+
     .alert-notification:not(:empty) {
-        margin-top: -5px;
-        margin-left: unset;
+        vertical-align: unset;
+        margin-top: 10px;
     }
 
     .loading_indicator_text {

--- a/static/templates/help_link_widget.hbs
+++ b/static/templates/help_link_widget.hbs
@@ -1,0 +1,3 @@
+<a href="{{ link }}" target="_blank">
+    <i class="fa fa-question-circle-o" aria-hidden="true"></i>
+</a>

--- a/static/templates/settings/data_exports_admin.hbs
+++ b/static/templates/settings/data_exports_admin.hbs
@@ -1,8 +1,6 @@
 <div id="data-exports" class="settings-section" data-name="data-exports-admin">
     <h3>{{t "Data exports" }}
-        <a href="/help/export-your-organization" target="_blank">
-            <i class="fa fa-question-circle-o" aria-hidden="true"></i>
-        </a>
+        {{> ../help_link_widget link="/help/export-your-organization" }}
     </h3>
     <p>
         {{t 'Exports all users, settings, and all data visible in public streams.' }}

--- a/static/templates/settings/deactivated_users_admin.hbs
+++ b/static/templates/settings/deactivated_users_admin.hbs
@@ -1,8 +1,6 @@
 <div id="admin-deactivated-users-list" class="settings-section" data-name="deactivated-users-admin">
     <h3 class="inline-block">{{t "Deactivated users" }}
-        <a href="/help/deactivate-or-reactivate-a-user" target="_blank">
-            <i class="fa fa-question-circle-o" aria-hidden="true"></i>
-        </a>
+        {{> ../help_link_widget link="/help/deactivate-or-reactivate-a-user" }}
     </h3>
     <input type="text" class="search" placeholder="{{t 'Filter deactivated users' }}" aria-label="{{t 'Filter deactivated users' }}"/>
     <div class="alert-notification" id="deactivated-user-field-status"></div>

--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -31,9 +31,7 @@
 
             <div class="input-group">
                 <label for="demote_inactive_streams" class="dropdown-title">{{t "Demote inactive streams" }}
-                    <a href="/help/manage-inactive-streams" target="_blank">
-                        <i class="fa fa-question-circle-o" aria-hidden="true"></i>
-                    </a>
+                    {{> ../help_link_widget link="/help/manage-inactive-streams" }}
                 </label>
                 <select name="demote_inactive_streams" id="demote_inactive_streams">
                     {{> dropdown_options_widget option_values=demote_inactive_streams_values}}

--- a/static/templates/settings/organization_permissions_admin.hbs
+++ b/static/templates/settings/organization_permissions_admin.hbs
@@ -34,9 +34,7 @@
                 <div class="input-group">
                     <label for="realm_waiting_period_setting" class="dropdown-title">
                         {{t "Waiting period before new members turn into full members" }}
-                        <a href="/help/restrict-permissions-of-new-members" target="_blank">
-                            <i class="fa fa-question-circle-o" aria-hidden="true"></i>
-                        </a>
+                        {{> ../help_link_widget link="/help/restrict-permissions-of-new-members" }}
                     </label>
                     <select name="realm_waiting_period_setting" id="id_realm_waiting_period_setting" class="prop-element">
                         <option value="none">{{t "None" }}</option>
@@ -81,9 +79,7 @@
             </div>
             <div class="input-group">
                 <label for="realm_email_address_visibility">{{t "Who can access user email addresses" }}
-                    <a href="/help/restrict-visibility-of-email-addresses" target="_blank">
-                        <i class="fa fa-question-circle-o" aria-hidden="true"></i>
-                    </a>
+                    {{> ../help_link_widget link="/help/restrict-visibility-of-email-addresses" }}
                 </label>
                 <select name="realm_email_address_visibility" class="setting-widget prop-element" id="id_realm_email_address_visibility" data-setting-widget-type="number">
                     {{> dropdown_options_widget option_values=email_address_visibility_values}}
@@ -142,9 +138,7 @@
 
                 <div class="input-group">
                     <label for="realm_private_message_policy">{{t "Who can use private messages" }} ({{t "beta" }})
-                        <a href="/help/restrict-private-messages" target="_blank">
-                            <i class="fa fa-question-circle-o" aria-hidden="true"></i>
-                        </a>
+                        {{> ../help_link_widget link="/help/restrict-private-messages" }}
                     </label>
                     <select name="realm_private_message_policy" class="setting-widget prop-element" id="id_realm_private_message_policy" data-setting-widget-type="number">
                         {{> dropdown_options_widget option_values=private_message_policy_values}}

--- a/static/templates/settings/organization_profile_admin.hbs
+++ b/static/templates/settings/organization_profile_admin.hbs
@@ -5,9 +5,7 @@
         <div id="org-org-profile" class="org-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "Organization profile" }}
-                    <a href="/help/create-your-organization-profile" target="_blank">
-                        <i class="fa fa-question-circle-o" aria-hidden="true"></i>
-                    </a>
+                    {{> ../help_link_widget link="/help/create-your-organization-profile" }}
                 </h3>
                 {{> settings_save_discard_widget section_name="org-profile" }}
             </div>
@@ -54,9 +52,7 @@
 
         <div class="subsection-header">
             <h3>{{t "Organization logo" }}
-                <a href="/help/create-your-organization-profile#add-a-wide-logo" target="_blank">
-                    <i class="fa fa-question-circle-o" aria-hidden="true"></i>
-                </a>
+                {{> ../help_link_widget link="/help/create-your-organization-profile#add-a-wide-logo" }}
             </h3>
             {{> upgrade_tip_widget }}
         </div>

--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -4,9 +4,7 @@
         <div id="org-msg-editing" class="org-subsection-parent">
             <div class="subsection-header">
                 <h3>{{t "Message editing" }}
-                    <a href="/help/configure-message-editing-and-deletion" target="_blank">
-                        <i class="fa fa-question-circle-o" aria-hidden="true"></i>
-                    </a>
+                    {{> ../help_link_widget link="/help/configure-message-editing-and-deletion" }}
                 </h3>
                 {{> settings_save_discard_widget section_name="msg-editing" }}
             </div>

--- a/static/templates/settings/settings_checkbox.hbs
+++ b/static/templates/settings/settings_checkbox.hbs
@@ -8,9 +8,7 @@
     <label for="{{prefix}}{{setting_name}}" class="inline-block" id="{{prefix}}{{setting_name}}_label">
         {{{label}}}
         {{#if help_link}}
-        <a href="{{help_link}}" target="_blank">
-            <i class="fa fa-question-circle-o" aria-hidden="true"></i>
-        </a>
+        {{> ../help_link_widget link=help_link }}
         {{/if}}
     </label>
 </div>

--- a/static/templates/stream_types.hbs
+++ b/static/templates/stream_types.hbs
@@ -1,8 +1,6 @@
 <ul class="grey-box">
     <h4>{{t 'Who can access the stream?'}}
-        <a href="/help/stream-permissions" target="_blank">
-            <i class="fa fa-question-circle-o" aria-hidden="true"></i>
-        </a>
+        {{> help_link_widget link="/help/stream-permissions" }}
     </h4>
     <li>
         <label class="radio">
@@ -23,9 +21,7 @@
         </label>
     </li>
     <h4>{{t 'Who can post to the stream?'}}
-        <a href="/help/stream-sending-policy" target="_blank">
-            <i class="fa fa-question-circle-o" aria-hidden="true"></i>
-        </a>
+        {{> help_link_widget link="/help/stream-sending-policy" }}
     </h4>
     {{#each stream_post_policy_values}}
     <li>

--- a/static/templates/subscription_settings.hbs
+++ b/static/templates/subscription_settings.hbs
@@ -64,14 +64,14 @@
                     </li>
                 </ul>
             </div>
-            <div class="stream-email-box" {{#unless sub.email_address}}style="display: none;"{{/unless}}>
-                <label class="sub_settings_title">
-                    {{t "Email address" }}
-                    {{> help_link_widget link="/help/message-a-stream-by-email" }}
-                </label>
-                <div class="stream-email">
-                    <span class="email-address">{{sub.email_address}}</span>
-                </div>
+        </div>
+        <div class="stream-email-box" {{#unless sub.email_address}}style="display: none;"{{/unless}}>
+            <label class="sub_settings_title">
+                {{t "Email address" }}
+                {{> help_link_widget link="/help/message-a-stream-by-email" }}
+            </label>
+            <div class="stream-email">
+                <span class="email-address">{{sub.email_address}}</span>
             </div>
         </div>
         {{#with sub}}

--- a/static/templates/subscription_settings.hbs
+++ b/static/templates/subscription_settings.hbs
@@ -1,6 +1,7 @@
 <div class="subscription_settings" data-stream-id="{{sub.stream_id}}">
     <div class="inner-box">
         <div class="alert stream_change_property_info"></div>
+
         {{#with sub}}
         <div class="stream-header">
             {{> subscription_privacy
@@ -13,7 +14,6 @@
                 <span class="checkmark" data-finish-editing=".stream-name-editable">✓</span>
                 {{/if}}
             </div>
-            <div id="stream_change_property_status{{stream_id}}" class="alert-notification"></div>
             <div class="button-group">
                 {{#if is_admin}}
                 <button class="button small rounded btn-danger deactivate" type="button" name="delete_button" title="{{t 'Delete stream'}}"> <i class="fa fa-trash-o" aria-hidden="true"></i></button>
@@ -40,10 +40,14 @@
             <a class="change-stream-privacy" {{#unless can_change_stream_permissions}}style="display: none;"{{/unless}}>[{{t "Change" }}]</a>
         </div>
         {{/with}}
+
         <div class="regular_subscription_settings collapse {{#sub.subscribed}}in{{/sub.subscribed}}">
-            <label class="sub_settings_title">
-                {{t "Personal settings" }}
-            </label>
+            <div id="personal_settings_label_container">
+                <label class="sub_settings_title inline-block">
+                    {{t "Personal settings" }}
+                </label>
+                <div id="stream_change_property_status{{sub.stream_id}}" class="alert-notification"></div>
+            </div>
             <div class="subscription-config">
                 <ul class="grey-box">
                     {{#each settings}}

--- a/static/templates/subscription_settings.hbs
+++ b/static/templates/subscription_settings.hbs
@@ -67,9 +67,7 @@
             <div class="stream-email-box" {{#unless sub.email_address}}style="display: none;"{{/unless}}>
                 <label class="sub_settings_title">
                     {{t "Email address" }}
-                    <a href="/help/message-a-stream-by-email" target="_blank">
-                        <i class="fa fa-question-circle-o" aria-hidden="true"></i>
-                    </a>
+                    {{> help_link_widget link="/help/message-a-stream-by-email" }}
                 </label>
                 <div class="stream-email">
                     <span class="email-address">{{sub.email_address}}</span>

--- a/static/templates/subscription_settings.hbs
+++ b/static/templates/subscription_settings.hbs
@@ -41,6 +41,9 @@
         </div>
         {{/with}}
         <div class="regular_subscription_settings collapse {{#sub.subscribed}}in{{/sub.subscribed}}">
+            <label class="sub_settings_title">
+                {{t "Personal settings" }}
+            </label>
             <div class="subscription-config">
                 <ul class="grey-box">
                     {{#each settings}}


### PR DESCRIPTION
Rather than showing the "Saving" widget beside stream name, it's more
intuitive to have it in personal settings section because it's the only
section which uses `settings_ui.do_settings_change` function and we follow
having a separate "Saving" widget for each section everywhere.
[Part of the discussion at czo](https://chat.zulip.org/#narrow/stream/6-frontend/topic/stream.20settings/near/862385)
![Peek 2020-05-24 18-59](https://user-images.githubusercontent.com/40331304/82755388-c588a500-9df0-11ea-9f57-4df5221c7b4f.gif)
This PR also has few unrelated commits which can be merged if it makes sense.