### PR TITLE
node_tests: Fix incorrect stub of discard button.

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -157,7 +157,7 @@ function createSaveButtons(subsection) {
     const stub_save_button_header = $(`#org-${subsection}`);
     const save_button_controls = $('.save-button-controls');
     const stub_save_button = $(`#org-submit-${subsection}`);
-    const stub_discard_button = $(`#org-submit-${subsection}`);
+    const stub_discard_button = $(`#org-discard-${subsection}`);
     const stub_save_button_text = $('.icon-button-text');
     stub_save_button_header.set_find_results(
         '.subsection-failed-status p', $('<failed status element>')


### PR DESCRIPTION
The discard button stub in createSaveButtons is set same
as that of save button. This isn't desired because it hides
the save button on running `change_save_button_sate` instead
of hiding discard button. It was previously working as we weren't
testing visibility of save button anywhere.


Made it `#org-discard-${subsection}` because we set the `id` as `id="org-discard-{{section_name}}` in `static/templates/settings/settings_save_discard_widget.hbs`.

**Testing Plan:** <!-- How have you tested? -->
https://circleci.com/gh/chdinesh1089/zulip/tree/discard_button_stub

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
