### PR TITLE
stream_edit: Use user_ids for subscribing/unsubscribing to a stream.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1261,10 +1261,16 @@ run_test('on_events', () => {
             name: 'test',
             subscribed: true,
         };
+        const mentioned = {
+            full_name: 'Foo Barson',
+            email: 'foo@bar.com',
+            user_id: 34,
+        };
+        people.add_active_user(mentioned);
         let invite_user_to_stream_called = false;
-        stream_edit.invite_user_to_stream = function (email, sub, success) {
+        stream_edit.invite_user_to_stream = function (user_ids, sub, success) {
             invite_user_to_stream_called = true;
-            assert.deepEqual(email, ['foo@bar.com']);
+            assert.deepEqual(user_ids, [mentioned.user_id]);
             assert.equal(sub, subscription);
             success();  // This will check success callback path.
         };
@@ -1286,7 +1292,7 @@ run_test('on_events', () => {
         $('#stream_message_recipient_stream').val('no-stream');
         helper.container.data = function (field) {
             assert.equal(field, 'useremail');
-            return 'foo@bar.com';
+            return mentioned.email;
         };
         $("#compose-textarea").select(noop);
         helper.target.prop('disabled', false);

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1149,7 +1149,7 @@ run_test('warn_if_mentioning_unsubscribed_user', () => {
             global.stub_templates(function (template_name, context) {
                 called = true;
                 assert.equal(template_name, 'compose_invite_users');
-                assert.equal(context.email, 'foo@bar.com');
+                assert.equal(context.user_id, 34);
                 assert.equal(context.name, 'Foo Barson');
                 return 'fake-compose-invite-user-template';
             });
@@ -1168,6 +1168,7 @@ run_test('warn_if_mentioning_unsubscribed_user', () => {
 
     mentioned = {
         email: 'foo@bar.com',
+        user_id: 34,
         full_name: 'Foo Barson',
     };
 
@@ -1181,9 +1182,9 @@ run_test('warn_if_mentioning_unsubscribed_user', () => {
 
     let looked_for_existing;
     warning_row.data = function (field) {
-        assert.equal(field, 'useremail');
+        assert.equal(field, 'user-id');
         looked_for_existing = true;
-        return 'foo@bar.com';
+        return '34';
     };
 
     const previous_users = $('#compose_invite_users .compose_invite_user');
@@ -1281,18 +1282,12 @@ run_test('on_events', () => {
             '.compose_invite_user'
         );
 
-        // .data in zjquery is a noop by default, so handler should just return
-        handler(helper.event);
-
-        assert(!invite_user_to_stream_called);
-        assert(!helper.container_was_removed());
-
         // !sub will result false here and we check the failure code path.
         blueslip.expect('warn', 'Stream no longer exists: no-stream');
         $('#stream_message_recipient_stream').val('no-stream');
         helper.container.data = function (field) {
-            assert.equal(field, 'useremail');
-            return mentioned.email;
+            assert.equal(field, 'user-id');
+            return '34';
         };
         $("#compose-textarea").select(noop);
         helper.target.prop('disabled', false);

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -998,7 +998,7 @@ exports.initialize = function () {
         if (email === undefined) {
             return;
         }
-
+        const user_id = people.get_user_id(email);
         function success() {
             const all_invites = $("#compose_invite_users");
             invite_row.remove();
@@ -1031,7 +1031,7 @@ exports.initialize = function () {
             return;
         }
 
-        stream_edit.invite_user_to_stream([email], sub, success, xhr_failure);
+        stream_edit.invite_user_to_stream([user_id], sub, success, xhr_failure);
     });
 
     $("#compose_invite_users").on('click', '.compose_invite_close', function (event) {

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -906,6 +906,7 @@ exports.warn_if_mentioning_unsubscribed_user = function (mentioned) {
     }
 
     const email = mentioned.email;
+    const user_id = mentioned.user_id;
 
     if (mentioned.is_broadcast) {
         return; // don't check if @all/@everyone/@stream
@@ -916,12 +917,12 @@ exports.warn_if_mentioning_unsubscribed_user = function (mentioned) {
         const existing_invites_area = $('#compose_invite_users .compose_invite_user');
 
         const existing_invites = Array.from($(existing_invites_area), user_row => {
-            return $(user_row).data('useremail');
+            return parseInt($(user_row).data('user-id'), 10);
         });
 
-        if (!existing_invites.includes(email)) {
+        if (!existing_invites.includes(user_id)) {
             const context = {
-                email: email,
+                user_id: user_id,
                 name: mentioned.full_name,
                 can_subscribe_other_users: page_params.can_subscribe_other_users,
             };
@@ -994,11 +995,8 @@ exports.initialize = function () {
 
         const invite_row = $(event.target).parents('.compose_invite_user');
 
-        const email = $(invite_row).data('useremail');
-        if (email === undefined) {
-            return;
-        }
-        const user_id = people.get_user_id(email);
+        const user_id = parseInt($(invite_row).data('user-id'), 10);
+
         function success() {
             const all_invites = $("#compose_invite_users");
             invite_row.remove();

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -176,9 +176,7 @@ function create_stream() {
     // TODO: We can eliminate the user_ids -> principals conversion
     //       once we upgrade the backend to accept user_ids.
     const user_ids = get_principals();
-    const persons = user_ids.map(user_id => people.get_by_user_id(user_id)).filter(Boolean);
-    const principals = persons.map(person => person.email);
-    data.principals = JSON.stringify(principals);
+    data.principals = JSON.stringify(user_ids);
 
     loading.make_indicator($('#stream_creating_indicator'), {text: i18n.t('Creating stream...')});
 

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -129,25 +129,25 @@ exports.update_stream_description = function (sub) {
     );
 };
 
-exports.invite_user_to_stream = function (emails, sub, success, failure) {
+exports.invite_user_to_stream = function (user_ids, sub, success, failure) {
     // TODO: use stream_id when backend supports it
     const stream_name = sub.name;
     return channel.post({
         url: "/json/users/me/subscriptions",
         data: {subscriptions: JSON.stringify([{name: stream_name}]),
-               principals: JSON.stringify(emails)},
+               principals: JSON.stringify(user_ids)},
         success: success,
         error: failure,
     });
 };
 
-exports.remove_user_from_stream = function (user_email, sub, success, failure) {
+exports.remove_user_from_stream = function (user_id, sub, success, failure) {
     // TODO: use stream_id when backend supports it
     const stream_name = sub.name;
     return channel.del({
         url: "/json/users/me/subscriptions",
         data: {subscriptions: JSON.stringify([stream_name]),
-               principals: JSON.stringify([user_email])},
+               principals: JSON.stringify([user_id])},
         success: success,
         error: failure,
     });
@@ -559,10 +559,6 @@ exports.initialize = function () {
         }
 
         const user_ids = user_pill.get_user_ids(exports.pill_widget);
-        const emails = user_ids.map(user_id => {
-            const person = people.get_by_user_id(user_id);
-            return person.email;
-        });
         const stream_subscription_info_elem = $('.stream_subscription_info').expectOne();
 
         function invite_success(data) {
@@ -586,7 +582,7 @@ exports.initialize = function () {
                 .addClass("text-error").removeClass("text-success");
         }
 
-        exports.invite_user_to_stream(emails, sub, invite_success, invite_failure);
+        exports.invite_user_to_stream(user_ids, sub, invite_success, invite_failure);
     });
 
     $("#subscriptions_table").on("submit", ".subscriber_list_remove form", function (e) {
@@ -594,7 +590,6 @@ exports.initialize = function () {
 
         const list_entry = $(e.target).closest("tr");
         const target_user_id = parseInt(list_entry.attr("data-subscriber-id"), 10);
-        const principal = people.get_by_user_id(target_user_id).email;
         const settings_row = $(e.target).closest('.subscription_settings');
 
         const sub = get_sub_for_target(settings_row);
@@ -622,7 +617,7 @@ exports.initialize = function () {
                 .addClass("text-error").removeClass("text-success");
         }
 
-        exports.remove_user_from_stream(principal, sub, removal_success,
+        exports.remove_user_from_stream(target_user_id, sub, removal_success,
                                         removal_failure);
     });
 

--- a/static/templates/compose_invite_users.hbs
+++ b/static/templates/compose_invite_users.hbs
@@ -1,4 +1,4 @@
-<div class="compose_invite_user" data-useremail="{{email}}">
+<div class="compose_invite_user" data-user-id="{{user_id}}">
     {{#if can_subscribe_other_users}}
     <p>{{#tr this}}<strong>__name__</strong> is not subscribed to this stream. They will not be notified unless you subscribe them.{{/tr}}</p>
     <div class="compose_invite_user_controls">


### PR DESCRIPTION
This PR changes the code of subscibing/unsusbscribing to a
stream to use user_ids instead of emails.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
