### PR TITLE
puppet: Stop distributing recovery.conf file.

### DIFF
--- a/puppet/zulip_ops/files/postgresql/recovery.conf
+++ b/puppet/zulip_ops/files/postgresql/recovery.conf
@@ -1,3 +1,0 @@
-standby_mode = on
-primary_conninfo = 'host=postgres3.zulipchat.net user=replicator'
-restore_command = '/usr/local/bin/env-wal-g wal-fetch "%f" "%p"'

--- a/puppet/zulip_ops/manifests/postgres_slave.pp
+++ b/puppet/zulip_ops/manifests/postgres_slave.pp
@@ -2,14 +2,6 @@ class zulip_ops::postgres_slave {
   include zulip_ops::base
   include zulip_ops::postgres_appdb
 
-  file { "${zulip::postgres_appdb_base::postgres_confdir}/recovery.conf":
-    ensure  => file,
-    require => Package["postgresql-${zulip::base::postgres_version}"],
-    owner   => 'postgres',
-    group   => 'postgres',
-    mode    => '0644',
-    source  => 'puppet:///modules/zulip_ops/postgresql/recovery.conf',
-  }
   file { '/etc/sysctl.d/40-postgresql.conf':
     ensure => file,
     owner  => 'root',


### PR DESCRIPTION
This file controls streaming replication, and recovery using wal-g on
the secondary.  The `primary_conninfo` data needs to change on short
notice when database failover happens, in a way that is not suitable
for being controlled by puppet.

PostgreSQL 12, in fact, removes the use of the `recovery.conf` file[1];
the `primary_conninfo` and `restore_command` information goes into the
main `postgresql.conf` file, and the standby status is controlled by
the presence of absence of an empty `standby.signal` file.

Remove the puppet control of the `recovery.conf` file.

[1] https://pgstef.github.io/2018/11/26/postgresql12_preview_recovery_conf_disappears.html

**Testing Plan:** `git grep recovery.conf`