### PR TITLE
compose: Fix subscribing the user from mention warning.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1263,7 +1263,7 @@ run_test('on_events', () => {
         let invite_user_to_stream_called = false;
         stream_edit.invite_user_to_stream = function (email, sub, success) {
             invite_user_to_stream_called = true;
-            assert.equal(email, 'foo@bar.com');
+            assert.deepEqual(email, ['foo@bar.com']);
             assert.equal(sub, subscription);
             success();  // This will check success callback path.
         };

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -1020,7 +1020,7 @@ exports.initialize = function () {
             return;
         }
 
-        stream_edit.invite_user_to_stream(email, sub, success, xhr_failure);
+        stream_edit.invite_user_to_stream([email], sub, success, xhr_failure);
     });
 
     $("#compose_invite_users").on('click', '.compose_invite_close', function (event) {


### PR DESCRIPTION
This PR fixes the bug for subscribing the user from mention
warning which was introduced in e52b544.

This is fixed by changing email to be passed as list to
'invite_user_to_stream'.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
