### PR TITLE
styles: Undo calc(x + y) → calc(x - -y) workaround.

### DIFF
--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -357,7 +357,7 @@ input.recipient_box {
 }
 
 #stream_message_recipient_topic.recipient_box {
-    width: calc(20% - -14px);
+    width: calc(20% + 14px);
     min-width: 140px;
     max-width: 165px;
 }

--- a/static/styles/portico/portico.scss
+++ b/static/styles/portico/portico.scss
@@ -250,7 +250,7 @@ html {
     /* Extend highlight to entire width of sidebar, not just link area */
     /* This has been changed from "+" to "- -" because of issue #8403.
        If the issue has been fixed, please change this back to "+" again. */
-    width: calc(100% - -20px);
+    width: calc(100% + 20px);
     margin-left: -40px;
     padding-left: 40px;
 }
@@ -845,7 +845,7 @@ a.bottom-signup-button {
 
 .contributors-list {
     margin-left: -40px;
-    width: calc(100% - -80px);
+    width: calc(100% + 80px);
 }
 
 .contributors {
@@ -1000,7 +1000,7 @@ input#terminal:checked ~ #tab-terminal {
 .login-form {
     margin: auto;
     /* plus input padding. */
-    width: calc(300px - -28px);
+    width: calc(300px + 28px);
     margin-bottom: 10px;
 }
 

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -847,7 +847,7 @@ input[type=checkbox] {
 .add-new-profile-field-box,
 .add-new-filter-box {
     button {
-        margin-left: calc(10em - -20px) !important;
+        margin-left: calc(10em + 20px) !important;
     }
 }
 

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -461,7 +461,7 @@ form#add_new_subscription {
     }
 
     .right {
-        width: calc(50% - -1px);
+        width: calc(50% + 1px);
 
         .nothing-selected {
             display: block;

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -498,10 +498,6 @@ bash_rules = RuleList(
 css_rules = RuleList(
     langs=['css', 'scss'],
     rules=[
-        {'pattern': r'calc\([^+]+\+[^+]+\)',
-         'description': "Avoid using calc with '+' operator. See #8403 : in CSS.",
-         'good_lines': ["width: calc(20% - -14px);"],
-         'bad_lines': ["width: calc(20% + 14px);"]},
         {'pattern': r'^[^:]*:\S[^:]*;$',
          'description': "Missing whitespace after : in CSS",
          'good_lines': ["background-color: white;", "text-size: 16px;"],


### PR DESCRIPTION
The bug this was working around does not affect our current toolchain, as confirmed by grepping through the minified output.

(Also, this linter rule only matched `calc(x + y)` with two arguments and we were already using `calc($far_left_gutter_size + $left_col_size + 4px)`.)

Cc @showell