### PR TITLE
sharding: Fix permissions on the nginx_sharding.conf file.

### DIFF
--- a/puppet/zulip/manifests/tornado_sharding.pp
+++ b/puppet/zulip/manifests/tornado_sharding.pp
@@ -11,7 +11,7 @@ class zulip::tornado_sharding {
     ensure  => file,
     owner   => 'root',
     group   => 'root',
-    mode    => '0640',
+    mode    => '0644',
     notify  => Service['nginx'],
     content => "set \$tornado_server http://tornado;\n",
     replace => false,


### PR DESCRIPTION
The zulip user needs to be able to read the file, when running the
backup tool.
We put root:root as owner on other nginx config files, so it's probably
correct to keep the ownership as it is, and set the mode to 0644.
