### PR TITLE
search: Refactor and polish pills implementation.

### DIFF
--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -74,7 +74,6 @@ run_test('initialize', () => {
     const search_query_box = $('#search_query');
     const searchbox_form = $('#searchbox_form');
     const search_button = $('.search_button');
-    const searchbox = $('#searchbox');
 
     searchbox_form.on = (event, func) => {
         assert.equal(event, 'compositionend');
@@ -181,6 +180,7 @@ run_test('initialize', () => {
 
             search.is_using_input_method = true;
             _setup('stream:Verona');
+            search_query_box.is = return_true;
 
             assert.equal(opts.updater('stream:Verona'), 'stream:Verona');
             assert(!is_blurred);
@@ -282,18 +282,6 @@ run_test('initialize', () => {
             narrow_state.search_string = () => 'ver';
             callback();
             assert.equal(search_query_box.val(), 'test string');
-        }
-    };
-
-    searchbox.on = (event, callback) => {
-        if (event === 'focusin') {
-            searchbox.css({"box-shadow": "unset"});
-            callback();
-            assert.deepEqual(searchbox.css(), {"box-shadow": "inset 0px 0px 0px 2px hsl(204, 20%, 74%)"});
-        } else if (event === 'focusout') {
-            searchbox.css({"box-shadow": "inset 0px 0px 0px 2px hsl(204, 20%, 74%)"});
-            callback();
-            assert.deepEqual(searchbox.css(), {"box-shadow": "unset"});
         }
     };
 

--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -4,7 +4,6 @@ set_global('page_params', {
 zrequire('search');
 zrequire('search_pill');
 zrequire('Filter', 'js/filter');
-zrequire('search_pill_widget');
 zrequire('tab_bar');
 
 const noop = () => {};
@@ -19,6 +18,11 @@ set_global('ui_util', {
     place_caret_at_end: noop,
 });
 set_global('narrow', {});
+set_global('search_pill_widget', {
+    widget: {
+        getByID: return_true,
+    },
+});
 
 search_pill.append_search_string = noop;
 search_pill.get_search_string_for_current_filter = noop;
@@ -272,6 +276,13 @@ run_test('initialize', () => {
         assert(!search_button.prop('disabled'));
     };
 
+    const search_pill_stub = $.create('.pill');
+    search_pill_stub.closest = () => {
+        return { data: noop };
+    };
+    const stub_event = {
+        relatedTarget: search_pill_stub,
+    };
     search_query_box.on = (event, callback) => {
         if (event === 'focus') {
             search_button.prop('disabled', true);
@@ -280,7 +291,7 @@ run_test('initialize', () => {
         } else if (event === 'blur') {
             search_query_box.val("test string");
             narrow_state.search_string = () => 'ver';
-            callback();
+            callback(stub_event);
             assert.equal(search_query_box.val(), 'test string');
         }
     };

--- a/frontend_tests/node_tests/search_legacy.js
+++ b/frontend_tests/node_tests/search_legacy.js
@@ -9,7 +9,7 @@ const return_true = () => true;
 const return_false = () => false;
 
 set_global('$', global.make_zjquery());
-set_global('narrow_state', {});
+set_global('narrow_state', {filter: return_false});
 set_global('search_suggestion', {});
 set_global('ui_util', {
     change_tab_to: noop,

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -1202,10 +1202,10 @@ run_test('multiple_operators_without_pills', () => {
     let suggestions = get_suggestions(base_query, query);
     let expected = [
         "is:private al",
-        "is:private, is:alerted",
-        "is:private, sender:alice@zulip.com",
-        "is:private, pm-with:alice@zulip.com",
-        "is:private, group-pm-with:alice@zulip.com",
+        "is:private is:alerted",
+        "is:private sender:alice@zulip.com",
+        "is:private pm-with:alice@zulip.com",
+        "is:private group-pm-with:alice@zulip.com",
     ];
     assert.deepEqual(suggestions.strings, expected);
 

--- a/static/js/input_pill.js
+++ b/static/js/input_pill.js
@@ -372,6 +372,7 @@ exports.create = function (opts) {
         appendValue: funcs.appendPill.bind(funcs),
         appendValidatedData: funcs.appendValidatedData.bind(funcs),
 
+        getByID: funcs.getByID,
         items: funcs.items,
 
         onPillCreate: function (callback) {

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -91,7 +91,15 @@ exports.initialize = function () {
             if (page_params.search_pills_enabled) {
                 search_pill.append_search_string(search_string,
                                                  search_pill_widget.widget);
-                return search_query_box.val();
+                if (search_query_box.is(':focus')) {
+                    // We usually allow the user to continue
+                    // typing until the enter key is pressed.
+                    // But we narrow when the user clicks on a
+                    // typeahead suggestion. This change in behaviour
+                    // is a workaround to be able to display the
+                    // navbar every time search_query_box loses focus.
+                    return search_query_box.val();
+                }
             }
             return exports.narrow_or_search_for_term(search_string);
         },
@@ -167,25 +175,17 @@ exports.initialize = function () {
         // selecting something in the typeahead menu causes
         // the box to lose focus a moment before.
         //
-        // The workaround is to check 100ms later -- long
+        // The workaround is to check 300ms later -- long
         // enough for the search to have gone through, but
         // short enough that the user won't notice (though
         // really it would be OK if they did).
 
         setTimeout(function () {
             exports.update_button_visibility();
-        }, 100);
-    });
-
-    if (page_params.search_pills_enabled) {
-        // Uses jquery instead of pure css as the `:focus` event occurs on `#search_query`,
-        // while we want to add box-shadow to `#searchbox`. This could have been done
-        // with `:focus-within` CSS selector, but it is not supported in IE or Opera.
-        searchbox.on('focusout', function () {
             tab_bar.close_search_bar_and_open_narrow_description();
             searchbox.css({"box-shadow": "unset"});
-        });
-    }
+        }, 300);
+    });
 };
 
 exports.focus_search = function () {

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -164,7 +164,7 @@ exports.initialize = function () {
     // more work to re-order everything and make them private.
 
     search_query_box.on('focus', exports.focus_search);
-    search_query_box.on('blur', function () {
+    search_query_box.on('blur', function (e) {
         // The search query box is a visual cue as to
         // whether search or narrowing is active.  If
         // the user blurs the search box, then we should
@@ -180,6 +180,18 @@ exports.initialize = function () {
         // short enough that the user won't notice (though
         // really it would be OK if they did).
 
+        if (page_params.search_pills_enabled) {
+            const pill_id = $(e.relatedTarget).closest(".pill").data('id');
+            const search_pill = search_pill_widget.widget.getByID(pill_id);
+            if (search_pill) {
+                // The searchbox loses focus while the search
+                // pill element gains focus.
+                // We do not consider the searchbox to actually
+                // lose focus when a pill inside it gets selected
+                // or deleted by a click.
+                return;
+            }
+        }
         setTimeout(function () {
             exports.update_button_visibility();
             tab_bar.close_search_bar_and_open_narrow_description();

--- a/static/js/search_pill.js
+++ b/static/js/search_pill.js
@@ -21,7 +21,11 @@ exports.create_pills = function (pill_container) {
 };
 
 exports.append_search_string = function (search_string, pill_widget) {
-    pill_widget.appendValue(search_string);
+    const operators = Filter.parse(search_string);
+    for (const operator of operators) {
+        const input = Filter.unparse([operator]);
+        pill_widget.appendValue(input);
+    }
     if (pill_widget.clear_text !== undefined) {
         pill_widget.clear_text();
     }

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -580,8 +580,7 @@ function make_attacher(base) {
 
     function prepend_base(suggestion) {
         if (base && base.description.length > 0) {
-            const sep = page_params.search_pills_enabled ? ", " : " ";
-            suggestion.search_string = base.search_string + sep + suggestion.search_string;
+            suggestion.search_string = base.search_string + " " + suggestion.search_string;
             suggestion.description = base.description + ", " + suggestion.description;
         }
     }

--- a/static/third/bootstrap-typeahead/typeahead.js
+++ b/static/third/bootstrap-typeahead/typeahead.js
@@ -56,6 +56,19 @@
  *  You can set an on_escape hook to take extra actions when the user hits
  *  the `Esc` key.  We use this in our navbar code to close the navbar when
  *  a user hits escape while in the typeahead.
+ *
+ * 5. Help on empty strings:
+ *
+ *   This adds support for displaying the typeahead for an empty string.
+ *   It is helpful when we want to render the typeahead, based on already
+ *   entered data (in the form of contenteditable elements) every time the
+ *   input block gains focus but is empty.
+ *
+ *   We also have logic so that there is an exception to this rule when this
+ *   option is set as true. We prevent the lookup of the typeahead and hide it
+ *   so that the `Backspace` key is free to interact with the other elements.
+ *
+ *   Our custom changes include all mentions of `helpOnEmptyStrings` and `hideOnEmpty`.
  * ============================================================ */
 
 !function($){
@@ -185,12 +198,12 @@
       return this
     }
 
-  , lookup: function (event) {
+  , lookup: function (hideOnEmpty) {
       var items
 
       this.query = this.$element.is("[contenteditable]") ? this.$element.text() :  this.$element.val();
 
-      if (!this.options.helpOnEmptyStrings) {
+      if (!this.options.helpOnEmptyStrings || hideOnEmpty) {
         if (!this.query || this.query.length < this.options.minLength) {
           return this.shown ? this.hide() : this
         }
@@ -378,7 +391,11 @@
             if (!this.shown) return;
             this.select(e);
           }
-          this.lookup()
+          var hideOnEmpty = false
+          if (e.keyCode === 8 && this.options.helpOnEmptyStrings) { // backspace
+            hideOnEmpty = true
+          }
+          this.lookup(hideOnEmpty)
       }
 
       if ((this.options.stopAdvance || (e.keyCode != 9 && e.keyCode != 13))


### PR DESCRIPTION
This is a WIP PR for the polishing work on search pills and a continuation of #14930.
( Will create a new PR when we want to migrate to the search_pills_enabled version. )

- [ ] If pills overflow, they break the 2 search icons.
- [ ] If the cursor is at the start of the input block and text exists, then it is not possible to delete the previous pill. This is an input pills specific problem and not a search pills one.