### PR TITLE
puppet: Install the latest postgresql-client on frontend hosts.

### DIFF
--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -8,12 +8,12 @@ class zulip::app_frontend_base {
   include zulip::tornado_sharding
 
   if $::osfamily == 'debian' {
-    $web_packages = [
-      # This is not necessary on CentOS because $postgresql package already includes the client
-      # Needed to access our database
-      "postgresql-client-${zulip::base::postgres_version}",
-    ]
-    zulip::safepackage { $web_packages: ensure => 'installed' }
+    # Upgrade and other tooling wants to be able to get a database
+    # shell.  This is not necessary on CentOS because the postgresql
+    # package already includes the client.  This may get us a more
+    # recent client than the database server is configured to be,
+    # ($zulip::base::postgres_version), but they're compatible.
+    zulip::safepackage { 'postgresql-client': ensure => 'installed' }
   }
   # For Slack import
   zulip::safepackage { 'unzip': ensure => 'installed' }

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -12,16 +12,11 @@ class zulip::app_frontend_base {
       # This is not necessary on CentOS because $postgresql package already includes the client
       # Needed to access our database
       "postgresql-client-${zulip::base::postgres_version}",
-      # Needed for Slack import
-      'unzip',
     ]
-  } else {
-      $web_packages = [
-        # Needed for Slack import
-        'unzip',
-      ]
+    zulip::safepackage { $web_packages: ensure => 'installed' }
   }
-  zulip::safepackage { $web_packages: ensure => 'installed' }
+  # For Slack import
+  zulip::safepackage { 'unzip': ensure => 'installed' }
 
   file { '/etc/nginx/zulip-include/app':
     require => Package[$zulip::common::nginx],

--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -190,7 +190,7 @@ case ",$PUPPET_CLASSES," in
             # We're going to install Postgres from the postgres apt
             # repository; this may conflict with the existing postgres.
             OTHER_PG="$(dpkg --get-selections |
-                             grep '^postgresql-[1-9].*\binstall$' |
+                             grep -E '^postgresql-[0-9]+\s+install$' |
                              grep -v "^postgresql-$POSTGRES_VERSION\b" |
                              cut -f 1)" || true
             if [ -n "$OTHER_PG" ]; then


### PR DESCRIPTION
Because frontend hosts (including docker hosts) need the PostgreSQL
command-line client, they too need the postgresql version to be
defined in `zulip.conf`.

**Testing Plan:** Inspection.  Tested the regex on `dpkg --get-selections` by hand.