### PR TITLE
feat: Added 'A','M' and 'G' text in the user list dropdown

### DIFF
--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -183,6 +183,8 @@ exports.info_for = function (user_id) {
         href: hash_util.pm_with_uri(person.email),
         name: person.full_name,
         user_id: user_id,
+        is_admin: person.is_admin,
+        is_guest: person.is_guest,
         my_user_status: my_user_status,
         is_current_user: people.is_my_user_id(user_id),
         num_unread: get_num_unread(user_id),

--- a/static/templates/user_presence_row.hbs
+++ b/static/templates/user_presence_row.hbs
@@ -1,16 +1,24 @@
-<li data-user-id="{{user_id}}" class="user_sidebar_entry {{#if num_unread}} user-with-count {{/if}} narrow-filter {{#if faded}} user-fade {{/if}}">
+<li data-user-id="{{user_id}}"
+  class="user_sidebar_entry {{#if num_unread}} user-with-count {{/if}} narrow-filter {{#if faded}} user-fade {{/if}}">
     <div class="selectable_sidebar_block">
         <span class="{{user_circle_class}} user_circle"></span>
-        <a class="user-presence-link"
-          href="{{href}}"
-          data-user-id="{{user_id}}"
-          data-name="{{name}}">
+        <a class="user-presence-link" href="{{href}}" data-user-id="{{user_id}}" data-name="{{name}}">
             {{name}}
             {{#if my_user_status}}
             <span class="my_user_status">{{my_user_status}}</span>
             {{/if}}
         </a>
         <span class="count"><span class="value">{{#if num_unread}}{{num_unread}}{{/if}}</span></span>
+        <span class="user_role">
+            {{#if is_admin}}
+            <b>A</b>
+            {{else if is_guest}}
+            <b>G</b>
+            {{else}}
+            <b>M</b>
+            {{/if}}
+        </span>
     </div>
+
     <span class="user-list-sidebar-menu-icon"><i class="fa fa-chevron-down" aria-hidden="true"></i></span>
 </li>


### PR DESCRIPTION
Earlier the user list didn't showed the user role, though you could've
accessed it through the down arrow beside the user name, added initials
for Admin, Guest and Member.
Fixes #15200

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Ran `./tools/test-all` and it passed locally.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot from 2020-06-07 13-02-30](https://user-images.githubusercontent.com/32628578/83962912-38991d80-a8bf-11ea-9e46-bf50206128d7.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
