### PR TITLE
users: Modify update user API endpoint to accept role as parameter.

### DIFF
--- a/static/js/settings_config.js
+++ b/static/js/settings_config.js
@@ -158,6 +158,21 @@ exports.msg_delete_limit_dropdown_values = time_limit_dropdown_values;
 
 exports.retain_message_forever = -1;
 
+exports.user_role_values = {
+    guest: {
+        code: 600,
+        description: i18n.t("Guest"),
+    },
+    member: {
+        code: 400,
+        description: i18n.t("Member"),
+    },
+    admin: {
+        code: 200,
+        description: i18n.t("Administrator"),
+    },
+};
+
 // NOTIFICATIONS
 
 exports.general_notifications_table_labels = {

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -1,4 +1,5 @@
 const settings_data = require("./settings_data");
+const settings_config = require("./settings_config");
 const render_admin_user_list = require("../templates/admin_user_list.hbs");
 const render_admin_human_form = require('../templates/admin_human_form.hbs');
 const render_admin_bot_form = require('../templates/admin_bot_form.hbs');
@@ -64,6 +65,16 @@ function sort_last_active(a, b) {
 
 function get_user_info_row(user_id) {
     return $("tr.user_row[data-user-id='" + user_id + "']");
+}
+
+function set_user_role_dropdown(person) {
+    let role_value = settings_config.user_role_values.member.code;
+    if (person.is_admin) {
+        role_value = settings_config.user_role_values.admin.code;
+    } else if (person.is_guest) {
+        role_value = settings_config.user_role_values.guest.code;
+    }
+    $('#user-role-select').val(role_value);
 }
 
 function update_view_on_deactivate(row) {
@@ -377,14 +388,13 @@ function open_human_form(person) {
         user_id: user_id,
         email: person.email,
         full_name: person.full_name,
-        is_admin: person.is_admin,
-        is_guest: person.is_guest,
-        is_member: !person.is_admin && !person.is_guest,
+        user_role_values: settings_config.user_role_values,
     });
     const div = $(html);
     const modal_container = $('#user-info-form-modal-container');
     modal_container.empty().append(div);
     overlays.open_modal('#admin-human-form');
+    set_user_role_dropdown(person);
 
     const element = "#admin-human-form .custom-profile-field-form";
     $(element).html("");
@@ -587,15 +597,14 @@ function handle_human_form(tbody, status_field) {
             e.preventDefault();
             e.stopPropagation();
 
-            const user_role_select_value = modal.find('#user-role-select').val();
+            const role = parseInt(modal.find('#user-role-select').val().trim(), 10);
             const full_name = modal.find("input[name='full_name']");
             const profile_data = get_human_profile_data(fields_user_pills);
 
             const url = "/json/users/" + encodeURIComponent(user_id);
             const data = {
                 full_name: JSON.stringify(full_name.val()),
-                is_admin: JSON.stringify(user_role_select_value === 'admin'),
-                is_guest: JSON.stringify(user_role_select_value === 'guest'),
+                role: JSON.stringify(role),
                 profile_data: JSON.stringify(profile_data),
             };
 

--- a/static/templates/admin_human_form.hbs
+++ b/static/templates/admin_human_form.hbs
@@ -17,10 +17,8 @@
                 </div>
                 <div class="input-group">
                     <label class="input-label" for="user-role-select">{{t 'User role' }}</label>
-                    <select name="user-role-select" id="user-role-select">
-                        <option value="guest" {{#if is_guest}}selected{{/if}}>{{t 'Guest'}}</option>
-                        <option value="regular" {{#if is_member}}selected{{/if}}>{{t 'Member' }}</option>
-                        <option value="admin" {{#if is_admin}}selected{{/if}}>{{t 'Administrator' }}</option>
+                    <select name="user-role-select" id="user-role-select" data-setting-widget-type="number">
+                        {{> settings/dropdown_options_widget option_values=user_role_values}}
                     </select>
                 </div>
                 <div class="custom-profile-field-form"></div>

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -880,6 +880,12 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
     ROLE_GUEST = 600
     role: int = models.PositiveSmallIntegerField(default=ROLE_MEMBER, db_index=True)
 
+    ROLE_TYPES = [
+        ROLE_REALM_ADMINISTRATOR,
+        ROLE_MEMBER,
+        ROLE_GUEST,
+    ]
+
     # Whether the user has been "soft-deactivated" due to weeks of inactivity.
     # For these users we avoid doing UserMessage table work, as an optimization
     # for large Zulip organizations with lots of single-visit users.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1579,21 +1579,13 @@ paths:
               type: string
             example: NewName
         required: false
-      - name: is_admin
+      - name: role
         in: query
         description: |
-          Whether the target user is an administrator.
+          Role of user.
         schema:
-          type: boolean
-        example: false
-        required: false
-      - name: is_guest
-        in: query
-        description: |
-          Whether the target user is a guest.
-        schema:
-          type: boolean
-        example: true
+          type: integer
+        example: 400
         required: false
       - name: profile_data
         in: query


### PR DESCRIPTION
This PR changes the update user API endpoint to accept role
as parameter instead of the bool parameters is_guest and is_admin.

User role dropdown in user info modal is also modified to use
"dropdown_options_widget".

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
