### PR TITLE
users: Modify do_create_user and create_user to accept role.

### DIFF
--- a/analytics/management/commands/populate_analytics_db.py
+++ b/analytics/management/commands/populate_analytics_db.py
@@ -59,7 +59,7 @@ class Command(BaseCommand):
         with mock.patch("zerver.lib.create_user.timezone_now", return_value=installation_time):
             shylock = create_user('shylock@analytics.ds', 'Shylock', realm,
                                   full_name='Shylock', short_name='shylock',
-                                  is_realm_admin=True)
+                                  role=UserProfile.ROLE_REALM_ADMINISTRATOR)
         do_change_user_role(shylock, UserProfile.ROLE_REALM_ADMINISTRATOR)
         stream = Stream.objects.create(
             name='all', realm=realm, date_created=installation_time)

--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -67,7 +67,7 @@ class AnalyticsTestCase(TestCase):
             return create_user(kwargs['email'], 'password', kwargs['realm'],
                                active=kwargs['is_active'],
                                full_name=kwargs['full_name'], short_name=kwargs['short_name'],
-                               is_realm_admin=True, **pass_kwargs)
+                               role=UserProfile.ROLE_REALM_ADMINISTRATOR, **pass_kwargs)
 
     def create_stream_with_recipient(self, **kwargs: Any) -> Tuple[Stream, Recipient]:
         self.name_counter += 1

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -498,8 +498,7 @@ def create_users(realm: Realm, name_list: Iterable[Tuple[str, str]], bot_type: O
     bulk_create_users(realm, user_set, bot_type)
 
 def do_create_user(email: str, password: Optional[str], realm: Realm, full_name: str,
-                   short_name: str, bot_type: Optional[int]=None,
-                   is_realm_admin: bool=False, is_guest: bool=False,
+                   short_name: str, bot_type: Optional[int]=None, role: Optional[int]=None,
                    bot_owner: Optional[UserProfile]=None, tos_version: Optional[str]=None,
                    timezone: str="", avatar_source: str=UserProfile.AVATAR_FROM_GRAVATAR,
                    default_sending_stream: Optional[Stream]=None,
@@ -513,8 +512,7 @@ def do_create_user(email: str, password: Optional[str], realm: Realm, full_name:
 
     user_profile = create_user(email=email, password=password, realm=realm,
                                full_name=full_name, short_name=short_name,
-                               is_realm_admin=is_realm_admin, is_guest=is_guest,
-                               bot_type=bot_type, bot_owner=bot_owner,
+                               role=role, bot_type=bot_type, bot_owner=bot_owner,
                                tos_version=tos_version, timezone=timezone, avatar_source=avatar_source,
                                default_sending_stream=default_sending_stream,
                                default_events_register_stream=default_events_register_stream,

--- a/zilencer/management/commands/add_new_realm.py
+++ b/zilencer/management/commands/add_new_realm.py
@@ -18,7 +18,7 @@ class Command(ZulipBaseCommand):
         name = '%02d-user' % (
             UserProfile.objects.filter(email__contains='user@').count(),)
         user = do_create_user('%s@%s.zulip.com' % (name, string_id),
-                              'password', realm, name, name, is_realm_admin=True)
+                              'password', realm, name, name, role=UserProfile.ROLE_REALM_ADMINISTRATOR)
         bulk_add_subscriptions([realm.signup_notifications_stream], [user])
 
         send_initial_realm_messages(realm)

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -57,6 +57,7 @@ from zerver.lib.actions import do_create_user, do_reactivate_user, do_deactivate
     do_update_user_custom_profile_data_if_changed
 from zerver.lib.avatar import is_avatar_new, avatar_url
 from zerver.lib.avatar_hash import user_avatar_content_hash
+from zerver.lib.create_user import get_role_for_new_user
 from zerver.lib.dev_ldap_directory import init_fakeldap
 from zerver.lib.email_validation import email_allowed_for_realm, \
     validate_email_not_already_in_realm
@@ -706,9 +707,7 @@ class ZulipLDAPAuthBackend(ZulipLDAPAuthBackendBase):
             invited_as = self._prereg_user.invited_as
             realm_creation = self._prereg_user.realm_creation
             opts['prereg_user'] = self._prereg_user
-            opts['is_realm_admin'] = (
-                invited_as == PreregistrationUser.INVITE_AS['REALM_ADMIN']) or realm_creation
-            opts['is_guest'] = invited_as == PreregistrationUser.INVITE_AS['GUEST_USER']
+            opts['role'] = get_role_for_new_user(invited_as, realm_creation)
             opts['realm_creation'] = realm_creation
             # TODO: Ideally, we should add a mechanism for the user
             # entering which default stream groups they've selected in


### PR DESCRIPTION
This PR changes do_create_user and create_user to accept
role as a paramter instead of 'is_realm_admin' and 'is_guest'.
These changes are done to minimize data  conversions between
role and boolean fields.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
