### PR TITLE
message view: Fix position of `loading_older_messages_indicator`.

### DIFF
--- a/templates/zerver/app/home.html
+++ b/templates/zerver/app/home.html
@@ -8,6 +8,7 @@
             </g>
         </svg>
     </div>
+    <div id="loading_older_messages_indicator"></div>
     <div class="history-limited-box">
         <p>
             <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
@@ -29,7 +30,6 @@
             {% endtrans %}
         </p>
     </div>
-    <div id="loading_older_messages_indicator"></div>
     <div id="page_loading_indicator"></div>
     <div id="empty_narrow_message" class="empty_feed_notice">
         <h4>{{ _("Nothing's been sent here yet!") }}</h4>


### PR DESCRIPTION
This bug can be viewed on entering a search query on CZO.