### PR TITLE
markdown: Escape HTML entities in inline code blocks.

### DIFF
--- a/zerver/lib/bugdown/__init__.py
+++ b/zerver/lib/bugdown/__init__.py
@@ -522,22 +522,16 @@ class InlineHttpsProcessor(markdown.treeprocessors.Treeprocessor):
                 continue
             img.set("src", get_camo_url(url))
 
-class BacktickPattern(markdown.inlinepatterns.Pattern):
+class BacktickInlineProcessor(markdown.inlinepatterns.BacktickInlineProcessor):
     """ Return a `<code>` element containing the matching text. """
-
-    def __init__(self, pattern: str) -> None:
-        markdown.inlinepatterns.Pattern.__init__(self, pattern)
-        self.ESCAPED_BSLASH = '{}{}{}'.format(markdown.util.STX, ord('\\'), markdown.util.ETX)
-        self.tag = 'code'
-
-    def handleMatch(self, m: Match[str]) -> Union[str, Element]:
-        if m.group(4):
-            el = Element(self.tag)
-            # Modified to not strip whitespace
-            el.text = markdown.util.AtomicString(m.group(4))
-            return el
-        else:
-            return m.group(2).replace('\\\\', self.ESCAPED_BSLASH)
+    def handleMatch(self, m: Match[str], data: str) -> Tuple[Union[None, Element], int, int]:
+        # Let upstream's implementation do its job as it is, we'll just replace the
+        # text to not strip the group
+        el, start, end = super().handleMatch(m, data)
+        if m.group(3):
+            # upstream's code here is: m.group(3).strip().
+            el.text = markdown.util.AtomicString(markdown.util.code_escape(m.group(3)))
+        return el, start, end
 
 class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
     TWITTER_MAX_IMAGE_HEIGHT = 400
@@ -1928,14 +1922,12 @@ class Bugdown(markdown.Markdown):
         EMPHASIS_RE = r'(\*)(?!\s+)([^\*^\n]+)(?<!\s)\*'
         ENTITY_RE = markdown.inlinepatterns.ENTITY_RE
         STRONG_EM_RE = r'(\*\*\*)(?!\s+)([^\*^\n]+)(?<!\s)\*\*\*'
-        # Inline code block without whitespace stripping
-        BACKTICK_RE = r'(?:(?<!\\)((?:\\{2})+)(?=`+)|(?<!\\)(`+)(.+?)(?<!`)\3(?!`))'
 
         # Add Inline Patterns.  We use a custom numbering of the
         # rules, that preserves the order from upstream but leaves
         # space for us to add our own.
         reg = markdown.util.Registry()
-        reg.register(BacktickPattern(BACKTICK_RE), 'backtick', 105)
+        reg.register(BacktickInlineProcessor(markdown.inlinepatterns.BACKTICK_RE), 'backtick', 105)
         reg.register(markdown.inlinepatterns.DoubleTagPattern(STRONG_EM_RE, 'strong,em'), 'strong_em', 100)
         reg.register(UserMentionPattern(mention.find_mentions, self), 'usermention', 95)
         reg.register(Tex(r'\B(?<!\$)\$\$(?P<body>[^\n_$](\\\$|[^$\n])*)\$\$(?!\$)\B'), 'tex', 90)

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -42,6 +42,12 @@
       "text_content": " outer      space    "
     },
     {
+      "name": "inline_code_html_entities",
+      "input": "`<&nbsp;>`",
+      "expected_output": "<p><code>&lt;&amp;nbsp;&gt;</code></p>",
+      "text_content": "<&nbsp;>"
+    },
+    {
       "name": "codeblock_backticks",
       "input": "\n```\nfenced code\n```\n\n```inline code```\n",
       "expected_output": "<div class=\"codehilite\"><pre><span></span><code>fenced code\n</code></pre></div>\n\n\n<p><code>inline code</code></p>",

--- a/zerver/tests/test_bugdown.py
+++ b/zerver/tests/test_bugdown.py
@@ -1,6 +1,7 @@
 import copy
 import os
 import re
+from textwrap import dedent
 from typing import Any, Dict, List, Optional, Set, Tuple
 from unittest import mock
 
@@ -2007,6 +2008,57 @@ class BugdownTest(ZulipTestCase):
             bugdown.convert(msg, message_realm=realm, message=message),
             '<p><a href="#narrow/stream/999-hello">hello</a></p>',
         )
+
+    def test_html_entity_conversion(self) -> None:
+        msg = """\
+            Test raw: Hello, &copy;
+            Test inline code: `&copy;`
+
+            Test fenced code:
+            ```
+            &copy;
+            &copy;
+            ```
+
+            Test quote:
+            ~~~quote
+            &copy;
+            ~~~
+
+            Test a list:
+            * &copy;
+            * `&copy;`
+            * ```&copy;```
+
+            Test an indented block:
+
+                &copy;"""
+
+        expected_output = """\
+            <p>Test raw: Hello, &copy;<br>
+            Test inline code: <code>&amp;copy;</code></p>
+            <p>Test fenced code:</p>
+            <div class="codehilite"><pre><span></span><code>&amp;copy;
+            &amp;copy;
+            </code></pre></div>
+
+
+            <p>Test quote:</p>
+            <blockquote>
+            <p>&copy;</p>
+            </blockquote>
+            <p>Test a list:</p>
+            <ul>
+            <li>&copy;</li>
+            <li><code>&amp;copy;</code></li>
+            <li><code>&amp;copy;</code></li>
+            </ul>
+            <p>Test an indented block:</p>
+            <div class="codehilite"><pre><span></span><code>&amp;copy;
+            </code></pre></div>"""
+
+        converted = bugdown_convert(dedent(msg))
+        self.assertEqual(converted, dedent(expected_output))
 
 class BugdownApiTests(ZulipTestCase):
     def test_render_message_api(self) -> None:


### PR DESCRIPTION
This fixes an issues that causes HTML entities inside of inline code
blocks to be converted rather than being displayed literally.

The upstream python-markdown now handles this correctly, so we just use
their implementation with our changes for removing .strip(). As a result
of this migration, we switch backtick pattern to an inline processor
too.

Fixes #12056.

Co-authored-by: Rohitt Vashishtha <aero31aero@gmail.com>

---

This PR is essentially a rewrite of #13904. We keep the testcases from it intact.

**Testing Plan:** <!-- How have you tested? -->
Manual and automated tests.