### PR TITLE
Change needs_subscribe_warning and would_receive_message to use user_id.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1065,7 +1065,7 @@ run_test('trigger_submit_compose_form', () => {
 });
 
 run_test('needs_subscribe_warning', () => {
-    people.get_active_user_for_email = function () {
+    people.get_by_user_id = function () {
         return;
     };
 
@@ -1082,17 +1082,15 @@ run_test('needs_subscribe_warning', () => {
     stream_data.add_sub(sub);
     assert.equal(compose.needs_subscribe_warning(), false);
 
-    people.get_active_user_for_email = function () {
+    people.get_by_user_id = function () {
         return {
-            user_id: 99,
             is_bot: true,
         };
     };
     assert.equal(compose.needs_subscribe_warning(), false);
 
-    people.get_active_user_for_email = function () {
+    people.get_by_user_id = function () {
         return {
-            user_id: 99,
             is_bot: false,
         };
     };
@@ -1136,9 +1134,9 @@ run_test('warn_if_mentioning_unsubscribed_user', () => {
     const checks = [
         (function () {
             let called;
-            compose.needs_subscribe_warning = function (email) {
+            compose.needs_subscribe_warning = function (user_id) {
                 called = true;
-                assert.equal(email, 'foo@bar.com');
+                assert.equal(user_id, 34);
                 return true;
             };
             return function () { assert(called); };

--- a/frontend_tests/node_tests/compose_fade.js
+++ b/frontend_tests/node_tests/compose_fade.js
@@ -55,10 +55,9 @@ run_test('set_focused_recipient', () => {
 
     compose_fade.set_focused_recipient('stream');
 
-    assert.equal(compose_fade.would_receive_message('me@example.com'), true);
-    assert.equal(compose_fade.would_receive_message('alice@example.com'), true);
-    assert.equal(compose_fade.would_receive_message('bob@example.com'), false);
-    assert.equal(compose_fade.would_receive_message('nonrealmuser@example.com'), true);
+    assert.equal(compose_fade.would_receive_message(me.user_id), true);
+    assert.equal(compose_fade.would_receive_message(alice.user_id), true);
+    assert.equal(compose_fade.would_receive_message(bob.user_id), false);
 
     const good_msg = {
         type: 'stream',

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -233,12 +233,6 @@ run_test('basics', () => {
     let person = people.get_by_email(email);
     assert.equal(person.full_name, full_name);
 
-    person = people.get_active_user_for_email('nobody@example.com');
-    assert(!person);
-
-    person = people.get_active_user_for_email(email);
-    assert.equal(person.email, email);
-
     realm_persons = people.get_realm_users();
     assert.equal(realm_persons.length, 2);
 
@@ -249,8 +243,6 @@ run_test('basics', () => {
 
     // Now deactivate isaac
     people.deactivate(isaac);
-    person = people.get_active_user_for_email(email);
-    assert(!person);
     assert.equal(people.get_non_active_human_ids().length, 1);
     assert.equal(people.get_active_human_count(), 1);
     assert.equal(people.is_active_user_for_popover(isaac.user_id), false);
@@ -301,7 +293,6 @@ run_test('basics', () => {
 
     // Test undefined people
     assert.equal(people.is_cross_realm_email('unknown@example.com'), undefined);
-    assert.equal(people.get_active_user_for_email('unknown@example.com'), undefined);
 
     // Test is_my_user_id function
     assert.equal(people.is_my_user_id(me.user_id), true);
@@ -446,8 +437,6 @@ run_test('get_by_user_id', () => {
     // now it takes a full person object.  Note that deactivate()
     // won't actually make the user disappear completely.
     people.deactivate(person);
-    person = people.get_active_user_for_email('mary@example.com');
-    assert.equal(person, undefined);
     person = people.get_by_user_id(42);
     assert.equal(person.user_id, 42);
 });
@@ -846,7 +835,6 @@ run_test('updates', () => {
 
     // Do sanity checks on our data.
     assert.equal(people.get_by_email(old_email).user_id, user_id);
-    assert.equal(people.get_active_user_for_email(old_email).user_id, user_id);
     assert (!people.is_cross_realm_email(old_email));
 
     assert.equal(people.get_by_email(new_email), undefined);
@@ -856,7 +844,6 @@ run_test('updates', () => {
 
     // Now look up using the new email.
     assert.equal(people.get_by_email(new_email).user_id, user_id);
-    assert.equal(people.get_active_user_for_email(new_email).user_id, user_id);
     assert (!people.is_cross_realm_email(new_email));
 
     const all_people = get_all_persons();
@@ -981,7 +968,6 @@ run_test('initialize', () => {
     const my_user_id = 42;
     people.initialize(my_user_id, params);
 
-    assert.equal(people.get_active_user_for_email('alice@example.com').full_name, 'Alice');
     assert.equal(people.is_active_user_for_popover(17), true);
     assert(people.is_cross_realm_email('bot@example.com'));
     assert(people.is_valid_email_for_compose('bot@example.com'));

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -34,10 +34,10 @@ run_test('extract_pm_recipients', () => {
 });
 
 run_test('is_pm_recipient', () => {
-    const message = { reply_to: 'alice@example.com,bOb@exaMple.com,fred@example.com' };
-    assert(util.is_pm_recipient('alice@example.com', message));
-    assert(util.is_pm_recipient('bob@example.com', message));
-    assert(!util.is_pm_recipient('unknown@example.com', message));
+    const message = { to_user_ids: '31,32,33' };
+    assert(util.is_pm_recipient(31, message));
+    assert(util.is_pm_recipient(32, message));
+    assert(!util.is_pm_recipient(34, message));
 });
 
 run_test('lower_bound', () => {

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -740,7 +740,7 @@ exports.handle_keyup = function (event, textarea) {
     rtl.set_rtl_class_for_textarea(textarea);
 };
 
-exports.needs_subscribe_warning = function (email) {
+exports.needs_subscribe_warning = function (user_id) {
     // This returns true if all of these conditions are met:
     //  * the user is valid
     //  * the stream in the compose box is valid
@@ -755,7 +755,7 @@ exports.needs_subscribe_warning = function (email) {
     //  We expect the caller to already have verified that we're
     //  sending to a stream and trying to mention the user.
 
-    const user = people.get_active_user_for_email(email);
+    const user = people.get_by_user_id(user_id);
     const stream_name = compose_state.stream_name();
 
     if (!stream_name) {
@@ -774,7 +774,7 @@ exports.needs_subscribe_warning = function (email) {
         return false;
     }
 
-    if (stream_data.is_user_subscribed(stream_name, user.user_id)) {
+    if (stream_data.is_user_subscribed(stream_name, user_id)) {
         // If our user is already subscribed
         return false;
     }
@@ -905,14 +905,13 @@ exports.warn_if_mentioning_unsubscribed_user = function (mentioned) {
         return;
     }
 
-    const email = mentioned.email;
     const user_id = mentioned.user_id;
 
     if (mentioned.is_broadcast) {
         return; // don't check if @all/@everyone/@stream
     }
 
-    if (exports.needs_subscribe_warning(email)) {
+    if (exports.needs_subscribe_warning(user_id)) {
         const error_area = $("#compose_invite_users");
         const existing_invites_area = $('#compose_invite_users .compose_invite_user');
 

--- a/static/js/compose_fade.js
+++ b/static/js/compose_fade.js
@@ -92,22 +92,21 @@ function fade_messages() {
     }, 0, current_msg_list, compose_state.private_message_recipient());
 }
 
-exports.would_receive_message = function (email) {
+exports.would_receive_message = function (user_id) {
     if (focused_recipient.type === 'stream') {
-        const user = people.get_active_user_for_email(email);
         const sub = stream_data.get_sub(focused_recipient.stream);
-        if (!sub || !user) {
-            // If the stream or user isn't valid, there is no risk of a mix
+        if (!sub) {
+            // If the stream isn't valid, there is no risk of a mix
             // yet, so we sort of "lie" and say they would receive a
             // message.
             return true;
         }
 
-        return stream_data.is_user_subscribed(focused_recipient.stream, user.user_id);
+        return stream_data.is_user_subscribed(focused_recipient.stream, user_id);
     }
 
     // PM, so check if the given email is in the recipients list.
-    return util.is_pm_recipient(email, focused_recipient);
+    return util.is_pm_recipient(user_id, focused_recipient);
 };
 
 const user_fade_config = {
@@ -124,8 +123,7 @@ const user_fade_config = {
 
 function update_user_row_when_fading(li, conf) {
     const user_id = conf.get_user_id(li);
-    const email = people.get_by_user_id(user_id).email;
-    const would_receive = exports.would_receive_message(email);
+    const would_receive = exports.would_receive_message(user_id);
 
     if (would_receive || people.is_my_user_id(user_id)) {
         conf.unfade(li);

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -670,14 +670,6 @@ exports.is_valid_bulk_emails_for_compose = function (emails) {
     });
 };
 
-exports.get_active_user_for_email = function (email) {
-    const person = exports.get_by_email(email);
-    if (!person) {
-        return;
-    }
-    return active_user_dict.get(person.user_id);
-};
-
 exports.is_active_user_for_popover = function (user_id) {
     // For popover menus, we include cross-realm bots as active
     // users.

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -62,9 +62,9 @@ exports.same_stream_and_topic = function util_same_stream_and_topic(a, b) {
         lower_same(a.topic, b.topic);
 };
 
-exports.is_pm_recipient = function (email, message) {
-    const recipients = message.reply_to.toLowerCase().split(',');
-    return recipients.includes(email.toLowerCase());
+exports.is_pm_recipient = function (user_id, message) {
+    const recipients = message.to_user_ids.split(',');
+    return recipients.includes(user_id.toString());
 };
 
 exports.extract_pm_recipients = function (recipients) {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR changes the `compose.needs_subscribe_warning` and `compose_fade.would_receive_message` functions to use user_ids instead of emails.

This also removes `people.get_active_user_for_email` function.

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
