### PR TITLE
openapi_responses: Fix various response schemas in zulip.yaml.

### DIFF
--- a/templates/zerver/api/get-subscribed-streams.md
+++ b/templates/zerver/api/get-subscribed-streams.md
@@ -64,7 +64,7 @@ You may pass the `include_subscribers` query parameter as follows:
     * `pin_to_top`: A boolean specifying whether the given stream has been pinned
       to the top.
     * `email_address`: Email address of the given stream.
-    * `in_home_view`: Whether the given stream is muted or not. Muted streams do
+    * `is_muted`: Whether the given stream is muted or not. Muted streams do
       not count towards your total unread count and thus, do not show up in
       `All messages` view (previously known as `Home` view).
     * `color`: Stream color.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -812,6 +812,41 @@ paths:
                       type: array
                       items:
                         type: object
+                        properties:
+                          topic:
+                            type: string
+                            description: |
+                              the topic for the message.
+                          content:
+                            type: string
+                            description: |
+                              the body of the message.
+                          rendered_content:
+                            type: string
+                            description: |
+                              the already rendered, HTML version of `content`.
+                          prev_content:
+                            type: string
+                            description: |
+                              the body of the message before being edited.
+                          prev_rendered_content:
+                            type: string
+                            description: |
+                              the already rendered, HTML version of
+                              `prev_content`.
+                          user_id:
+                            type: integer
+                            description: |
+                              the ID of the user that made the edit.
+                          content_html_diff:
+                            type: string
+                            description: |
+                              an HTML diff between this version of the message
+                              and the previous one.
+                          timestamp:
+                            type: integer
+                            description: |
+                              the UNIX timestamp for this editing.
                       description: |
                         A chronologically sorted array of `snapshot`
                         objects, each one with the values of the

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3470,6 +3470,25 @@ paths:
                       type: array
                       items:
                         type: object
+                        properties:
+                          description:
+                            type: string
+                            description: |
+                              The human-readable description of the user group.
+                          id:
+                            type: integer
+                            description: |
+                              The user group's integer id.
+                          members:
+                            type: array
+                            description: |
+                              The integer User IDs of the user group members.
+                            items:
+                              type: integer
+                          name:
+                            type: string
+                            description: |
+                              User group name.
                       description: |
                         A list of `user_group` objects, which contain a `description`, a `name`,
                         their `id` and the list of members of the user group.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1585,12 +1585,13 @@ paths:
                     max_message_id:
                       type: integer
                       description: |
-                        NA.
+                        The integer ID of the message that the pointer is currently on.
                       example: 30
                     pointer:
                       type: integer
                       description: |
-                        NA
+                        The integer ID of the last message by the user/bot with
+                        the given profile.
                       example: -1
                     short_name:
                       type: string

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2226,6 +2226,40 @@ paths:
                       description: |
                         An object that contains `emoji` objects, each identified with their
                         emoji ID as the key.
