### PR TITLE
slack_import: Map slack owners to zulip owners.

### DIFF
--- a/templates/zerver/help/import-from-slack.md
+++ b/templates/zerver/help/import-from-slack.md
@@ -117,8 +117,9 @@ root domain. Replace the last line above with the following, after replacing
   you'll need to configure these manually.
 
 - Import of [user roles](/help/roles-and-permissions):
-    - Slack's `Workspace Primary Owner`, `Workspace Owner`, and
-      `Workspace Admin` users are mapped to Zulip's `Organization
+    - Slack's `Workspace Primary Owner` and `Workspace Owner` users
+    are mapped to Zulip `Organization Owner` users.
+    - Slack's `Workspace Admin` users are mapped to Zulip's `Organization
       administrator` users.
     - Slack's `Member` users is mapped to Zulip `Member` users.
     - Slack's `Single Channel Guest` and `Multi Channel Guest` users

--- a/zerver/data_import/slack.py
+++ b/zerver/data_import/slack.py
@@ -163,7 +163,9 @@ def users_to_zerver_userprofile(slack_data_dir: str, users: List[ZerverFieldsT],
                                       user['profile']['avatar_hash'])
         build_avatar(user_id, realm_id, email, avatar_url, timestamp, avatar_list)
         role = UserProfile.ROLE_MEMBER
-        if get_admin(user):
+        if get_owner(user):
+            role = UserProfile.ROLE_REALM_OWNER
+        elif get_admin(user):
             role = UserProfile.ROLE_REALM_ADMINISTRATOR
         if get_guest(user):
             role = UserProfile.ROLE_GUEST
@@ -302,14 +304,15 @@ def build_avatar_url(slack_user_id: str, team_id: str, avatar_hash: str) -> str:
                                                              avatar_hash)
     return avatar_url
 
-def get_admin(user: ZerverFieldsT) -> bool:
-    admin = user.get('is_admin', False)
+def get_owner(user: ZerverFieldsT) -> bool:
     owner = user.get('is_owner', False)
     primary_owner = user.get('is_primary_owner', False)
 
-    if admin or owner or primary_owner:
-        return True
-    return False
+    return primary_owner or owner
+
+def get_admin(user: ZerverFieldsT) -> bool:
+    admin = user.get('is_admin', False)
+    return admin
 
 def get_guest(user: ZerverFieldsT) -> bool:
     restricted_user = user.get('is_restricted', False)


### PR DESCRIPTION
Slack owners and priamry owners will be mapped to zulip
realm owners on import.

Previously, we mapped the owner and primary owner roles of slack
to ROLE_REALM_ADMINISTRATOR in zulip. As we have added
ROLE_REALM_OWNER in 8bbc074, we now map slack owners and primary
owners to owners in zulip.

Tests are modified for checking all the 3 cases-
 - Slack workspace primary owner
 - Slack workspace owner
 - Slack workspace admin

This commit also has docs change in 'import_from_slack.md'.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
