### PR TITLE
auth: Fix incorrect encoding of whitespace in scope in Apple backend.

### DIFF
--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -1555,6 +1555,8 @@ class AppleAuthBackend(SocialAuthMixin, AppleIdAuth):
     full_name_validated = True
     REDIS_EXPIRATION_SECONDS = 60*10
 
+    SCOPE_SEPARATOR = "%20"  # https://github.com/python-social-auth/social-core/issues/470
+
     def is_native_flow(self) -> bool:
         return self.strategy.request_data().get('native_flow', False)
 


### PR DESCRIPTION
Fixes the infinitely confusing bug discussed around https://chat.zulip.org/#narrow/stream/3-backend/topic/apple.20auth/near/915299