### PR TITLE
Add support for setting message retention policy for individual streams.

### DIFF
--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -474,6 +474,7 @@ run_test('stream_settings', () => {
         invite_only: true,
         history_public_to_subscribers: true,
         stream_post_policy: stream_data.stream_post_policy_values.admins.code,
+        message_retention_days: 10,
     };
     stream_data.clear_subscriptions();
     stream_data.add_sub(cinnamon);
@@ -496,6 +497,7 @@ run_test('stream_settings', () => {
     assert.equal(sub_rows[0].history_public_to_subscribers, true);
     assert.equal(sub_rows[0].stream_post_policy ===
         stream_data.stream_post_policy_values.admins.code, true);
+    assert.equal(sub_rows[0].message_retention_days, 10);
 
     const sub = stream_data.get_sub('a');
     stream_data.update_stream_privacy(sub, {
@@ -503,11 +505,13 @@ run_test('stream_settings', () => {
         history_public_to_subscribers: false,
     });
     stream_data.update_stream_post_policy(sub, 1);
+    stream_data.update_message_retention_setting(sub, -1);
     stream_data.update_calculated_fields(sub);
     assert.equal(sub.invite_only, false);
     assert.equal(sub.history_public_to_subscribers, false);
     assert.equal(sub.stream_post_policy,
                  stream_data.stream_post_policy_values.everyone.code);
+    assert.equal(sub.message_retention_days, -1);
 
     // For guest user only retrieve subscribed streams
     sub_rows = stream_data.get_updated_unsorted_subs();

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -160,7 +160,7 @@ run_test('update_property', () => {
     // Test stream message_retention_days change event
     with_overrides(function (override) {
         global.with_stub(function (stub) {
-            override('stream_data.update_message_retention_setting', stub.f);
+            override('subs.update_message_retention_setting', stub.f);
             stream_events.update_property(1, 'message_retention_days', 20);
             const args = stub.get_args('sub', 'val');
             assert.equal(args.sub.stream_id, 1);

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -156,6 +156,17 @@ run_test('update_property', () => {
             assert.equal(args.val, stream_data.stream_post_policy_values.admins.code);
         });
     });
+
+    // Test stream message_retention_days change event
+    with_overrides(function (override) {
+        global.with_stub(function (stub) {
+            override('stream_data.update_message_retention_setting', stub.f);
+            stream_events.update_property(1, 'message_retention_days', 20);
+            const args = stub.get_args('sub', 'val');
+            assert.equal(args.sub.stream_id, 1);
+            assert.equal(args.val, 20);
+        });
+    });
 });
 
 run_test('marked_subscribed', () => {

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -169,6 +169,13 @@ function create_stream() {
 
     data.stream_post_policy = JSON.stringify(stream_post_policy);
 
+    let message_retention_selection = $('#stream_creation_form select[name=stream_message_retention_setting]').val();
+    if (message_retention_selection === "retain_for_period") {
+        message_retention_selection = parseInt($('#stream_creation_form input[name=stream-message-retention-days]').val(), 10);
+    }
+
+    data.message_retention_days = JSON.stringify(message_retention_selection);
+
     const announce = stream_data.realm_has_notifications_stream() &&
         $('#announce-new-stream input').prop('checked');
     data.announce = JSON.stringify(announce);
@@ -266,6 +273,8 @@ exports.show_new_stream_modal = function () {
     // Make the options default to the same each time:
     // public, "announce stream" on.
     $('#make-invite-only input:radio[value=public]').prop('checked', true);
+    $("#stream_creation_form .stream-message-retention-days-input").hide();
+    $("#stream_creation_form select[name=stream_message_retention_setting]").val("realm_default");
 
     if (stream_data.realm_has_notifications_stream()) {
         $('#announce-new-stream').show();

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -427,6 +427,10 @@ exports.update_stream_privacy = function (sub, values) {
     sub.history_public_to_subscribers = values.history_public_to_subscribers;
 };
 
+exports.update_message_retention_setting  = function (sub, message_retention_days) {
+    sub.message_retention_days = message_retention_days;
+};
+
 exports.receives_notifications = function (stream_name, notification_name) {
     const sub = exports.get_sub(stream_name);
     if (sub === undefined) {

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -63,6 +63,24 @@ exports.get_users_from_subscribers = function (subscribers) {
     });
 };
 
+exports.get_retention_policy_text_for_subscription_type = function (sub) {
+    let message_retention_days = sub.message_retention_days;
+    if ((page_params.realm_message_retention_days === -1 || page_params.realm_message_retention_days
+         === null) && (sub.message_retention_days === null || sub.message_retention_days === -1)) {
+        return;
+    }
+
+    if (sub.message_retention_days === -1) {
+        return i18n.t("Messages in this stream will be retained forever.");
+    }
+
+    if (message_retention_days === null)  {
+        message_retention_days = page_params.realm_message_retention_days;
+    }
+
+    return i18n.t("Messages in this stream will be automatically deleted after __retention_days__ days.", {retention_days: message_retention_days});
+};
+
 exports.get_display_text_for_realm_message_retention_setting = function () {
     const realm_message_retention_days = page_params.realm_message_retention_days;
     if (realm_message_retention_days === -1 || realm_message_retention_days === null) {
@@ -315,6 +333,7 @@ exports.show_settings_for = function (node) {
         sub: sub,
         settings: exports.stream_settings(sub),
         stream_post_policy_values: stream_data.stream_post_policy_values,
+        message_retention_text: exports.get_retention_policy_text_for_subscription_type(sub),
     });
     ui.get_content_element($('.subscriptions .right .settings')).html(html);
 

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -56,7 +56,7 @@ exports.update_property = function (stream_id, property, value, other_values) {
         subs.update_stream_post_policy(sub, value);
         break;
     case 'message_retention_days':
-        stream_data.update_message_retention_setting(sub, value);
+        subs.update_message_retention_setting(sub, value);
         break;
     default:
         blueslip.warn("Unexpected subscription property type", {property: property,

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -55,6 +55,9 @@ exports.update_property = function (stream_id, property, value, other_values) {
     case 'stream_post_policy':
         subs.update_stream_post_policy(sub, value);
         break;
+    case 'message_retention_days':
+        stream_data.update_message_retention_setting(sub, value);
+        break;
     default:
         blueslip.warn("Unexpected subscription property type", {property: property,
                                                                 value: value});

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -143,7 +143,11 @@ exports.update_stream_privacy_type_icon = function (sub) {
 
 exports.update_stream_subscription_type_text = function (sub) {
     const stream_settings = stream_edit.settings_for_sub(sub);
-    const html = render_subscription_type(sub);
+    const template_data = {
+        ...sub,
+        stream_post_policy_values: stream_data.stream_post_policy_values,
+    };
+    const html = render_subscription_type(template_data);
     if (stream_edit.is_sub_settings_active(sub)) {
         stream_settings.find('.subscription-type-text').expectOne().html(html);
     }

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -146,6 +146,7 @@ exports.update_stream_subscription_type_text = function (sub) {
     const template_data = {
         ...sub,
         stream_post_policy_values: stream_data.stream_post_policy_values,
+        message_retention_text: stream_edit.get_retention_policy_text_for_subscription_type(sub),
     };
     const html = render_subscription_type(template_data);
     if (stream_edit.is_sub_settings_active(sub)) {

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -586,6 +586,11 @@ exports.setup_page = function (callback) {
             is_admin: page_params.is_admin,
             stream_post_policy_values: stream_data.stream_post_policy_values,
             stream_post_policy: stream_data.stream_post_policy_values.everyone.code,
+            zulip_plan_is_not_limited: page_params.zulip_plan_is_not_limited,
+            realm_message_retention_setting:
+                stream_edit.get_display_text_for_realm_message_retention_setting,
+            upgrade_text_for_wide_organization_logo:
+                page_params.upgrade_text_for_wide_organization_logo,
         };
 
         const rendered = render_subscription_table_body(template_data);

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -192,6 +192,11 @@ exports.update_stream_post_policy = function (sub, new_value) {
     stream_ui_updates.update_stream_subscription_type_text(sub);
 };
 
+exports.update_message_retention_setting = function (sub, new_value) {
+    stream_data.update_message_retention_setting(sub, new_value);
+    stream_ui_updates.update_stream_subscription_type_text(sub);
+};
+
 exports.set_color = function (stream_id, color) {
     const sub = stream_data.get_sub_by_id(stream_id);
     stream_edit.set_stream_property(sub, 'color', color);

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -1061,6 +1061,20 @@ ul.grey-box {
                 margin-right: 5px;
             }
         }
+
+        input[type=text] {
+            width: 5ch;
+            text-align: right;
+        }
+
+        label.dropdown-title {
+            display: block;
+        }
+
+        select {
+            width: auto;
+            margin-bottom: 0px;
+        }
     }
 }
 

--- a/static/templates/stream_types.hbs
+++ b/static/templates/stream_types.hbs
@@ -31,4 +31,33 @@
         </label>
     </li>
     {{/each}}
+    {{#if is_admin}}
+    <h4>{{t "Message retention for stream" }}</h4>
+
+    {{> settings/upgrade_tip_widget}}
+
+    <li>
+        <div class="input-group inline-block">
+            <label for="stream_message_retention_setting" class="dropdown-title">{{t "Message retention period" }}</label>
+            <select name="stream_message_retention_setting"
+              class="stream_message_retention_setting" class="prop-element"
+              {{#unless zulip_plan_is_not_limited}}disabled{{/unless}}>
+                <option value="realm_default">{{t 'Use organization level settings '}}{{realm_message_retention_setting}} </option>
+                <option value="forever">{{t 'Retain forever' }}</option>
+                <option value="retain_for_period">{{t 'Retain for N days after posting' }}</option>
+            </select>
+
+            <div class="dependent-inline-block stream-message-retention-days-input">
+                <label class="inline-block">
+                    {{t 'N' }}:
+                </label>
+                <input type="text" autocomplete="off"
+                  name="stream-message-retention-days"
+                  class="stream-message-retention-days"
+                  value="{{ stream_message_retention_days }}"
+                  {{#unless zulip_plan_is_not_limited}}disabled{{/unless}}/>
+            </div>
+        </div>
+    </li>
+    {{/if}}
 </ul>

--- a/static/templates/subscription_settings.hbs
+++ b/static/templates/subscription_settings.hbs
@@ -35,7 +35,8 @@
         <div class="subscription-type">
             <div class="subscription-type-text">
                 {{> subscription_type
-                  stream_post_policy_values=../stream_post_policy_values}}
+                  stream_post_policy_values=../stream_post_policy_values
+                  message_retention_text=../message_retention_text}}
             </div>
             <a class="change-stream-privacy" {{#unless can_change_stream_permissions}}style="display: none;"{{/unless}}>[{{t "Change" }}]</a>
         </div>

--- a/static/templates/subscription_type.hbs
+++ b/static/templates/subscription_type.hbs
@@ -15,3 +15,4 @@
 {{else}}
 {{t 'All stream members can post.'}}
 {{/if}}
+{{message_retention_text}}

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -10,6 +10,14 @@ below features are supported.
 
 ## Changes in Zulip 2.2
 
+**Feature level 17**
+
+* [`GET users/me/subscriptions`](/api/get-subscribed-streams), [`GET /streams`]
+  (api/get-all-streams): Added `message_retention_days` to the Stream objects.
+* [`POST users/me/subscriptions`](/api/add-subscriptions), [`PATCH
+  streams/{stream_id}`](/api/update-stream): Added `message_retention_days`
+  parameter.
+
 **Feature level 16**
 
 * [`GET /users/me`]: Removed `pointer` from the response, as the

--- a/version.py
+++ b/version.py
@@ -29,7 +29,7 @@ DESKTOP_WARNING_VERSION = "5.2.0"
 #
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md.
-API_FEATURE_LEVEL = 16
+API_FEATURE_LEVEL = 17
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -3615,6 +3615,20 @@ def do_change_stream_description(stream: Stream, new_description: str) -> None:
     )
     send_event(stream.realm, event, can_access_stream_user_ids(stream))
 
+def do_change_stream_message_retention_days(stream: Stream, message_retention_days: Optional[int]=None) -> None:
+    stream.message_retention_days = message_retention_days
+    stream.save(update_fields=['message_retention_days'])
+
+    event = dict(
+        op="update",
+        type="stream",
+        property="message_retention_days",
+        value=message_retention_days,
+        stream_id=stream.id,
+        name=stream.name,
+    )
+    send_event(stream.realm, event, can_access_stream_user_ids(stream))
+
 def do_create_realm(string_id: str, name: str,
                     emails_restricted_to_domains: Optional[bool]=None) -> Realm:
     if Realm.objects.filter(string_id=string_id).exists():

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1507,8 +1507,6 @@ class Stream(models.Model):
     # * "realm" and "recipient" are not exposed to clients via the API.
     # * "date_created" should probably be added here, as it's useful information
     #   to subscribers.
-    # * message_retention_days should be added here once the feature is
-    #   complete.
     API_FIELDS = [
         "name",
         "id",
@@ -1519,6 +1517,7 @@ class Stream(models.Model):
         "stream_post_policy",
         "history_public_to_subscribers",
         "first_message_id",
+        "message_retention_days"
     ]
 
     @staticmethod

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2337,6 +2337,18 @@ paths:
 
                               **Changes**: New in Zulip 2.2, replacing the previous
                               `is_announcement_only` boolean.
+                          message_retention_days:
+                            type: integer
+                            nullable: true
+                            description: |
+                              Number of days for which messages of the stream are stored
+                              before being automatically deleted.
+
+                              A value of -1 means retain the messages of the stream forever
+                              and a null value means that the stream inherits the organizaton
+                              level setting.
+
+                              **Changes**: New in Zulip 2.2 (feature level 17).
                           history_public_to_subscribers:
                             type: boolean
                             description: |
@@ -2463,6 +2475,7 @@ paths:
         example: false
       - $ref: '#/components/parameters/HistoryPublicToSubscribers'
       - $ref: '#/components/parameters/StreamPostPolicy'
+      - $ref: '#/components/parameters/MessageRetentionDays'
       - name: announce
         in: query
         description: |
@@ -3813,6 +3826,18 @@ paths:
 
                               **Changes**: New in Zulip 2.2, replacing the previous
                               `is_announcement_only` boolean.
+                          message_retention_days:
+                            type: integer
+                            nullable: true
+                            description: |
+                              Number of days for which messages of the stream are stored
+                              before being automatically deleted.
+
+                              A value of -1 means retain the messages of the stream forever
+                              and a null value means that the stream inherits the organizaton
+                              level setting.
+
+                              **Changes**: New in Zulip 2.2 (feature level 17).
                           history_public_to_subscribers:
                             type: boolean
                             description: |
@@ -3988,6 +4013,7 @@ paths:
         required: false
       - $ref: '#/components/parameters/StreamPostPolicy'
       - $ref: '#/components/parameters/HistoryPublicToSubscribers'
+      - $ref: '#/components/parameters/MessageRetentionDays'
       responses:
         '200':
           description: Success.
@@ -4974,4 +5000,22 @@ components:
       schema:
         type: string
       example: '1f419'
+      required: false
+    MessageRetentionDays:
+      name: message_retention_days
+      in: query
+      description: |
+        Number of days for which messages sent to the stream will be stored
+        before being automatically deleted.  Accepts an integer or one of
+        these special string values-
+
+        * "realm_default" => Use the organization organization-level setting.
+        * "forever" => Retain messages forever.
+
+        **Changes**: New in Zulip 2.2 (feature level 17).
+      schema:
+        oneOf:
+          - type: string
+          - type: integer
+      example: '20'
       required: false

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -21,6 +21,7 @@ from zerver.lib.actions import (
     do_add_streams_to_default_stream_group,
     do_change_default_stream_group_description,
     do_change_default_stream_group_name,
+    do_change_plan_type,
     do_change_stream_post_policy,
     do_change_user_role,
     do_create_default_stream_group,
@@ -146,7 +147,8 @@ class TestCreateStreams(ZulipTestCase):
             [{"name": stream_name,
               "description": stream_description,
               "invite_only": True,
-              "stream_post_policy": Stream.STREAM_POST_POLICY_ADMINS}
+              "stream_post_policy": Stream.STREAM_POST_POLICY_ADMINS,
+              "message_retention_days": -1}
              for (stream_name, stream_description) in zip(stream_names, stream_descriptions)])
 
         self.assertEqual(len(new_streams), 3)
@@ -159,6 +161,7 @@ class TestCreateStreams(ZulipTestCase):
         for stream in new_streams:
             self.assertTrue(stream.invite_only)
             self.assertTrue(stream.stream_post_policy == Stream.STREAM_POST_POLICY_ADMINS)
+            self.assertTrue(stream.message_retention_days == -1)
 
         new_streams, existing_streams = create_streams_if_needed(
             realm,
@@ -855,6 +858,155 @@ class StreamAdminTest(ZulipTestCase):
             self.assert_json_success(result)
             stream = get_stream('stream_name1', user_profile.realm)
             self.assertEqual(stream.stream_post_policy, policy)
+
+    def test_change_stream_message_retention_days(self) -> None:
+        user_profile = self.example_user('desdemona')
+        self.login_user(user_profile)
+        realm = user_profile.realm
+        do_change_plan_type(realm, Realm.LIMITED)
+        stream = self.subscribe(user_profile, 'stream_name1')
+
+        result = self.client_patch(f'/json/streams/{stream.id}',
+                                   {'message_retention_days': ujson.dumps(2)})
+        self.assert_json_error(result, "Available on Zulip Standard. Upgrade to access.")
+
+        do_change_plan_type(realm, Realm.SELF_HOSTED)
+        events: List[Mapping[str, Any]] = []
+        with tornado_redirected_to_list(events):
+            result = self.client_patch(f'/json/streams/{stream.id}',
+                                       {'message_retention_days': ujson.dumps(2)})
+        self.assert_json_success(result)
+
+        event = events[0]['event']
+        self.assertEqual(event, dict(
+            op='update',
+            type='stream',
+            property='message_retention_days',
+            value=2,
+            stream_id=stream.id,
+            name='stream_name1',
+        ))
+        notified_user_ids = set(events[0]['users'])
+        stream = get_stream('stream_name1', realm)
+
+        self.assertEqual(notified_user_ids, set(active_non_guest_user_ids(realm.id)))
+        self.assertIn(user_profile.id, notified_user_ids)
+        self.assertIn(self.example_user('prospero').id, notified_user_ids)
+        self.assertNotIn(self.example_user('polonius').id, notified_user_ids)
+        self.assertEqual(stream.message_retention_days, 2)
+
+        events = []
+        with tornado_redirected_to_list(events):
+            result = self.client_patch(f'/json/streams/{stream.id}',
+                                       {'message_retention_days': ujson.dumps("forever")})
+        self.assert_json_success(result)
+        event = events[0]['event']
+        self.assertEqual(event, dict(
+            op='update',
+            type='stream',
+            property='message_retention_days',
+            value=-1,
+            stream_id=stream.id,
+            name='stream_name1',
+        ))
+        self.assert_json_success(result)
+        stream = get_stream('stream_name1', realm)
+        self.assertEqual(stream.message_retention_days, -1)
+
+        events = []
+        with tornado_redirected_to_list(events):
+            result = self.client_patch(f'/json/streams/{stream.id}',
+                                       {'message_retention_days': ujson.dumps("realm_default")})
+        self.assert_json_success(result)
+        event = events[0]['event']
+        self.assertEqual(event, dict(
+            op='update',
+            type='stream',
+            property='message_retention_days',
+            value=None,
+            stream_id=stream.id,
+            name='stream_name1',
+        ))
+        stream = get_stream('stream_name1', realm)
+        self.assertEqual(stream.message_retention_days, None)
+
+        result = self.client_patch(f'/json/streams/{stream.id}',
+                                   {'message_retention_days': ujson.dumps("invalid")})
+        self.assert_json_error(result, "Bad value for 'message_retention_days': invalid")
+
+        result = self.client_patch(f'/json/streams/{stream.id}',
+                                   {'message_retention_days': ujson.dumps(-1)})
+        self.assert_json_error(result, "Bad value for 'message_retention_days': -1")
+
+    def test_change_stream_message_retention_days_requires_realm_owner(self) -> None:
+        user_profile = self.example_user('iago')
+        self.login_user(user_profile)
+        realm = user_profile.realm
+        stream = self.subscribe(user_profile, 'stream_name1')
+
+        result = self.client_patch(f'/json/streams/{stream.id}',
+                                   {'message_retention_days': ujson.dumps(2)})
+        self.assert_json_error(result, "Must be an organization owner")
+
+        do_change_user_role(user_profile, UserProfile.ROLE_REALM_OWNER)
+        result = self.client_patch(f'/json/streams/{stream.id}',
+                                   {'message_retention_days': ujson.dumps(2)})
+        self.assert_json_success(result)
+        stream = get_stream('stream_name1', realm)
+        self.assertEqual(stream.message_retention_days, 2)
+
+    def test_stream_message_retention_days_on_stream_creation(self) -> None:
+        """
+        Only admins can create streams with message_retention_days
+        with value other than None.
+        """
+        admin = self.example_user('iago')
+
+        streams_raw = [{
+            'name': 'new_stream',
+            'message_retention_days': 10,
+        }]
+        with self.assertRaisesRegex(JsonableError, "User cannot create stream with this settings."):
+            list_to_streams(streams_raw, admin, autocreate=True)
+
+        streams_raw = [{
+            'name': 'new_stream',
+            'message_retention_days': -1,
+        }]
+        with self.assertRaisesRegex(JsonableError, "User cannot create stream with this settings."):
+            list_to_streams(streams_raw, admin, autocreate=True)
+
+        streams_raw = [{
+            'name': 'new_stream',
+            'message_retention_days': None,
+        }]
+        result = list_to_streams(streams_raw, admin, autocreate=True)
+        self.assert_length(result[0], 0)
+        self.assert_length(result[1], 1)
+        self.assertEqual(result[1][0].name, 'new_stream')
+        self.assertEqual(result[1][0].message_retention_days, None)
+
+        owner = self.example_user('desdemona')
+        realm = owner.realm
+        streams_raw = [
+            {'name': 'new_stream1',
+             'message_retention_days': 10},
+            {'name': 'new_stream2',
+             'message_retention_days': -1},
+        ]
+
+        do_change_plan_type(realm, Realm.LIMITED)
+        with self.assertRaisesRegex(JsonableError, "Available on Zulip Standard. Upgrade to access."):
+            list_to_streams(streams_raw, owner, autocreate=True)
+
+        do_change_plan_type(realm, Realm.SELF_HOSTED)
+        result = list_to_streams(streams_raw, owner, autocreate=True)
+        self.assert_length(result[0], 0)
+        self.assert_length(result[1], 2)
+        self.assertEqual(result[1][0].name, 'new_stream1')
+        self.assertEqual(result[1][0].message_retention_days, 10)
+        self.assertEqual(result[1][1].name, 'new_stream2')
+        self.assertEqual(result[1][1].message_retention_days, -1)
 
     def set_up_stream_for_deletion(self, stream_name: str, invite_only: bool=False,
                                    subscribed: bool=True) -> Stream:


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This adds support for setting message retention policy for individual streams.
Only admins are allowed to change it or set it while creating streams.



**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
While creating stream
![Screenshot (127)](https://user-images.githubusercontent.com/35494118/84709088-46b20280-af7f-11ea-9da5-57486c95e54f.png)

While updating stream permissions
![Screenshot (128)](https://user-images.githubusercontent.com/35494118/84709103-4ade2000-af7f-11ea-8b6c-50357246fbbd.png)




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
