### PR TITLE
attachments: Change timestamp format to normal UNIX timestamp.

### DIFF
--- a/static/js/attachments_ui.js
+++ b/static/js/attachments_ui.js
@@ -112,7 +112,7 @@ function render_attachments_ui() {
 
 function format_attachment_data(new_attachments) {
     for (const attachment of new_attachments) {
-        const time = new XDate(attachment.create_time);
+        const time = new XDate(attachment.create_time * 1000);
         attachment.create_time_str = timerender.render_now(time).time_str;
         attachment.size_str = exports.bytes_to_size(attachment.size);
     }

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -10,6 +10,12 @@ below features are supported.
 
 ## Changes in Zulip 4.0
 
+**Feature level 31**
+
+* [`GET /attachments`](/api/get-attachments): The
+  `date_sent` and `create_time` store the UNIX timestamp instead
+  of UNIX timestamp multiplied by 1000 which they stored earlier.
+
 **Feature Level 30**
 
 * [`GET users/me/subscriptions`](/api/get-subscriptions), [`GET

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -2178,10 +2178,10 @@ class Attachment(AbstractAttachment):
             'size': self.size,
             # convert to JavaScript-style UNIX timestamp so we can take
             # advantage of client timezones.
-            'create_time': int(time.mktime(self.create_time.timetuple()) * 1000),
+            'create_time': int(time.mktime(self.create_time.timetuple())),
             'messages': [{
                 'id': m.id,
-                'date_sent': int(time.mktime(m.date_sent.timetuple()) * 1000),
+                'date_sent': int(time.mktime(m.date_sent.timetuple())),
             } for m in self.messages.all()],
         }
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2969,11 +2969,11 @@ paths:
                               "name": "166050.jpg",
                               "path_id": "2/ce/DfOkzwdg_IwlrN3myw3KGtiJ/166050.jpg",
                               "size": 571946,
-                              "create_time": 1588145417000,
+                              "create_time": 1588145417,
                               "messages":
                                 [
-                                  {"id": 102, "date_sent": 1588145424000},
-                                  {"id": 103, "date_sent": 1588145448000},
+                                  {"id": 102, "date_sent": 1588145424},
+                                  {"id": 103, "date_sent": 1588145448},
                                 ],
                             },
                           ],
@@ -8142,11 +8142,14 @@ components:
         create_time:
           type: integer
           description: |
-            Time when the attachment was uploaded as a UNIX timestamp
-            multiplied by 1000 (matching the format of getTime() in JavaScript).
+            Time when the attachment was uploaded as a UNIX timestamp.
 
             **Changes**: Changed in Zulip 2.2 (feature level 22).  This field was
             previously a floating point number.
+
+            **Changes**: Changed in Zulip 4.0 (feature level 31).  This field was
+            previously stored the UNIX timestamp multiplied by 1000(Javascript time
+            format).
         messages:
           type: array
           description: |
@@ -8162,12 +8165,15 @@ components:
               date_sent:
                 type: integer
                 description: |
-                  Time when the message was sent as a UNIX timestamp
-                  multiplied by 1000 (matching the format of getTime() in JavaScript).
+                  Time when the message was sent as a UNIX timestamp.
 
                   **Changes**: Changed in Zulip 2.2 (feature level 22).  This
                   field was previously strangely called `name` and was a floating
                   point number.
+
+                  **Changes**: Changed in Zulip 4.0 (feature level 31).  This field was
+                  previously stored the UNIX timestamp multiplied by 1000(Javascript time
+                  format).
               id:
                 type: integer
                 description: |


### PR DESCRIPTION
Currently the timestamps, `create_time` and `date_sent` in
`/attachments` response used the javascript format of timestamp
which also includes milliseconds. But since the response doesn't
have milliseconds so we just have three zeroes at the end of every
timestamp. Fix this by changing the timestamps to normal UNIX
timestamp.