### PR TITLE
python: Replace silly uses of filter()

### DIFF
--- a/tools/check-templates
+++ b/tools/check-templates
@@ -42,10 +42,7 @@ def check_html_templates(templates: Iterable[str], all_dups: bool, fix: bool) ->
     # there are also cases where Casper deliberately uses invalid HTML,
     # so we exclude them from our linter.
     logging.basicConfig(format='%(levelname)s:%(message)s')
-    templates = filter(
-        lambda fn: ('casperjs' not in fn),
-        templates)
-    templates = sorted(list(templates))
+    templates = sorted(fn for fn in templates if 'casperjs' not in fn)
     # Use of underscore templates <%= %>.
     if 'templates/zerver/team.html' in templates:
         templates.remove('templates/zerver/team.html')
@@ -99,12 +96,8 @@ def check_html_templates(templates: Iterable[str], all_dups: bool, fix: bool) ->
         return bad_ids_dict
 
     bad_ids_list: List[str] = []
-    archive_templates = list(filter(
-        lambda fn: ('templates/zerver/archive' in fn),
-        templates))
-    templates = list(filter(
-        lambda fn: ('templates/zerver/archive' not in fn),
-        templates))
+    archive_templates = [fn for fn in templates if 'templates/zerver/archive' in fn]
+    templates = [fn for fn in templates if 'templates/zerver/archive' not in fn]
 
     bad_ids_list += list(check_for_duplicate_ids(archive_templates).keys())
     bad_ids_list += list(check_for_duplicate_ids(templates).keys())

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -497,10 +497,10 @@ def get_mobile_push_content(rendered_content: str) -> str:
         return elem.text or ''
 
     def format_as_quote(quote_text: str) -> str:
-        quote_text_list = filter(None, quote_text.split('\n'))  # Remove empty lines
-        quote_text = '\n'.join(map(lambda x: "> "+x, quote_text_list))
-        quote_text += '\n'
-        return quote_text
+        return "".join(
+            f"> {line}\n" for line in quote_text.splitlines()
+            if line  # Remove empty lines
+        )
 
     def render_olist(ol: lxml.html.HtmlElement) -> str:
         items = []

--- a/zerver/lib/send_email.py
+++ b/zerver/lib/send_email.py
@@ -297,8 +297,9 @@ def send_custom_email(users: List[UserProfile], options: Dict[str, Any]) -> None
     inline_template(email_filename)
 
     # Finally, we send the actual emails.
-    for user_profile in filter(lambda user:
-                               not options.get('admins_only') or user.is_realm_admin, users):
+    for user_profile in users:
+        if options.get('admins_only') and not user_profile.is_realm_admin:
+            continue
         context = {
             'realm_uri': user_profile.realm.uri,
             'realm_name': user_profile.realm.name,

--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -174,13 +174,12 @@ class TestCommandsCanStart(TestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.commands = filter(
-            lambda filename: filename != '__init__',
-            map(
-                lambda file: os.path.basename(file).replace('.py', ''),
-                glob.iglob('*/management/commands/*.py')
-            )
-        )
+        self.commands = [
+            command
+            for filename in glob.iglob('*/management/commands/*.py')
+            for command in [os.path.basename(filename).replace('.py', '')]
+            if command != '__init__'
+        ]
 
     @slow("Aggregate of runs dozens of individual --help tests")
     def test_management_commands_show_help(self) -> None:


### PR DESCRIPTION
The `test_management_commands` use in particular was causing pickling errors when the test failed, because Python 3 `filter` returns an iterator, not a list.