### PR TITLE
Refactor remaining bugdown to markdown.

### DIFF
--- a/docs/subsystems/markdown.md
+++ b/docs/subsystems/markdown.md
@@ -1,10 +1,10 @@
 # Markdown implementation
 
-Zulip has a special flavor of Markdown, currently called 'bugdown'
-after Zulip's original name of "humbug". End users are using Bugdown
-within the client, not original Markdown.
+Zulip has a special flavor of Markdown, previously called 'bugdown'
+after Zulip's original name of "humbug". Bugdown word is replaced by markdown now.
+End users are using Zulip flavor markdown within the client, not original Markdown.
 
-Zulip has two implementations of Bugdown.  The backend implementation
+Zulip has two implementations of Markdown. The backend implementation
 at `zerver/lib/markdown/` is based on
 [Python-Markdown](https://pypi.python.org/pypi/Markdown) and is used to
 authoritatively render messages to HTML (and implements
@@ -140,7 +140,7 @@ At a backend code level, these are controlled by the `message_realm`
 object and other arguments passed into `do_convert` (`sent_by_bot`,
 `translate_emoticons`, `mention_data`, etc.).  Because
 `python-markdown` doesn't support directly passing arguments into the
-markdown processor, Bugdown attaches these data to the Markdown
+markdown processor, Zulip's Markdown attaches these data to the Markdown
 processor object via e.g. `_md_engine.zulip_db_data`, and then
 individual markdown rules can access the data from there.
 

--- a/docs/testing/mypy.md
+++ b/docs/testing/mypy.md
@@ -193,7 +193,7 @@ have untracked files in your Zulip checkout safely).  So if you get a
 the existing codebase:
 
 ```
-mypy | zerver/models.py:1234: note: Import of 'zerver.lib.bugdown_wrappers' ignored
+mypy | zerver/models.py:1234: note: Import of 'zerver.lib.markdown_wrappers' ignored
 mypy | zerver/models.py:1234: note: (Using --follow-imports=error, module not passed on command line)
 ```
 

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -257,12 +257,12 @@ run_test('marked_shared', () => {
         const output = message.content;
         const error_message = `Failure in test: ${test.name}`;
         if (test.marked_expected_output) {
-            global.bugdown_assert.notEqual(test.expected_output, output, error_message);
-            global.bugdown_assert.equal(test.marked_expected_output, output, error_message);
+            global.markdown_assert.notEqual(test.expected_output, output, error_message);
+            global.markdown_assert.equal(test.marked_expected_output, output, error_message);
         } else if (test.backend_only_rendering) {
             assert.equal(markdown.contains_backend_only_syntax(test.input), true);
         } else {
-            global.bugdown_assert.equal(test.expected_output, output, error_message);
+            global.markdown_assert.equal(test.expected_output, output, error_message);
         }
     });
 });

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -191,9 +191,9 @@ markdown.initialize(
     markdown_config.get_helpers()
 );
 
-const bugdown_data = global.read_fixture_data('markdown_test_cases.json');
+const markdown_data = global.read_fixture_data('markdown_test_cases.json');
 
