### PR TITLE
navbar: Remove redundant .emoji styles from scss.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1563,10 +1563,6 @@ div.focused_table {
             overflow: hidden;
             white-space: nowrap;
             margin: 0;
-            .emoji {
-                margin: 0;
-                padding: 0;
-            }
             padding: 12px 0px;
             padding-left: 2px;
 


### PR DESCRIPTION
This commit fixes the alignment of emoji in the navbar by removing a
redundant style which was breaking the emoji alignment.

This block is probably just a remanent from WIP development of this
version of the navbar & its inclusion on master was as an oversight.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
BEFORE:
![image](https://user-images.githubusercontent.com/33805964/82902854-b8e58780-9f7d-11ea-99c7-8d38c03b9670.png)

AFTER:
![image](https://user-images.githubusercontent.com/33805964/82902741-8d629d00-9f7d-11ea-894b-08461229d733.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
