### PR TITLE
Avoid accidental message controls click on mobile web

### DIFF
--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -9,6 +9,7 @@ zrequire('buddy_data');
 zrequire('user_status');
 zrequire('feature_flags');
 zrequire('message_edit');
+zrequire('click_handlers');
 
 const noop =  function () {};
 $.fn.popover = noop; // this will get wrapped by our code

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -4,6 +4,13 @@ const util = require("./util");
 const render_buddy_list_tooltip = require('../templates/buddy_list_tooltip.hbs');
 const render_buddy_list_tooltip_content = require('../templates/buddy_list_tooltip_content.hbs');
 
+// On touchscreens, if the message control buttons are not visible,
+// a single click on a message box shouldn't trigger their click
+// listeners. Following two values check whether the buttons are
+// visible to users once a messagebox `touchstart` event is fired.
+let is_star_clickable = true;
+exports.are_msg_controls_clickable = true;
+
 exports.initialize = function () {
 
     // MESSAGE CLICKING
@@ -23,6 +30,8 @@ exports.initialize = function () {
         };
 
         $("#main_div").on("touchstart", ".messagebox", function () {
+            is_star_clickable = $(this).find('.star').css('pointer-events') !== 'none' || !util.is_mobile;
+            exports.are_msg_controls_clickable = $(this).find('.actions_hover').css('pointer-events') !== 'none' || !util.is_mobile;
             meta.touchdown = true;
             meta.invalid = false;
             const id = rows.id($(this).closest(".message_row"));
@@ -128,6 +137,9 @@ exports.initialize = function () {
     }
 
     $("#main_div").on("click", ".star", function (e) {
+        if (!is_star_clickable) {
+            return;
+        }
         e.stopPropagation();
         popovers.hide_all();
 
@@ -237,6 +249,9 @@ exports.initialize = function () {
     // MESSAGE EDITING
 
     $('body').on('click', '.edit_content_button', function (e) {
+        if (!exports.are_msg_controls_clickable) {
+            return;
+        }
         const row = current_msg_list.get_row(rows.id($(this).closest(".message_row")));
         current_msg_list.select_id(rows.id(row));
         message_edit.start(row);

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -658,6 +658,9 @@ exports.register_click_handlers = function () {
     });
 
     $("#main_div").on("click", ".reaction_button", function (e) {
+        if (!click_handlers.are_msg_controls_clickable) {
+            return;
+        }
         e.stopPropagation();
 
         const message_id = rows.get_message_id(this);

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -716,6 +716,9 @@ exports.set_suppress_scroll_hide = function () {
 
 exports.register_click_handlers = function () {
     $("#main_div").on("click", ".actions_hover", function (e) {
+        if (!click_handlers.are_msg_controls_clickable) {
+            return;
+        }
         const row = $(this).closest(".message_row");
         e.stopPropagation();
         exports.toggle_actions_popover(this, rows.id(row));


### PR DESCRIPTION
On touchscreens, if the message control buttons are not visible, a single click on a message box shouldn't trigger their click listeners. This commit checks whether the buttons are visible to users once a messagebox `touchstart` event is fired. If the buttons are not visible and a user clicks that area, the click events are just ignored.

Fixes #13642.
