### PR TITLE
Do case-insensitive exact match for topic when editing topic.

### DIFF
--- a/zerver/lib/topic.py
+++ b/zerver/lib/topic.py
@@ -108,7 +108,7 @@ def update_messages_for_topic_edit(message: Message,
                                    orig_topic_name: str,
                                    topic_name: Optional[str],
                                    new_stream: Optional[Stream]) -> List[Message]:
-    propagate_query = Q(recipient = message.recipient, subject = orig_topic_name)
+    propagate_query = Q(recipient = message.recipient, subject__iexact = orig_topic_name)
     if propagate_mode == 'change_all':
         propagate_query = propagate_query & ~Q(id = message.id)
     if propagate_mode == 'change_later':

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -3417,10 +3417,10 @@ class EditMessageTest(ZulipTestCase):
         })
         self.assert_json_success(result)
 
-        self.check_topic(id1, topic_name="topic1")
+        self.check_topic(id1, topic_name="edited")
         self.check_topic(id2, topic_name="edited")
         self.check_topic(id3, topic_name="topiC1")
-        self.check_topic(id4, topic_name="toPic1")
+        self.check_topic(id4, topic_name="edited")
 
     def test_propagate_invalid(self) -> None:
         self.login('hamlet')

--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -3399,6 +3399,29 @@ class EditMessageTest(ZulipTestCase):
         self.check_topic(id5, topic_name="edited")
         self.check_topic(id6, topic_name="topic3")
 
+    def test_propagate_all_topics_with_different_uppercase_letters(self) -> None:
+        self.login('hamlet')
+        id1 = self.send_stream_message(self.example_user("hamlet"), "Scotland",
+                                       topic_name="topic1")
+        id2 = self.send_stream_message(self.example_user("hamlet"), "Scotland",
+                                       topic_name="Topic1")
+        id3 = self.send_stream_message(self.example_user("iago"), "Rome",
+                                       topic_name="topiC1")
+        id4 = self.send_stream_message(self.example_user("iago"), "Scotland",
+                                       topic_name="toPic1")
+
+        result = self.client_patch("/json/messages/" + str(id2), {
+            'message_id': id2,
+            'topic': 'edited',
+            'propagate_mode': 'change_all',
+        })
+        self.assert_json_success(result)
+
+        self.check_topic(id1, topic_name="topic1")
+        self.check_topic(id2, topic_name="edited")
+        self.check_topic(id3, topic_name="topiC1")
+        self.check_topic(id4, topic_name="toPic1")
+
     def test_propagate_invalid(self) -> None:
         self.login('hamlet')
         id1 = self.send_stream_message(self.example_user("hamlet"), "Scotland",


### PR DESCRIPTION
CI: https://app.circleci.com/pipelines/github/amanagr/zulip?branch=topic_lower
STATUS: 
![image](https://user-images.githubusercontent.com/25124304/84567309-743b5800-ad95-11ea-9622-dc3c004ca0c5.png)
