### PR TITLE
move_topic_to_stream: Delete UserMessage for new stream unsubs.

### DIFF
--- a/zerver/tests/test_messages.py
+++ b/zerver/tests/test_messages.py
@@ -3576,11 +3576,15 @@ class EditMessageTest(ZulipTestCase):
             "iago", "test move stream", "new stream", "test")
 
         guest_user = self.example_user('polonius')
+        non_guest_user = self.example_user('hamlet')
         self.subscribe(guest_user, old_stream.name)
+        self.subscribe(non_guest_user, old_stream.name)
+
         msg_id_to_test_acesss = self.send_stream_message(user_profile, old_stream.name,
                                                          topic_name='test', content="fourth")
 
         self.assertEqual(has_message_access(guest_user, Message.objects.get(id=msg_id_to_test_acesss), None), True)
+        self.assertEqual(has_message_access(non_guest_user, Message.objects.get(id=msg_id_to_test_acesss), None), True)
 
         result = self.client_patch("/json/messages/" + str(msg_id), {
             'message_id': msg_id,
@@ -3591,6 +3595,11 @@ class EditMessageTest(ZulipTestCase):
         self.assert_json_success(result)
 
         self.assertEqual(has_message_access(guest_user, Message.objects.get(id=msg_id_to_test_acesss), None), False)
+        self.assertEqual(has_message_access(non_guest_user, Message.objects.get(id=msg_id_to_test_acesss), None), True)
+        self.assertEqual(UserMessage.objects.filter(
+            user_profile_id=non_guest_user.id,
+            message_id=msg_id_to_test_acesss,
+        ).count(), 0)
         self.assertEqual(has_message_access(self.example_user('iago'), Message.objects.get(id=msg_id_to_test_acesss), None), True)
 
     def test_no_notify_move_message_to_stream(self) -> None:


### PR DESCRIPTION
For users who are unsubscribed from the new stream but are in
the old stream, we delete the UserMessage.

We send the delete_message event only to guest users,
who have completely lost asses to the moved messages, for other
users we send the normal update_message event which moves
the messages to the new unsubed stream which
otherwise would look broken to the
user without reloading to the webpage.
