### PR TITLE
[WIP] Replace mock.patch with assertLogs

### DIFF
--- a/zerver/lib/soft_deactivation.py
+++ b/zerver/lib/soft_deactivation.py
@@ -242,8 +242,7 @@ def do_soft_deactivate_users(users: List[UserProfile]) -> List[UserProfile]:
                 users_soft_deactivated.append(user)
             RealmAuditLog.objects.bulk_create(realm_logs)
 
-        logging.info("Soft-deactivated batch of %s users; %s remain to process",
-                     len(user_batch), len(users))
+        logger.info("Soft-deactivated batch of %s users; %s remain to process", len(user_batch), len(users))
 
     return users_soft_deactivated
 
@@ -255,7 +254,7 @@ def do_auto_soft_deactivate_users(inactive_for_days: int, realm: Optional[Realm]
     users_deactivated = do_soft_deactivate_users(users_to_deactivate)
 
     if not settings.AUTO_CATCH_UP_SOFT_DEACTIVATED_USERS:
-        logging.info('Not catching up users since AUTO_CATCH_UP_SOFT_DEACTIVATED_USERS if off')
+        logger.info('Not catching up users since AUTO_CATCH_UP_SOFT_DEACTIVATED_USERS if off')
         return users_deactivated
 
     if realm is not None:

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -32,6 +32,7 @@ from zerver.models import (
 from zerver.views.home import compute_navbar_logo_url
 from zerver.worker.queue_processors import UserActivityWorker
 
+logger_string = "zulip.soft_deactivation"
 
 class HomeTest(ZulipTestCase):
     def test_home(self) -> None:
@@ -906,10 +907,11 @@ class HomeTest(ZulipTestCase):
         self.assertEqual(user_msg_list[-1].content, message)
         self.logout()
 
-        with self.assertLogs(level='INFO') as info_log:
+        with self.assertLogs(logger_string, level='INFO') as info_log:
             do_soft_deactivate_users([long_term_idle_user])
         self.assertEqual(info_log.output, [
-            'INFO:root:Soft-deactivated batch of 1 users; 0 remain to process'
+            f'INFO:{logger_string}:Soft Deactivated user {long_term_idle_user.id}',
+            f'INFO:{logger_string}:Soft-deactivated batch of 1 users; 0 remain to process'
         ])
 
         self.login_user(long_term_idle_user)
@@ -930,10 +932,11 @@ class HomeTest(ZulipTestCase):
         # We are sending this message to ensure that long_term_idle_user has
         # at least one UserMessage row.
         self.send_test_message('Testing', sender_name='hamlet')
-        with self.assertLogs(level='INFO') as info_log:
+        with self.assertLogs(logger_string, level='INFO') as info_log:
             do_soft_deactivate_users([long_term_idle_user])
         self.assertEqual(info_log.output, [
-            'INFO:root:Soft-deactivated batch of 1 users; 0 remain to process'
+            f'INFO:{logger_string}:Soft Deactivated user {long_term_idle_user.id}',
+            f'INFO:{logger_string}:Soft-deactivated batch of 1 users; 0 remain to process'
         ])
 
         message = 'Test Message 1'
@@ -958,10 +961,11 @@ class HomeTest(ZulipTestCase):
         self.assertEqual(idle_user_msg_list[-1].content, message)
         self.logout()
 
-        with self.assertLogs(level='INFO') as info_log:
+        with self.assertLogs(logger_string, level='INFO') as info_log:
             do_soft_deactivate_users([long_term_idle_user])
         self.assertEqual(info_log.output, [
-            'INFO:root:Soft-deactivated batch of 1 users; 0 remain to process'
+            f'INFO:{logger_string}:Soft Deactivated user {long_term_idle_user.id}',
+            f'INFO:{logger_string}:Soft-deactivated batch of 1 users; 0 remain to process'
         ])
 
         message = 'Test Message 3'

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -1088,10 +1088,12 @@ class HandlePushNotificationTest(PushNotificationTest):
         self.setup_gcm_tokens()
         self.make_stream('public_stream')
         self.subscribe(self.user_profile, 'public_stream')
-        with self.assertLogs(level='INFO') as info_logs:
+        logger_string = "zulip.soft_deactivation"
+        with self.assertLogs(logger_string, level='INFO') as info_logs:
             do_soft_deactivate_users([self.user_profile])
         self.assertEqual(info_logs.output, [
-            'INFO:root:Soft-deactivated batch of 1 users; 0 remain to process'
+            f"INFO:{logger_string}:Soft Deactivated user {self.user_profile.id}",
+            f"INFO:{logger_string}:Soft-deactivated batch of 1 users; 0 remain to process"
         ])
         sender = self.example_user('iago')
         message_id = self.send_stream_message(sender, "public_stream", "test")


### PR DESCRIPTION
Replaced mock.patch with assertLogs as asked in issue #15331.
Currently modified only at 3 places in GoogleAuthBackendTest class
in test_auth_backends.py file.
Work in progress still need to replace mock.patch with assertLogs in 
all the tests testing log output.
tested using ./tools/test-backend and circleCI

