### PR TITLE
clear_push_notif: Remove client support for unbatched events.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4169,6 +4169,9 @@ def do_update_mobile_push_notification(message: Message,
 
 def do_clear_mobile_push_notifications_for_ids(user_profile_ids: List[int],
                                                message_ids: List[int]) -> None:
+    if not message_ids:
+        return
+
     # This functions supports clearing notifications for several users
     # only for the message-edit use case where we'll have a single message_id.
     assert len(user_profile_ids) == 1 or len(message_ids) == 1
@@ -4183,25 +4186,12 @@ def do_clear_mobile_push_notifications_for_ids(user_profile_ids: List[int],
     for (user_id, message_id) in notifications_to_update:
         messages_by_user[user_id].append(message_id)
 
-    num_detached = settings.MAX_UNBATCHED_REMOVE_NOTIFICATIONS - 1
     for user_profile_id in user_profile_ids:
-        filtered_message_ids = messages_by_user[user_profile_id]
-        for message_id in filtered_message_ids[:num_detached]:
-            # Older clients (all clients older than 2019-02-13) will only
-            # see the first message ID in a given notification-message.
-            # To help them out, send a few of these separately.
-            queue_json_publish("missedmessage_mobile_notifications", {
-                "type": "remove",
-                "user_profile_id": user_profile_id,
-                "message_ids": [message_id],
-            })
-
-        if filtered_message_ids[num_detached:]:
-            queue_json_publish("missedmessage_mobile_notifications", {
-                "type": "remove",
-                "user_profile_id": user_profile_id,
-                "message_ids": filtered_message_ids[num_detached:],
-            })
+        queue_json_publish("missedmessage_mobile_notifications", {
+            "type": "remove",
+            "user_profile_id": user_profile_id,
+            "message_ids": messages_by_user[user_profile_id],
+        })
 
 def do_update_message_flags(user_profile: UserProfile,
                             client: Client,

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -282,13 +282,6 @@ APNS_SANDBOX = True
 APNS_TOPIC = 'org.zulip.Zulip'
 ZULIP_IOS_APP_ID = 'org.zulip.Zulip'
 
-# Max number of "remove notification" FCM/GCM messages to send separately
-# in one burst; the rest are batched.  Older clients ignore the batched
-# portion, so only receive this many removals.  Lower values mitigate
-# server congestion and client battery use.  To batch unconditionally,
-# set to 1.
-MAX_UNBATCHED_REMOVE_NOTIFICATIONS = 10
-
 # Limits related to the size of file uploads; last few in MB.
 DATA_UPLOAD_MAX_MEMORY_SIZE = 25 * 1024 * 1024
 MAX_AVATAR_FILE_SIZE = 5


### PR DESCRIPTION
We remove support for the old clients which required an event for
each message to clear notification.

This is justified since it has been around 1.5 years since we
started supporting the bulk operation and the old method is
becoming troublesome to maintain.
