### PR TITLE
Fix regression on unknown streams in navbar

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -1375,11 +1375,17 @@ run_test('navbar_helpers', () => {
         { operator: 'stream', operand: 'foo' },
         { operator: 'topic', operand: 'bar' },
     ];
+    // foo stream exists
     const stream_operator = [{ operator: 'stream', operand: 'foo'}];
     make_private_sub('psub', '22');
     const private_stream_operator = [{ operator: 'stream', operand: 'psub'}];
     make_web_public_sub('webPublicSub', '12'); // capitalized just to try be tricky and robust.
     const web_public_stream_operator = [{ operator: 'stream', operand: 'webPublicSub'}];
+    const non_existent_stream = [{ operator: 'stream', operand: 'Elephant' }];
+    const non_existent_stream_topic = [
+        { operator: 'stream', operand: 'Elephant' },
+        { operator: 'topic', operand: 'pink' },
+    ];
     const pm_with = [{ operator: 'pm-with', operand: 'joe@example.com'}];
     const group_pm = [{ operator: 'pm-with', operand: 'joe@example.com,STEVE@foo.com'}];
     const group_pm_including_missing_person = [{ operator: 'pm-with', operand: 'joe@example.com,STEVE@foo.com,sally@doesnotexist.com'}];
@@ -1440,6 +1446,20 @@ run_test('navbar_helpers', () => {
             icon: 'hashtag',
             title: 'Foo',
             redirect_url_with_search: '/#narrow/stream/42-Foo',
+        },
+        {
+            operator: non_existent_stream,
+            is_common_narrow: true,
+            icon: 'question-circle-o',
+            title: 'translated: Unknown stream',
+            redirect_url_with_search: '#',
+        },
+        {
+            operator: non_existent_stream_topic,
+            is_common_narrow: true,
+            icon: 'question-circle-o',
+            title: 'translated: Unknown stream',
+            redirect_url_with_search: '#',
         },
         {
             operator: private_stream_operator,

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -479,6 +479,10 @@ Filter.prototype = {
 
         // this comes first because it has 3 term_types but is not a "complex filter"
         if (_.isEqual(term_types, ['stream', 'topic', 'search'])) {
+            // if stream does not exist, redirect to All
+            if (!this._stream_params) {
+                return "#";
+            }
             return  '/#narrow/stream/' + stream_data.name_to_slug(this.operands('stream')[0]) + '/topic/' + this.operands('topic')[0];
         }
 
@@ -490,6 +494,10 @@ Filter.prototype = {
         if (term_types[1] === 'search') {
             switch (term_types[0]) {
             case 'stream':
+                // if stream does not exist, redirect to All
+                if (!this._stream_params) {
+                    return "#";
+                }
                 return  '/#narrow/stream/' + stream_data.name_to_slug(this.operands('stream')[0]);
             case 'is-private':
                 return  '/#narrow/is/private';
@@ -541,6 +549,9 @@ Filter.prototype = {
         case 'in-all':
             return 'home';
         case 'stream':
+            if (!this._stream_params) {
+                return 'question-circle-o';
+            }
             if (this._stream_params._is_stream_private) {
                 return 'lock';
             }
@@ -564,6 +575,9 @@ Filter.prototype = {
         const term_types = this.sorted_term_types();
         if (term_types.length === 3 && _.isEqual(term_types, ['stream', 'topic', 'search']) ||
             term_types.length === 2 && _.isEqual(term_types, ['stream', 'topic'])) {
+            if (!this._stream_params) {
+                return i18n.t('Unknown stream');
+            }
             return this._stream_params._stream_name;
         }
         if (term_types.length === 1 || term_types.length === 2 && term_types[1] === 'search') {
@@ -575,6 +589,9 @@ Filter.prototype = {
             case 'streams-public':
                 return i18n.t('Public stream messages in organization');
             case 'stream':
+                if (!this._stream_params) {
+                    return i18n.t('Unknown stream');
+                }
                 return this._stream_params._stream_name;
             case 'is-starred':
                 return i18n.t('Starred messages');

--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -10,7 +10,7 @@ function get_formatted_sub_count(current_stream) {
     let sub_count = get_sub_count(current_stream);
     if (sub_count >= 1000) {
         // parseInt() is used to floor the value of division to an integer
-        sub_count = parseInt(sub_count / 1000, 10) + "k";
+        sub_count = parseInt(sub_count / 1000, 10) + 'k';
     }
     return sub_count;
 }
@@ -19,7 +19,7 @@ function make_tab_data(filter) {
     const tab_data = {};
     if (filter === undefined) {
         return {
-            title: 'All messages',
+            title: i18n.t('All messages'),
             icon: 'home',
         };
     }
@@ -32,12 +32,15 @@ function make_tab_data(filter) {
             tab_data.rendered_narrow_description = current_stream.rendered_description;
             tab_data.sub_count = get_sub_count(current_stream);
             tab_data.formatted_sub_count = get_formatted_sub_count(current_stream);
+            // the "title" is passed as a variable and doesn't get translated (nor should it)
+            tab_data.sub_count_tooltip_text =
+            i18n.t("__count__ users are subscribed to #__title__", {count: tab_data.sub_count, title: tab_data.title});
             tab_data.stream_settings_link = "#streams/" + current_stream.stream_id + "/" + current_stream.name;
         } else {
-            tab_data.title = 'Unknown Stream';
+            tab_data.title = i18n.t('Unknown stream');
             tab_data.sub_count = '0';
             tab_data.formatted_sub_count = '0';
-            tab_data.rendered_narrow_description = "This stream does not exist or is private.";
+            tab_data.rendered_narrow_description = i18n.t("This stream does not exist or is private.");
         }
     }
     return tab_data;

--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -25,30 +25,31 @@ function make_tab_data(filter) {
     }
     tab_data.title = filter.get_title();
     tab_data.icon = filter.get_icon();
+    if (tab_data.icon === 'question-circle-o') {
+        tab_data.sub_count = '0';
+        tab_data.formatted_sub_count = '0';
+        tab_data.rendered_narrow_description = i18n.t("This stream does not exist or is private.");
+        return tab_data;
+    }
     if (['hashtag', 'lock', 'globe'].includes(tab_data.icon)) {
         const stream = filter.operands("stream")[0];
-        const current_stream  = stream_data.get_sub_by_name(stream);
-        if (current_stream) {
-            tab_data.rendered_narrow_description = current_stream.rendered_description;
-            tab_data.sub_count = get_sub_count(current_stream);
-            tab_data.formatted_sub_count = get_formatted_sub_count(current_stream);
-            // the "title" is passed as a variable and doesn't get translated (nor should it)
-            tab_data.sub_count_tooltip_text =
-            i18n.t("__count__ users are subscribed to #__title__", {count: tab_data.sub_count, title: tab_data.title});
-            tab_data.stream_settings_link = "#streams/" + current_stream.stream_id + "/" + current_stream.name;
-        } else {
-            tab_data.title = i18n.t('Unknown stream');
-            tab_data.sub_count = '0';
-            tab_data.formatted_sub_count = '0';
-            tab_data.rendered_narrow_description = i18n.t("This stream does not exist or is private.");
-        }
+        // We can rely on current_stream because if the stream doesn't
+        // exist then the "question-circle-o" case would case early exit.
+        const current_stream = stream_data.get_sub_by_name(stream);
+        tab_data.rendered_narrow_description = current_stream.rendered_description;
+        tab_data.sub_count = get_sub_count(current_stream);
+        tab_data.formatted_sub_count = get_formatted_sub_count(current_stream);
+        // the "title" is passed as a variable and doesn't get translated (nor should it)
+        tab_data.sub_count_tooltip_text =
+            i18n.t("__count__ users are subscribed to #__title__", { count: tab_data.sub_count, title: tab_data.title });
+        tab_data.stream_settings_link = "#streams/" + current_stream.stream_id + "/" + current_stream.name;
     }
     return tab_data;
 }
 
 exports.colorize_tab_bar = function () {
     const filter = narrow_state.filter();
-    if (filter === undefined || !filter.has_operator('stream')) {return;}
+    if (filter === undefined || !filter.has_operator('stream') || !filter._stream_params) {return;}
     const color_for_stream = stream_data.get_color(filter._stream_params._stream_name);
     const stream_light = colorspace.getHexColor(colorspace.getDecimalColor(color_for_stream));
     $("#tab_list .fa-hashtag").css('color', stream_light);

--- a/static/templates/tab_bar.hbs
+++ b/static/templates/tab_bar.hbs
@@ -10,7 +10,7 @@
         {{/if}}
     </span>
     {{#if sub_count}}
-        <span class="sub_count" data-toggle="tooltip" title="{{sub_count}} users are subscribed to #{{title}}"><i class="fa fa-user-o"></i>{{formatted_sub_count}}</span>
+        <span class="sub_count" data-toggle="tooltip" title="{{sub_count_tooltip_text}}"><i class="fa fa-user-o"></i>{{formatted_sub_count}}</span>
         {{#if rendered_narrow_description}}
         <span class="narrow_description rendered_markdown" data-toggle="tooltip">{{rendered_markdown rendered_narrow_description}}</span>
         {{else}}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This doubles down on "undefined" being an expected value for `_stream_params` (which will become the `sub` object in the future.)

**Testing Plan:** <!-- How have you tested? -->
Adds node tests to maintain coverage on `filter.js`

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![navbar-unknown-sub](https://user-images.githubusercontent.com/33805964/84704407-63e2d300-af77-11ea-8bc3-81e68b0b6b54.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
