### PR TITLE
timerender: Make moment() return static date.

### DIFF
--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -135,10 +135,18 @@ run_test('get_timestamp_for_flatpickr', () => {
     const unix_timestamp = 1495091573000; // 5/18/2017 7:12:53 AM (UTC+0)
     const iso_timestamp = '2017-05-18T07:12:53Z'; // ISO 8601 date format
     const func = timerender.get_timestamp_for_flatpickr;
+    // Freeze time for testing.
+    const date_now = Date.now;
+    Date.now = () => new Date('2020-07-07T10:00:00Z').getTime();
+
     // Invalid timestamps should show current time.
     assert.equal(func("random str").valueOf(), moment().valueOf());
+
     // Valid ISO timestamps should return Date objects.
     assert.equal(func(iso_timestamp).valueOf(), moment(unix_timestamp).valueOf());
+
+    // Restore the Date object.
+    Date.now = date_now;
 });
 
 run_test('absolute_time_12_hour', () => {


### PR DESCRIPTION
The previous iteration of the test was flaky when we could get
off by one errors between two moment() calls.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
