### PR TITLE
settings: Fix duplicate logging from zulip.auth logger.

### DIFF
--- a/zproject/settings.py
+++ b/zproject/settings.py
@@ -899,7 +899,8 @@ LOGGING: Dict[str, Any] = {
         },
         'zulip.auth': {
             'level': 'DEBUG',
-            'handlers': DEFAULT_ZULIP_HANDLERS + ['auth_file']
+            'handlers': DEFAULT_ZULIP_HANDLERS + ['auth_file'],
+            'propagate': False,
         },
         'zulip.ldap': {
             'level': 'DEBUG',


### PR DESCRIPTION
The logger defines a full list of handlers, meaning propagate=False is
needed, to avoid the log line propagating further up the logging tree
and getting logged multiple times by the duplicated handlers.
