### PR TITLE
puppet: Always use TLS certificates for postgres

### DIFF
--- a/puppet/zulip/manifests/postgres_appdb_tuned.pp
+++ b/puppet/zulip/manifests/postgres_appdb_tuned.pp
@@ -13,10 +13,6 @@ class zulip::postgres_appdb_tuned {
   $replication = zulipconf('postgresql', 'replication', undef)
   $listen_addresses = zulipconf('postgresql', 'listen_addresses', undef)
 
-  $ssl_cert_file = zulipconf('postgresql', 'ssl_cert_file', undef)
-  $ssl_key_file = zulipconf('postgresql', 'ssl_key_file', undef)
-  $ssl_ca_file = zulipconf('postgresql', 'ssl_ca_file', undef)
-
   file { $zulip::postgres_appdb_base::postgres_confdirs:
     ensure => directory,
     owner  => 'postgres',

--- a/puppet/zulip/templates/postgresql/10/postgresql.conf.centos.template.erb
+++ b/puppet/zulip/templates/postgresql/10/postgresql.conf.centos.template.erb
@@ -704,12 +704,6 @@ archive_command = '/usr/local/bin/env-wal-g wal-push %p'
 hot_standby = on
 <% end -%>
 
-<% if @ssl_cert_file != '' -%>
-ssl_cert_file = '<%= @ssl_cert_file %>'		# (change requires restart)
-<% end -%>
-<% if @ssl_key_file != '' -%>
-ssl_key_file = '<%= @ssl_key_file %>'		# (change requires restart)
-<% end -%>
-<% if @ssl_ca_file != '' -%>
-ssl_ca_file = '<%= @ssl_ca_file %>'		# (change requires restart)
-<% end -%>
+ssl_cert_file = '/etc/ssl/certs/server.crt'		# (change requires restart)
+ssl_key_file = '/etc/ssl/pricate/server.key'		# (change requires restart)
+ssl_ca_file = '/etc/ssl/certs/root.crt'		# (change requires restart)

--- a/puppet/zulip/templates/postgresql/10/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/10/postgresql.conf.template.erb
@@ -704,12 +704,6 @@ archive_command = '/usr/local/bin/env-wal-g wal-push %p'
 hot_standby = on
 <% end -%>
 
-<% if @ssl_cert_file != '' -%>
-ssl_cert_file = '<%= @ssl_cert_file %>'		# (change requires restart)
-<% end -%>
-<% if @ssl_key_file != '' -%>
-ssl_key_file = '<%= @ssl_key_file %>'		# (change requires restart)
-<% end -%>
-<% if @ssl_ca_file != '' -%>
-ssl_ca_file = '<%= @ssl_ca_file %>'		# (change requires restart)
-<% end -%>
+ssl_cert_file = '/etc/ssl/certs/server.crt'		# (change requires restart)
+ssl_key_file = '/etc/ssl/pricate/server.key'		# (change requires restart)
+ssl_ca_file = '/etc/ssl/certs/root.crt'		# (change requires restart)

--- a/puppet/zulip/templates/postgresql/11/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/11/postgresql.conf.template.erb
@@ -704,12 +704,6 @@ archive_command = '/usr/local/bin/env-wal-g wal-push %p'
 hot_standby = on
 <% end -%>
 
-<% if @ssl_cert_file != '' -%>
-ssl_cert_file = '<%= @ssl_cert_file %>'		# (change requires restart)
-<% end -%>
-<% if @ssl_key_file != '' -%>
-ssl_key_file = '<%= @ssl_key_file %>'		# (change requires restart)
-<% end -%>
-<% if @ssl_ca_file != '' -%>
-ssl_ca_file = '<%= @ssl_ca_file %>'		# (change requires restart)
-<% end -%>
+ssl_cert_file = '/etc/ssl/certs/server.crt'		# (change requires restart)
+ssl_key_file = '/etc/ssl/pricate/server.key'		# (change requires restart)
+ssl_ca_file = '/etc/ssl/certs/root.crt'		# (change requires restart)

--- a/puppet/zulip/templates/postgresql/12/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/12/postgresql.conf.template.erb
@@ -798,12 +798,6 @@ archive_command = '/usr/local/bin/env-wal-g wal-push %p'
 hot_standby = on
 <% end -%>
 
-<% if @ssl_cert_file != '' -%>
-ssl_cert_file = '<%= @ssl_cert_file %>'		# (change requires restart)
-<% end -%>
-<% if @ssl_key_file != '' -%>
-ssl_key_file = '<%= @ssl_key_file %>'		# (change requires restart)
-<% end -%>
-<% if @ssl_ca_file != '' -%>
-ssl_ca_file = '<%= @ssl_ca_file %>'		# (change requires restart)
-<% end -%>
+ssl_cert_file = '/etc/ssl/certs/server.crt'		# (change requires restart)
+ssl_key_file = '/etc/ssl/pricate/server.key'		# (change requires restart)
+ssl_ca_file = '/etc/ssl/certs/root.crt'		# (change requires restart)

--- a/puppet/zulip/templates/postgresql/9.5/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/9.5/postgresql.conf.template.erb
@@ -676,12 +676,6 @@ archive_command = '/usr/local/bin/env-wal-g wal-push %p'
 hot_standby = on
 <% end -%>
 
-<% if @ssl_cert_file != '' -%>
-ssl_cert_file = '<%= @ssl_cert_file %>'		# (change requires restart)
-<% end -%>
-<% if @ssl_key_file != '' -%>
-ssl_key_file = '<%= @ssl_key_file %>'		# (change requires restart)
-<% end -%>
-<% if @ssl_ca_file != '' -%>
-ssl_ca_file = '<%= @ssl_ca_file %>'		# (change requires restart)
-<% end -%>
+ssl_cert_file = '/etc/ssl/certs/server.crt'		# (change requires restart)
+ssl_key_file = '/etc/ssl/pricate/server.key'		# (change requires restart)
+ssl_ca_file = '/etc/ssl/certs/root.crt'		# (change requires restart)

--- a/puppet/zulip/templates/postgresql/9.6/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/9.6/postgresql.conf.template.erb
@@ -689,12 +689,6 @@ archive_command = '/usr/local/bin/env-wal-g wal-push %p'
 hot_standby = on
 <% end -%>
 
-<% if @ssl_cert_file != '' -%>
-ssl_cert_file = '<%= @ssl_cert_file %>'		# (change requires restart)
-<% end -%>
-<% if @ssl_key_file != '' -%>
-ssl_key_file = '<%= @ssl_key_file %>'		# (change requires restart)
-<% end -%>
-<% if @ssl_ca_file != '' -%>
-ssl_ca_file = '<%= @ssl_ca_file %>'		# (change requires restart)
-<% end -%>
+ssl_cert_file = '/etc/ssl/certs/server.crt'		# (change requires restart)
+ssl_key_file = '/etc/ssl/pricate/server.key'		# (change requires restart)
+ssl_ca_file = '/etc/ssl/certs/root.crt'		# (change requires restart)


### PR DESCRIPTION
TLS should never be optional.

**Testing Plan:** Inspection.  Remove the stanzas from `zulip.conf` post-deploy.
