### PR TITLE
auth: Require algorithms setting for JWT auth

### DIFF
--- a/docs/overview/changelog.md
+++ b/docs/overview/changelog.md
@@ -24,6 +24,10 @@ in bursts.
 
 - Logged in users may be logged out during this one-time upgrade to
   transition them to more secure session cookies.
+- The format of the `JWT_AUTH_KEYS` setting has changed to include an
+  [algorithms](https://pyjwt.readthedocs.io/en/latest/algorithms.html)
+  list: `{"subdomain": "key"}` becomes `{"subdomain": {"key": "key",
+  "algorithms": ["HS256"]}}`.
 
 **Full feature changelog:**
 

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -381,14 +381,15 @@ def remote_user_sso(
 def remote_user_jwt(request: HttpRequest) -> HttpResponse:
     subdomain = get_subdomain(request)
     try:
-        auth_key = settings.JWT_AUTH_KEYS[subdomain]
+        key = settings.JWT_AUTH_KEYS[subdomain]["key"]
+        algorithms = settings.JWT_AUTH_KEYS[subdomain]["algorithms"]
     except KeyError:
         raise JsonableError(_("Auth key for this subdomain not found."))
 
     try:
         json_web_token = request.POST["json_web_token"]
         options = {'verify_signature': True}
-        payload = jwt.decode(json_web_token, auth_key, options=options)
+        payload = jwt.decode(json_web_token, key, algorithms=algorithms, options=options)
     except KeyError:
         raise JsonableError(_("No JSON web token passed in request"))
     except jwt.InvalidTokenError:

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from django_auth_ldap.config import LDAPSearch
+    from typing_extensions import TypedDict
 
 from .config import PRODUCTION, DEVELOPMENT, get_secret
 if PRODUCTION:
@@ -316,7 +317,14 @@ FIRST_TIME_TOS_TEMPLATE: Optional[str] = None
 STATSD_HOST = ''
 
 # Configuration for JWT auth.
-JWT_AUTH_KEYS: Dict[str, str] = {}
+if TYPE_CHECKING:
+    class JwtAuthKey(TypedDict):
+        key: str
+        # See https://pyjwt.readthedocs.io/en/latest/algorithms.html for a list
+        # of supported algorithms.
+        algorithms: List[str]
+
+JWT_AUTH_KEYS: Dict[str, "JwtAuthKey"] = {}
 
 # https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-SERVER_EMAIL
 # Django setting for what from address to use in error emails.


### PR DESCRIPTION
Calling `jwt.decode` without an algorithms list raises a `DeprecationWarning`.  This is for protecting against symmetric/asymmetric key confusion attacks.

This is a backwards-incompatible configuration change.

Fixes #15207.