### PR TITLE
eslint: Enable arrow-parens, arrow-body-style, prefer-arrow-callback, comma-dangle for functions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,15 +22,7 @@
         "arrow-spacing": [ "error", { "before": true, "after": true } ],
         "block-scoped-var": "error",
         "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
-        "comma-dangle": [ "error",
-            {
-                "arrays": "always-multiline",
-                "objects": "always-multiline",
-                "imports": "always-multiline",
-                "exports": "always-multiline",
-                "functions": "never"
-            }
-        ],
+        "comma-dangle": [ "error", "always-multiline" ],
         "comma-spacing": [ "error",
             {
                 "before": false,
@@ -368,6 +360,16 @@
             ],
             "rules": {
                 // Don’t require ES features that PhantomJS doesn’t support
+                "comma-dangle": [
+                    "error",
+                    {
+                        "arrays": "always-multiline",
+                        "objects": "always-multiline",
+                        "imports": "always-multiline",
+                        "exports": "always-multiline",
+                        "functions": "never"
+                    }
+                ],
                 "no-var": "off",
                 "prefer-arrow-callback": "off"
             }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
     "rules": {
         "array-callback-return": "error",
         "array-bracket-spacing": "error",
+        "arrow-body-style": "error",
         "arrow-parens": "error",
         "arrow-spacing": [ "error", { "before": true, "after": true } ],
         "block-scoped-var": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -118,6 +118,7 @@
         "space-unary-ops": "error",
         "no-whitespace-before-property": "error",
         "one-var": [ "error", "never" ],
+        "prefer-arrow-callback": "error",
         "prefer-const": [ "error",
             {
                 "ignoreReadBeforeAssign": true
@@ -366,7 +367,9 @@
                 "frontend_tests/casper_lib/*.js"
             ],
             "rules": {
-                "no-var": "off" // PhantomJS doesn’t support let, const
+                // Don’t require ES features that PhantomJS doesn’t support
+                "no-var": "off",
+                "prefer-arrow-callback": "off"
             }
         },
         {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
     "rules": {
         "array-callback-return": "error",
         "array-bracket-spacing": "error",
+        "arrow-parens": "error",
         "arrow-spacing": [ "error", { "before": true, "after": true } ],
         "block-scoped-var": "error",
         "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -18,7 +18,7 @@ const _document = {
 const _channel = {};
 
 const _ui = {
-    get_content_element: element => element,
+    get_content_element: (element) => element,
 };
 
 const _keydown_util = {
@@ -686,7 +686,7 @@ run_test('initialize', () => {
             func();
         },
     });
-    $(window).focus = func => func();
+    $(window).focus = (func) => func();
     $(window).idle = () => {};
 
     channel.post = function (payload) {

--- a/frontend_tests/node_tests/billing.js
+++ b/frontend_tests/node_tests/billing.js
@@ -62,9 +62,7 @@ run_test("initialize", () => {
         };
     };
 
-    $("#payment-method").data = (key) => {
-        return document.querySelector("#payment-method").getAttribute("data-" + key);
-    };
+    $("#payment-method").data = (key) => document.querySelector("#payment-method").getAttribute("data-" + key);
 
     jquery_init();
 

--- a/frontend_tests/node_tests/billing_helpers.js
+++ b/frontend_tests/node_tests/billing_helpers.js
@@ -102,9 +102,7 @@ run_test('create_ajax_request', () => {
     };
 
 
-    $("#autopay-form").serializeArray = () => {
-        return jquery("#autopay-form").serializeArray();
-    };
+    $("#autopay-form").serializeArray = () => jquery("#autopay-form").serializeArray();
 
     $.post = ({url, data, success, error}) => {
         assert.equal(state.form_input_section_hide, 1);

--- a/frontend_tests/node_tests/blueslip_stacktrace.js
+++ b/frontend_tests/node_tests/blueslip_stacktrace.js
@@ -4,23 +4,23 @@ run_test("clean_path", () => {
     // Local file
     assert.strictEqual(
         blueslip_stacktrace.clean_path("webpack:///static/js/upload.js"),
-        "/static/js/upload.js"
+        "/static/js/upload.js",
     );
 
     // Third party library (jQuery)
     assert.strictEqual(
         blueslip_stacktrace.clean_path(
-            "webpack:///.-npm-cache/de76fb6f582a29b053274f9048b6158091351048/node_modules/jquery/dist/jquery.js"
+            "webpack:///.-npm-cache/de76fb6f582a29b053274f9048b6158091351048/node_modules/jquery/dist/jquery.js",
         ),
-        "jquery/dist/jquery.js"
+        "jquery/dist/jquery.js",
     );
 
     // Third party library (underscore)
     assert.strictEqual(
         blueslip_stacktrace.clean_path(
-            "webpack:///.-npm-cache/de76fb6f582a29b053274f9048b…58091351048/node_modules/underscore/underscore.js"
+            "webpack:///.-npm-cache/de76fb6f582a29b053274f9048b…58091351048/node_modules/underscore/underscore.js",
         ),
-        "underscore/underscore.js"
+        "underscore/underscore.js",
     );
 });
 
@@ -33,7 +33,7 @@ run_test("clean_function_name", () => {
         {
             scope: "Object../static/js/upload.js.exports.",
             name: "options",
-        }
+        },
     );
 
     // Third party library (jQuery)
@@ -45,12 +45,12 @@ run_test("clean_function_name", () => {
     // Third party library (underscore)
     assert.deepEqual(
         blueslip_stacktrace.clean_function_name(
-            "Function.../zulip-npm-cache/de76fb6f582a29b053274f…es/underscore/underscore.js?3817._.each._.forEach"
+            "Function.../zulip-npm-cache/de76fb6f582a29b053274f…es/underscore/underscore.js?3817._.each._.forEach",
         ),
         {
             scope:
                 "Function.../zulip-npm-cache/de76fb6f582a29b053274f…es/underscore/underscore.js?3817._.each._.",
             name: "forEach",
-        }
+        },
     );
 });

--- a/frontend_tests/node_tests/bot_data.js
+++ b/frontend_tests/node_tests/bot_data.js
@@ -137,7 +137,7 @@ run_test('test_basics', () => {
         bot_data.add({...test_bot, user_id: 45, email: 'bot2@zulip.com', owner_id: me.user_id, is_active: true});
         bot_data.add({...test_bot, user_id: 46, email: 'bot3@zulip.com', owner_id: fred.user_id, is_active: true});
 
-        const editable_bots = bot_data.get_editable().map(bot => bot.email);
+        const editable_bots = bot_data.get_editable().map((bot) => bot.email);
         assert.deepEqual(['bot1@zulip.com', 'bot2@zulip.com'], editable_bots);
     }());
 

--- a/frontend_tests/node_tests/buddy_list.js
+++ b/frontend_tests/node_tests/buddy_list.js
@@ -183,9 +183,7 @@ run_test('find_li w/force_render', () => {
     assert.equal(li, stub_li);
     assert(shown);
 
-    buddy_list.get_li_from_key = () => {
-        return {length: 0};
-    };
+    buddy_list.get_li_from_key = () => ({length: 0});
 
     const undefined_li = buddy_list.find_li({
         key: 'not-there',

--- a/frontend_tests/node_tests/channel.js
+++ b/frontend_tests/node_tests/channel.js
@@ -248,7 +248,7 @@ run_test('retry', () => {
         },
 
         check_ajax_options: function (options) {
-            global.patch_builtin('setTimeout', function (f, delay) {
+            global.patch_builtin('setTimeout', (f, delay) => {
                 assert.equal(delay, 0);
                 f();
             });
@@ -276,7 +276,7 @@ run_test('too_many_pending', () => {
     blueslip.expect('warn',
                     'The length of pending_requests is over 50. ' +
                     'Most likely they are not being correctly removed.');
-    _.times(50, function () {
+    _.times(50, () => {
         channel.post({});
     });
 });

--- a/frontend_tests/node_tests/common.js
+++ b/frontend_tests/node_tests/common.js
@@ -91,20 +91,20 @@ run_test('adjust_mac_shortcuts', () => {
 
     common.has_mac_keyboard = function () { return false; };
     key_no = 1;
-    keys_to_test_non_mac.forEach(function (value, key) {
+    keys_to_test_non_mac.forEach((value, key) => {
         keys_elem_list.push(get_key_stub_html(key, value, "hotkey_non_mac_" + key_no));
         key_no += 1;
     });
 
     common.adjust_mac_shortcuts(".markdown_content");
-    keys_elem_list.forEach(function (key_elem) {
+    keys_elem_list.forEach((key_elem) => {
         assert(key_elem.text(), key_elem.expected_key());
     });
 
     keys_elem_list = [];
     key_no = 1;
     common.has_mac_keyboard = function () { return true; };
-    keys_to_test_mac.forEach(function (value, key) {
+    keys_to_test_mac.forEach((value, key) => {
         keys_elem_list.push(get_key_stub_html(key, value, "hotkey_" + key_no));
         key_no += 1;
     });
@@ -115,7 +115,7 @@ run_test('adjust_mac_shortcuts', () => {
         }
     };
     common.adjust_mac_shortcuts(".markdown_content");
-    keys_elem_list.forEach(function (key_elem) {
+    keys_elem_list.forEach((key_elem) => {
         assert.equal(key_elem.text(), key_elem.expected_key());
     });
 

--- a/frontend_tests/node_tests/components.js
+++ b/frontend_tests/node_tests/components.js
@@ -108,7 +108,7 @@ run_test('basics', () => {
         return self;
     }());
 
-    set_global('$', function (sel) {
+    set_global('$', (sel) => {
         if (sel.stub) {
             // The component often redundantly re-wraps objects.
             return sel;

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1233,7 +1233,7 @@ run_test('on_events', () => {
         const helper = setup_parents_and_mock_remove(
             'compose-all-everyone',
             'compose-all-everyone',
-            '.compose-all-everyone'
+            '.compose-all-everyone',
         );
 
         $("#compose-all-everyone").show();
@@ -1277,7 +1277,7 @@ run_test('on_events', () => {
         const helper = setup_parents_and_mock_remove(
             'compose_invite_users',
             'compose_invite_link',
-            '.compose_invite_user'
+            '.compose_invite_user',
         );
 
         // !sub will result false here and we check the failure code path.
@@ -1322,7 +1322,7 @@ run_test('on_events', () => {
         const helper = setup_parents_and_mock_remove(
             'compose_invite_users_close',
             'compose_invite_close',
-            '.compose_invite_user'
+            '.compose_invite_user',
         );
 
         let all_invite_children_called = false;
@@ -1355,7 +1355,7 @@ run_test('on_events', () => {
         const helper = setup_parents_and_mock_remove(
             'compose-send-status',
             'sub_unsub_button',
-            '.compose_not_subscribed'
+            '.compose_not_subscribed',
         );
 
         handler(helper.event);
@@ -1378,7 +1378,7 @@ run_test('on_events', () => {
         const helper = setup_parents_and_mock_remove(
             'compose_user_not_subscribed_close',
             'compose_not_subscribed_close',
-            '.compose_not_subscribed'
+            '.compose_not_subscribed',
         );
 
         $("#compose-send-status").show();

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -142,7 +142,7 @@ run_test('validate_stream_message_address_info', () => {
 
     sub.subscribed = false;
     stream_data.add_sub(sub);
-    global.stub_templates(function (template_name) {
+    global.stub_templates((template_name) => {
         assert.equal(template_name, 'compose_not_subscribed');
         return 'compose_not_subscribed_stub';
     });
@@ -204,7 +204,7 @@ run_test('validate', () => {
         $("#zephyr-mirror-error").is = noop;
         $("#private_message_recipient").select(noop);
 
-        global.stub_templates(function (fn) {
+        global.stub_templates((fn) => {
             assert.equal(fn, 'input_pill');
             return '<div>pill-html</div>';
         });
@@ -325,7 +325,7 @@ run_test('validate_stream_message', () => {
         assert.equal(stream_name, 'social');
         return 16;
     };
-    global.stub_templates(function (template_name, data) {
+    global.stub_templates((template_name, data) => {
         assert.equal(template_name, 'compose_all_everyone');
         assert.equal(data.count, 16);
         return 'compose_all_everyone_stub';
@@ -601,7 +601,7 @@ run_test('send_message', () => {
         return stub_state;
     }
 
-    global.patch_builtin('setTimeout', function (func) {
+    global.patch_builtin('setTimeout', (func) => {
         func();
     });
     global.server_events = {
@@ -868,7 +868,7 @@ run_test('warn_if_private_stream_is_linked', () => {
     const checks = [
         (function () {
             let called;
-            global.stub_templates(function (template_name, context) {
+            global.stub_templates((template_name, context) => {
                 called = true;
                 assert.equal(template_name, 'compose_private_stream_alert');
                 assert.equal(context.stream_name, 'Denmark');
@@ -1144,7 +1144,7 @@ run_test('warn_if_mentioning_unsubscribed_user', () => {
 
         (function () {
             let called;
-            global.stub_templates(function (template_name, context) {
+            global.stub_templates((template_name, context) => {
                 called = true;
                 assert.equal(template_name, 'compose_invite_users');
                 assert.equal(context.user_id, 34);

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1706,7 +1706,7 @@ run_test('nonexistent_stream_reply_error', () => {
 });
 
 run_test('narrow_button_titles', () => {
-    util.is_mobile = () => { return false; };
+    util.is_mobile = () => false;
 
     compose.update_closed_compose_buttons_for_private();
     assert.equal($("#left_bar_compose_stream_button_big").text(), i18n.t("New stream message"));

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -287,7 +287,7 @@ run_test('topics_seen_for', () => {
 
     assert.deepEqual(
         ct.topics_seen_for('Denmark'),
-        ['With Twisted Metal', 'acceptance', 'civil fears']
+        ['With Twisted Metal', 'acceptance', 'civil fears'],
     );
 
     // Test when the stream doesn't exist (there are no topics)
@@ -711,7 +711,7 @@ run_test('initialize', () => {
                 people,
                 query,
                 compose_state.stream_name(),
-                compose_state.topic()
+                compose_state.topic(),
             );
         }
 
@@ -819,7 +819,7 @@ run_test('initialize', () => {
         let actual_value = options.source.call(fake_this, 'test #s');
         assert.deepEqual(
             sorted_names_from(actual_value),
-            ['Denmark', 'Sweden', 'The Netherlands']
+            ['Denmark', 'Sweden', 'The Netherlands'],
         );
         assert(caret_called);
 
@@ -1133,7 +1133,7 @@ run_test('begins_typeahead', () => {
             return [input, rest];
         };
         const values = ct.get_candidates.call(
-            begin_typehead_this, input
+            begin_typehead_this, input,
         );
         return values;
     }
@@ -1158,7 +1158,7 @@ run_test('begins_typeahead', () => {
         const values = get_values(input, rest);
         assert.deepEqual(
             sorted_names_from(values),
-            ['Denmark', 'Sweden', 'The Netherlands']
+            ['Denmark', 'Sweden', 'The Netherlands'],
         );
     }
 

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -14,9 +14,7 @@ zrequire('composebox_typeahead');
 zrequire('recent_senders');
 zrequire('settings_org');
 const settings_config = zrequire('settings_config');
-set_global('md5', function (s) {
-    return 'md5-' + s;
-});
+set_global('md5', (s) => 'md5-' + s);
 
 // To be eliminated in next commit:
 stream_data.update_calculated_fields = () => {};
@@ -320,7 +318,7 @@ run_test('content_typeahead_selected', () => {
         },
     });
     let set_timeout_called = false;
-    global.patch_builtin('setTimeout', function (f, time) {
+    global.patch_builtin('setTimeout', (f, time) => {
         f();
         assert.equal(time, 0);
         set_timeout_called = true;

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -114,7 +114,7 @@ const emojis_by_name = new Map(Object.entries({
     heart: emoji_heart,
     headphones: emoji_headphones,
 }));
-const emoji_list = Array.from(emojis_by_name.values(), emoji_dict => {
+const emoji_list = Array.from(emojis_by_name.values(), (emoji_dict) => {
     if (emoji_dict.is_realm_emoji === true) {
         return {
             emoji_name: emoji_dict.name,
@@ -518,7 +518,7 @@ run_test('content_typeahead_selected', () => {
 });
 
 function sorted_names_from(subs) {
-    return subs.map(sub => sub.name).sort();
+    return subs.map((sub) => sub.name).sort();
 }
 
 run_test('initialize', () => {
@@ -1320,7 +1320,7 @@ run_test('begins_typeahead', () => {
     assert_typeahead_equals("```test", "ing", false);
     assert_typeahead_equals("~~~test", "ing", false);
     const terminal_symbols = ',.;?!()[] "\'\n\t';
-    terminal_symbols.split().forEach(symbol => {
+    terminal_symbols.split().forEach((symbol) => {
         assert_stream_list("#test", symbol);
         assert_typeahead_equals("@test", symbol, all_mentions);
         assert_typeahead_equals(":test", symbol, emoji_list);

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -8,7 +8,7 @@ const test_user = events.test_user;
 
 set_global('$', global.make_zjquery());
 
-global.patch_builtin('setTimeout', func => func());
+global.patch_builtin('setTimeout', (func) => func());
 
 // These dependencies are closer to the dispatcher, and they
 // apply to all tests.
@@ -570,7 +570,7 @@ with_overrides(function (override) {
         override('subs.add_sub_to_table', noop);
         dispatch(event);
         const args = stub.get_args('streams');
-        assert_same(args.streams.map(stream => stream.stream_id), [42, 99]);
+        assert_same(args.streams.map((stream) => stream.stream_id), [42, 99]);
     });
 
     // stream delete

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -140,7 +140,7 @@ with_overrides((override) => {
 
     assert.deepEqual(
         alert_words.get_word_list(),
-        ['fire', 'lunch']
+        ['fire', 'lunch'],
     );
     assert(alert_words.has_alert_word('fire'));
     assert(alert_words.has_alert_word('lunch'));

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -129,7 +129,7 @@ function assert_same(actual, expected) {
 
 const with_overrides = global.with_overrides; // make lint happy
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // alert_words
     assert(!alert_words.has_alert_word('fire'));
     assert(!alert_words.has_alert_word('lunch'));
@@ -146,21 +146,21 @@ with_overrides(function (override) {
     assert(alert_words.has_alert_word('lunch'));
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // attachments
     const event = event_fixtures.attachment;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('attachments_ui.update_attachments', stub.f);
         dispatch(event);
         assert_same(stub.get_args('event').event, event);
     });
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // User groups
     let event = event_fixtures.user_group__add;
     override('settings_user_groups.reload', noop);
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('user_groups.add', stub.f);
         dispatch(event);
         const args = stub.get_args('group');
@@ -168,7 +168,7 @@ with_overrides(function (override) {
     });
 
     event = event_fixtures.user_group__add_members;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('user_groups.add_members', stub.f);
         dispatch(event);
         const args = stub.get_args('group_id', 'user_ids');
@@ -177,7 +177,7 @@ with_overrides(function (override) {
     });
 
     event = event_fixtures.user_group__remove_members;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('user_groups.remove_members', stub.f);
         dispatch(event);
         const args = stub.get_args('group_id', 'user_ids');
@@ -186,7 +186,7 @@ with_overrides(function (override) {
     });
 
     event = event_fixtures.user_group__update;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('user_groups.update', stub.f);
         dispatch(event);
         const args = stub.get_args('event');
@@ -196,7 +196,7 @@ with_overrides(function (override) {
     });
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // custom profile fields
     const event = event_fixtures.custom_profile_fields;
     override('settings_profile_fields.populate_profile_fields', noop);
@@ -206,11 +206,11 @@ with_overrides(function (override) {
 
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // default_streams
     const event = event_fixtures.default_streams;
     override('settings_streams.update_default_streams_table', noop);
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('stream_data.set_realm_default_streams', stub.f);
         dispatch(event);
         const args = stub.get_args('realm_default_streams');
@@ -219,7 +219,7 @@ with_overrides(function (override) {
 
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // hotspots
     const event = event_fixtures.hotspots;
     override('hotspots.load_new', noop);
@@ -227,21 +227,21 @@ with_overrides(function (override) {
     assert_same(page_params.hotspots, event.hotspots);
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // invites_changed
     const event = event_fixtures.invites_changed;
     $('#admin-invites-list').length = 1;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('settings_invites.set_up', stub.f);
         dispatch(event); // stub automatically checks if stub.f is called once
     });
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // muted_topics
     const event = event_fixtures.muted_topics;
 
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('muting_ui.handle_updates', stub.f);
         dispatch(event);
         const args = stub.get_args('muted_topics');
@@ -249,11 +249,11 @@ with_overrides(function (override) {
     });
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // presence
     const event = event_fixtures.presence;
 
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('activity.update_presence_info', stub.f);
         dispatch(event);
         const args = stub.get_args('user_id', 'presence', 'server_time');
@@ -263,10 +263,10 @@ with_overrides(function (override) {
     });
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // reaction
     let event = event_fixtures.reaction__add;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('reactions.add_reaction', stub.f);
         dispatch(event);
         const args = stub.get_args('event');
@@ -275,7 +275,7 @@ with_overrides(function (override) {
     });
 
     event = event_fixtures.reaction__remove;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('reactions.remove_reaction', stub.f);
         dispatch(event);
         const args = stub.get_args('event');
@@ -284,7 +284,7 @@ with_overrides(function (override) {
     });
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // realm
     function test_realm_boolean(event, parameter_name) {
         page_params[parameter_name] = true;
@@ -417,11 +417,11 @@ with_overrides(function (override) {
     assert_same(window.location.href, "/accounts/deactivated/");
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // realm_bot
     let event = event_fixtures.realm_bot__add;
-    global.with_stub(function (bot_stub) {
-        global.with_stub(function (admin_stub) {
+    global.with_stub((bot_stub) => {
+        global.with_stub((admin_stub) => {
             override('bot_data.add', bot_stub.f);
             override('settings_users.update_bot_data', admin_stub.f);
             dispatch(event);
@@ -433,8 +433,8 @@ with_overrides(function (override) {
     });
 
     event = event_fixtures.realm_bot__remove;
-    global.with_stub(function (bot_stub) {
-        global.with_stub(function (admin_stub) {
+    global.with_stub((bot_stub) => {
+        global.with_stub((admin_stub) => {
             override('bot_data.deactivate', bot_stub.f);
             override('settings_users.update_bot_data', admin_stub.f);
             dispatch(event);
@@ -450,8 +450,8 @@ with_overrides(function (override) {
     dispatch(event);
 
     event = event_fixtures.realm_bot__update;
-    global.with_stub(function (bot_stub) {
-        global.with_stub(function (admin_stub) {
+    global.with_stub((bot_stub) => {
+        global.with_stub((admin_stub) => {
             override('bot_data.update', bot_stub.f);
             override('settings_users.update_bot_data', admin_stub.f);
 
@@ -467,11 +467,11 @@ with_overrides(function (override) {
     });
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // realm_emoji
     const event = event_fixtures.realm_emoji;
 
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('emoji.update_emojis', stub.f);
         override('settings_emoji.populate_emoji', noop);
         override('emoji_picker.generate_emoji_picker_data', noop);
@@ -482,7 +482,7 @@ with_overrides(function (override) {
     });
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // realm_filters
     const event = event_fixtures.realm_filters;
     page_params.realm_filters = [];
@@ -492,7 +492,7 @@ with_overrides(function (override) {
 
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // realm_domains
     let event = event_fixtures.realm_domains__add;
     page_params.realm_domains = [];
@@ -509,7 +509,7 @@ with_overrides(function (override) {
     assert_same(page_params.realm_domains, []);
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // realm_user
     let event = event_fixtures.realm_user__add;
     dispatch(event);
@@ -527,7 +527,7 @@ with_overrides(function (override) {
     assert(!people.is_active_user_for_popover(event.person.user_id));
 
     event = event_fixtures.realm_user__update;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('user_events.update_person', stub.f);
         dispatch(event);
         const args = stub.get_args('person');
@@ -535,10 +535,10 @@ with_overrides(function (override) {
     });
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // restart
     const event = event_fixtures.restart;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('reload.initiate', stub.f);
         dispatch(event);
         const args = stub.get_args('options');
@@ -547,11 +547,11 @@ with_overrides(function (override) {
     });
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // stream update
     let event = event_fixtures.stream__update;
 
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('stream_events.update_property', stub.f);
         override('settings_streams.update_default_streams_table', noop);
         dispatch(event);
@@ -563,7 +563,7 @@ with_overrides(function (override) {
 
     // stream create
     event = event_fixtures.stream__create;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('stream_data.create_streams', stub.f);
         override('stream_data.get_sub_by_id', noop);
         override('stream_data.update_calculated_fields', noop);
@@ -575,15 +575,13 @@ with_overrides(function (override) {
 
     // stream delete
     event = event_fixtures.stream__delete;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('subs.remove_stream', noop);
         override('stream_data.delete_sub', noop);
         override('settings_streams.update_default_streams_table', noop);
         override('stream_data.remove_default_stream', noop);
 
-        override('stream_data.get_sub_by_id', function (id) {
-            return id === 42 ? {subscribed: true} : {subscribed: false};
-        });
+        override('stream_data.get_sub_by_id', (id) => id === 42 ? {subscribed: true} : {subscribed: false});
         override('stream_list.remove_sidebar_row', stub.f);
         dispatch(event);
         const args = stub.get_args('stream_id');
@@ -600,10 +598,10 @@ with_overrides(function (override) {
     });
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // submessage
     const event = event_fixtures.submessage;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('submessage.handle_event', stub.f);
         dispatch(event);
         const submsg = stub.get_args('submsg').submsg;
@@ -619,10 +617,10 @@ with_overrides(function (override) {
 
 // For subscriptions, see dispatch_subs.js
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // typing
     let event = event_fixtures.typing__start;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('typing_events.display_notification', stub.f);
         dispatch(event);
         const args = stub.get_args('event');
@@ -630,7 +628,7 @@ with_overrides(function (override) {
     });
 
     event = event_fixtures.typing__stop;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('typing_events.hide_notification', stub.f);
         dispatch(event);
         const args = stub.get_args('event');
@@ -642,7 +640,7 @@ with_overrides(function (override) {
     dispatch(event); // get line coverage
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // update_display_settings
     let event = event_fixtures.update_display_settings__default_language;
     page_params.default_language = 'en';
@@ -691,7 +689,7 @@ with_overrides(function (override) {
     $("body").fadeOut = (secs) => { assert_same(secs, 300); };
     $("body").fadeIn  = (secs) => { assert_same(secs, 300); };
 
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         event = event_fixtures.update_display_settings__color_scheme_dark;
         page_params.color_scheme = 1;
         override('night_mode.enable', stub.f); // automatically checks if called
@@ -700,7 +698,7 @@ with_overrides(function (override) {
         assert(page_params.color_scheme, 2);
     });
 
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         event = event_fixtures.update_display_settings__color_scheme_light;
         page_params.color_scheme = 1;
         override('night_mode.disable', stub.f); // automatically checks if called
@@ -709,7 +707,7 @@ with_overrides(function (override) {
         assert(page_params.color_scheme, 3);
     });
 
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         event = event_fixtures.update_display_settings__color_scheme_automatic;
         page_params.color_scheme = 2;
         override('night_mode.default_preference_checker', stub.f); // automatically checks if called
@@ -718,7 +716,7 @@ with_overrides(function (override) {
         assert(page_params.color_scheme, 1);
     });
 
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         event = event_fixtures.update_display_settings__emojiset;
         called = false;
         override('settings_display.report_emojiset_change', stub.f);
@@ -740,7 +738,7 @@ with_overrides(function (override) {
     dispatch(event);
     assert_same(page_params.fluid_layout_width, true);
 
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         event = event_fixtures.update_display_settings__demote_inactive_streams;
         override('stream_data.set_filter_out_inactives', noop);
         override('stream_list.update_streams_sidebar', stub.f);
@@ -750,10 +748,10 @@ with_overrides(function (override) {
     });
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // update_global_notifications
     const event = event_fixtures.update_global_notifications;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('notifications.handle_global_notification_updates', stub.f);
         dispatch(event);
         const args = stub.get_args('name', 'setting');
@@ -762,11 +760,11 @@ with_overrides(function (override) {
     });
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // update_message_flags__read
     const event = event_fixtures.update_message_flags__read;
 
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('unread_ops.process_read_messages_event', stub.f);
         dispatch(event);
         const args = stub.get_args('message_ids');
@@ -774,13 +772,13 @@ with_overrides(function (override) {
     });
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // update_message_flags__starred
 
     override('starred_messages.rerender_ui', noop);
 
     let event = event_fixtures.update_message_flags__starred_add;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('ui.update_starred_view', stub.f);
         dispatch(event);
         const args = stub.get_args('message_id', 'new_value');
@@ -791,7 +789,7 @@ with_overrides(function (override) {
     });
 
     event = event_fixtures.update_message_flags__starred_remove;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('ui.update_starred_view', stub.f);
         dispatch(event);
         const args = stub.get_args('message_id', 'new_value');
@@ -802,25 +800,25 @@ with_overrides(function (override) {
     });
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // delete_message
     const event = event_fixtures.delete_message;
 
     override('stream_list.update_streams_sidebar', noop);
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('unread_ops.process_read_messages_event', noop);
         override('ui.remove_messages', stub.f);
         dispatch(event);
         const args = stub.get_args('message_ids');
         assert_same(args.message_ids, [1337]);
     });
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('unread_ops.process_read_messages_event', stub.f);
         dispatch(event);
         const args = stub.get_args('message_ids');
         assert_same(args.message_ids, [1337]);
     });
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('stream_topic_history.remove_messages', stub.f);
         dispatch(event);
         const args = stub.get_args('opts');
@@ -830,10 +828,10 @@ with_overrides(function (override) {
     });
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     // attachments
     let event = event_fixtures.user_status__set_away;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('activity.on_set_away', stub.f);
         dispatch(event);
         const args = stub.get_args('user_id');
@@ -841,7 +839,7 @@ with_overrides(function (override) {
     });
 
     event = event_fixtures.user_status__revoke_away;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('activity.on_revoke_away', stub.f);
         dispatch(event);
         const args = stub.get_args('user_id');
@@ -849,7 +847,7 @@ with_overrides(function (override) {
     });
 
     event = event_fixtures.user_status__set_status_text;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('activity.redraw_user', stub.f);
         dispatch(event);
         const args = stub.get_args('user_id');
@@ -859,11 +857,11 @@ with_overrides(function (override) {
     });
 });
 
-with_overrides(function (override) {
+with_overrides((override) => {
     const event = event_fixtures.realm_export;
     override('settings_exports.populate_exports_table', noop);
     dispatch(event);
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('settings_exports.populate_exports_table', stub.f);
         dispatch(event);
 

--- a/frontend_tests/node_tests/dispatch_subs.js
+++ b/frontend_tests/node_tests/dispatch_subs.js
@@ -32,7 +32,7 @@ test('add', (override) => {
         name: sub.name,
     });
 
-    global.with_stub(function (subscription_stub) {
+    global.with_stub((subscription_stub) => {
         override('stream_events.mark_subscribed', subscription_stub.f);
         dispatch(event);
         const args = subscription_stub.get_args('sub', 'subscribers');
@@ -77,7 +77,7 @@ test('remove', (override) => {
 
     stream_data.add_sub(sub);
 
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('stream_events.mark_unsubscribed', stub.f);
         dispatch(event);
         const args = stub.get_args('sub');
@@ -87,7 +87,7 @@ test('remove', (override) => {
 
 test('update', (override) => {
     const event = event_fixtures.subscription__update;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('stream_events.update_property', stub.f);
         dispatch(event);
         const args = stub.get_args('stream_id', 'property', 'value');
@@ -100,7 +100,7 @@ test('update', (override) => {
 test('add error handling', (override) => {
     // test blueslip errors/warns
     const event = event_fixtures.subscription__add;
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         override('blueslip.error', stub.f);
         dispatch(event);
         assert.deepEqual(stub.get_args('param').param, 'Subscribing to unknown stream with ID 42');

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -93,7 +93,7 @@ const short_msg = {
 run_test('legacy', () => {
     assert.deepEqual(
         drafts.restore_message(legacy_draft),
-        compose_args_for_legacy_draft
+        compose_args_for_legacy_draft,
     );
 });
 

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -119,7 +119,7 @@ run_test('draft_model', () => {
 
     localStorage.clear();
     (function test_addDraft() {
-        stub_timestamp(1, function () {
+        stub_timestamp(1, () => {
             const expected = { ...draft_1 };
             expected.updatedAt = 1;
             const id = draft_model.addDraft({ ...draft_1 });
@@ -130,7 +130,7 @@ run_test('draft_model', () => {
 
     localStorage.clear();
     (function test_editDraft() {
-        stub_timestamp(2, function () {
+        stub_timestamp(2, () => {
             ls.set("drafts", { id1: draft_1 });
             const expected = { ...draft_2 };
             expected.updatedAt = 2;
@@ -313,7 +313,7 @@ run_test('format_drafts', () => {
         return stub_render_now(time, new XDate(1549958107000));
     };
 
-    global.stub_templates(function (template_name, data) {
+    global.stub_templates((template_name, data) => {
         assert.equal(template_name, 'draft_table_body');
         // Tests formatting and sorting of drafts
         assert.deepEqual(data.drafts, expected);

--- a/frontend_tests/node_tests/dropdown_list_widget.js
+++ b/frontend_tests/node_tests/dropdown_list_widget.js
@@ -24,7 +24,7 @@ run_test('basic_functions', () => {
     let updated_value;
     const opts = {
         widget_name: 'my_setting',
-        data: ['one', 'two', 'three'].map(x => ({name: x, value: x})),
+        data: ['one', 'two', 'three'].map((x) => ({name: x, value: x})),
         value: 'one',
         on_update: (val) => { updated_value = val; },
         default_text: i18n.t("not set"),
@@ -55,7 +55,7 @@ run_test('basic_functions', () => {
 run_test('no_default_value', () => {
     const opts = {
         widget_name: 'my_setting',
-        data: ['one', 'two', 'three'].map(x => ({name: x, value: x})),
+        data: ['one', 'two', 'three'].map((x) => ({name: x, value: x})),
         default_text: i18n.t("not set"),
         render_text: (text) => `rendered: ${text}`,
         null_value: 'null-value',

--- a/frontend_tests/node_tests/dropdown_list_widget.js
+++ b/frontend_tests/node_tests/dropdown_list_widget.js
@@ -4,9 +4,7 @@ set_global('$', global.make_zjquery());
 
 const noop = () => {};
 const _list_render = {
-    create: () => {
-        return { init: noop };
-    },
+    create: () => ({ init: noop }),
 };
 set_global('list_render', _list_render);
 

--- a/frontend_tests/node_tests/emoji.js
+++ b/frontend_tests/node_tests/emoji.js
@@ -15,7 +15,7 @@ run_test('build_emoji_upload_widget', () => {
         file_name_field,
         input_error,
         clear_button,
-        upload_button
+        upload_button,
     ) {
         assert.deepEqual(get_file_input(), $('#emoji_file_input'));
         assert.deepEqual(file_name_field, $('#emoji-file-name'));

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -1276,26 +1276,26 @@ run_test('term_type', () => {
 
     assert_term_sort(
         ['topic', 'stream', 'sender'],
-        ['stream', 'topic', 'sender']
+        ['stream', 'topic', 'sender'],
     );
 
     assert_term_sort(
         ['has-link', 'near', 'is-unread', 'pm-with'],
-        ['pm-with', 'near', 'is-unread', 'has-link']
+        ['pm-with', 'near', 'is-unread', 'has-link'],
     );
 
     assert_term_sort(
         ['bogus', 'stream', 'topic'],
-        ['stream', 'topic', 'bogus']
+        ['stream', 'topic', 'bogus'],
     );
     assert_term_sort(
         ['stream', 'topic', 'stream'],
-        ['stream', 'stream', 'topic']
+        ['stream', 'stream', 'topic'],
     );
 
     assert_term_sort(
         ['search', 'streams-public'],
-        ['streams-public', 'search']
+        ['streams-public', 'search'],
     );
 
     const terms = [
@@ -1398,7 +1398,7 @@ run_test('navbar_helpers', () => {
         const filter = new Filter(test_case.operator);
         assert.equal(
             filter.generate_redirect_url(),
-            test_case.redirect_url_with_search
+            test_case.redirect_url_with_search,
         );
     }
 
@@ -1600,7 +1600,7 @@ run_test('navbar_helpers', () => {
     let filter = new Filter(complex_operators_test_case.operator);
     assert.equal(
         filter.generate_redirect_url(),
-        complex_operators_test_case.redirect_url
+        complex_operators_test_case.redirect_url,
     );
     assert.equal(filter.is_common_narrow(), false);
 
@@ -1627,7 +1627,7 @@ run_test('navbar_helpers', () => {
     filter = new Filter(default_redirect.operator);
     assert.equal(
         filter.generate_redirect_url(),
-        default_redirect.redirect_url
+        default_redirect.redirect_url,
     );
 });
 

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -35,7 +35,7 @@ people.add_active_user(steve);
 people.initialize_current_user(me.user_id);
 
 function assert_same_operators(result, terms) {
-    terms = terms.map(term => {
+    terms = terms.map((term) => {
         // If negated flag is undefined, we explicitly
         // set it to false.
         let negated = term.negated;
@@ -571,7 +571,7 @@ run_test('canonicalizations', () => {
 });
 
 function get_predicate(operators) {
-    operators = operators.map(op => ({
+    operators = operators.map((op) => ({
         operator: op[0],
         operand: op[1],
     }));
@@ -1558,7 +1558,7 @@ run_test('navbar_helpers', () => {
         },
     ];
 
-    test_cases.forEach(test_case => {
+    test_cases.forEach((test_case) => {
         test_helpers(test_case);
     });
 
@@ -1579,7 +1579,7 @@ run_test('navbar_helpers', () => {
         },
     ];
 
-    redirect_edge_cases.forEach(test_case => {
+    redirect_edge_cases.forEach((test_case) => {
         test_redirect_url_with_search(test_case);
     });
 

--- a/frontend_tests/node_tests/hash_util.js
+++ b/frontend_tests/node_tests/hash_util.js
@@ -65,68 +65,68 @@ run_test('hash_util', () => {
 run_test('test_get_hash_category', () => {
     assert.deepEqual(
         hash_util.get_hash_category('streams/subscribed'),
-        'streams'
+        'streams',
     );
     assert.deepEqual(
         hash_util.get_hash_category('#settings/display-settings'),
-        'settings'
+        'settings',
     );
     assert.deepEqual(
         hash_util.get_hash_category('#drafts'),
-        'drafts'
+        'drafts',
     );
     assert.deepEqual(
         hash_util.get_hash_category('invites'),
-        'invites'
+        'invites',
     );
 });
 
 run_test('test_get_hash_section', () => {
     assert.equal(
         hash_util.get_hash_section('streams/subscribed'),
-        'subscribed'
+        'subscribed',
     );
     assert.equal(
         hash_util.get_hash_section('#settings/your-account'),
-        'your-account'
+        'your-account',
     );
 
     assert.equal(
         hash_util.get_hash_section('settings/10/general/'),
-        '10'
+        '10',
     );
 
     assert.equal(
         hash_util.get_hash_section('#drafts'),
-        ''
+        '',
     );
     assert.equal(
         hash_util.get_hash_section(''),
-        ''
+        '',
     );
 });
 
 run_test('test_parse_narrow', () => {
     assert.deepEqual(
         hash_util.parse_narrow(['narrow', 'stream', '99-frontend']),
-        [{negated: false, operator: 'stream', operand: 'frontend'}]
+        [{negated: false, operator: 'stream', operand: 'frontend'}],
     );
 
     assert.deepEqual(
         hash_util.parse_narrow(['narrow', '-stream', '99-frontend']),
-        [{negated: true, operator: 'stream', operand: 'frontend'}]
+        [{negated: true, operator: 'stream', operand: 'frontend'}],
     );
 
     assert.equal(
         hash_util.parse_narrow(['narrow', 'BOGUS']),
-        undefined
+        undefined,
     );
 
     // For nonexistent streams, we get the full slug.
     // We possibly should remove the prefix and fix this test.
     assert.deepEqual(
         hash_util.parse_narrow(['narrow', 'stream', '42-bogus']),
-        [{negated: false, operator: 'stream', operand: '42-bogus'}]
+        [{negated: false, operator: 'stream', operand: '42-bogus'}],
     );
 });
 

--- a/frontend_tests/node_tests/hashchange.js
+++ b/frontend_tests/node_tests/hashchange.js
@@ -152,9 +152,7 @@ function test_helper() {
         assert_events: (expected_events) => {
             assert.deepEqual(expected_events, events);
         },
-        get_narrow_terms: () => {
-            return narrow_terms;
-        },
+        get_narrow_terms: () => narrow_terms,
     };
 }
 

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -59,8 +59,8 @@ function return_true() { return true; }
 function return_false() { return false; }
 
 function stubbing(func_name_to_stub, test_function) {
-    global.with_overrides(function (override) {
-        global.with_stub(function (stub) {
+    global.with_overrides((override) => {
+        global.with_stub((stub) => {
             override(func_name_to_stub, stub.f);
             test_function(stub);
         });
@@ -165,7 +165,7 @@ run_test('basic_chars', () => {
     }
 
     function assert_mapping(c, func_name, shiftKey) {
-        stubbing(func_name, function () {
+        stubbing(func_name, () => {
             assert(process(c, shiftKey));
         });
     }
@@ -370,7 +370,7 @@ run_test('motion_keys', () => {
     }
 
     function assert_mapping(key_name, func_name, shiftKey, ctrlKey) {
-        stubbing(func_name, function () {
+        stubbing(func_name, () => {
             assert(process(key_name, shiftKey, ctrlKey));
         });
     }

--- a/frontend_tests/node_tests/input_pill.js
+++ b/frontend_tests/node_tests/input_pill.js
@@ -13,11 +13,9 @@ set_global('ui_util', {
     place_caret_at_end: noop,
 });
 
-set_global('getSelection', () => {
-    return {
-        anchorOffset: 0,
-    };
-});
+set_global('getSelection', () => ({
+    anchorOffset: 0,
+}));
 
 let id_seq = 0;
 run_test('set_up_ids', () => {
@@ -240,20 +238,16 @@ run_test('arrows on pills', () => {
     let next_focused = false;
 
     const pill_stub = {
-        prev: () => {
-            return {
-                focus: () => {
-                    prev_focused = true;
-                },
-            };
-        },
-        next: () => {
-            return {
-                focus: () => {
-                    next_focused = true;
-                },
-            };
-        },
+        prev: () => ({
+            focus: () => {
+                prev_focused = true;
+            },
+        }),
+        next: () => ({
+            focus: () => {
+                next_focused = true;
+            },
+        }),
     };
 
     container.set_find_results('.pill:focus', pill_stub);
@@ -282,13 +276,11 @@ run_test('left arrow on input', () => {
     let last_pill_focused = false;
 
     container.set_find_results('.pill', {
-        last: () => {
-            return {
-                focus: () => {
-                    last_pill_focused = true;
-                },
-            };
-        },
+        last: () => ({
+            focus: () => {
+                last_pill_focused = true;
+            },
+        }),
     });
 
     key_handler({
@@ -498,14 +490,12 @@ run_test('exit button on pill', () => {
     };
 
     const exit_button_stub = {
-        to_$: () => {
-            return {
-                closest: (sel) => {
-                    assert.equal(sel, '.pill');
-                    return curr_pill_stub;
-                },
-            };
-        },
+        to_$: () => ({
+            closest: (sel) => {
+                assert.equal(sel, '.pill');
+                return curr_pill_stub;
+            },
+        }),
     };
 
     const e = {
@@ -538,14 +528,12 @@ run_test('misc things', () => {
     let shake_class_removed = false;
 
     const input_stub = {
-        to_$: () => {
-            return {
-                removeClass: (cls) => {
-                    assert.equal(cls, 'shake');
-                    shake_class_removed = true;
-                },
-            };
-        },
+        to_$: () => ({
+            removeClass: (cls) => {
+                assert.equal(cls, 'shake');
+                shake_class_removed = true;
+            },
+        }),
     };
 
     animation_end_handler.call(input_stub);

--- a/frontend_tests/node_tests/input_pill.js
+++ b/frontend_tests/node_tests/input_pill.js
@@ -207,7 +207,7 @@ run_test('paste to input', () => {
     ]);
 
     let entered = false;
-    widget.createPillonPaste(function () {
+    widget.createPillonPaste(() => {
         entered = true;
     });
 
@@ -385,11 +385,11 @@ run_test('insert_remove', () => {
     let created;
     let removed;
 
-    widget.onPillCreate(function () {
+    widget.onPillCreate(() => {
         created = true;
     });
 
-    widget.onPillRemove(function () {
+    widget.onPillRemove(() => {
         removed = true;
     });
 

--- a/frontend_tests/node_tests/list_cursor.js
+++ b/frontend_tests/node_tests/list_cursor.js
@@ -59,9 +59,7 @@ run_test('single item list', () => {
 
     cursor.adjust_scroll = () => {};
 
-    conf.list.find_li = () => {
-        return li_stub;
-    };
+    conf.list.find_li = () => li_stub;
 
     cursor.go_to(valid_key);
 

--- a/frontend_tests/node_tests/list_render.js
+++ b/frontend_tests/node_tests/list_render.js
@@ -6,9 +6,10 @@ zrequire('list_render');
 // that are either jQuery, Element, or just raw HTML
 // strings.  We initially test with raw strings.
 set_global('jQuery', 'stub');
-set_global('Element', function () {
+function Element() {
     return { };
-});
+}
+set_global('Element', Element);
 
 // We only need very simple jQuery wrappers for when the
 // "real" code wraps html or sets up click handlers.

--- a/frontend_tests/node_tests/list_render.js
+++ b/frontend_tests/node_tests/list_render.js
@@ -198,9 +198,7 @@ run_test('filtering', () => {
     const opts = {
         filter: {
             element: search_input,
-            predicate: (item, value) => {
-                return item.includes(value);
-            },
+            predicate: (item, value) => item.includes(value),
         },
         modifier: (item) => div(item),
     };
@@ -294,9 +292,7 @@ function sort_button(opts) {
         addClass: (cls) => {
             classList.add(cls);
         },
-        hasClass: (cls) => {
-            return classList.has(cls);
-        },
+        hasClass: (cls) => classList.has(cls),
         removeClass: (cls) => {
             classList.delete(cls);
         },
@@ -332,11 +328,7 @@ run_test('wire up filter element', () => {
 
     const opts = {
         filter: {
-            filterer: (list, value) => {
-                return list.filter((item) => {
-                    return item.toLowerCase().includes(value);
-                });
-            },
+            filterer: (list, value) => list.filter((item) => item.toLowerCase().includes(value)),
             element: filter_element,
         },
         modifier: (s) => '(' + s + ')',
@@ -372,9 +364,7 @@ run_test('sorting', () => {
     const opts = {
         name: 'sorting-list',
         parent_container: sort_container,
-        modifier: (item) => {
-            return div(item.name) + div(item.salary);
-        },
+        modifier: (item) => div(item.name) + div(item.salary),
         filter: {
             predicate: () => true,
         },
@@ -698,9 +688,7 @@ run_test('opts.get_item', () => {
         ['one', 'two', 'three', 'four']
     );
 
-    const predicate = (item, value) => {
-        return item.startsWith(value);
-    };
+    const predicate = (item, value) => item.startsWith(value);
 
     const predicate_opts = {
         get_item: (n) => items[n],
@@ -719,11 +707,7 @@ run_test('opts.get_item', () => {
     const filterer_opts = {
         get_item: (n) => items[n],
         filter: {
-            filterer: (items, value) => {
-                return items.filter((item) => {
-                    return predicate(item, value);
-                });
-            },
+            filterer: (items, value) => items.filter((item) => predicate(item, value)),
         },
     };
 
@@ -821,9 +805,7 @@ run_test('render item', () => {
     let rendering_item = false;
     const widget_3 = list_render.create(container, list, {
         name: 'replace-list',
-        modifier: (item) => {
-            return rendering_item ? undefined : `${item}\n`;
-        },
+        modifier: (item) => rendering_item ? undefined : `${item}\n`,
         get_item: get_item,
         html_selector: (item) => `tr[data-item='${item}']`,
     });

--- a/frontend_tests/node_tests/list_render.js
+++ b/frontend_tests/node_tests/list_render.js
@@ -164,7 +164,7 @@ run_test('scrolling', () => {
 
     assert.deepEqual(
         container.appended_data.html(),
-        items.slice(0, 80).join('')
+        items.slice(0, 80).join(''),
     );
 
     // Set up our fake geometry so it forces a scroll action.
@@ -177,7 +177,7 @@ run_test('scrolling', () => {
     scroll_container.call_scroll();
     assert.deepEqual(
         container.appended_data.html(),
-        items.slice(80, 100).join('')
+        items.slice(80, 100).join(''),
     );
 });
 
@@ -339,7 +339,7 @@ run_test('wire up filter element', () => {
     filter_element.f.apply({value: 'se'});
     assert.equal(
         container.appended_data.html(),
-        '(JESSE)(moses)(Sean)'
+        '(JESSE)(moses)(Sean)',
     );
 });
 
@@ -505,7 +505,7 @@ run_test('custom sort', () => {
 
     assert.deepEqual(
         container.appended_data.html(),
-        '(6, 7)(1, 43)(4, 11)'
+        '(6, 7)(1, 43)(4, 11)',
     );
 
     const widget = list_render.get('custom-sort-list');
@@ -513,7 +513,7 @@ run_test('custom sort', () => {
     widget.sort('x_value');
     assert.deepEqual(
         container.appended_data.html(),
-        '(1, 43)(4, 11)(6, 7)'
+        '(1, 43)(4, 11)(6, 7)',
     );
 
     // We can sort without registering the function, too.
@@ -524,7 +524,7 @@ run_test('custom sort', () => {
     widget.sort(sort_by_y);
     assert.deepEqual(
         container.appended_data.html(),
-        '(6, 7)(4, 11)(1, 43)'
+        '(6, 7)(4, 11)(1, 43)',
     );
 });
 
@@ -654,7 +654,7 @@ run_test('replace_list_data w/filter update', () => {
 
     assert.deepEqual(
         container.appended_data.html(),
-        '(2)(4)'
+        '(2)(4)',
     );
 
     const widget = list_render.get('replace-list');
@@ -664,7 +664,7 @@ run_test('replace_list_data w/filter update', () => {
 
     assert.deepEqual(
         container.appended_data.html(),
-        '(6)(8)'
+        '(6)(8)',
     );
 });
 
@@ -684,9 +684,9 @@ run_test('opts.get_item', () => {
 
     assert.deepEqual(
         list_render.get_filtered_items(
-            'whatever', list, boring_opts
+            'whatever', list, boring_opts,
         ),
-        ['one', 'two', 'three', 'four']
+        ['one', 'two', 'three', 'four'],
     );
 
     const predicate = (item, value) => item.startsWith(value);
@@ -700,9 +700,9 @@ run_test('opts.get_item', () => {
 
     assert.deepEqual(
         list_render.get_filtered_items(
-            't', list, predicate_opts
+            't', list, predicate_opts,
         ),
-        ['two', 'three']
+        ['two', 'three'],
     );
 
     const filterer_opts = {
@@ -714,9 +714,9 @@ run_test('opts.get_item', () => {
 
     assert.deepEqual(
         list_render.get_filtered_items(
-            't', list, filterer_opts
+            't', list, filterer_opts,
         ),
-        ['two', 'three']
+        ['two', 'three'],
     );
 });
 

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -189,7 +189,7 @@ run_test('fenced_block_defaults', () => {
 
 markdown.initialize(
     page_params.realm_filters,
-    markdown_config.get_helpers()
+    markdown_config.get_helpers(),
 );
 
 const markdown_data = global.read_fixture_data('markdown_test_cases.json');

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -233,11 +233,11 @@ run_test('markdown_detection', () => {
         "youtube url https://www.youtube.com/watch?v=HHZ8iqswiCw&feature=youtu.be&a",
     ];
 
-    no_markup.forEach(function (content) {
+    no_markup.forEach((content) => {
         assert.equal(markdown.contains_backend_only_syntax(content), false);
     });
 
-    markup.forEach(function (content) {
+    markup.forEach((content) => {
         assert.equal(markdown.contains_backend_only_syntax(content), true);
     });
 });
@@ -245,7 +245,7 @@ run_test('markdown_detection', () => {
 run_test('marked_shared', () => {
     const tests = markdown_data.regular_tests;
 
-    tests.forEach(function (test) {
+    tests.forEach((test) => {
 
         // Ignore tests if specified
         if (test.ignore === true) {
@@ -423,7 +423,7 @@ run_test('marked', () => {
     // isn't present in emoji_codes.codepoint_to_name.
     delete emoji_codes.codepoint_to_name['1f6b2'];
 
-    test_cases.forEach(function (test_case) {
+    test_cases.forEach((test_case) => {
         // Disable emoji conversion by default.
         page_params.translate_emoticons = test_case.translate_emoticons || false;
 
@@ -563,7 +563,7 @@ run_test('backend_only_realm_filters', () => {
         'Here is the PR-#123.',
         'Function abc() was introduced in (PR)#123.',
     ];
-    backend_only_realm_filters.forEach(function (content) {
+    backend_only_realm_filters.forEach((content) => {
         assert.equal(markdown.contains_backend_only_syntax(content), true);
     });
 });

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -44,9 +44,10 @@ set_global('page_params', {
     translate_emoticons: false,
 });
 
-set_global('Image', function () {
+function Image() {
     return {};
-});
+}
+set_global('Image', Image);
 emoji.initialize();
 
 const doc = "";

--- a/frontend_tests/node_tests/message_events.js
+++ b/frontend_tests/node_tests/message_events.js
@@ -77,7 +77,7 @@ run_test('update_messages', () => {
 
     assert.deepEqual(
         stream_topic_history.get_recent_topic_names(denmark.stream_id),
-        ['lunch']
+        ['lunch'],
     );
 
     unread.update_message_for_mention(original_message);

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -107,7 +107,7 @@ function config_process_results(messages) {
         messages_processed_for_bools.push(message);
     };
 
-    message_store.add_message_metadata = message => message;
+    message_store.add_message_metadata = (message) => message;
 
     message_util.do_unread_count_updates = function (arg) {
         assert.deepEqual(arg, messages);
@@ -130,7 +130,7 @@ function config_process_results(messages) {
 }
 
 function message_range(start, end) {
-    return _.range(start, end).map(idx => ({
+    return _.range(start, end).map((idx) => ({
         id: idx,
     }));
 }

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -327,7 +327,7 @@ run_test('loading_newer', () => {
                 {
                     name: "Error",
                     message: "There are no message available to frontfill.",
-                }
+                },
             );
         } else {
             message_fetch.maybe_load_newer_messages({

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -5,7 +5,10 @@ zrequire('message_fetch');
 
 const noop = () => {};
 
-set_global('MessageListView', function () { return {}; });
+function MessageListView() {
+    return {};
+}
+set_global('MessageListView', MessageListView);
 
 zrequire('FetchStatus', 'js/fetch_status');
 zrequire('Filter', 'js/filter');

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -111,9 +111,7 @@ run_test('basics', () => {
     list.view.clear_table = function () {};
 
     list.remove_and_rerender([{id: 60}]);
-    const removed = list.all_messages().filter(function (msg) {
-        return msg.id !== 60;
-    });
+    const removed = list.all_messages().filter((msg) => msg.id !== 60);
     assert.deepEqual(list.all_messages(), removed);
 
     list.clear();
@@ -312,20 +310,16 @@ run_test('local_echo', () => {
 run_test('bookend', () => {
     const list = new MessageList({});
 
-    with_overrides(function (override) {
+    with_overrides((override) => {
         let expected = "translated: You subscribed to stream IceCream";
         list.view.clear_trailing_bookend = noop;
         list.narrowed = true;
 
-        override("narrow_state.stream", function () {
-            return "IceCream";
-        });
+        override("narrow_state.stream", () => "IceCream");
 
-        override("stream_data.is_subscribed", function () {
-            return true;
-        });
+        override("stream_data.is_subscribed", () => true);
 
-        global.with_stub(function (stub) {
+        global.with_stub((stub) => {
             list.view.render_trailing_bookend = stub.f;
             list.update_trailing_bookend();
             const bookend = stub.get_args('content', 'subscribed', 'show_button');
@@ -336,15 +330,11 @@ run_test('bookend', () => {
 
         expected = "translated: You unsubscribed from stream IceCream";
         list.last_message_historical = false;
-        override("stream_data.is_subscribed", function () {
-            return false;
-        });
+        override("stream_data.is_subscribed", () => false);
 
-        override("stream_data.get_sub", function () {
-            return {invite_only: false};
-        });
+        override("stream_data.get_sub", () => ({invite_only: false}));
 
-        global.with_stub(function (stub) {
+        global.with_stub((stub) => {
             list.view.render_trailing_bookend = stub.f;
             list.update_trailing_bookend();
             const bookend = stub.get_args('content', 'subscribed', 'show_button');
@@ -355,15 +345,11 @@ run_test('bookend', () => {
 
         // Test when the stream is privates (invite only)
         expected = "translated: You unsubscribed from stream IceCream";
-        override("stream_data.is_subscribed", function () {
-            return false;
-        });
+        override("stream_data.is_subscribed", () => false);
 
-        override("stream_data.get_sub", function () {
-            return {invite_only: true};
-        });
+        override("stream_data.get_sub", () => ({invite_only: true}));
 
-        global.with_stub(function (stub) {
+        global.with_stub((stub) => {
             list.view.render_trailing_bookend = stub.f;
             list.update_trailing_bookend();
             const bookend = stub.get_args('content', 'subscribed', 'show_button');
@@ -375,7 +361,7 @@ run_test('bookend', () => {
         expected = "translated: You are not subscribed to stream IceCream";
         list.last_message_historical = true;
 
-        global.with_stub(function (stub) {
+        global.with_stub((stub) => {
             list.view.render_trailing_bookend = stub.f;
             list.update_trailing_bookend();
             const bookend = stub.get_args('content', 'subscribed', 'show_button');
@@ -414,10 +400,8 @@ run_test('unmuted_messages', () => {
         },
     ];
 
-    with_overrides(function (override) {
-        override('muting.is_topic_muted', function (stream_id) {
-            return stream_id === muted_stream_id;
-        });
+    with_overrides((override) => {
+        override('muting.is_topic_muted', (stream_id) => stream_id === muted_stream_id);
 
         // Make sure unmuted_message filters out the "muted" entry,
         // which we mark as having a muted topic, and not mentioned.
@@ -437,7 +421,7 @@ run_test('add_remove_rerender', () => {
     list.add_messages(messages);
     assert.equal(list.num_items(), 3);
 
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         list.rerender = stub.f;
         list.remove_and_rerender(messages);
         assert.equal(stub.num_calls, 1);

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -18,9 +18,7 @@ const with_overrides = global.with_overrides; // make lint happy
 
 function accept_all_filter() {
     const filter = {
-        predicate: () => {
-            return () => true;
-        },
+        predicate: () => () => true,
     };
 
     return filter;

--- a/frontend_tests/node_tests/message_list_data.js
+++ b/frontend_tests/node_tests/message_list_data.js
@@ -155,12 +155,12 @@ run_test('more muting', () => {
     });
 
     assert.deepEqual(
-        mld._all_items.map(message => message.id),
+        mld._all_items.map((message) => message.id),
         [3, 4, 7, 8]
     );
 
     assert.deepEqual(
-        mld.all_messages().map(message => message.id),
+        mld.all_messages().map((message) => message.id),
         [4, 8]
     );
 
@@ -177,12 +177,12 @@ run_test('more muting', () => {
     const more_info = mld.add_messages(more_messages);
 
     assert.deepEqual(
-        mld._all_items.map(message => message.id),
+        mld._all_items.map((message) => message.id),
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     );
 
     assert.deepEqual(
-        mld.all_messages().map(message => message.id),
+        mld.all_messages().map((message) => message.id),
         [2, 4, 6, 8, 10]
     );
 

--- a/frontend_tests/node_tests/message_list_data.js
+++ b/frontend_tests/node_tests/message_list_data.js
@@ -156,12 +156,12 @@ run_test('more muting', () => {
 
     assert.deepEqual(
         mld._all_items.map((message) => message.id),
-        [3, 4, 7, 8]
+        [3, 4, 7, 8],
     );
 
     assert.deepEqual(
         mld.all_messages().map((message) => message.id),
-        [4, 8]
+        [4, 8],
     );
 
     const more_messages = [
@@ -178,12 +178,12 @@ run_test('more muting', () => {
 
     assert.deepEqual(
         mld._all_items.map((message) => message.id),
-        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     );
 
     assert.deepEqual(
         mld.all_messages().map((message) => message.id),
-        [2, 4, 6, 8, 10]
+        [2, 4, 6, 8, 10],
     );
 
     assert.deepEqual(more_info, {

--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -169,7 +169,7 @@ run_test('merge_message_groups', () => {
     }
 
     function extract_message_ids(lst) {
-        return lst.map(item => item.msg.id);
+        return lst.map((item) => item.msg.id);
     }
 
     function assert_message_list_equal(list1, list2) {
@@ -546,7 +546,7 @@ run_test('render_windows', () => {
     let messages;
 
     function reset_list(opts) {
-        messages = _.range(opts.count).map(i => ({
+        messages = _.range(opts.count).map((i) => ({
             id: i,
         }));
         list.selected_idx = function () { return 0; };

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -65,7 +65,7 @@ people.initialize_current_user(me.user_id);
 
 function convert_recipients(people) {
     // Display_recipient uses `id` for user_ids.
-    return people.map(p => ({
+    return people.map((p) => ({
         email: p.email,
         id: p.user_id,
         full_name: p.full_name,

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -279,7 +279,7 @@ run_test('message_id_change', () => {
         new_id: 402,
     };
 
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         home_msg_list.change_message_id = stub.f;
         message_store.reify_message_id(opts);
         const msg_id = stub.get_args('old', 'new');
@@ -288,7 +288,7 @@ run_test('message_id_change', () => {
     });
 
     home_msg_list.view = {};
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         home_msg_list.view.change_message_id = stub.f;
         message_store.reify_message_id(opts);
         const msg_id = stub.get_args('old', 'new');

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -17,7 +17,7 @@ set_global('resize', {
 zrequire('narrow');
 
 function set_filter(operators) {
-    operators = operators.map(op => ({
+    operators = operators.map((op) => ({
         operator: op[0],
         operand: op[1],
     }));

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -74,7 +74,7 @@ run_test('show_empty_narrow_message', () => {
     assert($('#empty_narrow_message').visible());
     assert.equal(
         $('#left_bar_compose_reply_button_big').attr('title'),
-        'translated: There are no messages to reply to.'
+        'translated: There are no messages to reply to.',
     );
 
     // for non-existent or private stream

--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -150,16 +150,14 @@ run_test('basics', () => {
 
     const row = {
         length: 1,
-        offset: () => { return {top: 25}; },
+        offset: () => ({top: 25}),
     };
 
-    current_msg_list.selected_id = () => { return -1; };
-    current_msg_list.get_row = () => { return row; };
+    current_msg_list.selected_id = () => -1;
+    current_msg_list.get_row = () => row;
 
     message_list.all = {
-        all_messages: () => {
-            return messages;
-        },
+        all_messages: () => messages,
         get: (msg_id) => {
             assert.equal(msg_id, selected_id);
             return selected_message;
@@ -170,12 +168,8 @@ run_test('basics', () => {
             },
         },
         empty: () => false,
-        first: () => {
-            return {id: 900};
-        },
-        last: () => {
-            return {id: 1100};
-        },
+        first: () => ({id: 900}),
+        last: () => ({id: 1100}),
     };
 
     let cont;
@@ -214,9 +208,9 @@ run_test('basics', () => {
         'tab_bar.initialize',
     ]);
 
-    current_msg_list.selected_id = () => { return -1; };
-    current_msg_list.get_row = () => { return row; };
-    util.sorted_ids = () => { return []; };
+    current_msg_list.selected_id = () => -1;
+    current_msg_list.get_row = () => row;
+    util.sorted_ids = () => [];
 
     narrow.activate([{ operator: 'is', operand: 'private' }], {
         then_select_id: selected_id,

--- a/frontend_tests/node_tests/narrow_local.js
+++ b/frontend_tests/node_tests/narrow_local.js
@@ -68,7 +68,7 @@ function test_with(fixture) {
     assert.deepEqual(id_info, fixture.expected_id_info);
 
     const msgs = msg_data.all_messages();
-    const msg_ids = msgs.map(message => message.id);
+    const msg_ids = msgs.map((message) => message.id);
     assert.deepEqual(msg_ids, fixture.expected_msg_ids);
 }
 

--- a/frontend_tests/node_tests/narrow_state.js
+++ b/frontend_tests/node_tests/narrow_state.js
@@ -7,7 +7,7 @@ zrequire('narrow_state');
 set_global('page_params', {});
 
 function set_filter(operators) {
-    operators = operators.map(op => ({
+    operators = operators.map((op) => ({
         operator: op[0],
         operand: op[1],
     }));

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -2,9 +2,7 @@ zrequire('people');
 set_global('message_store', {});
 set_global('page_params', {});
 set_global('settings_data', {});
-set_global('md5', function (s) {
-    return 'md5-' + s;
-});
+set_global('md5', (s) => 'md5-' + s);
 
 const settings_config = zrequire('settings_config');
 const visibility = settings_config.email_address_visibility_values;
@@ -401,7 +399,7 @@ run_test('user_timezone', () => {
     assert.deepEqual(people.get_user_time_preferences(me.user_id), expected_pref);
 
     const actual_moment = zrequire('actual_moment', 'moment-timezone');
-    set_global('moment', function () { return actual_moment('20130208T080910'); });
+    set_global('moment', () => actual_moment('20130208T080910'));
 
     global.page_params.twenty_four_hour_time = true;
     assert.equal(people.get_user_time(me.user_id), '0:09');
@@ -1097,7 +1095,7 @@ run_test('is_valid_full_name_and_user_id', () => {
     assert(people.is_valid_full_name_and_user_id(me.full_name, me.user_id));
 });
 
-run_test('emails_strings_to_user_ids_array', function () {
+run_test('emails_strings_to_user_ids_array', () => {
     people.add_active_user(steven);
     people.add_active_user(maria);
 
@@ -1109,7 +1107,7 @@ run_test('emails_strings_to_user_ids_array', function () {
     assert.equal(user_ids, undefined);
 });
 
-run_test('get_visible_email', function () {
+run_test('get_visible_email', () => {
     people.add_active_user(steven);
     people.add_active_user(maria);
 
@@ -1120,7 +1118,7 @@ run_test('get_visible_email', function () {
     assert.equal(email, maria.email);
 });
 
-run_test('get_active_message_people', function () {
+run_test('get_active_message_people', () => {
     message_store.user_ids = () => [
         steven.user_id,
         maria.user_id,

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -234,7 +234,7 @@ run_test('basics', () => {
 
     assert.equal(
         people.get_actual_name_from_user_id(32),
-        full_name
+        full_name,
     );
 
     assert(people.is_valid_full_name_and_user_id(full_name, 32));
@@ -266,7 +266,7 @@ run_test('basics', () => {
 
     assert.equal(
         people.get_bot_owner_user(bot_botson).full_name,
-        'Isaac Newton'
+        'Isaac Newton',
     );
 
     // Add our cross-realm bot.  It won't add to our human
@@ -276,7 +276,7 @@ run_test('basics', () => {
     assert.equal(people.get_active_human_count(), 1);
     assert.equal(
         people.get_by_email(welcome_bot.email).full_name,
-        'Welcome Bot'
+        'Welcome Bot',
     );
 
     // get_realm_users() will include our active bot,
@@ -286,7 +286,7 @@ run_test('basics', () => {
         [
             me.user_id,
             bot_botson.user_id,
-        ]
+        ],
     );
 
     // The bot doesn't add to our human count.
@@ -590,14 +590,14 @@ run_test('concat_huddle', () => {
 
     assert.equal(
         people.concat_huddle(user_ids, 304),
-        '301,302,303,304'
+        '301,302,303,304',
     );
 
     // IMPORTANT: we always want to sort
     // ids numerically to create huddle strings.
     assert.equal(
         people.concat_huddle(user_ids, 99),
-        '99,301,302,303'
+        '99,301,302,303',
     );
 });
 
@@ -670,7 +670,7 @@ run_test('message_methods', () => {
         sender_id: maria.user_id,
     };
     assert.equal(people.small_avatar_url(message),
-                 'https://secure.gravatar.com/avatar/md5-athens@example.com?d=identicon&s=50'
+                 'https://secure.gravatar.com/avatar/md5-athens@example.com?d=identicon&s=50',
     );
 
     blueslip.expect('error', 'Unknown user_id in get_by_user_id: 9999999');
@@ -680,14 +680,14 @@ run_test('message_methods', () => {
         sender_id: 9999999,
     };
     assert.equal(people.small_avatar_url(message),
-                 'https://secure.gravatar.com/avatar/md5-foo@example.com?d=identicon&s=50'
+                 'https://secure.gravatar.com/avatar/md5-foo@example.com?d=identicon&s=50',
     );
 
     message = {
         sender_id: ashton.user_id,
     };
     assert.equal(people.small_avatar_url(message),
-                 `/avatar/${ashton.user_id}&s=50`
+                 `/avatar/${ashton.user_id}&s=50`,
     );
 
     message = {
@@ -911,17 +911,17 @@ run_test('update_email_in_reply_to', () => {
     let reply_to = '    charles@example.com,   athens@example.com';
     assert.equal(
         people.update_email_in_reply_to(reply_to, 9999, 'whatever'),
-        reply_to
+        reply_to,
     );
     assert.equal(
         people.update_email_in_reply_to(reply_to, maria.user_id, 'maria@example.com'),
-        'charles@example.com,maria@example.com'
+        'charles@example.com,maria@example.com',
     );
 
     reply_to = '    charles@example.com,   athens@example.com, unknown@example.com';
     assert.equal(
         people.update_email_in_reply_to(reply_to, 9999, 'whatever'),
-        reply_to
+        reply_to,
     );
 });
 
@@ -934,7 +934,7 @@ run_test('track_duplicate_full_names', () => {
     assert(!people.is_duplicate_full_name('Stephen King'));
     assert.equal(
         people.get_user_id_from_name('Stephen King'),
-        stephen1.user_id
+        stephen1.user_id,
     );
 
     // Now duplicate the Stephen King name.
@@ -945,7 +945,7 @@ run_test('track_duplicate_full_names', () => {
     // other codepaths for disambiguation.
     assert.equal(
         people.get_user_id_from_name('Stephen King'),
-        undefined
+        undefined,
     );
 
     assert(people.is_duplicate_full_name('Stephen King'));

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -852,9 +852,7 @@ run_test('get_people_for_search_bar', () => {
 
     assert.equal(big_results.length, 20);
 
-    message_store.user_ids = () => {
-        return [1001, 1002, 1003, 1004, 1005, 1006];
-    };
+    message_store.user_ids = () => [1001, 1002, 1003, 1004, 1005, 1006];
 
     const small_results = people.get_people_for_search_bar('Jones');
 
@@ -1123,13 +1121,11 @@ run_test('get_visible_email', function () {
 });
 
 run_test('get_active_message_people', function () {
-    message_store.user_ids = () => {
-        return [
-            steven.user_id,
-            maria.user_id,
-            alice1.user_id,
-        ];
-    };
+    message_store.user_ids = () => [
+        steven.user_id,
+        maria.user_id,
+        alice1.user_id,
+    ];
 
     people.add_active_user(steven);
     people.add_active_user(maria);

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -894,7 +894,7 @@ run_test('updates', () => {
     const all_people = get_all_persons();
     assert.equal(all_people.length, 2);
 
-    person = all_people.filter(p => p.email === new_email)[0];
+    person = all_people.filter((p) => p.email === new_email)[0];
     assert.equal(person.full_name, 'Foo Barson');
 
     // Test shim where we can still retrieve user info using the

--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -2,7 +2,7 @@ set_global('$', global.make_zjquery());
 
 set_global('narrow_state', {});
 set_global('ui', {
-    get_content_element: element => element,
+    get_content_element: (element) => element,
 });
 set_global('stream_popover', {
     hide_topic_popover: function () {},

--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -10,9 +10,7 @@ set_global('stream_popover', {
 set_global('unread', {});
 set_global('unread_ui', {});
 set_global('vdom', {
-    render: () => {
-        return 'fake-dom-for-pm-list';
-    },
+    render: () => 'fake-dom-for-pm-list',
 });
 set_global('pm_list_dom', {});
 
@@ -196,14 +194,12 @@ run_test('get_active_user_ids_string', () => {
         undefined);
 
     function set_filter_result(emails) {
-        narrow_state.filter = () => {
-            return {
-                operands: (operand) => {
-                    assert.equal(operand, 'pm-with');
-                    return emails;
-                },
-            };
-        };
+        narrow_state.filter = () => ({
+            operands: (operand) => {
+                assert.equal(operand, 'pm-with');
+                return emails;
+            },
+        });
     }
 
     set_filter_result([]);
@@ -224,14 +220,12 @@ run_test('is_all_privates', () => {
         pm_list.is_all_privates(),
         false);
 
-    narrow_state.filter = () => {
-        return {
-            operands: (operand) => {
-                assert.equal(operand, 'is');
-                return ['private', 'starred'];
-            },
-        };
-    };
+    narrow_state.filter = () => ({
+        operands: (operand) => {
+            assert.equal(operand, 'is');
+            return ['private', 'starred'];
+        },
+    });
 
     assert.equal(
         pm_list.is_all_privates(),
@@ -240,9 +234,7 @@ run_test('is_all_privates', () => {
 
 function with_fake_list(f) {
     const orig = pm_list._build_private_messages_list;
-    pm_list._build_private_messages_list = () => {
-        return 'PM_LIST_CONTENTS';
-    };
+    pm_list._build_private_messages_list = () => 'PM_LIST_CONTENTS';
     f();
     pm_list._build_private_messages_list = orig;
 }

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -42,9 +42,10 @@ set_global('stream_popover', {
 
 set_global('stream_data', {});
 
-set_global('ClipboardJS', function (sel) {
+function ClipboardJS(sel) {
     assert.equal(sel, '.copy_link');
-});
+}
+set_global('ClipboardJS', ClipboardJS);
 
 const alice = {
     email: 'alice@example.com',
@@ -95,9 +96,7 @@ function make_image_stubber() {
         return image;
     }
 
-    set_global('Image', function () {
-        return stub_image();
-    });
+    set_global('Image', stub_image);
 
     return {
         get: (i) => images[i],

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -135,7 +135,7 @@ run_test('sender_hover', () => {
         return {};
     };
 
-    global.stub_templates(function (fn, opts) {
+    global.stub_templates((fn, opts) => {
         switch (fn) {
         case 'no_arrow_popover':
             assert.deepEqual(opts, {
@@ -229,7 +229,7 @@ run_test('actions_popover', () => {
         };
     };
 
-    global.stub_templates(function (fn, opts) {
+    global.stub_templates((fn, opts) => {
         // TODO: Test all the properties of the popover
         switch (fn) {
         case 'actions_popover_content':

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -63,11 +63,9 @@ const me = {
 };
 
 const target = $.create('click target');
-target.offset = () => {
-    return {
-        top: 10,
-    };
-};
+target.offset = () => ({
+    top: 10,
+});
 
 const e = {
     stopPropagation: noop,
@@ -87,14 +85,12 @@ function make_image_stubber() {
 
     function stub_image() {
         const image = {};
-        image.to_$ = () => {
-            return {
-                on: (name, f) => {
-                    assert.equal(name, "load");
-                    image.load_f = f;
-                },
-            };
-        };
+        image.to_$ = () => ({
+            on: (name, f) => {
+                assert.equal(name, "load");
+                image.load_f = f;
+            },
+        });
         images.push(image);
         return image;
     }

--- a/frontend_tests/node_tests/presence.js
+++ b/frontend_tests/node_tests/presence.js
@@ -7,7 +7,10 @@ set_global('server_events', {});
 set_global('reload_state', {
     is_in_progress: return_false,
 });
-set_global('XDate', function (ms) { return {seconds: ms}; });
+function XDate(ms) {
+    return {seconds: ms};
+}
+set_global('XDate', XDate);
 
 const OFFLINE_THRESHOLD_SECS = 140;
 

--- a/frontend_tests/node_tests/presence.js
+++ b/frontend_tests/node_tests/presence.js
@@ -114,7 +114,7 @@ run_test('status_from_raw', () => {
         {
             status: 'active',
             last_active: raw.active_timestamp,
-        }
+        },
     );
 
     raw = {
@@ -127,7 +127,7 @@ run_test('status_from_raw', () => {
         {
             status: 'offline',
             last_active: raw.active_timestamp,
-        }
+        },
     );
 
     raw = {
@@ -140,7 +140,7 @@ run_test('status_from_raw', () => {
         {
             status: 'idle',
             last_active: raw.idle_timestamp,
-        }
+        },
     );
 });
 
@@ -181,31 +181,31 @@ run_test('set_presence_info', () => {
     presence.initialize(params);
 
     assert.deepEqual(presence.presence_info.get(alice.user_id),
-                     { status: 'active', last_active: recent}
+                     { status: 'active', last_active: recent},
     );
     assert.equal(presence.get_status(alice.user_id), 'active');
     assert.deepEqual(
         presence.last_active_date(alice.user_id),
-        {seconds: recent * 1000}
+        {seconds: recent * 1000},
     );
 
     assert.deepEqual(presence.presence_info.get(fred.user_id),
-                     { status: 'idle', last_active: now}
+                     { status: 'idle', last_active: now},
     );
     assert.equal(presence.get_status(fred.user_id), 'idle');
 
     assert.deepEqual(presence.presence_info.get(me.user_id),
-                     { status: 'active', last_active: now}
+                     { status: 'active', last_active: now},
     );
     assert.equal(presence.get_status(me.user_id), 'active');
 
     assert.deepEqual(presence.presence_info.get(sally.user_id),
-                     { status: 'offline', last_active: a_while_ago}
+                     { status: 'offline', last_active: a_while_ago},
     );
     assert.equal(presence.get_status(sally.user_id), 'offline');
 
     assert.deepEqual(presence.presence_info.get(zoe.user_id),
-                     { status: 'offline', last_active: undefined}
+                     { status: 'offline', last_active: undefined},
     );
     assert.equal(presence.get_status(zoe.user_id), 'offline');
     assert.equal(presence.last_active_date(zoe.user_id), undefined);
@@ -214,12 +214,12 @@ run_test('set_presence_info', () => {
     assert.equal(presence.get_status(bot.user_id), 'offline');
 
     assert.deepEqual(presence.presence_info.get(john.user_id),
-                     { status: 'offline', last_active: a_while_ago}
+                     { status: 'offline', last_active: a_while_ago},
     );
     assert.equal(presence.get_status(john.user_id), 'offline');
 
     assert.deepEqual(presence.presence_info.get(jane.user_id),
-                     { status: 'idle', last_active: now}
+                     { status: 'idle', last_active: now},
     );
     assert.equal(presence.get_status(jane.user_id), 'idle');
 
@@ -250,7 +250,7 @@ run_test('falsy values', () => {
 
         assert.deepEqual(
             presence.presence_info.get(zoe.user_id),
-            { status: 'idle', last_active: a_bit_ago }
+            { status: 'idle', last_active: a_bit_ago },
         );
 
         presences[zoe.user_id.toString()] = {
@@ -262,7 +262,7 @@ run_test('falsy values', () => {
 
         assert.deepEqual(
             presence.presence_info.get(zoe.user_id),
-            { status: 'offline', last_active: undefined }
+            { status: 'offline', last_active: undefined },
         );
     }
 });
@@ -312,7 +312,7 @@ run_test('update_info_from_event', () => {
 
     assert.deepEqual(
         presence.presence_info.get(alice.user_id),
-        { status: 'active', last_active: 500 }
+        { status: 'active', last_active: 500 },
     );
 
     info = {
@@ -325,7 +325,7 @@ run_test('update_info_from_event', () => {
 
     assert.deepEqual(
         presence.presence_info.get(alice.user_id),
-        { status: 'active', last_active: 510 }
+        { status: 'active', last_active: 510 },
     );
 
     info = {
@@ -338,6 +338,6 @@ run_test('update_info_from_event', () => {
 
     assert.deepEqual(
         presence.presence_info.get(alice.user_id),
-        { status: 'idle', last_active: 1000 }
+        { status: 'idle', last_active: 1000 },
     );
 });

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -631,7 +631,7 @@ run_test('remove last user', () => {
     function assert_names(names) {
         assert.deepEqual(
             reactions.get_message_reactions(message).map((r) => r.emoji_name),
-            names
+            names,
         );
     }
 

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -123,7 +123,7 @@ run_test('basics', () => {
     assert(reactions.current_user_has_reacted_to_emoji(message, 'unicode_emoji,263a'));
     assert(!reactions.current_user_has_reacted_to_emoji(message, 'bogus'));
 
-    result.sort(function (a, b) { return a.count - b.count; });
+    result.sort((a, b) => a.count - b.count);
 
     const expected_result = [
         {
@@ -174,7 +174,7 @@ run_test('sending', () => {
     reactions.remove_reaction = function () {};
     reactions.add_reaction = function () {};
 
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         global.channel.del = stub.f;
         reactions.toggle_emoji_reaction(message_id, emoji_name);
         const args = stub.get_args('args').args;
@@ -194,7 +194,7 @@ run_test('sending', () => {
         args.error();
     });
     emoji_name = 'alien'; // not set yet
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         global.channel.post = stub.f;
         reactions.toggle_emoji_reaction(message_id, emoji_name);
         const args = stub.get_args('args').args;
@@ -207,7 +207,7 @@ run_test('sending', () => {
     });
 
     emoji_name = 'inactive_realm_emoji';
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         // Test removing a deactivated realm emoji. An user can interact with a
         // deactivated realm emoji only by clicking on a reaction, hence, only
         // `process_reaction_click()` codepath supports deleting/adding a deactivated
@@ -224,7 +224,7 @@ run_test('sending', () => {
     });
 
     emoji_name = 'zulip'; // Test adding zulip emoji.
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         global.channel.post = stub.f;
         reactions.toggle_emoji_reaction(message_id, emoji_name);
         const args = stub.get_args('args').args;
@@ -298,7 +298,7 @@ run_test('add_and_remove_reaction', () => {
     };
 
     let template_called;
-    global.stub_templates(function (template_name, data) {
+    global.stub_templates((template_name, data) => {
         template_called = true;
         assert.equal(template_name, 'message_reaction');
         assert.equal(data.class, 'message_reaction reacted');
@@ -386,7 +386,7 @@ run_test('add_and_remove_reaction', () => {
     };
 
     template_called = false;
-    global.stub_templates(function (template_name, data) {
+    global.stub_templates((template_name, data) => {
         assert.equal(data.class, 'message_reaction');
         assert(data.is_realm_emoji);
         template_called = true;
@@ -674,7 +674,7 @@ run_test('process_reaction_click', () => {
         emoji_name: 'smile',
         emoji_code: '263a',
     };
-    global.with_stub(function (stub) {
+    global.with_stub((stub) => {
         global.channel.del = stub.f;
         reactions.process_reaction_click(message_id, 'unicode_emoji,263a');
         const args = stub.get_args('args').args;

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -420,7 +420,7 @@ run_test('add_and_remove_reaction', () => {
 
     const result = reactions.get_message_reactions(message);
     assert(reaction_element.hasClass('reacted'));
-    const realm_emoji_data = result.filter(v => v.emoji_name === 'realm_emoji')[0];
+    const realm_emoji_data = result.filter((v) => v.emoji_name === 'realm_emoji')[0];
 
     assert.equal(realm_emoji_data.count, 2);
     assert.equal(realm_emoji_data.is_realm_emoji, true);

--- a/frontend_tests/node_tests/recent_senders.js
+++ b/frontend_tests/node_tests/recent_senders.js
@@ -5,7 +5,7 @@ const messages = [];
 
 set_global('message_util', {
     get_messages_in_topic: (stream_id, topic) => {
-        return messages.filter(x => {
+        return messages.filter((x) => {
             return x.stream_id === stream_id &&
                    x.topic.toLowerCase() === topic.toLowerCase();
         });

--- a/frontend_tests/node_tests/recent_senders.js
+++ b/frontend_tests/node_tests/recent_senders.js
@@ -145,10 +145,10 @@ run_test('process_message_for_senders', () => {
 
     // Test topic change
     assert.equal(
-        rs.get_topic_recent_senders(stream3, topic3).toString(), '3'
+        rs.get_topic_recent_senders(stream3, topic3).toString(), '3',
     );
     assert.equal(
-        rs.get_topic_recent_senders(stream3, topic2).toString(), '2,3'
+        rs.get_topic_recent_senders(stream3, topic2).toString(), '2,3',
     );
 
     // message7's topic was changed by user
@@ -156,36 +156,36 @@ run_test('process_message_for_senders', () => {
 
     rs.process_topic_edit(stream3, topic2, topic3);
     assert.equal(
-        rs.get_topic_recent_senders(stream3, topic3).toString(), '2,3'
+        rs.get_topic_recent_senders(stream3, topic3).toString(), '2,3',
     );
     assert.equal(
-        rs.get_topic_recent_senders(stream3, topic2).toString(), '3'
+        rs.get_topic_recent_senders(stream3, topic2).toString(), '3',
     );
 
     // Test stream change
     assert.equal(
-        rs.get_topic_recent_senders(stream3, topic3).toString(), '2,3'
+        rs.get_topic_recent_senders(stream3, topic3).toString(), '2,3',
     );
     assert.equal(
-        rs.get_topic_recent_senders(stream4, topic3).toString(), ''
+        rs.get_topic_recent_senders(stream4, topic3).toString(), '',
     );
     // stream of topic3 was changed to stream4.
     messages[6].stream_id = stream4; // message7's topic is topic3
     messages[7].stream_id = stream4;
     rs.process_topic_edit(stream3, topic3, topic3, stream4);
     assert.equal(
-        rs.get_topic_recent_senders(stream3, topic3).toString(), ''
+        rs.get_topic_recent_senders(stream3, topic3).toString(), '',
     );
     assert.equal(
-        rs.get_topic_recent_senders(stream4, topic3).toString(), '2,3'
+        rs.get_topic_recent_senders(stream4, topic3).toString(), '2,3',
     );
 
     // Test stream & topic change
     assert.equal(
-        rs.get_topic_recent_senders(stream4, topic3).toString(), '2,3'
+        rs.get_topic_recent_senders(stream4, topic3).toString(), '2,3',
     );
     assert.equal(
-        rs.get_topic_recent_senders(stream5, topic4).toString(), ''
+        rs.get_topic_recent_senders(stream5, topic4).toString(), '',
     );
     // stream of topic3 was changed to stream5 and topic was changed to topic4.
     messages[6].stream_id = stream5;
@@ -194,9 +194,9 @@ run_test('process_message_for_senders', () => {
     messages[7].topic = topic4;
     rs.process_topic_edit(stream4, topic3, topic4, stream5);
     assert.equal(
-        rs.get_topic_recent_senders(stream4, topic3).toString(), ''
+        rs.get_topic_recent_senders(stream4, topic3).toString(), '',
     );
     assert.equal(
-        rs.get_topic_recent_senders(stream5, topic4).toString(), '2,3'
+        rs.get_topic_recent_senders(stream5, topic4).toString(), '2,3',
     );
 });

--- a/frontend_tests/node_tests/recent_senders.js
+++ b/frontend_tests/node_tests/recent_senders.js
@@ -4,12 +4,8 @@ let next_id = 0;
 const messages = [];
 
 set_global('message_util', {
-    get_messages_in_topic: (stream_id, topic) => {
-        return messages.filter((x) => {
-            return x.stream_id === stream_id &&
-                   x.topic.toLowerCase() === topic.toLowerCase();
-        });
-    },
+    get_messages_in_topic: (stream_id, topic) => messages.filter((x) => x.stream_id === stream_id &&
+                   x.topic.toLowerCase() === topic.toLowerCase()),
 });
 
 run_test('process_message_for_senders', () => {

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -297,7 +297,7 @@ run_test("test_recent_topics_launch", () => {
         search_val: '',
     };
 
-    global.stub_templates(function (template_name, data) {
+    global.stub_templates((template_name, data) => {
         if (template_name === 'recent_topics_table') {
             assert.deepEqual(data, expected);
         } else if (template_name === 'recent_topics_filters') {
@@ -330,7 +330,7 @@ run_test('test_filter_all', () => {
     };
     let row_data;
     let i;
-    global.stub_templates(function (template_name, data) {
+    global.stub_templates((template_name, data) => {
         if (template_name === 'recent_topic_row') {
             // All the row will be processed.
             i -= 1;
@@ -386,14 +386,12 @@ run_test('test_filter_unread', () => {
 
     const rt = zrequire('recent_topics');
 
-    global.stub_templates(function () {
-        return '<recent_topics table stub>';
-    });
+    global.stub_templates(() => '<recent_topics table stub>');
     rt.process_messages(messages);
     assert.equal(rt.inplace_rerender('1:topic-1'), true);
 
     $('#recent_topics_filter_buttons').removeClass('btn-recent-selected');
-    global.stub_templates(function (template_name, data) {
+    global.stub_templates((template_name, data) => {
         assert.equal(template_name, 'recent_topics_filters');
         assert.equal(data.filter_unread, expected.filter_unread);
         assert.equal(data.filter_participated, expected.filter_participated);
@@ -403,7 +401,7 @@ run_test('test_filter_unread', () => {
     rt.set_filter('unread');
     rt.update_filters_view();
 
-    global.stub_templates(function (template_name, data) {
+    global.stub_templates((template_name, data) => {
         if (template_name === 'recent_topic_row') {
             // All the row will be processed.
             assert.deepEqual(data, row_data[i]);
@@ -452,9 +450,7 @@ run_test('test_filter_participated', () => {
 
     const rt = zrequire('recent_topics');
 
-    global.stub_templates(function () {
-        return '<recent_topics table stub>';
-    });
+    global.stub_templates(() => '<recent_topics table stub>');
     rt.process_messages(messages);
     assert.equal(rt.inplace_rerender('1:topic-4'), true);
 
@@ -466,7 +462,7 @@ run_test('test_filter_participated', () => {
     rt.set_filter('muted');
 
     $('#recent_topics_filter_buttons').removeClass('btn-recent-selected');
-    global.stub_templates(function (template_name, data) {
+    global.stub_templates((template_name, data) => {
         assert.equal(template_name, 'recent_topics_filters');
         assert.equal(data.filter_unread, expected.filter_unread);
         assert.equal(data.filter_participated, expected.filter_participated);
@@ -476,7 +472,7 @@ run_test('test_filter_participated', () => {
     rt.update_filters_view();
 
 
-    global.stub_templates(function (template_name, data) {
+    global.stub_templates((template_name, data) => {
         if (template_name === 'recent_topic_row') {
             // All the row will be processed.
             assert.deepEqual(data, row_data[i]);
@@ -495,9 +491,7 @@ run_test('test_filter_participated', () => {
 run_test('test_update_unread_count', () => {
     const rt = zrequire('recent_topics');
     rt.set_filter('all');
-    global.stub_templates(function () {
-        return '<recent_topics table stub>';
-    });
+    global.stub_templates(() => '<recent_topics table stub>');
     rt.process_messages(messages);
 
     // update a message
@@ -506,9 +500,7 @@ run_test('test_update_unread_count', () => {
 });
 
 // template rendering is tested in test_recent_topics_launch.
-global.stub_templates(function () {
-    return '<recent_topics table stub>';
-});
+global.stub_templates(() => '<recent_topics table stub>');
 
 run_test('basic assertions', () => {
     const rt = zrequire('recent_topics');

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -8,46 +8,36 @@ set_global('hashchange', {
     exit_overlay: noop,
 });
 set_global('stream_data', {
-    get_sub_by_id: () => {
-        return {
-            color: "",
-            invite_only: false,
-            is_web_public: true,
-        };
-    },
-    is_muted: () => {
+    get_sub_by_id: () => ({
+        color: "",
+        invite_only: false,
+        is_web_public: true,
+    }),
+    is_muted: () =>
         // We only test via muted topics for now.
         // TODO: Make muted streams and test them.
-        return false;
-    },
+        false
+    ,
 });
 set_global('overlays', {
     open_overlay: (opts) => {
         overlays.close_callback = opts.on_close;
     },
-    recent_topics_open: () => {
-        return true;
-    },
+    recent_topics_open: () => true,
 });
 set_global('people', {
     is_my_user_id: function (id) {
         return id === 1;
     },
-    sender_info_with_small_avatar_urls_for_sender_ids: (ids) => {
-        return ids;
-    },
+    sender_info_with_small_avatar_urls_for_sender_ids: (ids) => ids,
 });
 set_global('XDate', zrequire('XDate', 'xdate'));
 set_global('timerender', {
-    last_seen_status_from_date: () => {
-        return "Just now";
-    },
-    get_full_datetime: () => {
-        return {
-            date: "date",
-            time: "time",
-        };
-    },
+    last_seen_status_from_date: () => "Just now",
+    get_full_datetime: () => ({
+        date: "date",
+        time: "time",
+    }),
 });
 set_global('unread', {
     unread_topic_counter: {
@@ -61,15 +51,11 @@ set_global('unread', {
     },
 });
 set_global('hash_util', {
-    by_stream_uri: () => {
-        return "https://www.example.com";
-    },
-    by_stream_topic_uri: () => {
-        return "https://www.example.com";
-    },
+    by_stream_uri: () => "https://www.example.com",
+    by_stream_topic_uri: () => "https://www.example.com",
 });
 set_global('recent_senders', {
-    get_topic_recent_senders: () => { return [1, 2]; },
+    get_topic_recent_senders: () => [1, 2],
 });
 set_global('list_render', {
     modifier: noop,
@@ -93,9 +79,7 @@ set_global('list_render', {
         return list_render;
     },
     hard_redraw: noop,
-    render_item: (item) => {
-        return list_render.modifier(item);
-    },
+    render_item: (item) => list_render.modifier(item),
 });
 
 // Custom Data
@@ -142,9 +126,7 @@ set_global('message_list', {
     },
 });
 set_global('message_store', {
-    get: (msg_id) => {
-        return messages[msg_id - 1];
-    },
+    get: (msg_id) => messages[msg_id - 1],
 });
 
 let id = 0;

--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -52,7 +52,7 @@ stream_data.add_sub(stream);
 
 const $array = (array) => {
     const each = (func) => {
-        array.forEach(e => {
+        array.forEach((e) => {
             func.call(e);
         });
     };

--- a/frontend_tests/node_tests/schema.js
+++ b/frontend_tests/node_tests/schema.js
@@ -9,9 +9,7 @@ run_test('basics', () => {
         bar: schema.check_string,
     };
 
-    const check_rec = (val) => {
-        return schema.check_record('my_rec', val, fields);
-    };
+    const check_rec = (val) => schema.check_record('my_rec', val, fields);
 
     assert.equal(
         check_rec({foo: 'apple', bar: 'banana'}),
@@ -38,9 +36,7 @@ run_test('basics', () => {
         'in my_rec bar is not a string'
     );
 
-    const check_array = (val) => {
-        return schema.check_array('lst', val, schema.check_string);
-    };
+    const check_array = (val) => schema.check_array('lst', val, schema.check_string);
 
     assert.equal(
         check_array(['foo', 'bar']),

--- a/frontend_tests/node_tests/schema.js
+++ b/frontend_tests/node_tests/schema.js
@@ -13,43 +13,43 @@ run_test('basics', () => {
 
     assert.equal(
         check_rec({foo: 'apple', bar: 'banana'}),
-        undefined
+        undefined,
     );
 
     assert.equal(
         check_rec('bogus'),
-        'my_rec is not a record'
+        'my_rec is not a record',
     );
 
     assert.equal(
         check_rec({foo: 'apple'}),
-        'in my_rec bar is missing'
+        'in my_rec bar is missing',
     );
 
     assert.equal(
         check_rec({}),
-        'in my_rec bar is missing, foo is missing'
+        'in my_rec bar is missing, foo is missing',
     );
 
     assert.equal(
         check_rec({foo: 'apple', bar: 42}),
-        'in my_rec bar is not a string'
+        'in my_rec bar is not a string',
     );
 
     const check_array = (val) => schema.check_array('lst', val, schema.check_string);
 
     assert.equal(
         check_array(['foo', 'bar']),
-        undefined
+        undefined,
     );
 
     assert.equal(
         check_array('foo'),
-        'lst is not an array'
+        'lst is not an array',
     );
 
     assert.equal(
         check_array(['foo', 3]),
-        'in lst we found an item where item is not a string'
+        'in lst we found an item where item is not a string',
     );
 });

--- a/frontend_tests/node_tests/scroll_util.js
+++ b/frontend_tests/node_tests/scroll_util.js
@@ -102,7 +102,7 @@ run_test('get_list_scrolling_container error', () => {
     blueslip.expect(
         'error',
         "Please wrap lists in an element with " +
-        "'max-height' attribute."
+        "'max-height' attribute.",
     );
 
     scroll_util.get_list_scrolling_container(body);

--- a/frontend_tests/node_tests/scroll_util.js
+++ b/frontend_tests/node_tests/scroll_util.js
@@ -73,22 +73,18 @@ run_test('scroll_element_into_container', () => {
 
     const elem1 = {
         innerHeight: () => 25,
-        position: () => {
-            return {
-                top: 0,
-            };
-        },
+        position: () => ({
+            top: 0,
+        }),
     };
     scroll_util.scroll_element_into_container(elem1, container);
     assert.equal(container.scrollTop(), 3);
 
     const elem2 = {
         innerHeight: () => 15,
-        position: () => {
-            return {
-                top: 250,
-            };
-        },
+        position: () => ({
+            top: 250,
+        }),
     };
     scroll_util.scroll_element_into_container(elem2, container);
     assert.equal(container.scrollTop(), 250 - 100 + 3 + 15);

--- a/frontend_tests/node_tests/scroll_util.js
+++ b/frontend_tests/node_tests/scroll_util.js
@@ -1,6 +1,6 @@
 zrequire('scroll_util');
 set_global('ui', {
-    get_scroll_element: element => element,
+    get_scroll_element: (element) => element,
 });
 
 run_test('scroll_delta', () => {

--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -155,9 +155,7 @@ run_test('initialize', () => {
                     assert.deepEqual(raw_operators, operators);
                     assert.deepEqual(options, {trigger: 'search'});
                 };
-                search_pill.get_search_string_for_current_filter = () => {
-                    return search_box_val;
-                };
+                search_pill.get_search_string_for_current_filter = () => search_box_val;
             };
 
             operators = [{
@@ -230,9 +228,7 @@ run_test('initialize', () => {
                 assert.deepEqual(raw_operators, operators);
                 assert.deepEqual(options, {trigger: 'search'});
             };
-            search_pill.get_search_string_for_current_filter = () => {
-                return search_box_val;
-            };
+            search_pill.get_search_string_for_current_filter = () => search_box_val;
         };
 
         operators = [{
@@ -277,9 +273,7 @@ run_test('initialize', () => {
     };
 
     const search_pill_stub = $.create('.pill');
-    search_pill_stub.closest = () => {
-        return { data: noop };
-    };
+    search_pill_stub.closest = () => ({ data: noop });
     const stub_event = {
         relatedTarget: search_pill_stub,
     };

--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -27,7 +27,7 @@ set_global('search_pill_widget', {
 search_pill.append_search_string = noop;
 search_pill.get_search_string_for_current_filter = noop;
 
-global.patch_builtin('setTimeout', func => func());
+global.patch_builtin('setTimeout', (func) => func());
 
 run_test('clear_search_form', () => {
     $('#search_query').val('noise');

--- a/frontend_tests/node_tests/search_legacy.js
+++ b/frontend_tests/node_tests/search_legacy.js
@@ -17,7 +17,7 @@ set_global('ui_util', {
 set_global('narrow', {});
 set_global('Filter', {});
 
-global.patch_builtin('setTimeout', func => func());
+global.patch_builtin('setTimeout', (func) => func());
 
 run_test('update_button_visibility', () => {
     const search_query = $('#search_query');

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -387,11 +387,9 @@ run_test('group_suggestions', () => {
     function message(user_ids, timestamp) {
         return {
             type: 'private',
-            display_recipient: user_ids.map((id) => {
-                return {
-                    id: id,
-                };
-            }),
+            display_recipient: user_ids.map((id) => ({
+                id: id,
+            })),
             timestamp: timestamp,
         };
     }

--- a/frontend_tests/node_tests/search_suggestion_legacy.js
+++ b/frontend_tests/node_tests/search_suggestion_legacy.js
@@ -390,11 +390,9 @@ run_test('group_suggestions', () => {
     function message(user_ids, timestamp) {
         return {
             type: 'private',
-            display_recipient: user_ids.map((id) => {
-                return {
-                    id: id,
-                };
-            }),
+            display_recipient: user_ids.map((id) => ({
+                id: id,
+            })),
             timestamp: timestamp,
         };
     }

--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -36,7 +36,7 @@ run_test('generate_zuliprc_uri', () => {
     const expected = "data:application/octet-stream;charset=utf-8," + encodeURIComponent(
         "[api]\nemail=error-bot@zulip.org\n" +
         "key=QadL788EkiottHmukyhHgePUFHREiu8b\n" +
-        "site=https://chat.example.com\n"
+        "site=https://chat.example.com\n",
     );
 
     assert.equal(uri, expected);

--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -24,9 +24,10 @@ zrequire('bot_data');
 zrequire('settings_bots');
 zrequire('people');
 
-set_global('ClipboardJS', function (sel) {
+function ClipboardJS(sel) {
     assert.equal(sel, '#copy_zuliprc');
-});
+}
+set_global('ClipboardJS', ClipboardJS);
 
 bot_data.initialize(bot_data_params);
 

--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -116,9 +116,7 @@ function set_up() {
 
     $('#config_inputbox').children = () => {
         const mock_children = {
-            hide: () => {
-                return;
-            },
+            hide: () => {},
         };
         return mock_children;
     };

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -33,7 +33,7 @@ const _page_params = {
 const _realm_icon = {};
 const _channel = {};
 
-global.stub_templates(function (name, data) {
+global.stub_templates((name, data) => {
     if (name === 'settings/admin_realm_domains_list') {
         assert(data.realm_domain.domain);
         return 'stub-domains-list';

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -57,9 +57,7 @@ const _realm_logo = {
 };
 
 const _list_render = {
-    create: () => {
-        return { init: noop };
-    },
+    create: () => ({ init: noop }),
 };
 
 set_global('channel', _channel);
@@ -221,25 +219,19 @@ function test_submit_settings_form(submit_form) {
     let stubs = createSaveButtons(subsection);
     let save_button = stubs.save_button;
     save_button.attr('id', `org-submit-${subsection}`);
-    save_button.replace = () => {
-        return `${subsection}`;
-    };
+    save_button.replace = () => `${subsection}`;
 
     $("#id_realm_waiting_period_threshold").val(10);
 
     const invite_to_stream_policy_elem = $("#id_realm_invite_to_stream_policy");
     invite_to_stream_policy_elem.val('1');
     invite_to_stream_policy_elem.attr("id", 'id_realm_invite_to_stream_policy');
-    invite_to_stream_policy_elem.data = () => {
-        return "number";
-    };
+    invite_to_stream_policy_elem.data = () => "number";
 
     const create_stream_policy_elem = $("#id_realm_create_stream_policy");
     create_stream_policy_elem.val('2');
     create_stream_policy_elem.attr("id", 'id_realm_create_stream_policy');
-    create_stream_policy_elem.data = () => {
-        return "number";
-    };
+    create_stream_policy_elem.data = () => "number";
 
     const add_emoji_by_admins_only_elem = $("#id_realm_add_emoji_by_admins_only");
     add_emoji_by_admins_only_elem.val("by_anyone");
@@ -248,15 +240,11 @@ function test_submit_settings_form(submit_form) {
     const bot_creation_policy_elem = $("#id_realm_bot_creation_policy");
     bot_creation_policy_elem.val("1");
     bot_creation_policy_elem.attr('id', 'id_realm_bot_creation_policy');
-    bot_creation_policy_elem.data = () => {
-        return "number";
-    };
+    bot_creation_policy_elem.data = () => "number";
     const email_address_visibility_elem = $("#id_realm_email_address_visibility");
     email_address_visibility_elem.val("1");
     email_address_visibility_elem.attr('id', 'id_realm_email_address_visibility');
-    email_address_visibility_elem.data = () => {
-        return "number";
-    };
+    email_address_visibility_elem.data = () => "number";
 
     let subsection_elem = $(`#org-${subsection}`);
     subsection_elem.closest = () => subsection_elem;
@@ -290,15 +278,11 @@ function test_submit_settings_form(submit_form) {
     const realm_default_language_elem = $("#id_realm_default_language");
     realm_default_language_elem.val("en");
     realm_default_language_elem.attr('id', 'id_realm_default_language');
-    realm_default_language_elem.data = () => {
-        return "string";
-    };
+    realm_default_language_elem.data = () => "string";
     const realm_default_twenty_four_hour_time_elem = $("#id_realm_default_twenty_four_hour_time");
     realm_default_twenty_four_hour_time_elem.val('true');
     realm_default_twenty_four_hour_time_elem.attr('id', 'id_realm_default_twenty_four_hour_time');
-    realm_default_twenty_four_hour_time_elem.data = () => {
-        return "boolean";
-    };
+    realm_default_twenty_four_hour_time_elem.data = () => "boolean";
 
     subsection_elem = $(`#org-${subsection}`);
     subsection_elem.closest = () => subsection_elem;
@@ -732,10 +716,8 @@ function test_discard_changes_button(discard_changes) {
 run_test('set_up', () => {
     const callbacks = {};
 
-    const set_callback = (name) => {
-        return (f) => {
-            callbacks[name] = f;
-        };
+    const set_callback = (name) => (f) => {
+        callbacks[name] = f;
     };
 
     const verify_realm_domains = simulate_realm_domains_table();
@@ -784,12 +766,10 @@ run_test('set_up', () => {
     };
 
     const dropdown_list_widget_backup = dropdown_list_widget;
-    window.dropdown_list_widget = () => {
-        return {
-            render: noop,
-            update: noop,
-        };
-    };
+    window.dropdown_list_widget = () => ({
+        render: noop,
+        update: noop,
+    });
     $("#id_realm_message_content_edit_limit_minutes").set_parent($.create('<stub edit limit parent>'));
     $("#id_realm_message_content_delete_limit_minutes").set_parent($.create('<stub delete limit parent>'));
     $("#id_realm_message_retention_days").set_parent($.create('<stub retention period parent>'));
@@ -1018,9 +998,7 @@ run_test('misc', () => {
     dropdown_list_parent.set_find_results('.dropdown_list_reset_button:not([disabled])', $.create('<disable button>'));
     widget_settings.forEach((name) => {
         const elem = $.create(`#${name}_widget #${name}_name`);
-        elem.closest = () => {
-            return dropdown_list_parent;
-        };
+        elem.closest = () => dropdown_list_parent;
     });
 
     // We do not define any settings we need in page_params yet, but we don't need to for this test.

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -200,7 +200,7 @@ function test_submit_settings_form(submit_form) {
         realm_create_stream_policy: settings_config.create_stream_policy_values.by_members.code,
     });
 
-    global.patch_builtin('setTimeout', func => func());
+    global.patch_builtin('setTimeout', (func) => func());
     const ev = {
         preventDefault: noop,
         stopPropagation: noop,
@@ -1016,7 +1016,7 @@ run_test('misc', () => {
                              'realm_default_code_block_language'];
     const dropdown_list_parent = $.create(`<list parent>`);
     dropdown_list_parent.set_find_results('.dropdown_list_reset_button:not([disabled])', $.create('<disable button>'));
-    widget_settings.forEach(name => {
+    widget_settings.forEach((name) => {
         const elem = $.create(`#${name}_widget #${name}_name`);
         elem.closest = () => {
             return dropdown_list_parent;

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -92,7 +92,7 @@ run_test('unloaded', () => {
 function simulate_realm_domains_table() {
     $('#realm_domains_table tbody').set_find_results(
         'tr',
-        $.create('realm-tr-stub')
+        $.create('realm-tr-stub'),
     );
 
     let appended;
@@ -111,12 +111,12 @@ function test_realms_domain_modal(add_realm_domain) {
 
     $('#add-realm-domain-widget').set_find_results(
         '.new-realm-domain',
-        $.create('new-realm-domain-stub')
+        $.create('new-realm-domain-stub'),
     );
 
     $('#add-realm-domain-widget').set_find_results(
         '.new-realm-domain-allow-subdomains',
-        $.create('new-realm-domain-allow-subdomains-stub')
+        $.create('new-realm-domain-allow-subdomains-stub'),
     );
 
     let posted;
@@ -147,23 +147,23 @@ function createSaveButtons(subsection) {
     const stub_discard_button = $(`#org-discard-${subsection}`);
     const stub_save_button_text = $('.icon-button-text');
     stub_save_button_header.set_find_results(
-        '.subsection-failed-status p', $('<failed status element>')
+        '.subsection-failed-status p', $('<failed status element>'),
     );
     stub_save_button.closest = () => stub_save_button_header;
     save_button_controls.set_find_results(
-        '.save-button', stub_save_button
+        '.save-button', stub_save_button,
     );
     stub_save_button.set_find_results(
-        '.icon-button-text', stub_save_button_text
+        '.icon-button-text', stub_save_button_text,
     );
     stub_save_button_header.set_find_results(
-        '.save-button-controls', save_button_controls
+        '.save-button-controls', save_button_controls,
     );
     stub_save_button_header.set_find_results(
-        '.subsection-changes-discard .button', $(`#org-discard-${subsection}`)
+        '.subsection-changes-discard .button', $(`#org-discard-${subsection}`),
     );
     save_button_controls.set_find_results(
-        '.discard-button', stub_discard_button
+        '.discard-button', stub_discard_button,
     );
     const props  = {};
     props.hidden = false;
@@ -429,21 +429,21 @@ function test_extract_property_name() {
     $('#id_realm_allow_message_editing').attr('id', 'id_realm_allow_message_editing');
     assert.equal(
         settings_org.extract_property_name($('#id_realm_allow_message_editing')),
-        'realm_allow_message_editing'
+        'realm_allow_message_editing',
     );
 
     $('#id_realm_message_content_edit_limit_minutes_label').attr(
         'id', 'id_realm_message_content_edit_limit_minutes_label');
     assert.equal(
         settings_org.extract_property_name($('#id_realm_message_content_edit_limit_minutes_label')),
-        'realm_message_content_edit_limit_minutes_label'
+        'realm_message_content_edit_limit_minutes_label',
     );
 
     $('#id-realm-allow-message-deleting').attr(
         'id', 'id-realm-allow-message-deleting');
     assert.equal(
         settings_org.extract_property_name($('#id-realm-allow-message-deleting')),
-        'realm_allow_message_deleting'
+        'realm_allow_message_deleting',
     );
 }
 

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -126,7 +126,7 @@ run_test('populate_user_groups', () => {
 
     let templates_render_called = false;
     const fake_rendered_temp = $.create('fake_admin_user_group_list_template_rendered');
-    global.stub_templates(function (template, args) {
+    global.stub_templates((template, args) => {
         assert.equal(template, 'admin_user_group_list');
         assert.equal(args.user_group.id, 1);
         assert.equal(args.user_group.name, 'Mobile');
@@ -326,7 +326,7 @@ run_test('populate_user_groups', () => {
     }
 
     pills.onPillRemove = function (handler) {
-        global.patch_builtin('setTimeout', function (func) {
+        global.patch_builtin('setTimeout', (func) => {
             func();
         });
         realm_user_group.members = new Set([2, 31]);
@@ -364,9 +364,7 @@ run_test('with_external_user', () => {
         return noop;
     };
 
-    global.stub_templates(function () {
-        return noop;
-    });
+    global.stub_templates(() => noop);
 
     people.get_by_user_id = function () {
         return noop;
@@ -791,7 +789,7 @@ run_test('on_events', () => {
             assert.equal(opts.data.description, 'translated: All mobile members');
             api_endpoint_called = true;
             (function test_post_success() {
-                global.patch_builtin('setTimeout', function (func) {
+                global.patch_builtin('setTimeout', (func) => {
                     func();
                 });
                 opts.success();

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -210,7 +210,7 @@ run_test('populate_user_groups', () => {
 
         (function test_source() {
             const result = config.source.call(fake_context, iago);
-            const emails = result.map(user => user.email).sort();
+            const emails = result.map((user) => user.email).sort();
             assert.deepEqual(emails, [alice.email, bob.email]);
         }());
 

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -4,7 +4,7 @@ set_global('page_params', {
     is_guest: false,
 });
 
-set_global('$', function () {
+set_global('$', () => {
 });
 
 set_global('document', null);
@@ -948,7 +948,7 @@ run_test('filter inactives', () => {
     stream_data.initialize(params);
     assert(!stream_data.is_filtering_inactives());
 
-    _.times(30, function (i) {
+    _.times(30, (i) => {
         const name = 'random' + i.toString();
         const stream_id = 100 + i;
 

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -1069,7 +1069,7 @@ run_test('all_topics_in_cache', () => {
 
     message_list.all.data.add_messages(messages);
     assert.equal(stream_data.all_topics_in_cache(sub), false);
-    message_list.all.data.fetch_status.has_found_newest = () => {return true;};
+    message_list.all.data.fetch_status.has_found_newest = () => true;
     assert.equal(stream_data.all_topics_in_cache(sub), true);
 
     sub.first_message_id = 0;

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -197,7 +197,7 @@ run_test('subscribers', () => {
             fred.user_id,
             not_fred.user_id,
             george.user_id,
-        ]
+        ],
     );
 
     stream_data.set_subscribers(sub, [me.user_id, fred.user_id, george.user_id]);
@@ -211,7 +211,7 @@ run_test('subscribers', () => {
         potential_subscriber_ids(),
         [
             not_fred.user_id,
-        ]
+        ],
     );
 
     stream_data.set_subscribers(sub, []);
@@ -566,7 +566,7 @@ run_test('default_stream_names', () => {
         [
             announce.stream_id,
             general.stream_id,
-        ]
+        ],
     );
 });
 
@@ -836,7 +836,7 @@ run_test('remove_default_stream', () => {
 run_test('canonicalized_name', () => {
     assert.deepStrictEqual(
         stream_data.canonicalized_name('Stream_Bar'),
-        "stream_bar"
+        "stream_bar",
     );
 });
 
@@ -998,7 +998,7 @@ run_test('is_subscriber_subset', () => {
     for (const row of matrix) {
         assert.equal(
             stream_data.is_subscriber_subset(row[0], row[1]),
-            row[2]
+            row[2],
         );
     }
 });

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -35,7 +35,7 @@ people.add_active_user(me);
 people.initialize_current_user(me.user_id);
 
 function contains_sub(subs, sub) {
-    return subs.some(s => s.name === sub.name);
+    return subs.some((s) => s.name === sub.name);
 }
 
 run_test('basics', () => {
@@ -915,7 +915,7 @@ run_test('initialize', () => {
     initialize();
     assert(!stream_data.is_filtering_inactives());
 
-    const stream_names = stream_data.get_streams_for_admin().map(elem => elem.name);
+    const stream_names = stream_data.get_streams_for_admin().map((elem) => elem.name);
     assert(stream_names.includes('subscriptions'));
     assert(stream_names.includes('unsubscribed'));
     assert(stream_names.includes('never_subscribed'));

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -31,9 +31,9 @@ stream_data.add_sub(frontend);
 
 run_test('update_property', () => {
     // Invoke error for non-existent stream/property
-    with_overrides(function (override) {
+    with_overrides((override) => {
         let errors = 0;
-        override('blueslip.warn', function () {
+        override('blueslip.warn', () => {
             errors += 1;
         });
 
@@ -45,8 +45,8 @@ run_test('update_property', () => {
     });
 
     // Test update color
-    with_overrides(function (override) {
-        global.with_stub(function (stub) {
+    with_overrides((override) => {
+        global.with_stub((stub) => {
             override('stream_color.update_stream_color', stub.f);
             stream_events.update_property(1, 'color', 'blue');
             const args = stub.get_args('sub', 'val');
@@ -56,8 +56,8 @@ run_test('update_property', () => {
     });
 
     // Test in home view
-    with_overrides(function (override) {
-        global.with_stub(function (stub) {
+    with_overrides((override) => {
+        global.with_stub((stub) => {
             override('stream_muting.update_is_muted', stub.f);
             stream_events.update_property(1, 'in_home_view', false);
             const args = stub.get_args('sub', 'val');
@@ -97,8 +97,8 @@ run_test('update_property', () => {
     assert.equal(checkbox.prop('checked'), true);
 
     // Test name change
-    with_overrides(function (override) {
-        global.with_stub(function (stub) {
+    with_overrides((override) => {
+        global.with_stub((stub) => {
             override('subs.update_stream_name', stub.f);
             stream_events.update_property(1, 'name', 'the frontend');
             const args = stub.get_args('sub', 'val');
@@ -108,8 +108,8 @@ run_test('update_property', () => {
     });
 
     // Test description change
-    with_overrides(function (override) {
-        global.with_stub(function (stub) {
+    with_overrides((override) => {
+        global.with_stub((stub) => {
             override('subs.update_stream_description', stub.f);
             stream_events.update_property(1, 'description', 'we write code', {rendered_description: 'we write code'});
             const args = stub.get_args('sub', 'val');
@@ -123,7 +123,7 @@ run_test('update_property', () => {
     assert.equal(frontend.email_address, 'zooly@zulip.com');
 
     // Test pin to top
-    with_overrides(function (override) {
+    with_overrides((override) => {
         override('stream_list.refresh_pinned_or_unpinned_stream', noop);
         stream_events.update_property(1, 'pin_to_top', true);
         checkbox = $("#pin_to_top_1");
@@ -131,8 +131,8 @@ run_test('update_property', () => {
     });
 
     // Test stream privacy change event
-    with_overrides(function (override) {
-        global.with_stub(function (stub) {
+    with_overrides((override) => {
+        global.with_stub((stub) => {
             override('subs.update_stream_privacy', stub.f);
             stream_events.update_property(1, 'invite_only', true, {
                 history_public_to_subscribers: true,
@@ -147,8 +147,8 @@ run_test('update_property', () => {
     });
 
     // Test stream stream_post_policy change event
-    with_overrides(function (override) {
-        global.with_stub(function (stub) {
+    with_overrides((override) => {
+        global.with_stub((stub) => {
             override('subs.update_stream_post_policy', stub.f);
             stream_events.update_property(1, 'stream_post_policy', stream_data.stream_post_policy_values.admins.code);
             const args = stub.get_args('sub', 'val');
@@ -158,8 +158,8 @@ run_test('update_property', () => {
     });
 
     // Test stream message_retention_days change event
-    with_overrides(function (override) {
-        global.with_stub(function (stub) {
+    with_overrides((override) => {
+        global.with_stub((stub) => {
             override('subs.update_message_retention_setting', stub.f);
             stream_events.update_property(1, 'message_retention_days', 20);
             const args = stub.get_args('sub', 'val');
@@ -171,10 +171,10 @@ run_test('update_property', () => {
 
 run_test('marked_subscribed', () => {
     // Test undefined error
-    with_overrides(function (override) {
+    with_overrides((override) => {
         let errors = 0;
         override('stream_color.update_stream_color', noop);
-        override('blueslip.error', function () {
+        override('blueslip.error', () => {
             errors += 1;
         });
         stream_events.mark_subscribed(undefined, [], 'yellow');
@@ -182,9 +182,9 @@ run_test('marked_subscribed', () => {
     });
 
     // Test early return if subscribed
-    with_overrides(function (override) {
+    with_overrides((override) => {
         let completed = false;
-        override('message_util.do_unread_count_updates', function () {
+        override('message_util.do_unread_count_updates', () => {
             completed = true; // This gets run if we continue and don't early return
         });
         const subscribed = {subscribed: true};
@@ -208,7 +208,7 @@ run_test('marked_subscribed', () => {
     set_global('overlays', { streams_open: return_true });
 
     // Test basic dispatching and updating stream color
-    with_overrides(function (override) {
+    with_overrides((override) => {
         let args;
         let list_updated = false;
 
@@ -218,10 +218,8 @@ run_test('marked_subscribed', () => {
         override('stream_color.update_stream_color', noop);
         override('stream_list.add_sidebar_row', stream_list_stub.f);
         override('message_util.do_unread_count_updates', message_util_stub.f);
-        override('narrow_state.is_for_stream_id', function () {
-            return true;
-        });
-        override('current_msg_list.update_trailing_bookend', function () {
+        override('narrow_state.is_for_stream_id', () => true);
+        override('current_msg_list.update_trailing_bookend', () => {
             list_updated = true;
         });
 
@@ -239,17 +237,15 @@ run_test('marked_subscribed', () => {
     });
 
     // Test assigning generated color
-    with_overrides(function (override) {
+    with_overrides((override) => {
         frontend.color = undefined;
-        override('color_data.pick_color', function () {
-            return 'green';
-        });
+        override('color_data.pick_color', () => 'green');
         let warnings = 0;
-        override('blueslip.warn', function () {
+        override('blueslip.warn', () => {
             warnings += 1;
         });
 
-        global.with_stub(function (stub) {
+        global.with_stub((stub) => {
             override('narrow_state.is_for_stream_id', noop);
             override('message_util.do_unread_count_updates', noop);
             override('stream_list.add_sidebar_row', noop);
@@ -266,12 +262,12 @@ run_test('marked_subscribed', () => {
     narrow_state.is_for_stream_id = () => false;
 
     // Test assigning subscriber emails
-    with_overrides(function (override) {
+    with_overrides((override) => {
         override('stream_color.update_stream_color', noop);
         override('message_util.do_unread_count_updates', noop);
         override('stream_list.add_sidebar_row', noop);
 
-        global.with_stub(function (stub) {
+        global.with_stub((stub) => {
             override('stream_data.set_subscribers', stub.f);
             const user_ids = [15, 20, 25];
             stream_events.mark_subscribed(frontend, user_ids, '');
@@ -281,7 +277,7 @@ run_test('marked_subscribed', () => {
         });
 
         // assign self as well
-        global.with_stub(function (stub) {
+        global.with_stub((stub) => {
             override('stream_data.subscribe_myself', stub.f);
             stream_events.mark_subscribed(frontend, [], '');
             const args = stub.get_args('sub');
@@ -289,7 +285,7 @@ run_test('marked_subscribed', () => {
         });
 
         // and finally update subscriber settings
-        global.with_stub(function (stub) {
+        global.with_stub((stub) => {
             override('subs.update_settings_for_subscribed', stub.f);
             stream_events.mark_subscribed(frontend, [], '');
             const args = stub.get_args('sub');
@@ -299,7 +295,7 @@ run_test('marked_subscribed', () => {
 });
 
 run_test('mark_unsubscribed', () => {
-    with_overrides(function (override) {
+    with_overrides((override) => {
         let removed_sub = false;
         override('stream_list.remove_sidebar_row', () => {
             removed_sub = true;
@@ -317,8 +313,8 @@ run_test('mark_unsubscribed', () => {
 
     // Test unsubscribe
     frontend.subscribed = true;
-    with_overrides(function (override) {
-        global.with_stub(function (stub) {
+    with_overrides((override) => {
+        global.with_stub((stub) => {
             override('stream_data.unsubscribe_myself', stub.f);
             override('subs.update_settings_for_unsubscribed', noop);
             override('stream_list.remove_sidebar_row', noop);
@@ -329,8 +325,8 @@ run_test('mark_unsubscribed', () => {
     });
 
     // Test update settings after unsubscribe
-    with_overrides(function (override) {
-        global.with_stub(function (stub) {
+    with_overrides((override) => {
+        global.with_stub((stub) => {
             override('subs.update_settings_for_unsubscribed', stub.f);
             override('stream_data.unsubscribe_myself', noop);
             override('stream_list.remove_sidebar_row', noop);
@@ -341,15 +337,13 @@ run_test('mark_unsubscribed', () => {
     });
 
     // Test update bookend and remove done event
-    with_overrides(function (override) {
+    with_overrides((override) => {
         override('stream_data.unsubscribe_myself', noop);
         override('subs.update_settings_for_unsubscribed', noop);
-        override('narrow_state.is_for_stream_id', function () {
-            return true;
-        });
+        override('narrow_state.is_for_stream_id', () => true);
 
         let updated = false;
-        override('current_msg_list.update_trailing_bookend', function () {
+        override('current_msg_list.update_trailing_bookend', () => {
             updated = true;
         });
 

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -625,7 +625,7 @@ run_test('update_count_in_dom', () => {
     const stream_li = make_elem(
         $('<stream li>'),
         '<stream-count>',
-        '<stream-value>'
+        '<stream-value>',
     );
 
     $('<stream li>').length = 0;

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -718,9 +718,7 @@ run_test('refresh_pin', () => {
     const li_stub = $.create('li stub');
     li_stub.length = 0;
 
-    global.stub_templates(() => {
-        return {to_$: () => li_stub};
-    });
+    global.stub_templates(() => ({to_$: () => li_stub}));
 
     stream_list.update_count_in_dom = noop;
     $('#stream_filters').append = noop;

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -390,7 +390,7 @@ run_test('narrowing', () => {
     scroll_util.scroll_element_into_container = noop;
 
     set_global('ui', {
-        get_scroll_element: element => element,
+        get_scroll_element: (element) => element,
     });
 
     assert(!$('<devel sidebar row html>').hasClass('active-filter'));

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -68,7 +68,7 @@ run_test('create_sidebar_row', () => {
         devel_count.set_find_results('.value', devel_value);
         devel_count.set_parent(sidebar_row);
 
-        global.stub_templates(function (template_name, data) {
+        global.stub_templates((template_name, data) => {
             assert.equal(template_name, 'stream_sidebar_row');
             assert.equal(data.uri, '#narrow/stream/100-devel');
             return '<devel sidebar row>';
@@ -87,7 +87,7 @@ run_test('create_sidebar_row', () => {
         social_count.set_find_results('.value', social_value);
         social_count.set_parent(sidebar_row);
 
-        global.stub_templates(function (template_name, data) {
+        global.stub_templates((template_name, data) => {
             assert.equal(template_name, 'stream_sidebar_row');
             assert.equal(data.uri, '#narrow/stream/200-social');
             return '<social sidebar row>';
@@ -133,7 +133,7 @@ run_test('create_sidebar_row', () => {
 
     social.invite_only = true;
     social.color = '#222222';
-    global.stub_templates(function (template_name, data) {
+    global.stub_templates((template_name, data) => {
         assert.equal(template_name, 'stream_privacy');
         assert.equal(data.invite_only, true);
         assert.equal(data.dark_background, 'dark_background');
@@ -747,7 +747,7 @@ run_test('create_initial_sidebar_rows', () => {
 
     stream_list.update_count_in_dom = noop;
 
-    global.stub_templates(function (template_name, data) {
+    global.stub_templates((template_name, data) => {
         assert.equal(template_name, 'stream_sidebar_row');
         return '<div>stub-html-' + data.name;
     });

--- a/frontend_tests/node_tests/stream_sort.js
+++ b/frontend_tests/node_tests/stream_sort.js
@@ -50,10 +50,8 @@ function sort_groups(query) {
     return stream_sort.sort_groups(streams, query);
 }
 
-with_overrides(function (override) {
-    override('stream_data.is_active', function (sub) {
-        return sub.name !== "pneumonia";
-    });
+with_overrides((override) => {
+    override('stream_data.is_active', (sub) => sub.name !== "pneumonia");
 
     // Test sorting into categories/alphabetized
     let sorted = sort_groups("");

--- a/frontend_tests/node_tests/stream_topic_history.js
+++ b/frontend_tests/node_tests/stream_topic_history.js
@@ -92,9 +92,7 @@ run_test('is_complete_for_stream_id', () => {
                 has_found_newest: () => true,
             },
         },
-        first: () => {
-            return {id: 5};
-        },
+        first: () => ({id: 5}),
     };
 
     assert.equal(
@@ -102,9 +100,7 @@ run_test('is_complete_for_stream_id', () => {
         true);
 
     // Now simulate a more recent message id.
-    message_list.all.first = () => {
-        return {id: sub.first_message_id + 1};
-    };
+    message_list.all.first = () => ({id: sub.first_message_id + 1});
 
     // Note that we'll return `true` here due to
     // fetched_stream_ids having the stream_id now.

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -1,8 +1,8 @@
 global.stub_out_jquery();
 
 set_global('ui', {
-    get_content_element: element => element,
-    get_scroll_element: element => element,
+    get_content_element: (element) => element,
+    get_scroll_element: (element) => element,
 });
 zrequire('stream_data');
 zrequire('search_util');

--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -225,49 +225,49 @@ run_test('last_seen_status_from_date', () => {
         assert.equal(actual_status, expected_status);
     }
 
-    assert_same(function (d) { return d.addSeconds(-20); },
+    assert_same((d) => d.addSeconds(-20),
                 i18n.t("Just now"));
 
-    assert_same(function (d) { return d.addMinutes(-1); },
+    assert_same((d) => d.addMinutes(-1),
                 i18n.t("Just now"));
 
-    assert_same(function (d) { return d.addMinutes(-2); },
+    assert_same((d) => d.addMinutes(-2),
                 i18n.t("Just now"));
 
-    assert_same(function (d) { return d.addMinutes(-30); },
+    assert_same((d) => d.addMinutes(-30),
                 i18n.t("30 minutes ago"));
 
-    assert_same(function (d) { return d.addHours(-1); },
+    assert_same((d) => d.addHours(-1),
                 i18n.t("An hour ago"));
 
-    assert_same(function (d) { return d.addHours(-2); },
+    assert_same((d) => d.addHours(-2),
                 i18n.t("2 hours ago"));
 
-    assert_same(function (d) { return d.addHours(-20); },
+    assert_same((d) => d.addHours(-20),
                 i18n.t("20 hours ago"));
 
-    assert_same(function (d) { return d.addDays(-1); },
+    assert_same((d) => d.addDays(-1),
                 i18n.t("Yesterday"));
 
-    assert_same(function (d) { return d.addDays(-2); },
+    assert_same((d) => d.addDays(-2),
                 i18n.t("2 days ago"));
 
-    assert_same(function (d) { return d.addDays(-61); },
+    assert_same((d) => d.addDays(-61),
                 i18n.t("61 days ago"));
 
-    assert_same(function (d) { return d.addDays(-300); },
+    assert_same((d) => d.addDays(-300),
                 i18n.t("May 06,\xa02015"));
 
-    assert_same(function (d) { return d.addDays(-366); },
+    assert_same((d) => d.addDays(-366),
                 i18n.t("Mar 01,\xa02015"));
 
-    assert_same(function (d) { return d.addYears(-3); },
+    assert_same((d) => d.addYears(-3),
                 i18n.t("Mar 01,\xa02013"));
 
     // Set base_dateto to May 1 2016 12.30 AM (months are zero based)
     base_date = new XDate(2016, 4, 1, 0, 30);
 
-    assert_same(function (d) { return d.addDays(-91); },
+    assert_same((d) => d.addDays(-91),
                 i18n.t("Jan\xa031"));
 
 });

--- a/frontend_tests/node_tests/top_left_corner.js
+++ b/frontend_tests/node_tests/top_left_corner.js
@@ -108,19 +108,19 @@ run_test('update_count_in_dom', () => {
     make_elem(
         $(".top_left_mentions"),
         '<mentioned-count>',
-        '<mentioned-value>'
+        '<mentioned-value>',
     );
 
     make_elem(
         $(".top_left_all_messages"),
         '<home-count>',
-        '<home-value>'
+        '<home-value>',
     );
 
     make_elem(
         $(".top_left_starred_messages"),
         '<starred-count>',
-        '<starred-value>'
+        '<starred-value>',
     );
 
     top_left_corner.update_dom_with_unread_counts(counts);

--- a/frontend_tests/node_tests/topic_list_data.js
+++ b/frontend_tests/node_tests/topic_list_data.js
@@ -81,7 +81,7 @@ run_test('get_list_info unreads', () => {
     // Going forward, we just stub get_recent_topic_names
     // for simpler test setup.
     stream_topic_history.get_recent_topic_names = () => {
-        return _.range(15).map(i => 'topic ' + i);
+        return _.range(15).map((i) => 'topic ' + i);
     };
 
     const unread_cnt = new Map();
@@ -108,7 +108,7 @@ run_test('get_list_info unreads', () => {
     assert.equal(list_info.num_possible_topics, 15);
 
     assert.deepEqual(
-        list_info.items.map(li => li.topic_name),
+        list_info.items.map((li) => li.topic_name),
         [
             'topic 0',
             'topic 1',
@@ -128,7 +128,7 @@ run_test('get_list_info unreads', () => {
     assert.equal(list_info.num_possible_topics, 15);
 
     assert.deepEqual(
-        list_info.items.map(li => li.topic_name),
+        list_info.items.map((li) => li.topic_name),
         [
             'topic 0',
             'topic 1',
@@ -155,7 +155,7 @@ run_test('get_list_info unreads', () => {
     assert.equal(list_info.num_possible_topics, 15);
 
     assert.deepEqual(
-        list_info.items.map(li => li.topic_name),
+        list_info.items.map((li) => li.topic_name),
         [
             'topic 0',
             'topic 1',

--- a/frontend_tests/node_tests/topic_list_data.js
+++ b/frontend_tests/node_tests/topic_list_data.js
@@ -80,9 +80,7 @@ run_test('get_list_info unreads', () => {
 
     // Going forward, we just stub get_recent_topic_names
     // for simpler test setup.
-    stream_topic_history.get_recent_topic_names = () => {
-        return _.range(15).map((i) => 'topic ' + i);
-    };
+    stream_topic_history.get_recent_topic_names = () => _.range(15).map((i) => 'topic ' + i);
 
     const unread_cnt = new Map();
     unread.num_unread_for_topic = (stream_id, topic_name) => {

--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -35,7 +35,7 @@ run_test('get_emoji_matcher', () => {
         const matcher = typeahead.get_emoji_matcher(query);
         assert.deepEqual(
             emojis.filter(matcher),
-            expected
+            expected,
         );
     }
 
@@ -67,7 +67,7 @@ run_test('triage', () => {
         {
             matches: [alice, Alicia],
             rest: [steve, Stephanie],
-        }
+        },
     );
 
     assert.deepEqual(
@@ -75,7 +75,7 @@ run_test('triage', () => {
         {
             matches: [Alicia, alice],
             rest: [steve, Stephanie],
-        }
+        },
     );
 
     assert.deepEqual(
@@ -83,7 +83,7 @@ run_test('triage', () => {
         {
             matches: [Stephanie, steve],
             rest: [alice, Alicia],
-        }
+        },
     );
 
     assert.deepEqual(
@@ -91,7 +91,7 @@ run_test('triage', () => {
         {
             matches: [],
             rest: [alice, Alicia, steve, Stephanie],
-        }
+        },
     );
 });
 
@@ -119,7 +119,7 @@ run_test('sort_emojis th', () => {
             thermometer,
             thumbs_down,
             mother_nature,
-        ]
+        ],
     );
 });
 
@@ -143,7 +143,7 @@ run_test('sort_emojis sm', () => {
             slight_smile,
             small_airplane,
             big_smile,
-        ]
+        ],
     );
 });
 

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -26,8 +26,8 @@ let next_id = 0;
 
 function assertSameEmails(lst1, lst2) {
     assert.deepEqual(
-        lst1.map(r => r.email),
-        lst2.map(r => r.email)
+        lst1.map((r) => r.email),
+        lst2.map((r) => r.email)
     );
 }
 
@@ -211,7 +211,7 @@ function get_typeahead_result(query, current_stream, current_topic) {
         current_stream,
         current_topic
     );
-    return result.map(person => person.email);
+    return result.map((person) => person.email);
 }
 
 run_test('sort_recipients', () => {
@@ -363,7 +363,7 @@ run_test('sort_recipients dup bots', () => {
     const dup_objects = matches.concat([a_bot]);
 
     const recipients = th.sort_recipients(dup_objects, "b", "", "");
-    const recipients_email = recipients.map(person => person.email);
+    const recipients_email = recipients.map((person) => person.email);
     const expected = [
         'b_bot@example.com',
         'b_user_3@zulip.net',
@@ -400,7 +400,7 @@ run_test('sort_recipients subscribers', () => {
     // b_user_2 is a subscriber and b_user_1 is not.
     const small_matches = [b_user_2, b_user_1];
     const recipients = th.sort_recipients(small_matches, "b", "Dev", "Dev Topic");
-    const recipients_email = recipients.map(person => person.email);
+    const recipients_email = recipients.map((person) => person.email);
     const expected = [
         'b_user_2@zulip.net',
         'b_user_1@zulip.net',
@@ -413,7 +413,7 @@ run_test('sort_recipients pm partners', () => {
     // both are not subscribered to the stream Linux.
     const small_matches = [b_user_3, b_user_2];
     const recipients = th.sort_recipients(small_matches, "b", "Linux", "Linux Topic");
-    const recipients_email = recipients.map(person => person.email);
+    const recipients_email = recipients.map((person) => person.email);
     const expected = [
         'b_user_3@zulip.net',
         'b_user_2@zulip.net',
@@ -432,7 +432,7 @@ run_test('sort broadcast mentions', () => {
         '');
 
     assert.deepEqual(
-        results.map(r => r.email),
+        results.map((r) => r.email),
         ['all', 'everyone', 'stream']
     );
 
@@ -449,7 +449,7 @@ run_test('sort broadcast mentions', () => {
         '');
 
     assert.deepEqual(
-        results2.map(r => r.email),
+        results2.map((r) => r.email),
         ['all',
          'everyone',
          'stream',
@@ -709,7 +709,7 @@ run_test('sort_slash_commands', () => {
 
 run_test('sort_recipientbox_typeahead', () => {
     let recipients = th.sort_recipientbox_typeahead("b, a", matches, ""); // search "a"
-    let recipients_email = recipients.map(person => person.email);
+    let recipients_email = recipients.map((person) => person.email);
     assert.deepEqual(recipients_email, [
         'a_user@zulip.org', // matches "a"
         'a_bot@zulip.com', // matches "a"
@@ -721,7 +721,7 @@ run_test('sort_recipientbox_typeahead', () => {
     ]);
 
     recipients = th.sort_recipientbox_typeahead("b, a, b", matches, ""); // search "b"
-    recipients_email = recipients.map(person => person.email);
+    recipients_email = recipients.map((person) => person.email);
     assert.deepEqual(recipients_email, [
         'b_bot@example.com',
         'b_user_3@zulip.net',

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -1,7 +1,5 @@
 set_global('page_params', {realm_is_zephyr_mirror_realm: false});
-set_global('md5', function (s) {
-    return 'md5-' + s;
-});
+set_global('md5', (s) => 'md5-' + s);
 
 const settings_config = zrequire('settings_config');
 page_params.realm_email_address_visibility =
@@ -504,7 +502,7 @@ run_test('render_person when emails hidden', () => {
     // Test render_person with regular person, under hidden email visibility case
     page_params.is_admin = false;
     let rendered = false;
-    global.stub_templates(function (template_name, args) {
+    global.stub_templates((template_name, args) => {
         assert.equal(template_name, 'typeahead_list_item');
         assert.equal(args.primary, b_user_1.full_name);
         assert.equal(args.secondary, undefined);
@@ -519,7 +517,7 @@ run_test('render_person', () => {
     page_params.is_admin = true;
     // Test render_person with regular person
     let rendered = false;
-    global.stub_templates(function (template_name, args) {
+    global.stub_templates((template_name, args) => {
         assert.equal(template_name, 'typeahead_list_item');
         assert.equal(args.primary, a_user.full_name);
         assert.equal(args.secondary, a_user.email);
@@ -539,7 +537,7 @@ run_test('render_person', () => {
         special_item_text: "special_text",
     };
     rendered = false;
-    global.stub_templates(function (template_name, args) {
+    global.stub_templates((template_name, args) => {
         assert.equal(template_name, 'typeahead_list_item');
         assert.equal(args.primary, special_person.special_item_text);
         rendered = true;
@@ -551,7 +549,7 @@ run_test('render_person', () => {
 
 run_test('clear_rendered_person', () => {
     let rendered = false;
-    global.stub_templates(function (template_name, args) {
+    global.stub_templates((template_name, args) => {
         assert.equal(template_name, 'typeahead_list_item');
         assert.equal(args.primary, b_bot.full_name);
         assert.equal(args.secondary, b_bot.email);
@@ -583,7 +581,7 @@ run_test('render_stream', () => {
         stream_id: 42,
         name: 'Short Description',
     };
-    global.stub_templates(function (template_name, args) {
+    global.stub_templates((template_name, args) => {
         assert.equal(template_name, 'typeahead_list_item');
         assert.equal(args.primary, stream.name);
         assert.equal(args.secondary, stream.description);
@@ -600,7 +598,7 @@ run_test('render_stream', () => {
         stream_id: 43,
         name: 'Long Description',
     };
-    global.stub_templates(function (template_name, args) {
+    global.stub_templates((template_name, args) => {
         assert.equal(template_name, 'typeahead_list_item');
         assert.equal(args.primary, stream.name);
         const short_desc = stream.description.substring(0, 35);
@@ -619,7 +617,7 @@ run_test('clear_rendered_stream', () => {
         stream_id: 44,
         name: 'Stream To Be Cleared',
     };
-    global.stub_templates(function (template_name, args) {
+    global.stub_templates((template_name, args) => {
         assert.equal(template_name, 'typeahead_list_item');
         assert.equal(args.primary, stream.name);
         assert.equal(args.secondary, stream.description);
@@ -650,7 +648,7 @@ run_test('render_emoji', () => {
         realm_emoji: 'TBD',
     }));
 
-    global.stub_templates(function (template_name, args) {
+    global.stub_templates((template_name, args) => {
         assert.equal(template_name, 'typeahead_list_item');
         assert.deepEqual(args, {
             primary: 'thumbs up',
@@ -672,7 +670,7 @@ run_test('render_emoji', () => {
         emoji_url: 'TBD',
     };
 
-    global.stub_templates(function (template_name, args) {
+    global.stub_templates((template_name, args) => {
         assert.equal(template_name, 'typeahead_list_item');
         assert.deepEqual(args, {
             primary: 'realm emoji',

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -25,7 +25,7 @@ let next_id = 0;
 function assertSameEmails(lst1, lst2) {
     assert.deepEqual(
         lst1.map((r) => r.email),
-        lst2.map((r) => r.email)
+        lst2.map((r) => r.email),
     );
 }
 
@@ -207,7 +207,7 @@ function get_typeahead_result(query, current_stream, current_topic) {
         people.get_realm_users(),
         query,
         current_stream,
-        current_topic
+        current_topic,
     );
     return result.map((person) => person.email);
 }
@@ -322,7 +322,7 @@ run_test('sort_recipients all mention', () => {
         test_objs,
         'a',
         'Linux',
-        'Linux Topic'
+        'Linux Topic',
     );
 
     assertSameEmails(results, [
@@ -431,7 +431,7 @@ run_test('sort broadcast mentions', () => {
 
     assert.deepEqual(
         results.map((r) => r.email),
-        ['all', 'everyone', 'stream']
+        ['all', 'everyone', 'stream'],
     );
 
     // Reverse the list to test actual sorting
@@ -452,7 +452,7 @@ run_test('sort broadcast mentions', () => {
          'everyone',
          'stream',
          a_user.email,
-         zman.email]
+         zman.email],
     );
 });
 

--- a/frontend_tests/node_tests/typing_status.js
+++ b/frontend_tests/node_tests/typing_status.js
@@ -268,7 +268,7 @@ run_test('basics', () => {
 
     // stub functions to see how may time they are called
     for (const method of Object.keys(call_count)) {
-        typing_status.__Rewire__(method, function () {
+        typing_status.__Rewire__(method, () => {
             call_count[method] += 1;
         });
     }

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -128,7 +128,7 @@ const ui_init = rewiremock.proxy(
         "../../static/js/emojisets": {
             initialize: () => {},
         },
-    }
+    },
 );
 
 set_global('$', global.make_zjquery());

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -72,7 +72,7 @@ emoji.emojis_by_name = new Map();
 
 util.is_mobile = () => false;
 global.stub_templates(() => 'some-html');
-ui.get_scroll_element = element => element;
+ui.get_scroll_element = (element) => element;
 
 zrequire('alert_words');
 zrequire('hash_util');

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -109,7 +109,7 @@ run_test('changing_topics', () => {
     assert.deepEqual(unread.get_unread_message_ids([15, 16]), [15, 16]);
     assert.deepEqual(
         unread.get_unread_messages([message, other_message]),
-        [message, other_message]
+        [message, other_message],
     );
 
     count = unread.num_unread_for_topic(stream_id, 'Lunch');
@@ -563,7 +563,7 @@ run_test('mention updates', () => {
         unread.update_message_for_mention(message);
         assert.equal(
             unread.unread_mentions_counter.has(message.id),
-            counted
+            counted,
         );
     }
 

--- a/frontend_tests/node_tests/upgrade.js
+++ b/frontend_tests/node_tests/upgrade.js
@@ -88,17 +88,11 @@ run_test("initialize", () => {
         assert.equal(schedule, "monthly");
     };
 
-    $('input[type=radio][name=license_management]:checked').val = () => {
-        return document.querySelector("input[type=radio][name=license_management]:checked").value;
-    };
+    $('input[type=radio][name=license_management]:checked').val = () => document.querySelector("input[type=radio][name=license_management]:checked").value;
 
-    $('input[type=radio][name=schedule]:checked').val = () => {
-        return document.querySelector("input[type=radio][name=schedule]:checked").value;
-    };
+    $('input[type=radio][name=schedule]:checked').val = () => document.querySelector("input[type=radio][name=schedule]:checked").value;
 
-    $("#autopay-form").data = (key) => {
-        return document.querySelector("#autopay-form").getAttribute("data-" + key);
-    };
+    $("#autopay-form").data = (key) => document.querySelector("#autopay-form").getAttribute("data-" + key);
 
     jquery_init();
 
@@ -110,16 +104,12 @@ run_test("initialize", () => {
     const invoice_click_handler = $('#invoice-button').get_on_handler('click');
     const request_sponsorship_click_handler = $('#sponsorship-button').get_on_handler('click');
 
-    helpers.is_valid_input = () => {
-        return true;
-    };
+    helpers.is_valid_input = () => true;
 
     add_card_click_handler(e);
     invoice_click_handler(e);
 
-    helpers.is_valid_input = () => {
-        return false;
-    };
+    helpers.is_valid_input = () => false;
     add_card_click_handler(e);
     invoice_click_handler(e);
 

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -75,7 +75,7 @@ run_test('get_item', () => {
         {
             name: "Error",
             message: "Missing config",
-        }
+        },
     );
     assert.throws(
         () => {
@@ -84,7 +84,7 @@ run_test('get_item', () => {
         {
             name: "Error",
             message: "Missing row in config",
-        }
+        },
     );
     assert.throws(
         () => {
@@ -93,7 +93,7 @@ run_test('get_item', () => {
         {
             name: "Error",
             message: "Invalid upload mode!",
-        }
+        },
     );
     assert.throws(
         () => {
@@ -102,7 +102,7 @@ run_test('get_item', () => {
         {
             name: "Error",
             message: 'Invalid key name for mode "compose"',
-        }
+        },
     );
     assert.throws(
         () => {
@@ -111,7 +111,7 @@ run_test('get_item', () => {
         {
             name: "Error",
             message: 'Invalid key name for mode "edit"',
-        }
+        },
     );
 });
 

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -436,23 +436,17 @@ run_test('uppy_events', () => {
             on: (event_name, callback) => {
                 callbacks[event_name] = callback;
             },
-            getFiles: () => {
-                return [...files];
-            },
+            getFiles: () => [...files],
             removeFile: (file_id) => {
-                files = files.filter((file) => {
-                    return file.id !== file_id;
-                });
+                files = files.filter((file) => file.id !== file_id);
             },
-            getState: () => {
-                return {
-                    info: {
-                        type: state.type,
-                        details: state.details,
-                        message: state.message,
-                    },
-                };
-            },
+            getState: () => ({
+                info: {
+                    type: state.type,
+                    details: state.details,
+                    message: state.message,
+                },
+            }),
         };
     }
     uppy_stub.Plugin = plugin_stub;

--- a/frontend_tests/node_tests/user_pill.js
+++ b/frontend_tests/node_tests/user_pill.js
@@ -1,7 +1,5 @@
 zrequire('people');
-set_global('md5', function (s) {
-    return 'md5-' + s;
-});
+set_global('md5', (s) => 'md5-' + s);
 zrequire('user_pill');
 
 set_global('page_params', {

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -101,7 +101,7 @@ run_test('robust_uri_decode', () => {
     assert.equal(util.robust_uri_decode('xxx%3Ayyy'), 'xxx:yyy');
     assert.equal(util.robust_uri_decode('xxx%3'), 'xxx');
 
-    set_global('decodeURIComponent', function () { throw 'foo'; });
+    set_global('decodeURIComponent', () => { throw 'foo'; });
     try {
         util.robust_uri_decode('%E0%A4%A');
     } catch (e) {
@@ -151,7 +151,7 @@ run_test('random_int', () => {
     const min = 0;
     const max = 100;
 
-    _.times(500, function () {
+    _.times(500, () => {
         const val = util.random_int(min, max);
         assert(min <= val);
         assert(val <= max);

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -299,12 +299,12 @@ run_test("clean_user_content_links", () => {
             '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/file.png">upload</a> ' +
             '<a href="http://localhost:NNNN">invalid</a> ' +
             '<a href="javascript:alert(1)">unsafe</a> ' +
-            '<a href="/#fragment" target="_blank">fragment</a>'
+            '<a href="/#fragment" target="_blank">fragment</a>',
         ),
         '<a href="http://example.com" target="_blank" rel="noopener noreferrer" title="http://example.com/">good</a> ' +
         '<a href="http://zulip.zulipdev.com/user_uploads/w/ha/tever/file.png" target="_blank" rel="noopener noreferrer" title="file.png">upload</a> ' +
         '<a>invalid</a> ' +
         '<a>unsafe</a> ' +
-        '<a href="/#fragment" title="http://zulip.zulipdev.com/#fragment">fragment</a>'
+        '<a href="/#fragment" title="http://zulip.zulipdev.com/#fragment">fragment</a>',
     );
 });

--- a/frontend_tests/node_tests/vdom.js
+++ b/frontend_tests/node_tests/vdom.js
@@ -119,7 +119,7 @@ function make_child(i, name) {
 }
 
 function make_children(lst) {
-    return lst.map(i => make_child(i, 'foo' + i));
+    return lst.map((i) => make_child(i, 'foo' + i));
 }
 
 run_test('children', () => {

--- a/frontend_tests/node_tests/vdom.js
+++ b/frontend_tests/node_tests/vdom.js
@@ -16,7 +16,7 @@ run_test('basics', () => {
     assert.equal(
         html,
         '<ul class="foo" title="cats &amp; &lt;&quot;dogs&quot;&gt;">\n\n' +
-        '</ul>'
+        '</ul>',
     );
 });
 
@@ -40,7 +40,7 @@ run_test('attribute escaping', () => {
     assert.equal(
         html,
         '<ul class="&quot;&gt;something evil&lt;div class=&quot;" ' +
-        'title="apples &amp; oranges">\n\n</ul>'
+        'title="apples &amp; oranges">\n\n</ul>',
     );
 });
 
@@ -61,7 +61,7 @@ run_test('attribute updates', () => {
     assert.equal(
         html,
         '<ul class="same" color="blue" id="101">\n\n' +
-        '</ul>'
+        '</ul>',
     );
 
     let updated;
@@ -144,7 +144,7 @@ run_test('children', () => {
         '<li>foo1</li>\n' +
         '<li>foo2</li>\n' +
         '<li>foo3</li>\n' +
-        '</ul>'
+        '</ul>',
     );
 
     // Force a complete redraw.
@@ -164,7 +164,7 @@ run_test('children', () => {
         '<ul class="main">\n' +
         '<li>foo4</li>\n' +
         '<li>foo5</li>\n' +
-        '</ul>'
+        '</ul>',
     );
 });
 
@@ -194,7 +194,7 @@ run_test('partial updates', () => {
         '<li>foo1</li>\n' +
         '<li>foo2</li>\n' +
         '<li>foo3</li>\n' +
-        '</ul>'
+        '</ul>',
     );
 
     replace_content = () => {

--- a/frontend_tests/node_tests/vdom.js
+++ b/frontend_tests/node_tests/vdom.js
@@ -102,13 +102,9 @@ run_test('attribute updates', () => {
 });
 
 function make_child(i, name) {
-    const render = () => {
-        return '<li>' + name + '</li>';
-    };
+    const render = () => '<li>' + name + '</li>';
 
-    const eq = (other) => {
-        return name === other.name;
-    };
+    const eq = (other) => name === other.name;
 
     return {
         key: i,
@@ -207,22 +203,18 @@ run_test('partial updates', () => {
 
     let patched_html;
 
-    find = () => {
-        return {
-            children: () => {
+    find = () => ({
+        children: () => ({
+            eq: (i) => {
+                assert.equal(i, 0);
                 return {
-                    eq: (i) => {
-                        assert.equal(i, 0);
-                        return {
-                            replaceWith: (html) => {
-                                patched_html = html;
-                            },
-                        };
+                    replaceWith: (html) => {
+                        patched_html = html;
                     },
                 };
             },
-        };
-    };
+        }),
+    });
 
     const new_nodes = make_children([1, 2, 3]);
     new_nodes[0] = make_child(1, 'modified1');

--- a/frontend_tests/node_tests/zjquery.js
+++ b/frontend_tests/node_tests/zjquery.js
@@ -212,8 +212,8 @@ run_test('extensions', () => {
     // using direct syntax:
 
     const rect = $.create('rectangle');
-    rect.width = () => { return 5; };
-    rect.height = () => { return 7; };
+    rect.width = () => 5;
+    rect.height = () => 7;
 
     assert.equal(rect.width(), 5);
     assert.equal(rect.height(), 7);

--- a/frontend_tests/node_tests/zjquery.js
+++ b/frontend_tests/node_tests/zjquery.js
@@ -117,11 +117,11 @@ run_test('clicks', () => {
     const state = {};
 
     function set_up_click_handlers() {
-        $('#widget1').click(function () {
+        $('#widget1').click(() => {
             state.clicked = true;
         });
 
-        $('.some-class').keydown(function () {
+        $('.some-class').keydown(() => {
             state.keydown = true;
         });
     }
@@ -149,12 +149,12 @@ run_test('events', () => {
     let value;
 
     function initialize_handler() {
-        $('#my-parent').on('click', '.button-red', function (e) {
+        $('#my-parent').on('click', '.button-red', (e) => {
             value = 'red'; // just a dummy side effect
             e.stopPropagation();
         });
 
-        $('#my-parent').on('click', '.button-blue', function (e) {
+        $('#my-parent').on('click', '.button-blue', (e) => {
             value = 'blue';
             e.stopPropagation();
         });

--- a/frontend_tests/puppeteer_lib/common.js
+++ b/frontend_tests/puppeteer_lib/common.js
@@ -105,7 +105,7 @@ class CommonUtils {
         // is parsed but before DOMContentLoaded event is fired.
         await Promise.all([
             page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
-            page.$eval('#login_form', form => form.submit()),
+            page.$eval('#login_form', (form) => form.submit()),
         ]);
     }
 
@@ -224,7 +224,7 @@ class CommonUtils {
 
         // confirm if compose box is empty.
         const compose_box_element = await page.$("#compose-textarea");
-        const compose_box_content = await page.evaluate(element => element.textContent,
+        const compose_box_content = await page.evaluate((element) => element.textContent,
                                                         compose_box_element);
         assert.equal(compose_box_content, '', 'Compose box not empty after message sent');
 

--- a/frontend_tests/puppeteer_lib/common.js
+++ b/frontend_tests/puppeteer_lib/common.js
@@ -244,7 +244,7 @@ class CommonUtils {
             await this.send_message(
                 page,
                 msg.stream !== undefined ? 'stream' : 'private',
-                msg
+                msg,
             );
         }
     }

--- a/frontend_tests/puppeteer_tests/00-realm-creation.js
+++ b/frontend_tests/puppeteer_tests/00-realm-creation.js
@@ -14,7 +14,7 @@ async function realm_creation_tests(page) {
     await page.type('#email', email);
     await Promise.all([
         page.waitForNavigation(),
-        page.$eval('#send_confirm', form => form.submit()),
+        page.$eval('#send_confirm', (form) => form.submit()),
     ]);
 
     // Make sure onfirmation email is sent.
@@ -53,9 +53,9 @@ async function realm_creation_tests(page) {
     };
     // For some reason, page.click() does not work this for particular checkbox
     // so use page.$eval here to call the .click method in the browser.
-    await page.$eval('#realm_in_root_domain', el => el.click());
+    await page.$eval('#realm_in_root_domain', (el) => el.click());
     await common.fill_form(page, '#registration', params);
-    await page.$eval('#registration', form => form.submit());
+    await page.$eval('#registration', (form) => form.submit());
 
     // Check if realm is created and user is logged in by checking if
     // element of id `lightbox_overlay` exists.

--- a/frontend_tests/zjsunit/finder.js
+++ b/frontend_tests/zjsunit/finder.js
@@ -8,8 +8,8 @@ exports.find_files_to_run = function () {
     if (process.argv[2]) {
         oneFileFilter = process.argv
             .slice(2)
-            .filter(function (filename) {return (/[.]js$/).test(filename);})
-            .map(function (filename) {return filename.replace(/\.js$/i, '');});
+            .filter((filename) => (/[.]js$/).test(filename))
+            .map((filename) => filename.replace(/\.js$/i, ''));
     }
 
     // tests_dir is where we find our specific unit tests (as opposed
@@ -17,24 +17,22 @@ exports.find_files_to_run = function () {
     const tests_dir = __dirname.replace(/zjsunit/, 'node_tests');
 
     let tests = fs.readdirSync(tests_dir)
-        .filter(function (filename) {return !(/^\./i).test(filename);})
-        .filter(function (filename) {return (/\.js$/i).test(filename);})
-        .map(function (filename) {return filename.replace(/\.js$/i, '');});
+        .filter((filename) => !(/^\./i).test(filename))
+        .filter((filename) => (/\.js$/i).test(filename))
+        .map((filename) => filename.replace(/\.js$/i, ''));
 
     if (oneFileFilter.length > 0) {
-        tests = tests.filter(function (filename) {
-            return oneFileFilter.includes(filename);
-        });
+        tests = tests.filter((filename) => oneFileFilter.includes(filename));
         testsDifference = _.difference(oneFileFilter, tests);
     }
 
-    testsDifference.forEach(function (filename) {
+    testsDifference.forEach((filename) => {
         throw filename + ".js does not exist";
     });
 
     tests.sort();
 
-    const files = tests.map(function (fn) {
+    const files = tests.map((fn) => {
         const obj = {};
         obj.name = fn;
         obj.full_name = path.join(tests_dir, fn);

--- a/frontend_tests/zjsunit/handlebars.js
+++ b/frontend_tests/zjsunit/handlebars.js
@@ -7,7 +7,7 @@ const templates_path = path.resolve(__dirname, "../../static/templates");
 
 exports.make_handlebars = () => Handlebars.create();
 
-exports.stub_templates = stub => {
+exports.stub_templates = (stub) => {
     window.template_stub = stub;
 };
 

--- a/frontend_tests/zjsunit/handlebars.js
+++ b/frontend_tests/zjsunit/handlebars.js
@@ -53,6 +53,6 @@ require.extensions[".hbs"] = (module, filename) => {
         out.code +
             "\n//# sourceMappingURL=data:application/json;charset=utf-8;base64," +
             Buffer.from(out.map.toString()).toString("base64"),
-        filename
+        filename,
     );
 };

--- a/frontend_tests/zjsunit/i18n.js
+++ b/frontend_tests/zjsunit/i18n.js
@@ -17,7 +17,7 @@ exports.t = function (str, context) {
     */
     const keyword_regex = /__(- )?(\w)+__/g;
     const keys_in_str = str.match(keyword_regex) || [];
-    const substitutions = keys_in_str.map(key => {
+    const substitutions = keys_in_str.map((key) => {
         let prefix_length;
         if (key.startsWith("__- ")) {
             prefix_length = 4;

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -104,7 +104,7 @@ global.run_test = (label, f) => {
 };
 
 try {
-    files.forEach(function (file) {
+    files.forEach((file) => {
         set_global('location', {
             hash: '#',
         });

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -79,7 +79,7 @@ global.read_fixture_data = (fn) => {
 function short_tb(tb) {
     const lines = tb.split('\n');
 
-    const i = lines.findIndex(line => line.includes('run_test') || line.includes('run_one_module'));
+    const i = lines.findIndex((line) => line.includes('run_test') || line.includes('run_one_module'));
 
     if (i === -1) {
         return tb;

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -17,9 +17,7 @@ const _ = global._;
 
 // Create a helper function to avoid sneaky delays in tests.
 function immediate(f) {
-    return () => {
-        return f();
-    };
+    return () => f();
 }
 
 // Find the files we need to run.

--- a/frontend_tests/zjsunit/markdown_assert.js
+++ b/frontend_tests/zjsunit/markdown_assert.js
@@ -59,7 +59,7 @@ class MarkdownComparer {
             return false;
         }
         return _.zip(node1.content.childNodes, node2.content.childNodes).every(([child1, child2]) =>
-            child1.isEqualNode(child2)
+            child1.isEqualNode(child2),
         );
     }
 
@@ -138,7 +138,7 @@ class MarkdownComparer {
             throw new assert.AssertionError({
                 message: message + this._output_formatter(
                     comparison_results.html.actual,
-                    comparison_results.html.expected
+                    comparison_results.html.expected,
                 ),
             });
         }

--- a/frontend_tests/zjsunit/markdown_assert.js
+++ b/frontend_tests/zjsunit/markdown_assert.js
@@ -165,12 +165,10 @@ class MarkdownComparer {
 
 function returnComparer() {
     if (!_markdownComparerInstance) {
-        _markdownComparerInstance = new MarkdownComparer((actual, expected) => {
-            return [
-                "Actual and expected output do not match.  Showing diff",
-                mdiff.diff_strings(actual, expected),
-            ].join('\n');
-        });
+        _markdownComparerInstance = new MarkdownComparer((actual, expected) => [
+            "Actual and expected output do not match.  Showing diff",
+            mdiff.diff_strings(actual, expected),
+        ].join('\n'));
     }
     return _markdownComparerInstance;
 }

--- a/frontend_tests/zjsunit/mdiff.js
+++ b/frontend_tests/zjsunit/mdiff.js
@@ -27,7 +27,7 @@ function apply_color(input_string, changes) {
         if (formatter.has(change.tag)) {
             processed_string += input_string.slice(previous_index, change.beginning_index);
             processed_string += formatter.get(change.tag)(
-                input_string.slice(change.beginning_index, change.ending_index)
+                input_string.slice(change.beginning_index, change.ending_index),
             );
             previous_index = change.ending_index;
         }
@@ -134,7 +134,7 @@ if (require.main === module) {
             " string_0" +
             " string_1" +
             "\n" +
-            "Where string_0 and string_1 are the strings to be diffed"
+            "Where string_0 and string_1 are the strings to be diffed",
         );
     }
 

--- a/frontend_tests/zjsunit/mdiff.js
+++ b/frontend_tests/zjsunit/mdiff.js
@@ -19,9 +19,9 @@ function apply_color(input_string, changes) {
     input_string = input_string.slice(2);
 
     const formatter = new Map([
-        ["delete", (string) => { return "\u001b[31m" + string + "\u001b[0m"; }],
-        ["insert", (string) => { return "\u001b[32m" + string + "\u001b[0m"; }],
-        ["replace", (string) => { return "\u001b[33m" + string + "\u001b[0m"; }],
+        ["delete", (string) => "\u001b[31m" + string + "\u001b[0m"],
+        ["insert", (string) => "\u001b[32m" + string + "\u001b[0m"],
+        ["replace", (string) => "\u001b[33m" + string + "\u001b[0m"],
     ]);
     changes.forEach((change) => {
         if (formatter.has(change.tag)) {
@@ -114,9 +114,7 @@ function diff_strings(string_0, string_1) {
         }
     });
 
-    const emphasize_codes = (string) => {
-        return "\u001b[34m" + string.slice(0, 1) + "\u001b[0m" + string.slice(1);
-    };
+    const emphasize_codes = (string) => "\u001b[34m" + string.slice(0, 1) + "\u001b[0m" + string.slice(1);
     output_lines = output_lines.map(emphasize_codes);
 
     return output_lines.join("\n");

--- a/frontend_tests/zjsunit/namespace.js
+++ b/frontend_tests/zjsunit/namespace.js
@@ -45,7 +45,7 @@ exports.clear_zulip_refs = function () {
 };
 
 exports.restore = function () {
-    requires.forEach(function (fn) {
+    requires.forEach((fn) => {
         delete require.cache[require.resolve(fn)];
     });
     Object.assign(global, old_globals);
@@ -57,14 +57,12 @@ exports.restore = function () {
 };
 
 exports.stub_out_jquery = function () {
-    set_global('$', function () {
-        return {
-            on: function () {},
-            trigger: function () {},
-            hide: function () {},
-            removeClass: function () {},
-        };
-    });
+    set_global('$', () => ({
+        on: function () {},
+        trigger: function () {},
+        hide: function () {},
+        removeClass: function () {},
+    }));
     $.fn = {};
     $.now = function () {};
 };
@@ -86,7 +84,7 @@ exports.with_overrides = function (test_function) {
 
         global[module][func_name] = f;
 
-        clobber_callbacks.push(function () {
+        clobber_callbacks.push(() => {
             // If you get a failure from this, you probably just
             // need to have your test do its own overrides and
             // not cherry-pick off of the prior test's setup.

--- a/frontend_tests/zjsunit/stub.js
+++ b/frontend_tests/zjsunit/stub.js
@@ -33,7 +33,7 @@ exports.with_stub = function (f) {
 };
 
 (function test_ourselves() {
-    exports.with_stub(function (stub) {
+    exports.with_stub((stub) => {
         stub.f('blue', 42);
         const args = stub.get_args('color', 'n');
         assert.equal(args.color, 'blue');

--- a/frontend_tests/zjsunit/zblueslip.js
+++ b/frontend_tests/zjsunit/zblueslip.js
@@ -75,9 +75,7 @@ exports.make_zblueslip = function () {
         }
     };
 
-    lib.get_test_logs = (name) => {
-        return lib.test_logs[name];
-    };
+    lib.get_test_logs = (name) => lib.test_logs[name];
 
     // Create logging functions
     for (const name of names) {
@@ -113,13 +111,9 @@ exports.make_zblueslip = function () {
         return ex.message;
     };
 
-    lib.start_timing = () => {
-        return () => {};
-    };
+    lib.start_timing = () => () => {};
 
-    lib.preview_node = (node) => {
-        return 'node:' + node;
-    };
+    lib.preview_node = (node) => 'node:' + node;
 
     return lib;
 };

--- a/frontend_tests/zjsunit/zblueslip.js
+++ b/frontend_tests/zjsunit/zblueslip.js
@@ -41,7 +41,7 @@ exports.make_zblueslip = function () {
         for (const name of names) {
             for (const obj of lib.test_logs[name]) {
                 const message = obj.message;
-                const i = lib.test_data[name].findIndex(x => x.message === message);
+                const i = lib.test_data[name].findIndex((x) => x.message === message);
                 if (i === -1) {
                     // Only throw this for message types we want to explicitly track.
                     // For example, we do not want to throw here for debug messages.
@@ -99,7 +99,7 @@ exports.make_zblueslip = function () {
                 }
             }
             lib.test_logs[name].push({message, more_info, stack});
-            const matched_error_message = lib.test_data[name].find(x => x.message === message);
+            const matched_error_message = lib.test_data[name].find((x) => x.message === message);
             const exact_match_fail = !matched_error_message;
             if (exact_match_fail) {
                 const error = Error(`Invalid ${name} message: "${message}".`);

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -523,9 +523,9 @@ exports.make_zjquery = function (opts) {
 
     zjquery.state = function () {
         // useful for debugging
-        let res = Array.from(elems.values(), v => v.debug());
+        let res = Array.from(elems.values(), (v) => v.debug());
 
-        res = res.map(v => [v.selector, v.value, v.shown]);
+        res = res.map((v) => [v.selector, v.value, v.shown]);
 
         res.sort();
 

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -305,7 +305,7 @@ exports.make_new_elem = function (selector, opts) {
         },
         removeClass: function (class_names) {
             class_names = class_names.split(' ');
-            class_names.forEach(function (class_name) {
+            class_names.forEach((class_name) => {
                 classes.delete(class_name);
             });
             return self;

--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -202,7 +202,7 @@ function mark_client_active() {
 }
 
 exports.initialize = function () {
-    $("html").on("mousemove", function () {
+    $("html").on("mousemove", () => {
         exports.new_user_input = true;
     });
 

--- a/static/js/alert_words.js
+++ b/static/js/alert_words.js
@@ -41,8 +41,8 @@ exports.process_message = function (message) {
         const regex = new RegExp('(' + before_punctuation + ')' +
                                '(' + clean + ')' +
                                '(' + after_punctuation + ')', 'ig');
-        message.content = message.content.replace(regex, function (match, before, word,
-                                                                   after, offset, content) {
+        message.content = message.content.replace(regex, (match, before, word,
+                                                          after, offset, content) => {
             // Logic for ensuring that we don't muck up rendered HTML.
             const pre_match = content.substring(0, offset);
             // We want to find the position of the `<` and `>` only in the

--- a/static/js/alert_words_ui.js
+++ b/static/js/alert_words_ui.js
@@ -76,17 +76,17 @@ exports.set_up_alert_words = function () {
 
     exports.render_alert_words_ui();
 
-    $('#create_alert_word_form').on('click', '#create_alert_word_button', function () {
+    $('#create_alert_word_form').on('click', '#create_alert_word_button', () => {
         const word = $('#create_alert_word_name').val();
         add_alert_word(word);
     });
 
-    $('#alert_words_list').on('click', '.remove-alert-word', function (event) {
+    $('#alert_words_list').on('click', '.remove-alert-word', (event) => {
         const word = $(event.currentTarget).parents('li').find('.value').text();
         remove_alert_word(word);
     });
 
-    $('#create_alert_word_form').on('keypress', '#create_alert_word_name', function (event) {
+    $('#create_alert_word_form').on('keypress', '#create_alert_word_name', (event) => {
         const key = event.which;
         // Handle enter (13) as "add".
         if (key === 13) {
@@ -97,7 +97,7 @@ exports.set_up_alert_words = function () {
         }
     });
 
-    $('#alert-word-settings').on('click', '.close-alert-word-status', function (event) {
+    $('#alert-word-settings').on('click', '.close-alert-word-status', (event) => {
         event.preventDefault();
         const alert = $(event.currentTarget).parents('.alert');
         alert.hide();

--- a/static/js/analytics/activity.js
+++ b/static/js/analytics/activity.js
@@ -1,4 +1,4 @@
-$(function () {
+$(() => {
     $('a.envelope-link').click(function () {
         common.copy_data_attribute_value($(this), "admin-emails");
     });

--- a/static/js/analytics/support.js
+++ b/static/js/analytics/support.js
@@ -1,4 +1,4 @@
-$(function () {
+$(() => {
     $("body").on("click", ".scrub-realm-button", function (e) {
         e.preventDefault();
         const string_id = $(this).data("string-id");

--- a/static/js/archive.js
+++ b/static/js/archive.js
@@ -117,14 +117,14 @@ function scroll_finish() {
     scroll_timer = setTimeout(floating_recipient_bar.update, 100);
 }
 
-$(function () {
+$(() => {
     $.fn.safeOuterHeight = function (...args) {
         return this.outerHeight(...args) || 0;
     };
     $.fn.safeOuterWidth = function (...args) {
         return this.outerWidth(...args) || 0;
     };
-    $('.app').scroll(_.throttle(function () {
+    $('.app').scroll(_.throttle(() => {
         scroll_finish();
     }, 50));
     exports.initialize();

--- a/static/js/attachments_ui.js
+++ b/static/js/attachments_ui.js
@@ -115,9 +115,7 @@ exports.update_attachments = function (event) {
         return;
     }
     if (event.op === 'remove' || event.op === 'update') {
-        attachments = attachments.filter(function (a) {
-            return a.id !== event.attachment.id;
-        });
+        attachments = attachments.filter((a) => a.id !== event.attachment.id);
     }
     if (event.op === 'add' || event.op === 'update') {
         format_attachment_data([event.attachment]);
@@ -135,7 +133,7 @@ exports.set_up_attachments = function () {
     const status = $('#delete-upload-status');
     loading.make_indicator($('#attachments_loading_indicator'), {text: 'Loading...'});
 
-    $('#uploaded_files_table').on('click', '.remove-attachment', function (e) {
+    $('#uploaded_files_table').on('click', '.remove-attachment', (e) => {
         delete_attachments($(e.target).closest(".uploaded_file_row").attr('data-attachment-id'));
     });
 

--- a/static/js/avatar.js
+++ b/static/js/avatar.js
@@ -17,7 +17,7 @@ exports.build_bot_create_widget = function () {
         file_name_field,
         input_error,
         clear_button,
-        upload_button
+        upload_button,
     );
 };
 
@@ -36,7 +36,7 @@ exports.build_bot_edit_widget = function (target) {
         file_name_field,
         input_error,
         clear_button,
-        upload_button
+        upload_button,
     );
 };
 
@@ -74,7 +74,7 @@ exports.build_user_avatar_widget = function (upload_function) {
             $("#user-avatar-upload-widget .image_file_input_error").expectOne(),
             $("#user-avatar-upload-widget .image_upload_button").expectOne(),
             upload_function,
-            page_params.max_avatar_file_size_mib
+            page_params.max_avatar_file_size_mib,
         );
     }
 };

--- a/static/js/avatar.js
+++ b/static/js/avatar.js
@@ -52,7 +52,7 @@ exports.build_user_avatar_widget = function (upload_function) {
         $("#user-avatar-source").hide();
     }
 
-    $("#user-avatar-upload-widget .settings-page-delete-button").on('click keydown', function (e) {
+    $("#user-avatar-upload-widget .settings-page-delete-button").on('click keydown', (e) => {
         e.preventDefault();
         e.stopPropagation();
         channel.del({

--- a/static/js/billing/billing.js
+++ b/static/js/billing/billing.js
@@ -11,7 +11,7 @@ exports.initialize = function () {
         },
     });
 
-    $('#update-card-button').on('click', function (e) {
+    $('#update-card-button').on('click', (e) => {
         const email = $("#payment-method").data("email");
         card_change_handler.open({
             name: 'Zulip',
@@ -25,7 +25,7 @@ exports.initialize = function () {
         e.preventDefault();
     });
 
-    $("#change-plan-status").on('click', function (e) {
+    $("#change-plan-status").on('click', (e) => {
         helpers.create_ajax_request("/json/billing/plan/change", "planchange", undefined, ["status"]);
         e.preventDefault();
     });
@@ -33,6 +33,6 @@ exports.initialize = function () {
 
 window.billing = exports;
 
-$(function () {
+$(() => {
     exports.initialize();
 });

--- a/static/js/billing/helpers.js
+++ b/static/js/billing/helpers.js
@@ -71,7 +71,7 @@ exports.format_money = function (cents) {
 
 exports.update_charged_amount = function (prices, schedule) {
     $("#charged_amount").text(
-        exports.format_money(page_params.seat_count * prices[schedule])
+        exports.format_money(page_params.seat_count * prices[schedule]),
     );
 };
 

--- a/static/js/billing/helpers.js
+++ b/static/js/billing/helpers.js
@@ -22,7 +22,7 @@ exports.create_ajax_request = function (url, form_name, stripe_token = null, num
         data.stripe_token = JSON.stringify(stripe_token.id);
     }
 
-    form.serializeArray().forEach(function (item) {
+    form.serializeArray().forEach((item) => {
         if (numeric_inputs.includes(item.name)) {
             data[item.name] = item.value;
         } else {

--- a/static/js/billing/upgrade.js
+++ b/static/js/billing/upgrade.js
@@ -10,7 +10,7 @@ exports.initialize = () => {
         },
     });
 
-    $('#add-card-button').on('click', function (e) {
+    $('#add-card-button').on('click', (e) => {
         const license_management = $('input[type=radio][name=license_management]:checked').val();
         if (helpers.is_valid_input($("#" + license_management + "_license_count")) === false) {
             return;
@@ -28,7 +28,7 @@ exports.initialize = () => {
         e.preventDefault();
     });
 
-    $("#invoice-button").on("click", function (e) {
+    $("#invoice-button").on("click", (e) => {
         if (helpers.is_valid_input($("#invoiced_licenses")) === false) {
             return;
         }
@@ -36,7 +36,7 @@ exports.initialize = () => {
         helpers.create_ajax_request("/json/billing/upgrade", "invoice", undefined, ["licenses"]);
     });
 
-    $("#sponsorship-button").on("click", function (e) {
+    $("#sponsorship-button").on("click", (e) => {
         e.preventDefault();
         helpers.create_ajax_request("/json/billing/sponsorship", "sponsorship", undefined, undefined, "/");
     });
@@ -69,6 +69,6 @@ exports.initialize = () => {
 
 window.upgrade = exports;
 
-$(function () {
+$(() => {
     exports.initialize();
 });

--- a/static/js/blueslip.js
+++ b/static/js/blueslip.js
@@ -200,7 +200,7 @@ exports.exception_msg = function blueslip_exception_msg(ex) {
     return message;
 };
 
-$(window).on('error', function (event) {
+$(window).on('error', (event) => {
     const ex = event.originalEvent.error;
     if (!ex || ex instanceof BlueslipError) {
         return;

--- a/static/js/blueslip.js
+++ b/static/js/blueslip.js
@@ -37,7 +37,7 @@ Logger.prototype = (function () {
                 pad(now.getUTCSeconds(), 2) + '.' +
                 pad(now.getUTCMilliseconds(), 3) + ' UTC';
 
-            const str_args = args.map(x => typeof x === "object" ? JSON.stringify(x) : x);
+            const str_args = args.map((x) => typeof x === "object" ? JSON.stringify(x) : x);
 
             const log_entry = date_str + " " + name.toUpperCase() +
                 ': ' + str_args.join("");

--- a/static/js/blueslip_stacktrace.ts
+++ b/static/js/blueslip_stacktrace.ts
@@ -37,7 +37,7 @@ export function clean_path(full_path: string): string {
 }
 
 export function clean_function_name(
-    function_name: string | undefined
+    function_name: string | undefined,
 ): { scope: string; name: string } | undefined {
     if (function_name === undefined) {
         return undefined;
@@ -78,7 +78,7 @@ export async function display_stacktrace(error: string, stack: string): Promise<
             const location = await stack_trace_gps.getMappedLocation(
                 // Work around mistake in ErrorStackParser.StackFrame definition
                 // https://github.com/stacktracejs/error-stack-parser/pull/49
-                (stack_frame as unknown) as StackFrame
+                (stack_frame as unknown) as StackFrame,
             );
             return {
                 full_path: location.getFileName(),
@@ -87,11 +87,11 @@ export async function display_stacktrace(error: string, stack: string): Promise<
                 function_name: clean_function_name(location.getFunctionName()),
                 context: await get_context(location),
             };
-        })
+        }),
     );
 
     const $alert = $("<div class='stacktrace'>").html(
-        render_blueslip_stacktrace({ error, stackframes })
+        render_blueslip_stacktrace({ error, stackframes }),
     );
     $(".alert-box").append($alert);
     $alert.addClass("show");

--- a/static/js/bot_data.js
+++ b/static/js/bot_data.js
@@ -30,7 +30,7 @@ exports.all_user_ids = function () {
 exports.add = function (bot) {
     const clean_bot = _.pick(bot, bot_fields);
     bots.set(bot.user_id, clean_bot);
-    const clean_services = bot.services.map(service => _.pick(service, services_fields));
+    const clean_services = bot.services.map((service) => _.pick(service, services_fields));
     services.set(bot.user_id, clean_services);
 
     send_change_event();

--- a/static/js/bot_data.js
+++ b/static/js/bot_data.js
@@ -19,7 +19,7 @@ const services = new Map();
 const services_fields = ['base_url', 'interface',
                          'config_data', 'service_name', 'token'];
 
-const send_change_event = _.debounce(function () {
+const send_change_event = _.debounce(() => {
     settings_bots.render_bots();
 }, 50);
 

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -116,12 +116,12 @@ function filter_user_ids(user_filter_text, user_ids) {
         return user_ids;
     }
 
-    user_ids = user_ids.filter(user_id => !people.is_my_user_id(user_id));
+    user_ids = user_ids.filter((user_id) => !people.is_my_user_id(user_id));
 
     let search_terms = user_filter_text.toLowerCase().split(/[|,]+/);
-    search_terms = search_terms.map(s => s.trim());
+    search_terms = search_terms.map((s) => s.trim());
 
-    const persons = user_ids.map(user_id => people.get_by_user_id(user_id));
+    const persons = user_ids.map((user_id) => people.get_by_user_id(user_id));
 
     const user_id_dict = people.filter_people_by_search_terms(persons, search_terms);
     return Array.from(user_id_dict.keys());
@@ -306,7 +306,7 @@ function get_user_id_list(user_filter_text) {
         user_ids = presence.get_user_ids();
     }
 
-    user_ids = user_ids.filter(user_id => {
+    user_ids = user_ids.filter((user_id) => {
         const person = people.get_by_user_id(user_id);
 
         if (!person) {
@@ -334,7 +334,7 @@ exports.get_items_for_users = function (user_ids) {
 };
 
 exports.huddle_fraction_present = function (huddle) {
-    const user_ids = huddle.split(',').map(s => parseInt(s, 10));
+    const user_ids = huddle.split(',').map((s) => parseInt(s, 10));
 
     let num_present = 0;
 

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -220,7 +220,7 @@ exports.get_title_data = function (user_ids_string, is_group) {
         if (bot_owner) {
             const bot_owner_name = i18n.t(
                 'Owner: __name__',
-                {name: bot_owner.full_name}
+                {name: bot_owner.full_name},
             );
 
             return {

--- a/static/js/buddy_list.js
+++ b/static/js/buddy_list.js
@@ -123,9 +123,7 @@ function buddy_list_create() {
 
     self.get_items = function () {
         const obj = self.container.find(self.item_sel);
-        return obj.map(function (i, elem) {
-            return $(elem);
-        });
+        return obj.map((i, elem) => $(elem));
     };
 
     self.first_key = function () {
@@ -317,7 +315,7 @@ function buddy_list_create() {
         // sure everything's in place.
         const scroll_container = ui.get_scroll_element($(self.scroll_container_sel));
 
-        scroll_container.scroll(function () {
+        scroll_container.scroll(() => {
             self.fill_screen_with_content();
         });
     };

--- a/static/js/channel.js
+++ b/static/js/channel.js
@@ -77,7 +77,7 @@ function call(args, idempotent) {
         if (!data && idempotent) {
             // If idempotent, retry
             blueslip.log("Retrying idempotent" + args);
-            setTimeout(function () {
+            setTimeout(() => {
                 const jqXHR = $.ajax(args);
                 add_pending_request(jqXHR);
             }, 0);

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -607,10 +607,10 @@ exports.initialize = function () {
     // NB: This just binds to current elements, and won't bind to elements
     // created after ready() is called.
     $('#compose-send-status .compose-send-status-close').click(
-        () => { $('#compose-send-status').stop(true).fadeOut(500); }
+        () => { $('#compose-send-status').stop(true).fadeOut(500); },
     );
     $('#nonexistent_stream_reply_error .compose-send-status-close').click(
-        () => { $('#nonexistent_stream_reply_error').stop(true).fadeOut(500); }
+        () => { $('#nonexistent_stream_reply_error').stop(true).fadeOut(500); },
     );
 
 

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -32,7 +32,7 @@ exports.initialize = function () {
                 return;
             }
             current_msg_list.select_id(id);
-            setTimeout(function () {
+            setTimeout(() => {
                 // The algorithm to trigger long tap is that first, we check
                 // whether the message is still touched after MS_DELAY ms and
                 // the user isn't scrolling the messages(see other touch event
@@ -45,18 +45,18 @@ exports.initialize = function () {
                         $(this).trigger("longtap");
                     }
                 }
-            }.bind(this), MS_DELAY);
+            }, MS_DELAY);
         });
 
-        $("#main_div").on("touchend", ".messagebox", function () {
+        $("#main_div").on("touchend", ".messagebox", () => {
             meta.touchdown = false;
         });
 
-        $("#main_div").on("touchmove", ".messagebox", function () {
+        $("#main_div").on("touchmove", ".messagebox", () => {
             meta.invalid = true;
         });
 
-        $("#main_div").on("contextmenu", ".messagebox", function (e) {
+        $("#main_div").on("contextmenu", ".messagebox", (e) => {
             e.preventDefault();
         });
     }
@@ -178,19 +178,19 @@ exports.initialize = function () {
         $(".tooltip").remove();
     });
 
-    $('body').on('mouseenter', '.message_edit_notice', function (e) {
+    $('body').on('mouseenter', '.message_edit_notice', (e) => {
         if (page_params.realm_allow_edit_history) {
             $(e.currentTarget).addClass("message_edit_notice_hover");
         }
     });
 
-    $('body').on('mouseleave', '.message_edit_notice', function (e) {
+    $('body').on('mouseleave', '.message_edit_notice', (e) => {
         if (page_params.realm_allow_edit_history) {
             $(e.currentTarget).removeClass("message_edit_notice_hover");
         }
     });
 
-    $('body').on('click', '.message_edit_notice', function (e) {
+    $('body').on('click', '.message_edit_notice', (e) => {
         popovers.hide_all();
         const message_id = rows.id($(e.currentTarget).closest(".message_row"));
         const row = current_msg_list.get_row(message_id);
@@ -207,7 +207,7 @@ exports.initialize = function () {
 
     // TOOLTIP FOR MESSAGE REACTIONS
 
-    $('#main_div').on('mouseenter', '.message_reaction', function (e) {
+    $('#main_div').on('mouseenter', '.message_reaction', (e) => {
         e.stopPropagation();
         const elem = $(e.currentTarget);
         const local_id = elem.attr('data-reaction-id');
@@ -226,14 +226,14 @@ exports.initialize = function () {
         $(".tooltip-arrow").remove();
     });
 
-    $('#main_div').on('mouseleave', '.message_reaction', function (e) {
+    $('#main_div').on('mouseleave', '.message_reaction', (e) => {
         e.stopPropagation();
         $(e.currentTarget).tooltip('destroy');
     });
 
     // DESTROY PERSISTING TOOLTIPS ON HOVER
 
-    $("body").on('mouseenter', '.tooltip', function (e) {
+    $("body").on('mouseenter', '.tooltip', (e) => {
         e.stopPropagation();
         $(e.currentTarget).remove();
     });
@@ -252,7 +252,7 @@ exports.initialize = function () {
 
     // USER STATUS MODAL
 
-    $(".user-status-value").on("click", function (e) {
+    $(".user-status-value").on("click", (e) => {
         e.stopPropagation();
         const user_status_value = $(e.currentTarget).attr("data-user-status-value");
         $("input.user_status").val(user_status_value);
@@ -373,7 +373,7 @@ exports.initialize = function () {
 
     // MUTING
 
-    $('body').on('click', '.on_hover_topic_mute', function (e) {
+    $('body').on('click', '.on_hover_topic_mute', (e) => {
         e.stopPropagation();
         const stream_id = parseInt($(e.currentTarget).attr('data-stream-id'), 10);
         const topic = $(e.currentTarget).attr('data-topic-name');
@@ -382,7 +382,7 @@ exports.initialize = function () {
 
     $('body').on('keydown', '.on_hover_topic_mute', convert_enter_to_click);
 
-    $('body').on('click', '.on_hover_topic_unmute', function (e) {
+    $('body').on('click', '.on_hover_topic_unmute', (e) => {
         e.stopPropagation();
         const stream_id = parseInt($(e.currentTarget).attr('data-stream-id'), 10);
         const topic = $(e.currentTarget).attr('data-topic-name');
@@ -393,12 +393,12 @@ exports.initialize = function () {
 
     // RECENT TOPICS
 
-    $('body').on('click', '#recent_topics_search', function (e) {
+    $('body').on('click', '#recent_topics_search', (e) => {
         e.stopPropagation();
         recent_topics.change_focused_element(e, 'click');
     });
 
-    $('body').on('click', '.on_hover_topic_read', function (e) {
+    $('body').on('click', '.on_hover_topic_read', (e) => {
         e.stopPropagation();
         const stream_id = parseInt($(e.currentTarget).attr('data-stream-id'), 10);
         const topic = $(e.currentTarget).attr('data-topic-name');
@@ -407,19 +407,19 @@ exports.initialize = function () {
 
     $('body').on('keydown', '.on_hover_topic_read', convert_enter_to_click);
 
-    $('body').on('click', '.btn-recent-filters', function (e) {
+    $('body').on('click', '.btn-recent-filters', (e) => {
         e.stopPropagation();
         recent_topics.set_filter(e.currentTarget.dataset.filter);
         recent_topics.update_filters_view();
     });
 
     // Search for all table rows (this combines stream & topic names)
-    $('body').on('keyup', '#recent_topics_search', _.debounce(function () {
+    $('body').on('keyup', '#recent_topics_search', _.debounce(() => {
         recent_topics.update_filters_view();
     // Wait for user to go idle before initiating search.
     }, 300));
 
-    $('body').on('click', '#recent_topics_search_clear', function (e) {
+    $('body').on('click', '#recent_topics_search_clear', (e) => {
         e.stopPropagation();
         $('#recent_topics_search').val("");
         recent_topics.update_filters_view();
@@ -459,7 +459,7 @@ exports.initialize = function () {
 
     // SIDEBARS
 
-    $("#userlist-toggle-button").on("click", function (e) {
+    $("#userlist-toggle-button").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();
 
@@ -470,7 +470,7 @@ exports.initialize = function () {
         }
     });
 
-    $("#streamlist-toggle-button").on("click", function (e) {
+    $("#streamlist-toggle-button").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();
 
@@ -481,7 +481,7 @@ exports.initialize = function () {
         }
     });
 
-    $('#user_presences').expectOne().on('click', '.selectable_sidebar_block', function (e) {
+    $('#user_presences').expectOne().on('click', '.selectable_sidebar_block', (e) => {
         const li = $(e.target).parents('li');
 
         activity.narrow_for_user({li: li});
@@ -508,7 +508,7 @@ exports.initialize = function () {
     }
 
     // BUDDY LIST TOOLTIPS
-    $('#user_presences').on('mouseenter', '.user-presence-link, .user_sidebar_entry .user_circle, .user_sidebar_entry .selectable_sidebar_block', function (e) {
+    $('#user_presences').on('mouseenter', '.user-presence-link, .user_sidebar_entry .user_circle, .user_sidebar_entry .selectable_sidebar_block', (e) => {
         e.stopPropagation();
         const elem = $(e.currentTarget).closest(".user_sidebar_entry").find(".user-presence-link");
         const user_id_string = elem.attr('data-user-id');
@@ -516,14 +516,14 @@ exports.initialize = function () {
         do_render_buddy_list_tooltip(elem, title_data);
     });
 
-    $('#user_presences').on('mouseleave click', '.user-presence-link, .user_sidebar_entry .user_circle, .user_sidebar_entry .selectable_sidebar_block', function (e) {
+    $('#user_presences').on('mouseleave click', '.user-presence-link, .user_sidebar_entry .user_circle, .user_sidebar_entry .selectable_sidebar_block', (e) => {
         e.stopPropagation();
         const elem = $(e.currentTarget).closest(".user_sidebar_entry").find(".user-presence-link");
         $(elem).tooltip('destroy');
     });
 
     // PM LIST TOOLTIPS
-    $("body").on('mouseenter', '#pm_user_status', function (e) {
+    $("body").on('mouseenter', '#pm_user_status', (e) => {
         $(".tooltip").remove();
         e.stopPropagation();
         const elem = $(e.currentTarget);
@@ -535,14 +535,14 @@ exports.initialize = function () {
         do_render_buddy_list_tooltip(elem, title_data);
     });
 
-    $("body").on('mouseleave', '#pm_user_status', function (e) {
+    $("body").on('mouseleave', '#pm_user_status', (e) => {
         e.stopPropagation();
         $(e.currentTarget).tooltip('destroy');
     });
 
     // HOME
 
-    $(document).on('click', ".top_left_all_messages", function (e) {
+    $(document).on('click', ".top_left_all_messages", (e) => {
         ui_util.change_tab_to('#home');
         narrow.deactivate();
         search.update_button_visibility();
@@ -552,7 +552,7 @@ exports.initialize = function () {
         e.preventDefault();
     });
 
-    $(".brand").on('click', function (e) {
+    $(".brand").on('click', (e) => {
         if (overlays.is_active()) {
             overlays.close_active();
         } else {
@@ -577,11 +577,11 @@ exports.initialize = function () {
     stream_popover.register_click_handlers();
     notifications.register_click_handlers();
 
-    $('body').on('click', '.logout_button', function () {
+    $('body').on('click', '.logout_button', () => {
         $('#logout_form').submit();
     });
 
-    $('.restart_get_events_button').click(function () {
+    $('.restart_get_events_button').click(() => {
         server_events.restart_get_events({dont_block: true});
     });
 
@@ -589,12 +589,12 @@ exports.initialize = function () {
     $("body").on("click", ".alert-box > div .exit", function () {
         const $alert = $(this).closest(".alert-box > div");
         $alert.addClass("fade-out");
-        setTimeout(function () {
+        setTimeout(() => {
             $alert.removeClass("fade-out show");
         }, 300);
     });
 
-    $("#settings_page").on("click", ".collapse-settings-btn", function () {
+    $("#settings_page").on("click", ".collapse-settings-btn", () => {
         settings_toggle.toggle_org_setting_collapse();
     });
 
@@ -607,40 +607,40 @@ exports.initialize = function () {
     // NB: This just binds to current elements, and won't bind to elements
     // created after ready() is called.
     $('#compose-send-status .compose-send-status-close').click(
-        function () { $('#compose-send-status').stop(true).fadeOut(500); }
+        () => { $('#compose-send-status').stop(true).fadeOut(500); }
     );
     $('#nonexistent_stream_reply_error .compose-send-status-close').click(
-        function () { $('#nonexistent_stream_reply_error').stop(true).fadeOut(500); }
+        () => { $('#nonexistent_stream_reply_error').stop(true).fadeOut(500); }
     );
 
 
-    $('.compose_stream_button').click(function () {
+    $('.compose_stream_button').click(() => {
         popovers.hide_mobile_message_buttons_popover();
         compose_actions.start('stream', {trigger: 'new topic button'});
     });
-    $('.compose_private_button').click(function () {
+    $('.compose_private_button').click(() => {
         popovers.hide_mobile_message_buttons_popover();
         compose_actions.start('private');
     });
 
-    $('body').on('click', '.compose_mobile_stream_button', function () {
+    $('body').on('click', '.compose_mobile_stream_button', () => {
         popovers.hide_mobile_message_buttons_popover();
         compose_actions.start('stream', {trigger: 'new topic button'});
     });
-    $('body').on('click', '.compose_mobile_private_button', function () {
+    $('body').on('click', '.compose_mobile_private_button', () => {
         popovers.hide_mobile_message_buttons_popover();
         compose_actions.start('private');
     });
 
-    $('.compose_reply_button').click(function () {
+    $('.compose_reply_button').click(() => {
         compose_actions.respond_to_message({trigger: 'reply button'});
     });
 
-    $('.empty_feed_compose_stream').click(function (e) {
+    $('.empty_feed_compose_stream').click((e) => {
         compose_actions.start('stream', {trigger: 'empty feed message'});
         e.preventDefault();
     });
-    $('.empty_feed_compose_private').click(function (e) {
+    $('.empty_feed_compose_private').click((e) => {
         compose_actions.start('private', {trigger: 'empty feed message'});
         e.preventDefault();
     });
@@ -677,23 +677,23 @@ exports.initialize = function () {
     $("#compose_buttons").click(handle_compose_click);
     $(".compose-content").click(handle_compose_click);
 
-    $("#compose_close").click(function () {
+    $("#compose_close").click(() => {
         compose_actions.cancel();
     });
 
-    $("#streams_inline_cog").click(function (e) {
+    $("#streams_inline_cog").click((e) => {
         e.stopPropagation();
         hashchange.go_to_location('streams/subscribed');
     });
 
-    $("#streams_filter_icon").click(function (e) {
+    $("#streams_filter_icon").click((e) => {
         e.stopPropagation();
         stream_list.toggle_filter_displayed(e);
     });
 
     // WEBATHENA
 
-    $('body').on('click', '.webathena_login', function (e) {
+    $('body').on('click', '.webathena_login', (e) => {
         $("#zephyr-mirror-error").removeClass("show");
         const principal = ["zephyr", "zephyr"];
         WinChan.open({
@@ -703,7 +703,7 @@ exports.initialize = function () {
                 realm: "ATHENA.MIT.EDU",
                 principal: principal,
             },
-        }, function (err, r) {
+        }, (err, r) => {
             if (err) {
                 blueslip.warn(err);
                 return;
@@ -731,9 +731,7 @@ exports.initialize = function () {
     // End Webathena code
 
     // disable the draggability for left-sidebar components
-    $('#stream_filters, #global_filters').on('dragstart', function () {
-        return false;
-    });
+    $('#stream_filters, #global_filters').on('dragstart', () => false);
 
     (function () {
         const map = {
@@ -760,9 +758,7 @@ exports.initialize = function () {
             }
         });
 
-        $(document).on("drop", ".editable-section", function () {
-            return false;
-        });
+        $(document).on("drop", ".editable-section", () => false);
 
         $(document).on("input", ".editable-section", function () {
             // if there are any child nodes, inclusive of <br> which means you
@@ -863,7 +859,7 @@ exports.initialize = function () {
         $('#hotspot_' + hotspot_name + '_icon').remove();
     });
 
-    $('body').on('click', '.hotspot-button', function (e) {
+    $('body').on('click', '.hotspot-button', (e) => {
         e.preventDefault();
         e.stopPropagation();
 
@@ -872,14 +868,14 @@ exports.initialize = function () {
     });
 
     // stop propagation
-    $('body').on('click', '.hotspot.overlay .hotspot-popover', function (e) {
+    $('body').on('click', '.hotspot.overlay .hotspot-popover', (e) => {
         e.stopPropagation();
     });
 
 
     // MAIN CLICK HANDLER
 
-    $(document).on('click', function (e) {
+    $(document).on('click', (e) => {
         if (e.button !== 0 || $(e.target).is(".drag")) {
             // Firefox emits right click events on the document, but not on
             // the child nodes, so the #compose stopPropagation doesn't get a
@@ -925,11 +921,11 @@ exports.initialize = function () {
     // Workaround for Bootstrap issue #5900, which basically makes dropdowns
     // unclickable on mobile devices.
     // https://github.com/twitter/bootstrap/issues/5900
-    $('a.dropdown-toggle, .dropdown-menu a').on('touchstart', function (e) {
+    $('a.dropdown-toggle, .dropdown-menu a').on('touchstart', (e) => {
         e.stopPropagation();
     });
 
-    $(".settings-header.mobile .fa-chevron-left").on("click", function () {
+    $(".settings-header.mobile .fa-chevron-left").on("click", () => {
         settings_panel_menu.mobile_deactivate_section();
     });
 };

--- a/static/js/color_data.js
+++ b/static/js/color_data.js
@@ -33,7 +33,7 @@ exports.claim_color = function (color) {
 };
 
 exports.claim_colors = function (subs) {
-    const colors = new Set(subs.map(sub => sub.color));
+    const colors = new Set(subs.map((sub) => sub.color));
     colors.forEach(exports.claim_color);
 };
 

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -6,7 +6,7 @@ if (module.hot) {
 exports.status_classes = 'alert-error alert-success alert-info alert-warning';
 
 exports.autofocus = function (selector) {
-    $(function () {
+    $(() => {
         $(selector).focus();
     });
 };

--- a/static/js/components.js
+++ b/static/js/components.js
@@ -55,7 +55,7 @@ exports.toggle = function (opts) {
         if (opts.callback) {
             opts.callback(
                 opts.values[idx].label,
-                opts.values[idx].key
+                opts.values[idx].key,
             );
         }
 

--- a/static/js/components.js
+++ b/static/js/components.js
@@ -103,7 +103,7 @@ exports.toggle = function (opts) {
         maybe_go_right: maybe_go_right,
 
         disable_tab: function (name) {
-            const value = opts.values.find(o => o.key === name);
+            const value = opts.values.find((o) => o.key === name);
 
             const idx = opts.values.indexOf(value);
             meta.$ind_tab.eq(idx).addClass('disabled');
@@ -121,7 +121,7 @@ exports.toggle = function (opts) {
         // go through the process of finding the correct tab for a given name,
         // and when found, select that one and provide the proper callback.
         goto: function (name) {
-            const value = opts.values.find(o => o.label === name || o.key === name);
+            const value = opts.values.find((o) => o.label === name || o.key === name);
 
             const idx = opts.values.indexOf(value);
 

--- a/static/js/components.js
+++ b/static/js/components.js
@@ -18,7 +18,7 @@ exports.toggle = function (opts) {
             // classes need to be added for correct alignment or other purposes
             _component.addClass(opts.html_class);
         }
-        opts.values.forEach(function (value, i) {
+        opts.values.forEach((value, i) => {
             // create a tab with a tab-id so they don't have to be referenced
             // by text value which can be inconsistent.
             const tab = $("<div class='ind-tab' data-tab-key='" + value.key + "' data-tab-id='" + i + "' tabindex='0'>" + value.label + "</div>");

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -423,7 +423,7 @@ exports.get_invalid_recipient_emails = function () {
     const private_recipients = util.extract_pm_recipients(
         compose_state.private_message_recipient());
     const invalid_recipients = private_recipients.filter(
-        (email) => !people.is_valid_email_for_compose(email)
+        (email) => !people.is_valid_email_for_compose(email),
     );
 
     return invalid_recipients;
@@ -1118,7 +1118,7 @@ exports.initialize = function () {
                         window.location.host +
                         "/calls/zoom/register",
                     "_blank",
-                    "width=800,height=500,noopener,noreferrer"
+                    "width=800,height=500,noopener,noreferrer",
                 );
             }
         } else if (

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -423,7 +423,7 @@ exports.get_invalid_recipient_emails = function () {
     const private_recipients = util.extract_pm_recipients(
         compose_state.private_message_recipient());
     const invalid_recipients = private_recipients.filter(
-        email => !people.is_valid_email_for_compose(email)
+        (email) => !people.is_valid_email_for_compose(email)
     );
 
     return invalid_recipients;
@@ -916,7 +916,7 @@ exports.warn_if_mentioning_unsubscribed_user = function (mentioned) {
         const error_area = $("#compose_invite_users");
         const existing_invites_area = $('#compose_invite_users .compose_invite_user');
 
-        const existing_invites = Array.from($(existing_invites_area), user_row => {
+        const existing_invites = Array.from($(existing_invites_area), (user_row) => {
             return parseInt($(user_row).data('user-id'), 10);
         });
 

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -916,9 +916,7 @@ exports.warn_if_mentioning_unsubscribed_user = function (mentioned) {
         const error_area = $("#compose_invite_users");
         const existing_invites_area = $('#compose_invite_users .compose_invite_user');
 
-        const existing_invites = Array.from($(existing_invites_area), (user_row) => {
-            return parseInt($(user_row).data('user-id'), 10);
-        });
+        const existing_invites = Array.from($(existing_invites_area), (user_row) => parseInt($(user_row).data('user-id'), 10));
 
         if (!existing_invites.includes(user_id)) {
             const context = {

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -259,7 +259,7 @@ exports.compose_error = compose_error;
 function nonexistent_stream_reply_error() {
     $("#nonexistent_stream_reply_error").show();
     $("#compose-reply-error-msg").html("There are no messages to reply to yet.");
-    setTimeout(function () {
+    setTimeout(() => {
         $("#nonexistent_stream_reply_error").hide();
     }, 5000);
 }
@@ -936,14 +936,14 @@ exports.initialize = function () {
     $("#below-compose-content .video_link").toggle(exports.compute_show_video_chat_button());
     $('#stream_message_recipient_stream,#stream_message_recipient_topic,#private_message_recipient').on('keyup', update_fade);
     $('#stream_message_recipient_stream,#stream_message_recipient_topic,#private_message_recipient').on('change', update_fade);
-    $('#compose-textarea').on('keydown', function (event) {
+    $('#compose-textarea').on('keydown', (event) => {
         exports.handle_keydown(event, $("#compose-textarea").expectOne());
     });
-    $('#compose-textarea').on('keyup', function (event) {
+    $('#compose-textarea').on('keyup', (event) => {
         exports.handle_keyup(event, $("#compose-textarea").expectOne());
     });
 
-    $("#compose form").on("submit", function (e) {
+    $("#compose form").on("submit", (e) => {
         e.preventDefault();
         exports.finish();
     });
@@ -952,7 +952,7 @@ exports.initialize = function () {
 
     upload.feature_check($("#compose #attach_files"));
 
-    $("#compose-all-everyone").on('click', '.compose-all-everyone-confirm', function (event) {
+    $("#compose-all-everyone").on('click', '.compose-all-everyone-confirm', (event) => {
         event.preventDefault();
 
         $(event.target).parents('.compose-all-everyone').remove();
@@ -961,7 +961,7 @@ exports.initialize = function () {
         exports.finish();
     });
 
-    $("#compose-announce").on('click', '.compose-announce-confirm', function (event) {
+    $("#compose-announce").on('click', '.compose-announce-confirm', (event) => {
         event.preventDefault();
 
         $(event.target).parents('.compose-announce').remove();
@@ -970,7 +970,7 @@ exports.initialize = function () {
         exports.finish();
     });
 
-    $("#compose-send-status").on('click', '.sub_unsub_button', function (event) {
+    $("#compose-send-status").on('click', '.sub_unsub_button', (event) => {
         event.preventDefault();
 
         const stream_name = $('#stream_message_recipient_stream').val();
@@ -982,13 +982,13 @@ exports.initialize = function () {
         $("#compose-send-status").hide();
     });
 
-    $("#compose-send-status").on('click', '#compose_not_subscribed_close', function (event) {
+    $("#compose-send-status").on('click', '#compose_not_subscribed_close', (event) => {
         event.preventDefault();
 
         $("#compose-send-status").hide();
     });
 
-    $("#compose_invite_users").on('click', '.compose_invite_link', function (event) {
+    $("#compose_invite_users").on('click', '.compose_invite_link', (event) => {
         event.preventDefault();
 
         const invite_row = $(event.target).parents('.compose_invite_user');
@@ -1030,7 +1030,7 @@ exports.initialize = function () {
         stream_edit.invite_user_to_stream([user_id], sub, success, xhr_failure);
     });
 
-    $("#compose_invite_users").on('click', '.compose_invite_close', function (event) {
+    $("#compose_invite_users").on('click', '.compose_invite_close', (event) => {
         const invite_row = $(event.target).parents('.compose_invite_user');
         const all_invites = $("#compose_invite_users");
 
@@ -1041,7 +1041,7 @@ exports.initialize = function () {
         }
     });
 
-    $("#compose_private_stream_alert").on('click', '.compose_private_stream_alert_close', function (event) {
+    $("#compose_private_stream_alert").on('click', '.compose_private_stream_alert_close', (event) => {
         const stream_alert_row = $(event.target).parents('.compose_private_stream_alert');
         const stream_alert = $("#compose_private_stream_alert");
 
@@ -1055,12 +1055,12 @@ exports.initialize = function () {
     // Click event binding for "Attach files" button
     // Triggers a click on a hidden file input field
 
-    $("#compose").on("click", "#attach_files", function (e) {
+    $("#compose").on("click", "#attach_files", (e) => {
         e.preventDefault();
         $("#compose #file_input").trigger("click");
     });
 
-    $('body').on('click', '.video_link', function (e) {
+    $('body').on('click', '.video_link', (e) => {
         e.preventDefault();
 
         let target_textarea;
@@ -1138,7 +1138,7 @@ exports.initialize = function () {
         }
     });
 
-    $("#compose").on("click", "#markdown_preview", function (e) {
+    $("#compose").on("click", "#markdown_preview", (e) => {
         e.preventDefault();
         const content = $("#compose-textarea").val();
         $("#compose-textarea").hide();
@@ -1149,7 +1149,7 @@ exports.initialize = function () {
         exports.render_and_show_preview($("#markdown_preview_spinner"), $("#preview_content"), content);
     });
 
-    $("#compose").on("click", "#undo_markdown_preview", function (e) {
+    $("#compose").on("click", "#undo_markdown_preview", (e) => {
         e.preventDefault();
         exports.clear_preview_area();
     });
@@ -1158,7 +1158,7 @@ exports.initialize = function () {
         mode: "compose",
     });
 
-    $("#compose-textarea").focus(function () {
+    $("#compose-textarea").focus(() => {
         const opts = {
             message_type: compose_state.get_message_type(),
             stream: $('#stream_message_recipient_stream').val(),

--- a/static/js/compose_fade.js
+++ b/static/js/compose_fade.js
@@ -69,7 +69,7 @@ function fade_messages() {
     }
 
     // Defer updating all message groups so that the compose box can open sooner
-    setTimeout(function (expected_msg_list, expected_recipient) {
+    setTimeout((expected_msg_list, expected_recipient) => {
         const all_groups = rows.get_table(current_msg_list.table_name).find(".recipient_row");
 
         if (current_msg_list !== expected_msg_list ||

--- a/static/js/compose_pm_pill.js
+++ b/static/js/compose_pm_pill.js
@@ -51,9 +51,7 @@ exports.get_user_ids_string = function () {
 exports.get_emails = function () {
     // return something like "alice@example.com,bob@example.com"
     const user_ids = exports.get_user_ids();
-    const emails = user_ids.map(function (id) {
-        return people.get_by_user_id(id).email;
-    }).join(",");
+    const emails = user_ids.map((id) => people.get_by_user_id(id).email).join(",");
     return emails;
 };
 

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -92,7 +92,7 @@ exports.compute_placeholder_text = function (opts) {
     // For Private Messages
     if (opts.private_message_recipient) {
         const recipient_list = opts.private_message_recipient.split(",");
-        const recipient_names = recipient_list.map(recipient => {
+        const recipient_names = recipient_list.map((recipient) => {
             const user = people.get_by_email(recipient);
             return user.full_name;
         }).join(", ");

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -63,13 +63,13 @@ exports.replace_syntax = function (old_syntax, new_syntax, textarea) {
         textarea = $('#compose-textarea');
     }
 
-    textarea.val(textarea.val().replace(old_syntax, function () {
+    textarea.val(textarea.val().replace(old_syntax, () =>
         // We need this anonymous function to avoid JavaScript's
         // replace() function treating `$`s in new_syntax as special syntax.  See
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Description
         // for details.
-        return new_syntax;
-    }));
+        new_syntax
+    ));
 };
 
 exports.compute_placeholder_text = function (opts) {

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -68,7 +68,7 @@ exports.replace_syntax = function (old_syntax, new_syntax, textarea) {
         // replace() function treating `$`s in new_syntax as special syntax.  See
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Description
         // for details.
-        new_syntax
+        new_syntax,
     ));
 };
 

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -381,7 +381,7 @@ function should_show_custom_query(query, items) {
     if (!query) {
         return false;
     }
-    const matched = items.some(elem => elem.toLowerCase() === query.toLowerCase());
+    const matched = items.some((elem) => elem.toLowerCase() === query.toLowerCase());
     return !matched;
 }
 
@@ -590,7 +590,7 @@ exports.get_sorted_filtered_items = function (query) {
 exports.filter_and_sort_candidates = function (completing, candidates, token) {
     const matcher = exports.compose_content_matcher(completing, token);
 
-    const small_results = candidates.filter(item => matcher(item));
+    const small_results = candidates.filter((item) => matcher(item));
 
     const sorted_results = exports.sort_results(completing, small_results, token);
 

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -442,13 +442,9 @@ exports.get_pm_people = function (query) {
 exports.get_person_suggestions = function (query, opts) {
     query = typeahead.clean_query_lowercase(query);
 
-    const person_matcher = (item) => {
-        return exports.query_matches_person(query, item);
-    };
+    const person_matcher = (item) => exports.query_matches_person(query, item);
 
-    const group_matcher = (item) => {
-        return query_matches_name_description(query, item);
-    };
+    const group_matcher = (item) => query_matches_name_description(query, item);
 
     function filter_persons(all_persons) {
         let persons;

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -496,7 +496,7 @@ exports.get_person_suggestions = function (query, opts) {
     const cutoff_length = exports.max_num_items;
 
     const filtered_message_persons = filter_persons(
-        people.get_active_message_people()
+        people.get_active_message_people(),
     );
 
     let filtered_persons;
@@ -505,7 +505,7 @@ exports.get_person_suggestions = function (query, opts) {
         filtered_persons = filtered_message_persons;
     } else {
         filtered_persons = filter_persons(
-            people.get_realm_users()
+            people.get_realm_users(),
         );
     }
 
@@ -515,7 +515,7 @@ exports.get_person_suggestions = function (query, opts) {
         opts.stream,
         opts.topic,
         filtered_groups,
-        exports.max_num_items
+        exports.max_num_items,
     );
 };
 

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -257,12 +257,12 @@ function select_on_focus(field_id) {
     // conditions in Chrome so we need to protect against infinite
     // recursion.
     let in_handler = false;
-    $("#" + field_id).focus(function () {
+    $("#" + field_id).focus(() => {
         if (in_handler) {
             return;
         }
         in_handler = true;
-        $("#" + field_id).select().one('mouseup', function (e) {
+        $("#" + field_id).select().one('mouseup', (e) => {
             e.preventDefault();
         });
         in_handler = false;
@@ -907,7 +907,7 @@ exports.content_typeahead_selected = function (item, event) {
 
     // Keep the cursor after the newly inserted text, as Bootstrap will call textbox.change() to
     // overwrite the text in the textbox.
-    setTimeout(function () {
+    setTimeout(() => {
         textbox.caret(beginning.length, beginning.length);
         // Also, trigger autosize to check if compose box needs to be resized.
         compose_ui.autosize_textarea();
@@ -954,7 +954,7 @@ exports.sort_results = function (completing, matches, token) {
         // topic_jump doesn't actually have a typeahead popover, so we return quickly here.
         return matches;
     case 'topic_list':
-        return typeahead_helper.sorter(token, matches, function (x) {return x;});
+        return typeahead_helper.sorter(token, matches, (x) => x);
     }
 };
 
@@ -1044,7 +1044,7 @@ exports.initialize = function () {
     $("form#send_message_form").keydown(handle_keydown);
     $("form#send_message_form").keyup(handle_keyup);
 
-    $("#enter_sends").click(function () {
+    $("#enter_sends").click(() => {
         const send_button = $("#compose-send-button");
         page_params.enter_sends = $("#enter_sends").is(":checked");
         if (page_params.enter_sends) {
@@ -1097,7 +1097,7 @@ exports.initialize = function () {
             return typeahead_helper.render_typeahead_item({ primary: item });
         },
         sorter: function (items) {
-            const sorted = typeahead_helper.sorter(this.query, items, function (x) {return x;});
+            const sorted = typeahead_helper.sorter(this.query, items, (x) => x);
             if (sorted.length > 0 && !sorted.includes(this.query)) {
                 sorted.unshift(this.query);
             }

--- a/static/js/confirm_dialog.js
+++ b/static/js/confirm_dialog.js
@@ -62,12 +62,12 @@ exports.launch = function (conf) {
     yes_button.html(conf.html_yes_button);
 
     // Set up handlers.
-    yes_button.on('click', function () {
+    yes_button.on('click', () => {
         overlays.close_modal('#confirm_dialog_modal');
         conf.on_click();
     });
 
-    confirm_dialog.on('hide', function () {
+    confirm_dialog.on('hide', () => {
         confirm_dialog.remove();
     });
 

--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -108,7 +108,7 @@ function select_div(div, selection) {
 }
 
 function remove_div(div, ranges, selection) {
-    window.setTimeout(function () {
+    window.setTimeout(() => {
         selection = window.getSelection();
         selection.removeAllRanges();
 
@@ -210,9 +210,7 @@ exports.analyze_selection = function (selection) {
         ranges.push(range);
 
         startc = $(range.startContainer);
-        start_data = find_boundary_tr($(startc.parents('.selectable_row, .message_header')[0]), function (row) {
-            return row.next();
-        });
+        start_data = find_boundary_tr($(startc.parents('.selectable_row, .message_header')[0]), (row) => row.next());
         if (start_data === undefined) {
             // Skip any selection sections that don't intersect a message.
             continue;
@@ -237,9 +235,7 @@ exports.analyze_selection = function (selection) {
         } else {
             initial_end_tr = $(endc.parents('.selectable_row')[0]);
         }
-        end_data = find_boundary_tr(initial_end_tr, function (row) {
-            return row.prev();
-        });
+        end_data = find_boundary_tr(initial_end_tr, (row) => row.prev());
 
         if (end_data === undefined) {
             // Skip any selection sections that don't intersect a message.

--- a/static/js/csrf.js
+++ b/static/js/csrf.js
@@ -1,5 +1,5 @@
 let csrf_token;
-$(function () {
+$(() => {
     // This requires that we used Jinja2's {% csrf_input %} somewhere on the page.
     const csrf_input = $('input[name="csrfmiddlewaretoken"]');
     if (csrf_input.length > 0) {

--- a/static/js/debug.js
+++ b/static/js/debug.js
@@ -30,11 +30,9 @@ export function check_duplicate_ids() {
     const collisions = [];
     let total_collisions = 0;
 
-    Array.prototype.slice.call(document.querySelectorAll("*")).forEach(function (o) {
+    Array.prototype.slice.call(document.querySelectorAll("*")).forEach((o) => {
         if (o.id && ids.has(o.id)) {
-            const el = collisions.find(function (c) {
-                return c.id === o.id;
-            });
+            const el = collisions.find((c) => c.id === o.id);
 
             ids.add(o.id);
             total_collisions += 1;

--- a/static/js/debug.js
+++ b/static/js/debug.js
@@ -105,7 +105,7 @@ IterationProfiler.prototype = {
         if (diff > 1) {
             this.sections.set(
                 "_rest_of_iteration",
-                (this.sections.get("_rest_of_iteration") || 0) + diff
+                (this.sections.get("_rest_of_iteration") || 0) + diff,
             );
         }
         this.last_time = now;

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -245,7 +245,7 @@ exports.format_draft = function (draft) {
         };
     } else {
         const emails = util.extract_pm_recipients(draft.private_message_recipient);
-        const recipients = emails.map(email => {
+        const recipients = emails.map((email) => {
             email = email.trim();
             const person = people.get_by_email(email);
             if (person !== undefined) {

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -175,7 +175,7 @@ exports.restore_draft = function (draft_id) {
                     {operator: "stream", operand: compose_args.stream},
                     {operator: "topic", operand: compose_args.topic},
                 ],
-                {trigger: "restore draft"}
+                {trigger: "restore draft"},
             );
         }
     } else {
@@ -184,7 +184,7 @@ exports.restore_draft = function (draft_id) {
                 [
                     {operator: "pm-with", operand: compose_args.private_message_recipient},
                 ],
-                {trigger: "restore draft"}
+                {trigger: "restore draft"},
             );
         }
     }
@@ -319,7 +319,7 @@ exports.launch = function () {
         const unsorted_raw_drafts = Object.values(data);
 
         const sorted_raw_drafts = unsorted_raw_drafts.sort(
-            (draft_a, draft_b) => draft_b.updatedAt - draft_a.updatedAt
+            (draft_a, draft_b) => draft_b.updatedAt - draft_a.updatedAt,
         );
 
         const sorted_formatted_drafts = sorted_raw_drafts.map(exports.format_draft).filter(Boolean);

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -318,9 +318,9 @@ exports.launch = function () {
 
         const unsorted_raw_drafts = Object.values(data);
 
-        const sorted_raw_drafts = unsorted_raw_drafts.sort(function (draft_a, draft_b) {
-            return draft_b.updatedAt - draft_a.updatedAt;
-        });
+        const sorted_raw_drafts = unsorted_raw_drafts.sort(
+            (draft_a, draft_b) => draft_b.updatedAt - draft_a.updatedAt
+        );
 
         const sorted_formatted_drafts = sorted_raw_drafts.map(exports.format_draft).filter(Boolean);
 
@@ -514,7 +514,7 @@ exports.set_initial_element = function (drafts) {
 };
 
 exports.initialize = function () {
-    window.addEventListener("beforeunload", function () {
+    window.addEventListener("beforeunload", () => {
         exports.update_draft();
     });
 
@@ -522,7 +522,7 @@ exports.initialize = function () {
 
     $("#compose-textarea").focusout(exports.update_draft);
 
-    $('body').on('focus', '.draft-info-box', function (e) {
+    $('body').on('focus', '.draft-info-box', (e) => {
         activate_element(e.target);
     });
 };

--- a/static/js/dropdown_list_widget.js
+++ b/static/js/dropdown_list_widget.js
@@ -55,7 +55,7 @@ const DropdownListWidget = function (opts) {
             const value = $(this).attr('data-value');
             update(value);
         });
-        $(`#${opts.container_id} .dropdown_list_reset_button`).click(function (e) {
+        $(`#${opts.container_id} .dropdown_list_reset_button`).click((e) => {
             update(opts.null_value);
             e.preventDefault();
         });
@@ -79,22 +79,22 @@ const DropdownListWidget = function (opts) {
                 },
             },
         });
-        $(`#${opts.container_id} .dropdown-search`).click(function (e) {
+        $(`#${opts.container_id} .dropdown-search`).click((e) => {
             e.stopPropagation();
         });
 
-        dropdown_toggle.click(function () {
+        dropdown_toggle.click(() => {
             search_input.val("").trigger("input");
         });
 
-        dropdown_toggle.focus(function (e) {
+        dropdown_toggle.focus((e) => {
             // On opening a Bootstrap Dropdown, the parent element recieves focus.
             // Here, we want our search input to have focus instead.
             e.preventDefault();
             search_input.focus();
         });
 
-        search_input.keydown(function (e) {
+        search_input.keydown((e) => {
             if (!/(38|40|27)/.test(e.keyCode)) {
                 return;
             }

--- a/static/js/dropdown_list_widget.js
+++ b/static/js/dropdown_list_widget.js
@@ -30,7 +30,7 @@ const DropdownListWidget = function (opts) {
         }
 
         // Happy path
-        const item = opts.data.find(x => x.value === value.toString());
+        const item = opts.data.find((x) => x.value === value.toString());
         const text = opts.render_text(item.name);
         elem.text(text);
         elem.removeClass('text-warning');

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -30,7 +30,7 @@ function resend_message(message, row) {
 
     function on_error(response) {
         exports.message_send_error(message.id, response);
-        setTimeout(function () {
+        setTimeout(() => {
             retry_spinner.toggleClass('rotating', false);
         }, 300);
         blueslip.log("Manual resend of message failed");

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -52,7 +52,7 @@ exports.build_display_recipient = function (message) {
     const emails = util.extract_pm_recipients(message.private_message_recipient);
 
     let sender_in_display_recipients = false;
-    const display_recipient = emails.map(email => {
+    const display_recipient = emails.map((email) => {
         email = email.trim();
         const person = people.get_by_email(email);
         if (person === undefined) {

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -103,7 +103,7 @@ function show_emoji_catalog() {
 
 exports.generate_emoji_picker_data = function (realm_emojis) {
     const catalog = new Map();
-    catalog.set("Custom", Array.from(realm_emojis.keys(), realm_emoji_name =>
+    catalog.set("Custom", Array.from(realm_emojis.keys(), (realm_emoji_name) =>
         emoji.emojis_by_name.get(realm_emoji_name)
     ));
 
@@ -133,8 +133,8 @@ exports.generate_emoji_picker_data = function (realm_emojis) {
     }
     catalog.set("Popular", popular);
 
-    const categories = get_all_emoji_categories().filter(category => catalog.has(category.name));
-    exports.complete_emoji_catalog = categories.map(category => ({
+    const categories = get_all_emoji_categories().filter((category) => catalog.has(category.name));
+    exports.complete_emoji_catalog = categories.map((category) => ({
         name: category.name,
         icon: category.icon,
         emojis: catalog.get(category.name),
@@ -148,7 +148,7 @@ const generate_emoji_picker_content = function (id) {
         emojis_used = reactions.get_emojis_used_by_user_for_message_id(id);
     }
     for (const emoji_dict of emoji.emojis_by_name.values()) {
-        emoji_dict.has_reacted = emoji_dict.aliases.some(alias => emojis_used.includes(alias));
+        emoji_dict.has_reacted = emoji_dict.aliases.some((alias) => emojis_used.includes(alias));
     }
 
     return render_emoji_popover_content({
@@ -212,7 +212,7 @@ function filter_emojis() {
 
             for (const emoji_dict of emojis) {
                 for (const alias of emoji_dict.aliases) {
-                    const match = search_terms.every(search_term => alias.includes(search_term));
+                    const match = search_terms.every((search_term) => alias.includes(search_term));
                     if (match) {
                         search_results.push({ ...emoji_dict, name: alias });
                         break;  // We only need the first matching alias per emoji.

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -505,7 +505,7 @@ exports.emoji_select_tab = function (elt) {
     const scrollheight = elt.prop('scrollHeight');
     const elt_height = elt.height();
     let currently_selected = "";
-    section_head_offsets.forEach(function (o) {
+    section_head_offsets.forEach((o) => {
         if (scrolltop + elt_height / 2 >= o.position_y) {
             currently_selected = o.section;
         }
@@ -528,14 +528,14 @@ exports.emoji_select_tab = function (elt) {
 function register_popover_events(popover) {
     const $emoji_map = popover.find('.emoji-popover-emoji-map');
 
-    ui.get_scroll_element($emoji_map).on("scroll", function () {
+    ui.get_scroll_element($emoji_map).on("scroll", () => {
         exports.emoji_select_tab(ui.get_scroll_element($emoji_map));
     });
 
     $('.emoji-popover-filter').on('input', filter_emojis);
     $('.emoji-popover-filter').keydown(maybe_select_emoji);
     $('.emoji-popover').keypress(process_keypress);
-    $('.emoji-popover').keydown(function (e) {
+    $('.emoji-popover').keydown((e) => {
         // Because of cross-browser issues we need to handle backspace
         // key separately. Firefox fires `keypress` event for backspace
         // key but chrome doesn't so we need to trigger the logic for
@@ -670,7 +670,7 @@ exports.register_click_handlers = function () {
         exports.toggle_emoji_popover(this, message_id);
     });
 
-    $("#main_div").on("mouseenter", ".reaction_button", function (e) {
+    $("#main_div").on("mouseenter", ".reaction_button", (e) => {
         e.stopPropagation();
 
         const elem = $(e.currentTarget);
@@ -685,12 +685,12 @@ exports.register_click_handlers = function () {
         $(".tooltip-arrow").remove();
     });
 
-    $('#main_div').on('mouseleave', '.reaction_button', function (e) {
+    $('#main_div').on('mouseleave', '.reaction_button', (e) => {
         e.stopPropagation();
         $(e.currentTarget).tooltip('hide');
     });
 
-    $("body").on("click", ".actions_popover .reaction_button", function (e) {
+    $("body").on("click", ".actions_popover .reaction_button", (e) => {
         const message_id = $(e.currentTarget).data('message-id');
         e.preventDefault();
         e.stopPropagation();
@@ -710,20 +710,18 @@ exports.register_click_handlers = function () {
         const $popover = $(e.currentTarget).closest('.emoji-info-popover').expectOne();
         const $emoji_map = $popover.find(".emoji-popover-emoji-map");
 
-        const offset = section_head_offsets.find(function (o) {
-            return o.section === $(this).attr("data-tab-name");
-        }.bind(this));
+        const offset = section_head_offsets.find((o) => o.section === $(this).attr("data-tab-name"));
 
         if (offset) {
             ui.get_scroll_element($emoji_map).scrollTop(offset.position_y);
         }
     });
 
-    $("body").on("click", ".emoji-popover-filter", function () {
+    $("body").on("click", ".emoji-popover-filter", () => {
         reset_emoji_showcase();
     });
 
-    $("body").on("mouseenter", ".emoji-popover-emoji", function (e) {
+    $("body").on("mouseenter", ".emoji-popover-emoji", (e) => {
         const emoji_id = $(e.currentTarget).data("emoji-id");
         const emoji_coordinates = get_emoji_coordinates(emoji_id);
 

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -104,7 +104,7 @@ function show_emoji_catalog() {
 exports.generate_emoji_picker_data = function (realm_emojis) {
     const catalog = new Map();
     catalog.set("Custom", Array.from(realm_emojis.keys(), (realm_emoji_name) =>
-        emoji.emojis_by_name.get(realm_emoji_name)
+        emoji.emojis_by_name.get(realm_emoji_name),
     ));
 
     for (const [category, codepoints] of Object.entries(emoji_codes.emoji_catalog)) {
@@ -730,7 +730,7 @@ exports.register_click_handlers = function () {
             $emoji_map,
             emoji_coordinates.section,
             emoji_coordinates.index,
-            true
+            true,
         );
     });
 };

--- a/static/js/feedback_widget.js
+++ b/static/js/feedback_widget.js
@@ -71,7 +71,7 @@ function set_up_handlers() {
     meta.handlers_set = true;
 
     // if the user mouses over the notification, don't hide it.
-    meta.$container.mouseenter(function () {
+    meta.$container.mouseenter(() => {
         if (!meta.opened) {
             return;
         }
@@ -80,7 +80,7 @@ function set_up_handlers() {
     });
 
     // once the user's mouse leaves the notification, restart the countdown.
-    meta.$container.mouseleave(function () {
+    meta.$container.mouseleave(() => {
         if (!meta.opened) {
             return;
         }
@@ -91,11 +91,11 @@ function set_up_handlers() {
         meta.hide_me_time = Math.max(meta.hide_me_time, new Date().getTime() + 2000);
     });
 
-    meta.$container.on('click', '.exit-me', function () {
+    meta.$container.on('click', '.exit-me', () => {
         animate.fadeOut();
     });
 
-    meta.$container.on('click', '.feedback_undo', function () {
+    meta.$container.on('click', '.feedback_undo', () => {
         if (meta.undo) {
             meta.undo();
         }

--- a/static/js/fenced_code.js
+++ b/static/js/fenced_code.js
@@ -42,7 +42,7 @@ function wrap_quote(text) {
     // beginning of each line
     for (const paragraph of paragraphs) {
         const lines = paragraph.split('\n');
-        quoted_paragraphs.push(lines.filter(line => line !== '').map(line => '> ' + line).join('\n'));
+        quoted_paragraphs.push(lines.filter((line) => line !== '').map((line) => '> ' + line).join('\n'));
     }
 
     return quoted_paragraphs.join('\n\n');

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -323,7 +323,7 @@ Filter.parse = function (str) {
    might need to support multiple operators of the same type.
 */
 Filter.unparse = function (operators) {
-    const parts = operators.map(elem => {
+    const parts = operators.map((elem) => {
 
         if (elem.operator === 'search') {
             // Search terms are the catch-all case.
@@ -357,7 +357,7 @@ Filter.prototype = {
     public_operators: function () {
         const safe_to_return = this._operators.filter(
             // Filter out the embedded narrow (if any).
-            value =>
+            (value) =>
                 !(
                     page_params.narrow_stream !== undefined &&
                     value.operator === "stream" &&
@@ -376,18 +376,18 @@ Filter.prototype = {
 
     has_negated_operand: function (operator, operand) {
         return this._operators.some(
-            elem => elem.negated && (elem.operator === operator && elem.operand === operand)
+            (elem) => elem.negated && (elem.operator === operator && elem.operand === operand)
         );
     },
 
     has_operand: function (operator, operand) {
         return this._operators.some(
-            elem => !elem.negated && (elem.operator === operator && elem.operand === operand)
+            (elem) => !elem.negated && (elem.operator === operator && elem.operand === operand)
         );
     },
 
     has_operator: function (operator) {
-        return this._operators.some(elem => {
+        return this._operators.some((elem) => {
             if (elem.negated && !['search', 'has'].includes(elem.operator)) {
                 return false;
             }
@@ -591,7 +591,7 @@ Filter.prototype = {
                 return i18n.t('Private messages');
             case 'pm-with': {
                 const emails = this.operands('pm-with')[0].split(',');
-                const names = emails.map(email => {
+                const names = emails.map((email) => {
                     if (!people.get_by_email(email)) {
                         return email;
                     }
@@ -673,15 +673,15 @@ Filter.prototype = {
             return terms;
         }
 
-        return terms.filter(term => Filter.term_type(term) !== 'is-private');
+        return terms.filter((term) => Filter.term_type(term) !== 'is-private');
     },
 
     _canonicalize_operators: function (operators_mixed_case) {
-        return operators_mixed_case.map(tuple => Filter.canonicalize_term(tuple));
+        return operators_mixed_case.map((tuple) => Filter.canonicalize_term(tuple));
     },
 
     filter_with_new_params: function (params) {
-        const terms = this._operators.map(term => {
+        const terms = this._operators.map((term) => {
             const new_term = { ...term };
             if (new_term.operator === params.operator && !new_term.negated) {
                 new_term.operand = params.operand;
@@ -729,7 +729,7 @@ Filter.prototype = {
     first_valid_id_from: function (msg_ids) {
         const predicate = this.predicate();
 
-        const first_id = msg_ids.find(msg_id => {
+        const first_id = msg_ids.find((msg_id) => {
             const message = message_store.get(msg_id);
 
             if (message === undefined) {
@@ -771,7 +771,7 @@ Filter.prototype = {
         // build JavaScript code in a string and then eval() it.
 
         return function (message) {
-            return operators.every(term => {
+            return operators.every((term) => {
                 let ok = message_matches_search_term(message, term.operator, term.operand);
                 if (term.negated) {
                     ok = !ok;
@@ -910,7 +910,7 @@ function describe_unescaped(operators) {
         }
     }
 
-    const more_parts = operators.map(elem => {
+    const more_parts = operators.map((elem) => {
         const operand = elem.operand;
         const canonicalized_operator = Filter.canonicalize_operator(elem.operator);
         if (canonicalized_operator === 'is') {

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -665,9 +665,7 @@ Filter.prototype = {
     },
 
     _fix_redundant_is_private: function (terms) {
-        const is_pm_with = (term) => {
-            return Filter.term_type(term) === 'pm-with';
-        };
+        const is_pm_with = (term) => Filter.term_type(term) === 'pm-with';
 
         if (!terms.some(is_pm_with)) {
             return terms;

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -369,8 +369,8 @@ Filter.prototype = {
 
     operands: function (operator) {
         return _.chain(this._operators)
-            .filter(function (elem) { return !elem.negated && elem.operator === operator; })
-            .map(function (elem) { return elem.operand; })
+            .filter((elem) => !elem.negated && elem.operator === operator)
+            .map((elem) => elem.operand)
             .value();
     },
 

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -362,7 +362,7 @@ Filter.prototype = {
                     page_params.narrow_stream !== undefined &&
                     value.operator === "stream" &&
                     value.operand.toLowerCase() === page_params.narrow_stream.toLowerCase()
-                )
+                ),
         );
         return safe_to_return;
     },
@@ -376,13 +376,13 @@ Filter.prototype = {
 
     has_negated_operand: function (operator, operand) {
         return this._operators.some(
-            (elem) => elem.negated && (elem.operator === operator && elem.operand === operand)
+            (elem) => elem.negated && (elem.operator === operator && elem.operand === operand),
         );
     },
 
     has_operand: function (operator, operand) {
         return this._operators.some(
-            (elem) => !elem.negated && (elem.operator === operator && elem.operand === operand)
+            (elem) => !elem.negated && (elem.operator === operator && elem.operand === operand),
         );
     },
 
@@ -750,7 +750,7 @@ Filter.prototype = {
                 term.operand = people.update_email_in_reply_to(
                     term.operand,
                     user_id,
-                    new_email
+                    new_email,
                 );
             }
         }

--- a/static/js/gear_menu.js
+++ b/static/js/gear_menu.js
@@ -86,12 +86,12 @@ exports.update_org_settings_menu_item = function () {
 exports.initialize = function () {
     exports.update_org_settings_menu_item();
 
-    $('#gear-menu a[data-toggle="tab"]').on('show', function (e) {
+    $('#gear-menu a[data-toggle="tab"]').on('show', (e) => {
         // Save the position of our old tab away, before we switch
         const old_tab = $(e.relatedTarget).attr('href');
         scroll_positions.set(old_tab, message_viewport.scrollTop());
     });
-    $('#gear-menu a[data-toggle="tab"]').on('shown', function (e) {
+    $('#gear-menu a[data-toggle="tab"]').on('shown', (e) => {
         const target_tab = $(e.target).attr('href');
         // Hide all our error messages when switching tabs
         $('.alert').removeClass("show");

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -281,7 +281,7 @@ exports.go_to_location = function (hash) {
 };
 
 exports.initialize = function () {
-    $(window).on('hashchange', function (e) {
+    $(window).on('hashchange', (e) => {
         hashchanged(false, e.originalEvent);
     });
     hashchanged(true);

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -634,7 +634,7 @@ exports.process_hotkey = function (e, hotkey) {
         compose_actions.start('private', {trigger: "compose_hotkey"});
         return true;
     case 'narrow_private':
-        return do_narrow_action(function (target, opts) {
+        return do_narrow_action((target, opts) => {
             narrow.by('is', 'private', opts);
         });
     case 'query_streams':
@@ -792,7 +792,7 @@ exports.process_keydown = function (e) {
     return exports.process_hotkey(e, hotkey);
 };
 
-$(document).keydown(function (e) {
+$(document).keydown((e) => {
     if (exports.process_keydown(e)) {
         e.preventDefault();
     }
@@ -806,7 +806,7 @@ exports.process_keypress = function (e) {
     return exports.process_hotkey(e, hotkey);
 };
 
-$(document).keypress(function (e) {
+$(document).keypress((e) => {
     if (exports.process_keypress(e)) {
         e.preventDefault();
     }

--- a/static/js/hotspots.js
+++ b/static/js/hotspots.js
@@ -96,7 +96,7 @@ function place_popover(hotspot) {
             $(hotspot.location.element),
             popover_height,
             popover_width,
-            false
+            false,
         );
 
     switch (orientation) {
@@ -151,7 +151,7 @@ function place_popover(hotspot) {
     default:
         blueslip.error(
             'Invalid popover placement value for hotspot \'' +
-                hotspot.name + '\''
+                hotspot.name + '\'',
         );
         break;
     }
@@ -237,7 +237,7 @@ exports.close_hotspot_icon = function (elem) {
 function close_read_hotspots(new_hotspots) {
     const unwanted_hotspots = _.difference(
         Array.from(HOTSPOT_LOCATIONS.keys()),
-        new_hotspots.map((hotspot) => hotspot.name)
+        new_hotspots.map((hotspot) => hotspot.name),
     );
 
     for (const hotspot_name of unwanted_hotspots) {

--- a/static/js/hotspots.js
+++ b/static/js/hotspots.js
@@ -237,7 +237,7 @@ exports.close_hotspot_icon = function (elem) {
 function close_read_hotspots(new_hotspots) {
     const unwanted_hotspots = _.difference(
         Array.from(HOTSPOT_LOCATIONS.keys()),
-        new_hotspots.map(hotspot => hotspot.name)
+        new_hotspots.map((hotspot) => hotspot.name)
     );
 
     for (const hotspot_name of unwanted_hotspots) {

--- a/static/js/hotspots.js
+++ b/static/js/hotspots.js
@@ -203,7 +203,7 @@ function insert_hotspot_into_DOM(hotspot) {
             '<div class="bounce"><span class="bounce-icon">?</span></div>' +
         '</div>';
 
-    setTimeout(function () {
+    setTimeout(() => {
         $('body').prepend(hotspot_icon_HTML);
         $('body').prepend(hotspot_overlay_HTML);
         if (place_icon(hotspot)) {
@@ -211,8 +211,8 @@ function insert_hotspot_into_DOM(hotspot) {
         }
 
         // reposition on any event that might update the UI
-        ['resize', 'scroll', 'onkeydown', 'click'].forEach(function (event_name) {
-            window.addEventListener(event_name, _.debounce(function () {
+        ['resize', 'scroll', 'onkeydown', 'click'].forEach((event_name) => {
+            window.addEventListener(event_name, _.debounce(() => {
                 if (place_icon(hotspot)) {
                     place_popover(hotspot);
                 }
@@ -247,7 +247,7 @@ function close_read_hotspots(new_hotspots) {
 
 exports.load_new = function (new_hotspots) {
     close_read_hotspots(new_hotspots);
-    new_hotspots.forEach(function (hotspot) {
+    new_hotspots.forEach((hotspot) => {
         hotspot.location = HOTSPOT_LOCATIONS.get(hotspot.name);
     });
     new_hotspots.forEach(insert_hotspot_into_DOM);

--- a/static/js/huddle_data.js
+++ b/static/js/huddle_data.js
@@ -16,9 +16,7 @@ exports.process_loaded_messages = function (messages) {
 
 exports.get_huddles = function () {
     let huddles = Array.from(huddle_timestamps.keys());
-    huddles = _.sortBy(huddles, function (huddle) {
-        return huddle_timestamps.get(huddle);
-    });
+    huddles = _.sortBy(huddles, (huddle) => huddle_timestamps.get(huddle));
     return huddles.reverse();
 };
 

--- a/static/js/info_overlay.js
+++ b/static/js/info_overlay.js
@@ -22,7 +22,7 @@ exports.set_up_toggler = function () {
     const elem = exports.toggler.get();
     elem.addClass('large allow-overflow');
 
-    const modals = opts.values.map(item => {
+    const modals = opts.values.map((item) => {
         const key = item.key; // e.g. message-formatting
         const modal = $('#' + key).find('.modal-body');
         return modal;

--- a/static/js/input_pill.js
+++ b/static/js/input_pill.js
@@ -219,11 +219,11 @@ exports.create = function (opts) {
         },
 
         getByID: function (id) {
-            return store.pills.find(pill => pill.id === id);
+            return store.pills.find((pill) => pill.id === id);
         },
 
         items: function () {
-            return store.pills.map(pill => pill.item);
+            return store.pills.map((pill) => pill.item);
         },
 
         createPillonPaste: function () {

--- a/static/js/input_pill.js
+++ b/static/js/input_pill.js
@@ -187,16 +187,14 @@ exports.create = function (opts) {
 
         insertManyPills: function (pills) {
             if (typeof pills === "string") {
-                pills = pills.split(/,/g).map(function (pill) {
-                    return pill.trim();
-                });
+                pills = pills.split(/,/g).map((pill) => pill.trim());
             }
 
             // this is an array to push all the errored values to, so it's drafts
             // of pills for the user to fix.
             const drafts = [];
 
-            pills.forEach(function (pill) {
+            pills.forEach((pill) => {
                 // if this returns `false`, it erroed and we should push it to
                 // the draft pills.
                 if (funcs.appendPill(pill) === false) {
@@ -235,7 +233,7 @@ exports.create = function (opts) {
     };
 
     (function events() {
-        store.$parent.on("keydown", ".input", function (e) {
+        store.$parent.on("keydown", ".input", (e) => {
             const char = e.keyCode || e.charCode;
 
             if (char === KEY.ENTER) {
@@ -300,7 +298,7 @@ exports.create = function (opts) {
 
         // handle events while hovering on ".pill" elements.
         // the three primary events are next, previous, and delete.
-        store.$parent.on("keydown", ".pill", function (e) {
+        store.$parent.on("keydown", ".pill", (e) => {
             const char = e.keyCode || e.charCode;
 
             const $pill = store.$parent.find(".pill:focus");
@@ -328,7 +326,7 @@ exports.create = function (opts) {
 
         // replace formatted input with plaintext to allow for sane copy-paste
         // actions.
-        store.$parent.on("paste", ".input", function (e) {
+        store.$parent.on("paste", ".input", (e) => {
             e.preventDefault();
 
             // get text representation of clipboard
@@ -360,7 +358,7 @@ exports.create = function (opts) {
             }
         });
 
-        store.$parent.on("copy", ".pill", function (e) {
+        store.$parent.on("copy", ".pill", (e) => {
             const id = store.$parent.find(":focus").data("id");
             const data = funcs.getByID(id);
             e.originalEvent.clipboardData.setData("text/plain", store.get_text_from_item(data.item));

--- a/static/js/invite.js
+++ b/static/js/invite.js
@@ -73,7 +73,7 @@ function submit_invitation_form() {
                 const invitee_emails_errored = [];
                 const error_list = [];
                 let is_invitee_deactivated = false;
-                arr.errors.forEach(function (value) {
+                arr.errors.forEach((value) => {
                     const [email, error_message, deactivated] = value;
                     error_list.push(`${email}: ${error_message}`);
                     if (deactivated) {
@@ -161,17 +161,17 @@ exports.launch = function () {
 };
 
 exports.initialize = function () {
-    $(document).on('click', '.invite_check_all_button', function (e) {
+    $(document).on('click', '.invite_check_all_button', (e) => {
         $('#streams_to_add :checkbox').prop('checked', true);
         e.preventDefault();
     });
 
-    $(document).on('click', '.invite_uncheck_all_button', function (e) {
+    $(document).on('click', '.invite_uncheck_all_button', (e) => {
         $('#streams_to_add :checkbox').prop('checked', false);
         e.preventDefault();
     });
 
-    $("#submit-invitation").on("click", function () {
+    $("#submit-invitation").on("click", () => {
         const is_generate_invite_link = $('#generate_multiuse_invite_radio').prop('checked');
         if (is_generate_invite_link) {
             generate_multiuse_invite();
@@ -180,7 +180,7 @@ exports.initialize = function () {
         }
     });
 
-    $("#generate_multiuse_invite_button").on("click", function () {
+    $("#generate_multiuse_invite_button").on("click", () => {
         $("#generate_multiuse_invite_radio").prop("checked", true);
         $("#multiuse_radio_section").show();
         $("#invite-method-choice").hide();
@@ -190,7 +190,7 @@ exports.initialize = function () {
         reset_error_messages();
     });
 
-    $('#invite-user').on('change', '#generate_multiuse_invite_radio', function () {
+    $('#invite-user').on('change', '#generate_multiuse_invite_radio', () => {
         $('#invitee_emails').prop('disabled', false);
         $('#submit-invitation').text(i18n.t('Invite'));
         $('#submit-invitation').data('loading-text', i18n.t('Inviting...'));

--- a/static/js/keydown_util.js
+++ b/static/js/keydown_util.js
@@ -11,7 +11,7 @@ const keys = {
 };
 
 exports.handle = function (opts) {
-    opts.elem.keydown(function (e) {
+    opts.elem.keydown((e) => {
         const key = e.which || e.keyCode;
 
         if (e.altKey || e.ctrlKey || e.shiftKey) {

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -8,7 +8,7 @@ function render_lightbox_list_images(preview_source) {
         const images = Array.prototype.slice.call($(".focused_table .message_inline_image img"));
         const $image_list = $("#lightbox_overlay .image-list").html("");
 
-        images.forEach(function (img) {
+        images.forEach((img) => {
             const src = img.getAttribute("src");
             const className = preview_source === src ? "image selected" : "image";
 
@@ -321,7 +321,7 @@ exports.initialize = function () {
         }
     });
 
-    $("#lightbox_overlay .image-preview").on("dblclick", "img, canvas", function (e) {
+    $("#lightbox_overlay .image-preview").on("dblclick", "img, canvas", (e) => {
         $("#lightbox_overlay .lightbox-canvas-trigger").click();
         e.preventDefault();
     });
@@ -332,7 +332,7 @@ exports.initialize = function () {
         }
     });
 
-    $("#lightbox_overlay").on("click", ".image-info-wrapper, .center", function (e) {
+    $("#lightbox_overlay").on("click", ".image-info-wrapper, .center", (e) => {
         if ($(e.target).is(".image-info-wrapper, .center")) {
             overlays.close_overlay("lightbox");
         }

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -70,7 +70,7 @@ function display_video(payload) {
         // Use data: to load the player in a unique origin for security.
         source = "data:text/html," + window.encodeURIComponent(
             "<!DOCTYPE html><style>iframe{position:absolute;left:0;top:0;width:100%;height:100%;box-sizing:border-box}</style>" +
-                payload.source
+                payload.source,
         );
     }
 

--- a/static/js/lightbox_canvas.js
+++ b/static/js/lightbox_canvas.js
@@ -4,7 +4,7 @@ const events = {
 };
 
 window.onload = function () {
-    document.body.addEventListener("mouseup", function (e) {
+    document.body.addEventListener("mouseup", (e) => {
         events.documentMouseup = events.documentMouseup.filter(function (event) {
             // go through automatic cleanup when running events.
             if (!document.body.contains(event.canvas)) {
@@ -17,7 +17,7 @@ window.onload = function () {
     });
 
     window.addEventListener("resize", function (e) {
-        events.windowResize = events.windowResize.filter(function (event) {
+        events.windowResize = events.windowResize.filter((event) => {
             if (!document.body.contains(event.canvas)) {
                 return false;
             }
@@ -25,7 +25,7 @@ window.onload = function () {
             event.callback.call(this, e);
 
             return true;
-        }.bind(this));
+        });
     });
 };
 
@@ -76,7 +76,7 @@ const funcs = {
         // actually an element that can scroll. The wheel event will
         // detect the *gesture* of scrolling over an element, without actually
         // worrying about scrollable content.
-        canvas.addEventListener("wheel", function (e) {
+        canvas.addEventListener("wheel", (e) => {
             e.preventDefault();
 
             // this is to reverse scrolling directions for the image.
@@ -111,12 +111,12 @@ const funcs = {
 
         // the only valid mousedown events should originate inside of the
         // canvas.
-        canvas.addEventListener("mousedown", function () {
+        canvas.addEventListener("mousedown", () => {
             mousedown = true;
         });
 
         // on mousemove, actually run the pan events.
-        canvas.addEventListener("mousemove", function (e) {
+        canvas.addEventListener("mousemove", (e) => {
             // to pan, there must be mousedown and mousemove, check if valid.
             if (mousedown === true) {
                 polyfillMouseMovement(e);
@@ -145,7 +145,7 @@ const funcs = {
         // that the LightboxCanvas instance created in lightbox.js can be
         // accessed from hotkey.js. Major code refactoring is required in lightbox.js
         // to implement these keyboard shortcuts in hotkey.js
-        document.addEventListener('keydown', function (e) {
+        document.addEventListener('keydown', (e) => {
             if (!overlays.lightbox_open()) {
                 return;
             }
@@ -165,7 +165,7 @@ const funcs = {
 
         // make sure that when the mousedown is lifted on <canvas>to prevent
         // panning events.
-        canvas.addEventListener("mouseup", function () {
+        canvas.addEventListener("mouseup", () => {
             mousedown = false;
             // reset this to be empty so that the values will `NaN` on first
             // mousemove and default to a change of (0, 0).

--- a/static/js/list_render.js
+++ b/static/js/list_render.js
@@ -39,7 +39,7 @@ exports.get_filtered_items = (value, list, opts) => {
         if (get_item) {
             return opts.filter.filterer(
                 list.map(get_item),
-                value
+                value,
             );
         }
         return opts.filter.filterer(list, value);
@@ -159,12 +159,12 @@ exports.create = function ($container, list, opts) {
         meta.filtered_list = exports.get_filtered_items(
             meta.filter_value,
             meta.list,
-            opts
+            opts,
         );
 
         if (meta.sorting_function) {
             meta.filtered_list.sort(
-                meta.sorting_function
+                meta.sorting_function,
             );
         }
 

--- a/static/js/list_render.js
+++ b/static/js/list_render.js
@@ -45,9 +45,7 @@ exports.get_filtered_items = (value, list, opts) => {
         return opts.filter.filterer(list, value);
     }
 
-    const predicate = (item) => {
-        return opts.filter.predicate(item, value);
-    };
+    const predicate = (item) => opts.filter.predicate(item, value);
 
     if (get_item) {
         const result = [];
@@ -65,32 +63,28 @@ exports.get_filtered_items = (value, list, opts) => {
     return list.filter(predicate);
 };
 
-exports.alphabetic_sort = (prop) => {
-    return function (a, b) {
-        // The conversion to uppercase helps make the sorting case insensitive.
-        const str1 = a[prop].toUpperCase();
-        const str2 = b[prop].toUpperCase();
+exports.alphabetic_sort = (prop) => function (a, b) {
+    // The conversion to uppercase helps make the sorting case insensitive.
+    const str1 = a[prop].toUpperCase();
+    const str2 = b[prop].toUpperCase();
 
-        if (str1 === str2) {
-            return 0;
-        } else if (str1 > str2) {
-            return 1;
-        }
+    if (str1 === str2) {
+        return 0;
+    } else if (str1 > str2) {
+        return 1;
+    }
 
-        return -1;
-    };
+    return -1;
 };
 
-exports.numeric_sort = (prop) => {
-    return function (a, b) {
-        if (parseFloat(a[prop]) > parseFloat(b[prop])) {
-            return 1;
-        } else if (parseFloat(a[prop]) === parseFloat(b[prop])) {
-            return 0;
-        }
+exports.numeric_sort = (prop) => function (a, b) {
+    if (parseFloat(a[prop]) > parseFloat(b[prop])) {
+        return 1;
+    } else if (parseFloat(a[prop]) === parseFloat(b[prop])) {
+        return 0;
+    }
 
-        return -1;
-    };
+    return -1;
 };
 
 exports.valid_filter_opts = (opts) => {

--- a/static/js/localstorage.js
+++ b/static/js/localstorage.js
@@ -62,11 +62,9 @@ const ls = {
     // Remove keys which match a regex.
     removeDataRegex: function (version, regex) {
         const key_regex = new RegExp(this.formGetter(version, regex));
-        const keys = Object.keys(localStorage).filter(function (key) {
-            return key_regex.test(key);
-        });
+        const keys = Object.keys(localStorage).filter((key) => key_regex.test(key));
 
-        keys.forEach(function (key) {
+        keys.forEach((key) => {
             localStorage.removeItem(key);
         });
     },

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -176,7 +176,7 @@ exports.apply_markdown = function (message) {
         silencedMentionHandler: function (quote) {
             // Silence quoted mentions.
             const user_mention_re = /<span.*user-mention.*data-user-id="(\d+|\*)"[^>]*>@/gm;
-            quote = quote.replace(user_mention_re, function (match) {
+            quote = quote.replace(user_mention_re, (match) => {
                 match = match.replace(/"user-mention"/g, '"user-mention silent"');
                 match = match.replace(/>@/g, '>');
                 return match;
@@ -502,9 +502,7 @@ exports.initialize = function (realm_filters, helper_config) {
 
     // Tell our fenced code preprocessor how to insert arbitrary
     // HTML into the output. This generated HTML is safe to not escape
-    fenced_code.set_stash_func(function (html) {
-        return marked.stashHtml(html, true);
-    });
+    fenced_code.set_stash_func((html) => marked.stashHtml(html, true));
 
     marked.setOptions({
         gfm: true,

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -71,12 +71,12 @@ exports.contains_backend_only_syntax = function (content) {
     // Try to guess whether or not a message contains syntax that only the
     // backend markdown processor can correctly handle.
     // If it doesn't, we can immediately render it client-side for local echo.
-    const markedup = backend_only_markdown_re.find(re => re.test(content));
+    const markedup = backend_only_markdown_re.find((re) => re.test(content));
 
     // If a realm filter doesn't start with some specified characters
     // then don't render it locally. It is workaround for the fact that
     // javascript regex doesn't support lookbehind.
-    const false_filter_match = realm_filter_list.find(re => {
+    const false_filter_match = realm_filter_list.find((re) => {
         const pattern = /(?:[^\s'"\(,:<])/.source + re[0].source + /(?![\w])/.source;
         const regex = new RegExp(pattern);
         return regex.test(content);
@@ -455,7 +455,7 @@ exports.initialize = function (realm_filters, helper_config) {
 
     // No <code> around our code blocks instead a codehilite <div> and disable
     // class-specific highlighting.
-    r.code = code => fenced_code.wrap_code(code) + '\n\n';
+    r.code = (code) => fenced_code.wrap_code(code) + '\n\n';
 
     // Prohibit empty links for some reason.
     const old_link = r.link;

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -380,7 +380,7 @@ function edit_message(row, raw_content) {
         // Do this right away, rather than waiting for the timer to do its first update,
         // since otherwise there is a noticeable lag
         message_edit_countdown_timer.text(timer_text(seconds_left));
-        const countdown_timer = setInterval(function () {
+        const countdown_timer = setInterval(() => {
             seconds_left -= 1;
             if (seconds_left <= 0) {
                 clearInterval(countdown_timer);
@@ -437,11 +437,11 @@ function edit_message(row, raw_content) {
     }
 
     if (!message.locally_echoed) {
-        message_edit_topic.keyup(function () {
+        message_edit_topic.keyup(() => {
             set_propagate_selector_display();
         });
 
-        message_edit_stream.on('change', function () {
+        message_edit_stream.on('change', () => {
             set_propagate_selector_display();
         });
     }
@@ -781,7 +781,7 @@ exports.edit_last_sent_message = function () {
 
     // Finally do the real work!
     compose_actions.cancel();
-    exports.start(msg_row, function () {
+    exports.start(msg_row, () => {
         $('#message_edit_content').focus();
     });
 };
@@ -807,7 +807,7 @@ exports.delete_message = function (msg_id) {
     } else {
         hide_delete_btn_show_spinner(false);
     }
-    $('#do_delete_message_button').off().on('click', function (e) {
+    $('#do_delete_message_button').off().on('click', (e) => {
         e.stopPropagation();
         e.preventDefault();
         currently_deleting_messages.push(msg_id);

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -271,7 +271,7 @@ function edit_message(row, raw_content) {
     const show_edit_stream = message.is_stream && page_params.is_admin;
     // current message's stream has been already been added and selected in handlebar
     const available_streams = show_edit_stream ? stream_data.subscribed_subs()
-        .filter(s => s.stream_id !== message.stream_id) : null;
+        .filter((s) => s.stream_id !== message.stream_id) : null;
 
     const form = $(render_message_edit_form({
         is_stream: message.type === 'stream',
@@ -817,13 +817,13 @@ exports.delete_message = function (msg_id) {
             success: function () {
                 $('#delete_message_modal').modal("hide");
                 currently_deleting_messages = currently_deleting_messages.filter(
-                    id => id !== msg_id
+                    (id) => id !== msg_id
                 );
                 hide_delete_btn_show_spinner(false);
             },
             error: function (xhr) {
                 currently_deleting_messages = currently_deleting_messages.filter(
-                    id => id !== msg_id
+                    (id) => id !== msg_id
                 );
                 hide_delete_btn_show_spinner(false);
                 ui_report.error(i18n.t("Error deleting message"), xhr,

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -817,13 +817,13 @@ exports.delete_message = function (msg_id) {
             success: function () {
                 $('#delete_message_modal').modal("hide");
                 currently_deleting_messages = currently_deleting_messages.filter(
-                    (id) => id !== msg_id
+                    (id) => id !== msg_id,
                 );
                 hide_delete_btn_show_spinner(false);
             },
             error: function (xhr) {
                 currently_deleting_messages = currently_deleting_messages.filter(
-                    (id) => id !== msg_id
+                    (id) => id !== msg_id,
                 );
                 hide_delete_btn_show_spinner(false);
                 ui_report.error(i18n.t("Error deleting message"), xhr,

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -45,7 +45,7 @@ function maybe_add_narrowed_messages(messages, msg_list) {
         },
         error: function () {
             // We might want to be more clever here
-            setTimeout(function () {
+            setTimeout(() => {
                 if (msg_list === current_msg_list) {
                     // Don't actually try again if we unnarrowed
                     // while waiting

--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -109,7 +109,7 @@ function get_messages_success(data, opts) {
     if (!data) {
         // The server occasionally returns no data during a
         // restart.  Ignore those responses and try again
-        setTimeout(function () {
+        setTimeout(() => {
             exports.load_messages(opts);
         }, 0);
         return;
@@ -239,7 +239,7 @@ exports.load_messages = function (opts) {
 
             // We might want to be more clever here
             $('#connection-error').addClass("show");
-            setTimeout(function () {
+            setTimeout(() => {
                 exports.load_messages(opts);
             }, consts.error_retry_time);
         },

--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -131,7 +131,7 @@ function handle_operators_supporting_id_based_api(data) {
     }
 
     data.narrow = JSON.parse(data.narrow);
-    data.narrow = data.narrow.map(filter => {
+    data.narrow = data.narrow.map((filter) => {
         if (operators_supporting_ids.includes(filter.operator)) {
             filter.operand = people.emails_strings_to_user_ids_array(filter.operand);
         }

--- a/static/js/message_flags.js
+++ b/static/js/message_flags.js
@@ -16,8 +16,8 @@ exports.send_read = (function () {
     let start;
     function server_request() {
         // Wait for server IDs before sending flags
-        const real_msgs = queue.filter(msg => !msg.locally_echoed);
-        const real_msg_ids = real_msgs.map(msg => msg.id);
+        const real_msgs = queue.filter((msg) => !msg.locally_echoed);
+        const real_msg_ids = real_msgs.map((msg) => msg.id);
 
         if (real_msg_ids.length === 0) {
             setTimeout(start, 100);
@@ -46,7 +46,7 @@ exports.send_read = (function () {
             return;
         }
 
-        queue = queue.filter(message => !data.messages.includes(message.id));
+        queue = queue.filter((message) => !data.messages.includes(message.id));
 
         if (queue.length > 0) {
             start();

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -445,7 +445,7 @@ exports.all = new exports.MessageList({
 // doing something.  Be careful, though, if you try to capture
 // mousemove, then you will have to contend with the autoscroll
 // itself generating mousemove events.
-$(document).on('message_selected.zulip wheel', function () {
+$(document).on('message_selected.zulip wheel', () => {
     message_viewport.stop_auto_scrolling();
 });
 

--- a/static/js/message_list_data.js
+++ b/static/js/message_list_data.js
@@ -170,7 +170,7 @@ MessageListData.prototype = {
         return messages.filter(
             (message) =>
                 !muting.is_topic_muted(message.stream_id, message.topic) ||
-                message.mentioned
+                message.mentioned,
         );
     },
 
@@ -345,7 +345,7 @@ MessageListData.prototype = {
         this._items = this._items.filter((message) => !msg_ids_to_remove.has(message.id));
         if (this.muting_enabled) {
             this._all_items = this._all_items.filter(
-                (message) => !msg_ids_to_remove.has(message.id)
+                (message) => !msg_ids_to_remove.has(message.id),
             );
         }
     },

--- a/static/js/message_list_data.js
+++ b/static/js/message_list_data.js
@@ -43,7 +43,7 @@ MessageListData.prototype = {
         if (this._selected_id === -1) {
             return;
         }
-        const ids = this._items.map(message => message.id);
+        const ids = this._items.map((message) => message.id);
 
         const i = ids.indexOf(this._selected_id);
         if (i === -1) {
@@ -158,7 +158,7 @@ MessageListData.prototype = {
     valid_non_duplicated_messages: function (messages) {
         const predicate = this._get_predicate();
         const self = this;
-        return messages.filter(msg => self.get(msg.id) === undefined && predicate(msg));
+        return messages.filter((msg) => self.get(msg.id) === undefined && predicate(msg));
     },
 
     filter_incoming: function (messages) {
@@ -168,7 +168,7 @@ MessageListData.prototype = {
 
     unmuted_messages: function (messages) {
         return messages.filter(
-            message =>
+            (message) =>
                 !muting.is_topic_muted(message.stream_id, message.topic) ||
                 message.mentioned
         );
@@ -182,7 +182,7 @@ MessageListData.prototype = {
     },
 
     first_unread_message_id: function () {
-        const first_unread = this._items.find(message => unread.message_unread(message));
+        const first_unread = this._items.find((message) => unread.message_unread(message));
 
         if (first_unread) {
             return first_unread.id;
@@ -231,7 +231,7 @@ MessageListData.prototype = {
         // bottom_messages regardless
         if (self.selected_id() === -1 && self.empty()) {
             const narrow_messages = self.filter_incoming(messages);
-            bottom_messages = narrow_messages.filter(msg => !self.get(msg.id));
+            bottom_messages = narrow_messages.filter((msg) => !self.get(msg.id));
         } else {
             // Filter out duplicates that are already in self, and all messages
             // that fail our filter predicate
@@ -342,10 +342,10 @@ MessageListData.prototype = {
             msg_ids_to_remove.add(message.id);
         }
 
-        this._items = this._items.filter(message => !msg_ids_to_remove.has(message.id));
+        this._items = this._items.filter((message) => !msg_ids_to_remove.has(message.id));
         if (this.muting_enabled) {
             this._all_items = this._all_items.filter(
-                message => !msg_ids_to_remove.has(message.id)
+                (message) => !msg_ids_to_remove.has(message.id)
             );
         }
     },

--- a/static/js/message_list_data.js
+++ b/static/js/message_list_data.js
@@ -282,7 +282,7 @@ MessageListData.prototype = {
         let viewable_messages;
         if (this.muting_enabled) {
             this._all_items = messages.concat(this._all_items);
-            this._all_items.sort(function (a, b) {return a.id - b.id;});
+            this._all_items.sort((a, b) => a.id - b.id);
 
             viewable_messages = this.unmuted_messages(messages);
             this._items = viewable_messages.concat(this._items);
@@ -292,7 +292,7 @@ MessageListData.prototype = {
             this._items = messages.concat(this._items);
         }
 
-        this._items.sort(function (a, b) {return a.id - b.id;});
+        this._items.sort((a, b) => a.id - b.id);
         this._add_to_hash(messages);
         return viewable_messages;
     },
@@ -371,7 +371,7 @@ MessageListData.prototype = {
             if (self._is_localonly_id(msg.id)) {
                 // First non-local message before this one
                 const effective = self._next_nonlocal_message(self._items, a_idx,
-                                                              function (idx) { return idx - 1; });
+                                                              (idx) => idx - 1);
                 if (effective) {
                     // Turn the 10.02 in [11, 10.02, 12] into 11.02
                     const decimal = parseFloat((msg.id % 1).toFixed(0.02));
@@ -472,7 +472,7 @@ MessageListData.prototype = {
 
     _add_to_hash: function (messages) {
         const self = this;
-        messages.forEach(function (elem) {
+        messages.forEach((elem) => {
             const id = parseFloat(elem.id);
             if (isNaN(id)) {
                 blueslip.fatal("Bad message id");
@@ -525,7 +525,7 @@ MessageListData.prototype = {
 
         // If this message is now out of order, re-order and re-render
         const self = this;
-        setTimeout(function () {
+        setTimeout(() => {
             const current_message = self._hash.get(new_id);
             const index = self._items.indexOf(current_message);
 
@@ -537,9 +537,9 @@ MessageListData.prototype = {
             }
 
             const next = self._next_nonlocal_message(self._items, index,
-                                                     function (idx) { return idx + 1; });
+                                                     (idx) => idx + 1);
             const prev = self._next_nonlocal_message(self._items, index,
-                                                     function (idx) { return idx - 1; });
+                                                     (idx) => idx - 1);
 
             if (next !== undefined && current_message.id > next.id ||
                 prev !== undefined && current_message.id < prev.id) {

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -1026,7 +1026,7 @@ MessageListView.prototype = {
             // Since we don't have a way to get a message group from
             // the containing message container, we just do a search
             // to find it.
-            (message_group) => message_group.message_group_id === message_group_id
+            (message_group) => message_group.message_group_id === message_group_id,
         );
     },
 
@@ -1100,7 +1100,7 @@ MessageListView.prototype = {
         let message_containers = messages.map((message) => self.message_containers.get(message.id));
         // We may not have the message_container if the stream or topic was muted
         message_containers = message_containers.filter(
-            (message_container) => message_container !== undefined
+            (message_container) => message_container !== undefined,
         );
 
         const message_groups = [];

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -562,7 +562,7 @@ MessageListView.prototype = {
         // all messages lists. To prevent having both list views overwriting
         // each others data we will make a new message object to add data to
         // for rendering.
-        const message_containers = messages.map(message => {
+        const message_containers = messages.map((message) => {
             if (message.starred) {
                 message.starred_status = i18n.t("Unstar");
             } else {
@@ -671,7 +671,7 @@ MessageListView.prototype = {
         if (message_actions.append_messages.length > 0) {
             last_message_row = table.find('.message_row').last().expectOne();
             last_group_row = rows.get_message_recipient_row(last_message_row);
-            dom_messages = $(message_actions.append_messages.map(message_container => self._get_message_template(message_container)).join('')).filter('.message_row');
+            dom_messages = $(message_actions.append_messages.map((message_container) => self._get_message_template(message_container)).join('')).filter('.message_row');
 
             self._post_process(dom_messages);
             last_group_row.append(dom_messages);
@@ -1026,7 +1026,7 @@ MessageListView.prototype = {
             // Since we don't have a way to get a message group from
             // the containing message container, we just do a search
             // to find it.
-            message_group => message_group.message_group_id === message_group_id
+            (message_group) => message_group.message_group_id === message_group_id
         );
     },
 
@@ -1097,10 +1097,10 @@ MessageListView.prototype = {
         const self = this;
 
         // Convert messages to list messages
-        let message_containers = messages.map(message => self.message_containers.get(message.id));
+        let message_containers = messages.map((message) => self.message_containers.get(message.id));
         // We may not have the message_container if the stream or topic was muted
         message_containers = message_containers.filter(
-            message_container => message_container !== undefined
+            (message_container) => message_container !== undefined
         );
 
         const message_groups = [];

--- a/static/js/message_scroll.js
+++ b/static/js/message_scroll.js
@@ -153,13 +153,13 @@ function scroll_finish() {
 }
 
 exports.initialize = function () {
-    message_viewport.message_pane.scroll(_.throttle(function () {
+    message_viewport.message_pane.scroll(_.throttle(() => {
         unread_ops.process_visible();
         scroll_finish();
     }, 50));
 
     // Scroll handler that marks messages as read when you scroll past them.
-    $(document).on('message_selected.zulip', function (event) {
+    $(document).on('message_selected.zulip', (event) => {
         if (event.id === -1) {
             return;
         }

--- a/static/js/message_util.js
+++ b/static/js/message_util.js
@@ -49,11 +49,9 @@ exports.get_messages_in_topic = function (stream_id, topic) {
     // all the messages. Please only use it in case of
     // very rare events like topic edits. Its primary
     // use case is the new experimental Recent Topics UI.
-    return message_list.all.all_messages().filter((x) => {
-        return x.type === 'stream' &&
+    return message_list.all.all_messages().filter((x) => x.type === 'stream' &&
                x.stream_id === stream_id &&
-               x.topic.toLowerCase() === topic.toLowerCase();
-    });
+               x.topic.toLowerCase() === topic.toLowerCase());
 };
 
 window.message_util = exports;

--- a/static/js/message_util.js
+++ b/static/js/message_util.js
@@ -49,7 +49,7 @@ exports.get_messages_in_topic = function (stream_id, topic) {
     // all the messages. Please only use it in case of
     // very rare events like topic edits. Its primary
     // use case is the new experimental Recent Topics UI.
-    return message_list.all.all_messages().filter(x => {
+    return message_list.all.all_messages().filter((x) => {
         return x.type === 'stream' &&
                x.stream_id === stream_id &&
                x.topic.toLowerCase() === topic.toLowerCase();

--- a/static/js/message_viewport.js
+++ b/static/js/message_viewport.js
@@ -419,14 +419,14 @@ exports.initialize = function () {
     jwindow = $(window);
     exports.message_pane = $(".app");
     // This handler must be placed before all resize handlers in our application
-    jwindow.resize(function () {
+    jwindow.resize(() => {
         dimensions.height.reset();
         dimensions.width.reset();
         top_of_feed.reset();
         bottom_of_feed.reset();
     });
 
-    $(document).on('compose_started compose_canceled compose_finished', function () {
+    $(document).on('compose_started compose_canceled compose_finished', () => {
         bottom_of_feed.reset();
     });
 };

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -151,7 +151,7 @@ exports.activate = function (raw_operators, opts) {
     message_scroll.hide_top_of_narrow_notices();
     message_scroll.hide_indicators();
 
-    blueslip.debug("Narrowed", {operators: operators.map(e => e.operator),
+    blueslip.debug("Narrowed", {operators: operators.map((e) => e.operator),
                                 trigger: opts ? opts.trigger : undefined,
                                 previous_id: current_msg_list.selected_id()});
 
@@ -725,7 +725,7 @@ exports.to_compose_target = function () {
     if (compose_state.get_message_type() === 'private') {
         const recipient_string = compose_state.private_message_recipient();
         const emails = util.extract_pm_recipients(recipient_string);
-        const invalid = emails.filter(email => !people.is_valid_email_for_compose(email));
+        const invalid = emails.filter((email) => !people.is_valid_email_for_compose(email));
         // If there are no recipients or any recipient is
         // invalid, narrow to all PMs.
         if (emails.length === 0 || invalid.length > 0) {

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -435,7 +435,7 @@ exports.maybe_add_local_messages = function (opts) {
         // need to look at unread here.
         id_info.final_select_id = min_defined(
             id_info.target_id,
-            unread_info.msg_id
+            unread_info.msg_id,
         );
 
         if (!load_local_messages(msg_data)) {
@@ -601,7 +601,7 @@ exports.narrow_to_next_topic = function () {
 
     const next_narrow = topic_generator.get_next_topic(
         curr_info.stream,
-        curr_info.topic
+        curr_info.topic,
     );
 
     if (!next_narrow) {

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -334,7 +334,7 @@ exports.activate = function (raw_operators, opts) {
     tab_bar.initialize();
 
     msg_list.initial_core_time = new Date();
-    setTimeout(function () {
+    setTimeout(() => {
         resize.resize_stream_filters_container();
         msg_list.initial_free_time = new Date();
         maybe_report_narrow_time(msg_list);
@@ -840,7 +840,7 @@ exports.deactivate = function () {
     handle_post_narrow_deactivate_processes();
 
     unnarrow_times.initial_core_time = new Date();
-    setTimeout(function () {
+    setTimeout(() => {
         resize.resize_stream_filters_container();
         unnarrow_times.initial_free_time = new Date();
         report_unnarrow_time();

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -63,7 +63,7 @@ function get_audio_file_path(audio_element, audio_file_without_extension) {
 }
 
 exports.initialize = function () {
-    $(window).focus(function () {
+    $(window).focus(() => {
         window_has_focus = true;
 
         for (const notice_mem_entry of notice_memory.values()) {
@@ -75,7 +75,7 @@ exports.initialize = function () {
         // counts.
         unread_ops.process_visible();
 
-    }).blur(function () {
+    }).blur(() => {
         window_has_focus = false;
     });
 
@@ -250,7 +250,7 @@ if (window.electron_bridge !== undefined) {
     if (window.electron_bridge.set_send_notification_reply_message_supported !== undefined) {
         window.electron_bridge.set_send_notification_reply_message_supported(true);
     }
-    window.electron_bridge.on_event('send_notification_reply_message', function (message_id, reply) {
+    window.electron_bridge.on_event('send_notification_reply_message', (message_id, reply) => {
         const message = message_store.get(message_id);
         const data = {
             type: message.type,
@@ -658,7 +658,7 @@ exports.notify_local_mixes = function (messages, need_user_to_scroll) {
             if (need_user_to_scroll) {
                 reason = i18n.t("Sent! Scroll down to view your message.");
                 exports.notify_above_composebox(reason, "", null, "");
-                setTimeout(function () {
+                setTimeout(() => {
                     $('#out-of-view-notification').hide();
                 }, 3000);
             }
@@ -716,20 +716,20 @@ exports.reify_message_id = function (opts) {
 };
 
 exports.register_click_handlers = function () {
-    $('#out-of-view-notification').on('click', '.compose_notification_narrow_by_topic', function (e) {
+    $('#out-of-view-notification').on('click', '.compose_notification_narrow_by_topic', (e) => {
         const message_id = $(e.currentTarget).data('message-id');
         narrow.by_topic(message_id, {trigger: 'compose_notification'});
         e.stopPropagation();
         e.preventDefault();
     });
-    $('#out-of-view-notification').on('click', '.compose_notification_scroll_to_message', function (e) {
+    $('#out-of-view-notification').on('click', '.compose_notification_scroll_to_message', (e) => {
         const message_id = $(e.currentTarget).data('message-id');
         current_msg_list.select_id(message_id);
         navigate.scroll_to_selected();
         e.stopPropagation();
         e.preventDefault();
     });
-    $('#out-of-view-notification').on('click', '.out-of-view-notification-close', function (e) {
+    $('#out-of-view-notification').on('click', '.out-of-view-notification-close', (e) => {
         exports.clear_compose_notifications();
         e.stopPropagation();
         e.preventDefault();

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -28,8 +28,8 @@ if (window.electron_bridge && window.electron_bridge.new_notification) {
             Object.assign(
                 this,
                 window.electron_bridge.new_notification(title, options, (type, eventInit) =>
-                    this.dispatchEvent(new Event(type, eventInit))
-                )
+                    this.dispatchEvent(new Event(type, eventInit)),
+                ),
             );
         }
 

--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -221,7 +221,7 @@ exports.open_settings = function () {
 };
 
 exports.initialize = function () {
-    $("body").on("click", ".overlay, .overlay .exit", function (e) {
+    $("body").on("click", ".overlay, .overlay .exit", (e) => {
         let $target = $(e.target);
 
         // if the target is not the .overlay element, search up the node tree

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -139,9 +139,7 @@ exports.is_known_user_id = function (user_id) {
 };
 
 function sort_numerically(user_ids) {
-    user_ids.sort(function (a, b) {
-        return a - b;
-    });
+    user_ids.sort((a, b) => a - b);
 
     return user_ids;
 }
@@ -847,9 +845,9 @@ exports.get_message_people = function () {
 
 exports.get_active_message_people = function () {
     const message_people = exports.get_message_people();
-    const active_message_people = message_people.filter(function (item) {
-        return active_user_dict.has(item.user_id);
-    });
+    const active_message_people = message_people.filter((item) =>
+        active_user_dict.has(item.user_id)
+    );
     return active_message_people;
 };
 

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -41,7 +41,7 @@ exports.init = function () {
 exports.init();
 
 function split_to_ints(lst) {
-    return lst.split(',').map(s => parseInt(s, 10));
+    return lst.split(',').map((s) => parseInt(s, 10));
 }
 
 
@@ -151,7 +151,7 @@ exports.huddle_string = function (message) {
         return;
     }
 
-    let user_ids = message.display_recipient.map(recip => recip.id);
+    let user_ids = message.display_recipient.map((recip) => recip.id);
 
     function is_huddle_recip(user_id) {
         return user_id &&
@@ -173,7 +173,7 @@ exports.huddle_string = function (message) {
 exports.user_ids_string_to_emails_string = function (user_ids_string) {
     const user_ids = split_to_ints(user_ids_string);
 
-    let emails = user_ids.map(user_id => {
+    let emails = user_ids.map((user_id) => {
         const person = people_by_user_id_dict.get(user_id);
         return person && person.email;
     });
@@ -183,7 +183,7 @@ exports.user_ids_string_to_emails_string = function (user_ids_string) {
         return;
     }
 
-    emails = emails.map(email => email.toLowerCase());
+    emails = emails.map((email) => email.toLowerCase());
 
     emails.sort();
 
@@ -192,7 +192,7 @@ exports.user_ids_string_to_emails_string = function (user_ids_string) {
 
 exports.user_ids_string_to_ids_array = function (user_ids_string) {
     const user_ids = user_ids_string.split(',');
-    const ids = user_ids.map(id => Number(id));
+    const ids = user_ids.map((id) => Number(id));
     return ids;
 };
 
@@ -212,7 +212,7 @@ exports.reply_to_to_user_ids_string = function (emails_string) {
     // invalid data.
     const emails = emails_string.split(',');
 
-    let user_ids = emails.map(email => {
+    let user_ids = emails.map((email) => {
         const person = exports.get_by_email(email);
         return person && person.user_id;
     });
@@ -261,7 +261,7 @@ exports.emails_strings_to_user_ids_string = function (emails_string) {
 };
 
 exports.email_list_to_user_ids_string = function (emails) {
-    let user_ids = emails.map(email => {
+    let user_ids = emails.map((email) => {
         const person = exports.get_by_email(email);
         return person && person.user_id;
     });
@@ -277,7 +277,7 @@ exports.email_list_to_user_ids_string = function (emails) {
 };
 
 exports.safe_full_names = function (user_ids) {
-    let names = user_ids.map(user_id => {
+    let names = user_ids.map((user_id) => {
         const person = people_by_user_id_dict.get(user_id);
         return person && person.full_name;
     });
@@ -295,7 +295,7 @@ exports.get_recipients = function (user_ids_string) {
     // See message_store.get_pm_full_names() for a similar function.
 
     const user_ids = split_to_ints(user_ids_string);
-    const other_ids = user_ids.filter(user_id => !exports.is_my_user_id(user_id));
+    const other_ids = user_ids.filter((user_id) => !exports.is_my_user_id(user_id));
 
     if (other_ids.length === 0) {
         // private message with oneself
@@ -323,7 +323,7 @@ exports.pm_reply_to = function (message) {
         return;
     }
 
-    const emails = user_ids.map(user_id => {
+    const emails = user_ids.map((user_id) => {
         const person = people_by_user_id_dict.get(user_id);
         if (!person) {
             blueslip.error('Unknown user id in message: ' + user_id);
@@ -343,7 +343,7 @@ function sorted_other_user_ids(user_ids) {
     // This excludes your own user id unless you're the only user
     // (i.e. you sent a message to yourself).
 
-    const other_user_ids = user_ids.filter(user_id => !exports.is_my_user_id(user_id));
+    const other_user_ids = user_ids.filter((user_id) => !exports.is_my_user_id(user_id));
 
     if (other_user_ids.length >= 1) {
         user_ids = other_user_ids;
@@ -389,7 +389,7 @@ exports.all_user_ids_in_pm = function (message) {
         return;
     }
 
-    let user_ids = message.display_recipient.map(recip => recip.id);
+    let user_ids = message.display_recipient.map((recip) => recip.id);
 
     user_ids = sort_numerically(user_ids);
     return user_ids;
@@ -405,7 +405,7 @@ exports.pm_with_user_ids = function (message) {
         return;
     }
 
-    const user_ids = message.display_recipient.map(recip => recip.id);
+    const user_ids = message.display_recipient.map((recip) => recip.id);
 
     return sorted_other_user_ids(user_ids);
 };
@@ -420,8 +420,8 @@ exports.group_pm_with_user_ids = function (message) {
         return;
     }
 
-    const user_ids = message.display_recipient.map(recip => recip.id);
-    const is_user_present = user_ids.some(user_id => exports.is_my_user_id(user_id));
+    const user_ids = message.display_recipient.map((recip) => recip.id);
+    const is_user_present = user_ids.some((user_id) => exports.is_my_user_id(user_id));
     if (is_user_present) {
         user_ids.sort();
         if (user_ids.length > 2) {
@@ -483,19 +483,19 @@ exports.update_email_in_reply_to = function (reply_to, user_id, new_email) {
     // and we don't warn on any errors.
     let emails = reply_to.split(',');
 
-    const persons = emails.map(email => people_dict.get(email.trim()));
+    const persons = emails.map((email) => people_dict.get(email.trim()));
 
     if (!persons.every(Boolean)) {
         return reply_to;
     }
 
-    const needs_patch = persons.some(person => person.user_id === user_id);
+    const needs_patch = persons.some((person) => person.user_id === user_id);
 
     if (!needs_patch) {
         return reply_to;
     }
 
-    emails = persons.map(person => {
+    emails = persons.map((person) => {
         if (person.user_id === user_id) {
             return new_email;
         }
@@ -507,8 +507,8 @@ exports.update_email_in_reply_to = function (reply_to, user_id, new_email) {
 
 exports.pm_with_operand_ids = function (operand) {
     let emails = operand.split(',');
-    emails = emails.map(email => email.trim());
-    let persons = emails.map(email => people_dict.get(email));
+    emails = emails.map((email) => email.trim());
+    let persons = emails.map((email) => people_dict.get(email));
 
     // If your email is included in a PM group with other people, just ignore it
     if (persons.length > 1) {
@@ -519,7 +519,7 @@ exports.pm_with_operand_ids = function (operand) {
         return;
     }
 
-    let user_ids = persons.map(person => person.user_id);
+    let user_ids = persons.map((person) => person.user_id);
 
     user_ids = sort_numerically(user_ids);
 
@@ -567,7 +567,7 @@ exports.exclude_me_from_string = function (user_ids_string) {
         return user_ids.join(',');
     }
 
-    user_ids = user_ids.filter(user_id => !exports.is_my_user_id(user_id));
+    user_ids = user_ids.filter((user_id) => !exports.is_my_user_id(user_id));
 
     return user_ids.join(',');
 };
@@ -688,7 +688,7 @@ exports.is_valid_email_for_compose = function (email) {
 
 exports.is_valid_bulk_emails_for_compose = function (emails) {
     // Returns false if at least one of the emails is invalid.
-    return emails.every(email => {
+    return emails.every((email) => {
         if (!exports.is_valid_email_for_compose(email)) {
             return false;
         }
@@ -839,7 +839,7 @@ exports.get_message_people = function () {
         semantics
     */
     const message_people = message_store.user_ids().map(
-        user_id => people_by_user_id_dict.get(user_id)
+        (user_id) => people_by_user_id_dict.get(user_id)
     ).filter(Boolean);
 
     return message_people;
@@ -880,7 +880,7 @@ exports.build_termlet_matcher = function (termlet) {
         }
         const names = full_name.toLowerCase().split(' ');
 
-        return names.some(name => name.startsWith(termlet));
+        return names.some((name) => name.startsWith(termlet));
     };
 };
 
@@ -897,7 +897,7 @@ exports.build_person_matcher = function (query) {
             return true;
         }
 
-        return termlet_matchers.every(matcher => matcher(user));
+        return termlet_matchers.every((matcher) => matcher(user));
     };
 };
 
@@ -906,7 +906,7 @@ exports.filter_people_by_search_terms = function (users, search_terms) {
 
     // Build our matchers outside the loop to avoid some
     // search overhead that is not user-specific.
-    const matchers = search_terms.map(search_term => exports.build_person_matcher(search_term));
+    const matchers = search_terms.map((search_term) => exports.build_person_matcher(search_term));
 
     // Loop through users and populate filtered_users only
     // if they include search_terms
@@ -918,7 +918,7 @@ exports.filter_people_by_search_terms = function (users, search_terms) {
         }
 
         // Return user emails that include search terms
-        const match = matchers.some(matcher => matcher(user));
+        const match = matchers.some((matcher) => matcher(user));
 
         if (match) {
             filtered_users.set(person.user_id, true);
@@ -1186,7 +1186,7 @@ exports.filter_for_user_settings_search = function (persons, query) {
 
               See #13554 for more context.
     */
-    return persons.filter(person => exports.matches_user_settings_search(person, query));
+    return persons.filter((person) => exports.matches_user_settings_search(person, query));
 };
 
 exports.maybe_incr_recipient_count = function (message) {

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -63,7 +63,7 @@ exports.get_by_email = function (email) {
     if (person.email.toLowerCase() !== email.toLowerCase()) {
         blueslip.warn(
             'Obsolete email passed to get_by_email: ' + email +
-            ' new email = ' + person.email
+            ' new email = ' + person.email,
         );
     }
 
@@ -837,7 +837,7 @@ exports.get_message_people = function () {
         semantics
     */
     const message_people = message_store.user_ids().map(
-        (user_id) => people_by_user_id_dict.get(user_id)
+        (user_id) => people_by_user_id_dict.get(user_id),
     ).filter(Boolean);
 
     return message_people;
@@ -846,7 +846,7 @@ exports.get_message_people = function () {
 exports.get_active_message_people = function () {
     const message_people = exports.get_message_people();
     const active_message_people = message_people.filter((item) =>
-        active_user_dict.has(item.user_id)
+        active_user_dict.has(item.user_id),
     );
     return active_message_people;
 };

--- a/static/js/pm_conversations.js
+++ b/static/js/pm_conversations.js
@@ -53,9 +53,7 @@ exports.recent = (function () {
             conversation.max_message_id = message_id;
         }
 
-        recent_private_messages.sort(function (a, b) {
-            return b.max_message_id - a.max_message_id;
-        });
+        recent_private_messages.sort((a, b) => b.max_message_id - a.max_message_id);
     };
 
     self.get = function () {

--- a/static/js/pm_conversations.js
+++ b/static/js/pm_conversations.js
@@ -67,7 +67,7 @@ exports.recent = (function () {
     self.get_strings = function () {
         // returns array of structs with user_ids_string and
         // message_id
-        return recent_private_messages.map(conversation => conversation.user_ids_string);
+        return recent_private_messages.map((conversation) => conversation.user_ids_string);
     };
 
     self.initialize = function (params) {

--- a/static/js/pm_list_dom.js
+++ b/static/js/pm_list_dom.js
@@ -1,13 +1,9 @@
 const render_pm_list_item = require('../templates/pm_list_item.hbs');
 
 exports.keyed_pm_li = (convo) => {
-    const render = () => {
-        return render_pm_list_item(convo);
-    };
+    const render = () => render_pm_list_item(convo);
 
-    const eq = (other) => {
-        return _.isEqual(convo, other.convo);
-    };
+    const eq = (other) => _.isEqual(convo, other.convo);
 
     const key = convo.user_ids_string;
 

--- a/static/js/poll_widget.js
+++ b/static/js/poll_widget.js
@@ -284,12 +284,12 @@ exports.activate = function (opts) {
         const html = render_widgets_poll_widget();
         elem.html(html);
 
-        elem.find('input.poll-question').on('keyup', function (e) {
+        elem.find('input.poll-question').on('keyup', (e) => {
             e.stopPropagation();
             update_edit_controls();
         });
 
-        elem.find('input.poll-question').on('keydown', function (e) {
+        elem.find('input.poll-question').on('keydown', (e) => {
             e.stopPropagation();
 
             if (e.keyCode === 13) {
@@ -303,27 +303,27 @@ exports.activate = function (opts) {
             }
         });
 
-        elem.find('.poll-edit-question').on('click', function (e) {
+        elem.find('.poll-edit-question').on('click', (e) => {
             e.stopPropagation();
             start_editing();
         });
 
-        elem.find("button.poll-question-check").on('click', function (e) {
+        elem.find("button.poll-question-check").on('click', (e) => {
             e.stopPropagation();
             submit_question();
         });
 
-        elem.find("button.poll-question-remove").on('click', function (e) {
+        elem.find("button.poll-question-remove").on('click', (e) => {
             e.stopPropagation();
             abort_edit();
         });
 
-        elem.find("button.poll-option").on('click', function (e) {
+        elem.find("button.poll-option").on('click', (e) => {
             e.stopPropagation();
             submit_option();
         });
 
-        elem.find('input.poll-option').on('keydown', function (e) {
+        elem.find('input.poll-option').on('keydown', (e) => {
             e.stopPropagation();
 
             if (e.keyCode === 13) {
@@ -345,7 +345,7 @@ exports.activate = function (opts) {
         const html = render_widgets_poll_widget_results(widget_data);
         elem.find('ul.poll-widget').html(html);
 
-        elem.find("button.poll-vote").off('click').on('click', function (e) {
+        elem.find("button.poll-vote").off('click').on('click', (e) => {
             e.stopPropagation();
             const key = $(e.target).attr('data-key');
             submit_vote(key);

--- a/static/js/poll_widget.js
+++ b/static/js/poll_widget.js
@@ -162,7 +162,7 @@ exports.poll_data_holder = function (is_my_poll, question, options) {
 
     // function to check whether option already exists
     self.is_option_present = function (data, latest_option) {
-        return data.some(el => el.option === latest_option);
+        return data.some((el) => el.option === latest_option);
     };
 
     // function to add all options added along with the /poll command

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -56,7 +56,7 @@ function copy_email_handler(e) {
     email_el.addClass('email_copied');
     email_textnode.nodeValue = i18n.t('Email copied');
 
-    setTimeout(function () {
+    setTimeout(() => {
         email_el.removeClass('email_copied');
         email_textnode.nodeValue = copy_icon.attr('data-clipboard-text');
     }, 1500);
@@ -306,8 +306,8 @@ exports.show_user_profile = function (user) {
     const dateFormat = moment.localeData().longDateFormat('LL');
     const field_types = page_params.custom_profile_field_types;
     const profile_data = page_params.custom_profile_fields
-        .map(function (f) {return get_custom_profile_field_data(user, f, field_types, dateFormat);})
-        .filter(function (f) {return f.name !== undefined;});
+        .map((f) => get_custom_profile_field_data(user, f, field_types, dateFormat))
+        .filter((f) => f.name !== undefined);
 
     const args = {
         full_name: user.full_name,
@@ -346,26 +346,18 @@ function get_user_info_popover_items() {
 
 function fetch_group_members(member_ids) {
     return member_ids
-        .map(function (m) {
-            return people.get_by_user_id(m);
-        })
-        .filter(function (m) {
-            return m !== undefined;
-        })
-        .map(function (p) {
-            return Object.assign({}, p, {
-                user_circle_class: buddy_data.get_user_circle_class(p.user_id),
-                is_active: people.is_active_user_for_popover(p.user_id),
-                user_last_seen_time_status: buddy_data.user_last_seen_time_status(p.user_id),
-            });
-        });
+        .map((m) => people.get_by_user_id(m))
+        .filter((m) => m !== undefined)
+        .map((p) => Object.assign({}, p, {
+            user_circle_class: buddy_data.get_user_circle_class(p.user_id),
+            is_active: people.is_active_user_for_popover(p.user_id),
+            user_last_seen_time_status: buddy_data.user_last_seen_time_status(p.user_id),
+        }));
 }
 
 function sort_group_members(members) {
     return members
-        .sort(function (a, b) {
-            return a.full_name.localeCompare(b.full_name);
-        });
+        .sort((a, b) => a.full_name.localeCompare(b.full_name));
 }
 
 // exporting these functions for testing purposes
@@ -762,7 +754,7 @@ exports.register_click_handlers = function () {
     });
 
 
-    $('body').on('click', '.info_popover_actions .narrow_to_private_messages', function (e) {
+    $('body').on('click', '.info_popover_actions .narrow_to_private_messages', (e) => {
         const user_id = elem_to_user_id($(e.target).parents('ul'));
         const email = people.get_by_user_id(user_id).email;
         exports.hide_message_info_popover();
@@ -771,7 +763,7 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
 
-    $('body').on('click', '.info_popover_actions .narrow_to_messages_sent', function (e) {
+    $('body').on('click', '.info_popover_actions .narrow_to_messages_sent', (e) => {
         const user_id = elem_to_user_id($(e.target).parents('ul'));
         const email = people.get_by_user_id(user_id).email;
         exports.hide_message_info_popover();
@@ -780,7 +772,7 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
 
-    $('body').on('click', '.user_popover .mention_user', function (e) {
+    $('body').on('click', '.user_popover .mention_user', (e) => {
         if (!compose_state.composing()) {
             compose_actions.start('stream', {trigger: 'sidebar user actions'});
         }
@@ -794,7 +786,7 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
 
-    $('body').on('click', '.message-info-popover .mention_user', function (e) {
+    $('body').on('click', '.message-info-popover .mention_user', (e) => {
         if (!compose_state.composing()) {
             compose_actions.respond_to_message({trigger: 'user sidebar popover'});
         }
@@ -807,7 +799,7 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
 
-    $('body').on('click', '.info_popover_actions .view_user_profile', function (e) {
+    $('body').on('click', '.info_popover_actions .view_user_profile', (e) => {
         const user_id = elem_to_user_id($(e.target).parents('ul'));
         const user = people.get_by_user_id(user_id);
         exports.show_user_profile(user);
@@ -815,7 +807,7 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
 
-    $('body').on('click', '.info_popover_actions .clear_status', function (e) {
+    $('body').on('click', '.info_popover_actions .clear_status', (e) => {
         e.preventDefault();
         const me = elem_to_user_id($(e.target).parents('ul'));
         user_status.server_update({
@@ -827,13 +819,13 @@ exports.register_click_handlers = function () {
         });
     });
 
-    $('body').on('click', '.bot-owner-name', function (e) {
+    $('body').on('click', '.bot-owner-name', (e) => {
         const user_id = parseInt($(e.target).attr('data-bot-owner-id'), 10);
         const user = people.get_by_user_id(user_id);
         exports.show_user_profile(user);
     });
 
-    $('body').on('click', '#user-profile-modal #name #edit-button', function () {
+    $('body').on('click', '#user-profile-modal #name #edit-button', () => {
         exports.hide_user_profile();
     });
 
@@ -843,21 +835,21 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
 
-    $('body').on('click', '.set_away_status', function (e) {
+    $('body').on('click', '.set_away_status', (e) => {
         exports.hide_all();
         user_status.server_set_away();
         e.stopPropagation();
         e.preventDefault();
     });
 
-    $('body').on('click', '.revoke_away_status', function (e) {
+    $('body').on('click', '.revoke_away_status', (e) => {
         exports.hide_all();
         user_status.server_revoke_away();
         e.stopPropagation();
         e.preventDefault();
     });
 
-    $('body').on('click', '.update_status_text', function (e) {
+    $('body').on('click', '.update_status_text', (e) => {
         exports.hide_all();
 
         user_status_ui.open_overlay();
@@ -909,7 +901,7 @@ exports.register_click_handlers = function () {
         }
     });
 
-    $('body').on('click', '.respond_button', function (e) {
+    $('body').on('click', '.respond_button', (e) => {
         // Arguably, we should fetch the message ID to respond to from
         // e.target, but that should always be the current selected
         // message in the current message list (and
@@ -921,14 +913,14 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
 
-    $('body').on('click', '.reminder_button', function (e) {
+    $('body').on('click', '.reminder_button', (e) => {
         const message_id = $(e.currentTarget).data('message-id');
         exports.render_actions_remind_popover($(".selected_message .actions_hover")[0], message_id);
         e.stopPropagation();
         e.preventDefault();
     });
 
-    $('body').on('click', '.remind.custom', function (e) {
+    $('body').on('click', '.remind.custom', (e) => {
         $(e.currentTarget)[0]._flatpickr.toggle();
         e.stopPropagation();
         e.preventDefault();
@@ -942,42 +934,42 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     }
 
-    $('body').on('click', '.remind.in_20m', function (e) {
+    $('body').on('click', '.remind.in_20m', (e) => {
         const datestr = moment().add(20, 'm').format();
         reminder_click_handler(datestr, e);
     });
 
-    $('body').on('click', '.remind.in_1h', function (e) {
+    $('body').on('click', '.remind.in_1h', (e) => {
         const datestr = moment().add(1, 'h').format();
         reminder_click_handler(datestr, e);
     });
 
-    $('body').on('click', '.remind.in_3h', function (e) {
+    $('body').on('click', '.remind.in_3h', (e) => {
         const datestr = moment().add(3, 'h').format();
         reminder_click_handler(datestr, e);
     });
 
-    $('body').on('click', '.remind.tomo', function (e) {
+    $('body').on('click', '.remind.tomo', (e) => {
         const datestr = moment().add(1, 'd').hour(9).minute(0).seconds(0).format();
         reminder_click_handler(datestr, e);
     });
 
-    $('body').on('click', '.remind.nxtw', function (e) {
+    $('body').on('click', '.remind.nxtw', (e) => {
         const datestr = moment().add(1, 'w').day('monday').hour(9).minute(0).seconds(0).format();
         reminder_click_handler(datestr, e);
     });
 
-    $('body').on('click', '.flatpickr-calendar', function (e) {
+    $('body').on('click', '.flatpickr-calendar', (e) => {
         e.stopPropagation();
         e.preventDefault();
     });
 
-    $('body').on('click', '.flatpickr-confirm', function (e) {
+    $('body').on('click', '.flatpickr-confirm', (e) => {
         const datestr = $(".remind.custom")[0].value;
         reminder_click_handler(datestr, e);
     });
 
-    $('body').on('click', '.respond_personal_button, .compose_private_message', function (e) {
+    $('body').on('click', '.respond_personal_button, .compose_private_message', (e) => {
         const user_id = elem_to_user_id($(e.target).parents('ul'));
         const email = people.get_by_user_id(user_id).email;
         compose_actions.start('private', {
@@ -987,7 +979,7 @@ exports.register_click_handlers = function () {
         e.stopPropagation();
         e.preventDefault();
     });
-    $('body').on('click', '.popover_toggle_collapse', function (e) {
+    $('body').on('click', '.popover_toggle_collapse', (e) => {
         const message_id = $(e.currentTarget).data('message-id');
         const row = current_msg_list.get_row(message_id);
         const message = current_msg_list.get(rows.id(row));
@@ -1005,7 +997,7 @@ exports.register_click_handlers = function () {
         e.stopPropagation();
         e.preventDefault();
     });
-    $('body').on('click', '.popover_edit_message', function (e) {
+    $('body').on('click', '.popover_edit_message', (e) => {
         const message_id = $(e.currentTarget).data('message-id');
         const row = current_msg_list.get_row(message_id);
         exports.hide_actions_popover();
@@ -1013,7 +1005,7 @@ exports.register_click_handlers = function () {
         e.stopPropagation();
         e.preventDefault();
     });
-    $('body').on('click', '.view_edit_history', function (e) {
+    $('body').on('click', '.view_edit_history', (e) => {
         const message_id = $(e.currentTarget).data('message-id');
         const row = current_msg_list.get_row(message_id);
         const message = current_msg_list.get(rows.id(row));
@@ -1026,7 +1018,7 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
 
-    $('body').on('click', '.popover_mute_topic', function (e) {
+    $('body').on('click', '.popover_mute_topic', (e) => {
         const stream_id = parseInt($(e.currentTarget).attr('data-msg-stream-id'), 10);
         const topic = $(e.currentTarget).attr('data-msg-topic');
 
@@ -1036,7 +1028,7 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
 
-    $('body').on('click', '.popover_unmute_topic', function (e) {
+    $('body').on('click', '.popover_unmute_topic', (e) => {
         const stream_id = parseInt($(e.currentTarget).attr('data-msg-stream-id'), 10);
         const topic = $(e.currentTarget).attr('data-msg-topic');
 
@@ -1046,7 +1038,7 @@ exports.register_click_handlers = function () {
         e.preventDefault();
     });
 
-    $('body').on('click', '.delete_message', function (e) {
+    $('body').on('click', '.delete_message', (e) => {
         const message_id = $(e.currentTarget).data('message-id');
         exports.hide_actions_popover();
         message_edit.delete_message(message_id);
@@ -1065,7 +1057,7 @@ exports.register_click_handlers = function () {
             .css("display", "block")
             .delay(1000).fadeOut(300);
 
-        setTimeout(function () {
+        setTimeout(() => {
             // The Cliboard library works by focusing to a hidden textarea.
             // We unfocus this so keyboard shortcuts, etc., will work again.
             $(":focus").blur();
@@ -1078,7 +1070,7 @@ exports.register_click_handlers = function () {
     (function () {
         let last_scroll = 0;
 
-        $('.app').on('scroll', function () {
+        $('.app').on('scroll', () => {
             if (suppress_scroll_hide) {
                 suppress_scroll_hide = false;
                 return;
@@ -1125,7 +1117,7 @@ exports.hide_all_except_sidebars = function () {
     exports.hide_user_profile();
 
     // look through all the popovers that have been added and removed.
-    list_of_popovers.forEach(function ($o) {
+    list_of_popovers.forEach(($o) => {
         if (!document.body.contains($o.$element[0]) && $o.$tip) {
             $o.$tip.remove();
         }

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -447,7 +447,7 @@ exports.toggle_actions_popover = function (element, id) {
 
         const should_display_edit_history_option =
             message.edit_history &&
-            message.edit_history.some(entry => entry.prev_content !== undefined ||
+            message.edit_history.some((entry) => entry.prev_content !== undefined ||
             util.get_edit_event_prev_topic(entry) !== undefined) &&
             page_params.realm_allow_edit_history;
 

--- a/static/js/portico/confirm-preregistrationuser.js
+++ b/static/js/portico/confirm-preregistrationuser.js
@@ -1,3 +1,3 @@
-$(function () {
+$(() => {
     $("#register").submit();
 });

--- a/static/js/portico/desktop-login.js
+++ b/static/js/portico/desktop-login.js
@@ -16,14 +16,14 @@ async function decrypt_manual() {
                 document.querySelector("#submit").disabled = tokenElement.value === "";
                 try {
                     const data = new Uint8Array(
-                        tokenElement.value.match(/../g).map((b) => parseInt(b, 16))
+                        tokenElement.value.match(/../g).map((b) => parseInt(b, 16)),
                     );
                     const iv = data.slice(0, 12);
                     const ciphertext = data.slice(12);
                     const plaintext = await crypto.subtle.decrypt(
                         { name: "AES-GCM", iv },
                         key,
-                        ciphertext
+                        ciphertext,
                     );
                     resolve(new TextDecoder().decode(plaintext));
                 } catch {
@@ -50,7 +50,7 @@ async function decrypt_manual() {
         (window.location.search ? window.location.search + "&" : "?") +
             "desktop_flow_otp=" +
             encodeURIComponent(keyHex),
-        "_blank"
+        "_blank",
     );
 
     const token = await pasted;

--- a/static/js/portico/dev-login.js
+++ b/static/js/portico/dev-login.js
@@ -1,4 +1,4 @@
-$(function () {
+$(() => {
     // This code will be executed when the user visits /login and
     // dev_login.html is rendered.
     if ($("[data-page-id='dev-login']").length > 0) {

--- a/static/js/portico/email_log.js
+++ b/static/js/portico/email_log.js
@@ -1,7 +1,7 @@
-$(function () {
+$(() => {
     // This code will be executed when the user visits /emails in
     // development mode and email_log.html is rendered.
-    $('#toggle').change(function () {
+    $('#toggle').change(() => {
         if ($('.email-text').css('display') === 'none') {
             $(".email-text").each(function () {
                 $(this).css("display", "block");
@@ -25,7 +25,7 @@ $(function () {
             $("#forward_address_sections").hide();
         }
     });
-    $("#save_smptp_details").on("click", function () {
+    $("#save_smptp_details").on("click", () => {
         const address = $('input[name=forward]:checked').val() === "enabled" ? $("#address").val() : "";
         const csrf_token = $('input[name="csrfmiddlewaretoken"]').attr('value');
         const data = {forward_address: address, csrfmiddlewaretoken: csrf_token};
@@ -35,7 +35,7 @@ $(function () {
             data: data,
             success: function () {
                 $("#smtp_form_status").show();
-                setTimeout(function () {
+                setTimeout(() => {
                     $("#smtp_form_status").hide();
                 }, 3000);
             },

--- a/static/js/portico/header.js
+++ b/static/js/portico/header.js
@@ -1,10 +1,10 @@
-$(function () {
-    $('.portico-header li.logout').on('click', function () {
+$(() => {
+    $('.portico-header li.logout').on('click', () => {
         $('#logout_form').submit();
         return false;
     });
 
-    $("body").click(function (e) {
+    $("body").click((e) => {
         const $this = $(e.target);
 
         if ($this.closest(".dropdown .dropdown-pill").length > 0 && !$(".dropdown").hasClass("show")) {

--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -72,7 +72,7 @@ const loading = {
 const markdownSB = new SimpleBar($(".markdown")[0]);
 
 const fetch_page = function (path, callback) {
-    $.get(path, function (res) {
+    $.get(path, (res) => {
         const $html = $(res).find(".markdown .content");
 
         callback($html.html().trim());
@@ -87,7 +87,7 @@ const update_page = function (html_map, path) {
         scrollToHash(markdownSB);
     } else {
         loading.name = path;
-        fetch_page(path, function (res) {
+        fetch_page(path, (res) => {
             html_map.set(path, res);
             $(".markdown .content").html(res);
             loading.name = null;
@@ -99,7 +99,7 @@ const update_page = function (html_map, path) {
 
 new SimpleBar($(".sidebar")[0]);
 
-$(".sidebar.slide h2").click(function (e) {
+$(".sidebar.slide h2").click((e) => {
     const $next = $(e.target).next();
 
     if ($next.is("ul")) {
@@ -146,11 +146,11 @@ $(document).on('click', '.markdown .content h1, .markdown .content h2, .markdown
     scrollToHash(markdownSB);
 });
 
-$(".hamburger").click(function () {
+$(".hamburger").click(() => {
     $(".sidebar").toggleClass("show");
 });
 
-$(".markdown").click(function () {
+$(".markdown").click(() => {
     if ($(".sidebar.show").length) {
         $(".sidebar.show").toggleClass("show");
     }
@@ -162,7 +162,7 @@ render_code_sections();
 // to the right place.
 scrollToHash(markdownSB);
 
-window.addEventListener("popstate", function () {
+window.addEventListener("popstate", () => {
     const path = window.location.pathname;
     update_page(html_map, path);
 });

--- a/static/js/portico/integrations.js
+++ b/static/js/portico/integrations.js
@@ -91,7 +91,7 @@ function update_categories() {
 
     $('.integration-lozenges').animate(
         { opacity: 1 },
-        { duration: 400 }
+        { duration: 400 },
     );
 
     adjust_font_sizing();
@@ -174,11 +174,11 @@ function hide_catalog_show_integration() {
 
         $("html, body").animate(
             { scrollTop: 0 },
-            { duration: 200 }
+            { duration: 200 },
         );
         $('#integration-instructions-group').animate(
             { opacity: 1 },
-            { duration: 300 }
+            { duration: 300 },
         );
 
         adjust_font_sizing();
@@ -207,7 +207,7 @@ function hide_integration_show_catalog() {
     function show_catalog() {
         $("html, body").animate(
             { scrollTop: 0 },
-            { duration: 200 }
+            { duration: 200 },
         );
 
         $(".integration-categories-dropdown").css('display', '');

--- a/static/js/portico/integrations.js
+++ b/static/js/portico/integrations.js
@@ -10,7 +10,7 @@ const INTEGRATIONS = new Map();
 const CATEGORIES = new Map();
 
 function load_data() {
-    $('.integration-lozenge').toArray().forEach(function (integration) {
+    $('.integration-lozenge').toArray().forEach((integration) => {
         const name = $(integration).data('name');
         const display_name = $(integration).find('.integration-name').text().trim();
 
@@ -19,7 +19,7 @@ function load_data() {
         }
     });
 
-    $('.integration-category').toArray().forEach(function (category) {
+    $('.integration-category').toArray().forEach((category) => {
         const name = $(category).data('category');
         const display_name = $(category).text().trim();
 
@@ -39,7 +39,7 @@ let state = Object.assign({}, INITIAL_STATE);
 
 
 function adjust_font_sizing() {
-    $('.integration-lozenge').toArray().forEach(function (integration) {
+    $('.integration-lozenge').toArray().forEach((integration) => {
         const $integration_name = $(integration).find('.integration-name');
         const $integration_category = $(integration).find('.integration-category');
 
@@ -97,11 +97,11 @@ function update_categories() {
     adjust_font_sizing();
 }
 
-const update_integrations = _.debounce(function () {
+const update_integrations = _.debounce(() => {
     const max_scrollY = window.scrollY;
 
     const integrations = $('.integration-lozenges').children().toArray();
-    integrations.forEach(function (integration) {
+    integrations.forEach((integration) => {
         const $integration = $(integration).find('.integration-lozenge');
         const $integration_category = $integration.find('.integration-category');
 
@@ -140,14 +140,12 @@ function hide_catalog_show_integration() {
     const categories = $('.integration-' + state.integration).data('categories')
         .slice(1, -1)
         .split(',')
-        .map(function (category) {
-            return category.trim().slice(1, -1);
-        });
+        .map((category) => category.trim().slice(1, -1));
 
     function show_integration(doc) {
         $('#integration-instructions-group .name').text(INTEGRATIONS.get(state.integration));
         $('#integration-instructions-group .categories .integration-category').remove();
-        categories.forEach(function (category) {
+        categories.forEach((category) => {
             let link;
             for (const [name, display_name] of CATEGORIES) {
                 if (display_name === category) {
@@ -323,7 +321,7 @@ function toggle_categories_dropdown() {
 }
 
 function integration_events() {
-    $('#integration-search input[type="text"]').keypress(function (e) {
+    $('#integration-search input[type="text"]').keypress((e) => {
         const integrations = $('.integration-lozenges').children().toArray();
         if (e.which === 13 && e.target.value !== '') {
             for (let i = 0; i < integrations.length; i += 1) {
@@ -337,24 +335,24 @@ function integration_events() {
         }
     });
 
-    $('.integration-categories-dropdown .dropdown-toggle').click(function () {
+    $('.integration-categories-dropdown .dropdown-toggle').click(() => {
         toggle_categories_dropdown();
     });
 
-    $('.integration-instruction-block').on('click', 'a .integration-category', function (e) {
+    $('.integration-instruction-block').on('click', 'a .integration-category', (e) => {
         const category = $(e.target).data('category');
         dispatch('SHOW_CATEGORY', { category: category });
         return false;
     });
 
-    $('.integrations a .integration-category').on('click', function (e) {
+    $('.integrations a .integration-category').on('click', (e) => {
         const category = $(e.target).data('category');
         dispatch('CHANGE_CATEGORY', { category: category });
         toggle_categories_dropdown();
         return false;
     });
 
-    $('.integrations a .integration-lozenge').on('click', function (e) {
+    $('.integrations a .integration-lozenge').on('click', (e) => {
         if (!$(e.target).closest('.integration-lozenge').hasClass('integration-create-your-own')) {
             const integration = $(e.target).closest('.integration-lozenge').data('name');
             dispatch('SHOW_INTEGRATION', { integration: integration });
@@ -362,7 +360,7 @@ function integration_events() {
         }
     });
 
-    $('a#integration-list-link span, a#integration-list-link i').on('click', function () {
+    $('a#integration-list-link span, a#integration-list-link i').on('click', () => {
         dispatch('HIDE_INTEGRATION');
         return false;
     });
@@ -371,11 +369,11 @@ function integration_events() {
     // the input event.
     $(".integrations .searchbar input[type='text']")
         .focus()
-        .on('input', function (e) {
+        .on('input', (e) => {
             dispatch('UPDATE_QUERY', { query: e.target.value.toLowerCase() });
         });
 
-    $(window).scroll(function () {
+    $(window).scroll(() => {
         if (document.body.scrollTop > 330) {
             $('.integration-categories-sidebar').addClass('sticky');
         } else {
@@ -383,11 +381,11 @@ function integration_events() {
         }
     });
 
-    $(window).on('resize', function () {
+    $(window).on('resize', () => {
         adjust_font_sizing();
     });
 
-    $(window).on('popstate', function () {
+    $(window).on('popstate', () => {
         if (window.location.pathname.startsWith('/integrations')) {
             dispatch('LOAD_PATH');
         } else {
@@ -397,7 +395,7 @@ function integration_events() {
 }
 
 // init
-$(function () {
+$(() => {
     integration_events();
     load_data();
     dispatch('LOAD_PATH');

--- a/static/js/portico/integrations_dev_panel.js
+++ b/static/js/portico/integrations_dev_panel.js
@@ -24,7 +24,7 @@ const clear_handlers = {
 function clear_elements(elements) {
     // Supports strings (a selector to clear) or calling a function
     // (for more complex logic).
-    elements.forEach(function (element_name) {
+    elements.forEach((element_name) => {
         const handler = clear_handlers[element_name];
         if (typeof handler === "string") {
             const element_object = $(handler)[0];
@@ -88,7 +88,7 @@ function set_results(response) {
     const responses = response.responses;
 
     let data = "Results:\n\n";
-    responses.forEach(function (response) {
+    responses.forEach((response) => {
         if (response.fixture_name !== undefined) {
             data += "Fixture:            " + response.fixture_name;
             data += "\nStatus Code:    "  + response.status_code;
@@ -128,7 +128,7 @@ function load_fixture_options(integration_name) {
     const fixtures_options_dropdown = $("#fixture_name")[0];
     const fixtures_names = Object.keys(loaded_fixtures.get(integration_name)).sort();
 
-    fixtures_names.forEach(function (fixture_name) {
+    fixtures_names.forEach((fixture_name) => {
         const new_dropdown_option = document.createElement("option");
         new_dropdown_option.value = fixture_name;
         new_dropdown_option.innerHTML = fixture_name;
@@ -295,7 +295,7 @@ function send_all_fixture_messages() {
 }
 
 // Initialization
-$(function () {
+$(() => {
     clear_elements(["stream_name", "topic_name", "URL", "bot_name", "integration_name",
                     "fixture_name", "custom_http_headers", "fixture_body", "results_notice",
                     "results"]);
@@ -323,12 +323,12 @@ $(function () {
         return;
     });
 
-    $('#send_fixture_button').click(function () {
+    $('#send_fixture_button').click(() => {
         send_webhook_fixture_message();
         return;
     });
 
-    $('#send_all_fixtures_button').click(function () {
+    $('#send_all_fixtures_button').click(() => {
         clear_elements(["results_notice"]);
         send_all_fixture_messages();
         return;

--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -3,9 +3,7 @@ import { detect_user_os } from './tabbed-instructions.js';
 import render_tabs from './team.js';
 
 export function path_parts() {
-    return window.location.pathname.split('/').filter(function (chunk) {
-        return chunk !== '';
-    });
+    return window.location.pathname.split('/').filter((chunk) => chunk !== '');
 }
 
 const hello_events = function () {
@@ -78,7 +76,7 @@ const apps_events = function () {
         let result;
         const parts = path_parts();
 
-        Object.keys(info).forEach(function (version) {
+        Object.keys(info).forEach((version) => {
             if (parts.includes(version)) {
                 result = version;
             }
@@ -123,14 +121,14 @@ const apps_events = function () {
         $download_from_apple_app_store.toggle(version === "ios");
     };
 
-    $(window).on('popstate', function () {
+    $(window).on('popstate', () => {
         version = get_version_from_path();
         update_page();
         $("body").animate({ scrollTop: 0 }, 200);
         google_analytics.config({page_path: window.location.pathname});
     });
 
-    $(".apps a .icon").click(function (e) {
+    $(".apps a .icon").click((e) => {
         const next_version = $(e.target).closest('a')
             .attr('href')
             .replace('/apps/', '');
@@ -158,7 +156,7 @@ const events = function () {
 
     $("[data-on-page='" + location + "']").addClass("active");
 
-    $("body").click(function (e) {
+    $("body").click((e) => {
         const $e = $(e.target);
 
         if ($e.is("nav ul .exit")) {
@@ -170,7 +168,7 @@ const events = function () {
         }
     });
 
-    $(".hamburger").click(function (e) {
+    $(".hamburger").click((e) => {
         $("nav ul").addClass("show");
         e.stopPropagation();
     });
@@ -229,7 +227,7 @@ if (document.readyState === "complete") {
     $(load);
 }
 
-$(function () {
+$(() => {
     if (window.location.pathname === '/team/') {
         render_tabs();
     }
@@ -239,6 +237,6 @@ $(function () {
 // According to https://developer.mozilla.org/en-US/docs/DOM/window.onunload
 // Using this event handler in your page prevents Firefox from caching the
 // page in the in-memory bfcache (backward/forward cache).
-$(window).on('unload', function () {
+$(window).on('unload', () => {
     $(window).unbind('unload');
 });

--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -1,14 +1,10 @@
-$(function () {
+$(() => {
     // NB: this file is included on multiple pages.  In each context,
     // some of the jQuery selectors below will return empty lists.
 
     const password_field = $('#id_password, #id_new_password1');
     if (password_field.length > 0) {
-        $.validator.addMethod('password_strength', function (value) {
-            return common.password_quality(value, undefined, password_field);
-        }, function () {
-            return common.password_warning(password_field.val(), password_field);
-        });
+        $.validator.addMethod('password_strength', (value) => common.password_quality(value, undefined, password_field), () => common.password_warning(password_field.val(), password_field));
         // Reset the state of the password strength bar if the page
         // was just reloaded due to a validation failure on the backend.
         common.password_quality(password_field.val(), $('#pw_strength .bar'), password_field);
@@ -76,7 +72,7 @@ $(function () {
     // Code in this block will be executed when the /accounts/send_confirm
     // endpoint is visited i.e. accounts_send_confirm.html is rendered.
     if ($("[data-page-id='accounts-send-confirm']").length > 0) {
-        $("#resend_email_link").click(function () {
+        $("#resend_email_link").click(() => {
             $('.resend_confirm').submit();
         });
     }
@@ -155,7 +151,7 @@ $(function () {
 
     function check_subdomain_avilable(subdomain) {
         const url = "/json/realm/subdomain/" + subdomain;
-        $.get(url, function (response) {
+        $.get(url, (response) => {
             if (response.msg !== "available") {
                 $("#id_team_subdomain_error_client").html(response.msg);
                 $("#id_team_subdomain_error_client").show();
@@ -182,12 +178,12 @@ $(function () {
     update_full_name_section();
 
     let timer;
-    $('#id_team_subdomain').on("keydown", function () {
+    $('#id_team_subdomain').on("keydown", () => {
         $('.team_subdomain_error_server').text('').css('display', 'none');
         $("#id_team_subdomain_error_client").css('display', 'none');
         clearTimeout(timer);
     });
-    $('#id_team_subdomain').on("keyup", function () {
+    $('#id_team_subdomain').on("keyup", () => {
         clearTimeout(timer);
         timer = setTimeout(check_subdomain_avilable, 250, $('#id_team_subdomain').val());
     });

--- a/static/js/portico/team.js
+++ b/static/js/portico/team.js
@@ -11,7 +11,7 @@ const loaded_repos = [];
 
 function contrib_total_commits(contrib) {
     let commits = 0;
-    repos.concat(hidden_repos).forEach(function (repo) {
+    repos.concat(hidden_repos).forEach((repo) => {
         commits += contrib[repo] || 0;
     });
     return commits;
@@ -32,17 +32,15 @@ export default function render_tabs() {
         .value()[0].server;
 
     const total_tab_html = _.chain(contributors_list)
-        .map(function (c) {
-            return {
-                name: c.name,
-                avatar: c.avatar,
-                commits: contrib_total_commits(c),
-            };
-        })
+        .map((c) => ({
+            name: c.name,
+            avatar: c.avatar,
+            commits: contrib_total_commits(c),
+        }))
         .sortBy('commits')
         .reverse()
-        .filter(function (c) { return c.commits >= least_server_commits; })
-        .map(function (c) { return template(c); })
+        .filter((c) => c.commits >= least_server_commits)
+        .map((c) => template(c))
         .value()
         .join('');
 
@@ -52,19 +50,17 @@ export default function render_tabs() {
         // Set as the loading template for now, and load when clicked.
         $('#tab-' + repo).html($('#loading-template').html());
 
-        $('#' + repo).click(function () {
+        $('#' + repo).click(() => {
             if (!loaded_repos.includes(repo)) {
                 const html = _.chain(contributors_list)
                     .filter(repo)
                     .sortBy(repo)
                     .reverse()
-                    .map(function (c) {
-                        return template({
-                            name: c.name,
-                            avatar: c.avatar,
-                            commits: c[repo],
-                        });
-                    })
+                    .map((c) => template({
+                        name: c.name,
+                        avatar: c.avatar,
+                        commits: c[repo],
+                    }))
                     .value()
                     .join('');
 

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -347,7 +347,7 @@ exports.remove_reaction = function (event) {
         return;
     }
 
-    r.user_ids = r.user_ids.filter(id => id !== user_id);
+    r.user_ids = r.user_ids.filter((id) => id !== user_id);
     if (r.user_ids.length > 0) {
         exports.update_user_fields(r);
     } else {

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -53,7 +53,7 @@ function update_ui_and_send_reaction_ajax(message_id, reaction_info) {
     const local_id = exports.get_local_reaction_id(reaction_info);
     const has_reacted = exports.current_user_has_reacted_to_emoji(
         message,
-        local_id
+        local_id,
     );
     const operation = has_reacted ? 'remove' : 'add';
     const reaction = create_reaction(message_id, reaction_info);

--- a/static/js/realm_icon.js
+++ b/static/js/realm_icon.js
@@ -24,7 +24,7 @@ exports.build_realm_icon_widget = function (upload_function) {
         $("#realm-icon-upload-widget .image_file_input_error").expectOne(),
         $("#realm-icon-upload-widget .image_upload_button").expectOne(),
         upload_function,
-        page_params.max_icon_file_size
+        page_params.max_icon_file_size,
     );
 };
 

--- a/static/js/realm_icon.js
+++ b/static/js/realm_icon.js
@@ -11,7 +11,7 @@ exports.build_realm_icon_widget = function (upload_function) {
     } else {
         $("#realm-icon-upload-widget .settings-page-delete-button").show();
     }
-    $("#realm-icon-upload-widget .settings-page-delete-button").on('click', function (e) {
+    $("#realm-icon-upload-widget .settings-page-delete-button").on('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
         channel.del({

--- a/static/js/realm_logo.js
+++ b/static/js/realm_logo.js
@@ -29,7 +29,7 @@ exports.build_realm_logo_widget = function (upload_function, is_night) {
     }
 
     const data = {night: JSON.stringify(is_night)};
-    delete_button_elem.on('click', function (e) {
+    delete_button_elem.on('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
         channel.del({

--- a/static/js/realm_logo.js
+++ b/static/js/realm_logo.js
@@ -43,7 +43,7 @@ exports.build_realm_logo_widget = function (upload_function, is_night) {
         file_input_error_elem.expectOne(),
         upload_button_elem.expectOne(),
         upload_function,
-        page_params.max_logo_file_size
+        page_params.max_logo_file_size,
     );
 };
 

--- a/static/js/recent_senders.js
+++ b/static/js/recent_senders.js
@@ -114,7 +114,7 @@ exports.get_topic_recent_senders = function (stream_id, topic) {
     }
 
     const sorted_senders = Array.from(sender_message_ids.entries()).sort(
-        (s1, s2) => { return s1[1] - s2[1]; }
+        (s1, s2) => s1[1] - s2[1]
     );
     const recent_senders = [];
     for (const item of sorted_senders) {

--- a/static/js/recent_senders.js
+++ b/static/js/recent_senders.js
@@ -114,7 +114,7 @@ exports.get_topic_recent_senders = function (stream_id, topic) {
     }
 
     const sorted_senders = Array.from(sender_message_ids.entries()).sort(
-        (s1, s2) => s1[1] - s2[1]
+        (s1, s2) => s1[1] - s2[1],
     );
     const recent_senders = [];
     for (const item of sorted_senders) {

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -139,9 +139,9 @@ exports.reify_message_id_if_available = function (opts) {
 
 function get_sorted_topics() {
     // Sort all recent topics by last message time.
-    return new Map(Array.from(topics.entries()).sort(function (a, b) {
-        return  b[1].last_msg_id -  a[1].last_msg_id;
-    }));
+    return new Map(
+        Array.from(topics.entries()).sort((a, b) => b[1].last_msg_id - a[1].last_msg_id)
+    );
 }
 
 exports.get = function () {
@@ -390,9 +390,7 @@ exports.complete_rerender = function () {
     // Show topics list
     const container = $('.recent_topics_table table tbody');
     container.empty();
-    const mapped_topic_values = Array.from(exports.get().values()).map(function (value) {
-        return value;
-    });
+    const mapped_topic_values = Array.from(exports.get().values()).map((value) => value);
 
     topics_widget = list_render.create(container, mapped_topic_values, {
         name: "recent_topics_table",

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -224,7 +224,7 @@ exports.topic_in_search_results = function (keyword, stream, topic) {
     keyword = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const text = (stream + ' ' + topic).toLowerCase().replace(/\s+/g, ' ');
     const search_words = keyword.toLowerCase().replace(/\s+/g, ' ').split(' ');
-    return search_words.every(word => {
+    return search_words.every((word) => {
         if (text.search(word) !== -1) {
             return true;
         }

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -140,7 +140,7 @@ exports.reify_message_id_if_available = function (opts) {
 function get_sorted_topics() {
     // Sort all recent topics by last message time.
     return new Map(
-        Array.from(topics.entries()).sort((a, b) => b[1].last_msg_id - a[1].last_msg_id)
+        Array.from(topics.entries()).sort((a, b) => b[1].last_msg_id - a[1].last_msg_id),
     );
 }
 

--- a/static/js/reload.js
+++ b/static/js/reload.js
@@ -199,11 +199,11 @@ function do_reload_app(send_after_reload, save_pointer, save_narrow, save_compos
     // broken state and cause lots of confusing tracebacks.  So, we
     // set ourselves to try reloading a bit later, both periodically
     // and when the user focuses the window.
-    $(window).on('focus', function () {
+    $(window).on('focus', () => {
         blueslip.log("Retrying on-focus page reload");
         window.location.reload(true);
     });
-    setInterval(function () {
+    setInterval(() => {
         blueslip.log("Retrying page reload due to 30s timer");
         window.location.reload(true);
     }, 30000);
@@ -322,7 +322,7 @@ exports.initiate = function (options) {
     }
 };
 
-window.addEventListener('beforeunload', function () {
+window.addEventListener('beforeunload', () => {
     // When navigating away from the page do not try to reload.
     // The polling get_events call will fail after we delete the event queue.
     // When that happens we reload the page to correct the problem. If this

--- a/static/js/reminder.js
+++ b/static/js/reminder.js
@@ -46,7 +46,7 @@ exports.schedule_message = function (request) {
     const message = raw_message.slice(1).join('\n');
 
     const deferred_message_type = deferred_message_types.filter(
-        props => command_line.match(props.test) !== null
+        (props) => command_line.match(props.test) !== null
     )[0];
     const command = command_line.match(deferred_message_type.test)[0];
 

--- a/static/js/reminder.js
+++ b/static/js/reminder.js
@@ -46,7 +46,7 @@ exports.schedule_message = function (request) {
     const message = raw_message.slice(1).join('\n');
 
     const deferred_message_type = deferred_message_types.filter(
-        (props) => command_line.match(props.test) !== null
+        (props) => command_line.match(props.test) !== null,
     )[0];
     const command = command_line.match(deferred_message_type.test)[0];
 
@@ -67,7 +67,7 @@ exports.schedule_message = function (request) {
     }
 
     request = patch_request_for_scheduling(
-        request, message, deliver_at, deferred_message_type.delivery_type
+        request, message, deliver_at, deferred_message_type.delivery_type,
     );
 
     const success = function (data) {
@@ -143,7 +143,7 @@ exports.do_set_reminder_for_message = function (message_id, timestamp) {
 
     reminder_message = patch_request_for_scheduling(
         reminder_message, reminder_msg_content, timestamp,
-        deferred_message_types.reminders.delivery_type
+        deferred_message_types.reminders.delivery_type,
     );
     transmit.send_message(reminder_message, success, error);
 };

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -144,7 +144,7 @@ exports.watch_manual_resize = function (element) {
         document.body.addEventListener("mouseup", body_handler);
 
         return [box_handler, body_handler];
-    }(function (height) {
+    }((height) => {
         // This callback disables autosize on the textarea.  It
         // will be re-enabled when this component is next opened.
         autosize.destroy($(element))

--- a/static/js/scroll_util.js
+++ b/static/js/scroll_util.js
@@ -35,14 +35,14 @@ exports.scroll_delta = function (opts) {
     if (elem_top < 0) {
         delta = Math.max(
             elem_top,
-            elem_bottom - container_height
+            elem_bottom - container_height,
         );
         delta = Math.min(0, delta);
     } else {
         if (elem_bottom > container_height) {
             delta = Math.min(
                 elem_top,
-                elem_bottom - container_height
+                elem_bottom - container_height,
             );
             delta = Math.max(0, delta);
         }

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -120,7 +120,7 @@ exports.initialize = function () {
         on_escape: tab_bar.exit_search,
     });
 
-    searchbox_form.on('compositionend', function () {
+    searchbox_form.on('compositionend', () => {
         // Set `is_using_input_method` to true if enter is pressed to exit
         // the input tool popover and get the text in the search bar. Then
         // we suppress searching triggered by this enter key by checking
@@ -129,7 +129,7 @@ exports.initialize = function () {
         exports.is_using_input_method = true;
     });
 
-    searchbox_form.keydown(function (e) {
+    searchbox_form.keydown((e) => {
         exports.update_button_visibility();
         const code = e.which;
         if (code === 13 && search_query_box.is(":focus")) {
@@ -138,7 +138,7 @@ exports.initialize = function () {
             // to be done will be handled in the keyup.
             return false;
         }
-    }).keyup(function (e) {
+    }).keyup((e) => {
         if (exports.is_using_input_method) {
             exports.is_using_input_method = false;
             return;
@@ -164,7 +164,7 @@ exports.initialize = function () {
     // more work to re-order everything and make them private.
 
     search_query_box.on('focus', exports.focus_search);
-    search_query_box.on('blur', function (e) {
+    search_query_box.on('blur', (e) => {
         // The search query box is a visual cue as to
         // whether search or narrowing is active.  If
         // the user blurs the search box, then we should
@@ -192,7 +192,7 @@ exports.initialize = function () {
                 return;
             }
         }
-        setTimeout(function () {
+        setTimeout(() => {
             exports.update_button_visibility();
             tab_bar.close_search_bar_and_open_narrow_description();
             searchbox.css({"box-shadow": "unset"});

--- a/static/js/search_pill.js
+++ b/static/js/search_pill.js
@@ -33,7 +33,7 @@ exports.append_search_string = function (search_string, pill_widget) {
 
 exports.get_search_string_for_current_filter = function (pill_widget) {
     const items = pill_widget.items();
-    const search_strings = items.map(item => item.display_value);
+    const search_strings = items.map((item) => item.display_value);
     return search_strings.join(' ');
 };
 

--- a/static/js/search_pill_widget.js
+++ b/static/js/search_pill_widget.js
@@ -5,16 +5,14 @@ exports.initialize = function () {
     const container = $('#search_arrows');
     exports.widget = search_pill.create_pills(container);
 
-    exports.widget.onPillRemove(function () {
+    exports.widget.onPillRemove(() => {
         if (exports.widget.items().length === 0) {
             ui_util.change_tab_to('#home');
             narrow.deactivate();
         }
     });
 
-    exports.widget.createPillonPaste(function () {
-        return false;
-    });
+    exports.widget.createPillonPaste(() => false);
 };
 
 window.search_pill_widget = exports;

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -143,7 +143,7 @@ function get_group_suggestions(last, operators) {
     const parts = all_but_last_part.split(',').concat(people.my_current_email());
 
     const person_matcher = people.build_person_matcher(last_part);
-    let persons = people.filter_all_persons(function (person) {
+    let persons = people.filter_all_persons((person) => {
         if (parts.includes(person.email)) {
             return false;
         }

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -20,7 +20,7 @@ function make_person_highlighter(query) {
 
 function match_criteria(operators, criteria) {
     const filter = new Filter(operators);
-    return criteria.some(cr => {
+    return criteria.some((cr) => {
         if (Object.prototype.hasOwnProperty.call(cr, 'operand')) {
             return filter.has_operand(cr.operator, cr.operand);
         }
@@ -48,7 +48,7 @@ function format_as_suggestion(terms) {
 }
 
 function compare_by_huddle(huddle) {
-    huddle = huddle.slice(0, -1).map(person => {
+    huddle = huddle.slice(0, -1).map((person) => {
         person = people.get_by_email(person);
         return person && person.user_id;
     });
@@ -91,14 +91,14 @@ function get_stream_suggestions(last, operators) {
     const query = last.operand;
     let streams = stream_data.subscribed_streams();
 
-    streams = streams.filter(stream => stream_matches_query(stream, query));
+    streams = streams.filter((stream) => stream_matches_query(stream, query));
 
     streams = typeahead_helper.sorter(query, streams);
 
     const regex = typeahead_helper.build_highlight_regex(query);
     const hilite = typeahead_helper.highlight_with_escaping_and_regex;
 
-    const objs = streams.map(stream => {
+    const objs = streams.map((stream) => {
         const prefix = 'stream';
         const highlighted_stream = hilite(regex, stream);
         const verb = last.negated ? 'exclude ' : '';
@@ -159,7 +159,7 @@ function get_group_suggestions(last, operators) {
 
     const highlight_person = make_person_highlighter(last_part);
 
-    const suggestions = persons.map(person => {
+    const suggestions = persons.map((person) => {
         const term = {
             operator: 'pm-with',
             operand: all_but_last_part + ',' + person.email,
@@ -239,7 +239,7 @@ function get_person_suggestions(people_getter, last, operators, autocomplete_ope
 
     const highlight_person = make_person_highlighter(query);
 
-    const objs = persons.map(person => {
+    const objs = persons.map((person) => {
         const name = highlight_person(person);
         const description = prefix + ' ' + name;
         const terms = [{
@@ -340,7 +340,7 @@ function get_topic_suggestions(last, operators) {
     topics = topics.slice(0, 300);
 
     if (guess !== '') {
-        topics = topics.filter(topic => common.phrase_match(guess, topic));
+        topics = topics.filter((topic) => common.phrase_match(guess, topic));
     }
 
     topics = topics.slice(0, 10);
@@ -351,7 +351,7 @@ function get_topic_suggestions(last, operators) {
     // care about case.
     topics.sort();
 
-    return topics.map(topic => {
+    return topics.map((topic) => {
         const topic_term = {operator: 'topic', operand: topic, negated: negated};
         const operators = suggest_operators.concat([topic_term]);
         return format_as_suggestion(operators);
@@ -382,7 +382,7 @@ function get_special_filter_suggestions(last, operators, suggestions) {
     // Negating suggestions on is_search_operand_negated is required for
     // suggesting negated operators.
     if (last.negated || is_search_operand_negated) {
-        suggestions = suggestions.map(suggestion => ({
+        suggestions = suggestions.map((suggestion) => ({
             search_string: '-' + suggestion.search_string,
             description: 'exclude ' + suggestion.description,
             invalid: suggestion.invalid,
@@ -390,7 +390,7 @@ function get_special_filter_suggestions(last, operators, suggestions) {
     }
 
     const last_string = Filter.unparse([last]).toLowerCase();
-    suggestions = suggestions.filter(s => {
+    suggestions = suggestions.filter((s) => {
         if (match_criteria(operators, s.invalid)) {
             return false;
         }
@@ -565,9 +565,9 @@ function get_operator_suggestions(last) {
     }
 
     let choices = ['stream', 'topic', 'pm-with', 'sender', 'near', 'from', 'group-pm-with'];
-    choices = choices.filter(choice => common.phrase_match(last_operand, choice));
+    choices = choices.filter((choice) => common.phrase_match(last_operand, choice));
 
-    return choices.map(choice => {
+    return choices.map((choice) => {
         const op = [{operator: choice, operand: '', negated: negated}];
         return format_as_suggestion(op);
     });
@@ -743,7 +743,7 @@ exports.finalize_search_result = function (result) {
         lookup_table.set(obj.search_string, obj);
     }
 
-    const strings = result.map(obj => obj.search_string);
+    const strings = result.map((obj) => obj.search_string);
     return {
         strings: strings,
         lookup_table: lookup_table,

--- a/static/js/search_util.js
+++ b/static/js/search_util.js
@@ -17,7 +17,7 @@ exports.vanilla_match = function (opts) {
         This is case insensitive.
     */
     const val = opts.val.toLowerCase();
-    return opts.search_terms.some(term => val.includes(term));
+    return opts.search_terms.some((term) => val.includes(term));
 };
 
 window.search_util = exports;

--- a/static/js/search_util.js
+++ b/static/js/search_util.js
@@ -1,7 +1,5 @@
 exports.get_search_terms = function (input) {
-    const search_terms = input.toLowerCase().split(",").map(function (s) {
-        return s.trim();
-    });
+    const search_terms = input.toLowerCase().split(",").map((s) => s.trim());
     return search_terms;
 };
 

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -286,7 +286,7 @@ exports.check_for_unsuspend = function () {
 setInterval(exports.check_for_unsuspend, 5000);
 
 exports.initialize = function () {
-    $(document).on('unsuspend', function () {
+    $(document).on('unsuspend', () => {
         // Immediately poll for new events on unsuspend
         blueslip.log("Restarting get_events due to unsuspend");
         get_events_failures = 0;
@@ -310,7 +310,7 @@ exports.cleanup_event_queue = function cleanup_event_queue() {
     });
 };
 
-window.addEventListener("beforeunload", function () {
+window.addEventListener("beforeunload", () => {
     exports.cleanup_event_queue();
 });
 

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -100,7 +100,7 @@ function get_events_success(events) {
                 messages.forEach(message_store.set_message_booleans);
 
                 const sent_by_this_client = messages.some((msg) =>
-                    sent_messages.messages.has(msg.local_id)
+                    sent_messages.messages.has(msg.local_id),
                 );
                 // If some message in this batch of events was sent by this
                 // client, almost every time, this message will be the only one

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -99,7 +99,7 @@ function get_events_success(events) {
             if (messages.length > 0) {
                 messages.forEach(message_store.set_message_booleans);
 
-                const sent_by_this_client = messages.some(msg =>
+                const sent_by_this_client = messages.some((msg) =>
                     sent_messages.messages.has(msg.local_id)
                 );
                 // If some message in this batch of events was sent by this

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -376,7 +376,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             stream_events.update_property(
                 event.stream_id,
                 event.property,
-                event.value
+                event.value,
             );
         }
         break;

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -437,7 +437,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
         }
         if (event.setting_name === 'color_scheme') {
             $("body").fadeOut(300);
-            setTimeout(function () {
+            setTimeout(() => {
                 if (event.setting === settings_config.color_scheme_values.night.code) {
                     night_mode.enable();
                     realm_logo.rerender();

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -1,8 +1,8 @@
 const settings_config = require("./settings_config");
 const render_settings_tab = require('../templates/settings_tab.hbs');
 
-$("body").ready(function () {
-    $("#settings_overlay_container").click(function (e) {
+$("body").ready(() => {
+    $("#settings_overlay_container").click((e) => {
         if (!overlays.is_modal_open()) {
             return;
         }

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -135,7 +135,7 @@ exports.append_custom_profile_fields = function (element_id, user_id) {
         [all_field_types.URL.id, "url"],
     ]);
 
-    all_custom_fields.forEach(function (field) {
+    all_custom_fields.forEach((field) => {
         let field_value = people.get_custom_profile_data(user_id, field.id);
         const is_choice_field = field.type === all_field_types.CHOICE.id;
         const field_choices = [];
@@ -200,7 +200,7 @@ exports.initialize_custom_user_type_fields = function (element_id, user_id, is_e
         return user_pills;
     }
 
-    page_params.custom_profile_fields.forEach(function (field) {
+    page_params.custom_profile_fields.forEach((field) => {
         let field_value_raw = people.get_custom_profile_data(user_id, field.id);
 
         if (field_value_raw) {
@@ -229,7 +229,7 @@ exports.initialize_custom_user_type_fields = function (element_id, user_id, is_e
             if (field_value_raw) {
                 const field_value = JSON.parse(field_value_raw);
                 if (field_value) {
-                    field_value.forEach(function (pill_user_id) {
+                    field_value.forEach((pill_user_id) => {
                         const user = people.get_by_user_id(pill_user_id);
                         user_pill.append_user(user, pills);
                     });
@@ -240,11 +240,11 @@ exports.initialize_custom_user_type_fields = function (element_id, user_id, is_e
                 const input = pill_container.children('.input');
                 if (set_handler_on_update) {
                     user_pill.set_up_typeahead_on_pills(input, pills, update_custom_user_field);
-                    pills.onPillRemove(function () {
+                    pills.onPillRemove(() => {
                         update_custom_user_field();
                     });
                 } else {
-                    user_pill.set_up_typeahead_on_pills(input, pills, function () {});
+                    user_pill.set_up_typeahead_on_pills(input, pills, () => {});
                 }
             }
             user_pills.set(field.id, pills);
@@ -277,7 +277,7 @@ exports.set_up = function () {
     exports.add_custom_profile_fields_to_settings();
     $("#account-settings-status").hide();
 
-    const setup_api_key_modal = _.once(function () {
+    const setup_api_key_modal = _.once(() => {
         function request_api_key(data) {
             channel.post({
                 url: '/json/fetch_api_key',
@@ -308,7 +308,7 @@ exports.set_up = function () {
             // Skip the password prompt step, since the user doesn't have one.
             request_api_key({});
         } else {
-            $("#get_api_key_button").on("click", function (e) {
+            $("#get_api_key_button").on("click", (e) => {
                 const data = {};
                 e.preventDefault();
                 e.stopPropagation();
@@ -318,7 +318,7 @@ exports.set_up = function () {
             });
         }
 
-        $("#show_api_key").on("click", "button.regenerate_api_key", function (e) {
+        $("#show_api_key").on("click", "button.regenerate_api_key", (e) => {
             channel.post({
                 url: '/json/users/me/api_key/regenerate',
                 success: function (data) {
@@ -343,7 +343,7 @@ exports.set_up = function () {
         });
     });
 
-    $('#api_key_button').click(function (e) {
+    $('#api_key_button').click((e) => {
         setup_api_key_modal();
         overlays.open_modal('#api_key_modal');
         e.preventDefault();
@@ -359,7 +359,7 @@ exports.set_up = function () {
 
     clear_password_change();
 
-    $("#change_full_name").on('click', function (e) {
+    $("#change_full_name").on('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
         if (exports.user_can_change_name()) {
@@ -368,7 +368,7 @@ exports.set_up = function () {
         }
     });
 
-    $('#change_password').on('click', function (e) {
+    $('#change_password').on('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
         overlays.open_modal('#change_password_modal');
@@ -376,24 +376,24 @@ exports.set_up = function () {
         if (page_params.realm_password_auth_enabled !== false) {
             // zxcvbn.js is pretty big, and is only needed on password
             // change, so load it asynchronously.
-            require(['zxcvbn'], function (zxcvbn) {
+            require(['zxcvbn'], (zxcvbn) => {
                 window.zxcvbn = zxcvbn;
                 $('#pw_strength .bar').removeClass("fade");
             });
         }
     });
 
-    $('#change_password_modal').find('[data-dismiss=modal]').on('click', function () {
+    $('#change_password_modal').find('[data-dismiss=modal]').on('click', () => {
         clear_password_change();
     });
 
     // If the modal is closed using the 'close' button or the 'Cancel' button
-    $('.modal').find('[data-dismiss=modal]').on('click', function () {
+    $('.modal').find('[data-dismiss=modal]').on('click', () => {
         // Enable mouse events for the background on closing modal
         $('.overlay.show').attr("style", null);
     });
 
-    $('#change_password_button').on('click', function (e) {
+    $('#change_password_button').on('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
         const change_password_error = $('#change_password_modal').find(".change_password_info").expectOne();
@@ -431,12 +431,12 @@ exports.set_up = function () {
         clear_password_change();
     });
 
-    $('#new_password').on('input', function () {
+    $('#new_password').on('input', () => {
         const field = $('#new_password');
         common.password_quality(field.val(), $('#pw_strength .bar'), field);
     });
 
-    $("#change_full_name_button").on('click', function (e) {
+    $("#change_full_name_button").on('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
         const change_full_name_error = $('#change_full_name_modal').find(".change_full_name_info").expectOne();
@@ -454,7 +454,7 @@ exports.set_up = function () {
                                        $('#account-settings-status').expectOne(), opts);
     });
 
-    $('#change_email_button').on('click', function (e) {
+    $('#change_email_button').on('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
         const change_email_error = $('#change_email_modal').find(".change_email_info").expectOne();
@@ -477,7 +477,7 @@ exports.set_up = function () {
                                        $('#account-settings-status').expectOne(), opts);
     });
 
-    $('#change_email').on('click', function (e) {
+    $('#change_email').on('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
         if (!page_params.realm_email_changes_disabled || page_params.is_admin) {
@@ -487,7 +487,7 @@ exports.set_up = function () {
         }
     });
 
-    $("#user_deactivate_account_button").on('click', function (e) {
+    $("#user_deactivate_account_button").on('click', (e) => {
         // This click event must not get propagated to parent container otherwise the modal
         // will not show up because of a call to `close_active_modal` in `settings.js`.
         e.preventDefault();
@@ -495,7 +495,7 @@ exports.set_up = function () {
         $("#deactivate_self_modal").modal("show");
     });
 
-    $('#account-settings').on('click', '.custom_user_field .remove_date', function (e) {
+    $('#account-settings').on('click', '.custom_user_field .remove_date', (e) => {
         e.preventDefault();
         e.stopPropagation();
         const field = $(e.target).closest('.custom_user_field').expectOne();
@@ -516,7 +516,7 @@ exports.set_up = function () {
         }
     });
 
-    $("#do_deactivate_self_button").on('click', function () {
+    $("#do_deactivate_self_button").on('click', () => {
         $("#do_deactivate_self_button .loader").css('display', 'inline-block');
         $("#do_deactivate_self_button span").hide();
         $("#do_deactivate_self_button object").on("load", function () {
@@ -525,7 +525,7 @@ exports.set_up = function () {
             $svg.find("rect").css("fill", "#000");
         });
 
-        setTimeout(function () {
+        setTimeout(() => {
             channel.del({
                 url: '/json/users/me',
                 success: function () {
@@ -550,22 +550,22 @@ exports.set_up = function () {
         }, 5000);
     });
 
-    $("#show_my_user_profile_modal").on('click', function () {
+    $("#show_my_user_profile_modal").on('click', () => {
         overlays.close_overlay("settings");
         const user = people.get_by_user_id(people.my_current_user_id());
-        setTimeout(function () {
+        setTimeout(() => {
             popovers.show_user_profile(user);
         }, 100);
 
         // If user opened the "preview profile" modal from user
         // settings, then closing preview profile modal should
         // send them back to the settings modal.
-        $('body').one('hidden.bs.modal', '#user-profile-modal', function (e) {
+        $('body').one('hidden.bs.modal', '#user-profile-modal', (e) => {
             e.preventDefault();
             e.stopPropagation();
             popovers.hide_user_profile();
 
-            setTimeout(function () {
+            setTimeout(() => {
                 if (!overlays.settings_open()) {
                     overlays.open_settings();
                 }

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -64,7 +64,7 @@ function is_local_part(value, element) {
 }
 
 exports.type_id_to_string = function (type_id) {
-    return page_params.bot_types.find(bot_type => bot_type.type_id === type_id).name;
+    return page_params.bot_types.find((bot_type) => bot_type.type_id === type_id).name;
 };
 
 exports.render_bots = function () {
@@ -392,7 +392,7 @@ exports.set_up = function () {
         const bot_id = parseInt(li.find('.bot_info').attr('data-user-id'), 10);
         const bot = bot_data.get(bot_id);
         const user_ids = people.get_active_human_ids();
-        const users_list = user_ids.map(user_id => ({
+        const users_list = user_ids.map((user_id) => ({
             name: people.get_full_name(user_id),
             value: user_id.toString(),
         }));

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -312,7 +312,7 @@ exports.set_up = function () {
         },
     });
 
-    $("#create_bot_type").on("change", function () {
+    $("#create_bot_type").on("change", () => {
         const bot_type = $('#create_bot_type :selected').val();
         // For "generic bot" or "incoming webhook" both these fields need not be displayed.
         $('#service_name_list').hide();
@@ -333,20 +333,20 @@ exports.set_up = function () {
         }
     });
 
-    $("#select_service_name").on("change", function () {
+    $("#select_service_name").on("change", () => {
         $('#config_inputbox').children().hide();
         const selected_bot = $('#select_service_name :selected').val();
         $("[name*='" + selected_bot + "']").show();
     });
 
-    $("#active_bots_list").on("click", "button.delete_bot", function (e) {
+    $("#active_bots_list").on("click", "button.delete_bot", (e) => {
         const bot_id = parseInt($(e.currentTarget).attr('data-user-id'), 10);
 
         channel.del({
             url: '/json/bots/' + encodeURIComponent(bot_id),
             success: function () {
                 const row = $(e.currentTarget).closest("li");
-                row.hide('slow', function () { row.remove(); });
+                row.hide('slow', () => { row.remove(); });
             },
             error: function (xhr) {
                 exports.bot_error(bot_id, xhr);
@@ -354,7 +354,7 @@ exports.set_up = function () {
         });
     });
 
-    $("#inactive_bots_list").on("click", "button.reactivate_bot", function (e) {
+    $("#inactive_bots_list").on("click", "button.reactivate_bot", (e) => {
         const user_id = parseInt($(e.currentTarget).attr('data-user-id'), 10);
 
         channel.post({
@@ -365,7 +365,7 @@ exports.set_up = function () {
         });
     });
 
-    $("#active_bots_list").on("click", "button.regenerate_bot_api_key", function (e) {
+    $("#active_bots_list").on("click", "button.regenerate_bot_api_key", (e) => {
         const bot_id = parseInt($(e.currentTarget).attr('data-user-id'), 10);
         channel.post({
             url: '/json/bots/' + encodeURIComponent(bot_id) + '/api_key/regenerate',
@@ -384,7 +384,7 @@ exports.set_up = function () {
 
     let image_version = 0;
 
-    $("#active_bots_list").on("click", "button.open_edit_bot_form", function (e) {
+    $("#active_bots_list").on("click", "button.open_edit_bot_form", (e) => {
         e.preventDefault();
         e.stopPropagation();
         overlays.open_modal('#edit_bot_modal');
@@ -515,19 +515,19 @@ exports.set_up = function () {
         },
     });
 
-    $("#bots_lists_navbar .add-a-new-bot-tab").click(function (e) {
+    $("#bots_lists_navbar .add-a-new-bot-tab").click((e) => {
         e.preventDefault();
         e.stopPropagation();
         focus_tab.add_a_new_bot_tab();
     });
 
-    $("#bots_lists_navbar .active-bots-tab").click(function (e) {
+    $("#bots_lists_navbar .active-bots-tab").click((e) => {
         e.preventDefault();
         e.stopPropagation();
         focus_tab.active_bots_tab();
     });
 
-    $("#bots_lists_navbar .inactive-bots-tab").click(function (e) {
+    $("#bots_lists_navbar .inactive-bots-tab").click((e) => {
         e.preventDefault();
         e.stopPropagation();
         focus_tab.inactive_bots_tab();

--- a/static/js/settings_config.js
+++ b/static/js/settings_config.js
@@ -192,7 +192,7 @@ exports.user_role_values = {
 };
 
 const user_role_array = Object.values(exports.user_role_values);
-exports.user_role_map = new Map(user_role_array.map(role => [role.code, role.description]));
+exports.user_role_map = new Map(user_role_array.map((role) => [role.code, role.description]));
 
 // NOTIFICATIONS
 

--- a/static/js/settings_config.js
+++ b/static/js/settings_config.js
@@ -262,12 +262,12 @@ const other_notification_settings = desktop_notification_settings.concat(
     mobile_notification_settings,
     email_notification_settings,
     presence_notification_settings,
-    ["notification_sound"]
+    ["notification_sound"],
 );
 
 exports.all_notification_settings = other_notification_settings.concat(
     pm_mention_notification_settings,
-    exports.stream_notification_settings
+    exports.stream_notification_settings,
 );
 
 exports.all_notifications = () => ({

--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -35,7 +35,7 @@ exports.set_up = function () {
 
     $(".emojiset_choice[value=" + page_params.emojiset + "]").prop("checked", true);
 
-    $("#default_language_modal [data-dismiss]").click(function () {
+    $("#default_language_modal [data-dismiss]").click(() => {
         overlays.close_modal('#default_language_modal');
     });
 
@@ -56,7 +56,7 @@ exports.set_up = function () {
         });
     }
 
-    $("#default_language_modal .language").click(function (e) {
+    $("#default_language_modal .language").click((e) => {
         e.preventDefault();
         e.stopPropagation();
         overlays.close_modal('#default_language_modal');
@@ -73,7 +73,7 @@ exports.set_up = function () {
 
     });
 
-    $('#default_language').on('click', function (e) {
+    $('#default_language').on('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
         overlays.open_modal('#default_language_modal');
@@ -89,7 +89,7 @@ exports.set_up = function () {
         change_display_setting(data, '#display-settings-status');
     });
 
-    $('body').on('click', '.reload_link', function () {
+    $('body').on('click', '.reload_link', () => {
         window.location.reload();
     });
 

--- a/static/js/settings_emoji.js
+++ b/static/js/settings_emoji.js
@@ -130,7 +130,7 @@ exports.build_emoji_upload_widget = function () {
         clear_button,
         upload_button,
         preview_text,
-        preview_image
+        preview_image,
     );
 };
 

--- a/static/js/settings_exports.js
+++ b/static/js/settings_exports.js
@@ -85,7 +85,7 @@ exports.populate_exports_table = function (exports) {
 exports.set_up = function () {
     meta.loaded = true;
 
-    $("#export-data").on('click', function (e) {
+    $("#export-data").on('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
         const export_status = $('#export_status');

--- a/static/js/settings_exports.js
+++ b/static/js/settings_exports.js
@@ -33,13 +33,13 @@ exports.populate_exports_table = function (exports) {
 
             if (failed_timestamp !== null) {
                 failed_timestamp = timerender.last_seen_status_from_date(
-                    new XDate(failed_timestamp * 1000)
+                    new XDate(failed_timestamp * 1000),
                 );
             }
 
             if (deleted_timestamp !== null) {
                 deleted_timestamp = timerender.last_seen_status_from_date(
-                    new XDate(deleted_timestamp * 1000)
+                    new XDate(deleted_timestamp * 1000),
                 );
             }
 
@@ -49,7 +49,7 @@ exports.populate_exports_table = function (exports) {
                     acting_user: people.get_full_name(data.acting_user_id),
                     // Convert seconds -> milliseconds
                     event_time: timerender.last_seen_status_from_date(
-                        new XDate(data.export_time * 1000)
+                        new XDate(data.export_time * 1000),
                     ),
                     url: data.export_url,
                     time_failed: failed_timestamp,

--- a/static/js/settings_invites.js
+++ b/static/js/settings_invites.js
@@ -128,7 +128,7 @@ exports.on_load_success = function (invites_data, initialize_event_handlers) {
     if (!initialize_event_handlers) {
         return;
     }
-    $(".admin_invites_table").on("click", ".revoke", function (e) {
+    $(".admin_invites_table").on("click", ".revoke", (e) => {
         // This click event must not get propagated to parent container otherwise the modal
         // will not show up because of a call to `close_active_modal` in `settings.js`.
         e.preventDefault();
@@ -149,7 +149,7 @@ exports.on_load_success = function (invites_data, initialize_event_handlers) {
         $("#do_revoke_invite_button").click(do_revoke_invite);
     });
 
-    $(".admin_invites_table").on("click", ".resend", function (e) {
+    $(".admin_invites_table").on("click", ".resend", (e) => {
         // This click event must not get propagated to parent container otherwise the modal
         // will not show up because of a call to `close_active_modal` in `settings.js`.
         e.preventDefault();
@@ -165,7 +165,7 @@ exports.on_load_success = function (invites_data, initialize_event_handlers) {
         $("#resend_invite_modal").modal("show");
     });
 
-    $("#do_resend_invite_button").click(function () {
+    $("#do_resend_invite_button").click(() => {
         const modal_invite_id = $("#resend_invite_modal #do_resend_invite_button").attr("data-invite-id");
         const resend_button = meta.current_resend_invite_user_modal_row.find("button.resend");
 

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -105,7 +105,7 @@ exports.set_up = function () {
 
     $("#send_test_notification").click(() => {
         notifications.send_test_notification(
-            i18n.t("This is what a Zulip notification looks like.")
+            i18n.t("This is what a Zulip notification looks like."),
         );
     });
 

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -109,14 +109,14 @@ exports.set_up = function () {
         );
     });
 
-    $("#play_notification_sound").click(function () {
+    $("#play_notification_sound").click(() => {
         $("#notifications-area").find("audio")[0].play();
     });
 
     const notification_sound_dropdown = $("#notification_sound");
     notification_sound_dropdown.val(page_params.notification_sound);
 
-    $("#enable_sounds, #enable_stream_audible_notifications").change(function () {
+    $("#enable_sounds, #enable_stream_audible_notifications").change(() => {
         if ($("#enable_stream_audible_notifications").prop("checked") || $("#enable_sounds").prop("checked")) {
             notification_sound_dropdown.prop("disabled", false);
             notification_sound_dropdown.parent().removeClass("control-label-disabled");

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -43,7 +43,7 @@ exports.maybe_disable_widgets = function () {
 };
 
 exports.get_sorted_options_list = function (option_values_object) {
-    const options_list = Object.keys(option_values_object).map(key => ({
+    const options_list = Object.keys(option_values_object).map((key) => ({
         ...option_values_object[key],
         key: key,
     }));
@@ -264,7 +264,7 @@ exports.populate_realm_domains = function (realm_domains) {
     }
 
     const domains_list = realm_domains.map(
-        realm_domain => realm_domain.allow_subdomains ? "*." + realm_domain.domain : realm_domain.domain
+        (realm_domain) => realm_domain.allow_subdomains ? "*." + realm_domain.domain : realm_domain.domain
     );
     let domains = domains_list.join(', ');
     if (domains.length === 0) {
@@ -547,7 +547,7 @@ exports.signup_notifications_stream_widget = null;
 exports.init_dropdown_widgets = () => {
     const streams = stream_data.get_streams_for_settings_page();
     const notification_stream_options = {
-        data: streams.map(x => {
+        data: streams.map((x) => {
             const item = {
                 name: x.name,
                 value: x.stream_id.toString(),
@@ -575,7 +575,7 @@ exports.init_dropdown_widgets = () => {
                       notification_stream_options));
     exports.default_code_language_widget = dropdown_list_widget({
         widget_name: 'realm_default_code_block_language',
-        data: Object.keys(pygments_data.langs).map(x => {
+        data: Object.keys(pygments_data.langs).map((x) => {
             return {
                 name: x,
                 value: x,

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -398,7 +398,7 @@ exports.change_save_button_state = function ($element, state) {
             $element.removeClass('hide').addClass('.show').fadeIn(300);
             return;
         }
-        setTimeout(function () {
+        setTimeout(() => {
             $element.fadeOut(300);
         }, fadeout_delay);
     }
@@ -611,7 +611,7 @@ exports.build_page = function () {
     set_message_content_in_email_notifications_visiblity();
     set_digest_emails_weekday_visibility();
 
-    $('.admin-realm-form').on('change input', 'input, select, textarea', function (e) {
+    $('.admin-realm-form').on('change input', 'input, select, textarea', (e) => {
         e.preventDefault();
         e.stopPropagation();
 
@@ -633,7 +633,7 @@ exports.build_page = function () {
         exports.save_discard_widget_status_handler(subsection);
     });
 
-    $('.organization').on('click', '.subsection-header .subsection-changes-discard .button', function (e) {
+    $('.organization').on('click', '.subsection-header .subsection-changes-discard .button', (e) => {
         e.preventDefault();
         e.stopPropagation();
         get_subsection_property_elements(e.target).forEach(discard_property_element_changes);
@@ -785,7 +785,7 @@ exports.build_page = function () {
         return data;
     }
 
-    $(".organization").on("click", ".subsection-header .subsection-changes-save .button", function (e) {
+    $(".organization").on("click", ".subsection-header .subsection-changes-save .button", (e) => {
         e.preventDefault();
         e.stopPropagation();
         const save_button = $(e.currentTarget);
@@ -800,7 +800,7 @@ exports.build_page = function () {
         exports.save_organization_settings(data, save_button);
     });
 
-    $(".org-subsection-parent").on("keydown", "input", function (e) {
+    $(".org-subsection-parent").on("keydown", "input", (e) => {
         e.stopPropagation();
         if (e.keyCode === 13) {
             e.preventDefault();
@@ -808,19 +808,19 @@ exports.build_page = function () {
         }
     });
 
-    $("#id_realm_msg_edit_limit_setting").change(function (e) {
+    $("#id_realm_msg_edit_limit_setting").change((e) => {
         const msg_edit_limit_dropdown_value = e.target.value;
         change_element_block_display_property('id_realm_message_content_edit_limit_minutes',
                                               msg_edit_limit_dropdown_value === 'custom_limit');
     });
 
-    $("#id_realm_msg_delete_limit_setting").change(function (e) {
+    $("#id_realm_msg_delete_limit_setting").change((e) => {
         const msg_delete_limit_dropdown_value = e.target.value;
         change_element_block_display_property('id_realm_message_content_delete_limit_minutes',
                                               msg_delete_limit_dropdown_value === 'custom_limit');
     });
 
-    $("#id_realm_message_retention_setting").change(function (e) {
+    $("#id_realm_message_retention_setting").change((e) => {
         const message_retention_setting_dropdown_value = e.target.value;
         change_element_block_display_property('id_realm_message_retention_days',
                                               message_retention_setting_dropdown_value === 'retain_for_period');
@@ -832,7 +832,7 @@ exports.build_page = function () {
                                               waiting_period_threshold === 'custom_days');
     });
 
-    $("#id_realm_org_join_restrictions").change(function (e) {
+    $("#id_realm_org_join_restrictions").change((e) => {
         const org_join_restrictions = e.target.value;
         const node = $("#allowed_domains_label").parent();
         if (org_join_restrictions === 'only_selected_domain') {
@@ -845,7 +845,7 @@ exports.build_page = function () {
         }
     });
 
-    $("#id_realm_org_join_restrictions").click(function (e) {
+    $("#id_realm_org_join_restrictions").click((e) => {
         // This prevents the disappearance of modal when there are
         // no allowed domains otherwise it gets closed due to
         // the click event handler attached to `#settings_overlay_container`
@@ -853,7 +853,7 @@ exports.build_page = function () {
     });
 
     function fade_status_element(elem) {
-        setTimeout(function () {
+        setTimeout(() => {
             elem.fadeOut(500);
         }, 1000);
     }
@@ -876,7 +876,7 @@ exports.build_page = function () {
         });
     });
 
-    $("#submit-add-realm-domain").click(function () {
+    $("#submit-add-realm-domain").click(() => {
         const realm_domains_info = $(".realm_domains_info");
         const widget = $("#add-realm-domain-widget");
         const domain = widget.find(".new-realm-domain").val();
@@ -995,7 +995,7 @@ exports.build_page = function () {
     }
 
 
-    $('#deactivate_realm_button').on('click', function (e) {
+    $('#deactivate_realm_button').on('click', (e) => {
         if (!overlays.is_modal_open()) {
             e.preventDefault();
             e.stopPropagation();
@@ -1003,7 +1003,7 @@ exports.build_page = function () {
         }
     });
 
-    $('#do_deactivate_realm_button').on('click', function () {
+    $('#do_deactivate_realm_button').on('click', () => {
         if (overlays.is_modal_open()) {
             overlays.close_modal('#deactivate-realm-modal');
         }

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -264,7 +264,7 @@ exports.populate_realm_domains = function (realm_domains) {
     }
 
     const domains_list = realm_domains.map(
-        (realm_domain) => realm_domain.allow_subdomains ? "*." + realm_domain.domain : realm_domain.domain
+        (realm_domain) => realm_domain.allow_subdomains ? "*." + realm_domain.domain : realm_domain.domain,
     );
     let domains = domains_list.join(', ');
     if (domains.length === 0) {
@@ -279,7 +279,7 @@ exports.populate_realm_domains = function (realm_domains) {
         realm_domains_table_body.append(
             render_settings_admin_realm_domains_list({
                 realm_domain: realm_domain,
-            })
+            }),
         );
     }
 };
@@ -680,7 +680,7 @@ exports.build_page = function () {
                 data.allow_message_editing = true;
                 data.message_content_edit_limit_seconds =
                     settings_config.msg_edit_limit_dropdown_values.get(
-                        edit_limit_setting_value
+                        edit_limit_setting_value,
                     ).seconds;
             }
             const delete_limit_setting_value = $("#id_realm_msg_delete_limit_setting").val();
@@ -694,7 +694,7 @@ exports.build_page = function () {
                 data.allow_message_deleting = true;
                 data.message_content_delete_limit_seconds =
                     settings_config.msg_delete_limit_dropdown_values.get(
-                        delete_limit_setting_value
+                        delete_limit_setting_value,
                     ).seconds;
             }
         } else if (subsection === 'notifications') {
@@ -1011,7 +1011,7 @@ exports.build_page = function () {
             url: '/json/realm/deactivate',
             error: function (xhr) {
                 ui_report.error(
-                    i18n.t("Failed"), xhr, $('#admin-realm-deactivation-status').expectOne()
+                    i18n.t("Failed"), xhr, $('#admin-realm-deactivation-status').expectOne(),
                 );
             },
         });

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -558,7 +558,7 @@ exports.init_dropdown_widgets = () => {
             exports.save_discard_widget_status_handler($(`#org-notifications`));
         },
         default_text: i18n.t("Disabled"),
-        render_text: (x) => {return `#${x}`;},
+        render_text: (x) => `#${x}`,
         null_value: -1,
     };
     exports.notifications_stream_widget = dropdown_list_widget(
@@ -575,12 +575,10 @@ exports.init_dropdown_widgets = () => {
                       notification_stream_options));
     exports.default_code_language_widget = dropdown_list_widget({
         widget_name: 'realm_default_code_block_language',
-        data: Object.keys(pygments_data.langs).map((x) => {
-            return {
-                name: x,
-                value: x,
-            };
-        }),
+        data: Object.keys(pygments_data.langs).map((x) => ({
+            name: x,
+            value: x,
+        })),
         value: page_params.realm_default_code_block_language,
         on_update: () => {
             exports.save_discard_widget_status_handler($(`#org-other-settings`));

--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -244,7 +244,7 @@ function set_up_choices_field_edit_form(profile_field, field_data) {
         choice_list.append(
             render_settings_profile_field_choice({
                 text: choice.text,
-            })
+            }),
         );
     }
 
@@ -369,7 +369,7 @@ exports.do_populate_profile_fields = function (profile_fields_data) {
                 },
                 can_modify: page_params.is_admin,
                 realm_default_external_accounts: page_params.realm_default_external_accounts,
-            })
+            }),
         );
     }
 

--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -280,12 +280,12 @@ function open_edit_form(e) {
         set_up_external_account_field_edit_form(profile_field, field_data.url_pattern);
     }
 
-    profile_field.form.find('.reset').on("click", function () {
+    profile_field.form.find('.reset').on("click", () => {
         profile_field.form.hide();
         profile_field.row.show();
     });
 
-    profile_field.form.find('.submit').on("click", function () {
+    profile_field.form.find('.submit').on("click", () => {
         e.preventDefault();
         e.stopPropagation();
 
@@ -306,7 +306,7 @@ function open_edit_form(e) {
 
     profile_field.form.find(".edit_profile_field_choices_container").on("input", ".choice-row input", add_choice_row);
     profile_field.form.find(".edit_profile_field_choices_container").on("click", "button.delete-choice", delete_choice_row);
-    $(".profile_field_external_accounts_edit select").on('change', function (e) {
+    $(".profile_field_external_accounts_edit select").on('change', (e) => {
         const field_id = parseInt($(e.target).closest('.profile-field-form').attr('data-profile-field-id'), 10);
         const field_form = get_profile_field_info(field_id);
         set_up_external_account_field_edit_form(field_form, "");
@@ -402,7 +402,7 @@ function set_up_choices_field() {
         $("#profile_field_choices_row").hide();
     }
 
-    $('#profile_field_type').on('change', function (e) {
+    $('#profile_field_type').on('change', (e) => {
         const selected_field_id = parseInt($(e.target).val(), 10);
         if (selected_field_id === field_types.CHOICE.id) {
             $("#profile_field_choices_row").show();
@@ -416,11 +416,11 @@ function set_up_choices_field() {
 }
 
 function set_up_external_account_field() {
-    $('#profile_field_type').on('change', function () {
+    $('#profile_field_type').on('change', () => {
         set_up_create_field_form();
     });
 
-    $("#profile_field_external_accounts_type").on("change", function () {
+    $("#profile_field_external_accounts_type").on("change", () => {
         set_up_create_field_form();
     });
 }

--- a/static/js/settings_streams.js
+++ b/static/js/settings_streams.js
@@ -98,7 +98,7 @@ exports.build_page = function () {
 
     exports.update_default_streams_table();
 
-    $('.create_default_stream').keypress(function (e) {
+    $('.create_default_stream').keypress((e) => {
         if (e.which === 13) {
             e.preventDefault();
             e.stopPropagation();
@@ -119,7 +119,7 @@ exports.build_page = function () {
         },
     });
 
-    $(".default-stream-form").on("click", "#do_submit_stream", function (e) {
+    $(".default-stream-form").on("click", "#do_submit_stream", (e) => {
         e.preventDefault();
         e.stopPropagation();
         const default_stream_input = $(".create_default_stream");

--- a/static/js/settings_ui.js
+++ b/static/js/settings_ui.js
@@ -40,7 +40,7 @@ exports.do_settings_change = function (request_method, url, data, status_element
         url: url,
         data: data,
         success: function (reponse_data) {
-            setTimeout(function () {
+            setTimeout(() => {
                 ui_report.success(success_msg, spinner, remove_after);
                 exports.display_checkmark(spinner);
             }, appear_after);

--- a/static/js/settings_user_groups.js
+++ b/static/js/settings_user_groups.js
@@ -198,7 +198,7 @@ exports.populate_user_groups = function () {
                                               except_class);
             if ($(event.relatedTarget).closest('#user-groups #' + data.id).length) {
                 return blur_exceptions.some(
-                    class_name => $(event.relatedTarget).closest(class_name).length
+                    (class_name) => $(event.relatedTarget).closest(class_name).length
                 );
             }
             return false;

--- a/static/js/settings_user_groups.js
+++ b/static/js/settings_user_groups.js
@@ -198,7 +198,7 @@ exports.populate_user_groups = function () {
                                               except_class);
             if ($(event.relatedTarget).closest('#user-groups #' + data.id).length) {
                 return blur_exceptions.some(
-                    (class_name) => $(event.relatedTarget).closest(class_name).length
+                    (class_name) => $(event.relatedTarget).closest(class_name).length,
                 );
             }
             return false;

--- a/static/js/settings_user_groups.js
+++ b/static/js/settings_user_groups.js
@@ -57,7 +57,7 @@ exports.populate_user_groups = function () {
         }
 
         const userg = $('div.user-group[id="' + data.id + '"]');
-        data.members.forEach(function (user_id) {
+        data.members.forEach((user_id) => {
             const user = people.get_by_user_id(user_id);
             user_pill.append_user(user, pills);
         });
@@ -75,12 +75,12 @@ exports.populate_user_groups = function () {
             pill_container.off('keydown', '.pill');
             pill_container.off('keydown', '.input');
             pill_container.off('click');
-            pill_container.on('click', function (e) {
+            pill_container.on('click', (e) => {
                 e.stopPropagation();
             });
-            pill_container.find('.pill').hover(function () {
+            pill_container.find('.pill').hover(() => {
                 pill_container.find('.pill').find('.exit').css('opacity', '0.5');
-            }, function () {});
+            }, () => {});
         }
         update_membership(data.id);
 
@@ -221,21 +221,21 @@ exports.populate_user_groups = function () {
             save_members();
         }
 
-        $('#user-groups #' + data.id).on('blur', '.input', function (event) {
+        $('#user-groups #' + data.id).on('blur', '.input', (event) => {
             auto_save('.input', event);
         });
 
-        $('#user-groups #' + data.id).on('blur', '.name', function (event) {
+        $('#user-groups #' + data.id).on('blur', '.name', (event) => {
             auto_save('.name', event);
         });
-        $('#user-groups #' + data.id).on('input', '.name', function () {
+        $('#user-groups #' + data.id).on('input', '.name', () => {
             update_cancel_button();
         });
 
-        $('#user-groups #' + data.id).on('blur', '.description', function (event) {
+        $('#user-groups #' + data.id).on('blur', '.description', (event) => {
             auto_save('.description', event);
         });
-        $('#user-groups #' + data.id).on('input', '.description', function () {
+        $('#user-groups #' + data.id).on('input', '.description', () => {
             update_cancel_button();
         });
 
@@ -248,11 +248,11 @@ exports.populate_user_groups = function () {
             if (!exports.can_edit(data.id)) {
                 return;
             }
-            pills.onPillRemove(function () {
+            pills.onPillRemove(() => {
                 // onPillRemove is fired before the pill is removed from
                 // the DOM.
                 update_cancel_button();
-                setTimeout(function () {
+                setTimeout(() => {
                     input.focus();
                 }, 100);
             });
@@ -338,7 +338,7 @@ exports.set_up = function () {
         });
     });
 
-    $('#user-groups').on('keypress', '.user-group h4 > span', function (e) {
+    $('#user-groups').on('keypress', '.user-group h4 > span', (e) => {
         if (e.which === 13) {
             e.preventDefault();
         }

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -24,7 +24,7 @@ function sort_email(a, b) {
     const email_b = settings_data.email_for_user_settings(b) || '';
     return compare_a_b(
         email_a.toLowerCase(),
-        email_b.toLowerCase()
+        email_b.toLowerCase(),
     );
 }
 
@@ -52,14 +52,14 @@ function sort_bot_owner(a, b) {
 
     return compare_a_b(
         owner_name(a),
-        owner_name(b)
+        owner_name(b),
     );
 }
 
 function sort_last_active(a, b) {
     return compare_a_b(
         presence.last_active_date(a.user_id) || 0,
-        presence.last_active_date(b.user_id) || 0
+        presence.last_active_date(b.user_id) || 0,
     );
 }
 
@@ -401,7 +401,7 @@ function open_human_form(person) {
         element,
         user_id,
         true,
-        false
+        false,
     );
 
     return {

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -458,7 +458,7 @@ function open_bot_form(person) {
     const owner_id = bot_data.get(person.user_id).owner_id;
 
     const user_ids = people.get_active_human_ids();
-    const users_list = user_ids.map(user_id => ({
+    const users_list = user_ids.map((user_id) => ({
         name: people.get_full_name(user_id),
         value: user_id.toString(),
     }));

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -512,7 +512,7 @@ function confirm_deactivation(row, user_id, status_field) {
 }
 
 function handle_deactivation(tbody, status_field) {
-    tbody.on("click", ".deactivate", function (e) {
+    tbody.on("click", ".deactivate", (e) => {
         // This click event must not get propagated to parent container otherwise the modal
         // will not show up because of a call to `close_active_modal` in `settings.js`.
         e.preventDefault();
@@ -525,7 +525,7 @@ function handle_deactivation(tbody, status_field) {
 }
 
 function handle_bot_deactivation(tbody, status_field) {
-    tbody.on("click", ".deactivate", function (e) {
+    tbody.on("click", ".deactivate", (e) => {
         e.preventDefault();
         e.stopPropagation();
 
@@ -548,7 +548,7 @@ function handle_bot_deactivation(tbody, status_field) {
 }
 
 function handle_reactivation(tbody, status_field) {
-    tbody.on("click", ".reactivate", function (e) {
+    tbody.on("click", ".reactivate", (e) => {
         e.preventDefault();
         e.stopPropagation();
         // Go up the tree until we find the user row, then grab the email element
@@ -572,7 +572,7 @@ function handle_reactivation(tbody, status_field) {
 }
 
 function handle_bot_owner_profile(tbody) {
-    tbody.on('click', '.user_row .view_user_profile', function (e) {
+    tbody.on('click', '.user_row .view_user_profile', (e) => {
         const owner_id = parseInt($(e.target).attr('data-owner-id'), 10);
         const owner = people.get_by_user_id(owner_id);
         popovers.show_user_profile(owner);
@@ -582,7 +582,7 @@ function handle_bot_owner_profile(tbody) {
 }
 
 function handle_human_form(tbody, status_field) {
-    tbody.on("click", ".open-user-form", function (e) {
+    tbody.on("click", ".open-user-form", (e) => {
         e.stopPropagation();
         e.preventDefault();
         const user_id = parseInt($(e.currentTarget).attr("data-user-id"), 10);
@@ -596,7 +596,7 @@ function handle_human_form(tbody, status_field) {
         const modal = ret.modal;
         const fields_user_pills = ret.fields_user_pills;
 
-        modal.find('.submit_human_change').on("click", function (e) {
+        modal.find('.submit_human_change').on("click", (e) => {
             e.preventDefault();
             e.stopPropagation();
 
@@ -618,7 +618,7 @@ function handle_human_form(tbody, status_field) {
 }
 
 function handle_bot_form(tbody, status_field) {
-    tbody.on("click", ".open-user-form", function (e) {
+    tbody.on("click", ".open-user-form", (e) => {
         e.stopPropagation();
         e.preventDefault();
         const user_id = parseInt($(e.currentTarget).attr("data-user-id"), 10);
@@ -630,7 +630,7 @@ function handle_bot_form(tbody, status_field) {
 
         const {modal, owner_widget} = open_bot_form(bot);
 
-        modal.find('.submit_bot_change').on("click", function (e) {
+        modal.find('.submit_bot_change').on("click", (e) => {
             e.preventDefault();
             e.stopPropagation();
 

--- a/static/js/setup.js
+++ b/static/js/setup.js
@@ -1,7 +1,7 @@
 const util = require("./util");
 // Miscellaneous early setup.
 
-$(function () {
+$(() => {
     if (util.is_mobile()) {
         // Disable the tutorial; it's ugly on mobile.
         page_params.needs_tutorial = false;
@@ -29,7 +29,7 @@ $(function () {
     };
 
     // For some reason, jQuery wants this to be attached to an element.
-    $(document).ajaxError(function (event, xhr) {
+    $(document).ajaxError((event, xhr) => {
         if (xhr.status === 401) {
             // We got logged out somehow, perhaps from another window or a session timeout.
             // We could display an error message, but jumping right to the login page seems

--- a/static/js/spoilers.js
+++ b/static/js/spoilers.js
@@ -3,11 +3,11 @@ function collapse_spoiler(spoiler) {
 
     // Set height to rendered height on next frame, then to zero on following
     // frame to allow CSS transition animation to work
-    requestAnimationFrame(function () {
+    requestAnimationFrame(() => {
         spoiler.height(spoiler_height + 'px');
         spoiler.removeClass("spoiler-content-open");
 
-        requestAnimationFrame(function () {
+        requestAnimationFrame(() => {
             spoiler.height("0px");
         });
     });
@@ -25,7 +25,7 @@ function expand_spoiler(spoiler) {
     // will trigger on the frame after this class change.
     spoiler.addClass("spoiler-content-open");
 
-    spoiler.on('transitionend', function () {
+    spoiler.on('transitionend', () => {
         spoiler.off('transitionend');
         // When the CSS transition is over, reset the height to auto
         // This keeps things working if, e.g., the viewport is resized

--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -9,7 +9,7 @@ let last_full_update = Infinity;
 // TODO: should take a dict of arrays and do it for all keys
 function partial_sums(array) {
     let accumulator = 0;
-    return array.map(function (o) {
+    return array.map((o) => {
         accumulator += o;
         return accumulator;
     });
@@ -71,13 +71,13 @@ function update_last_full_update(end_times) {
     $('#id_last_full_update').closest('.last-update').show();
 }
 
-$(function tooltips() {
+$(() => {
     $('span[data-toggle="tooltip"]').tooltip({
         animation: false,
         placement: 'top',
         trigger: 'manual',
     });
-    $('#id_last_update_question_sign').hover(function () {
+    $('#id_last_update_question_sign').hover(() => {
         $('span.last_update_tooltip').tooltip('toggle');
     });
     // Add configuration for any additional tooltips here.
@@ -91,9 +91,7 @@ function populate_messages_sent_over_time(data) {
 
     // Helper functions
     function make_traces(dates, values, type, date_formatter) {
-        const text = dates.map(function (date) {
-            return date_formatter(date);
-        });
+        const text = dates.map((date) => date_formatter(date));
         const common = { x: dates, type: type, hoverinfo: 'none', text: text };
         return {
             human: { // 5062a0
@@ -147,12 +145,12 @@ function populate_messages_sent_over_time(data) {
         {count: 6, label: i18n.t('Last 6 months'), step: 'month'});
 
     function add_hover_handler() {
-        document.getElementById('id_messages_sent_over_time').on('plotly_hover', function (data) {
+        document.getElementById('id_messages_sent_over_time').on('plotly_hover', (data) => {
             $("#hoverinfo").show();
             document.getElementById('hover_date').innerText =
                 data.points[0].data.text[data.points[0].pointNumber];
             const values = [null, null, null];
-            data.points.forEach(function (trace) {
+            data.points.forEach((trace) => {
                 values[trace.curveNumber] = trace.y;
             });
             const hover_text_ids = ['hover_me', 'hover_human', 'hover_bot'];
@@ -170,10 +168,10 @@ function populate_messages_sent_over_time(data) {
         });
     }
 
-    const start_dates = data.end_times.map(function (timestamp) {
+    const start_dates = data.end_times.map((timestamp) =>
         // data.end_times are the ends of hour long intervals.
-        return new Date(timestamp * 1000 - 60 * 60 * 1000);
-    });
+        new Date(timestamp * 1000 - 60 * 60 * 1000)
+    );
 
     function aggregate_data(aggregation) {
         let start;
@@ -240,9 +238,7 @@ function populate_messages_sent_over_time(data) {
     const last_week_is_partial = info.last_value_is_partial;
     const weekly_traces = make_traces(info.dates, info.values, 'bar', date_formatter);
 
-    const dates = data.end_times.map(function (timestamp) {
-        return new Date(timestamp * 1000);
-    });
+    const dates = data.end_times.map((timestamp) => new Date(timestamp * 1000));
     values = {human: partial_sums(data.everyone.human), bot: partial_sums(data.everyone.bot),
               me: partial_sums(data.user.human)};
     date_formatter = function (date) {
@@ -313,7 +309,7 @@ function populate_messages_sent_over_time(data) {
 }
 
 function round_to_percentages(values, total) {
-    return values.map(function (x) {
+    return values.map((x) => {
         if (x === total) {
             return '100%';
         }
@@ -349,7 +345,7 @@ function compute_summary_chart_data(time_series_data, num_steps, labels_) {
     }
     const labels = labels_.slice();
     const values = [];
-    labels.forEach(function (label) {
+    labels.forEach((label) => {
         if (data.has(label)) {
             values.push(data.get(label));
             data.delete(label);
@@ -363,7 +359,7 @@ function compute_summary_chart_data(time_series_data, num_steps, labels_) {
             values[labels.length - 1] += sum;
         }
     }
-    const total = values.reduce(function (a, b) { return a + b; }, 0);
+    const total = values.reduce((a, b) => a + b, 0);
     return {
         values: values,
         labels: labels,
@@ -393,9 +389,9 @@ function populate_messages_sent_by_client(data) {
             value: everyone_month.labels[i] === "Other" ? -1 : everyone_month.values[i],
         });
     }
-    label_values.sort(function (a, b) { return b.value - a.value; });
+    label_values.sort((a, b) => b.value - a.value);
     const labels = [];
-    label_values.forEach(function (item) { labels.push(item.label); });
+    label_values.forEach((item) => { labels.push(item.label); });
 
     function make_plot_data(time_series_data, num_steps) {
         const plot_data = compute_summary_chart_data(time_series_data, num_steps, labels);
@@ -547,7 +543,7 @@ function populate_messages_sent_by_message_type(data) {
                 rotation: -90,
                 sort: false,
                 textinfo: "text",
-                text: plot_data.labels.map(function () { return ''; }),
+                text: plot_data.labels.map(() => ''),
                 hoverinfo: "label+value",
                 pull: 0.05,
                 marker: {
@@ -649,13 +645,9 @@ function populate_number_of_users(data) {
         font: font_14pt,
     };
 
-    const end_dates = data.end_times.map(function (timestamp) {
-        return new Date(timestamp * 1000);
-    });
+    const end_dates = data.end_times.map((timestamp) => new Date(timestamp * 1000));
 
-    const text = end_dates.map(function (date) {
-        return format_date(date, false);
-    });
+    const text = end_dates.map((date) => format_date(date, false));
 
     function make_traces(values, type) {
         return {
@@ -670,12 +662,12 @@ function populate_number_of_users(data) {
     }
 
     function add_hover_handler() {
-        document.getElementById('id_number_of_users').on('plotly_hover', function (data) {
+        document.getElementById('id_number_of_users').on('plotly_hover', (data) => {
             $("#users_hover_info").show();
             document.getElementById('users_hover_date').innerText =
                 data.points[0].data.text[data.points[0].pointNumber];
             const values = [null, null, null];
-            data.points.forEach(function (trace) {
+            data.points.forEach((trace) => {
                 values[trace.curveNumber] = trace.y;
             });
             const hover_value_ids = [
@@ -733,9 +725,7 @@ function populate_messages_read_over_time(data) {
 
     // Helper functions
     function make_traces(dates, values, type, date_formatter) {
-        const text = dates.map(function (date) {
-            return date_formatter(date);
-        });
+        const text = dates.map((date) => date_formatter(date));
         const common = { x: dates, type: type, hoverinfo: 'none', text: text };
         return {
             everyone: {
@@ -785,12 +775,12 @@ function populate_messages_read_over_time(data) {
         {count: 6, label: i18n.t('Last 6 months'), step: 'month'});
 
     function add_hover_handler() {
-        document.getElementById('id_messages_read_over_time').on('plotly_hover', function (data) {
+        document.getElementById('id_messages_read_over_time').on('plotly_hover', (data) => {
             $("#read_hover_info").show();
             document.getElementById('read_hover_date').innerText =
                 data.points[0].data.text[data.points[0].pointNumber];
             const values = [null, null];
-            data.points.forEach(function (trace) {
+            data.points.forEach((trace) => {
                 values[trace.curveNumber] = trace.y;
             });
             const read_hover_text_ids = ['read_hover_me', 'read_hover_everyone'];
@@ -808,10 +798,10 @@ function populate_messages_read_over_time(data) {
         });
     }
 
-    const start_dates = data.end_times.map(function (timestamp) {
+    const start_dates = data.end_times.map((timestamp) =>
         // data.end_times are the ends of hour long intervals.
-        return new Date(timestamp * 1000 - 60 * 60 * 1000);
-    });
+        new Date(timestamp * 1000 - 60 * 60 * 1000)
+    );
 
     function aggregate_data(aggregation) {
         let start;
@@ -874,9 +864,7 @@ function populate_messages_read_over_time(data) {
     const last_week_is_partial = info.last_value_is_partial;
     const weekly_traces = make_traces(info.dates, info.values, 'bar', date_formatter);
 
-    const dates = data.end_times.map(function (timestamp) {
-        return new Date(timestamp * 1000);
-    });
+    const dates = data.end_times.map((timestamp) => new Date(timestamp * 1000));
     values = {everyone: partial_sums(data.everyone.read),
               me: partial_sums(data.user.read)};
     date_formatter = function (date) {

--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -170,7 +170,7 @@ function populate_messages_sent_over_time(data) {
 
     const start_dates = data.end_times.map((timestamp) =>
         // data.end_times are the ends of hour long intervals.
-        new Date(timestamp * 1000 - 60 * 60 * 1000)
+        new Date(timestamp * 1000 - 60 * 60 * 1000),
     );
 
     function aggregate_data(aggregation) {
@@ -322,8 +322,8 @@ function round_to_percentages(values, total) {
             6, // this is the max precision (two #, 4 decimal points; 99.9999%).
             Math.max(
                 2, // the minimum amount of precision (40% or 6.0%).
-                Math.floor(-Math.log10(100 - unrounded)) + 3
-            )
+                Math.floor(-Math.log10(100 - unrounded)) + 3,
+            ),
         );
 
         return unrounded.toPrecision(precision) + '%';
@@ -528,7 +528,7 @@ function populate_messages_sent_by_message_type(data) {
         const plot_data = compute_summary_chart_data(
             time_series_data,
             num_steps,
-            data.display_order
+            data.display_order,
         );
         const labels = [];
         for (let i = 0; i < plot_data.labels.length; i += 1) {
@@ -800,7 +800,7 @@ function populate_messages_read_over_time(data) {
 
     const start_dates = data.end_times.map((timestamp) =>
         // data.end_times are the ends of hour long intervals.
-        new Date(timestamp * 1000 - 60 * 60 * 1000)
+        new Date(timestamp * 1000 - 60 * 60 * 1000),
     );
 
     function aggregate_data(aggregation) {
@@ -949,25 +949,25 @@ function get_chart_data(data, callback) {
 
 get_chart_data(
     {chart_name: 'messages_sent_over_time', min_length: '10'},
-    populate_messages_sent_over_time
+    populate_messages_sent_over_time,
 );
 
 get_chart_data(
     {chart_name: 'messages_sent_by_client', min_length: '10'},
-    populate_messages_sent_by_client
+    populate_messages_sent_by_client,
 );
 
 get_chart_data(
     {chart_name: 'messages_sent_by_message_type', min_length: '10'},
-    populate_messages_sent_by_message_type
+    populate_messages_sent_by_message_type,
 );
 
 get_chart_data(
     {chart_name: 'number_of_humans', min_length: '10'},
-    populate_number_of_users
+    populate_number_of_users,
 );
 
 get_chart_data(
     {chart_name: 'messages_read_over_time', min_length: '10'},
-    populate_messages_read_over_time
+    populate_messages_read_over_time,
 );

--- a/static/js/stream_color.js
+++ b/static/js/stream_color.js
@@ -124,7 +124,7 @@ exports.initialize = function () {
 // already saved on the server, etc.
 //
 // This gets called on every message, so cache the results.
-exports.get_color_class = _.memoize(function (color) {
+exports.get_color_class = _.memoize((color) => {
     let match;
     let i;
     const channel = [0, 0, 0];

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -126,7 +126,7 @@ function update_announce_stream_state() {
 }
 
 function get_principals() {
-    return Array.from($("#stream_creation_form input:checkbox[name=user]:checked"), elem => {
+    return Array.from($("#stream_creation_form input:checkbox[name=user]:checked"), (elem) => {
         const label = $(elem).closest(".add-user-label");
         return parseInt(label.attr("data-user-id"), 10);
     });

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -309,8 +309,8 @@ exports.create_handlers_for_users = function (container) {
     container.on('change', '#user-checkboxes input', update_announce_stream_state);
 
     // 'Check all' and 'Uncheck all' visible users
-    container.on('click', '.subs_set_all_users', function (e) {
-        $('#user-checkboxes .checkbox').each(function (idx, li) {
+    container.on('click', '.subs_set_all_users', (e) => {
+        $('#user-checkboxes .checkbox').each((idx, li) => {
             if  (li.style.display !== "none") {
                 $(li.firstElementChild).prop('checked', true);
             }
@@ -319,8 +319,8 @@ exports.create_handlers_for_users = function (container) {
         update_announce_stream_state();
     });
 
-    container.on('click', '.subs_unset_all_users', function (e) {
-        $('#user-checkboxes .checkbox').each(function (idx, li) {
+    container.on('click', '.subs_unset_all_users', (e) => {
+        $('#user-checkboxes .checkbox').each((idx, li) => {
             if (li.style.display !== "none") {
                 // The first checkbox is the one for ourself; this is the code path for:
                 // `stream_subscription_error.cant_create_stream_without_susbscribing`
@@ -334,14 +334,14 @@ exports.create_handlers_for_users = function (container) {
         update_announce_stream_state();
     });
 
-    container.on('click', '#copy-from-stream-expand-collapse', function (e) {
+    container.on('click', '#copy-from-stream-expand-collapse', (e) => {
         $('#stream-checkboxes').toggle();
         $("#copy-from-stream-expand-collapse .toggle").toggleClass('fa-caret-right fa-caret-down');
         e.preventDefault();
     });
 
     // Search People or Streams
-    container.on('input', '.add-user-list-filter', function (e) {
+    container.on('input', '.add-user-list-filter', (e) => {
         const user_list = $(".add-user-list-filter");
         if (user_list === 0) {
             return;
@@ -386,7 +386,7 @@ exports.set_up_handlers = function () {
 
     container.on('change', '#make-invite-only input', update_announce_stream_state);
 
-    container.on("submit", "#stream_creation_form", function (e) {
+    container.on("submit", "#stream_creation_form", (e) => {
         e.preventDefault();
         clear_error_display();
 
@@ -418,23 +418,23 @@ exports.set_up_handlers = function () {
         }
     });
 
-    container.on("click", ".close-invites-warning-modal", function () {
+    container.on("click", ".close-invites-warning-modal", () => {
         $("#invites-warning-overlay").remove();
     });
 
-    container.on("click", ".confirm-invites-warning-modal", function () {
+    container.on("click", ".confirm-invites-warning-modal", () => {
         create_stream();
         $("#invites-warning-overlay").remove();
     });
 
-    container.on("input", "#create_stream_name", function () {
+    container.on("input", "#create_stream_name", () => {
         const stream_name = $.trim($("#create_stream_name").val());
 
         // This is an inexpensive check.
         stream_name_error.pre_validate(stream_name);
     });
 
-    container.on("mouseover", "#announce-stream-docs", function (e) {
+    container.on("mouseover", "#announce-stream-docs", (e) => {
         const announce_stream_docs = $("#announce-stream-docs");
         announce_stream_docs.popover({
             placement: "right",
@@ -448,14 +448,14 @@ exports.set_up_handlers = function () {
         announce_stream_docs.data('popover').tip().find('.popover-content').css('margin', '9px 14px');
         e.stopPropagation();
     });
-    container.on("mouseout", "#announce-stream-docs", function (e) {
+    container.on("mouseout", "#announce-stream-docs", (e) => {
         $("#announce-stream-docs").popover('hide');
         e.stopPropagation();
     });
 
     // Do not allow the user to enter newline characters while typing out the
     // stream's description during it's creation.
-    container.on("keydown", "#create_stream_description", function (e) {
+    container.on("keydown", "#create_stream_description", (e) => {
         if ((e.keyCode || e.which) === 13) {
             e.preventDefault();
         }

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -167,7 +167,7 @@ exports.is_subscriber_subset = function (sub1, sub2) {
     if (sub1.subscribers && sub2.subscribers) {
         const sub2_set = sub2.subscribers;
 
-        return Array.from(sub1.subscribers.keys()).every(key => sub2_set.has(key));
+        return Array.from(sub1.subscribers.keys()).every((key) => sub2_set.has(key));
     }
 
     return false;
@@ -287,9 +287,10 @@ exports.delete_sub = function (stream_id) {
 exports.get_non_default_stream_names = function () {
     let subs = Array.from(stream_info.values());
     subs = subs.filter(
-        sub => !exports.is_default_stream_id(sub.stream_id) && (sub.subscribed || !sub.invite_only)
+        (sub) =>
+            !exports.is_default_stream_id(sub.stream_id) && (sub.subscribed || !sub.invite_only)
     );
-    const names = subs.map(sub => sub.name);
+    const names = subs.map((sub) => sub.name);
     return names;
 };
 
@@ -310,7 +311,7 @@ exports.get_updated_unsorted_subs = function () {
 
     // We don't display unsubscribed streams to guest users.
     if (page_params.is_guest) {
-        all_subs = all_subs.filter(sub => sub.subscribed);
+        all_subs = all_subs.filter((sub) => sub.subscribed);
     }
 
     return all_subs;
@@ -329,7 +330,7 @@ exports.unsubscribed_subs = function () {
 };
 
 exports.subscribed_streams = function () {
-    return exports.subscribed_subs().map(sub => sub.name);
+    return exports.subscribed_subs().map((sub) => sub.name);
 };
 
 exports.get_invite_stream_data = function () {
@@ -361,7 +362,7 @@ exports.get_invite_stream_data = function () {
 };
 
 exports.get_colors = function () {
-    return exports.subscribed_subs().map(sub => sub.color);
+    return exports.subscribed_subs().map((sub) => sub.color);
 };
 
 exports.update_subscribers_count = function (sub) {
@@ -478,12 +479,12 @@ exports.update_calculated_fields = function (sub) {
 };
 
 exports.all_subscribed_streams_are_in_home_view = function () {
-    return exports.subscribed_subs().every(sub => !sub.is_muted);
+    return exports.subscribed_subs().every((sub) => !sub.is_muted);
 };
 
 exports.home_view_stream_names = function () {
-    const home_view_subs = exports.subscribed_subs().filter(sub => !sub.is_muted);
-    return home_view_subs.map(sub => sub.name);
+    const home_view_subs = exports.subscribed_subs().filter((sub) => !sub.is_muted);
+    return home_view_subs.map((sub) => sub.name);
 };
 
 exports.canonicalized_name = function (stream_name) {

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -286,7 +286,7 @@ exports.get_non_default_stream_names = function () {
     let subs = Array.from(stream_info.values());
     subs = subs.filter(
         (sub) =>
-            !exports.is_default_stream_id(sub.stream_id) && (sub.subscribed || !sub.invite_only)
+            !exports.is_default_stream_id(sub.stream_id) && (sub.subscribed || !sub.invite_only),
     );
     const names = subs.map((sub) => sub.name);
     return names;

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -106,9 +106,7 @@ exports.stream_post_policy_values = {
 };
 
 exports.clear_subscriptions = function () {
-    stream_info = new BinaryDict(function (sub) {
-        return sub.subscribed;
-    });
+    stream_info = new BinaryDict((sub) => sub.subscribed);
     subs_by_stream_id = new Map();
 };
 
@@ -583,7 +581,7 @@ exports.all_topics_in_cache = function (sub) {
 exports.set_realm_default_streams = function (realm_default_streams) {
     default_stream_ids.clear();
 
-    realm_default_streams.forEach(function (stream) {
+    realm_default_streams.forEach((stream) => {
         default_stream_ids.add(stream.stream_id);
     });
 };
@@ -917,7 +915,7 @@ exports.initialize = function (params) {
     color_data.claim_colors(subscriptions);
 
     function populate_subscriptions(subs, subscribed, previously_subscribed) {
-        subs.forEach(function (sub) {
+        subs.forEach((sub) => {
             sub.subscribed = subscribed;
             sub.previously_subscribed = previously_subscribed;
 

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -175,7 +175,7 @@ exports.update_stream_description = function (sub) {
     const stream_settings = exports.settings_for_sub(sub);
     stream_settings.find('input.description').val(sub.description);
     stream_settings.find('.stream-description-editable').html(
-        util.clean_user_content_links(sub.rendered_description)
+        util.clean_user_content_links(sub.rendered_description),
     );
 };
 
@@ -569,7 +569,7 @@ exports.change_stream_description = function (e) {
         },
         error: function (xhr) {
             sub_settings.find('.stream-description-editable').html(
-                util.clean_user_content_links(sub.rendered_description)
+                util.clean_user_content_links(sub.rendered_description),
             );
             ui_report.error(i18n.t("Error"), xhr, $(".stream_change_property_info"));
         },

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -49,9 +49,7 @@ exports.is_sub_settings_active = function (sub) {
 };
 
 exports.get_users_from_subscribers = function (subscribers) {
-    return subscribers.map(function (user_id) {
-        return people.get_by_user_id(user_id);
-    });
+    return subscribers.map((user_id) => people.get_by_user_id(user_id));
 };
 
 exports.get_retention_policy_text_for_subscription_type = function (sub) {
@@ -326,7 +324,7 @@ function show_subscription_settings(sub_row) {
 
     user_pill.set_up_typeahead_on_pills(sub_settings.find('.input'),
                                         exports.pill_widget,
-                                        function () {},
+                                        () => {},
                                         get_users_for_subscriber_typeahead);
 }
 
@@ -591,7 +589,7 @@ exports.delete_stream = function (stream_id, alert_element, stream_row) {
 };
 
 exports.initialize = function () {
-    $("#main_div").on("click", ".stream_sub_unsub_button", function (e) {
+    $("#main_div").on("click", ".stream_sub_unsub_button", (e) => {
         e.preventDefault();
         e.stopPropagation();
 
@@ -603,7 +601,7 @@ exports.initialize = function () {
         subs.sub_or_unsub(sub);
     });
 
-    $("#subscriptions_table").on("click", ".change-stream-privacy", function (e) {
+    $("#subscriptions_table").on("click", ".change-stream-privacy", (e) => {
         const stream_id = get_stream_id(e.target);
         const stream = stream_data.get_sub_by_id(stream_id);
         const template_data = {
@@ -638,7 +636,7 @@ exports.initialize = function () {
     $("#subscriptions_table").on('click', '#change-stream-privacy-button',
                                  change_stream_privacy);
 
-    $("#subscriptions_table").on('click', '.close-privacy-modal', function (e) {
+    $("#subscriptions_table").on('click', '.close-privacy-modal', (e) => {
         // Re-enable background mouse events when we close the modal
         // via the "x" in the corner.  (The other modal-close code
         // paths call `overlays.close_modal`, rather than using
@@ -661,19 +659,19 @@ exports.initialize = function () {
     $("#subscriptions_table").on("click", ".sub_setting_checkbox",
                                  exports.stream_setting_clicked);
 
-    $("#subscriptions_table").on("keyup", ".subscriber_list_add form", function (e) {
+    $("#subscriptions_table").on("keyup", ".subscriber_list_add form", (e) => {
         if (e.which === 13) {
             e.preventDefault();
             submit_add_subscriber_form(e);
         }
     });
 
-    $("#subscriptions_table").on("submit", ".subscriber_list_add form", function (e) {
+    $("#subscriptions_table").on("submit", ".subscriber_list_add form", (e) => {
         e.preventDefault();
         submit_add_subscriber_form(e);
     });
 
-    $("#subscriptions_table").on("submit", ".subscriber_list_remove form", function (e) {
+    $("#subscriptions_table").on("submit", ".subscriber_list_remove form", (e) => {
         e.preventDefault();
 
         const list_entry = $(e.target).closest("tr");
@@ -711,7 +709,7 @@ exports.initialize = function () {
 
     // This handler isn't part of the normal edit interface; it's the convenient
     // checkmark in the subscriber list.
-    $("#subscriptions_table").on("click", ".sub_unsub_button", function (e) {
+    $("#subscriptions_table").on("click", ".sub_unsub_button", (e) => {
         const sub = get_sub_for_target(e.target);
         // Makes sure we take the correct stream_row.
         const stream_row = $("#subscriptions_table div.stream-row[data-stream-id='" + sub.stream_id + "']");
@@ -726,7 +724,7 @@ exports.initialize = function () {
         e.stopPropagation();
     });
 
-    $("#subscriptions_table").on("click", ".deactivate", function (e) {
+    $("#subscriptions_table").on("click", ".deactivate", (e) => {
         e.preventDefault();
         e.stopPropagation();
 
@@ -745,7 +743,7 @@ exports.initialize = function () {
         overlays.open_modal('#deactivation_stream_modal');
     });
 
-    $("#subscriptions_table").on("click", "#do_deactivate_stream_button", function (e) {
+    $("#subscriptions_table").on("click", "#do_deactivate_stream_button", (e) => {
         const stream_id = $(e.target).data("stream-id");
         overlays.close_modal('#deactivation_stream_modal');
         $("#deactivation_stream_modal").remove();
@@ -757,7 +755,7 @@ exports.initialize = function () {
         exports.delete_stream(stream_id, $(".stream_change_property_info"), row);
     });
 
-    $("#subscriptions_table").on("hide.bs.modal", "#deactivation_stream_modal", function () {
+    $("#subscriptions_table").on("hide.bs.modal", "#deactivation_stream_modal", () => {
         $("#deactivation_stream_modal").remove();
     });
 
@@ -767,7 +765,7 @@ exports.initialize = function () {
         }
     });
 
-    $("#subscriptions_table").on("change", ".stream_message_retention_setting", function (e) {
+    $("#subscriptions_table").on("change", ".stream_message_retention_setting", (e) => {
         const dropdown_value = e.target.value;
         change_stream_message_retention_days_block_display_property(dropdown_value);
     });

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -479,7 +479,7 @@ exports.initialize = function () {
 };
 
 exports.set_event_handlers = function () {
-    $('#stream_filters').on('click', 'li .subscription_block', function (e) {
+    $('#stream_filters').on('click', 'li .subscription_block', (e) => {
         if (e.metaKey || e.ctrlKey) {
             return;
         }
@@ -496,7 +496,7 @@ exports.set_event_handlers = function () {
 
     $('#clear_search_stream_button').on('click', exports.clear_search);
 
-    $("#streams_header").expectOne().click(function (e) {
+    $("#streams_header").expectOne().click((e) => {
         exports.toggle_filter_displayed(e);
     });
 

--- a/static/js/stream_muting.js
+++ b/static/js/stream_muting.js
@@ -1,7 +1,7 @@
 exports.update_is_muted = function (sub, value) {
     sub.is_muted = value;
 
-    setTimeout(function () {
+    setTimeout(() => {
         let msg_offset;
         let saved_ypos;
         // Save our current scroll position

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -273,7 +273,7 @@ function build_move_topic_to_stream_popover(e, current_stream_id, topic_name) {
     // likely will make it possible to move messages to/from private
     // streams in the future.
     const available_streams = stream_data.subscribed_subs()
-        .filter(s => s.stream_id !== current_stream_id);
+        .filter((s) => s.stream_id !== current_stream_id);
     const current_stream_name = stream_data.maybe_get_stream_name(current_stream_id);
     const args = {
         available_streams, topic_name, current_stream_id, current_stream_name,

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -154,7 +154,7 @@ function build_stream_popover(opts) {
     $(elt).popover("show");
     const popover = $('.streams_popover[data-stream-id=' + stream_id + ']');
 
-    update_spectrum(popover, function (colorpicker) {
+    update_spectrum(popover, (colorpicker) => {
         colorpicker.spectrum(stream_color.sidebar_popover_colorpicker_options);
     });
 
@@ -297,7 +297,7 @@ function build_move_topic_to_stream_popover(e, current_stream_id, topic_name) {
 }
 
 exports.register_click_handlers = function () {
-    $('#stream_filters').on('click', '.stream-sidebar-menu-icon', function (e) {
+    $('#stream_filters').on('click', '.stream-sidebar-menu-icon', (e) => {
         e.stopPropagation();
 
         const elt = e.target;
@@ -310,7 +310,7 @@ exports.register_click_handlers = function () {
         });
     });
 
-    $('#stream_filters').on('click', '.topic-sidebar-menu-icon', function (e) {
+    $('#stream_filters').on('click', '.topic-sidebar-menu-icon', (e) => {
         e.stopPropagation();
 
         const elt = $(e.target).closest('.topic-sidebar-menu-icon').expectOne()[0];
@@ -335,7 +335,7 @@ exports.register_click_handlers = function () {
 
 exports.register_stream_handlers = function () {
     // Stream settings
-    $('body').on('click', '.open_stream_settings', function (e) {
+    $('body').on('click', '.open_stream_settings', (e) => {
         const sub = stream_popover_sub(e);
         exports.hide_stream_popover();
 
@@ -344,7 +344,7 @@ exports.register_stream_handlers = function () {
     });
 
     // Pin/unpin
-    $('body').on('click', '.pin_to_top', function (e) {
+    $('body').on('click', '.pin_to_top', (e) => {
         const sub = stream_popover_sub(e);
         exports.hide_stream_popover();
         subs.toggle_pin_to_top_stream(sub);
@@ -352,7 +352,7 @@ exports.register_stream_handlers = function () {
     });
 
     // Mark all messages in stream as read
-    $('body').on('click', '.mark_stream_as_read', function (e) {
+    $('body').on('click', '.mark_stream_as_read', (e) => {
         const sub = stream_popover_sub(e);
         exports.hide_stream_popover();
         unread_ops.mark_stream_as_read(sub.stream_id);
@@ -360,14 +360,14 @@ exports.register_stream_handlers = function () {
     });
 
     // Mark all messages as read
-    $('body').on('click', '#mark_all_messages_as_read', function (e) {
+    $('body').on('click', '#mark_all_messages_as_read', (e) => {
         exports.hide_all_messages_popover();
         unread_ops.mark_all_as_read();
         e.stopPropagation();
     });
 
     // Unstar all messages
-    $('body').on('click', '#unstar_all_messages', function (e) {
+    $('body').on('click', '#unstar_all_messages', (e) => {
         exports.hide_starred_messages_popover();
         e.preventDefault();
         e.stopPropagation();
@@ -376,14 +376,14 @@ exports.register_stream_handlers = function () {
         $("#unstar-messages-modal").modal("show");
     });
 
-    $('body').on('click', '#do_unstar_messages_button', function (e) {
+    $('body').on('click', '#do_unstar_messages_button', (e) => {
         $("#unstar-messages-modal").modal("hide");
         message_flags.unstar_all_messages();
         e.stopPropagation();
     });
 
     // Toggle displaying starred message count
-    $('body').on('click', '#toggle_display_starred_msg_count', function (e) {
+    $('body').on('click', '#toggle_display_starred_msg_count', (e) => {
         exports.hide_starred_messages_popover();
         e.preventDefault();
         e.stopPropagation();
@@ -396,7 +396,7 @@ exports.register_stream_handlers = function () {
         });
     });
     // Mute/unmute
-    $('body').on('click', '.toggle_home', function (e) {
+    $('body').on('click', '.toggle_home', (e) => {
         const sub = stream_popover_sub(e);
         exports.hide_stream_popover();
         subs.toggle_home(sub);
@@ -415,8 +415,8 @@ exports.register_stream_handlers = function () {
     });
 
     // Choose a different color.
-    $('body').on('click', '.choose_stream_color', function (e) {
-        update_spectrum($(e.target).closest('.streams_popover'), function (colorpicker) {
+    $('body').on('click', '.choose_stream_color', (e) => {
+        update_spectrum($(e.target).closest('.streams_popover'), (colorpicker) => {
             $('.colorpicker-container').show();
             colorpicker.spectrum("destroy");
             colorpicker.spectrum(stream_color.sidebar_popover_colorpicker_options_full);
@@ -429,7 +429,7 @@ exports.register_stream_handlers = function () {
             $(e.target).hide();
         });
 
-        $('.streams_popover').on('click', 'a.sp-cancel', function () {
+        $('.streams_popover').on('click', 'a.sp-cancel', () => {
             exports.hide_stream_popover();
         });
     });
@@ -453,7 +453,7 @@ function topic_popover_sub(e) {
 
 exports.register_topic_handlers = function () {
     // Narrow to topic
-    $('body').on('click', '.narrow_to_topic', function (e) {
+    $('body').on('click', '.narrow_to_topic', (e) => {
         exports.hide_topic_popover();
 
         const sub = topic_popover_sub(e);
@@ -473,7 +473,7 @@ exports.register_topic_handlers = function () {
     });
 
     // Mute the topic
-    $('body').on('click', '.sidebar-popover-mute-topic', function (e) {
+    $('body').on('click', '.sidebar-popover-mute-topic', (e) => {
         const stream_id = topic_popover_stream_id(e);
         if (!stream_id) {
             return;
@@ -486,7 +486,7 @@ exports.register_topic_handlers = function () {
     });
 
     // Unmute the topic
-    $('body').on('click', '.sidebar-popover-unmute-topic', function (e) {
+    $('body').on('click', '.sidebar-popover-unmute-topic', (e) => {
         const stream_id = topic_popover_stream_id(e);
         if (!stream_id) {
             return;
@@ -499,7 +499,7 @@ exports.register_topic_handlers = function () {
     });
 
     // Mark all messages as read
-    $('body').on('click', '.sidebar-popover-mark-topic-read', function (e) {
+    $('body').on('click', '.sidebar-popover-mark-topic-read', (e) => {
         const stream_id = topic_popover_stream_id(e);
         if (!stream_id) {
             return;
@@ -512,7 +512,7 @@ exports.register_topic_handlers = function () {
     });
 
     // Deleting all message in a topic
-    $('body').on('click', '.sidebar-popover-delete-topic-messages', function (e) {
+    $('body').on('click', '.sidebar-popover-delete-topic-messages', (e) => {
         const stream_id = topic_popover_stream_id(e);
         if (!stream_id) {
             return;
@@ -527,7 +527,7 @@ exports.register_topic_handlers = function () {
 
         $('#delete-topic-modal-holder').html(render_delete_topic_modal(args));
 
-        $('#do_delete_topic_button').on('click', function () {
+        $('#do_delete_topic_button').on('click', () => {
             message_edit.delete_topic(stream_id, topic);
         });
 
@@ -536,7 +536,7 @@ exports.register_topic_handlers = function () {
         e.stopPropagation();
     });
 
-    $('body').on('click', '.sidebar-popover-move-topic-messages', function (e) {
+    $('body').on('click', '.sidebar-popover-move-topic-messages', (e) => {
         const topic_row = $(e.currentTarget);
         const stream_id = parseInt(topic_row.attr('data-stream-id'), 10);
         const topic_name = topic_row.attr('data-topic-name');
@@ -545,17 +545,17 @@ exports.register_topic_handlers = function () {
         e.preventDefault();
     });
 
-    $('body').on('click', '#topic_stream_edit_form_error .send-status-close', function () {
+    $('body').on('click', '#topic_stream_edit_form_error .send-status-close', () => {
         $("#topic_stream_edit_form_error").hide();
     });
 
-    $('body').on('click', '#do_move_topic_button', function (e) {
+    $('body').on('click', '#do_move_topic_button', (e) => {
         function show_error_msg(msg) {
             $("#topic_stream_edit_form_error .error-msg").text(msg);
             $("#topic_stream_edit_form_error").show();
         }
 
-        const params = $('#move_topic_form').serializeArray().reduce(function (obj, item) {
+        const params = $('#move_topic_form').serializeArray().reduce((obj, item) => {
             obj[item.name] = item.value;
             return obj;
         }, {});

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -594,7 +594,7 @@ exports.register_topic_handlers = function () {
             num_after: 0,
             narrow: JSON.stringify(
                 [{operator: "stream", operand: current_stream_id},
-                 {operator: "topic", operand: old_topic_name}]
+                 {operator: "topic", operand: old_topic_name}],
             ),
         };
 

--- a/static/js/stream_sort.js
+++ b/static/js/stream_sort.js
@@ -16,13 +16,13 @@ function filter_streams_by_search(streams, search_term) {
     }
 
     let search_terms = search_term.toLowerCase().split(",");
-    search_terms = search_terms.map(s => s.trim());
+    search_terms = search_terms.map((s) => s.trim());
 
-    const filtered_streams = streams.filter(stream => search_terms.some(search_term => {
+    const filtered_streams = streams.filter((stream) => search_terms.some((search_term) => {
         const lower_stream_name = stream.toLowerCase();
         const cands = lower_stream_name.split(" ");
         cands.push(lower_stream_name);
-        return cands.some(name => name.startsWith(search_term));
+        return cands.some((name) => name.startsWith(search_term));
     }));
 
     return filtered_streams;

--- a/static/js/stream_topic_history.js
+++ b/static/js/stream_topic_history.js
@@ -184,7 +184,7 @@ exports.per_stream_history = function (stream_id) {
             return b.message_id - a.message_id;
         });
 
-        const names = recents.map(obj => obj.pretty_name);
+        const names = recents.map((obj) => obj.pretty_name);
 
         return names;
     };

--- a/static/js/stream_topic_history.js
+++ b/static/js/stream_topic_history.js
@@ -180,9 +180,7 @@ exports.per_stream_history = function (stream_id) {
 
         const recents = my_recents.concat(missing_topics);
 
-        recents.sort(function (a, b) {
-            return b.message_id - a.message_id;
-        });
+        recents.sort((a, b) => b.message_id - a.message_id);
 
         const names = recents.map((obj) => obj.pretty_name);
 

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -31,12 +31,12 @@ exports.initialize_disable_btn_hint_popover = function (btn_wrapper, popover_btn
         animation: false,
     });
 
-    btn_wrapper.on('mouseover', function (e) {
+    btn_wrapper.on('mouseover', (e) => {
         popover_btn.popover('show');
         e.stopPropagation();
     });
 
-    btn_wrapper.on('mouseout', function (e) {
+    btn_wrapper.on('mouseout', (e) => {
         popover_btn.popover('hide');
         e.stopPropagation();
     });

--- a/static/js/submessage.js
+++ b/static/js/submessage.js
@@ -11,9 +11,7 @@ exports.get_message_events = function (message) {
         return;
     }
 
-    message.submessages.sort(function (m1, m2) {
-        return parseInt(m1.id, 10) - parseInt(m2.id, 10);
-    });
+    message.submessages.sort((m1, m2) => parseInt(m1.id, 10) - parseInt(m2.id, 10));
 
     const events = message.submessages.map((obj) => ({
         sender_id: obj.sender_id,

--- a/static/js/submessage.js
+++ b/static/js/submessage.js
@@ -15,7 +15,7 @@ exports.get_message_events = function (message) {
         return parseInt(m1.id, 10) - parseInt(m2.id, 10);
     });
 
-    const events = message.submessages.map(obj => ({
+    const events = message.submessages.map((obj) => ({
         sender_id: obj.sender_id,
         data: JSON.parse(obj.content),
     }));
@@ -90,7 +90,7 @@ exports.update_message = function (submsg) {
         message.submessages = [];
     }
 
-    const existing = message.submessages.find(sm => sm.id === submsg.id);
+    const existing = message.submessages.find((sm) => sm.id === submsg.id);
 
     if (existing !== undefined) {
         blueslip.warn("Got submessage multiple times: " + submsg.id);

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -606,12 +606,12 @@ exports.setup_page = function (callback) {
         exports.actually_filter_streams();
         stream_create.set_up_handlers();
 
-        $("#stream_filter input[type='text']").on("input", function () {
+        $("#stream_filter input[type='text']").on("input", () => {
             // Debounce filtering in case a user is typing quickly
             filter_streams();
         });
 
-        $("#clear_search_stream_name").on("click", function () {
+        $("#clear_search_stream_name").on("click", () => {
             $("#stream_filter input[type='text']").val("");
             filter_streams();
         });
@@ -637,7 +637,7 @@ exports.switch_to_stream_row = function (stream_id) {
     scroll_util.scroll_element_into_container(stream_row, stream_row.parent());
 
     // It's dubious that we need this timeout any more.
-    setTimeout(function () {
+    setTimeout(() => {
         if (stream_id === exports.get_active_data().id) {
             stream_row.click();
         }
@@ -684,7 +684,7 @@ exports.change_state = function (section) {
 };
 
 exports.launch = function (section) {
-    exports.setup_page(function () {
+    exports.setup_page(() => {
         overlays.open_overlay({
             name: 'subscriptions',
             overlay: $("#subscription_overlay"),
@@ -889,12 +889,12 @@ exports.sub_or_unsub = function (sub, stream_row) {
 
 
 exports.initialize = function () {
-    $("#subscriptions_table").on("click", ".create_stream_button", function (e) {
+    $("#subscriptions_table").on("click", ".create_stream_button", (e) => {
         e.preventDefault();
         exports.open_create_stream();
     });
 
-    $(".subscriptions").on("click", "[data-dismiss]", function (e) {
+    $(".subscriptions").on("click", "[data-dismiss]", (e) => {
         e.preventDefault();
         // we want to make sure that the click is not just a simulated
         // click; this fixes an issue where hitting "enter" would
@@ -904,9 +904,9 @@ exports.initialize = function () {
         }
     });
 
-    $("body").on("mouseover", ".subscribed-button", function (e) {
+    $("body").on("mouseover", ".subscribed-button", (e) => {
         $(e.target).addClass("btn-danger").text(i18n.t("Unsubscribe"));
-    }).on("mouseout", ".subscribed-button", function (e) {
+    }).on("mouseout", ".subscribed-button", (e) => {
         $(e.target).removeClass("btn-danger").text(i18n.t("Subscribed"));
     });
 
@@ -914,12 +914,12 @@ exports.initialize = function () {
         selectText(this);
     });
 
-    $("#subscriptions_table").on("click", ".stream-row, .create_stream_button", function () {
+    $("#subscriptions_table").on("click", ".stream-row, .create_stream_button", () => {
         $(".right").addClass("show");
         $(".subscriptions-header").addClass("slide-left");
     });
 
-    $("#subscriptions_table").on("click", ".fa-chevron-left", function () {
+    $("#subscriptions_table").on("click", ".fa-chevron-left", () => {
         $(".right").removeClass("show");
         $(".subscriptions-header").removeClass("slide-left");
     });
@@ -927,7 +927,7 @@ exports.initialize = function () {
     (function defocus_sub_settings() {
         const sel = ".search-container, .streams-list, .subscriptions-header";
 
-        $("#subscriptions_table").on("click", sel, function (e) {
+        $("#subscriptions_table").on("click", sel, (e) => {
             if ($(e.target).is(sel)) {
                 stream_edit.open_edit_panel_empty();
             }

--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -70,13 +70,13 @@ function append_and_display_title_area(tab_bar_data) {
 }
 
 function bind_title_area_handlers() {
-    $(".search_closed").on("click", function (e) {
+    $(".search_closed").on("click", (e) => {
         search.initiate_search();
         e.preventDefault();
         e.stopPropagation();
     });
 
-    $("#tab_list span:nth-last-child(2)").on("click", function (e) {
+    $("#tab_list span:nth-last-child(2)").on("click", (e) => {
         if (document.getSelection().type === "Range") {
             // Allow copy/paste to work normally without interference.
             return;
@@ -95,13 +95,13 @@ function bind_title_area_handlers() {
 
     // make sure that hover plays nicely with whether search is being
     // opened or not.
-    $(".narrow_description > a").hover(function () {
+    $(".narrow_description > a").hover(() => {
         if (night_mode_color) {
             $(".search_closed").css("color", night_mode_color);
         } else {
             $(".search_closed").css("color", color);
         }
-    }, function () {
+    }, () => {
         $(".search_closed").css("color", "");
     });
 }
@@ -150,7 +150,7 @@ exports.initialize = function () {
     exports.render_title_area();
 
     // register searchbar click handler
-    $('#search_exit').on("click", function (e) {
+    $('#search_exit').on("click", (e) => {
         tab_bar.exit_search();
         e.preventDefault();
         e.stopPropagation();

--- a/static/js/templates.js
+++ b/static/js/templates.js
@@ -89,7 +89,7 @@ Handlebars.registerHelper('tr', (context, options) => {
 
 Handlebars.registerHelper(
     "rendered_markdown",
-    (content) => new Handlebars.SafeString(util.clean_user_content_links(content))
+    (content) => new Handlebars.SafeString(util.clean_user_content_links(content)),
 );
 
 window.templates = exports;

--- a/static/js/templates.js
+++ b/static/js/templates.js
@@ -85,13 +85,13 @@ Handlebars.registerHelper('tr', function (context, options) {
     //     1. `context` is very important. It can be `this` or an
     //        object or key of the current context.
     //     2. Use `__` instead of `{{` and `}}` to declare expressions
-    const result = i18n.t(options.fn(context).trim().split("\n").map(s => s.trim()).join(" "), context);
+    const result = i18n.t(options.fn(context).trim().split("\n").map((s) => s.trim()).join(" "), context);
     return new Handlebars.SafeString(result);
 });
 
 Handlebars.registerHelper(
     "rendered_markdown",
-    content => new Handlebars.SafeString(util.clean_user_content_links(content))
+    (content) => new Handlebars.SafeString(util.clean_user_content_links(content))
 );
 
 window.templates = exports;

--- a/static/js/templates.js
+++ b/static/js/templates.js
@@ -12,9 +12,7 @@ const util = require("./util");
 // Furthermore, waiting for DOM ready would introduce race conditions with
 // other DOM-ready callbacks that attempt to render templates.
 
-Handlebars.registerHelper('plural', function (condition, one, other) {
-    return condition === 1 ? one : other;
-});
+Handlebars.registerHelper('plural', (condition, one, other) => condition === 1 ? one : other);
 
 Handlebars.registerHelper({
     eq: function (a, b) { return a === b; },
@@ -54,7 +52,7 @@ Handlebars.registerHelper({
 // Jinja2 templating engine, so we don't consider this important.
 const t_cache = new Map();
 
-Handlebars.registerHelper('t', function (i18n_key) {
+Handlebars.registerHelper('t', (i18n_key) => {
     // Marks a string for translation.
     // Example usage:
     //     {{t "some English text"}}
@@ -69,7 +67,7 @@ Handlebars.registerHelper('t', function (i18n_key) {
     return safe_result;
 });
 
-Handlebars.registerHelper('tr', function (context, options) {
+Handlebars.registerHelper('tr', (context, options) => {
     // Marks a block for translation.
     // Example usage 1:
     //     {{#tr context}}

--- a/static/js/tictactoe_widget.js
+++ b/static/js/tictactoe_widget.js
@@ -128,7 +128,7 @@ exports.activate = function (opts) {
         const html = render_widgets_tictactoe_widget(widget_data);
         elem.html(html);
 
-        elem.find("button.tictactoe-square").on('click', function (e) {
+        elem.find("button.tictactoe-square").on('click', (e) => {
             e.stopPropagation();
             const str_idx = $(e.target).attr('data-idx');
             const idx = parseInt(str_idx, 10);

--- a/static/js/todo_widget.js
+++ b/static/js/todo_widget.js
@@ -133,7 +133,7 @@ exports.activate = function (opts) {
         const html = render_widgets_todo_widget();
         elem.html(html);
 
-        elem.find("button.add-task").on('click', function (e) {
+        elem.find("button.add-task").on('click', (e) => {
             e.stopPropagation();
             elem.find(".widget-error").text('');
             const task = elem.find("input.add-task").val().trim();
@@ -163,7 +163,7 @@ exports.activate = function (opts) {
         elem.find('ul.todo-widget').html(html);
         elem.find(".widget-error").text('');
 
-        elem.find("button.task").on('click', function (e) {
+        elem.find("button.task").on('click', (e) => {
             e.stopPropagation();
             const key = $(e.target).attr('data-key');
 

--- a/static/js/topic_generator.js
+++ b/static/js/topic_generator.js
@@ -222,7 +222,7 @@ exports.get_next_topic = function (curr_stream, curr_topic) {
         get_unmuted_topics,
         has_unread_messages,
         curr_stream,
-        curr_topic
+        curr_topic,
     );
 };
 

--- a/static/js/topic_generator.js
+++ b/static/js/topic_generator.js
@@ -193,7 +193,7 @@ exports.next_topic = function (streams, get_topics, has_unread_messages, curr_st
 exports.get_next_topic = function (curr_stream, curr_topic) {
     let my_streams = stream_sort.get_streams();
 
-    my_streams = my_streams.filter(stream_name => {
+    my_streams = my_streams.filter((stream_name) => {
         if (!stream_data.is_stream_muted_by_name(stream_name)) {
             return true;
         }
@@ -208,7 +208,7 @@ exports.get_next_topic = function (curr_stream, curr_topic) {
     function get_unmuted_topics(stream_name) {
         const stream_id = stream_data.get_stream_id(stream_name);
         let topics = stream_topic_history.get_recent_topic_names(stream_id);
-        topics = topics.filter(topic => !muting.is_topic_muted(stream_id, topic));
+        topics = topics.filter((topic) => !muting.is_topic_muted(stream_id, topic));
         return topics;
     }
 

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -55,13 +55,9 @@ exports.zoom_out = function () {
 };
 
 exports.keyed_topic_li = (convo) => {
-    const render = () => {
-        return render_topic_list_item(convo);
-    };
+    const render = () => render_topic_list_item(convo);
 
-    const eq = (other) => {
-        return _.isEqual(convo, other.convo);
-    };
+    const eq = (other) => _.isEqual(convo, other.convo);
 
     const key = 't:' + convo.topic_name;
 
@@ -74,16 +70,12 @@ exports.keyed_topic_li = (convo) => {
 };
 
 exports.more_li = (more_topics_unreads) => {
-    const render = () => {
-        return render_more_topics({
-            more_topics_unreads: more_topics_unreads,
-        });
-    };
+    const render = () => render_more_topics({
+        more_topics_unreads: more_topics_unreads,
+    });
 
-    const eq = (other) => {
-        return other.more_items &&
+    const eq = (other) => other.more_items &&
             more_topics_unreads === other.more_topics_unreads;
-    };
 
     const key = 'more';
 
@@ -97,13 +89,9 @@ exports.more_li = (more_topics_unreads) => {
 };
 
 exports.spinner_li = () => {
-    const render = () => {
-        return render_more_topics_spinner();
-    };
+    const render = () => render_more_topics_spinner();
 
-    const eq = (other) => {
-        return other.spinner;
-    };
+    const eq = (other) => other.spinner;
 
     const key = 'more';
 

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -248,7 +248,7 @@ exports.zoom_in = function () {
 };
 
 exports.initialize = function () {
-    $('#stream_filters').on('click', '.topic-box', function (e) {
+    $('#stream_filters').on('click', '.topic-box', (e) => {
         if (e.metaKey || e.ctrlKey) {
             return;
         }

--- a/static/js/topic_zoom.js
+++ b/static/js/topic_zoom.js
@@ -47,14 +47,14 @@ exports.clear_topics = function () {
 };
 
 exports.initialize = function () {
-    $('#stream_filters').on('click', '.show-more-topics', function (e) {
+    $('#stream_filters').on('click', '.show-more-topics', (e) => {
         zoom_in();
 
         e.preventDefault();
         e.stopPropagation();
     });
 
-    $('.show-all-streams').on('click', function (e) {
+    $('.show-all-streams').on('click', (e) => {
         exports.zoom_out();
 
         e.preventDefault();

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -240,31 +240,25 @@ exports.sort_people_for_relevance = function (objs, current_stream_name, current
         current_stream = stream_data.get_sub(current_stream_name);
     }
     if (!current_stream) {
-        objs.sort(function (person_a, person_b) {
-            return exports.compare_people_for_relevance(
-                person_a,
-                person_b,
-                exports.compare_by_pms
-            );
-        });
+        objs.sort((person_a, person_b) => exports.compare_people_for_relevance(
+            person_a,
+            person_b,
+            exports.compare_by_pms
+        ));
     } else {
         const stream_id = current_stream.stream_id;
 
-        objs.sort(function (person_a, person_b) {
-            return exports.compare_people_for_relevance(
-                person_a,
-                person_b,
-                function (user_a, user_b) {
-                    return recent_senders.compare_by_recency(
-                        user_a,
-                        user_b,
-                        stream_id,
-                        current_topic
-                    );
-                },
-                current_stream.name
-            );
-        });
+        objs.sort((person_a, person_b) => exports.compare_people_for_relevance(
+            person_a,
+            person_b,
+            (user_a, user_b) => recent_senders.compare_by_recency(
+                user_a,
+                user_b,
+                stream_id,
+                current_topic
+            ),
+            current_stream.name
+        ));
     }
 
     return objs;

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -243,7 +243,7 @@ exports.sort_people_for_relevance = function (objs, current_stream_name, current
         objs.sort((person_a, person_b) => exports.compare_people_for_relevance(
             person_a,
             person_b,
-            exports.compare_by_pms
+            exports.compare_by_pms,
         ));
     } else {
         const stream_id = current_stream.stream_id;
@@ -255,9 +255,9 @@ exports.sort_people_for_relevance = function (objs, current_stream_name, current
                 user_a,
                 user_b,
                 stream_id,
-                current_topic
+                current_topic,
             ),
-            current_stream.name
+            current_stream.name,
         ));
     }
 
@@ -296,7 +296,7 @@ exports.sort_recipients = function (
     current_stream,
     current_topic,
     groups,
-    max_num_items
+    max_num_items,
 ) {
     if (!groups) {
         groups = [];

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -8,7 +8,7 @@ const settings_data = require("./settings_data");
 // For example, "a,,b, " => ["a", "b"]
 exports.get_cleaned_pm_recipients = function (query_string) {
     let recipients = util.extract_pm_recipients(query_string);
-    recipients = recipients.filter(elem => elem.match(/\S/));
+    recipients = recipients.filter((elem) => elem.match(/\S/));
     return recipients;
 };
 

--- a/static/js/typing.js
+++ b/static/js/typing.js
@@ -58,7 +58,7 @@ exports.initialize = function () {
         notify_server_stop: notify_server_stop,
     };
 
-    $(document).on('input', '#compose-textarea', function () {
+    $(document).on('input', '#compose-textarea', () => {
         // If our previous state was no typing notification, send a
         // start-typing notice immediately.
         const new_recipient =
@@ -68,7 +68,7 @@ exports.initialize = function () {
 
     // We send a stop-typing notification immediately when compose is
     // closed/cancelled
-    $(document).on('compose_canceled.zulip compose_finished.zulip', function () {
+    $(document).on('compose_canceled.zulip compose_finished.zulip', () => {
         typing_status.update(worker, null);
     });
 };

--- a/static/js/typing_data.js
+++ b/static/js/typing_data.js
@@ -32,7 +32,7 @@ exports.remove_typist = function (group, typist) {
         return false;
     }
 
-    current = current.filter(user_id => to_int(user_id) !== to_int(typist));
+    current = current.filter((user_id) => to_int(user_id) !== to_int(typist));
 
     typist_dct.set(key, current);
     return true;

--- a/static/js/typing_events.js
+++ b/static/js/typing_events.js
@@ -78,7 +78,7 @@ exports.display_notification = function (event) {
         TYPING_STARTED_EXPIRY_PERIOD,
         () => {
             exports.hide_notification(event);
-        }
+        },
     );
 };
 window.typing_events = exports;

--- a/static/js/typing_events.js
+++ b/static/js/typing_events.js
@@ -30,9 +30,7 @@ function get_users_typing_for_narrow() {
         if (!narrow_user_ids_string) {
             return [];
         }
-        const narrow_user_ids = narrow_user_ids_string.split(',').map(function (user_id_string) {
-            return parseInt(user_id_string, 10);
-        });
+        const narrow_user_ids = narrow_user_ids_string.split(',').map((user_id_string) => parseInt(user_id_string, 10));
         const group = narrow_user_ids.concat([page_params.user_id]);
         return typing_data.get_group_typists(group);
     }
@@ -52,9 +50,7 @@ exports.render_notifications_for_narrow = function () {
 };
 
 exports.hide_notification = function (event) {
-    const recipients = event.recipients.map(function (user) {
-        return user.user_id;
-    });
+    const recipients = event.recipients.map((user) => user.user_id);
     recipients.sort();
 
     typing_data.clear_inbound_timer(recipients);
@@ -67,9 +63,7 @@ exports.hide_notification = function (event) {
 };
 
 exports.display_notification = function (event) {
-    const recipients = event.recipients.map(function (user) {
-        return user.user_id;
-    });
+    const recipients = event.recipients.map((user) => user.user_id);
     recipients.sort();
 
     const sender_id = event.sender.user_id;
@@ -82,7 +76,7 @@ exports.display_notification = function (event) {
     typing_data.kickstart_inbound_timer(
         recipients,
         TYPING_STARTED_EXPIRY_PERIOD,
-        function () {
+        () => {
             exports.hide_notification(event);
         }
     );

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -141,7 +141,7 @@ exports.get_hotkey_deprecation_notice = function (originalHotkey, replacementHot
     return i18n.t(
         'We\'ve replaced the "__originalHotkey__" hotkey with "__replacementHotkey__" '
             + 'to make this common shortcut easier to trigger.',
-        { originalHotkey: originalHotkey, replacementHotkey: replacementHotkey }
+        { originalHotkey: originalHotkey, replacementHotkey: replacementHotkey },
     );
 };
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -93,7 +93,7 @@ exports.update_starred_view = function (message_id, new_value) {
 
     // Avoid a full re-render, but update the star in each message
     // table in which it is visible.
-    update_message_in_all_views(message_id, function update_row(row) {
+    update_message_in_all_views(message_id, (row) => {
         const elt = row.find(".star");
         if (starred) {
             elt.addClass("fa-star").removeClass("fa-star-o").removeClass("empty-star");
@@ -107,7 +107,7 @@ exports.update_starred_view = function (message_id, new_value) {
 
 exports.show_message_failed = function (message_id, failed_msg) {
     // Failed to send message, so display inline retry/cancel
-    update_message_in_all_views(message_id, function update_row(row) {
+    update_message_in_all_views(message_id, (row) => {
         const failed_div = row.find('.message_failed');
         failed_div.toggleClass('notvisible', false);
         failed_div.find('.failed_text').attr('title', failed_msg);
@@ -132,7 +132,7 @@ exports.remove_messages = function (message_ids) {
 
 exports.show_failed_message_success = function (message_id) {
     // Previously failed message succeeded
-    update_message_in_all_views(message_id, function update_row(row) {
+    update_message_in_all_views(message_id, (row) => {
         row.find('.message_failed').toggleClass('notvisible', true);
     });
 };

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -223,7 +223,7 @@ exports.initialize_kitchen_sink_stuff = function () {
                     render_end: event.msg_list.view._render_win_end,
                     selected_id_from_idx: messages[event.msg_list.selected_idx()].id,
                     msg_list_sorted: _.isEqual(
-                        messages.map(message => message.id),
+                        messages.map((message) => message.id),
                         _.chain(current_msg_list.all_messages()).pluck('id').clone().value().sort()
                     ),
                     found_in_dom: row_from_dom.length,

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -224,7 +224,7 @@ exports.initialize_kitchen_sink_stuff = function () {
                     selected_id_from_idx: messages[event.msg_list.selected_idx()].id,
                     msg_list_sorted: _.isEqual(
                         messages.map((message) => message.id),
-                        _.chain(current_msg_list.all_messages()).pluck('id').clone().value().sort()
+                        _.chain(current_msg_list.all_messages()).pluck('id').clone().value().sort(),
                     ),
                     found_in_dom: row_from_dom.length,
                 });
@@ -386,41 +386,41 @@ exports.initialize_everything = function () {
     }
 
     const alert_words_params = pop_fields(
-        'alert_words'
+        'alert_words',
     );
 
     const bot_params = pop_fields(
-        'realm_bots'
+        'realm_bots',
     );
 
     const people_params = pop_fields(
         'realm_users',
         'realm_non_active_users',
-        'cross_realm_bots'
+        'cross_realm_bots',
     );
 
     const pm_conversations_params = pop_fields(
-        'recent_private_conversations'
+        'recent_private_conversations',
     );
 
     const presence_params = pop_fields(
         'presences',
-        'initial_servertime'
+        'initial_servertime',
     );
 
     const stream_data_params = pop_fields(
         'subscriptions',
         'unsubscribed',
         'never_subscribed',
-        'realm_default_streams'
+        'realm_default_streams',
     );
 
     const user_groups_params = pop_fields(
-        'realm_user_groups'
+        'realm_user_groups',
     );
 
     const user_status_params = pop_fields(
-        'user_status'
+        'user_status',
     );
 
     alert_words.initialize(alert_words_params);
@@ -459,7 +459,7 @@ exports.initialize_everything = function () {
     emoji.initialize();
     markdown.initialize(
         page_params.realm_filters,
-        markdown_config.get_helpers()
+        markdown_config.get_helpers(),
     );
     compose.initialize();
     composebox_typeahead.initialize(); // Must happen after compose.initialize()

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -52,7 +52,7 @@ exports.initialize_kitchen_sink_stuff = function () {
     //      the code here can probably be moved to more
     //      specific-purpose modules like message_viewport.js.
 
-    const throttled_mousewheelhandler = _.throttle(function (e, delta) {
+    const throttled_mousewheelhandler = _.throttle((e, delta) => {
         // Most of the mouse wheel's work will be handled by the
         // scroll handler, but when we're at the top or bottom of the
         // page, the pointer may still need to move.
@@ -70,7 +70,7 @@ exports.initialize_kitchen_sink_stuff = function () {
         message_viewport.set_last_movement_direction(delta);
     }, 50);
 
-    message_viewport.message_pane.on('wheel', function (e) {
+    message_viewport.message_pane.on('wheel', (e) => {
         const delta = e.originalEvent.deltaY;
         if (!overlays.is_active()) {
             // In the message view, we use a throttled mousewheel handler.
@@ -104,7 +104,7 @@ exports.initialize_kitchen_sink_stuff = function () {
     });
 
     // Ignore wheel events in the compose area which weren't already handled above.
-    $('#compose').on('wheel', function (e) {
+    $('#compose').on('wheel', (e) => {
         e.stopPropagation();
         e.preventDefault();
     });
@@ -133,7 +133,7 @@ exports.initialize_kitchen_sink_stuff = function () {
         message_hover(row);
     });
 
-    $("#main_div").on("mouseleave", ".message_table .message_row", function () {
+    $("#main_div").on("mouseleave", ".message_table .message_row", () => {
         message_unhover();
     });
 
@@ -190,15 +190,15 @@ exports.initialize_kitchen_sink_stuff = function () {
         ui_util.decorate_stream_bar(this.value, $("#stream-message .message_header_stream"), true);
     });
 
-    $(window).on('blur', function () {
+    $(window).on('blur', () => {
         $(document.body).addClass('window_blurred');
     });
 
-    $(window).on('focus', function () {
+    $(window).on('focus', () => {
         $(document.body).removeClass('window_blurred');
     });
 
-    $(document).on('message_selected.zulip', function (event) {
+    $(document).on('message_selected.zulip', (event) => {
         if (current_msg_list !== event.msg_list) {
             return;
         }
@@ -242,7 +242,7 @@ exports.initialize_kitchen_sink_stuff = function () {
         }
     });
 
-    $("#main_div").on("mouseenter", ".message_time", function (e) {
+    $("#main_div").on("mouseenter", ".message_time", (e) => {
         const time_elem = $(e.target);
         const row = time_elem.closest(".message_row");
         const message = current_msg_list.get(rows.id(row));
@@ -488,7 +488,7 @@ exports.initialize_everything = function () {
     user_status_ui.initialize();
 };
 
-$(function () {
+$(() => {
     const finish = blueslip.start_timing('initialize_everything');
     exports.initialize_everything();
     finish();

--- a/static/js/ui_report.js
+++ b/static/js/ui_report.js
@@ -50,7 +50,7 @@ exports.generic_embed_error = function (error) {
 exports.generic_row_button_error = function (xhr, btn) {
     if (xhr.status.toString().charAt(0) === "4") {
         btn.closest("td").html(
-            $("<p>").addClass("text-error").text(JSON.parse(xhr.responseText).msg)
+            $("<p>").addClass("text-error").text(JSON.parse(xhr.responseText).msg),
         );
     } else {
         btn.text(i18n.t("Failed!"));

--- a/static/js/ui_report.js
+++ b/static/js/ui_report.js
@@ -14,7 +14,7 @@ exports.message = function (response, status_box, cls, remove_after) {
     status_box.removeClass(common.status_classes).addClass(cls)
         .html(response).stop(true).fadeTo(0, 1);
     if (remove_after) {
-        setTimeout(function () {
+        setTimeout(() => {
             status_box.fadeTo(200, 0);
         }, remove_after);
     }
@@ -59,7 +59,7 @@ exports.generic_row_button_error = function (xhr, btn) {
 
 exports.hide_error = function ($target) {
     $target.addClass("fade-out");
-    setTimeout(function () {
+    setTimeout(() => {
         $target.removeClass("show fade-out");
     }, 300);
 };

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -404,13 +404,13 @@ exports.update_unread_topics = function (msg, event) {
     }
 
     exports.unread_topic_counter.delete(
-        msg.id
+        msg.id,
     );
 
     exports.unread_topic_counter.add(
         new_stream_id || msg.stream_id,
         new_topic || msg.topic,
-        msg.id
+        msg.id,
     );
 };
 
@@ -430,7 +430,7 @@ exports.process_loaded_messages = function (messages) {
             exports.unread_topic_counter.add(
                 message.stream_id,
                 message.topic,
-                message.id
+                message.id,
             );
         }
 

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -273,9 +273,9 @@ exports.unread_topic_counter = (function () {
 
         let topic_names = Array.from(per_stream_bucketer.keys());
 
-        topic_names = topic_names.filter(topic_name => !topic_dict.has(topic_name));
+        topic_names = topic_names.filter((topic_name) => !topic_dict.has(topic_name));
 
-        const result = topic_names.map(topic_name => {
+        const result = topic_names.map((topic_name) => {
             const msgs = per_stream_bucketer.get_bucket(topic_name);
 
             return {
@@ -384,11 +384,11 @@ exports.message_unread = function (message) {
 };
 
 exports.get_unread_message_ids = function (message_ids) {
-    return message_ids.filter(message_id => unread_messages.has(message_id));
+    return message_ids.filter((message_id) => unread_messages.has(message_id));
 };
 
 exports.get_unread_messages = function (messages) {
-    return messages.filter(message => unread_messages.has(message.id));
+    return messages.filter((message) => unread_messages.has(message.id));
 };
 
 exports.update_unread_topics = function (msg, event) {

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -162,7 +162,7 @@ exports.setup_upload = function (config) {
                     timedOut: i18n.t('Upload stalled for %{seconds} seconds, aborting.'),
                 },
             },
-        }
+        },
     );
 
     uppy.use(ProgressBar, {

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -104,14 +104,14 @@ exports.upload_files = function (uppy, config, files) {
     exports.get_item("send_button", config).attr("disabled", "");
     exports.get_item("send_status", config).addClass("alert-info").removeClass("alert-error").show();
     exports.get_item("send_status_message", config).html($("<p>").text(i18n.t("Uploading…")));
-    exports.get_item("send_status_close_button", config).one('click', function () {
+    exports.get_item("send_status_close_button", config).one('click', () => {
         uppy.getFiles().forEach((file) => {
             compose_ui.replace_syntax(exports.get_translated_status(file), "", exports.get_item("textarea", config));
         });
         compose_ui.autosize_textarea();
         uppy.cancelAll();
         exports.get_item("textarea", config).focus();
-        setTimeout(function () {
+        setTimeout(() => {
             exports.hide_upload_status(config);
         }, 500);
     });
@@ -236,7 +236,7 @@ exports.setup_upload = function (config) {
 
         const has_errors = exports.get_item("send_status", config).hasClass("alert-error");
         if (!uploads_in_progress && !has_errors) {
-            setTimeout(function () {
+            setTimeout(() => {
                 exports.hide_upload_status(config);
             }, 500);
         }

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -221,7 +221,7 @@ exports.setup_upload = function (config) {
 
     uppy.on('complete', () => {
         let uploads_in_progress = false;
-        uppy.getFiles().forEach(file => {
+        uppy.getFiles().forEach((file) => {
             if (file.progress.uploadComplete) {
                 // The uploaded files should be removed since uppy don't allow files in the store
                 // to be re-uploaded again.

--- a/static/js/upload_widget.js
+++ b/static/js/upload_widget.js
@@ -53,12 +53,12 @@ exports.build_widget = function (
 
 
 
-    clear_button.on('click', function (e) {
+    clear_button.on('click', (e) => {
         clear();
         e.preventDefault();
     });
 
-    upload_button.on('drop', function (e) {
+    upload_button.on('drop', (e) => {
         const files = e.dataTransfer.files;
         if (files === null || files === undefined || files.length === 0) {
             return false;
@@ -69,7 +69,7 @@ exports.build_widget = function (
     });
 
     get_file_input().attr('accept', supported_types.toString());
-    get_file_input().on('change', function (e) {
+    get_file_input().on('change', (e) => {
         if (e.target.files.length === 0) {
             input_error.hide();
         } else if (e.target.files.length === 1) {
@@ -92,7 +92,7 @@ exports.build_widget = function (
         }
     });
 
-    upload_button.on('click', function (e) {
+    upload_button.on('click', (e) => {
         get_file_input().trigger('click');
         e.preventDefault();
     });
@@ -140,7 +140,7 @@ exports.build_direct_upload_widget = function (
         control.val('');
     }
 
-    upload_button.on('drop', function (e) {
+    upload_button.on('drop', (e) => {
         const files = e.dataTransfer.files;
         if (files === null || files === undefined || files.length === 0) {
             return false;
@@ -151,7 +151,7 @@ exports.build_direct_upload_widget = function (
     });
 
     get_file_input().attr('accept', supported_types.toString());
-    get_file_input().on('change', function (e) {
+    get_file_input().on('change', (e) => {
         if (e.target.files.length === 0) {
             input_error.hide();
         } else if (e.target.files.length === 1) {
@@ -174,7 +174,7 @@ exports.build_direct_upload_widget = function (
         }
     });
 
-    upload_button.on('click', function (e) {
+    upload_button.on('click', (e) => {
         get_file_input().trigger('click');
         e.preventDefault();
     });

--- a/static/js/upload_widget.js
+++ b/static/js/upload_widget.js
@@ -23,7 +23,7 @@ exports.build_widget = function (
     upload_button, // jQuery button to open file dialog
     preview_text = null,
     preview_image = null,
-    max_file_upload_size
+    max_file_upload_size,
 ) {
     // default value of max uploaded file size
     max_file_upload_size = max_file_upload_size || default_max_file_size;
@@ -119,7 +119,7 @@ exports.build_direct_upload_widget = function (
     input_error, // jQuery object for error text
     upload_button, // jQuery button to open file dialog
     upload_function,
-    max_file_upload_size
+    max_file_upload_size,
 ) {
     // default value of max uploaded file size
     max_file_upload_size = max_file_upload_size || default_max_file_size;

--- a/static/js/user_groups.js
+++ b/static/js/user_groups.js
@@ -54,9 +54,7 @@ exports.get_user_group_from_name = function (name) {
 };
 
 exports.get_realm_user_groups = function () {
-    return Array.from(user_group_by_id_dict.values()).sort(function (a, b) {
-        return a.id - b.id;
-    });
+    return Array.from(user_group_by_id_dict.values()).sort((a, b) => a.id - b.id);
 };
 
 exports.is_member_of = function (user_group_id, user_id) {

--- a/static/js/user_pill.js
+++ b/static/js/user_pill.js
@@ -8,7 +8,7 @@ exports.create_item_from_email = function (email, current_items) {
 
     if (!user) {
         if (page_params.realm_is_zephyr_mirror_realm) {
-            const existing_emails = current_items.map(item => item.email);
+            const existing_emails = current_items.map((item) => item.email);
 
             if (existing_emails.includes(email)) {
                 return;
@@ -27,7 +27,7 @@ exports.create_item_from_email = function (email, current_items) {
         return;
     }
 
-    const existing_ids = current_items.map(item => item.user_id);
+    const existing_ids = current_items.map((item) => item.user_id);
 
     if (existing_ids.includes(user.user_id)) {
         return;
@@ -67,7 +67,7 @@ exports.append_person = function (opts) {
 
 exports.get_user_ids = function (pill_widget) {
     const items = pill_widget.items();
-    let user_ids = items.map(item => item.user_id);
+    let user_ids = items.map((item) => item.user_id);
     user_ids = user_ids.filter(Boolean); // be defensive about undefined users
 
     return user_ids;
@@ -81,7 +81,7 @@ exports.has_unconverted_data = function (pill_widget) {
     }
 
     const items = pill_widget.items();
-    const has_unknown_items = items.some(item => item.user_id === undefined);
+    const has_unknown_items = items.some((item) => item.user_id === undefined);
 
     return has_unknown_items;
 };
@@ -93,7 +93,7 @@ exports.typeahead_source = function (pill_widget) {
 
 exports.filter_taken_users = function (items, pill_widget) {
     const taken_user_ids = exports.get_user_ids(pill_widget);
-    items = items.filter(item => !taken_user_ids.includes(item.user_id));
+    items = items.filter((item) => !taken_user_ids.includes(item.user_id));
     return items;
 };
 

--- a/static/js/user_status_ui.js
+++ b/static/js/user_status_ui.js
@@ -78,11 +78,11 @@ exports.clear_message = function () {
 };
 
 exports.initialize = function () {
-    $('body').on('click', '.user_status_overlay .set_user_status', function () {
+    $('body').on('click', '.user_status_overlay .set_user_status', () => {
         exports.submit_new_status();
     });
 
-    $('body').on('keypress', '.user_status_overlay .user_status', function (event) {
+    $('body').on('keypress', '.user_status_overlay .user_status', (event) => {
         if (event.key === 'Enter') {
             event.preventDefault();
 
@@ -90,12 +90,12 @@ exports.initialize = function () {
         }
     });
 
-    $('body').on('keyup', '.user_status_overlay input.user_status', function () {
+    $('body').on('keyup', '.user_status_overlay input.user_status', () => {
         exports.update_button();
         exports.toggle_clear_message_button();
     });
 
-    $('#clear_status_message_button').on('click', function () {
+    $('#clear_status_message_button').on('click', () => {
         exports.clear_message();
         exports.update_button();
     });

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -68,7 +68,7 @@ exports.is_pm_recipient = function (user_id, message) {
 };
 
 exports.extract_pm_recipients = function (recipients) {
-    return recipients.split(/\s*[,;]\s*/).filter(recipient => recipient.trim() !== "");
+    return recipients.split(/\s*[,;]\s*/).filter((recipient) => recipient.trim() !== "");
 };
 
 exports.same_recipient = function util_same_recipient(a, b) {
@@ -102,9 +102,9 @@ exports.normalize_recipients = function (recipients) {
     // Converts a string listing emails of message recipients
     // into a canonical formatting: emails sorted ASCIIbetically
     // with exactly one comma and no spaces between each.
-    recipients = recipients.split(',').map(s => s.trim());
-    recipients = recipients.map(s => s.toLowerCase());
-    recipients = recipients.filter(s => s.length > 0);
+    recipients = recipients.split(',').map((s) => s.trim());
+    recipients = recipients.map((s) => s.toLowerCase());
+    recipients = recipients.filter((s) => s.length > 0);
     recipients.sort();
     return recipients.join(',');
 };

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -223,9 +223,7 @@ exports.sorted_ids = function (ids) {
     // This mapping makes sure we are using ints, and
     // it also makes sure we don't mutate the list.
     let id_list = ids.map(to_int);
-    id_list.sort(function (a, b) {
-        return a - b;
-    });
+    id_list.sort((a, b) => a - b);
     id_list = _.uniq(id_list, true);
 
     return id_list;

--- a/static/js/vdom.js
+++ b/static/js/vdom.js
@@ -126,7 +126,7 @@ exports.update = (replace_content, find, new_dom, old_dom) => {
     const same_structure = exports.eq_array(
         new_opts.keyed_nodes,
         old_opts.keyed_nodes,
-        (a, b) => a.key === b.key
+        (a, b) => a.key === b.key,
     );
 
     if (!same_structure) {
@@ -161,7 +161,7 @@ exports.update = (replace_content, find, new_dom, old_dom) => {
     exports.update_attrs(
         find(),
         new_opts.attrs,
-        old_opts.attrs
+        old_opts.attrs,
     );
 };
 

--- a/static/js/vdom.js
+++ b/static/js/vdom.js
@@ -37,7 +37,7 @@ exports.render_tag = (tag) => {
     */
     const opts = tag.opts;
     const tag_name = tag.tag_name;
-    const attr_str = opts.attrs.map(attr => ' ' + attr[0] + '="' + _.escape(attr[1]) + '"').join('');
+    const attr_str = opts.attrs.map((attr) => ' ' + attr[0] + '="' + _.escape(attr[1]) + '"').join('');
 
     const start_tag = '<' + tag_name + attr_str + '>';
     const end_tag = '</' + tag_name + '>';
@@ -47,7 +47,7 @@ exports.render_tag = (tag) => {
         return;
     }
 
-    const innards = opts.keyed_nodes.map(node => node.render()).join('\n');
+    const innards = opts.keyed_nodes.map((node) => node.render()).join('\n');
     return start_tag + '\n' + innards + '\n' + end_tag;
 };
 

--- a/static/js/vdom.js
+++ b/static/js/vdom.js
@@ -16,12 +16,10 @@ exports.eq_array = (a, b, eq) => {
     return a.every((item, i) => eq(item, b[i]));
 };
 
-exports.ul = (opts) => {
-    return {
-        tag_name: 'ul',
-        opts: opts,
-    };
-};
+exports.ul = (opts) => ({
+    tag_name: 'ul',
+    opts: opts,
+});
 
 exports.render_tag = (tag) => {
     /*

--- a/static/js/zform.js
+++ b/static/js/zform.js
@@ -65,7 +65,7 @@ exports.activate = function (opts) {
         const html = render_widgets_zform_choices(data);
         const elem = $(html);
 
-        elem.find('button').on('click', function (e) {
+        elem.find('button').on('click', (e) => {
             e.stopPropagation();
 
             // Grab our index from the markup.

--- a/static/js/zform.js
+++ b/static/js/zform.js
@@ -15,7 +15,7 @@ exports.validate_extra_data = function (data) {
                 return schema.check_array(
                     field_name,
                     val,
-                    check_choice_item
+                    check_choice_item,
                 );
             }
 

--- a/static/shared/js/typeahead.js
+++ b/static/shared/js/typeahead.js
@@ -167,7 +167,7 @@ export function sort_emojis(objs, query) {
     const triage_results = triage(
         query,
         others,
-        (x) => x.emoji_name
+        (x) => x.emoji_name,
     );
 
     return [

--- a/static/shared/js/typeahead.js
+++ b/static/shared/js/typeahead.js
@@ -75,7 +75,7 @@ function query_matches_string(query, source_str, split_char) {
 // account, there might be 2 attrs: their full name and their email.
 // * split_char is the separator for this syntax (e.g. ' ').
 export function query_matches_source_attrs(query, source, match_attrs, split_char) {
-    return match_attrs.some(attr => {
+    return match_attrs.some((attr) => {
         const source_str = source[attr].toLowerCase();
         return query_matches_string(query, source_str, split_char);
     });
@@ -151,7 +151,7 @@ export function sort_emojis(objs, query) {
 
     function decent_match(name) {
         const pieces = name.toLowerCase().split('_');
-        return pieces.some(piece => piece.startsWith(lowerQuery));
+        return pieces.some((piece) => piece.startsWith(lowerQuery));
     }
 
     const popular_set = new Set(popular_emojis);
@@ -162,7 +162,7 @@ export function sort_emojis(objs, query) {
     }
 
     const popular_emoji_matches = objs.filter(is_popular);
-    const others = objs.filter(obj => !is_popular(obj));
+    const others = objs.filter((obj) => !is_popular(obj));
 
     const triage_results = triage(
         query,

--- a/static/shared/js/typing_status.js
+++ b/static/shared/js/typing_status.js
@@ -48,7 +48,7 @@ export function start_or_extend_idle_timer(worker) {
     }
     state.idle_timer = setTimeout(
         on_idle_timeout,
-        TYPING_STOPPED_WAIT_PERIOD
+        TYPING_STOPPED_WAIT_PERIOD,
     );
 }
 

--- a/tools/debug-require-webpack-plugin.ts
+++ b/tools/debug-require-webpack-plugin.ts
@@ -47,10 +47,10 @@ export default class DebugRequirePlugin {
                         __dirname,
                         "./debug-require.js",
                         {},
-                        (err?: Error, result?: string) => err ? reject(err) : resolve(result)
-                    )
+                        (err?: Error, result?: string) => err ? reject(err) : resolve(result),
+                    ),
                 );
-            }
+            },
         );
 
         compiler.hooks.compilation.tap("DebugRequirePlugin", (compilation: any) => {
@@ -72,7 +72,7 @@ export default class DebugRequirePlugin {
                             }
                             return false;
                         },
-                        () => true
+                        () => true,
                     );
 
                     if (debugRequireId === undefined) {
@@ -84,10 +84,10 @@ export default class DebugRequirePlugin {
                     return Template.asString([
                         source,
                         `${requireFn}(${JSON.stringify(
-                            debugRequireId
+                            debugRequireId,
                         )}).initialize(${JSON.stringify(Object.fromEntries(ids), null, "\t")});`,
                     ]);
-                }
+                },
             );
         });
     }

--- a/zerver/openapi/javascript_examples.js
+++ b/zerver/openapi/javascript_examples.js
@@ -1,3 +1,5 @@
+/* eslint-disable arrow-body-style */
+
 const ExamplesHandler = function () {
     const config = {
         username: process.env.ZULIP_USERNAME,


### PR DESCRIPTION
This automatically migrates a whole lot of functions to arrow functions using ESLint.

Before merging this we should decide whether we prefer the `x => x` style (`arrow-parens: ["error", "as-needed"]`, Prettier 1 default) or the `(x) => x` style (`arrow-parens: "error"`, Prettier 2 default).