### PR TITLE
Fix installer interactions with postgres; installer flag cleanup

### DIFF
--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -79,14 +79,14 @@ below.
 #### Step 1: Setup Zulip
 
 Follow the [standard instructions](../production/install.md), with one
-change.  When running the installer, pass the `--remote-postgres`
+change.  When running the installer, pass the `--no-init-db`
 flag, e.g.:
 
 ```
 sudo -s  # If not already root
 ./zulip-server-*/scripts/setup/install --certbot \
     --email=YOUR_EMAIL --hostname=YOUR_HOSTNAME \
-    --remote-postgres --postgres-missing-dictionaries
+    --no-init-db --postgres-missing-dictionaries
 ```
 
 The script also installs and starts Postgres on the server by

--- a/docs/production/install-existing-server.md
+++ b/docs/production/install-existing-server.md
@@ -62,9 +62,16 @@ $ sudo service puppet-agent stop
 $ sudo service puppet stop
 ```
 
-### Postgres
+### PostgreSQL
 
-If you have an existing postgres database, note that Zulip will use
+Zulip expects to install PostgreSQL 12, and find that listening on
+port 5432; any other version of PostgreSQL that is detected at install
+time will cause the install to abort.  If you already have PostgreSQL
+installed, you can pass `--postgres-version=` to the installer to have
+it use that version.  It will replace the package with the latest from
+the PostgreSQL apt repository, but existing data will be retained.
+
+If you have an existing PostgreSQL database, note that Zulip will use
 the default `main` as its database name; make sure you're not using
 that.
 

--- a/puppet/zulip/manifests/supervisor.pp
+++ b/puppet/zulip/manifests/supervisor.pp
@@ -80,12 +80,4 @@ class zulip::supervisor {
     source  => 'puppet:///modules/zulip/supervisor/supervisord.conf',
     notify  => Service[$supervisor_service],
   }
-
-  if $zulip::base::release_name == 'xenial' {
-    exec {'enable supervisor':
-      unless  => "systemctl is-enabled ${supervisor_service}",
-      command => "systemctl enable ${supervisor_service}",
-      require => Package['supervisor'],
-    }
-  }
 }

--- a/puppet/zulip/templates/memcached.conf.template.erb
+++ b/puppet/zulip/templates/memcached.conf.template.erb
@@ -34,11 +34,6 @@ logfile /var/log/memcached.log
 # it's listening on a firewalled interface.
 -l 127.0.0.1
 
-<% if scope["zulip::base::release_name"] == "xenial" -%>
-# Use "modern" features.
--o slab_reassign,slab_automove,lru_crawler,lru_maintainer,maxconns_fast,hash_algorithm=murmur3
-<% end -%>
-
 # Limit the number of simultaneous incoming connections. The daemon default is 1024
 # -c 1024
 

--- a/puppet/zulip/templates/nginx.conf.template.erb
+++ b/puppet/zulip/templates/nginx.conf.template.erb
@@ -47,11 +47,7 @@ http {
     ssl_session_cache shared:SSL:50m;
     ssl_session_tickets off;
     ssl_dhparam /etc/nginx/dhparam.pem;
-<% if scope["zulip::base::release_name"] == "stretch" or scope["zulip::base::release_name"] == "xenial" -%>
-    ssl_protocols TLSv1.2;
-<% else -%>
     ssl_protocols TLSv1.2 TLSv1.3;
-<% end -%>
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers off;
     ssl_stapling on;

--- a/puppet/zulip_ops/files/zulip-ec2-configure-interfaces
+++ b/puppet/zulip_ops/files/zulip-ec2-configure-interfaces
@@ -97,10 +97,6 @@ for device in macs.values():
     else:
         to_configure = list(device['local-ipv4s'])
     device_number = int(device['device-number'])
-    if subprocess.check_output(["lsb_release", '-sc']).strip() == "xenial":
-        # HACK: It appears on Xenial device_number in the data set is 0 but in reality it is 3
-        device_number += 3
-
     address = address_of(device_number)
 
     if address is None:

--- a/puppet/zulip_ops/manifests/zmirror.pp
+++ b/puppet/zulip_ops/manifests/zmirror.pp
@@ -25,7 +25,7 @@ class zulip_ops::zmirror {
 
   apt::source {'debathena':
     location    => 'http://debathena.mit.edu/apt',
-    release     => 'xenial',
+    release     => $zulip::base::release_name,
     repos       => 'debathena debathena-config',
     key         => 'D1CD49BDD30B677273A75C66E4EE62700D8A9E8F',
     key_source  => 'https://debathena.mit.edu/apt/debathena-archive.asc',

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -28,6 +28,8 @@ Options:
       install process; used when this command is run once in a highly-controlled
       environment to produce an image which is used elsewhere.  Uncommon.
 
+  --postgres-version=12
+      Sets the version of Postgres that will be installed.
   --postgres-missing-dictionaries
       Set postgresql.missing_dictionaries, which alters the initial database.  Use with
       cloud managed databases like RDS.  Conflicts with --no-overwrite-settings.
@@ -45,7 +47,7 @@ EOF
 
 # Shell option parsing.  Over time, we'll want to move some of the
 # environment variables below into this self-documenting system.
-args="$(getopt -o '' --long help,hostname:,email:,certbot,self-signed-cert,cacert:,postgres-missing-dictionaries,no-init-db,no-overwrite-settings,no-dist-upgrade -n "$0" -- "$@")"
+args="$(getopt -o '' --long help,hostname:,email:,certbot,self-signed-cert,cacert:,postgres-version:,postgres-missing-dictionaries,no-init-db,no-overwrite-settings,no-dist-upgrade -n "$0" -- "$@")"
 eval "set -- $args"
 while true; do
     case "$1" in
@@ -58,6 +60,7 @@ while true; do
         --cacert) export CUSTOM_CA_CERTIFICATES="$2"; shift; shift;;
         --self-signed-cert) SELF_SIGNED_CERT=1; shift;;
 
+        --postgres-version) POSTGRES_VERSION="$2"; shift; shift;;
         --postgres-missing-dictionaries) POSTGRES_MISSING_DICTIONARIES=1; shift;;
         --no-init-db) NO_INIT_DB=1; shift;;
 
@@ -85,6 +88,7 @@ DEPLOYMENT_TYPE="${DEPLOYMENT_TYPE:-voyager}"
 # Docker.  Use e.g. zulip::app_frontend for a Zulip frontend server.
 PUPPET_CLASSES="${PUPPET_CLASSES:-zulip::voyager}"
 VIRTUALENV_NEEDED="${VIRTUALENV_NEEDED:-yes}"
+POSTGRES_VERSION="${POSTGRES_VERSION:-12}"
 
 if [ -n "$SELF_SIGNED_CERT" ] && [ -n "$USE_CERTBOT" ]; then
     set +x
@@ -335,7 +339,7 @@ EOF
                     cat <<EOF
 
 [postgresql]
-version = 12
+version = $POSTGRES_VERSION
 EOF
                 fi
                 ;;

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -184,6 +184,37 @@ EOF
     exit 1
 fi
 
+case ",$PUPPET_CLASSES," in
+    *,zulip::voyager,* | *,zulip::postgres_appdb_tuned,*)
+        if [ "$package_system" = apt ]; then
+            # We're going to install Postgres from the postgres apt
+            # repository; this may conflict with the existing postgres.
+            OTHER_PG="$(dpkg --get-selections |
+                             grep '^postgresql-[1-9].*\binstall$' |
+                             grep -v "^postgresql-$POSTGRES_VERSION\b" |
+                             cut -f 1)" || true
+            if [ -n "$OTHER_PG" ]; then
+                INDENTED="${OTHER_PG//$'\n'/$'\n'    }"
+                SPACED="${OTHER_PG//$'\n'/ }"
+                cat <<EOF
+
+The following PostgreSQL servers were found to already be installed:
+
+    $INDENTED
+
+Zulip needs to install PostgreSQL $POSTGRES_VERSION, but does not wish
+to uninstall existing databases in order to do so.  Remove all other
+PostgreSQL servers manually before running the installer:
+
+    sudo apt-get remove $SPACED
+
+EOF
+                exit 1
+            fi
+        fi
+        ;;
+esac
+
 # Check for at least ~1.86GB of RAM before starting installation;
 # otherwise users will find out about insufficient RAM via weird
 # errors like a segfault running `pip install`.

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -329,15 +329,17 @@ auto_renew = yes
 EOF
         fi
 
-        if [ -e "/etc/init.d/postgresql" ]; then
-            if [ "$package_system" = apt ]; then
-                cat <<EOF
+        case ",$PUPPET_CLASSES," in
+            *,zulip::voyager,* | *,zulip::postgres_appdb_tuned,*)
+                if [ "$package_system" = apt ]; then
+                    cat <<EOF
 
 [postgresql]
 version = 12
 EOF
-            fi
-        fi
+                fi
+                ;;
+        esac
     ) > /etc/zulip/zulip.conf
 fi
 

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -118,7 +118,7 @@ if [ -f /etc/os-release ]; then
 fi
 
 case "$os_id$os_version_id" in
-    ubuntu16.04|ubuntu18.04|debian9|debian10|ubuntu20.04) ;;
+    debian10|ubuntu18.04|ubuntu20.04) ;;
     *)
         set +x
         cat <<EOF
@@ -128,6 +128,7 @@ Unsupported OS release: $os_id $os_version_id
 Zulip in production is supported only on:
  - Debian 10 "buster"
  - Ubuntu 18.04 LTS "bionic"
+ - Ubuntu 20.04 LTS "focal"
 
 For more information, see:
   https://zulip.readthedocs.io/en/latest/production/requirements.html

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -10,11 +10,14 @@ Usage:
 Other options:
   --certbot
   --self-signed-cert
-  --no-init-db
-  --cacert
-  --no-dist-upgrade
+  --cacert=/path/to
+
   --postgres-missing-dictionaries
   --remote-postgres
+  --no-init-db
+
+  --no-overwrite-settings
+  --no-dist-upgrade
 
 The --hostname and --email options are required,
 unless --no-init-db is set and --certbot is not.
@@ -24,21 +27,25 @@ EOF
 
 # Shell option parsing.  Over time, we'll want to move some of the
 # environment variables below into this self-documenting system.
-args="$(getopt -o '' --long help,no-init-db,no-dist-upgrade,no-overwrite-settings,self-signed-cert,certbot,postgres-missing-dictionaries,remote-postgres,hostname:,email:,cacert: -n "$0" -- "$@")"
+args="$(getopt -o '' --long help,hostname:,email:,certbot,self-signed-cert,cacert:,postgres-missing-dictionaries,remote-postgres,no-init-db,no-overwrite-settings,no-dist-upgrade -n "$0" -- "$@")"
 eval "set -- $args"
 while true; do
     case "$1" in
         --help) usage; exit 0;;
-        --self-signed-cert) SELF_SIGNED_CERT=1; shift;;
-        --cacert) export CUSTOM_CA_CERTIFICATES="$2"; shift; shift;;
-        --certbot) USE_CERTBOT=1; shift;;
+
         --hostname) EXTERNAL_HOST="$2"; shift; shift;;
         --email) ZULIP_ADMINISTRATOR="$2"; shift; shift;;
-        --no-overwrite-settings) NO_OVERWRITE_SETTINGS=1; shift;;
-        --no-init-db) NO_INIT_DB=1; shift;;
-        --no-dist-upgrade) NO_DIST_UPGRADE=1; shift;;
+
+        --certbot) USE_CERTBOT=1; shift;;
+        --cacert) export CUSTOM_CA_CERTIFICATES="$2"; shift; shift;;
+        --self-signed-cert) SELF_SIGNED_CERT=1; shift;;
+
         --postgres-missing-dictionaries) POSTGRES_MISSING_DICTIONARIES=1; shift;;
         --remote-postgres) REMOTE_POSTGRES=1; shift;;
+        --no-init-db) NO_INIT_DB=1; shift;;
+
+        --no-overwrite-settings) NO_OVERWRITE_SETTINGS=1; shift;;
+        --no-dist-upgrade) NO_DIST_UPGRADE=1; shift;;
         --) shift; break;;
     esac
 done

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -13,7 +13,6 @@ Other options:
   --cacert=/path/to
 
   --postgres-missing-dictionaries
-  --remote-postgres
   --no-init-db
 
   --no-overwrite-settings
@@ -27,7 +26,7 @@ EOF
 
 # Shell option parsing.  Over time, we'll want to move some of the
 # environment variables below into this self-documenting system.
-args="$(getopt -o '' --long help,hostname:,email:,certbot,self-signed-cert,cacert:,postgres-missing-dictionaries,remote-postgres,no-init-db,no-overwrite-settings,no-dist-upgrade -n "$0" -- "$@")"
+args="$(getopt -o '' --long help,hostname:,email:,certbot,self-signed-cert,cacert:,postgres-missing-dictionaries,no-init-db,no-overwrite-settings,no-dist-upgrade -n "$0" -- "$@")"
 eval "set -- $args"
 while true; do
     case "$1" in
@@ -41,7 +40,6 @@ while true; do
         --self-signed-cert) SELF_SIGNED_CERT=1; shift;;
 
         --postgres-missing-dictionaries) POSTGRES_MISSING_DICTIONARIES=1; shift;;
-        --remote-postgres) REMOTE_POSTGRES=1; shift;;
         --no-init-db) NO_INIT_DB=1; shift;;
 
         --no-overwrite-settings) NO_OVERWRITE_SETTINGS=1; shift;;
@@ -369,10 +367,6 @@ if [ -n "$POSTGRES_MISSING_DICTIONARIES" ]; then
     crudini --set /etc/zulip/zulip.conf postgresql missing_dictionaries true
 fi
 
-if [ -n "$REMOTE_POSTGRES" ]; then
-  has_postgres=1
-fi
-
 # These server restarting bits should be moveable into puppet-land, ideally
 case " $os_id $os_id_like " in
     *' debian '*)
@@ -446,13 +440,13 @@ if [ -e "/var/run/supervisor.sock" ]; then
     chown zulip:zulip /var/run/supervisor.sock
 fi
 
-if [ -n "$NO_INIT_DB" ] || [ -n "$REMOTE_POSTGRES" ]; then
+if [ -n "$NO_INIT_DB" ]; then
     set +x
     cat <<EOF
 
  Success!
 
- Stopping because --no-init-db or --remote-postgres was passed.
+ Stopping because --no-init-db was passed.
  To complete the installation, configure postgres and then run:
 
    su zulip -c '/home/zulip/deployments/current/scripts/setup/initialize-database'

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -115,6 +115,14 @@ export LANGUAGE="en_US.UTF-8"
 if [ -f /etc/os-release ]; then
     os_info="$(. /etc/os-release; printf '%s\n' "$ID" "$ID_LIKE" "$VERSION_ID" "$VERSION_CODENAME")"
     { read -r os_id; read -r os_id_like; read -r os_version_id; read -r os_version_codename || true; } <<< "$os_info"
+    case " $os_id $os_id_like " in
+        *' debian '*)
+            package_system="apt"
+            ;;
+        *' rhel '*)
+            package_system="yum"
+            ;;
+    esac
 fi
 
 case "$os_id$os_version_id" in
@@ -169,15 +177,12 @@ if [ "$mem_kb" -lt 1860000 ]; then
 fi
 
 # Do package update, e.g. do `apt-get update` on Debian
-case " $os_id $os_id_like " in
-    *' debian '*)
-        # setup-apt-repo does an `apt-get update`
-        "$ZULIP_PATH"/scripts/lib/setup-apt-repo
-        ;;
-    *' rhel '*)
-        "$ZULIP_PATH"/scripts/lib/setup-yum-repo
-        ;;
-esac
+if [ "$package_system" = apt ]; then
+    # setup-apt-repo does an `apt-get update`
+    "$ZULIP_PATH"/scripts/lib/setup-apt-repo
+elif [ "$package_system" = yum ]; then
+    "$ZULIP_PATH"/scripts/lib/setup-yum-repo
+fi
 
 # Check early for missing SSL certificates
 if [ "$PUPPET_CLASSES" = "zulip::voyager" ] && [ -z "$USE_CERTBOT""$SELF_SIGNED_CERT" ] && { ! [ -e "/etc/ssl/private/zulip.key" ] || ! [ -e "/etc/ssl/certs/zulip.combined-chain.crt" ]; }; then
@@ -206,49 +211,46 @@ fi
 # don't run dist-upgrade in one click apps to make the
 # installation process more seamless.
 if [ -z "$NO_DIST_UPGRADE" ]; then
-    case " $os_id $os_id_like " in
-        *' debian '*)
-            apt-get -y dist-upgrade "${APT_OPTIONS[@]}"
-            ;;
+    if [ "$package_system" = apt ]; then
+        apt-get -y dist-upgrade "${APT_OPTIONS[@]}"
+    elif [ "$package_system" = yum ]; then
         # On CentOS, there is no need to do `yum -y upgrade` because `yum -y
         # update` already does the same thing.
