### PR TITLE
Avoid sending avatar URLs of long term idle users to clients

### DIFF
--- a/version.py
+++ b/version.py
@@ -29,7 +29,7 @@ DESKTOP_WARNING_VERSION = "5.2.0"
 #
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md.
-API_FEATURE_LEVEL = 13
+API_FEATURE_LEVEL = 14
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -505,8 +505,10 @@ def notify_created_user(user_profile: UserProfile) -> None:
     person = format_user_row(user_profile.realm, user_profile, user_row,
                              # Since we don't know what the client
                              # supports at this point in the code, we
-                             # just assume client_gravatar=False :(
+                             # just assume client_gravatar and
+                             # user_avatar_url_field_optional = False :(
                              client_gravatar=False,
+                             user_avatar_url_field_optional=False,
                              # We assume there's no custom profile
                              # field data for a new user; initial
                              # values are expected to be added in a

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -454,7 +454,7 @@ realm_user_dict_fields: List[str] = [
     'avatar_source', 'avatar_version', 'is_active',
     'role', 'is_bot', 'realm_id', 'timezone',
     'date_joined', 'bot_owner_id', 'delivery_email',
-    'bot_type',
+    'bot_type', 'long_term_idle'
 ]
 
 def realm_user_dicts_cache_key(realm_id: int) -> str:

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -88,6 +88,7 @@ def always_want(msg_type: str) -> bool:
 def fetch_initial_state_data(user_profile: UserProfile,
                              event_types: Optional[Iterable[str]],
                              queue_id: str, client_gravatar: bool,
+                             user_avatar_url_field_optional: bool,
                              slim_presence: bool = False,
                              include_subscribers: bool = True) -> Dict[str, Any]:
     state: Dict[str, Any] = {'queue_id': queue_id}
@@ -208,7 +209,8 @@ def fetch_initial_state_data(user_profile: UserProfile,
 
     if want('realm_user'):
         state['raw_users'] = get_raw_user_data(realm, user_profile,
-                                               client_gravatar=client_gravatar)
+                                               client_gravatar=client_gravatar,
+                                               user_avatar_url_field_optional=user_avatar_url_field_optional)
 
         # For the user's own avatar URL, we force
         # client_gravatar=False, since that saves some unnecessary
@@ -844,6 +846,7 @@ def do_events_register(user_profile: UserProfile, user_client: Client,
 
     notification_settings_null = client_capabilities.get('notification_settings_null', False)
     bulk_message_deletion = client_capabilities.get('bulk_message_deletion', False)
+    user_avatar_url_field_optional = client_capabilities.get('user_avatar_url_field_optional', False)
 
     if user_profile.realm.email_address_visibility != Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE:
         # If real email addresses are not available to the user, their
@@ -873,6 +876,7 @@ def do_events_register(user_profile: UserProfile, user_client: Client,
 
     ret = fetch_initial_state_data(user_profile, event_types_set, queue_id,
                                    client_gravatar=client_gravatar,
+                                   user_avatar_url_field_optional=user_avatar_url_field_optional,
                                    slim_presence=slim_presence,
                                    include_subscribers=include_subscribers)
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3121,6 +3121,14 @@ paths:
              in a loop.  New in Zulip 2.2 (feature level 13).  This
              capability is for backwards-compatibility; it will be
              required in a future server release.
+
+          * `user_avatar_url_field_optional`: Boolean for whether the
+             clients can compute avatar URLs of the users who are
+             unlikely to appear in messages using GET /avatar/{user_id}
+             endpoint. In such cases, the server will send None for the
+             `avatar_url` field. New in Zulip 2.2 (feature level 14).
+             This capability is for backward-compatibility; it will be
+             required in a future server release.
         schema:
           type: object
         example:

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -502,8 +502,8 @@ class EventsRegisterTest(ZulipTestCase):
 
     def do_test(self, action: Callable[[], object], event_types: Optional[List[str]]=None,
                 include_subscribers: bool=True, state_change_expected: bool=True,
-                notification_settings_null: bool=False,
-                client_gravatar: bool=True, slim_presence: bool=False,
+                notification_settings_null: bool=False, client_gravatar: bool=True,
+                user_avatar_url_field_optional: bool=False, slim_presence: bool=False,
                 num_events: int=1, bulk_message_deletion: bool=True) -> List[Dict[str, Any]]:
         '''
         Make sure we have a clean slate of client descriptors for these tests.
@@ -535,6 +535,7 @@ class EventsRegisterTest(ZulipTestCase):
         hybrid_state = fetch_initial_state_data(
             self.user_profile, event_types, "",
             client_gravatar=client_gravatar,
+            user_avatar_url_field_optional=user_avatar_url_field_optional,
             slim_presence=slim_presence,
             include_subscribers=include_subscribers,
         )
@@ -566,6 +567,7 @@ class EventsRegisterTest(ZulipTestCase):
         normal_state = fetch_initial_state_data(
             self.user_profile, event_types, "",
             client_gravatar=client_gravatar,
+            user_avatar_url_field_optional=user_avatar_url_field_optional,
             slim_presence=slim_presence,
             include_subscribers=include_subscribers,
         )
@@ -2052,7 +2054,7 @@ class EventsRegisterTest(ZulipTestCase):
     def test_realm_update_plan_type(self) -> None:
         realm = self.user_profile.realm
 
-        state_data = fetch_initial_state_data(self.user_profile, None, "", False)
+        state_data = fetch_initial_state_data(self.user_profile, None, "", False, False)
         self.assertEqual(state_data['realm_plan_type'], Realm.SELF_HOSTED)
         self.assertEqual(state_data['zulip_plan_is_not_limited'], True)
 
@@ -2069,7 +2071,7 @@ class EventsRegisterTest(ZulipTestCase):
         error = schema_checker('events[0]', events[0])
         self.assert_on_error(error)
 
-        state_data = fetch_initial_state_data(self.user_profile, None, "", False)
+        state_data = fetch_initial_state_data(self.user_profile, None, "", False, False)
         self.assertEqual(state_data['realm_plan_type'], Realm.LIMITED)
         self.assertEqual(state_data['zulip_plan_is_not_limited'], False)
 
@@ -2832,7 +2834,7 @@ class EventsRegisterTest(ZulipTestCase):
             lambda: do_delete_messages(self.user_profile.realm, [message]),
             state_change_expected=True,
         )
-        result = fetch_initial_state_data(user_profile, None, "", client_gravatar=False)
+        result = fetch_initial_state_data(user_profile, None, "", client_gravatar=False, user_avatar_url_field_optional=False)
         self.assertEqual(result['max_message_id'], -1)
 
     def test_add_attachment(self) -> None:
@@ -3055,7 +3057,7 @@ class FetchInitialStateDataTest(ZulipTestCase):
     def test_realm_bots_non_admin(self) -> None:
         user_profile = self.example_user('cordelia')
         self.assertFalse(user_profile.is_realm_admin)
-        result = fetch_initial_state_data(user_profile, None, "", client_gravatar=False)
+        result = fetch_initial_state_data(user_profile, None, "", client_gravatar=False, user_avatar_url_field_optional=False)
         self.assert_length(result['realm_bots'], 0)
 
         # additionally the API key for a random bot is not present in the data
@@ -3067,14 +3069,14 @@ class FetchInitialStateDataTest(ZulipTestCase):
         user_profile = self.example_user('hamlet')
         do_change_user_role(user_profile, UserProfile.ROLE_REALM_ADMINISTRATOR)
         self.assertTrue(user_profile.is_realm_admin)
-        result = fetch_initial_state_data(user_profile, None, "", client_gravatar=False)
+        result = fetch_initial_state_data(user_profile, None, "", client_gravatar=False, user_avatar_url_field_optional=False)
         self.assertTrue(len(result['realm_bots']) > 2)
 
     def test_max_message_id_with_no_history(self) -> None:
         user_profile = self.example_user('aaron')
         # Delete all historical messages for this user
         UserMessage.objects.filter(user_profile=user_profile).delete()
-        result = fetch_initial_state_data(user_profile, None, "", client_gravatar=False)
+        result = fetch_initial_state_data(user_profile, None, "", client_gravatar=False, user_avatar_url_field_optional=False)
         self.assertEqual(result['max_message_id'], -1)
 
     def test_delivery_email_presence_for_non_admins(self) -> None:
@@ -3083,13 +3085,13 @@ class FetchInitialStateDataTest(ZulipTestCase):
 
         do_set_realm_property(user_profile.realm, "email_address_visibility",
                               Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE)
-        result = fetch_initial_state_data(user_profile, None, "", client_gravatar=False)
+        result = fetch_initial_state_data(user_profile, None, "", client_gravatar=False, user_avatar_url_field_optional=False)
         for key, value in result['raw_users'].items():
             self.assertNotIn('delivery_email', value)
 
         do_set_realm_property(user_profile.realm, "email_address_visibility",
                               Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS)
-        result = fetch_initial_state_data(user_profile, None, "", client_gravatar=False)
+        result = fetch_initial_state_data(user_profile, None, "", client_gravatar=False, user_avatar_url_field_optional=False)
         for key, value in result['raw_users'].items():
             self.assertNotIn('delivery_email', value)
 
@@ -3099,16 +3101,62 @@ class FetchInitialStateDataTest(ZulipTestCase):
 
         do_set_realm_property(user_profile.realm, "email_address_visibility",
                               Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE)
-        result = fetch_initial_state_data(user_profile, None, "", client_gravatar=False)
+        result = fetch_initial_state_data(user_profile, None, "", client_gravatar=False, user_avatar_url_field_optional=False)
         for key, value in result['raw_users'].items():
             self.assertNotIn('delivery_email', value)
 
         do_set_realm_property(user_profile.realm, "email_address_visibility",
                               Realm.EMAIL_ADDRESS_VISIBILITY_ADMINS)
-        result = fetch_initial_state_data(user_profile, None, "", client_gravatar=False)
+        result = fetch_initial_state_data(user_profile, None, "", client_gravatar=False, user_avatar_url_field_optional=False)
         for key, value in result['raw_users'].items():
             self.assertIn('delivery_email', value)
 
+    def test_user_avatar_url_field_optional(self) -> None:
+        hamlet = self.example_user('hamlet')
+        users = [
+            self.example_user('iago'),
+            self.example_user('cordelia'),
+            self.example_user('ZOE'),
+            self.example_user('othello'),
+        ]
+
+        for user in users:
+            user.long_term_idle = True
+            user.save()
+
+        long_term_idle_users_ids = [user.id for user in users]
+
+        result = fetch_initial_state_data(user_profile=hamlet,
+                                          event_types=None,
+                                          queue_id='',
+                                          client_gravatar=False,
+                                          user_avatar_url_field_optional=True)
+
+        raw_users = result['raw_users']
+
+        for user_dict in raw_users.values():
+            if user_dict['user_id'] in long_term_idle_users_ids:
+                self.assertFalse('avatar_url' in user_dict)
+            else:
+                self.assertIsNotNone(user_dict['avatar_url'])
+
+        gravatar_users_id = [user_dict['user_id'] for user_dict in raw_users.values()
+                             if 'avatar_url' in user_dict and 'gravatar.com' in user_dict['avatar_url']]
+
+        # Test again with client_gravatar = True
+        result = fetch_initial_state_data(user_profile=hamlet,
+                                          event_types=None,
+                                          queue_id='',
+                                          client_gravatar=True,
+                                          user_avatar_url_field_optional=True)
+
+        raw_users = result['raw_users']
+
+        for user_dict in raw_users.values():
+            if user_dict['user_id'] in gravatar_users_id:
+                self.assertIsNone(user_dict['avatar_url'])
+            else:
+                self.assertFalse('avatar_url' in user_dict)
 
 class GetUnreadMsgsTest(ZulipTestCase):
     def mute_stream(self, user_profile: UserProfile, stream: Stream) -> None:
@@ -3822,6 +3870,7 @@ class FetchQueriesTest(ZulipTestCase):
                     event_types=None,
                     queue_id='x',
                     client_gravatar=False,
+                    user_avatar_url_field_optional=False
                 )
 
         self.assert_length(queries, 30)
@@ -3878,6 +3927,7 @@ class FetchQueriesTest(ZulipTestCase):
                     event_types=event_types,
                     queue_id='x',
                     client_gravatar=False,
+                    user_avatar_url_field_optional=False
                 )
             self.assert_length(queries, count)
 
@@ -3957,7 +4007,7 @@ class TestEventsRegisterNarrowDefaults(ZulipTestCase):
 
 class TestGetRawUserDataSystemBotRealm(ZulipTestCase):
     def test_get_raw_user_data_on_system_bot_realm(self) -> None:
-        result = get_raw_user_data(get_realm("zulipinternal"), self.example_user('hamlet'), True)
+        result = get_raw_user_data(get_realm("zulipinternal"), self.example_user('hamlet'), True, True)
 
         for bot_email in settings.CROSS_REALM_BOT_EMAILS:
             bot_profile = get_system_bot(bot_email)

--- a/zerver/views/events_register.py
+++ b/zerver/views/events_register.py
@@ -40,6 +40,7 @@ def events_register_backend(
         ], [
             # Any new fields of `client_capabilities` should be optional. Add them here.
             ("bulk_message_deletion", check_bool),
+            ('user_avatar_url_field_optional', check_bool),
         ]), default=None),
         event_types: Optional[Iterable[str]]=REQ(validator=check_list(check_string), default=None),
         fetch_event_types: Optional[Iterable[str]]=REQ(validator=check_list(check_string), default=None),

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -452,7 +452,7 @@ def get_members_backend(request: HttpRequest, user_profile: UserProfile, user_id
                                         allow_bots=True, read_only=True)
 
     members = get_raw_user_data(realm, user_profile, client_gravatar=client_gravatar,
-                                target_user=target_user,
+                                user_avatar_url_field_optional=False, target_user=target_user,
                                 include_custom_profile_fields=include_custom_profile_fields)
 
     if target_user is not None:
@@ -500,7 +500,9 @@ def create_user_backend(request: HttpRequest, user_profile: UserProfile,
 
 def get_profile_backend(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
     raw_user_data = get_raw_user_data(user_profile.realm, user_profile,
-                                      client_gravatar=False, target_user=user_profile)
+                                      client_gravatar=False,
+                                      user_avatar_url_field_optional=False,
+                                      target_user=user_profile)
     result: Dict[str, Any] = raw_user_data[user_profile.id]
 
     result['max_message_id'] = -1


### PR DESCRIPTION
This adds a new property `exclude_old_users_avatars` which is sent from clients to the server.

The purpose is to avoid sending avatar URLs of the long term idle users to the clients regardless of the `client_gravatar` value. This will reduce the user payload size even if email visibility is limited to admins.

This approach will be more efficient especially for realms with 10,000+ users like chat.zulip.org.

Fixes #15287.

Marked as WIP because this PR requires one more commit to enable this feature on the web client.