### PR TITLE
puppet: Stop removing file that contains only comments.

### DIFF
--- a/puppet/zulip/manifests/postgres_appdb_base.pp
+++ b/puppet/zulip/manifests/postgres_appdb_base.pp
@@ -46,11 +46,6 @@ class zulip::postgres_appdb_base {
     }
   }
 
-  # We bundle a bunch of other sysctl parameters into 40-postgresql.conf
-  file { '/etc/sysctl.d/30-postgresql-shm.conf':
-    ensure => absent,
-  }
-
   file { "${tsearch_datadir}/en_us.dict":
     ensure  => 'link',
     require => Package[$postgresql],


### PR DESCRIPTION
Ensuring it is absent is easy if the package has not been installed
yet.

**Testing Plan:** Ran puppet twice on a new host; before this commit, saw the list of changes was not a no-op.
