### PR TITLE
emoji_picker: Fix keys not working if search yields no results.

### DIFF
--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -396,7 +396,8 @@ exports.navigate = function (event_name, e) {
 
     // If search is active and results are empty then return immediately.
     if (search_is_active === true && search_results.length === 0) {
-        return true;
+        // We don't want to prevent default for keys like backspace and space.
+        return false;
     }
 
     if (event_name === 'enter') {


### PR DESCRIPTION
As a consequence of commit 1113589b9d the backspace key and some other keys did not respond if the search yielded no results. This change fixes that bug.

[Relevant discussion.](https://chat.zulip.org/#narrow/stream/9-issues/topic/emoji.20picker.20search.20bug/near/929262)

Original bug:

![BUG_emoji_search_sort](https://user-images.githubusercontent.com/25329595/87038632-aa8cbb80-c20b-11ea-824f-3217f9319617.gif)
