### PR TITLE
emails: Add a custom header specifying the organization when possible.

### DIFF
--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -313,7 +313,8 @@ class ZulipPasswordResetForm(PasswordResetForm):
             send_email('zerver/emails/password_reset', to_emails=[email],
                        from_name=FromAddress.security_email_from_name(language=language),
                        from_address=FromAddress.tokenized_no_reply_address(),
-                       language=language, context=context)
+                       language=language, context=context,
+                       realm=realm)
 
 class RateLimitedPasswordResetByEmail(RateLimitedObject):
     def __init__(self, email: str) -> None:

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -994,7 +994,8 @@ def do_start_email_change_process(user_profile: UserProfile, new_email: str) -> 
     send_email('zerver/emails/confirm_new_email', to_emails=[new_email],
                from_name=FromAddress.security_email_from_name(language=language),
                from_address=FromAddress.tokenized_no_reply_address(),
-               language=language, context=context)
+               language=language, context=context,
+               realm=user_profile.realm)
 
 def compute_irc_user_fullname(email: str) -> str:
     return email.split("@")[0] + " (IRC)"
@@ -5077,7 +5078,8 @@ def do_send_confirmation_email(invitee: PreregistrationUser,
     from_name = f"{referrer.full_name} (via Zulip)"
     send_email('zerver/emails/invitation', to_emails=[invitee.email], from_name=from_name,
                from_address=FromAddress.tokenized_no_reply_address(),
-               language=referrer.realm.default_language, context=context)
+               language=referrer.realm.default_language, context=context,
+               realm=referrer.realm)
     return activation_url
 
 def email_not_system_bot(email: str) -> None:

--- a/zerver/tests/test_email_change.py
+++ b/zerver/tests/test_email_change.py
@@ -108,6 +108,8 @@ class EmailChangeTestCase(ZulipTestCase):
             fr"^Zulip Account Security <{self.TOKENIZED_NOREPLY_REGEX}>\Z",
         )
 
+        self.assertEqual(email_message.extra_headers["List-Id"], "Zulip Dev <zulip.testserver>")
+
         activation_url = [s for s in body.split('\n') if s][2]
         response = self.client_get(activation_url)
 

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -251,6 +251,8 @@ class TestMissedMessages(ZulipTestCase):
         for text in verify_body_does_not_include:
             self.assertNotIn(text, self.normalize_string(msg.body))
 
+        self.assertEqual(msg.extra_headers["List-Id"], "Zulip Dev <zulip.testserver>")
+
     def _realm_name_in_missed_message_email_subject(self, realm_name_in_notifications: bool) -> None:
         msg_id = self.send_personal_message(
             self.example_user('othello'),

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -476,10 +476,12 @@ def prepare_activation_url(email: str, request: HttpRequest,
         request.session['confirmation_key'] = {'confirmation_key': activation_url.split('/')[-1]}
     return activation_url
 
-def send_confirm_registration_email(email: str, activation_url: str, language: str) -> None:
+def send_confirm_registration_email(email: str, activation_url: str, language: str,
+                                    realm: Optional[Realm]=None) -> None:
     send_email('zerver/emails/confirm_registration', to_emails=[email],
                from_address=FromAddress.tokenized_no_reply_address(),
-               language=language, context={'activate_url': activation_url})
+               language=language, context={'activate_url': activation_url},
+               realm=realm)
 
 def redirect_to_email_login_url(email: str) -> HttpResponseRedirect:
     login_url = reverse('django.contrib.auth.views.login')
@@ -556,7 +558,7 @@ def accounts_home(request: HttpRequest, multiuse_object_key: str="",
             activation_url = prepare_activation_url(email, request, streams=streams_to_subscribe,
                                                     invited_as=invited_as)
             try:
-                send_confirm_registration_email(email, activation_url, request.LANGUAGE_CODE)
+                send_confirm_registration_email(email, activation_url, request.LANGUAGE_CODE, realm=realm)
             except smtplib.SMTPException as e:
                 logging.error('Error in accounts_home: %s', str(e))
                 return HttpResponseRedirect("/config-error/smtp")

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -65,7 +65,8 @@ def confirm_email_change(request: HttpRequest, confirmation_key: str) -> HttpRes
     send_email('zerver/emails/notify_change_in_email', to_emails=[old_email],
                from_name=FromAddress.security_email_from_name(user_profile=user_profile),
                from_address=FromAddress.SUPPORT, language=language,
-               context=context)
+               context=context,
+               realm=user_profile.realm)
 
     ctx = {
         'new_email': new_email,


### PR DESCRIPTION
Closes #15135.

Not sure if this is the right place to put addition of the header, but this way it'll cover all emails where it is viable, without needing to plumb through some kind of `set_organization_header` argument through multiple functions and worrying in setting in all the right email-sending codepaths.

Tested manually in production, by inspecting the headers of the email my server sent to me.
```
...
Date: Sun, 14 Jun 2020 12:08:41 -0000
Message-ID: <159213652145.6636.6569303924278563511@instance-1.us-central1-a.c.sonic-totem-257122.internal>
X-Zulip-Organization: myrealm1
....
```