### PR TITLE
openapi_docs: Replace `argument` with `parameter`.

### DIFF
--- a/templates/zerver/api/add-emoji-reaction.md
+++ b/templates/zerver/api/add-emoji-reaction.md
@@ -15,7 +15,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 
 {generate_api_arguments_table|zulip.yaml|/messages/{message_id}/reactions:post}

--- a/templates/zerver/api/add-linkifiers.md
+++ b/templates/zerver/api/add-linkifiers.md
@@ -15,7 +15,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/realm/filters:post}
 

--- a/templates/zerver/api/add-subscriptions.md
+++ b/templates/zerver/api/add-subscriptions.md
@@ -32,7 +32,7 @@ zulip(config).then((client) => {
     client.users.me.subscriptions.add(meParams).then(console.log);
 
     // To subscribe another user to a stream, you may pass in
-    // the `principals` argument, like so:
+    // the `principals` parameter, like so:
     const anotherUserParams = {
         subscriptions: JSON.stringify([
             {'name': 'Verona'},
@@ -49,13 +49,13 @@ zulip(config).then((client) => {
 {generate_code_example(curl, include=["subscriptions"])|/users/me/subscriptions:post|example}
 
 To subscribe another user to a stream, you may pass in
-the `principals` argument, like so:
+the `principals` parameter, like so:
 
 {generate_code_example(curl, include=["subscriptions", "principals"])|/users/me/subscriptions:post|example}
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/users/me/subscriptions:post}
 

--- a/templates/zerver/api/create-stream.md
+++ b/templates/zerver/api/create-stream.md
@@ -3,5 +3,5 @@
 You can create a stream using Zulip's REST API by submitting a
 [subscribe](/api/add-subscriptions) request with a stream name that
 doesn't yet exist.  You can specify the initial configuration of the
-stream using the `invite_only` and `announce` arguments to that
+stream using the `invite_only` and `announce` parameters to that
 request.

--- a/templates/zerver/api/create-user-group.md
+++ b/templates/zerver/api/create-user-group.md
@@ -15,7 +15,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/user_groups/create:post}
 

--- a/templates/zerver/api/create-user.md
+++ b/templates/zerver/api/create-user.md
@@ -23,7 +23,7 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/users:post}
 

--- a/templates/zerver/api/deactivate-user.md
+++ b/templates/zerver/api/deactivate-user.md
@@ -17,7 +17,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/users/{user_id}:delete}
 

--- a/templates/zerver/api/delete-message.md
+++ b/templates/zerver/api/delete-message.md
@@ -17,7 +17,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/messages/{message_id}:delete}
 

--- a/templates/zerver/api/delete-queue.md
+++ b/templates/zerver/api/delete-queue.md
@@ -43,7 +43,7 @@ zulip(config).then((client) => {
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/events:delete}
 

--- a/templates/zerver/api/delete-stream.md
+++ b/templates/zerver/api/delete-stream.md
@@ -15,9 +15,9 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
-**Note**: The following arguments are all URL query parameters.
+**Note**: The following parameters are all URL query parameters.
 
 {generate_api_arguments_table|zulip.yaml|/streams/{stream_id}:delete}
 

--- a/templates/zerver/api/delete-user-group.md
+++ b/templates/zerver/api/delete-user-group.md
@@ -15,7 +15,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/user_groups/{group_id}:delete}
 

--- a/templates/zerver/api/dev-fetch-api-key.md
+++ b/templates/zerver/api/dev-fetch-api-key.md
@@ -11,7 +11,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/dev_fetch_api_key:post}
 

--- a/templates/zerver/api/get-all-streams.md
+++ b/templates/zerver/api/get-all-streams.md
@@ -38,9 +38,9 @@ as URL query parameters, like so:
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
-**Note**: The following arguments are all URL query parameters.
+**Note**: The following parameters are all URL query parameters.
 
 {generate_api_arguments_table|zulip.yaml|/streams:get}
 

--- a/templates/zerver/api/get-all-users.md
+++ b/templates/zerver/api/get-all-users.md
@@ -41,9 +41,9 @@ You may pass the `client_gravatar` query parameter as follows:
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
-**Note**: The following arguments are all URL query parameters.
+**Note**: The following parameters are all URL query parameters.
 
 {generate_api_arguments_table|zulip.yaml|/users:get}
 

--- a/templates/zerver/api/get-attachments.md
+++ b/templates/zerver/api/get-attachments.md
@@ -15,7 +15,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/attachments:get}
 

