### PR TITLE
Fix social signup and Remote User SSO

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -3089,6 +3089,20 @@ class TestDevAuthBackend(ZulipTestCase):
         self.assertRedirects(response, reverse('config_error', kwargs={'error_category_name': 'dev'}))
 
 class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
+    def test_start_remote_user_sso(self) -> None:
+        result = self.client_get('/accounts/login/start/sso/?param1=value1&params=value2')
+        self.assertEqual(result.status_code, 302)
+
+        url = result.url
+        parsed_url = urllib.parse.urlparse(url)
+        self.assertEqual(parsed_url.path, '/accounts/login/sso/')
+        self.assertEqual(parsed_url.query, 'param1=value1&params=value2')
+
+    def test_start_remote_user_sso_with_desktop_app(self) -> None:
+        headers = dict(HTTP_USER_AGENT="ZulipElectron/5.0.0")
+        result = self.client_get('/accounts/login/start/sso/', **headers)
+        self.verify_desktop_flow_app_page(result)
+
     def test_login_success(self) -> None:
         user_profile = self.example_user('hamlet')
         email = user_profile.delivery_email

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -3093,7 +3093,7 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
         user_profile = self.example_user('hamlet')
         email = user_profile.delivery_email
         with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',)):
-            result = self.client_post('/accounts/login/sso/', REMOTE_USER=email)
+            result = self.client_get('/accounts/login/sso/', REMOTE_USER=email)
             self.assertEqual(result.status_code, 302)
             self.assert_logged_in_user_id(user_profile.id)
 
@@ -3102,13 +3102,13 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
         user_profile = self.example_user('hamlet')
         with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',),
                            SSO_APPEND_DOMAIN='zulip.com'):
-            result = self.client_post('/accounts/login/sso/', REMOTE_USER=username)
+            result = self.client_get('/accounts/login/sso/', REMOTE_USER=username)
             self.assertEqual(result.status_code, 302)
             self.assert_logged_in_user_id(user_profile.id)
 
     def test_login_failure(self) -> None:
         email = self.example_email("hamlet")
-        result = self.client_post('/accounts/login/sso/', REMOTE_USER=email)
+        result = self.client_get('/accounts/login/sso/', REMOTE_USER=email)
         self.assertEqual(result.status_code, 302)
 
         result = self.client_get(result["Location"])
@@ -3118,7 +3118,7 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
     def test_login_failure_due_to_nonexisting_user(self) -> None:
         email = 'nonexisting@zulip.com'
         with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',)):
-            result = self.client_post('/accounts/login/sso/', REMOTE_USER=email)
+            result = self.client_get('/accounts/login/sso/', REMOTE_USER=email)
             self.assertEqual(result.status_code, 200)
             self.assert_logged_in_user_id(None)
             self.assert_in_response("No account found for", result)
@@ -3126,12 +3126,12 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
     def test_login_failure_due_to_invalid_email(self) -> None:
         email = 'hamlet'
         with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',)):
-            result = self.client_post('/accounts/login/sso/', REMOTE_USER=email)
+            result = self.client_get('/accounts/login/sso/', REMOTE_USER=email)
             self.assert_json_error_contains(result, "Enter a valid email address.", 400)
 
     def test_login_failure_due_to_missing_field(self) -> None:
         with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',)):
-            result = self.client_post('/accounts/login/sso/')
+            result = self.client_get('/accounts/login/sso/')
             self.assertEqual(result.status_code, 302)
 
             result = self.client_get(result["Location"])
@@ -3141,8 +3141,8 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
         email = self.example_email("hamlet")
         with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',)):
             with mock.patch('zerver.views.auth.get_subdomain', return_value='acme'):
-                result = self.client_post('http://testserver:9080/accounts/login/sso/',
-                                          REMOTE_USER=email)
+                result = self.client_get('http://testserver:9080/accounts/login/sso/',
+                                         REMOTE_USER=email)
                 self.assertEqual(result.status_code, 200)
                 self.assert_logged_in_user_id(None)
                 self.assert_in_response("You need an invitation to join this organization.", result)
