### PR TITLE
Added Message Read Over Time Graph (#15167)

### DIFF
--- a/analytics/lib/counts.py
+++ b/analytics/lib/counts.py
@@ -648,15 +648,15 @@ def get_count_stats(realm: Optional[Realm]=None) -> Dict[str, CountStat]:
                   sql_data_collector(RealmCount, count_user_by_realm_query(realm), (UserProfile, 'is_bot')),
                   CountStat.DAY, interval=TIMEDELTA_MAX),
 
-        # Messages read stats.  messages_read::hour is the total
+        # Messages read stats.  messages_read::day is the total
         # number of messages read, whereas
-        # messages_read_interactions::hour tries to count the total
+        # messages_read_interactions::day tries to count the total
         # number of UI interactions resulting in messages being marked
         # as read (imperfect because of batching of some request
         # types, but less likely to be overwhelmed by a single bulk
         # operation).
-        LoggingCountStat('messages_read::hour', UserCount, CountStat.HOUR),
-        LoggingCountStat('messages_read_interactions::hour', UserCount, CountStat.HOUR),
+        LoggingCountStat('messages_read::day', UserCount, CountStat.DAY),
+        LoggingCountStat('messages_read_interactions::day', UserCount, CountStat.DAY),
 
         # User Activity stats
         # Stats that measure user activity in the UserActivityInterval sense.

--- a/analytics/management/commands/populate_analytics_db.py
+++ b/analytics/management/commands/populate_analytics_db.py
@@ -223,7 +223,7 @@ class Command(BaseCommand):
         FillState.objects.create(property=stat.property, end_time=last_end_time,
                                  state=FillState.DONE)
 
-        stat = COUNT_STATS['messages_read::hour']
+        stat = COUNT_STATS['messages_read::day']
         user_data = {
             None: self.generate_fixture_data(stat, 7, 3, 2, .6, 8, holiday_rate=.1),
         }

--- a/analytics/tests/test_counts.py
+++ b/analytics/tests/test_counts.py
@@ -1155,8 +1155,8 @@ class TestLoggingCountStats(AnalyticsTestCase):
         assertInviteCountEquals(6)
 
     def test_messages_read_hour(self) -> None:
-        read_count_property = 'messages_read::hour'
-        interactions_property = 'messages_read_interactions::hour'
+        read_count_property = 'messages_read::day'
+        interactions_property = 'messages_read_interactions::day'
 
         user1 = self.create_user()
         user2 = self.create_user()

--- a/analytics/tests/test_views.py
+++ b/analytics/tests/test_views.py
@@ -182,7 +182,7 @@ class TestGetChartData(ZulipTestCase):
         })
 
     def test_messages_read_over_time(self) -> None:
-        stat = COUNT_STATS['messages_read::hour']
+        stat = COUNT_STATS['messages_read::day']
         self.insert_data(stat, [None], [])
         result = self.client_get('/json/analytics/chart_data',
                                  {'chart_name': 'messages_read_over_time'})
