### PR TITLE
[WIP] zulip_tools: Use mkstemp inplace of insecure mktemp method.

### DIFF
--- a/scripts/lib/zulip_tools.py
+++ b/scripts/lib/zulip_tools.py
@@ -41,18 +41,19 @@ CYAN = '\x1b[36m'
 
 def overwrite_symlink(src: str, dst: str) -> None:
     while True:
-        tmp = tempfile.mktemp(
+        tmp = tempfile.NamedTemporaryFile(
             prefix='.' + os.path.basename(dst) + '.',
-            dir=os.path.dirname(dst))
+            dir=os.path.dirname(dst),
+            delete=False)
         try:
-            os.symlink(src, tmp)
+            os.symlink(src, tmp.name)
         except FileExistsError:
             continue
         break
     try:
-        os.rename(tmp, dst)
+        os.rename(tmp.name, dst)
     except Exception:
-        os.remove(tmp)
+        os.remove(tmp.name)
         raise
 
 def parse_cache_script_args(description: str) -> argparse.Namespace:


### PR DESCRIPTION
See CodeQL Rule - py/insecure-temporary-file

Functions that create temporary file names (such as tempfile.mktemp and
os.tempnam) are fundamentally insecure, as they do not ensure exclusive
access to a file with the temporary name they return. The file name
returned by these functions is guaranteed to be unique on creation but
the file must be opened in a separate operation. There is no guarantee
that the creation and open operations will happen atomically. This
provides an opportunity for an attacker to interfere with the file
before it is opened.

Note that mktemp has been deprecated since Python 2.3.