### PR TITLE
messages: Lazy load inline profile pictures (user avatars).

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1411,6 +1411,7 @@ div.focused_table {
     vertical-align: top;
     border-radius: 4px;
     overflow: hidden;
+    background-color: hsl(0, 0%, 90%);
 
     &.guest-avatar::after {
         outline: 2px solid hsl(0, 0%, 100%);

--- a/static/templates/message_avatar.hbs
+++ b/static/templates/message_avatar.hbs
@@ -1,3 +1,3 @@
 <div class="u-{{msg/sender_id}} inline_profile_picture {{#sender_is_guest}} guest-avatar{{/sender_is_guest}}" aria-hidden="true">
-    <img src="{{small_avatar_url}}" alt="" class="no-drag"/>
+    <img src="{{small_avatar_url}}" alt="" loading="lazy" class="no-drag"/>
 </div>


### PR DESCRIPTION
We use the loading attribute to tell the browser to lazy load the
images when they are needed. With this change profile pictures will
only be loaded in they are in the viewport as opposed to previous
behavior where they were loaded when they are added to the DOM and
loaded even though they are not on screen.

We also add a greyish background color to the image tag, which makes
the empty space look nicer in case there is delay in loading the
image or if it fails to load due to internet failure.

Finally, I verfied that there were no issues when sending messages
or reciving message like last time we used lazysizes to do this
(see revert #12112 commit 8a15b9ee87d42ba8b4f810c5aa4e6f9ae45b6b25).
The two issues were profile pictures flashes (or flickering) when
sending messages or when reciving new messages when they are
dynamically rendered.

**Testing Plan:** 
I tried bunch of things devtools' Network Tab (including testing things that didn't work out last time as mentioned in commit message.) For example, Disabling Cache and them emulating `Slow 3G` and `Fast 3G` to see the experience of avatars being loaded and it works smoothly. 

**GIFs or Screenshots:**
<details>
  <summary>Day and Night mode screenshots</summary>

![image](https://user-images.githubusercontent.com/23620441/86040276-c0330180-ba11-11ea-9a91-d365618a134e.png)
![image](https://user-images.githubusercontent.com/23620441/86040353-e22c8400-ba11-11ea-8f82-e9dd6c80cdc7.png)
</details>