### PR TITLE
Adds Uppercase words in topic name randomly

### DIFF
--- a/zerver/tests/fixtures/config.generate_data.json
+++ b/zerver/tests/fixtures/config.generate_data.json
@@ -1,12 +1,12 @@
 {
   "gen_fodder":
   {
-    "nouns":["server", "laptop", "router", "bridge",
-      "cat5", "nas", "file server", "wifi", "printer",
-      "plotter", "desktop", "database", "keurig"],
+    "nouns":["server", "FAILED EXPORT", "RECENT TOPICS",  "laptop", "BOTS", "router", "bridge",
+      "cat5", "nas", "MOBILE", "file server", "API", "wifi", "printer",
+      "plotter", "WEBAPP", "desktop", "PLOTS", "database", "URLS", "keurig"],
 
-    "adjectives": ["new", "old", "first", "last", "big", "little",
-      "leased", "owned", "red", "blue", "green"],
+    "adjectives": ["new", "LAST",  "old", "first", "NEW", "last", "big", "little",
+      "leased", "FIRST", "owned", "red", "blue", "OLD", "green"],
 
      "verbs": ["running", "skipping", "loading", "linking",
       "over-heating", "de-duping", "compiling"],


### PR DESCRIPTION
This adds uppercase words in the topic name randomly.

THE ISSUE: https://github.com/zulip/zulip/issues/14991

Testing Plan:
1) repopulate the database by using : ./manage.py populate_db
2) ./tools/run-dev.py
