### PR TITLE
edit_history: Fix a few UI issues in the modal.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -231,6 +231,7 @@
                 "marked": false,
                 "md5": false,
                 "message_edit": false,
+                "message_edit_history": false,
                 "message_events": false,
                 "message_fetch": false,
                 "message_flags": false,

--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -98,6 +98,7 @@ import "../stream_create.js";
 import "../stream_edit.js";
 import "../subs.js";
 import "../message_edit.js";
+import "../message_edit_history.js";
 import "../condense.js";
 import "../resize.js";
 import "../list_render.js";

--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -218,6 +218,7 @@ import "../../styles/drafts.scss";
 import "../../styles/input_pill.scss";
 import "../../styles/informational-overlays.scss";
 import "../../styles/compose.scss";
+import "../../styles/message_edit_history.scss";
 import "../../styles/reactions.scss";
 import "../../styles/user_circles.scss";
 import "../../styles/left-sidebar.scss";

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -164,7 +164,7 @@ exports.initialize = function () {
         const message_history_cancel_btn = $('#message-history-cancel');
 
         if (page_params.realm_allow_edit_history) {
-            message_edit.show_history(message);
+            message_edit_history.show_history(message);
             message_history_cancel_btn.focus();
         }
         e.stopPropagation();

--- a/static/js/global.d.ts
+++ b/static/js/global.d.ts
@@ -68,6 +68,7 @@ declare let local_message: any;
 declare let localstorage: any;
 declare let markdown: any;
 declare let message_edit: any;
+declare let message_edit_history: any;
 declare let message_events: any;
 declare let message_fetch: any;
 declare let message_flags: any;

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -1,5 +1,4 @@
 const render_message_edit_form = require('../templates/message_edit_form.hbs');
-const render_message_edit_history = require('../templates/message_edit_history.hbs');
 const render_topic_edit_form = require('../templates/topic_edit_form.hbs');
 
 const currently_editing_messages = new Map();
@@ -785,70 +784,6 @@ exports.edit_last_sent_message = function () {
     exports.start(msg_row, function () {
         $('#message_edit_content').focus();
     });
-};
-
-exports.fetch_and_render_message_history = function (message) {
-    channel.get({
-        url: "/json/messages/" + message.id + "/history",
-        data: {message_id: JSON.stringify(message.id)},
-        success: function (data) {
-            const content_edit_history = [];
-            let prev_timestamp;
-
-            for (const [index, msg] of data.message_history.entries()) {
-                // Format timestamp nicely for display
-                const timestamp = timerender.get_full_time(msg.timestamp);
-                const item = {
-                    timestamp: moment(timestamp).format("h:mm A"),
-                    display_date: moment(timestamp).format("MMMM D, YYYY"),
-                };
-                if (msg.user_id) {
-                    const person = people.get_by_user_id(msg.user_id);
-                    item.edited_by = person.full_name;
-                }
-
-                if (index === 0) {
-                    item.posted_or_edited = "Posted by";
-                    item.body_to_render = msg.rendered_content;
-                    prev_timestamp = timestamp;
-                    item.show_date_row = true;
-                } else if (msg.prev_topic && msg.prev_content) {
-                    item.posted_or_edited = "Edited by";
-                    item.body_to_render = msg.content_html_diff;
-                    item.show_date_row = !moment(timestamp).isSame(prev_timestamp, 'day');
-                    item.topic_edited = true;
-                    item.prev_topic = msg.prev_topic;
-                    item.new_topic = msg.topic;
-                } else if (msg.prev_topic) {
-                    item.posted_or_edited = "Topic edited by";
-                    item.topic_edited = true;
-                    item.prev_topic = msg.prev_topic;
-                    item.new_topic = msg.topic;
-                } else {
-                    // just a content edit
-                    item.posted_or_edited = "Edited by";
-                    item.body_to_render = msg.content_html_diff;
-                    item.show_date_row = !moment(timestamp).isSame(prev_timestamp, 'day');
-                }
-
-                content_edit_history.push(item);
-            }
-            $('#message-history').attr('data-message-id', message.id);
-            $('#message-history').html(render_message_edit_history({
-                edited_messages: content_edit_history,
-            }));
-        },
-        error: function (xhr) {
-            ui_report.error(i18n.t("Error fetching message edit history"), xhr,
-                            $("#message-history-error"));
-        },
-    });
-};
-
-exports.show_history = function (message) {
-    $('#message-history').html('');
-    $('#message-edit-history').modal("show");
-    exports.fetch_and_render_message_history(message);
 };
 
 function hide_delete_btn_show_spinner(deleting) {

--- a/static/js/message_edit_history.js
+++ b/static/js/message_edit_history.js
@@ -23,7 +23,6 @@ exports.fetch_and_render_message_history = function (message) {
                 if (index === 0) {
                     item.posted_or_edited = "Posted by";
                     item.body_to_render = msg.rendered_content;
-                    prev_timestamp = timestamp;
                     item.show_date_row = true;
                 } else if (msg.prev_topic && msg.prev_content) {
                     item.posted_or_edited = "Edited by";
@@ -46,6 +45,8 @@ exports.fetch_and_render_message_history = function (message) {
                 }
 
                 content_edit_history.push(item);
+
+                prev_timestamp = timestamp;
             }
             $('#message-history').attr('data-message-id', message.id);
             $('#message-history').html(render_message_edit_history({

--- a/static/js/message_edit_history.js
+++ b/static/js/message_edit_history.js
@@ -1,0 +1,67 @@
+const render_message_edit_history = require('../templates/message_edit_history.hbs');
+
+exports.fetch_and_render_message_history = function (message) {
+    channel.get({
+        url: "/json/messages/" + message.id + "/history",
+        data: {message_id: JSON.stringify(message.id)},
+        success: function (data) {
+            const content_edit_history = [];
+            let prev_timestamp;
+
+            for (const [index, msg] of data.message_history.entries()) {
+                // Format timestamp nicely for display
+                const timestamp = timerender.get_full_time(msg.timestamp);
+                const item = {
+                    timestamp: moment(timestamp).format("h:mm A"),
+                    display_date: moment(timestamp).format("MMMM D, YYYY"),
+                };
+                if (msg.user_id) {
+                    const person = people.get_by_user_id(msg.user_id);
+                    item.edited_by = person.full_name;
+                }
+
+                if (index === 0) {
+                    item.posted_or_edited = "Posted by";
+                    item.body_to_render = msg.rendered_content;
+                    prev_timestamp = timestamp;
+                    item.show_date_row = true;
+                } else if (msg.prev_topic && msg.prev_content) {
+                    item.posted_or_edited = "Edited by";
+                    item.body_to_render = msg.content_html_diff;
+                    item.show_date_row = !moment(timestamp).isSame(prev_timestamp, 'day');
+                    item.topic_edited = true;
+                    item.prev_topic = msg.prev_topic;
+                    item.new_topic = msg.topic;
+                } else if (msg.prev_topic) {
+                    item.posted_or_edited = "Topic edited by";
+                    item.topic_edited = true;
+                    item.prev_topic = msg.prev_topic;
+                    item.new_topic = msg.topic;
+                } else {
+                    // just a content edit
+                    item.posted_or_edited = "Edited by";
+                    item.body_to_render = msg.content_html_diff;
+                    item.show_date_row = !moment(timestamp).isSame(prev_timestamp, 'day');
+                }
+
+                content_edit_history.push(item);
+            }
+            $('#message-history').attr('data-message-id', message.id);
+            $('#message-history').html(render_message_edit_history({
+                edited_messages: content_edit_history,
+            }));
+        },
+        error: function (xhr) {
+            ui_report.error(i18n.t("Error fetching message edit history"), xhr,
+                            $("#message-history-error"));
+        },
+    });
+};
+
+exports.show_history = function (message) {
+    $('#message-history').html('');
+    $('#message-edit-history').modal("show");
+    exports.fetch_and_render_message_history(message);
+};
+
+window.message_edit_history = exports;

--- a/static/js/message_edit_history.js
+++ b/static/js/message_edit_history.js
@@ -6,7 +6,7 @@ exports.fetch_and_render_message_history = function (message) {
         data: {message_id: JSON.stringify(message.id)},
         success: function (data) {
             const content_edit_history = [];
-            let prev_timestamp;
+            let prev_timestamp = null;
 
             for (const [index, msg] of data.message_history.entries()) {
                 // Format timestamp nicely for display
@@ -23,7 +23,8 @@ exports.fetch_and_render_message_history = function (message) {
                 if (index === 0) {
                     item.posted_or_edited = "Posted by";
                     item.body_to_render = msg.rendered_content;
-                    item.show_date_row = true;
+                    // This will always be true because of `prev_timestamp = null` above.
+                    item.show_date_row = !moment(timestamp).isSame(prev_timestamp, 'day');
                 } else if (msg.prev_topic && msg.prev_content) {
                     item.posted_or_edited = "Edited by";
                     item.body_to_render = msg.content_html_diff;

--- a/static/js/message_edit_history.js
+++ b/static/js/message_edit_history.js
@@ -14,6 +14,7 @@ exports.fetch_and_render_message_history = function (message) {
                 const item = {
                     timestamp: moment(timestamp).format("h:mm A"),
                     display_date: moment(timestamp).format("MMMM D, YYYY"),
+                    show_date_row: !moment(timestamp).isSame(prev_timestamp, 'day'),
                 };
                 if (msg.user_id) {
                     const person = people.get_by_user_id(msg.user_id);
@@ -23,18 +24,14 @@ exports.fetch_and_render_message_history = function (message) {
                 if (index === 0) {
                     item.posted_or_edited = "Posted by";
                     item.body_to_render = msg.rendered_content;
-                    // This will always be true because of `prev_timestamp = null` above.
-                    item.show_date_row = !moment(timestamp).isSame(prev_timestamp, 'day');
                 } else if (msg.prev_topic && msg.prev_content) {
                     item.posted_or_edited = "Edited by";
                     item.body_to_render = msg.content_html_diff;
-                    item.show_date_row = !moment(timestamp).isSame(prev_timestamp, 'day');
                     item.topic_edited = true;
                     item.prev_topic = msg.prev_topic;
                     item.new_topic = msg.topic;
                 } else if (msg.prev_topic) {
                     item.posted_or_edited = "Topic edited by";
-                    item.show_date_row = !moment(timestamp).isSame(prev_timestamp, 'day');
                     item.topic_edited = true;
                     item.prev_topic = msg.prev_topic;
                     item.new_topic = msg.topic;
@@ -42,7 +39,6 @@ exports.fetch_and_render_message_history = function (message) {
                     // just a content edit
                     item.posted_or_edited = "Edited by";
                     item.body_to_render = msg.content_html_diff;
-                    item.show_date_row = !moment(timestamp).isSame(prev_timestamp, 'day');
                 }
 
                 content_edit_history.push(item);

--- a/static/js/message_edit_history.js
+++ b/static/js/message_edit_history.js
@@ -34,6 +34,7 @@ exports.fetch_and_render_message_history = function (message) {
                     item.new_topic = msg.topic;
                 } else if (msg.prev_topic) {
                     item.posted_or_edited = "Topic edited by";
+                    item.show_date_row = !moment(timestamp).isSame(prev_timestamp, 'day');
                     item.topic_edited = true;
                     item.prev_topic = msg.prev_topic;
                     item.new_topic = msg.topic;

--- a/static/js/message_edit_history.js
+++ b/static/js/message_edit_history.js
@@ -13,7 +13,7 @@ exports.fetch_and_render_message_history = function (message) {
                 const time = new XDate(msg.timestamp * 1000);
                 const datestamp = time.toDateString();
                 const item = {
-                    timestamp: time.toString('h:mm TT'),
+                    timestamp: timerender.stringify_time(time),
                     display_date: time.toString("MMMM d, yyyy"),
                     show_date_row: datestamp !== prev_datestamp,
                 };

--- a/static/js/message_edit_history.js
+++ b/static/js/message_edit_history.js
@@ -6,16 +6,18 @@ exports.fetch_and_render_message_history = function (message) {
         data: {message_id: JSON.stringify(message.id)},
         success: function (data) {
             const content_edit_history = [];
-            let prev_timestamp = null;
+            let prev_datestamp = null;
 
             for (const [index, msg] of data.message_history.entries()) {
-                // Format timestamp nicely for display
-                const timestamp = timerender.get_full_time(msg.timestamp);
+                // Format times and dates nicely for display
+                const time = new XDate(msg.timestamp * 1000);
+                const datestamp = time.toDateString();
                 const item = {
-                    timestamp: moment(timestamp).format("h:mm A"),
-                    display_date: moment(timestamp).format("MMMM D, YYYY"),
-                    show_date_row: !moment(timestamp).isSame(prev_timestamp, 'day'),
+                    timestamp: time.toString('h:mm TT'),
+                    display_date: time.toString("MMMM d, yyyy"),
+                    show_date_row: datestamp !== prev_datestamp,
                 };
+
                 if (msg.user_id) {
                     const person = people.get_by_user_id(msg.user_id);
                     item.edited_by = person.full_name;
@@ -43,7 +45,7 @@ exports.fetch_and_render_message_history = function (message) {
 
                 content_edit_history.push(item);
 
-                prev_timestamp = timestamp;
+                prev_datestamp = datestamp;
             }
             $('#message-history').attr('data-message-id', message.id);
             $('#message-history').html(render_message_edit_history({

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -324,7 +324,7 @@ exports.update_messages = function update_messages(events) {
         // Rerender "Message edit history" if it was open to the edited message.
         if ($('#message-edit-history').hasClass('in') &&
             msg.id === parseInt($('#message-history').attr('data-message-id'), 10)) {
-            message_edit.fetch_and_render_message_history(msg);
+            message_edit_history.fetch_and_render_message_history(msg);
         }
     }
 

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1020,7 +1020,7 @@ exports.register_click_handlers = function () {
         const message_history_cancel_btn = $('#message-history-cancel');
 
         exports.hide_actions_popover();
-        message_edit.show_history(message);
+        message_edit_history.show_history(message);
         message_history_cancel_btn.focus();
         e.stopPropagation();
         e.preventDefault();

--- a/static/styles/message_edit_history.scss
+++ b/static/styles/message_edit_history.scss
@@ -1,0 +1,35 @@
+#message-edit-history {
+    .message_time {
+        position: static;
+    }
+
+    .message_author {
+        position: relative;
+    }
+
+    .author_details {
+        display: block;
+        font-size: 12px;
+        padding: 1px;
+        text-align: right;
+    }
+
+    .messagebox-content {
+        padding: 0px 10px;
+    }
+}
+
+.rendered_markdown {
+    /* Highlighting for message edit history */
+    .highlight_text_inserted {
+        color: hsl(122, 72%, 30%);
+        background-color: hsl(120, 64%, 95%);
+    }
+
+    .highlight_text_deleted {
+        color: hsl(0, 100%, 50%);
+        background-color: hsl(7, 90%, 92%);
+        text-decoration: line-through;
+        word-break: break-all;
+    }
+}

--- a/static/styles/message_edit_history.scss
+++ b/static/styles/message_edit_history.scss
@@ -17,19 +17,20 @@
     .messagebox-content {
         padding: 0px 10px;
     }
+
+    .message_edit_history_content {
+        .highlight_text_inserted {
+            color: hsl(122, 72%, 30%);
+            background-color: hsl(120, 64%, 95%);
+        }
+
+        .highlight_text_deleted {
+            color: hsl(0, 100%, 50%);
+            background-color: hsl(7, 90%, 92%);
+            text-decoration: line-through;
+            word-break: break-all;
+        }
+    }
 }
 
-.rendered_markdown {
-    /* Highlighting for message edit history */
-    .highlight_text_inserted {
-        color: hsl(122, 72%, 30%);
-        background-color: hsl(120, 64%, 95%);
-    }
 
-    .highlight_text_deleted {
-        color: hsl(0, 100%, 50%);
-        background-color: hsl(7, 90%, 92%);
-        text-decoration: line-through;
-        word-break: break-all;
-    }
-}

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -491,7 +491,6 @@ on a dark background, and don't change the dark labels dark either. */
             .highlight_text_deleted {
                 color: hsl(0, 90%, 67%);
                 background-color: hsla(7, 54%, 62%, 0.38);
-                text-decoration: line-through;
             }
         }
     }

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -479,16 +479,20 @@ on a dark background, and don't change the dark labels dark either. */
             background-color: hsla(355, 37%, 31%, 1);
             box-shadow: 0px 0px 0px 1px hsla(330, 40%, 20%, 1);
         }
+    }
 
-        .highlight_text_inserted {
-            color: hsl(122, 100%, 81%);
-            background-color: hsla(120, 64%, 95%, 0.3);
-        }
+    #message-edit-history {
+        .message_edit_history_content {
+            .highlight_text_inserted {
+                color: hsl(122, 100%, 81%);
+                background-color: hsla(120, 64%, 95%, 0.3);
+            }
 
-        .highlight_text_deleted {
-            text-decoration: line-through;
-            background-color: hsla(7, 54%, 62%, 0.38);
-            color: hsl(0, 90%, 67%);
+            .highlight_text_deleted {
+                color: hsl(0, 90%, 67%);
+                background-color: hsla(7, 54%, 62%, 0.38);
+                text-decoration: line-through;
+            }
         }
     }
 

--- a/static/styles/rendered_markdown.scss
+++ b/static/styles/rendered_markdown.scss
@@ -154,19 +154,6 @@
         margin-bottom: 1px;
     }
 
-    /* Highlighting for message edit history */
-    .highlight_text_inserted {
-        color: hsl(122, 72%, 30%);
-        background-color: hsl(120, 64%, 95%);
-    }
-
-    .highlight_text_deleted {
-        color: hsl(0, 100%, 50%);
-        text-decoration: line-through;
-        background-color: hsl(7, 90%, 92%);
-        word-break: break-all;
-    }
-
     /* LaTeX styling */
     .katex-display {
         margin: 0em 0;

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -651,27 +651,6 @@ td.pointer {
     transition: background-color 1.5s ease-in, color 1.5s ease-in;
 }
 
-#message-edit-history {
-    .message_time {
-        position: static;
-    }
-
-    .message_author {
-        position: relative;
-    }
-
-    .author_details {
-        display: block;
-        font-size: 12px;
-        padding: 1px;
-        text-align: right;
-    }
-
-    .messagebox-content {
-        padding: 0px 10px;
-    }
-}
-
 /* The way this overrides the menus with a background-color and a high
    z-index is kinda hacky, and requires some annoying color-matching,
    but it works. */

--- a/tools/test-js-with-node
+++ b/tools/test-js-with-node
@@ -72,6 +72,7 @@ EXEMPT_FILES = {
     'static/js/local_message.js',
     'static/js/localstorage.js',
     'static/js/message_edit.js',
+    'static/js/message_edit_history.js',
     'static/js/message_events.js',
     'static/js/message_fetch.js',
     'static/js/message_flags.js',


### PR DESCRIPTION
This fixes a few UI issues with the edit history modal, along with some refactoring and cleanup:

- Fix topic-only edits never showing a date row.
- Don't repeat date rows.
- Respect time format setting (12h/24h). (Fixes #15171)
- Highlight topic edit diffs by using correct CSS selector.

**Testing Plan:**

I applied each commit to the dev server and checked that the edit history modal was working as expected.

**Screenshots:**

Both screenshots were taken with the time format set to 24-hour.

In the first, note: the 12-hour time; lack of date rows on the topic-only edits; "repeated" date row on the bottom visible edit (it would be repeated if topic-only edits showed date rows); and lack of diff highlighting for the topic edits.
![edit_history_modal_02c670f5a344086767481862b7093bdff33e6c11](https://user-images.githubusercontent.com/977850/83972853-69655c80-a897-11ea-8d8b-e5c14a600977.png)

In the second, note: the 24-hour time; the date row on the topic-only, first edit of June 3; no repeating date rows; and the diff highlighting for the topic edits.
![edit_history_modal_bf85b82822358d6f8acab02cea40a2d39113ce06](https://user-images.githubusercontent.com/977850/83972855-6e2a1080-a897-11ea-9616-ac306ebd1449.png)

**Future Plans:**

The UI does not currently take stream edits into account; I'm planning to fix that. I also have some ideas for UI/UX improvements.