### PR TITLE
ts: Convert util module to typescript.

### DIFF
--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -59,6 +59,11 @@ run_test('lower_bound', () => {
     assert.equal(util.lower_bound(arr, 10, compare), 0);
     assert.equal(util.lower_bound(arr, 15, compare), 1);
 
+    // Blueslip should throw an error when no less (compare) function
+    // is passed when non-number array is used.
+    blueslip.expect('error', 'less function not given for non-number array');
+    util.lower_bound(arr, 5);
+    blueslip.reset();
 });
 
 run_test('same_recipient', () => {

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -37,6 +37,13 @@ exports.lower_bound = function (array, arg1, arg2, arg3, arg4) {
     }
 
     if (less === undefined) {
+        // Throw and error and return 0 if no less function is passed
+        // and the array is not made up of numbers.
+        if (array.length !== 0 && typeof array[0] !== 'number') {
+            blueslip.error('less function not given for non-number array');
+            return 0;
+        }
+
         less = function (a, b) { return a < b; };
     }
 

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -23,10 +23,15 @@ exports.lower_bound = function (array, arg1, arg2, arg3, arg4) {
         first = 0;
         last = array.length;
         value = arg1;
-        less = arg2;
+        if (typeof arg2 !== 'number') {
+            less = arg2;
+        }
     } else {
         first = arg1;
-        last = arg2;
+        if (typeof arg2 === 'number') {
+            last = arg2;
+        }
+
         value = arg3;
         less = arg4;
     }

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -197,7 +197,7 @@ exports.CachedValue.prototype = {
 };
 
 exports.find_wildcard_mentions = function (message_content) {
-    const mention = message_content.match(/(^|\s)(@\*{2}(all|everyone|stream)\*{2})($|\s)/);
+    const mention = /(^|\s)(@\*{2}(all|everyone|stream)\*{2})($|\s)/.exec(message_content);
     if (mention === null) {
         return null;
     }

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -1,7 +1,7 @@
 // From MDN: https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Math/random
-exports.random_int = function random_int(min, max) {
+export function random_int(min, max) {
     return Math.floor(Math.random() * (max - min + 1)) + min;
-};
+}
 
 // Like C++'s std::lower_bound.  Returns the first index at which
 // `value` could be inserted without changing the ordering.  Assumes
@@ -14,7 +14,7 @@ exports.random_int = function random_int(min, max) {
 //
 // Usage: lower_bound(array, value, [less])
 //        lower_bound(array, first, last, value, [less])
-exports.lower_bound = function (array, arg1, arg2, arg3, arg4) {
+export function lower_bound(array, arg1, arg2, arg3, arg4) {
     let first;
     let last;
     let value;
@@ -62,28 +62,28 @@ exports.lower_bound = function (array, arg1, arg2, arg3, arg4) {
         }
     }
     return first;
-};
+}
 
 function lower_same(a, b) {
     return a.toLowerCase() === b.toLowerCase();
 }
 
-exports.same_stream_and_topic = function util_same_stream_and_topic(a, b) {
+export function same_stream_and_topic(a, b) {
     // Streams and topics are case-insensitive.
     return a.stream_id === b.stream_id &&
         lower_same(a.topic, b.topic);
-};
+}
 
-exports.is_pm_recipient = function (user_id, message) {
+export function is_pm_recipient(user_id, message) {
     const recipients = message.to_user_ids.split(',');
     return recipients.includes(user_id.toString());
-};
+}
 
-exports.extract_pm_recipients = function (recipients) {
+export function extract_pm_recipients(recipients) {
     return recipients.split(/\s*[,;]\s*/).filter((recipient) => recipient.trim() !== "");
-};
+}
 
-exports.same_recipient = function util_same_recipient(a, b) {
+export function same_recipient(a, b) {
     if (a === undefined || b === undefined) {
         return false;
     }
@@ -98,19 +98,19 @@ exports.same_recipient = function util_same_recipient(a, b) {
         }
         return a.to_user_ids === b.to_user_ids;
     case 'stream':
-        return exports.same_stream_and_topic(a, b);
+        return same_stream_and_topic(a, b);
     }
 
     // should never get here
     return false;
-};
+}
 
-exports.same_sender = function util_same_sender(a, b) {
+export function same_sender(a, b) {
     return a !== undefined && b !== undefined &&
             a.sender_email.toLowerCase() === b.sender_email.toLowerCase();
-};
+}
 
-exports.normalize_recipients = function (recipients) {
+export function normalize_recipients(recipients) {
     // Converts a string listing emails of message recipients
     // into a canonical formatting: emails sorted ASCIIbetically
     // with exactly one comma and no spaces between each.
@@ -119,13 +119,13 @@ exports.normalize_recipients = function (recipients) {
     recipients = recipients.filter((s) => s.length > 0);
     recipients.sort();
     return recipients.join(',');
-};
+}
 
 // Avoid URI decode errors by removing characters from the end
 // one by one until the decode succeeds.  This makes sense if
 // we are decoding input that the user is in the middle of
 // typing.
-exports.robust_uri_decode = function (str) {
+export function robust_uri_decode(str) {
     let end = str.length;
     while (end > 0) {
         try {
@@ -138,13 +138,13 @@ exports.robust_uri_decode = function (str) {
         }
     }
     return '';
-};
+}
 
 // If we can, use a locale-aware sorter.  However, if the browser
 // doesn't support the ECMAScript Internationalization API
 // Specification, do a dumb string comparison because
 // String.localeCompare is really slow.
-exports.make_strcmp = function () {
+export function make_strcmp() {
     try {
         const collator = new Intl.Collator();
         return collator.compare;
@@ -155,16 +155,17 @@ exports.make_strcmp = function () {
     return function util_strcmp(a, b) {
         return a < b ? -1 : a > b ? 1 : 0;
     };
-};
-exports.strcmp = exports.make_strcmp();
+}
 
-exports.escape_regexp = function (string) {
+export const strcmp = make_strcmp();
+
+export function escape_regexp(string) {
     // code from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
     // Modified to escape the ^ to appease jslint. :/
     return string.replace(/([.*+?\^=!:${}()|\[\]\/\\])/g, "\\$1");
-};
+}
 
-exports.array_compare = function util_array_compare(a, b) {
+export function array_compare(a, b) {
     if (a.length !== b.length) {
         return false;
     }
@@ -175,7 +176,7 @@ exports.array_compare = function util_array_compare(a, b) {
         }
     }
     return true;
-};
+}
 
 /* Represents a value that is expensive to compute and should be
  * computed on demand and then cached.  The value can be forcefully
@@ -209,9 +210,9 @@ exports.find_wildcard_mentions = function (message_content) {
         return null;
     }
     return mention[3];
-};
+}
 
-exports.move_array_elements_to_front = function util_move_array_elements_to_front(array, selected) {
+export function move_array_elements_to_front(array, selected) {
     const selected_hash = new Set(selected);
     const selected_elements = [];
     const unselected_elements = [];
@@ -219,19 +220,19 @@ exports.move_array_elements_to_front = function util_move_array_elements_to_fron
         (selected_hash.has(element) ? selected_elements : unselected_elements).push(element);
     }
     return [...selected_elements, ...unselected_elements];
-};
+}
 
 // check by the userAgent string if a user's client is likely mobile.
-exports.is_mobile = function () {
+export function is_mobile() {
     const regex = "Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini";
     return new RegExp(regex, "i").test(window.navigator.userAgent);
-};
+}
 
 function to_int(s) {
     return parseInt(s, 10);
 }
 
-exports.sorted_ids = function (ids) {
+export function sorted_ids(ids) {
     // This mapping makes sure we are using ints, and
     // it also makes sure we don't mutate the list.
     let id_list = ids.map(to_int);
@@ -239,30 +240,30 @@ exports.sorted_ids = function (ids) {
     id_list = _.uniq(id_list, true);
 
     return id_list;
-};
+}
 
-exports.set_match_data = function (target, source) {
+export function set_match_data(target, source) {
     target.match_subject = source.match_subject;
     target.match_content = source.match_content;
-};
+}
 
-exports.get_match_topic = function (obj) {
+export function get_match_topic(obj) {
     return obj.match_subject;
-};
+}
 
-exports.get_draft_topic = function (obj) {
+export function get_draft_topic(obj) {
     // We will need to support subject for old drafts.
     return obj.topic || obj.subject || '';
-};
+}
 
-exports.get_reload_topic = function (obj) {
+export function get_reload_topic(obj) {
     // When we first upgrade to releases that have
     // topic=foo in the code, the user's reload URL
     // may still have subject=foo from the prior version.
     return obj.topic || obj.subject || '';
-};
+}
 
-exports.get_edit_event_topic = function (obj) {
+export function get_edit_event_topic(obj) {
     if (obj.topic === undefined) {
         return obj.subject;
     }
@@ -270,27 +271,27 @@ exports.get_edit_event_topic = function (obj) {
     // This code won't be reachable till we fix the
     // server, but we use it now in tests.
     return obj.topic;
-};
+}
 
-exports.get_edit_event_orig_topic = function (obj) {
+export function get_edit_event_orig_topic(obj) {
     return obj.orig_subject;
-};
+}
 
-exports.get_edit_event_prev_topic = function (obj) {
+export function get_edit_event_prev_topic(obj) {
     return obj.prev_subject;
-};
+}
 
-exports.is_topic_synonym = function (operator) {
+export function is_topic_synonym(operator) {
     return operator === 'subject';
-};
+}
 
-exports.convert_message_topic = function (message) {
+export function convert_message_topic(message) {
     if (message.topic === undefined) {
         message.topic = message.subject;
     }
-};
+}
 
-exports.clean_user_content_links = function (html) {
+export function clean_user_content_links(html) {
     const content = new DOMParser().parseFromString(html, "text/html").body;
     for (const elt of content.getElementsByTagName("a")) {
         // Ensure that all external links have target="_blank"
@@ -341,4 +342,4 @@ exports.clean_user_content_links = function (html) {
         elt.setAttribute("title", ["", legacy_title].includes(elt.title) ? title : `${title}\n${elt.title}`);
     }
     return content.innerHTML;
-};
+}

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -178,23 +178,23 @@ exports.array_compare = function util_array_compare(a, b) {
  * which should be a function that computes the uncached value.
  */
 const unassigned_value_sentinel = {};
-exports.CachedValue = function (opts) {
-    this._value = unassigned_value_sentinel;
-    Object.assign(this, opts);
-};
+export class CachedValue {
+    constructor(opts) {
+        this._value = unassigned_value_sentinel;
+        this.compute_value = opts.compute_value;
+    }
 
-exports.CachedValue.prototype = {
-    get: function CachedValue_get() {
+    get() {
         if (this._value === unassigned_value_sentinel) {
             this._value = this.compute_value();
         }
         return this._value;
-    },
+    }
 
-    reset: function CachedValue_reset() {
+    reset() {
         this._value = unassigned_value_sentinel;
-    },
-};
+    }
+}
 
 exports.find_wildcard_mentions = function (message_content) {
     const mention = /(^|\s)(@\*{2}(all|everyone|stream)\*{2})($|\s)/.exec(message_content);

--- a/static/js/zulip.d.ts
+++ b/static/js/zulip.d.ts
@@ -1,0 +1,55 @@
+interface Message {
+    id: number;
+    sender_id: number;
+    content: string;
+    recipient_id: number;
+    timestamp: number;
+    client: string;
+    topic_links: string[];
+    is_me_message: boolean;
+    reactions: unknown[];
+    submessages: unknown[];
+    sender_full_name: string;
+    sender_short_name: string;
+    sender_email: string;
+    sender_realm_str: string;
+    display_recipient: string | unknown[];
+    type: string;
+    avatar_url: string;
+    content_type: string;
+    unread: boolean;
+    historical: boolean;
+    starred: boolean;
+    mentioned: boolean;
+    mentioned_me_directly: boolean;
+    collapsed: boolean;
+    alerted: boolean;
+    sent_by_me: boolean;
+    topic: string;
+    is_stream: boolean;
+    stream: string;
+    reply_to: string;
+    starred_status: string;
+    clean_reactions: Map<string, unknown>;
+    message_reactions: unknown[];
+
+    match_data?: string;
+    match_topic?: string;
+    match_subject?: string;
+    match_content?: string;
+
+    // stream_id is not present in Group or Private PM message.
+    stream_id?: number;
+
+    // Subject is always present, as of now, but we mark it optional
+    // because we intent to remove it in favor of topic eventually.
+    subject?: string;
+
+    // Set in timerender.js for some messages only
+    full_date_str?: string;
+    full_time_str?: string;
+
+    // Only set for private messages
+    pm_with_url?: string;
+    to_user_ids?: string;
+}

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -91,11 +91,11 @@ markdown_whitespace_rules = list([rule for rule in whitespace_rules if rule['pat
 
 
 js_rules = RuleList(
-    langs=['js'],
+    langs=['js', 'ts'],
     rules=[
         {'pattern': 'subject|SUBJECT',
-         'exclude': {'static/js/util.js',
-                     'frontend_tests/'},
+         'exclude': {'static/js/util.ts',
+                     'frontend_tests/', 'static/js/zulip.d.ts'},
          'exclude_pattern': 'emails',
          'description': 'avoid subject in JS code',
          'good_lines': ['topic_name'],

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -159,6 +159,7 @@ EXEMPT_FILES = {
     'static/js/user_status_ui.js',
     'static/js/zcommand.js',
     'static/js/zform.js',
+    'static/js/zulip.d.ts',
     'static/js/zulip.js',
 }
 


### PR DESCRIPTION
<details>
  <summary>JSCodeShift script to convert to ES6</summary>

```typescript
import type j from 'jscodeshift';
import type { Type } from 'ast-types/lib/types';

let codeshift: j.JSCodeshift;
function check<T>(node: unknown, type: Type<T>): node is T {
    return type.check(node);
}

// TODO: Convert module.exports = ...; to export default ...
// when we face a module that uses it.
function convertToES6Exports(path: j.ASTPath<j.ExpressionStatement>) {
    if (
        check(path.value.expression, codeshift.AssignmentExpression) &&
        check(path.value.expression.left, codeshift.MemberExpression) &&
        check(path.value.expression.left.object, codeshift.Identifier) &&
        check(path.value.expression.left.property, codeshift.Identifier) &&
        path.value.expression.operator === '=' &&
        path.value.expression.left.object.name == 'exports'
    ) {
        const expression = path.value.expression;
        const left = path.value.expression.left; // left side of =
        const leftProperty = path.value.expression.left.property;
        const right = expression.right; // right side of =

        let exportStatment;
        if (codeshift.FunctionExpression.check(right)) {
            // Make sure the exported function name is what
            // it is supposed to be. It could be blank or diffrent!
            right.id = codeshift.identifier(leftProperty.name);
            exportStatment = codeshift.exportDeclaration.from({
                comments: path.value.comments || null,
                default: false,
                declaration: right,
                specifiers: [codeshift.exportSpecifier(null, codeshift.identifier(leftProperty.name))],
            });
        } else {
            exportStatment = codeshift.exportNamedDeclaration.from({
                comments: path.value.comments || null,
                declaration: codeshift.variableDeclaration(
                    'let', [codeshift.variableDeclarator(leftProperty, right)]
                )
            });
        }

        path.replace(exportStatment);
    }
}

// This function just turns exports.name() to name() or
// export.name.prop = value to name.prop = value.
function removeExportsUse(path: j.ASTPath<j.MemberExpression>) {
    if (check(path.value.object, codeshift.Identifier)) {
        if (path.value.object.name === 'exports') {
            path.replace(path.value.property);
        }
    }
}

// TODO: Currently this function converts require calls to default
// imports. Update the logic so it does * as or default as required
// depending on the exports of the module being imported.
function requireToImport(path: j.ASTPath<j.VariableDeclaration>) {
    if (
        check(path.value.declarations[0], codeshift.VariableDeclarator) &&
        check(path.value.declarations[0].init, codeshift.CallExpression) &&
        check(path.value.declarations[0].id, codeshift.Identifier) &&
        check(path.value.declarations[0].init.callee, codeshift.Identifier) &&
        check(path.value.declarations[0].init.arguments[0], codeshift.Literal)
    ) {
        const declaration = path.value.declarations[0];
        const callExpresion = path.value.declarations[0].init;
        const moduleIdentifier = path.value.declarations[0].id;
        const callee = path.value.declarations[0].init.callee;
        const requireArgument = path.value.declarations[0].init.arguments[0];
        if (callee.name !== 'require') {
            return;
        }

        const variableName = moduleIdentifier.name;
        const modulePath = requireArgument.value;
        const importStatement = codeshift.importDeclaration(
            [codeshift.importDefaultSpecifier(codeshift.identifier(variableName))],
            codeshift.literal(modulePath)
        );

        path.replace(importStatement);
    }
}

export default function transformer(fileInfo: j.FileInfo, api: j.API) {
    codeshift = api.jscodeshift;
    const transformer = codeshift(fileInfo.source);

    transformer.find(codeshift.VariableDeclaration).forEach(requireToImport);
    transformer.find(codeshift.ExpressionStatement).forEach(convertToES6Exports);
    transformer.find(codeshift.MemberExpression).forEach(removeExportsUse);
    return transformer.toSource();
}
```
</details>

**Testing Plan:** `tools/lint`, `tools/test-js-with-node`, `tools/test-js-with-casper`,  `tools/test-js-with-puppeteer`.