### PR TITLE
fetch_api_key: Return `email` in JSON response.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4794,6 +4794,7 @@ components:
       - $ref: '#/components/schemas/JsonSuccess'
       - required:
         - api_key
+        - email
       - properties:
           api_key:
             type: string

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -946,7 +946,7 @@ def json_fetch_api_key(request: HttpRequest, user_profile: UserProfile,
             return json_error(_("Your username or password is incorrect."))
 
     api_key = get_api_key(user_profile)
-    return json_success({"api_key": api_key})
+    return json_success({"api_key": api_key, "email": user_profile.delivery_email})
 
 @csrf_exempt
 def api_fetch_google_client_id(request: HttpRequest) -> HttpResponse:


### PR DESCRIPTION
`/api/v1/fetch_api_key`'s response had a key `email` with the user's
    delivery email. But its JSON counterpart `/json/fetch_api_key` did not
    return `email` in its success response. So to avoid confusion
    `/json/fetch_api_key`'s response has been made identical with it's `/api`
    counterpart by adding the `email` key. Also it is safe to send as the calling
    user will only see their own email. Make changes in zulip.yaml accordingly.