### PR TITLE
GitHub WebHook: include full repository name in repository event notifications

### DIFF
--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -21,7 +21,7 @@ class GithubWebhookTest(WebhookTestCase):
         self.send_and_test_stream_message('ping', self.EXPECTED_TOPIC_REPO_EVENTS, expected_message)
 
     def test_star_event(self) -> None:
-        expected_message = "Codertocat starred the repository."
+        expected_message = "Codertocat starred the repository [Codertocat/Hello-World](https://github.com/Codertocat/Hello-World)."
         expected_topic = "Hello-World"
         self.send_and_test_stream_message('star', expected_topic, expected_message)
 
@@ -182,7 +182,7 @@ class GithubWebhookTest(WebhookTestCase):
         self.send_and_test_stream_message('pull_request__merged', self.EXPECTED_TOPIC_PR_EVENTS, expected_message)
 
     def test_public_msg(self) -> None:
-        expected_message = "baxterthehacker made [the repository](https://github.com/baxterthehacker/public-repo) public."
+        expected_message = "baxterthehacker made the repository [baxterthehacker/public-repo](https://github.com/baxterthehacker/public-repo) public."
         self.send_and_test_stream_message('public', self.EXPECTED_TOPIC_REPO_EVENTS, expected_message)
 
     def test_wiki_pages_msg(self) -> None:
@@ -190,15 +190,15 @@ class GithubWebhookTest(WebhookTestCase):
         self.send_and_test_stream_message('gollum__wiki_pages', self.EXPECTED_TOPIC_WIKI_EVENTS, expected_message)
 
     def test_watch_msg(self) -> None:
-        expected_message = "baxterthehacker starred [the repository](https://github.com/baxterthehacker/public-repo)."
+        expected_message = "baxterthehacker starred the repository [baxterthehacker/public-repo](https://github.com/baxterthehacker/public-repo)."
         self.send_and_test_stream_message('watch__repository', self.EXPECTED_TOPIC_REPO_EVENTS, expected_message)
 
     def test_repository_msg(self) -> None:
-        expected_message = "baxterthehacker created [the repository](https://github.com/baxterandthehackers/public-repo)."
+        expected_message = "baxterthehacker created the repository [baxterandthehackers/public-repo](https://github.com/baxterandthehackers/public-repo)."
         self.send_and_test_stream_message('repository', self.EXPECTED_TOPIC_REPO_EVENTS, expected_message)
 
     def test_team_add_msg(self) -> None:
-        expected_message = "[The repository](https://github.com/baxterandthehackers/public-repo) was added to team github."
+        expected_message = "The repository [baxterandthehackers/public-repo](https://github.com/baxterandthehackers/public-repo) was added to team github."
         self.send_and_test_stream_message('team_add', self.EXPECTED_TOPIC_REPO_EVENTS, expected_message)
 
     def test_release_msg(self) -> None:

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -207,8 +207,9 @@ def get_push_commits_body(payload: Dict[str, Any]) -> str:
     )
 
 def get_public_body(payload: Dict[str, Any]) -> str:
-    return "{} made [the repository]({}) public.".format(
+    return "{} made the repository [{}]({}) public.".format(
         get_sender_name(payload),
+        get_repository_full_name(payload),
         payload['repository']['html_url'],
     )
 
@@ -224,20 +225,23 @@ def get_wiki_pages_body(payload: Dict[str, Any]) -> str:
     return f"{get_sender_name(payload)}:\n{wiki_info.rstrip()}"
 
 def get_watch_body(payload: Dict[str, Any]) -> str:
-    return "{} starred [the repository]({}).".format(
+    return "{} starred the repository [{}]({}).".format(
         get_sender_name(payload),
+        get_repository_full_name(payload),
         payload['repository']['html_url'],
     )
 
 def get_repository_body(payload: Dict[str, Any]) -> str:
-    return "{} {} [the repository]({}).".format(
+    return "{} {} the repository [{}]({}).".format(
         get_sender_name(payload),
         payload.get('action'),
+        get_repository_full_name(payload),
         payload['repository']['html_url'],
     )
 
 def get_add_team_body(payload: Dict[str, Any]) -> str:
-    return "[The repository]({}) was added to team {}.".format(
+    return "The repository [{}]({}) was added to team {}.".format(
+        get_repository_full_name(payload),
         payload['repository']['html_url'],
         payload['team']['name'],
     )
@@ -407,10 +411,12 @@ Check [{name}]({html_url}) {status} ({conclusion}). ([{short_hash}]({commit_url}
     return template.format(**kwargs)
 
 def get_star_body(payload: Dict[str, Any]) -> str:
-    template = "{user} {action} the repository."
+    template = "{user} {action} the repository [{repo}]({url})."
     return template.format(
         user=payload['sender']['login'],
         action='starred' if payload['action'] == 'created' else 'unstarred',
+        repo=get_repository_full_name(payload),
+        url=payload['repository']['html_url'],
     )
 
 def get_ping_body(payload: Dict[str, Any]) -> str:
@@ -418,6 +424,9 @@ def get_ping_body(payload: Dict[str, Any]) -> str:
 
 def get_repository_name(payload: Dict[str, Any]) -> str:
     return payload['repository']['name']
+
+def get_repository_full_name(payload: Dict[str, Any]) -> str:
+    return payload['repository']['full_name']
 
 def get_organization_name(payload: Dict[str, Any]) -> str:
     return payload['organization']['login']


### PR DESCRIPTION
This changes the notification messages for events that currently just include the string `"the repository"` to also include the full (`org/repo`) name of the affected repository. Messages for the following events are changed:
- `public`
- `star`
- `watch`
- `repository`
- `team_add`

Background: we're using the GitHub integration for org-wide notifications for the [Bytecode Alliance Zulip](bytecodealliance.zulipchat.com/), and having all messages just say "the repository" isn't ideal. Even now one can hover over the link to see the repo's url, but it'd be much nicer if the message just contained the full name.

I also changed the message for `star` to include a link to the repository, same as the `watch` notification. It might make sense to just use the same notification for both — let me know if you agree and I'm happy to add a patch making that change, too.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
I tried setting up a local dev environment using Vagrant, but failed to do so, so I haven't done more than manual verification. I'd be grateful if someone with an existing dev environment could run the tests!

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
See above: I wasn't able to set up a dev environment, so can't provide screenshots.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
