### PR TITLE
openapi_docs: Display deprecated parameters with a `deprecated` tag.

### DIFF
--- a/zerver/lib/bugdown/api_arguments_table_generator.py
+++ b/zerver/lib/bugdown/api_arguments_table_generator.py
@@ -92,7 +92,7 @@ class APIArgumentsTablePreprocessor(Preprocessor):
         table = []
         argument_template = """
 <div class="api-argument">
-    <p class="api-argument-name"><strong>{argument}</strong> {required}</p>
+    <p class="api-argument-name"><strong>{argument}</strong> {required} {deprecated}</p>
     <div class="api-example">
         <span class="api-argument-example-label">Example</span>: <code>{example}</code>
     </div>
@@ -101,7 +101,7 @@ class APIArgumentsTablePreprocessor(Preprocessor):
 </div>"""
 
         md_engine = markdown.Markdown(extensions=[])
-
+        arguments = sorted(arguments, key=lambda argument: 'deprecated' in argument)
         for argument in arguments:
             description = argument['description']
             oneof = ['`' + str(item) + '`'
@@ -132,10 +132,19 @@ class APIArgumentsTablePreprocessor(Preprocessor):
             else:
                 required_block = '<span class="api-argument-optional">optional</span>'
 
+            # Test to make sure deprecated parameters are marked so.
+            if 'Deprecated' in description:
+                assert(argument['deprecated'])
+            if argument.get('deprecated', False):
+                deprecated_block = '<span class="api-argument-required">Deprecated</span>'
+            else:
+                deprecated_block = ''
+
             table.append(argument_template.format(
                 argument=argument.get('argument') or argument.get('name'),
                 example=escape_html(example),
                 required=required_block,
+                deprecated=deprecated_block,
                 description=md_engine.convert(description),
             ))
 

--- a/zerver/lib/bugdown/api_return_values_table_generator.py
+++ b/zerver/lib/bugdown/api_return_values_table_generator.py
@@ -62,6 +62,9 @@ class APIReturnValuesTablePreprocessor(Preprocessor):
             if return_value in IGNORE:
                 continue
             description = return_values[return_value]['description']
+            # Test to make sure deprecated keys are marked appropriately.
+            if 'Deprecated' in description:
+                assert(return_values[return_value]['deprecated'])
             ans.append(self.render_desc(description, spacing, return_value))
             if 'properties' in return_values[return_value]:
                 ans += self.render_table(return_values[return_value]['properties'], spacing + 4)

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -404,6 +404,7 @@ paths:
                               properties:
                                 name:
                                   type: number
+                                  deprecated: true
                                   description: |
                                     Time when the message was sent as a UNIX timestamp
                                     multiplied by 1000 (matching the format of getTime() in JavaScript).
@@ -546,6 +547,7 @@ paths:
         example: false
       - name: use_first_unread_anchor
         in: query
+        deprecated: true
         description: |
           Legacy way to specify `anchor="first_unread"` in Zulip 2.1.x and older.
 
@@ -1955,6 +1957,7 @@ paths:
                       example: "2019-10-20T07:50:53.728864+00:00"
                     max_message_id:
                       type: integer
+                      deprecated: true
                       description: |
                         The integer ID of the last message received by your account.
 
@@ -2268,12 +2271,14 @@ paths:
                               opposite value, `in_home_view=!is_muted`).
                           in_home_view:
                             type: boolean
+                            deprecated: true
                             description: |
                               Legacy property for if the given stream is muted, with inverted meeting.
 
                               **Deprecated**; clients should use is_muted where available.
                           is_announcement_only:
                             type: boolean
+                            deprecated: true
                             description: |
                               Whether only organization administrators can post to the stream.
 
@@ -3271,6 +3276,7 @@ paths:
                 - properties:
                     authentication_methods:
                       type: object
+                      deprecated: true
                       description: |
                         Each key-value pair in the object indicates whether the authentication
                         method is enabled on this server.
@@ -3836,6 +3842,7 @@ paths:
                               Null is used for streams with no message history.
                           is_announcement_only:
                             type: boolean
+                            deprecated: true
                             description: |
                               Whether the given stream is announcement only or not.
 
@@ -3988,6 +3995,7 @@ paths:
         required: false
       - name: is_announcement_only
         in: query
+        deprecated: true
         description: |
           Whether the stream is limited to announcements.
 
@@ -4535,6 +4543,7 @@ components:
                     namespace the `zulip` emoji.
               user_id:
                 type: integer
+                deprecated: true
                 description: |
                   The ID of the user who added the reaction.
 
@@ -4542,6 +4551,7 @@ components:
                   object is deprecated and will be removed in the future.
               user:
                 type: object
+                deprecated: true
                 description: |
                   Dictionary with data on the user who added the reaction, including
                   the user ID as the `id` field.  **Note**: In the [events
@@ -5028,6 +5038,7 @@ components:
     Topic:
       name: topic
       in: query
+      deprecated: true
       description: |
         The topic of the message. Only required for stream messages
         (`type="stream"`), ignored otherwise.


### PR DESCRIPTION
In zulip.yaml, add `deprecated` tags to all parameters/keys with
`Deprecated` in the description. Then add tests to ensure that deprecated
parameters/keys will always have the `deprecated` key. Also, in
the API docs, sort the parameters according to presence of `deprecated`
key, presenting the `deprecated` keys at the end and add a `deprecated`
tag next to them.

