### PR TITLE
rate_limit: Restrict tornado backend to explicitly specified domains.

### DIFF
--- a/zerver/tests/test_rate_limiter.py
+++ b/zerver/tests/test_rate_limiter.py
@@ -184,8 +184,12 @@ class TornadoInMemoryRateLimiterBackendTest(RateLimiterBackendBase):
     def test_used_in_tornado(self) -> None:
         user_profile = self.example_user("hamlet")
         with self.settings(RUNNING_INSIDE_TORNADO=True):
-            obj = RateLimitedUser(user_profile)
+            obj = RateLimitedUser(user_profile, domain='api_by_user')
         self.assertEqual(obj.backend, TornadoInMemoryRateLimiterBackend)
+
+        with self.settings(RUNNING_INSIDE_TORNADO=True):
+            obj = RateLimitedUser(user_profile, domain='some_domain')
+        self.assertEqual(obj.backend, RedisRateLimiterBackend)
 
     def test_block_access(self) -> None:
         obj = self.create_object('test', [(2, 5), ])

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -367,6 +367,13 @@ RATE_LIMITING_RULES = {
     ],
 }
 
+# List of domains that, when applied to a request in a Tornado process,
+# will be handled with the separate in-memory rate limiting backend for Tornado,
+# which has its own buckets separate from the default backend.
+# In principle, it should be impossible to make requests to tornado that fall into
+# other domains, but we use this list as an extra precaution.
+RATE_LIMITING_DOMAINS_FOR_TORNADO = ['api_by_user']
+
 RATE_LIMITING_MIRROR_REALM_RULES = [
     (60, 50),  # 50 emails per minute
     (300, 120),  # 120 emails per 5 minutes


### PR DESCRIPTION
This addresses the 2nd point from https://github.com/zulip/zulip/pull/14091#issuecomment-614202868

This will protect in case of some kinds of bugs that could allow making
requests such as password authentication attempts to tornado. Without
restricting the domains to which the in-memory backend can be applied,
such bugs would lead to attackers having multiple times larger rate
limits for these sensitive requests.
