### PR TITLE
bot_config: Avoid deprecated ConfigParser.readfp method

### DIFF
--- a/zerver/lib/bot_config.py
+++ b/zerver/lib/bot_config.py
@@ -66,7 +66,7 @@ def load_bot_config_template(bot: str) -> Dict[str, str]:
     if os.path.isfile(config_path):
         config = configparser.ConfigParser()
         with open(config_path) as conf:
-            config.readfp(conf)
+            config.read_file(conf)
         return dict(config.items(bot))
     else:
         return dict()


### PR DESCRIPTION
Fixes this warning with python -Wd:

```
/home/circleci/zulip/zerver/lib/bot_config.py:69: DeprecationWarning: This method will be removed in future versions.  Use 'parser.read_file()' instead.
  config.readfp(conf)
```

https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.readfp