### PR TITLE
Installer classes

### DIFF
--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -390,21 +390,19 @@ EOF
     fi
 fi
 
-case ",$PUPPET_CLASSES," in
-    *,zulip::voyager,* | *,zulip::dockervoyager,* | *,zulip::app_frontend,*)
-        if [ -z "$NO_OVERWRITE_SETTINGS" ] || ! [ -e "/etc/zulip/settings.py" ]; then
-            cp -a "$ZULIP_PATH"/zproject/prod_settings_template.py /etc/zulip/settings.py
-            if [ -n "$EXTERNAL_HOST" ]; then
-                sed -i "s/^EXTERNAL_HOST =.*/EXTERNAL_HOST = '$EXTERNAL_HOST'/" /etc/zulip/settings.py
-            fi
-            if [ -n "$ZULIP_ADMINISTRATOR" ]; then
-                sed -i "s/^ZULIP_ADMINISTRATOR =.*/ZULIP_ADMINISTRATOR = '$ZULIP_ADMINISTRATOR'/" /etc/zulip/settings.py
-            fi
+if has_class "zulip::app_frontend_base"; then
+    if [ -z "$NO_OVERWRITE_SETTINGS" ] || ! [ -e "/etc/zulip/settings.py" ]; then
+        cp -a "$ZULIP_PATH"/zproject/prod_settings_template.py /etc/zulip/settings.py
+        if [ -n "$EXTERNAL_HOST" ]; then
+            sed -i "s/^EXTERNAL_HOST =.*/EXTERNAL_HOST = '$EXTERNAL_HOST'/" /etc/zulip/settings.py
         fi
-        ln -nsf /etc/zulip/settings.py "$ZULIP_PATH"/zproject/prod_settings.py
-        "$ZULIP_PATH"/scripts/setup/generate_secrets.py --production
-        ;;
-esac
+        if [ -n "$ZULIP_ADMINISTRATOR" ]; then
+            sed -i "s/^ZULIP_ADMINISTRATOR =.*/ZULIP_ADMINISTRATOR = '$ZULIP_ADMINISTRATOR'/" /etc/zulip/settings.py
+        fi
+    fi
+    ln -nsf /etc/zulip/settings.py "$ZULIP_PATH"/zproject/prod_settings.py
+    "$ZULIP_PATH"/scripts/setup/generate_secrets.py --production
+fi
 
 "$ZULIP_PATH"/scripts/zulip-puppet-apply -f
 

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -404,7 +404,6 @@ fi
 
 "$ZULIP_PATH"/scripts/zulip-puppet-apply -f
 
-# These server restarting bits should be moveable into puppet-land, ideally
 if [ "$package_system" = apt ]; then
     apt-get -y upgrade
 elif [ "$package_system" = yum ]; then

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -353,6 +353,10 @@ EOF
         crudini --set /etc/zulip/zulip.conf certbot auto_renew yes
     fi
 
+    if [ -n "$POSTGRES_MISSING_DICTIONARIES" ]; then
+        crudini --set /etc/zulip/zulip.conf postgresql missing_dictionaries true
+    fi
+
     "$ZULIP_PATH"/scripts/zulip-puppet-apply --force --noop \
                  --write-catalog-summary \
                  --classfile=/var/lib/puppet/classes.txt \
@@ -424,10 +428,6 @@ if [ "$DEPLOYMENT_TYPE" = "dockervoyager" ]; then
     has_appserver=0
     has_rabbit=1
     has_postgres=1
-fi
-
-if [ -n "$POSTGRES_MISSING_DICTIONARIES" ]; then
-    crudini --set /etc/zulip/zulip.conf postgresql missing_dictionaries true
 fi
 
 # These server restarting bits should be moveable into puppet-land, ideally

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -325,57 +325,65 @@ fi
 
 # Generate /etc/zulip/zulip.conf .
 mkdir -p /etc/zulip
