### PR TITLE
do_update_message: Send old topic with stream edit event.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4445,6 +4445,7 @@ def do_update_message(user_profile: UserProfile, message: Message,
         assert stream_being_edited is not None
 
         edit_history_event['prev_stream'] = stream_being_edited.id
+        event[ORIG_TOPIC] = orig_topic_name
         message.recipient_id = new_stream.recipient_id
 
         event["new_stream_id"] = new_stream.id


### PR DESCRIPTION
Old topic of the msg edit event can be used to help the client
calculate useful information such as if a change
in current narrow is required.

This fixes our re narrow logic after a stream edit of a topic, with
no change in topic name itself, since the original topic was not
present in the event received and hence the `orig_topic` was
undefined in this case.
