### PR TITLE
events: Use stream_id for peer_add/peer_remove.

### DIFF
--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -405,14 +405,14 @@ exports.fixtures = {
         type: 'subscription',
         op: 'peer_add',
         user_id: exports.test_user.user_id,
-        subscriptions: ['devel'],
+        stream_id: 42,
     },
 
     subscription__peer_remove: {
         type: 'subscription',
         op: 'peer_remove',
         user_id: exports.test_user.user_id,
-        subscriptions: ['devel'],
+        stream_id: 42,
     },
 
     subscription__update: {

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -2919,7 +2919,7 @@ def bulk_add_subscriptions(streams: Iterable[Stream],
         if peer_user_ids:
             for new_user_id in new_user_ids:
                 event = dict(type="subscription", op="peer_add",
-                             subscriptions=[stream.name],
+                             stream_id=stream.id,
                              user_id=new_user_id)
                 send_event(realm, event, peer_user_ids)
 
@@ -3063,7 +3063,7 @@ def bulk_remove_subscriptions(users: Iterable[UserProfile],
             for removed_user in altered_users:
                 event = dict(type="subscription",
                              op="peer_remove",
-                             subscriptions=[stream.name],
+                             stream_id=stream.id,
                              user_id=removed_user.id)
                 send_event(our_realm, event, peer_user_ids)
 

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -650,19 +650,21 @@ def apply_event(state: Dict[str, Any],
                 if sub['name'].lower() == event['name'].lower():
                     sub[event['property']] = event['value']
         elif event['op'] == 'peer_add':
+            stream_id = event['stream_id']
             user_id = event['user_id']
             for sub in state['subscriptions']:
-                if (sub['name'] in event['subscriptions'] and
+                if (sub['stream_id'] == stream_id and
                         user_id not in sub['subscribers']):
                     sub['subscribers'].append(user_id)
             for sub in state['never_subscribed']:
-                if (sub['name'] in event['subscriptions'] and
+                if (sub['stream_id'] == stream_id and
                         user_id not in sub['subscribers']):
                     sub['subscribers'].append(user_id)
         elif event['op'] == 'peer_remove':
+            stream_id = event['stream_id']
             user_id = event['user_id']
             for sub in state['subscriptions']:
-                if (sub['name'] in event['subscriptions'] and
+                if (sub['stream_id'] == stream_id and
                         user_id in sub['subscribers']):
                     sub['subscribers'].remove(user_id)
     elif event['type'] == "presence":

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2541,7 +2541,7 @@ class EventsRegisterTest(ZulipTestCase):
             ('type', equals('subscription')),
             ('op', equals('peer_add')),
             ('user_id', check_int),
-            ('subscriptions', check_list(check_string)),
+            ('stream_id', check_int),
         ])
         error = peer_add_schema_checker('events[1]', events[1])
         self.assert_on_error(error)
@@ -2613,13 +2613,13 @@ class EventsRegisterTest(ZulipTestCase):
             ('type', equals('subscription')),
             ('op', equals('peer_add')),
             ('user_id', check_int),
-            ('subscriptions', check_list(check_string)),
+            ('stream_id', check_int),
         ])
         peer_remove_schema_checker = self.check_events_dict([
             ('type', equals('subscription')),
             ('op', equals('peer_remove')),
             ('user_id', check_int),
-            ('subscriptions', check_list(check_string)),
+            ('stream_id', check_int),
         ])
         stream_update_schema_checker = self.check_events_dict([
             ('type', equals('stream')),

--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -2781,9 +2781,10 @@ class SubscriptionAPITest(ZulipTestCase):
         notifications = set()
         for event in peer_events:
             for user_id in event['users']:
-                for stream_name in event['event']['subscriptions']:
-                    removed_user_id = event['event']['user_id']
-                    notifications.add((user_id, removed_user_id, stream_name))
+                stream_id = event['event']['stream_id']
+                stream_name = Stream.objects.get(id=stream_id).name
+                removed_user_id = event['event']['user_id']
+                notifications.add((user_id, removed_user_id, stream_name))
 
         # POSITIVE CASES FIRST
         self.assertIn((user3.id, user1.id, 'stream1'), notifications)


### PR DESCRIPTION
Two things were broken here:
    * we were using name(s) instead of id(s)
    * we were always sending lists that only
      had one element

Now we just send "stream_id" instead of "subscriptions".

If anything, we should start sending a list of users
instead of a list of streams.  For example, see
the code below:

    if peer_user_ids:
        for new_user_id in new_user_ids:
            event = dict(type="subscription", op="peer_add",
                         stream_id=stream.id,
                         user_id=new_user_id)
            send_event(realm, event, peer_user_ids)

Note that this only affects the webapp, as mobile/ZT
don't use this.
