### PR TITLE
Replaced 'author' dict with 'author_id'

### DIFF
--- a/zerver/models.py
+++ b/zerver/models.py
@@ -633,7 +633,7 @@ def get_realm_emoji_dicts(realm: Realm,
                                       name=realm_emoji.name,
                                       source_url=emoji_url,
                                       deactivated=realm_emoji.deactivated,
-                                      author=author_id)
+                                      author_id=author_id)
     return d
 
 def get_realm_emoji_uncached(realm: Realm) -> Dict[str, Dict[str, Any]]:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -627,16 +627,13 @@ def get_realm_emoji_dicts(realm: Realm,
     for realm_emoji in query.all():
         author = None
         if realm_emoji.author:
-            author = {
-                'id': realm_emoji.author.id,
-                'email': realm_emoji.author.email,
-                'full_name': realm_emoji.author.full_name}
+            author_id = realm_emoji.author.id
         emoji_url = get_emoji_url(realm_emoji.file_name, realm_emoji.realm_id)
         d[str(realm_emoji.id)] = dict(id=str(realm_emoji.id),
                                       name=realm_emoji.name,
                                       source_url=emoji_url,
                                       deactivated=realm_emoji.deactivated,
-                                      author=author)
+                                      author=author_id)
     return d
 
 def get_realm_emoji_uncached(realm: Realm) -> Dict[str, Dict[str, Any]]:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -625,7 +625,7 @@ def get_realm_emoji_dicts(realm: Realm,
     from zerver.lib.emoji import get_emoji_url
 
     for realm_emoji in query.all():
-        author = None
+        author_id = None
         if realm_emoji.author:
             author_id = realm_emoji.author.id
         emoji_url = get_emoji_url(realm_emoji.file_name, realm_emoji.realm_id)

--- a/zerver/tests/test_realm_emoji.py
+++ b/zerver/tests/test_realm_emoji.py
@@ -12,7 +12,7 @@ class RealmEmojiTest(ZulipTestCase):
         with get_test_image_file('img.png') as img_file:
             realm_emoji = check_add_realm_emoji(realm=author.realm,
                                                 name=name,
-                                                author=author_id,
+                                                author=author,
                                                 image_file=img_file)
             if realm_emoji is None:
                 raise Exception("Error creating test emoji.")   # nocoverage
@@ -42,7 +42,7 @@ class RealmEmojiTest(ZulipTestCase):
         content = result.json()
         self.assertEqual(len(content["emoji"]), 2)
         test_emoji = content["emoji"][str(realm_emoji.id)]
-        self.assertIsNone(test_emoji['author'])
+        self.assertIsNone(test_emoji['author_id'])
 
     def test_list_admins_only(self) -> None:
         # Test that realm emoji list is public and realm emojis
@@ -58,7 +58,7 @@ class RealmEmojiTest(ZulipTestCase):
         content = result.json()
         self.assertEqual(len(content["emoji"]), 2)
         test_emoji = content["emoji"][str(realm_emoji.id)]
-        self.assertIsNone(test_emoji['author'])
+        self.assertIsNone(test_emoji['author_id'])
 
     def test_upload(self) -> None:
         user = self.example_user('iago')
@@ -77,8 +77,9 @@ class RealmEmojiTest(ZulipTestCase):
         self.assert_json_success(result)
         self.assertEqual(len(content["emoji"]), 2)
         test_emoji = content["emoji"][str(realm_emoji.id)]
-        self.assertIn('author', test_emoji)
-        self.assertEqual(test_emoji['author']['email'], email)
+        self.assertIn('author_id', test_emoji)
+        author = UserProfile.objects.get(id = test_emoji['author_id'])
+        self.assertEqual(author.email, email)
 
     def test_realm_emoji_repr(self) -> None:
         realm_emoji = RealmEmoji.objects.get(name='green_tick')

--- a/zerver/tests/test_realm_emoji.py
+++ b/zerver/tests/test_realm_emoji.py
@@ -12,7 +12,7 @@ class RealmEmojiTest(ZulipTestCase):
         with get_test_image_file('img.png') as img_file:
             realm_emoji = check_add_realm_emoji(realm=author.realm,
                                                 name=name,
-                                                author=author,
+                                                author=author_id,
                                                 image_file=img_file)
             if realm_emoji is None:
                 raise Exception("Error creating test emoji.")   # nocoverage


### PR DESCRIPTION

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/15115
Replaced the `author` dict in the `get_realm_emoji_dicts` function with a simple `author_id` to make API cleaner.

**Testing Plan:** <!-- How have you tested? -->
Tested the API using ```./tools/test-api``` and all tests passed.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