@@ -3151,8 +3151,8 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
         email = self.example_email("hamlet")
         with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',)):
             with mock.patch('zerver.views.auth.get_subdomain', return_value=''):
-                result = self.client_post('http://testserver:9080/accounts/login/sso/',
-                                          REMOTE_USER=email)
+                result = self.client_get('http://testserver:9080/accounts/login/sso/',
+                                         REMOTE_USER=email)
                 self.assertEqual(result.status_code, 200)
                 self.assert_logged_in_user_id(None)
                 self.assert_in_response("You need an invitation to join this organization.", result)
@@ -3163,7 +3163,7 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
         with mock.patch('zerver.views.auth.get_subdomain', return_value='zulip'):
             with self.settings(
                     AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',)):
-                result = self.client_post('/accounts/login/sso/', REMOTE_USER=email)
+                result = self.client_get('/accounts/login/sso/', REMOTE_USER=email)
                 self.assertEqual(result.status_code, 302)
                 self.assert_logged_in_user_id(user_profile.id)
 
@@ -3177,24 +3177,24 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
         mobile_flow_otp = '1234abcd' * 8
 
         # Verify that the right thing happens with an invalid-format OTP
-        result = self.client_post('/accounts/login/sso/',
-                                  dict(mobile_flow_otp="1234"),
-                                  REMOTE_USER=email,
-                                  HTTP_USER_AGENT = "ZulipAndroid")
+        result = self.client_get('/accounts/login/sso/',
+                                 dict(mobile_flow_otp="1234"),
+                                 REMOTE_USER=email,
+                                 HTTP_USER_AGENT = "ZulipAndroid")
         self.assert_logged_in_user_id(None)
         self.assert_json_error_contains(result, "Invalid OTP", 400)
 
-        result = self.client_post('/accounts/login/sso/',
-                                  dict(mobile_flow_otp="invalido" * 8),
-                                  REMOTE_USER=email,
-                                  HTTP_USER_AGENT = "ZulipAndroid")
+        result = self.client_get('/accounts/login/sso/',
+                                 dict(mobile_flow_otp="invalido" * 8),
+                                 REMOTE_USER=email,
+                                 HTTP_USER_AGENT = "ZulipAndroid")
         self.assert_logged_in_user_id(None)
         self.assert_json_error_contains(result, "Invalid OTP", 400)
 
-        result = self.client_post('/accounts/login/sso/',
-                                  dict(mobile_flow_otp=mobile_flow_otp),
-                                  REMOTE_USER=email,
-                                  HTTP_USER_AGENT = "ZulipAndroid")
+        result = self.client_get('/accounts/login/sso/',
+                                 dict(mobile_flow_otp=mobile_flow_otp),
+                                 REMOTE_USER=email,
+                                 HTTP_USER_AGENT = "ZulipAndroid")
         self.assertEqual(result.status_code, 302)
         redirect_url = result['Location']
         parsed_url = urllib.parse.urlparse(redirect_url)
@@ -3220,24 +3220,24 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
         mobile_flow_otp = '1234abcd' * 8
 
         # Verify that the right thing happens with an invalid-format OTP
-        result = self.client_post('/accounts/login/sso/',
-                                  dict(mobile_flow_otp="1234"),
-                                  REMOTE_USER=remote_user,
-                                  HTTP_USER_AGENT = "ZulipAndroid")
+        result = self.client_get('/accounts/login/sso/',
+                                 dict(mobile_flow_otp="1234"),
+                                 REMOTE_USER=remote_user,
+                                 HTTP_USER_AGENT = "ZulipAndroid")
         self.assert_logged_in_user_id(None)
         self.assert_json_error_contains(result, "Invalid OTP", 400)
 
-        result = self.client_post('/accounts/login/sso/',
-                                  dict(mobile_flow_otp="invalido" * 8),
-                                  REMOTE_USER=remote_user,
-                                  HTTP_USER_AGENT = "ZulipAndroid")
+        result = self.client_get('/accounts/login/sso/',
+                                 dict(mobile_flow_otp="invalido" * 8),
+                                 REMOTE_USER=remote_user,
+                                 HTTP_USER_AGENT = "ZulipAndroid")
         self.assert_logged_in_user_id(None)
         self.assert_json_error_contains(result, "Invalid OTP", 400)
 
-        result = self.client_post('/accounts/login/sso/',
-                                  dict(mobile_flow_otp=mobile_flow_otp),
-                                  REMOTE_USER=remote_user,
-                                  HTTP_USER_AGENT = "ZulipAndroid")
+        result = self.client_get('/accounts/login/sso/',
+                                 dict(mobile_flow_otp=mobile_flow_otp),
+                                 REMOTE_USER=remote_user,
+                                 HTTP_USER_AGENT = "ZulipAndroid")
         self.assertEqual(result.status_code, 302)
         redirect_url = result['Location']
         parsed_url = urllib.parse.urlparse(redirect_url)
@@ -3262,21 +3262,21 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
         desktop_flow_otp = '1234abcd' * 8
 
         # Verify that the right thing happens with an invalid-format OTP
-        result = self.client_post('/accounts/login/sso/',
-                                  dict(desktop_flow_otp="1234"),
-                                  REMOTE_USER=email)
+        result = self.client_get('/accounts/login/sso/',
+                                 dict(desktop_flow_otp="1234"),
+                                 REMOTE_USER=email)
         self.assert_logged_in_user_id(None)
         self.assert_json_error_contains(result, "Invalid OTP", 400)
 
-        result = self.client_post('/accounts/login/sso/',
-                                  dict(desktop_flow_otp="invalido" * 8),
-                                  REMOTE_USER=email)
+        result = self.client_get('/accounts/login/sso/',
+                                 dict(desktop_flow_otp="invalido" * 8),
+                                 REMOTE_USER=email)
         self.assert_logged_in_user_id(None)
         self.assert_json_error_contains(result, "Invalid OTP", 400)
 
-        result = self.client_post('/accounts/login/sso/',
-                                  dict(desktop_flow_otp=desktop_flow_otp),
-                                  REMOTE_USER=email)
+        result = self.client_get('/accounts/login/sso/',
+                                 dict(desktop_flow_otp=desktop_flow_otp),
+                                 REMOTE_USER=email)
         self.verify_desktop_flow_end_page(result, email, desktop_flow_otp)
 
     @override_settings(SEND_LOGIN_EMAILS=True)
@@ -3292,21 +3292,21 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
         desktop_flow_otp = '1234abcd' * 8
 
         # Verify that the right thing happens with an invalid-format OTP
-        result = self.client_post('/accounts/login/sso/',
-                                  dict(desktop_flow_otp="1234"),
-                                  REMOTE_USER=remote_user)
+        result = self.client_get('/accounts/login/sso/',
+                                 dict(desktop_flow_otp="1234"),
+                                 REMOTE_USER=remote_user)
         self.assert_logged_in_user_id(None)
         self.assert_json_error_contains(result, "Invalid OTP", 400)
 
-        result = self.client_post('/accounts/login/sso/',
-                                  dict(desktop_flow_otp="invalido" * 8),
-                                  REMOTE_USER=remote_user)
+        result = self.client_get('/accounts/login/sso/',
+                                 dict(desktop_flow_otp="invalido" * 8),
+                                 REMOTE_USER=remote_user)
         self.assert_logged_in_user_id(None)
         self.assert_json_error_contains(result, "Invalid OTP", 400)
 
-        result = self.client_post('/accounts/login/sso/',
-                                  dict(desktop_flow_otp=desktop_flow_otp),
-                                  REMOTE_USER=remote_user)
+        result = self.client_get('/accounts/login/sso/',
+                                 dict(desktop_flow_otp=desktop_flow_otp),
+                                 REMOTE_USER=remote_user)
         self.verify_desktop_flow_end_page(result, email, desktop_flow_otp)
 
     def test_redirect_to(self) -> None:
@@ -3316,7 +3316,7 @@ class TestZulipRemoteUserBackend(DesktopFlowTestingLib, ZulipTestCase):
             user_profile = self.example_user('hamlet')
             email = user_profile.delivery_email
             with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.ZulipRemoteUserBackend',)):
-                result = self.client_post('/accounts/login/sso/?next=' + next, REMOTE_USER=email)
+                result = self.client_get('/accounts/login/sso/?next=' + next, REMOTE_USER=email)
             return result
 
         res = test_with_redirect_to_param_set_as_next()

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -464,6 +464,17 @@ def handle_desktop_flow(func: ViewFuncT) -> ViewFuncT:
     return wrapper  # type: ignore[return-value] # https://github.com/python/mypy/issues/1927
 
 @handle_desktop_flow
+def start_remote_user_sso(request: HttpRequest) -> HttpResponse:
+    """
+    The purpose of this endpoint is to provide an initial step in the flow
+    on which we can handle the special behavior for the desktop app.
+    /accounts/login/sso may have Apache intercepting requests to it
+    to do authentication, so we need this additional endpoint.
+    """
+    query = request.META['QUERY_STRING']
+    return redirect(add_query_to_redirect_url(reverse('login-sso'), query))
+
+@handle_desktop_flow
 def start_social_login(request: HttpRequest, backend: str, extra_arg: Optional[str]=None
                        ) -> HttpResponse:
     backend_url = reverse('social:begin', args=[backend])

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -490,6 +490,7 @@ def start_social_login(request: HttpRequest, backend: str, extra_arg: Optional[s
 
     return oauth_redirect_to_root(request, backend_url, 'social', extra_url_params=extra_url_params)
 
+@handle_desktop_flow
 def start_social_signup(request: HttpRequest, backend: str, extra_arg: Optional[str]=None
                         ) -> HttpResponse:
     backend_url = reverse('social:begin', args=[backend])

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -1035,8 +1035,8 @@ class ZulipRemoteUserBackend(RemoteUserBackend, ExternalAuthMethod):
             display_name="SSO",
             display_icon=cls.display_icon,
             # The user goes to the same URL for both login and signup:
-            login_url=reverse('login-sso'),
-            signup_url=reverse('login-sso'),
+            login_url=reverse('start-login-sso'),
+            signup_url=reverse('start-login-sso'),
         )]
 
 def redirect_deactivated_user_to_login() -> HttpResponseRedirect:

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -426,6 +426,7 @@ i18n_urls = [
     url(r'^accounts/login/(google)/$', zerver.views.auth.start_social_login,
         name='login-social'),
 
+    url(r'^accounts/login/start/sso/$', zerver.views.auth.start_remote_user_sso, name='start-login-sso'),
     url(r'^accounts/login/sso/$', zerver.views.auth.remote_user_sso, name='login-sso'),
     url(r'^accounts/login/jwt/$', zerver.views.auth.remote_user_jwt, name='login-jwt'),
     url(r'^accounts/login/social/([\w,-]+)$', zerver.views.auth.start_social_login,


### PR DESCRIPTION
With the revert of https://github.com/zulip/zulip-desktop/pull/863 in favor of making the server serve JS code for handling its authentication to the desktop app in 40c80029034eea896e18de8add9db51ea7b8aa75 we missed the fact that we also need to serve this code in a couple other places - start of social sign up and Remote User SSO. Tested manually on dev environment (Sign up with Github/Google) and my test production server (Remote User SSO).

This will fix https://github.com/zulip/zulip-desktop/issues/906