### PR TITLE
Fix bug in rendering of organization settings tip and minor fixes in emoji settings page.

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -91,17 +91,6 @@ run_test('unloaded', () => {
     settings_org.populate_auth_methods();
 });
 
-function simulate_tip_box() {
-    const non_editables = $.create('auth-methods-not-edit-stub');
-    $('.organization-box').set_find_results(
-        '.settings-section:not(.can-edit)',
-        non_editables
-    );
-
-    non_editables.not = function () { return this; };
-    non_editables.prepend = noop;
-}
-
 function simulate_realm_domains_table() {
     $('#realm_domains_table tbody').set_find_results(
         'tr',
@@ -764,7 +753,6 @@ run_test('set_up', () => {
             name: "Big Blue Button",
         },
     };
-    simulate_tip_box();
 
     $('#id_realm_video_chat_provider').change = set_callback('realm_video_chat_provider');
     $("#id_realm_org_join_restrictions").change = set_callback('change_org_join_restrictions');

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -1,6 +1,7 @@
 const settings_config = require("./settings_config");
 const settings_data = require("./settings_data");
 const render_admin_tab = require('../templates/admin_tab.hbs');
+const render_settings_organization_settings_tip = require("../templates/settings/organization_settings_tip.hbs");
 
 const admin_settings_label = {
     // Organization settings
@@ -23,6 +24,18 @@ const admin_settings_label = {
     realm_email_changes_disabled: i18n.t("Prevent users from changing their email address"),
     realm_avatar_changes_disabled: i18n.t("Prevent users from changing their avatar"),
 };
+
+function insert_tip_box() {
+    if (page_params.is_admin) {
+        return;
+    }
+    const tip_box = render_settings_organization_settings_tip({is_admin: page_params.is_admin});
+    $(".organization-box").find(".settings-section:not(.can-edit)")
+        .not("#emoji-settings")
+        .not("#user-groups-admin")
+        .not("#organization-auth-settings")
+        .prepend(tip_box);
+}
 
 exports.build_page = function () {
     const options = {
@@ -101,6 +114,8 @@ exports.build_page = function () {
     $("#settings_content .alert").removeClass("show");
 
     settings_bots.update_bot_settings_tip();
+    insert_tip_box();
+
     $("#id_realm_bot_creation_policy").val(page_params.realm_bot_creation_policy);
     $("#id_realm_email_address_visibility").val(page_params.realm_email_address_visibility);
 

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -30,7 +30,7 @@ function insert_tip_box() {
         return;
     }
     const tip_box = render_settings_organization_settings_tip({is_admin: page_params.is_admin});
-    $(".organization-box").find(".settings-section:not(.can-edit)")
+    $(".organization-box").find(".settings-section")
         .not("#emoji-settings")
         .not("#user-groups-admin")
         .not("#organization-auth-settings")

--- a/static/js/settings_emoji.js
+++ b/static/js/settings_emoji.js
@@ -39,10 +39,8 @@ exports.update_custom_emoji_ui = function () {
     $('#emoji-settings').find('.emoji-settings-tip-container').html(rendered_tip);
     if (page_params.realm_add_emoji_by_admins_only && !page_params.is_admin) {
         $('.admin-emoji-form').hide();
-        $('#emoji-settings').removeClass('can_edit');
     } else {
         $('.admin-emoji-form').show();
-        $('#emoji-settings').addClass('can_edit');
     }
 
     exports.populate_emoji(page_params.realm_emoji);

--- a/static/js/settings_emoji.js
+++ b/static/js/settings_emoji.js
@@ -38,8 +38,10 @@ exports.update_custom_emoji_ui = function () {
     });
     $('#emoji-settings').find('.emoji-settings-tip-container').html(rendered_tip);
     if (page_params.realm_add_emoji_by_admins_only && !page_params.is_admin) {
+        $('.add-emoji-text').hide();
         $('.admin-emoji-form').hide();
     } else {
+        $('.add-emoji-text').show();
         $('.admin-emoji-form').show();
     }
 

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -1,7 +1,6 @@
 const settings_config = require("./settings_config");
 const render_settings_admin_auth_methods_list = require('../templates/settings/admin_auth_methods_list.hbs');
 const render_settings_admin_realm_domains_list = require("../templates/settings/admin_realm_domains_list.hbs");
-const render_settings_organization_settings_tip = require("../templates/settings/organization_settings_tip.hbs");
 const pygments_data = require("../generated/pygments_data.json");
 
 const meta = {
@@ -311,18 +310,6 @@ exports.populate_auth_methods = function (auth_methods) {
     auth_methods_table.html(rendered_auth_method_rows);
 };
 
-function insert_tip_box() {
-    if (page_params.is_admin) {
-        return;
-    }
-    const tip_box = render_settings_organization_settings_tip({is_admin: page_params.is_admin});
-    $(".organization-box").find(".settings-section:not(.can-edit)")
-        .not("#emoji-settings")
-        .not("#user-groups-admin")
-        .not("#organization-auth-settings")
-        .prepend(tip_box);
-}
-
 function update_dependent_subsettings(property_name) {
     if (simple_dropdown_properties.includes(property_name)) {
         set_property_dropdown_value(property_name);
@@ -614,7 +601,6 @@ exports.build_page = function () {
 
     // Populate authentication methods table
     exports.populate_auth_methods(page_params.realm_authentication_methods);
-    insert_tip_box();
 
     simple_dropdown_properties.forEach(set_property_dropdown_value);
 

--- a/static/templates/settings/emoji_settings_admin.hbs
+++ b/static/templates/settings/emoji_settings_admin.hbs
@@ -2,7 +2,9 @@
     <div class="emoji-settings-tip-container">
         {{> emoji_settings_tip}}
     </div>
-    <p>{{#tr this}}Add extra emoji for members of the __realm_name__ organization.{{/tr}}</p>
+    <p class="add-emoji-text {{#unless can_add_emojis}}hide{{/unless}}">
+        {{#tr this}}Add extra emoji for members of the __realm_name__ organization.{{/tr}}
+    </p>
     <form class="form-horizontal admin-emoji-form {{#unless can_add_emojis}}hide{{/unless}}">
         <div class="add-new-emoji-box grey-box">
             <div class="new-emoji-form">

--- a/static/templates/settings/emoji_settings_admin.hbs
+++ b/static/templates/settings/emoji_settings_admin.hbs
@@ -31,7 +31,7 @@
     </form>
 
     <input type="text" class="search" placeholder="{{t 'Filter emojis' }}"
-      aria-label="{{t 'Filter linkifiers' }}"/>
+      aria-label="{{t 'Filter emojis' }}"/>
     <div class="progressive-table-wrapper" data-simplebar>
         <table class="table table-condensed table-striped wrapped-table admin_emoji_table">
             <thead>

--- a/static/templates/settings/emoji_settings_admin.hbs
+++ b/static/templates/settings/emoji_settings_admin.hbs
@@ -1,4 +1,4 @@
-<div id="emoji-settings" data-name="emoji-settings" class="settings-section {{#if can_add_emojis}}can-edit{{/if}}">
+<div id="emoji-settings" data-name="emoji-settings" class="settings-section">
     <div class="emoji-settings-tip-container">
         {{> emoji_settings_tip}}
     </div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR fixes the bug of organization_settings_tip which is not displayed if the settings overlay is opened with sections other than
organization profile, settings and permissions.

This PR also contains some of the minor fixes in emoji settings code.
**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
