### PR TITLE
users: Modify 'GET /users/me' endpoint to accept additional arguments.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -10,6 +10,12 @@ below features are supported.
 
 ## Changes in Zulip 2.2
 
+**Feature level 13**
+
+* [`GET users/me`](/api/get-profile): Added `client_gravatar` and
+  `include_custom_profile_fields` paramters to make it consistent
+  with other user fetching endpoints.
+
 **Feature level 12**
 
 * [`GET users/{user_id}/subscriptions/{stream_id}`](/api/get-subscription-status):

--- a/templates/zerver/api/get-profile.md
+++ b/templates/zerver/api/get-profile.md
@@ -35,7 +35,9 @@ zulip(config).then((client) => {
 
 ## Arguments
 
-This endpoint takes no arguments.
+**Note**: The following arguments are all URL query parameters.
+
+{generate_api_arguments_table|zulip.yaml|/users/me:get}
 
 ## Response
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1824,6 +1824,9 @@ paths:
         Get basic data about the user/bot that requests this endpoint.
 
         `GET {{ api_url }}/v1/users/me`
+      parameters:
+      - $ref: '#/components/parameters/ClientGravatar'
+      - $ref: '#/components/parameters/IncludeCustomProfileFields'
       responses:
         '200':
           description: Success

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -701,12 +701,18 @@ class ListCustomProfileFieldTest(CustomProfileFieldTestCase):
             "avatar_version", "timezone", "delivery_email", "is_active", "is_guest",
             "date_joined"}
 
-        url = "/json/users/me"
+        url = "/json/users/me?include_custom_profile_fields=true"
         response = self.client_get(url)
         self.assertEqual(response.status_code, 200)
         raw_user_data = response.json()
         self.assertEqual(set(raw_user_data.keys()), expected_keys)
 
+        url = "/json/users/me"
+        response = self.client_get(url)
+        self.assertEqual(response.status_code, 200)
+        raw_user_data = response.json()
+        with self.assertRaises(KeyError):
+            raw_user_data["profile_data"]
 
 class ReorderCustomProfileFieldTest(CustomProfileFieldTestCase):
     def test_reorder(self) -> None:

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -121,7 +121,7 @@ class DocPageTest(ZulipTestCase):
         self._test('/api/get-events-from-queue', 'dont_block')
         self._test('/api/delete-queue', 'Delete a previously registered queue')
         self._test('/api/update-message', 'propagate_mode')
-        self._test('/api/get-profile', 'takes no arguments')
+        self._test('/api/get-profile', 'client_gravatar')
         self._test('/api/add-subscriptions', 'authorization_errors_fatal')
         self._test('/api/create-user', 'zuliprc-admin')
         self._test('/api/remove-subscriptions', 'not_removed')


### PR DESCRIPTION
This PR modifies 'GET /users/me' endpoint to accept additional
arguments - 'client_gravatar' and 'include_custom_profile_fields',
to make it consistent with other user fetching endpoints like
'GET /users/{user_id}' endpoint.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
