### PR TITLE
upgrade: Add management command to fix FTS indexes.

### DIFF
--- a/docs/production/upgrade-or-modify.md
+++ b/docs/production/upgrade-or-modify.md
@@ -239,12 +239,13 @@ instructions for other supported platforms.
 
 5. Finally, we need to reinstall the current version of Zulip, which
    among other things will recompile Zulip's Python module
-   dependencies for your new version of Python:
+   dependencies for your new version of Python, and fix any
+   Full-Text Search indexes that may have been corrupted by the PostgreSQL upgrade:
 
     ```
     rm -rf /srv/zulip-venv-cache/*
     /home/zulip/deployments/current/scripts/lib/upgrade-zulip-stage-2 \
-        /home/zulip/deployments/current/ --ignore-static-assets
+        /home/zulip/deployments/current/ --ignore-static-assets --audit-fts-indexes
     ```
 
 That last command will finish by restarting your Zulip server; you
@@ -378,7 +379,13 @@ To upgrade the version of PostgreSQL on the Zulip server:
     /home/zulip/deployments/current/scripts/setup/upgrade-postgres
     ```
 
-That last command will finish by restarting your Zulip server; you
+4. Finally, run a command that will fix any Full-Text Search indexes that may have been
+   corrupted by the PostgreSQL upgrade:
+   ```
+   su zulip -c '/home/zulip/deployments/current/manage.py audit_fts_indexes'
+   ```
+
+`upgrade-postgres` will have finished by restarting your Zulip server; you
 should now be able to navigate to its URL and confirm everything is
 working correctly.
 

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -81,6 +81,8 @@ parser.add_argument("--ignore-static-assets", dest="ignore_static_assets", actio
                     help="Do not attempt to copy/manage static assets.")
 parser.add_argument("--skip-purge-old-deployments", dest="skip_purge_old_deployments",
                     action="store_true", help="Skip purging old deployments.")
+parser.add_argument("--audit-fts-indexes", dest="audit_fts_indexes",
+                    action="store_true", help="Audit and fix full text search indexes.")
 args = parser.parse_args()
 
 deploy_path = args.deploy_path
@@ -263,6 +265,8 @@ if migrations_needed:
     subprocess.check_call(["./manage.py", "migrate", "--noinput"], preexec_fn=su_to_zulip)
 
 subprocess.check_call(["./manage.py", "create_realm_internal_bots"], preexec_fn=su_to_zulip)
+if args.audit_fts_indexes:
+    subprocess.check_call(["./manage.py", "audit_fts_indexes"], preexec_fn=su_to_zulip)
 
 logging.info("Restarting Zulip...")
 subprocess.check_output(["./scripts/restart-server", "--fill-cache"], preexec_fn=su_to_zulip)

--- a/zerver/management/commands/audit_fts_indexes.py
+++ b/zerver/management/commands/audit_fts_indexes.py
@@ -1,0 +1,19 @@
+from typing import Any
+
+from django.db import connection
+
+from zerver.lib.management import ZulipBaseCommand
+
+
+class Command(ZulipBaseCommand):
+    def handle(self, *args: Any, **kwargs: str) -> None:
+        with connection.cursor() as cursor:
+            cursor.execute("""
+                UPDATE zerver_message
+                SET search_tsvector =
+                to_tsvector('zulip.english_us_search', subject || rendered_content)
+                WHERE to_tsvector('zulip.english_us_search', subject || rendered_content) != search_tsvector
+            """)
+
+            fixed_message_count = cursor.rowcount
+            print(f"Fixed {fixed_message_count} messages.")


### PR DESCRIPTION
Fixes #14982.

`update_fts_indexes` is a weird background process that care of index updates on new messages in the background, it doesn't feel right to make it also a command for one-time audit and fix after an upgrade - I think it's more natural to just have a management command for that - especially since the changes to the code of `update_Fts_indexes` that would be needed would make it much less readable.

Doesn't check pgroonga records, as I don't think we're aware of any breakage happening there? And given that I haven't worked with pgroonga, I don't know what such hypothetical breakages would be that we should audit for. I can try to dive into it if we decide we need it for the release - or could leave it for a follow-up.