### PR TITLE
drafts: Save stream_id along with stream names for drafts.

### DIFF
--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -256,7 +256,7 @@ test("format_drafts", ({override, mock_template}) => {
         {
             draft_id: "id1",
             is_stream: true,
-            stream: "stream",
+            stream_name: "stream",
             stream_color: "#FFFFFF",
             dark_background: "",
             topic: "topic",
@@ -287,7 +287,7 @@ test("format_drafts", ({override, mock_template}) => {
         {
             draft_id: "id3",
             is_stream: true,
-            stream: "stream 2",
+            stream_name: "stream 2",
             stream_color: "#FFFFFF",
             dark_background: "",
             topic: "topic",
@@ -333,7 +333,7 @@ test("format_drafts", ({override, mock_template}) => {
         return {name: "stream-rename"};
     };
 
-    expected[0].stream = "stream-rename";
+    expected[0].stream_name = "stream-rename";
 
     drafts.launch();
     timerender.__Rewire__("render_now", stub_render_now);

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -32,7 +32,12 @@ mock_esm("../../static/js/stream_data", {
     get_color() {
         return "#FFFFFF";
     },
+    get_sub(stream_name) {
+        assert.equal(stream_name, "stream");
+        return {stream_id: 30};
+    },
 });
+const sub_store = mock_esm("../../static/js/sub_store");
 user_settings.twenty_four_hour_time = false;
 
 const {localstorage} = zrequire("localstorage");
@@ -55,6 +60,7 @@ const compose_args_for_legacy_draft = {
 
 const draft_1 = {
     stream: "stream",
+    stream_id: 30,
     topic: "topic",
     type: "stream",
     content: "Test stream message",
@@ -214,6 +220,7 @@ test("format_drafts", ({override, mock_template}) => {
         topic: "topic",
         type: "stream",
         content: "Test stream message",
+        stream_id: 30,
         updatedAt: feb12().getTime(),
     };
     const draft_2 = {
@@ -300,6 +307,11 @@ test("format_drafts", ({override, mock_template}) => {
     const stub_render_now = timerender.render_now;
     override(timerender, "render_now", (time) => stub_render_now(time, new Date(1549958107000)));
 
+    sub_store.get = function (stream_id) {
+        assert.equal(stream_id, 30);
+        return {name: "stream"};
+    };
+
     mock_template("draft_table_body.hbs", false, (data) => {
         // Tests formatting and sorting of drafts
         assert.deepEqual(data.drafts, expected);
@@ -310,6 +322,19 @@ test("format_drafts", ({override, mock_template}) => {
     override(drafts, "set_initial_element", noop);
 
     $.create("#drafts_table .draft-row", {children: []});
+    drafts.launch();
+
+    $.clear_all_elements();
+    $.create("#drafts_table .draft-row", {children: []});
+    $("#draft_overlay").css = () => {};
+
+    sub_store.get = function (stream_id) {
+        assert.equal(stream_id, 30);
+        return {name: "stream-rename"};
+    };
+
+    expected[0].stream = "stream-rename";
+
     drafts.launch();
     timerender.__Rewire__("render_now", stub_render_now);
 });

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -246,17 +246,17 @@ export function format_draft(draft) {
         // In case there is no stream for the draft, we need a
         // single space char for proper rendering of the stream label
         const space_string = new Handlebars.SafeString("&nbsp;");
-        let stream = draft.stream.length > 0 ? draft.stream : space_string;
+        let stream_name = draft.stream.length > 0 ? draft.stream : space_string;
         if (draft.stream_id) {
             const sub = sub_store.get(draft.stream_id);
-            if (sub && sub.name !== stream) {
-                stream = sub.name;
-                draft.stream = stream;
+            if (sub && sub.name !== stream_name) {
+                stream_name = sub.name;
+                draft.stream = stream_name;
                 draft_model.editDraft(id, draft);
             }
         }
         let draft_topic = util.get_draft_topic(draft);
-        const draft_stream_color = stream_data.get_color(stream);
+        const draft_stream_color = stream_data.get_color(stream_name);
 
         if (draft_topic === "") {
             draft_topic = compose.empty_topic_placeholder();
@@ -265,7 +265,7 @@ export function format_draft(draft) {
         formatted = {
             draft_id: draft.id,
             is_stream: true,
-            stream,
+            stream_name,
             stream_color: draft_stream_color,
             dark_background: color_class.get_css_class(draft_stream_color),
             topic: draft_topic,

--- a/static/templates/draft.hbs
+++ b/static/templates/draft.hbs
@@ -5,7 +5,7 @@
             <div class="message-header-contents">
                 <div class="message_label_clickable stream_label {{dark_background}}"
                   style="background: {{stream_color}}; border-left-color: {{stream_color}};">
-                    {{stream}}
+                    {{stream_name}}
                 </div>
 
                 <span class="stream_topic">


### PR DESCRIPTION
This PR changes snapshot_message to store stream_id for
drafts along with stream names. The stream_id field is
undefined if draft is for empty or invalid stream name.

This change helps us to show correct stream-name for drafts
in case of renaming a stream.

Fixes #15155.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
