### PR TITLE
presence: Fix "Last active:" in buddy list when last presence is idle.

### DIFF
--- a/frontend_tests/node_tests/presence.js
+++ b/frontend_tests/node_tests/presence.js
@@ -48,12 +48,26 @@ const bot = {
     is_bot: true,
 };
 
+const john = {
+    email: 'john@zulip.com',
+    user_id: 8,
+    full_name: "John Doe",
+};
+
+const jane = {
+    email: 'jane@zulip.com',
+    user_id: 9,
+    full_name: "Jane Doe",
+};
+
 people.add_active_user(me);
 people.add_active_user(alice);
 people.add_active_user(fred);
 people.add_active_user(sally);
 people.add_active_user(zoe);
 people.add_active_user(bot);
+people.add_active_user(john);
+people.add_active_user(jane);
 people.initialize_current_user(me.user_id);
 
 run_test('my user', () => {
@@ -122,7 +136,7 @@ run_test('status_from_raw', () => {
         status_from_raw(raw),
         {
             status: 'idle',
-            last_active: raw.active_timestamp,
+            last_active: raw.idle_timestamp,
         }
     );
 });
@@ -150,6 +164,14 @@ run_test('set_presence_info', () => {
         active_timestamp: a_while_ago,
     };
 
+    presences[john.user_id.toString()] = {
+        idle_timestamp: a_while_ago,
+    };
+
+    presences[jane.user_id.toString()] = {
+        idle_timestamp: now,
+    };
+
     const params = {};
     params.presences = presences;
     params.initial_servertime = now;
@@ -165,7 +187,7 @@ run_test('set_presence_info', () => {
     );
 
     assert.deepEqual(presence.presence_info.get(fred.user_id),
-                     { status: 'idle', last_active: a_while_ago}
+                     { status: 'idle', last_active: now}
     );
     assert.equal(presence.get_status(fred.user_id), 'idle');
 
@@ -187,6 +209,17 @@ run_test('set_presence_info', () => {
 
     assert(!presence.presence_info.has(bot.user_id));
     assert.equal(presence.get_status(bot.user_id), 'offline');
+
+    assert.deepEqual(presence.presence_info.get(john.user_id),
+                     { status: 'offline', last_active: a_while_ago}
+    );
+    assert.equal(presence.get_status(john.user_id), 'offline');
+
+    assert.deepEqual(presence.presence_info.get(jane.user_id),
+                     { status: 'idle', last_active: now}
+    );
+    assert.equal(presence.get_status(jane.user_id), 'idle');
+
 });
 
 run_test('falsy values', () => {
@@ -214,7 +247,19 @@ run_test('falsy values', () => {
 
         assert.deepEqual(
             presence.presence_info.get(zoe.user_id),
-            { status: 'idle', last_active: undefined }
+            { status: 'idle', last_active: a_bit_ago }
+        );
+
+        presences[zoe.user_id.toString()] = {
+            active_timestamp: falsy_value,
+            idle_timestamp: falsy_value,
+        };
+
+        presence.set_info(presences, now);
+
+        assert.deepEqual(
+            presence.presence_info.get(zoe.user_id),
+            { status: 'offline', last_active: undefined }
         );
     }
 });
@@ -277,7 +322,7 @@ run_test('update_info_from_event', () => {
 
     assert.deepEqual(
         presence.presence_info.get(alice.user_id),
-        { status: 'active', last_active: 500 }
+        { status: 'active', last_active: 510 }
     );
 
     info = {
@@ -290,6 +335,6 @@ run_test('update_info_from_event', () => {
 
     assert.deepEqual(
         presence.presence_info.get(alice.user_id),
-        { status: 'idle', last_active: 500 }
+        { status: 'idle', last_active: 1000 }
     );
 });

--- a/static/js/presence.js
+++ b/static/js/presence.js
@@ -58,6 +58,11 @@ exports.status_from_raw = function (raw) {
     const active_timestamp = raw.active_timestamp;
     const idle_timestamp = raw.idle_timestamp;
 
+    let last_active;
+    if (active_timestamp !== undefined || idle_timestamp !== undefined) {
+        last_active = Math.max(active_timestamp || 0, idle_timestamp || 0);
+    }
+
     /*
         If the server sends us `active_timestamp`, this
         means at least one client was active at this time
@@ -70,20 +75,20 @@ exports.status_from_raw = function (raw) {
     if (age(active_timestamp) < OFFLINE_THRESHOLD_SECS) {
         return {
             status: 'active',
-            last_active: active_timestamp,
+            last_active: last_active,
         };
     }
 
     if (age(idle_timestamp) < OFFLINE_THRESHOLD_SECS) {
         return {
             status: 'idle',
-            last_active: active_timestamp,
+            last_active: last_active,
         };
     }
 
     return {
         status: 'offline',
-        last_active: active_timestamp,
+        last_active: last_active,
     };
 };
 


### PR DESCRIPTION
The mechanism of the bug is explained below. To reproduce, just mouseover some of the Idle people on czo, it shows "Last active: more than 2 weeks ago", because the latest presence status update of the apps they use is IDLE. We chatted with @showell  and decided to restore the old behavior (explained below too) for now.


Commit message:

Restored old behavior accidentally removed in
https://github.com/zulip/zulip/commit/1ae07b93d892bbc1a5f939a2a099d5462f7e1970#diff-e353fab8bea58b8746ec68c83aa39b36L48

The server only remembers the most recent presence status update per
device. Meaning that, for instance, if the user only uses one client and
that client's last status update was IDLE, then the server only knows
that, doesn't know anything about the user's last ACTIVE time. Thus the
"active_timestamp" the server will serve about this user to the webapp
will be "undefined".
The old behavior was that for the sake of the "Last active: x ago"
status in buddy list popover, the latest status timestamp was used,
whether IDLE or ACTIVE.
The change linked about changed that to only pay attention to
ACTIVE. Thus, if the server doesn't remember any ACTIVE statuses, webapp
would show "Last active: More than 2 weeks ago", which was incorrect.

We restore the old behavior and further improvements can be made on top
of this.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
