### PR TITLE
Update Circle CI images.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
     docker:
       # This is built from tools/circleci/images/bionic/Dockerfile .
       # Bionic ships with Python 3.6.
-      - image: amanagr/circleci:bionic-python-2.test
+      - image: arpit551/circleci:bionic-python-test
 
     working_directory: ~/zulip
 
@@ -220,7 +220,7 @@ jobs:
       docker:
         # This is built from tools/circleci/images/focal/Dockerfile.
         # Focal ships with Python 3.8.2.
-        - image: arpit551/circleci:focal-test
+        - image: arpit551/circleci:focal-python-test
 
       working_directory: ~/zulip
 
@@ -243,7 +243,7 @@ jobs:
 
   "xenial-legacy":
     docker:
-      - image: gregprice/circleci:xenial-python-4.test
+      - image: arpit551/circleci:xenial-python-test
 
     working_directory: ~/zulip
 
@@ -258,7 +258,7 @@ jobs:
     docker:
         # This is built from tools/circleci/images/bionic/Dockerfile .
         # Bionic ships with Python 3.6.
-        - image: amanagr/circleci:bionic-python-2.test
+        - image: arpit551/circleci:bionic-python-test
 
     working_directory: ~/zulip
 
@@ -298,7 +298,7 @@ jobs:
     docker:
         # This is built from tools/circleci/images/bionic/Dockerfile .
         # Bionic ships with Python 3.6.
-        - image: amanagr/circleci:bionic-python-2.test
+        - image: arpit551/circleci:bionic-python-test
 
     working_directory: ~/zulip
 
@@ -320,7 +320,7 @@ jobs:
     docker:
         # This is built from tools/circleci/images/focal/Dockerfile.
         # Focal ships with Python 3.8.2.
-        - image: arpit551/circleci:focal-test
+        - image: arpit551/circleci:focal-python-test
 
     working_directory: ~/zulip
 

--- a/tools/circleci/Dockerfile.template
+++ b/tools/circleci/Dockerfile.template
@@ -91,9 +91,9 @@ RUN apt-get update \
   && apt-get install --no-install-recommends \
     memcached rabbitmq-server redis-server \
     hunspell-en-us supervisor libssl-dev puppet \
-    gettext libffi-dev libfreetype6-dev zlib1g-dev libjpeg-dev \
-    libldap2-dev libmemcached-dev python-pip \
-    python-six libxml2-dev libxslt1-dev libpq-dev \
+    gettext libffi-dev libfreetype6-dev zlib1g-dev \
+    libjpeg-dev libldap2-dev libmemcached-dev \
+    libxml2-dev libxslt1-dev libpq-dev \
     {extra_packages}
 
 RUN groupadd --gid 3434 circleci \

--- a/tools/circleci/images.yml
+++ b/tools/circleci/images.yml
@@ -1,7 +1,7 @@
 bionic:
   base_image: buildpack-deps:bionic-scm
-  extra_packages: postgresql-10 python-dev
+  extra_packages: python-dev
 
 focal:
   base_image: buildpack-deps:focal-scm
-  extra_packages: postgresql-12 python2-dev
+  extra_packages: python2-dev


### PR DESCRIPTION
Removed postgresql and python 2 packages when creating docker images
for Circle CI.
Rebuilt the images. 
Follow up to [https://github.com/zulip/zulip/pull/15534#issuecomment-648519122](https://github.com/zulip/zulip/pull/15534#issuecomment-648519122)
CI is failing with 
```
Error: Evaluation Error: Error while evaluating a Function Call, Could not find template 'zulip/postgresql//postgresql.conf.template.erb' (file: /home/circleci/zulip/puppet/zulip/manifests/postgres_appdb_tuned.pp, line: 33, column: 16) on node b22e07e6acc9.ec2.internal
 
Jun 24 13:55:52 
 
Jun 24 13:55:52 Zulip installation failed (exit code 1)!

```
I guess we have to merge this first.
[https://github.com/zulip/zulip/pull/15534/commits/03cf3087d7fede5f71896f77059e66696857870d](https://github.com/zulip/zulip/pull/15534/commits/03cf3087d7fede5f71896f77059e66696857870d)
@timabbott Ping.
