### PR TITLE
css: Start using variables for colors.

### DIFF
--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -199,6 +199,8 @@ import "spectrum-colorpicker/spectrum.css";
 import "katex/dist/katex.css";
 import "flatpickr/dist/flatpickr.css";
 import "flatpickr/dist/plugins/confirmDate/confirmDate.css";
+import "../../styles/themes/default.scss";
+import "../../styles/themes/night_mode.scss";
 import "../../styles/components.scss";
 import "../../styles/app_components.scss";
 import "../../styles/rendered_markdown.scss";
@@ -221,7 +223,6 @@ import "../../styles/popovers.scss";
 import "../../styles/recent_topics.scss";
 import "../../styles/typing_notifications.scss";
 import "../../styles/hotspots.scss";
-import "../../styles/night_mode.scss";
 import "../../styles/user_status.scss";
 import "../../styles/widgets.scss";
 

--- a/static/styles/app_components.scss
+++ b/static/styles/app_components.scss
@@ -152,8 +152,8 @@
         }
 
         &.btn-danger {
-            color: hsl(357, 64%, 72%);
-            border-color: hsl(4, 56%, 82%);
+            color: var(--danger);
+            border-color: var(--danger);
 
             &:hover,
             &:focus {

--- a/static/styles/drafts.scss
+++ b/static/styles/drafts.scss
@@ -122,7 +122,7 @@
             .restore-draft {
                 cursor: pointer;
                 margin-right: 5px;
-                color: hsl(170, 48%, 54%);
+                color: var(--success);
                 opacity: 0.7;
 
                 &:hover {
@@ -133,7 +133,7 @@
             .delete-draft {
                 cursor: pointer;
                 margin-left: 5px;
-                color: hsl(357, 52%, 57%);
+                color: var(--danger);
                 opacity: 0.7;
 
                 &:hover {

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -167,7 +167,7 @@ li.show-more-topics {
     &.top_left_row:hover,
     &.bottom_left_row:hover,
     &#stream_filters li.highlighted_stream {
-        background-color: hsla(120, 12.3%, 71.4%, 0.38);
+        background-color: var(--sidebar-item-hover);
         border-radius: 4px;
     }
 }
@@ -220,7 +220,7 @@ ul.filters {
 li.active-filter,
 li.active-sub-filter {
     font-weight: 600 !important;
-    background-color: hsl(202, 56%, 91%);
+    background-color: var(--active-filter);
     position: relative;
     border-radius: 4px;
 }

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -60,7 +60,7 @@
 
         &:hover,
         &.highlighted_user {
-            background-color: hsla(120, 12.3%, 71.4%, 0.38);
+            background-color: var(--sidebar-item-hover);
         }
     }
 

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -664,7 +664,7 @@ form#add_new_subscription {
     }
 
     .checked svg {
-        fill: hsl(170, 48%, 54%);
+        fill: var(--success);
     }
 
     .icon {

--- a/static/styles/themes/default.scss
+++ b/static/styles/themes/default.scss
@@ -1,0 +1,10 @@
+// Variables added here should be named after their purpose, and not after
+// how they look visually (since that depends on the color theme).
+
+body {
+    --success: hsl(170, 48%, 54%);
+    --danger: hsl(357, 52%, 57%);
+    --link: hsl(200, 100%, 40%);
+    --sidebar-item-hover: hsla(120, 12.3%, 71.4%, 0.38);
+    --active-filter: hsl(202, 56%, 91%);
+}

--- a/static/styles/themes/night_mode.scss
+++ b/static/styles/themes/night_mode.scss
@@ -384,23 +384,8 @@ on a dark background, and don't change the dark labels dark either. */
         }
     }
 
-    li.active-filter,
-    li.active-sub-filter {
-        background-color: hsla(199, 33%, 46%, 0.2);
-    }
-
-    :not(.active-sub-filter) {
-        &.top_left_row:hover,
-        &.bottom_left_row:hover,
-        &#stream_filters li.highlighted_stream {
-            background-color: hsla(136, 25%, 73%, 0.2);
-        }
-    }
-
-    #user_presences li:hover,
-    #user_presences li.highlighted_user {
-        background-color: hsla(136, 25%, 73%, 0.2);
-    }
+    --active-filter: hsla(199, 33%, 46%, 0.2);
+    --sidebar-item-hover: hsla(136, 25%, 73%, 0.2);
 
     .floating_recipient .recipient_row {
         border-top: none;

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -62,7 +62,7 @@ a {
 
     &.message_label_clickable:hover {
         cursor: pointer;
-        color: hsl(200, 100%, 40%);
+        color: var(--link);
     }
 }
 
@@ -1133,7 +1133,7 @@ td.pointer {
 }
 
 .actions_hover:hover {
-    color: hsl(200, 100%, 40%);
+    color: var(--link);
 }
 
 .on_hover_topic_edit,


### PR DESCRIPTION
Color variables make our CSS more readable and our color themes
more maintainable (since they are more decoupled from our markup).

Part of #12617.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->

[Discussion on CZO](https://chat.zulip.org/#narrow/stream/6-frontend/topic/css.20color.20vars/near/912775).
