### PR TITLE
compose: Use rendered_markdown.update_elements for previews.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1,3 +1,4 @@
+const rewiremock = require("rewiremock/node");
 const { JSDOM } = require("jsdom");
 
 set_global('bridge', false);
@@ -70,7 +71,11 @@ zrequire('input_pill');
 zrequire('user_pill');
 zrequire('compose_pm_pill');
 zrequire('echo');
-zrequire('compose');
+rewiremock.proxy(() => zrequire('compose'), {
+    "../../static/js/rendered_markdown": {
+        update_elements: () => {},
+    },
+});
 zrequire('upload');
 zrequire('server_events_dispatch');
 

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -1,3 +1,4 @@
+const rendered_markdown = require("./rendered_markdown");
 const util = require("./util");
 const render_compose_all_everyone = require("../templates/compose_all_everyone.hbs");
 const render_compose_announce = require("../templates/compose_announce.hbs");
@@ -802,12 +803,7 @@ exports.render_and_show_preview = function (preview_spinner, preview_content_box
         }
 
         preview_content_box.html(util.clean_user_content_links(rendered_preview_html));
-        if (page_params.emojiset === "text") {
-            preview_content_box.find(".emoji").replaceWith(function () {
-                const text = $(this).attr("title");
-                return ":" + text + ":";
-            });
-        }
+        rendered_markdown.update_elements(preview_content_box);
     }
 
     if (content.length === 0) {


### PR DESCRIPTION
As we add more features where rendered_markdown.update_elements does
something useful, it'll become important to run this code everywhere
we render markdown in the DOM.

One can see in this case that we had actually copied one hunk of
rendered_markdown.update_elements years ago, before we extracted it as
an independent function; we get to delete that copy.

Fixes #15500.

This PR fails node tests; we need to make `rendered_markdown.update_elements` a noop here.  I don't actually know how to do that for our new-style modules; @andersk can you help?

(I'd like your attention on this in any case; I think we might want to harden this interface a bit, or perhaps better, should we just be doing this in the same way as `clean_user_content_links`?)