### PR TITLE
models: Comment call to python2-esque `iteritems()`.

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -415,6 +415,9 @@ class Realm(models.Model):
 
         ret: Dict[str, bool] = {}
         supported_backends = [backend.__class__ for backend in supported_auth_backends()]
+        # `authentication_methods` is a bitfield.types.BitHandler, not
+        # a true dict; since it is still python2- and python3-compat,
+        # `iteritems` is its method to iterate over its contents.
         for k, v in self.authentication_methods.iteritems():
             backend = AUTH_BACKEND_NAME_MAP[k]
             if backend in supported_backends:


### PR DESCRIPTION
This method is called on a `bitfield.types.BitHandler` object, not a dict; as
such, it is not a runtime failure.

This was missed in 035ed93 and adjacent commits because it was not
`six.iteritems()` but just a bare `iteritems()` -- having been added
after 9e3c3e1 moved all other calls from `iteritems()` to
`six.iteritems()`.

Comment on why this is not a leftover python2-ism.

Grep finds no other remaining callsites to `iteritems` or friends:
```
$ rg '\.iter\w+\(' -t py
zerver/lib/url_preview/preview.py
44:        content = next(response.iter_content(1000))

zerver/lib/email_notifications.py
49:    for link_info in fragment.iterlinks():

zerver/lib/push_notifications.py
508:        nested_levels = len(list(ol.iterancestors('ol')))

zerver/lib/bugdown/__init__.py
1364:            parsed = etree.iterparse(StringIO(rendered))

zerver/lib/bugdown/nested_code_blocks.py
47:                if parent.text is None and len(list(parent)) == 1 and len(list(parent.itertext())) == 1:
```
