### PR TITLE
message list: Fix exception re-rendering messages following local echo.

### DIFF
--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -7,6 +7,7 @@ const noop = function () {};
 set_global('Filter', noop);
 global.stub_out_jquery();
 set_global('document', null);
+set_global('current_msg_list', {});
 
 zrequire('FetchStatus', 'js/fetch_status');
 zrequire('muting');

--- a/static/js/message_list_data.js
+++ b/static/js/message_list_data.js
@@ -521,9 +521,7 @@ MessageListData.prototype = {
             this._selected_id = new_id;
         }
 
-        setTimeout(() => {
-            this.reorder_messages(new_id, opts);
-        }, 0);
+        this.reorder_messages(new_id, opts);
     },
 
     reorder_messages: function (new_id, opts) {
@@ -553,7 +551,7 @@ MessageListData.prototype = {
                 self._all_items.sort(message_sort_func);
             }
 
-            opts.re_render();
+            setTimeout(opts.re_render, 0);
         }
     },
 


### PR DESCRIPTION
Fixes #15346.

Step to reproduce:
1. Set 10 secs delay in [`do_send_messages`](https://github.com/zulip/zulip/blob/master/zerver/lib/actions.py#L1365)
2. Update the setTimeout timer to 5000ms from 0 in [`change_message_id`](https://github.com/zulip/zulip/blob/master/static/js/message_list_data.js#L554)
3. [OPTIONAL] Comment out the [re-selection](https://github.com/zulip/zulip/blob/master/static/js/message_list_view.js#L1092).
(The first 2 points are enough to always reproduce this exception.
Added this to test out the other code path which raises the exception,
which isn't necessary, but it is helpful to know when to create the race by scrolling or clicking,
i.e. when the message pointer loses focus. )
4. Send a message to the narrow / all messages, from a user.
5. Using a different user, send a message to the same message list. This message gets locally echoed.
6. Select the locally echoed message. The other users message gets displayed out of order, just below it.
7. Our sent message is received and the message is still selected, thus raising the exception.
(If point 3 was done, then we would have to manually re-select the message).
This PR allows the re-ordering of the message without raising the exception.

**Previously:**
![echo_bug_before](https://user-images.githubusercontent.com/40122794/86536157-094bef80-bf03-11ea-8b0a-ba52a8b1ef01.gif)
**Now:**
![echo_bug_after](https://user-images.githubusercontent.com/40122794/86536161-123cc100-bf03-11ea-888c-710adf32e63f.gif)