### PR TITLE
Remove old references to "wiki" or "trac"

### DIFF
--- a/puppet/zulip_ops/files/munin/apache.conf
+++ b/puppet/zulip_ops/files/munin/apache.conf
@@ -27,9 +27,9 @@ Alias /munin /var/cache/munin/www
 	#
 
         AuthType Digest
-        AuthName "wiki"
+        AuthName "monitoring"
         AuthDigestProvider file
-        AuthUserFile /etc/apache2/users/wiki
+        AuthUserFile /etc/apache2/users/monitoring
         Require valid-user
 
 	# This next part requires mod_expires to be enabled.
@@ -62,9 +62,9 @@ Alias /munin /var/cache/munin/www
 ScriptAlias /munin-cgi/munin-cgi-graph /usr/lib/munin/cgi/munin-cgi-graph
 <Location /munin-cgi/munin-cgi-graph>
         AuthType Digest
-        AuthName "wiki"
+        AuthName "monitoring"
         AuthDigestProvider file
-        AuthUserFile /etc/apache2/users/wiki
+        AuthUserFile /etc/apache2/users/monitoring
         Require valid-user
 
 	<IfModule mod_fcgid.c>
@@ -78,9 +78,9 @@ ScriptAlias /munin-cgi/munin-cgi-graph /usr/lib/munin/cgi/munin-cgi-graph
 ScriptAlias /munin-cgi/munin-cgi-html /usr/lib/munin/cgi/munin-cgi-html
 <Location /munin-cgi/munin-cgi-html>
         AuthType Digest
-        AuthName "wiki"
+        AuthName "monitoring"
         AuthDigestProvider file
-        AuthUserFile /etc/apache2/users/wiki
+        AuthUserFile /etc/apache2/users/monitoring
         Require valid-user
 
 	<IfModule mod_fcgid.c>

--- a/puppet/zulip_ops/manifests/apache.pp
+++ b/puppet/zulip_ops/manifests/apache.pp
@@ -18,7 +18,7 @@ class zulip_ops::apache {
     mode    => '0600',
   }
 
-  file { '/etc/apache2/users/wiki':
+  file { '/etc/apache2/users/monitoring':
     ensure  => file,
     require => File['/etc/apache2/users/'],
     owner   => 'www-data',

--- a/puppet/zulip_ops/templates/nagios_apache_site.conf.template.erb
+++ b/puppet/zulip_ops/templates/nagios_apache_site.conf.template.erb
@@ -27,9 +27,9 @@
 
     <Location "/">
         AuthType Digest
-        AuthName "wiki"
+        AuthName "monitoring"
         AuthDigestProvider file
-        AuthUserFile /etc/apache2/users/wiki
+        AuthUserFile /etc/apache2/users/monitoring
         Require valid-user
     </Location>
 


### PR DESCRIPTION
Remove vestigial references to `trac` or `wiki`.

**Testing Plan:** <!-- How have you tested? -->
Untested.  How do we test `puppet apply`?
