### PR TITLE
add streams:Fix Add stream button position

### DIFF
--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -42,7 +42,8 @@ function get_new_heights() {
         - parseInt($(".narrows_panel").css("marginTop"), 10)
         - parseInt($(".narrows_panel").css("marginBottom"), 10)
         - $("#global_filters").safeOuterHeight(true)
-        - $("#streams_header").safeOuterHeight(true);
+        - $("#streams_header").safeOuterHeight(true)
+        - $('#add-stream-link').safeOuterHeight(true);
 
     // Don't let us crush the stream sidebar completely out of view
     res.stream_filters_max_height = Math.max(80, res.stream_filters_max_height);
@@ -89,6 +90,7 @@ function left_userlist_get_new_heights() {
                                 - $("#global_filters").safeOuterHeight(true)
                                 - $("#streams_header").safeOuterHeight(true)
                                 - $("#userlist-header").safeOuterHeight(true)
+                                - $('#add-stream-link').safeOuterHeight(true)
                                 - $("#user_search_section").safeOuterHeight(true)
                                 - parseInt(stream_filters.css("marginBottom"), 10);
 

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -178,7 +178,8 @@ li.show-more-topics {
 #add-stream-link {
     text-decoration: none;
     margin-left: 10px;
-    margin-bottom: 18px;
+    margin-top: 10px;
+    margin-bottom: 40px;
     i {
         min-width: 19px;
         text-align: center;

--- a/templates/zerver/app/left_sidebar.html
+++ b/templates/zerver/app/left_sidebar.html
@@ -74,12 +74,12 @@
             </div>
             <div id="stream-filters-container" class="scrolling_list" data-simplebar>
                 <ul id="stream_filters" class="filters"></ul>
-                {% if show_add_streams %}
-                <div id="add-stream-link">
-                    <a href="#streams/all"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{ _('Add streams') }}</a>
-                </div>
-                {% endif %}
             </div>
         </div>
+        {% if show_add_streams %}
+        <div id="add-stream-link">
+            <a href="#streams/all"><i class="fa fa-plus-circle" aria-hidden="true"></i>{{ _('Add streams') }}</a>
+        </div>
+        {% endif %}
     </div>
 </div>


### PR DESCRIPTION
The Add stream button will scroll along with the streams if a user
have many streams subscribed
So make a fixed Add stream button and allow only streams to scroll.

![Screenshot from 2020-06-29 13-32-53](https://user-images.githubusercontent.com/23723464/85988765-28331900-ba0d-11ea-8028-06d0ede26fe3.png)

fixes: #15040


