### PR TITLE
hotkeys: Quote selected text when '>' hotkey is pressed.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -325,7 +325,7 @@ run_test("basic_chars", () => {
     assert_mapping("u", "popovers.show_sender_info");
     assert_mapping("i", "popovers.open_message_menu");
     assert_mapping(":", "reactions.open_reactions_popover", true);
-    assert_mapping(">", "compose_actions.quote_and_reply");
+    assert_mapping(">", "compose_actions.quote_selected_text_and_reply");
     assert_mapping("e", "message_edit.start");
 
     overlays.is_active = return_true;

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -777,7 +777,7 @@ exports.process_hotkey = function (e, hotkey) {
             condense.toggle_collapse(msg);
             return true;
         case "compose_quote_reply": // > : respond to selected message with quote
-            compose_actions.quote_and_reply({trigger: "hotkey"});
+            compose_actions.quote_selected_text_and_reply({trigger: "hotkey"});
             return true;
         case "edit_message": {
             const row = current_msg_list.get_row(msg.id);


### PR DESCRIPTION
Currently, the 'r' hotkey can be used to respond to the selected message.
This commit slightly changes this behavior to quote the selected text, if any, in the response.

[Relevant conversation on CZO](https://chat.zulip.org/#narrow/stream/137-feedback/topic/Quote.20piece.20of.20message.20if.20it.20is.20selected.20when.20clicking.20Reply/near/895456).

Edit:
[Example GIF in a comment below](https://github.com/zulip/zulip/pull/15235#issuecomment-642719790).