### PR TITLE
list_render: Use simplebar container if present.

### DIFF
--- a/static/js/list_render.js
+++ b/static/js/list_render.js
@@ -264,7 +264,11 @@ exports.create = function ($container, list, opts) {
     };
 
     widget.set_up_event_handlers = function () {
-        meta.scroll_container = scroll_util.get_list_scrolling_container($container);
+        if (opts.simplebar_container) {
+            meta.scroll_container = ui.get_scroll_element(opts.simplebar_container);
+        } else {
+            meta.scroll_container = scroll_util.get_list_scrolling_container($container);
+        }
 
         // on scroll of the nearest scrolling container, if it hits the bottom
         // of the container then fetch a new block of items and render them.

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -320,6 +320,7 @@ function show_subscription_settings(sub_row) {
                 }
             },
         },
+        simplebar_container: $('.subscriber_list_container'),
     });
 
     user_pill.set_up_typeahead_on_pills(sub_settings.find('.input'),


### PR DESCRIPTION
Fixes  #15637.
If the table uses simplebar, track the scroll event using the
simplebar container.

Fixes new subs not rendering on scrolling at end of subs list in
stream settings.
