### PR TITLE
message_controls: Prevent clicks via visibility & not pointer-events.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -680,7 +680,7 @@ td.pointer {
 
     > div {
         opacity: 0;
-        pointer-events: none;
+        visibility: hidden;
         transition: all 0.2s ease;
         padding: 0px 1px;
     }
@@ -752,7 +752,7 @@ td.pointer {
 
         > div {
             opacity: 1;
-            pointer-events: all;
+            visibility: visible;
         }
     }
 
@@ -1150,6 +1150,7 @@ td.pointer {
 
 .has_actions_popover .info {
     opacity: 1;
+    visibility: visible;
 }
 
 /* Brighten text because of the dark background */


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Partially fixes: #13642 (see "Second bug" heading).

The commit message here is really long... Should I just delete the `Trivia` and `History` stuff?

**Testing Plan:** <!-- How have you tested? -->
Manually tested this on my mobile device.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before:
![message-controls-before](https://user-images.githubusercontent.com/33805964/85208065-171e4400-b34b-11ea-8644-a7d5d5bf1452.gif)
After:
![message-controls-after](https://user-images.githubusercontent.com/33805964/85208018-c4448c80-b34a-11ea-983e-6b1bf2a63a29.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
