### PR TITLE
tools: Fix message-screenshot.js failing to take screenshot.

### DIFF
--- a/tools/message-screenshot.js
+++ b/tools/message-screenshot.js
@@ -36,9 +36,14 @@ async function run() {
         // deviceScaleFactor:2 gives better quality screenshots (higher pixel density)
         await page.setViewport({ width: 1280, height: 1024, deviceScaleFactor: 2 });
         await page.goto('http://' + host);
-        // wait for devlogin admin button and click on it
-        await page.waitForSelector('.btn-admin');
-        await page.click('.btn-admin');
+        // wait for Iago devlogin button and click on it.
+        await page.waitForSelector('[value="iago@zulip.com"]');
+
+        // By waiting till DOMContentLoaded we're confirming that Iago is logged in.
+        await Promise.all([
+            page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+            page.click('[value="iago@zulip.com"]'),
+        ]);
 
         // Navigate to message and capture screenshot
         await page.goto(`http://${host}/#narrow/near/${options.messageId}`);


### PR DESCRIPTION
To take screenshots, we log in as Desdemonia who doesn't seem
to have permissions to the streams where we capture screenshots.
This commit fixes it by logging in as Iago.

Also added a waitForNavigation until DOMContentLoaded to
avoid flakes that could occur because of us going to another URL
before Iago gets logged in.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
https://circleci.com/gh/chdinesh1089/zulip/tree/message-screenshot

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