-    esac
+        :
+    fi
 fi
 
-case " $os_id $os_id_like " in
-    *' debian '*)
-        if [ "$os_id" = ubuntu ] && [ "$os_version_id" = 20.04 ]; then
-            PYTHON2="python2"
-        else
-            PYTHON2="python"
-        fi
+if [ "$package_system" = apt ]; then
+    if [ "$os_id" = ubuntu ] && [ "$os_version_id" = 20.04 ]; then
+        PYTHON2="python2"
+    else
+        PYTHON2="python"
+    fi
 
-        if ! apt-get install -y \
-            puppet git curl wget jq \
-            "$PYTHON2" python3 python-six python3-six crudini \
-            "${ADDITIONAL_PACKAGES[@]}"; then
-            set +x
-            echo -e '\033[0;31m' >&2
-            echo "Installing packages failed; is network working and (on Ubuntu) the universe repository enabled?" >&2
-            echo >&2
-            echo -e '\033[0m' >&2
-            exit 1
-        fi
-        ;;
-    *' rhel '*)
-        if ! yum install -y \
-            puppet git curl wget jq \
-            python python3 python-six python3-six crudini \
-            "${ADDITIONAL_PACKAGES[@]}"; then
-            set +x
-            echo -e '\033[0;31m' >&2
-            echo "Installing packages failed; is network working?" >&2
-            echo >&2
-            echo -e '\033[0m' >&2
-            exit 1
-        fi
-        ;;
-esac
+    if ! apt-get install -y \
+         puppet git curl wget jq \
+         "$PYTHON2" python3 python-six python3-six crudini \
+         "${ADDITIONAL_PACKAGES[@]}"; then
+        set +x
+        echo -e '\033[0;31m' >&2
+        echo "Installing packages failed; is network working and (on Ubuntu) the universe repository enabled?" >&2
+        echo >&2
+        echo -e '\033[0m' >&2
+        exit 1
+    fi
+elif [ "$package_system" = yum ]; then
+    if ! yum install -y \
+         puppet git curl wget jq \
+         python python3 python-six python3-six crudini \
+         "${ADDITIONAL_PACKAGES[@]}"; then
+        set +x
+        echo -e '\033[0;31m' >&2
+        echo "Installing packages failed; is network working?" >&2
+        echo >&2
+        echo -e '\033[0m' >&2
+        exit 1
+    fi
+fi
 
 if [ -n "$USE_CERTBOT" ]; then
     "$ZULIP_PATH"/scripts/setup/setup-certbot \
