### PR TITLE
to_dict_uncached: Don't do realm_id query for all users.

### DIFF
--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -606,7 +606,7 @@ def flush_used_upload_space_cache(sender: Any, **kwargs: Any) -> None:
 def to_dict_cache_key_id(message_id: int) -> str:
     return 'message_dict:%d' % (message_id,)
 
-def to_dict_cache_key(message: 'Message') -> str:
+def to_dict_cache_key(message: 'Message', realm_id: Optional[int]=None) -> str:
     return to_dict_cache_key_id(message.id)
 
 def open_graph_description_cache_key(content: Any, request: HttpRequest) -> str:

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -3512,12 +3512,14 @@ class EditMessageTest(ZulipTestCase):
         (user_profile, old_stream, new_stream, msg_id, msg_id_later) = self.prepare_move_topics(
             "iago", "test move stream", "new stream", "test")
 
-        result = self.client_patch("/json/messages/" + str(msg_id), {
-            'message_id': msg_id,
-            'stream_id': new_stream.id,
-            'propagate_mode': 'change_all',
-            'topic': 'new topic'
-        })
+        with queries_captured() as queries:
+            result = self.client_patch("/json/messages/" + str(msg_id), {
+                'message_id': msg_id,
+                'stream_id': new_stream.id,
+                'propagate_mode': 'change_all',
+                'topic': 'new topic'
+            })
+        self.assertEqual(len(queries), 54)
 
         messages = get_topic_messages(user_profile, old_stream, "test")
         self.assertEqual(len(messages), 1)

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2480,7 +2480,7 @@ class SubscriptionAPITest(ZulipTestCase):
                     streams_to_sub,
                     dict(principals=ujson.dumps([user1.id, user2.id])),
                 )
-        self.assert_length(queries, 40)
+        self.assert_length(queries, 39)
 
         self.assert_length(events, 7)
         for ev in [x for x in events if x['event']['type'] not in ('message', 'stream')]:
@@ -3255,7 +3255,7 @@ class SubscriptionAPITest(ZulipTestCase):
                 [new_streams[0]],
                 dict(principals=ujson.dumps([user1.id, user2.id])),
             )
-        self.assert_length(queries, 40)
+        self.assert_length(queries, 39)
 
         # Test creating private stream.
         with queries_captured() as queries:
@@ -3265,7 +3265,7 @@ class SubscriptionAPITest(ZulipTestCase):
                 dict(principals=ujson.dumps([user1.id, user2.id])),
                 invite_only=True,
             )
-        self.assert_length(queries, 40)
+        self.assert_length(queries, 39)
 
         # Test creating a public stream with announce when realm has a notification stream.
         notifications_stream = get_stream(self.streams[0], self.test_realm)
@@ -3280,7 +3280,7 @@ class SubscriptionAPITest(ZulipTestCase):
                     principals=ujson.dumps([user1.id, user2.id])
                 )
             )
-        self.assert_length(queries, 52)
+        self.assert_length(queries, 50)
 
 class GetStreamsTest(ZulipTestCase):
     def test_streams_api_for_bot_owners(self) -> None:


### PR DESCRIPTION
We only do realm_id query for bots, just to handle the case of
cross_realm bots. Ideally, we should check if the sender is cross
realm bot but that information is not readily available.
