### PR TITLE
overlay: Fix exception when modal is opened repeatedly.

### DIFF
--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -116,12 +116,6 @@ exports.open_modal = function (selector) {
         return;
     }
 
-    if (exports.is_modal_open()) {
-        blueslip.error('open_modal() was called while ' + exports.active_modal() +
-            ' modal was open.');
-        return;
-    }
-
     blueslip.debug('open modal: ' + selector);
 
     const elem = $(selector).expectOne();


### PR DESCRIPTION
Modal gets closed on a click in the background by default. So, there was no need to add unnecessary
if block.

Fixes #15463.

**Testing Plan:**
Unit tests and manual testing.