### PR TITLE
tests: Use do_change_user_role in lint rules and test docs.

### DIFF
--- a/docs/testing/testing-with-django.md
+++ b/docs/testing/testing-with-django.md
@@ -106,7 +106,7 @@ influence tests results.)
 Here are some example action methods that tests may use for data setup:
 
 - check_send_message
-- do_change_is_admin
+- do_change_user_role
 - do_create_user
 - do_make_stream_private
 

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -454,14 +454,14 @@ python_rules = RuleList(
          'description': 'Raise CommandError to exit with failure in management commands',
          },
         {'pattern': '.is_realm_admin =',
-         'description': 'Use do_change_is_admin function rather than setting UserProfile\'s is_realm_admin attribute directly.',
+         'description': 'Use do_change_user_role function rather than setting UserProfile\'s is_realm_admin attribute directly.',
          'exclude': {
              'zerver/migrations/0248_userprofile_role_start.py',
              'zerver/tests/test_users.py',
          },
          },
         {'pattern': '.is_guest =',
-         'description': 'Use do_change_is_guest function rather than setting UserProfile\'s is_guest attribute directly.',
+         'description': 'Use do_change_user_role function rather than setting UserProfile\'s is_guest attribute directly.',
          'exclude': {
              'zerver/migrations/0248_userprofile_role_start.py',
              'zerver/tests/test_users.py',


### PR DESCRIPTION
This commit changes test docs and lint rules to use do_change_user_role
instead of do_change_is_admin and do_change_is_guest.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
