### PR TITLE
python: More legacy syntax updates from pyupgrade

### DIFF
--- a/puppet/zulip_ops/files/zulip-ec2-configure-interfaces
+++ b/puppet/zulip_ops/files/zulip-ec2-configure-interfaces
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # Copyright © 2013 Zulip, Inc.
 #
@@ -42,7 +41,6 @@ interfaces.
 
 '''
 
-from __future__ import absolute_import
 import sys
 import logging
 import logging.handlers

--- a/tools/fetch-contributor-data
+++ b/tools/fetch-contributor-data
@@ -36,10 +36,9 @@ parser.add_argument('--max-retries', type=int, default=10,
                     help='Number of times to retry fetching data from Github')
 args = parser.parse_args()
 
-ContributorsJSON = TypedDict('ContributorsJSON', {
-    'date': str,
-    'contrib': List[Dict[str, Union[str, int]]],
-})
+class ContributorsJSON(TypedDict):
+    date: str
+    contrib: List[Dict[str, Union[str, int]]]
 
 logger = logging.getLogger('zulip.fetch_contributors_json')
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -987,17 +987,16 @@ def render_incoming_message(message: Message,
         raise JsonableError(_('Unable to render message'))
     return rendered_content
 
-RecipientInfoResult = TypedDict('RecipientInfoResult', {
-    'active_user_ids': Set[int],
-    'push_notify_user_ids': Set[int],
-    'stream_email_user_ids': Set[int],
-    'stream_push_user_ids': Set[int],
-    'wildcard_mention_user_ids': Set[int],
-    'um_eligible_user_ids': Set[int],
-    'long_term_idle_user_ids': Set[int],
-    'default_bot_user_ids': Set[int],
-    'service_bot_tuples': List[Tuple[int, int]],
-})
+class RecipientInfoResult(TypedDict):
+    active_user_ids: Set[int]
+    push_notify_user_ids: Set[int]
+    stream_email_user_ids: Set[int]
+    stream_push_user_ids: Set[int]
+    wildcard_mention_user_ids: Set[int]
+    um_eligible_user_ids: Set[int]
+    long_term_idle_user_ids: Set[int]
+    default_bot_user_ids: Set[int]
+    service_bot_tuples: List[Tuple[int, int]]
 
 def get_recipient_info(recipient: Recipient,
                        sender_id: int,
@@ -4185,10 +4184,9 @@ def do_update_message_flags(user_profile: UserProfile,
     statsd.incr("flags.%s.%s" % (flag, operation), count)
     return count
 
-MessageUpdateUserInfoResult = TypedDict('MessageUpdateUserInfoResult', {
-    'message_user_ids': Set[int],
-    'mention_user_ids': Set[int],
-})
+class MessageUpdateUserInfoResult(TypedDict):
+    message_user_ids: Set[int]
+    mention_user_ids: Set[int]
 
 def notify_topic_moved_streams(user_profile: UserProfile,
                                old_stream: Stream, old_topic: str,

--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -78,11 +78,10 @@ def one_time(method: Callable[[], ReturnT]) -> Callable[[], ReturnT]:
         return val
     return cache_wrapper
 
-FullNameInfo = TypedDict('FullNameInfo', {
-    'id': int,
-    'email': str,
-    'full_name': str,
-})
+class FullNameInfo(TypedDict):
+    id: int
+    email: str
+    full_name: str
 
 DbData = Dict[str, Any]
 
@@ -292,12 +291,11 @@ def walk_tree(root: Element,
 
     return results
 
-ElementFamily = NamedTuple('ElementFamily', [
-    ('grandparent', Optional[Element]),
-    ('parent', Element),
-    ('child', Element),
-    ('in_blockquote', bool),
-])
+class ElementFamily(NamedTuple):
+    grandparent: Optional[Element]
+    parent: Element
+    child: Element
+    in_blockquote: bool
 
 T = TypeVar("T")
 
@@ -1529,10 +1527,9 @@ class BugdownListPreprocessor(markdown.preprocessors.Preprocessor):
 
     def run(self, lines: List[str]) -> List[str]:
         """ Insert a newline between a paragraph and ulist if missing """
-        Fence = NamedTuple('Fence', [
-            ('fence_str', str),
-            ('is_code', bool),
-        ])
+        class Fence(NamedTuple):
+            fence_str: str
+            is_code: bool
 
         inserts = 0
         in_code_fence: bool = False

--- a/zerver/lib/display_recipient.py
+++ b/zerver/lib/display_recipient.py
@@ -14,10 +14,9 @@ display_recipient_fields = [
     "is_mirror_dummy",
 ]
 
-TinyStreamResult = TypedDict('TinyStreamResult', {
-    'id': int,
-    'name': str,
-})
+class TinyStreamResult(TypedDict):
+    id: int
+    name: str
 
 @cache_with_key(lambda *args: display_recipient_cache_key(args[0]),
                 timeout=3600*24*7)

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -225,7 +225,6 @@ class FakeMessage:
     We just need a stub object for do_render_markdown
     to write stuff to.
     '''
