### PR TITLE
puppet: Add an exec rule to reload the whole supervisor config.

### DIFF
--- a/puppet/zulip/files/supervisor/supervisord.conf
+++ b/puppet/zulip/files/supervisor/supervisord.conf
@@ -3,7 +3,7 @@
 [unix_http_server]
 file=/var/run/supervisor.sock   ; (the path to the socket file)
 chmod=0700                       ; socket file mode (default 0700)
-chown=zulip
+chown=zulip:zulip
 
 [supervisord]
 logfile=/var/log/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)

--- a/puppet/zulip/manifests/common.pp
+++ b/puppet/zulip/manifests/common.pp
@@ -9,6 +9,7 @@ class zulip::common {
       $supervisor_conf_file = '/etc/supervisor/supervisord.conf'
       $supervisor_service = 'supervisor'
       $supervisor_start = '/etc/init.d/supervisor start'
+      $supervisor_reload = '/etc/init.d/supervisor restart'
     }
     'redhat': {
       $nagios_plugins = 'nagios-plugins'
@@ -18,6 +19,7 @@ class zulip::common {
       $supervisor_conf_file = '/etc/supervisord.conf'
       $supervisor_service = 'supervisord'
       $supervisor_start = 'systemctl start supervisord'
+      $supervisor_reload = 'systemctl reload supervisord'
     }
     default: {
       fail('osfamily not supported')

--- a/puppet/zulip/manifests/common.pp
+++ b/puppet/zulip/manifests/common.pp
@@ -8,6 +8,7 @@ class zulip::common {
       $supervisor_conf_dir = '/etc/supervisor/conf.d'
       $supervisor_conf_file = '/etc/supervisor/supervisord.conf'
       $supervisor_service = 'supervisor'
+      $supervisor_start = '/etc/init.d/supervisor start'
     }
     'redhat': {
       $nagios_plugins = 'nagios-plugins'
@@ -16,6 +17,7 @@ class zulip::common {
       $supervisor_conf_dir = '/etc/supervisord.d/conf.d'
       $supervisor_conf_file = '/etc/supervisord.conf'
       $supervisor_service = 'supervisord'
+      $supervisor_start = 'systemctl start supervisord'
     }
     default: {
       fail('osfamily not supported')

--- a/puppet/zulip/manifests/supervisor.pp
+++ b/puppet/zulip/manifests/supervisor.pp
@@ -1,12 +1,6 @@
 class zulip::supervisor {
   package { 'supervisor': ensure => 'installed' }
 
-  # Command to start supervisor
-  $supervisor_start = $::osfamily ? {
-    'debian' => '/etc/init.d/supervisor start',
-    'redhat' => 'systemctl start supervisord',
-  }
-
   if $::osfamily == 'redhat' {
     file { $zulip::common::supervisor_conf_dir:
       ensure => 'directory',

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -489,10 +489,6 @@ if [ "$has_appserver" = 0 ]; then
     fi
 fi
 
-if [ -e "/var/run/supervisor.sock" ]; then
-    chown zulip:zulip /var/run/supervisor.sock
-fi
-
 if [ -n "$NO_INIT_DB" ]; then
     set +x
     cat <<EOF


### PR DESCRIPTION
The supervisor service can be correctly restarted by puppet on all
supported distributions, which allows it to pick up the `chown`
settings in its configuration.  This allows us to remove a hacky
manual "restart" which failed to pick up the updated socket ownership,
and thus skip the manual cleanup during installation.

**Testing Plan:** Installed on Bionic.
