### PR TITLE
puppet: Remove python-dateutil requirement from pg_backup_and_purge.

### DIFF
--- a/puppet/zulip_ops/manifests/postgres_common.pp
+++ b/puppet/zulip_ops/manifests/postgres_common.pp
@@ -33,7 +33,6 @@ class zulip_ops::postgres_common {
       Package[
         "postgresql-${zulip::base::postgres_version}",
         'python3-dateutil',
-        'python-dateutil'
       ]
     ]
   }


### PR DESCRIPTION
1f565a9f41 removed the `package` lines which install
`python-dateutil`, but not the line in `puppet_ops` that references it;
as such, Puppet manifests in `puppet_ops` fail to compile.

Remove the stale reference to `python-dateutil`, which is unnecessary
since the code is python3, not python2.

**Testing Plan:** Applied on `postgres2`
