### PR TITLE
Further improving gitlab pipeline event notifications

### DIFF
--- a/zerver/webhooks/gitlab/fixtures/pipeline_hook__pipline_succeeded_with_artifacts.json
+++ b/zerver/webhooks/gitlab/fixtures/pipeline_hook__pipline_succeeded_with_artifacts.json
@@ -1,0 +1,256 @@
+{
+    "object_kind": "pipeline",
+    "object_attributes": {
+        "id": 22668,
+        "ref": "test/links-in-zulip-pipeline-message",
+        "tag": false,
+        "sha": "fdf1367fcd3a3b18a465eeb719e397607c1b38dc",
+        "before_sha": "3321a6c3aa5f6ef636ab46d39638d67bdf24074b",
+        "source": "push",
+        "status": "success",
+        "detailed_status": "passed",
+        "stages": [
+        "setup",
+        "test",
+        "test_updated_packages",
+        "release",
+        "cleanup",
+        "deploy"
+        ],
+        "created_at": "2020-05-26 14:46:28 UTC",
+        "finished_at": "2020-05-26 14:50:13 UTC",
+        "duration": 215,
+        "variables": [
+
+        ]
+    },
+    "merge_request": null,
+    "user": {
+        "name": "Great Maintainer",
+        "username": "maintainer",
+        "avatar_url": "https://gitlab.example.com/uploads/-/system/user/avatar/130/avatar.png",
+        "email": "maintainer@example.com"
+    },
+    "project": {
+        "id": 345,
+        "name": "onlysomeproject",
+        "description": "just awesome",
+        "web_url": "https://gitlab.example.com/group1/onlysomeproject",
+        "avatar_url": "https://gitlab.example.com/uploads/-/system/project/avatar/345/onlysomeproject.jpg",
+        "git_ssh_url": "git@gitlab.example.com:group1/onlysomeproject.git",
+        "git_http_url": "https://gitlab.example.com/group1/onlysomeproject.git",
+        "namespace": "Group1",
+        "visibility_level": 10,
+        "path_with_namespace": "group1/onlysomeproject",
+        "default_branch": "master",
+        "ci_config_path": ""
+    },
+    "commit": {
+        "id": "fdf1367fcd3a3b18a465eeb719e397607c1b38dc",
+        "message": "fixed this, tested that",
+        "timestamp": "2020-05-26T16:46:18+02:00",
+        "url": "https://gitlab.example.com/group1/onlysomeproject/-/commit/fdf1367fcd3a3b18a465eeb719e397607c1b38dc",
+        "author": {
+        "name": "Great Maintainer",
+        "email": "maintainer@example.com"
+        }
+    },
+    "builds": [
+        {
+        "id": 58592,
+        "stage": "cleanup",
+        "name": "cleanup:cleanup docker image",
+        "status": "success",
+        "created_at": "2020-05-26 14:46:28 UTC",
+        "started_at": "2020-05-26 14:49:54 UTC",
+        "finished_at": "2020-05-26 14:50:13 UTC",
+        "when": "always",
+        "manual": false,
+        "allow_failure": true,
+        "user": {
+            "name": "Great Maintainer",
+            "username": "maintainer",
+            "avatar_url": "https://gitlab.example.com/uploads/-/system/user/avatar/130/avatar.png",
+            "email": "maintainer@example.com"
+        },
+        "runner": {
+            "id": 22,
+            "description": "global-runner",
+            "active": true,
+            "is_shared": true
+        },
+        "artifacts_file": {
+            "filename": null,
+            "size": null
+        }
+        },
+        {
+        "id": 58591,
+        "stage": "release",
+        "name": "pages",
+        "status": "success",
+        "created_at": "2020-05-26 14:46:28 UTC",
+        "started_at": "2020-05-26 14:49:36 UTC",
+        "finished_at": "2020-05-26 14:49:51 UTC",
+        "when": "on_success",
+        "manual": false,
+        "allow_failure": false,
+        "user": {
+            "name": "Great Maintainer",
+            "username": "maintainer",
+            "avatar_url": "https://gitlab.example.com/uploads/-/system/user/avatar/130/avatar.png",
+            "email": "maintainer@example.com"
+        },
+        "runner": {
+            "id": 22,
+            "description": "global-runner",
+            "active": true,
+            "is_shared": true
+        },
+        "artifacts_file": {
+            "filename": "artifacts.zip",
+            "size": 7049623
+        }
+        },
+        {
+        "id": 58590,
+        "stage": "test_updated_packages",
+        "name": "black+pytest:future environment",
+        "status": "success",
+        "created_at": "2020-05-26 14:46:28 UTC",
+        "started_at": "2020-05-26 14:48:34 UTC",
+        "finished_at": "2020-05-26 14:49:36 UTC",
+        "when": "on_success",
+        "manual": false,
+        "allow_failure": false,
+        "user": {
+            "name": "Great Maintainer",
+            "username": "maintainer",
+            "avatar_url": "https://gitlab.example.com/uploads/-/system/user/avatar/130/avatar.png",
+            "email": "maintainer@example.com"
+        },
+        "runner": {
+            "id": 22,
+            "description": "global-runner",
+            "active": true,
+            "is_shared": true
+        },
+        "artifacts_file": {
+            "filename": null,
+            "size": null
+        }
+        },
+        {
+        "id": 58589,
+        "stage": "test",
+        "name": "docs:anaconda environment",
+        "status": "success",
+        "created_at": "2020-05-26 14:46:28 UTC",
+        "started_at": "2020-05-26 14:48:15 UTC",
+        "finished_at": "2020-05-26 14:48:33 UTC",
+        "when": "on_success",
+        "manual": false,
+        "allow_failure": false,
+        "user": {
+            "name": "Great Maintainer",
+            "username": "maintainer",
+            "avatar_url": "https://gitlab.example.com/uploads/-/system/user/avatar/130/avatar.png",
+            "email": "maintainer@example.com"
+        },
+        "runner": {
+            "id": 22,
+            "description": "global-runner",
+            "active": true,
+            "is_shared": true
+        },
+        "artifacts_file": {
+            "filename": "sphinx-docs.zip",
+            "size": 7050633
+        }
+        },
+        {
+        "id": 58588,
+        "stage": "test",
+        "name": "pytest:current environment",
+        "status": "success",
+        "created_at": "2020-05-26 14:46:28 UTC",
+        "started_at": "2020-05-26 14:47:56 UTC",
+        "finished_at": "2020-05-26 14:48:15 UTC",
+        "when": "on_success",
+        "manual": false,
+        "allow_failure": false,
+        "user": {
+            "name": "Great Maintainer",
+            "username": "maintainer",
+            "avatar_url": "https://gitlab.example.com/uploads/-/system/user/avatar/130/avatar.png",
+            "email": "maintainer@example.com"
+        },
+        "runner": {
+            "id": 22,
+            "description": "global-runner",
+            "active": true,
+            "is_shared": true
+        },
+        "artifacts_file": {
+            "filename": null,
+            "size": null
+        }
+        },
+        {
+        "id": 58587,
+        "stage": "test",
+        "name": "black:current environment",
+        "status": "success",
+        "created_at": "2020-05-26 14:46:28 UTC",
+        "started_at": "2020-05-26 14:47:36 UTC",
+        "finished_at": "2020-05-26 14:47:56 UTC",
+        "when": "on_success",
+        "manual": false,
+        "allow_failure": false,
+        "user": {
+            "name": "Great Maintainer",
+            "username": "maintainer",
+            "avatar_url": "https://gitlab.example.com/uploads/-/system/user/avatar/130/avatar.png",
+            "email": "maintainer@example.com"
+        },
+        "runner": {
+            "id": 22,
+            "description": "global-runner",
+            "active": true,
+            "is_shared": true
+        },
+        "artifacts_file": {
+            "filename": null,
+            "size": null
+        }
+        },
+        {
+        "id": 58586,
+        "stage": "setup",
+        "name": "setup:docker image",
+        "status": "success",
+        "created_at": "2020-05-26 14:46:28 UTC",
+        "started_at": "2020-05-26 14:46:30 UTC",
+        "finished_at": "2020-05-26 14:47:33 UTC",
+        "when": "on_success",
+        "manual": false,
+        "allow_failure": false,
+        "user": {
+            "name": "Great Maintainer",
+            "username": "maintainer",
+            "avatar_url": "https://gitlab.example.com/uploads/-/system/user/avatar/130/avatar.png",
+            "email": "maintainer@example.com"
+        },
+        "runner": {
+            "id": 22,
+            "description": "global-runner",
+            "active": true,
+            "is_shared": true
+        },
+        "artifacts_file": {
+            "filename": null,
+            "size": null
+        }
+        }
+    ]
+}

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -489,6 +489,16 @@ class GitlabHookTests(WebhookTestCase):
             HTTP_X_GITLAB_EVENT="Build Hook"
         )
 
