### PR TITLE
Fix UI for stream message retention days.

### DIFF
--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -126,8 +126,7 @@ function get_property_value(property_name) {
     }
 
     if (property_name === 'realm_message_retention_setting') {
-        if (page_params.realm_message_retention_days === null ||
-            page_params.realm_message_retention_days === settings_config.retain_message_forever) {
+        if (page_params.realm_message_retention_days === settings_config.retain_message_forever) {
             return "retain_forever";
         }
         return "retain_for_period";

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -58,9 +58,8 @@ exports.get_retention_policy_text_for_subscription_type = function (sub) {
     let message_retention_days = sub.message_retention_days;
     // If both this stream and the organization-level policy are to retain forever,
     // there's no need to comment on retention policies when describing the stream.
-    if ((page_params.realm_message_retention_days === -1 ||
-         page_params.realm_message_retention_days === null)
-            && (sub.message_retention_days === null || sub.message_retention_days === -1)) {
+    if (page_params.realm_message_retention_days === -1 &&
+            (sub.message_retention_days === null || sub.message_retention_days === -1)) {
         return;
     }
 
@@ -80,7 +79,7 @@ exports.get_retention_policy_text_for_subscription_type = function (sub) {
 
 exports.get_display_text_for_realm_message_retention_setting = function () {
     const realm_message_retention_days = page_params.realm_message_retention_days;
-    if (realm_message_retention_days === -1 || realm_message_retention_days === null) {
+    if (realm_message_retention_days === -1) {
         return i18n.t("(forever)");
     }
     return i18n.t("(__message_retention_days__ days)", {message_retention_days: realm_message_retention_days});

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -58,13 +58,14 @@ exports.get_retention_policy_text_for_subscription_type = function (sub) {
     let message_retention_days = sub.message_retention_days;
     // If both this stream and the organization-level policy are to retain forever,
     // there's no need to comment on retention policies when describing the stream.
-    if (page_params.realm_message_retention_days === -1 &&
-            (sub.message_retention_days === null || sub.message_retention_days === -1)) {
+    if (page_params.realm_message_retention_days === settings_config.retain_message_forever
+        && (sub.message_retention_days === null ||
+            sub.message_retention_days === settings_config.retain_message_forever)) {
         return;
     }
 
     // Forever for this stream, overriding the organization default
-    if (sub.message_retention_days === -1) {
+    if (sub.message_retention_days === settings_config.retain_message_forever) {
         return i18n.t("Messages in this stream will be retained forever.");
     }
 
@@ -79,7 +80,7 @@ exports.get_retention_policy_text_for_subscription_type = function (sub) {
 
 exports.get_display_text_for_realm_message_retention_setting = function () {
     const realm_message_retention_days = page_params.realm_message_retention_days;
-    if (realm_message_retention_days === -1) {
+    if (realm_message_retention_days === settings_config.retain_message_forever) {
         return i18n.t("(forever)");
     }
     return i18n.t("(__message_retention_days__ days)", {message_retention_days: realm_message_retention_days});
@@ -97,7 +98,7 @@ function set_stream_message_retention_setting_dropdown(stream) {
     let value = "retain_for_period";
     if (stream.message_retention_days === null) {
         value = "realm_default";
-    } else if (stream.message_retention_days === -1) {
+    } else if (stream.message_retention_days === settings_config.retain_message_forever) {
         value = "forever";
     }
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -588,7 +588,7 @@ exports.setup_page = function (callback) {
             hide_all_streams: !should_list_all_streams(),
             max_name_length: page_params.stream_name_max_length,
             max_description_length: page_params.stream_description_max_length,
-            is_admin: page_params.is_admin,
+            is_owner: page_params.is_owner,
             stream_post_policy_values: stream_data.stream_post_policy_values,
             stream_post_policy: stream_data.stream_post_policy_values.everyone.code,
             zulip_plan_is_not_limited: page_params.zulip_plan_is_not_limited,

--- a/static/templates/settings/organization_settings_admin.hbs
+++ b/static/templates/settings/organization_settings_admin.hbs
@@ -142,7 +142,9 @@
 
         <div id="org-message-retention" class="org-subsection-parent">
             <div class="subsection-header">
-                <h3>{{t "Message retention" }}</h3>
+                <h3>{{t "Message retention" }}
+                    {{> ../help_link_widget link="/help/message-retention-policy" }}
+                </h3>
                 {{> settings_save_discard_widget section_name="message-retention" }}
             </div>
 

--- a/static/templates/stream_creation_form.hbs
+++ b/static/templates/stream_creation_form.hbs
@@ -27,7 +27,7 @@
                     {{t 'These settings are explained in detail in the <a target="_blank" rel="noopener noreferrer" href="/help/stream-permissions">help center</a>.'}}
                 </div>
 
-                {{> stream_types is_public=true stream_post_policy=stream_post_policy_values.everyone.code}}
+                {{> stream_types is_public=true stream_post_policy=stream_post_policy_values.everyone.code is_stream_edit=false}}
 
                 <div id="announce-new-stream">
                     <label class="checkbox">

--- a/static/templates/stream_types.hbs
+++ b/static/templates/stream_types.hbs
@@ -31,17 +31,19 @@
         </label>
     </li>
     {{/each}}
-    {{#if is_admin}}
+    {{#if (or is_owner is_stream_edit)}}
     <h4>{{t "Message retention for stream" }}</h4>
 
     {{> settings/upgrade_tip_widget}}
 
     <li>
         <div class="input-group inline-block">
-            <label for="stream_message_retention_setting" class="dropdown-title">{{t "Message retention period" }}</label>
+            <label for="stream_message_retention_setting" class="dropdown-title">{{t "Message retention period" }}
+                <i class="fa fa-info-circle settings-info-icon realm_allow_message_deleting_tooltip" data-toggle="tooltip" aria-hidden="true" title="{{t 'Only owners can change stream message retention policy.' }}"></i>
+            </label>
             <select name="stream_message_retention_setting"
               class="stream_message_retention_setting" class="prop-element"
-              {{#unless zulip_plan_is_not_limited}}disabled{{/unless}}>
+              {{#if disable_message_retention_setting}}disabled{{/if}}>
                 <option value="realm_default">{{t 'Use organization level settings '}}{{realm_message_retention_setting}} </option>
                 <option value="forever">{{t 'Retain forever' }}</option>
                 <option value="retain_for_period">{{t 'Retain for N days after posting' }}</option>
@@ -55,7 +57,7 @@
                   name="stream-message-retention-days"
                   class="stream-message-retention-days"
                   value="{{ stream_message_retention_days }}"
-                  {{#unless zulip_plan_is_not_limited}}disabled{{/unless}}/>
+                  {{#if disable_message_retention_setting}}disabled{{/if}}/>
             </div>
         </div>
     </li>

--- a/static/templates/stream_types.hbs
+++ b/static/templates/stream_types.hbs
@@ -32,7 +32,9 @@
     </li>
     {{/each}}
     {{#if (or is_owner is_stream_edit)}}
-    <h4>{{t "Message retention for stream" }}</h4>
+    <h4>{{t "Message retention for stream" }}
+        {{> help_link_widget link="/help/message-retention-policy" }}
+    </h4>
 
     {{> settings/upgrade_tip_widget}}
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR fixes the UI for stream message retention days. We hide the setting in stream creation form and disable it in privacy modal. 
I have also added a commit which removes the checks for null value of realm_message_retention_days as it was removed in 7a03e2a.

Other things that we can change -
1. We can add a link to the retention docs next to the heading for message retention (in both stream settings and org settings)
2. If we add link to the docs, we can probably remove the `i` icon as docs already mentions the restriction of changing this settings. (not sure of this)

Solves a Part of #15558. (have not done deactivate organization part here, will do it in separate PR after the required changes are finalized).

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Privacy modal for admin - 
![Screenshot (136)](https://user-images.githubusercontent.com/35494118/85800130-0bbd8500-b75e-11ea-85b5-25a15893c47e.png)

 Stream creation form for admins now - 
![Screenshot (135)](https://user-images.githubusercontent.com/35494118/85800159-18da7400-b75e-11ea-97af-d08751edfc1d.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
