### PR TITLE
unread_ops: Don't read messages when any overlay is open.

### DIFF
--- a/static/js/unread_ops.js
+++ b/static/js/unread_ops.js
@@ -83,7 +83,7 @@ exports.notify_server_message_read = function (message, options) {
 // If we ever materially change the algorithm for this function, we
 // may need to update notifications.received_messages as well.
 exports.process_visible = function () {
-    if (!notifications.window_has_focus()) {
+    if (overlays.is_active() || !notifications.window_has_focus()) {
         return;
     }
 


### PR DESCRIPTION
Messages are automatically marked read when all the messages in
the current narrow are visible. While this is handy, this is
should not happen when any of the overlays are open.