### PR TITLE
logging: Set up a different logger for each backend.

### DIFF
--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -1362,7 +1362,7 @@ class SocialAuthMixin(ZulipAuthMixin, ExternalAuthMethod):
             # the flow or the IdP is unreliable and returns a bad http response),
             # don't throw a 500, just send them back to the
             # login page and record the event at the info log level.
-            self.logger.info(str(e))
+            self.logger.info(f"{e.__class__.__name__}: {str(e)}")
             return None
         except SocialAuthBaseException as e:
             # Other python-social-auth exceptions are likely

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -303,6 +303,8 @@ class EmailAuthBackend(ZulipAuthMixin):
     Allows a user to sign in using an email/password pair.
     """
 
+    name = 'email'
+
     @rate_limit_auth
     def authenticate(self, request: Optional[HttpRequest]=None, *,
                      username: str, password: str,
@@ -397,6 +399,8 @@ class ZulipLDAPAuthBackendBase(ZulipAuthMixin, LDAPBackend):
     library.  It's not a lot of code, and searching around in that
     file makes the flow for LDAP authentication clear.
     """
+
+    name = "ldap"
 
     def __init__(self) -> None:
         # Used to initialize a fake LDAP directly for both manual
@@ -870,6 +874,8 @@ def query_ldap(email: str) -> List[str]:
 class DevAuthBackend(ZulipAuthMixin):
     """Allow logging in as any user without a password.  This is used for
     convenience when developing Zulip, and is disabled in production."""
+
+    name = 'dev'
 
     def authenticate(self, request: Optional[HttpRequest]=None, *,
                      dev_auth_username: str, realm: Realm,

--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -680,6 +680,7 @@ SOFT_DEACTIVATION_LOG_PATH = zulip_path("/var/log/zulip/soft_deactivation.log")
 TRACEMALLOC_DUMP_DIR = zulip_path("/var/log/zulip/tracemalloc")
 SCHEDULED_MESSAGE_DELIVERER_LOG_PATH = zulip_path("/var/log/zulip/scheduled_message_deliverer.log")
 RETENTION_LOG_PATH = zulip_path("/var/log/zulip/message_retention.log")
+AUTH_LOG_PATH = zulip_path("/var/log/zulip/auth.log")
 
 # The EVENT_LOGS feature is an ultra-legacy piece of code, which
 # originally logged all significant database changes for debugging.
@@ -752,6 +753,12 @@ LOGGING: Dict[str, Any] = {
             'filters': (['ZulipLimiter', 'require_debug_false', 'require_really_deployed']
                         if not DEBUG_ERROR_REPORTING else []),
             'formatter': 'default'
+        },
+        'auth_file': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.WatchedFileHandler',
+            'formatter': 'default',
+            'filename': AUTH_LOG_PATH,
         },
         'console': {
             'level': 'DEBUG',
@@ -889,6 +896,10 @@ LOGGING: Dict[str, Any] = {
         },
         'zerver.management.commands.deliver_scheduled_messages': {
             'level': 'DEBUG',
+        },
+        'zulip.auth': {
+            'level': 'DEBUG',
+            'handlers': DEFAULT_ZULIP_HANDLERS + ['auth_file']
         },
         'zulip.ldap': {
             'level': 'DEBUG',


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
    Adds a top-level logger in `settings.LOGGING` `zulip.auth`
    with the default handlers `DEFAULT_ZULIP_HANDLERS` and
    an extra hanlder that writes to `/var/log/zulip/auth.log`.
    
    Each auth backend uses it's own logger, `self.logger` which
    is in form 'zulip.auth.<backend name>'.
    
    This way it's clear which auth backend generated the log
    and is easier to look for all authentication logs in one file.
(https://chat.zulip.org/#narrow/stream/3-backend/topic/auth.20backend.20loggers/near/882092)

**Testing Plan:** <!-- How have you tested? -->
Automated tests passed.
