### PR TITLE
Fix 'user-avatar-source' text reflow bug.

### DIFF
--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1341,7 +1341,6 @@ input[type=checkbox] {
 
 
 #user-avatar-source {
-    position: absolute;
     font-size: 1em;
     z-index: 99;
     a {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR fixes the reflow bug in the 'user-avatar-source' text.

**Bug image**
![image](https://user-images.githubusercontent.com/45326319/85181089-b804f480-b2a2-11ea-88f2-cb2558166d51.png)

**After**
![Screenshot_2020-06-20 home - Zulip Dev - Zulip](https://user-images.githubusercontent.com/45326319/85183530-ac68fc00-b2a9-11ea-9f46-5e0a02170d7f.png)




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
