### PR TITLE
casper_tests: Adjust for the addition of Desdemona

### DIFF
--- a/frontend_tests/casper_tests/03-narrow.js
+++ b/frontend_tests/casper_tests/03-narrow.js
@@ -532,15 +532,17 @@ casper.then(function () {
                         {keepFocus: true});
     }
 
-    // go down 2, up 3 (which is really 2), then down 2
+    // go down 2, up 3 (which is really 2), then down 3
     //    Iago
     //    Cordelia
+    //    Desdemona
     //    Hamlet
     arrow('Down');
     arrow('Down');
     arrow('Up');
     arrow('Up');
     arrow('Up'); // does nothing
+    arrow('Down');
     arrow('Down');
     arrow('Down');
 });

--- a/frontend_tests/casper_tests/05-subscriptions.js
+++ b/frontend_tests/casper_tests/05-subscriptions.js
@@ -151,8 +151,9 @@ casper.then(function () {
     casper.test.assertSelectorHasText('.description', 'Oimeesaw');
     // Based on the selected checkboxes while creating stream,
     // 4 users from Scotland are added.
-    // 1 user, Cordelia, is added. Othello (subscribed to Scotland) is not added twice.
-    casper.test.assertSelectorHasText('.subscriber-count-text', '5');
+    // 1 user, Cordelia, is added. Othello (subscribed to Scotland) is removed.
+    // FIXME: This assertion may pick up the count from a random other stream.
+    casper.test.assertSelectorHasText('.subscriber-count-text', '4');
     casper.fill('form#stream_creation_form', {stream_name: '  '});
     casper.click('form#stream_creation_form button.button.sea-green');
 });


### PR DESCRIPTION
Commit 9b78a73e3692726d0e6e6cfe21f7e9116f61e2d0 (#15005) made some of our poorly written Casper tests fail.  Now they’re just as poorly written but passing again.

**Testing Plan:** `test-js-with-casper`