### PR TITLE
users: Refactor get_profile_backend to be based on format_user_row.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -12,6 +12,9 @@ below features are supported.
 
 **Feature level 10**
 
+* [`GET users/me`](/api/get-profile): Added `avatar_version`, `is_guest`,
+  `is_active`, `timezone`, and `date_joined` fields to the User objects.
+
 **Feature level 9**
 
 * [`POST users/me/subscriptions`](/api/add-subscriptions), [`DELETE

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -14,6 +14,8 @@ below features are supported.
 
 * [`GET users/me`](/api/get-profile): Added `avatar_version`, `is_guest`,
   `is_active`, `timezone`, and `date_joined` fields to the User objects.
+* [`GET users/me`](/api/get-profile): `client_id` and `short_name` fields
+  are removed from the User objects returned by this endpoint.
 
 **Feature level 9**
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1836,6 +1836,16 @@ paths:
 
                         **Changes**: New in Zulip 2.1.0.
                       example: "x"
+                    avatar_version:
+                      type: integer
+                      description: |
+                        Version for the the user's avatar.  Used for cache-busting requests
+                        for the user's avatar.  Clients generally shouldn't need to use this;
+                        most avatar URLs sent by Zulip will already end with `?v={avatar_version}`.
+
+                        **Changes**: New in Zulip 2.2 (feature level 10). Previous
+                        versions do not return this field with this endpoint.
+                      example: 1
                     client_id:
                       type: string
                       description: |
@@ -1864,11 +1874,43 @@ paths:
 
                         **Changes**: New in Zulip 2.2 (feature level 8).
                       example: false
+                    is_guest:
+                      type: boolean
+                      description: |
+                        A boolean indicating if the requesting user is a guest.
+
+                        **Changes**: New in Zulip 2.2 (feature level 10). Previous
+                        versions do not return this field with this endpoint.
+                      example: false
                     is_bot:
                       type: boolean
                       description: |
                         A boolean indicating if the requesting user is a bot.
                       example: false
+                    is_active:
+                      type: boolean
+                      description: |
+                        A boolean specifying whether the user account has been deactivated.
+
+                        **Changes**: New in Zulip 2.2 (feature level 10). Previous
+                        versions do not return this field with this endpoint.
+                      example: true
+                    timezone:
+                      type: string
+                      description: |
+                        The time zone of the user.
+
+                        **Changes**: New in Zulip 2.2 (feature level 10). Previous
+                        versions do not return this field with this endpoint.
+                      example: ""
+                    date_joined:
+                      type: string
+                      description: |
+                        The time the user account was created.
+
+                        **Changes**: New in Zulip 2.2 (feature level 10). Previous
+                        versions do not return this field with this endpoint.
+                      example: "2019-10-20T07:50:53.728864+00:00"
                     max_message_id:
                       type: integer
                       description: |
@@ -1899,12 +1941,17 @@ paths:
                 - example:
                     {
                         "avatar_url": "https://secure.gravatar.com/avatar/af4f06322c177ef4e1e9b2c424986b54?d=identicon&version=1",
+                        "avatar_version": 1,
                         "client_id": "74c768b081076fdb3c4326256c17467e",
                         "email": "iago@zulip.com",
                         "full_name": "Iago",
                         "is_admin": true,
                         "is_owner": false,
+                        "is_guest": false,
                         "is_bot": false,
+                        "is_active": true,
+                        "timezone": "",
+                        "date_joined": "2019-10-20T07:50:53.728864+00:00",
                         "max_message_id": 30,
                         "msg": "",
                         "pointer": -1,

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1846,11 +1846,6 @@ paths:
                         **Changes**: New in Zulip 2.2 (feature level 10). Previous
                         versions do not return this field with this endpoint.
                       example: 1
-                    client_id:
-                      type: string
-                      description: |
-                        NA
-                      example: "74c768b081076fdb3c4326256c17467e"
                     email:
                       type: string
                       description: |
@@ -1926,11 +1921,6 @@ paths:
 
                         **Deprecated**.  We plan to remove the `pointer` as a concept in Zulip.
                       example: -1
-                    short_name:
-                      type: string
-                      description: |
-                        Short name of the requesting user.
-                      example: "iago"
                     user_id:
                       type: integer
                       description: |
@@ -1942,7 +1932,6 @@ paths:
                     {
                         "avatar_url": "https://secure.gravatar.com/avatar/af4f06322c177ef4e1e9b2c424986b54?d=identicon&version=1",
                         "avatar_version": 1,
-                        "client_id": "74c768b081076fdb3c4326256c17467e",
                         "email": "iago@zulip.com",
                         "full_name": "Iago",
                         "is_admin": true,
@@ -1956,7 +1945,6 @@ paths:
                         "msg": "",
                         "pointer": -1,
                         "result": "success",
-                        "short_name": "iago",
                         "user_id": 5,
                         "profile_data": {
                             "5": {

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -696,10 +696,10 @@ class ListCustomProfileFieldTest(CustomProfileFieldTestCase):
     def test_get_custom_profile_fields_from_api_for_single_user(self) -> None:
         self.login('iago')
         expected_keys = {
-            "result", "msg", "pointer", "client_id", "max_message_id", "user_id",
-            "avatar_url", "full_name", "email", "is_bot", "is_admin", "is_owner",
-            "short_name", "profile_data", "avatar_version", "timezone", "delivery_email",
-            "is_active", "is_guest", "date_joined"}
+            "result", "msg", "pointer", "max_message_id", "user_id", "avatar_url",
+            "full_name", "email", "is_bot", "is_admin", "is_owner", "profile_data",
+            "avatar_version", "timezone", "delivery_email", "is_active", "is_guest",
+            "date_joined"}
 
         url = "/json/users/me"
         response = self.client_get(url)

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -698,7 +698,8 @@ class ListCustomProfileFieldTest(CustomProfileFieldTestCase):
         expected_keys = {
             "result", "msg", "pointer", "client_id", "max_message_id", "user_id",
             "avatar_url", "full_name", "email", "is_bot", "is_admin", "is_owner",
-            "short_name", "profile_data"}
+            "short_name", "profile_data", "avatar_version", "timezone", "delivery_email",
+            "is_active", "is_guest", "date_joined"}
 
         url = "/json/users/me"
         response = self.client_get(url)

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1337,7 +1337,6 @@ class GetProfileTest(ZulipTestCase):
         self.assert_json_success(result)
         json = result.json()
 
-        self.assertIn("client_id", json)
         self.assertIn("max_message_id", json)
         self.assertIn("pointer", json)
 
@@ -1372,7 +1371,6 @@ class GetProfileTest(ZulipTestCase):
 
         self.login('hamlet')
         result = ujson.loads(self.client_get('/json/users/me').content)
-        self.assertEqual(result['short_name'], 'hamlet')
         self.assertEqual(result['email'], hamlet.email)
         self.assertEqual(result['full_name'], 'King Hamlet')
         self.assertIn("user_id", result)
@@ -1383,7 +1381,6 @@ class GetProfileTest(ZulipTestCase):
         self.assertFalse('delivery_email' in result)
         self.login('iago')
         result = ujson.loads(self.client_get('/json/users/me').content)
-        self.assertEqual(result['short_name'], 'iago')
         self.assertEqual(result['email'], iago.email)
         self.assertEqual(result['full_name'], 'Iago')
         self.assertFalse(result['is_bot'])
@@ -1392,7 +1389,6 @@ class GetProfileTest(ZulipTestCase):
         self.assertFalse(result['is_guest'])
         self.login('desdemona')
         result = ujson.loads(self.client_get('/json/users/me').content)
-        self.assertEqual(result['short_name'], 'desdemona')
         self.assertEqual(result['email'], desdemona.email)
         self.assertFalse(result['is_bot'])
         self.assertTrue(result['is_admin'])

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1379,6 +1379,7 @@ class GetProfileTest(ZulipTestCase):
         self.assertFalse(result['is_bot'])
         self.assertFalse(result['is_admin'])
         self.assertFalse(result['is_owner'])
+        self.assertFalse(result['is_guest'])
         self.assertFalse('delivery_email' in result)
         self.login('iago')
         result = ujson.loads(self.client_get('/json/users/me').content)
@@ -1388,6 +1389,7 @@ class GetProfileTest(ZulipTestCase):
         self.assertFalse(result['is_bot'])
         self.assertTrue(result['is_admin'])
         self.assertFalse(result['is_owner'])
+        self.assertFalse(result['is_guest'])
         self.login('desdemona')
         result = ujson.loads(self.client_get('/json/users/me').content)
         self.assertEqual(result['short_name'], 'desdemona')
@@ -1395,6 +1397,7 @@ class GetProfileTest(ZulipTestCase):
         self.assertFalse(result['is_bot'])
         self.assertTrue(result['is_admin'])
         self.assertTrue(result['is_owner'])
+        self.assertFalse(result['is_guest'])
 
         # Tests the GET ../users/{id} api endpoint.
         user = self.example_user('hamlet')

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -31,7 +31,7 @@ from zerver.lib.users import check_valid_bot_type, check_bot_creation_policy, \
     check_full_name, check_short_name, check_valid_interface_type, check_valid_bot_config, \
     access_bot_by_id, add_service, access_user_by_id, check_bot_name_available, \
     validate_user_custom_profile_data, get_raw_user_data, get_api_key
-from zerver.lib.utils import generate_api_key, generate_random_token
+from zerver.lib.utils import generate_api_key
 from zerver.models import UserProfile, Stream, Message, \
     get_user_by_delivery_email, Service, get_user_including_cross_realm, \
     DomainNotAllowedForRealmError, DisposableEmailError, get_user_profile_by_id_in_realm, \
@@ -454,16 +454,11 @@ def create_user_backend(request: HttpRequest, user_profile: UserProfile,
     do_create_user(email, password, realm, full_name, short_name)
     return json_success()
 
-def generate_client_id() -> str:
-    return generate_random_token(32)
-
 def get_profile_backend(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
     raw_user_data = get_raw_user_data(user_profile.realm, user_profile,
                                       client_gravatar=False, target_user=user_profile)
     result: Dict[str, Any] = raw_user_data[user_profile.id]
 
-    result['client_id'] = generate_client_id()
-    result['short_name'] = user_profile.short_name
     result['max_message_id'] = -1
     result['pointer'] = user_profile.pointer
 


### PR DESCRIPTION
This PR changes get_profile_backend to be based on format_user_row
such that it's a superset of the fields for our other endpoints for
getting data on a user.

This change adds some fields to the User object returned by the
endpoint. API docs are updated accordingly for the added fields.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
