### PR TITLE
puppet: nagios-plugins-basic is replaced by monitoring-plugins-basic.

### DIFF
--- a/puppet/zulip/manifests/base.pp
+++ b/puppet/zulip/manifests/base.pp
@@ -29,8 +29,8 @@ class zulip::base {
         'moreutils',
         # Used in scripts
         'netcat',
-        # Nagios plugins; needed to ensure $zulip::common::nagios_plugins exists
-        'nagios-plugins-basic',
+        # Nagios monitoring plugins
+        $zulip::common::nagios_plugins,
         # Required for using HTTPS in apt repositories.
         'apt-transport-https',
         # Needed for the cron jobs installed by puppet

--- a/puppet/zulip/manifests/common.pp
+++ b/puppet/zulip/manifests/common.pp
@@ -2,7 +2,7 @@ class zulip::common {
   # Common parameters
   case $::osfamily {
     'debian': {
-      $nagios_plugins = 'nagios-plugins-basic'
+      $nagios_plugins = 'monitoring-plugins-basic'
       $nagios_plugins_dir = '/usr/lib/nagios/plugins'
       $nginx = 'nginx-full'
       $supervisor_conf_dir = '/etc/supervisor/conf.d'

--- a/puppet/zulip/manifests/nagios.pp
+++ b/puppet/zulip/manifests/nagios.pp
@@ -1,7 +1,7 @@
 # This manifest installs Zulip's Nagios plugins intended to be on
 # localhost on a Nagios server.
 #
-# Depends on zulip::base to have installed `nagios-plugins-basic`.
+# Depends on zulip::base to have installed `monitoring-plugins-basic`.
 class zulip::nagios {
   include zulip::common
   file { "${zulip::common::nagios_plugins_dir}/zulip_nagios_server":

--- a/puppet/zulip_ops/files/nagios3/commands.cfg
+++ b/puppet/zulip_ops/files/nagios3/commands.cfg
@@ -24,7 +24,7 @@ define command{
 ################################################################################
 
 # On Debian, check-host-alive is being defined from within the
-# nagios-plugins-basic package
+# monitoring-plugins-basic package
 
 ################################################################################
 # PERFORMANCE DATA COMMANDS

--- a/puppet/zulip_ops/manifests/prod_app_frontend.pp
+++ b/puppet/zulip_ops/manifests/prod_app_frontend.pp
@@ -20,7 +20,7 @@ class zulip_ops::prod_app_frontend {
   }
 
   file { '/usr/lib/nagios/plugins/zulip_zephyr_mirror':
-    require => Package[nagios-plugins-basic],
+    require => Package[$zulip::common::nagios_plugins],
     recurse => true,
     purge   => true,
     owner   => 'root',

--- a/puppet/zulip_ops/manifests/zmirror.pp
+++ b/puppet/zulip_ops/manifests/zmirror.pp
@@ -59,7 +59,7 @@ class zulip_ops::zmirror {
   }
 
   file { '/usr/lib/nagios/plugins/zulip_zephyr_mirror':
-    require => Package[nagios-plugins-basic],
+    require => Package[$zulip::common::nagios_plugins],
     recurse => true,
     purge   => true,
     owner   => 'root',

--- a/puppet/zulip_ops/manifests/zmirror_personals.pp
+++ b/puppet/zulip_ops/manifests/zmirror_personals.pp
@@ -40,7 +40,7 @@ class zulip_ops::zmirror_personals {
   }
 
   file { '/usr/lib/nagios/plugins/zulip_zephyr_mirror':
-    require => Package[nagios-plugins-basic],
+    require => Package[$zulip::common::nagios_plugins],
     recurse => true,
     purge   => true,
     owner   => 'root',


### PR DESCRIPTION
In Bionic, nagios-plugins-basic is a transitional package which
depends on monitoring-plugins-basic.  In Focal, it is a virtual
package, which means that every time puppet runs, it tries to
re-install the nagios-plugins-basic package.

Switch all instances to referring to `$zulip::common::nagios_plugins`,
and repoint that to monitoring-plugins-basic.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