--- a/templates/zerver/api/get-events-from-queue.md
+++ b/templates/zerver/api/get-events-from-queue.md
@@ -18,7 +18,7 @@ client = zulip.Client(config_file="~/zuliprc")
 
 # If you already have a queue registered and thus, have a queue_id
 # on hand, you may use client.get_events() and pass in the above
-# arguments, like so:
+# parameters, like so:
 print(client.get_events(
     queue_id="1515010080:4",
     last_event_id=-1
@@ -63,13 +63,13 @@ zulip(config).then((client) => {
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/events:get}
 
-**Note**: The arguments documented above are optional in the sense that
+**Note**: The parameters documented above are optional in the sense that
 even if you haven't registered a queue by explicitly requesting the
-`{{ api_url}}/v1/register` endpoint, you could pass the arguments for
+`{{ api_url}}/v1/register` endpoint, you could pass the parameters for
 [the `{{ api_url}}/v1/register` endpoint](/api/register-queue) to this
 endpoint and a queue would be registered in the absence of a `queue_id`.
 

--- a/templates/zerver/api/get-message-history.md
+++ b/templates/zerver/api/get-message-history.md
@@ -15,7 +15,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/messages/{message_id}/history:get}
 

--- a/templates/zerver/api/get-messages.md
+++ b/templates/zerver/api/get-messages.md
@@ -40,7 +40,7 @@ zulip(config).then((client) => {
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/messages:get}
 

--- a/templates/zerver/api/get-org-emoji.md
+++ b/templates/zerver/api/get-org-emoji.md
@@ -31,7 +31,7 @@ zulip(config).then((client) => {
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/realm/emoji:get}
 

--- a/templates/zerver/api/get-presence.md
+++ b/templates/zerver/api/get-presence.md
@@ -15,7 +15,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/users/{email}/presence:get}
 

--- a/templates/zerver/api/get-profile.md
+++ b/templates/zerver/api/get-profile.md
@@ -33,9 +33,9 @@ zulip(config).then((client) => {
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
-This endpoint takes no arguments.
+This endpoint takes no parameters.
 
 ## Response
 

--- a/templates/zerver/api/get-raw-message.md
+++ b/templates/zerver/api/get-raw-message.md
@@ -15,7 +15,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/messages/{message_id}:get}
 

--- a/templates/zerver/api/get-stream-id.md
+++ b/templates/zerver/api/get-stream-id.md
@@ -32,9 +32,9 @@ zulip(config).then((client) => {
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
-**Note**: The following arguments are all URL query parameters.
+**Note**: The following parameters are all URL query parameters.
 
 {generate_api_arguments_table|zulip.yaml|/get_stream_id:get}
 

--- a/templates/zerver/api/get-stream-topics.md
+++ b/templates/zerver/api/get-stream-topics.md
@@ -33,7 +33,7 @@ zulip(config).then((client) => {
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/users/me/{stream_id}/topics:get}
 

--- a/templates/zerver/api/get-subscribed-streams.md
+++ b/templates/zerver/api/get-subscribed-streams.md
@@ -38,7 +38,7 @@ You may pass the `include_subscribers` query parameter as follows:
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/users/me/subscriptions:get}
 

--- a/templates/zerver/api/get-subscription-status.md
+++ b/templates/zerver/api/get-subscription-status.md
@@ -15,7 +15,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/users/{user_id}/subscriptions/{stream_id}:get}
 

--- a/templates/zerver/api/get-user-groups.md
+++ b/templates/zerver/api/get-user-groups.md
@@ -17,7 +17,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/user_groups:get}
 

--- a/templates/zerver/api/get-user.md
+++ b/templates/zerver/api/get-user.md
@@ -19,9 +19,9 @@ You may pass the `client_gravatar` or `include_custom_profile_fields` query para
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
-**Note**: The following arguments are all URL query parameters.
+**Note**: The following parameters are all URL query parameters.
 
 {generate_api_arguments_table|zulip.yaml|/users/{user_id}:get}
 

--- a/templates/zerver/api/list-linkifiers.md
+++ b/templates/zerver/api/list-linkifiers.md
@@ -15,7 +15,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/realm/filters:get}
 

--- a/templates/zerver/api/mark-as-read-bulk.md
+++ b/templates/zerver/api/mark-as-read-bulk.md
@@ -15,7 +15,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/mark_all_as_read:post}
 
@@ -47,7 +47,7 @@ Mark all the unread messages in a stream as read.
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/mark_stream_as_read:post}
 
@@ -79,7 +79,7 @@ Mark all the unread messages in a topic as read.
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/mark_topic_as_read:post}
 

