### PR TITLE
test_subs: Add tests for unsubscribing multiple users from stream.

### DIFF
--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -264,7 +264,7 @@ def remove_subscriptions_backend(
                 removing_someone_else = principals[0] != user_profile.id
             else:
                 removing_someone_else = principals[0] != user_profile.email
-        else:  # nocoverage # TODO: Fix me.
+        else:
             removing_someone_else = True
 
     if removing_someone_else and not user_profile.is_realm_admin:


### PR DESCRIPTION
This PR adds tests for unsusbcribing multiple users from a
stream and fixes the missing coverage issue introduced in 2187c84.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
