### PR TITLE
filter: Implement has: filters on client side.

### DIFF
--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -142,6 +142,17 @@ exports.is_slash_command = function (content) {
 
 
 exports.try_deliver_locally = function (message_request) {
+
+    // Even though has: filers can be applied locally,
+    // We dont want to locally echo those has: messages
+    // because:
+    //  1. has:image, has:attachment are backend only syntax.
+    //  2. has:link do not get displayed in current narrow
+    //     if local echo is on.
+    if (narrow_state.active() && narrow_state.filter() && narrow_state.filter().has_operator('has')) {
+        return;
+    }
+
     if (markdown.contains_backend_only_syntax(message_request.content)) {
         return;
     }

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -46,6 +46,15 @@ function message_in_home(message) {
 
 function message_matches_search_term(message, operator, operand) {
     switch (operator) {
+    case 'has':
+        if (operand === 'image') {
+            return message_util.message_has_image(message);
+        } else if (operand === 'link') {
+            return message_util.message_has_link(message);
+        } else if (operand === 'attachment') {
+            return message_util.message_has_attachment(message);
+        }
+        return false; // has:something_else returns false
     case 'is':
         if (operand === 'private') {
             return message.type === 'private';
@@ -630,10 +639,7 @@ Filter.prototype = {
         }
 
         if (this.has_operator('has')) {
-            // See #6186 to see why we currently punt on 'has:foo'
-            // queries.  This can be fixed, there are just some random
-            // complications that make it non-trivial.
-            return false;
+            return true;
         }
 
         if (this.has_operator('streams') ||

--- a/static/js/message_util.js
+++ b/static/js/message_util.js
@@ -16,6 +16,18 @@ function add_messages(messages, msg_list, opts) {
     return render_info;
 }
 
+exports.message_has_link = function (message) {
+    return $(message.content).find(`a`).length > 0;
+};
+
+exports.message_has_image = function (message) {
+    return $(message.content).find(`.message_inline_image`).length > 0;
+};
+
+exports.message_has_attachment = function (message) {
+    return $(message.content).find(`a[href^='/user_uploads']`).length > 0;
+};
+
 exports.add_old_messages = function (messages, msg_list) {
     return add_messages(messages, msg_list, {messages_are_new: false});
 };


### PR DESCRIPTION
Prior to this commit has:link, has:attachment, has:image
filter couldn't be applied locally and deferred filtering to
web server. This commits make sure client filters all messages
it can instead of completely deferring to the server and hence
improve speed.

A tradeoff is also made to turn off local echo for has: narrows
as messages with link sent to has:link narrow were locally echoing
to another narrow and not appearing in the active has:link narrow.

Fixes: #6186.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
