### PR TITLE
gitignore: Ignore the core file generated in dev environments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ package-lock.json
 
 /.dmypy.json
 
+core
+
 # Dockerfiles generated for CircleCI
 /tools/circleci/images
 


### PR DESCRIPTION
It keeps getting in the way...