### PR TITLE
Fix some extensionless scripts missed by semgrep

### DIFF
--- a/puppet/zulip/files/postgresql/pg_backup_and_purge
+++ b/puppet/zulip/files/postgresql/pg_backup_and_purge
@@ -25,8 +25,8 @@ def run(args: List[str], dry_run: bool = False) -> str:
                          stderr=subprocess.PIPE)
     stdout, stderr = p.communicate()
     if p.returncode:
-        logger.error("Could not invoke %s\nstdout: %r\nstderror: %r"
-                     % (args[0], stdout, stderr))
+        logger.error("Could not invoke %s\nstdout: %r\nstderror: %r",
+                     args[0], stdout, stderr)
         sys.exit(1)
     return stdout.decode()
 

--- a/puppet/zulip/files/postgresql/process_fts_updates
+++ b/puppet/zulip/files/postgresql/process_fts_updates
@@ -48,8 +48,10 @@ else:
     logger.setLevel(logging.DEBUG)
 
 def update_fts_columns(cursor: psycopg2.extensions.cursor) -> int:
-    cursor.execute("SELECT id, message_id FROM fts_update_log LIMIT %s;" % (
-        BATCH_SIZE,))
+    cursor.execute(
+        "SELECT id, message_id FROM fts_update_log LIMIT %s;",
+        [BATCH_SIZE],
+    )
     ids = []
     for (id, message_id) in cursor.fetchall():
         if USING_PGROONGA:

--- a/scripts/lib/upgrade-zulip
+++ b/scripts/lib/upgrade-zulip
@@ -38,7 +38,7 @@ try:
     # the Zulip user, and then unpack it from that directory, so that
     # we can unpack using the Zulip user even if the original path was
     # not readable by the Zulip user.
-    logging.info("Archiving the tarball under %s" % (TARBALL_ARCHIVE_PATH,))
+    logging.info("Archiving the tarball under %s", TARBALL_ARCHIVE_PATH)
     os.makedirs(TARBALL_ARCHIVE_PATH, exist_ok=True)
     archived_tarball_path = os.path.join(TARBALL_ARCHIVE_PATH, os.path.basename(tarball_path))
     shutil.copy(tarball_path, archived_tarball_path)

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -43,7 +43,7 @@ os_version = distro_info['VERSION_ID']
 
 if (vendor, os_version) in UNSUPPORTED_DISTROS:
     # Link to documentation for how to correctly upgrade the OS.
-    logging.critical("Unsupported platform: {} {}".format(vendor, os_version))
+    logging.critical("Unsupported platform: %s %s", vendor, os_version)
     logging.info("Sorry! The support for your OS has been discontinued.\n"
                  "Please upgrade your OS to a supported release first.\n"
                  "See https://zulip.readthedocs.io/en/latest/production/"

--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -65,7 +65,7 @@ if tornado_processes > 1:
         # restarts.  This also avoids behavior with restarting a whole
         # supervisord group where if any individual process is slow to
         # stop, the whole bundle stays stopped for an extended time.
-        logging.info("Restarting Tornado process on port %s" % (p,))
+        logging.info("Restarting Tornado process on port %s", p)
         subprocess.check_call(["supervisorctl", "restart", "zulip-tornado:port-%s" % (p,)])
 else:
     logging.info("Restarting Tornado process")


### PR DESCRIPTION
I created #14841 and #14852 with the aid of semgrep, but it turns out semgrep has been ignoring scripts without an extension despite being told otherwise (returntocorp/semgrep#831), so here are some additional fixes in those categories.