### PR TITLE
docs: Add steps for configuring message retention policy in the docs.

### DIFF
--- a/templates/zerver/help/message-retention-policy.md
+++ b/templates/zerver/help/message-retention-policy.md
@@ -24,6 +24,35 @@ Cloud Standard and Zulip Cloud Plus [plans](https://zulip.com/plans),
 as well as for the hundreds of communities with sponsored Cloud
 Standard hosting.
 
+### Configure message retention policy for organization
+
+{start_tabs}
+
+{settings_tab|organization-settings}
+
+4. Under **Message retention**, configure **Message retention period**.
+
+{!save-changes.md!}
+
+{end_tabs}
+
+### Configure message retention policy for individual streams
+
+{start_tabs}
+
+{relative|stream|all}
+
+1. Select a stream.
+
+1. On the right, click **[Change]** next to the description of the stream
+   permissions.
+
+1. Under **Message retention for stream**, configure **Message retention period**.
+
+{!save-changes.md!}
+
+{end_tabs}
+
 ## Important details
 
 * Retention policies are processed in a daily job; so changes in the


### PR DESCRIPTION
This PR adds the steps for configuring message retention policy
for an organization and for individual streams in message retention
policy docs.

Fixes #15495.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![Screenshot (148)](https://user-images.githubusercontent.com/35494118/86633524-61abeb80-bfee-11ea-981f-96dd86c7ac04.png)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
