### PR TITLE
memcached: Change the default MEMCACHED_USERNAME to zulip@localhost

### DIFF
--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -123,7 +123,7 @@ BOT_CONFIG_SIZE_LIMIT = 10000
 # External service configuration
 CAMO_URI = ''
 MEMCACHED_LOCATION = '127.0.0.1:11211'
-MEMCACHED_USERNAME = None if get_secret("memcached_password") is None else "zulip"
+MEMCACHED_USERNAME = None if get_secret("memcached_password") is None else "zulip@localhost"
 RABBITMQ_HOST = '127.0.0.1'
 RABBITMQ_USERNAME = 'zulip'
 REDIS_HOST = '127.0.0.1'

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -615,8 +615,8 @@ CAMO_URI = '/external_content/'
 # Format HOST:PORT
 # MEMCACHED_LOCATION = 127.0.0.1:11211
 # To authenticate to memcached, set memcached_password in zulip-secrets.conf,
-# and optionally change the default username 'zulip' here.
-# MEMCACHED_USERNAME = 'zulip'
+# and optionally change the default username 'zulip@localhost' here.
+# MEMCACHED_USERNAME = 'zulip@localhost'
 
 # Redis configuration
 #


### PR DESCRIPTION
This prevents memcached from automatically appending the hostname to the username, which was a source of problems on servers where the hostname was changed.

(This will need a corresponding docker-zulip change.)

**Testing Plan:** Production at https://andersk.zulipdev.org