### PR TITLE
openapi: Use OpenAPI for request validation in tests.

### DIFF
--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -64,7 +64,7 @@ from zerver.models import (
     get_user,
     get_user_by_delivery_email,
 )
-from zerver.openapi.openapi import validate_against_openapi_schema
+from zerver.openapi.openapi import validate_against_openapi_schema, validate_request
 from zerver.tornado.event_queue import clear_client_event_queues_for_testing
 from zilencer.models import get_remote_server_by_uuid
 
@@ -151,7 +151,21 @@ class ZulipTestCase(TestCase):
         elif 'HTTP_USER_AGENT' not in kwargs:
             kwargs['HTTP_USER_AGENT'] = default_user_agent
 
-    def validate_api_response_openapi(self, url: str, method: str, result: HttpResponse) -> None:
+    def extract_api_suffix_url(self, url: str) -> Tuple[str, Dict[str, Any]]:
+        """
+        Function that extracts the url after `/api/v1` or `/json` and also
+        returns the query data in the url, if there is any.
+        """
+        url_split = url.split('?')
+        data: Dict[str, Any] = {}
+        if len(url_split) == 2:
+            data = urllib.parse.parse_qs(url_split[1])
+        url = url_split[0]
+        url = url.replace("/json/", "/").replace("/api/v1/", "/")
+        return (url, data)
+
+    def validate_api_response_openapi(self, url: str, method: str, result: HttpResponse, data: Dict[str, Any],
+                                      http_headers: Dict[str, Any], intentionally_undocumented: Optional[bool] = False) -> None:
         """
         Validates all API responses received by this test against Zulip's API documentation,
         declared in zerver/openapi/zulip.yaml.  This powerful test lets us use Zulip's
@@ -160,18 +174,26 @@ class ZulipTestCase(TestCase):
         """
         if not (url.startswith("/json") or url.startswith("/api/v1")):
             return
-
         try:
             content = ujson.loads(result.content)
         except ValueError:
             return
-        url = re.sub(r"\?.*", "", url)
-        validate_against_openapi_schema(content,
-                                        url.replace("/json/", "/").replace("/api/v1/", "/"),
-                                        method, str(result.status_code))
+        json_url = False
+        if url.startswith('/json'):
+            json_url = True
+        url, query_data = self.extract_api_suffix_url(url)
+        if len(query_data) != 0:
+            # In some cases the query parameters are defined in the url itself. In such cases
+            # The `data` argument of our function is not used. Hence get `data` arguement
+            # from url.
+            data = query_data
+        response_validated = validate_against_openapi_schema(content, url, method, str(result.status_code))
+        if response_validated:
+            validate_request(url, method, data, http_headers, json_url, str(result.status_code),
+                             intentionally_undocumented=intentionally_undocumented)
 
     @instrument_url
-    def client_patch(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
+    def client_patch(self, url: str, info: Dict[str, Any]={}, intentionally_undocumented: bool=False, **kwargs: Any) -> HttpResponse:
         """
         We need to urlencode, since Django's function won't do it for us.
         """
@@ -179,7 +201,7 @@ class ZulipTestCase(TestCase):
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
         result = django_client.patch(url, encoded, **kwargs)
-        self.validate_api_response_openapi(url, "patch", result)
+        self.validate_api_response_openapi(url, "patch", result, info, kwargs, intentionally_undocumented=intentionally_undocumented)
         return result
 
     @instrument_url
@@ -200,7 +222,7 @@ class ZulipTestCase(TestCase):
             encoded,
             content_type=MULTIPART_CONTENT,
             **kwargs)
-        self.validate_api_response_openapi(url, "patch", result)
+        self.validate_api_response_openapi(url, "patch", result, info, kwargs)
         return result
 
     @instrument_url
@@ -216,7 +238,7 @@ class ZulipTestCase(TestCase):
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
         result = django_client.delete(url, encoded, **kwargs)
-        self.validate_api_response_openapi(url, "delete", result)
+        self.validate_api_response_openapi(url, "delete", result, info, kwargs)
         return result
 
     @instrument_url
@@ -234,11 +256,11 @@ class ZulipTestCase(TestCase):
         return django_client.head(url, encoded, **kwargs)
 
     @instrument_url
