### PR TITLE
puppet: Don't run thumbor services in production.

### DIFF
--- a/puppet/zulip/manifests/dockervoyager.pp
+++ b/puppet/zulip/manifests/dockervoyager.pp
@@ -9,7 +9,7 @@ class zulip::dockervoyager {
   include zulip::app_frontend
   include zulip::supervisor
   include zulip::process_fts_updates
-  include zulip::thumbor
+  # include zulip::thumbor
 
   file { "${zulip::common::supervisor_conf_dir}/cron.conf":
     ensure  => file,

--- a/puppet/zulip/manifests/voyager.pp
+++ b/puppet/zulip/manifests/voyager.pp
@@ -33,5 +33,5 @@ class zulip::voyager {
     include zulip::localhost_camo
   }
   include zulip::static_asset_compiler
-  include zulip::thumbor
+  # include zulip::thumbor
 }


### PR DESCRIPTION
Fixes #15649.
Currently, no production services use thumbor; so, it makes sense
to not run them in production systems.

This also avoids users facing issues like #15649.