### PR TITLE
Capture server-side errors in Sentry

### DIFF
--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -46,6 +46,7 @@ from .configured_settings import (
     REMOTE_POSTGRES_PORT,
     REMOTE_POSTGRES_SSLMODE,
     SENDFILE_BACKEND,
+    SENTRY_DSN,
     SOCIAL_AUTH_APPLE_SERVICES_ID,
     SOCIAL_AUTH_GITHUB_KEY,
     SOCIAL_AUTH_GITHUB_ORG_NAME,
@@ -1123,3 +1124,7 @@ CROSS_REALM_BOT_EMAILS = {
 THUMBOR_KEY = get_secret('thumbor_key')
 
 TWO_FACTOR_PATCH_ADMIN = False
+
+if SENTRY_DSN:
+    from .sentry import setup_sentry
+    setup_sentry(SENTRY_DSN)

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -1125,6 +1125,8 @@ THUMBOR_KEY = get_secret('thumbor_key')
 
 TWO_FACTOR_PATCH_ADMIN = False
 
+# Allow the environment to override the default DSN
+SENTRY_DSN = os.environ.get("SENTRY_DSN", SENTRY_DSN)
 if SENTRY_DSN:
     from .sentry import setup_sentry
     setup_sentry(SENTRY_DSN)

--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -108,6 +108,9 @@ BROWSER_ERROR_REPORTING = False
 LOGGING_SHOW_MODULE = False
 LOGGING_SHOW_PID = False
 
+# Sentry.io error defaults to off
+SENTRY_DSN: Optional[str] = None
+
 # File uploads and avatars
 DEFAULT_AVATAR_URI = '/static/images/default-avatar.png'
 DEFAULT_LOGO_URI = '/static/images/logo/zulip-org-logo.svg'

--- a/zproject/prod_settings_template.py
+++ b/zproject/prod_settings_template.py
@@ -366,6 +366,9 @@ SESSION_COOKIE_AGE = 60 * 60 * 24 * 7 * 2  # 2 weeks
 # For frontend (JavaScript) tracebacks
 #BROWSER_ERROR_REPORTING = False
 
+# Controls the DSN used to report erors to Sentry.io
+#SENTRY_DSN = 'https://bbb@bbb.ingest.sentry.io/1235'
+
 # If True, each log message in the server logs will identify the
 # Python module where it came from.  Useful for tracking down a
 # mysterious log message, but a little verbose.

--- a/zproject/sentry.py
+++ b/zproject/sentry.py
@@ -1,11 +1,25 @@
+from typing import TYPE_CHECKING, Optional
+
 import sentry_sdk
 from sentry_sdk.integrations import Integration
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+from sentry_sdk.utils import capture_internal_exceptions
 
 from .config import PRODUCTION
 
+if TYPE_CHECKING:
+    from sentry_sdk._types import Event, Hint
+
+def add_context(event: 'Event', hint: 'Hint') -> 'Event':
+    from zerver.models import get_user_profile_by_id
+    with capture_internal_exceptions():
+        user_info = event.get("user", {})
+        if user_info.get("id"):
+            user_profile = get_user_profile_by_id(user_info["id"])
+            user_info["realm"] = user_profile.realm.string_id or 'root'
+    return event
 
 def setup_sentry(dsn: Optional[str], *integrations: Integration) -> None:
     if not dsn:
@@ -19,4 +33,5 @@ def setup_sentry(dsn: Optional[str], *integrations: Integration) -> None:
             SqlalchemyIntegration(),
             *integrations,
         ],
+        before_send=add_context,
     )

--- a/zproject/sentry.py
+++ b/zproject/sentry.py
@@ -1,0 +1,22 @@
+import sentry_sdk
+from sentry_sdk.integrations import Integration
+from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.redis import RedisIntegration
+from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+
+from .config import PRODUCTION
+
+
+def setup_sentry(dsn: Optional[str], *integrations: Integration) -> None:
+    if not dsn:
+        return
+    sentry_sdk.init(
+        dsn=dsn,
+        environment="production" if PRODUCTION else "development",
+        integrations=[
+            DjangoIntegration(),
+            RedisIntegration(),
+            SqlalchemyIntegration(),
+            *integrations,
+        ],
+    )


### PR DESCRIPTION
**Testing Plan:** Set `SENTRY_DSN` in environment, triggered server-side errors.

Errors appear on https://sentry.io/organizations/zulip/issues/?project=5303926