### PR TITLE
openapi: Fix documentation of narrow parameter

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4646,19 +4646,20 @@ components:
       name: narrow
       in: query
       description: |
-        A JSON-encoded array of length 2 indicating the narrow for which you'd
-        like to receive events for. For instance, to receive events for the
-        stream `Denmark`, you would specify `narrow=['stream', 'Denmark']`.
-        Another example is `narrow=['is', 'private']` for private messages.
+        A JSON-encoded array of arrays of length 2 indicating the
+        narrow for which you'd like to receive events for. For
+        instance, to receive events for the stream `Denmark`, you
+        would specify `narrow=[['stream', 'Denmark']]`.  Another
+        example is `narrow=[['is', 'private']]` for private messages.
         Default is `[]`.
       schema:
         type: array
         items:
-          anyOf:
-          - type: string
-          - type: integer
+          type: array
+          items:
+            type: string
         default: []
-      example: ['stream', 'Denmark']
+      example: [['stream', 'Denmark']]
       required: false
     GroupId:
       name: group_id


### PR DESCRIPTION
The `narrow` parameter was incorrectly documented as a one-level array rather than an array of arrays, and the tests incorrectly expected this due to a combination of design and implementation bugs.