--- a/templates/zerver/api/mute-topics.md
+++ b/templates/zerver/api/mute-topics.md
@@ -15,7 +15,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/users/me/subscriptions/muted_topics:patch}
 

--- a/templates/zerver/api/reactivate-user.md
+++ b/templates/zerver/api/reactivate-user.md
@@ -18,7 +18,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/users/{user_id}/reactivate:post}
 

--- a/templates/zerver/api/real-time-events.md
+++ b/templates/zerver/api/real-time-events.md
@@ -13,7 +13,7 @@ The simplest way to use Zulip's real-time events API is by using
 `call_on_each_event` from our Python bindings.  You just need to write
 a Python function (in the examples below, the `lambda`s) and pass it
 into `call_on_each_event`; your function will be called whenever a new
-event matching the specific `event_type` and/or `narrow` arguments
+event matching the specific `event_type` and/or `narrow` parameters
 occurs in Zulip.
 
 `call_on_each_event` takes care of all the potentially tricky details
@@ -50,7 +50,7 @@ client.call_on_each_event(lambda event: sys.stdout.write(str(event) + "\n"))
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 You may also pass in the following keyword arguments to `call_on_each_event`:
 

--- a/templates/zerver/api/register-queue.md
+++ b/templates/zerver/api/register-queue.md
@@ -32,7 +32,7 @@ browser reloading the Zulip webapp when your laptop comes back online
 after being offline for more than 10 minutes).
 
 When prototyping with this API, we recommend first calling `register`
-with no `event_types` argument to see all the available data from all
+with no `event_types` parameter to see all the available data from all
 supported event types.  Before using your client in production, you
 should set appropriate `event_types` and `fetch_event_types` filters
 so that your client only requests the data it needs.  A few minutes
@@ -79,7 +79,7 @@ zulip(config).then((client) => {
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/register:post}
 

--- a/templates/zerver/api/remove-emoji-reaction.md
+++ b/templates/zerver/api/remove-emoji-reaction.md
@@ -16,7 +16,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 
 {generate_api_arguments_table|zulip.yaml|/messages/{message_id}/reactions:delete}

--- a/templates/zerver/api/remove-linkifiers.md
+++ b/templates/zerver/api/remove-linkifiers.md
@@ -15,7 +15,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/realm/filters/{filter_id}:delete}
 