-if [ -z "$NO_OVERWRITE_SETTINGS" ] || ! [ -e "/etc/zulip/zulip.conf" ]; then
-    (
-        cat <<EOF
+has_class() {
+    grep -qx "$1" /var/lib/puppet/classes.txt
+}
+
+# puppet apply --noop fails unless the user that it _would_ chown
+# files to exists; https://tickets.puppetlabs.com/browse/PUP-3907
+useradd -m zulip
+if [ -n "$NO_OVERWRITE_SETTINGS" ] && [ -e "/etc/zulip/zulip.conf" ]; then
+    "$ZULIP_PATH"/scripts/zulip-puppet-apply --force --noop \
+                 --write-catalog-summary \
+                 --classfile=/var/lib/puppet/classes.txt \
+                 >/dev/null
+else
+    # Write out more than we need, and remove sections that are not
+    # applicable to the classes that are actually necessary.
+    cat <<EOF > /etc/zulip/zulip.conf
 [machine]
 puppet_classes = $PUPPET_CLASSES
 deploy_type = $DEPLOYMENT_TYPE
-EOF
-
-        # Note: there are four dpkg-query outputs to consider:
-        #
-        # root@host# dpkg-query --showformat '${Status}\n' -W rabbitmq-server 2>/dev/null
-        # root@host# apt install rabbitmq-server
-        # root@host# dpkg-query --showformat '${Status}\n' -W rabbitmq-server 2>/dev/null
-        # install ok installed
-        # root@host# apt remove rabbitmq-server
-        # root@host# dpkg-query --showformat '${Status}\n' -W rabbitmq-server 2>/dev/null
-        # deinstall ok config-files
-        # root@host# apt purge rabbitmq-server
-        # root@host# dpkg-query --showformat '${Status}\n' -W rabbitmq-server 2>/dev/null
-        # unknown ok not-installed
-        #
-        # (There are more possibilities in the case of dpkg errors.)  Here
-        # we are checking for either empty or not-installed.
-        if ! dpkg-query --showformat '${Status}\n' -W rabbitmq-server 2>/dev/null | grep -vq ' not-installed$'; then
-            cat <<EOF
-
-[rabbitmq]
-nodename = zulip@localhost
-EOF
-        fi
-
-        if [ -n "$USE_CERTBOT" ]; then
-            cat <<EOF
-
-[certbot]
-auto_renew = yes
-EOF
-        fi
-
-        case ",$PUPPET_CLASSES," in
-            *,zulip::voyager,* | *,zulip::postgres_appdb_tuned,*)
-                if [ "$package_system" = apt ]; then
-                    cat <<EOF
 
 [postgresql]
 version = $POSTGRES_VERSION
 EOF
-                fi
-                ;;
-        esac
-    ) > /etc/zulip/zulip.conf
+
+    if [ -n "$USE_CERTBOT" ]; then
+        crudini --set /etc/zulip/zulip.conf certbot auto_renew yes
+    fi
+
+    "$ZULIP_PATH"/scripts/zulip-puppet-apply --force --noop \
+                 --write-catalog-summary \
+                 --classfile=/var/lib/puppet/classes.txt \
+                 >/dev/null
+
+    if ! has_class "zulip::postgres_common" || [ "$package_system" != apt ]; then
+        crudini --del /etc/zulip/zulip.conf postgresql
+    fi
+
+    # Note: there are four dpkg-query outputs to consider:
+    #
+    # root@host# dpkg-query --showformat '${Status}\n' -W rabbitmq-server 2>/dev/null
+    # root@host# apt install rabbitmq-server
+    # root@host# dpkg-query --showformat '${Status}\n' -W rabbitmq-server 2>/dev/null
+    # install ok installed
+    # root@host# apt remove rabbitmq-server
+    # root@host# dpkg-query --showformat '${Status}\n' -W rabbitmq-server 2>/dev/null
+    # deinstall ok config-files
+    # root@host# apt purge rabbitmq-server
+    # root@host# dpkg-query --showformat '${Status}\n' -W rabbitmq-server 2>/dev/null
+    # unknown ok not-installed
+    #
+    # (There are more possibilities in the case of dpkg errors.)  Here
+    # we are checking for either empty or not-installed.
+    if ! dpkg-query --showformat '${Status}\n' -W rabbitmq-server 2>/dev/null | grep -vq ' not-installed$'; then
+        cat <<EOF >>/etc/zulip/zulip.conf
+
+[rabbitmq]
+nodename = zulip@localhost
+EOF
+    fi
 fi
 
 case ",$PUPPET_CLASSES," in

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -81,8 +81,6 @@ fi
 read -r -a APT_OPTIONS <<< "${APT_OPTIONS:-}"
 # Install additional packages.
 read -r -a ADDITIONAL_PACKAGES <<< "${ADDITIONAL_PACKAGES:-}"
