### PR TITLE
i18n: Don't hardcode zulip.com URLs in translation tags

### DIFF
--- a/templates/zerver/app/navbar_alerts.html
+++ b/templates/zerver/app/navbar_alerts.html
@@ -40,9 +40,9 @@
     <div data-process="insecure-desktop-app" class="alert alert-info red">
         <span class="close" data-dismiss="alert" aria-label="{{ _('Close') }}">&times;</span>
         <div data-step="1">
-            {% trans %}
+            {% trans apps_page_link="https://zulip.com/apps" %}
             You are using an old version of the Zulip desktop app with known security bugs.
-            <a class="alert-link" href="https://zulip.com/apps" target="_blank">
+            <a class="alert-link" href="{{ apps_page_link }}" target="_blank">
                 Download the latest version.
             </a>
             {% endtrans %}

--- a/templates/zerver/emails/followup_day1.source.html
+++ b/templates/zerver/emails/followup_day1.source.html
@@ -27,7 +27,7 @@
     {% else %}
         <li>{{ _('Email:') }} {{ email }}<br></li>
     {% endif %}
-    {% trans %}(you'll need these to sign in to the <a href="https://zulip.com/apps">mobile and desktop</a> apps){% endtrans %}
+    {% trans apps_page_link="https://zulip.com/apps" %}(you'll need these to sign in to the <a href="{{ apps_page_link }}">mobile and desktop</a> apps){% endtrans %}
 </p>
 
 <p>

--- a/templates/zerver/emails/followup_day1.txt
+++ b/templates/zerver/emails/followup_day1.txt
@@ -18,7 +18,7 @@
 {% else %}
 * {{ _('Email:') }} {{ email }}
 {% endif %}
-{% trans %}(you'll need these to sign in to the mobile and desktop apps (https://zulip.com/apps)){% endtrans %}
+{% trans apps_page_link="https://zulip.com/apps" %}(you'll need these to sign in to the mobile and desktop apps ({{ apps_page_link }})){% endtrans %}
 
 
 {% if is_realm_admin %}

--- a/templates/zerver/realm_creation_failed.html
+++ b/templates/zerver/realm_creation_failed.html
@@ -18,12 +18,9 @@
             <div class="inner-content">
                 <p>{{ _('This server does not allow members of the public to create new organizations.') }}</p>
                 <p>
-                    {% trans %}
-                    Zulip is open source, so you
-                    can <a href="https://zulip.readthedocs.io/en/stable/production/install.html">install
-                    your own Zulip server</a> or create a new
-                    organization on
-                    <a href="https://zulip.com">Zulip Cloud</a>
+                    {% trans zulip_cloud_link="https://zulip.com",production_install_url="https://zulip.readthedocs.io/en/stable/production/install.html" %}
+                    Zulip is open source, so you can <a href="{{ production_install_url}}">install your own Zulip server</a> or create a new organization on
+                    <a href="{{ zulip_cloud_link }}">Zulip Cloud</a>
                     {% endtrans %}
                 </p>
             </div>

--- a/templates/zerver/unsupported_browser.html
+++ b/templates/zerver/unsupported_browser.html
@@ -21,10 +21,8 @@
                         {% endtrans %}
                     </p>
                     <p>
-                        {% trans %}
-                        You can also use
-                        the <a href="https://zulip.com/apps">Zulip
-                        desktop app</a>.
+                        {% trans apps_page_link="https://zulip.com/apps" %}
+                        You can also use the <a href="{{ apps_page_link }}">Zulip desktop app</a>.
                         {% endtrans %}
                     </p>
                 </div>

--- a/version.py
+++ b/version.py
@@ -44,4 +44,4 @@ API_FEATURE_LEVEL = 12
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '86.2'
+PROVISION_VERSION = '86.3'


### PR DESCRIPTION
Was thinking of setting `apps_page_link` in context_processors.py. But probably not that useful.

---
Migrated 6/7

❌ Left out this one in zulipchat_migration_tos.html

```
<p>This organization has been migrated to new hosting on zulip.com. We just need you to do one last thing.</p>
```

✅ templates/zerver/app/navbar_alerts.html 
```
locale/bg/LC_MESSAGES/django.po:"            <a class=\"alert-link\" href=\"https://zulipchat.com/apps\" target=\"_blank\">\n"
```

✅ templates/zerver/emails/followup_day1.source.html
```
locale/bg/LC_MESSAGES/django.po:"(you'll need these to sign in to the <a href=\"https://zulipchat.com/apps\" "
```

```
locale/bg/LC_MESSAGES/django.po:"href=\"https://zulipchat.com/apps\">mobile and desktop</a> apps)"
```


✅ templates/zerver/emails/followup_day1.txt
```
locale/bg/LC_MESSAGES/django.po:"(https://zulipchat.com/apps))"
```

✅ templates/zerver/realm_creation_failed.html 
```
locale/bg/LC_MESSAGES/django.po:"                    <a href=\"https://zulipchat.com\">Zulip Cloud</a>\n"

```

✅ templates/zerver/unsupported_browser.html
```
locale/bg/LC_MESSAGES/django.po:"                        the <a href=\"https://zulipchat.com/apps\">Zulip\n"
```