### PR TITLE
emoji_picker: Improve emoji picker search results.

### DIFF
--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -214,15 +214,16 @@ function filter_emojis() {
                 for (const alias of emoji_dict.aliases) {
                     const match = search_terms.every((search_term) => alias.includes(search_term));
                     if (match) {
-                        search_results.push({ ...emoji_dict, name: alias });
+                        search_results.push({ ...emoji_dict, emoji_name: alias });
                         break;  // We only need the first matching alias per emoji.
                     }
                 }
             }
         }
 
+        const sorted_search_results = typeahead.sort_emojis(search_results, query);
         const rendered_search_results = render_emoji_popover_search_results({
-            search_results: search_results,
+            search_results: sorted_search_results,
             message_id: message_id,
         });
         $('.emoji-search-results').html(rendered_search_results);


### PR DESCRIPTION
This sorts the emoji picker's search results using the same `typehead.sort_emojis` function as the compose typehead.

Resolves #15694.

**GIFs or Screenshots:**

![emoji_search_sort](https://user-images.githubusercontent.com/25329595/86922358-1e668f80-c14a-11ea-999e-c452d7e8d36b.gif)
