### PR TITLE
overlay: Mitigate issue with dropdown list widget getting clipped.

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1906,6 +1906,11 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
         margin: 9px;
     }
 
+    .dropdown-menu {
+        top: -7px; // -(margin+padding), both are set by bootstrap.
+        bottom: auto;
+    }
+
     .dropdown-list-body {
         position: relative;
         height: auto;

--- a/static/templates/admin_bot_form.hbs
+++ b/static/templates/admin_bot_form.hbs
@@ -7,14 +7,6 @@
         <div id="user-name-form" data-user-id="{{user_id}}">
             <form class="form-horizontal name-setting">
                 <input type="hidden" name="is_full_name" value="true" />
-                <div class="input-group name_change_container">
-                    <label for="full_name">{{t "Full name" }}</label>
-                    <input type="text" autocomplete="off" name="full_name" value="{{ full_name }}" />
-                </div>
-                <div class="input-group email_change_container">
-                    <label for="email">{{t "Email" }}</label>
-                    <input type="text" autocomplete="off" name="email" value="{{ email }}" readonly/>
-                </div>
                 <div class="input-group edit_bot_owner_container">
                     <label for="bot_owner_select">{{t "Owner" }}</label>
                     {{> settings/dropdown_list_widget
@@ -22,6 +14,14 @@
                       list_placeholder=(t 'Filter users')
                       reset_button_text=(t '[Remove owner]')
                       label="" }}
+                </div>
+                <div class="input-group name_change_container">
+                    <label for="full_name">{{t "Full name" }}</label>
+                    <input type="text" autocomplete="off" name="full_name" value="{{ full_name }}" />
+                </div>
+                <div class="input-group email_change_container">
+                    <label for="email">{{t "Email" }}</label>
+                    <input type="text" autocomplete="off" name="email" value="{{ email }}" readonly/>
                 </div>
             </form>
         </div>

--- a/static/templates/edit_bot.hbs
+++ b/static/templates/edit_bot.hbs
@@ -11,11 +11,6 @@
             <div class="edit_bot_email">{{bot.email}}</div>
         </div>
         <div class="edit-bot-form-box">
-            <div class="">
-                <label for="edit_bot_name">{{t "Full name" }}</label>
-                <input id="edit_bot_name" type="text" name="bot_name" class="edit_bot_name required" value="{{bot.full_name}}" maxlength=50 />
-                <div><label for="edit_bot_name" generated="true" class="text-error"></label></div>
-            </div>
             <div class="edit-bot-owner">
                 <label for="bot_owner_select">{{t "Owner" }}</label>
                 {{> settings/dropdown_list_widget
@@ -23,6 +18,11 @@
                   list_placeholder=(t 'Filter users')
                   reset_button_text=(t '[Remove owner]')
                   label="" }}
+            </div>
+            <div class="">
+                <label for="edit_bot_name">{{t "Full name" }}</label>
+                <input id="edit_bot_name" type="text" name="bot_name" class="edit_bot_name required" value="{{bot.full_name}}" maxlength=50 />
+                <div><label for="edit_bot_name" generated="true" class="text-error"></label></div>
             </div>
             <div id="service_data">
             </div>


### PR DESCRIPTION
This isn't a complete fix, but we move the widget's popup to be
on/below the button to open the widget. We also move the bot owner
field to be on the top of the page so that we can see most of the
widget before it is clipped by the parent overlay.

We have discussed some approaches for a permanent fix on:

https://chat.zulip.org/#narrow/stream/321-s/topic/DropdownListWidget/near/894674

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Manual testing


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
After:

![image](https://user-images.githubusercontent.com/8033238/83806455-2c4e6e00-a6cf-11ea-926e-74f42f215dbf.png)

Before:

![image](https://user-images.githubusercontent.com/8033238/83806505-3d977a80-a6cf-11ea-9a0d-c628f8949763.png)

