### PR TITLE
compose: Fix video call button when Big Blue Button isn’t enabled

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -1123,7 +1123,9 @@ exports.initialize = function () {
                 );
             }
         } else if (
-            page_params.realm_video_chat_provider === available_providers.big_blue_button.id) {
+            available_providers.big_blue_button
+            && page_params.realm_video_chat_provider === available_providers.big_blue_button.id
+        ) {
 
             channel.get({
                 url: '/json/calls/bigbluebutton/create',


### PR DESCRIPTION
Fixes ‘Uncaught TypeError: can't access property "id", available_providers.big_blue_button is undefined’ introduced by commit a389c7390d8a90e66fc9df259411a5ce61682fc0 (#14775).

Cc @strifel

**Testing Plan:** Dev server