### PR TITLE
Deprecate sub_validator

### DIFF
--- a/docs/testing/mypy.md
+++ b/docs/testing/mypy.md
@@ -148,42 +148,6 @@ because a list can have many elements, which would make the output too large.
 Similarly in dicts, one key's type and the corresponding value's type are printed.
 So `{1: 'a', 2: 'b', 3: 'c'}` will be printed as `{int: str, ...}`.
 
-## Using @overload to accurately describe variations
-
-Sometimes, a function's type is most precisely expressed as a few
-possibilites, and which possibility can be determined by looking at
-the arguments.  You can express that idea in a way mypy understands
-using `@overload`.  For example, `check_list` returns a `Validator`
-function that verifies that an object is a list, raising an exception
-if it isn't.
-
-It supports being passed a `sub_validator`, which will verify that
-each element in the list has a given type as well.  One can express
-the idea "If `sub_validator` validates that something is a `ResultT`,
-`check_list(sub_validator)` validators that something is a
-`List[ResultT]` as follows:
-
-~~~ py
-@overload
-def check_list(sub_validator: None, length: Optional[int]=None) -> Validator[List[object]]:
-    ...
-@overload
-def check_list(sub_validator: Validator[ResultT],
-               length: Optional[int]=None) -> Validator[List[ResultT]]:
-    ...
-def check_list(sub_validator: Optional[Validator[ResultT]]=None,
-               length: Optional[int]=None) -> Validator[List[ResultT]]:
-~~~
-
-The first overload expresses the types for the case where no
-`sub_validator` is passed, in which case all we know is that it
-returns a `Validator[List[object]]`; whereas the second defines the
-type logic for the case where we are passed a `sub_validator`.
-
-See the [mypy overloading documentation][mypy-overloads] for more details.
-
-[mypy-overloads]: https://mypy.readthedocs.io/en/stable/more_types.html#function-overloading
-
 ## Troubleshooting advice
 
 All of our linters, including mypy, are designed to only check files

--- a/zerver/lib/request.py
+++ b/zerver/lib/request.py
@@ -137,10 +137,7 @@ class _REQ(Generic[ResultT]):
 # functions using has_request_variables. In reality, REQ returns an
 # instance of class _REQ to enable the decorator to scan the parameter
 # list for _REQ objects and patch the parameters as the true types.