-    pass
 
 def fix_message_rendered_content(realm: Realm,
                                  sender_map: Dict[int, Record],
@@ -416,7 +415,6 @@ def re_map_foreign_keys_internal(data_table: List[Record],
                 # subscription object
                 # check function 'get_huddles_from_subscription'
                 ID_MAP['recipient_to_huddle_map'][item['id']] = lookup_table[old_id]
-                pass
             else:
                 continue
         old_id = item[field_name]

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -60,22 +60,20 @@ from typing_extensions import TypedDict
 
 RealmAlertWord = Dict[int, List[str]]
 
-RawUnreadMessagesResult = TypedDict('RawUnreadMessagesResult', {
-    'pm_dict': Dict[int, Any],
-    'stream_dict': Dict[int, Any],
-    'huddle_dict': Dict[int, Any],
-    'mentions': Set[int],
-    'muted_stream_ids': List[int],
-    'unmuted_stream_msgs': Set[int],
-})
+class RawUnreadMessagesResult(TypedDict):
+    pm_dict: Dict[int, Any]
+    stream_dict: Dict[int, Any]
+    huddle_dict: Dict[int, Any]
+    mentions: Set[int]
+    muted_stream_ids: List[int]
+    unmuted_stream_msgs: Set[int]
 
-UnreadMessagesResult = TypedDict('UnreadMessagesResult', {
-    'pms': List[Dict[str, Any]],
-    'streams': List[Dict[str, Any]],
-    'huddles': List[Dict[str, Any]],
-    'mentions': List[int],
-    'count': int,
-})
+class UnreadMessagesResult(TypedDict):
+    pms: List[Dict[str, Any]]
+    streams: List[Dict[str, Any]]
+    huddles: List[Dict[str, Any]]
+    mentions: List[int]
+    count: int
 
 # We won't try to fetch more unread message IDs from the database than
 # this limit.  The limit is super high, in large part because it means

--- a/zerver/lib/rate_limiter.py
+++ b/zerver/lib/rate_limiter.py
@@ -153,7 +153,6 @@ class RateLimiterBackend(ABC):
     @abstractmethod
     def block_access(cls, entity_key: str, seconds: int) -> None:
         "Manually blocks an entity for the desired number of seconds"
-        pass
 
     @classmethod
     @abstractmethod

--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -477,7 +477,6 @@ class Runner(DiscoverRunner):
             shutil.rmtree(TEST_RUN_DIR)
         except OSError:
             print("Unable to clean up the test run's directory.")
-            pass
         return super().teardown_test_environment(*args, **kwargs)
 
     def test_imports(self, test_labels: List[str], suite: Union[TestSuite, ParallelTestSuite]) -> None:

--- a/zerver/lib/types.py
+++ b/zerver/lib/types.py
@@ -28,6 +28,10 @@ UserFieldElement = Tuple[int, str, RealmUserValidator, Callable[[Any], Any], str
 
 ProfileFieldData = Dict[str, Union[Dict[str, str], str]]
 
-UserDisplayRecipient = TypedDict('UserDisplayRecipient', {'email': str, 'full_name': str, 'short_name': str,
-                                                          'id': int, 'is_mirror_dummy': bool})
+class UserDisplayRecipient(TypedDict):
+    email: str
+    full_name: str
+    short_name: str
+    id: int
+    is_mirror_dummy: bool
 DisplayRecipientT = Union[str, List[UserDisplayRecipient]]

--- a/zerver/migrations/0273_migrate_old_bot_messages.py
+++ b/zerver/migrations/0273_migrate_old_bot_messages.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.conf import settings
 from django.db import migrations
 from django.db.backends.postgresql.schema import DatabaseSchemaEditor

--- a/zerver/migrations/0276_alertword.py
+++ b/zerver/migrations/0276_alertword.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from django.conf import settings
 from django.db import migrations, models
 import django.db.models.deletion

--- a/zerver/migrations/0277_migrate_alert_word.py
+++ b/zerver/migrations/0277_migrate_alert_word.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from django.db import migrations
 from django.db.backends.postgresql_psycopg2.schema import DatabaseSchemaEditor
 from django.db.migrations.state import StateApps

--- a/zerver/tests/test_alert_words.py
+++ b/zerver/tests/test_alert_words.py
@@ -66,14 +66,14 @@ class AlertWordTests(ZulipTestCase):
         self.assert_length(realm_alert_words[user.id], 3)
 
         # Test the case-insensitivity of adding words
-        do_add_alert_words(user, set(["ALert", "ALERT"]))
+        do_add_alert_words(user, {"ALert", "ALERT"})
         words = user_alert_words(user)
         self.assertEqual(set(words), set(self.interesting_alert_word_list))
         realm_alert_words = alert_words_in_realm(user.realm)
         self.assert_length(realm_alert_words[user.id], 3)
 
         # Test the case-insensitivity of removing words
-        do_remove_alert_words(user, set(["ALert"]))
+        do_remove_alert_words(user, {"ALert"})
         words = user_alert_words(user)
         self.assertEqual(set(words), set(self.interesting_alert_word_list) - {'alert'})
         realm_alert_words = alert_words_in_realm(user.realm)

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -2835,8 +2835,8 @@ class ExternalMethodDictsTests(ZulipTestCase):
             external_auth_methods = get_external_method_dicts(get_realm("zephyr"))
             # Both idps enabled for the zephyr realm, + github auth.
             self.assert_length(external_auth_methods, 3)
-            self.assertEqual(set([external_auth_methods[0]['name'], external_auth_methods[1]['name']]),
-                             set(['saml:test_idp', 'saml:test_idp2']))
+            self.assertEqual({external_auth_methods[0]['name'], external_auth_methods[1]['name']},
+                             {'saml:test_idp', 'saml:test_idp2'})
 
 class FetchAuthBackends(ZulipTestCase):
     def assert_on_error(self, error: Optional[str]) -> None:

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -769,11 +769,10 @@ def maybe_enqueue_notifications(user_profile_id: int, message_id: int, private_m
 
     return notified
 
-ClientInfo = TypedDict('ClientInfo', {
-    'client': ClientDescriptor,
-    'flags': Optional[Iterable[str]],
-    'is_sender': bool,
-})
+class ClientInfo(TypedDict):
+    client: ClientDescriptor
+    flags: Optional[Iterable[str]]
+    is_sender: bool
 
 def get_client_info_for_message_event(event_template: Mapping[str, Any],
                                       users: Iterable[Mapping[str, Any]]) -> Dict[str, ClientInfo]:

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -367,7 +367,6 @@ ldap_logger = logging.getLogger("zulip.ldap")
 class ZulipLDAPException(_LDAPUser.AuthenticationFailed):
     """Since this inherits from _LDAPUser.AuthenticationFailed, these will
     be caught and logged at debug level inside django-auth-ldap's authenticate()"""
-    pass
 
 class ZulipLDAPExceptionNoMatchingLDAPUser(ZulipLDAPException):
     pass

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -872,13 +872,12 @@ class DevAuthBackend(ZulipAuthMixin):
             return None
         return common_get_active_user(dev_auth_username, realm, return_data=return_data)
 
-ExternalAuthMethodDictT = TypedDict('ExternalAuthMethodDictT', {
-    'name': str,
-    'display_name': str,
-    'display_icon': Optional[str],
-    'login_url': str,
-    'signup_url': str,
-})
+class ExternalAuthMethodDictT(TypedDict):
+    name: str
+    display_name: str
+    display_icon: Optional[str]
+    login_url: str
+    signup_url: str
 
 class ExternalAuthMethod(ABC):
     """


### PR DESCRIPTION
While I’m still working on the f-strings migration, here’s everything else that `pyupgrade` wants to do for 3.6 (along with #15091).