### PR TITLE
hotspots: Add feature to skip introduction tour.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -784,12 +784,34 @@ exports.initialize = function () {
         $('#hotspot_' + hotspot_name + '_icon').remove();
     });
 
-    $('body').on('click', '.hotspot-button', function (e) {
+    $('body').on('click', '.hotspot-button.hotspot-confirm', function (e) {
         e.preventDefault();
         e.stopPropagation();
 
         hotspots.post_hotspot_as_read('intro_reply');
         hotspots.close_hotspot_icon($('#hotspot_intro_reply_icon'));
+    });
+
+    // skip
+    $('body').on('click', '.hotspot-skip', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        if ($(this).is('#hotspot-intro')) {
+            hotspots.close_hotspot_icon($('#hotspot_intro_reply_icon'));
+            hotspots.post_hotspot_as_skip('intro_reply');
+        } else {
+            const overlay_name = $(this).closest('.hotspot.overlay').attr('id');
+
+            const hotspot_name = overlay_name
+                .replace('hotspot_', '')
+                .replace('_overlay', '');
+
+            overlays.close_overlay(overlay_name);
+            $('#hotspot_' + hotspot_name + '_icon').remove();
+
+            hotspots.post_hotspot_as_skip(hotspot_name);
+        }
     });
 
     // stop propagation

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -286,6 +286,16 @@ exports.initialize_kitchen_sink_stuff = function () {
         $(this).tooltip('hide');
     });
 
+    $("body").on("mouseenter", ".hotspot-cross", function () {
+        $(this).show();
+        $(this).tooltip({placement: 'left'});
+        $(this).tooltip('show');
+    });
+
+    $("body").on("mouseleave", ".hotspot-cross", function () {
+        $(this).tooltip('hide');
+    });
+
     if (!page_params.realm_allow_message_editing) {
         $("#edit-message-hotkey-help").hide();
     }

--- a/static/styles/hotspots.scss
+++ b/static/styles/hotspots.scss
@@ -78,7 +78,7 @@
 
     .hotspot-popover {
         position: fixed;
-        width: 250px;
+        max-width: 320px;
         text-align: left;
         box-shadow: 0 5px 10px hsla(223, 4%, 54%, 0.2);
         border: 1px solid hsl(0, 0%, 80%);
@@ -188,6 +188,7 @@
         font-size: 1.15em;
         font-weight: 600;
         color: hsl(0, 0%, 100%);
+        display: inline;
     }
 
     .hotspot-popover-content {
@@ -208,7 +209,7 @@
         left: 4px;
     }
 
-    .hotspot-confirm {
+    .button-container {
         position: absolute;
         bottom: 15px;
         right: 15px;
@@ -219,7 +220,8 @@
     height: 83px;
 }
 
-.hotspot-confirm {
+.hotspot-confirm,
+.hotspot-skip {
     max-width: 125px;
     max-height: 70px;
     border: none;
@@ -234,6 +236,17 @@
 
     &:hover {
         background-color: hsl(164, 44%, 56%);
+    }
+}
+
+.hotspot-cross {
+    cursor: pointer;
+    float: right;
+    margin: 11px 0 0 0;
+    padding: 1px;
+
+    &:hover {
+        background-color: transparent;
     }
 }
 
@@ -258,7 +271,7 @@
     }
 
     .hotspot-confirm {
-        display: block;
+        display: inline-block;
     }
 
     .hotspot-inline-top .hotspot-title {

--- a/static/templates/hotspot_overlay.hbs
+++ b/static/templates/hotspot_overlay.hbs
@@ -2,13 +2,16 @@
     <div class="hotspot-popover">
         <div class="hotspot-popover-top">
             <h1 class="hotspot-title">{{title}}</h1>
+            <i class="hotspot-skip hotspot-cross fa fa-times" aria-hidden="true" data-toggle="tooltip" title="{{t 'Skip tour' }}"></i>
         </div>
         <div class="hotspot-popover-content">
             <p class="hotspot-description">{{description}}</p>
         </div>
         <div class="hotspot-popover-bottom">
             <img class="hotspot-img" alt=_("hotspot illustration") src="{{img}}">
-            <button class="hotspot-confirm">{{t 'Got it!' }}</button>
+            <div class="button-container">
+                <button class="hotspot-confirm">{{t 'Next' }}</button>
+            </div>
         </div>
     </div>
 </div>

--- a/static/templates/intro_reply_hotspot.hbs
+++ b/static/templates/intro_reply_hotspot.hbs
@@ -5,6 +5,9 @@
     </div>
     <div class="hotspot-inline-right">
         <p>{{t 'Click anywhere on a message to reply.' }}</p>
-        <button class="hotspot-button hotspot-confirm" type="button">{{t 'Got it!' }}</button>
+        <div class="button-container">
+            <button class="hotspot-skip" id="hotspot-intro">{{t 'Skip tour' }}</button>
+            <button class="hotspot-button hotspot-confirm" type="button">{{t 'Next' }}</button>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
This commit adds a feature to skip the introduction tour for the users
familiar with Zulip's interface.

Fixes #8217.


**Testing Plan:** <!-- How have you tested? -->
1. Create a new user
2. Skip
  a. the first hotspot or
  b. confirm first 'x' hotspots and then skip.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/23737560/83617682-0ded5300-a5a7-11ea-8e2f-e9d4b3eb4ff8.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
