### PR TITLE
Show normal user popover for bot owners instead of extended profile.

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -210,6 +210,7 @@ run_test("basic_chars", () => {
         actions_popped: return_false,
         message_info_popped: return_false,
         user_sidebar_popped: return_false,
+        user_info_popped: return_false,
     });
     set_global("stream_popover", {
         stream_popped: return_false,

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -43,9 +43,7 @@ set_global("stream_popover", {
 
 set_global("stream_data", {});
 
-function ClipboardJS(sel) {
-    assert.equal(sel, ".copy_link");
-}
+const ClipboardJS = noop;
 
 rewiremock.proxy(() => zrequire("popovers"), {
     clipboard: ClipboardJS,
@@ -176,7 +174,9 @@ run_test("sender_hover", (override) => {
                     is_active: true,
                     is_bot: undefined,
                     is_sender_popover: true,
+                    has_message_context: true,
                     status_text: "on the beach",
+                    user_mention_syntax: "@**Alice Smith**",
                 });
                 return "content-html";
 

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -306,6 +306,11 @@ exports.process_enter_key = function (e) {
         return true;
     }
 
+    if (popovers.user_info_popped()) {
+        popovers.user_info_popover_handle_keyboard("enter");
+        return true;
+    }
+
     if (stream_popover.stream_popped()) {
         stream_popover.stream_sidebar_menu_handle_keyboard("enter");
         return true;
@@ -524,7 +529,7 @@ exports.process_hotkey = function (e, hotkey) {
         return false;
     }
 
-    if (overlays.settings_open()) {
+    if (overlays.settings_open() && !popovers.user_info_popped()) {
         return false;
     }
 
@@ -576,6 +581,11 @@ exports.process_hotkey = function (e, hotkey) {
 
         if (popovers.message_info_popped()) {
             popovers.user_info_popover_for_message_handle_keyboard(event_name);
+            return true;
+        }
+
+        if (popovers.user_info_popped()) {
+            popovers.user_info_popover_handle_keyboard(event_name);
             return true;
         }
 

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -192,6 +192,11 @@ exports.process_escape_key = function (e) {
         return true;
     }
 
+    if (popovers.any_active()) {
+        popovers.hide_all();
+        return true;
+    }
+
     if (overlays.is_modal_open()) {
         overlays.close_active_modal();
         return true;
@@ -250,11 +255,6 @@ exports.process_escape_key = function (e) {
         // We pressed Esc and something was focused, and the composebox
         // wasn't open. In that case, we should blur the input.
         $("input:focus,textarea:focus").trigger("blur");
-        return true;
-    }
-
-    if (popovers.any_active()) {
-        popovers.hide_all();
         return true;
     }
 

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -575,7 +575,7 @@ exports.process_hotkey = function (e, hotkey) {
         }
 
         if (popovers.message_info_popped()) {
-            popovers.user_info_popover_handle_keyboard(event_name);
+            popovers.user_info_popover_for_message_handle_keyboard(event_name);
             return true;
         }
 

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -169,6 +169,7 @@ function render_user_info_popover(
     user,
     popover_element,
     is_sender_popover,
+    has_message_context,
     private_msg_class,
     template_class,
     popover_placement,
@@ -189,6 +190,7 @@ function render_user_info_popover(
     const args = {
         can_revoke_away,
         can_set_away,
+        has_message_context,
         is_active: people.is_active_user_for_popover(user.user_id),
         is_bot: user.is_bot,
         is_me,
@@ -206,6 +208,7 @@ function render_user_info_popover(
         user_time: people.get_user_time(user.user_id),
         user_type: people.get_user_type(user.user_id),
         status_text: user_status.get_status_text(user.user_id),
+        user_mention_syntax: people.get_mention_syntax(user.full_name, user.user_id),
     };
 
     if (user.is_bot) {
@@ -271,6 +274,7 @@ function show_user_info_popover_for_message(element, user, message) {
             user,
             elt,
             is_sender_popover,
+            true,
             "respond_personal_button",
             "message-info-popover",
             "right",
@@ -921,6 +925,7 @@ exports.register_click_handlers = function () {
             user,
             target,
             false,
+            false,
             "compose_private_message",
             "user_popover",
             popover_placement,
@@ -1104,6 +1109,14 @@ exports.register_click_handlers = function () {
             $(":focus").trigger("blur");
         }, 0);
 
+        e.stopPropagation();
+        e.preventDefault();
+    });
+
+    new ClipboardJS(".copy_mention_syntax");
+
+    $("body").on("click", ".copy_mention_syntax", (e) => {
+        exports.hide_all();
         e.stopPropagation();
         e.preventDefault();
     });

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -893,7 +893,7 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
 
-    $("body").on("click", ".info_popover_actions .view_user_profile", (e) => {
+    $("body").on("click", ".info_popover_actions .view_full_user_profile", (e) => {
         const user_id = elem_to_user_id($(e.target).parents("ul"));
         const user = people.get_by_user_id(user_id);
         exports.show_user_profile(user);
@@ -913,10 +913,12 @@ exports.register_click_handlers = function () {
         });
     });
 
-    $("body").on("click", ".bot-owner-name", (e) => {
+    $("body").on("click", ".view_user_profile", (e) => {
         const user_id = parseInt($(e.target).attr("data-user-id"), 10);
         const user = people.get_by_user_id(user_id);
         exports.show_user_info_popover(e.target, user);
+        e.stopPropagation();
+        e.preventDefault();
     });
 
     $("body").on("click", "#user-profile-modal #name #edit-button", () => {

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -853,7 +853,7 @@ exports.register_click_handlers = function () {
     });
 
     $("body").on("click", ".bot-owner-name", (e) => {
-        const user_id = parseInt($(e.target).attr("data-bot-owner-id"), 10);
+        const user_id = parseInt($(e.target).attr("data-user-id"), 10);
         const user = people.get_by_user_id(user_id);
         exports.show_user_profile(user);
     });

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -349,7 +349,7 @@ exports.show_user_profile = function (user) {
     );
 };
 
-function get_user_info_popover_items() {
+function get_user_info_popover_for_message_items() {
     if (!current_message_info_popover_elem) {
         blueslip.error("Trying to get menu items when action popover is closed.");
         return;
@@ -687,7 +687,7 @@ exports.hide_user_sidebar_popover = function () {
 function focus_user_info_popover_item() {
     // For now I recommend only calling this when the user opens the menu with a hotkey.
     // Our popup menus act kind of funny when you mix keyboard and mouse.
-    const items = get_user_info_popover_items();
+    const items = get_user_info_popover_for_message_items();
     exports.focus_first_popover_item(items);
 }
 
@@ -705,8 +705,8 @@ exports.user_sidebar_popover_handle_keyboard = function (key) {
     exports.popover_items_handle_keyboard(key, items);
 };
 
-exports.user_info_popover_handle_keyboard = function (key) {
-    const items = get_user_info_popover_items();
+exports.user_info_popover_for_message_handle_keyboard = function (key) {
+    const items = get_user_info_popover_for_message_items();
     exports.popover_items_handle_keyboard(key, items);
 };
 

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -388,6 +388,21 @@ function get_user_info_popover_for_message_items() {
     return $("li:not(.divider):visible a", popover_data.$tip);
 }
 
+function get_user_info_popover_items() {
+    const popover_elt = $("div.user-info-popover");
+    if (!current_user_info_popover_elem || !popover_elt.length) {
+        blueslip.error("Trying to get menu items when action popover is closed.");
+        return;
+    }
+
+    if (popover_elt.length >= 2) {
+        blueslip.error("More than one user info popovers cannot be opened at same time.");
+        return;
+    }
+
+    return $("li:not(.divider):visible a", popover_elt);
+}
+
 function fetch_group_members(member_ids) {
     return member_ids
         .map((m) => people.get_by_user_id(m))
@@ -742,6 +757,11 @@ exports.user_sidebar_popover_handle_keyboard = function (key) {
 
 exports.user_info_popover_for_message_handle_keyboard = function (key) {
     const items = get_user_info_popover_for_message_items();
+    exports.popover_items_handle_keyboard(key, items);
+};
+
+exports.user_info_popover_handle_keyboard = function (key) {
+    const items = get_user_info_popover_items();
     exports.popover_items_handle_keyboard(key, items);
 };
 

--- a/static/js/settings_invites.js
+++ b/static/js/settings_invites.js
@@ -53,19 +53,19 @@ function populate_invites(invites_data) {
             item.disable_buttons =
                 item.invited_as === settings_config.user_role_values.owner.code &&
                 !page_params.is_owner;
-            item.referrer_email = people.get_by_user_id(item.invited_by_user_id).email;
+            item.referrer_name = people.get_by_user_id(item.invited_by_user_id).full_name;
             return render_admin_invites_list({invite: item});
         },
         filter: {
             element: invites_table.closest(".settings-section").find(".search"),
             predicate(item, value) {
-                const referrer_email = people.get_by_user_id(item.invited_by_user_id).email;
-                const referrer_email_matched = referrer_email.toLowerCase().includes(value);
+                const referrer_name = people.get_by_user_id(item.invited_by_user_id).full_name;
+                const referrer_name_matched = referrer_name.toLowerCase().includes(value);
                 if (item.is_multiuse) {
-                    return referrer_email_matched;
+                    return referrer_name_matched;
                 }
                 const invitee_email_matched = item.email.toLowerCase().includes(value);
-                return referrer_email_matched || invitee_email_matched;
+                return referrer_name_matched || invitee_email_matched;
             },
         },
         parent_container: $("#admin-invites-list").expectOne(),

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -585,7 +585,7 @@ function handle_reactivation(tbody, status_field) {
 
 function handle_bot_owner_profile(tbody) {
     tbody.on("click", ".user_row .view_user_profile", (e) => {
-        const owner_id = parseInt($(e.target).attr("data-owner-id"), 10);
+        const owner_id = parseInt($(e.target).attr("data-user-id"), 10);
         const owner = people.get_by_user_id(owner_id);
         popovers.show_user_profile(owner);
         e.stopPropagation();

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -587,7 +587,7 @@ function handle_bot_owner_profile(tbody) {
     tbody.on("click", ".user_row .view_user_profile", (e) => {
         const owner_id = parseInt($(e.target).attr("data-user-id"), 10);
         const owner = people.get_by_user_id(owner_id);
-        popovers.show_user_profile(owner);
+        popovers.show_user_info_popover(e.target, owner);
         e.stopPropagation();
         e.preventDefault();
     });

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -583,16 +583,6 @@ function handle_reactivation(tbody, status_field) {
     });
 }
 
-function handle_bot_owner_profile(tbody) {
-    tbody.on("click", ".user_row .view_user_profile", (e) => {
-        const owner_id = parseInt($(e.target).attr("data-user-id"), 10);
-        const owner = people.get_by_user_id(owner_id);
-        popovers.show_user_info_popover(e.target, owner);
-        e.stopPropagation();
-        e.preventDefault();
-    });
-}
-
 function handle_human_form(tbody, status_field) {
     tbody.on("click", ".open-user-form", (e) => {
         e.stopPropagation();
@@ -686,7 +676,6 @@ section.bots.handle_events = () => {
     const tbody = $("#admin_bots_table").expectOne();
     const status_field = $("#bot-field-status").expectOne();
 
-    handle_bot_owner_profile(tbody);
     handle_bot_deactivation(tbody, status_field);
     handle_reactivation(tbody, status_field);
     handle_bot_form(tbody, status_field);

--- a/static/styles/popovers.css
+++ b/static/styles/popovers.css
@@ -179,7 +179,8 @@ ul {
     }
 }
 
-.message-info-popover {
+.message-info-popover,
+.user-info-popover {
     width: 240px;
     padding: 0;
 
@@ -353,7 +354,8 @@ ul {
 }
 
 @media (max-width: 768px) {
-    .message-info-popover {
+    .message-info-popover,
+    .user-info-popover {
         display: flex !important;
         justify-content: center;
         align-items: center;

--- a/static/templates/admin_invites_list.hbs
+++ b/static/templates/admin_invites_list.hbs
@@ -13,7 +13,9 @@
     </td>
     {{#if is_admin}}
     <td>
-        <span class="referred_by">{{referrer_email}}</span>
+        <span class="referred_by">
+            <a data-user-id="{{invited_by_user_id}}" href="#" class="view_user_profile">{{referrer_name}}</a>
+        </span>
     </td>
     {{/if}}
     <td>

--- a/static/templates/admin_user_list.hbs
+++ b/static/templates/admin_user_list.hbs
@@ -29,7 +29,7 @@
             {{#if no_owner }}
             {{bot_owner_full_name}}
             {{else}}
-            <a data-owner-id="{{bot_owner_id}}" href="#" class="view_user_profile">{{bot_owner_full_name}}</a>
+            <a data-user-id="{{bot_owner_id}}" href="#" class="view_user_profile">{{bot_owner_full_name}}</a>
             {{/if}}
         </span>
     </td>

--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -35,7 +35,7 @@
         {{#if is_bot}}
             {{#if bot_owner}}
                 <li>{{#tr this}}Owner{{/tr}}:
-                    <span class="bot-owner-name" data-user-id='{{ bot_owner.user_id }}'>
+                    <span class="bot-owner-name view_user_profile" data-user-id='{{ bot_owner.user_id }}'>
                         {{bot_owner.full_name}}
                     </span>
                 </li>
@@ -92,7 +92,7 @@
     <hr>
     {{#if show_user_profile}}
     <li>
-        <a tabindex="0" class="view_user_profile">
+        <a tabindex="0" class="view_full_user_profile">
             {{#if is_me}}
                 <i class="fa fa-user" aria-hidden="true"></i> {{#tr this}}View your profile{{/tr}}
             {{else}}

--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -35,7 +35,7 @@
         {{#if is_bot}}
             {{#if bot_owner}}
                 <li>{{#tr this}}Owner{{/tr}}:
-                    <span class="bot-owner-name" data-bot-owner-id='{{ bot_owner.user_id }}'>
+                    <span class="bot-owner-name" data-user-id='{{ bot_owner.user_id }}'>
                         {{bot_owner.full_name}}
                     </span>
                 </li>

--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -112,9 +112,19 @@
     {{/if}}
     {{#unless is_me}}
     <li>
+        {{#if has_message_context}}
         <a tabindex="0" class="mention_user">
-            <i class="fa fa-at" aria-hidden="true"></i> {{#tr this}}Reply mentioning user{{/tr}} {{#if is_sender_popover}}<span class="hotkey-hint">(@)</span>{{/if}}
+            <i class="fa fa-at" aria-hidden="true"></i>
+            {{#tr this}}Reply mentioning user{{/tr}}
+            {{#if is_sender_popover}}<span class="hotkey-hint">(@)</span>{{/if}}
         </a>
+        {{else}}
+        <a tabindex="0" class="copy_mention_syntax" data-clipboard-text="{{ user_mention_syntax }}">
+            <i class="fa fa-at" aria-hidden="true"></i>
+            {{#tr this}}Copy user mention syntax{{/tr}}
+            {{#if is_sender_popover}}<span class="hotkey-hint">(@)</span>{{/if}}
+        </a>
+        {{/if}}
     </li>
     {{/unless}}
     {{#if is_me}}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR changes the user popover for bot owner to be normal one instead of extended profile one.

This also has two prep commits-
1. Rename show_user_info_popover to show_sender_info_popover as this is used to show the user popover for message sender.
(A function named show_user_info_popover is added which is used for bot owners case and also will be used for 'invited_by' column in invites table.)
2.  Change the popover to show 'Reply mentioning user' option only in msg sender popover and not on popovers openend from right sidebar.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![right](https://user-images.githubusercontent.com/35494118/85790784-72d33d80-b74e-11ea-897e-01c0e441a0cd.gif)
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