@@ -309,15 +311,13 @@ EOF
         fi
 
         if [ -e "/etc/init.d/postgresql" ]; then
-            case " $os_id $os_id_like " in
-                *' debian '*)
-                    cat <<EOF
+            if [ "$package_system" = apt ]; then
+                cat <<EOF
 
 [postgresql]
 version = 12
 EOF
-                    ;;
-            esac
+            fi
         fi
     ) > /etc/zulip/zulip.conf
 fi
@@ -340,14 +340,12 @@ esac
 
 "$ZULIP_PATH"/scripts/zulip-puppet-apply -f
 
-case " $os_id $os_id_like " in
-    *' debian '*)
-        SUPERVISOR_CONF_DIR="/etc/supervisor/conf.d"
-        ;;
-    *' rhel '*)
-        SUPERVISOR_CONF_DIR="/etc/supervisord.d/conf.d"
-        ;;
-esac
+if [ "$package_system" = apt ]; then
+    SUPERVISOR_CONF_DIR="/etc/supervisor/conf.d"
+elif [ "$package_system" = yum ]; then
+    SUPERVISOR_CONF_DIR="/etc/supervisord.d/conf.d"
+fi
+
 # Detect which features were selected for the below
 set +e
 [ -e "/etc/init.d/nginx" ]; has_nginx=$?
