### PR TITLE
emoji: Rename :slight_smile: to :smile:.

### DIFF
--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -467,7 +467,7 @@ run_test("marked", () => {
         {
             input: ":)",
             expected:
-                '<p><span aria-label="slight smile" class="emoji emoji-1f642" role="img" title="slight smile">:slight_smile:</span></p>',
+                '<p><span aria-label="smile" class="emoji emoji-1f642" role="img" title="smile">:smile:</span></p>',
             translate_emoticons: true,
         },
         // Test HTML Escape in Custom Zulip Rules
@@ -708,7 +708,7 @@ run_test("katex_throws_unexpected_exceptions", () => {
 run_test("translate_emoticons_to_names", () => {
     // Simple test
     const test_text = "Testing :)";
-    const expected = "Testing :slight_smile:";
+    const expected = "Testing :smile:";
     const result = markdown.translate_emoticons_to_names(test_text);
     assert.equal(expected, result);
 

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -58,8 +58,8 @@ people.add_active_user(cali);
 const message = {
     id: 1001,
     reactions: [
-        {emoji_name: "smile", user_id: 5, reaction_type: "unicode_emoji", emoji_code: "263a"},
-        {emoji_name: "smile", user_id: 6, reaction_type: "unicode_emoji", emoji_code: "263a"},
+        {emoji_name: "smile", user_id: 5, reaction_type: "unicode_emoji", emoji_code: "1f642"},
+        {emoji_name: "smile", user_id: 6, reaction_type: "unicode_emoji", emoji_code: "1f642"},
         {emoji_name: "frown", user_id: 7, reaction_type: "unicode_emoji", emoji_code: "1f641"},
         {
             emoji_name: "inactive_realm_emoji",
@@ -126,7 +126,7 @@ run_test("basics", () => {
     blueslip.expect("warn", "Unknown user_id 8888 in reaction for message 1001");
     blueslip.expect("warn", "Unknown user_id 9999 in reaction for message 1001");
     const result = reactions.get_message_reactions(message);
-    assert(reactions.current_user_has_reacted_to_emoji(message, "unicode_emoji,263a"));
+    assert(reactions.current_user_has_reacted_to_emoji(message, "unicode_emoji,1f642"));
     assert(!reactions.current_user_has_reacted_to_emoji(message, "bogus"));
 
     result.sort((a, b) => a.count - b.count);
@@ -159,8 +159,8 @@ run_test("basics", () => {
         {
             emoji_name: "smile",
             reaction_type: "unicode_emoji",
-            emoji_code: "263a",
-            local_id: "unicode_emoji,263a",
+            emoji_code: "1f642",
+            local_id: "unicode_emoji,1f642",
             count: 2,
             user_ids: [5, 6],
             label: "You (click to remove) and Bob van Roberts reacted with :smile:",
@@ -188,7 +188,7 @@ run_test("sending", () => {
         assert.deepEqual(args.data, {
             reaction_type: "unicode_emoji",
             emoji_name: "smile",
-            emoji_code: "263a",
+            emoji_code: "1f642",
         });
         // args.success() does nothing; just make sure it doesn't crash
         args.success();
@@ -277,7 +277,7 @@ run_test("get_reaction_section", () => {
 
 run_test("emoji_reaction_title", () => {
     const message_id = 1001;
-    const local_id = "unicode_emoji,263a";
+    const local_id = "unicode_emoji,1f642";
 
     assert.equal(
         reactions.get_reaction_title_data(message_id, local_id),
@@ -685,11 +685,11 @@ run_test("process_reaction_click", () => {
     expected_reaction_info = {
         reaction_type: "unicode_emoji",
         emoji_name: "smile",
-        emoji_code: "263a",
+        emoji_code: "1f642",
     };
     global.with_stub((stub) => {
         global.channel.del = stub.f;
-        reactions.process_reaction_click(message_id, "unicode_emoji,263a");
+        reactions.process_reaction_click(message_id, "unicode_emoji,1f642");
         const args = stub.get_args("args").args;
         assert.equal(args.url, "/json/messages/1001/reactions");
         assert.deepEqual(args.data, expected_reaction_info);
@@ -730,12 +730,15 @@ run_test("duplicates", () => {
     const dup_reaction_message = {
         id: 1001,
         reactions: [
-            {emoji_name: "smile", user_id: 5, reaction_type: "unicode_emoji", emoji_code: "263a"},
-            {emoji_name: "smile", user_id: 5, reaction_type: "unicode_emoji", emoji_code: "263a"},
+            {emoji_name: "smile", user_id: 5, reaction_type: "unicode_emoji", emoji_code: "1f642"},
+            {emoji_name: "smile", user_id: 5, reaction_type: "unicode_emoji", emoji_code: "1f642"},
         ],
     };
 
-    blueslip.expect("error", "server sent duplicate reactions for user 5 (key=unicode_emoji,263a)");
+    blueslip.expect(
+        "error",
+        "server sent duplicate reactions for user 5 (key=unicode_emoji,1f642)",
+    );
     reactions.set_clean_reactions(dup_reaction_message);
 });
 

--- a/static/js/emoji.js
+++ b/static/js/emoji.js
@@ -17,8 +17,8 @@ const emoticon_translations = (() => {
     like this:
 
     [
-        { regex: /(\:\))/g, replacement_text: ':slight_smile:' },
-        { regex: /(\(\:)/g, replacement_text: ':slight_smile:' },
+        { regex: /(\:\))/g, replacement_text: ':smile:' },
+        { regex: /(\(\:)/g, replacement_text: ':smile:' },
         { regex: /(\:\/)/g, replacement_text: ':confused:' },
         { regex: /(<3)/g, replacement_text: ':heart:' },
         { regex: /(\:\()/g, replacement_text: ':frown:' },

--- a/static/shared/js/typeahead.js
+++ b/static/shared/js/typeahead.js
@@ -22,7 +22,7 @@
 export const popular_emojis = [
     "1f44d", // +1
     "1f389", // tada
-    "1f642", // slight_smile
+    "1f642", // smile
     "2764", // heart
     "1f6e0", // working_on_it
     "1f419", // octopus

--- a/templates/zerver/help/emoji-and-emoticons.md
+++ b/templates/zerver/help/emoji-and-emoticons.md
@@ -37,7 +37,7 @@ emoji picker, or hover over the emoji in a message.
 
 ### Use emoticons
 
-Use `:)` and `:/` instead of typing `:slight_smile:` and `:confused:`.
+Use `:)` and `:/` instead of typing `:smile:` and `:confused:`.
 
 {start_tabs}
 

--- a/templates/zerver/help/enable-emoticon-translations.md
+++ b/templates/zerver/help/enable-emoticon-translations.md
@@ -4,7 +4,7 @@ If you use emoticons like `:)` or `:/`, you can have them translated into
 emoji equivalents like
 <img
     src="/static/generated/emoji/images-google-64/1f642.png"
-    alt="slight_smile"
+    alt="smile"
     class="emoji-small"
 />
 or

--- a/tools/setup/emoji/emoji_names.py
+++ b/tools/setup/emoji/emoji_names.py
@@ -16,11 +16,11 @@ EMOJI_NAME_MAPS: Dict[str, Dict[str, Any]] = {
     '1f602': {'canonical_name': 'joy', 'aliases': ['tears', 'laughter_tears']},
     '1f923': {'canonical_name': 'rolling_on_the_floor_laughing', 'aliases': ['rofl']},
     # not sure how the glyphs match relaxed, but both iamcal and gemoji have it
-    '263a': {'canonical_name': 'smile', 'aliases': ['relaxed']},
+    '263a': {'canonical_name': 'smiling_face', 'aliases': ['relaxed']},
     '1f60a': {'canonical_name': 'blush', 'aliases': []},
     # halo comes from gemoji/unicode
     '1f607': {'canonical_name': 'innocent', 'aliases': ['halo']},
-    '1f642': {'canonical_name': 'slight_smile', 'aliases': []},
+    '1f642': {'canonical_name': 'smile', 'aliases': []},
     '1f643': {'canonical_name': 'upside_down', 'aliases': ['oops']},
     '1f609': {'canonical_name': 'wink', 'aliases': []},
     '1f60c': {'canonical_name': 'relieved', 'aliases': []},

--- a/tools/setup/emoji/emoji_setup_utils.py
+++ b/tools/setup/emoji/emoji_setup_utils.py
@@ -36,8 +36,8 @@ REMAPPED_EMOJIS = {
 # Emoticons and which emoji they should become. Duplicate emoji are allowed.
 # Changes here should be mimicked in `templates/zerver/help/enable-emoticon-translations.md`.
 EMOTICON_CONVERSIONS = {
-    ':)': ':slight_smile:',
-    '(:': ':slight_smile:',
+    ':)': ':smile:',
+    '(:': ':smile:',
     ':(': ':frown:',
     '<3': ':heart:',
     ':|': ':neutral:',

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -327,8 +327,8 @@
     {
       "name": "star_emoji",
       "input": "**:smile:**",
-      "expected_output": "<p><strong><span aria-label=\"smile\" class=\"emoji emoji-263a\" role=\"img\" title=\"smile\">:smile:</span></strong></p>",
-      "text_content": "\u263A"
+      "expected_output": "<p><strong><span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span></strong></p>",
+      "text_content": "\ud83d\ude42"
     },
     {
       "name": "star_strong_em",
@@ -478,8 +478,8 @@
     {
       "name": "many_emoji",
       "input":  "test :smile: again :poop:\n:) foo:)bar x::y::z :wasted waste: :fakeemojithisshouldnotrender:",
-      "expected_output": "<p>test <span aria-label=\"smile\" class=\"emoji emoji-263a\" role=\"img\" title=\"smile\">:smile:</span> again <span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span><br>\n:) foo:)bar x::y::z :wasted waste: :fakeemojithisshouldnotrender:</p>",
-      "text_content": "test \u263A again \ud83d\udca9\n:) foo:)bar x::y::z :wasted waste: :fakeemojithisshouldnotrender:"
+      "expected_output": "<p>test <span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span> again <span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span><br>\n:) foo:)bar x::y::z :wasted waste: :fakeemojithisshouldnotrender:</p>",
+      "text_content": "test \ud83d\ude42 again \ud83d\udca9\n:) foo:)bar x::y::z :wasted waste: :fakeemojithisshouldnotrender:"
     },
     {
       "name": "translate_emoticons_not_enabled",
@@ -491,14 +491,14 @@
     {
       "name": "translate_emoticons_enabled",
       "input": ":)",
-      "expected_output": "<p><span aria-label=\"slight smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"slight smile\">:slight_smile:</span></p>",
+      "expected_output": "<p><span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span></p>",
       "text_content": "\ud83d\ude42",
       "translate_emoticons": true
     },
     {
       "name": "translate_emoticons",
-      "input":  ":) foo :( bar <3 with space : ) real emoji :slight_smile:",
-      "expected_output": "<p><span aria-label=\"slight smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"slight smile\">:slight_smile:</span> foo <span aria-label=\"frown\" class=\"emoji emoji-1f641\" role=\"img\" title=\"frown\">:frown:</span> bar <span aria-label=\"heart\" class=\"emoji emoji-2764\" role=\"img\" title=\"heart\">:heart:</span> with space : ) real emoji <span aria-label=\"slight smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"slight smile\">:slight_smile:</span></p>",
+      "input":  ":) foo :( bar <3 with space : ) real emoji :smile:",
+      "expected_output": "<p><span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span> foo <span aria-label=\"frown\" class=\"emoji emoji-1f641\" role=\"img\" title=\"frown\">:frown:</span> bar <span aria-label=\"heart\" class=\"emoji emoji-2764\" role=\"img\" title=\"heart\">:heart:</span> with space : ) real emoji <span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span></p>",
       "text_content": "\ud83d\ude42 foo \ud83d\ude41 bar \u2764 with space : ) real emoji \ud83d\ude42",
       "translate_emoticons": true
     },
@@ -512,7 +512,7 @@
     {
       "name": "translate_emoticons_newline",
       "input":  ":) test\n:) test",
-      "expected_output": "<p><span aria-label=\"slight smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"slight smile\">:slight_smile:</span> test<br>\n<span aria-label=\"slight smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"slight smile\">:slight_smile:</span> test</p>",
+      "expected_output": "<p><span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span> test<br>\n<span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span> test</p>",
       "text_content": "\ud83d\ude42 test\n\ud83d\ude42 test",
       "translate_emoticons": true
     },
@@ -526,14 +526,14 @@
     {
       "name": "translate_emoticons_at_sentence_end",
       "input": "Translate this :).",
-      "expected_output": "<p>Translate this <span aria-label=\"slight smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"slight smile\">:slight_smile:</span>.</p>",
+      "expected_output": "<p>Translate this <span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span>.</p>",
       "text_content": "Translate this \ud83d\ude42.",
       "translate_emoticons": true
     },
     {
       "name": "translate_emoticons_between_symbols",
       "input": "Translate this !:)?",
-      "expected_output": "<p>Translate this !<span aria-label=\"slight smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"slight smile\">:slight_smile:</span>?</p>",
+      "expected_output": "<p>Translate this !<span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span>?</p>",
       "marked_expected_output": "<p>Translate this !:)?</p>",
       "text_content": "Translate this !\ud83d\ude42?",
       "translate_emoticons": true
@@ -625,7 +625,7 @@
     {
       "name": "emoji_alongside_punctuation",
       "input": ":smile:, :smile:; :smile:",
-      "expected_output": "<p><span aria-label=\"smile\" class=\"emoji emoji-263a\" role=\"img\" title=\"smile\">:smile:</span>, <span aria-label=\"smile\" class=\"emoji emoji-263a\" role=\"img\" title=\"smile\">:smile:</span>; <span aria-label=\"smile\" class=\"emoji emoji-263a\" role=\"img\" title=\"smile\">:smile:</span></p>"
+      "expected_output": "<p><span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span>, <span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span>; <span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span></p>"
     },
     {
       "name": "new_emoji_test",
@@ -666,7 +666,7 @@
     {
       "name": "valid_emoji_preceded_by_invalid_emoji",
       "input": "This is :invalidemoji: which should not prevent rendering :smile:",
-      "expected_output": "<p>This is :invalidemoji: which should not prevent rendering <span aria-label=\"smile\" class=\"emoji emoji-263a\" role=\"img\" title=\"smile\">:smile:</span></p>"
+      "expected_output": "<p>This is :invalidemoji: which should not prevent rendering <span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span></p>"
     },
     {
       "name": "safe_html",
@@ -872,8 +872,8 @@
     {
       "name": "spoilers_with_header_markdown",
       "input": "```spoiler [Header](https://example.com) :smile:\ncontent\n```",
-      "expected_output": "<div class=\"spoiler-block\"><div class=\"spoiler-header\">\n\n<p><a href=\"https://example.com\">Header</a> <span aria-label=\"smile\" class=\"emoji emoji-263a\" role=\"img\" title=\"smile\">:smile:</span></p>\n</div><div class=\"spoiler-content\" aria-hidden=\"true\">\n\n<p>content</p>\n</div></div>",
-      "text_content": "Header ☺ (…)\n"
+      "expected_output": "<div class=\"spoiler-block\"><div class=\"spoiler-header\">\n\n<p><a href=\"https://example.com\">Header</a> <span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span></p>\n</div><div class=\"spoiler-content\" aria-hidden=\"true\">\n\n<p>content</p>\n</div></div>",
+      "text_content": "Header 🙂 (…)\n"
     },
     {
       "name": "spoiler_with_inline_image",

--- a/zerver/tests/test_reactions.py
+++ b/zerver/tests/test_reactions.py
@@ -100,7 +100,7 @@ class ReactionEmojiTest(ZulipTestCase):
 
         expected_reaction_data = [{
             'emoji_name': 'smile',
-            'emoji_code': '263a',
+            'emoji_code': '1f642',
             'reaction_type': 'unicode_emoji',
             'user': {
                 'email': 'user10@zulip.testserver',


### PR DESCRIPTION
Zulip converts :) to the 1F642 Unicode emoji and promotes the same emoji
in the popular section of the emoji picker.

Previously Zulip has labeled 1F642 as "slight smile". While that name
conforms to the Unicode standard (which describes the code point as
SLIGHTLY SMILING FACE), it didn't match our use case of the emoji.

If a user types :) or selects the first smile in the emoji picker they
probably mean to express a regular "smile" and not a "slight smile",
which raises the question why they are only smiling slightly.

This commit relabels 1F642 as :smile: and our previous :smile: 263A as
:smiling_face:. Note that 263A looks different in our three supported
emoji sets, so it is not suited to be our "default smile".

This change does not require a migration since our emoji system stores
both unicode points and names and handles name changes transparently.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
