### PR TITLE
node_tests: Remove stray assert.

### DIFF
--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -21,7 +21,7 @@ set_global('page_params', {
 set_global('ui_report', {
     hide_error: noop,
 });
-set_global('activity', {});
+
 set_global('channel', {});
 set_global('document', 'document-stub');
 set_global('message_scroll', {
@@ -114,10 +114,6 @@ function config_process_results(messages) {
     message_util.add_old_messages = function (new_messages, msg_list) {
         assert.deepEqual(new_messages, messages);
         msg_list.add_messages(new_messages);
-    };
-
-    activity.process_loaded_messages = function (arg) {
-        assert.deepEqual(arg, messages);
     };
 
     stream_list.update_streams_sidebar = noop;


### PR DESCRIPTION
The activity.process_loaded_messages code path was called when these
tests were originally written in f8e0137. We stopped calling that
code path in 43e5b2d (#15118). This assert test code is no longer
relevant; tested by adding console.log in the function. I came across
this when working on removing activity from the window.

cc @showell