### PR TITLE
settings_panel_menu: Remove "settings-wrapper" class from jquery selectors.

### DIFF
--- a/static/js/settings_panel_menu.js
+++ b/static/js/settings_panel_menu.js
@@ -93,7 +93,7 @@ exports.make_menu = function (opts) {
         const settings_section_hash = '#' + hash_prefix + section;
         hashchange.update_browser_history(settings_section_hash);
 
-        $(".settings-section, .settings-wrapper").removeClass("show");
+        $(".settings-section").removeClass("show");
 
         settings_sections.load_settings_section(section);
 
@@ -111,7 +111,7 @@ exports.make_menu = function (opts) {
     self.get_panel = function () {
         const section = curr_li.data('section');
         const sel = "[data-name='" + section + "']";
-        const panel = $(".settings-section" + sel + ", .settings-wrapper" + sel);
+        const panel = $(".settings-section" + sel);
         return panel;
     };
 


### PR DESCRIPTION
This PR changes the jquery selector to remove "settings-wrapper" class.
There is no element in the templates with this class.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
