### PR TITLE
zerver_tests: Use validate_against_openapi_schema in testing.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -62,6 +62,7 @@ from zerver.models import (
     get_user,
     get_user_by_delivery_email,
 )
+from zerver.openapi.openapi import validate_against_openapi_schema
 from zerver.tornado.event_queue import clear_client_event_queues_for_testing
 from zilencer.models import get_remote_server_by_uuid
 
@@ -152,7 +153,14 @@ class ZulipTestCase(TestCase):
         encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
-        return django_client.patch(url, encoded, **kwargs)
+        result = django_client.patch(url, encoded, **kwargs)
+        if (url.startswith("/json") or url.startswith("/api/v1")):
+            content = ujson.loads(result.content)
+            url = re.sub(r"\?.*", "", url)
+            validate_against_openapi_schema(content,
+                                            url.replace("/json/", "/").replace("/api/v1/", "/"),
+                                            "patch", str(result.status_code))
+        return result
 
     @instrument_url
     def client_patch_multipart(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
@@ -167,11 +175,18 @@ class ZulipTestCase(TestCase):
         encoded = encode_multipart(BOUNDARY, info)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
-        return django_client.patch(
+        result = django_client.patch(
             url,
             encoded,
             content_type=MULTIPART_CONTENT,
             **kwargs)
+        if (url.startswith("/json") or url.startswith("/api/v1")):
+            content = ujson.loads(result.content)
+            url = re.sub(r"\?.*", "", url)
+            validate_against_openapi_schema(content,
+                                            url.replace("/json/", "/").replace("/api/v1/", "/"),
+                                            "patch", str(result.status_code))
+        return result
 
     @instrument_url
     def client_put(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
@@ -185,7 +200,14 @@ class ZulipTestCase(TestCase):
         encoded = urllib.parse.urlencode(info)
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
-        return django_client.delete(url, encoded, **kwargs)
+        result = django_client.delete(url, encoded, **kwargs)
+        if (url.startswith("/json") or url.startswith("/api/v1")):
+            content = ujson.loads(result.content)
+            url = re.sub(r"\?.*", "", url)
+            validate_against_openapi_schema(content,
+                                            url.replace("/json/", "/").replace("/api/v1/", "/"),
+                                            "delete", str(result.status_code))
+        return result
 
     @instrument_url
     def client_options(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
@@ -205,7 +227,17 @@ class ZulipTestCase(TestCase):
     def client_post(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
-        return django_client.post(url, info, **kwargs)
+        result = django_client.post(url, info, **kwargs)
+        if (url.startswith("/json") or url.startswith("/api/v1")):
+            try:
+                content = ujson.loads(result.content)
+            except ValueError:
+                return result
+            url = re.sub(r"\?.*", "", url)
+            validate_against_openapi_schema(content,
+                                            url.replace("/json/", "/").replace("/api/v1/", "/"),
+                                            "post", str(result.status_code))
+        return result
 
     @instrument_url
     def client_post_request(self, url: str, req: Any) -> HttpResponse:
@@ -225,8 +257,17 @@ class ZulipTestCase(TestCase):
     def client_get(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
-        return django_client.get(url, info, **kwargs)
-
+        result = django_client.get(url, info, **kwargs)
+        if (url.startswith("/json") or url.startswith("/api/v1")):
+            try:
+                content = ujson.loads(result.content)
+            except ValueError:
+                return result
+            url = re.sub(r"\?.*", "", url)
+            validate_against_openapi_schema(content,
+                                            url.replace("/json/", "/").replace("/api/v1/", "/"),
+                                            "get", str(result.status_code))
+        return result
     example_user_map = dict(
         hamlet='hamlet@zulip.com',
         cordelia='cordelia@zulip.com',

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -1,6 +1,7 @@
 # Set of helper functions to manipulate the OpenAPI files that define our REST
 # API's specification.
 import os
+import re
 from typing import Any, Dict, List, Optional, Set
 
 OPENAPI_SPEC_PATH = os.path.abspath(os.path.join(
@@ -13,21 +14,63 @@ OPENAPI_SPEC_PATH = os.path.abspath(os.path.join(
 EXCLUDE_PROPERTIES = {
     '/register': {
         'post': {
-            '200': ['max_message_id', 'realm_emoji'],
+            '200': ['max_message_id', 'realm_emoji', 'pointer'],
         },
     },
+    '/settings/notifications': {
+        'patch': {
+            # Extraneous key
+            '200': ['notification_sound', 'enable_login_emails',
+                    'enable_stream_desktop_notifications', 'wildcard_mentions_notify',
+                    'pm_content_in_desktop_notifications', 'desktop_icon_count_display',
+                    'realm_name_in_notifications', 'presence_enabled'],
+        },
+    },
+
     '/zulip-outgoing-webhook': {
         'post': {
             '200': ['result', 'msg', 'message'],
         },
     },
+    '/users/me': {
+        'get': {
+            # Extraneous key
+            '200': ['delivery_email'],
+        },
+    },
+    '/users/{user_id}': {
+        'get': {
+            # Extraneous key
+            '200': ['delivery_email'],
+        },
+        'delete': {
+            # Extraneous key
+            '200': ['delivery_email'],
+        }
+    },
+    '/fetch_api_key': {
+        'post': {
+            # Required key not present in response
+            '200': ['email'],
+        }
+    },
+    '/messages': {
+        'post': {
+            '200': ['deliver_at'],
+        }
+    }
 }
-
+# If we want to exclude the endpoint entirely we just write the
+# endpoint in EXCLUDE_ENDPOINTS else we can write ENDPOINT:METHOD
+# if we just want to skip a single method of that endpoint
+EXCLUDE_ENDPOINTS = ["/users/me/presence", "/messages/matches_narrow",
+                     "/realm/emoji/{emoji_name}:delete"]
 class OpenAPISpec():
     def __init__(self, path: str) -> None:
         self.path = path
         self.last_update: Optional[float] = None
-        self.data: Optional[Dict[str, Any]] = None
+        self.data: Dict[str, Any] = {}
+        self.regex_dict: Dict[str, str] = {}
 
     def reload(self) -> None:
         # Because importing yamole (and in turn, yaml) takes
@@ -45,6 +88,15 @@ class OpenAPISpec():
             yaml_parser = YamoleParser(f)
 
         self.data = yaml_parser.data
+        self.regex_dict = {}
+        for keys in self.data['paths']:
+            if '{' not in keys:
+                continue
+            regex_key = '^' + keys + '$'
+            regex_key = re.sub(r'{[^}]*}', r'[^\/]*', regex_key)
+            regex_key = regex_key.replace(r'/', r'\/')
+            regex_key = fr'{regex_key}'
+            self.regex_dict[regex_key] = keys
         self.last_update = os.path.getmtime(self.path)
 
     def spec(self) -> Dict[str, Any]:
@@ -56,8 +108,21 @@ class OpenAPISpec():
         # earlier version than the current one
         if self.last_update != last_modified:
             self.reload()
-        assert(self.data)
+        assert(len(self.data))
         return self.data
+
+    def regex_keys(self) -> Dict[str, str]:
+        """Reload the OpenAPI file if it has been modified after the last time
+        it was read, and then return the parsed data.
+        """
+        last_modified = os.path.getmtime(self.path)
+        # Using != rather than < to cover the corner case of users placing an
+        # earlier version than the current one
+        if self.last_update != last_modified:
+            self.reload()
+        assert(len(self.regex_dict))
+        return self.regex_dict
+
 
 class SchemaError(Exception):
     pass
@@ -65,6 +130,12 @@ class SchemaError(Exception):
 openapi_spec = OpenAPISpec(OPENAPI_SPEC_PATH)
 
 def get_schema(endpoint: str, method: str, response: str) -> Dict[str, Any]:
+    if len(response) == 3 and ('oneOf' in (openapi_spec.spec())['paths'][endpoint]
+                               [method.lower()]['responses'][response]['content']
+                               ['application/json']['schema']):
+        # Currently at places where multiple schemas are defined they only
+        # differ in example so either can be used.
+        response += '_0'
     if len(response) == 3:
         schema = (openapi_spec.spec()['paths'][endpoint][method.lower()]['responses']
                   [response]['content']['application/json']['schema'])
@@ -117,28 +188,51 @@ def get_openapi_return_values(endpoint: str, method: str,
     response = response['properties']
     return response
 
-exclusion_list: List[str] = []
-
 def validate_against_openapi_schema(content: Dict[str, Any], endpoint: str,
                                     method: str, response: str) -> None:
     """Compare a "content" dict with the defined schema for a specific method
     in an endpoint.
     """
+    if endpoint in EXCLUDE_ENDPOINTS:
+        return
+    # Collision between /users/me/subscriptions/{id} and /users/{id}/subscripitions/{id}
+    if endpoint.startswith('/users/me/subscriptions/'):
+        return
+    # No 500 responses have been documented, so skip them
+    if response.startswith('5'):
+        return
+    if endpoint not in openapi_spec.spec()['paths'].keys():
+        match: bool = False
+        for keys in openapi_spec.regex_keys():
+            matches = re.match(fr'{keys}', endpoint)
+            if matches:
+                match = True
+                endpoint = openapi_spec.regex_keys()[keys]
+                break
+        # If it doesn't match it hasn't been documented yet.
+        if not match:
+            return
+    if endpoint + ':' + method in EXCLUDE_ENDPOINTS:
+        return
+
     # Check if the response matches its code
     if response.startswith('2') and (content.get('result', 'success').lower() != 'success'):
         raise SchemaError("Response is not 200 but is validating against 200 schema")
-    global exclusion_list
-    schema = get_schema(endpoint, method, response)
     # In a single response schema we do not have two keys with the same name.
     # Hence exclusion list is declared globally
-    exclusion_list = (EXCLUDE_PROPERTIES.get(endpoint, {}).get(method, {}).get(response, []))
+    exclusion_list = (EXCLUDE_PROPERTIES.get(endpoint, {}).get(method.lower(), {}).get(response, []))
     # Code is not declared but appears in various 400 responses. If common, it can be added
     # to 400 response schema
     if response.startswith('4'):
         exclusion_list.append('code')
-    validate_object(content, schema)
+        # This return statement should ideally be not here. But since we have not defined 400
+        # responses for various paths this has been added as all 400 have the same schema.
+        # When all 400 response have been defined this should be removed.
+        return
+    schema = get_schema(endpoint, method, response)
+    validate_object(content, schema, exclusion_list)
 
-def validate_array(content: List[Any], schema: Dict[str, Any]) -> None:
+def validate_array(content: List[Any], schema: Dict[str, Any], exclusion_list: List[str]) -> None:
     valid_types: List[type] = []
     if 'oneOf' in schema['items']:
         for valid_type in schema['items']['oneOf']:
@@ -153,7 +247,9 @@ def validate_array(content: List[Any], schema: Dict[str, Any]) -> None:
         # and arrays.
         if 'object' in valid_types:
             if 'oneOf' not in schema['items']:
-                validate_object(item, schema['items'])
+                if 'properties' not in schema['items']:
+                    raise SchemaError('Opaque object in array')
+                validate_object(item, schema['items'], exclusion_list)
             continue
         # If the object was not an opaque object then
         # the continue statement above should have
@@ -161,9 +257,9 @@ def validate_array(content: List[Any], schema: Dict[str, Any]) -> None:
         if type(item) is dict:
             raise SchemaError('Opaque object in array')
         if 'items' in schema['items']:
-            validate_array(item, schema['items'])
+            validate_array(item, schema['items'], exclusion_list)
 
-def validate_object(content: Dict[str, Any], schema: Dict[str, Any]) -> None:
+def validate_object(content: Dict[str, Any], schema: Dict[str, Any], exclusion_list: List[str]) -> None:
     for key, value in content.items():
         if key in exclusion_list:
             continue
@@ -186,18 +282,18 @@ def validate_object(content: Dict[str, Any], schema: Dict[str, Any]) -> None:
             raise SchemaError('Expected type {} for key "{}", but actually '
                               'got {}'.format(expected_type, key, actual_type))
         if expected_type is list:
-            validate_array(value, schema['properties'][key])
+            validate_array(value, schema['properties'][key], exclusion_list)
         if 'properties' in schema['properties'][key]:
-            validate_object(value, schema['properties'][key])
+            validate_object(value, schema['properties'][key], exclusion_list)
             continue
         if 'additionalProperties' in schema['properties'][key]:
             for child_keys in value:
                 if type(value[child_keys]) is list:
                     validate_array(value[child_keys],
-                                   schema['properties'][key]['additionalProperties'])
+                                   schema['properties'][key]['additionalProperties'], exclusion_list)
                     continue
                 validate_object(value[child_keys],
-                                schema['properties'][key]['additionalProperties'])
+                                schema['properties'][key]['additionalProperties'], exclusion_list)
             continue
         # If the object is not opaque then continue statements
         # will be executed above and this will be skipped

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -34,6 +34,7 @@ from zerver.openapi.openapi import (
     get_openapi_fixture,
     get_openapi_parameters,
     get_openapi_paths,
+    match_against_openapi_regex,
     openapi_spec,
     to_python_type,
     validate_against_openapi_schema,
@@ -1010,3 +1011,25 @@ class OpenAPIAttributesTest(ZulipTestCase):
                         continue
                     assert(validate_against_openapi_schema(response_schema['example'], path,
                                                            method, response))
+
+class OpenAPIRegexTest(ZulipTestCase):
+    def test_regex(self) -> None:
+        """
+        Calls a few documented  and undocumented endpoints and checks whether they
+        find a match or not.
+        """
+        # Some of the undocumentd endpoints which are very similar to
+        # some of the documented endpoints.
+        assert(match_against_openapi_regex('/users/me/presence') is None)
+        assert(match_against_openapi_regex('/users/me/subscriptions/23') is None)
+        assert(match_against_openapi_regex('/users/iago/subscriptions/23') is None)
+        assert(match_against_openapi_regex('/messages/matches_narrow') is None)
+        # Making sure documented endpoints are matched correctly.
+        assert(match_against_openapi_regex('/users/23/subscriptions/21') ==
+               '/users/{user_id}/subscriptions/{stream_id}')
+        assert(match_against_openapi_regex('/users/iago@zulip.com/presence') ==
+               '/users/{email}/presence')
+        assert(match_against_openapi_regex('/messages/23') ==
+               '/messages/{message_id}')
+        assert(match_against_openapi_regex('/realm/emoji/realm_emoji_1') ==
+               '/realm/emoji/{emoji_name}')

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -141,16 +141,18 @@ class OpenAPIToolsTest(ZulipTestCase):
                 },
             },
         }
-        good_content = {
-            'msg': '',
-            'result': 'success',
-            'foo': 'bar',
-        }
-        validate_against_openapi_schema(good_content,
-                                        TEST_ENDPOINT,
-                                        TEST_METHOD,
-                                        TEST_RESPONSE_SUCCESS)
-        openapi.EXCLUDE_PROPERTIES = exclude_properties
+        try:
+            good_content = {
+                'msg': '',
+                'result': 'success',
+                'foo': 'bar',
+            }
+            validate_against_openapi_schema(good_content,
+                                            TEST_ENDPOINT,
+                                            TEST_METHOD,
+                                            TEST_RESPONSE_SUCCESS)
+        finally:
+            openapi.EXCLUDE_PROPERTIES = exclude_properties
 
     def test_to_python_type(self) -> None:
         TYPES = {
@@ -1002,9 +1004,9 @@ class OpenAPIAttributesTest(ZulipTestCase):
                     if 'oneOf' in response_schema:
                         cnt = 0
                         for entry in response_schema['oneOf']:
-                            validate_against_openapi_schema(entry['example'], path,
-                                                            method, response + '_' + str(cnt))
+                            assert(validate_against_openapi_schema(entry['example'], path,
+                                                                   method, response + '_' + str(cnt)))
                             cnt += 1
                         continue
-                    validate_against_openapi_schema(response_schema['example'], path,
-                                                    method, response)
+                    assert(validate_against_openapi_schema(response_schema['example'], path,
+                                                           method, response))

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -133,6 +133,7 @@ class OpenAPIToolsTest(ZulipTestCase):
                                         TEST_RESPONSE_SUCCESS)
 
         # Overwrite the exception list with a mocked one
+        exclude_properties = openapi.EXCLUDE_PROPERTIES
         openapi.EXCLUDE_PROPERTIES = {
             TEST_ENDPOINT: {
                 TEST_METHOD: {
@@ -149,6 +150,7 @@ class OpenAPIToolsTest(ZulipTestCase):
                                         TEST_ENDPOINT,
                                         TEST_METHOD,
                                         TEST_RESPONSE_SUCCESS)
+        openapi.EXCLUDE_PROPERTIES = exclude_properties
 
     def test_to_python_type(self) -> None:
         TYPES = {


### PR DESCRIPTION
This fixes #15340 .
Currently the API responses in zerver tests are not validated.
Add validation for these responses as discussed in #15340.
For the core problems mentioned in the issue:

1. A exclusion list is already present in openapi.py and while
   creating this commit I added some values to it. Also if the
   url does not match any known urls then it is skipped.

2. I created a regex based system for matching urls to their
   zulip.yaml endpoints. I have checked for collisions and
   added all such cases to skipping.

3. Currently the places where multiple schemas are defined differ
   only in example not the schema, so this is not a problem right
   now.

EDIT: There are now zero collisions.