### PR TITLE
tests: Extend test_get_accounts_for_email.

### DIFF
--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -853,6 +853,14 @@ class UserProfileTest(ZulipTestCase):
         self.assert_length(accounts, 1)
         check_account_present_in_accounts(self.example_user("iago"), accounts)
 
+        # We verify that get_accounts_for_email don't return deactivated users accounts
+        user = self.example_user("hamlet")
+        do_deactivate_user(user)
+        email = self.example_email("hamlet")
+        accounts = get_accounts_for_email(email)
+        with self.assertRaises(AssertionError):
+            check_account_present_in_accounts(user, accounts)
+
     def test_get_source_profile(self) -> None:
         reset_emails_in_zulip_realm()
         iago = get_source_profile("iago@zulip.com", "zulip")


### PR DESCRIPTION
This adds is_active key in the list of dicts returned in
get_accounts_for_email function, and extends test_get_accounts_for_email
test function to check for active accounts
in check_account_present_in_accounts function.

Fixes #14807.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
