### PR TITLE
Notification settings UI bug-fixes.

### DIFF
--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -717,6 +717,7 @@ exports.create_sub_from_server_data = function (stream_name, attrs) {
         audible_notifications: page_params.enable_stream_audible_notifications,
         push_notifications: page_params.enable_stream_push_notifications,
         email_notifications: page_params.enable_stream_email_notifications,
+        wildcard_mentions_notify: page_params.wildcard_mentions_notify,
         description: '',
         rendered_description: '',
         first_message_id: attrs.first_message_id,

--- a/static/templates/settings/notification_settings.hbs
+++ b/static/templates/settings/notification_settings.hbs
@@ -9,7 +9,7 @@
                     <tr>
                         <th rowspan="2" width="30%"></th>
                         <th colspan="2" width="28%">{{t "Desktop"}}</th>
-                        <th rowspan="2" width="14%" class="{{#if show_push_notifications_tooltip}}control-label-disabled{{/if}}">
+                        <th rowspan="2" width="14%" class="{{#if show_push_notifications_tooltip.push_notifications}}control-label-disabled{{/if}}">
                             {{t "Mobile"}}
                             {{#if (not page_params.realm_push_notifications_enabled) }}
                             <i class="fa fa-question-circle settings-info-icon" data-toggle="tooltip"


### PR DESCRIPTION
First commit issue [#issues > @ all for newly subscribed stream](https://chat.zulip.org/#narrow/stream/9-issues/topic/.40all.20for.20newly.20subscribed.20stream).

Tested 2nd commit by uncommenting `PUSH_NOTIFICATION_BOUNCER_URL`
in [prod_settings_template -L315](https://github.com/zulip/zulip/blob/master/zproject/prod_settings_template.py#L315).