@@ -369,14 +367,12 @@ if [ -n "$POSTGRES_MISSING_DICTIONARIES" ]; then
 fi
 
 # These server restarting bits should be moveable into puppet-land, ideally
-case " $os_id $os_id_like " in
-    *' debian '*)
-        apt-get -y upgrade
-        ;;
-    *' rhel '*)
-        # No action is required because `yum update` already does upgrade.
-        ;;
-esac
+if [ "$package_system" = apt ]; then
+    apt-get -y upgrade
+elif [ "$package_system" = yum ]; then
+    # No action is required because `yum update` already does upgrade.
+    :
+fi
 
 if [ "$has_nginx" = 0 ]; then
     # Check nginx was configured properly now that we've installed it.

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -2,24 +2,43 @@
 set -e
 
 usage() {
-    cat <<EOF
+    # A subset of this documentation also appears in docs/production/install.md
+    cat <<'EOF'
 Usage:
   install --hostname=zulip.example.com --email=zulip-admin@example.com [options...]
   install --help
 
-Other options:
+Options:
+  --hostname=zulip.example.com
+      The user-accessible domain name for this Zulip server, i.e., what users will type
+      in their web browser.  Required, unless --no-init-db is set and --certbot is not.
+  --email=zulip-admin@example.com
+      The email address of the person or team who should get support and error emails
+      from this Zulip server.  Required, unless --no-init-db is set and --certbot is
+      not.
+
   --certbot
+      Obtains a free SSL certificate for the server using Certbot,
+      https://certbot.eff.org/  Recommended.  Conflicts with --self-signed-cert.
   --self-signed-cert
-  --cacert=/path/to
+      Generate a self-signed SSL certificate for the server. This isn’t suitable for
+      production use, but may be convenient for testing.  Conflicts with --certbot.
+  --cacert=/path/to/ca.pem
+      Set the CA which used to establish TLS to all public internet sites during the
+      install process; used when this command is run once in a highly-controlled
+      environment to produce an image which is used elsewhere.  Uncommon.
 
   --postgres-missing-dictionaries
+      Set postgresql.missing_dictionaries, which alters the initial database.  Use with
+      cloud managed databases like RDS.  Conflicts with --no-overwrite-settings.
   --no-init-db
+      Does not do any database initialization; use when you already have a Zulip
+      database.
 
   --no-overwrite-settings
+      Preserve existing `/etc/zulip` configuration files.
   --no-dist-upgrade
-
-The --hostname and --email options are required,
-unless --no-init-db is set and --certbot is not.
+      Skip the initial `apt-get dist-upgrade`.
 
 EOF
 };