-run_test('bugdown_detection', () => {
+run_test('markdown_detection', () => {
     const no_markup = [
         "This is a plaintext message",
         "This is a plaintext: message",
@@ -242,7 +242,7 @@ run_test('bugdown_detection', () => {
 });
 
 run_test('marked_shared', () => {
-    const tests = bugdown_data.regular_tests;
+    const tests = markdown_data.regular_tests;
 
     tests.forEach(function (test) {
 

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -88,8 +88,8 @@ function short_tb(tb) {
     return lines.splice(0, i + 1).join('\n') + '\n(...)\n';
 }
 
-// Set up bugdown comparison helper
-global.bugdown_assert = require('./bugdown_assert.js');
+// Set up markdown comparison helper
+global.markdown_assert = require('./markdown_assert.js');
 
 function run_one_module(file) {
     console.info('running tests for ' + file.name);

--- a/frontend_tests/zjsunit/markdown_assert.js
+++ b/frontend_tests/zjsunit/markdown_assert.js
@@ -1,5 +1,5 @@
 /**
- * bugdown_assert.js
+ * markdown_assert.js
  *
  * Used to determine whether two Markdown HTML strings are semantically
  * equivalent. Differs from the naive string-comparison approach in that

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -818,7 +818,7 @@ exports.render_and_show_preview = function (preview_spinner, preview_content_box
             loading.make_indicator(spinner);
         } else {
             // For messages that don't appear to contain
-            // bugdown-specific syntax not present in our
+            // zulip markdown-specific syntax not present in our
             // marked.js frontend processor, we render using the
             // frontend markdown processor message (but still
             // render server-side to ensure the preview is

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -15,7 +15,7 @@ let helpers;
 const realm_filter_map = new Map();
 let realm_filter_list = [];
 
-// Regexes that match some of our common bugdown markup
+// Regexes that match some of our common backend markdown markup
 const backend_only_markdown_re = [
     // Inline image previews, check for contiguous chars ending in image suffix
     // To keep the below regexes simple, split them out for the end-of-message case
@@ -68,7 +68,7 @@ exports.translate_emoticons_to_names = (text) => {
 };
 
 exports.contains_backend_only_syntax = function (content) {
-    // Try to guess whether or not a message has bugdown in it
+    // Try to guess whether or not a message has backend markdown in it
     // If it doesn't, we can immediately render it client-side
     const markedup = backend_only_markdown_re.find(re => re.test(content));
 
@@ -292,8 +292,8 @@ function handleTimestamp(time) {
     let timeobject;
     if (isNaN(time)) {
         // Moment throws a large deprecation warning when it has to fallback
-        // to the Date() constructor. We needn't worry here and can let bugdown
-        // handle any dates that moment misses.
+        // to the Date() constructor. We needn't worry here and can let backend
+        // markdown handle any dates that moment misses.
         moment.suppressDeprecationWarnings = true;
         timeobject = moment(time); // not a Unix timestamp
     } else {
@@ -460,7 +460,7 @@ exports.initialize = function (realm_filters, helper_config) {
     const old_link = r.link;
     r.link = (href, title, text) => old_link.call(r, href, title, text.trim() ? text : href);
 
-    // Put a newline after a <br> in the generated HTML to match bugdown
+    // Put a newline after a <br> in the generated HTML to match markdown
     r.br = function () {
         return '<br>\n';
     };

--- a/static/js/rendered_markdown.js
+++ b/static/js/rendered_markdown.js
@@ -146,7 +146,7 @@ exports.update_elements = (content) => {
         }
 
         // Moment throws a large deprecation warning when it has to fallback
-        // to the Date() constructor. We needn't worry here and can let bugdown
+        // to the Date() constructor. We needn't worry here and can let markdown
         // handle any dates that moment misses.
         moment.suppressDeprecationWarnings = true;
         const timestamp = moment(time_str);

--- a/tools/build-release-tarball
+++ b/tools/build-release-tarball
@@ -93,7 +93,7 @@ EOF
 
 ./tools/update-prod-static
 
-# We don't need duplicate copies of emoji with hashed paths, and they would break bugdown
+# We don't need duplicate copies of emoji with hashed paths, and they would break markdown
 find prod-static/serve/generated/emoji/images/emoji/ -regex '.*\.[0-9a-f]+\.png' -delete
 
 echo "$GITID" > build_id

--- a/tools/setup/emoji/build_emoji
+++ b/tools/setup/emoji/build_emoji
@@ -318,7 +318,7 @@ def setup_old_emoji_farm(cache_path: str,
             pass
 
 def generate_map_files(cache_path: str, emoji_catalog: Dict[str, List[str]]) -> None:
-    # This function generates the data file consumed by webapp, mobile apps, bugdown etc.
+    # This function generates the data file consumed by webapp, mobile apps, markdown etc.
     names = emoji_names_for_picker(EMOJI_NAME_MAPS)
     codepoint_to_name = generate_codepoint_to_name_map(EMOJI_NAME_MAPS)
     name_to_codepoint = generate_name_to_codepoint_map(EMOJI_NAME_MAPS)

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -96,7 +96,7 @@ from zerver.lib.export import get_realm_exports_serialized
 from zerver.lib.external_accounts import DEFAULT_EXTERNAL_ACCOUNTS
 from zerver.lib.hotspots import get_next_hotspots
 from zerver.lib.i18n import get_language_name
-from zerver.lib.markdown import version as bugdown_version
+from zerver.lib.markdown import version as markdown_version
 from zerver.lib.message import (
     MessageDict,
     access_message,
@@ -1430,7 +1430,7 @@ def do_send_messages(messages_maybe_none: Sequence[Optional[MutableMapping[str, 
             email_gateway=email_gateway,
         )
         message['message'].rendered_content = rendered_content
-        message['message'].rendered_content_version = bugdown_version
+        message['message'].rendered_content_version = markdown_version
         links_for_embed |= message['message'].links_for_preview
 
         # Add members of the mentioned user groups into `mentions_user_ids`.
@@ -4396,7 +4396,7 @@ def do_update_embedded_data(user_profile: UserProfile,
         update_user_message_flags(message, ums)
         message.content = content
         message.rendered_content = rendered_content
-        message.rendered_content_version = bugdown_version
+        message.rendered_content_version = markdown_version
         event["content"] = content
         event["rendered_content"] = rendered_content
 
@@ -4492,7 +4492,7 @@ def do_update_message(user_profile: UserProfile, message: Message,
         edit_history_event["prev_rendered_content_version"] = message.rendered_content_version
         message.content = content
         message.rendered_content = rendered_content
-        message.rendered_content_version = bugdown_version
+        message.rendered_content_version = markdown_version
         event["content"] = content
         event["rendered_content"] = rendered_content
         event['prev_rendered_content_version'] = message.rendered_content_version

--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -15,7 +15,6 @@ from psycopg2.extras import execute_values
 from psycopg2.sql import SQL, Identifier
 
 from analytics.models import RealmCount, StreamCount, UserCount
-from zerver.lib import markdown as bugdown
 from zerver.lib.actions import (
     UserMessageLite,
     bulk_insert_ums,
@@ -25,7 +24,8 @@ from zerver.lib.actions import (
 from zerver.lib.avatar_hash import user_avatar_path_from_ids
 from zerver.lib.bulk_create import bulk_create_users, bulk_set_users_or_streams_recipient_fields
 from zerver.lib.export import DATE_FIELDS, Field, Path, Record, TableData, TableName
-from zerver.lib.markdown import version as bugdown_version
+from zerver.lib.markdown import convert as markdown_convert
+from zerver.lib.markdown import version as markdown_version
 from zerver.lib.parallel import run_parallel
 from zerver.lib.server_initialization import create_internal_realm, server_initialized
 from zerver.lib.streams import render_stream_description
@@ -316,7 +316,7 @@ def fix_message_rendered_content(realm: Realm,
             # words" type feature, and notifications aren't important anyway.
             realm_alert_words_automaton = None
 
-            rendered_content = bugdown.convert(
+            rendered_content = markdown_convert(
                 content=content,
                 realm_alert_words_automaton=realm_alert_words_automaton,
                 message_realm=realm,
@@ -325,12 +325,12 @@ def fix_message_rendered_content(realm: Realm,
             )
 
             message['rendered_content'] = rendered_content
-            message['rendered_content_version'] = bugdown_version
+            message['rendered_content_version'] = markdown_version
         except Exception:
             # This generally happens with two possible causes:
             # * rendering markdown throwing an uncaught exception
             # * rendering markdown failing with the exception being
-            #   caught in bugdown (which then returns None, causing the the
+            #   caught in markdown (which then returns None, causing the the
             #   rendered_content assert above to fire).
             logging.warning("Error in markdown rendering for message ID %s; continuing", message['id'])
 

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -2102,7 +2102,7 @@ _privacy_re = re.compile('\\w', flags=re.UNICODE)
 def privacy_clean_markdown(content: str) -> str:
     return repr(_privacy_re.sub('x', content))
 
-def log_bugdown_error(msg: str) -> None:
+def log_markdown_error(msg: str) -> None:
     """We use this unusual logging approach to log the markdown error, in
     order to prevent AdminNotifyHandler from sending the sanitized
     original markdown formatting into another Zulip message, which

--- a/zerver/lib/markdown/fenced_code.py
+++ b/zerver/lib/markdown/fenced_code.py
@@ -355,7 +355,7 @@ class FencedBlockPreprocessor(markdown.preprocessors.Preprocessor):
             self.handlers[-1].done()
 
         # This fiddly handling of new lines at the end of our output was done to make
-        # existing tests pass.  Bugdown is just kind of funny when it comes to new lines,
+        # existing tests pass. Markdown is just kind of funny when it comes to new lines,
         # but we could probably remove this hack.
         if len(output) > 2 and output[-2] != '':
             output.append('')

--- a/zerver/lib/realm_description.py
+++ b/zerver/lib/realm_description.py
@@ -4,15 +4,15 @@ from zerver.lib.cache import (
     realm_text_description_cache_key,
 )
 from zerver.lib.html_to_text import html_to_text
-from zerver.lib.markdown import convert as bugdown_convert
+from zerver.lib.markdown import convert as markdown_convert
 from zerver.models import Realm
 
 
 @cache_with_key(realm_rendered_description_cache_key, timeout=3600*24*7)
 def get_realm_rendered_description(realm: Realm) -> str:
     realm_description_raw = realm.description or "The coolest place in the universe."
-    return bugdown_convert(realm_description_raw, message_realm=realm,
-                           no_previews=True)
+    return markdown_convert(realm_description_raw, message_realm=realm,
+                            no_previews=True)
 
 @cache_with_key(realm_text_description_cache_key, timeout=3600*24*7)
 def get_realm_text_description(realm: Realm) -> str:

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.db.models.query import QuerySet
 from django.utils.translation import ugettext as _
 
-from zerver.lib.markdown import convert as bugdown_convert
+from zerver.lib.markdown import convert as markdown_convert
 from zerver.lib.request import JsonableError
 from zerver.models import (
     DefaultStreamGroup,
@@ -45,7 +45,7 @@ def get_default_value_for_history_public_to_subscribers(
     return history_public_to_subscribers
 
 def render_stream_description(text: str) -> str:
-    return bugdown_convert(text, no_previews=True)
+    return markdown_convert(text, no_previews=True)
 
 def send_stream_creation_event(stream: Stream, user_ids: List[int]) -> None:
     event = dict(type="stream", op="create",

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -819,7 +819,7 @@ class ZulipTestCase(TestCase):
     def simulated_markdown_failure(self) -> Iterator[None]:
         '''
         This raises a failure inside of the try/except block of
-        bugdown.__init__.do_convert.
+        markdown.__init__.do_convert.
         '''
         with \
                 self.settings(ERROR_BOT=None), \

--- a/zerver/logging_handlers.py
+++ b/zerver/logging_handlers.py
@@ -86,12 +86,12 @@ class AdminNotifyHandler(logging.Handler):
         # message in exception handler (that's the stuff of which
         # recursive exception loops are made).
         #
-        # We initialize is_bugdown_rendering_exception to `True` to
+        # We initialize is_markdown_rendering_exception to `True` to
         # prevent the infinite loop of zulip messages by ERROR_BOT if
         # the outer try block here throws an exception before we have
         # a chance to check the exception for whether it comes from
-        # bugdown.
-        is_bugdown_rendering_exception = True
+        # markdown.
+        is_markdown_rendering_exception = True
 
         try:
             report['node'] = platform.node()
@@ -105,7 +105,7 @@ class AdminNotifyHandler(logging.Handler):
             if record.exc_info:
                 stack_trace = ''.join(traceback.format_exception(*record.exc_info))
                 message = str(record.exc_info[1])
-                is_bugdown_rendering_exception = record.msg.startswith('Exception in Markdown parser')
+                is_markdown_rendering_exception = record.msg.startswith('Exception in Markdown parser')
             else:
                 stack_trace = 'No stack trace available'
                 message = record.getMessage()
@@ -114,7 +114,7 @@ class AdminNotifyHandler(logging.Handler):
                     # seem to result in super-long messages
                     stack_trace = message
                     message = message.split('\n')[0]
-                is_bugdown_rendering_exception = False
+                is_markdown_rendering_exception = False
             report['stack_trace'] = stack_trace
             report['message'] = message
 
@@ -143,7 +143,7 @@ class AdminNotifyHandler(logging.Handler):
                 # On staging, process the report directly so it can happen inside this
                 # try/except to prevent looping
                 from zerver.lib.error_notify import notify_server_error
-                notify_server_error(report, is_bugdown_rendering_exception)
+                notify_server_error(report, is_markdown_rendering_exception)
             else:
                 queue_json_publish('error_reports', dict(
                     type = "server",

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1792,10 +1792,10 @@ class Message(AbstractMessage):
     @staticmethod
     def need_to_render_content(rendered_content: Optional[str],
                                rendered_content_version: Optional[int],
-                               bugdown_version: int) -> bool:
+                               markdown_version: int) -> bool:
         return (rendered_content is None or
                 rendered_content_version is None or
-                rendered_content_version < bugdown_version)
+                rendered_content_version < markdown_version)
 
     def to_log_dict(self) -> Dict[str, Any]:
         return dict(

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -747,13 +747,13 @@
       "text_content": "!gravatar(username@example.com)"
     },
     {
-      "name": "timestamp_bugdown_only",
+      "name": "timestamp_backend_markdown_only",
       "input": "!time(Jun 5th 2017, 10:30PM)",
       "expected_output": "<p><time datetime=\"2017-06-05T22:30:00Z\">Jun 5th 2017, 10:30PM</time></p>",
       "marked_expected_output": "<p><span class=\"timestamp-error\">Invalid time format: Jun 5th 2017, 10:30PM</span></p>"
     },
     {
-      "name": "timestamp_bugdown_and_marked",
+      "name": "timestamp_backend_markdown_and_marked",
       "input": "!time(31 Dec 2017)",
       "expected_output": "<p><time datetime=\"2017-12-31T00:00:00Z\">31 Dec 2017</time></p>"
     },

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -10,7 +10,7 @@ from zerver.lib.actions import (
     try_reorder_realm_custom_profile_fields,
 )
 from zerver.lib.external_accounts import DEFAULT_EXTERNAL_ACCOUNTS
-from zerver.lib.markdown import convert as bugdown_convert
+from zerver.lib.markdown import convert as markdown_convert
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import queries_captured
 from zerver.models import (
@@ -536,7 +536,7 @@ class UpdateCustomProfileFieldTest(CustomProfileFieldTestCase):
         expected_rendered_value: Dict[Union[int, float, str, None], Union[str, None]] = {}
         for f in data:
             if f['field'].is_renderable():
-                expected_rendered_value[f['id']] = bugdown_convert(f['value'])
+                expected_rendered_value[f['id']] = markdown_convert(f['value'])
             else:
                 expected_rendered_value[f['id']] = None
 

--- a/zerver/tests/test_thumbnail.py
+++ b/zerver/tests/test_thumbnail.py
@@ -173,7 +173,7 @@ class ThumbnailTest(ZulipTestCase):
 
         # Test full size image.
         # We remove the forward slash infront of the `/user_uploads/` to match
-        # bugdown behaviour.
+        # markdown behaviour.
         quoted_uri = urllib.parse.quote(uri[1:], safe='')
         result = self.client_get(f"/thumbnail?url={quoted_uri}&size=full")
         self.assertEqual(result.status_code, 302, result)
@@ -197,7 +197,7 @@ class ThumbnailTest(ZulipTestCase):
         uri = json["uri"]
 
         # We remove the forward slash infront of the `/user_uploads/` to match
-        # bugdown behaviour.
+        # markdown behaviour.
         quoted_uri = urllib.parse.quote(uri[1:], safe='')
         result = self.client_get(f"/thumbnail?url={quoted_uri}&size=full")
         self.assertEqual(result.status_code, 302, result)

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -8,7 +8,6 @@ from django.utils.timezone import now as timezone_now
 from django.utils.translation import ugettext as _
 
 from zerver.decorator import REQ, has_request_variables
-from zerver.lib import markdown as bugdown
 from zerver.lib.actions import (
     do_delete_messages,
     do_update_message,
@@ -17,6 +16,7 @@ from zerver.lib.actions import (
 )
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.html_diff import highlight_html_differences
+from zerver.lib.markdown import MentionData
 from zerver.lib.message import access_message, truncate_body
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.response import json_error, json_success
@@ -159,14 +159,14 @@ def update_message_backend(request: HttpRequest, user_profile: UserMessage,
     links_for_embed: Set[str] = set()
     prior_mention_user_ids: Set[int] = set()
     mention_user_ids: Set[int] = set()
-    mention_data: Optional[bugdown.MentionData] = None
+    mention_data: Optional[MentionData] = None
     if content is not None:
         content = content.strip()
         if content == "":
             content = "(deleted)"
         content = truncate_body(content)
 
-        mention_data = bugdown.MentionData(
+        mention_data = MentionData(
             realm_id=user_profile.realm.id,
             content=content,
         )


### PR DESCRIPTION
This is This commit is part of series of commits aimed at renaming bugdown to
markdown.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Continuation to #15569  

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
