### PR TITLE
Fix settings menu on mobile

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -121,7 +121,7 @@ exports.launch = function (section) {
     settings_sections.reset_sections();
 
     overlays.open_settings();
-    settings_panel_menu.org_settings.activate_section(section);
+    settings_panel_menu.org_settings.activate_section_or_default(section);
     settings_toggle.highlight_toggle('organization');
 };
 

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -1,4 +1,5 @@
 const util = require("./util");
+const settings_panel_menu = require('./settings_panel_menu');
 // You won't find every click handler here, but it's a good place to start!
 
 const render_buddy_list_tooltip = require('../templates/buddy_list_tooltip.hbs');
@@ -903,8 +904,7 @@ exports.initialize = function () {
     });
 
     $(".settings-header.mobile .fa-chevron-left").on("click", function () {
-        $("#settings_page").find(".right").removeClass("show");
-        $(this).parent().removeClass("slide-left");
+        settings_panel_menu.mobile_deactivate_section();
     });
 };
 

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -132,7 +132,7 @@ function do_hashchange_normal(from_reload) {
 function do_hashchange_overlay(old_hash) {
     const base = hash_util.get_hash_category(window.location.hash);
     const old_base = hash_util.get_hash_category(old_hash);
-    let section = hash_util.get_hash_section(window.location.hash);
+    const section = hash_util.get_hash_section(window.location.hash);
 
     const coming_from_overlay = is_overlay_hash(old_hash || '#');
 
@@ -153,9 +153,8 @@ function do_hashchange_overlay(old_hash) {
                     // We may be on a really old browser or somebody
                     // hand-typed a hash.
                     blueslip.warn('missing section for settings');
-                    section = 'your-account';
                 }
-                settings_panel_menu.normal_settings.activate_section(section);
+                settings_panel_menu.normal_settings.activate_section_or_default(section);
                 return;
             }
 
@@ -164,9 +163,8 @@ function do_hashchange_overlay(old_hash) {
                     // We may be on a really old browser or somebody
                     // hand-typed a hash.
                     blueslip.warn('missing section for organization');
-                    section = 'organization-profile';
                 }
-                settings_panel_menu.org_settings.activate_section(section);
+                settings_panel_menu.org_settings.activate_section_or_default(section);
                 return;
             }
 
@@ -201,23 +199,11 @@ function do_hashchange_overlay(old_hash) {
     }
 
     if (base === 'settings') {
-        if (!section) {
-            section = settings_panel_menu.normal_settings.current_tab();
-            const settings_hash = '#settings/' + section;
-            exports.replace_hash(settings_hash);
-        }
-
         settings.launch(section);
         return;
     }
 
     if (base === 'organization') {
-        if (!section) {
-            section = settings_panel_menu.org_settings.current_tab();
-            const org_hash = '#organization/' + section;
-            exports.replace_hash(org_hash);
-        }
-
         admin.launch(section);
         return;
     }

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -78,7 +78,7 @@ exports.launch = function (section) {
     settings_sections.reset_sections();
 
     overlays.open_settings();
-    settings_panel_menu.normal_settings.activate_section(section);
+    settings_panel_menu.normal_settings.activate_section_or_default(section);
     settings_toggle.highlight_toggle('settings');
 };
 

