### PR TITLE
Update docs and tooling for upgrading postgres

### DIFF
--- a/docs/production/upgrade-or-modify.md
+++ b/docs/production/upgrade-or-modify.md
@@ -304,6 +304,10 @@ match the new OS version:
 
 5. Same as for Bionic to Focal.
 
+That last command will finish by restarting your Zulip server; you
+should now be able to navigate to its URL and confirm everything is
+working correctly.
+
 ### Upgrading from Debian Stretch to Debian Buster
 
 1. Upgrade your server to the latest Zulip `2.1.x` release, since
@@ -338,6 +342,10 @@ match the new OS version:
     ```
 
 5. Same as for Xenial to Bionic.
+
+That last command will finish by restarting your Zulip server; you
+should now be able to navigate to its URL and confirm everything is
+working correctly.
 
 ## Modifying Zulip
 

--- a/docs/production/upgrade-or-modify.md
+++ b/docs/production/upgrade-or-modify.md
@@ -249,7 +249,8 @@ working correctly.
 ### Upgrading from Ubuntu 16.04 Xenial to 18.04 Bionic
 
 1. Upgrade your server to the latest Zulip `2.1.x` release, since
-   newer releases don't support Ubuntu 16.04 Xenial.
+   newer releases don't support Ubuntu 16.04 Xenial.  The instructions
+   below will not work if you are running Zulip 3.0.
 
 2. Same as for Bionic to Focal.
 
@@ -278,8 +279,9 @@ working correctly.
 
 ### Upgrading from Ubuntu 14.04 Trusty to 16.04 Xenial
 
-1. Upgrade your server to the latest Zulip `2.0.x` release, since newer
-   releases don't support Ubuntu 14.04 Trusty.
+1. Upgrade your server to the latest Zulip `2.0.x` release, since
+   newer releases don't support Ubuntu 14.04 Trusty.  The instructions
+   below will not work if you are running Zulip 3.0.
 
 2. Same as for Bionic to Focal.
 
@@ -304,8 +306,9 @@ match the new OS version:
 
 ### Upgrading from Debian Stretch to Debian Buster
 
-1. Upgrade your server to the latest Zulip `2.1.x` release, since newer
-   releases don't support Debian Stretch.
+1. Upgrade your server to the latest Zulip `2.1.x` release, since
+   newer releases don't support Debian Stretch.  The instructions
+   below will not work if you are already running Zulip 3.0.
 
 2. Same as for Xenial to Bionic, above.
 

--- a/docs/production/upgrade-or-modify.md
+++ b/docs/production/upgrade-or-modify.md
@@ -226,26 +226,15 @@ instructions for other supported platforms.
     currently installed version.  But it's not important; the next
     step will re-install Zulip's configuration in any case.
 
-4. As root, upgrade the database installation and OS configuration to
-   match the new OS version:
+4. As root, upgrade the database to the latest version of PostgreSQL:
 
     ```
