### PR TITLE
message_header: Fix overlap on mobile with flex.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -871,17 +871,18 @@ td.pointer {
 
 .stream_topic {
     display: inline-block;
-    padding: 3px 3px 2px 12px;
-    margin-left: -5px;
+    padding: 3px 3px 2px 9px;
     height: 17px;
     line-height: 17px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.recipient_bar_controls {
+    flex-grow: 1;
 }
 
 .recipient_row_date {
-    position: absolute;
-    right: 0;
-    top: 0;
-
     color: hsl(0, 0%, 53%);
     font-size: 12px;
     font-weight: 600;
@@ -1016,6 +1017,8 @@ td.pointer {
 }
 
 .message-header-contents {
+    display: flex;
+    align-items: center;
     border-right: 1px solid hsl(0, 0%, 88%);
     background-color: hsl(0, 0%, 88%);
 }

--- a/static/templates/recipient_row.hbs
+++ b/static/templates/recipient_row.hbs
@@ -51,8 +51,8 @@
                 </span>
 
                 <i class="fa fa-bell-slash on_hover_topic_mute recipient_bar_icon" data-stream-id="{{stream_id}}" data-topic-name="{{topic}}" title="{{t 'Mute topic' }} (M)" role="button" tabindex="0" aria-label="{{t 'Mute topic' }} (M)"></i>
-                <span class="recipient_row_date {{#if group_date_divider_html}}{{else}}hide-date{{/if}}">{{{date}}}</span>
             </span>
+            <span class="recipient_row_date {{#if group_date_divider_html}}{{else}}hide-date{{/if}}">{{{date}}}</span>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Fixes #15501.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

before:

![Screenshot_2020-07-06 leased database wasn't over-heating slowly - Zulip Dev - Zulip](https://user-images.githubusercontent.com/47354597/86602131-85494480-bfa2-11ea-8959-4250430f2c8a.png)

after:

![Screenshot_2020-07-06 leased database wasn't over-heating slowly - Zulip Dev - Zulip(1)](https://user-images.githubusercontent.com/47354597/86602144-88dccb80-bfa2-11ea-86b9-56de861f02c8.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
