### PR TITLE
test-install: Do not install rabbitmq in base install.

### DIFF
--- a/tools/test-install/prepare-base
+++ b/tools/test-install/prepare-base
@@ -49,7 +49,7 @@ run apt-get install -y --no-install-recommends \
   xvfb parallel netcat unzip zip jq python3-pip wget curl eatmydata \
   git crudini openssl ssl-cert \
   build-essential python3-dev \
-  memcached rabbitmq-server redis-server \
+  memcached redis-server \
   hunspell-en-us supervisor libssl-dev puppet \
   gettext libffi-dev libfreetype6-dev zlib1g-dev libjpeg-dev \
   libldap2-dev libmemcached-dev \


### PR DESCRIPTION
The installer does not adjust the node name if the rabbitmq already
exists, and the default node name bakes in the
`zulip-install-bionic-base` hostname.  As such, the resulting LXC
image does not properly start rabbitmq.

Remove rabbitmq, allowing the installer to install and configure it
with a nodename of `zulip@localhost`.  This also lets the installed
image be successfully copied and booted under a new hostname without
breaking rabbitmq.