-    touch /usr/share/postgresql/12/pgroonga_setup.sql.applied
-    /home/zulip/deployments/current/scripts/zulip-puppet-apply -f
-    pg_dropcluster 12 main --stop
-    systemctl stop postgresql
-    pg_upgradecluster 10 main
-    pg_dropcluster 10 main
-    apt remove postgresql-10
-    systemctl start postgresql
-    systemctl restart memcached
+    /home/zulip/deployments/current/scripts/setup/upgrade-postgres
     ```
 
-5. At this point, you are now running the version of postgres that
-   comes with the new Ubuntu version.  Finally, we need to reinstall
-   the current version of Zulip, which among other things will
-   recompile Zulip's Python module dependencies for your new version
-   of Python:
+5. Finally, we need to reinstall the current version of Zulip, which
+   among other things will recompile Zulip's Python module
+   dependencies for your new version of Python:
 
     ```
     rm -rf /srv/zulip-venv-cache/*

--- a/docs/production/upgrade-or-modify.md
+++ b/docs/production/upgrade-or-modify.md
@@ -314,7 +314,7 @@ working correctly.
    newer releases don't support Debian Stretch.  The instructions
    below will not work if you are already running Zulip 3.0.
 
-2. Same as for Xenial to Bionic, above.
+2. Same as for Bionic to Focal.
 
 3. Follow [Debian's instructions to upgrade the OS][debian-upgrade-os].
 
@@ -341,7 +341,7 @@ working correctly.
     service memcached restart
     ```
 
-5. Same as for Xenial to Bionic.
+5. Same as for Bionic to Focal.
 
 That last command will finish by restarting your Zulip server; you
 should now be able to navigate to its URL and confirm everything is

--- a/docs/production/upgrade-or-modify.md
+++ b/docs/production/upgrade-or-modify.md
@@ -7,6 +7,7 @@ This page explains how to upgrade, patch, or modify Zulip, including:
 - [Troubleshooting and rollback](#troubleshooting-and-rollback)
 - [Preserving local changes to configuration files](#preserving-local-changes-to-configuration-files)
 - [Upgrading the operating system](#upgrading-the-operating-system)
+- [Upgrading PostgreSQL](#upgrading-postgresql)
 - [Modifying Zulip](#modifying-zulip)
 - [Applying changes from master](#applying-changes-from-master)
 
@@ -346,6 +347,43 @@ working correctly.
 That last command will finish by restarting your Zulip server; you
 should now be able to navigate to its URL and confirm everything is
 working correctly.
+
+## Upgrading PostgreSQL
+
+Starting with Zulip 3.0, we use the latest available version of
+PostgreSQL at installation time (currently version 12).  Upgrades to
+the version of PostgreSQL are no longer linked to upgrades of the
+distribution; that is, you may opt to upgrade to PostgreSQL 12 while
+running Ubuntu 18.04 Bionic.
+
+To upgrade the version of PostgreSQL on the Zulip server:
+
+1. Upgrade your server to the latest Zulip release (at least 3.0).
+
+2. Stop the server and take a backup:
+
+    ```
+    sudo -i # Or otherwise get a root shell
+    supervisorctl stop all
+    /home/zulip/deployments/current/manage.py backup --output=/home/zulip/postgresql-upgrade.backup.tar.gz
+    ```
+
+3. As root, run the database upgrade tool:
+
+    ```
+    /home/zulip/deployments/current/scripts/setup/upgrade-postgres
+    ```
+
+   During this step, it is normal to see output containing:
+   ```
+   ERROR:  could not open stop-word file "/usr/share/postgresql/12/tsearch_data/zulip_english.stop": No such file or directory
+   ERROR:  text search dictionary "zulip.english_us_hunspell" does not exist
+   ```
+
+That last command will finish by restarting your Zulip server; you
+should now be able to navigate to its URL and confirm everything is
+working correctly.
+
 
 ## Modifying Zulip
 

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -256,7 +256,7 @@ if (not args.skip_puppet or migrations_needed) and IS_SERVER_UP:
 if not args.skip_puppet:
     logging.info("Applying puppet changes...")
     subprocess.check_call(["./scripts/zulip-puppet-apply", "--force"])
-    subprocess.check_call(["apt-get", "upgrade"])
+    subprocess.check_call(["apt-get", "-y", "upgrade"])
 
 if migrations_needed:
     logging.info("Applying database migrations...")

--- a/scripts/setup/upgrade-postgres
+++ b/scripts/setup/upgrade-postgres
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -e
+
+if [ "$EUID" -ne 0 ]; then
+    echo "Error: This script must be run as root" >&2
+    exit 1
+fi
+
+UPGRADE_TO=${1:-12}
+UPGRADE_FROM=$(crudini --get /etc/zulip/zulip.conf postgresql version)
+ZULIP_PATH="$(dirname "$0")/../.."
+
+if [ "$UPGRADE_TO" = "$UPGRADE_FROM" ]; then
+    echo "Already running PostgreSQL $UPGRADE_TO!"
+    exit 1
+fi
+
+set -x
+
+"$ZULIP_PATH"/scripts/lib/setup-apt-repo
+apt-get install -y "postgresql-$UPGRADE_TO"
+if pg_lsclusters -h | grep -qE "^$UPGRADE_TO\s+main\b"; then
+    pg_dropcluster "$UPGRADE_TO" main --stop
+fi
+
+# Work around `systemctl stop postgresql` being asynchronous, since
+# the pg_upsgrdecluster command fails if it is still running
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=759725
+systemctl stop postgresql "postgresql@*"
+pg_upgradecluster "$UPGRADE_FROM" main
+
+crudini --set /etc/zulip/zulip.conf postgresql version "$UPGRADE_TO"
+touch "/usr/share/postgresql/$UPGRADE_TO/pgroonga_setup.sql.applied"
+"$ZULIP_PATH"/scripts/zulip-puppet-apply -f
+
+systemctl restart memcached
+
+pg_dropcluster "$UPGRADE_FROM" main
+apt remove -y "postgresql-$UPGRADE_FROM"


### PR DESCRIPTION
Fixes #15415.

One note is that upgrading Bionic -> Focal _without_ upgrading the database leaves an empty PostgreSQL 12 running on port 5433.  That seems Fine, since the DB upgrade fixes it, but it seemed worth noting.

**Testing Plan:** Installed Bionic with `--postgres-version=10`, upgraded to Focal.  Also installed Bionic and upgraded Postgres to 12 in-place.