### PR TITLE
migrations: Escape more pedantically in pgroonga.0001_enable

### DIFF
--- a/pgroonga/migrations/0003_v2_api_upgrade.py
+++ b/pgroonga/migrations/0003_v2_api_upgrade.py
@@ -11,24 +11,28 @@ class Migration(migrations.Migration):
 
     database_setting = settings.DATABASES["default"]
     operations = [
-        migrations.RunSQL(["""
-ALTER ROLE %(USER)s SET search_path TO %(SCHEMA)s,public;
+        migrations.RunSQL([("""
+DO $$BEGIN
+EXECUTE format('ALTER ROLE %%I SET search_path TO %%L,public', %(USER)s, %(SCHEMA)s);
 
 SET search_path = %(SCHEMA)s,public;
 
 DROP INDEX zerver_message_search_pgroonga;
-""" % database_setting, """
+END$$
+""", database_setting), """
 
 CREATE INDEX CONCURRENTLY zerver_message_search_pgroonga ON zerver_message
   USING pgroonga(search_pgroonga pgroonga_text_full_text_search_ops_v2);
 """],
-                          ["""
-ALTER ROLE %(USER)s SET search_path TO %(SCHEMA)s,public,pgroonga,pg_catalog;
+                          [("""
+DO $$BEGIN
+EXECUTE format('ALTER ROLE %%I SET search_path TO %%L,public,pgroonga,pg_catalog', %(USER)s, %(SCHEMA)s);
 
 SET search_path = %(SCHEMA)s,public,pgroonga,pg_catalog;
 
 DROP INDEX zerver_message_search_pgroonga;
-""" % database_setting, """
+END$$
+""", database_setting), """
 
 CREATE INDEX CONCURRENTLY zerver_message_search_pgroonga ON zerver_message
   USING pgroonga(search_pgroonga pgroonga.text_full_text_search_ops);

--- a/tools/semgrep.yml
+++ b/tools/semgrep.yml
@@ -74,6 +74,8 @@ rules:
       - pattern: psycopg2.sql.SQL(... .format(...))
       - pattern: django.db.migrations.RunSQL(..., ... % ..., ...)
       - pattern: django.db.migrations.RunSQL(..., "..." .format(...), ...)
+      - pattern: django.db.migrations.RunSQL(..., [..., ... % ..., ...], ...)
+      - pattern: django.db.migrations.RunSQL(..., [..., "..." .format(...), ...], ...)
     severity: ERROR
     message: "Do not write a SQL injection vulnerability please"
 

--- a/tools/semgrep.yml
+++ b/tools/semgrep.yml
@@ -72,6 +72,8 @@ rules:
       - pattern: ... .execute("...".format(...))
       - pattern: psycopg2.sql.SQL(... % ...)
       - pattern: psycopg2.sql.SQL(... .format(...))
+      - pattern: django.db.migrations.RunSQL(..., ... % ..., ...)
+      - pattern: django.db.migrations.RunSQL(..., "..." .format(...), ...)
     severity: ERROR
     message: "Do not write a SQL injection vulnerability please"
 


### PR DESCRIPTION
The `psycopg2.SQL` API unfortunately doesn’t work with `django.db.migrations.RunSQL`, so we need to take a detour into PL/pgSQL for `EXECUTE` and `format`.

**Testing Plan:** The forward path at least is used by `rebuild-test-database`.