### PR TITLE
populate_db: Reduce 'boring users' threshold.

### DIFF
--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -246,7 +246,7 @@ class Command(BaseCommand):
             # functions somewhat realistic.  We'll still create 1000 users
             # like Extra222 User for some predicability.
             num_names = options['extra_users']
-            num_boring_names = 1000
+            num_boring_names = 300
 
             for i in range(min(num_names, num_boring_names)):
                 full_name = 'Extra%03d User' % (i,)


### PR DESCRIPTION
I reduced `num_boring_users` from 1000 to 300 per the request of @showell,
who originally set that constant and feels it should be reduced.

He wanted me to reduce it partly to make it easier to have more realistic
names in the buddy list before hitting the 600-users limit on the buddy list.