+    def test_pipeline_succeeded_with_artifacts_event_message(self) -> None:
+        expected_topic = "onlysomeproject / test/links-in-zulip-pipeline-message"
+        expected_message = "[Pipeline](https://gitlab.example.com/group1/onlysomeproject/pipelines/22668) changed status to success with build(s):\n* [cleanup:cleanup docker image](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58592) - success\n* [pages](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58591) - success\n  * built artifact: *artifacts.zip* [[Browse](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58591/artifacts/browse)|[Download](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58591/artifacts/download)]\n* [black+pytest:future environment](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58590) - success\n* [docs:anaconda environment](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58589) - success\n  * built artifact: *sphinx-docs.zip* [[Browse](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58589/artifacts/browse)|[Download](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58589/artifacts/download)]\n* [pytest:current environment](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58588) - success\n* [black:current environment](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58587) - success\n* [setup:docker image](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58586) - success."
+
+        self.send_and_test_stream_message(
+            'pipeline_hook__pipline_succeeded_with_artifacts',
+            expected_topic,
+            expected_message
+        )
+
     def test_pipeline_succeeded_event_message(self) -> None:
         expected_topic = "my-awesome-project / master"
         expected_message = "[Pipeline](https://gitlab.com/TomaszKolek/my-awesome-project/pipelines/4414206) changed status to success with build(s):\n* [job_name2](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541113) - success\n* [job_name](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541112) - success."

