### PR TITLE
recent_topics: Fix buggy scrolling.

### DIFF
--- a/static/styles/recent_topics.scss
+++ b/static/styles/recent_topics.scss
@@ -56,6 +56,8 @@
         margin: 0px;
         padding: 15px;
         overflow: hidden !important;
+        display: flex;
+        flex-direction: column;
 
         a {
             color: hsl(205, 47%, 42%);
@@ -85,7 +87,6 @@
             padding: 10px;
             padding-top: 0px !important;
             overflow-y: auto;
-            max-height: 100%;
         }
 
         .table_fix_head table {


### PR DESCRIPTION
The knob of the scroll bar scrolled out of view in both Firefox and
Chromium and on Firefox it even cut off the last entry.

Fixes #15511.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
