### PR TITLE
stream edit:Add keyboard shortcut to submit subscribers form

### DIFF
--- a/static/js/input_pill.js
+++ b/static/js/input_pill.js
@@ -259,6 +259,8 @@ exports.create = function (opts) {
                         funcs.clear(e.target);
                         e.stopPropagation();
                     }
+                } else if (value.length === 0 && store.$parent.find(".pill").length > 0) {
+                    $('.subscriber_list_add form').submit();
                 }
 
                 return;


### PR DESCRIPTION
The add-new-subscribers form was not submitting on pressing
<Enter> key. This is a useful feature for users to add new
subscribers quickly and easily.
Submit the form on pressing the Enter key from the keyboard.

![ezgif-2-2101ec6fd87c](https://user-images.githubusercontent.com/23723464/83638397-b363ef00-a5c6-11ea-81c3-f8b143f57a66.gif)


fixes: #15185

