### PR TITLE
provision: Install `crudini` for zulip.conf shell scripting.

### DIFF
--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -127,6 +127,7 @@ COMMON_DEPENDENCIES = [
     "curl",                 # Used for fetching PhantomJS as wget occasionally fails on redirects
     "moreutils",            # Used for sponge command
     "unzip",                # Needed for Slack import
+    "crudini",              # Used for shell tooling w/ zulip.conf
 
     # Puppeteer dependencies from here
     "gconf-service",


### PR DESCRIPTION
A few tools already use this, and it is part of server installation;
install it in development environments as well.

**Testing Plan:** `./tools/provision` inside Vagrant.
