### PR TITLE
Unify and improve sidebar hover effects

### DIFF
--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -100,10 +100,6 @@ li.show-more-topics {
         }
     }
 
-    li.active-sub-filter:hover {
-        background-color: hsl(120, 11%, 82%);
-    }
-
     .count {
         margin-right: 15px;
     }
@@ -170,7 +166,7 @@ li.show-more-topics {
 .top_left_row:hover,
 .bottom_left_row:hover,
 #stream_filters li.highlighted_stream {
-    background-color: hsl(93, 18%, 82%);
+    background-color: hsla(120, 12.3%, 71.4%, 0.38);
     border-radius: 4px;
 }
 

--- a/static/styles/left-sidebar.scss
+++ b/static/styles/left-sidebar.scss
@@ -163,11 +163,13 @@ li.show-more-topics {
     max-height: 200px;
 }
 
-.top_left_row:hover,
-.bottom_left_row:hover,
-#stream_filters li.highlighted_stream {
-    background-color: hsla(120, 12.3%, 71.4%, 0.38);
-    border-radius: 4px;
+:not(.active-sub-filter) {
+    &.top_left_row:hover,
+    &.bottom_left_row:hover,
+    &#stream_filters li.highlighted_stream {
+        background-color: hsla(120, 12.3%, 71.4%, 0.38);
+        border-radius: 4px;
+    }
 }
 
 #add-stream-link {

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -389,10 +389,6 @@ on a dark background, and don't change the dark labels dark either. */
         background-color: hsla(136, 25%, 73%, 0.2);
     }
 
-    #stream_filters li.active-sub-filter:hover {
-        background-color: hsla(136, 25%, 73%, 0.5);
-    }
-
     .floating_recipient .recipient_row {
         border-top: none;
     }

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -381,9 +381,14 @@ on a dark background, and don't change the dark labels dark either. */
         background-color: hsla(199, 33%, 46%, 0.2);
     }
 
-    .top_left_row:hover,
-    .bottom_left_row:hover,
-    #stream_filters li.highlighted_stream,
+    :not(.active-sub-filter) {
+        &.top_left_row:hover,
+        &.bottom_left_row:hover,
+        &#stream_filters li.highlighted_stream {
+            background-color: hsla(136, 25%, 73%, 0.2);
+        }
+    }
+
     #user_presences li:hover,
     #user_presences li.highlighted_user {
         background-color: hsla(136, 25%, 73%, 0.2);

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -60,7 +60,7 @@
 
         &:hover,
         &.highlighted_user {
-            background-color: hsl(93, 19%, 88%);
+            background-color: hsla(120, 12.3%, 71.4%, 0.38);
         }
     }
 


### PR DESCRIPTION
1. commit: a18ddde 

Left shows before, right shows after. Note that before the hover color was darker than in the Users sidebar.

![before](https://user-images.githubusercontent.com/47354597/86510670-1af1a200-bdf2-11ea-86e5-32965e5ef30c.gif) ![after1](https://user-images.githubusercontent.com/47354597/86510678-26dd6400-bdf2-11ea-9044-a5a673bfd169.gif)

2. commit 5268293

Left shows before, right shows after.

![before2](https://user-images.githubusercontent.com/47354597/86510707-64da8800-bdf2-11ea-869b-5e745425f825.gif) ![after2](https://user-images.githubusercontent.com/47354597/86510711-67d57880-bdf2-11ea-843a-088e3716f4d6.gif)
