### PR TITLE
minor: Fix typos in migration to image upload widget.

### DIFF
--- a/static/templates/settings/organization_profile_admin.hbs
+++ b/static/templates/settings/organization_profile_admin.hbs
@@ -53,7 +53,7 @@
               upload_text = (t "Upload logo")
               delete_text = (t "Delete logo")
               is_editable_by_current_user = user_can_change_logo
-              image = realm_icon_url }}
+              image = realm_logo_url }}
         </div>
         <div class="realm-logo-block realm-logo-section">
             {{> image_upload_widget
@@ -61,7 +61,7 @@
               upload_text = (t "Upload logo")
               delete_text = (t "Delete logo")
               is_editable_by_current_user = user_can_change_logo
-              image = realm_icon_url }}
+              image = realm_night_logo_url }}
         </div>
         <h3 class="light">
             {{t "Deactivate organization" }}


### PR DESCRIPTION
We were showing the organisation profile picture  in place of the
logo and night-mode logo after the migration. This change fixes it.

Fixes #15493.
