### PR TITLE
auth: Make apple log in and sign up buttons consistent with others.

### DIFF
--- a/static/styles/portico/portico-signin.scss
+++ b/static/styles/portico/portico-signin.scss
@@ -699,29 +699,6 @@ button.login-social-button {
     }
 }
 
-/*
-Apple is very particular about the appearance of its authentication
-buttons, which means we cannot use our generic label+icon system for
-their authentication backend while complying with their policies.
-
-So here we use the buttons provided by Apple, which include the sign
-in text (Sign in with Apple/Continue with Apple).  To make these
-consistent with other buttons, we request buttons of size 328x50 and
-the following styling sets the appropriate width and height to make it
-fit with other other social authentication buttons.  We also set the
-font size to zero to hide the text our own code in the
-login/registration pages would generate, to avoid extra conditionals
-in the HTML templates.
-*/
-button#login_auth_button_apple,
-button#register_auth_button_apple {
-    width: 328px;
-    height: 50px;
-    background-size: auto 100%;
-    background-position: 0px 100%;
-    font-size: 0px;
-}
-
 #find-account-section {
     text-decoration: none;
     font-weight: 600;

--- a/static/styles/portico/portico-signin.scss
+++ b/static/styles/portico/portico-signin.scss
@@ -682,6 +682,13 @@ button.login-social-button {
     }
 }
 
