### PR TITLE
puppeteer: Fix a flake in 02-message-basics.js.

### DIFF
--- a/frontend_tests/puppeteer_lib/common.js
+++ b/frontend_tests/puppeteer_lib/common.js
@@ -157,6 +157,10 @@ class CommonUtils {
                       re-rendered based on server info?
             */
             const last_msg = current_msg_list.last();
+            if (last_msg === undefined) {
+                return false;
+            }
+
             if (last_msg.raw_content !== content) {
                 return false;
             }


### PR DESCRIPTION
The flake was caused due to the fact that current_msg_list was not
populated with any messages in rare cases. We were missing a
conditional checking that is was not undefined which means the
messages in the current narrow were still loading. The failure
screenshot show no messages to prove this.
