### PR TITLE
stream: Fix message on clicking add button with empty subscribers form.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -636,6 +636,12 @@ exports.initialize = function () {
         const user_ids = user_pill.get_user_ids(exports.pill_widget);
         const stream_subscription_info_elem = $('.stream_subscription_info').expectOne();
 
+        if (user_ids.length === 0) {
+            stream_subscription_info_elem.text(i18n.t("No user to subscribe."))
+                .addClass("text-error").removeClass("text-success");
+            return;
+        }
+
         function invite_success(data) {
             exports.pill_widget.clear();
             if (!Object.entries(data.already_subscribed).length) {


### PR DESCRIPTION
This PR corrects the message shown when we click the add button
for subscribing users to stream with empty input.
We show 'No user to subscribe.' as the message when trying to add
subscribers with empty input.
Let me know if we want to change the message, I have added the one that
felt appropriate to me.

Fixes #15450.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot (132)](https://user-images.githubusercontent.com/35494118/85165598-b24be680-b283-11ea-8307-c4ac40352622.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
