### PR TITLE
openapi: Parse {!api-admin-only.md!} in OpenAPI markdown extension.

### DIFF
--- a/templates/zerver/api/create-user.md
+++ b/templates/zerver/api/create-user.md
@@ -1,7 +1,5 @@
 # Create a user
 
-{!api-admin-only.md!}
-
 {generate_api_description(/users:post)}
 
 ## Usage examples

--- a/templates/zerver/api/deactivate-user.md
+++ b/templates/zerver/api/deactivate-user.md
@@ -1,7 +1,5 @@
 # Deactivate a user
 
-{!api-admin-only.md!}
-
 {generate_api_description(/users/{user_id}:delete)}
 
 ## Usage examples

--- a/templates/zerver/api/reactivate-user.md
+++ b/templates/zerver/api/reactivate-user.md
@@ -1,8 +1,5 @@
 # Reactivate a user
 
-{!api-admin-only.md!}
-
-
 {generate_api_description(/users/{user_id}/reactivate:post)}
 
 ## Usage examples

--- a/templates/zerver/api/update-user.md
+++ b/templates/zerver/api/update-user.md
@@ -1,7 +1,5 @@
 # Update a user
 
-{!api-admin-only.md!}
-
 {generate_api_description(/users/{user_id}:patch)}
 
 ## Usage examples

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1543,6 +1543,8 @@ paths:
       operationId: create_user
       tags: ["users"]
       description: |
+        {!api-admin-only.md!}
+
         Create a new user account via the API.
 
         `POST {{ api_url }}/v1/users`
@@ -1679,6 +1681,8 @@ paths:
       operationId: update_user
       tags: ["users"]
       description: |
+        {!api-admin-only.md!}
+
         Administrative endpoint to update the details of another user in the organization.
 
         `PATCH {{ api_url }}/v1/users/{user_id}`
@@ -1761,6 +1765,8 @@ paths:
       operationId: deactivate_user
       tags: ["users"]
       description: |
+        {!api-admin-only.md!}
+
         [Deactivates a
         user](https://zulip.com/help/deactivate-or-reactivate-a-user)
         given their user ID.
@@ -1799,6 +1805,8 @@ paths:
       operationId: reactivate_user
       tags: ["users"]
       description: |
+        {!api-admin-only.md!}
+
         [Reactivates a
         user](https://zulip.com/help/deactivate-or-reactivate-a-user)
         given their user ID.

--- a/zerver/templatetags/app_filters.py
+++ b/zerver/templatetags/app_filters.py
@@ -128,7 +128,7 @@ def render_markdown_path(markdown_file_path: str,
             api_url=context["api_url"],
         )]
     if not any(doc in markdown_file_path for doc in docs_without_macros):
-        extensions = extensions + [md_macro_extension]
+        extensions = [md_macro_extension] + extensions
 
     md_engine = markdown.Markdown(extensions=extensions)
     md_engine.reset()


### PR DESCRIPTION
Currently, the OpenAPI extension for rendering description in docs
cannot parse {!api-admin-only.md!}. Edit order of markdown extensions
so that substitution of OpenAPI elements takes place before substitution
of files. 