### PR TITLE
tests: Fix tests to use role instead of is_admin for updating user.

### DIFF
--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -265,9 +265,6 @@ class PermissionTest(ZulipTestCase):
         self.assert_json_success(result)
         hamlet = self.example_user('hamlet')
         self.assertEqual(hamlet.full_name, new_name)
-        req['is_admin'] = ujson.dumps(False)
-        result = self.client_patch('/json/users/{}'.format(hamlet.id), req)
-        self.assert_json_success(result)
 
     def test_non_admin_cannot_change_full_name(self) -> None:
         self.login('hamlet')

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -252,7 +252,7 @@ class PermissionTest(ZulipTestCase):
 
     def test_user_cannot_promote_to_admin(self) -> None:
         self.login('hamlet')
-        req = dict(is_admin=ujson.dumps(True))
+        req = dict(role=ujson.dumps(UserProfile.ROLE_REALM_ADMINISTRATOR))
         result = self.client_patch('/json/users/{}'.format(self.example_user('hamlet').id), req)
         self.assert_json_error(result, 'Insufficient permission')
 


### PR DESCRIPTION
This PR fixes the tests to use role instead of is_admin in
update user endpoint. These changes got missed in the original
commit in #15143 which included the change of using role in update user
endpoint and were also not caught in tests.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
