### PR TITLE
wsgi: Try to avoid extra django.setup calls

### DIFF
--- a/zproject/wsgi.py
+++ b/zproject/wsgi.py
@@ -24,10 +24,14 @@ setup_path()
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "zproject.settings")
 
-import django
+from django.core.wsgi import get_wsgi_application
 
 try:
-    django.setup()
+    # This application object is used by any WSGI server configured to use this
+    # file. This includes Django's development server, if the WSGI_APPLICATION
+    # setting points here.
+
+    application = get_wsgi_application()
 except Exception:
     # If /etc/zulip/settings.py contains invalid syntax, Django
     # initialization will fail in django.setup().  In this case, our
@@ -39,19 +43,5 @@ except Exception:
     logging.basicConfig(filename='/var/log/zulip/errors.log', level=logging.INFO,
                         format='%(asctime)s %(levelname)s %(name)s %(message)s')
     logger = logging.getLogger(__name__)
-    logger.exception("django.setup() failed:")
+    logger.exception("get_wsgi_application() failed:")
     raise
-
-# Because import_module does not correctly handle safe circular imports we
-# need to import zerver.models first before the middleware tries to import it.
-
-import zerver.models
-
-zerver.models
-
-# This application object is used by any WSGI server configured to use this
-# file. This includes Django's development server, if the WSGI_APPLICATION
-# setting points here.
-from django.core.wsgi import get_wsgi_application
-
-application = get_wsgi_application()


### PR DESCRIPTION
The `zerver.models` hack does not appear to be necessary now. Meanwhile, `get_wsgi_application` has its own `django.setup` call, which would overwrite the parts of our logging configuration pulled in by `zerver.models`.

This fixes part of #15391; specifically, fixes it in production, but not in development, where `manage.py runserver` calls its own `django.setup` and then imports various bits of our code before finding `zproject.wsgi`.

**Testing Plan:** Production at https://andersk.zulipdev.org