--- a/scripts/lib/setup-apt-repo
+++ b/scripts/lib/setup-apt-repo
@@ -36,7 +36,7 @@ apt-get -y install "${pre_setup_deps[@]}"
 SCRIPTS_PATH="$(dirname "$(dirname "$0")")"
 
 release=$(lsb_release -sc)
-if [[ "$release" =~ ^(xenial|bionic|cosmic|disco|eoan|focal)$ ]] ; then
+if [[ "$release" =~ ^(bionic|cosmic|disco|eoan|focal)$ ]] ; then
     apt-key add "$SCRIPTS_PATH"/setup/pgdg.asc
     apt-key add "$SCRIPTS_PATH"/setup/pgroonga-ppa.asc
     cat >$SOURCES_FILE <<EOF
@@ -46,7 +46,7 @@ deb-src http://apt.postgresql.org/pub/repos/apt/ $release-pgdg main
 deb http://ppa.launchpad.net/groonga/ppa/ubuntu $release main
 deb-src http://ppa.launchpad.net/groonga/ppa/ubuntu $release main
 EOF
-elif [[ "$release" =~ ^(stretch|buster)$ ]] ; then
+elif [[ "$release" =~ ^(buster)$ ]] ; then
     apt-key add "$SCRIPTS_PATH"/setup/pgdg.asc
     apt-key add "$SCRIPTS_PATH"/setup/pgroonga-debian.asc
     cat >$SOURCES_FILE <<EOF
