### PR TITLE
Update documentation for Bionic to Focal upgrade.

### DIFF
--- a/docs/production/upgrade-or-modify.md
+++ b/docs/production/upgrade-or-modify.md
@@ -218,9 +218,11 @@ instructions for other supported platforms.
 
     ```
     sudo -i # Or otherwise get a root shell
-    do-release-upgrade
+    do-release-upgrade -d
     ```
-
+    The -d switch is necessary to upgrade from Ubuntu 18.04 LTS as
+    upgrades have not yet been enabled and will only be enabled after
+    the first point release of 20.04 LTS.
     When `do-release-upgrade` asks you how to upgrade configuration
     files for services that Zulip manages like `redis`, `postgres`,
     `nginx`, and `memcached`, the best choice is `N` to keep the


### PR DESCRIPTION
Tested Bionic to Focal upgrade on Digital Ocean Droplet.

We have to use this -d Flag till Focal first point release.

The first Ubuntu 20.04 point release is scheduled for release on August 6, 2020. [Source](https://www.omgubuntu.co.uk/2020/05/ubuntu-20-04-1-coming-july#:~:text=The%20first%20Ubuntu%2020.04%20point,to%20the%20distro%20since%20April.)
Follow up to [https://github.com/zulip/zulip/issues/14589#issuecomment-652711320](https://github.com/zulip/zulip/issues/14589#issuecomment-652711320)

@timabbott  Can you check this?