### PR TITLE
upgrade-zulip, build-release-tarball: Add umask override

### DIFF
--- a/scripts/lib/upgrade-zulip
+++ b/scripts/lib/upgrade-zulip
@@ -20,6 +20,9 @@ deploy_options = get_deploy_options(config_file)
 
 assert_running_as_root(strip_lib_from_paths=True)
 
+# make sure we have appropriate file permissions
+os.umask(0o22)
+
 logging.Formatter.converter = time.gmtime
 logging.basicConfig(format="%(asctime)s upgrade-zulip: %(message)s",
                     level=logging.INFO)

--- a/scripts/lib/upgrade-zulip-from-git
+++ b/scripts/lib/upgrade-zulip-from-git
@@ -20,6 +20,9 @@ remote_url = get_config(config_file, 'deployment', 'git_repo_url', "https://gith
 
 assert_running_as_root(strip_lib_from_paths=True)
 
+# make sure we have appropriate file permissions
+os.umask(0o22)
+
 logging.Formatter.converter = time.gmtime
 logging.basicConfig(format="%(asctime)s upgrade-zulip-from-git: %(message)s",
                     level=logging.INFO)

--- a/tools/build-release-tarball
+++ b/tools/build-release-tarball
@@ -36,6 +36,8 @@ if ! git diff --exit-code >/dev/null; then
     exit 1
 fi
 
+umask 022
+
 TMPDIR=$(mktemp -d)
 TARBALL=$TMPDIR/$prefix.tar
 BASEDIR=$(pwd)


### PR DESCRIPTION
We already override the umask in `upgrade-zulip-stage-2`, but that’s too late since we’ve already written a bunch of files in stage 1. I would have removed the stage 2 override, but the OS upgrade documentation references running stage 2 directly.

Fixes #15164. Note that an affected installation will need to upgrade twice, because the first upgrade uses the old stage 1.