### PR TITLE
subs: Remove click handler for a non-existent class.

### DIFF
--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -914,21 +914,6 @@ exports.initialize = function () {
         selectText(this);
     });
 
-    $('.empty_feed_sub_unsub').click(function (e) {
-        e.preventDefault();
-
-        $('#subscription-status').hide();
-        const stream_name = narrow_state.stream();
-        if (stream_name === undefined) {
-            return;
-        }
-        const sub = stream_data.get_sub(stream_name);
-        exports.sub_or_unsub(sub);
-
-        $('.empty_feed_notice').hide();
-        $('#empty_narrow_message').show();
-    });
-
     $("#subscriptions_table").on("click", ".stream-row, .create_stream_button", function () {
         $(".right").addClass("show");
         $(".subscriptions-header").addClass("slide-left");


### PR DESCRIPTION
This PR removes the handler used for class 'empty_feed_sub_unsub'.
This class was used only in home.html and was replaced by
'stream_sub_unsub_button' in 576be51.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
