### PR TITLE
openapi: Fix bug and add tests to validate_against_openapi_schema.

### DIFF
--- a/zerver/openapi/testing.yaml
+++ b/zerver/openapi/testing.yaml
@@ -1,0 +1,136 @@
+test1:
+  responses:
+    '200':
+       content:
+         application/json:
+           schema:
+             properties:
+               top_array:
+                 type: array
+                 items:
+                   oneOf:
+                   - type: object
+                     properties:
+                       obj:
+                         oneOf:
+                         - type: array
+                           items:
+                             type: string
+                         - type: object
+                           properties:
+                             str3:
+                               type: string
+                   - type: array
+                     items:
+                       type: object
+                       properties:
+                           str1:
+                             type: string
+                           str2:
+                             type: string
+           example:
+             {
+                 "top_array": [
+                     {
+                         "obj": {
+                             "str3": "test"
+                         }
+                     },
+                     [
+                         {
+                             "str1": "success",
+                             "str2": "success"
+                         }
+                     ]
+                 ]
+             }
+test2:
+  responses:
+    '200':
+       content:
+         application/json:
+           schema:
+             properties:
+               top_array:
+                 type: array
+                 items:
+                   oneOf:
+                   - type: object
+                     properties:
+                       obj:
+                         oneOf:
+                         - type: array
+                           items:
+                             type: string
+                         - type: object
+                           properties:
+                             str3:
+                               type: string
+                   - type: array
+                     items:
+                       type: object
+                       properties:
+                           str1:
+                             type: string
+                           str2:
+                             type: string
+           example:
+             {
+                 "top_array": [
+                     {
+                         "obj": {
+                             "str3": "test",
+                             "str4": "extraneous"
+                         }
+                     },
+                     [
+                         {
+                             "str1": "success",
+                             "str2": "success"
+                         }
+                     ]
+                 ]
+             }
+test3:
+  responses:
+    '200':
+       content:
+         application/json:
+           schema:
+             properties:
+               top_array:
+                 type: array
+                 items:
+                   oneOf:
+                   - type: object
+                     properties:
+                       obj:
+                         oneOf:
+                         - type: array
+                           items:
+                             type: string
+                         - type: object
+                   - type: array
+                     items:
+                       type: object
+                       properties:
+                           str1:
+                             type: string
+                           str2:
+                             type: string
+           example:
+             {
+                 "top_array": [
+                     {
+                         "obj": {
+                             "str3": "test"
+                         }
+                     },
+                     [
+                         {
+                             "str1": "success",
+                             "str2": "success"
+                         }
+                     ]
+                 ]
+             }

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -383,10 +383,13 @@ paths:
                               `{server_url}/user_uploads/{realm_id}/ab/cdef/temp_file.py`.
                           size:
                             type: integer
+                            nullable: true
                             description: |
                               Size of the file in bytes.
                           create_time:
-                            type: integer
+                            oneOf:
+                            - type: number
+                            - type: integer
                             description: |
                               Time when the attachment was uploaded.
                           messages:
@@ -593,6 +596,7 @@ paths:
                         properties:
                           avatar_url:
                             type: string
+                            nullable: true
                             description: |
                               The URL of the user's avatar.
                           client:
@@ -643,7 +647,9 @@ paths:
                               type: object
                               properties:
                                 emoji_code:
-                                  type: integer
+                                  oneOf:
+                                  - type: string
+                                  - type: integer
                                   description: |
                                     An encoded version of the emoji's unicode codepoint.
                                 emoji_name:
@@ -3918,6 +3924,7 @@ paths:
                               assumption, as we may change that behavior in the future.
                           first_message_id:
                             type: integer
+                            nullable: true
                             description: |
                               The id of the first message in the stream.
 

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -1,4 +1,5 @@
 import inspect
+import os
 import re
 import sys
 from collections import abc
@@ -18,6 +19,7 @@ from typing import (
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
+import yaml
 from django.http import HttpResponse
 
 from zerver.lib.request import _REQ, arguments_map
@@ -163,6 +165,29 @@ class OpenAPIToolsTest(ZulipTestCase):
                                             TEST_RESPONSE_SUCCESS)
         finally:
             openapi.EXCLUDE_PROPERTIES = exclude_properties
+        test_dict: Dict[str, Any] = {}
+        # Tests for verifying that validate_against_openapi_schema validate 'deep' objects.
+        # Test 1 should pass, Test 2 has a 'deep' extraneous key and Test 3 has a deep
+        # opaque object. Also the parameters are a heterogenous mix of arrays and objects
+        # to verify that the function goes deep no matter what the data type.
+        with open(os.path.join(os.path.dirname(OPENAPI_SPEC_PATH),
+                  "testing.yaml")) as test_file:
+            test_dict = yaml.safe_load(test_file)
+        openapi_spec.spec()['paths']['testing'] = test_dict
+        try:
+            validate_against_openapi_schema((test_dict['test1']['responses']['200']['content']
+                                            ['application/json']['example']),
+                                            'testing', 'test1', '200')
+            with self.assertRaises(SchemaError, msg = 'Extraneous key "str4" in response\'s content'):
+                validate_against_openapi_schema((test_dict['test2']['responses']['200']
+                                                ['content']['application/json']['example']),
+                                                'testing', 'test2', '200')
+            with self.assertRaises(SchemaError, msg = 'Opaque object "obj"'):
+                validate_against_openapi_schema((test_dict['test3']['responses']['200']
+                                                ['content']['application/json']['example']),
+                                                'testing', 'test3', '200')
+        finally:
+            openapi_spec.spec()['paths'].pop('testing', None)
 
     def test_to_python_type(self) -> None:
         TYPES = {


### PR DESCRIPTION
`validate_against_openapi_schema` had a bug such that it couldn't
go to deeper levels in some cases. Fix the bug and add conflicting
response keys to the exception list so that they can be resolved
later. Also add tests so that this bug does not arise again.