+                      properties:
+                        id:
+                          type: integer
+                          description: |
+                            The ID for this emoji, same as the object's key.
+                        name:
+                          type: string
+                          description: |
+                            The user-friendly name for this emoji. Users in the organization
+                            can use this emoji by writing this name between colons (`:name:`).
+                        source_url:
+                          type: string
+                          description: |
+                            The path relative to the organization's URL where the
+                            emoji's image can be found.
+                        deactivated:
+                          type: string
+                          description: |
+                            Whether the emoji has been deactivated or not.
+                        author:
+                          description: |
+                            An object describing the user who created the custom emoji,
+                            with the following fields:
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                              description: The creator's user ID.
+                            email:
+                              type: string
+                              description: The creator's email address.
+                            full_name:
+                              type: string
+                              description: The creator's full name.
                 - example:
                     {
                         "result": "success",

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -499,6 +499,190 @@ paths:
                       type: array
                       items:
                         type: object
+                - properties:
+                    anchor:
+                      type: integer
+                      description: |
+                        The same `anchor` specified in the request (or the computed one, if
+                        `use_first_unread_anchor` is `true`).
+                    found_newest:
+                      type: boolean
+                      description: |
+                        Whether the `messages` list includes the very newest messages matching
+                        the narrow (used by clients that paginate their requests to decide
+                        whether there are more messages to fetch).
+                    found_oldest:
+                      type: boolean
+                      description: |
+                        Whether the `messages` list includes the very oldest messages matching
+                        the narrow (used by clients that paginate their requests to decide
+                        whether there are more messages to fetch).
+                    found_anchor:
+                      type: boolean
+                      description: |
+                        Whether the anchor message is included in the
+                        response. If the message with the ID specified
+                        in the request does not exist or did not match
+                        the narrow, this will be false.
+                    history_limited:
+                      type: boolean
+                      description: |
+                        Whether the message history was limited due to
+                        plan restrictions. This flag is set to `true`
+                        only when the oldest messages(`found_oldest`)
+                        matching the narrow is fetched.
+                    messages:
+                      type: array
+                      description: |
+                        an array of `message` objects, each containing the following
+                        fields:
+                      items:
+                        type: object
+                        properties:
+                          avatar_url:
+                            type: string
+                            description: |
+                              The URL of the user's avatar.
+                          client:
+                            type: string
+                            description: |
+                              A Zulip "client" string, describing what Zulip client
+                              sent the message.
+                          content:
+                            type: string
+                            description: |
+                              The content/body of the message.
+                          content_type:
+                            type: string
+                            description: |
+                              The HTTP `content_type` for the message content.  This
+                              will be `text/html` or `text/x-markdown`, depending on
+                              whether `apply_markdown` was set.
+                          display_recepient:
+                            oneOf:
+                            - type: string
+                            - type: array
+                              items:
+                                type: object
+                            description: |
+                              Data on the recipient of the message;
+                              either the name of a stream or a dictionary containing data on
+                              the users who received the message.
+                          flags:
+                            type: array
+                            description: |
+                              The user's [message flags][message-flags] for the message.
+                            items:
+                              type: string
+                          id:
+                            type: integer
+                            description: |
+                              The unique message ID.  Messages should always be
+                              displayed sorted by ID.
+                          is_me_message:
+                            type: boolean
+                            description: |
+                              Whether the message is a [/me status message][status-messages]
+                          reactions:
+                            type: array
+                            description: |
+                              Data on any reactions to the message.
+                            items:
+                              type: object
+                              properties:
+                                emoji_code:
+                                  type: integer
+                                  description: |
+                                    An encoded version of the emoji's unicode codepoint.
+                                emoji_name:
+                                  type: string
+                                  description: |
+                                    Name of the emoji.
+                                reaction_type:
+                                  type: string
+                                  description: |
+                                    If the reaction uses a [custom emoji](/help/add-custom-emoji),
+                                    `reaction_type` will be set to `realm_emoji`.
+                                user_id:
+                                  type: integer
+                                  description: |
+                                    The ID of the user who added the reaction.
+                                    **Changes**: New in Zulip 2.2 (feature level 2). The `user`
+                                    object is deprecated and will be removed in the future.
+                                user:
+                                  type: object
+                                  description: |
+                                    Dictionary with data on the user who added the reaction, including
+                                    the user ID as the `id` field.  **Note**: In the [events
+                                    API](/api/get-events-from-queue), this `user` dictionary
+                                    confusing had the user ID in a field called `user_id`
+                                    instead.  We recommend ignoring fields other than the user
+                                    ID.  **Deprecated** and to be removed in a future release
+                                    once core clients have migrated to use the `user_id` field.
+                          recipient_id:
+                            type: integer
+                            description: |
+                              A unique ID for the set of users receiving the
+                              message (either a stream or group of users).  Useful primarily
+                              for hashing.
+                          sender_email:
+                            type: string
+                            description: |
+                              The email address of the message's sender.
+                          sender_full_name:
+                            type: string
+                            description: |
+                              The full name of the message's sender.
+                          sender_id:
+                            type: integer
+                            description: |
+                              The user ID of the message's sender.
+                          sender_realm_str:
+                            type: string
+                            description: |
+                              A string identifier for the realm the sender
+                              is in.
+                          sender_short_name:
+                            type: string
+                            description: |
+                              Reserved for future use.
+                          stream_id:
+                            type: integer
+                            description: |
+                              Only present for stream messages; the ID of the stream.
+                          subject:
+                            type: string
+                            description: |
+                             The `topic` of the message (only present for stream
+                             messages).  The name is a legacy holdover from when topics were
+                             called "subjects"
+                          topic_links:
+                            type: array
+                            items:
+                              type: string
+                            description: |
+                              Data on any links to be included in the `topic`
+                              line (these are generated by [custom linkification
+                              filters][linkification-filters] that match content in the
+                              message's topic.)  **Changes**: New in Zulip 2.2 (feature level
+                              1).  Previously, this field was called `subject_links`; clients
+                              are recommended to rename `subject_links` to `topic_links` if
+                              present for compatibility with older Zulip servers.
+                          submessages:
+                            type: array
+                            items:
+                              type: string
+                            description: |
+                              Data used for certain experimental Zulip integrations.
+                          timestamp:
+                            type: integer
+                            description: |
+                              The UNIX timestamp for when the message was sent,
+                              in UTC seconds.
+                          type:
+                            type: string
+                            description: |
+                              The type of the message: `stream` or `private`.
                 - example:
                     {
                         "anchor": 21,

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1838,8 +1838,70 @@ paths:
                 - properties:
                     subscriptions:
                       type: array
+                      description: |
+                        A list of dictionaries where each dictionary contains
+                        information about one of the subscribed streams.
                       items:
                         type: object
+                        properties:
+                          stream_id:
+                            type: integer
+                            description: |
+                              The unique ID of a stream.
+                          name:
+                            type: string
+                            description: |
+                              The name of a stream.
+                          description:
+                            type: string
+                            description: |
+                              A short description of a stream.
+                          invite-only:
+                            type: boolean
+                            description: |
+                              Specifies whether a stream is private or not.
+                              Only people who have been invited can access a private stream.
+                          subscribers:
+                            type: array
+                            items:
+                             type: string
+                            description: |
+                              A list of email addresses of users who are also subscribed
+                              to a given stream. Included only if `include_subscribers` is `true`.
+                          desktop_notifications:
+                            type: boolean
+                            description: |
+                              A boolean specifying whether desktop notifications
+                              are enabled for the given stream.
+                          push_notifications:
+                            type: boolean
+                            description: |
+                              A boolean specifying whether push notifications
+                              are enabled for the given stream.
+                          audible_notifications:
+                            type: boolean
+                            description: |
+                              A boolean specifying whether audible notifications
+                              are enabled for the given stream.
+                          pin_to_top:
+                            type: boolean
+                            description: |
+                              A boolean specifying whether the given stream has been pinned
+                              to the top.
+                          email_address:
+                            type: string
+                            description: |
+                              Email address of the given stream.
+                          is_muted:
+                            type: boolean
+                            description: |
+                              Whether the given stream is muted or not. Muted streams do
+                              not count towards your total unread count and thus, do not show up in
+                              `All messages` view (previously known as `Home` view).
+                          color:
+                            type: string
+                            description: |
+                              Stream color
                 - example:
                     {
                       "msg": "",

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1514,6 +1514,31 @@ paths:
                       description: |
                         An object containing the presence details for every client the user has
                         logged into.
+                      additionalProperties:
+                        type: object
+                        properties:
+                          timestamp:
+                            type: integer
+                            description: |
+                              when this update was received; if the timestamp
+                              is more than a few minutes in the past, the user is offline.
+                          status:
+                            type: string
+                            description: |
+                              either `active` or `idle`: whether the user had
+                              recently interacted with Zulip at the time in the timestamp
+                              (this distinguishes orange vs. green dots in the Zulip web
+                              UI; orange/idle means we don't know whether the user is
+                              actually at their computer or just left the Zulip app open
+                              on their desktop).
+                        description: |
+                          `{client_name}` or `aggregated`: the keys for these objects are
+                          the names of the different clients where this user is logged in,
+                          like `website`, `ZulipDesktop`, `ZulipTerminal`, or
+                          `ZulipMobile`. There is also an `aggregated` key, which matches
+                          the contents of the object that has been updated most
+                          recently. For most applications, you'll just want to look at the
+                          `aggregated` key.
                 - example:
                     {
                         "presence": {


### PR DESCRIPTION
The response schemas of various endpoints in zulip.yaml are not complete or not at par with their documentation. Fix the response schemas in such cases. Also in some cases the documentation is wrong so fix the documentation accordingly.