### PR TITLE
list_render: Use simplebar for scrolling.

### DIFF
--- a/frontend_tests/node_tests/list_render.js
+++ b/frontend_tests/node_tests/list_render.js
@@ -10,6 +10,7 @@ function Element() {
     return { };
 }
 set_global('Element', Element);
+set_global('ui', {});
 
 // We only need very simple jQuery wrappers for when the
 // "real" code wraps html or sets up click handlers.
@@ -151,6 +152,12 @@ run_test('scrolling', () => {
 
     const items = [];
 
+    let get_scroll_element_called = false;
+    ui.get_scroll_element = (element) => {
+        get_scroll_element_called = true;
+        return element;
+    };
+
     for (let i = 0; i < 200; i += 1) {
         items.push('item ' + i);
     }
@@ -166,11 +173,29 @@ run_test('scrolling', () => {
         container.appended_data.html(),
         items.slice(0, 80).join(''),
     );
+    assert.equal(get_scroll_element_called, false);
 
     // Set up our fake geometry so it forces a scroll action.
     scroll_container.scrollTop = 180;
     scroll_container.clientHeight = 100;
     scroll_container.scrollHeight = 260;
+
+    // Scrolling gets the next two elements from the list into
+    // our widget.
+    scroll_container.call_scroll();
+    assert.deepEqual(
+        container.appended_data.html(),
+        items.slice(80, 100).join(''),
+    );
+
+    opts.simplebar_container = scroll_container;
+    list_render.create(container, items, opts);
+
+    assert.deepEqual(
+        container.appended_data.html(),
+        items.slice(0, 80).join(''),
+    );
+    assert.equal(get_scroll_element_called, true);
 
     // Scrolling gets the next two elements from the list into
     // our widget.

--- a/static/js/attachments_ui.js
+++ b/static/js/attachments_ui.js
@@ -96,6 +96,7 @@ function render_attachments_ui() {
         sort_fields: {
             mentioned_in: sort_mentioned_in,
         },
+        simplebar_container: $('#attachments-settings .progressive-table-wrapper'),
     });
 
     ui.reset_scrollbar(uploaded_files_table.closest(".progressive-table-wrapper"));

--- a/static/js/list_render.js
+++ b/static/js/list_render.js
@@ -264,7 +264,11 @@ exports.create = function ($container, list, opts) {
     };
 
     widget.set_up_event_handlers = function () {
-        meta.scroll_container = scroll_util.get_list_scrolling_container($container);
+        if (opts.simplebar_container) {
+            meta.scroll_container = ui.get_scroll_element(opts.simplebar_container);
+        } else {
+            meta.scroll_container = scroll_util.get_list_scrolling_container($container);
+        }
 
         // on scroll of the nearest scrolling container, if it hits the bottom
         // of the container then fetch a new block of items and render them.

--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -88,6 +88,7 @@ exports.set_up_muted_topics_ui = function () {
             },
         },
         parent_container: $('#muted-topic-settings'),
+        simplebar_container: $('#muted-topic-settings .progressive-table-wrapper'),
     });
 };
 

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -410,6 +410,7 @@ exports.complete_rerender = function () {
             topic_sort: topic_sort,
         },
         html_selector: get_topic_row,
+        simplebar_container: $('#recent_topics_table .table_fix_head'),
     });
     revive_current_focus();
 };

--- a/static/js/settings_emoji.js
+++ b/static/js/settings_emoji.js
@@ -106,6 +106,7 @@ exports.populate_emoji = function (emoji_data) {
             author_full_name: sort_author_full_name,
         },
         init_sort: ['alphabetic', 'name'],
+        simplebar_container: $('#emoji-settings .progressive-table-wrapper'),
     });
 
     loading.destroy_indicator($('#admin_page_emoji_loading_indicator'));

--- a/static/js/settings_exports.js
+++ b/static/js/settings_exports.js
@@ -72,6 +72,7 @@ exports.populate_exports_table = function (exports) {
         sort_fields: {
             user: sort_user,
         },
+        simplebar_container: $('#data-exports .progressive-table-wrapper'),
     });
 
     const spinner = $('.export_row .export_url_spinner');

--- a/static/js/settings_invites.js
+++ b/static/js/settings_invites.js
@@ -68,6 +68,7 @@ function populate_invites(invites_data) {
         sort_fields: {
             invitee: sort_invitee,
         },
+        simplebar_container: $('#admin-invites-list .progressive-table-wrapper'),
     });
 
     loading.destroy_indicator($('#admin_page_invites_loading_indicator'));

--- a/static/js/settings_linkifiers.js
+++ b/static/js/settings_linkifiers.js
@@ -65,6 +65,7 @@ exports.populate_filters = function (filters_data) {
             pattern: sort_pattern,
             url: sort_url,
         },
+        simplebar_container: $('#filter-settings .progressive-table-wrapper'),
     });
 
     loading.destroy_indicator($('#admin_page_filters_loading_indicator'));

--- a/static/js/settings_streams.js
+++ b/static/js/settings_streams.js
@@ -42,6 +42,7 @@ exports.build_default_stream_table = function () {
         },
         parent_container: $("#admin-default-streams-list").expectOne(),
         init_sort: ['alphabetic', 'name'],
+        simplebar_container: $('#admin-default-streams-list .progressive-table-wrapper'),
     });
 
     loading.destroy_indicator($('#admin_page_default_streams_loading_indicator'));

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -271,6 +271,7 @@ section.bots.create_table = () => {
             email: sort_bot_email,
             bot_owner: sort_bot_owner,
         },
+        simplebar_container: $('#admin-bot-list .progressive-table-wrapper'),
     });
 
     loading.destroy_indicator($('#admin_page_bots_loading_indicator'));
@@ -298,6 +299,7 @@ section.active.create_table = (active_users) => {
             last_active: sort_last_active,
             role: sort_role,
         },
+        simplebar_container: $('#admin-user-list .progressive-table-wrapper'),
     });
 
     loading.destroy_indicator($('#admin_page_users_loading_indicator'));
@@ -324,6 +326,7 @@ section.deactivated.create_table = (deactivated_users) => {
             email: sort_email,
             role: sort_role,
         },
+        simplebar_container: $('#admin-deactivated-users-list .progressive-table-wrapper'),
     });
 
     loading.destroy_indicator($('#admin_page_deactivated_users_loading_indicator'));

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -320,6 +320,7 @@ function show_subscription_settings(sub_row) {
                 }
             },
         },
+        simplebar_container: $('.subscriber_list_container'),
     });
 
     user_pill.set_up_typeahead_on_pills(sub_settings.find('.input'),

--- a/static/styles/recent_topics.scss
+++ b/static/styles/recent_topics.scss
@@ -105,7 +105,7 @@
             padding: 10px;
             padding-top: 0px !important;
             overflow-y: auto;
-            max-height: 100%;
+            max-height: 89%;
         }
 
         .table_fix_head table {

--- a/static/templates/recent_topics_table.hbs
+++ b/static/templates/recent_topics_table.hbs
@@ -7,7 +7,7 @@
         <i class="fa fa-remove" aria-hidden="true"></i>
     </button>
 </div>
-<div class="table_fix_head">
+<div class="table_fix_head" data-simplebar>
     <table class="table table-responsive table-hover">
         <thead>
             <tr>


### PR DESCRIPTION
We add simplebar_container parameter to opts sent to list_render.create
for different lists in settings overlay.

This will help us in avoiding scrolling bugs by creating Simplebar
early in case we need to add event listeners.

Fixes #15637.
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
