### PR TITLE
openapi: Add example validation and fix response validation bug.x

### DIFF
--- a/zerver/openapi/javascript_examples.js
+++ b/zerver/openapi/javascript_examples.js
@@ -90,7 +90,7 @@ add_example('send_message', '/messages:post', 200, async (client) => {
 add_example('create_user', '/users:post', 200, async (client) => {
     // {code_example|start}
     const params = {
-        email: 'newbie@zulip.com',
+        email: 'notnewbie@zulip.com',
         password: 'temp',
         full_name: 'New User',
         short_name: 'newbie',

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -15,6 +15,11 @@ EXCLUDE_PROPERTIES = {
         'post': {
             '200': ['max_message_id', 'realm_emoji']
         }
+    },
+    '/zulip-outgoing-webhook': {
+        'post': {
+            '200': ['result', 'msg', 'message']
+        }
     }
 }
 
@@ -124,6 +129,10 @@ def validate_against_openapi_schema(content: Dict[str, Any], endpoint: str,
     # In a single response schema we do not have two keys with the same name.
     # Hence exclusion list is declared globally
     exclusion_list = (EXCLUDE_PROPERTIES.get(endpoint, {}).get(method, {}).get(response, []))
+    # Code is not declared but appears in various 400 responses. If common, it can be added
+    # to 400 response schema
+    if response.startswith('4'):
+        exclusion_list.append('code')
     validate_object(content, schema)
 
 def validate_array(content: List[Any], schema: Dict[str, Any]) -> None:
@@ -139,13 +148,14 @@ def validate_array(content: List[Any], schema: Dict[str, Any]) -> None:
         # We can directly check for objects and arrays as
         # there are no mixed arrays consisting of objects
         # and arrays.
-        if 'properties' in schema['items']:
-            validate_object(item, schema['items'])
+        if 'object' in valid_types:
+            if 'oneOf' not in schema['items']:
+                validate_object(item, schema['items'])
             continue
         # If the object was not an opaque object then
         # the continue statement above should have
         # been executed.
-        if 'object' in valid_types:
+        if type(item) is dict:
             raise SchemaError('Opaque object in array')
         if 'items' in schema['items']:
             validate_array(item, schema['items'])
@@ -158,14 +168,18 @@ def validate_object(content: Dict[str, Any], schema: Dict[str, Any]) -> None:
         if key not in schema['properties']:
             raise SchemaError('Extraneous key "{}" in the response\'s '
                               'content'.format(key))
-
         # Check that the types match
-        expected_type = to_python_type(schema['properties'][key]['type'])
+        expected_type: List[type] = []
+        if 'oneOf' in schema['properties'][key]:
+            for types in schema['properties'][key]['oneOf']:
+                expected_type.append(to_python_type(types['type']))
+        else:
+            expected_type.append(to_python_type(schema['properties'][key]['type']))
         actual_type = type(value)
         # We have only define nullable property if it is nullable
         if value is None and 'nullable' in schema['properties'][key]:
             continue
-        if expected_type is not actual_type:
+        if actual_type not in expected_type:
             raise SchemaError('Expected type {} for key "{}", but actually '
                               'got {}'.format(expected_type, key, actual_type))
         if expected_type is list:
@@ -189,8 +203,10 @@ def validate_object(content: Dict[str, Any], schema: Dict[str, Any]) -> None:
     # Check that at least all the required keys are present
     if 'required' in schema:
         for req_key in schema['required']:
+            if req_key in exclusion_list:
+                continue
             if req_key not in content.keys():
-                raise SchemaError('Expected to find the "{}" required key')
+                raise SchemaError('Expected to find the "{}" required key'.format(req_key))
 
 def to_python_type(py_type: str) -> type:
     """Transform an OpenAPI-like type to a Python one.

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -124,6 +124,9 @@ def validate_against_openapi_schema(content: Dict[str, Any], endpoint: str,
     """Compare a "content" dict with the defined schema for a specific method
     in an endpoint.
     """
+    # Check if the response matches its code
+    if response.startswith('2') and (content.get('result', 'success').lower() != 'success'):
+        raise SchemaError("Response is not 200 but is validating against 200 schema")
     global exclusion_list
     schema = get_schema(endpoint, method, response)
     # In a single response schema we do not have two keys with the same name.

--- a/zerver/openapi/python_examples.py
+++ b/zerver/openapi/python_examples.py
@@ -280,7 +280,7 @@ def remove_realm_filter(client: Client) -> None:
 
     # {code_example|start}
     # Remove the organization filter with ID 42
-    result = client.remove_realm_filter(42)
+    result = client.remove_realm_filter(1)
     # {code_example|end}
 
     validate_against_openapi_schema(result, '/realm/filters/{filter_id}', 'delete', '200')
@@ -532,7 +532,7 @@ def update_subscription_settings(client: Client) -> None:
     }, {
         'stream_id': 3,
         'property': 'color',
-        'value': 'f00'
+        'value': '#f00f00'
     }]
     result = client.update_subscription_settings(request)
     # {code_example|end}
@@ -1121,8 +1121,8 @@ def test_users(client: Client) -> None:
     update_notification_settings(client)
     upload_file(client)
     set_typing_status(client)
-    get_user_presence(client)
     update_presence(client)
+    get_user_presence(client)
     create_user_group(client)
     group_id = get_user_groups(client)
     update_user_group(client, group_id)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1029,6 +1029,10 @@ paths:
                             type: string
                             description: |
                               the topic for the message.
+                          prev_topic:
+                            type: string
+                            description: |
+                              the topic for the message before being edited.
                           content:
                             type: string
                             description: |
@@ -2304,11 +2308,11 @@ paths:
                           "push_notifications": false,
                           "stream_id": 1,
                           "subscribers": [
-                              "ZOE@zulip.com",
-                              "hamlet@zulip.com",
-                              "iago@zulip.com",
-                              "othello@zulip.com",
-                              "prospero@zulip.com"
+                              7,
+                              10,
+                              11,
+                              12,
+                              14
                           ]
                         },
                         {
@@ -2324,10 +2328,10 @@ paths:
                           "push_notifications": false,
                           "stream_id": 3,
                           "subscribers": [
-                              "ZOE@zulip.com",
-                              "iago@zulip.com",
-                              "othello@zulip.com",
-                              "prospero@zulip.com"
+                              7,
+                              11,
+                              12,
+                              14
                           ]
                         }
                       ]
@@ -2509,7 +2513,6 @@ paths:
                 - $ref: '#/components/schemas/JsonSuccess'
                 - required:
                   - subscribed
-                  - not_subscribed
                   - already_subscribed
                   - removed
                 - properties:
@@ -2520,6 +2523,13 @@ paths:
                         address of the user/bot and the value is a
                         list of the names of the streams that were
                         subscribed to as a result of the query.
+                      additionalProperties:
+                        description: |
+                          `{email_id}`: A list of the names of streams that
+                          the user was subscribed to as a result of the query.
+                        type: array
+                        items:
+                          type: string
                     already_subscribed:
                       type: object
                       description: |
@@ -2527,6 +2537,13 @@ paths:
                         address of the user/bot and the value is a
                         list of the names of the streams that the
                         user/bot is already subscribed to.
+                      additionalProperties:
+                        description: |
+                          `{email_id}`: A list of the names of streams that
+                          the user was already subscribed to.
+                        type: array
+                        items:
+                          type: string
                     not_removed:
                       type: array
                       items:
@@ -2817,41 +2834,53 @@ paths:
                       items:
                         type: object
                         properties:
-                          color:
+                          property:
                             type: string
                             description: |
-                              The hex value of the user's personal display color for the stream.
-                          is_muted:
-                            type: boolean
-                            description: |
-                              Whether the stream is [muted](/help/mute-a-stream).
+                              The property to be changed. It is one of:
+                                  *`color`: The hex value of the user's personal display color for the stream.
 
-                              **Changes**: Prior to Zulip 2.1, this feature was
-                              represented by the more confusingly named `in_home_view` (with the
-                              opposite value, `in_home_view=!is_muted`); for
-                              backwards-compatibility, modern Zulip still accepts that value.
-                          pin_to_top:
-                            type: boolean
+                                  *`is_muted`: Whether the stream is [muted](/help/mute-a-stream).
+
+                                  **Changes**: Prior to Zulip 2.1, this feature was
+                                  represented by the more confusingly named `in_home_view` (with the
+                                  opposite value, `in_home_view=!is_muted`); for
+                                  backwards-compatibility, modern Zulip still accepts that value.
+
+                                  *`pin_to_top`: Whether to pin the stream at the top of the stream list.
+
+                                  *`desktop_notifications`: Whether to show desktop notifications for all
+                                  messages sent to the stream.
+
+                                  *`audible_notifications`: Whether to play a sound notification for all
+                                  messages sent to the stream.
+
+                                  *`push_notifications`: Whether to trigger a mobile push notification for
+                                  all messages sent to the stream.
+
+                                  *`email_notifications`: Whether to trigger an email notification for all
+                                  messages sent to the stream.
+                            enum:
+                            - color
+                            - push_notifications
+                            - is_muted
+                            - pin_to_top
+                            - desktop_notifications
+                            - audible_notifications
+                            - push_notifications
+                            - email_notifications
+                          value:
                             description: |
-                              Whether to pin the stream at the top of the stream list.
-                          desktop_notifications:
-                            type: boolean
+                              The desired value of the property
+                            oneOf:
+                            - type: boolean
+                            - type: string
+                          stream_id:
                             description: |
-                              Whether to show desktop notifications for all messages sent to the stream.
-                          audible_notifications:
-                            type: boolean
-                            description: |
-                              Whether to play a sound notification for all messages sent to the stream.
-                          push_notifications:
-                            type: boolean
-                            description: |
-                              Whether to trigger a mobile push notification for all messages sent to the stream.
-                          email_notifications:
-                            type: boolean
-                            description: |
-                              Whether to trigger an email notification for all messages sent to the stream.
+                              The desired value of the property
+                            type: integer
                       description: |
-                        The same `subscription_data` object sent by the client for the request.
+                        The same `subscription_data` array sent by the client for the request.
                 - example:
                     {
                         "subscription_data": [
@@ -2862,7 +2891,7 @@ paths:
                             },
                             {
                                 "property": "color",
-                                "value": 'f00',
+                                "value": '#f00f00',
                                 "stream_id": 3
                             }
                         ],

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -986,3 +986,15 @@ class OpenAPIAttributesTest(ZulipTestCase):
                 assert("tags" in openapi_spec[path][method])
                 tag = openapi_spec[path][method]["tags"][0]
                 assert(tag in VALID_TAGS)
+                for response in openapi_spec[path][method]['responses']:
+                    response_schema = (openapi_spec[path][method]['responses'][response]
+                                       ['content']['application/json']['schema'])
+                    if 'oneOf' in response_schema:
+                        cnt = 0
+                        for entry in response_schema['oneOf']:
+                            validate_against_openapi_schema(entry['example'], path,
+                                                            method, response + '_' + str(cnt))
+                            cnt += 1
+                        continue
+                    validate_against_openapi_schema(response_schema['example'], path,
+                                                    method, response)


### PR DESCRIPTION
Add test to validate example responses in zulip.yaml. Also change
zulip.yaml for some wrong examples or for cases which were not
covered by `test-api`. Also enhance `validate_against_openapi_schema`.

Also, Currently there are no checks in validate_against_openapi_schema
to check whether the `content` it received actually matched with
the `response code`. For example during testing if a certain endpoint
was returning 400 but it was expected to return 200, then it would
pass schema validation as it would only have `msg` and `result` keys.
Add this validation and fix the wrong response returning points