### PR TITLE
realm logo: Fix realm logo unsupported file upload bug.

### DIFF
--- a/static/js/upload_widget.js
+++ b/static/js/upload_widget.js
@@ -136,8 +136,7 @@ exports.build_direct_upload_widget = function (
 
     function clear() {
         const control = get_file_input();
-        const new_control = control.clone(true);
-        control.replaceWith(new_control);
+        control.val('');
     }
 
     upload_button.on('drop', function (e) {


### PR DESCRIPTION
Unable to upload a realm logo once we encounter file input error bug
was fixed by clearing `get_file_input()` after file input error
with `get_file_input().val('')`.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
fixes #15198

**Testing Plan:** <!-- How have you tested? -->
Tested in browser

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
