### PR TITLE
stream_color.js: Fix color picker not saving custom color.

### DIFF
--- a/static/js/stream_color.js
+++ b/static/js/stream_color.js
@@ -93,7 +93,7 @@ exports.sidebar_popover_colorpicker_options = {
 };
 
 exports.sidebar_popover_colorpicker_options_full = {
-    clickoutFiresChange: true,
+    clickoutFiresChange: false,
     showPalette: true,
     showInput: true,
     flat: true,


### PR DESCRIPTION
Fix a bug where the color picker reverted the custom color to the
previous one after clicking outside the popover. The bug occurred
because although there is a confirm button, the 'clickoutFiresChanges'
option was set as true, which made the frontend always send two POST
request to edit the stream and, for a reason I wasn't able to discover,
if you hit the confirm button and click outside fast enough, the change
fired by the clickout event sent the old color to the server. It was
fixed by setting the 'clickoutFiresChanges' option to false.

Fixes #15101

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![colorpickor](https://user-images.githubusercontent.com/16260725/83314024-f3099000-a1ee-11ea-8f48-f750b694203d.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
