### PR TITLE
ci: Only attempt to post the failure if we have a key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ aliases:
       branches:
         only: master
       command: |
-        if [[ "$CIRCLE_REPOSITORY_URL" == "git@github.com:zulip/zulip.git" ]]; then
+        if [[ "$CIRCLE_REPOSITORY_URL" == "git@github.com:zulip/zulip.git" && "$ZULIP_BOT_KEY" != "" ]]; then
           curl  -H "Content-Type: application/json" \
           -X POST -i 'https://chat.zulip.org/api/v1/external/circleci?api_key='"$ZULIP_BOT_KEY"'&stream=automated%20testing&topic=master%20failing' \
           -d '{"payload": { "branch": "'"$CIRCLE_BRANCH"'", "reponame": "'"$CIRCLE_PROJECT_REPONAME"'", "status": "failed", "build_url": "'"$CIRCLE_BUILD_URL"'", "username": "'"$CIRCLE_USERNAME"'"}}'


### PR DESCRIPTION
Only some branches define the `ZULIP_BOT_KEY`; others, including PRs,
thus currently fail to POST:

    {"result":"error","msg":"Malformed API key","code":"INVALID_API_KEY"}

Simply abort early, without attempting to report the result, if the
key is not present.


**Testing Plan:** https://app.circleci.com/pipelines/github/zulip/zulip/8891/workflows/2a857640-e068-49d2-8ca8-60bdd1d8f3a2/jobs/50859/steps