### PR TITLE
Refactor server_events_dispatch to use nested switch/cases

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -882,4 +882,10 @@ run_test("server_event_dispatch_op_errors", () => {
     server_events_dispatch.dispatch_normal_event({type: "subscription", op: "other"});
     blueslip.expect("error", "Unexpected event type reaction/other");
     server_events_dispatch.dispatch_normal_event({type: "reaction", op: "other"});
+    blueslip.expect("error", "Unexpected event type realm/update_dict/other");
+    server_events_dispatch.dispatch_normal_event({
+        type: "realm",
+        op: "update_dict",
+        property: "other",
+    });
 });

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -890,4 +890,6 @@ run_test("server_event_dispatch_op_errors", () => {
     });
     blueslip.expect("error", "Unexpected event type realm_bot/other");
     server_events_dispatch.dispatch_normal_event({type: "realm_bot", op: "other"});
+    blueslip.expect("error", "Unexpected event type realm_domains/other");
+    server_events_dispatch.dispatch_normal_event({type: "realm_domains", op: "other"});
 });

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -888,4 +888,6 @@ run_test("server_event_dispatch_op_errors", () => {
         op: "update_dict",
         property: "other",
     });
+    blueslip.expect("error", "Unexpected event type realm_bot/other");
+    server_events_dispatch.dispatch_normal_event({type: "realm_bot", op: "other"});
 });

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -894,4 +894,6 @@ run_test("server_event_dispatch_op_errors", () => {
     server_events_dispatch.dispatch_normal_event({type: "realm_domains", op: "other"});
     blueslip.expect("error", "Unexpected event type realm_user/other");
     server_events_dispatch.dispatch_normal_event({type: "realm_user", op: "other"});
+    blueslip.expect("error", "Unexpected event type stream/other");
+    server_events_dispatch.dispatch_normal_event({type: "stream", op: "other"});
 });

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -5,6 +5,7 @@ const {strict: assert} = require("assert");
 const {mock_cjs, mock_esm, set_global, with_field, zrequire} = require("../zjsunit/namespace");
 const {make_stub} = require("../zjsunit/stub");
 const {run_test} = require("../zjsunit/test");
+const blueslip = require("../zjsunit/zblueslip");
 const $ = require("../zjsunit/zjquery");
 
 const noop = () => {};
@@ -874,4 +875,9 @@ run_test("realm_export", (override) => {
     assert.equal(stub.num_calls, 1);
     const args = stub.get_args("exports");
     assert.equal(args.exports, event.exports);
+});
+
+run_test("server_event_dispatch_op_errors", () => {
+    blueslip.expect("error", "Unexpected event type subscription/other");
+    server_events_dispatch.dispatch_normal_event({type: "subscription", op: "other"});
 });

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -877,7 +877,7 @@ run_test("realm_export", (override) => {
     assert.equal(args.exports, event.exports);
 });
 