@@ -69,10 +69,6 @@ else
     # `apt-get update` finishes successfully.
     touch "$STAMP_FILE"
     apt-get update && rm -f "$STAMP_FILE"
-fi
-
-if [ "$release" = "stretch" ]; then
-    apt-get install -y groonga-keyring
 fi
 
 echo "$DEPENDENCIES_HASH" > "$DEPENDENCIES_HASH_FILE"

--- a/scripts/lib/setup-apt-repo-debathena
+++ b/scripts/lib/setup-apt-repo-debathena
@@ -32,7 +32,7 @@ apt-get install -y lsb-release apt-transport-https gnupg
 SCRIPTS_PATH="$(dirname "$(dirname "$0")")"
 
 release=$(lsb_release -sc)
-if [ "$release" = "xenial" ]; then
+if [ "$release" = "bionic" ]; then
     apt-key add "$SCRIPTS_PATH"/setup/debathena-archive.asc
     cat >$SOURCES_FILE <<EOF
     deb http://debathena.mit.edu/apt $release debathena debathena-config

--- a/scripts/zulip-puppet-apply
+++ b/scripts/zulip-puppet-apply
@@ -21,11 +21,6 @@ config = configparser.RawConfigParser()
 config.read("/etc/zulip/zulip.conf")
 
 distro_info = parse_os_release()