-# Deployment type is almost always voyager.
-DEPLOYMENT_TYPE="${DEPLOYMENT_TYPE:-voyager}"
 # Comma-separated list of puppet manifests to install.  default is
 # zulip::voyager for an all-in-one system or zulip::dockervoyager for
 # Docker.  Use e.g. zulip::app_frontend for a Zulip frontend server.
@@ -343,7 +341,7 @@ else
     cat <<EOF > /etc/zulip/zulip.conf
 [machine]
 puppet_classes = $PUPPET_CLASSES
-deploy_type = $DEPLOYMENT_TYPE
+deploy_type = production
 
 [postgresql]
 version = $POSTGRES_VERSION

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -430,7 +430,6 @@ EOF
             exit 1
         )
     fi
-    service nginx restart
 fi
 
 if has_class "zulip::rabbit"; then

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -406,28 +406,6 @@ fi
 
 "$ZULIP_PATH"/scripts/zulip-puppet-apply -f
 
-if [ "$package_system" = apt ]; then
-    SUPERVISOR_CONF_DIR="/etc/supervisor/conf.d"
-elif [ "$package_system" = yum ]; then
-    SUPERVISOR_CONF_DIR="/etc/supervisord.d/conf.d"
-fi
-
-# Detect which features were selected for the below
-set +e
-[ -e "/etc/init.d/nginx" ]; has_nginx=$?
-[ -e "$SUPERVISOR_CONF_DIR/zulip.conf" ]; has_appserver=$?
-[ -e "/etc/cron.d/rabbitmq-numconsumers" ]; has_rabbit=$?
-[ -e "/etc/init.d/postgresql" ]; has_postgres=$?
-set -e
-
-# Docker service setup is done in the docker config, not here
-if [ "$DEPLOYMENT_TYPE" = "dockervoyager" ]; then
-    has_nginx=1
-    has_appserver=0
-    has_rabbit=1
-    has_postgres=1
-fi
-
 # These server restarting bits should be moveable into puppet-land, ideally
 if [ "$package_system" = apt ]; then
     apt-get -y upgrade
@@ -436,12 +414,13 @@ elif [ "$package_system" = yum ]; then
     :
 fi
 
-if [ "$has_nginx" = 0 ]; then
+if has_class "zulip::nginx" && [ ! "$DEPLOYMENT_TYPE" = "dockervoyager" ]; then
     # Check nginx was configured properly now that we've installed it.
     # Most common failure mode is certs not having been installed.
-    nginx -t || (
-        set +x
-        cat <<EOF
+    if ! nginx -t; then
+        (
+            set +x
+            cat <<EOF
 
 Verifying the Zulip nginx configuration failed!
 
@@ -451,12 +430,13 @@ This is almost always a problem with your SSL certificates.  See:
 Once fixed, just rerun scripts/setup/install; it'll pick up from here!
 
 EOF
-        exit 1
-    )
+            exit 1
+        )
+    fi
     service nginx restart
 fi
 
-if [ "$has_rabbit" = 0 ]; then
+if has_class "zulip::rabbit"; then
     if ! rabbitmqctl status >/dev/null; then
         set +x
         cat <<EOF
