### PR TITLE
mobile: Add alternate mobile URI option

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -2793,6 +2793,27 @@ class GoogleAuthBackendTest(SocialAuthBase):
             "warning",
         )])
 
+    def test_social_auth_mobile_realm_uri(self) -> None:
+        mobile_flow_otp = '1234abcd' * 8
+        account_data_dict = self.get_account_data_dict(email=self.email, name='Full Name')
+
+        with self.settings(REALM_MOBILE_URIS={'http://zulip.testserver': 'http://zulip-mobile.testserver'}):
+            result = self.social_auth_test(account_data_dict, subdomain='zulip',
+                                           expect_choose_email_screen=True,
+                                           alternative_start_url="/accounts/login/google/",
+                                           mobile_flow_otp=mobile_flow_otp)
+
+        self.assertEqual(result.status_code, 302)
+        redirect_url = result['Location']
+        parsed_url = urllib.parse.urlparse(redirect_url)
+        query_params = urllib.parse.parse_qs(parsed_url.query)
+        self.assertEqual(parsed_url.scheme, 'zulip')
+        self.assertEqual(query_params["realm"], ['http://zulip-mobile.testserver'])
+        self.assertEqual(query_params["email"], [self.example_email("hamlet")])
+        encrypted_api_key = query_params["otp_encrypted_api_key"][0]
+        hamlet_api_keys = get_all_api_keys(self.example_user('hamlet'))
+        self.assertIn(otp_decrypt_api_key(encrypted_api_key, mobile_flow_otp), hamlet_api_keys)
+
     def test_social_auth_mobile_success_legacy_url(self) -> None:
         mobile_flow_otp = '1234abcd' * 8
         account_data_dict = self.get_account_data_dict(email=self.email, name='Full Name')

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -321,12 +321,12 @@ def finish_mobile_flow(request: HttpRequest, user_profile: UserProfile, otp: str
 
 def create_response_for_otp_flow(key: str, otp: str, user_profile: UserProfile,
                                  encrypted_key_field_name: str) -> HttpResponse:
-    
+
     realm_uri = user_profile.realm.uri
     # Check if the mobile URI is overridden in settings, if so replace it
     if realm_uri in settings.REALM_MOBILE_URIS:
         realm_uri = settings.REALM_MOBILE_URIS[realm_uri]
-    
+
     params = {
         encrypted_key_field_name: otp_encrypt_api_key(key, otp),
         'email': user_profile.delivery_email,

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -321,10 +321,16 @@ def finish_mobile_flow(request: HttpRequest, user_profile: UserProfile, otp: str
 
 def create_response_for_otp_flow(key: str, otp: str, user_profile: UserProfile,
                                  encrypted_key_field_name: str) -> HttpResponse:
+    
+    realm_uri = user_profile.realm.uri
+    # Check if the mobile URI is overridden in settings, if so replace it
+    if realm_uri in settings.REALM_MOBILE_URIS:
+        realm_uri = settings.REALM_MOBILE_URIS[realm_uri]
+    
     params = {
         encrypted_key_field_name: otp_encrypt_api_key(key, otp),
         'email': user_profile.delivery_email,
-        'realm': user_profile.realm.uri,
+        'realm': realm_uri,
     }
     # We can't use HttpResponseRedirect, since it only allows HTTP(S) URLs
     response = HttpResponse(status=302)

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -243,7 +243,7 @@ REALM_HOSTS: Dict[str, str] = {}
 
 # Alternate uris to serve particular realms on mobile, in addition
 # to their usual uris. Keys are realm uris
-REALM_MOBILE_URIS = {} # type: Dict[str, str]
+REALM_MOBILE_URIS: Dict[str, str] = {}
 
 # Whether the server is using the Pgroonga full-text search
 # backend.  Plan is to turn this on for everyone after further

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -241,6 +241,10 @@ SYSTEM_ONLY_REALMS = {"zulip"}
 # The values will also be added to ALLOWED_HOSTS.
 REALM_HOSTS: Dict[str, str] = {}
 
+# Alternate uris to serve particular realms on mobile, in addition
+# to their usual uris. Keys are realm uris
+REALM_MOBILE_URIS = {} # type: Dict[str, str]
+
 # Whether the server is using the Pgroonga full-text search
 # backend.  Plan is to turn this on for everyone after further
 # testing.


### PR DESCRIPTION
due to authentication restrictions, a deployment may need to
direct traffic for mobile applications to an alternate uri to
take advantage alternate authentication mechansism. By default
the standard realm URI will be used but if overridden in the
settings file an alternate uri can be substituded.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
