### PR TITLE
Remove get_sub calls and use stream_id to get sub objects.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -137,8 +137,6 @@ run_test('validate_stream_message_address_info', () => {
     assert(compose.validate_stream_message_address_info('social'));
 
     $('#stream_message_recipient_stream').select(noop);
-    assert(!compose.validate_stream_message_address_info('foobar'));
-    assert.equal($('#compose-error-msg').html(), "translated: <p>The stream <b>foobar</b> does not exist.</p><p>Manage your subscriptions <a href='#streams/all'>on your Streams page</a>.</p>");
 
     sub.subscribed = false;
     stream_data.add_sub(sub);
@@ -321,8 +319,8 @@ run_test('validate_stream_message', () => {
     assert(!$("#compose-all-everyone").visible());
     assert(!$("#compose-send-status").visible());
 
-    stream_data.get_subscriber_count = function (stream_name) {
-        assert.equal(stream_name, 'social');
+    stream_data.get_subscriber_count = function (stream_id) {
+        assert.equal(stream_id, 101);
         return 16;
     };
     global.stub_templates((template_name, data) => {
@@ -346,7 +344,7 @@ run_test('test_validate_stream_message_post_policy', () => {
     // This test is in continuation with test_validate but it has been separated out
     // for better readability. Their relative position of execution should not be changed.
     // Although the position with respect to test_validate_stream_message does not matter
-    // as `get_stream_post_policy` is reset at the end.
+    // as different stream is used for this test.
     page_params.is_admin = false;
     const sub = {
         stream_id: 102,
@@ -354,19 +352,16 @@ run_test('test_validate_stream_message_post_policy', () => {
         subscribed: true,
         stream_post_policy: stream_data.stream_post_policy_values.admins.code,
     };
-    stream_data.get_stream_post_policy = function () {
-        return 2;
-    };
+
     compose_state.topic('subject102');
+    compose_state.stream_name('stream102');
     stream_data.add_sub(sub);
     assert(!compose.validate());
     assert.equal($('#compose-error-msg').html(), i18n.t("Only organization admins are allowed to post to this stream."));
 
-    // reset `get_stream_post_policy` so that any tests occurung after this
+    // reset compose_state.stream_name to 'social' again so that any tests occurung after this
     // do not reproduce this error.
-    stream_data.get_stream_post_policy = function () {
-        return stream_data.stream_post_policy_values.everyone.code;
-    };
+    compose_state.stream_name('social');
 });
 
 run_test('markdown_rtl', () => {

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -83,8 +83,6 @@ run_test('basics', () => {
 
     assert(stream_data.get_invite_only('social'));
     assert(!stream_data.get_invite_only('unknown'));
-    assert(stream_data.get_stream_post_policy('social'));
-    assert(!stream_data.get_stream_post_policy('unknown'));
 
     assert.equal(stream_data.get_color('social'), 'red');
     assert.equal(stream_data.get_color('unknown'), global.stream_color.default_color);
@@ -608,10 +606,10 @@ run_test('get_subscriber_count', () => {
     stream_data.clear_subscriptions();
 
     blueslip.expect('warn', 'We got a get_subscriber_count count call for a non-existent stream.');
-    assert.equal(stream_data.get_subscriber_count('India'), undefined);
+    assert.equal(stream_data.get_subscriber_count(india.stream_id), undefined);
 
     stream_data.add_sub(india);
-    assert.equal(stream_data.get_subscriber_count('India'), 0);
+    assert.equal(stream_data.get_subscriber_count(india.stream_id), 0);
 
     const fred = {
         email: 'fred@zulip.com',
@@ -620,7 +618,7 @@ run_test('get_subscriber_count', () => {
     };
     people.add_active_user(fred);
     stream_data.add_subscriber(india.stream_id, 102);
-    assert.equal(stream_data.get_subscriber_count('India'), 1);
+    assert.equal(stream_data.get_subscriber_count(india.stream_id), 1);
     const george = {
         email: 'george@zulip.com',
         full_name: 'George',
@@ -628,11 +626,11 @@ run_test('get_subscriber_count', () => {
     };
     people.add_active_user(george);
     stream_data.add_subscriber(india.stream_id, 103);
-    assert.equal(stream_data.get_subscriber_count('India'), 2);
+    assert.equal(stream_data.get_subscriber_count(india.stream_id), 2);
 
     const sub = stream_data.get_sub_by_name('India');
     delete sub.subscribers;
-    assert.deepStrictEqual(stream_data.get_subscriber_count('India'), 0);
+    assert.deepStrictEqual(stream_data.get_subscriber_count(india.stream_id), 0);
 });
 
 run_test('notifications', () => {

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -437,8 +437,8 @@ exports.update_stream_email_address = function (sub, email) {
     sub.email_address = email;
 };
 
-exports.get_subscriber_count = function (stream_name) {
-    const sub = exports.get_sub_by_name(stream_name);
+exports.get_subscriber_count = function (stream_id) {
+    const sub = exports.get_sub_by_id(stream_id);
     if (sub === undefined) {
         blueslip.warn('We got a get_subscriber_count count call for a non-existent stream.');
         return;
@@ -567,14 +567,6 @@ exports.get_invite_only = function (stream_name) {
         return false;
     }
     return sub.invite_only;
-};
-
-exports.get_stream_post_policy = function (stream_name) {
-    const sub = exports.get_sub(stream_name);
-    if (sub === undefined) {
-        return false;
-    }
-    return sub.stream_post_policy;
 };
 
 exports.all_topics_in_cache = function (sub) {

--- a/static/templates/compose_invite_users.hbs
+++ b/static/templates/compose_invite_users.hbs
@@ -1,4 +1,4 @@
-<div class="compose_invite_user" data-user-id="{{user_id}}">
+<div class="compose_invite_user" data-user-id="{{user_id}}" data-stream-id="{{stream_id}}">
     {{#if can_subscribe_other_users}}
     <p>{{#tr this}}<strong>__name__</strong> is not subscribed to this stream. They will not be notified unless you subscribe them.{{/tr}}</p>
     <div class="compose_invite_user_controls">


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Changes done in this PR are - 
1. Add stream id to the compose_invite_users link and use stream_id instead of stream name to get sub object.
2. Modify validate_stream_message to check if stream name is valid or not early and then sending stream_id or sub
objects to other validate functions. This helps in changing some functions in stream_data.js to use stream_id instead of 
stream name and avoiding the use of stream_data.get_sub. 

This is **Part 1** of the PR as I am planning to add more commits in this.
**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