--- a/templates/zerver/api/remove-subscriptions.md
+++ b/templates/zerver/api/remove-subscriptions.md
@@ -40,7 +40,7 @@ zulip(config).then((client) => {
 
 {generate_code_example(curl, include=["subscriptions"])|/users/me/subscriptions:delete|example}
 
-You may specify the `principals` argument like so:
+You may specify the `principals` parameter like so:
 
 {generate_code_example(curl)|/users/me/subscriptions:delete|example}
 
@@ -49,7 +49,7 @@ administrative privileges.
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/users/me/subscriptions:delete}
 

--- a/templates/zerver/api/render-message.md
+++ b/templates/zerver/api/render-message.md
@@ -36,7 +36,7 @@ zulip(config).then((client) => {
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/messages/render:post}
 

--- a/templates/zerver/api/rest-error-handling.md
+++ b/templates/zerver/api/rest-error-handling.md
@@ -23,9 +23,9 @@ A typical failed JSON response for when the API key is invalid:
 
 {generate_code_example|/rest-error-handling:post|fixture(400_0)}
 
-## Missing request argument(s)
+## Missing request parameter(s)
 
-A typical failed JSON response for when a required request argument
+A typical failed JSON response for when a required request parameter
 is not supplied:
 
 {generate_code_example|/rest-error-handling:post|fixture(400_1)}

--- a/templates/zerver/api/send-message.md
+++ b/templates/zerver/api/send-message.md
@@ -62,12 +62,12 @@ zulip-send --stream Denmark --subject Castle \
     --user othello-bot@example.com --api-key a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5
 ```
 
-You can omit the `user` and `api-key` arguments if you have a `~/.zuliprc`
+You can omit the `user` and `api-key` parameters if you have a `~/.zuliprc`
 file.
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/messages:post}
 

--- a/templates/zerver/api/server-settings.md
+++ b/templates/zerver/api/server-settings.md
@@ -15,7 +15,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/server_settings:get}
 

--- a/templates/zerver/api/typing.md
+++ b/templates/zerver/api/typing.md
@@ -40,7 +40,7 @@ zulip(config).then((client) => {
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/typing:post}
 

--- a/templates/zerver/api/update-message-flags.md
+++ b/templates/zerver/api/update-message-flags.md
@@ -42,7 +42,7 @@ zulip(config).then((client) => {
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/messages/flags:post}
 

--- a/templates/zerver/api/update-message.md
+++ b/templates/zerver/api/update-message.md
@@ -45,7 +45,7 @@ You only have permission to edit a message if:
 2. This is a topic-only edit for a (no topic) message, **OR**:
 3. This is a topic-only edit and you are an admin.
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/messages/{message_id}:patch}
 

--- a/templates/zerver/api/update-notification-settings.md
+++ b/templates/zerver/api/update-notification-settings.md
@@ -15,7 +15,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/settings/notifications:patch}
 

--- a/templates/zerver/api/update-stream.md
+++ b/templates/zerver/api/update-stream.md
@@ -15,7 +15,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/streams/{stream_id}:patch}
 

--- a/templates/zerver/api/update-subscription-properties.md
+++ b/templates/zerver/api/update-subscription-properties.md
@@ -15,7 +15,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/users/me/subscriptions/properties:post}
 

--- a/templates/zerver/api/update-user-group.md
+++ b/templates/zerver/api/update-user-group.md
@@ -15,7 +15,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/user_groups/{group_id}:patch}
 

--- a/templates/zerver/api/update-user.md
+++ b/templates/zerver/api/update-user.md
@@ -17,7 +17,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 {generate_api_arguments_table|zulip.yaml|/users/{user_id}:patch}
 

--- a/templates/zerver/api/upload-custom-emoji.md
+++ b/templates/zerver/api/upload-custom-emoji.md
@@ -17,7 +17,7 @@
 {end_tabs}
 
 
-## Arguments
+## Parameters
 
 As described above, the image file to upload must be provided in the
 request's body.

--- a/templates/zerver/api/upload-file.md
+++ b/templates/zerver/api/upload-file.md
@@ -16,7 +16,7 @@
 
 {end_tabs}
 
-## Arguments
+## Parameters
 
 As described above, the file to upload must be provided in the
 request's body.

--- a/templates/zerver/api/writing-bots.md
+++ b/templates/zerver/api/writing-bots.md
@@ -132,7 +132,7 @@ Response: stream: followup topic: foo_sender@zulip.com
 
 ```
 
-Note that the `-b` (aka `--bot-config-file`) argument is for an optional third party
+Note that the `-b` (aka `--bot-config-file`) parameter is for an optional third party
 config file (e.g. ~/giphy.conf), which only applies to certain types of bots.
 
 ## Bot API
@@ -157,7 +157,7 @@ explicit recipient).
 
 is called to retrieve information about the bot.
 
-#### Arguments
+#### Parameters
 
 * self - the instance the method is called on.
 
@@ -184,7 +184,7 @@ def usage(self):
 
 handles user message.
 
-#### Arguments
+#### Parameters
 
 * self - the instance the method is called on.
 
@@ -220,7 +220,7 @@ will send a message as the bot user.  Generally, this is less
 convenient than *send_reply*, but it offers additional flexibility
 about where the message is sent to.
 
-#### Arguments
+#### Parameters
 
 * message - a dictionary describing the message to be sent by the bot
 
@@ -242,7 +242,7 @@ bot_handler.send_message(dict(
 will reply to the triggering message to the same place the original
 message was sent to, with the content of the reply being *response*.
 
-#### Arguments
+#### Parameters
 
 * message - Dictionary containing information on message to respond to
  (provided by `handle_message`).
@@ -254,7 +254,7 @@ message was sent to, with the content of the reply being *response*.
 
 will edit the content of a previously sent message.
 
-#### Arguments
+#### Parameters
 
 * message - dictionary defining what message to edit and the new content
 
@@ -297,7 +297,7 @@ automatically.
 
 will store the value `value` in the entry `key`.
 
-##### Arguments
+##### Parameters
 
 * key - a UTF-8 string
 * value - a UTF-8 string
@@ -314,7 +314,7 @@ bot_handler.storage.put("foo", "bar")  # set entry "foo" to "bar"
 
 will retrieve the value for the entry `key`.
 
-###### Arguments
+###### Parameters
 
 * key - a UTF-8 string
 
@@ -331,7 +331,7 @@ print(bot_handler.storage.get("foo"))  # print "bar"
 
 will check if the entry `key` exists.
 
-##### Arguments
+##### Parameters
 
 * key - a UTF-8 string
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2426,7 +2426,7 @@ paths:
 
         If any of the specified streams do not exist, they are automatically
         created, and configured using the `invite_only` setting specified in
-        the arguments (see below).
+        the parameters (see below).
       parameters:
       - name: subscriptions
         in: query
@@ -2438,7 +2438,7 @@ paths:
           appropriate value.
 
 
-          **Note**: This argument is called `streams` and not `subscriptions`
+          **Note**: This parameter is called `streams` and not `subscriptions`
           in our Python API."
         schema:
           type: array
@@ -2661,7 +2661,7 @@ paths:
       - name: subscriptions
         in: query
         description: |
-          A list of stream names to unsubscribe from. This argument is called
+          A list of stream names to unsubscribe from. This parameter is called
           `streams` in our Python API.
         schema:
           type: array
@@ -3210,10 +3210,10 @@ paths:
       - name: fetch_event_types
         in: query
         description: |
-          Same as the `event_types` argument except that the values in
+          Same as the `event_types` parameter except that the values in
           `fetch_event_types` are used to fetch initial data. If
           `fetch_event_types` is not provided, `event_types` is used and if
-          `event_types` is not provided, this argument defaults to `None`.
+          `event_types` is not provided, this parameter defaults to `None`.
         schema:
           type: array
           items:
@@ -4276,7 +4276,7 @@ paths:
                     }
   /real-time:
     # This entry is a hack; it exists to give us a place to put the text
-    # documenting the arguments for call_on_each_event and friends.
+    # documenting the parameters for call_on_each_event and friends.
     post:
       tags: ["real_time_events"]
       description: |
@@ -4676,7 +4676,7 @@ components:
           var_name:
             type: string
             description: |
-              It contains the information about the missing argument.
+              It contains the information about the missing parameter.
       - example:
           {
               "code": "REQUEST_VARIABLE_MISSING",
@@ -4721,7 +4721,7 @@ components:
           * **realm_user** (changes to users in the organization and
             their properties, such as their name).
 
-        If you do not specify this argument, you will receive all
+        If you do not specify this parameter, you will receive all
         events, and have to filter out the events not relevant to
         your client in your client code.  For most applications, one
         is only interested in messages, so one specifies:
@@ -4928,7 +4928,7 @@ components:
       description: |
         A list of user ids (preferred) or Zulip display email
         addresses of the users to be subscribed to or unsubscribed
-        from the streams specified in the `subscriptions` argument. If
+        from the streams specified in the `subscriptions` parameter. If
         not provided, then the requesting user/bot is subscribed.
 
         **Changes**: The integer format is new in Zulip 2.2 (Feature level 9).

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -120,7 +120,7 @@ class DocPageTest(ZulipTestCase):
         self._test('/api/get-events-from-queue', 'dont_block')
         self._test('/api/delete-queue', 'Delete a previously registered queue')
         self._test('/api/update-message', 'propagate_mode')
-        self._test('/api/get-profile', 'takes no arguments')
+        self._test('/api/get-profile', 'takes no parameters')
         self._test('/api/add-subscriptions', 'authorization_errors_fatal')
         self._test('/api/create-user', 'zuliprc-admin')
         self._test('/api/remove-subscriptions', 'not_removed')


### PR DESCRIPTION
`parameter` is a better word than `argument` for data passed to
API endpoint. Hence replace `argument` with `parameter` in the
API docs.

Fixes #15435 .