### PR TITLE
streams: Format subscriber count according to browser locale.

### DIFF
--- a/static/js/templates.js
+++ b/static/js/templates.js
@@ -92,4 +92,6 @@ Handlebars.registerHelper(
     (content) => new Handlebars.SafeString(util.clean_user_content_links(content)),
 );
 
+Handlebars.registerHelper('numberFormat', (number) => number.toLocaleString());
+
 window.templates = exports;

--- a/static/templates/subscription_count.hbs
+++ b/static/templates/subscription_count.hbs
@@ -1,6 +1,6 @@
 <i class="fa fa-user-o" aria-hidden="true"></i>
 {{#if can_access_subscribers}}
-<span class="subscriber-count-text">{{subscriber_count}}</span>
+<span class="subscriber-count-text">{{numberFormat subscriber_count}}</span>
 {{else}}
 <i class="subscriber-count-lock fa fa-lock" aria-hidden="true"></i>
 {{/if}}


### PR DESCRIPTION
If a channel has a thousand subscribers this commit results in the count
being displayed with a thousands separator, e.g. with English locale you
get 1,000 instead of 1000.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

before: ![image](https://user-images.githubusercontent.com/47354597/86571029-19021d00-bf71-11ea-84e6-bea2b0b16554.png)

after: ![Screenshot_2020-07-06 home - Zulip Community - Zulip](https://user-images.githubusercontent.com/47354597/86570977-0b4c9780-bf71-11ea-9fa3-ceca3e00c258.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
