### PR TITLE
people tests: Move test users to top of file.

### DIFF
--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -50,6 +50,147 @@ function initialize() {
 
 initialize();
 
+/*
+    TEST SETUP NOTES:
+
+    We don't add all these users right away,
+    but they are convenient to have for various
+    tests, and we just add them as needed after
+    calling something like `people.init()`.
+
+    Note that we deliberately make it so that
+    alphabetical order mismatches id order,
+    since that can uncover bugs where we neglect
+    to be rigorous about sort order.
+*/
+
+const realm_admin = {
+    email: 'realm_admin@example.com',
+    full_name: 'Realm Admin',
+    user_id: 32,
+    is_admin: true,
+    is_guest: false,
+    is_bot: false,
+};
+
+const guest = {
+    email: 'guest@example.com',
+    full_name: 'Guest User',
+    user_id: 33,
+    is_admin: false,
+    is_guest: true,
+    is_bot: false,
+};
+
+const bot_botson = {
+    email: 'botson-bot@example.com',
+    user_id: 35,
+    full_name: 'Bot Botson',
+    is_bot: true,
+    bot_owner_id: isaac.user_id,
+};
+
+const steven = {
+    email: 'steven@example.com',
+    delivery_email: 'steven-delivery@example.com',
+    user_id: 77,
+    full_name: 'Steven',
+};
+
+const alice1 = {
+    email: 'alice1@example.com',
+    user_id: 202,
+    full_name: 'Alice',
+};
+
+const bob = {
+    email: 'bob@example.com',
+    user_id: 203,
+    full_name: 'Bob van Roberts',
+};
+
+const alice2 = {
+    email: 'alice2@example.com',
+    user_id: 204,
+    full_name: 'Alice',
+};
+
+const charles = {
+    email: 'charles@example.com',
+    user_id: 301,
+    full_name: 'Charles Dickens',
+    avatar_url: 'charles.com/foo.png',
+    is_guest: false,
+};
+
+const maria = {
+    email: 'Athens@example.com',
+    user_id: 302,
+    full_name: 'Maria Athens',
+};
+
+const ashton = {
+    email: 'ashton@example.com',
+    user_id: 303,
+    full_name: 'Ashton Smith',
+};
+
+const linus = {
+    email: 'ltorvalds@example.com',
+    user_id: 304,
+    full_name: 'Linus Torvalds',
+};
+
+const emp401 = {
+    email: 'emp401@example.com',
+    user_id: 401,
+    full_name: 'whatever 401',
+};
+
+const emp402 = {
+    email: 'EMP402@example.com',
+    user_id: 402,
+    full_name: 'whatever 402',
+};
+
+const debbie = {
+    email: 'deBBie71@example.com',
+    user_id: 501,
+    full_name: 'Debra Henton',
+};
+
+const stephen1 = {
+    email: 'stephen-the-author@example.com',
+    user_id: 601,
+    full_name: 'Stephen King',
+};
+
+const stephen2 = {
+    email: 'stephen-the-explorer@example.com',
+    user_id: 602,
+    full_name: 'Stephen King',
+};
+
+const noah = {
+    email: 'emnoa@example.com',
+    user_id: 1200,
+    full_name: 'Nöôáàh Ëmerson',
+};
+
+const plain_noah = {
+    email: 'otheremnoa@example.com',
+    user_id: 1201,
+    full_name: 'Nooaah Emerson',
+};
+
+// This is for error checking--never actually
+// tell people.js about this user.
+const unknown_user = {
+    email: 'unknown@example.com',
+    user_id: 999,
+    unknown_local_echo_user: true,
+};
+
 function get_all_persons() {
     return people.filter_all_persons(() => true);
 }
@@ -114,13 +255,6 @@ run_test('basics', () => {
     assert.equal(people.is_active_user_for_popover(isaac.user_id), false);
     assert.equal(people.is_valid_email_for_compose(isaac.email), false);
 
-    const bot_botson = {
-        email: 'botson-bot@example.com',
-        user_id: 35,
-        full_name: 'Bot Botson',
-        is_bot: true,
-        bot_owner_id: isaac.user_id,
-    };
     people.add(bot_botson);
     assert.equal(people.is_active_user_for_popover(bot_botson.user_id), true);
 
@@ -209,14 +343,8 @@ run_test('bot_custom_profile_data', () => {
     // If this test fails, then try opening organization settings > bots
     // http://localhost:9991/#organization/bot-list-admin
     // and then try to edit any of the bots.
-    const bot = {
-        email: 'bot@example.com',
-        user_id: 31,
-        full_name: 'Bot',
-        is_bot: true,
-    };
-    people.add(bot);
-    assert.equal(people.get_custom_profile_data(31, 3), null);
+    people.add(bot_botson);
+    assert.equal(people.get_custom_profile_data(bot_botson.user_id, 3), null);
 });
 
 run_test('user_timezone', () => {
@@ -244,38 +372,16 @@ run_test('user_timezone', () => {
 });
 
 run_test('user_type', () => {
-    const realm_admin = {
-        email: 'realm_admin@example.com',
-        full_name: 'Realm Admin',
-        user_id: 32,
-        is_admin: true,
-        is_guest: false,
-        is_bot: false,
-    };
-    const guest = {
-        email: 'guest@example.com',
-        full_name: 'Guest User',
-        user_id: 33,
-        is_admin: false,
-        is_guest: true,
-        is_bot: false,
-    };
-    const bot = {
-        email: 'bot@example.com',
-        full_name: 'Example Bot',
-        user_id: 34,
-        is_admin: false,
-        is_guest: false,
-        is_bot: true,
-    };
+    people.init();
 
+    people.add(me);
     people.add(realm_admin);
     people.add(guest);
-    people.add(bot);
+    people.add(bot_botson);
     assert.equal(people.get_user_type(me.user_id), i18n.t('Member'));
     assert.equal(people.get_user_type(realm_admin.user_id), i18n.t('Administrator'));
     assert.equal(people.get_user_type(guest.user_id), i18n.t('Guest'));
-    assert.equal(people.get_user_type(bot.user_id), i18n.t('Bot'));
+    assert.equal(people.get_user_type(bot_botson.user_id), i18n.t('Bot'));
 });
 
 run_test('updates', () => {
@@ -326,21 +432,6 @@ run_test('set_custom_profile_field_data', () => {
 initialize();
 
 run_test('get_people_for_stream_create', () => {
-    const alice1 = {
-        email: 'alice1@example.com',
-        user_id: 202,
-        full_name: 'Alice',
-    };
-    const alice2 = {
-        email: 'alice2@example.com',
-        user_id: 203,
-        full_name: 'Alice',
-    };
-    const bob = {
-        email: 'bob@example.com',
-        user_id: 204,
-        full_name: 'Bob van Roberts',
-    };
     people.add(alice1);
     people.add(bob);
     people.add(alice2);
@@ -348,9 +439,9 @@ run_test('get_people_for_stream_create', () => {
 
     const others = people.get_people_for_stream_create();
     const expected = [
-        { email: 'alice1@example.com', user_id: 202, full_name: 'Alice' },
-        { email: 'alice2@example.com', user_id: 203, full_name: 'Alice' },
-        { email: 'bob@example.com', user_id: 204, full_name: 'Bob van Roberts' },
+        { email: 'alice1@example.com', user_id: alice1.user_id, full_name: 'Alice' },
+        { email: 'alice2@example.com', user_id: alice2.user_id, full_name: 'Alice' },
+        { email: 'bob@example.com', user_id: bob.user_id, full_name: 'Bob van Roberts' },
     ];
     assert.deepEqual(others, expected);
 
@@ -369,37 +460,6 @@ run_test('recipient_counts', () => {
 });
 
 run_test('filtered_users', () => {
-    const charles = {
-        email: 'charles@example.com',
-        user_id: 301,
-        full_name: 'Charles Dickens',
-    };
-    const maria = {
-        email: 'athens@example.com',
-        user_id: 302,
-        full_name: 'Maria Athens',
-    };
-    const ashton = {
-        email: 'ashton@example.com',
-        user_id: 303,
-        full_name: 'Ashton Smith',
-    };
-    const linus = {
-        email: 'ltorvalds@example.com',
-        user_id: 304,
-        full_name: 'Linus Torvalds',
-    };
-    const noah = {
-        email: 'emnoa@example.com',
-        user_id: 305,
-        full_name: 'Nöôáàh Ëmerson',
-    };
-    const plain_noah = {
-        email: 'otheremnoa@example.com',
-        user_id: 306,
-        full_name: 'Nooaah Emerson',
-    };
-
     people.add(charles);
     people.add(maria);
     people.add(ashton);
@@ -440,12 +500,7 @@ run_test('filtered_users', () => {
     assert(filtered_people.has(noah.user_id));
 
     // Test filtering with undefined user
-    const foo = {
-        email: 'foo@example.com',
-        user_id: 42,
-        full_name: 'Foo Bar',
-    };
-    users.push(foo);
+    users.push(unknown_user);
 
     filtered_people = people.filter_people_by_search_terms(users, ['ltorv']);
     assert.equal(filtered_people.size, 1);
@@ -455,19 +510,12 @@ run_test('filtered_users', () => {
 people.init();
 
 run_test('multi_user_methods', () => {
-    const emp401 = {
-        email: 'emp401@example.com',
-        user_id: 401,
-        full_name: 'whatever 401',
-    };
-    const emp402 = {
-        email: 'EMP402@example.com',
-        user_id: 402,
-        full_name: 'whatever 402',
-    };
-
     people.add(emp401);
     people.add(emp402);
+
+    // The order of user_ids is relevant here.
+    assert.equal(emp401.user_id, 401);
+    assert.equal(emp402.user_id, 402);
 
     let emails_string = people.user_ids_string_to_emails_string('402,401');
     assert.equal(emails_string, 'emp401@example.com,emp402@example.com');
@@ -491,21 +539,12 @@ run_test('multi_user_methods', () => {
 initialize();
 
 run_test('message_methods', () => {
-    const charles = {
-        email: 'charles@example.com',
-        user_id: 451,
-        full_name: 'Charles Dickens',
-        avatar_url: 'charles.com/foo.png',
-        is_guest: false,
-    };
-    // Maria is an intentionally incomplete user object without all attributes
-    const maria = {
-        email: 'Athens@example.com',
-        user_id: 452,
-        full_name: 'Maria Athens',
-    };
     people.add(charles);
     people.add(maria);
+
+    // We don't rely on Maria to have all flags set explicitly--
+    // undefined values are just treated as falsy.
+    assert.equal(maria.is_guest, undefined);
 
     assert.equal(people.small_avatar_url_for_person(maria),
                  'https://secure.gravatar.com/avatar/md5-athens@example.com?d=identicon&s=50');
@@ -518,8 +557,8 @@ run_test('message_methods', () => {
         ],
         sender_id: charles.user_id,
     };
-    assert.equal(people.pm_with_url(message), '#narrow/pm-with/451,452-group');
-    assert.equal(people.pm_perma_link(message), '#narrow/pm-with/30,451,452-group');
+    assert.equal(people.pm_with_url(message), '#narrow/pm-with/301,302-group');
+    assert.equal(people.pm_perma_link(message), '#narrow/pm-with/30,301,302-group');
     assert.equal(people.pm_reply_to(message),
                  'Athens@example.com,charles@example.com');
     assert.equal(people.small_avatar_url(message),
@@ -533,8 +572,8 @@ run_test('message_methods', () => {
         ],
         avatar_url: 'legacy.png',
     };
-    assert.equal(people.pm_with_url(message), '#narrow/pm-with/452-athens');
-    assert.equal(people.pm_perma_link(message), '#narrow/pm-with/30,452-pm');
+    assert.equal(people.pm_with_url(message), '#narrow/pm-with/302-athens');
+    assert.equal(people.pm_perma_link(message), '#narrow/pm-with/30,302-pm');
     assert.equal(people.pm_reply_to(message),
                  'Athens@example.com');
     assert.equal(people.small_avatar_url(message),
@@ -577,12 +616,7 @@ run_test('message_methods', () => {
     assert.equal(people.pm_with_url(message), undefined);
 
     // Test sender_is_bot
-    const bot = {
-        email: 'bot@example.com',
-        user_id: 42,
-        full_name: 'Test Bot',
-        is_bot: true,
-    };
+    const bot = bot_botson;
     people.add(bot);
 
     message = { sender_id: bot.user_id };
@@ -595,16 +629,9 @@ run_test('message_methods', () => {
     assert.equal(people.sender_is_bot(message), false);
 
     // Test sender_is_guest
-    const polonius = {
-        email: 'polonius@example.com',
-        user_id: 43,
-        full_name: 'Guest User',
-        is_bot: false,
-        is_guest: true,
-    };
-    people.add(polonius);
+    people.add(guest);
 
-    message = { sender_id: polonius.user_id };
+    message = { sender_id: guest.user_id };
     assert.equal(people.sender_is_guest(message), true);
 
     message = { sender_id: maria.user_id };
@@ -620,18 +647,6 @@ run_test('message_methods', () => {
 initialize();
 
 run_test('extract_people_from_message', () => {
-    const unknown_user = {
-        email: 'unknown@example.com',
-        user_id: 500,
-        unknown_local_echo_user: true,
-    };
-
-    const maria = {
-        email: 'athens@example.com',
-        user_id: 452,
-        full_name: 'Maria Athens',
-    };
-
     let message = {
         type: 'stream',
         sender_full_name: maria.full_name,
@@ -666,11 +681,6 @@ run_test('extract_people_from_message', () => {
 initialize();
 
 run_test('maybe_incr_recipient_count', () => {
-    const maria = {
-        email: 'athens@example.com',
-        user_id: 452,
-        full_name: 'Maria Athens',
-    };
     const maria_recip = {
         id: maria.user_id,
     };
@@ -717,14 +727,9 @@ run_test('maybe_incr_recipient_count', () => {
 });
 
 run_test('slugs', () => {
-    const person = {
-        email: 'deBBie71@example.com',
-        user_id: 501,
-        full_name: 'Debra Henton',
-    };
-    people.add(person);
+    people.add(debbie);
 
-    const slug = people.emails_to_slug(person.email);
+    const slug = people.emails_to_slug(debbie.email);
     assert.equal(slug, '501-debbie71');
 
     const email = people.slug_to_emails(slug);
@@ -811,16 +816,6 @@ run_test('updates', () => {
 initialize();
 
 run_test('update_email_in_reply_to', () => {
-    const charles = {
-        email: 'charles@example.com',
-        user_id: 601,
-        full_name: 'Charles Dickens',
-    };
-    const maria = {
-        email: 'athens@example.com',
-        user_id: 602,
-        full_name: 'Maria Athens',
-    };
     people.add(charles);
     people.add(maria);
 
@@ -844,22 +839,6 @@ run_test('update_email_in_reply_to', () => {
 initialize();
 
 run_test('track_duplicate_full_names', () => {
-    const stephen1 = {
-        email: 'stephen-the-author@example.com',
-        user_id: 601,
-        full_name: 'Stephen King',
-    };
-    const stephen2 = {
-        email: 'stephen-the-explorer@example.com',
-        user_id: 602,
-        full_name: 'Stephen King',
-    };
-    const maria = {
-        email: 'athens@example.com',
-        user_id: 603,
-        full_name: 'Maria Athens',
-    };
-
     people.add(maria);
     people.add(stephen1);
 
@@ -870,7 +849,7 @@ run_test('track_duplicate_full_names', () => {
     );
 
     // Now duplicate the Stephen King name.
-    people.add(stephen2);
+    people.add({...stephen2});
 
     // For duplicate names we won't try to guess which
     // user_id the person means; the UI should use
@@ -883,33 +862,28 @@ run_test('track_duplicate_full_names', () => {
     assert(people.is_duplicate_full_name('Stephen King'));
     assert(!people.is_duplicate_full_name('Maria Athens'));
     assert(!people.is_duplicate_full_name('Some Random Name'));
-    people.set_full_name(stephen2, 'Stephen King JP');
+
+    // It is somewhat janky that we have to clone
+    // stephen2 here.  It would be nice if people.set_full_name
+    // just took a user_id as the first parameter.
+    people.set_full_name({...stephen2}, 'Stephen King JP');
     assert(!people.is_duplicate_full_name('Stephen King'));
     assert(!people.is_duplicate_full_name('Stephen King JP'));
 });
 
-run_test('track_duplicate_full_names', () => {
-    const stephen1 = {
-        email: 'stephen-the-author@example.com',
-        user_id: 601,
-        full_name: 'Stephen King',
-    };
-    const stephen2 = {
-        email: 'stephen-the-explorer@example.com',
-        user_id: 602,
-        full_name: 'Stephen King',
-    };
-    const maria = {
-        email: 'athens@example.com',
-        user_id: 603,
-        full_name: 'Maria Athens',
-    };
+initialize();
+
+run_test('get_mention_syntax', () => {
     people.add(stephen1);
     people.add(stephen2);
     people.add(maria);
 
+    assert(people.is_duplicate_full_name('Stephen King'));
+
     blueslip.expect('warn', 'get_mention_syntax called without user_id.');
     assert.equal(people.get_mention_syntax('Stephen King'), '@**Stephen King**');
+    blueslip.reset();
+
     assert.equal(people.get_mention_syntax('Stephen King', 601), '@**Stephen King|601**');
     assert.equal(people.get_mention_syntax('Stephen King', 602), '@**Stephen King|602**');
     assert.equal(people.get_mention_syntax('Maria Athens', 603), '@**Maria Athens**');
@@ -1034,18 +1008,6 @@ run_test('is_valid_full_name_and_user_id', () => {
 });
 
 run_test('emails_strings_to_user_ids_array', function () {
-    const steven = {
-        email: 'steven@example.com',
-        user_id: 7,
-        full_name: 'Steven',
-    };
-
-    const maria = {
-        email: 'maria@example.com',
-        user_id: 728,
-        full_name: 'Maria',
-    };
-
     people.add(steven);
     people.add(maria);
 
@@ -1058,19 +1020,6 @@ run_test('emails_strings_to_user_ids_array', function () {
 });
 
 run_test('get_visible_email', function () {
-    const steven = {
-        email: 'steven@example.com',
-        delivery_email: 'steven-delivery@example.com',
-        user_id: 7,
-        full_name: 'Steven',
-    };
-
-    const maria = {
-        email: 'maria@example.com',
-        user_id: 728,
-        full_name: 'Maria',
-    };
-
     people.add(steven);
     people.add(maria);
 
@@ -1082,36 +1031,22 @@ run_test('get_visible_email', function () {
 });
 
 run_test('get_active_message_people', function () {
-    const steven = {
-        email: 'steven@example.com',
-        user_id: 1,
-        full_name: 'Steven',
-    };
-
-    const maria = {
-        email: 'maria@example.com',
-        user_id: 2,
-        full_name: 'Maria',
-    };
-
-    const alice = {
-        email: 'alice@example.com',
-        user_id: 3,
-        full_name: 'Alice',
-    };
-
     message_store.user_ids = () => {
-        return [1, 2, 3];
+        return [
+            steven.user_id,
+            maria.user_id,
+            alice1.user_id,
+        ];
     };
 
     people.add(steven);
     people.add(maria);
-    people.add(alice);
+    people.add(alice1);
 
     let active_message_people = people.get_active_message_people();
-    assert.deepEqual(active_message_people, [steven, maria, alice]);
+    assert.deepEqual(active_message_people, [steven, maria, alice1]);
 
-    people.deactivate(alice);
+    people.deactivate(alice1);
     active_message_people = people.get_active_message_people();
     assert.deepEqual(active_message_people, [steven, maria]);
 });


### PR DESCRIPTION
I consolidate most of our users toward the top
of the file, so that we don't have to clutter
up individual tests.  This also avoids some
confusion where charles/maria got repeated
in different tests with different ids.

I also introduce a couple four-digit ids to
try to expose more bugs related to sorting.

Note that it's still easy to keep tests
isolated here, as we have always been able
to cheaply re-initialize `people.js` and then
add individual users back.

There are still some tests where it makes
sense to just declare users locally, especially
if we are mutating their data.

There are a few minor incidental cleanups here,
mostly involving replacing hard coded ids
with things like `maria.user_id`.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
