### PR TITLE
settings: Fix race condition in getting users' last active time.

### DIFF
--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -467,12 +467,12 @@ exports.initialize_everything = function () {
     tutorial.initialize();
     notifications.initialize();
     gear_menu.initialize();
+    presence.initialize(presence_params);
     settings_panel_menu.initialize();
     settings_sections.initialize();
     settings_toggle.initialize();
     hashchange.initialize();
     unread_ui.initialize();
-    presence.initialize(presence_params);
     activity.initialize();
     emoji_picker.initialize();
     pm_list.initialize();


### PR DESCRIPTION
We recently removed an API call for fetching user list for our
Settings>Users/Deactivated panels, which introduced a bug where
we rendered the users table before last active information is
processed by the frontend.

This commit makes us process presence before rendering our settings
panels. We move the presence init above because we need to initialize
settings_sections before hashchange.

Fixes #15453.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
