### PR TITLE
wal-g: Update pg_backup_and_purge for wal-g format.

### DIFF
--- a/puppet/zulip/files/postgresql/pg_backup_and_purge
+++ b/puppet/zulip/files/postgresql/pg_backup_and_purge
@@ -56,7 +56,7 @@ backups: Dict[datetime, str] = {}
 lines = run(['env-wal-g', 'backup-list']).split("\n")
 for line in lines[1:]:
     if line:
-        backup_name, date_str, _, _ = line.split()
+        backup_name, date_str, _ = line.split()
         backups[dateutil.parser.parse(date_str)] = backup_name
 
 one_month_ago = now - timedelta(days=30)


### PR DESCRIPTION
wal-g has a slihghtly different format than wal-e in its `backup-list`
output; it only contains three columns:
 - `name`
 - `last_modified`,
 - `wal_segment_backup_start`

..rather than wal-e's plethora, most of which were blank:
 - `name`
 - `last_modified`
 - `expanded_size_bytes`
 - `wal_segment_backup_start`
 - `wal_segment_offset_backup_start`
 - `wal_segment_backup_stop`
 - `wal_segment_offset_backup_stop`

Remove one argument from the split.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
