### PR TITLE
settings: Fix modal out of screen on mobile.

### DIFF
--- a/static/styles/components.scss
+++ b/static/styles/components.scss
@@ -106,30 +106,6 @@ a.no-underline:hover {
     }
 }
 
-/* -- flex forms -- */
-.flex-row {
-    display: flex;
-
-    * {
-        box-sizing: border-box;
-    }
-
-    input[type=text],
-    input[type=password] {
-        height: auto;
-        width: 100%;
-    }
-
-    &.normal {
-        width: 500px;
-    }
-
-    .field {
-        margin: 10px;
-        width: 100%;
-    }
-}
-
 i.zulip-icon.bot {
     color: hsl(180, 5%, 74%);
     vertical-align: top;

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -111,11 +111,11 @@ h3 .fa-question-circle-o {
 }
 
 #change_email_modal {
-    width: 460px;
+    max-width: 460px;
 }
 
 #change_full_name_modal {
-    width: 480px;
+    max-width: 480px;
 }
 
 .admin-realm-description {

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -96,7 +96,7 @@
                             <h3 class="inline-block" id="change_password_modal_label">{{t "Change password" }}</h3>
                             <div class="alert-notification change_password_info"></div>
                         </div>
-                        <div class="flex-row normal">
+                        <div class="modal-body">
                             <div class="field">
                                 <label for="old_password" class="title">{{t "Old password" }}</label>
                                 <input type="password" autocomplete="off" name="old_password" id="old_password" class="w-200 inline-block" value="" />


### PR DESCRIPTION
For the email and full name modals we simply change width to max-width.

The password modal used a flex-row class for no apparent reason,
the class wasn't used anywhere else and removing it fixes the UI bug.

Fixes #15311.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
before:
![modal_broken](https://user-images.githubusercontent.com/47354597/86320902-2731ff80-bc38-11ea-850a-6204c95c2a37.gif)

after:
![modal_fixed](https://user-images.githubusercontent.com/47354597/86320914-2b5e1d00-bc38-11ea-97b1-d84ee5a9faf0.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