+button#login_auth_button_gitlab,
+button#register_auth_button_gitlab {
+    // GitLab icon size looks a bit inconsistent with others. This fixes it.
+    background-size: auto 90%;
+    background-position-x: 3px;
+}
+
 .login-page-container .right-side .actions,
 .back-to-login-wrapper {
     margin: 20px 0px 0px;

--- a/templates/zerver/accounts_home.html
+++ b/templates/zerver/accounts_home.html
@@ -78,8 +78,7 @@ page can be easily identified in it's respective JavaScript file -->
                             <form class="form-inline" action="{{ backend.signup_url }}" method="get">
                                 <input type='hidden' name='multiuse_object_key' value='{{ multiuse_object_key }}' />
                                 <button id="register_{{ backend.button_id_suffix }}" class="login-social-button full-width"
-                                  {% if backend.display_name == "Apple" %} style="background-image:url(https://appleid.cdn-apple.com/appleid/button/?width=328&height=50&color=white&locale={{ apple_locale }}&type=continue)"
-                              {% elif backend.display_icon %} style="background-image:url({{ backend.display_icon }})"  {% endif %}>
+                                  {% if backend.display_icon %} style="background-image:url({{ backend.display_icon }})"  {% endif %}>
                                     {{ _('Sign up with %(identity_provider)s', identity_provider=backend.display_name) }}
                                 </button>
                             </form>

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -114,9 +114,7 @@ page can be easily identified in it's respective JavaScript file. -->
                         <form class="social_login_form form-inline" action="{{ backend.login_url }}" method="get">
                             <input type="hidden" name="next" value="{{ next }}">
                             <button id="login_{{ backend.button_id_suffix }}" class="login-social-button"
-                              {% if backend.display_name == "Apple" %} style="background-image: url(https://appleid.cdn-apple.com/appleid/button/?width=328&height=50&color=white&locale={{ apple_locale }});"
-                          {% elif backend.display_icon %} style="background-image:url({{ backend.display_icon }})"  {% endif %}>
-                                {{ _('Log in with %(identity_provider)s', identity_provider=backend.display_name) }}
+                              {% if backend.display_icon %} style="background-image:url({{ backend.display_icon }})"  {% endif %}>                                {{ _('Log in with %(identity_provider)s', identity_provider=backend.display_name) }}
                             </button>
                         </form>
                     </div>

--- a/zerver/context_processors.py
+++ b/zerver/context_processors.py
@@ -18,7 +18,6 @@ from zerver.lib.subdomains import get_subdomain
 from zerver.models import Realm, UserProfile, get_realm
 from zproject.backends import (
     AUTH_BACKEND_NAME_MAP,
-    AppleAuthBackend,
     any_social_backend_enabled,
     auth_enabled_helper,
     get_external_method_dicts,
@@ -168,7 +167,6 @@ def login_context(request: HttpRequest) -> Dict[str, Any]:
         'password_auth_enabled': password_auth_enabled(realm),
         'any_social_backend_enabled': any_social_backend_enabled(realm),
         'two_factor_authentication_enabled': settings.TWO_FACTOR_AUTHENTICATION_ENABLED,
-        'apple_locale': AppleAuthBackend.get_apple_locale(request.LANGUAGE_CODE),
     }
 
     if realm is not None and realm.description:

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -2017,25 +2017,6 @@ class AppleIdAuthBackendTest(AppleAuthMixin, SocialAuthBase):
         with self.settings(AUTHENTICATION_BACKENDS=('zproject.backends.AppleAuthBackend',)):
             self.assertTrue(apple_auth_enabled())
 
-    def test_get_apple_locale(self) -> None:
-        language_locale = [('ar', 'ar_SA'), ('ca', 'ca_ES'), ('cs', 'cs_CZ'),
-                           ('da', 'da_DK'), ('de', 'de_DE'), ('el', 'el_GR'),
-                           ('en', 'en_US'), ('es', 'es_ES'), ('fi', 'fi_FI'),
-                           ('fr', 'fr_FR'), ('hr', 'hr_HR'), ('hu', 'hu_HU'),
-                           ('id', 'id_ID'), ('it', 'it_IT'), ('iw', 'iw_IL'),
-                           ('ja', 'ja_JP'), ('ko', 'ko_KR'), ('ms', 'ms_MY'),
-                           ('nl', 'nl_NL'), ('no', 'no_NO'), ('pl', 'pl_PL'),
-                           ('pt', 'pt_PT'), ('ro', 'ro_RO'), ('ru', 'ru_RU'),
-                           ('sk', 'sk_SK'), ('sv', 'sv_SE'), ('th', 'th_TH'),
-                           ('tr', 'tr_TR'), ('uk', 'uk_UA'), ('vi', 'vi_VI'),
-                           ('zh', 'zh_CN')]
-
-        for language_code, locale in language_locale:
-            self.assertEqual(AppleAuthBackend.get_apple_locale(language_code), locale)
-
-        # return 'en_US' if invalid `language_code` is given.
-        self.assertEqual(AppleAuthBackend.get_apple_locale(':)'), 'en_US')
-
     def test_auth_registration_with_no_name_sent_from_apple(self) -> None:
         """
         Apple doesn't send the name in consecutive attempts if user registration

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -1548,6 +1548,7 @@ class AppleAuthBackend(SocialAuthMixin, AppleIdAuth):
     sort_order = 10
     name = "apple"
     auth_backend_name = "Apple"
+    display_icon = "/static/images/landing-page/logos/apple-icon.png"
 
     # Apple only sends `name` in its response the first time a user
     # tries to sign up, so we won't have it in consecutive attempts.
@@ -1555,28 +1556,6 @@ class AppleAuthBackend(SocialAuthMixin, AppleIdAuth):
     # so it's appropriate to set full_name_validated here.
     full_name_validated = True
     REDIS_EXPIRATION_SECONDS = 60*10
-
-    @staticmethod
-    def get_apple_locale(django_language_code: str) -> str:
-        '''
-        Get the suitable apple supported locale with language code
-        for the Sign in / Continue with Apple buttons it provides.
-        '''
-        # The following is a list of locale values supported by Apple to send
-        # as params to URL which renders "Sign in with Apple" and "Continue with Apple"
-        # buttons. Gathered from
-        # https://developer.apple.com/documentation/signinwithapplejs/incorporating_sign_in_with_apple_into_other_platforms .
-        supported_locales = ['ar_SA', 'ca_ES', 'cs_CZ', 'da_DK', 'de_DE',
-                             'el_GR', 'en_US', 'es_ES', 'fi_FI', 'fr_FR',
-                             'hr_HR', 'hu_HU', 'id_ID', 'it_IT', 'iw_IL',
-                             'ja_JP', 'ko_KR', 'ms_MY', 'nl_NL', 'no_NO',
-                             'pl_PL', 'pt_PT', 'ro_RO', 'ru_RU', 'sk_SK',
-                             'sv_SE', 'th_TH', 'tr_TR', 'uk_UA', 'vi_VI',
-                             'zh_CN']
-        for locale in supported_locales:
-            if django_language_code in locale:
-                return locale
-        return 'en_US'
 
     def is_native_flow(self) -> bool:
         return self.strategy.request_data().get('native_flow', False)


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
https://circleci.com/gh/chdinesh1089/zulip/tree/apple_button

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![apple-login](https://user-images.githubusercontent.com/44665669/85061721-eca27e80-b1c4-11ea-90dc-47718e7a2078.png)
![apple-signup](https://user-images.githubusercontent.com/44665669/85061724-edd3ab80-b1c4-11ea-9786-00dde1297192.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
