### PR TITLE
ci: Re-enable check_send_receive_time in production-verify.

### DIFF
--- a/tools/ci/production-install
+++ b/tools/ci/production-install
@@ -26,7 +26,7 @@ if [ "$os_version_codename" = "bionic" ]; then
 fi
 
 # Install Zulip
-"$ZULIP_PATH"/scripts/setup/install --self-signed-cert --hostname 127.0.0.1 --email circleci@example.com
+"$ZULIP_PATH"/scripts/setup/install --self-signed-cert --hostname zulip.example.net --email circleci@example.com
 
 if [ "$os_version_codename" = "bionic" ]; then
     if [ "$(crudini --get /etc/zulip/zulip.conf postgresql version)" != "10" ]; then

--- a/tools/ci/production-verify
+++ b/tools/ci/production-verify
@@ -91,12 +91,10 @@ for consumer in $consumer_list; do
     fi
 done
 
-# Some of the Nagios tests have been temporarily disabled to work
-# around a Travis CI infrastructure issue.
 echo; echo "Now running additional Nagios tests"; echo
 if ! /usr/lib/nagios/plugins/zulip_app_frontend/check_queue_worker_errors || \
-   ! su zulip -c /usr/lib/nagios/plugins/zulip_postgres_appdb/check_fts_update_log; then # || \
-#   ! su zulip -c "/usr/lib/nagios/plugins/zulip_app_frontend/check_send_receive_time --site=https://127.0.0.1/api --nagios --insecure"; then
+   ! su zulip -c /usr/lib/nagios/plugins/zulip_postgres_appdb/check_fts_update_log || \
+   ! su zulip -c "/usr/lib/nagios/plugins/zulip_app_frontend/check_send_receive_time --site=https://127.0.0.1/api --nagios --insecure"; then
     set +x
     echo
     echo "FAILURE: Nagios checks don't pass:"

--- a/tools/ci/success-http-headers.template.txt
+++ b/tools/ci/success-http-headers.template.txt
@@ -1,5 +1,6 @@
   Self-signed certificate encountered.
-    WARNING: certificate common name ‘127.0.0.1’ doesn't match requested host name ‘localhost’.
+WARNING: no certificate subject alternative name matches
+	requested host name ‘localhost’.
   HTTP/1.1 302 Found
   Server: {nginx_version_string}
   Content-Type: text/html; charset=utf-8


### PR DESCRIPTION
This was disabled in 5db3f60c7d, back in 2017, due to a bug in Travis
CI, which we no longer use.

Re-enable so the verification step in CI verifies we can send an
receive messages.
