### PR TITLE
webhooks/circleci: Add support for super minimal payloads.

### DIFF
--- a/zerver/webhooks/circleci/fixtures/super_minimal_payload.json
+++ b/zerver/webhooks/circleci/fixtures/super_minimal_payload.json
@@ -1,0 +1,9 @@
+{
+    "payload": {
+        "branch": "master",
+        "reponame": "zulip",
+        "status": "failed",
+        "build_url": "https:\/\/circleci.com\/gh\/zulip\/zulip\/48056",
+        "username": "timabbott"
+    }
+}

--- a/zerver/webhooks/circleci/tests.py
+++ b/zerver/webhooks/circleci/tests.py
@@ -48,3 +48,8 @@ Build [#1420](https://circleci.com/gh/Hypro999/zulip/1420) of `bionic-production
 - **Committer:** Hemanth V. Alluri (Hypro999)
 """.strip()
         self.send_and_test_stream_message("github_bionic_production_install_cancelled", expected_topic, expected_message)
+
+    def test_super_minimal_payload(self) -> None:
+        expected_topic = "zulip"
+        expected_message = "[Build](https://circleci.com/gh/zulip/zulip/48056) triggered by timabbott on branch `master` has failed."
+        self.send_and_test_stream_message("super_minimal_payload", expected_topic, expected_message)

--- a/zerver/webhooks/circleci/view.py
+++ b/zerver/webhooks/circleci/view.py
@@ -99,9 +99,19 @@ def get_authors_and_committer_info(payload: Dict[str, Any]) -> str:
 
     return body
 
+def super_minimal_body(payload: Dict[str, Any]) -> str:
+    branch_name = payload["branch"]
+    status = payload["status"]
+    formatted_status = outcome_to_formatted_status_map.get(status, status)
+    build_url = payload["build_url"]
+    username = payload["username"]
+    return f"[Build]({build_url}) triggered by {username} on branch `{branch_name}` {formatted_status}."
 
 def get_body(payload: Dict[str, Any]) -> str:
-    build_num = payload["build_num"]
+    build_num = payload.get("build_num", None)
+    if not build_num:
+        return super_minimal_body(payload)
+
     build_url = payload["build_url"]
 
     outcome = payload["outcome"]


### PR DESCRIPTION
After merging PR #15355 we found that CircleCI may send super minimal payloads. This does not seem to depend on .circleci/config.yml since we received two different types of payloads off of the same configuration.

@timabbott pinging for review. Not much was really added so I think that it's just a matter of merging after the CI tests pass.