### PR TITLE
Experiment: Add a fullscreen button in display settings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "postcss-simple-vars": "^5.0.2",
     "regenerator-runtime": "^0.13.3",
     "rewiremock": "^3.13.9",
+    "screenfull": "^5.0.2",
     "script-loader": "^0.7.2",
     "shebang-loader": "^0.0.1",
     "simplebar": "^5.0.7",

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -1,5 +1,6 @@
 const settings_config = require("./settings_config");
 const render_settings_tab = require('../templates/settings_tab.hbs');
+const screenfull = require('screenfull');
 
 $("body").ready(function () {
     $("#settings_overlay_container").click(function (e) {
@@ -70,6 +71,13 @@ exports.build_page = function () {
     });
 
     $(".settings-box").html(rendered_settings_tab);
+
+    $('#fullscreen-button').on('click', (e) => {
+        if (screenfull.isEnabled) {
+            screenfull.request();
+        }
+        $(e.target).removeClass("b");
+    });
 };
 
 exports.launch = function (section) {

--- a/static/templates/settings/display_settings.hbs
+++ b/static/templates/settings/display_settings.hbs
@@ -20,7 +20,7 @@
         <div id="user-display-settings">
             <h3 class="inline-block">{{t "Display settings" }}</h3>
             <div class="alert-notification" id="display-settings-status"></div>
-
+            <button id="fullscreen-button" type="button" class="btn btn-primary">toggle fullscreen</button>
             {{#each display_settings.settings.user_display_settings}}
             {{> settings_checkbox
               setting_name=this

--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -240,6 +240,7 @@ export default (env?: string): webpack.Configuration[] => {
         { path: "underscore/underscore.js", name: '_' },
         { path: "handlebars/dist/cjs/handlebars.runtime.js", name: 'Handlebars' },
         { path: "sortablejs/Sortable.js"},
+        { path: "screenfull/dist/screenfull.js"},
         { path: "winchan/winchan.js", name: 'WinChan'},
     ];
     config.module.rules.unshift(...getExposeLoaders(exposeOptions));

--- a/yarn.lock
+++ b/yarn.lock
@@ -10614,6 +10614,11 @@ schema-utils@^2.0.0, schema-utils@^2.6.4, schema-utils@^2.6.5:
     ajv "^6.12.0"
     ajv-keywords "^3.4.1"
 
+screenfull@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-5.0.2.tgz#b9acdcf1ec676a948674df5cd0ff66b902b0bed7"
+  integrity sha512-cCF2b+L/mnEiORLN5xSAz6H3t18i2oHh9BA8+CQlAh5DRw2+NFAGQJOSYbcGw8B2k04g/lVvFcfZ83b3ysH5UQ==
+
 script-loader@^0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/script-loader/-/script-loader-0.7.2.tgz#2016db6f86f25f5cf56da38915d83378bb166ba7"


### PR DESCRIPTION
This is not intended to be merged, It was just an experiment to see how we'd do on fullscreen on mobile. If this is something that we decide to move forward on, we'll need to improve the style of the button.

Bellow are the contents of the commit message:
On mobile browsers, such as chrome, the browser UI takes up a decent
portion of the limited view space, as such it's a good idea to allow
mobile users to be able to switch to fullscreen mode.

The toggle works on the web app on desktop as well, but desktop users
also have `F11`.

The library added here can be found at:
https://github.com/sindresorhus/screenfull.js and was chosen because
it's recommended here:
https://developers.google.com/web/fundamentals/native-hardware/fullscreen/.

Unfortunately, we can not just default to fullscreen because:
    1. Doing this would be very annoying, especially on mobile.
    2. The browser API require an explicit user action (because 1).

A major annoyance in this setup is that using the hardware "back"
will exit the fullscreen because browser vendors prefer it that way
listening to window.onhashchange is a workaround worth investigating.
