### PR TITLE
emails: Improve handling of timeouts when sending.

### DIFF
--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -149,9 +149,10 @@ def retry_send_email_failures(
     def wrapper(worker: ConcreteQueueWorker, data: Dict[str, Any]) -> None:
         try:
             func(worker, data)
-        except (smtplib.SMTPServerDisconnected, socket.gaierror, EmailNotDeliveredException):
+        except (smtplib.SMTPServerDisconnected, socket.gaierror, socket.timeout,
+                EmailNotDeliveredException) as e:
             def on_failure(event: Dict[str, Any]) -> None:
-                logging.exception("Event %r failed", event)
+                logging.exception("Event %r failed due to exception %s", event, e.__class__.__name__)
 
             retry_event(worker.queue_name, data, on_failure)
 

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -1106,6 +1106,8 @@ elif not EMAIL_HOST:
 else:
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 
+EMAIL_TIMEOUT = 15
+
 EMAIL_HOST_PASSWORD = get_secret('email_password')
 EMAIL_GATEWAY_PASSWORD = get_secret('email_gateway_password')
 AUTH_LDAP_BIND_PASSWORD = get_secret('auth_ldap_bind_password', '')


### PR DESCRIPTION
Tested manually on my production server misconfigured in such a way to get timeouts when trying to send emails.

We use the EMAIL_TIMEOUT django setting to timeout after 15s of trying
to send an email. This will nicely lead to retries in the email_senders
queue, due to the retry_send_email_failures decorator.

smtlib documentation suggests that socket.timeout can be raised as the
result of timing out, so in attempts I'm getting
smtplib.SMTPServerDisconnected. Either way, seems appropriate to add
socket.timeout to the exception that we catch.
