### PR TITLE
Fix bug in subscribing and unsubscribing to a stream from stream settings.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -709,7 +709,7 @@ exports.initialize = function () {
 
     // This handler isn't part of the normal edit interface; it's the convenient
     // checkmark in the subscriber list.
-    $("#subscriptions_table").on("click", ".check.sub_unsub_button", (e) => {
+    $("#subscriptions_table").on("click", ".sub_unsub_button", (e) => {
         const sub = get_sub_for_target(e.target);
         // Makes sure we take the correct stream_row.
         const stream_row = $("#subscriptions_table div.stream-row[data-stream-id='" + sub.stream_id + "']");

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -768,7 +768,7 @@ exports.view_stream = function () {
 /* For the given stream_row, remove the tick and replace by a spinner. */
 function display_subscribe_toggle_spinner(stream_row) {
     /* Prevent sending multiple requests by removing the button class. */
-    $(stream_row).removeClass("sub_unsub_button");
+    $(stream_row).find('.check').removeClass("sub_unsub_button");
 
     /* Hide the tick. */
     const tick = $(stream_row).find("svg");
@@ -783,7 +783,7 @@ function display_subscribe_toggle_spinner(stream_row) {
 /* For the given stream_row, add the tick and delete the spinner. */
 function hide_subscribe_toggle_spinner(stream_row) {
     /* Re-enable the button to handle requests. */
-    $(stream_row).addClass("sub_unsub_button");
+    $(stream_row).find('.check').addClass("sub_unsub_button");
 
     /* Show the tick. */
     const tick = $(stream_row).find("svg");


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
The subscribe/unusbscribe button in right section was not working and the bug was introduced in c234b4f2.
This PR has two commits-
1. Fix the subscribe/unsubscribe button to work as expected by reverting the changes made in c234b4f2.
2. FIx the bug of subscribing/unsubscribing to a stream from clicking on stream row (which was intended in c234b4f2).

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
