### PR TITLE
populate_db: Add markdown syntax in stream descriptions.

### DIFF
--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -326,11 +326,14 @@ class Command(BaseCommand):
             # Create public streams.
             stream_list = ["Verona", "Denmark", "Scotland", "Venice", "Rome"]
             stream_dict: Dict[str, Dict[str, Any]] = {
-                "Verona": {"description": "A city in Italy"},
-                "Denmark": {"description": "A Scandinavian country"},
+                "Verona": {"description": "A city in **Italy** famous for its artistic heritage \
+                            and ~~second~~ third largest in northeast Italy."},
+                "Denmark": {"description": "A Scandinavian ~~city~~ country officially \
+                            know as *Kingdom of Denmark*."},
                 "Scotland": {"description": "Located in the United Kingdom"},
                 "Venice": {"description": "A northeastern Italian city"},
-                "Rome": {"description": "Yet another Italian city", "is_web_public": True}
+                "Rome": {"description": "Yet another Italian city, know for its exceptional \
+                          *history*.", "is_web_public": True}
             }
 
             bulk_create_streams(zulip_realm, stream_dict)
@@ -538,11 +541,11 @@ class Command(BaseCommand):
                     "all": {"description": "For **everything**"},
                     "announce": {"description": "For announcements",
                                  'stream_post_policy': Stream.STREAM_POST_POLICY_ADMINS},
-                    "design": {"description": "For design"},
+                    "design": {"description": "For **design**"},
                     "support": {"description": "For support"},
                     "social": {"description": "For socializing"},
                     "test": {"description": "For testing `code`"},
-                    "errors": {"description": "For errors"},
+                    "errors": {"description": "For *errors*"},
                     "sales": {"description": "For sales discussion"}
                 }
 
@@ -559,7 +562,8 @@ class Command(BaseCommand):
                     extra_stream_name = 'Extra Stream ' + number_str
 
                     zulip_stream_dict[extra_stream_name] = {
-                        "description": "Auto-generated extra stream.",
+                        "description": "Auto-generated **extra** stream.\
+                                       These help ~~us~~ you out with testing large batches of streams.",
                     }
 
                 bulk_create_streams(zulip_realm, zulip_stream_dict)


### PR DESCRIPTION
I have added some extra markdown syntax in the stream description of the streams generated by populate_db.
THE ISSUE: https://github.com/zulip/zulip/issues/14991

**Testing Plan:** 
./manage.py populate_db --extra-streams 10


**GIFs or Screenshots:**
![Screenshot from 2020-06-02 22-58-31](https://user-images.githubusercontent.com/56222188/83559335-7693eb80-a525-11ea-95f2-d7dfab0153b3.png)
