### PR TITLE
team: Fix inaccurately specific sentence.

### DIFF
--- a/templates/zerver/team.html
+++ b/templates/zerver/team.html
@@ -80,7 +80,7 @@
                 </p>
                 <p>
                     Here, we recognize the top contributors to the
-                    Zulip server project on GitHub.  Zulip's community
+                    Zulip project on GitHub.  Zulip's community
                     is unusual in how many people outside the core
                     team have made major contributions to the project.
                 </p>


### PR DESCRIPTION
This `/team` page lists contributors across several Zulip codebases, not just
the server.