### PR TITLE
stream_header_colorblock: Create resuable css class.

### DIFF
--- a/static/styles/app_components.scss
+++ b/static/styles/app_components.scss
@@ -392,8 +392,7 @@
     }
 }
 
-.message_header_colorblock,
-.stream_header_colorblock {
+.stream-selection-header-colorblock {
     /* box-shadow: 0px 2px 3px hsl(0, 0%, 80%); */
     box-shadow: inset 0px 2px 1px -2px hsl(0, 0%, 20%), inset 2px 0px 1px -2px hsl(0, 0%, 20%), inset 0px -2px 1px -2px hsl(0, 0%, 20%);
     width: 10px;
@@ -402,6 +401,7 @@
 }
 
 .stream_header_colorblock {
+    @extend .stream-selection-header-colorblock;
     margin-bottom: 5px;
     z-index: 1000;
 }

--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -65,7 +65,7 @@
 }
 
 .compose_table {
-    .message_header_colorblock {
+    .stream-selection-header-colorblock {
         &.message_header_private_message {
             border-radius: 3px 0px 0px 3px;
             border-bottom: 0px;

--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -63,7 +63,7 @@
                     {{ csrf_input }}
                     <div class="compose_table">
                         <div id="stream-message">
-                            <div class="message_header_colorblock message_header_stream left_part"></div>
+                            <div class="stream-selection-header-colorblock message_header_stream left_part"></div>
                             <div class="right_part">
                                 <span id="compose-lock-icon">
                                     <i class="fa fa-lock" title="{{ _('This is a private stream') }}" aria-hidden="true"></i>


### PR DESCRIPTION
stream-selection-header-colorblock css class can now be used
to reproduce stream header color block everywhere.
