### PR TITLE
stream_header: Fix broken header color and outflowing boundary.

### DIFF
--- a/static/styles/app_components.scss
+++ b/static/styles/app_components.scss
@@ -403,6 +403,7 @@
 
 .stream_header_colorblock {
     margin-bottom: 5px;
+    z-index: 1000;
 }
 
 .edit-controls .fa-angle-right,

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -428,9 +428,8 @@ ul {
         margin-bottom: 5px !important;
         border-left: 0px;
         padding-left: 0px;
-        border-radius: 0px 3px 3px 0px;
-        // Extra 1px for post-selection boundry
-        margin: 0 5px 0 -11px;
+        border-radius: 3px;
+        margin: 0 5px 0 -10px;
         text-indent: 10px;
     }
     .inline_topic_edit {


### PR DESCRIPTION
The stream header was moved below the selection option and the
boundary selection input was overflowing, both were fixed via
this commit.
