### PR TITLE
compose: Set wildcard_mention for message before further validations for showing warnings.

### DIFF
--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -463,7 +463,6 @@ function check_unsubscribed_stream_for_send(stream_name, autosubscribe) {
 
 function validate_stream_message_mentions(stream_id) {
     const stream_count = stream_data.get_subscriber_count(stream_id) || 0;
-    wildcard_mention = util.find_wildcard_mentions(compose_state.message_content());
 
     // check if wildcard_mention has any mention and henceforth execute the warning message.
     if (wildcard_mention !== null && stream_count > exports.all_everyone_warn_threshold) {
@@ -594,6 +593,8 @@ function validate_stream_message() {
     if (!validate_stream_message_post_policy(sub)) {
         return false;
     }
+
+    wildcard_mention = util.find_wildcard_mentions(compose_state.message_content());
 
     // If both `@all` is mentioned and it's in `#announce`, just validate
     // for `@all`. Users shouldn't have to hit "yes" more than once.


### PR DESCRIPTION
We do not show the warning while sending messages to announce
stream if there is a wildcard mention in the message (i.e.
when wildcard_mention != null)

There are two cases where we should ideally show the warning
but we don't-

 - When there is no wildcard mention in the message and
   wildcard_mention is set to undefined (initial value of
   wildcard_mention).
   This is because "wildcard_mention != null" returns true for
   this case and thus the warning is not shown, assuming the
   message to have wildcard mention.

 - When previous message had a wildcard mention and now a message
   is being sent with no wildcard mention.
   This is because the condition "wildcard_mention != null" is
   checked with the previous value of wildcard_mention and not
   with the value according to current message content, and thus
   the warning is not shown, assuming the message to have wildcard
   mention.

This commit changes the code to set wildcard_mention from the
latest message content before performing other validations and
thus solves the problems described above.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
