### PR TITLE
popovers: Improve keyboard navigation

### DIFF
--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -212,6 +212,7 @@ run_test("basic_chars", () => {
     });
     set_global("stream_popover", {
         stream_popped: return_false,
+        topic_popped: return_false,
     });
     set_global("emoji_picker", {
         reactions_popped: return_false,

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -209,6 +209,7 @@ run_test("basic_chars", () => {
     set_global("popovers", {
         actions_popped: return_false,
         message_info_popped: return_false,
+        user_sidebar_popped: return_false,
     });
     set_global("stream_popover", {
         stream_popped: return_false,

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -214,6 +214,7 @@ run_test("basic_chars", () => {
         stream_popped: return_false,
         topic_popped: return_false,
         all_messages_popped: return_false,
+        starred_messages_popped: return_false,
     });
     set_global("emoji_picker", {
         reactions_popped: return_false,

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -213,6 +213,7 @@ run_test("basic_chars", () => {
     set_global("stream_popover", {
         stream_popped: return_false,
         topic_popped: return_false,
+        all_messages_popped: return_false,
     });
     set_global("emoji_picker", {
         reactions_popped: return_false,

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -210,6 +210,9 @@ run_test("basic_chars", () => {
         actions_popped: return_false,
         message_info_popped: return_false,
     });
+    set_global("stream_popover", {
+        stream_popped: return_false,
+    });
     set_global("emoji_picker", {
         reactions_popped: return_false,
     });

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -316,6 +316,11 @@ exports.process_enter_key = function (e) {
         return true;
     }
 
+    if (stream_popover.starred_messages_popped()) {
+        stream_popover.starred_messages_sidebar_menu_handle_keyboard("enter");
+        return true;
+    }
+
     if (overlays.settings_open()) {
         // On the settings page just let the browser handle
         // the Enter key for things like submitting forms.
@@ -581,6 +586,11 @@ exports.process_hotkey = function (e, hotkey) {
 
         if (stream_popover.all_messages_popped()) {
             stream_popover.all_messages_sidebar_menu_handle_keyboard(event_name);
+            return true;
+        }
+
+        if (stream_popover.starred_messages_popped()) {
+            stream_popover.starred_messages_sidebar_menu_handle_keyboard(event_name);
             return true;
         }
     }

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -301,6 +301,11 @@ exports.process_enter_key = function (e) {
         return true;
     }
 
+    if (popovers.user_sidebar_popped()) {
+        popovers.user_sidebar_popover_handle_keyboard("enter");
+        return true;
+    }
+
     if (stream_popover.stream_popped()) {
         stream_popover.stream_sidebar_menu_handle_keyboard("enter");
         return true;
@@ -571,6 +576,11 @@ exports.process_hotkey = function (e, hotkey) {
 
         if (popovers.message_info_popped()) {
             popovers.user_info_popover_handle_keyboard(event_name);
+            return true;
+        }
+
+        if (popovers.user_sidebar_popped()) {
+            popovers.user_sidebar_popover_handle_keyboard(event_name);
             return true;
         }
 

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -301,6 +301,11 @@ exports.process_enter_key = function (e) {
         return true;
     }
 
+    if (stream_popover.stream_popped()) {
+        stream_popover.stream_sidebar_menu_handle_keyboard("enter");
+        return true;
+    }
+
     if (overlays.settings_open()) {
         // On the settings page just let the browser handle
         // the Enter key for things like submitting forms.
@@ -551,6 +556,11 @@ exports.process_hotkey = function (e, hotkey) {
 
         if (popovers.message_info_popped()) {
             popovers.user_info_popover_handle_keyboard(event_name);
+            return true;
+        }
+
+        if (stream_popover.stream_popped()) {
+            stream_popover.stream_sidebar_menu_handle_keyboard(event_name);
             return true;
         }
     }

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -306,6 +306,11 @@ exports.process_enter_key = function (e) {
         return true;
     }
 
+    if (stream_popover.topic_popped()) {
+        stream_popover.topic_sidebar_menu_handle_keyboard("enter");
+        return true;
+    }
+
     if (overlays.settings_open()) {
         // On the settings page just let the browser handle
         // the Enter key for things like submitting forms.
@@ -561,6 +566,11 @@ exports.process_hotkey = function (e, hotkey) {
 
         if (stream_popover.stream_popped()) {
             stream_popover.stream_sidebar_menu_handle_keyboard(event_name);
+            return true;
+        }
+
+        if (stream_popover.topic_popped()) {
+            stream_popover.topic_sidebar_menu_handle_keyboard(event_name);
             return true;
         }
     }

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -311,6 +311,11 @@ exports.process_enter_key = function (e) {
         return true;
     }
 
+    if (stream_popover.all_messages_popped()) {
+        stream_popover.all_messages_sidebar_menu_handle_keyboard("enter");
+        return true;
+    }
+
     if (overlays.settings_open()) {
         // On the settings page just let the browser handle
         // the Enter key for things like submitting forms.
@@ -571,6 +576,11 @@ exports.process_hotkey = function (e, hotkey) {
 
         if (stream_popover.topic_popped()) {
             stream_popover.topic_sidebar_menu_handle_keyboard(event_name);
+            return true;
+        }
+
+        if (stream_popover.all_messages_popped()) {
+            stream_popover.all_messages_sidebar_menu_handle_keyboard(event_name);
             return true;
         }
     }

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -690,6 +690,20 @@ function focus_user_info_popover_item() {
     exports.focus_first_popover_item(items);
 }
 
+function get_user_sidebar_popover_items() {
+    if (!current_user_sidebar_popover) {
+        blueslip.error("Trying to get menu items when user sidebar popover is closed.");
+        return;
+    }
+
+    return $("li:not(.divider):visible > a", current_user_sidebar_popover.$tip);
+}
+
+exports.user_sidebar_popover_handle_keyboard = function (key) {
+    const items = get_user_sidebar_popover_items();
+    exports.popover_items_handle_keyboard(key, items);
+};
+
 exports.user_info_popover_handle_keyboard = function (key) {
     const items = get_user_info_popover_items();
     exports.popover_items_handle_keyboard(key, items);

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -44,6 +44,11 @@ exports.all_messages_sidebar_menu_handle_keyboard = (key) => {
     popovers.popover_items_handle_keyboard(key, items);
 };
 
+exports.starred_messages_sidebar_menu_handle_keyboard = (key) => {
+    const items = get_popover_menu_items(starred_messages_sidebar_elem);
+    popovers.popover_items_handle_keyboard(key, items);
+};
+
 function elem_to_stream_id(elem) {
     const stream_id = parseInt(elem.attr("data-stream-id"), 10);
 

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -34,6 +34,11 @@ exports.stream_sidebar_menu_handle_keyboard = (key) => {
     popovers.popover_items_handle_keyboard(key, items);
 };
 
+exports.topic_sidebar_menu_handle_keyboard = (key) => {
+    const items = get_popover_menu_items(current_topic_sidebar_elem);
+    popovers.popover_items_handle_keyboard(key, items);
+};
+
 function elem_to_stream_id(elem) {
     const stream_id = parseInt(elem.attr("data-stream-id"), 10);
 

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -39,6 +39,11 @@ exports.topic_sidebar_menu_handle_keyboard = (key) => {
     popovers.popover_items_handle_keyboard(key, items);
 };
 
+exports.all_messages_sidebar_menu_handle_keyboard = (key) => {
+    const items = get_popover_menu_items(all_messages_sidebar_elem);
+    popovers.popover_items_handle_keyboard(key, items);
+};
+
 function elem_to_stream_id(elem) {
     const stream_id = parseInt(elem.attr("data-stream-id"), 10);
 

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -15,6 +15,25 @@ let current_topic_sidebar_elem;
 let all_messages_sidebar_elem;
 let starred_messages_sidebar_elem;
 
+function get_popover_menu_items(sidebar_elem) {
+    if (!sidebar_elem) {
+        blueslip.error("Trying to get menu items when action popover is closed.");
+        return;
+    }
+
+    const popover_data = $(sidebar_elem).data("popover");
+    if (!popover_data) {
+        blueslip.error("Cannot find popover data for stream sidebar menu.");
+        return;
+    }
+    return $("li:not(.divider):visible > a", popover_data.$tip);
+}
+
+exports.stream_sidebar_menu_handle_keyboard = (key) => {
+    const items = get_popover_menu_items(current_stream_sidebar_elem);
+    popovers.popover_items_handle_keyboard(key, items);
+};
+
 function elem_to_stream_id(elem) {
     const stream_id = parseInt(elem.attr("data-stream-id"), 10);
 

--- a/static/templates/all_messages_sidebar_actions.hbs
+++ b/static/templates/all_messages_sidebar_actions.hbs
@@ -1,7 +1,8 @@
 {{! Contents of the "all messages sidebar" popup }}
 <ul class="nav nav-list">
     <li>
-        <a id="mark_all_messages_as_read">
+        {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
+        <a tabindex="0" id="mark_all_messages_as_read">
             <i class="fa fa-book" aria-hidden="true"></i>
             {{#tr this}}Mark all messages as read{{/tr}}
         </a>

--- a/static/templates/starred_messages_sidebar_actions.hbs
+++ b/static/templates/starred_messages_sidebar_actions.hbs
@@ -1,13 +1,14 @@
 {{! Contents of the "starred messages sidebar" popup }}
 <ul class="nav nav-list">
+    {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
     <li>
-        <a id="unstar_all_messages">
+        <a tabindex="0" id="unstar_all_messages">
             <i class="fa fa-star-o" aria-hidden="true"></i>
             {{#tr this}}Unstar all messages{{/tr}}
         </a>
     </li>
     <li>
-        <a id="toggle_display_starred_msg_count">
+        <a tabindex="0" id="toggle_display_starred_msg_count">
             {{#if starred_message_counts}}
                 <i class="fa fa-eye-slash" aria-hidden="true"></i>
                 {{#tr this}}Hide starred message count{{/tr}}

--- a/static/templates/stream_sidebar_actions.hbs
+++ b/static/templates/stream_sidebar_actions.hbs
@@ -13,14 +13,15 @@
 
     <hr>
 
+    {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
     <li>
-        <a class="open_stream_settings">
+        <a tabindex="0" class="open_stream_settings">
             <i class="fa fa-cog" aria-hidden="true"></i>
             {{t "Stream settings" }}
         </a>
     </li>
     <li>
-        <a class="pin_to_top">
+        <a tabindex="0" class="pin_to_top">
             <i class="fa fa-thumb-tack stream-pin-icon" aria-hidden="true"></i>
             {{#if stream.pin_to_top}}
             {{t "Unpin stream from top"}}
@@ -30,13 +31,13 @@
         </a>
     </li>
     <li>
-        <a class="mark_stream_as_read">
+        <a tabindex="0" class="mark_stream_as_read">
             <i class="fa fa-book" aria-hidden="true"></i>
             {{t "Mark all messages as read"}}
         </a>
     </li>
     <li>
-        <a class="toggle_stream_muted">
+        <a tabindex="0" class="toggle_stream_muted">
             {{#if stream.is_muted}}
             <i class="fa fa-bell" aria-hidden="true"></i>
             {{t "Unmute stream"}}
@@ -47,14 +48,14 @@
         </a>
     </li>
     <li>
-        <a class="popover_sub_unsub_button" data-name="{{stream.name}}">
+        <a tabindex="0" class="popover_sub_unsub_button" data-name="{{stream.name}}">
             <i class='fa fa-envelope' aria-hidden="true"></i>
             {{t "Unsubscribe" }}
         </a>
     </li>
     <li>
         <span class="colorpicker-container"><input stream_id="{{stream.stream_id}}" class="colorpicker" type="text" value="{{stream.color}}" /></span>
-        <a class="choose_stream_color">
+        <a tabindex="0" class="choose_stream_color">
             <i class="fa fa-eyedropper" aria-hidden="true"></i>
             {{t "Change color" }}
         </a>

--- a/static/templates/topic_sidebar_actions.hbs
+++ b/static/templates/topic_sidebar_actions.hbs
@@ -8,8 +8,9 @@
 
     <hr>
 
+    {{! tabindex="0" Makes anchor tag focusable. Needed for keyboard support. }}
     <li>
-        <a class="narrow_to_topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
+        <a tabindex="0" class="narrow_to_topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
             <i class="fa fa-bullhorn" aria-hidden="true"></i>
             {{t "Narrow to topic"}}
         </a>
@@ -18,7 +19,7 @@
 
     {{#if can_mute_topic}}
     <li>
-        <a href="#" class="sidebar-popover-mute-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
+        <a tabindex="0" tabindex="0" class="sidebar-popover-mute-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
             <i class="fa fa-bell-slash" aria-hidden="true"></i>
             {{t "Mute topic"}}
         </a>
@@ -27,14 +28,14 @@
 
     {{#if can_unmute_topic}}
     <li>
-        <a href="#" class="sidebar-popover-unmute-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
+        <a tabindex="0" tabindex="0" class="sidebar-popover-unmute-topic" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
             <i class="fa fa-bell" aria-hidden="true"></i>
             {{t "Unmute topic"}}
         </a>
     </li>
     {{/if}}
     <li>
-        <a class="sidebar-popover-mark-topic-read" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
+        <a tabindex="0" class="sidebar-popover-mark-topic-read" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
             <i class="fa fa-book" aria-hidden="true"></i>
             {{t "Mark all messages as read"}}
         </a>
@@ -45,7 +46,7 @@
     <div class="admin-separator">{{#tr this}}ADMIN ACTIONS{{/tr}}</div>
 
     <li>
-        <a class="sidebar-popover-delete-topic-messages" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
+        <a tabindex="0" class="sidebar-popover-delete-topic-messages" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
             <i class="fa fa-trash" aria-hidden="true"></i>
             {{t "Delete all messages in topic"}}
         </a>
@@ -54,7 +55,7 @@
 
     {{#if is_admin}}
     <li>
-        <a class="sidebar-popover-move-topic-messages" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
+        <a tabindex="0" class="sidebar-popover-move-topic-messages" data-stream-id="{{ stream_id }}" data-topic-name="{{ topic_name }}">
             <i class="fa fa-arrows" aria-hidden="true"></i>
             {{t "Move topic"}}
         </a>

--- a/static/templates/user_info_popover_content.hbs
+++ b/static/templates/user_info_popover_content.hbs
@@ -55,20 +55,20 @@
         <hr>
         {{#if can_set_away}}
         <li>
-            <a href="#" class="set_away_status">
+            <a tabindex="0" class="set_away_status">
                 <i class="fa fa-minus-circle" aria-hidden="true"></i> {{#tr this}}Set yourself as unavailable{{/tr}}
             </a>
         </li>
         {{/if}}
         {{#if can_revoke_away}}
         <li>
-            <a href="#" class="revoke_away_status">
+            <a tabindex="0" class="revoke_away_status">
                 <i class="fa fa-minus-circle" aria-hidden="true"></i> {{#tr this}}Set yourself as active{{/tr}}
             </a>
         </li>
         {{/if}}
         <li>
-            <a href="#" class="update_status_text">
+            <a tabindex="0" class="update_status_text">
                 <i class="fa fa-comments" aria-hidden="true"></i>
                 {{#if status_text}}
                     {{#tr this}}Edit status message{{/tr}}
@@ -84,7 +84,7 @@
         <li class="user_info_status_text">
             <span id="status_message">
                 {{status_text}}
-                {{#if is_me}}(<a href="#" class="clear_status">{{#tr this}}clear{{/tr}}</a>){{/if}}
+                {{#if is_me}}(<a tabindex="0" class="clear_status">{{#tr this}}clear{{/tr}}</a>){{/if}}
             </span>
         </li>
     {{/if}}
@@ -92,7 +92,7 @@
     <hr>
     {{#if show_user_profile}}
     <li>
-        <a href="#" class="view_user_profile">
+        <a tabindex="0" class="view_user_profile">
             {{#if is_me}}
                 <i class="fa fa-user" aria-hidden="true"></i> {{#tr this}}View your profile{{/tr}}
             {{else}}
@@ -104,7 +104,7 @@
     {{#if is_active}}
         {{#unless is_me}}
         <li>
-            <a href="#" class="{{ private_message_class }}">
+            <a tabindex="0" class="{{ private_message_class }}">
                 <i class="fa fa-envelope" aria-hidden="true"></i> {{#tr this}}Send private message{{/tr}} {{#if is_sender_popover}}<span class="hotkey-hint">(R)</span>{{/if}}
             </a>
         </li>
@@ -112,7 +112,7 @@
     {{/if}}
     {{#unless is_me}}
     <li>
-        <a href="#" class="mention_user">
+        <a tabindex="0" class="mention_user">
             <i class="fa fa-at" aria-hidden="true"></i> {{#tr this}}Reply mentioning user{{/tr}} {{#if is_sender_popover}}<span class="hotkey-hint">(@)</span>{{/if}}
         </a>
     </li>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes  #15448

**Testing Plan:** <!-- How have you tested? -->
1. Run the server.
2. Clicked different popovers opening buttons/icons
3. Used arrow keys and vim up down keys to navigate.
4. Hit enter key to click on it via keyboard.
5. Also used tab to navigate to next focusable element. (This is browser's handling not out hotkeys)


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![zulip_#15722](https://user-images.githubusercontent.com/23462580/87258637-b950c800-c4c2-11ea-8982-27a475726221.gif)


~**NOTE:** Sometimes the browser doesn't highlight the focused element but it's focused, just not highlighted. Bug is appearing inconsistently to me so exact steps to reproduce it is still WIP. Opened Issue: https://github.com/zulip/zulip/issues/15768~
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