-if not os.path.exists("/etc/puppet/hiera.yaml"):
-    if (distro_info['ID'], distro_info['VERSION_ID']) in [('debian', '9'), ('ubuntu', '16.04')]:
-        # Suppress warnings in old puppet about hiera.yaml not existing.
-        open("/etc/puppet/hiera.yaml", "a").close()
-
 puppet_config = """
 Exec { path => "/usr/sbin:/usr/bin:/sbin:/bin" }
 """

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -88,14 +88,10 @@ else:
 distro_info = parse_os_release()
 vendor = distro_info['ID']
 os_version = distro_info['VERSION_ID']
-if vendor == "debian" and os_version == "10":  # buster
-    POSTGRES_VERSION = "11"
-elif vendor == "ubuntu" and os_version in ["18.04", "18.10"]:  # bionic, cosmic
-    POSTGRES_VERSION = "10"
-elif vendor == "ubuntu" and os_version in ["19.04", "19.10"]:  # disco, eoan
-    POSTGRES_VERSION = "11"
-elif vendor == "ubuntu" and os_version == "20.04":  # focal
-    POSTGRES_VERSION = "12"
+if vendor == "debian" and os_version == "10":
+    POSTGRES_VERSION = "12"  # From postgres apt repo
+elif vendor == "ubuntu" and os_version in ["18.04", "18.10", "19.04", "19.10", "20.04"]:
+    POSTGRES_VERSION = "12"  # From postgres apt repo
 elif vendor == "fedora" and os_version == "29":
     POSTGRES_VERSION = "10"
 elif vendor == "rhel" and os_version.startswith("7."):
@@ -166,9 +162,9 @@ COMMON_YUM_DEPENDENCIES = COMMON_DEPENDENCIES + [
 ] + YUM_THUMBOR_VENV_DEPENDENCIES
 
 BUILD_PGROONGA_FROM_SOURCE = False
