### PR TITLE
tests: Avoid deprecated TestCase method aliases

### DIFF
--- a/zerver/tests/test_middleware.py
+++ b/zerver/tests/test_middleware.py
@@ -40,7 +40,7 @@ class SlowQueryTest(ZulipTestCase):
             mock_normal_logger.info.assert_called_once()
 
             logged_line = mock_slow_query_logger.info.call_args_list[0][0][0]
-            self.assertRegexpMatches(
+            self.assertRegex(
                 logged_line,
                 r"123\.456\.789\.012 GET     200 10\.\ds .* \(unknown via \?\)"
             )

--- a/zerver/webhooks/travis/tests.py
+++ b/zerver/webhooks/travis/tests.py
@@ -37,7 +37,7 @@ class TravisHookTests(WebhookTestCase):
         )
         self.assert_json_success(result)
         msg = self.get_last_message()
-        self.assertNotEquals(msg.topic_name(), self.TOPIC)
+        self.assertNotEqual(msg.topic_name(), self.TOPIC)
 
     def test_travis_pull_requests_are_not_ignored_when_applicable(self) -> None:
         self.url = "{}&ignore_pull_requests=false".format(self.build_webhook_url())


### PR DESCRIPTION
Fixes these warnings with `python -Wd`:

````
/home/circleci/zulip/zerver/tests/test_middleware.py:43: DeprecationWarning: Please use assertRegex instead.
  self.assertRegexpMatches(
/home/circleci/zulip/zerver/webhooks/travis/tests.py:40: DeprecationWarning: Please use assertNotEqual instead.
  self.assertNotEquals(msg.topic_name(), self.TOPIC)
```

https://docs.python.org/3/library/unittest.html#deprecated-aliases