### PR TITLE
requirements: Drop direct dependency on mock

### DIFF
--- a/analytics/management/commands/populate_analytics_db.py
+++ b/analytics/management/commands/populate_analytics_db.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Any, Dict, List, Mapping, Optional, Type
 
-import mock
+from unittest import mock
 from django.core.management.base import BaseCommand
 from django.utils.timezone import now as timezone_now
 

--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple, Type
 
-import mock
+from unittest import mock
 import ujson
 from django.apps import apps
 from django.db import models

--- a/analytics/tests/test_views.py
+++ b/analytics/tests/test_views.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from typing import List, Optional
 
-import mock
+from unittest import mock
 from django.utils.timezone import utc
 from django.http import HttpResponse
 import ujson

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -54,7 +54,7 @@ if settings.ZILENCER_ENABLED:
     from zilencer.models import RemoteInstallationCount, RemoteRealmCount, \
         RemoteZulipServer
 else:
-    from mock import Mock
+    from unittest.mock import Mock
     RemoteInstallationCount = Mock()  # type: ignore[misc] # https://github.com/JukkaL/mypy/issues/1188
     RemoteZulipServer = Mock()  # type: ignore[misc] # https://github.com/JukkaL/mypy/issues/1188
     RemoteRealmCount = Mock()  # type: ignore[misc] # https://github.com/JukkaL/mypy/issues/1188

--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from decimal import Decimal
 from functools import wraps
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import operator
 import os
 import re

--- a/requirements/common.in
+++ b/requirements/common.in
@@ -68,9 +68,6 @@ PyJWT
 # Needed for including other markdown files for user docs
 markdown-include
 
-# Needed for mock objects in decorators
-mock
-
 # Needed to access rabbitmq
 pika
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -539,7 +539,7 @@ matrix-client==0.3.2 \
 mock==3.0.5 \
     --hash=sha256:83657d894c90d5681d62155c82bda9c1187827525880eda8ff5df4ec813437c3 \
     --hash=sha256:d157e52d4e5b938c550f39eb2fd15610db062441a9c2747d3dbfa9298211d0f8 \
-    # via -r requirements/common.in, moto
+    # via moto
 moto==1.3.14 \
     --hash=sha256:2b3fa22778504b45715868cad95ad458fdea7227f9005b12e522fc9c2ae0cabc \
     --hash=sha256:79aeaeed1592a24d3c488840065a3fcb3f4fa7ba40259e112482454c0e48a03a \

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -379,10 +379,6 @@ matrix-client==0.3.2 \
     --hash=sha256:2855a2614a177db66f9bc3ba38cbd2876041456f663c334f72a160ab6bb11c49 \
     --hash=sha256:dce3ccb8665df0d519f08e07a16e6d3f9fab3a947df4b7a7c4bb26573d68f2d5 \
     # via zulip
-mock==3.0.5 \
-    --hash=sha256:83657d894c90d5681d62155c82bda9c1187827525880eda8ff5df4ec813437c3 \
-    --hash=sha256:d157e52d4e5b938c550f39eb2fd15610db062441a9c2747d3dbfa9298211d0f8 \
-    # via -r requirements/common.in
 oauthlib==3.1.0 \
     --hash=sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889 \
     --hash=sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea \
@@ -581,7 +577,7 @@ requests[security]==2.23.0 \
 six==1.14.0 \
     --hash=sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a \
     --hash=sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c \
-    # via -r requirements/common.in, argon2-cffi, cryptography, django-bitfield, hypchat, isodate, libthumbor, mock, prompt-toolkit, pyopenssl, python-dateutil, qrcode, social-auth-app-django, social-auth-core, talon, traitlets, twilio, zulip
+    # via -r requirements/common.in, argon2-cffi, cryptography, django-bitfield, hypchat, isodate, libthumbor, prompt-toolkit, pyopenssl, python-dateutil, qrcode, social-auth-app-django, social-auth-core, talon, traitlets, twilio, zulip
 social-auth-app-django==3.1.0 \
     --hash=sha256:6d0dd18c2d9e71ca545097d57b44d26f59e624a12833078e8e52f91baf849778 \
     --hash=sha256:9237e3d7b6f6f59494c3b02e0cce6efc69c9d33ad9d1a064e3b2318bcbe89ae3 \

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -8,7 +8,7 @@ from typing import List, Iterator
 import glob
 import argparse
 import contextlib
