### PR TITLE
Revert "buddy list: Adjust sizing calc for narrow mode."

### DIFF
--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -49,25 +49,8 @@ function get_new_heights() {
 
     // RIGHT SIDEBAR
 
-    // Calculate our top offset, which should typically be 50px,
-    // even though we sometimes split that as 40px of margin
-    // and 10px of padding, and other times its just 50px of
-    // margin.  (See the commit message for this comment for
-    // more history).
-
-    const top_offset = $('#right-sidebar').position().top * -1;
-
-    if (top_offset !== 0 && top_offset !== 50) {
-        // If somebody changes the CSS for the right-sidebar without
-        // re-testing this code, it might introduce subtle bugs.  I
-        // am only making it a warning, since I think we have some
-        // legacy media rules for really old screens that might trigger
-        // this.
-        blueslip.warn('Possibly unexpected `top` for #right-sidebar is: ' + top_offset);
-    }
-
     const usable_height = viewport_height
-        - top_offset
+        - parseInt($("#right-sidebar").css("marginTop"), 10)
         - $("#userlist-header").safeOuterHeight(true)
         - $("#user_search_section").safeOuterHeight(true)
         - invite_user_link_height


### PR DESCRIPTION
This reverts commit 9f5725d2659560a15399bf0ff3e64a0dbdb0be94.

I was trying to fix how we display the buddy list in
narrow mode, which was 10px, but my fix ended up making
things worse for regular mode, and somebody reported
a traceback related to this, which I didn't fully research,
but which I suspect is related to some media-query settings
for small screens or due to the put-buddy-list-in-left-pane
setting.  (Basically, `$('#right-sidebar').position()` may
be undefined in some cases, and I wasn't handling that.)

After reverting this, we still have the original
off-by-10px bug that I was trying to fix, but I will
attempt to do that more cleanly in a separate commit.

This should make it so that in normal situations where
the buddy list is in the right sidebar, we will be
able to see the "Invite more users" link again.

Fortunally, this regression was only on master for a
couple days, and users could still invite users via
the gear menu.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
