### PR TITLE
email integration: Add subject line as first line of body.

### DIFF
--- a/zerver/tests/test_email_mirror.py
+++ b/zerver/tests/test_email_mirror.py
@@ -19,6 +19,7 @@ from zerver.models import (
     MissedMessageEmailAddress,
     Recipient,
     UserProfile,
+    MAX_TOPIC_NAME_LENGTH
 )
 
 from zerver.lib.actions import ensure_stream, do_deactivate_realm, do_deactivate_user
@@ -215,6 +216,47 @@ class TestFilterFooter(ZulipTestCase):
         result = filter_footer(text)
         # Multiple possible footers, don't strip
         self.assertEqual(result, text)
+
+class TestStreamEmailTruncation(ZulipTestCase):
+    def test_stream_email_message_with_topic_length_equal_max_length(self) -> None:
+        user_profile = self.example_user('hamlet')
+        self.login('hamlet')
+        self.subscribe(user_profile, "Denmark")
+        stream = get_stream("Denmark", user_profile.realm)
+
+        stream_to_address = encode_email_address(stream)
+
+        incoming_valid_message = MIMEText('TestStreamEmailWithTrucnatedTopic Body')
+
+        incoming_valid_message['Subject'] = 'X' * MAX_TOPIC_NAME_LENGTH
+        incoming_valid_message['From'] = self.example_email('hamlet')
+        incoming_valid_message['To'] = stream_to_address
+        incoming_valid_message['Reply-to'] = self.example_email('othello')
+
+        process_message(incoming_valid_message)
+        message = most_recent_message(user_profile)
+        self.assertEqual(message.topic_name(), incoming_valid_message['Subject'][:MAX_TOPIC_NAME_LENGTH+1])
+        self.assertEqual(message.content, "TestStreamEmailWithTrucnatedTopic Body")
+
+    def test_stream_email_message_with_topic_length_greater_max_length(self) -> None:
+        user_profile = self.example_user('hamlet')
+        self.login('hamlet')
+        self.subscribe(user_profile, "Denmark")
+        stream = get_stream("Denmark", user_profile.realm)
+
+        stream_to_address = encode_email_address(stream)
+
+        incoming_valid_message = MIMEText('TestStreamEmailWithTrucnatedTopic Body')
+
+        incoming_valid_message['Subject'] = 'X' * (MAX_TOPIC_NAME_LENGTH + 10)
+        incoming_valid_message['From'] = self.example_email('hamlet')
+        incoming_valid_message['To'] = stream_to_address
+        incoming_valid_message['Reply-to'] = self.example_email('othello')
+
+        process_message(incoming_valid_message)
+        message = most_recent_message(user_profile)
+        self.assertEqual(message.topic_name(), incoming_valid_message['Subject'][:MAX_TOPIC_NAME_LENGTH-3]+'...')
+        self.assertEqual(message.content, 'Subject: {}\n\nTestStreamEmailWithTrucnatedTopic Body'.format(incoming_valid_message['Subject']))
 
 class TestStreamEmailMessagesSuccess(ZulipTestCase):
     def test_receive_stream_email_messages_success(self) -> None:


### PR DESCRIPTION
If the message sent to a stream is an email and the subject of this
email is greater than 60 charachters, then include the subject as
the first line of the message if it is the first message within a week.
I worked along the lines pointed out by @cornjuliox in #12041 and
@madhavsikka in #13855.
Tests for this change have been added accordingly.

Fixes: #10539

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
` ./tools/test-backend zerver.tests.test_email_mirror`


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Not a UI change.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