-import mock
+from unittest import mock
 import os
 import shlex
 import sys

--- a/tools/tests/test_check_rabbitmq_queue.py
+++ b/tools/tests/test_check_rabbitmq_queue.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from unittest import TestCase
 
 from scripts.lib.check_rabbitmq_queue import (

--- a/tools/tests/test_zulint_custom_rules.py
+++ b/tools/tests/test_zulint_custom_rules.py
@@ -1,6 +1,6 @@
 import os
 
-from mock import patch
+from unittest.mock import patch
 from unittest import TestCase
 
 from zulint.custom_rules import RuleList

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -47,7 +47,7 @@ from zerver.lib.logging_util import log_to_file
 if settings.ZILENCER_ENABLED:
     from zilencer.models import get_remote_server_by_uuid, RemoteZulipServer
 else:  # nocoverage # Hack here basically to make impossible code paths compile
-    from mock import Mock
+    from unittest.mock import Mock
     get_remote_server_by_uuid = Mock()
     RemoteZulipServer = Mock()  # type: ignore[misc] # https://github.com/JukkaL/mypy/issues/1188
 

--- a/zerver/lib/dev_ldap_directory.py
+++ b/zerver/lib/dev_ldap_directory.py
@@ -58,7 +58,7 @@ def init_fakeldap(directory: Optional[Dict[str, Dict[str, List[str]]]]=None) -> 
     # avoids the expensive import of the mock module (slow
     # because its dependency pbr uses pkgresources, which is
     # really slow to import.)
-    import mock
+    from unittest import mock
     from fakeldap import MockLDAP
 
     # Silent `django_auth_ldap` logger in dev mode to avoid

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 if settings.ZILENCER_ENABLED:
     from zilencer.models import RemotePushDeviceToken
 else:  # nocoverage  -- Not convenient to add test for this.
-    from mock import Mock
+    from unittest.mock import Mock
     RemotePushDeviceToken = Mock()  # type: ignore[misc] # https://github.com/JukkaL/mypy/issues/1188
 
 DeviceToken = Union[PushDeviceToken, RemotePushDeviceToken]

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -68,7 +68,7 @@ from zerver.decorator import do_two_factor_login
 from zerver.tornado.event_queue import clear_client_event_queues_for_testing
 
 import base64
-import mock
+from unittest import mock
 import os
 import re
 import ujson

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     from zerver.lib.test_classes import ZulipTestCase, MigrationsTestCase
 
 import collections
-import mock
+from unittest import mock
 import os
 import re
 import sys

--- a/zerver/migrations/0032_verify_all_medium_avatar_images.py
+++ b/zerver/migrations/0032_verify_all_medium_avatar_images.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.db import migrations
 from django.db.backends.postgresql.schema import DatabaseSchemaEditor
 from django.db.migrations.state import StateApps
-from mock import patch
+from unittest.mock import patch
 
 from zerver.lib.upload import upload_backend
 from zerver.lib.utils import make_safe_digest

--- a/zerver/tests/test_attachments.py
+++ b/zerver/tests/test_attachments.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from typing import Any
 

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -15,7 +15,7 @@ import responses
 
 import ldap
 import jwt
-import mock
+from unittest import mock
 import re
 import datetime
 import time
@@ -1598,8 +1598,10 @@ class SAMLAuthBackendTest(SocialAuthBase):
                 result = self.client_post('/complete/saml/',  post_params)
             self.assertEqual(result.status_code, 302)
             self.assertEqual('/login/', result.url)
-            self.assertIn("/complete/saml/: Can't figure out subdomain for this authentication request",
-                          m.call_args.args[0])
+            m.assert_called_once_with(
+                "/complete/saml/: Can't figure out subdomain for this authentication request. relayed_params: %s",
+                {},
+            )
 
     def test_social_auth_complete_wrong_issuing_idp(self) -> None:
         relay_state = ujson.dumps(dict(
@@ -1619,8 +1621,9 @@ class SAMLAuthBackendTest(SocialAuthBase):
                 result = self.client_post('/complete/saml/',  post_params)
                 self.assertEqual(result.status_code, 302)
                 self.assertEqual('/login/', result.url)
-                self.assertIn("/complete/saml/: No valid IdP as issuer of the SAMLResponse.",
-                              m.call_args.args[0])
+                m.assert_called_once_with(
+                    "/complete/saml/: No valid IdP as issuer of the SAMLResponse.",
+                )
 
     def test_social_auth_complete_valid_get_idp_bad_samlresponse(self) -> None:
         """
@@ -1864,8 +1867,10 @@ class SAMLAuthBackendTest(SocialAuthBase):
 
             self.assertEqual(result.status_code, 302)
             self.assertEqual('/login/', result.url)
-            self.assertIn("/complete/saml/: Can't figure out subdomain for this authentication request",
-                          m.call_args.args[0])
+            m.assert_called_once_with(
+                "/complete/saml/: Can't figure out subdomain for this authentication request. relayed_params: %s",
+                {},
+            )
 
 class GitHubAuthBackendTest(SocialAuthBase):
     __unittest_skip__ = False

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -4,7 +4,7 @@ import ujson
 
 from django.core import mail
 from django.test import override_settings
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from typing import Any, Dict, List, Mapping, Optional
 
 from zerver.lib.actions import do_change_stream_invite_only, do_deactivate_user, \

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -44,7 +44,7 @@ from zerver.models import (
 )
 
 import copy
-import mock
+from unittest import mock
 import os
 import ujson
 import re

--- a/zerver/tests/test_cache.py
+++ b/zerver/tests/test_cache.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from typing import Any, List, Dict, Optional
 
 from zerver.apps import flush_cache

--- a/zerver/tests/test_compatibility.py
+++ b/zerver/tests/test_compatibility.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.views.compatibility import find_mobile_os, version_lt, is_outdated_desktop_app

--- a/zerver/tests/test_create_video_call.py
+++ b/zerver/tests/test_create_video_call.py
@@ -1,5 +1,5 @@
 import json
-import mock
+from unittest import mock
 from zerver.lib.test_classes import ZulipTestCase
 from typing import Dict
 

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -11,7 +11,7 @@ from zerver.models import CustomProfileField, \
 from zerver.lib.external_accounts import DEFAULT_EXTERNAL_ACCOUNTS
 import ujson
 
-import mock
+from unittest import mock
 
 class CustomProfileFieldTestCase(ZulipTestCase):
     def setUp(self) -> None:

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1,5 +1,5 @@
 import base64
-import mock
+from unittest import mock
 import re
 import os
 from collections import defaultdict

--- a/zerver/tests/test_digest.py
+++ b/zerver/tests/test_digest.py
@@ -1,5 +1,5 @@
 import datetime
-import mock
+from unittest import mock
 import time
 from typing import List
 

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -1,6 +1,6 @@
 import os
 import ujson
-import mock
+from unittest import mock
 from urllib.parse import urlsplit
 
 from django.conf import settings

--- a/zerver/tests/test_email_log.py
+++ b/zerver/tests/test_email_log.py
@@ -1,5 +1,5 @@
 import os
-import mock
+from unittest import mock
 from django.conf import settings
 
 from zerver.lib.test_classes import ZulipTestCase

--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -53,7 +53,7 @@ from email.mime.image import MIMEImage
 from email.mime.multipart import MIMEMultipart
 
 import ujson
-import mock
+from unittest import mock
 import os
 from django.conf import settings
 

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -8,7 +8,7 @@ from django.core import mail
 from django.test import override_settings
 from django_auth_ldap.config import LDAPSearch
 from email.utils import formataddr
-from mock import patch
+from unittest.mock import patch
 from typing import List, Optional
 
 from zerver.lib.email_notifications import fix_emojis, handle_missedmessage_emails, \

--- a/zerver/tests/test_embedded_bot_system.py
+++ b/zerver/tests/test_embedded_bot_system.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 from zerver.lib.bot_lib import EmbeddedBotQuitException
 from zerver.lib.test_classes import ZulipTestCase

--- a/zerver/tests/test_event_queue.py
+++ b/zerver/tests/test_event_queue.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import time
 import ujson
 

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -147,7 +147,7 @@ from zerver.tornado.event_queue import (
 )
 from zerver.tornado.views import get_events
 
-import mock
+from unittest import mock
 import time
 import ujson
 

--- a/zerver/tests/test_external.py
+++ b/zerver/tests/test_external.py
@@ -21,7 +21,7 @@ from zerver.models import (
 )
 
 import DNS
-import mock
+from unittest import mock
 import time
 
 class MITNameTest(ZulipTestCase):

--- a/zerver/tests/test_gitter_importer.py
+++ b/zerver/tests/test_gitter_importer.py
@@ -17,7 +17,7 @@ from zerver.data_import.gitter import (
 import ujson
 import logging
 import os
-import mock
+from unittest import mock
 from typing import Any
 
 class GitterImporter(ZulipTestCase):

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -6,7 +6,7 @@ import ujson
 from django.conf import settings
 from django.http import HttpResponse
 from django.utils.timezone import now as timezone_now
-from mock import patch
+from unittest.mock import patch
 import urllib
 from typing import Any, Dict
 from zerver.lib.actions import (

--- a/zerver/tests/test_i18n.py
+++ b/zerver/tests/test_i18n.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-import mock
+from unittest import mock
 import ujson
 from django.test import TestCase
 from django.utils import translation

--- a/zerver/tests/test_import_export.py
+++ b/zerver/tests/test_import_export.py
@@ -3,7 +3,7 @@ from django.conf import settings
 import os
 import ujson
 
-from mock import patch
+from unittest.mock import patch
 from typing import Any, Dict, List, Set, Optional, Tuple, Callable, \
     FrozenSet
 from django.db.models import Q

--- a/zerver/tests/test_integrations_dev_panel.py
+++ b/zerver/tests/test_integrations_dev_panel.py
@@ -1,5 +1,5 @@
 import ujson
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.models import get_user, get_realm, Message, Stream
 

--- a/zerver/tests/test_link_embed.py
+++ b/zerver/tests/test_link_embed.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import ujson
 from typing import Any, Callable, Dict, Optional
 from requests.exceptions import ConnectionError

--- a/zerver/tests/test_logging_handlers.py
+++ b/zerver/tests/test_logging_handlers.py
@@ -7,7 +7,7 @@ from django.http import HttpRequest
 from django.test import TestCase
 from django.utils.log import AdminEmailHandler
 from functools import wraps
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from types import TracebackType
 from typing import Any, Callable, Dict, Iterator, Optional, Tuple, Type
 from typing_extensions import NoReturn

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -3,8 +3,8 @@ import os
 import re
 from datetime import timedelta
 from email.utils import parseaddr
-import mock
-from mock import MagicMock, patch, call
+from unittest import mock
+from unittest.mock import MagicMock, patch, call
 from typing import List, Dict, Any, Optional
 
 from django.conf import settings

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Mapping, Union
 
-import mock
+from unittest import mock
 
 from django.utils.timezone import now as timezone_now
 

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -117,7 +117,7 @@ from analytics.lib.counts import COUNT_STATS
 from analytics.models import RealmCount
 
 import datetime
-import mock
+from unittest import mock
 from operator import itemgetter
 import time
 import ujson

--- a/zerver/tests/test_muting.py
+++ b/zerver/tests/test_muting.py
@@ -1,7 +1,7 @@
 from django.utils.timezone import now as timezone_now
 from datetime import timedelta, datetime
 from typing import Any, Dict
-import mock
+from unittest import mock
 
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.stream_topic import StreamTopicTarget

--- a/zerver/tests/test_narrow.py
+++ b/zerver/tests/test_narrow.py
@@ -49,7 +49,7 @@ from zerver.views.messages import (
 from zerver.lib.streams import create_streams_if_needed
 
 from typing import Dict, Mapping, List, Sequence, Tuple, Union, Any, Optional
-import mock
+from unittest import mock
 import os
 import ujson
 

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -1,6 +1,6 @@
 import re
 import sys
-import mock
+from unittest import mock
 import inspect
 from typing import Dict, Any, Set, Union, List, Callable, Tuple, Optional, Iterable, Mapping, Sequence
 from unittest.mock import patch, MagicMock

--- a/zerver/tests/test_outgoing_webhook_interfaces.py
+++ b/zerver/tests/test_outgoing_webhook_interfaces.py
@@ -1,6 +1,6 @@
 from typing import cast, Any, Dict
 
-import mock
+from unittest import mock
 import json
 import requests
 

--- a/zerver/tests/test_outgoing_webhook_system.py
+++ b/zerver/tests/test_outgoing_webhook_system.py
@@ -1,6 +1,6 @@
 import ujson
 import logging
-import mock
+from unittest import mock
 import requests
 
 from typing import Any, Optional

--- a/zerver/tests/test_presence.py
+++ b/zerver/tests/test_presence.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 from django.utils.timezone import now as timezone_now
-import mock
+from unittest import mock
 
 from typing import Any, Dict
 from zerver.lib.actions import do_deactivate_user

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -2,8 +2,8 @@ from contextlib import contextmanager
 import datetime
 import itertools
 import requests
-import mock
-from mock import call
+from unittest import mock
+from unittest.mock import call
 from typing import Any, Dict, List, Optional
 
 import base64

--- a/zerver/tests/test_queue.py
+++ b/zerver/tests/test_queue.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from typing import Any, Dict
 
 from django.test import override_settings

--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -5,7 +5,7 @@ import smtplib
 
 from django.conf import settings
 from django.test import override_settings
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from typing import Any, Callable, Dict, List, Mapping, Tuple
 
 from zerver.lib.email_mirror import RateLimitedRealmMirror

--- a/zerver/tests/test_rate_limiter.py
+++ b/zerver/tests/test_rate_limiter.py
@@ -13,7 +13,7 @@ from zerver.lib.utils import generate_random_token
 
 from typing import Dict, List, Tuple, Type
 
-import mock
+from unittest import mock
 import time
 
 RANDOM_KEY_PREFIX = generate_random_token(32)

--- a/zerver/tests/test_realm.py
+++ b/zerver/tests/test_realm.py
@@ -1,7 +1,7 @@
 import datetime
 import ujson
 import re
-import mock
+from unittest import mock
 from email.utils import parseaddr
 
 from django.conf import settings

--- a/zerver/tests/test_realm_emoji.py
+++ b/zerver/tests/test_realm_emoji.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from zerver.lib.actions import do_create_realm, do_create_user, \
     check_add_realm_emoji

--- a/zerver/tests/test_realm_export.py
+++ b/zerver/tests/test_realm_export.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 from analytics.models import RealmCount
 

--- a/zerver/tests/test_redis_utils.py
+++ b/zerver/tests/test_redis_utils.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.redis_utils import get_redis_client, get_dict_from_redis, put_dict_in_redis, \

--- a/zerver/tests/test_report.py
+++ b/zerver/tests/test_report.py
@@ -6,7 +6,7 @@ from zerver.lib.test_classes import (
 )
 from zerver.lib.utils import statsd
 
-import mock
+from unittest import mock
 import ujson
 
 def fix_params(raw_params: Dict[str, Any]) -> Dict[str, str]:

--- a/zerver/tests/test_service_bot_system.py
+++ b/zerver/tests/test_service_bot_system.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from typing import Any, Union, Mapping, Callable
 
 from django.conf import settings

--- a/zerver/tests/test_sessions.py
+++ b/zerver/tests/test_sessions.py
@@ -19,7 +19,7 @@ from zerver.models import (
 
 from zerver.lib.test_classes import ZulipTestCase
 
-import mock
+from unittest import mock
 
 class TestSessions(ZulipTestCase):
 

--- a/zerver/tests/test_settings.py
+++ b/zerver/tests/test_settings.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import time
 import ujson
 

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -9,7 +9,7 @@ from django.test import TestCase, override_settings
 from django.utils.timezone import now as timezone_now
 from django.core.exceptions import ValidationError
 
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from zerver.lib.test_helpers import (
     avatar_disk_path,
     get_test_image_file,

--- a/zerver/tests/test_slack_importer.py
+++ b/zerver/tests/test_slack_importer.py
@@ -55,8 +55,8 @@ import ujson
 import logging
 import shutil
 import os
-import mock
-from mock import ANY, call
+from unittest import mock
+from unittest.mock import ANY, call
 from typing import Any, Dict, List, Set, Tuple, Iterator
 
 def remove_folder(path: str) -> None:

--- a/zerver/tests/test_soft_deactivation.py
+++ b/zerver/tests/test_soft_deactivation.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from django.utils.timezone import now as timezone_now
 

--- a/zerver/tests/test_subdomains.py
+++ b/zerver/tests/test_subdomains.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from typing import Any, Dict, List
 
 from django.test import TestCase

--- a/zerver/tests/test_submessage.py
+++ b/zerver/tests/test_submessage.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from zerver.lib.test_classes import ZulipTestCase
 

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -79,7 +79,7 @@ from zerver.lib.message import (
 from zerver.lib.stream_recipient import StreamRecipientMap
 
 from datetime import timedelta
-import mock
+from unittest import mock
 import random
 import ujson
 

--- a/zerver/tests/test_transfer.py
+++ b/zerver/tests/test_transfer.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 
 from moto import mock_s3_deprecated
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import logging
 
 from zerver.lib.upload import upload_message_file, resize_emoji

--- a/zerver/tests/test_unread.py
+++ b/zerver/tests/test_unread.py
@@ -25,7 +25,7 @@ from zerver.lib.test_classes import (
 )
 from zerver.lib.topic_mutes import add_topic_mute
 
-import mock
+from unittest import mock
 import ujson
 
 class PointerTest(ZulipTestCase):

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -48,7 +48,7 @@ import ujson
 from PIL import Image
 
 from io import StringIO
-import mock
+from unittest import mock
 import os
 import io
 import shutil

--- a/zerver/tests/test_user_groups.py
+++ b/zerver/tests/test_user_groups.py
@@ -1,5 +1,5 @@
 import ujson
-import mock
+from unittest import mock
 
 from zerver.lib.actions import (
     ensure_stream,

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -48,7 +48,7 @@ from django.conf import settings
 from django.test import override_settings
 
 import datetime
-import mock
+from unittest import mock
 import ujson
 
 K = TypeVar('K')

--- a/zerver/tests/test_webhooks_common.py
+++ b/zerver/tests/test_webhooks_common.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from typing import Dict
 
 from django.http import HttpRequest

--- a/zerver/tests/test_zephyr.py
+++ b/zerver/tests/test_zephyr.py
@@ -1,7 +1,7 @@
 import ujson
 
 from django.http import HttpResponse
-from mock import patch
+from unittest.mock import patch
 from typing import Any
 
 from zerver.lib.test_classes import ZulipTestCase

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -616,7 +616,7 @@ class TwoFactorLoginView(BaseTwoFactorLoginView):
         # LOGIN_REDIRECT_URL setting.  But until then, it works.  We
         # import mock.patch here because mock has an expensive import
         # process involving pbr -> pkgresources (which is really slow).
-        from mock import patch
+        from unittest.mock import patch
         with patch.object(settings, 'LOGIN_REDIRECT_URL', realm_uri):
             return super().done(form_list, **kwargs)
 

--- a/zerver/webhooks/beanstalk/tests.py
+++ b/zerver/webhooks/beanstalk/tests.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from zerver.lib.test_classes import WebhookTestCase
 from zerver.lib.webhooks.git import COMMITS_LIMIT

--- a/zerver/webhooks/bitbucket/tests.py
+++ b/zerver/webhooks/bitbucket/tests.py
@@ -1,6 +1,6 @@
 from typing import Dict, Union
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from zerver.lib.test_classes import WebhookTestCase
 

--- a/zerver/webhooks/bitbucket2/tests.py
+++ b/zerver/webhooks/bitbucket2/tests.py
@@ -1,4 +1,4 @@
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from zerver.lib.test_classes import WebhookTestCase
 

--- a/zerver/webhooks/clubhouse/tests.py
+++ b/zerver/webhooks/clubhouse/tests.py
@@ -1,6 +1,6 @@
 import json
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from zerver.lib.test_classes import WebhookTestCase
 

--- a/zerver/webhooks/freshdesk/tests.py
+++ b/zerver/webhooks/freshdesk/tests.py
@@ -1,4 +1,4 @@
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from zerver.lib.test_classes import WebhookTestCase
 

--- a/zerver/webhooks/gitea/tests.py
+++ b/zerver/webhooks/gitea/tests.py
@@ -1,4 +1,4 @@
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from zerver.lib.test_classes import WebhookTestCase
 

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -1,4 +1,4 @@
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from zerver.lib.test_classes import WebhookTestCase
 from zerver.lib.webhooks.git import COMMITS_LIMIT

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -1,4 +1,4 @@
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from zerver.lib.test_classes import WebhookTestCase
 from zerver.lib.webhooks.git import COMMITS_LIMIT

--- a/zerver/webhooks/gogs/tests.py
+++ b/zerver/webhooks/gogs/tests.py
@@ -1,4 +1,4 @@
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from zerver.lib.test_classes import WebhookTestCase
 from zerver.lib.webhooks.git import COMMITS_LIMIT

--- a/zerver/webhooks/greenhouse/tests.py
+++ b/zerver/webhooks/greenhouse/tests.py
@@ -1,4 +1,4 @@
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from zerver.lib.test_classes import WebhookTestCase
 

--- a/zerver/webhooks/harbor/tests.py
+++ b/zerver/webhooks/harbor/tests.py
@@ -1,4 +1,4 @@
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from zerver.lib.test_classes import WebhookTestCase
 

--- a/zerver/webhooks/intercom/tests.py
+++ b/zerver/webhooks/intercom/tests.py
@@ -1,4 +1,4 @@
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from zerver.lib.test_classes import WebhookTestCase
 

--- a/zerver/webhooks/semaphore/tests.py
+++ b/zerver/webhooks/semaphore/tests.py
@@ -1,5 +1,5 @@
 import ujson
-from mock import patch
+from unittest.mock import patch
 from zerver.lib.test_classes import WebhookTestCase
 
 

--- a/zerver/webhooks/stripe/tests.py
+++ b/zerver/webhooks/stripe/tests.py
@@ -1,5 +1,5 @@
-import mock
-from mock import MagicMock, patch
+from unittest import mock
+from unittest.mock import MagicMock, patch
 
 from zerver.lib.test_classes import WebhookTestCase
 

--- a/zerver/webhooks/trello/tests.py
+++ b/zerver/webhooks/trello/tests.py
@@ -1,4 +1,4 @@
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from zerver.lib.test_classes import WebhookTestCase
 


### PR DESCRIPTION
`mock` is just a backport of the standard library’s `unittest.mock` now.

The `SAMLAuthBackendTest` change is needed because `MagicMock.call_args.args` wasn’t introduced until Python 3.8 (https://bugs.python.org/issue21269).

The `PROVISION_VERSION` bump is skipped because `mock` is still an indirect dev requirement via `moto`.