### PR TITLE
portico: Use green btn for `call-to-action-button`.

### DIFF
--- a/static/styles/portico/landing-page.scss
+++ b/static/styles/portico/landing-page.scss
@@ -1958,20 +1958,9 @@ nav ul li.active::after {
 .portico-landing.hello .call-to-action-bottom .button {
     display: table;
     margin: 20px auto 0 auto;
-    padding: 11px 25px 11px 25px;
-
-    font-size: 1.2rem;
-    color: hsl(220, 15%, 66%);
-
-    border: 1px solid hsl(220, 15%, 66%);
-    background-color: transparent;
-
-    transition: all 0.2s ease;
-}
-
-.portico-landing.hello .call-to-action-bottom .button:hover {
-    color: hsl(219, 23%, 33%);
-    border: 1px solid hsl(220, 15%, 20%);
+    padding: 10px 20px;
+    font-size: 1em;
+    font-weight: 600;
 }
 
 .portico-landing.hello .call-to-action-bottom h1 {

--- a/templates/zerver/hello.html
+++ b/templates/zerver/hello.html
@@ -528,17 +528,17 @@
     <div class="padded-content call-to-action-bottom">
         <h1>Experience Zulip today!</h1>
         {% if root_domain_landing_page %}
-        <a href="{{ url('plans') }}" class="download-button button">
+        <a href="{{ url('plans') }}" class="download-button button green">
             {{ _('See plans and pricing') }}
         </a>
         {% endif %}
         {% if register_link_disabled %}
         {% elif only_sso %}
-        <a href="{{ url('login-sso') }}" class="button">
+        <a href="{{ url('login-sso') }}" class="button green">
             {{ _('Log in now') }}
         </a>
         {% else %}
-        <a href="{{ url('register') }}" class="button">
+        <a href="{{ url('register') }}" class="button green">
             {{ _('Sign up now') }}
         </a>
         {% endif %}


### PR DESCRIPTION
This button will now look similar in design as we have on
our /app page.

Fixes: #15077

![Screenshot from 2020-05-28 02-43-16](https://user-images.githubusercontent.com/32801674/83072797-06044f00-a08d-11ea-858b-d58b8b9ac3d6.png)
