### PR TITLE
Fix tsearch and upgrade-postgres

### DIFF
--- a/docs/production/upgrade-or-modify.md
+++ b/docs/production/upgrade-or-modify.md
@@ -378,12 +378,6 @@ To upgrade the version of PostgreSQL on the Zulip server:
     /home/zulip/deployments/current/scripts/setup/upgrade-postgres
     ```
 
-   During this step, it is normal to see output containing:
-   ```
-   ERROR:  could not open stop-word file "/usr/share/postgresql/12/tsearch_data/zulip_english.stop": No such file or directory
-   ERROR:  text search dictionary "zulip.english_us_hunspell" does not exist
-   ```
-
 That last command will finish by restarting your Zulip server; you
 should now be able to navigate to its URL and confirm everything is
 working correctly.

--- a/puppet/zulip/lib/puppet/parser/functions/zulipconf.rb
+++ b/puppet/zulip/lib/puppet/parser/functions/zulipconf.rb
@@ -2,7 +2,8 @@ module Puppet::Parser::Functions
   newfunction(:zulipconf, :type => :rvalue) do |args|
     default = args.pop
     joined = args.join(" ")
-    output = `/usr/bin/crudini --get /etc/zulip/zulip.conf #{joined} 2>&1`; result=$?.success?
+    zulip_conf_path = lookupvar('zulip_conf_path')
+    output = `/usr/bin/crudini --get #{zulip_conf_path} #{joined} 2>&1`; result=$?.success?
     if result
       output.strip()
     else

--- a/scripts/setup/upgrade-postgres
+++ b/scripts/setup/upgrade-postgres
@@ -27,10 +27,25 @@ fi
 # the pg_upgradecluster command fails if it is still running
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=759725
 pg_ctlcluster "$UPGRADE_FROM" main stop
+
+(
+    # Two-stage application of puppet; we apply the bare-bones
+    # postgresql configuration first, so that FTS will be configured
+    # prior to the pg_upgradecluster.
+    TEMP_CONF_DIR=$(mktemp -d)
+    cp /etc/zulip/zulip.conf "$TEMP_CONF_DIR"
+    ZULIP_CONF="${TEMP_CONF_DIR}/zulip.conf"
+    crudini --set "$ZULIP_CONF" postgresql version "$UPGRADE_TO"
+    crudini --set "$ZULIP_CONF" machine puppet_classes zulip::base,zulip::postgres_appdb_base
+    touch "/usr/share/postgresql/$UPGRADE_TO/pgroonga_setup.sql.applied"
+
+    "$ZULIP_PATH"/scripts/zulip-puppet-apply -f --config "$ZULIP_CONF"
+    rm -rf "$TEMP_CONF_DIR"
+)
+
 pg_upgradecluster "$UPGRADE_FROM" main
 
 crudini --set /etc/zulip/zulip.conf postgresql version "$UPGRADE_TO"
-touch "/usr/share/postgresql/$UPGRADE_TO/pgroonga_setup.sql.applied"
 "$ZULIP_PATH"/scripts/zulip-puppet-apply -f
 
 service memcached restart

--- a/scripts/zulip-puppet-apply
+++ b/scripts/zulip-puppet-apply
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import argparse
 import configparser
 import os
 import re
@@ -10,12 +11,10 @@ from lib.zulip_tools import assert_running_as_root, parse_os_release
 assert_running_as_root()
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-force = False
-extra_args = sys.argv[1:]
-
-if len(extra_args) and extra_args[0] in ('-f', '--force'):
-    force = True
-    extra_args = extra_args[1:]
+parser = argparse.ArgumentParser(description="Run puppet")
+parser.add_argument('--force', '-f', action="store_true",
+                    help="Do not prompt with proposed changes")
+args, extra_args = parser.parse_known_args()
 
 config = configparser.RawConfigParser()
 config.read("/etc/zulip/zulip.conf")
@@ -42,7 +41,7 @@ puppet_env["FACTER_zulip_scripts_path"] = scripts_path
 if (distro_info['ID'], distro_info['VERSION_ID']) in [('ubuntu', '20.04')]:
     puppet_env["RUBYOPT"] = "-W0"
 
-if not force:
+if not args.force:
     subprocess.check_call(puppet_cmd + ['--noop', '--show_diff'], env=puppet_env)
 
     do_apply = None

--- a/scripts/zulip-puppet-apply
+++ b/scripts/zulip-puppet-apply
@@ -14,10 +14,13 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 parser = argparse.ArgumentParser(description="Run puppet")
 parser.add_argument('--force', '-f', action="store_true",
                     help="Do not prompt with proposed changes")
+parser.add_argument('--config', action="store",
+                    default="/etc/zulip/zulip.conf",
+                    help="Alternate zulip.conf path")
 args, extra_args = parser.parse_known_args()
 
 config = configparser.RawConfigParser()
-config.read("/etc/zulip/zulip.conf")
+config.read(args.config)
 
 distro_info = parse_os_release()
 puppet_config = """
@@ -35,6 +38,7 @@ puppet_cmd += extra_args
 
 # Set the scripts path to be a factor so it can be used by puppet code
 puppet_env = os.environ.copy()
+puppet_env["FACTER_zulip_conf_path"] = args.config
 puppet_env["FACTER_zulip_scripts_path"] = scripts_path
 
 # This is to suppress puppet warnings with ruby 2.7.


### PR DESCRIPTION
Fixes that `upgrade-postgres` broke FTS


**Testing Plan:** Ran `scripts/setup/upgrade-postgres`, observed that search still worked, and ERROR lines seen previously were absent.