### PR TITLE
push_notif: Don't clear notif if stream notif enabled.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4185,7 +4185,9 @@ def do_mark_stream_messages_as_read(user_profile: UserProfile,
                               None, event_time, increment=min(1, count))
     return count
 
-def do_update_mobile_push_notification(message: Message, prior_mention_user_ids: Set[int]) -> None:
+def do_update_mobile_push_notification(message: Message,
+                                       prior_mention_user_ids: Set[int],
+                                       stream_push_user_ids: Set[int]) -> None:
     # Called during the message edit code path to remove mobile push
     # notifications for users who are no longer mentioned following
     # the edit.  See #15428 for details.
@@ -4202,7 +4204,7 @@ def do_update_mobile_push_notification(message: Message, prior_mention_user_ids:
     if not message.is_stream_message():
         return
 
-    remove_notify_users = prior_mention_user_ids - message.mentions_user_ids
+    remove_notify_users = prior_mention_user_ids - message.mentions_user_ids - stream_push_user_ids
     do_clear_mobile_push_notifications_for_ids(list(remove_notify_users), [message.id])
 
 def do_clear_mobile_push_notifications_for_ids(user_profile_ids: List[int],
@@ -4571,7 +4573,7 @@ def do_update_message(user_profile: UserProfile, message: Message,
         else:
             event['wildcard_mention_user_ids'] = []
 
-        do_update_mobile_push_notification(message, prior_mention_user_ids)
+        do_update_mobile_push_notification(message, prior_mention_user_ids, info['stream_push_user_ids'])
 
     if topic_name is not None or new_stream is not None:
         orig_topic_name = message.topic_name()


### PR DESCRIPTION
If a message was edited to remove a user mention, we don't
remove the push_notification for the user if the user has
stream_push_notfications enabled.
