### PR TITLE
logging: Fix the broken logging configuration for webhooks.

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -40,7 +40,6 @@ from zerver.lib.exceptions import (
     OrganizationOwnerRequired,
     UnexpectedWebhookEventType,
 )
-from zerver.lib.logging_util import log_to_file
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.rate_limiter import RateLimitedUser
 from zerver.lib.request import REQ, has_request_variables
@@ -62,12 +61,9 @@ else:  # nocoverage # Hack here basically to make impossible code paths compile
 
 ReturnT = TypeVar('ReturnT')
 
-webhook_logger = logging.getLogger("zulip.zerver.webhooks")
-log_to_file(webhook_logger, settings.API_KEY_ONLY_WEBHOOK_LOG_PATH)
-
-webhook_unexpected_events_logger = logging.getLogger("zulip.zerver.lib.webhooks.common")
-log_to_file(webhook_unexpected_events_logger,
-            settings.WEBHOOK_UNEXPECTED_EVENTS_LOG_PATH)
+# These loggers are configured in zproject/computed_settings.py:
+webhook_logger = logging.getLogger('zulip.zerver.webhooks')
+webhook_unexpected_events_logger = logging.getLogger('zulip.zerver.lib.webhooks.common')
 
 def cachify(method: Callable[..., ReturnT]) -> Callable[..., ReturnT]:
     dct: Dict[Tuple[Any, ...], ReturnT] = {}

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -718,6 +718,9 @@ LOGGING: Dict[str, Any] = {
         'default': {
             '()': 'zerver.lib.logging_util.ZulipFormatter',
         },
+        'webhooks': {
+            'format': '%(asctime)s %(levelname)-8s %(message)s',
+        },
     },
     'filters': {
         'ZulipLimiter': {
@@ -792,6 +795,18 @@ LOGGING: Dict[str, Any] = {
             'class': 'logging.handlers.WatchedFileHandler',
             'formatter': 'default',
             'filename': SLOW_QUERIES_LOG_PATH,
+        },
+        'webhook_errors_file': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.WatchedFileHandler',
+            'formatter': 'webhooks',
+            'filename': API_KEY_ONLY_WEBHOOK_LOG_PATH,
+        },
+        'webhook_unexpected_events_file': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.WatchedFileHandler',
+            'formatter': 'webhooks',
+            'filename': WEBHOOK_UNEXPECTED_EVENTS_LOG_PATH,
         },
     },
     'loggers': {
@@ -932,12 +947,12 @@ LOGGING: Dict[str, Any] = {
         },
         'zulip.zerver.lib.webhooks.common': {
             'level': 'DEBUG',
-            'handlers': ['file', 'errors_file'],
+            'handlers': ['file', 'errors_file', 'webhook_unexpected_events_file'],
             'propagate': False,
         },
         'zulip.zerver.webhooks': {
             'level': 'DEBUG',
-            'handlers': ['file', 'errors_file'],
+            'handlers': ['file', 'errors_file', 'webhook_errors_file'],
             'propagate': False,
         },
     },


### PR DESCRIPTION
The webhooks code relies on two special loggers one for errors in general and one for unexpected events.

These loggers were previously configured in a few lines of global scope code at the top of zerver/decorator.py using `log_to_file` and then stored in global variables.

This, for reasons I'm not entirely certain of, lead to issues where sometimes the loggers would not be configured with the extra handlers added via. `log_to_file` but rather only the loggers specified in the configuration dictionary in computed_settings.py. So by specifying all of the handlers for these loggers in computed_settings.py itself we can both fix this issue and keep our logging configuration cleaner (in just one easy to read dictionary).

Fixes #15391.

Part of the series of issues that need to be fixed for the Zulip 2.2 release. @timabbott FYI.