### PR TITLE
events: Update person dict in event for do_change_user_role to send role.

### DIFF
--- a/frontend_tests/node_tests/user_events.js
+++ b/frontend_tests/node_tests/user_events.js
@@ -75,14 +75,14 @@ run_test('updates', () => {
     };
     people.add_active_user(isaac);
 
-    user_events.update_person({user_id: isaac.user_id, is_guest: true});
+    user_events.update_person({user_id: isaac.user_id, role: 600});
     person = people.get_by_email(isaac.email);
     assert(person.is_guest);
-    user_events.update_person({user_id: isaac.user_id, is_guest: false});
+    user_events.update_person({user_id: isaac.user_id, role: 400});
     person = people.get_by_email(isaac.email);
     assert(!person.is_guest);
 
-    user_events.update_person({user_id: isaac.user_id, is_admin: true});
+    user_events.update_person({user_id: isaac.user_id, role: 200});
     person = people.get_by_email(isaac.email);
     assert.equal(person.full_name, 'Isaac Newton');
     assert.equal(person.is_admin, true);
@@ -101,7 +101,7 @@ run_test('updates', () => {
     assert.equal(user_id, isaac.user_id);
     assert.equal(full_name, 'Sir Isaac');
 
-    user_events.update_person({user_id: me.user_id, is_admin: false});
+    user_events.update_person({user_id: me.user_id, role: 400});
     assert(!global.page_params.is_admin);
 
     user_events.update_person({user_id: me.user_id, full_name: 'Me V2'});

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -360,7 +360,7 @@ exports.update_user_data = function (user_id, new_data) {
         }
     }
 
-    if (new_data.is_admin !== undefined || new_data.is_guest !== undefined) {
+    if (new_data.role !== undefined) {
         user_row.find(".user_role").text(people.get_user_type(user_id));
     }
 };

--- a/static/js/user_events.js
+++ b/static/js/user_events.js
@@ -2,7 +2,7 @@
 // server_events.js simple while breaking some circular
 // dependencies that existed when this code was in people.js.
 // (We should do bot updates here too.)
-
+const settings_config = require('./settings_config');
 exports.update_person = function update(person) {
     const person_obj = people.get_by_user_id(person.user_id);
 
@@ -47,23 +47,19 @@ exports.update_person = function update(person) {
         }
     }
 
-    if (Object.prototype.hasOwnProperty.call(person, 'is_admin')) {
-        person_obj.is_admin = person.is_admin;
+    if (Object.prototype.hasOwnProperty.call(person, 'role')) {
+        person_obj.is_admin = person.role === settings_config.user_role_values.admin.code;
+        person_obj.is_guest = person.role === settings_config.user_role_values.guest.code;
         settings_users.update_user_data(person.user_id, person);
 
-        if (people.is_my_user_id(person.user_id)) {
-            page_params.is_admin = person.is_admin;
+        if (people.is_my_user_id(person.user_id) && page_params.is_admin !== person_obj.is_admin) {
+            page_params.is_admin = person_obj.is_admin;
             gear_menu.update_org_settings_menu_item();
             settings_linkifiers.maybe_disable_widgets();
             settings_org.maybe_disable_widgets();
             settings_profile_fields.maybe_disable_widgets();
             settings_streams.maybe_disable_widgets();
         }
-    }
-
-    if (Object.prototype.hasOwnProperty.call(person, 'is_guest')) {
-        person_obj.is_guest = person.is_guest;
-        settings_users.update_user_data(person.user_id, person);
     }
 
     if (Object.prototype.hasOwnProperty.call(person, 'avatar_url')) {

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3438,21 +3438,9 @@ def do_change_user_role(user_profile: UserProfile, value: int) -> None:
             RealmAuditLog.NEW_VALUE: value,
             RealmAuditLog.ROLE_COUNT: realm_user_count_by_role(user_profile.realm),
         }))
-    if UserProfile.ROLE_REALM_ADMINISTRATOR in [old_value, value]:
-        event = dict(type="realm_user", op="update",
-                     person=dict(user_id=user_profile.id,
-                                 is_admin=value == UserProfile.ROLE_REALM_ADMINISTRATOR))
-        send_event(user_profile.realm, event, active_user_ids(user_profile.realm_id))
-    if UserProfile.ROLE_GUEST in [old_value, value]:
-        event = dict(type="realm_user", op="update",
-                     person=dict(user_id=user_profile.id,
-                                 is_guest=value == UserProfile.ROLE_GUEST))
-        send_event(user_profile.realm, event, active_user_ids(user_profile.realm_id))
-    if UserProfile.ROLE_REALM_OWNER in [old_value, value]:
-        event = dict(type="realm_user", op="update",
-                     person=dict(user_id=user_profile.id,
-                                 is_owner=value == UserProfile.ROLE_REALM_OWNER))
-        send_event(user_profile.realm, event, active_user_ids(user_profile.realm_id))
+    event = dict(type="realm_user", op="update",
+                 person=dict(user_id=user_profile.id, role=user_profile.role))
+    send_event(user_profile.realm, event, active_user_ids(user_profile.realm_id))
 
 def do_change_is_api_super_user(user_profile: UserProfile, value: bool) -> None:
     user_profile.is_api_super_user = value

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -418,7 +418,11 @@ def apply_event(state: Dict[str, Any],
                     state['avatar_url'] = person['avatar_url']
                     state['avatar_url_medium'] = person['avatar_url_medium']
 
-                for field in ['is_admin', 'delivery_email', 'email', 'full_name']:
+                if 'role' in person:
+                    state['is_admin'] = person['role'] == UserProfile.ROLE_REALM_ADMINISTRATOR
+                    state['is_guest'] = person['role'] == UserProfile.ROLE_GUEST
+
+                for field in ['delivery_email', 'email', 'full_name']:
                     if field in person and field in state:
                         state[field] = person[field]
 
@@ -428,10 +432,10 @@ def apply_event(state: Dict[str, Any],
                 # realm.  This is ugly and probably better
                 # solved by removing the all-realm-bots data
                 # given to admin users from this flow.
-                if ('is_admin' in person and 'realm_bots' in state):
+                if ('role' in person and 'realm_bots' in state):
                     prev_state = state['raw_users'][user_profile.id]
                     was_admin = prev_state['is_admin']
-                    now_admin = person['is_admin']
+                    now_admin = person['role'] == UserProfile.ROLE_REALM_ADMINISTRATOR
 
                     if was_admin and not now_admin:
                         state['realm_bots'] = []
@@ -449,6 +453,9 @@ def apply_event(state: Dict[str, Any],
                 for field in p:
                     if field in person:
                         p[field] = person[field]
+                    if 'role' in person:
+                        p['is_admin'] = person['role'] == UserProfile.ROLE_REALM_ADMINISTRATOR
+                        p['is_guest'] = person['role'] == UserProfile.ROLE_GUEST
                     if 'custom_profile_field' in person:
                         custom_field_id = person['custom_profile_field']['id']
                         custom_field_new_value = person['custom_profile_field']['value']

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1830,7 +1830,7 @@ class EventsRegisterTest(ZulipTestCase):
             ('type', equals('realm_user')),
             ('op', equals('update')),
             ('person', check_dict_only([
-                ('is_admin', check_bool),
+                ('role', check_int_in(UserProfile.ROLE_TYPES)),
                 ('user_id', check_int),
             ])),
         ])


### PR DESCRIPTION
This PR changes the person dict in event sent by
do_change_user_role to send role instead of is_admin
or is_guest.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