-run_test("server_event_dispatch_op_errors", () => {
+run_test("server_event_dispatch_op_errors", (override) => {
     blueslip.expect("error", "Unexpected event type subscription/other");
     server_events_dispatch.dispatch_normal_event({type: "subscription", op: "other"});
     blueslip.expect("error", "Unexpected event type reaction/other");
@@ -896,4 +896,13 @@ run_test("server_event_dispatch_op_errors", () => {
     server_events_dispatch.dispatch_normal_event({type: "realm_user", op: "other"});
     blueslip.expect("error", "Unexpected event type stream/other");
     server_events_dispatch.dispatch_normal_event({type: "stream", op: "other"});
+    blueslip.expect("error", "Unexpected event type typing/other");
+    server_events_dispatch.dispatch_normal_event({
+        type: "typing",
+        sender: {user_id: 5},
+        op: "other",
+    });
+    override(settings_user_groups, "reload", noop);
+    blueslip.expect("error", "Unexpected event type user_group/other");
+    server_events_dispatch.dispatch_normal_event({type: "user_group", op: "other"});
 });

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -892,4 +892,6 @@ run_test("server_event_dispatch_op_errors", () => {
     server_events_dispatch.dispatch_normal_event({type: "realm_bot", op: "other"});
     blueslip.expect("error", "Unexpected event type realm_domains/other");
     server_events_dispatch.dispatch_normal_event({type: "realm_domains", op: "other"});
+    blueslip.expect("error", "Unexpected event type realm_user/other");
+    server_events_dispatch.dispatch_normal_event({type: "realm_user", op: "other"});
 });

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -880,4 +880,6 @@ run_test("realm_export", (override) => {
 run_test("server_event_dispatch_op_errors", () => {
     blueslip.expect("error", "Unexpected event type subscription/other");
     server_events_dispatch.dispatch_normal_event({type: "subscription", op: "other"});
+    blueslip.expect("error", "Unexpected event type reaction/other");
+    server_events_dispatch.dispatch_normal_event({type: "reaction", op: "other"});
 });

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -528,6 +528,9 @@ export function dispatch_normal_event(event) {
                 case "stop":
                     typing_events.hide_notification(event);
                     break;
+                default:
+                    blueslip.error("Unexpected event type typing/" + event.op);
+                    break;
             }
             break;
 
@@ -664,6 +667,9 @@ export function dispatch_normal_event(event) {
                     break;
                 case "update":
                     user_groups.update(event);
+                    break;
+                default:
+                    blueslip.error("Unexpected event type user_group/" + event.op);
                     break;
             }
             settings_user_groups.reload();

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -316,6 +316,9 @@ export function dispatch_normal_event(event) {
                     settings_bots.eventually_render_bots();
                     settings_users.update_bot_data(event.bot.user_id);
                     break;
+                default:
+                    blueslip.error("Unexpected event type realm_bot/" + event.op);
+                    break;
             }
             break;
         case "realm_emoji":

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -150,10 +150,13 @@ export function dispatch_normal_event(event) {
         }
 
         case "reaction":
-            if (event.op === "add") {
-                reactions.add_reaction(event);
-            } else if (event.op === "remove") {
-                reactions.remove_reaction(event);
+            switch (event.op) {
+                case "add":
+                    reactions.add_reaction(event);
+                    break;
+                case "remove":
+                    reactions.remove_reaction(event);
+                    break;
             }
             break;
 

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -296,21 +296,28 @@ export function dispatch_normal_event(event) {
         }
 
         case "realm_bot":
-            if (event.op === "add") {
-                bot_data.add(event.bot);
-            } else if (event.op === "remove") {
-                bot_data.deactivate(event.bot.user_id);
-                event.bot.is_active = false;
-            } else if (event.op === "delete") {
-                blueslip.info("ignoring bot deletion for live UI update");
-                break;
-            } else if (event.op === "update") {
-                bot_data.update(event.bot.user_id, event.bot);
+            switch (event.op) {
+                case "add":
+                    bot_data.add(event.bot);
+                    settings_bots.eventually_render_bots();
+                    settings_users.update_bot_data(event.bot.user_id);
+                    break;
+                case "remove":
+                    bot_data.deactivate(event.bot.user_id);
+                    event.bot.is_active = false;
+                    settings_bots.eventually_render_bots();
+                    settings_users.update_bot_data(event.bot.user_id);
+                    break;
+                case "delete":
+                    blueslip.info("ignoring bot deletion for live UI update");
+                    break;
+                case "update":
+                    bot_data.update(event.bot.user_id, event.bot);
+                    settings_bots.eventually_render_bots();
+                    settings_users.update_bot_data(event.bot.user_id);
+                    break;
             }
-            settings_bots.eventually_render_bots();
-            settings_users.update_bot_data(event.bot.user_id);
             break;
-
         case "realm_emoji":
             // The authoritative data source is here.
             emoji.update_emojis(event.realm_emoji);

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -437,6 +437,9 @@ export function dispatch_normal_event(event) {
                         }
                     }
                     break;
+                default:
+                    blueslip.error("Unexpected event type stream/" + event.op);
+                    break;
             }
             break;
 

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -364,6 +364,9 @@ export function dispatch_normal_event(event) {
                         }
                         settings_org.populate_realm_domains(page_params.realm_domains);
                         break;
+                    default:
+                        blueslip.error("Unexpected event type realm_domains/" + event.op);
+                        break;
                 }
             }
             break;

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -261,6 +261,9 @@ export function dispatch_normal_event(event) {
                         page_params.realm_night_logo_source = event.data.night_logo_source;
                         realm_logo.rerender();
                         break;
+                    default:
+                        blueslip.error("Unexpected event type realm/update_dict/" + event.property);
+                        break;
                 }
             } else if (event.op === "deactivated") {
                 // This handler is likely unnecessary, in that if we

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -471,6 +471,9 @@ export function dispatch_normal_event(event) {
                 case "update":
                     stream_events.update_property(event.stream_id, event.property, event.value);
                     break;
+                default:
+                    blueslip.error("Unexpected event type subscription/" + event.op);
+                    break;
             }
             break;
         case "typing":

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -157,6 +157,9 @@ export function dispatch_normal_event(event) {
                 case "remove":
                     reactions.remove_reaction(event);
                     break;
+                default:
+                    blueslip.error("Unexpected event type reaction/" + event.op);
+                    break;
             }
             break;
 

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -383,6 +383,9 @@ export function dispatch_normal_event(event) {
                 case "update":
                     user_events.update_person(event.person);
                     break;
+                default:
+                    blueslip.error("Unexpected event type realm_user/" + event.op);
+                    break;
             }
             break;
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
As this currently is: it's intended to demonstrate a kind of refactor we could do over the *entire* server_events_dispatch file. If it seems like this direction would lead to better code, this PR and description will be updated.

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
