### PR TITLE
Add Pysa coverage to Zulip

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -1,0 +1,14 @@
+{
+  "source_directories": ["."],
+  "taint_models_path": [
+      "stubs/taint",
+      "zulip-py3-venv/lib/pyre_check/taint/"
+  ],
+  "search_path": [
+      "stubs/",
+      "zulip-py3-venv/lib/pyre_check/stubs/"
+  ],
+  "exclude": [
+      "/srv/zulip/zulip-py3-venv/.*"
+  ]
+}

--- a/stubs/taint/false_positives.pysa
+++ b/stubs/taint/false_positives.pysa
@@ -1,0 +1,59 @@
+# This function ensures that a redirect is only within the specified domain.
+# Assuming that the domain isn't attacker controllable, the result is safe to
+# redirect to
+def zerver.views.auth.get_safe_redirect_to(url, redirect_host) -> Sanitize: ...
+
+# This function was previously the source of an open redirect, but has now been
+# reviewed and patched, so the output should now be safe to redirect to,
+# regardless of the value of the specified 'path'.
+def zerver.lib.thumbnail.generate_thumbnail_url(
+    path,
+    size=...,
+    is_camo_url=...
+) -> Sanitize: ...
+
+# This function returns a version of name that only contains word and space
+# characters, or ., -, _ characters. This should be safe to put into URLs and
+# filesystem operations.
+def zerver.lib.upload.sanitize_name(value) -> Sanitize: ...
+
+# This function accepts two integers and then concatenates them into a path
+# segment. The result should be safe for use in filesystem and other operations.
+def zerver.lib.avatar_hash.user_avatar_path_from_ids(user_profile_id, realm_id) -> Sanitize: ...
+
+# This function creates a list of 'UserMessageLite' objects, which contain only
+# integral IDs and flags. These should safe for use with SQL and other
+# operations.
+def zerver.lib.actions.create_user_messages(
+    message,
+    um_eligible_user_ids,
+    long_term_idle_user_ids,
+    stream_push_user_ids,
+    stream_email_user_ids,
+    mentioned_user_ids,
+    mark_as_read
+) -> Sanitize: ...
+
+# This function is an identity function used for removing taint from variables
+# when there is no convenient way to do it by annotating existing functions.
+def zerver.lib.pysa.mark_sanitized(arg) -> Sanitize: ...
+
+############################
+# Overbroad Approximations #
+############################
+
+# Note that the below functions are overbroad approximations of Sanitizers and
+# could lead to false negatives. They should be replaced with more specific
+# feature-based filtering when that is available through SAPP.
+
+# This function generates a URL pointing to a valid Django endpoint, with
+# arguments properly URL encoded. The resulting URL can usually be used as a
+# part of a redirect or HTTP request without fear of open redirect or SSRF
+# vulnerabilities respectively.
+def django.urls.base.reverse(
+    viewname,
+    urlconf=...,
+    args=...,
+    kwargs=...,
+    current_app=...
+) -> Sanitize: ...

--- a/stubs/taint/req_lib.pysa
+++ b/stubs/taint/req_lib.pysa
@@ -1,0 +1,4 @@
+# One of the ways user-controlled data enters the application is through the
+# request variables framework. This model teaches Pysa that every instance of
+# 'REQ()' in a view function is a source of UserControlled taint.
+class zerver.lib.request._REQ(TaintSource[UserControlled]): ...

--- a/stubs/taint/taint.config
+++ b/stubs/taint/taint.config
@@ -1,0 +1,6 @@
+{
+  sources: [],
+  sinks: [],
+  features: [],
+  rules: []
+}

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -50,6 +50,7 @@ from zerver.lib.message import (
     truncate_body,
     truncate_topic,
 )
+from zerver.lib.pysa import mark_sanitized
 from zerver.lib.realm_icon import realm_icon_url
 from zerver.lib.realm_logo import get_realm_logo_data
 from zerver.lib.retention import move_messages_to_archive
