### PR TITLE
Add support for setting counts in iOS push notifications

### DIFF
--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -923,15 +923,16 @@ class HandlePushNotificationTest(PushNotificationTest):
 
         with self.settings(PUSH_NOTIFICATION_BOUNCER_URL=True), \
                 mock.patch('zerver.lib.push_notifications'
-                           '.send_notifications_to_bouncer') as mock_send_android, \
-                mock.patch('zerver.lib.push_notifications.get_base_payload',
-                           return_value={'gcm': True}):
+                           '.send_notifications_to_bouncer') as mock_send_android:
             handle_remove_push_notification(user_profile.id, [message.id])
             mock_send_android.assert_called_with(
                 user_profile.id,
                 {},
                 {
-                    'gcm': True,
+                    'server': 'testserver',
+                    'realm_id': self.sender.realm.id,
+                    'realm_uri': 'http://zulip.testserver',
+                    'user_id': self.user_profile.id,
                     'event': 'remove',
                     'zulip_message_ids': str(message.id),
                     'zulip_message_id': message.id,
@@ -956,14 +957,15 @@ class HandlePushNotificationTest(PushNotificationTest):
                                            kind=PushDeviceToken.GCM))
 
         with mock.patch('zerver.lib.push_notifications'
-                        '.send_android_push_notification') as mock_send_android, \
-                mock.patch('zerver.lib.push_notifications.get_base_payload',
-                           return_value={'gcm': True}):
+                        '.send_android_push_notification') as mock_send_android:
             handle_remove_push_notification(self.user_profile.id, [message.id])
             mock_send_android.assert_called_with(
                 android_devices,
                 {
-                    'gcm': True,
+                    'server': 'testserver',
+                    'realm_id': self.sender.realm.id,
+                    'realm_uri': 'http://zulip.testserver',
+                    'user_id': self.user_profile.id,
                     'event': 'remove',
                     'zulip_message_ids': str(message.id),
                     'zulip_message_id': message.id,

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -24,12 +24,14 @@ from zerver.lib.actions import (
     do_delete_messages,
     do_mark_stream_messages_as_read,
     do_regenerate_api_key,
+    do_update_message_flags,
 )
 from zerver.lib.push_notifications import (
     DeviceToken,
     absolute_avatar_url,
     b64_to_hex,
     datetime_to_timestamp,
+    get_apns_badge_count,
     get_apns_client,
     get_display_recipient,
     get_message_payload_apns,
@@ -923,11 +925,23 @@ class HandlePushNotificationTest(PushNotificationTest):
 
         with self.settings(PUSH_NOTIFICATION_BOUNCER_URL=True), \
                 mock.patch('zerver.lib.push_notifications'
-                           '.send_notifications_to_bouncer') as mock_send_android:
+                           '.send_notifications_to_bouncer') as mock_send:
             handle_remove_push_notification(user_profile.id, [message.id])
-            mock_send_android.assert_called_with(
+            mock_send.assert_called_with(
                 user_profile.id,
-                {},
+                {
+                    'badge': 0,
+                    'custom': {
+                        'zulip': {
+                            'server': 'testserver',
+                            'realm_id': self.sender.realm.id,
+                            'realm_uri': 'http://zulip.testserver',
+                            'user_id': self.user_profile.id,
+                            'event': 'remove',
+                            'zulip_message_ids': str(message.id),
+                        },
+                    },
+                },
                 {
                     'server': 'testserver',
                     'realm_id': self.sender.realm.id,
@@ -956,8 +970,14 @@ class HandlePushNotificationTest(PushNotificationTest):
             PushDeviceToken.objects.filter(user=self.user_profile,
                                            kind=PushDeviceToken.GCM))
 
+        apple_devices = list(
+            PushDeviceToken.objects.filter(user=self.user_profile,
+                                           kind=PushDeviceToken.APNS))
+
         with mock.patch('zerver.lib.push_notifications'
-                        '.send_android_push_notification') as mock_send_android:
+                        '.send_android_push_notification') as mock_send_android, \
+                mock.patch('zerver.lib.push_notifications'
+                           '.send_apple_push_notification') as mock_send_apple:
             handle_remove_push_notification(self.user_profile.id, [message.id])
             mock_send_android.assert_called_with(
                 android_devices,
@@ -971,6 +991,20 @@ class HandlePushNotificationTest(PushNotificationTest):
                     'zulip_message_id': message.id,
                 },
                 {'priority': 'normal'})
+            mock_send_apple.assert_called_with(
+                self.user_profile.id,
+                apple_devices,
+                {'badge': 0,
+                 'custom': {
+                     'zulip': {
+                         'server': 'testserver',
+                         'realm_id': self.sender.realm.id,
+                         'realm_uri': 'http://zulip.testserver',
+                         'user_id': self.user_profile.id,
+                         'event': 'remove',
+                         'zulip_message_ids': str(message.id),
+                     }
+                 }})
             user_message = UserMessage.objects.get(user_profile=self.user_profile,
                                                    message=message)
             self.assertEqual(user_message.flags.active_mobile_push_notification, False)
@@ -1152,11 +1186,38 @@ class TestAPNs(PushNotificationTest):
         self.assertEqual(
             modernize_apns_payload(
                 {'alert': 'Message from Hamlet',
-                 'message_ids': [3]}),
+                 'message_ids': [3],
+                 'badge': 0}),
             payload)
         self.assertEqual(
             modernize_apns_payload(payload),
             payload)
+
+    @mock.patch('zerver.lib.push_notifications.push_notifications_enabled', return_value = True)
+    def test_apns_badge_count(self, mock_push_notifications: mock.MagicMock) -> None:
+        user_profile = self.example_user('othello')
+        # Test APNs badge count for personal messages.
+        message_ids = [self.send_personal_message(self.sender,
+                                                  user_profile,
+                                                  'Content of message')
+                       for i in range(3)]
+        self.assertEqual(get_apns_badge_count(user_profile), 3)
+        # Similarly, test APNs badge count for stream mention.
+        stream = self.subscribe(user_profile, "Denmark")
+        message_ids += [self.send_stream_message(self.sender,
+                                                 stream.name,
+                                                 'Hi, @**Othello, the Moor of Venice**')
+                        for i in range(2)]
+        self.assertEqual(get_apns_badge_count(user_profile), 5)
+
+        num_messages = len(message_ids)
+        # Mark the messages as read and test whether
+        # the count decreases correctly.
+        for i, message_id in enumerate(message_ids):
+            do_update_message_flags(user_profile, get_client("website"), 'add', 'read', [message_id])
+            self.assertEqual(get_apns_badge_count(user_profile), num_messages - i - 1)
+
+        mock_push_notifications.assert_called()
 
 class TestGetAPNsPayload(PushNotificationTest):
     def test_get_message_payload_apns_personal_message(self) -> None:
@@ -1208,7 +1269,7 @@ class TestGetAPNsPayload(PushNotificationTest):
                 'body': message.content,
             },
             'sound': 'default',
-            'badge': 0,
+            'badge': 1,
             'custom': {
                 'zulip': {
                     'message_ids': [message.id],


### PR DESCRIPTION
This adds a new function `get_apns_badge_count()` to fetch count value for a user push notification and then sends that value with the APNs payload.

Once a message is read from the web app, the count is decremented accordingly and a push notification with `event: remove` is sent to the iOS clients.

Closes #10271