### PR TITLE
auth: Change the "continue in browser" link in desktop flow end page.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -664,10 +664,10 @@ class DesktopFlowTestingLib(ZulipTestCase):
         desktop_data = soup.find("input", value=True)["value"]
         browser_url = soup.find("a", href=True)["href"]
 
+        self.assertEqual(browser_url, '/login/')
         decrypted_key = self.verify_desktop_data_and_return_key(desktop_data, desktop_flow_otp)
-        self.assertEqual(browser_url, f'http://zulip.testserver/accounts/login/subdomain/{decrypted_key}')
 
-        result = self.client_get(browser_url)
+        result = self.client_get(f'http://zulip.testserver/accounts/login/subdomain/{decrypted_key}')
         self.assertEqual(result.status_code, 302)
         realm = get_realm("zulip")
         user_profile = get_user_by_delivery_email(email, realm)

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -283,9 +283,9 @@ def finish_desktop_flow(request: HttpRequest, user_profile: UserProfile,
     key = bytes.fromhex(otp)
     iv = os.urandom(12)
     desktop_data = (iv + AESGCM(key).encrypt(iv, token.encode(), b"")).hex()
-    browser_url = user_profile.realm.uri + reverse('zerver.views.auth.log_into_subdomain', args=[token])
     context = {'desktop_data': desktop_data,
-               'browser_url': browser_url,
+               'browser_url': reverse('zerver.views.auth.login_page',
+                                      kwargs = {'template_name': 'zerver/login.html'}),
                'realm_icon_url': realm_icon_url(user_profile.realm)}
     return render(request, 'zerver/desktop_redirect.html', context=context)
 


### PR DESCRIPTION
As suggested by @andersk in https://github.com/zulip/zulip/issues/14828#issuecomment-623627319

Fixes #14828.
Giving the /subdomain/<token>/ url there could feel buggy if the user
ended up using the token in the desktop app, and then tried clicking the
"continue in browser" link - which had the same token that would now be
expired. It's sufficient to simply link to /login/ instead.