@@ -5146,6 +5147,11 @@ def check_add_realm_emoji(realm: Realm,
     realm_emoji.save()
 
     emoji_file_name = get_emoji_file_name(image_file.name, realm_emoji.id)
+
+    # The only user-controlled portion of 'emoji_file_name' is an extension,
+    # which can not contain '..' or '/' or '\', making it difficult to exploit
+    emoji_file_name = mark_sanitized(emoji_file_name)
+
     emoji_uploaded_successfully = False
     try:
         upload_emoji_image(image_file, emoji_file_name, author)

--- a/zerver/lib/pysa.py
+++ b/zerver/lib/pysa.py
@@ -1,0 +1,8 @@
+from typing import TypeVar
+
+
+T = TypeVar("T")
+
+
+def mark_sanitized(arg: T) -> T:
+    return arg

--- a/zerver/lib/unminify.py
+++ b/zerver/lib/unminify.py
@@ -4,6 +4,8 @@ import sourcemap
 
 from typing import Dict, List
 
+from zerver.lib.pysa import mark_sanitized
+
 
 class SourceMap:
     '''Map (line, column) pairs from generated to source file.'''
@@ -15,11 +17,25 @@ class SourceMap:
     def _index_for(self, minified_src: str) -> sourcemap.SourceMapDecoder:
         '''Return the source map index for minified_src, loading it if not
            already loaded.'''
+
+        # Prevent path traversal
+        assert ".." not in minified_src and "/" not in minified_src
+
         if minified_src not in self._indices:
             for source_dir in self._dirs:
                 filename = os.path.join(source_dir, minified_src + '.map')
                 if os.path.isfile(filename):
-                    with open(filename) as fp:
+                    # Use 'mark_sanitized' to force Pysa to ignore the fact that
+                    # 'filename' is user controlled. While putting user
+                    # controlled data into a filesystem operation is bad, in
+                    # this case it's benign because 'filename' can't traverse
+                    # directories outside of the pre-configured 'sourcemap_dirs'
+                    # (due to the above assertions) and will always end in
+                    # '.map'. Additionally, the result of this function is used
+                    # for error logging and not returned to the user, so
+                    # controlling the loaded file would not be useful to an
+                    # attacker.
+                    with open(mark_sanitized(filename)) as fp:
                         self._indices[minified_src] = sourcemap.load(fp)
                         break
 

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -98,7 +98,9 @@ def sanitize_name(value: str) -> str:
     """
     value = unicodedata.normalize('NFKC', value)
     value = re.sub(r'[^\w\s._-]', '', value, flags=re.U).strip()
-    return mark_safe(re.sub(r'[-\s]+', '-', value, flags=re.U))
+    value = re.sub(r'[-\s]+', '-', value, flags=re.U)
+    assert value not in {'', '.', '..'}
+    return mark_safe(value)
 
 def random_name(bytes: int=60) -> str:
     return base64.urlsafe_b64encode(os.urandom(bytes)).decode('utf-8')
@@ -653,6 +655,7 @@ class S3UploadBackend(ZulipUploadBackend):
 
 def write_local_file(type: str, path: str, file_data: bytes) -> None:
     file_path = os.path.join(settings.LOCAL_UPLOADS_DIR, type, path)
+
     os.makedirs(os.path.dirname(file_path), exist_ok=True)
     with open(file_path, 'wb') as f:
         f.write(file_data)

--- a/zerver/lib/url_encoding.py
+++ b/zerver/lib/url_encoding.py
@@ -1,6 +1,7 @@
 import urllib
 from typing import Any, Dict, List
 
+from zerver.lib.pysa import mark_sanitized
 from zerver.lib.topic import get_topic_from_message_info
 from zerver.models import Realm, Stream, UserProfile
 
@@ -97,8 +98,12 @@ def near_pm_message_url(realm: Realm,
     return full_url
 
 def add_query_to_redirect_url(original_url: str, query: str) -> str:
-    return original_url + "?" + query
+    # Using 'mark_sanitized' because user-controlled data after the '?' is
+    # not relevant for open redirects
+    return original_url + "?" + mark_sanitized(query)
 
 def add_query_arg_to_redirect_url(original_url: str, query_arg: str) -> str:
     assert '?' in original_url
-    return original_url + "&" + query_arg
+    # Using 'mark_sanitized' because user-controlled data after the '?' is
+    # not relevant for open redirects
+    return original_url + "&" + mark_sanitized(query_arg)

--- a/zerver/lib/url_preview/preview.py
+++ b/zerver/lib/url_preview/preview.py
@@ -9,6 +9,7 @@ from typing.re import Match
 
 from version import ZULIP_VERSION
 from zerver.lib.cache import cache_with_key, get_cache_with_key, preview_url_cache_key
+from zerver.lib.pysa import mark_sanitized
 from zerver.lib.url_preview.oembed import get_oembed_data
 from zerver.lib.url_preview.parsers import OpenGraphParser, GenericParser
 
@@ -88,7 +89,7 @@ def get_link_embed_data(url: str,
     if data.get('oembed'):
         return data
 
-    response = requests.get(url, stream=True, headers=HEADERS, timeout=TIMEOUT)
+    response = requests.get(mark_sanitized(url), stream=True, headers=HEADERS, timeout=TIMEOUT)
     if response.ok:
         og_data = OpenGraphParser(response.text).extract_data()
         for key in ['title', 'description', 'image']:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -28,6 +28,7 @@ from zerver.lib.timestamp import datetime_to_timestamp
 from django.db.models.signals import post_save, post_delete
 from django.utils.translation import ugettext_lazy as _
 from zerver.lib import cache
+from zerver.lib.pysa import mark_sanitized
 from zerver.lib.validator import check_int, \
     check_short_string, check_long_string, validate_choice_field, check_date, \
     check_url, check_list
@@ -518,7 +519,9 @@ class Realm(models.Model):
 
     @property
     def host(self) -> str:
-        return self.host_for_subdomain(self.subdomain)
+        # Use mark sanitized to prevent false positives from Pysa thinking that
+        # the host is user controlled.
+        return mark_sanitized(self.host_for_subdomain(self.subdomain))
 
     @staticmethod
     def host_for_subdomain(subdomain: str) -> str:

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -444,7 +444,7 @@ def send_confirm_registration_email(email: str, activation_url: str, language: s
 def redirect_to_email_login_url(email: str) -> HttpResponseRedirect:
     login_url = reverse('django.contrib.auth.views.login')
     email = urllib.parse.quote_plus(email)
-    redirect_url = login_url + '?already_registered=' + email
+    redirect_url = add_query_to_redirect_url(login_url, 'already_registered=' + email)
     return HttpResponseRedirect(redirect_url)
 
 def create_realm(request: HttpRequest, creation_key: Optional[str]=None) -> HttpResponse:

--- a/zerver/views/zephyr.py
+++ b/zerver/views/zephyr.py
@@ -3,6 +3,7 @@ from django.http import HttpResponse, HttpRequest
 from django.utils.translation import ugettext as _
 from zerver.decorator import authenticated_json_view
 from zerver.lib.ccache import make_ccache
+from zerver.lib.pysa import mark_sanitized
 from zerver.lib.request import has_request_variables, REQ
 from zerver.lib.response import json_success, json_error
 from zerver.lib.users import get_api_key
@@ -43,6 +44,14 @@ def webathena_kerberos_login(request: HttpRequest, user_profile: UserProfile,
         # This is important for security since DNS is not secure.
         assert(re.match(r'^[a-z0-9_.-]+$', user) is not None)
         ccache = make_ccache(parsed_cred)
+
+        # 'user' has been verified to contain only benign characters that won't
+        # help with shell injection.
+        user = mark_sanitized(user)
+
+        # 'ccache' is only written to disk by the script and used as a kerberos
+        # credential cache file.
+        ccache = mark_sanitized(ccache)
     except Exception:
         return json_error(_("Invalid Kerberos cache"))
 

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -45,6 +45,7 @@ from zerver.lib.bot_lib import EmbeddedBotHandler, get_bot_handler, EmbeddedBotQ
 from zerver.lib.exceptions import RateLimited
 from zerver.lib.export import export_realm_wrapper
 from zerver.lib.remote_server import PushNotificationBouncerRetryLaterError
+from zerver.lib.pysa import mark_sanitized
 
 import os
 import ujson
@@ -204,7 +205,9 @@ class QueueProcessingWorker(ABC):
         self._log_problem()
         if not os.path.exists(settings.QUEUE_ERROR_DIR):
             os.mkdir(settings.QUEUE_ERROR_DIR)  # nocoverage
-        fname = f'{self.queue_name}.errors'
+        # Use 'mark_sanitized' to prevent Pysa from detecting this false positive
+        # flow. 'queue_name' is always a constant string.
+        fname = mark_sanitized(f'{self.queue_name}.errors')
         fn = os.path.join(settings.QUEUE_ERROR_DIR, fname)
         line = f'{time.asctime()}\t{ujson.dumps(events)}\n'
         lock_fn = fn + '.lock'


### PR DESCRIPTION
This PR adds support for [Pysa](https://pyre-check.org/docs/pysa-basics.html), a tool for detecting security issues via static taint flow analysis. This is the tool that was used to detect a number of Zulip security issues, including CVE-2019-19775.

The PR makes a few key changes:
1. Introduces a `.pyre_configuration` file. This provides the necessary configuration information for Pysa to find type stubs, taint information, and the source code.
1. Introduces a dependency on `pyre-check`. This is the package contains Pysa (accessed through the `pyre analyze` command).
1. Introduces `stubs/taint/false_positives.pysa`, a file containing [`Sanitize`](https://pyre-check.org/docs/pysa-basics.html#sanitizers) models used to remove false positive taint flows. 
1. Introduces `mark_sanitized`, an identity function with no runtime effect. It is used inline in some functions to remove false positives.

With the existing sanitizers in place, Pysa currently shows no issues on Zulip (other than in the 5010 category covering UserControlled -> `getattr` flows, which you will likely choose to ignore).

**Testing Plan:**
Ran the following commands:
```
$ cd /srv/zulip
$ pyre analyze --no-verify --save-results-to /srv/zulip
$ sapp analyze taint-output.json
$ sapp explore
```
Observed the results in `sapp explore` to only show issues with code 5010.

Note that because `sapp` is not actually needed nor used in this diff, I did not add a dependency. Additionally, due to a bug in it's dependency setup, installing `pyre-check` is not sufficient for it to run. You will need run this command to install additional packages if you want to run SAPP:
```
pip install click click-log ipython==7.6.1 munch pygments SQLAlchemy ujson~=1.35 xxhash~=1.3.0 prompt-toolkit~=2.0.9
```

**Documentation:**
This section of the Pyre documentation covers Pysa:
https://pyre-check.org/docs/pysa-basics.html

Pysa code lives in this repository:
https://github.com/facebook/pyre-check

A tutorial to learn the basics is accessible here:
https://github.com/facebook/pyre-check/tree/master/pysa_tutorial

The sources, sinks, sanitizers, and rules that will influence what issues you see in your results are defined in these two folders:
https://github.com/facebook/pyre-check/tree/master/stubs/taint
https://github.com/facebook/pyre-check/tree/master/stubs/third_party_taint

**Future Work:**
This PR introduces everything that is needed to run Pysa locally inside the vagrant development environment. To make it more useful, additional work will be needed to incorporate it into the CI system.