### PR TITLE
node-tests: Log file name and test label on failure.

### DIFF
--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -89,8 +89,11 @@ function short_tb(tb) {
 // Set up markdown comparison helper
 global.markdown_assert = require('./markdown_assert.js');
 
+let current_file_name;
+
 function run_one_module(file) {
     console.info('running tests for ' + file.name);
+    current_file_name = file.name;
     require(file.full_name);
 }
 
@@ -98,7 +101,14 @@ global.run_test = (label, f) => {
     if (files.length === 1) {
         console.info('        test: ' + label);
     }
-    f();
+    try {
+        f();
+    } catch (error) {
+        console.info('-'.repeat(50));
+        console.info(`test failed: ${current_file_name} > ${label}`);
+        console.info();
+        throw error;
+    }
     // defensively reset blueslip after each test.
     blueslip.reset();
 };


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

The resulting output is like:

```
running tests for compose_fade
running tests for compose_pm_pill
running tests for compose_ui
running tests for composebox_typeahead
--------------------------------------------------
test failed: composebox_typeahead > filter_and_sort_mentions (normal)

AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
+ actual - expected ... Lines skipped

(more lines below)
```