### PR TITLE
invite: Add option to invite user as an organization owner.

### DIFF
--- a/static/js/settings_invites.js
+++ b/static/js/settings_invites.js
@@ -19,6 +19,7 @@ exports.invited_as_values = new Map([
     [1, i18n.t("Member")],
     [2, i18n.t("Organization administrator")],
     [3, i18n.t("Guest")],
+    [4, i18n.t("Organization owner")],
 ]);
 
 function add_invited_as_text(invites) {
@@ -51,6 +52,7 @@ function populate_invites(invites_data) {
         modifier: function (item) {
             item.invited_absolute_time = timerender.absolute_time(item.invited * 1000);
             item.is_admin = page_params.is_admin;
+            item.disable_buttons = item.invited_as === 4 && !page_params.is_owner;
             return render_admin_invites_list({ invite: item });
         },
         filter: {

--- a/static/templates/admin_invites_list.hbs
+++ b/static/templates/admin_invites_list.hbs
@@ -23,11 +23,11 @@
         <span>{{invited_as_text}}</span>
     </td>
     <td class="actions">
-        <button class="button rounded small revoke btn-danger" data-invite-id="{{id}}" data-is-multiuse="{{is_multiuse}}">
+        <button class="button rounded small revoke btn-danger" {{#if disable_buttons}}disabled="disabled"{{/if}} data-invite-id="{{id}}" data-is-multiuse="{{is_multiuse}}">
             {{t "Revoke" }}
         </button>
         {{#unless is_multiuse}}
-        <button class="button rounded small resend btn-warning" data-invite-id="{{id}}">
+        <button class="button rounded small resend btn-warning" {{#if disable_buttons}}disabled="disabled"{{/if}} data-invite-id="{{id}}">
             {{t "Resend" }}
         </button>
         {{/unless}}

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -10,6 +10,10 @@ below features are supported.
 
 ## Changes in Zulip 2.2
 
+**Feature level 20**
+
+* Added option of inviting users as organization owners.
+
 **Feature level 19**
 
 * [`GET /events`](/api/get-events): `subscriptions` event with

--- a/templates/zerver/app/invite_user.html
+++ b/templates/zerver/app/invite_user.html
@@ -38,6 +38,9 @@
                             <option name="invite_as" value="{{ invite_as.REALM_ADMIN }}">{{ _('Organization administrators') }}</option>
                             {% endif %}
                             <option name="invite_as" value="{{ invite_as.GUEST_USER }}">{{ _('Guests') }}</option>
+                            {% if is_owner %}
+                            <option name="invite_as" value="{{ invite_as.REALM_OWNER }}">{{ _('Organization owners') }}</option>
+                            {% endif %}
                         </select>
                     </div>
                 </div>

--- a/templates/zerver/help/invite-new-users.md
+++ b/templates/zerver/help/invite-new-users.md
@@ -12,7 +12,7 @@ the article below describes each in more detail.
 * Share a **reusable invitation link**.
 
 The last two, invite-based, techniques also allow you to control the
-[role (admin, member, or guest)](/help/roles-and-permissions) that the
+[role (owner, admin, member, or guest)](/help/roles-and-permissions) that the
 invited people will have.
 
 You can also manage access by
@@ -134,7 +134,8 @@ restrict invites to admins only.
 ## Manage pending invitations
 
 Organization administrators can revoke or resend any invitation or reusable
-invitation link.
+invitation link. Only organization owners can revoke or resend owner invitaiton
+or reusable owner invitation link.
 
 {start_tabs}
 

--- a/version.py
+++ b/version.py
@@ -29,7 +29,7 @@ DESKTOP_WARNING_VERSION = "5.2.0"
 #
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md.
-API_FEATURE_LEVEL = 18
+API_FEATURE_LEVEL = 20
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -45,7 +45,7 @@ def get_display_email_address(user_profile: UserProfile, realm: Realm) -> str:
     return user_profile.delivery_email
 
 def get_role_for_new_user(invited_as: int, realm_creation: bool=False) -> int:
-    if realm_creation:
+    if realm_creation or invited_as == PreregistrationUser.INVITE_AS['REALM_OWNER']:
         return UserProfile.ROLE_REALM_OWNER
     elif invited_as == PreregistrationUser.INVITE_AS['REALM_ADMIN']:
         return UserProfile.ROLE_REALM_ADMINISTRATOR

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1355,6 +1355,7 @@ class PreregistrationUser(models.Model):
         MEMBER = 1,
         REALM_ADMIN = 2,
         GUEST_USER = 3,
+        REALM_OWNER = 4,
     )
     invited_as: int = models.PositiveSmallIntegerField(default=INVITE_AS['MEMBER'])
 


### PR DESCRIPTION
We can now invite new users as realm owner. We restrict only
owners to invite new users as owners both for single invite
and multiuse invite link. Also, only owners can revoke or resend
owner invitations.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
