### PR TITLE
docs: Avoid deprecated app.add_stylesheet alias

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -334,4 +334,4 @@ def setup(app: Any) -> None:
     app.add_transform(AutoStructify)
 
     # overrides for wide tables in RTD theme
-    app.add_stylesheet('theme_overrides.css')  # path relative to _static
+    app.add_css_file('theme_overrides.css')  # path relative to _static


### PR DESCRIPTION
Fixes this warning:

```
/srv/zulip/docs/conf.py:337: RemovedInSphinx40Warning: The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.
  app.add_stylesheet('theme_overrides.css')  # path relative to _static
```

https://www.sphinx-doc.org/en/3.x/extdev/deprecated.html