### PR TITLE
refactor: Rename convert to markdown_convert.

### DIFF
--- a/zerver/lib/import_realm.py
+++ b/zerver/lib/import_realm.py
@@ -24,7 +24,7 @@ from zerver.lib.actions import (
 from zerver.lib.avatar_hash import user_avatar_path_from_ids
 from zerver.lib.bulk_create import bulk_create_users, bulk_set_users_or_streams_recipient_fields
 from zerver.lib.export import DATE_FIELDS, Field, Path, Record, TableData, TableName
-from zerver.lib.markdown import convert as markdown_convert
+from zerver.lib.markdown import markdown_convert
 from zerver.lib.markdown import version as markdown_version
 from zerver.lib.parallel import run_parallel
 from zerver.lib.server_initialization import create_internal_realm, server_initialized

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -2400,15 +2400,15 @@ def markdown_stats_finish() -> None:
     markdown_total_requests += 1
     markdown_total_time += (time.time() - markdown_time_start)
 
-def convert(content: str,
-            realm_alert_words_automaton: Optional[ahocorasick.Automaton] = None,
-            message: Optional[Message]=None,
-            message_realm: Optional[Realm]=None,
-            sent_by_bot: bool=False,
-            translate_emoticons: bool=False,
-            mention_data: Optional[MentionData]=None,
-            email_gateway: bool=False,
-            no_previews: bool=False) -> str:
+def markdown_convert(content: str,
+                     realm_alert_words_automaton: Optional[ahocorasick.Automaton] = None,
+                     message: Optional[Message]=None,
+                     message_realm: Optional[Realm]=None,
+                     sent_by_bot: bool=False,
+                     translate_emoticons: bool=False,
+                     mention_data: Optional[MentionData]=None,
+                     email_gateway: bool=False,
+                     no_previews: bool=False) -> str:
     markdown_stats_start()
     ret = do_convert(content, realm_alert_words_automaton,
                      message, message_realm, sent_by_bot,

--- a/zerver/lib/message.py
+++ b/zerver/lib/message.py
@@ -25,9 +25,7 @@ from zerver.lib.display_recipient import (
     UserDisplayRecipient,
     bulk_fetch_display_recipients,
 )
-from zerver.lib.markdown import MentionData
-from zerver.lib.markdown import convert as markdown_convert
-from zerver.lib.markdown import topic_links
+from zerver.lib.markdown import MentionData, markdown_convert, topic_links
 from zerver.lib.markdown import version as markdown_version
 from zerver.lib.request import JsonableError
 from zerver.lib.stream_subscription import get_stream_subscriptions_for_user

--- a/zerver/lib/realm_description.py
+++ b/zerver/lib/realm_description.py
@@ -4,7 +4,7 @@ from zerver.lib.cache import (
     realm_text_description_cache_key,
 )
 from zerver.lib.html_to_text import html_to_text
-from zerver.lib.markdown import convert as markdown_convert
+from zerver.lib.markdown import markdown_convert
 from zerver.models import Realm
 
 

--- a/zerver/lib/streams.py
+++ b/zerver/lib/streams.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.db.models.query import QuerySet
 from django.utils.translation import ugettext as _
 
-from zerver.lib.markdown import convert as markdown_convert
+from zerver.lib.markdown import markdown_convert
 from zerver.lib.request import JsonableError
 from zerver.models import (
     DefaultStreamGroup,

--- a/zerver/tests/test_custom_profile_data.py
+++ b/zerver/tests/test_custom_profile_data.py
@@ -10,7 +10,7 @@ from zerver.lib.actions import (
     try_reorder_realm_custom_profile_fields,
 )
 from zerver.lib.external_accounts import DEFAULT_EXTERNAL_ACCOUNTS
-from zerver.lib.markdown import convert as markdown_convert
+from zerver.lib.markdown import markdown_convert
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import queries_captured
 from zerver.models import (


### PR DESCRIPTION
Prior to this commit whenever convert was imported from zerver.lib.markdown
it was aliased as markdown_convert for readability.
This commit rename convert function to markdown_convert so that it can be
directly import it without aliasing and without compromising readability.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
