### PR TITLE
fix: Fixed the gear icon positioning in frontend

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -541,13 +541,16 @@ strong {
 li.actual-dropdown-menu i {
     /* In gear menu, make icons the same width so labels line up. */
     display: inline-block;
-    width: 14px;
+    width: 20px;
     text-align: center;
-    margin-right: 3px;
+    margin-right: 4px;
 }
 
 .settings-dropdown-cog {
-    padding-right: 14px;
+    padding-left: 15px;
+    padding-right: 15px;
+    padding-top: 10px;
+    padding-bottom: 10px;
 }
 
 .message_area_padder {
@@ -1759,7 +1762,6 @@ div.focused_table {
 #navbar-buttons {
     white-space: nowrap;
     margin-left: 15px;
-    margin-top: 7px;
     display: inline-block;
     float: right;
 
@@ -1776,7 +1778,6 @@ div.focused_table {
             background-color: inherit;
             box-shadow: inherit;
             display: block;
-            position: absolute;
             right: 0px;
             top: 3px;
         }
@@ -2535,7 +2536,10 @@ select.inline_select_topic_edit {
     }
 
     .settings-dropdown-cog {
-        padding-right: 21px;
+        padding-left: 15px;
+        padding-right: 15px;
+        padding-top: 10px;
+        padding-bottom: 10px;
     }
 
     .column-middle {
@@ -2764,6 +2768,13 @@ select.inline_select_topic_edit {
         white-space: nowrap;
         text-overflow: ellipsis;
         line-height: 15px;
+    }
+
+    .settings-dropdown-cog {
+        padding-left: 15px;
+        padding-right: 15px;
+        padding-top: 5px;
+        padding-bottom: 5px;
     }
 
     #tab_bar_underpadding {


### PR DESCRIPTION
fix: Added height, left and right padding in settings-dropdown-cog
present in zulip.scss.
Fixes #15222

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
`./tools/test-all`

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Web:
![web](https://user-images.githubusercontent.com/32628578/84225028-c1040200-aafb-11ea-9e80-9a3b6c756c57.png)

IPad Pro:
![iPad_Pro](https://user-images.githubusercontent.com/32628578/84225053-d11be180-aafb-11ea-8075-7d922dcae0ce.png)


iPhone 6:
![IPhone6](https://user-images.githubusercontent.com/32628578/84225064-d711c280-aafb-11ea-8959-af71f267e65f.png)

iPhone SE:
![IPHONESE](https://user-images.githubusercontent.com/32628578/84225077-e0029400-aafb-11ea-9f29-fa63a374c813.png)


Moto G4:
![MOTOG4](https://user-images.githubusercontent.com/32628578/84225082-e42eb180-aafb-11ea-9f97-60e66cc8cded.png)


Nexus 10:
![NEXUS10](https://user-images.githubusercontent.com/32628578/84225093-ea249280-aafb-11ea-8dea-20151f0a7cd2.png)




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
