### PR TITLE
docs: Fix a few link issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You might be interested in:
   [beginner-friendly issues][beginner-friendly].
 
 * **Contributing non-code**.
-  [Report an issue](https://zulip.readthedocs.io/en/latest/overview/contributing.html#reporting-issue),
+  [Report an issue](https://zulip.readthedocs.io/en/latest/overview/contributing.html#reporting-issues),
   [translate](https://zulip.readthedocs.io/en/latest/translating/translating.html) Zulip
   into your language,
   [write](https://zulip.readthedocs.io/en/latest/overview/contributing.html#zulip-outreach)

--- a/docs/documentation/api.md
+++ b/docs/documentation/api.md
@@ -28,7 +28,7 @@ Our API documentation is defined by a few sets of files:
 
 This first section is focused on explaining how the API documentation
 system is put together; when actually documenting an endpoint, you'll
-want to also read the [Step by step guide][#step-by-step-guide].
+want to also read the [Step by step guide](#step-by-step-guide).
 
 ## How it works
 

--- a/docs/git/pull-requests.md
+++ b/docs/git/pull-requests.md
@@ -147,6 +147,6 @@ for another review.
 [github-help-create-pr-fork]: https://help.github.com/en/articles/creating-a-pull-request-from-a-fork
 [images-create-pr]: ../images/zulip-open-pr.png
 [keep-up-to-date]: ../git/using.html#keep-your-fork-up-to-date
-[push-commits]: ../git/using.html#push-your-commits-to-github
+[self-push-commits]: ../git/using.html#push-your-commits-to-github
 [screenshots-gifs]: ../tutorials/screenshot-and-gif-software.md
 [wip-prs]: #work-in-progress-pull-requests

--- a/docs/git/using.md
+++ b/docs/git/using.md
@@ -448,6 +448,7 @@ complicated rebase.
 [github-help-rebase]: https://help.github.com/en/articles/using-git-rebase
 [github-help-sync-fork]: https://help.github.com/en/articles/syncing-a-fork
 [how-git-is-different]: ./the-git-difference.md
+[self-multiple-computers]: ../git/troubleshooting.html#working-from-multiple-computers
 [zulip-git-guide-up-to-date]: ../git/using.html#keep-your-fork-up-to-date
 [zulip-rtd-commit-discipline]: ../contributing/version-control.html#commit-discipline
 [zulip-rtd-commit-messages]: ../contributing/version-control.html#commit-messages


### PR DESCRIPTION
These references broke in November 2017, when git-guide.md was split
into multiple files in fa3602b61fe2752488c11b3f4a934ebc4e9fceba.