### PR TITLE
navbar: Fix search input margin.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1646,6 +1646,7 @@ div.focused_table {
         font-family: 'Source Sans Pro';
         font-weight: 300;
         line-height: $header_height;
+        margin-left: 10px;
     }
 
     #search_arrows:focus {


### PR DESCRIPTION
The commit fixes the spacing between the search icon and the input
field by adding `margin-left` to the search input field. The following
issue is only visible in dark mode as the nav and search input have
different background color while normal theme uses same background color
for nav and search input.

**Testing Plan:** <!-- How have you tested? -->
Manually launching running Zulip instance and clicking on navbar.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before:
![image](https://user-images.githubusercontent.com/23737560/83654536-e31cf200-a5da-11ea-9bdb-d30db7e3c4fd.png)

After:
![image](https://user-images.githubusercontent.com/23737560/83654596-f7f98580-a5da-11ea-94a4-996931c1ae26.png)