--- a/static/js/settings_panel_menu.js
+++ b/static/js/settings_panel_menu.js
@@ -1,3 +1,9 @@
+exports.mobile_deactivate_section = function () {
+    const $settings_overlay_container = $("#settings_overlay_container");
+    $settings_overlay_container.find(".right").removeClass("show");
+    $settings_overlay_container.find(".settings-header.mobile").removeClass("slide-left");
+};
+
 exports.make_menu = function (opts) {
     const main_elem = opts.main_elem;
     const hash_prefix = opts.hash_prefix;
@@ -5,11 +11,16 @@ exports.make_menu = function (opts) {
 
     const self = {};
 
+    function two_column_mode() {
+        return $('#settings_overlay_container').css('--single-column') === undefined;
+    }
+
     self.show = function () {
         main_elem.show();
         const section = self.current_tab();
-        if ($('#settings_overlay_container').css('--single-column') === undefined) {
-            self.activate_section(section);
+        if (two_column_mode()) {
+            // In one colum mode want to show the settings list, not the first settings section.
+            self.activate_section_or_default(section);
         }
         curr_li.focus();
     };
@@ -59,7 +70,21 @@ exports.make_menu = function (opts) {
         return true;
     };
 
-    self.activate_section = function (section) {
+    self.activate_section_or_default = function (section) {
+        if (!section) {
+            // No section is given so we display the default.
+
+            if (two_column_mode()) {
+                // In two column mode we resume to the last active section.
+                section = self.current_tab();
+            } else {
+                // In single column mode we close the active section
+                // so that you always start at the settings list.
+                exports.mobile_deactivate_section();
+                return;
+            }
+        }
+
         curr_li = self.li_for_section(section);
 
         main_elem.children("li").removeClass("active");
@@ -93,7 +118,7 @@ exports.make_menu = function (opts) {
     main_elem.on("click", "li[data-section]", function (e) {
         const section = $(this).attr('data-section');
 
-        self.activate_section(section);
+        self.activate_section_or_default(section);
 
         // You generally want to add logic to activate_section,
         // not to this click handler.

--- a/static/js/settings_panel_menu.js
+++ b/static/js/settings_panel_menu.js
@@ -8,7 +8,9 @@ exports.make_menu = function (opts) {
     self.show = function () {
         main_elem.show();
         const section = self.current_tab();
-        self.activate_section(section);
+        if ($('#settings_overlay_container').css('--single-column') === undefined) {
+            self.activate_section(section);
+        }
         curr_li.focus();
     };
 
@@ -60,9 +62,8 @@ exports.make_menu = function (opts) {
     self.activate_section = function (section) {
         curr_li = self.li_for_section(section);
 
-        main_elem.children("li").removeClass("active no-border");
+        main_elem.children("li").removeClass("active");
         curr_li.addClass("active");
-        curr_li.prev().addClass("no-border");
 
         const settings_section_hash = '#' + hash_prefix + section;
         hashchange.update_browser_history(settings_section_hash);

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1600,10 +1600,6 @@ input[type=checkbox] {
                 border-bottom: none;
             }
 
-            &.no-border {
-                border-color: transparent;
-            }
-
             &.active {
                 background-color: hsl(0, 0%, 93%);
                 border-bottom: 1px solid transparent;
@@ -2062,9 +2058,19 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
 }
 
 @media (max-width: 700px) {
+    #settings_overlay_container {
+        // this variable allows JavaScript to detect this media query
+        --single-column: yes;
+    }
+
     #settings_page {
         .settings-header.mobile {
             display: block;
+
+            &:not(.slide-left) .section {
+                // When viewing the settings list we hide the active section.
+                display: none;
+            }
         }
 
         .content-wrapper {
@@ -2086,6 +2092,12 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
             position: relative;
             width: 250px;
             height: 100%;
+
+            li.active {
+                // Don't highlight the active section in the settings list.
+                background: inherit;
+                border-bottom: 1px solid hsl(0, 0%, 93%);
+            }
         }
     }
 }

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -2057,7 +2057,7 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
     }
 }
 
-@media (max-width: 700px) {
+@media (max-width: 750px) {
     #settings_overlay_container {
         // this variable allows JavaScript to detect this media query
         --single-column: yes;


### PR DESCRIPTION
Currently when switching between the setting tabs on mobile it annoyingly opens the first section:

![tab_mobile_bug](https://user-images.githubusercontent.com/47354597/85522178-96d73780-b605-11ea-97c8-86f5ae076dc9.gif)

Also note how the list view has the title of the last viewed section and highlights it in the list (which is quite confusing).

With the first commit it looks like this:

![tab_bug_fixed](https://user-images.githubusercontent.com/47354597/85522484-01887300-b606-11ea-84e1-d14a4eaa5957.gif)

The second commit fixes a media query edge case that completely broke the settings navigation.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
