### PR TITLE
isort: Set src_paths, remove unnecessary known_third_party overrides

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,7 @@
 [settings]
+src_paths = .
 multi_line_output = 3
-known_third_party = decorator, jinja2, netifaces, tc_aws, social_django, stripe, thumbor, tornado, zulip
+known_third_party = decorator, jinja2, stripe, tornado, zulip
 include_trailing_comma = True
 use_parentheses = True
 line_length = 100


### PR DESCRIPTION
Tim thought commit 51acca2672ef0f583b65066ff0ab21750c5dc54d was needed because he had an extra `social_django` directory in his checkout.