### PR TITLE
styles: Use @supports for Mozilla detection

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -785,7 +785,7 @@ on a dark background, and don't change the dark labels dark either. */
     }
 }
 
-@-moz-document url-prefix() {
+@supports (-moz-appearance: none) {
     body.night-mode #settings_page select {
         background-color: hsla(0, 0%, 0%, 0.2);
     }

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1946,7 +1946,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
     margin-left: 2px;
 }
 
-@-moz-document url-prefix() {
+@supports (-moz-appearance: none) {
     #settings_page select {
         -moz-appearance: none;
         background: hsl(0, 0%, 100%) url('../images/dropdown.png') right / 20px no-repeat;


### PR DESCRIPTION
Fixes these compilation errors from webpack and PostCSS, exposed by commit b10f156250e3b982d8b7200479279cbb85069f1d (#14997) which tries to `@extend` these directives:

```
Unexpected '}' at app.d5da4b9d46e79634b8fb.css:9103:4.
Unexpected '}' at app.d5da4b9d46e79634b8fb.css:9104:0.
Invalid property name '@-moz-document url-prefix() {

            @nest & #settings_page select {
        background-color' at night_mode.scss:788:0. Ignoring.
Invalid selector '}
}

.user_status_overlay .overlay-content' at night_mode.scss:797:4. Ignoring.
```

**Testing Plan:** Dev server.

Cc @MariaGkoulta
