### PR TITLE
fix(travis): fix display emoji for `Pending` status

### DIFF
--- a/zerver/webhooks/travis/view.py
+++ b/zerver/webhooks/travis/view.py
@@ -39,7 +39,7 @@ def api_travis_webhook(request: HttpRequest, user_profile: UserProfile,
     elif message_status in BAD_STATUSES:
         emoji = ':thumbs_down:'
     elif message_status in PENDING_STATUSES:
-        emoji = ':arrows_counterclockwise:'
+        emoji = ':counterclockwise:'
     else:
         emoji = "(No emoji specified for status '{}'.)".format(message_status)
 


### PR DESCRIPTION
Fix as requested by @timabbott:

*  https://github.com/zulip/zulip/pull/15034#issuecomment-634451615

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->

---

In terms of the `repository_slug` in `MESSAGE_TEMPLATE` idea, then the following is relevant.

https://docs.travis-ci.com/user/notifications/#webhooks-delivery-format

> To quickly identify the repository involved, we include a `Travis-Repo-Slug` header, with a format of `account/repository`, so for instance `travis-ci/travis-ci`.