### PR TITLE
streams: Do not allow to set message retention days value as zero.

### DIFF
--- a/zerver/tests/test_subs.py
+++ b/zerver/tests/test_subs.py
@@ -938,6 +938,10 @@ class StreamAdminTest(ZulipTestCase):
                                    {'message_retention_days': ujson.dumps(-1)})
         self.assert_json_error(result, "Bad value for 'message_retention_days': -1")
 
+        result = self.client_patch(f'/json/streams/{stream.id}',
+                                   {'message_retention_days': ujson.dumps(0)})
+        self.assert_json_error(result, "Bad value for 'message_retention_days': 0")
+
     def test_change_stream_message_retention_days_requires_realm_owner(self) -> None:
         user_profile = self.example_user('iago')
         self.login_user(user_profile)

--- a/zerver/views/streams.py
+++ b/zerver/views/streams.py
@@ -132,7 +132,7 @@ def parse_message_retention_days(value: Union[int, str]) -> Optional[int]:
         return -1
     if value == "realm_default":
         return None
-    if isinstance(value, str) or value < 0:
+    if isinstance(value, str) or value <= 0:
         raise RequestVariableConversionError('message_retention_days', value)
     assert isinstance(value, int)
     return value


### PR DESCRIPTION
We should not allow message_retention_days value to be zero, as it
doesn't make any sense to set it as zero.
Also added test for zero case to prevent accidental bugs in future. 
This change should have been included in c488a35 itself.


<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
