### PR TITLE
openapi: Show API argument type in docs.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1400,7 +1400,7 @@ paths:
         schema:
           type: integer
         example: 1
-        required: True
+        required: true
       - name: filename
         in: path
         description: |
@@ -1408,7 +1408,7 @@ paths:
         schema:
           type: string
         example: 4e/m2A3MSqFnWRLUf9SaPzQ0Up_/zulip.txt
-        required: True
+        required: true
       responses:
         '200':
           description: Success.


### PR DESCRIPTION
Currently the API docs do not specify whether a given API parameter
is to be specified in `query` or in `path`. Edit the docs so as
to show the type of argument right beside argument name.

As of posting, the design is basic.This PR needs some review 
on design and then I will change it accordingly.
