### PR TITLE
emoji_picker: Fix DOM race condition with offsets.

### DIFF
--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -585,7 +585,7 @@ exports.render_emoji_popover = function (elt, id) {
     };
     show_emoji_catalog();
 
-    refill_section_head_offsets(popover);
+    elt.ready(() => refill_section_head_offsets(popover));
     register_popover_events(popover);
 };
 


### PR DESCRIPTION
We need to wait for the DOM to be ready before we save the
section_head_offsets ... otherwise they can be off.

Fixes #15380.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
