### PR TITLE
dev_login: Move owners to the top

### DIFF
--- a/templates/zerver/dev_login.html
+++ b/templates/zerver/dev_login.html
@@ -31,7 +31,7 @@ page can be easily identified in it's respective JavaScript file -->
                         <h2>{{_('Owners') }}</h2>
                         {% if direct_owners %}
                             {% for direct_owner in direct_owners %}
-                            <p><input type="submit" formaction="{{ direct_owner.realm.uri }}{{ url('zerver.views.auth.dev_direct_login') }}?next={{ next }}"
+                            <p><input type="submit" formaction="{{ direct_owner.realm.uri }}{{ url('zerver.views.auth.dev_direct_login') }}"
                                       name="direct_email" class="btn-direct btn-admin" value="{{ direct_owner.delivery_email }}" /></p>
                             {% endfor %}
                         {% else %}

--- a/templates/zerver/dev_login.html
+++ b/templates/zerver/dev_login.html
@@ -19,15 +19,6 @@ page can be easily identified in it's respective JavaScript file -->
             <div class="control-group">
                 <div class="controls">
                     <div class="group">
-                        <h2>{{ _('Administrators') }}</h2>
-                        {% if direct_admins %}
-                            {% for direct_admin in direct_admins %}
-                            <p><input type="submit" formaction="{{ direct_admin.realm.uri }}{{ url('zerver.views.auth.dev_direct_login') }}"
-                                      name="direct_email" class="btn-direct btn-admin" value="{{ direct_admin.delivery_email }}" /></p>
-                            {% endfor %}
-                        {% else %}
-                            <p>No administrators found in this realm</p>
-                        {% endif %}
                         <h2>{{_('Owners') }}</h2>
                         {% if direct_owners %}
                             {% for direct_owner in direct_owners %}
@@ -36,6 +27,15 @@ page can be easily identified in it's respective JavaScript file -->
                             {% endfor %}
                         {% else %}
                             <p>No owners found in this realm</p>
+                        {% endif %}
+                        <h2>{{ _('Administrators') }}</h2>
+                        {% if direct_admins %}
+                            {% for direct_admin in direct_admins %}
+                            <p><input type="submit" formaction="{{ direct_admin.realm.uri }}{{ url('zerver.views.auth.dev_direct_login') }}"
+                                      name="direct_email" class="btn-direct btn-admin" value="{{ direct_admin.delivery_email }}" /></p>
+                            {% endfor %}
+                        {% else %}
+                            <p>No administrators found in this realm</p>
                         {% endif %}
                         <h2>{{ _('Guest users') }}</h2>
                         {% if guest_users %}

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -599,8 +599,8 @@ def add_dev_login_context(realm: Optional[Realm], context: Dict[str, Any]) -> No
     def sort(lst: List[UserProfile]) -> List[UserProfile]:
         return sorted(lst, key=lambda u: u.delivery_email)
 
-    context['direct_admins'] = sort([u for u in users if u.is_realm_admin and not u.is_realm_owner])
     context['direct_owners'] = sort([u for u in users if u.is_realm_owner])
+    context['direct_admins'] = sort([u for u in users if u.is_realm_admin and not u.is_realm_owner])
     context['guest_users'] = sort([u for u in users if u.is_guest])
     context['direct_users'] = sort([u for u in users if not (u.is_realm_admin or u.is_guest)])
 


### PR DESCRIPTION
Since owners have the highest privilege level, it made little sense to sandwich them between administrators and guests.