-if vendor == 'debian' and os_version in [] or vendor == 'ubuntu' and os_version in []:
-    # For platforms without a pgroonga release, we need to build it
-    # from source.
+if vendor == 'debian' and os_version in ["10"] or vendor == 'ubuntu' and os_version in ["18.04", "18.10", "19.04", "19.10"]:
+    # For platforms without a pgroonga release, or lacking one for
+    # postgres 12, we need to build it from source.
     BUILD_PGROONGA_FROM_SOURCE = True
     SYSTEM_DEPENDENCIES = UBUNTU_COMMON_APT_DEPENDENCIES + [
         pkg.format(POSTGRES_VERSION) for pkg in [

--- a/tools/test-install/lxc-wait
+++ b/tools/test-install/lxc-wait
@@ -27,16 +27,36 @@ if [ "$EUID" -ne 0 ]; then
 fi
 
 # We poll.
-for _ in {1..60}; do
-    echo "lxc-wait: $CONTAINER_NAME: polling for boot..." >&2
-    runlevel="$(lxc-attach --clear-env -n "$CONTAINER_NAME" -- runlevel 2>/dev/null)" \
-        || { sleep 1; continue; }
-    if [ "$runlevel" != "${0%[0-9]}" ]; then
-        echo "lxc-wait: $CONTAINER_NAME: booted!" >&2
-        exit 0
-    fi
-    sleep 1
-done
+poll_runlevel() {
+    for _ in {1..60}; do
+        echo "lxc-wait: $CONTAINER_NAME: polling for boot..." >&2
+        runlevel="$(lxc-attach --clear-env -n "$CONTAINER_NAME" -- runlevel 2>/dev/null)" \
+            || { sleep 1; continue; }
+        if [ "$runlevel" != "${0%[0-9]}" ]; then
+            echo "lxc-wait: $CONTAINER_NAME: booted!" >&2
+            poll_network
+        fi
+        sleep 1
+    done
+    echo "error: timeout waiting for container to boot" >&2
+    exit 1
+}
 
-echo "error: timeout waiting for container to boot" >&2
-exit 1
+
+poll_network() {
+    for _ in {1..60}; do
+        echo "lxc-wait: $CONTAINER_NAME: polling for network..." >&2
+        # New hosts don't have `host` or `nslookup`
+        lxc-attach --clear-env -n "$CONTAINER_NAME" -- \
+                   ping -q -c 1 archive.ubuntu.com 2>/dev/null >/dev/null \
+            || { sleep 1; continue; }
+        echo "lxc-wait: $CONTAINER_NAME: network is up!" >&2
+        exit 0
+    done
+    echo "error: timeout waiting for container to get network" >&2
+    exit 1
+}
+
+
+poll_runlevel
+

--- a/tools/test-install/prepare-base
+++ b/tools/test-install/prepare-base
@@ -10,8 +10,10 @@ RELEASE="$1"
 ARCH=amd64  # TODO: maybe i686 too
 
 case "$RELEASE" in
-    bionic) extra_packages=(virtualenv)
-        ;;
+    bionic) extra_packages=(python-pip)
+            ;;
+    focal) extra_packages=(python3-pip)
+           ;;
     *)
         echo "error: unsupported target release: $RELEASE" >&2
         exit 1
@@ -50,8 +52,9 @@ run apt-get install -y --no-install-recommends \
   memcached rabbitmq-server redis-server \
   hunspell-en-us supervisor libssl-dev puppet \
   gettext libffi-dev libfreetype6-dev zlib1g-dev libjpeg-dev \
-  libldap2-dev libmemcached-dev python-dev python-pip \
+  libldap2-dev libmemcached-dev \
   python-six libxml2-dev libxslt1-dev libpq-dev \
+  virtualenv \
   "${extra_packages[@]}"
 
 run ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime

--- a/tools/test-install/prepare-base
+++ b/tools/test-install/prepare-base
@@ -10,7 +10,7 @@ RELEASE="$1"
 ARCH=amd64  # TODO: maybe i686 too
 
 case "$RELEASE" in
-    bionic) extra_packages=(virtualenv postgresql-10)
+    bionic) extra_packages=(virtualenv)
         ;;
     *)
         echo "error: unsupported target release: $RELEASE" >&2


### PR DESCRIPTION
This sequence is a bunch of cleanup, followed by two commits which fix release blockers.  Those can be separated out if need be.

**Cleanups:**
- Group and unify ordering of installer options.
- Do not initialize db with --no-init-db.
- Remove `--remote-postgres`, redundant with `--no-init-db`.
- Make `--no-overwrite-settings` also preserve `zulip.conf`.
- Note `--postgres-missing-dictionaries` conflicts with `--no-overwrite-settings`.
- Update inline documentation.  This is _not_ the user-facing upgrade docs, merely the command-line flags.

**Important bugfixes:**
- Make installation work _without_ a pre-existing postgres 
- Make installation work _with_ a pre-existing postgres

---

**Testing Plan:**
- `./tools/test-install/install` with a base image with and without postgres10 installed.  
- `./tools/test-install/install` with each of the altered configuration options
