### PR TITLE
emojis: Add JS tooltips for emojis in messages.

### DIFF
--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -376,17 +376,17 @@ run_test("marked", () => {
         {
             input: "mmm...:burrito:s",
             expected:
-                '<p>mmm...<img alt=":burrito:" class="emoji" src="/static/generated/emoji/images/emoji/burrito.png" title="burrito">s</p>',
+                '<p>mmm...<img alt=":burrito:" class="emoji message-emoji" src="/static/generated/emoji/images/emoji/burrito.png" title="burrito">s</p>',
         },
         {
             input: "This is an :poop: message",
             expected:
-                '<p>This is an <span aria-label="poop" class="emoji emoji-1f4a9" role="img" title="poop">:poop:</span> message</p>',
+                '<p>This is an <span aria-label="poop" class="emoji message-emoji emoji-1f4a9" role="img" title="poop">:poop:</span> message</p>',
         },
         {
             input: "\ud83d\udca9",
             expected:
-                '<p><span aria-label="poop" class="emoji emoji-1f4a9" role="img" title="poop">:poop:</span></p>',
+                '<p><span aria-label="poop" class="emoji message-emoji emoji-1f4a9" role="img" title="poop">:poop:</span></p>',
         },
         {
             input: "Silent mention: @_**Cordelia Lear**",
@@ -470,7 +470,7 @@ run_test("marked", () => {
         {
             input: ":)",
             expected:
-                '<p><span aria-label="smile" class="emoji emoji-1f642" role="img" title="smile">:smile:</span></p>',
+                '<p><span aria-label="smile" class="emoji message-emoji emoji-1f642" role="img" title="smile">:smile:</span></p>',
             translate_emoticons: true,
         },
         // Test HTML Escape in Custom Zulip Rules
@@ -749,7 +749,7 @@ run_test("missing unicode emojis", () => {
     markdown.apply_markdown(message);
     assert.equal(
         message.content,
-        '<p><span aria-label="bike" class="emoji emoji-1f6b2" role="img" title="bike">:bike:</span></p>',
+        '<p><span aria-label="bike" class="emoji message-emoji emoji-1f6b2" role="img" title="bike">:bike:</span></p>',
     );
 
     // Now simulate that we don't know any emoji names.

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -238,6 +238,26 @@ exports.initialize = function () {
         $(e.currentTarget).tooltip("destroy");
     });
 
+    // TOOLTIP FOR EMOJIS IN MESSAGES
+    $("#main_div").on("mouseenter", ".message-emoji", (e) => {
+        e.stopPropagation();
+        const elem = $(e.currentTarget);
+        const title = elem.attr("title");
+
+        elem.tooltip({
+            title,
+            trigger: "hover",
+            placement: "bottom",
+            animation: false,
+        });
+        elem.tooltip("show");
+    });
+
+    $("#main_div").on("mouseleave", ".message-emoji", (e) => {
+        e.stopPropagation();
+        $(e.currentTarget).tooltip("destroy");
+    });
+
     // DESTROY PERSISTING TOOLTIPS ON HOVER
 
     $("body").on("mouseenter", ".tooltip", (e) => {

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -255,7 +255,7 @@ function make_emoji_span(codepoint, title, alt_text) {
         '<span aria-label="' +
         title +
         '"' +
-        ' class="emoji emoji-' +
+        ' class="emoji message-emoji emoji-' +
         codepoint +
         '"' +
         ' role="img" title="' +
@@ -297,7 +297,7 @@ function handleEmoji(emoji_name) {
             '<img alt="' +
             alt_text +
             '"' +
-            ' class="emoji" src="' +
+            ' class="emoji message-emoji" src="' +
             emoji_url +
             '"' +
             ' title="' +

--- a/templates/zerver/app/markdown_help.html
+++ b/templates/zerver/app/markdown_help.html
@@ -62,7 +62,7 @@
                     </tr>
                     <tr>
                         <td>:heart: (and <a href="https://www.webfx.com/tools/emoji-cheat-sheet/" target="_blank" rel="noopener noreferrer">many others</a>, from the <a href="https://code.google.com/p/noto/" target="_blank" rel="noopener noreferrer">Noto Project</a>)</td>
-                        <td class="rendered_markdown"><img alt=":heart:" class="emoji" src="/static/generated/emoji/images/emoji/heart.png" title=":heart:" /></td>
+                        <td class="rendered_markdown"><img alt=":heart:" class="emoji message-emoji" src="/static/generated/emoji/images/emoji/heart.png" title=":heart:" /></td>
                     </tr>
                     <tr>
                         <td>@**Joe Smith**<br>

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -482,7 +482,7 @@ html_rules: List["Rule"] = whitespace_rules + prose_style_rules + [
     {'pattern': r'title="[^{\:]',
      'exclude_line': {
          ('templates/zerver/app/markdown_help.html',
-             '<td class="rendered_markdown"><img alt=":heart:" class="emoji" src="/static/generated/emoji/images/emoji/heart.png" title=":heart:" /></td>'),
+             '<td class="rendered_markdown"><img alt=":heart:" class="emoji message-emoji" src="/static/generated/emoji/images/emoji/heart.png" title=":heart:" /></td>'),
      },
      'exclude': {"templates/zerver/emails", "templates/analytics/realm_details.html", "templates/analytics/support.html"},
      'description': "`title` value should be translatable."},

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1325,7 +1325,7 @@ def make_emoji(codepoint: str, display_string: str) -> Element:
     # Replace underscore in emoji's title with space
     title = display_string[1:-1].replace("_", " ")
     span = Element('span')
-    span.set('class', f'emoji emoji-{codepoint}')
+    span.set('class', f'emoji message-emoji emoji-{codepoint}')
     span.set('title', title)
     span.set('role', 'img')
     span.set('aria-label', title)
@@ -1335,7 +1335,7 @@ def make_emoji(codepoint: str, display_string: str) -> Element:
 def make_realm_emoji(src: str, display_string: str) -> Element:
     elt = Element('img')
     elt.set('src', src)
-    elt.set('class', 'emoji')
+    elt.set('class', 'emoji message-emoji')
     elt.set("alt", display_string)
     elt.set("title", display_string[1:-1].replace("_", " "))
     return elt

--- a/zerver/tests/fixtures/markdown_test_cases.json
+++ b/zerver/tests/fixtures/markdown_test_cases.json
@@ -327,7 +327,7 @@
     {
       "name": "star_emoji",
       "input": "**:smile:**",
-      "expected_output": "<p><strong><span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span></strong></p>",
+      "expected_output": "<p><strong><span aria-label=\"smile\" class=\"emoji message-emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span></strong></p>",
       "text_content": "\ud83d\ude42"
     },
     {
@@ -478,7 +478,7 @@
     {
       "name": "many_emoji",
       "input":  "test :smile: again :poop:\n:) foo:)bar x::y::z :wasted waste: :fakeemojithisshouldnotrender:",
-      "expected_output": "<p>test <span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span> again <span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span><br>\n:) foo:)bar x::y::z :wasted waste: :fakeemojithisshouldnotrender:</p>",
+      "expected_output": "<p>test <span aria-label=\"smile\" class=\"emoji message-emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span> again <span aria-label=\"poop\" class=\"emoji message-emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span><br>\n:) foo:)bar x::y::z :wasted waste: :fakeemojithisshouldnotrender:</p>",
       "text_content": "test \ud83d\ude42 again \ud83d\udca9\n:) foo:)bar x::y::z :wasted waste: :fakeemojithisshouldnotrender:"
     },
     {
@@ -491,14 +491,14 @@
     {
       "name": "translate_emoticons_enabled",
       "input": ":)",
-      "expected_output": "<p><span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span></p>",
+      "expected_output": "<p><span aria-label=\"smile\" class=\"emoji message-emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span></p>",
       "text_content": "\ud83d\ude42",
       "translate_emoticons": true
     },
     {
       "name": "translate_emoticons",
       "input":  ":) foo :( bar <3 with space : ) real emoji :smile:",
-      "expected_output": "<p><span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span> foo <span aria-label=\"frown\" class=\"emoji emoji-1f641\" role=\"img\" title=\"frown\">:frown:</span> bar <span aria-label=\"heart\" class=\"emoji emoji-2764\" role=\"img\" title=\"heart\">:heart:</span> with space : ) real emoji <span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span></p>",
+      "expected_output": "<p><span aria-label=\"smile\" class=\"emoji message-emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span> foo <span aria-label=\"frown\" class=\"emoji message-emoji emoji-1f641\" role=\"img\" title=\"frown\">:frown:</span> bar <span aria-label=\"heart\" class=\"emoji message-emoji emoji-2764\" role=\"img\" title=\"heart\">:heart:</span> with space : ) real emoji <span aria-label=\"smile\" class=\"emoji message-emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span></p>",
       "text_content": "\ud83d\ude42 foo \ud83d\ude41 bar \u2764 with space : ) real emoji \ud83d\ude42",
       "translate_emoticons": true
     },
@@ -512,7 +512,7 @@
     {
       "name": "translate_emoticons_newline",
       "input":  ":) test\n:) test",
-      "expected_output": "<p><span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span> test<br>\n<span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span> test</p>",
+      "expected_output": "<p><span aria-label=\"smile\" class=\"emoji message-emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span> test<br>\n<span aria-label=\"smile\" class=\"emoji message-emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span> test</p>",
       "text_content": "\ud83d\ude42 test\n\ud83d\ude42 test",
       "translate_emoticons": true
     },
@@ -526,14 +526,14 @@
     {
       "name": "translate_emoticons_at_sentence_end",
       "input": "Translate this :).",
-      "expected_output": "<p>Translate this <span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span>.</p>",
+      "expected_output": "<p>Translate this <span aria-label=\"smile\" class=\"emoji message-emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span>.</p>",
       "text_content": "Translate this \ud83d\ude42.",
       "translate_emoticons": true
     },
     {
       "name": "translate_emoticons_between_symbols",
       "input": "Translate this !:)?",
-      "expected_output": "<p>Translate this !<span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span>?</p>",
+      "expected_output": "<p>Translate this !<span aria-label=\"smile\" class=\"emoji message-emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span>?</p>",
       "marked_expected_output": "<p>Translate this !:)?</p>",
       "text_content": "Translate this !\ud83d\ude42?",
       "translate_emoticons": true
@@ -541,29 +541,29 @@
     {
       "name": "random_emoji_1",
       "input": ":airplane:",
-      "expected_output": "<p><span aria-label=\"airplane\" class=\"emoji emoji-2708\" role=\"img\" title=\"airplane\">:airplane:</span></p>"
+      "expected_output": "<p><span aria-label=\"airplane\" class=\"emoji message-emoji emoji-2708\" role=\"img\" title=\"airplane\">:airplane:</span></p>"
     },
     {
       "name": "zulip_emoji",
       "input": ":zulip:",
-      "expected_output": "<p><img alt=\":zulip:\" class=\"emoji\" src=\"/static/generated/emoji/images/emoji/unicode/zulip.png\" title=\"zulip\"></p>",
+      "expected_output": "<p><img alt=\":zulip:\" class=\"emoji message-emoji\" src=\"/static/generated/emoji/images/emoji/unicode/zulip.png\" title=\"zulip\"></p>",
       "text_content": ":zulip:"
     },
     {
       "name": "random_emoji_2",
       "input": ":poop:",
-      "expected_output": "<p><span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span></p>"
+      "expected_output": "<p><span aria-label=\"poop\" class=\"emoji message-emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span></p>"
     },
     {
       "name": "emojis_without_space",
       "input": ":cat:hello:dog::rabbit:",
-      "expected_output": "<p><span aria-label=\"cat\" class=\"emoji emoji-1f408\" role=\"img\" title=\"cat\">:cat:</span>hello<span aria-label=\"dog\" class=\"emoji emoji-1f415\" role=\"img\" title=\"dog\">:dog:</span><span aria-label=\"rabbit\" class=\"emoji emoji-1f407\" role=\"img\" title=\"rabbit\">:rabbit:</span></p>",
+      "expected_output": "<p><span aria-label=\"cat\" class=\"emoji message-emoji emoji-1f408\" role=\"img\" title=\"cat\">:cat:</span>hello<span aria-label=\"dog\" class=\"emoji message-emoji emoji-1f415\" role=\"img\" title=\"dog\">:dog:</span><span aria-label=\"rabbit\" class=\"emoji message-emoji emoji-1f407\" role=\"img\" title=\"rabbit\">:rabbit:</span></p>",
       "text_content": "\ud83d\udc08hello\ud83d\udc15\ud83d\udc07"
     },
     {
       "name": "emojis_newline",
       "input": ":cat:\n:dog:",
-      "expected_output": "<p><span aria-label=\"cat\" class=\"emoji emoji-1f408\" role=\"img\" title=\"cat\">:cat:</span><br>\n<span aria-label=\"dog\" class=\"emoji emoji-1f415\" role=\"img\" title=\"dog\">:dog:</span></p>",
+      "expected_output": "<p><span aria-label=\"cat\" class=\"emoji message-emoji emoji-1f408\" role=\"img\" title=\"cat\">:cat:</span><br>\n<span aria-label=\"dog\" class=\"emoji message-emoji emoji-1f415\" role=\"img\" title=\"dog\">:dog:</span></p>",
       "text_content": "\ud83d\udc08\n\ud83d\udc15"
     },
     {
@@ -575,67 +575,67 @@
     {
       "name": "unicode_emoji",
       "input": "\ud83d\udca9",
-      "expected_output":"<p><span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span></p>",
+      "expected_output":"<p><span aria-label=\"poop\" class=\"emoji message-emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span></p>",
       "text_content": "\ud83d\udca9"
     },
     {
       "name": "two_unicode_emoji",
       "input": "\ud83d\udca9\ud83d\udca9",
-      "expected_output":"<p><span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span><span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span><\/p>",
+      "expected_output":"<p><span aria-label=\"poop\" class=\"emoji message-emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span><span aria-label=\"poop\" class=\"emoji message-emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span><\/p>",
       "text_content": "\ud83d\udca9\ud83d\udca9"
     },
     {
       "name": "two_unicode_emoji_separated_by_text",
       "input": "\ud83d\udca9 word \ud83d\udca9",
-      "expected_output":"<p><span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span> word <span aria-label=\"poop\" class=\"emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span><\/p>",
+      "expected_output":"<p><span aria-label=\"poop\" class=\"emoji message-emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span> word <span aria-label=\"poop\" class=\"emoji message-emoji emoji-1f4a9\" role=\"img\" title=\"poop\">:poop:</span><\/p>",
       "text_content": "\ud83d\udca9 word \ud83d\udca9"
     },
     {
       "name": "miscellaneous_symbols_and_pictographs",
       "input": "Merry Christmas!!\ud83c\udf84",
-      "expected_output":"<p>Merry Christmas!!<span aria-label=\"holiday tree\" class=\"emoji emoji-1f384\" role=\"img\" title=\"holiday tree\">:holiday_tree:</span><\/p>",
+      "expected_output":"<p>Merry Christmas!!<span aria-label=\"holiday tree\" class=\"emoji message-emoji emoji-1f384\" role=\"img\" title=\"holiday tree\">:holiday_tree:</span><\/p>",
       "text_content": "Merry Christmas!!\ud83c\udf84"
     },
     {
       "name": "miscellaneous_and_dingbats_emoji",
       "input": "\u2693\u2797",
-      "expected_output":"<p><span aria-label=\"anchor\" class=\"emoji emoji-2693\" role=\"img\" title=\"anchor\">:anchor:</span><span aria-label=\"division\" class=\"emoji emoji-2797\" role=\"img\" title=\"division\">:division:</span><\/p>"
+      "expected_output":"<p><span aria-label=\"anchor\" class=\"emoji message-emoji emoji-2693\" role=\"img\" title=\"anchor\">:anchor:</span><span aria-label=\"division\" class=\"emoji message-emoji emoji-2797\" role=\"img\" title=\"division\">:division:</span><\/p>"
     },
     {
       "name": "supplemental_symbols_and_pictographs",
       "input": "I am a robot \ud83e\udd16.",
-      "expected_output":"<p>I am a robot <span aria-label=\"robot\" class=\"emoji emoji-1f916\" role=\"img\" title=\"robot\">:robot:</span>.<\/p>"
+      "expected_output":"<p>I am a robot <span aria-label=\"robot\" class=\"emoji message-emoji emoji-1f916\" role=\"img\" title=\"robot\">:robot:</span>.<\/p>"
     },
     {
       "name": "miscellaneous_symbols_and_arrows",
       "input": "Black upward arrow \u2b06",
-      "expected_output":"<p>Black upward arrow <span aria-label=\"up\" class=\"emoji emoji-2b06\" role=\"img\" title=\"up\">:up:</span><\/p>"
+      "expected_output":"<p>Black upward arrow <span aria-label=\"up\" class=\"emoji message-emoji emoji-2b06\" role=\"img\" title=\"up\">:up:</span><\/p>"
     },
     {
       "name": "unicode_emoji_without_space",
       "input": "Extra\ud83d\udc7dTerrestrial",
-      "expected_output":"<p>Extra<span aria-label=\"alien\" class=\"emoji emoji-1f47d\" role=\"img\" title=\"alien\">:alien:</span>Terrestrial<\/p>"
+      "expected_output":"<p>Extra<span aria-label=\"alien\" class=\"emoji message-emoji emoji-1f47d\" role=\"img\" title=\"alien\">:alien:</span>Terrestrial<\/p>"
     },
     {
       "name": "unicode_emojis_new_line",
       "input": "\ud83d\udc7d\n\ud83d\udc7d",
-      "expected_output":"<p><span aria-label=\"alien\" class=\"emoji emoji-1f47d\" role=\"img\" title=\"alien\">:alien:</span><br>\n<span aria-label=\"alien\" class=\"emoji emoji-1f47d\" role=\"img\" title=\"alien\">:alien:</span></p>",
+      "expected_output":"<p><span aria-label=\"alien\" class=\"emoji message-emoji emoji-1f47d\" role=\"img\" title=\"alien\">:alien:</span><br>\n<span aria-label=\"alien\" class=\"emoji message-emoji emoji-1f47d\" role=\"img\" title=\"alien\">:alien:</span></p>",
       "text_content": "\ud83d\udc7d\n\ud83d\udc7d"
     },
     {
       "name": "emoji_alongside_punctuation",
       "input": ":smile:, :smile:; :smile:",
-      "expected_output": "<p><span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span>, <span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span>; <span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span></p>"
+      "expected_output": "<p><span aria-label=\"smile\" class=\"emoji message-emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span>, <span aria-label=\"smile\" class=\"emoji message-emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span>; <span aria-label=\"smile\" class=\"emoji message-emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span></p>"
     },
     {
       "name": "new_emoji_test",
       "input": ":avocado:, :kiwi:, :selfie:, :gear:, :comet:, :gold:",
-      "expected_output": "<p><span aria-label=\"avocado\" class=\"emoji emoji-1f951\" role=\"img\" title=\"avocado\">:avocado:</span>, <span aria-label=\"kiwi\" class=\"emoji emoji-1f95d\" role=\"img\" title=\"kiwi\">:kiwi:</span>, <span aria-label=\"selfie\" class=\"emoji emoji-1f933\" role=\"img\" title=\"selfie\">:selfie:</span>, <span aria-label=\"gear\" class=\"emoji emoji-2699\" role=\"img\" title=\"gear\">:gear:</span>, <span aria-label=\"comet\" class=\"emoji emoji-2604\" role=\"img\" title=\"comet\">:comet:</span>, <span aria-label=\"gold\" class=\"emoji emoji-1f947\" role=\"img\" title=\"gold\">:gold:</span></p>"
+      "expected_output": "<p><span aria-label=\"avocado\" class=\"emoji message-emoji emoji-1f951\" role=\"img\" title=\"avocado\">:avocado:</span>, <span aria-label=\"kiwi\" class=\"emoji message-emoji emoji-1f95d\" role=\"img\" title=\"kiwi\">:kiwi:</span>, <span aria-label=\"selfie\" class=\"emoji message-emoji emoji-1f933\" role=\"img\" title=\"selfie\">:selfie:</span>, <span aria-label=\"gear\" class=\"emoji message-emoji emoji-2699\" role=\"img\" title=\"gear\">:gear:</span>, <span aria-label=\"comet\" class=\"emoji message-emoji emoji-2604\" role=\"img\" title=\"comet\">:comet:</span>, <span aria-label=\"gold\" class=\"emoji message-emoji emoji-1f947\" role=\"img\" title=\"gold\">:gold:</span></p>"
     },
     {
       "name": "emoji_pipeline_newline",
       "input": "The winner is:\nsmiley:smiley:",
-      "expected_output": "<p>The winner is:<br>\nsmiley<span aria-label=\"smiley\" class=\"emoji emoji-1f603\" role=\"img\" title=\"smiley\">:smiley:</span></p>"
+      "expected_output": "<p>The winner is:<br>\nsmiley<span aria-label=\"smiley\" class=\"emoji message-emoji emoji-1f603\" role=\"img\" title=\"smiley\">:smiley:</span></p>"
     },
     {
       "name": "emoji_pipeline_emphasis",
@@ -645,7 +645,7 @@
     {
       "name": "emoji_pipeline_link",
       "input": "Visit https:smiley://google.com.",
-      "expected_output": "<p>Visit https<span aria-label=\"smiley\" class=\"emoji emoji-1f603\" role=\"img\" title=\"smiley\">:smiley:</span>//google.com.</p>"
+      "expected_output": "<p>Visit https<span aria-label=\"smiley\" class=\"emoji message-emoji emoji-1f603\" role=\"img\" title=\"smiley\">:smiley:</span>//google.com.</p>"
     },
     {
       "name": "skin_tones_are_banned",
@@ -666,7 +666,7 @@
     {
       "name": "valid_emoji_preceded_by_invalid_emoji",
       "input": "This is :invalidemoji: which should not prevent rendering :smile:",
-      "expected_output": "<p>This is :invalidemoji: which should not prevent rendering <span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span></p>"
+      "expected_output": "<p>This is :invalidemoji: which should not prevent rendering <span aria-label=\"smile\" class=\"emoji message-emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span></p>"
     },
     {
       "name": "safe_html",
@@ -872,7 +872,7 @@
     {
       "name": "spoilers_with_header_markdown",
       "input": "```spoiler [Header](https://example.com) :smile:\ncontent\n```",
-      "expected_output": "<div class=\"spoiler-block\"><div class=\"spoiler-header\">\n\n<p><a href=\"https://example.com\">Header</a> <span aria-label=\"smile\" class=\"emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span></p>\n</div><div class=\"spoiler-content\" aria-hidden=\"true\">\n\n<p>content</p>\n</div></div>",
+      "expected_output": "<div class=\"spoiler-block\"><div class=\"spoiler-header\">\n\n<p><a href=\"https://example.com\">Header</a> <span aria-label=\"smile\" class=\"emoji message-emoji emoji-1f642\" role=\"img\" title=\"smile\">:smile:</span></p>\n</div><div class=\"spoiler-content\" aria-hidden=\"true\">\n\n<p>content</p>\n</div></div>",
       "text_content": "Header 🙂 (…)\n"
     },
     {

--- a/zerver/tests/test_email_notifications.py
+++ b/zerver/tests/test_email_notifications.py
@@ -977,7 +977,7 @@ class TestMissedMessages(ZulipTestCase):
 
     def test_fix_emoji(self) -> None:
         # An emoji.
-        test_data = '<p>See <span aria-label="cloud with lightning and rain" class="emoji emoji-26c8" role="img" title="cloud with lightning and rain">' + \
+        test_data = '<p>See <span aria-label="cloud with lightning and rain" class="emoji message-emoji emoji-26c8" role="img" title="cloud with lightning and rain">' + \
                     ':cloud_with_lightning_and_rain:</span>.</p>'
         actual_output = fix_emojis(test_data, "http://example.com", "google")
         expected_output = '<p>See <img alt=":cloud_with_lightning_and_rain:" src="http://example.com/static/generated/emoji/images-google-64/26c8.png" ' + \

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -766,7 +766,7 @@ class MarkdownTest(ZulipTestCase):
         media_tweet_html = ('<a href="http://t.co/xo7pAhK6n3">'
                             'http://twitter.com/NEVNBoston/status/421654515616849920/photo/1</a>')
 
-        emoji_in_tweet_html = """Zulip is <span aria-label=\"100\" class="emoji emoji-1f4af" role=\"img\" title="100">:100:</span>% open-source!"""
+        emoji_in_tweet_html = """Zulip is <span aria-label="100" class="emoji message-emoji emoji-1f4af" role="img" title="100">:100:</span>% open-source!"""
 
         def make_inline_twitter_preview(url: str, tweet_html: str, image_html: str='') -> str:
             ## As of right now, all previews are mocked to be the exact same tweet
@@ -917,7 +917,7 @@ class MarkdownTest(ZulipTestCase):
 
     def test_realm_emoji(self) -> None:
         def emoji_img(name: str, file_name: str, realm_id: int) -> str:
-            return '<img alt="{}" class="emoji" src="{}" title="{}">'.format(
+            return '<img alt="{}" class="emoji message-emoji" src="{}" title="{}">'.format(
                 name, get_emoji_url(file_name, realm_id), name[1:-1].replace("_", " "))
 
         realm = get_realm('zulip')
@@ -947,11 +947,11 @@ class MarkdownTest(ZulipTestCase):
     def test_unicode_emoji(self) -> None:
         msg = '\u2615'  # ☕
         converted = markdown_convert_wrapper(msg)
-        self.assertEqual(converted, '<p><span aria-label=\"coffee\" class="emoji emoji-2615" role=\"img\" title="coffee">:coffee:</span></p>')
+        self.assertEqual(converted, '<p><span aria-label="coffee" class="emoji message-emoji emoji-2615" role="img" title="coffee">:coffee:</span></p>')
 
         msg = '\u2615\u2615'  # ☕☕
         converted = markdown_convert_wrapper(msg)
-        self.assertEqual(converted, '<p><span aria-label=\"coffee\" class="emoji emoji-2615" role=\"img\" title="coffee">:coffee:</span><span aria-label=\"coffee\" class="emoji emoji-2615" role=\"img\" title="coffee">:coffee:</span></p>')
+        self.assertEqual(converted, '<p><span aria-label="coffee" class="emoji message-emoji emoji-2615" role="img" title="coffee">:coffee:</span><span aria-label="coffee" class="emoji message-emoji emoji-2615" role="img" title="coffee">:coffee:</span></p>')
 
     def test_no_translate_emoticons_if_off(self) -> None:
         user_profile = self.example_user('othello')

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -2104,7 +2104,7 @@ class TestPushNotificationsContent(ZulipTestCase):
         fixtures = [
             {
                 'name': 'realm_emoji',
-                'rendered_content': f'<p>Testing <img alt=":green_tick:" class="emoji" src="/user_avatars/{realm.id}/emoji/green_tick.png" title="green tick"> realm emoji.</p>',
+                'rendered_content': f'<p>Testing <img alt=":green_tick:" class="emoji message-emoji" src="/user_avatars/{realm.id}/emoji/green_tick.png" title="green tick"> realm emoji.</p>',
                 'expected_output': 'Testing :green_tick: realm emoji.',
             },
             {


### PR DESCRIPTION
This replaces the current HTML hover with JS tooltips for both
normal and custom emojis in messages.

Part of Issue #15632.

![msg_emojis_1](https://user-images.githubusercontent.com/25329595/86517365-fd4e2800-be45-11ea-9beb-0d4b5c8eae68.gif)