-    def client_post(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
+    def client_post(self, url: str, info: Dict[str, Any]={}, intentionally_undocumented: bool=False, **kwargs: Any) -> HttpResponse:
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
         result = django_client.post(url, info, **kwargs)
-        self.validate_api_response_openapi(url, "post", result)
+        self.validate_api_response_openapi(url, "post", result, info, kwargs, intentionally_undocumented=intentionally_undocumented)
         return result
 
     @instrument_url
@@ -256,11 +278,11 @@ class ZulipTestCase(TestCase):
         return match.func(req)
 
     @instrument_url
-    def client_get(self, url: str, info: Dict[str, Any]={}, **kwargs: Any) -> HttpResponse:
+    def client_get(self, url: str, info: Dict[str, Any]={}, intentionally_undocumented: bool=False, **kwargs: Any) -> HttpResponse:
         django_client = self.client  # see WRAPPER_COMMENT
         self.set_http_headers(kwargs)
         result = django_client.get(url, info, **kwargs)
-        self.validate_api_response_openapi(url, "get", result)
+        self.validate_api_response_openapi(url, "get", result, info, kwargs, intentionally_undocumented=intentionally_undocumented)
         return result
 
     example_user_map = dict(
@@ -550,9 +572,9 @@ class ZulipTestCase(TestCase):
         kwargs['HTTP_AUTHORIZATION'] = self.encode_user(user)
         return self.client_get(*args, **kwargs)
 
-    def api_post(self, user: UserProfile, *args: Any, **kwargs: Any) -> HttpResponse:
+    def api_post(self, user: UserProfile, *args: Any, intentionally_undocumented: bool=False, **kwargs: Any) -> HttpResponse:
         kwargs['HTTP_AUTHORIZATION'] = self.encode_user(user)
-        return self.client_post(*args, **kwargs)
+        return self.client_post(*args, intentionally_undocumented=intentionally_undocumented, **kwargs)
 
     def api_patch(self, user: UserProfile, *args: Any, **kwargs: Any) -> HttpResponse:
         kwargs['HTTP_AUTHORIZATION'] = self.encode_user(user)

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -306,7 +306,7 @@ SKIP_JSON = {'/fetch_api_key:post'}
 
 def validate_request(url: str, method: str, data: Dict[str, Any],
                      http_headers: Dict[str, Any], json_url: bool,
-                     uses_invalid_parameters: bool) -> None:
+                     status_code: str, intentionally_undocumented: bool=False) -> None:
     # Some JSON endpoints have different parameters compared to
     # their `/api/v1` counterparts.
     if json_url and url + ':' + method in SKIP_JSON:
@@ -322,13 +322,11 @@ def validate_request(url: str, method: str, data: Dict[str, Any],
     mock_request = MockRequest('http://localhost:9991/', method, '/api/v1' + url,
                                headers=http_headers, args=data)
     result = openapi_spec.core_validator().validate(mock_request)
-
-    if uses_invalid_parameters:
-        # This assertion helps us avoid unnecessary use of the
-        # uses_invalid_parameters argument.
-        assert(len(result.errors) != 0)
-        return
-
+    if len(result.errors) != 0:
+        if status_code.startswith('4'):
+            return
+        if status_code.startswith('2') and intentionally_undocumented:
+            return
     # If no errors are raised, then validation is successful
     if len(result.errors) == 0:
         return
@@ -341,8 +339,8 @@ with the parameters passed in this HTTP request.  Consider:
 
 * Updating the OpenAPI schema defined in zerver/openapi/zulip.yaml
 * Adjusting the test to pass valid parameters.  If the test
-  deliberately passes invalid parameters, you need to pass
-  `uses_invalid_parameters=True` to self.client_{method.lower()} or
+  fails due to intentionally_undocumented features, you need to pass
+  `intentionally_undocumented=True` to self.client_{method.lower()} or
   self.api_{method.lower()} to document your intent.
 
 See https://zulip.readthedocs.io/en/latest/documentation/api.html for help.

--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -265,10 +265,12 @@ class MessagePOSTTest(ZulipTestCase):
         user = self.example_user('hamlet')
         user.default_sending_stream_id = get_stream('Verona', user.realm).id
         user.save()
+        # The `to` field is required according to OpenAPI specification
         result = self.api_post(user, "/api/v1/messages", {"type": "stream",
                                                           "client": "test suite",
                                                           "content": "Test message no to",
-                                                          "topic": "Test topic"})
+                                                          "topic": "Test topic"},
+                               intentionally_undocumented=True)
         self.assert_json_success(result)
 
         sent_message = self.get_last_message()
@@ -940,8 +942,10 @@ class ScheduledMessageTest(ZulipTestCase):
                    "tz_guess": tz_guess}
         if defer_until:
             payload["deliver_at"] = defer_until
-
-        result = self.client_post("/json/messages", payload)
+        # `Topic` cannot be empty according to OpenAPI specification.
+        intentionally_undocumented: bool = (topic_name == '')
+        result = self.client_post("/json/messages", payload,
+                                  intentionally_undocumented=intentionally_undocumented)
         return result
 
     def test_schedule_message(self) -> None:

--- a/zerver/tests/test_openapi.py
+++ b/zerver/tests/test_openapi.py
@@ -1078,12 +1078,15 @@ class OpenAPIRequestValidatorTest(ZulipTestCase):
         """
         # `/users/me/subscriptions` doesn't require any parameters
         validate_request('/users/me/subscriptions', 'get', {}, {}, False,
-                         uses_invalid_parameters=False)
-        with self.assertRaises(AssertionError):
-            validate_request('/users/me/subscriptions', 'get', {}, {},
-                             False, uses_invalid_parameters=True)
-        validate_request('/dev_fetch_api_key', 'post', {}, {}, False,
-                         uses_invalid_parameters=True)
+                         '200')
         with self.assertRaises(SchemaError):
-            validate_request('/dev_fetch_api_key', 'post', {}, {},
-                             False, uses_invalid_parameters=False)
+            # `/messages` POST does not work on an empty response
+            validate_request('/messages', 'post', {}, {},
+                             False, '200')
+        # 400 responses are allowed to fail validation.
+        validate_request('/messages', 'post', {}, {},
+                         False, '400')
+        # `intentionally_undocumented` allows validation errors on
+        # 200 responses.
+        validate_request('/dev_fetch_api_key', 'post', {}, {},
+                         False, '200', intentionally_undocumented=True)


### PR DESCRIPTION
Use openapi-core for valiating the requests made during backend
tests against their schema define in `zulip.yaml`. openapi-core has
a few bugs so make the required changes and comment them accordingly.
Also add tests for checking the new functionality.