### PR TITLE
Flatpickr Changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "postcss-simple-vars": "^5.0.2",
     "regenerator-runtime": "^0.13.3",
     "rewiremock": "^3.13.9",
+    "sass": "^1.26.5",
+    "sass-loader": "^8.0.2",
     "script-loader": "^0.7.2",
     "shebang-loader": "^0.0.1",
     "simplebar": "^5.0.7",

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -1,6 +1,10 @@
+@use "static/third/flatpickr/flatpickr.scss" as flatpickr;
+
 body.night-mode {
     background-color: hsl(212, 28%, 18%);
     color: hsl(236, 33%, 90%);
+
+    @include flatpickr.night;
 
     a:hover {
         color: hsl(200, 79%, 66%);

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2518,9 +2518,24 @@ select.inline_select_topic_edit {
     margin: 0;
 }
 
-// Hide the up and down arrows in the Flatpickr datepicker year
-.flatpickr-months .numInputWrapper span {
-    display: none;
+.flatpickr-calendar {
+    .numInputWrapper {
+        margin-left: 5px;
+        margin-right: 5px;
+
+        // Override background from flatpickr's theme.
+        &:hover {
+            background-color: transparent !important;
+        }
+
+        // Hide the up and down arrows in the Flatpickr datepicker year
+        span {
+            display: none;
+        }
+        input {
+            margin: 0;
+        }
+    }
 }
 
 /* This max-width must be synced with message_viewport.is_narrow */

--- a/static/third/flatpickr/flatpickr.scss
+++ b/static/third/flatpickr/flatpickr.scss
@@ -1,0 +1,265 @@
+/*
+    flatpickr.scss
+
+    This file contains night-mode theme for flatpickr. We leverage the flatpickr
+    project's work to generate themes cleanly. However, since they use stylus as
+    their CSS langauge, our systems aren't directly compatible.
+
+    We build this file by running:
+
+    $ git clone git@github.com:aero31aero/flatpickr.git
+    $ cd flatpickr
+    $ git checkout zulip
+    $ npm install
+    $ npm run build
+    $ # This file has been generated at dist/themes/zulip-dark.scss.
+    $ cp dist/themes/zulip-dark.scss ../zulip/static/third/flatpickr/flatpickr.scss
+
+    This is somewhat convoluted and we should decide on a better strategy, or just
+    roll our own theme, but this method allows us to stay up-to-date with upstream.
+
+    Theme built for flatpickr version: 4.6.4
+*/
+
+@mixin night {
+    .flatpickr-calendar {
+        background-color: hsla(0, 0%, 0%, 0);
+        border-color: hsl(0, 0%, 0%);
+        background-color: hsl(212, 28%, 18%);
+        box-shadow: 1px 0 0 #20222c, -1px 0 0 #20222c, 0 1px 0 #20222c, 0 -1px 0 #20222c, 0 3px 13px rgba(0,0,0,0.08);
+    }
+    .flatpickr-calendar.multiMonth .flatpickr-days .dayContainer:nth-child(n+2) .flatpickr-day.inRange:nth-child(7n+1) {
+        box-shadow: -2px 0 0 #e6e6e6, 5px 0 0 #e6e6e6;
+    }
+    .flatpickr-calendar .hasWeeks .dayContainer,
+    .flatpickr-calendar .hasTime .dayContainer {
+        border-bottom-color: hsl(0, 0%, 0%);
+    }
+    .flatpickr-calendar .hasWeeks .dayContainer {
+        border-left-color: hsl(0, 0%, 0%);
+    }
+    .flatpickr-calendar.showTimeInput.hasTime .flatpickr-time {
+        border-top-color: hsl(230, 16%, 15%);
+    }
+    .flatpickr-calendar:before,
+    .flatpickr-calendar:after {
+        border-color: hsla(0, 0%, 0%, 0);
+    }
+    .flatpickr-calendar.arrowTop:before {
+        border-bottom-color: #20222c;
+    }
+    .flatpickr-calendar.arrowTop:after {
+        border-bottom-color: #212d3b;
+    }
+    .flatpickr-calendar.arrowBottom:before {
+        border-top-color: #20222c;
+    }
+    .flatpickr-calendar.arrowBottom:after {
+        border-top-color: #212d3b;
+    }
+    .flatpickr-calendar:focus {
+        outline-color: hsl(0, 0%, 0%);
+    }
+    .flatpickr-months .flatpickr-month {
+        background-color: hsl(212, 28%, 18%);
+        color: #dddeee;
+    }
+    .flatpickr-months .flatpickr-prev-month,
+    .flatpickr-months .flatpickr-next-month {
+        color: #dddeee;
+    }
+    .flatpickr-months .flatpickr-prev-month:hover,
+    .flatpickr-months .flatpickr-next-month:hover {
+        color: #dedfed;
+    }
+    .numInputWrapper span {
+        border-color: hsla(0, 0%, 100%, 0.15);
+    }
+    .numInputWrapper span:hover {
+        background-color: hsla(0, 0%, 82%, 0.1);
+    }
+    .numInputWrapper span:active {
+        background-color: hsla(0, 0%, 82%, 0.2);
+    }
+    .numInputWrapper span.arrowUp {
+        border-bottom-color: hsl(0, 0%, 0%);
+    }
+    .numInputWrapper span.arrowUp:after {
+        border-left-color: hsla(0, 0%, 0%, 0);
+        border-right-color: hsla(0, 0%, 0%, 0);
+        border-bottom-color: hsla(0, 0%, 100%, 0.6);
+    }
+    .numInputWrapper span.arrowDown:after {
+        border-left-color: hsla(0, 0%, 0%, 0);
+        border-right-color: hsla(0, 0%, 0%, 0);
+        border-top-color: hsla(0, 0%, 100%, 0.6);
+    }
+    .numInputWrapper:hover {
+        background-color: hsla(0, 0%, 82%, 0.05);
+    }
+    .flatpickr-current-month span.cur-month:hover {
+        background-color: hsla(0, 0%, 82%, 0.05);
+    }
+    .flatpickr-current-month .numInputWrapper span.arrowUp:after {
+        border-bottom-color: #dddeee;
+    }
+    .flatpickr-current-month .numInputWrapper span.arrowDown:after {
+        border-top-color: #dddeee;
+    }
+    .flatpickr-current-month input.cur-year {
+        background-color: hsla(0, 0%, 0%, 0);
+        border-color: hsl(0, 0%, 0%);
+    }
+    .flatpickr-current-month input.cur-year:focus {
+        outline-color: hsl(0, 0%, 0%);
+    }
+    .flatpickr-current-month input.cur-year[disabled],
+    .flatpickr-current-month input.cur-year[disabled]:hover {
+        color: rgba(221,222,238,0.5);
+        background-color: hsla(0, 0%, 0%, 0);
+    }
+    .flatpickr-current-month .flatpickr-monthDropdown-months {
+        background-color: hsl(212, 28%, 18%);
+    }
+    .flatpickr-current-month .flatpickr-monthDropdown-months:hover {
+        background-color: hsla(0, 0%, 82%, 0.05);
+    }
+    .flatpickr-current-month .flatpickr-monthDropdown-months .flatpickr-monthDropdown-month {
+        background-color: #212d3b;
+    }
+    .flatpickr-weekdays {
+        background-color: hsla(0, 0%, 0%, 0);
+    }
+    span.flatpickr-weekday {
+        background-color: hsl(212, 28%, 18%);
+        color: #dddeee;
+    }
+    .flatpickr-days:focus {
+        outline-color: hsl(0, 0%, 0%);
+    }
+    .dayContainer {
+        outline-color: hsl(0, 0%, 0%);
+    }
+    .dayContainer + .dayContainer {
+        box-shadow: -1px 0 0 #20222c;
+    }
+    .flatpickr-day {
+        border-color: hsla(0, 0%, 0%, 0);
+        color: rgba(255,255,255,0.95);
+    }
+    .flatpickr-day.inRange,
+    .flatpickr-day.prevMonthDay.inRange,
+    .flatpickr-day.nextMonthDay.inRange,
+    .flatpickr-day.today.inRange,
+    .flatpickr-day.prevMonthDay.today.inRange,
+    .flatpickr-day.nextMonthDay.today.inRange,
+    .flatpickr-day:hover,
+    .flatpickr-day.prevMonthDay:hover,
+    .flatpickr-day.nextMonthDay:hover,
+    .flatpickr-day:focus,
+    .flatpickr-day.prevMonthDay:focus,
+    .flatpickr-day.nextMonthDay:focus {
+        outline-color: hsl(0, 0%, 0%);
+        background-color: hsl(213, 28%, 39%);
+        border-color: #47607e;
+    }
+    .flatpickr-day.today {
+        border-color: #dedfed;
+    }
+    .flatpickr-day.today:hover,
+    .flatpickr-day.today:focus {
+        border-color: #dedfed;
+        background-color: hsl(236, 29%, 90%);
+        color: #121d26;
+    }
+    .flatpickr-day.selected,
+    .flatpickr-day.startRange,
+    .flatpickr-day.endRange,
+    .flatpickr-day.selected.inRange,
+    .flatpickr-day.startRange.inRange,
+    .flatpickr-day.endRange.inRange,
+    .flatpickr-day.selected:focus,
+    .flatpickr-day.startRange:focus,
+    .flatpickr-day.endRange:focus,
+    .flatpickr-day.selected:hover,
+    .flatpickr-day.startRange:hover,
+    .flatpickr-day.endRange:hover,
+    .flatpickr-day.selected.prevMonthDay,
+    .flatpickr-day.startRange.prevMonthDay,
+    .flatpickr-day.endRange.prevMonthDay,
+    .flatpickr-day.selected.nextMonthDay,
+    .flatpickr-day.startRange.nextMonthDay,
+    .flatpickr-day.endRange.nextMonthDay {
+        background-color: hsla(0, 0%, 0%, 0.5);
+        color: #fff;
+        border-color: rgba(0,0,0,0.5);
+    }
+    .flatpickr-day.selected.startRange + .endRange:not(:nth-child(7n+1)),
+    .flatpickr-day.startRange.startRange + .endRange:not(:nth-child(7n+1)),
+    .flatpickr-day.endRange.startRange + .endRange:not(:nth-child(7n+1)) {
+        box-shadow: -10px 0 0 rgba(0,0,0,0.5);
+    }
+    .flatpickr-day.inRange {
+        box-shadow: -5px 0 0 #47607e, 5px 0 0 #47607e;
+    }
+    .flatpickr-day.flatpickr-disabled,
+    .flatpickr-day.flatpickr-disabled:hover,
+    .flatpickr-day.prevMonthDay,
+    .flatpickr-day.nextMonthDay,
+    .flatpickr-day.notAllowed,
+    .flatpickr-day.notAllowed.prevMonthDay,
+    .flatpickr-day.notAllowed.nextMonthDay {
+        color: rgba(255,255,255,0.3);
+        background-color: hsla(0, 0%, 0%, 0);
+        border-color: transparent;
+    }
+    .flatpickr-day.flatpickr-disabled,
+    .flatpickr-day.flatpickr-disabled:hover {
+        color: rgba(255,255,255,0.1);
+    }
+    .flatpickr-day.week.selected {
+        box-shadow: -5px 0 0 rgba(0,0,0,0.5), 5px 0 0 rgba(0,0,0,0.5);
+    }
+    .flatpickr-weekwrapper .flatpickr-weeks {
+        box-shadow: 1px 0 0 #20222c;
+    }
+    .flatpickr-weekwrapper span.flatpickr-day,
+    .flatpickr-weekwrapper span.flatpickr-day:hover {
+        color: rgba(255,255,255,0.3);
+        background-color: hsla(0, 0%, 0%, 0);
+    }
+    .flatpickr-time {
+        outline-color: hsl(0, 0%, 0%);
+    }
+    .flatpickr-time .numInputWrapper span.arrowUp:after {
+        border-bottom-color: rgba(255,255,255,0.95);
+    }
+    .flatpickr-time .numInputWrapper span.arrowDown:after {
+        border-top-color: rgba(255,255,255,0.95);
+    }
+    .flatpickr-time input {
+        background-color: hsla(0, 0%, 0%, 0);
+        border-color: hsl(0, 0%, 0%);
+        color: rgba(255,255,255,0.95);
+    }
+    .flatpickr-time input:focus {
+        outline-color: hsl(0, 0%, 0%);
+        border-color: hsl(0, 0%, 0%);
+    }
+    .flatpickr-time .flatpickr-time-separator,
+    .flatpickr-time .flatpickr-am-pm {
+        color: rgba(255,255,255,0.95);
+    }
+    .flatpickr-time .flatpickr-am-pm {
+        outline-color: hsl(0, 0%, 0%);
+    }
+    .flatpickr-time input:hover,
+    .flatpickr-time .flatpickr-am-pm:hover,
+    .flatpickr-time input:focus,
+    .flatpickr-time .flatpickr-am-pm:focus {
+        background-color: hsl(214, 28%, 42%);
+    }
+    .flatpickr-calendar {
+        box-shadow: 0px 0px 30px #0c1118;
+    }
+}

--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -83,7 +83,10 @@ export default (env?: string): webpack.Configuration[] => {
                 // scss loader
                 {
                     test: /\.scss$/,
-                    include: resolve(__dirname, '../static/styles'),
+                    include: [
+                        resolve(__dirname, '../static/styles'),
+                        resolve(__dirname, '../static/third'),
+                    ],
                     use: [
                         {
                             loader: MiniCssExtractPlugin.loader,

--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -95,7 +95,14 @@ export default (env?: string): webpack.Configuration[] => {
                         {
                             loader: 'css-loader',
                             options: {
-                                importLoaders: 1,
+                                importLoaders: 2,
+                                sourceMap: true,
+                            },
+                        },
+                        {
+                            loader: 'sass-loader',
+                            options: {
+                                implementation: require('sass'),
                                 sourceMap: true,
                             },
                         },

--- a/version.py
+++ b/version.py
@@ -44,4 +44,4 @@ API_FEATURE_LEVEL = 6
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '82.3'
+PROVISION_VERSION = '82.4'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1807,6 +1807,14 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
+anymatch@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
+  integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
 append-transform@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-2.0.0.tgz#99d9d29c7b38391e6f428d28ce136551f0b77e12"
@@ -2129,6 +2137,11 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
+binary-extensions@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
+  integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
+
 binary-search-bounds@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz#323ca317e3f2a40f4244c7255f5384a5b207bb69"
@@ -2267,7 +2280,7 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@^3.0.1:
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -2697,6 +2710,21 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+"chokidar@>=2.0.0 <4.0.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.0.tgz#b30611423ce376357c765b9b8f904b9fba3c0be8"
+  integrity sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.4.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
+
 chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -2847,6 +2875,15 @@ cliui@^6.0.0:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
+
+clone-deep@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz#c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"
+  integrity sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==
+  dependencies:
+    is-plain-object "^2.0.4"
+    kind-of "^6.0.2"
+    shallow-clone "^3.0.0"
 
 clone-regexp@^2.1.0:
   version "2.2.0"
@@ -5050,6 +5087,11 @@ fsevents@^1.2.7:
     bindings "^1.5.0"
     nan "^2.12.1"
 
+fsevents@~2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
+  integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
+
 function-bind@^1.1.1, function-bind@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -5556,7 +5598,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@^5.0.0, glob-parent@^5.1.0:
+glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
@@ -6497,6 +6539,13 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
+
 is-blob@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-blob/-/is-blob-2.1.0.tgz#e36cd82c90653f1e1b930f11baf9c64216a05385"
@@ -6637,7 +6686,7 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
-is-glob@^4.0.0, is-glob@^4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
@@ -8203,7 +8252,7 @@ normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
-normalize-path@^3.0.0:
+normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -8913,7 +8962,7 @@ pick-by-alias@^1.2.0:
   resolved "https://registry.yarnpkg.com/pick-by-alias/-/pick-by-alias-1.2.0.tgz#5f7cb2b1f21a6e1e884a0c87855aa4a37361107b"
   integrity sha1-X3yysfIabh6ISgyHhVqko3NhEHs=
 
-picomatch@^2.0.5, picomatch@^2.2.1:
+picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
@@ -9916,6 +9965,13 @@ readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
+readdirp@~3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.4.0.tgz#9fdccdf9e9155805449221ac645e8303ab5b9ada"
+  integrity sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==
+  dependencies:
+    picomatch "^2.2.1"
+
 redent@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
@@ -10585,6 +10641,24 @@ sane-topojson@^4.0.0:
   resolved "https://registry.yarnpkg.com/sane-topojson/-/sane-topojson-4.0.0.tgz#624cdb26fc6d9392c806897bfd1a393f29bb5308"
   integrity sha512-bJILrpBboQfabG3BNnHI2hZl52pbt80BE09u4WhnrmzuF2JbMKZdl62G5glXskJ46p+gxE2IzOwGj/awR4g8AA==
 
+sass-loader@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-8.0.2.tgz#debecd8c3ce243c76454f2e8290482150380090d"
+  integrity sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==
+  dependencies:
+    clone-deep "^4.0.1"
+    loader-utils "^1.2.3"
+    neo-async "^2.6.1"
+    schema-utils "^2.6.1"
+    semver "^6.3.0"
+
+sass@^1.26.5:
+  version "1.26.5"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.26.5.tgz#2d7aecfbbabfa298567c8f06615b6e24d2d68099"
+  integrity sha512-FG2swzaZUiX53YzZSjSakzvGtlds0lcbF+URuU9mxOv7WBh7NhXEVDa4kPKN4hN6fC2TkOTOKqiqp6d53N9X5Q==
+  dependencies:
+    chokidar ">=2.0.0 <4.0.0"
+
 sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -10606,7 +10680,7 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.0.0, schema-utils@^2.6.4, schema-utils@^2.6.5:
+schema-utils@^2.0.0, schema-utils@^2.6.1, schema-utils@^2.6.4, schema-utils@^2.6.5:
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.6.tgz#299fe6bd4a3365dc23d99fd446caff8f1d6c330c"
   integrity sha512-wHutF/WPSbIi9x6ctjGGk2Hvl0VOz5l3EKEuKbjPlB30mKZUzb9A5k9yEXRX3pwyqVLPvpfZZEllaFq/M718hA==
@@ -10747,6 +10821,13 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+shallow-clone@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.1.tgz#8f2981ad92531f55035b01fb230769a40e02efa3"
+  integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
+  dependencies:
+    kind-of "^6.0.2"
 
 shallow-copy@0.0.1, shallow-copy@~0.0.1:
   version "0.0.1"


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR fixes some of our really jarring issues with Flatpickr styling.

In order to not maintain flatpickr styles ourselves, we fork upstream to add a theme with our nightmode colors in it: https://github.com/aero31aero/flatpickr .

Also, we add sass-loader to our webpack pipeline, which should enable us to use a lot of sass features we currently do not use.

**Testing Plan:** <!-- How have you tested? -->
Manual testing

**GIFs or Screenshots:**
We go from:

![image](https://user-images.githubusercontent.com/8033238/82803126-9ed47800-9e9d-11ea-930c-aa2a4d7a0ee1.png)

to:

![image](https://user-images.githubusercontent.com/8033238/82803149-a5fb8600-9e9d-11ea-95cc-599b8d419733.png)
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
