### PR TITLE
openapi_responses: Improve response validation tests.

### DIFF
--- a/zerver/lib/bugdown/api_return_values_table_generator.py
+++ b/zerver/lib/bugdown/api_return_values_table_generator.py
@@ -67,8 +67,9 @@ class APIReturnValuesTablePreprocessor(Preprocessor):
             if 'additionalProperties' in return_values[return_value]:
                 ans.append(self.render_desc(return_values[return_value]['additionalProperties']
                                             ['description'], spacing + 4))
-                ans += self.render_table(return_values[return_value]['additionalProperties']['properties'],
-                                         spacing + 8)
+                if 'properties' in return_values[return_value]['additionalProperties']:
+                    ans += self.render_table(return_values[return_value]['additionalProperties']
+                                             ['properties'], spacing + 8)
             if ('items' in return_values[return_value] and
                'properties' in return_values[return_value]['items']):
                 ans += self.render_table(return_values[return_value]['items']['properties'], spacing + 4)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1873,13 +1873,7 @@ paths:
                         The user's ID.
                       example: 1
                     profile_data:
-                      type: object
-                      description: |
-                        A dictionary containing custom profile field data for the user. Each entry
-                        maps the integer ID of a custom profile field in the organization to a
-                        dictionary containing the user's data for that field.  Generally the data
-                        includes just a single `value` key; for those custom profile fields
-                        supporting markdown, a `rendered_value` key will also be present.
+                      $ref: '#/components/schemas/profile_data'
                 - example:
                     {
                         "avatar_url": "https://secure.gravatar.com/avatar/af4f06322c177ef4e1e9b2c424986b54?d=identicon&version=1",
@@ -3090,6 +3084,47 @@ paths:
                       description: |
                         Each key-value pair in the object indicates whether the authentication
                         method is enabled on this server.
+                      properties:
+                        password:
+                          description: |
+                            Whether the user can authenticate using password.
+                          type: boolean
+                        dev:
+                          description: |
+                            Whether the user can authenticate using development api key.
+                          type: boolean
+                        email:
+                          description: |
+                            Whether the user can authenticate using email.
+                          type: boolean
+                        ldap:
+                          description: |
+                            Whether the user can authenticate using ldap.
+                          type: boolean
+                        remoteuser:
+                          description: |
+                            Whether the user can authenticate using remoteuser.
+                          type: boolean
+                        github:
+                          description: |
+                            Whether the user can authenticate using their github account.
+                          type: boolean
+                        azuread:
+                          description: |
+                            Whether the user can authenticate using their azuread account.
+                          type: boolean
+                        gitlab:
+                          description: |
+                            Whether the user can authenticate using their gitlab account.
+                          type: boolean
+                        google:
+                          description: |
+                            Whether the user can authenticate using their google account.
+                          type: boolean
+                        saml:
+                          description: |
+                            Whether the user can authenticate using saml.
+                          type: boolean
                     external_authentication_methods:
                       type: array
                       description: |
@@ -3109,6 +3144,28 @@ paths:
                         **Changes**: New in Zulip 2.1.
                       items:
                         type: object
+                        properties:
+                          name:
+                            type: string
+                            description: |
+                              Name of the authentication method.
+                          display_name:
+                            type: string
+                            description: |
+                              Display name of the authentication method.
+                          display_icon:
+                            type: string
+                            nullable: true
+                            description: |
+                              Link to the display icon of the method.
+                          login_url:
+                            type: string
+                            description: |
+                              Login url for authentication.
+                          signup_url:
+                            type: string
+                            description: |
+                              Signup url for authentication.
                     zulip_version:
                       type: string
                       description: |
@@ -4215,10 +4272,29 @@ components:
           description: |
             The time the user account was created.
         profile_data:
-          type: object
-          description: |
-            Object containing data on the user's personal values for the organization's
-            configured custom profile fields.
+          $ref: '#/components/schemas/profile_data'
+    profile_data:
+      type: object
+      description: |
+        A dictionary containing custom profile field data for the user. Each entry
+        maps the integer ID of a custom profile field in the organization to a
+        dictionary containing the user's data for that field.  Generally the data
+        includes just a single `value` key; for those custom profile fields
+        supporting markdown, a `rendered_value` key will also be present.
+      additionalProperties:
+        type: object
+        description: |
+          '{id}': Object with data about what value user filled in the custom
+                      profile field with id `id`.
+        properties:
+          value:
+            type: string
+            description: |
+              User's personal value in the custom profile field.
+          rendered_value:
+            type: string
+            description: |
+              `value` rendered in HTML.
     JsonResponse:
       type: object
       properties:
@@ -4337,12 +4413,26 @@ components:
               A dictionary where the key is the email address of the user/bot and the
               value is a list of the names of the streams that were subscribed to as a
               result of the query.
+            additionalProperties:
+              description: |
+                `{email_address}`: List of the names of the streams that were subscribed
+                 to as a result of the query.
+              type: array
+              items:
+                type: string
           already_subscribed:
             type: object
             description: |
               A dictionary where the key is the email address of the user/bot and the
               value is a list of the names of the streams that the user/bot is already
               subscribed to.
+            additionalProperties:
+              description: |
+                {email_address}`: List of the names of the streams that the user is
+                already subscribed to.
+              type: array
+              items:
+                type: string
           unauthorized:
             type: array
             items:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2681,34 +2681,39 @@ paths:
                       description: |
                         An object that contains `emoji` objects, each identified with their
                         emoji ID as the key.
-                      properties:
-                        id:
-                          type: integer
-                          description: |
-                            The ID for this emoji, same as the object's key.
-                        name:
-                          type: string
-                          description: |
-                            The user-friendly name for this emoji. Users in the organization
-                            can use this emoji by writing this name between colons (`:name:`).
-                        source_url:
-                          type: string
-                          description: |
-                            The path relative to the organization's URL where the
-                            emoji's image can be found.
-                        deactivated:
-                          type: string
-                          description: |
-                            Whether the emoji has been deactivated or not.
-                        author_id:
-                          type: integer
-                          nullable: true
-                          description: |
-                            The user ID of the user who uploaded the custom emoji.
-                            Will be null if the uploader is unknown.
+                      additionalProperties:
+                        type: object
+                        description: |
+                          `{emoji_id}`: Object containing details about the emoji with
+                           the specified ID. It has the following properties:
+                        properties:
+                          id:
+                            type: string
+                            description: |
+                              The ID for this emoji, same as the object's key.
+                          name:
+                            type: string
+                            description: |
+                              The user-friendly name for this emoji. Users in the organization
+                              can use this emoji by writing this name between colons (`:name  :`).
+                          source_url:
+                            type: string
+                            description: |
+                              The path relative to the organization's URL where the
+                              emoji's image can be found.
+                          deactivated:
+                            type: boolean
+                            description: |
+                              Whether the emoji has been deactivated or not.
+                          author_id:
+                            type: integer
+                            nullable: true
+                            description: |
+                              The user ID of the user who uploaded the custom emoji.
+                              Will be null if the uploader is unknown.
 
-                            **Changes**: New in Zulip 2.2 (feature level 7).  Previously
-                            was accessible via and `author` object with an `id` field.
+                              **Changes**: New in Zulip 2.2 (feature level 7).  Previously
+                              was accessible via and `author` object with an `id` field.
                 - example:
                     {
                         "result": "success",


### PR DESCRIPTION
Currently, `validate_against_openapi_schema` checks only the top
level of the response dictionary. Improve it so that it can
validate objects and arrays at all levels. Also edit zulip.yaml
accordingly. And for new response keys which were not defined
before add VERY basic documentation.