### PR TITLE
get_safe_redirect_to: Fix handling of redirect_host.

### DIFF
--- a/zerver/tests/test_internet.py
+++ b/zerver/tests/test_internet.py
@@ -1,4 +1,5 @@
 from zerver.lib.test_classes import ZulipTestCase
+from zerver.views.auth import get_safe_redirect_to
 
 import responses
 import requests
@@ -18,3 +19,31 @@ class ResponsesTest(ZulipTestCase):
             result = requests.request('GET', 'https://www.google.com')
             self.assertEqual(result.status_code, 200)
             self.assertEqual(result.text, '{}')
+
+class GetSafeRedirectUrlTest(ZulipTestCase):
+    def test_get_safe_redirect_to(self) -> None:
+        self.assertEqual(
+            get_safe_redirect_to('/test/endpoint?query', 'example.com'),
+            '/test/endpoint?query'
+        )
+        self.assertEqual(
+            get_safe_redirect_to('/test/endpoint?query', 'https://example.com'),
+            '/test/endpoint?query'
+        )
+        self.assertEqual(
+            get_safe_redirect_to('https://example.com/test/endpoint?query', 'example.com'),
+            'https://example.com/test/endpoint?query'
+        )
+        self.assertEqual(
+            get_safe_redirect_to('https://example.com/test/endpoint?query', 'https://example.com'),
+            'https://example.com/test/endpoint?query'
+        )
+        # Don't allow redirect to an unintended host. Convert to a redirect to the safe host.
+        self.assertEqual(
+            get_safe_redirect_to('https://evilexample.com/test/endpoint?query', 'example.com'),
+            'https://example.com'
+        )
+        self.assertEqual(
+            get_safe_redirect_to('https://evilexample.com/test/endpoint?query', 'https://example.com'),
+            'https://example.com'
+        )

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -62,11 +62,20 @@ from two_factor.views import LoginView as BaseTwoFactorLoginView
 ExtraContext = Optional[Dict[str, Any]]
 
 def get_safe_redirect_to(url: str, redirect_host: str) -> str:
-    is_url_safe = is_safe_url(url=url, allowed_hosts=None)
+    # allowed_hosts given to is_safe_url are supposed to be without the scheme,
+    # e.g. example.com is valid, but https://example.com is not. We want to allow
+    # passing redirect_host with the scheme here, so we'll handle those cases by
+    # extracting the netloc.
+    parsed_host = urllib.parse.urlparse(redirect_host)
+    if parsed_host.scheme:
+        redirect_host = parsed_host.netloc
+
+    is_url_safe = is_safe_url(url=url, allowed_hosts={redirect_host})
     if is_url_safe:
         return urllib.parse.urljoin(redirect_host, url)
     else:
-        return redirect_host
+        scheme = parsed_host.scheme or 'https'
+        return f"{scheme}://{redirect_host}"
 
 def create_preregistration_user(email: str, request: HttpRequest, realm_creation: bool=False,
                                 password_required: bool=True, full_name: Optional[str]=None,


### PR DESCRIPTION
5c9d56d2f7b3ec5b3daa42d7c11f000ff7a1885f fixed a bug with calling set()
on a string, but completely removed the utility of allowed_hosts in
is_safe_url.
This commit fixes up the whole handling of redirect_host more
comprehensively.
We need to support passing redirect_host with a scheme because the
typical usage of this function is something like
get_safe_redirect_to(redirect_to, user_profile.realm.uri)
where user_profile.realm.uri will contain the scheme, and it would be
very messy to require the caller to extract the host. That's why this
should be handled in the function.

@andersk Could you take a look too?