### PR TITLE
invites: Send user_id of the referrer instead of email in invites dict.

### DIFF
--- a/static/js/settings_invites.js
+++ b/static/js/settings_invites.js
@@ -48,12 +48,14 @@ function populate_invites(invites_data) {
             item.is_admin = page_params.is_admin;
             item.disable_buttons = item.invited_as === settings_config.user_role_values.owner.code
                 && !page_params.is_owner;
+            item.referrer_email = people.get_by_user_id(item.referrer_id).email;
             return render_admin_invites_list({ invite: item });
         },
         filter: {
             element: invites_table.closest(".settings-section").find(".search"),
             predicate: function (item, value) {
-                const referrer_email_matched = item.ref.toLowerCase().includes(value);
+                const referrer_email = people.get_by_user_id(item.referrer_id).email;
+                const referrer_email_matched = referrer_email.toLowerCase().includes(value);
                 if (item.is_multiuse) {
                     return referrer_email_matched;
                 }

--- a/static/templates/admin_invites_list.hbs
+++ b/static/templates/admin_invites_list.hbs
@@ -13,7 +13,7 @@
     </td>
     {{#if is_admin}}
     <td>
-        <span class="referred_by">{{ref}}</span>
+        <span class="referred_by">{{referrer_email}}</span>
     </td>
     {{/if}}
     <td>

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -10,6 +10,11 @@ below features are supported.
 
 ## Changes in Zulip 3.0
 
+**Feature level 22**
+
+* `GET /invites`: Replace the `ref` field, used for sending referrer email,
+  in the invites object with `referrer_id` for sending user_id of referrer.
+
 **Feature level 21**
 
 * `PATCH /settings/display`: Replaced the `night_mode` boolean with

--- a/version.py
+++ b/version.py
@@ -29,7 +29,7 @@ DESKTOP_WARNING_VERSION = "5.2.0"
 #
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md.
-API_FEATURE_LEVEL = 21
+API_FEATURE_LEVEL = 22
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5229,7 +5229,7 @@ def do_get_user_invites(user_profile: UserProfile) -> List[Dict[str, Any]]:
 
     for invitee in prereg_users:
         invites.append(dict(email=invitee.email,
-                            ref=invitee.referred_by.email,
+                            referrer_id=invitee.referred_by.id,
                             invited=datetime_to_timestamp(invitee.invited_at),
                             id=invitee.id,
                             invited_as=invitee.invited_as,
@@ -5245,7 +5245,7 @@ def do_get_user_invites(user_profile: UserProfile) -> List[Dict[str, Any]]:
                                                              date_sent__gte=lowest_datetime)
     for confirmation_obj in multiuse_confirmation_objs:
         invite = confirmation_obj.content_object
-        invites.append(dict(ref=invite.referred_by.email,
+        invites.append(dict(referrer_id=invite.referred_by.id,
                             invited=datetime_to_timestamp(confirmation_obj.date_sent),
                             id=invite.id,
                             link_url=confirmation_url(confirmation_obj.confirmation_key,

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1664,12 +1664,13 @@ class InvitationsTestCase(InviteUserBase):
 
         result = self.client_get("/json/invites")
         self.assertEqual(result.status_code, 200)
-        self.assert_in_success_response(
-            ["TestOne@zulip.com", hamlet.email],
-            result)
-        self.assert_not_in_success_response(
-            ["TestTwo@zulip.com", "TestThree@zulip.com", "othello@zulip.com", othello.email],
-            result)
+        invites = ujson.loads(result.content)["invites"]
+        self.assertEqual(len(invites), 2)
+
+        self.assertFalse(invites[0]["is_multiuse"])
+        self.assertEqual(invites[0]["email"], "TestOne@zulip.com")
+        self.assertTrue(invites[1]["is_multiuse"])
+        self.assertEqual(invites[1]["referrer_id"], hamlet.id)
 
     def test_successful_delete_invitation(self) -> None:
         """


### PR DESCRIPTION
We send user_id of the referrer instead of email in the invites dict.
Sending user_ids is more robust, as those are an immutable reference
to a user, rather than something that can change with time.

I am waiting for #15574 to merge before changing the UI to display name of the referrer instead of email with the user popover.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
