### PR TITLE
populate_db:Add non-ASCII and non-BMP characters in username and streamname

### DIFF
--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -253,17 +253,18 @@ class Command(BaseCommand):
                 names.append((full_name, 'extrauser%d@zulip.com' % (i,)))
 
             if num_names > num_boring_names:
-                fnames = ['Amber', 'Arpita', 'Bob', 'Cindy', 'Daniela', 'Dan', 'Dinesh',
-                          'Faye', 'François', 'George', 'Hank', 'Irene',
-                          'James', 'Janice', 'Jenny', 'Jill', 'John',
-                          'Kate', 'Katelyn', 'Kobe', 'Lexi', 'Manish', 'Mark', 'Matt', 'Mayna',
-                          'Michael', 'Pete', 'Peter', 'Phil', 'Phillipa', 'Preston',
-                          'Sally', 'Scott', 'Sandra', 'Steve', 'Stephanie',
-                          'Vera']
+                fnames = ['Amber', 'Arpita', 'Анш', 'Αναπρας', 'Bob',
+                          'Cindy', 'Симон', 'Daniela', 'Faye',
+                          'François', 'Gisela', 'Hank', 'Irene', 'Janice',
+                          'John', 'Jürgen', 'Kate', 'Katelyn', 'Kobe',
+                          'Lexi', 'Manish', 'Mark', 'Matt', 'Μαρταζα',
+                          'Pete', 'Peter', 'Phil', 'Sandra', 'Schmidt',
+                          'Steve', 'Stephanie', 'Vera', 'しどひ', 'انش']
                 mnames = ['de', 'van', 'von', 'Shaw', 'T.']
-                lnames = ['Adams', 'Agarwal', 'Beal', 'Benson', 'Bonita', 'Davis',
-                          'George', 'Harden', 'James', 'Jones', 'Johnson', 'Jordan',
-                          'Lee', 'Leonard', 'Singh', 'Smith', 'Patel', 'Towns', 'Wall']
+                lnames = ['Adams', 'Agarwal', 'Beal', 'Bonita', 'Davis',
+                          'George', 'Groß', 'Harden', 'James', 'Jones',
+                          'Lee', 'Leonard', 'Минтр', 'Müller', 'Singh', 'Patel',
+                          'Towns', 'Wall', 'ᏌᏦ', '湊蓮', 'ᎩᎭᏂᏕᎵᏩᎵ', 'خاندَلوال']
 
             for i in range(num_boring_names, num_names):
                 fname = random.choice(fnames) + str(i)
@@ -546,18 +547,18 @@ class Command(BaseCommand):
                     "sales": {"description": "For sales discussion"}
                 }
 
-                # Calculate the maximum number of digits in any extra stream's
-                # number, since a stream with name "Extra Stream 3" could show
-                # up after "Extra Stream 29". (Used later to pad numbers with
-                # 0s).
-                maximum_digits = len(str(options['extra_streams'] - 1))
+                # For testing really large batches:
+                # Create extra streams with semi realistic names to make search
+                # functions somewhat realistic.
+                streamname = ['24hrs', 'android', 'automated help', 'backend dev', 'bot',
+                              'checkins', 'code review', 'commits', 'Current User status', 'desktop',
+                              'development help', 'desktop', 'discussions', 'Django guide', 'GCI',
+                              'git test', 'GSoC archive', 'issues', 'live', 'markdown', 'mobile',
+                              'new members', 'provision', 'terminal testing', 'user guide', '测试',
+                              '冰未寒']
 
                 for i in range(options['extra_streams']):
-                    # Pad the number with 0s based on `maximum_digits`.
-                    number_str = str(i).zfill(maximum_digits)
-
-                    extra_stream_name = 'Extra Stream ' + number_str
-
+                    extra_stream_name = random.choice(streamname) + str(i)
                     zulip_stream_dict[extra_stream_name] = {
                         "description": "Auto-generated extra stream.",
                     }


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
THE ISSUE: https://github.com/zulip/zulip/issues/14991

I added non-ASCII and non-BMP characters in some usernames and stream names generated by populate_db. Also changed the way of naming "extra streams" by making a list of stream names and then selecting randomly from it (similar approach as creating extra usernames).
**Testing Plan:** 
./manage.py populate_db --extra-users 500 --extra-streams 25


**GIFs or Screenshots:** 
![Screenshot from 2020-05-31 20-59-37](https://user-images.githubusercontent.com/56222188/83358238-385ec680-a383-11ea-9c18-c8c880c283e6.png)

