### PR TITLE
settings: Use correct label for signup notifications stream.

### DIFF
--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -110,7 +110,7 @@
               widget_name="realm_signup_notifications_stream_id"
               list_placeholder=(t 'Filter streams')
               reset_button_text=(t '[Disable]')
-              label=admin_settings_label.realm_notifications_stream }}
+              label=admin_settings_label.realm_signup_notifications_stream }}
 
         </div>
 


### PR DESCRIPTION
When migrating to dropdown list widget, we incorrectly used the same label
for both realm_notifications_stream and realm_signup_notifications_stream.

This was introduced in b580baf6821160a32e6a0c205e8fad7723c2323b.