@@ -190,8 +190,8 @@ class TestGetChartData(ZulipTestCase):
         data = result.json()
         self.assertEqual(data, {
             'msg': '',
-            'end_times': [datetime_to_timestamp(dt) for dt in self.end_times_hour],
-            'frequency': CountStat.HOUR,
+            'end_times': [datetime_to_timestamp(dt) for dt in self.end_times_day],
+            'frequency': CountStat.DAY,
             'everyone': {'read': self.data(100)},
             'user': {'read': self.data(0)},
             'display_order': None,

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -236,7 +236,7 @@ def get_chart_data(request: HttpRequest, user_profile: UserProfile, chart_name: 
         labels_sort_function = sort_client_labels
         include_empty_subgroups = False
     elif chart_name == 'messages_read_over_time':
-        stats = [COUNT_STATS['messages_read::hour']]
+        stats = [COUNT_STATS['messages_read::day']]
         tables = [aggregate_table, UserCount]
         subgroup_to_label = {stats[0]: {None: 'read'}}
         labels_sort_function = None

--- a/static/styles/portico/stats.scss
+++ b/static/styles/portico/stats.scss
@@ -153,6 +153,7 @@ p {
 }
 
 #users_hover_humans,
+#read_hover_everyone,
 #hover_human {
     margin-left: 10px;
 }
@@ -169,7 +170,8 @@ p {
     position: relative;
 }
 
-#id_messages_sent_over_time {
+#id_messages_sent_over_time,
+#id_messages_read_over_time {
     height: 400px;
     width: 750px;
     position: relative;
@@ -190,6 +192,7 @@ p {
 }
 
 #users_hover_info,
+#read_hover_info,
 #hoverinfo {
     display: none;
     font-size: 0.8em;

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -55,6 +55,28 @@
                         </div>
                     </div>
                 </div>
+
+                <div class="chart-container">
+                    <h1>{{ _("Messages read over time") }}</h1>
+                    <div class="button-container">
+                        <label>{{ _("Aggregation") }}</label>
+                        <div class="buttons">
+                            <button class="button" type="button" id='read_daily_button'>{{ _("Daily") }} </button>
+                            <button class="button" type="button" id='read_weekly_button'>{{ _("Weekly") }} </button>
+                            <button class="button" type="button" id='read_cumulative_button'>{{ _("Cumulative") }} </button>
+                        </div>
+                    </div>
+                    <div id="id_messages_read_over_time">
+                        <div class="spinner"></div>
+                    </div>
+                    <div id="read_hover_info">
+                        <span id="read_hover_date"></span>
+                        <span id="read_hover_me">{{ _("Me") }}:</span>
+                        <span id="read_hover_me_value"></span>
+                        <b id="read_hover_everyone">{{ _("Everyone") }}:</b>
+                        <span id="read_hover_everyone_value"></span>
+                    </div>
+                </div>
             </div>
 
             <div class="right">

--- a/templates/analytics/stats.html
+++ b/templates/analytics/stats.html
@@ -57,24 +57,23 @@
                 </div>
 
                 <div class="chart-container">
-                    <h1>{{ _("Messages read over time") }}</h1>
+                    <h1>{{ _("Active users") }}</h1>
                     <div class="button-container">
-                        <label>{{ _("Aggregation") }}</label>
-                        <div class="buttons">
-                            <button class="button" type="button" id='read_daily_button'>{{ _("Daily") }} </button>
-                            <button class="button" type="button" id='read_weekly_button'>{{ _("Weekly") }} </button>
-                            <button class="button" type="button" id='read_cumulative_button'>{{ _("Cumulative") }} </button>
+                        <div class="buttons button-active-users">
+                            <button class="button" type="button" id="1day_actives_button">{{ _("Daily actives") }}</button>
+                            <button class="button" type="button" id="15day_actives_button">{{ _("15 day actives") }}</button>
+                            <button class="button" type="button" id="all_time_actives_button">{{ _("Total users") }}</button>
                         </div>
                     </div>
-                    <div id="id_messages_read_over_time">
+                    <div id="id_number_of_users">
                         <div class="spinner"></div>
                     </div>
-                    <div id="read_hover_info">
-                        <span id="read_hover_date"></span>
-                        <span id="read_hover_me">{{ _("Me") }}:</span>
-                        <span id="read_hover_me_value"></span>
-                        <b id="read_hover_everyone">{{ _("Everyone") }}:</b>
-                        <span id="read_hover_everyone_value"></span>
+                    <div id="users_hover_info" class="number-stat">
+                        <span id="users_hover_date"></span>
+                        <b id="users_hover_humans">{{ _("Users") }}: </b>
+                        <span id="users_hover_1day_value"></span>
+                        <span id="users_hover_15day_value"></span>
+                        <span id="users_hover_all_time_value"></span>
                     </div>
                 </div>
             </div>
@@ -98,23 +97,24 @@
                     </div>
                 </div>
                 <div class="chart-container">
-                    <h1>{{ _("Active users") }}</h1>
+                    <h1>{{ _("Messages read over time") }}</h1>
                     <div class="button-container">
-                        <div class="buttons button-active-users">
-                            <button class="button" type="button" id="1day_actives_button">{{ _("Daily actives") }}</button>
-                            <button class="button" type="button" id="15day_actives_button">{{ _("15 day actives") }}</button>
-                            <button class="button" type="button" id="all_time_actives_button">{{ _("Total users") }}</button>
+                        <label>{{ _("Aggregation") }}</label>
+                        <div class="buttons">
+                            <button class="button" type="button" id='read_daily_button'>{{ _("Daily") }} </button>
+                            <button class="button" type="button" id='read_weekly_button'>{{ _("Weekly") }} </button>
+                            <button class="button" type="button" id='read_cumulative_button'>{{ _("Cumulative") }} </button>
                         </div>
                     </div>
-                    <div id="id_number_of_users">
+                    <div id="id_messages_read_over_time">
                         <div class="spinner"></div>
                     </div>
-                    <div id="users_hover_info" class="number-stat">
-                        <span id="users_hover_date"></span>
-                        <b id="users_hover_humans">{{ _("Users") }}: </b>
-                        <span id="users_hover_1day_value"></span>
-                        <span id="users_hover_15day_value"></span>
-                        <span id="users_hover_all_time_value"></span>
+                    <div id="read_hover_info">
+                        <span id="read_hover_date"></span>
+                        <span id="read_hover_me">{{ _("Me") }}:</span>
+                        <span id="read_hover_me_value"></span>
+                        <b id="read_hover_everyone">{{ _("Everyone") }}:</b>
+                        <span id="read_hover_everyone_value"></span>
                     </div>
                 </div>
             </div>

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4034,9 +4034,9 @@ def do_update_pointer(user_profile: UserProfile, client: Client,
         event_time = timezone_now()
 
         count = len(app_message_ids)
-        do_increment_logging_stat(user_profile, COUNT_STATS['messages_read::hour'],
+        do_increment_logging_stat(user_profile, COUNT_STATS['messages_read::day'],
                                   None, event_time, increment=count)
-        do_increment_logging_stat(user_profile, COUNT_STATS['messages_read_interactions::hour'],
+        do_increment_logging_stat(user_profile, COUNT_STATS['messages_read_interactions::day'],
                                   None, event_time, increment=min(1, count))
 
     event = dict(type='pointer', pointer=pointer)
@@ -4106,9 +4106,9 @@ def do_mark_all_as_read(user_profile: UserProfile, client: Client) -> int:
 
     send_event(user_profile.realm, event, [user_profile.id])
 
-    do_increment_logging_stat(user_profile, COUNT_STATS['messages_read::hour'],
+    do_increment_logging_stat(user_profile, COUNT_STATS['messages_read::day'],
                               None, event_time, increment=count)
-    do_increment_logging_stat(user_profile, COUNT_STATS['messages_read_interactions::hour'],
+    do_increment_logging_stat(user_profile, COUNT_STATS['messages_read_interactions::day'],
                               None, event_time, increment=min(1, count))
 
     return count
@@ -4154,9 +4154,9 @@ def do_mark_stream_messages_as_read(user_profile: UserProfile,
     send_event(user_profile.realm, event, [user_profile.id])
     do_clear_mobile_push_notifications_for_ids(user_profile, message_ids)
 
-    do_increment_logging_stat(user_profile, COUNT_STATS['messages_read::hour'],
+    do_increment_logging_stat(user_profile, COUNT_STATS['messages_read::day'],
                               None, event_time, increment=count)
-    do_increment_logging_stat(user_profile, COUNT_STATS['messages_read_interactions::hour'],
+    do_increment_logging_stat(user_profile, COUNT_STATS['messages_read_interactions::day'],
                               None, event_time, increment=min(1, count))
     return count
 
@@ -4243,9 +4243,9 @@ def do_update_message_flags(user_profile: UserProfile,
         event_time = timezone_now()
         do_clear_mobile_push_notifications_for_ids(user_profile, messages)
 
-        do_increment_logging_stat(user_profile, COUNT_STATS['messages_read::hour'],
+        do_increment_logging_stat(user_profile, COUNT_STATS['messages_read::day'],
                                   None, event_time, increment=count)
-        do_increment_logging_stat(user_profile, COUNT_STATS['messages_read_interactions::hour'],
+        do_increment_logging_stat(user_profile, COUNT_STATS['messages_read_interactions::day'],
                                   None, event_time, increment=min(1, count))
     return count
 


### PR DESCRIPTION
Updated PR for [https://github.com/zulip/zulip/pull/15260](https://github.com/zulip/zulip/pull/15260)

Currently, this PR only shows the graph for reads per time not for read interaction.
@timabbott Can you check this.
Fixes #15167 
CI is passing.
![Screenshot from 2020-06-11 21-08-14](https://user-images.githubusercontent.com/36269420/84406917-cb231f00-ac27-11ea-83e4-a37f5444115d.png)
