### PR TITLE
Configure Zulip to be scanned by SonarCloud

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,1 @@
-#sonar.inclusions=**/*.py,**/*.html
+sonar.inclusions=**/*.py,**/*.html

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,1 @@
-sonar.inclusions=**/*.py,**/*.html
+#sonar.inclusions=**/*.py,**/*.html

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,1 @@
-sonar.inclusions=**/*.py
+sonar.inclusions=**/*.py,**/*.html

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,1 @@
+sonar.inclusions=**/*.py


### PR DESCRIPTION
It appears there is a failure on SonarCloud that prevents Zulip to be scanned and to report valuable issues on Python code.
In order to move forward, I provide a config file that will allow at least to scan the Python and HTML Template files.

I tested this configuration and it works. See: https://sonarcloud.io/dashboard?id=agigleux_zulip