### PR TITLE
topic-popover: Add chevron-right icon in topic popover title.

### DIFF
--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -193,6 +193,7 @@ function build_topic_popover(opts) {
         can_mute_topic: can_mute_topic,
         can_unmute_topic: can_unmute_topic,
         is_admin: sub.is_admin,
+        color: sub.color,
     });
 
     $(elt).popover({

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -122,6 +122,10 @@ ul {
             text-align: center;
             margin-top: 5px;
             margin-bottom: 5px;
+
+            .fa-chevron-right {
+                font-size: 12px;
+            }
         }
 
         .admin-separator {

--- a/static/templates/topic_sidebar_actions.hbs
+++ b/static/templates/topic_sidebar_actions.hbs
@@ -1,6 +1,7 @@
 <ul class="nav nav-list topics_popover">
     <li>
         <p class="topic-name">
+            <i class="fa fa-chevron-right" aria-hidden="true" style="color: {{color}}"></i>
             <b>{{topic_name}}</b>
         </p>
     </li>


### PR DESCRIPTION
Instead of adding `>` as a text, I have added right chevron as it was looking better.

For comparison, the first one is with text and the second one is chevron:
![Screenshot from 2020-06-20 21-27-33](https://user-images.githubusercontent.com/32801674/85206072-1088d000-b33d-11ea-908a-c5d0e37b724c.png)
![Screenshot from 2020-06-20 21-28-16](https://user-images.githubusercontent.com/32801674/85206074-11b9fd00-b33d-11ea-92c3-76c73b5deb01.png)

