### PR TITLE
settings_user: Fix event propagation for bot and user edit form modal.

### DIFF
--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -583,6 +583,8 @@ function handle_bot_owner_profile(tbody) {
 
 function handle_human_form(tbody, status_field) {
     tbody.on("click", ".open-user-form", function (e) {
+        e.stopPropagation();
+        e.preventDefault();
         const user_id = parseInt($(e.currentTarget).attr("data-user-id"), 10);
         const person = people.get_by_user_id(user_id);
 
@@ -617,6 +619,8 @@ function handle_human_form(tbody, status_field) {
 
 function handle_bot_form(tbody, status_field) {
     tbody.on("click", ".open-user-form", function (e) {
+        e.stopPropagation();
+        e.preventDefault();
         const user_id = parseInt($(e.currentTarget).attr("data-user-id"), 10);
         const bot = people.get_by_user_id(user_id);
 


### PR DESCRIPTION
When the user clicks a button that opens a modal, and if we don't break off
the corresponding click event. This condition in the global click handler
will become true and enables all mouse events outside modal.

```js
    $(document).on('click', function (e) {
        ...
        // If user clicks outside an active modal
        if ($('.modal.in').has(e.target).length === 0) {
            // Enable mouse events for the background as the modal closes
            $('.overlay.show').attr("style", null);
        }
```

Related to #12369.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Manual testing

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before,
![before](https://user-images.githubusercontent.com/40331304/85167805-0906ef80-b287-11ea-8e8e-a49cc7523431.gif)
After,
![after](https://user-images.githubusercontent.com/40331304/85167793-03a9a500-b287-11ea-98fb-6abccde7276a.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
