### PR TITLE
delete_event_notify_user_ids: Fix UnboundLocalError.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4614,6 +4614,7 @@ def do_update_message(user_profile: UserProfile, message: Message,
         event[TOPIC_LINKS] = topic_links(message.sender.realm_id, topic_name)
         edit_history_event[LEGACY_PREV_TOPIC] = orig_topic_name
 
+    delete_event_notify_user_ids = None
     if propagate_mode in ["change_later", "change_all"]:
         assert topic_name is not None or new_stream is not None
         messages_list = update_messages_for_topic_edit(


### PR DESCRIPTION
This commit should (not able to reproduce and test) fix the error report here:
```
Traceback (most recent call last):
  File "/srv/zulip-venv-cache/e5ddc5a01e62fc299dc9f06dea8c3a2747382b13/zulip-py3-venv/lib/python3.6/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "./zerver/lib/rest.py", line 30, in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
  File "/srv/zulip-venv-cache/e5ddc5a01e62fc299dc9f06dea8c3a2747382b13/zulip-py3-venv/lib/python3.6/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "./zerver/lib/rest.py", line 168, in rest_dispatch
    return target_function(request, **kwargs)
  File "/srv/zulip-venv-cache/e5ddc5a01e62fc299dc9f06dea8c3a2747382b13/zulip-py3-venv/lib/python3.6/site-packages/django/utils/decorators.py", line 142, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "./zerver/decorator.py", line 690, in _wrapped_view_func
    **kwargs,
  File "./zerver/decorator.py", line 671, in authenticate_log_and_execute_json
    return limited_view_func(request, user_profile, *args, **kwargs)
  File "./zerver/decorator.py", line 801, in wrapped_func
    return func(request, *args, **kwargs)
  File "./zerver/lib/request.py", line 366, in _wrapped_view_func
    return view_func(request, *args, **kwargs)
  File "./zerver/views/message_edit.py", line 214, in update_message_backend
    mention_user_ids, mention_data)
  File "/usr/lib/python3.6/contextlib.py", line 52, in inner
    return func(*args, **kwds)
  File "./zerver/lib/actions.py", line 4670, in do_update_message
    assert delete_event_notify_user_ids is not None
UnboundLocalError: local variable 'delete_event_notify_user_ids' referenced before assignment
```

I am not sure what causes this though, It would have made sense if   `delete_event_notify_user_ids`  was used outside of the `if new_stream is not None:` statement.