### PR TITLE
fix searchbox background in nightmode

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1654,7 +1654,6 @@ div.focused_table {
         font-family: 'Source Sans Pro';
         font-weight: 300;
         line-height: $header_height;
-        margin-left: 10px;
     }
 
     #search_arrows:focus {
@@ -1705,7 +1704,7 @@ div.focused_table {
     }
 
     #search_arrows {
-        padding-left: 30px;
+        padding-left: 35px;
         font-size: 90%;
         letter-spacing: normal;
     }
@@ -1729,6 +1728,15 @@ div.focused_table {
                 top: 0;
             }
         }
+    }
+}
+
+#searchbox_legacy {
+    #search_arrows {
+        padding-left: 0px;
+    }
+    #search_query {
+        padding-left: 35px;
     }
 }
 

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1620,7 +1620,7 @@ div.focused_table {
         position: absolute;
         .search_button {
             display: inline;
-            margin-right: 16px;
+            margin-right: 15px;
         }
     }
 
@@ -1663,7 +1663,7 @@ div.focused_table {
     .search_button,
     .search_button[disabled]:hover {
         position: absolute;
-        right: 20px;
+        right: 35px;
         top: 6px;
         background: none;
         border-radius: 0px;
@@ -1737,6 +1737,14 @@ div.focused_table {
     }
     #search_query {
         padding-left: 35px;
+    }
+    .search_button {
+        right: 0px;
+    }
+    .navbar-search.expanded {
+        .search_button {
+            margin-right: 14px;
+        }
     }
 }
 


### PR DESCRIPTION

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![nightmode-search-background-regression](https://user-images.githubusercontent.com/33805964/84203631-60f36880-aac7-11ea-8db8-c46e80726da7.gif)
![nightmode-search-background-regression-pills](https://user-images.githubusercontent.com/33805964/84203891-d6f7cf80-aac7-11ea-8e39-fb8e5fc9a9e4.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