--- a/zerver/webhooks/gitlab/tests.py
+++ b/zerver/webhooks/gitlab/tests.py
@@ -491,7 +491,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_pipeline_succeeded_with_artifacts_event_message(self) -> None:
         expected_topic = "onlysomeproject / test/links-in-zulip-pipeline-message"
-        expected_message = "[Pipeline](https://gitlab.example.com/group1/onlysomeproject/pipelines/22668) changed status to success with build(s):\n* [cleanup:cleanup docker image](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58592) - success\n* [pages](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58591) - success\n  * built artifact: *artifacts.zip* [[Browse](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58591/artifacts/browse)|[Download](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58591/artifacts/download)]\n* [black+pytest:future environment](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58590) - success\n* [docs:anaconda environment](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58589) - success\n  * built artifact: *sphinx-docs.zip* [[Browse](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58589/artifacts/browse)|[Download](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58589/artifacts/download)]\n* [pytest:current environment](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58588) - success\n* [black:current environment](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58587) - success\n* [setup:docker image](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58586) - success."
+        expected_message = "[Pipeline (22668)](https://gitlab.example.com/group1/onlysomeproject/pipelines/22668) changed status to success with build(s):\n* [cleanup:cleanup docker image](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58592) - success\n* [pages](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58591) - success\n  * built artifact: *artifacts.zip* [[Browse](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58591/artifacts/browse)|[Download](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58591/artifacts/download)]\n* [black+pytest:future environment](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58590) - success\n* [docs:anaconda environment](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58589) - success\n  * built artifact: *sphinx-docs.zip* [[Browse](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58589/artifacts/browse)|[Download](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58589/artifacts/download)]\n* [pytest:current environment](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58588) - success\n* [black:current environment](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58587) - success\n* [setup:docker image](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58586) - success."
 
         self.send_and_test_stream_message(
             'pipeline_hook__pipline_succeeded_with_artifacts',
@@ -501,7 +501,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_pipeline_succeeded_event_message(self) -> None:
         expected_topic = "my-awesome-project / master"
-        expected_message = "[Pipeline](https://gitlab.com/TomaszKolek/my-awesome-project/pipelines/4414206) changed status to success with build(s):\n* [job_name2](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541113) - success\n* [job_name](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541112) - success."
+        expected_message = "[Pipeline (4414206)](https://gitlab.com/TomaszKolek/my-awesome-project/pipelines/4414206) changed status to success with build(s):\n* [job_name2](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541113) - success\n* [job_name](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541112) - success."
 
         self.send_and_test_stream_message(
             'pipeline_hook__pipeline_succeeded',
@@ -511,7 +511,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_pipeline_started_event_message(self) -> None:
         expected_topic = "my-awesome-project / master"
-        expected_message = "[Pipeline](https://gitlab.com/TomaszKolek/my-awesome-project/pipelines/4414206) started with build(s):\n* [job_name](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541112) - running\n* [job_name2](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541113) - pending."
+        expected_message = "[Pipeline (4414206)](https://gitlab.com/TomaszKolek/my-awesome-project/pipelines/4414206) started with build(s):\n* [job_name](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541112) - running\n* [job_name2](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541113) - pending."
 
         self.send_and_test_stream_message(
             'pipeline_hook__pipeline_started',
@@ -521,7 +521,7 @@ class GitlabHookTests(WebhookTestCase):
 
     def test_pipeline_pending_event_message(self) -> None:
         expected_topic = "my-awesome-project / master"
-        expected_message = "[Pipeline](https://gitlab.com/TomaszKolek/my-awesome-project/pipelines/4414206) was created with build(s):\n* [job_name2](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541113) - pending\n* [job_name](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541112) - created."
+        expected_message = "[Pipeline (4414206)](https://gitlab.com/TomaszKolek/my-awesome-project/pipelines/4414206) was created with build(s):\n* [job_name2](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541113) - pending\n* [job_name](https://gitlab.com/TomaszKolek/my-awesome-project/-/jobs/4541112) - created."
 
         self.send_and_test_stream_message(
             'pipeline_hook__pipeline_pending',

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -265,10 +265,22 @@ def get_pipeline_event_body(payload: Dict[str, Any]) -> str:
             project_homepage,
             build.get('id')
         )
-        builds_status += "* [{}]({}) - {}\n".format(
+        artifact_filename = build.get('artifacts_file', {}).get('filename', None)
+        if artifact_filename:
+            artifact_download_url = '{}/artifacts/download'.format(build_url)
+            artifact_browse_url = '{}/artifacts/browse'.format(build_url)
+            artifact_string = '  * built artifact: *{}* [[Browse]({})|[Download]({})]\n'.format(
+                artifact_filename,
+                artifact_browse_url,
+                artifact_download_url
+            )
+        else:
+            artifact_string = ''
+        builds_status += "* [{}]({}) - {}\n{}".format(
             build.get('name'),
             build_url,
-            build.get('status')
+            build.get('status'),
+            artifact_string
         )
     return "[Pipeline]({}) {} with build(s):\n{}.".format(pipeline_url, action, builds_status[:-1])
 

--- a/zerver/webhooks/gitlab/view.py
+++ b/zerver/webhooks/gitlab/view.py
@@ -282,7 +282,12 @@ def get_pipeline_event_body(payload: Dict[str, Any]) -> str:
             build.get('status'),
             artifact_string
         )
-    return "[Pipeline]({}) {} with build(s):\n{}.".format(pipeline_url, action, builds_status[:-1])
+    return "[Pipeline ({})]({}) {} with build(s):\n{}.".format(
+        payload['object_attributes'].get('id'),
+        pipeline_url,
+        action,
+        builds_status[:-1]
+    )
 
 def get_repo_name(payload: Dict[str, Any]) -> str:
     if 'project' in payload:


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR is meant to further improve gitlab pipeline notifications by providing additional information and faster access to necessary files.
This is done by two things:

- the link to the pipeeline will now also feature the pipeline ID to ease communication about pipelines.
- each job producing artifacts will now also feature these artifacts in the event notification by a new indented point in the job list.

**Testing Plan:** <!-- How have you tested? -->
Tested by running the function inside a JupyterLab by loading the json content of real webhooks coming from our own gitlab instance. Tested the resulting links and visual appearance by pasting the function output to our zulip instance.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
See two examples of how a pipeline event notification now will look:
*light theme*
![pipline_light](https://user-images.githubusercontent.com/60500134/83803409-c94bdf80-a6ac-11ea-975b-49e82f946ca6.png)
*dark theme*
![pipline_dark](https://user-images.githubusercontent.com/60500134/83803416-cbae3980-a6ac-11ea-8d62-c3265f4ad350.png)

or as pure markdown:
```markdown
[Pipeline (22668)](https://gitlab.example.com/group1/onlysomeproject/pipelines/22668) changed status to success with build(s):
* [cleanup:cleanup docker image](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58592) - success
* [pages](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58591) - success
  * built artifact: *artifacts.zip* [[Browse](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58591/artifacts/browse)|[Download](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58591/artifacts/download)]
* [black+pytest:future environment](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58590) - success
* [docs:anaconda environment](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58589) - success
  * built artifact: *sphinx-docs.zip* [[Browse](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58589/artifacts/browse)|[Download](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58589/artifacts/download)]
* [pytest:current environment](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58588) - success
* [black:current environment](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58587) - success
* [setup:docker image](https://gitlab.example.com/group1/onlysomeproject/-/jobs/58586) - success.
```

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
