### PR TITLE
invites: Do not return multi-use invites to non-admin users.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5232,6 +5232,10 @@ def do_get_user_invites(user_profile: UserProfile) -> List[Dict[str, Any]]:
                             invited_as=invitee.invited_as,
                             is_multiuse=False))
 
+    if not user_profile.is_realm_admin:
+        # We do not return multiuse invites to non-admin users.
+        return invites
+
     lowest_datetime = timezone_now() - datetime.timedelta(days=settings.INVITATION_LINK_VALIDITY_DAYS)
     multiuse_confirmation_objs = Confirmation.objects.filter(realm=user_profile.realm,
                                                              type=Confirmation.MULTIUSE_INVITE,

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1621,7 +1621,9 @@ class InvitationsTestCase(InviteUserBase):
         prereg_user_other_realm = PreregistrationUser(
             email="TestOne@zulip.com", referred_by=self.mit_user("sipbtest"))
         prereg_user_other_realm.save()
-        self.assertEqual(len(do_get_user_invites(user_profile)), 4)
+        multiuse_invite = MultiuseInvite.objects.create(referred_by=user_profile, realm=user_profile.realm)
+        create_confirmation_link(multiuse_invite, Confirmation.MULTIUSE_INVITE)
+        self.assertEqual(len(do_get_user_invites(user_profile)), 5)
         self.assertEqual(len(do_get_user_invites(hamlet)), 1)
         self.assertEqual(len(do_get_user_invites(othello)), 1)
 


### PR DESCRIPTION
This commit changes do_get_user_invites function to not return
multiuse invites to non-admin users. We should only return multiuse
invites to admins, as we only allow admins to create them.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
