### PR TITLE
api: Remove is_old_stream property from the stream objects.

### DIFF
--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -15,8 +15,9 @@ set_global('location', {
 zrequire('subs');
 
 set_global('$', global.make_zjquery());
-
-stream_data.update_calculated_fields = () => {};
+set_global('hash_util', {
+    by_stream_uri: () => {},
+});
 
 run_test('filter_table', () => {
     const stream_list = $(".streams-list");
@@ -39,7 +40,7 @@ run_test('filter_table', () => {
             stream_id: 1,
             description: 'Copenhagen',
             subscribers: {size: 1},
-            is_old_stream: false,
+            stream_weekly_traffic: null,
         },
         {
             elem: 'poland',
@@ -48,7 +49,6 @@ run_test('filter_table', () => {
             stream_id: 2,
             description: 'monday',
             subscribers: {size: 3},
-            is_old_stream: true,
             stream_weekly_traffic: 13,
         },
         {
@@ -58,7 +58,6 @@ run_test('filter_table', () => {
             stream_id: 3,
             description: 'college',
             subscribers: {size: 0},
-            is_old_stream: true,
             stream_weekly_traffic: 0,
         },
         {
@@ -68,7 +67,6 @@ run_test('filter_table', () => {
             stream_id: 4,
             description: 'programming lang',
             subscribers: {size: 2},
-            is_old_stream: true,
             stream_weekly_traffic: 6,
         },
         {
@@ -78,7 +76,6 @@ run_test('filter_table', () => {
             stream_id: 5,
             description: 'california town',
             subscribers: {size: 2},
-            is_old_stream: true,
             stream_weekly_traffic: 6,
         },
     ];

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -461,6 +461,7 @@ exports.update_calculated_fields = function (sub) {
                                  !sub.invite_only;
     sub.preview_url = hash_util.by_stream_uri(sub.stream_id);
     sub.can_add_subscribers = !page_params.is_guest && (!sub.invite_only || sub.subscribed);
+    sub.is_old_stream = sub.stream_weekly_traffic !== null;
     if (sub.rendered_description !== undefined) {
         sub.rendered_description = sub.rendered_description.replace('<p>', '').replace('</p>', '');
     }

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -10,6 +10,12 @@ below features are supported.
 
 ## Changes in Zulip 2.2
 
+**Feature level 14**
+
+* [`GET users/me/subscriptions`](/api/get-subscribed-streams): Removed
+  `is_old_stream` field from the Stream objects. This field was
+  unnecessary and equivalent to `stream_weekly_traffic != null`.
+
 **Feature level 13**
 
 * [`POST /register`](/api/register-queue): Added

--- a/version.py
+++ b/version.py
@@ -29,7 +29,7 @@ DESKTOP_WARNING_VERSION = "5.2.0"
 #
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md.
-API_FEATURE_LEVEL = 13
+API_FEATURE_LEVEL = 14
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -522,7 +522,6 @@ def apply_event(state: Dict[str, Any],
                     if include_subscribers:
                         stream_data['subscribers'] = []
                     stream_data['stream_weekly_traffic'] = None
-                    stream_data['is_old_stream'] = False
                     stream_data['stream_post_policy'] = Stream.STREAM_POST_POLICY_EVERYONE
                     # Add stream to never_subscribed (if not invite_only)
                     state['never_subscribed'].append(stream_data)

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1501,7 +1501,7 @@ class Stream(models.Model):
     # * "deactivated" streams are filtered from the API entirely.
     # * "realm" and "recipient" are not exposed to clients via the API.
     # * "date_created" should probably be added here, as it's useful information
-    #   to subscribers and is needed to compute is_old_stream.
+    #   to subscribers.
     # * message_retention_days should be added here once the feature is
     #   complete.
     API_FIELDS = [

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2230,14 +2230,6 @@ paths:
                               Legacy property for if the given stream is muted, with inverted meeting.
 
                               **Deprecated**; clients should use is_muted where available.
-                          is_old_stream:
-                            type: boolean
-                            description: |
-                              Whether the stream is old enough to have data in
-                              `stream_weekly_traffic`.
-
-                              **Deprecated**: To me removed.  Clients should simply check
-                              whether stream_weekly_traffic is null.
                           is_announcement_only:
                             type: boolean
                             description: |

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2578,7 +2578,6 @@ class EventsRegisterTest(ZulipTestCase):
             ('history_public_to_subscribers', check_bool),
             ('pin_to_top', check_bool),
             ('stream_weekly_traffic', check_none_or(check_int)),
-            ('is_old_stream', check_bool),
             ('wildcard_mentions_notify', check_none_or(check_bool)),
         ]
         if include_subscribers:


### PR DESCRIPTION
This commit removes is_old_stream property from the stream objects
returned by the API. This property was unnecessary and is essentially
equivalent to 'stream_weekly_traffic != null'.

We compute sub.is_old_stream in stream_data.update_calculated_fields
in frontend code and it is used to check whether we have a non-null
stream_weekly_traffic or not.

Fixes #15181.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
