### PR TITLE
search pills: Fix nightmode color of sub counts & narrow description.

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -263,11 +263,9 @@ on a dark background, and don't change the dark labels dark either. */
         color: hsl(0, 0%, 100%);
     }
 
-    #searchbox_legacy {
-        #tab_bar #tab_list .sub_count,
-        #tab_bar #tab_list .narrow_description {
-            color: hsla(0, 0%, 90%, 1);
-        }
+    #tab_bar #tab_list .sub_count,
+    #tab_bar #tab_list .narrow_description {
+        color: hsla(0, 0%, 90%, 1);
     }
 
     .overlay,


### PR DESCRIPTION
The fix works on both the legacy and pills version, as shown in the gifs bellow:
![night_mode_color_for_search_pills](https://user-images.githubusercontent.com/33805964/83880870-7d0ca800-a75d-11ea-998a-8edb229aa327.gif)
![night_mode_color_for_search_legacy](https://user-images.githubusercontent.com/33805964/83880852-7716c700-a75d-11ea-9d33-2150ac2fbb57.gif)