### PR TITLE
upload.py: Support using non S3-providers.

### DIFF
--- a/zerver/lib/transfer.py
+++ b/zerver/lib/transfer.py
@@ -45,9 +45,8 @@ def transfer_message_files_to_s3(processes: int) -> None:
         file_path = os.path.join(settings.LOCAL_UPLOADS_DIR, "files", attachment.path_id)
         try:
             with open(file_path, 'rb') as f:
-                bucket_name = settings.S3_AUTH_UPLOADS_BUCKET
                 guessed_type = guess_type(attachment.file_name)[0]
-                upload_image_to_s3(bucket_name, attachment.path_id, guessed_type, attachment.owner, f.read())
+                upload_image_to_s3(s3backend.uploads_bucket, attachment.path_id, guessed_type, attachment.owner, f.read())
                 logging.info("Uploaded message file in path %s", file_path)
         except FileNotFoundError:  # nocoverage
             pass

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -32,14 +32,7 @@ from PIL.Image import DecompressionBombError
 from zerver.lib.avatar_hash import user_avatar_path
 from zerver.lib.exceptions import ErrorCode, JsonableError
 from zerver.lib.utils import generate_random_token
-from zerver.models import (
-    Attachment,
-    Message,
-    Realm,
-    RealmEmoji,
-    UserProfile,
-    get_user_profile_by_id,
-)
+from zerver.models import Attachment, Message, Realm, RealmEmoji, UserProfile
 
 DEFAULT_AVATAR_SIZE = 100
 MEDIUM_AVATAR_SIZE = 500
@@ -338,17 +331,6 @@ def get_signed_upload_url(path: str) -> str:
                                              'Key': path},
                                          ExpiresIn=SIGNED_UPLOAD_URL_DURATION,
                                          HttpMethod='GET')
-
-def get_realm_for_filename(path: str) -> Optional[int]:
-    session = boto3.Session(settings.S3_KEY, settings.S3_SECRET_KEY)
-    bucket = get_bucket(session, settings.S3_AUTH_UPLOADS_BUCKET)
-    key = bucket.Object(path)
-
-    try:
-        user_profile_id = key.metadata['user_profile_id']
-    except botocore.exceptions.ClientError:
-        return None
-    return get_user_profile_by_id(user_profile_id).realm_id
 
 class S3UploadBackend(ZulipUploadBackend):
     def __init__(self) -> None:

--- a/zerver/tests/test_upload.py
+++ b/zerver/tests/test_upload.py
@@ -53,7 +53,6 @@ from zerver.lib.upload import (
     delete_export_tarball,
     delete_message_image,
     exif_rotate,
-    get_realm_for_filename,
     resize_avatar,
     resize_emoji,
     sanitize_name,
@@ -1770,19 +1769,6 @@ class S3Test(ZulipTestCase):
             bucket.Object(avatar_original_image_path_id).load()
         with self.assertRaises(botocore.exceptions.ClientError):
             bucket.Object(avatar_medium_path_id).load()
-
-    @use_s3_backend
-    def test_get_realm_for_filename(self) -> None:
-        create_s3_buckets(settings.S3_AUTH_UPLOADS_BUCKET)
-
-        user_profile = self.example_user('hamlet')
-        uri = upload_message_file('dummy.txt', len(b'zulip!'), 'text/plain', b'zulip!', user_profile)
-        path_id = re.sub('/user_uploads/', '', uri)
-        self.assertEqual(user_profile.realm_id, get_realm_for_filename(path_id))
-
-    @use_s3_backend
-    def test_get_realm_for_filename_when_key_doesnt_exist(self) -> None:
-        self.assertIsNone(get_realm_for_filename('non-existent-file-path'))
 
     @use_s3_backend
     def test_upload_realm_icon_image(self) -> None:


### PR DESCRIPTION
With #14378, we regressed back to the state of that
prior to 7e0ea61b004ed12e653ed085d75c2508882862e2.

We fix this by getting our avatar bucket on
object initialization, and use the appropriate means
of gathering the network location for the urls.

Partially adresses #14484

Testing:
`tools/test-backend`

**No testing has been done with the S3 backend set up**
