### PR TITLE
message_controls: Don't show pencil icon until server ack.

### DIFF
--- a/static/templates/message_controls.hbs
+++ b/static/templates/message_controls.hbs
@@ -1,6 +1,8 @@
 <div class="message_controls{{#status_message}} sender-status-controls{{/status_message}} no-select">
     {{#if msg/sent_by_me}}
-    <div class="edit_content"></div>
+        {{#unless msg/locally_echoed}}
+        <div class="edit_content"></div>
+        {{/unless}}
     {{/if}}
 
     {{#unless msg/sent_by_me}}


### PR DESCRIPTION
Previously, this was unconditional wrt local echoe which caused a bug
where by the pencil edit icon was visible first, then got hidden when
the chevron and star became visible.




This commit resolves the above bug, but this area still behaves
slightly weirdly in that, if, within a PM narrow, the user's mouse is
over the spot where the message edit controls will appear after
sending, and then a message is sent by the user, only the chevron ans
star appear at first. On hover exit and reenter, all three controls
reappear, correctly.

Similar to the other "unless locally echoed" cases here, this will
probably prevent unexpected bugs caused by eg trying to enter edit
state before the message was received by the server.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Before:
![B](https://user-images.githubusercontent.com/33805964/85910056-7c39d400-b83a-11ea-87a7-070c3cd5a3e2.gif)

After:
![A](https://user-images.githubusercontent.com/33805964/85909976-13525c00-b83a-11ea-8a76-1e8cf293a770.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