-#
-# See also this documentation to learn how @overload helps here.
-# https://zulip.readthedocs.io/en/latest/testing/mypy.html#using-overload-to-accurately-describe-variations
-#
+
 # Overload 1: converter
 @overload
 def REQ(

--- a/zerver/lib/topic_mutes.py
+++ b/zerver/lib/topic_mutes.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from django.utils.timezone import now as timezone_now
 from sqlalchemy.sql import Selectable, and_, column, not_, or_
@@ -9,7 +9,7 @@ from zerver.lib.topic import topic_match_sa
 from zerver.models import MutedTopic, UserProfile, get_stream
 
 
-def get_topic_mutes(user_profile: UserProfile) -> List[List[Union[str, float]]]:
+def get_topic_mutes(user_profile: UserProfile) -> List[Tuple[str, str, float]]:
     rows = MutedTopic.objects.filter(
         user_profile=user_profile,
     ).values(
@@ -18,7 +18,7 @@ def get_topic_mutes(user_profile: UserProfile) -> List[List[Union[str, float]]]:
         'date_muted',
     )
     return [
-        [row['stream__name'], row['topic_name'], datetime_to_timestamp(row['date_muted'])]
+        (row['stream__name'], row['topic_name'], datetime_to_timestamp(row['date_muted']))
         for row in rows
     ]
 

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -137,7 +137,6 @@ def check_none_or(sub_validator: Validator[ResultT]) -> Validator[Optional[Resul
             return sub_validator(var_name, val)
     return f
 
-# https://zulip.readthedocs.io/en/latest/testing/mypy.html#using-overload-to-accurately-describe-variations
 @overload
 def check_list(sub_validator: None, length: Optional[int]=None) -> Validator[List[object]]:
     ...
@@ -181,7 +180,6 @@ def check_tuple(sub_validators: List[Validator[ResultT]]) -> Validator[Tuple[Any
         return val
     return f
 
-# https://zulip.readthedocs.io/en/latest/testing/mypy.html#using-overload-to-accurately-describe-variations
 @overload
 def check_dict(required_keys: Iterable[Tuple[str, Validator[object]]]=[],
                optional_keys: Iterable[Tuple[str, Validator[object]]]=[],

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -163,6 +163,24 @@ def check_list(sub_validator: Optional[Validator[ResultT]]=None, length: Optiona
         return cast(List[ResultT], val)
     return f
 
+def check_tuple(sub_validators: List[Validator[ResultT]]) -> Validator[Tuple[Any, ...]]:
+    def f(var_name: str, val: object) -> Tuple[Any, ...]:
+        if not isinstance(val, tuple):
+            raise ValidationError(_('{var_name} is not a tuple').format(var_name=var_name))
+
+        desired_len = len(sub_validators)
+        if desired_len != len(val):
+            raise ValidationError(_('{var_name} should have exactly {desired_len} items').format(
+                var_name=var_name, desired_len=desired_len,
+            ))
+
+        for i, sub_validator in enumerate(sub_validators):
+            vname = f'{var_name}[{i}]'
+            sub_validator(vname, val[i])
+
+        return val
+    return f
+
 # https://zulip.readthedocs.io/en/latest/testing/mypy.html#using-overload-to-accurately-describe-variations
 @overload
 def check_dict(required_keys: Iterable[Tuple[str, Validator[object]]]=[],

--- a/zerver/lib/validator.py
+++ b/zerver/lib/validator.py
@@ -137,13 +137,7 @@ def check_none_or(sub_validator: Validator[ResultT]) -> Validator[Optional[Resul
             return sub_validator(var_name, val)
     return f
 
-@overload
-def check_list(sub_validator: None, length: Optional[int]=None) -> Validator[List[object]]:
-    ...
-@overload
 def check_list(sub_validator: Validator[ResultT], length: Optional[int]=None) -> Validator[List[ResultT]]:
-    ...
-def check_list(sub_validator: Optional[Validator[ResultT]]=None, length: Optional[int]=None) -> Validator[List[ResultT]]:
     def f(var_name: str, val: object) -> List[ResultT]:
         if not isinstance(val, list):
             raise ValidationError(_('{var_name} is not a list').format(var_name=var_name))
@@ -153,11 +147,10 @@ def check_list(sub_validator: Optional[Validator[ResultT]]=None, length: Optiona
                 container=var_name, length=length,
             ))
 
-        if sub_validator:
-            for i, item in enumerate(val):
-                vname = f'{var_name}[{i}]'
-                valid_item = sub_validator(vname, item)
-                assert item is valid_item  # To justify the unchecked cast below
+        for i, item in enumerate(val):
+            vname = f'{var_name}[{i}]'
+            valid_item = sub_validator(vname, item)
+            assert item is valid_item  # To justify the unchecked cast below
 
         return cast(List[ResultT], val)
     return f

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -70,6 +70,7 @@ from zerver.lib.utils import generate_random_token
 from zerver.lib.validator import (
     Validator,
     check_bool,
+    check_dict,
     check_dict_only,
     check_int,
     check_list,
@@ -3285,7 +3286,7 @@ class FetchAuthBackends(ZulipTestCase):
             self.assert_json_success(result)
             checker = check_dict_only([
                 ('authentication_methods', check_dict_only(authentication_methods_list)),
-                ('external_authentication_methods', check_list(None, length=len(external_auth_methods))),
+                ('external_authentication_methods', check_list(check_dict(), length=len(external_auth_methods))),
                 ('email_auth_enabled', check_bool),
                 ('is_incompatible', check_bool),
                 ('require_email_format_usernames', check_bool),

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -68,6 +68,7 @@ from zerver.lib.validator import (
     check_string_in,
     check_string_or_int,
     check_string_or_int_list,
+    check_tuple,
     check_union,
     check_url,
     equals,
@@ -847,6 +848,21 @@ class ValidatorTestCase(TestCase):
 
         with self.assertRaisesRegex(ValidationError, r'color is not a string'):
             check_color('color', z)
+
+    def test_check_tuple(self) -> None:
+        x: Any = 999
+        with self.assertRaisesRegex(ValidationError, r'x is not a tuple'):
+            check_tuple([check_string])('x', x)
+
+        x = (5, 2)
+        with self.assertRaisesRegex(ValidationError, r'x\[0\] is not a string'):
+            check_tuple([check_string, check_string])('x', x)
+
+        x = (1, 2, 3)
+        with self.assertRaisesRegex(ValidationError, r'x should have exactly 2 items'):
+            check_tuple([check_int, check_int])('x', x)
+
+        check_tuple([check_string, check_int])('x', ('string', 42))
 
     def test_check_list(self) -> None:
         x: Any = 999

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -2027,12 +2027,18 @@ class EventsRegisterTest(ZulipTestCase):
         schema_checker('events[0]', events[0])
 
     def test_realm_filter_events(self) -> None:
+        regex = "#(?P<id>[123])"
+        url = "https://realm.com/my_realm_filter/%(id)s"
+
         schema_checker = self.check_events_dict([
             ('type', equals('realm_filters')),
-            ('realm_filters', check_list(None)),  # TODO: validate tuples in the list
+            ('realm_filters', check_list(check_tuple([
+                check_string,
+                check_string,
+                check_int,
+            ]))),
         ])
-        events = self.do_test(lambda: do_add_realm_filter(self.user_profile.realm, "#(?P<id>[123])",
-                                                          "https://realm.com/my_realm_filter/%(id)s"))
+        events = self.do_test(lambda: do_add_realm_filter(self.user_profile.realm, regex, url))
         schema_checker('events[0]', events[0])
 
         events = self.do_test(lambda: do_remove_realm_filter(self.user_profile.realm, "#(?P<id>[123])"))

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -139,6 +139,7 @@ from zerver.lib.validator import (
     check_list,
     check_none_or,
     check_string,
+    check_tuple,
     check_url,
     equals,
 )
@@ -1493,7 +1494,11 @@ class EventsRegisterTest(ZulipTestCase):
     def test_muted_topics_events(self) -> None:
         muted_topics_checker = self.check_events_dict([
             ('type', equals('muted_topics')),
-            ('muted_topics', check_list(check_list(sub_validator=None, length=3))),
+            ('muted_topics', check_list(check_tuple([
+                check_string,  # stream name
+                check_string,  # topic name
+                check_int,  # timestamp
+            ]))),
         ])
         stream = get_stream('Denmark', self.user_profile.realm)
         recipient = stream.recipient

--- a/zerver/tests/test_muting.py
+++ b/zerver/tests/test_muting.py
@@ -73,7 +73,7 @@ class MutedTopicsTests(ZulipTestCase):
                 result = self.api_patch(user, url, data)
                 self.assert_json_success(result)
 
-            self.assertIn([stream.name, 'Verona3', mock_date_muted], get_topic_mutes(user))
+            self.assertIn((stream.name, 'Verona3', mock_date_muted), get_topic_mutes(user))
             self.assertTrue(topic_is_muted(user, stream.id, 'Verona3'))
             self.assertTrue(topic_is_muted(user, stream.id, 'verona3'))
 
@@ -106,12 +106,12 @@ class MutedTopicsTests(ZulipTestCase):
                 topic_name='Verona3',
                 date_muted=datetime(2020, 1, 1, tzinfo=timezone.utc),
             )
-            self.assertIn([stream.name, 'Verona3', mock_date_muted], get_topic_mutes(user))
+            self.assertIn((stream.name, 'Verona3', mock_date_muted), get_topic_mutes(user))
 
             result = self.api_patch(user, url, data)
 
             self.assert_json_success(result)
-            self.assertNotIn([stream.name, 'Verona3', mock_date_muted], get_topic_mutes(user))
+            self.assertNotIn((stream.name, 'Verona3', mock_date_muted), get_topic_mutes(user))
             self.assertFalse(topic_is_muted(user, stream.id, 'verona3'))
 
     def test_muted_topic_add_invalid(self) -> None:


### PR DESCRIPTION
The goal here is to simplify check_list.  The sub_validator=None feature is only used for muted topics, and it's a format we eventually want to deprecate.