### PR TITLE
Split out postgres directory config

### DIFF
--- a/puppet/zulip/manifests/postgres_appdb_base.pp
+++ b/puppet/zulip/manifests/postgres_appdb_base.pp
@@ -9,7 +9,11 @@ class zulip::postgres_appdb_base {
       include zulip::apt_repository
       $postgresql = "postgresql-${zulip::base::postgres_version}"
       $postgres_sharedir = "/usr/share/postgresql/${zulip::base::postgres_version}"
-      $postgres_confdir = "/etc/postgresql/${zulip::base::postgres_version}/main"
+      $postgres_confdirs = [
+        "/etc/postgresql/${zulip::base::postgres_version}",
+        "/etc/postgresql/${zulip::base::postgres_version}/main",
+      ]
+      $postgres_confdir = $postgres_confdirs[-1]
       $postgres_datadir = "/var/lib/postgresql/${zulip::base::postgres_version}/main"
       $tsearch_datadir = "${postgres_sharedir}/tsearch_data"
       $pgroonga_setup_sql_path = "${postgres_sharedir}/pgroonga_setup.sql"
@@ -20,7 +24,11 @@ class zulip::postgres_appdb_base {
       include zulip::yum_repository
       $postgresql = "postgresql${zulip::base::postgres_version}"
       $postgres_sharedir = "/usr/pgsql-${zulip::base::postgres_version}/share"
-      $postgres_confdir = "/var/lib/pgsql/${zulip::base::postgres_version}/data"
+      $postgres_confdirs = [
+        "/var/lib/pgsql/${zulip::base::postgres_version}",
+        "/var/lib/pgsql/${zulip::base::postgres_version}/data",
+      ]
+      $postgres_confdir = $postgres_confdirs[-1]
       $postgres_datadir = "/var/lib/pgsql/${zulip::base::postgres_version}/data"
       $tsearch_datadir = "${postgres_sharedir}/tsearch_data/"
       $pgroonga_setup_sql_path = "${postgres_sharedir}/pgroonga_setup.sql"

--- a/puppet/zulip/manifests/postgres_appdb_base.pp
+++ b/puppet/zulip/manifests/postgres_appdb_base.pp
@@ -12,6 +12,7 @@ class zulip::postgres_appdb_base {
       $tsearch_datadir = "${postgres_sharedir}/tsearch_data"
       $pgroonga_setup_sql_path = "${postgres_sharedir}/pgroonga_setup.sql"
       $setup_system_deps = 'setup_apt_repo'
+      $postgres_restart = "pg_ctlcluster ${zulip::base::postgres_version} main restart"
     }
     'redhat': {
       include zulip::yum_repository
@@ -20,6 +21,7 @@ class zulip::postgres_appdb_base {
       $tsearch_datadir = "${postgres_sharedir}/tsearch_data/"
       $pgroonga_setup_sql_path = "${postgres_sharedir}/pgroonga_setup.sql"
       $setup_system_deps = 'setup_yum_repo'
+      $postgres_restart = "systemctl restart postgresql-${zulip::base::postgres_version}"
     }
     default: {
       fail('osfamily not supported')

--- a/puppet/zulip/manifests/postgres_appdb_base.pp
+++ b/puppet/zulip/manifests/postgres_appdb_base.pp
@@ -9,6 +9,7 @@ class zulip::postgres_appdb_base {
       include zulip::apt_repository
       $postgresql = "postgresql-${zulip::base::postgres_version}"
       $postgres_sharedir = "/usr/share/postgresql/${zulip::base::postgres_version}"
+      $postgres_confdir = "/etc/postgresql/${zulip::base::postgres_version}/main"
       $tsearch_datadir = "${postgres_sharedir}/tsearch_data"
       $pgroonga_setup_sql_path = "${postgres_sharedir}/pgroonga_setup.sql"
       $setup_system_deps = 'setup_apt_repo'
@@ -18,6 +19,7 @@ class zulip::postgres_appdb_base {
       include zulip::yum_repository
       $postgresql = "postgresql${zulip::base::postgres_version}"
       $postgres_sharedir = "/usr/pgsql-${zulip::base::postgres_version}/share"
+      $postgres_confdir = "/var/lib/pgsql/${zulip::base::postgres_version}/data"
       $tsearch_datadir = "${postgres_sharedir}/tsearch_data/"
       $pgroonga_setup_sql_path = "${postgres_sharedir}/pgroonga_setup.sql"
       $setup_system_deps = 'setup_yum_repo'

--- a/puppet/zulip/manifests/postgres_appdb_base.pp
+++ b/puppet/zulip/manifests/postgres_appdb_base.pp
@@ -10,6 +10,7 @@ class zulip::postgres_appdb_base {
       $postgresql = "postgresql-${zulip::base::postgres_version}"
       $postgres_sharedir = "/usr/share/postgresql/${zulip::base::postgres_version}"
       $postgres_confdir = "/etc/postgresql/${zulip::base::postgres_version}/main"
+      $postgres_datadir = "/var/lib/postgresql/${zulip::base::postgres_version}/main"
       $tsearch_datadir = "${postgres_sharedir}/tsearch_data"
       $pgroonga_setup_sql_path = "${postgres_sharedir}/pgroonga_setup.sql"
       $setup_system_deps = 'setup_apt_repo'
@@ -20,6 +21,7 @@ class zulip::postgres_appdb_base {
       $postgresql = "postgresql${zulip::base::postgres_version}"
       $postgres_sharedir = "/usr/pgsql-${zulip::base::postgres_version}/share"
       $postgres_confdir = "/var/lib/pgsql/${zulip::base::postgres_version}/data"
+      $postgres_datadir = "/var/lib/pgsql/${zulip::base::postgres_version}/data"
       $tsearch_datadir = "${postgres_sharedir}/tsearch_data/"
       $pgroonga_setup_sql_path = "${postgres_sharedir}/pgroonga_setup.sql"
       $setup_system_deps = 'setup_yum_repo'

--- a/puppet/zulip/manifests/postgres_appdb_tuned.pp
+++ b/puppet/zulip/manifests/postgres_appdb_tuned.pp
@@ -17,8 +17,6 @@ class zulip::postgres_appdb_tuned {
   $ssl_key_file = zulipconf('postgresql', 'ssl_key_file', undef)
   $ssl_ca_file = zulipconf('postgresql', 'ssl_ca_file', undef)
 
-  # Only used in CentOS for now
-  $pg_datadir = "/var/lib/pgsql/${zulip::base::postgres_version}/data"
 
   $postgres_conf_file = "${zulip::postgres_appdb_base::postgres_confdir}/postgresql.conf"
   file { $postgres_conf_file:

--- a/puppet/zulip/manifests/postgres_appdb_tuned.pp
+++ b/puppet/zulip/manifests/postgres_appdb_tuned.pp
@@ -17,6 +17,11 @@ class zulip::postgres_appdb_tuned {
   $ssl_key_file = zulipconf('postgresql', 'ssl_key_file', undef)
   $ssl_ca_file = zulipconf('postgresql', 'ssl_ca_file', undef)
 
+  file { $zulip::postgres_appdb_base::postgres_confdirs:
+    ensure => directory,
+    owner  => 'postgres',
+    group  => 'postgres',
+  }
 
   $postgres_conf_file = "${zulip::postgres_appdb_base::postgres_confdir}/postgresql.conf"
   file { $postgres_conf_file:

--- a/puppet/zulip/manifests/postgres_appdb_tuned.pp
+++ b/puppet/zulip/manifests/postgres_appdb_tuned.pp
@@ -7,11 +7,6 @@ class zulip::postgres_appdb_tuned {
     'debian' => "/etc/postgresql/${zulip::base::postgres_version}/main/postgresql.conf",
     'redhat' => "/var/lib/pgsql/${zulip::base::postgres_version}/data/postgresql.conf",
   }
-  $postgres_restart = $::osfamily ? {
-    'debian' => "pg_ctlcluster ${zulip::base::postgres_version} main restart",
-    'redhat' => "systemctl restart postgresql-${zulip::base::postgres_version}",
-  }
-
   $work_mem = $zulip::base::total_memory_mb / 512
   $shared_buffers = $zulip::base::total_memory_mb / 8
   $effective_cache_size = $zulip::base::total_memory_mb * 10 / 32
@@ -38,7 +33,7 @@ class zulip::postgres_appdb_tuned {
     content => template("zulip/postgresql/${zulip::base::postgres_version}/postgresql.conf.template.erb"),
   }
 
-  exec { $postgres_restart:
+  exec { $zulip::postgres_appdb_base::postgres_restart:
     require     => Package[$zulip::postgres_appdb_base::postgresql],
     refreshonly => true,
     subscribe   => [ File[$postgres_conf] ]

--- a/puppet/zulip/manifests/postgres_appdb_tuned.pp
+++ b/puppet/zulip/manifests/postgres_appdb_tuned.pp
@@ -3,10 +3,6 @@
 class zulip::postgres_appdb_tuned {
   include zulip::postgres_appdb_base
 
-  $postgres_conf = $::osfamily ? {
-    'debian' => "/etc/postgresql/${zulip::base::postgres_version}/main/postgresql.conf",
-    'redhat' => "/var/lib/pgsql/${zulip::base::postgres_version}/data/postgresql.conf",
-  }
   $work_mem = $zulip::base::total_memory_mb / 512
   $shared_buffers = $zulip::base::total_memory_mb / 8
   $effective_cache_size = $zulip::base::total_memory_mb * 10 / 32
@@ -24,7 +20,8 @@ class zulip::postgres_appdb_tuned {
   # Only used in CentOS for now
   $pg_datadir = "/var/lib/pgsql/${zulip::base::postgres_version}/data"
 
-  file { $postgres_conf:
+  $postgres_conf_file = "${zulip::postgres_appdb_base::postgres_confdir}/postgresql.conf"
+  file { $postgres_conf_file:
     ensure  => file,
     require => Package[$zulip::postgres_appdb_base::postgresql],
     owner   => 'postgres',
@@ -36,6 +33,6 @@ class zulip::postgres_appdb_tuned {
   exec { $zulip::postgres_appdb_base::postgres_restart:
     require     => Package[$zulip::postgres_appdb_base::postgresql],
     refreshonly => true,
-    subscribe   => [ File[$postgres_conf] ]
+    subscribe   => [ File[$postgres_conf_file] ]
   }
 }

--- a/puppet/zulip/templates/postgresql/10/postgresql.conf.centos.template.erb
+++ b/puppet/zulip/templates/postgresql/10/postgresql.conf.centos.template.erb
@@ -40,9 +40,9 @@
 
 data_directory = '<%= scope["zulip::postgres_appdb_tuned::pg_datadir"] %>'		# use data in another directory
 					# (change requires restart)
-hba_file = '<%= scope["zulip::postgres_appdb_tuned::pg_datadir"] %>/pg_hba.conf'	# host-based authentication file
+hba_file = '<%= scope["zulip::postgres_appdb_base::postgres_confdir"] %>/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)
-ident_file = '<%= scope["zulip::postgres_appdb_tuned::pg_datadir"] %>/pg_ident.conf'	# ident configuration file
+ident_file = '<%= scope["zulip::postgres_appdb_base::postgres_confdir"] %>/pg_ident.conf'	# ident configuration file
 					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.

--- a/puppet/zulip/templates/postgresql/10/postgresql.conf.centos.template.erb
+++ b/puppet/zulip/templates/postgresql/10/postgresql.conf.centos.template.erb
@@ -38,7 +38,7 @@
 # The default values of these variables are driven from the -D command-line
 # option or PGDATA environment variable, represented here as ConfigDir.
 
-data_directory = '<%= scope["zulip::postgres_appdb_tuned::pg_datadir"] %>'		# use data in another directory
+data_directory = '<%= scope["zulip::postgres_appdb_base::postgres_datadir"] %>'		# use data in another directory
 					# (change requires restart)
 hba_file = '<%= scope["zulip::postgres_appdb_base::postgres_confdir"] %>/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)

--- a/puppet/zulip/templates/postgresql/10/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/10/postgresql.conf.template.erb
@@ -40,9 +40,9 @@
 
 data_directory = '/var/lib/postgresql/<%= scope["zulip::base::postgres_version"] %>/main'		# use data in another directory
 					# (change requires restart)
-hba_file = '/etc/postgresql/<%= scope["zulip::base::postgres_version"] %>/main/pg_hba.conf'	# host-based authentication file
+hba_file = '<%= scope["zulip::postgres_appdb_base::postgres_confdir"] %>/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)
-ident_file = '/etc/postgresql/<%= scope["zulip::base::postgres_version"] %>/main/pg_ident.conf'	# ident configuration file
+ident_file = '<%= scope["zulip::postgres_appdb_base::postgres_confdir"] %>/pg_ident.conf'	# ident configuration file
 					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.

--- a/puppet/zulip/templates/postgresql/10/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/10/postgresql.conf.template.erb
@@ -38,7 +38,7 @@
 # The default values of these variables are driven from the -D command-line
 # option or PGDATA environment variable, represented here as ConfigDir.
 
-data_directory = '/var/lib/postgresql/<%= scope["zulip::base::postgres_version"] %>/main'		# use data in another directory
+data_directory = '<%= scope["zulip::postgres_appdb_base::postgres_datadir"] %>'		# use data in another directory
 					# (change requires restart)
 hba_file = '<%= scope["zulip::postgres_appdb_base::postgres_confdir"] %>/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)

--- a/puppet/zulip/templates/postgresql/11/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/11/postgresql.conf.template.erb
@@ -40,9 +40,9 @@
 
 data_directory = '/var/lib/postgresql/<%= scope["zulip::base::postgres_version"] %>/main'		# use data in another directory
 					# (change requires restart)
-hba_file = '/etc/postgresql/<%= scope["zulip::base::postgres_version"] %>/main/pg_hba.conf'	# host-based authentication file
+hba_file = '<%= scope["zulip::postgres_appdb_base::postgres_confdir"] %>/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)
-ident_file = '/etc/postgresql/<%= scope["zulip::base::postgres_version"] %>/main/pg_ident.conf'	# ident configuration file
+ident_file = '<%= scope["zulip::postgres_appdb_base::postgres_confdir"] %>/pg_ident.conf'	# ident configuration file
 					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.

--- a/puppet/zulip/templates/postgresql/11/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/11/postgresql.conf.template.erb
@@ -38,7 +38,7 @@
 # The default values of these variables are driven from the -D command-line
 # option or PGDATA environment variable, represented here as ConfigDir.
 
-data_directory = '/var/lib/postgresql/<%= scope["zulip::base::postgres_version"] %>/main'		# use data in another directory
+data_directory = '<%= scope["zulip::postgres_appdb_base::postgres_datadir"] %>'		# use data in another directory
 					# (change requires restart)
 hba_file = '<%= scope["zulip::postgres_appdb_base::postgres_confdir"] %>/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)

--- a/puppet/zulip/templates/postgresql/12/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/12/postgresql.conf.template.erb
@@ -40,9 +40,9 @@
 
 data_directory = '/var/lib/postgresql/<%= scope["zulip::base::postgres_version"] %>/main'		# use data in another directory
 					# (change requires restart)
-hba_file = '/etc/postgresql/<%= scope["zulip::base::postgres_version"] %>/main/pg_hba.conf'	# host-based authentication file
+hba_file = '<%= scope["zulip::postgres_appdb_base::postgres_confdir"] %>/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)
-ident_file = '/etc/postgresql/<%= scope["zulip::base::postgres_version"] %>/main/pg_ident.conf'	# ident configuration file
+ident_file = '<%= scope["zulip::postgres_appdb_base::postgres_confdir"] %>/pg_ident.conf'	# ident configuration file
 					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.

--- a/puppet/zulip/templates/postgresql/12/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/12/postgresql.conf.template.erb
@@ -38,7 +38,7 @@
 # The default values of these variables are driven from the -D command-line
 # option or PGDATA environment variable, represented here as ConfigDir.
 
-data_directory = '/var/lib/postgresql/<%= scope["zulip::base::postgres_version"] %>/main'		# use data in another directory
+data_directory = '<%= scope["zulip::postgres_appdb_base::postgres_datadir"] %>'		# use data in another directory
 					# (change requires restart)
 hba_file = '<%= scope["zulip::postgres_appdb_base::postgres_confdir"] %>/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)

--- a/puppet/zulip/templates/postgresql/9.3/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/9.3/postgresql.conf.template.erb
@@ -40,9 +40,9 @@
 
 data_directory = '/var/lib/postgresql/<%= scope["zulip::base::postgres_version"] %>/main'		# use data in another directory
 					# (change requires restart)
-hba_file = '/etc/postgresql/<%= scope["zulip::base::postgres_version"] %>/main/pg_hba.conf'	# host-based authentication file
+hba_file = '<%= scope["zulip::postgres_appdb_base::postgres_confdir"] %>/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)
-ident_file = '/etc/postgresql/<%= scope["zulip::base::postgres_version"] %>/main/pg_ident.conf'	# ident configuration file
+ident_file = '<%= scope["zulip::postgres_appdb_base::postgres_confdir"] %>/pg_ident.conf'	# ident configuration file
 					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.

--- a/puppet/zulip/templates/postgresql/9.3/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/9.3/postgresql.conf.template.erb
@@ -38,7 +38,7 @@
 # The default values of these variables are driven from the -D command-line
 # option or PGDATA environment variable, represented here as ConfigDir.
 
-data_directory = '/var/lib/postgresql/<%= scope["zulip::base::postgres_version"] %>/main'		# use data in another directory
+data_directory = '<%= scope["zulip::postgres_appdb_base::postgres_datadir"] %>'		# use data in another directory
 					# (change requires restart)
 hba_file = '<%= scope["zulip::postgres_appdb_base::postgres_confdir"] %>/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)

--- a/puppet/zulip/templates/postgresql/9.5/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/9.5/postgresql.conf.template.erb
@@ -40,9 +40,9 @@
 
 data_directory = '/var/lib/postgresql/<%= scope["zulip::base::postgres_version"] %>/main'		# use data in another directory
 					# (change requires restart)
-hba_file = '/etc/postgresql/<%= scope["zulip::base::postgres_version"] %>/main/pg_hba.conf'	# host-based authentication file
+hba_file = '<%= scope["zulip::postgres_appdb_base::postgres_confdir"] %>/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)
-ident_file = '/etc/postgresql/<%= scope["zulip::base::postgres_version"] %>/main/pg_ident.conf'	# ident configuration file
+ident_file = '<%= scope["zulip::postgres_appdb_base::postgres_confdir"] %>/pg_ident.conf'	# ident configuration file
 					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.

--- a/puppet/zulip/templates/postgresql/9.5/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/9.5/postgresql.conf.template.erb
@@ -38,7 +38,7 @@
 # The default values of these variables are driven from the -D command-line
 # option or PGDATA environment variable, represented here as ConfigDir.
 
-data_directory = '/var/lib/postgresql/<%= scope["zulip::base::postgres_version"] %>/main'		# use data in another directory
+data_directory = '<%= scope["zulip::postgres_appdb_base::postgres_datadir"] %>'		# use data in another directory
 					# (change requires restart)
 hba_file = '<%= scope["zulip::postgres_appdb_base::postgres_confdir"] %>/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)

--- a/puppet/zulip/templates/postgresql/9.6/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/9.6/postgresql.conf.template.erb
@@ -40,9 +40,9 @@
 
 data_directory = '/var/lib/postgresql/<%= scope["zulip::base::postgres_version"] %>/main'		# use data in another directory
 					# (change requires restart)
-hba_file = '/etc/postgresql/<%= scope["zulip::base::postgres_version"] %>/main/pg_hba.conf'	# host-based authentication file
+hba_file = '<%= scope["zulip::postgres_appdb_base::postgres_confdir"] %>/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)
-ident_file = '/etc/postgresql/<%= scope["zulip::base::postgres_version"] %>/main/pg_ident.conf'	# ident configuration file
+ident_file = '<%= scope["zulip::postgres_appdb_base::postgres_confdir"] %>/pg_ident.conf'	# ident configuration file
 					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.

--- a/puppet/zulip/templates/postgresql/9.6/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/9.6/postgresql.conf.template.erb
@@ -38,7 +38,7 @@
 # The default values of these variables are driven from the -D command-line
 # option or PGDATA environment variable, represented here as ConfigDir.
 
-data_directory = '/var/lib/postgresql/<%= scope["zulip::base::postgres_version"] %>/main'		# use data in another directory
+data_directory = '<%= scope["zulip::postgres_appdb_base::postgres_datadir"] %>'		# use data in another directory
 					# (change requires restart)
 hba_file = '<%= scope["zulip::postgres_appdb_base::postgres_confdir"] %>/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)

--- a/puppet/zulip_ops/manifests/postgres_appdb.pp
+++ b/puppet/zulip_ops/manifests/postgres_appdb.pp
@@ -2,7 +2,7 @@ class zulip_ops::postgres_appdb {
   include zulip_ops::postgres_common
   include zulip::postgres_appdb_tuned
 
-  file { "/etc/postgresql/${zulip::base::postgres_version}/main/pg_hba.conf":
+  file { "${zulip::postgres_appdb_base::postgres_confdir}/pg_hba.conf":
     ensure  => file,
     require => Package["postgresql-${zulip::base::postgres_version}"],
     owner   => 'postgres',

--- a/puppet/zulip_ops/manifests/postgres_slave.pp
+++ b/puppet/zulip_ops/manifests/postgres_slave.pp
@@ -2,7 +2,7 @@ class zulip_ops::postgres_slave {
   include zulip_ops::base
   include zulip_ops::postgres_appdb
 
-  file { "/var/lib/postgresql/${zulip::base::postgres_version}/main/recovery.conf":
+  file { "${zulip::postgres_appdb_base::postgres_confdir}/recovery.conf":
     ensure  => file,
     require => Package["postgresql-${zulip::base::postgres_version}"],
     owner   => 'postgres',


### PR DESCRIPTION
Split out a few pieces of postgres config into `zulip::postgres_appdb_base` and use them consistently in the `erb` files.  Make sure we make parent directories before making the postgres config file that is inside them.

**Testing Plan:** No-op applied on `postgres2`
