### PR TITLE
[WIP] Remove get_sub calls and use stream id to get sub object.

### DIFF
--- a/frontend_tests/node_tests/dispatch_subs.js
+++ b/frontend_tests/node_tests/dispatch_subs.js
@@ -49,20 +49,20 @@ test('peer add/remove', (override) => {
         stream_id: event.stream_id,
     });
 
-    const stream_edit_stub = global.make_stub();
-    override('stream_edit.rerender', stream_edit_stub.f);
+    const subs_stub = global.make_stub();
+    override('subs.rerender_subscriptions_settings', subs_stub.f);
 
     const compose_fade_stub = global.make_stub();
     override('compose_fade.update_faded_users', compose_fade_stub.f);
 
     dispatch(event);
     assert.equal(compose_fade_stub.num_calls, 1);
-    assert.equal(stream_edit_stub.num_calls, 1);
+    assert.equal(subs_stub.num_calls, 1);
 
     event = event_fixtures.subscription__peer_remove;
     dispatch(event);
     assert.equal(compose_fade_stub.num_calls, 2);
-    assert.equal(stream_edit_stub.num_calls, 2);
+    assert.equal(subs_stub.num_calls, 2);
 });
 
 test('remove', (override) => {

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -8,7 +8,7 @@ set_global('hashchange', {
     exit_overlay: noop,
 });
 set_global('stream_data', {
-    get_sub: () => {
+    get_sub_by_id: () => {
         return {
             color: "",
             invite_only: false,

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -243,7 +243,7 @@ run_test('subscribers', () => {
     assert.equal(sub.subscriber_count, 1);
 
     // remove
-    ok = stream_data.remove_subscriber('Rome', brutus.user_id);
+    ok = stream_data.remove_subscriber(sub.stream_id, brutus.user_id);
     assert(ok);
     assert(!stream_data.is_user_subscribed('Rome', brutus.user_id));
     sub = stream_data.get_sub('Rome');
@@ -256,14 +256,14 @@ run_test('subscribers', () => {
     assert.equal(stream_data.is_user_subscribed('Rome', undefined), undefined);
 
     // Verify noop for bad stream when removing subscriber
-    const bad_stream = 'UNKNOWN';
-    blueslip.expect('warn', 'We got a remove_subscriber call for a non-existent stream ' + bad_stream);
-    ok = stream_data.remove_subscriber(bad_stream, brutus.user_id);
+    const bad_stream_id = 999999;
+    blueslip.expect('warn', 'We got a remove_subscriber call for a non-existent stream ' + bad_stream_id);
+    ok = stream_data.remove_subscriber(bad_stream_id, brutus.user_id);
     assert(!ok);
 
     // verify that removing an already-removed subscriber is a noop
     blueslip.expect('warn', 'We tried to remove invalid subscriber: 104');
-    ok = stream_data.remove_subscriber('Rome', brutus.user_id);
+    ok = stream_data.remove_subscriber(sub.stream_id, brutus.user_id);
     assert(!ok);
     assert(!stream_data.is_user_subscribed('Rome', brutus.user_id));
     sub = stream_data.get_sub('Rome');
@@ -284,7 +284,7 @@ run_test('subscribers', () => {
     ok = stream_data.add_subscriber(sub.stream_id, brutus.user_id);
     assert(ok);
     assert.equal(stream_data.is_user_subscribed('Rome', brutus.user_id), true);
-    stream_data.remove_subscriber('Rome', brutus.user_id);
+    stream_data.remove_subscriber(sub.stream_id, brutus.user_id);
     assert.equal(stream_data.is_user_subscribed('Rome', brutus.user_id), false);
     stream_data.add_subscriber(sub.stream_id, brutus.user_id);
     assert.equal(stream_data.is_user_subscribed('Rome', brutus.user_id), true);
@@ -295,7 +295,7 @@ run_test('subscribers', () => {
     sub.invite_only = true;
     stream_data.update_calculated_fields(sub);
     assert.equal(stream_data.is_user_subscribed('Rome', brutus.user_id), undefined);
-    stream_data.remove_subscriber('Rome', brutus.user_id);
+    stream_data.remove_subscriber(sub.stream_id, brutus.user_id);
     assert.equal(stream_data.is_user_subscribed('Rome', brutus.user_id), undefined);
 
     // Verify that we don't crash and return false for a bad stream.

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -864,17 +864,18 @@ run_test('create_sub', () => {
         return '#bd86e5';
     };
 
-    const india_sub = stream_data.create_sub_from_server_data('India', india);
+    const india_sub = stream_data.create_sub_from_server_data(india);
     assert(india_sub);
     assert.equal(india_sub.color, '#bd86e5');
-    const new_sub = stream_data.create_sub_from_server_data('India', india); // make sure sub doesn't get created twice
+    const new_sub = stream_data.create_sub_from_server_data(india);
+    // make sure sub doesn't get created twice
     assert.equal(india_sub, new_sub);
 
     assert.throws(() => {
         stream_data.create_sub_from_server_data('Canada', canada);
     }, {message: 'We cannot create a sub without a stream_id'});
 
-    const antarctica_sub = stream_data.create_sub_from_server_data('Antarctica', antarctica);
+    const antarctica_sub = stream_data.create_sub_from_server_data(antarctica);
     assert(antarctica_sub);
     assert.equal(antarctica_sub.color, '#76ce90');
 });
@@ -1062,7 +1063,7 @@ run_test('all_topics_in_cache', () => {
         {id: 2, stream_id: 21},
         {id: 3, stream_id: 21},
     ];
-    const sub = stream_data.create_sub_from_server_data('general', general);
+    const sub = stream_data.create_sub_from_server_data(general);
 
     assert.equal(stream_data.all_topics_in_cache(sub), false);
 

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -645,60 +645,60 @@ run_test('notifications', () => {
     stream_data.clear_subscriptions();
     stream_data.add_sub(india);
 
-    assert(!stream_data.receives_notifications('Indiana', "desktop_notifications"));
-    assert(!stream_data.receives_notifications('Indiana', "audible_notifications"));
+    assert(!stream_data.receives_notifications(india.stream_id, "desktop_notifications"));
+    assert(!stream_data.receives_notifications(india.stream_id, "audible_notifications"));
 
     page_params.enable_stream_desktop_notifications = true;
     page_params.enable_stream_audible_notifications = true;
-    assert(stream_data.receives_notifications('India', "desktop_notifications"));
-    assert(stream_data.receives_notifications('India', "audible_notifications"));
+    assert(stream_data.receives_notifications(india.stream_id, "desktop_notifications"));
+    assert(stream_data.receives_notifications(india.stream_id, "audible_notifications"));
 
     page_params.enable_stream_desktop_notifications = false;
     page_params.enable_stream_audible_notifications = false;
-    assert(!stream_data.receives_notifications('India', "desktop_notifications"));
-    assert(!stream_data.receives_notifications('India', "audible_notifications"));
+    assert(!stream_data.receives_notifications(india.stream_id, "desktop_notifications"));
+    assert(!stream_data.receives_notifications(india.stream_id, "audible_notifications"));
 
     india.desktop_notifications = true;
     india.audible_notifications = true;
-    assert(stream_data.receives_notifications('India', "desktop_notifications"));
-    assert(stream_data.receives_notifications('India', "audible_notifications"));
+    assert(stream_data.receives_notifications(india.stream_id, "desktop_notifications"));
+    assert(stream_data.receives_notifications(india.stream_id, "audible_notifications"));
 
     india.desktop_notifications = false;
     india.audible_notifications = false;
     page_params.enable_stream_desktop_notifications = true;
     page_params.enable_stream_audible_notifications = true;
-    assert(!stream_data.receives_notifications('India', "desktop_notifications"));
-    assert(!stream_data.receives_notifications('India', "audible_notifications"));
+    assert(!stream_data.receives_notifications(india.stream_id, "desktop_notifications"));
+    assert(!stream_data.receives_notifications(india.stream_id, "audible_notifications"));
 
     page_params.wildcard_mentions_notify = true;
-    assert(stream_data.receives_notifications('India', "wildcard_mentions_notify"));
+    assert(stream_data.receives_notifications(india.stream_id, "wildcard_mentions_notify"));
     page_params.wildcard_mentions_notify = false;
-    assert(!stream_data.receives_notifications('India', "wildcard_mentions_notify"));
+    assert(!stream_data.receives_notifications(india.stream_id, "wildcard_mentions_notify"));
     india.wildcard_mentions_notify = true;
-    assert(stream_data.receives_notifications('India', "wildcard_mentions_notify"));
+    assert(stream_data.receives_notifications(india.stream_id, "wildcard_mentions_notify"));
     page_params.wildcard_mentions_notify = true;
     india.wildcard_mentions_notify = false;
-    assert(!stream_data.receives_notifications('India', "wildcard_mentions_notify"));
+    assert(!stream_data.receives_notifications(india.stream_id, "wildcard_mentions_notify"));
 
     page_params.enable_stream_push_notifications = true;
-    assert(stream_data.receives_notifications('India', "push_notifications"));
+    assert(stream_data.receives_notifications(india.stream_id, "push_notifications"));
     page_params.enable_stream_push_notifications = false;
-    assert(!stream_data.receives_notifications('India', "push_notifications"));
+    assert(!stream_data.receives_notifications(india.stream_id, "push_notifications"));
     india.push_notifications = true;
-    assert(stream_data.receives_notifications('India', "push_notifications"));
+    assert(stream_data.receives_notifications(india.stream_id, "push_notifications"));
     page_params.enable_stream_push_notifications = true;
     india.push_notifications = false;
-    assert(!stream_data.receives_notifications('India', "push_notifications"));
+    assert(!stream_data.receives_notifications(india.stream_id, "push_notifications"));
 
     page_params.enable_stream_email_notifications = true;
-    assert(stream_data.receives_notifications('India', "email_notifications"));
+    assert(stream_data.receives_notifications(india.stream_id, "email_notifications"));
     page_params.enable_stream_email_notifications = false;
-    assert(!stream_data.receives_notifications('India', "email_notifications"));
+    assert(!stream_data.receives_notifications(india.stream_id, "email_notifications"));
     india.email_notifications = true;
-    assert(stream_data.receives_notifications('India', "email_notifications"));
+    assert(stream_data.receives_notifications(india.stream_id, "email_notifications"));
     page_params.enable_stream_email_notifications = true;
     india.email_notifications = false;
-    assert(!stream_data.receives_notifications('India', "email_notifications"));
+    assert(!stream_data.receives_notifications(india.stream_id, "email_notifications"));
 
     const canada = {
         stream_id: 103,

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -225,7 +225,7 @@ run_test('subscribers', () => {
     assert(!stream_data.is_user_subscribed('Rome', brutus.user_id));
 
     // add
-    let ok = stream_data.add_subscriber('Rome', brutus.user_id);
+    let ok = stream_data.add_subscriber(sub.stream_id, brutus.user_id);
     assert(ok);
     assert(stream_data.is_user_subscribed('Rome', brutus.user_id));
     sub = stream_data.get_sub('Rome');
@@ -236,7 +236,7 @@ run_test('subscribers', () => {
     assert.equal(sub.email_address, sub_email);
 
     // verify that adding an already-added subscriber is a noop
-    stream_data.add_subscriber('Rome', brutus.user_id);
+    stream_data.add_subscriber(sub.stream_id, brutus.user_id);
     assert(stream_data.is_user_subscribed('Rome', brutus.user_id));
     sub = stream_data.get_sub('Rome');
     stream_data.update_subscribers_count(sub);
@@ -274,19 +274,19 @@ run_test('subscribers', () => {
     // can be undefined.
     stream_data.set_subscribers(sub);
     stream_data.add_sub(sub);
-    stream_data.add_subscriber('Rome', brutus.user_id);
+    stream_data.add_subscriber(sub.stream_id, brutus.user_id);
     sub.subscribed = true;
     assert(stream_data.is_user_subscribed('Rome', brutus.user_id));
 
     // Verify that we noop and don't crash when unsubscribed.
     sub.subscribed = false;
     stream_data.update_calculated_fields(sub);
-    ok = stream_data.add_subscriber('Rome', brutus.user_id);
+    ok = stream_data.add_subscriber(sub.stream_id, brutus.user_id);
     assert(ok);
     assert.equal(stream_data.is_user_subscribed('Rome', brutus.user_id), true);
     stream_data.remove_subscriber('Rome', brutus.user_id);
     assert.equal(stream_data.is_user_subscribed('Rome', brutus.user_id), false);
-    stream_data.add_subscriber('Rome', brutus.user_id);
+    stream_data.add_subscriber(sub.stream_id, brutus.user_id);
     assert.equal(stream_data.is_user_subscribed('Rome', brutus.user_id), true);
 
     blueslip.expect(
@@ -302,13 +302,13 @@ run_test('subscribers', () => {
     blueslip.expect(
         'warn',
         'We got an add_subscriber call for a non-existent stream.');
-    ok = stream_data.add_subscriber('UNKNOWN', brutus.user_id);
+    ok = stream_data.add_subscriber(9999999, brutus.user_id);
     assert(!ok);
 
     // Verify that we don't crash and return false for a bad user id.
     blueslip.expect('error', 'Unknown user_id in get_by_user_id: 9999999');
     blueslip.expect('error', 'We tried to add invalid subscriber: 9999999');
-    ok = stream_data.add_subscriber('Rome', 9999999);
+    ok = stream_data.add_subscriber(sub.stream_id, 9999999);
     assert(!ok);
 });
 
@@ -613,7 +613,7 @@ run_test('get_subscriber_count', () => {
         user_id: 101,
     };
     people.add_active_user(fred);
-    stream_data.add_subscriber('India', 102);
+    stream_data.add_subscriber(india.stream_id, 102);
     assert.equal(stream_data.get_subscriber_count('India'), 1);
     const george = {
         email: 'george@zulip.com',
@@ -621,7 +621,7 @@ run_test('get_subscriber_count', () => {
         user_id: 103,
     };
     people.add_active_user(george);
-    stream_data.add_subscriber('India', 103);
+    stream_data.add_subscriber(india.stream_id, 103);
     assert.equal(stream_data.get_subscriber_count('India'), 2);
 
     const sub = stream_data.get_sub_by_name('India');

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -382,7 +382,7 @@ run_test('remove_deactivated_user_from_all_streams', () => {
     dev_help.can_access_subscribers = true;
 
     // verify that deactivating user should unsubscribe user from all streams
-    assert(stream_data.add_subscriber(dev_help.name, george.user_id));
+    assert(stream_data.add_subscriber(dev_help.stream_id, george.user_id));
     assert(dev_help.subscribers.has(george.user_id));
 
     stream_events.remove_deactivated_user_from_all_streams(george.user_id);

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -240,9 +240,9 @@ run_test('sort_recipients', () => {
     const subscriber_email_1 = "b_user_2@zulip.net";
     const subscriber_email_2 = "b_user_3@zulip.net";
     const subscriber_email_3 = "b_bot@example.com";
-    stream_data.add_subscriber("Dev", people.get_user_id(subscriber_email_1));
-    stream_data.add_subscriber("Dev", people.get_user_id(subscriber_email_2));
-    stream_data.add_subscriber("Dev", people.get_user_id(subscriber_email_3));
+    stream_data.add_subscriber(1, people.get_user_id(subscriber_email_1));
+    stream_data.add_subscriber(1, people.get_user_id(subscriber_email_2));
+    stream_data.add_subscriber(1, people.get_user_id(subscriber_email_3));
 
     const dev_sub = stream_data.get_sub("Dev");
     const linux_sub = stream_data.get_sub("Linux");

--- a/static/js/compose_fade.js
+++ b/static/js/compose_fade.js
@@ -94,7 +94,7 @@ function fade_messages() {
 
 exports.would_receive_message = function (user_id) {
     if (focused_recipient.type === 'stream') {
-        const sub = stream_data.get_sub(focused_recipient.stream);
+        const sub = stream_data.get_sub_by_id(focused_recipient.stream_id);
         if (!sub) {
             // If the stream isn't valid, there is no risk of a mix
             // yet, so we sort of "lie" and say they would receive a
@@ -154,7 +154,7 @@ function want_normal_display() {
     if (focused_recipient.type === "stream") {
         // If a stream doesn't exist, there is no real chance of a mix, so fading
         // is just noise to the user.
-        if (!stream_data.get_sub(focused_recipient.stream)) {
+        if (!stream_data.get_sub_by_id(focused_recipient.stream_id)) {
             return true;
         }
 

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -133,7 +133,7 @@ function populate_group_from_message_container(group, message_container) {
         group.match_topic = util.get_match_topic(message_container.msg);
         group.stream_url = message_container.stream_url;
         group.topic_url = message_container.topic_url;
-        const sub = stream_data.get_sub(message_container.msg.stream);
+        const sub = stream_data.get_sub_by_id(message_container.msg.stream_id);
         if (sub === undefined) {
             // Hack to handle unusual cases like the tutorial where
             // the streams used don't actually exist in the subs

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -467,7 +467,7 @@ exports.should_send_desktop_notification = function (message) {
     // For streams, send if desktop notifications are enabled for all
     // message on this stream.
     if (message.type === "stream" &&
-        stream_data.receives_notifications(message.stream, "desktop_notifications")) {
+        stream_data.receives_notifications(message.stream_id, "desktop_notifications")) {
         return true;
     }
 
@@ -493,7 +493,7 @@ exports.should_send_desktop_notification = function (message) {
 
     // wildcard mentions
     if (message.mentioned &&
-            stream_data.receives_notifications(message.stream, "wildcard_mentions_notify")) {
+            stream_data.receives_notifications(message.stream_id, "wildcard_mentions_notify")) {
         return true;
     }
 
@@ -504,7 +504,7 @@ exports.should_send_audible_notification = function (message) {
     // For streams, ding if sounds are enabled for all messages on
     // this stream.
     if (message.type === "stream" &&
-        stream_data.receives_notifications(message.stream, "audible_notifications")) {
+        stream_data.receives_notifications(message.stream_id, "audible_notifications")) {
         return true;
     }
 
@@ -529,7 +529,7 @@ exports.should_send_audible_notification = function (message) {
 
     // wildcard mentions
     if (message.mentioned &&
-            stream_data.receives_notifications(message.stream, "wildcard_mentions_notify")) {
+            stream_data.receives_notifications(message.stream_id, "wildcard_mentions_notify")) {
         return true;
     }
 

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -158,7 +158,7 @@ function format_topic(topic_data) {
     const last_msg = message_store.get(topic_data.last_msg_id);
     const stream = last_msg.stream;
     const stream_id = last_msg.stream_id;
-    const stream_info = stream_data.get_sub(stream);
+    const stream_info = stream_data.get_sub_by_id(stream_id);
     const topic = last_msg.topic;
     const time = new XDate(last_msg.timestamp * 1000);
     const last_msg_time = timerender.last_seen_status_from_date(time);

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -345,7 +345,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
                     return;
                 }
 
-                stream_edit.rerender(sub.name);
+                subs.rerender_subscriptions_settings(sub);
                 compose_fade.update_faded_users();
             }
             add_peer(event.stream_id, event.user_id);
@@ -363,7 +363,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
                     return;
                 }
 
-                stream_edit.rerender(sub.name);
+                subs.rerender_subscriptions_settings(sub);
                 compose_fade.update_faded_users();
             }
             remove_peer(event.stream_id, event.user_id);

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -358,7 +358,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
                     return;
                 }
 
-                if (!stream_data.remove_subscriber(sub.name, user_id)) {
+                if (!stream_data.remove_subscriber(sub.stream_id, user_id)) {
                     blueslip.warn('Cannot process peer_remove event.');
                     return;
                 }

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -340,7 +340,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
                     return;
                 }
 
-                if (!stream_data.add_subscriber(sub.name, user_id)) {
+                if (!stream_data.add_subscriber(stream_id, user_id)) {
                     blueslip.warn('Cannot process peer_add event');
                     return;
                 }

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -431,8 +431,8 @@ exports.update_message_retention_setting  = function (sub, message_retention_day
     sub.message_retention_days = message_retention_days;
 };
 
-exports.receives_notifications = function (stream_name, notification_name) {
-    const sub = exports.get_sub(stream_name);
+exports.receives_notifications = function (stream_id, notification_name) {
+    const sub = exports.get_sub_by_id(stream_id);
     if (sub === undefined) {
         return false;
     }
@@ -753,7 +753,7 @@ exports.get_unmatched_streams_for_notification_settings = function () {
         for (const notification_name of settings_config.stream_specific_notification_settings) {
             const prepend = notification_name === 'wildcard_mentions_notify' ? "" : "enable_stream_";
             const default_setting = page_params[prepend + notification_name];
-            const stream_setting = exports.receives_notifications(row.name, notification_name);
+            const stream_setting = exports.receives_notifications(row.stream_id, notification_name);
 
             settings_values[notification_name] = stream_setting;
             if (stream_setting !== default_setting) {

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -176,7 +176,7 @@ exports.is_subscriber_subset = function (sub1, sub2) {
 exports.unsubscribe_myself = function (sub) {
     // Remove user from subscriber's list
     const user_id = people.my_current_user_id();
-    exports.remove_subscriber(sub.name, user_id);
+    exports.remove_subscriber(sub.stream_id, user_id);
     sub.subscribed = false;
     sub.newly_subscribed = false;
     stream_info.set_false(sub.name, sub);
@@ -644,10 +644,10 @@ exports.add_subscriber = function (stream_id, user_id) {
     return true;
 };
 
-exports.remove_subscriber = function (stream_name, user_id) {
-    const sub = exports.get_sub(stream_name);
+exports.remove_subscriber = function (stream_id, user_id) {
+    const sub = exports.get_sub_by_id(stream_id);
     if (typeof sub === 'undefined') {
-        blueslip.warn("We got a remove_subscriber call for a non-existent stream " + stream_name);
+        blueslip.warn("We got a remove_subscriber call for a non-existent stream " + stream_id);
         return false;
     }
     if (!sub.subscribers.has(user_id)) {

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -157,7 +157,7 @@ exports.rename_sub = function (sub, new_name) {
 
 exports.subscribe_myself = function (sub) {
     const user_id = people.my_current_user_id();
-    exports.add_subscriber(sub.name, user_id);
+    exports.add_subscriber(sub.stream_id, user_id);
     sub.subscribed = true;
     sub.newly_subscribed = true;
     stream_info.set_true(sub.name, sub);
@@ -628,8 +628,8 @@ exports.set_subscribers = function (sub, user_ids) {
     sub.subscribers = new LazySet(user_ids || []);
 };
 
-exports.add_subscriber = function (stream_name, user_id) {
-    const sub = exports.get_sub(stream_name);
+exports.add_subscriber = function (stream_id, user_id) {
+    const sub = exports.get_sub_by_id(stream_id);
     if (typeof sub === 'undefined') {
         blueslip.warn("We got an add_subscriber call for a non-existent stream.");
         return false;

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -36,15 +36,6 @@ exports.settings_for_sub = function (sub) {
     return $("#subscription_overlay .subscription_settings[data-stream-id='" + sub.stream_id + "']");
 };
 
-exports.rerender = function (stream_name) {
-    // This is a shim--our caller should call
-    // rerender_subscriptions_settings directly,
-    // but we are in the middle of a stream_name -> stream_id
-    // refactoring.
-    const sub = stream_data.get_sub(stream_name);
-    subs.rerender_subscriptions_settings(sub);
-};
-
 exports.is_sub_settings_active = function (sub) {
     // This function return whether the provided given sub object is
     // currently being viewed/edited in the stream edit UI.  This is

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -137,7 +137,7 @@ exports.remove_deactivated_user_from_all_streams = function (user_id) {
 
     for (const sub of all_subs) {
         if (stream_data.is_user_subscribed(sub.name, user_id)) {
-            stream_data.remove_subscriber(sub.name, user_id);
+            stream_data.remove_subscriber(sub.stream_id, user_id);
             subs.rerender_subscriptions_settings(sub);
         }
     }

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -103,7 +103,7 @@ exports.update_notification_setting_checkbox = function (notification_name) {
     }
     const stream_id = stream_row.data('stream-id');
     $(`#${notification_name}_${stream_id}`).prop("checked", stream_data.receives_notifications(
-        stream_data.maybe_get_stream_name(stream_id), notification_name));
+        stream_id, notification_name));
 };
 
 exports.update_stream_row_in_settings_tab = function (sub) {


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR removes some of the get_sub calls and changes the code to use stream_id wherever possible.

Marked as WIP because many of the get_sub calls are still left to be removed.

#15350.
**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
