### PR TITLE
stream edit: Adds <Enter> key shortcut when inviting users to stream

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -144,7 +144,7 @@ function get_sub_for_target(target) {
     return sub;
 }
 
-function add_user_to_stream(e) {
+function submit_add_subscriber_form(e) {
     e.preventDefault();
     const settings_row = $(e.target).closest('.subscription_settings');
     const sub = get_sub_for_target(settings_row);
@@ -667,11 +667,13 @@ exports.initialize = function () {
                                  exports.stream_setting_clicked);
 
     $("#subscriptions_table").on("submit", ".subscriber_list_add form", function (e) {
-        add_user_to_stream(e);
+        submit_add_subscriber_form(e);
     });
 
     $("#subscriptions_table").on("keyup", ".subscriber_list_add form", function (e) {
-        add_user_to_stream(e);
+        if (e.which ==13) {
+            submit_add_subscriber_form(e);
+        }
     });
 
     $("#subscriptions_table").on("submit", ".subscriber_list_remove form", function (e) {

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -671,7 +671,7 @@ exports.initialize = function () {
     });
 
     $("#subscriptions_table").on("keyup", ".subscriber_list_add form", function (e) {
-        if (e.which == 13) {
+        if (e.which === 13) {
             submit_add_subscriber_form(e);
         }
     });

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -671,7 +671,7 @@ exports.initialize = function () {
     });
 
     $("#subscriptions_table").on("keyup", ".subscriber_list_add form", function (e) {
-        if (e.which ==13) {
+        if (e.which == 13) {
             submit_add_subscriber_form(e);
         }
     });

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -144,7 +144,7 @@ function get_sub_for_target(target) {
     return sub;
 }
 
-function add_user_to_stream(target) {
+function add_user_to_stream(e) {
     e.preventDefault();
     const settings_row = $(e.target).closest('.subscription_settings');
     const sub = get_sub_for_target(settings_row);


### PR DESCRIPTION
Adds <Enter> keyboard shortcut when adding users to a stream in the stream_edit modal. Implements submit_add_subscriber_form() function which is called whenever 'keyup' or 'submit' listener is triggered on the subscriber_list_add form.

This has been tested manually and with pylint. Fixed previous issue where shortcut was being triggered by tab key.

@timabbott 
@hackerkid 