@@ -472,11 +452,11 @@ EOF
     "$ZULIP_PATH"/scripts/setup/configure-rabbitmq
 fi
 
-if [ "$has_postgres" = 0 ] && [ -z "$NO_INIT_DB" ]; then
+if has_class "zulip::postgres_common" && [ -z "$NO_INIT_DB" ]; then
     "$ZULIP_PATH"/scripts/setup/postgres-init-db
 fi
 
-if [ "$has_appserver" = 0 ]; then
+if has_class "zulip::app_frontend_base"; then
     deploy_path=$("$ZULIP_PATH"/scripts/lib/zulip_tools.py make_deploy_path)
     mv "$ZULIP_PATH" "$deploy_path"
     ln -nsf /home/zulip/deployments/next "$ZULIP_PATH"

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -414,7 +414,7 @@ elif [ "$package_system" = yum ]; then
     :
 fi
 
-if has_class "zulip::nginx" && [ ! "$DEPLOYMENT_TYPE" = "dockervoyager" ]; then
+if has_class "zulip::nginx" && ! has_class "zulip::dockervoyager"; then
     # Check nginx was configured properly now that we've installed it.
     # Most common failure mode is certs not having been installed.
     if ! nginx -t; then


### PR DESCRIPTION
Some cleanup from https://github.com/zulip/zulip/pull/15534#issuecomment-649042827 in the first commit, and some tangentially-related cleanup that was biting me in the second.

- **installer: Use `puppet --write-catalog-summary` to determine classes.**

  Using checks of `,$PUPPET_CLASSES,` is repetitive and error-prone; it
  does not properly deal with `zulip_ops::` classes, for instance, which
  include the `zulip::` classes.

  As alluded to in ca9d27175b, this can be fixed by inspecting the
  classes that would be applied, using `puppet --write-catalog-summary`.
  We work around the chicken-and-egg problem alluded to therein by
  writing out as complete `zulip.conf` as would be necessary, before
  running puppet and removing the sections we then know to not be
  needed.

  Unfortunately, there are two checks for `$PUPPET_CLASSES` which cannot
  be switched to this technique, as they concern errors that we wish to
  catch quite early, and thus before we have puppet installed.  Since we
  expect failures of those to only concern warnings, and only be
  mistakenly omitted for internal `zulip_ops::` classes, this seems a
  reasonable risk to admit in exchange for catching common errors early.

- **installer: Set rabbitmq nodename on all rabbitmq hosts.**

  The existing code for `rabbitmq-server` detection is unfortunately
  neither idempotent nor correct.  In only writing out a `nodename` if
  rabbitmq is _not_ installed, it is not idempotent; after the first run
  of the installer, rabbitmq will now be installed, and the second
  `zulip.conf` will thus omit the `nodename`.  While the rabbitmq
  configuration files on disk will be left unchanged after the second
  run (with `rabbit@localhost` as the nodename), the `zulip.conf` will
  not be able to replicate the installation if used elsewhere, as it
  will lack the `nodename` setting.

  It also fails to set the nodename in cases where a prior step has
  installed `rabbitmq-server` already (e.g. `test-install/prepare-base`,
  `tools/provision`).  In both of these cases, the lack of `nodename` in
  the configuration file will cause later problems if the hostname
  changes.  It makes `test-install` unsuitable for testing upgrades via
  cloning, for instance.

  The potential reason to omit the nodename change if rabbitmq is
  already installed is that this results in changing the location where
  rabbitmq's data is stored.  The old data is preserved, merely under a
  directory with the previous nodename.

  For the rare cases where administrators wish to install Zulip on host
  with other software deployments, document this potential.  For new
  installs, predicate the configuration on if rabbitmq is will be
  configured on the host, not its current configuration.

  Even though the setting in zulip.conf only ever takes one value, which
  is always expected to be set, we must maintain the existence of the
  setting for backwards compatibility with installs which predate its
  existence, and have data with the hostname as part of the nodename.

---

**Testing Plan:** Ran the installer with standard and frontend-only classes.  Built with docker-zulip.