### PR TITLE
recent_topics: Set correct container as scrolling container.

### DIFF
--- a/static/styles/recent_topics.scss
+++ b/static/styles/recent_topics.scss
@@ -105,6 +105,7 @@
             padding: 10px;
             padding-top: 0px !important;
             overflow-y: auto;
+            max-height: 100%;
         }
 
         .table_fix_head table {


### PR DESCRIPTION
This fixes the bug of extra topics not being rendered on scrolling.
list_render uses `max-height` to determine which container is being
scrolled upon. Set the `max-height` on the scrolling container of
recent topics to help list_render identify it.


@timabbott we should either merge this or #15673 before release.