### PR TITLE
settings: Do not use list_render for stream specific notification settings and fix scrolling bugs.

### DIFF
--- a/frontend_tests/node_tests/scroll_util.js
+++ b/frontend_tests/node_tests/scroll_util.js
@@ -89,21 +89,3 @@ run_test('scroll_element_into_container', () => {
     scroll_util.scroll_element_into_container(elem2, container);
     assert.equal(container.scrollTop(), 250 - 100 + 3 + 15);
 });
-
-run_test('get_list_scrolling_container error', () => {
-    const body = {
-        length: 1,
-        is: (sel) => {
-            assert.equal(sel, 'body, html');
-            return true;
-        },
-    };
-
-    blueslip.expect(
-        'error',
-        "Please wrap lists in an element with " +
-        "'max-height' attribute.",
-    );
-
-    scroll_util.get_list_scrolling_container(body);
-});

--- a/frontend_tests/node_tests/settings_muting.js
+++ b/frontend_tests/node_tests/settings_muting.js
@@ -32,7 +32,10 @@ run_test('settings', () => {
         set_up_ui_called = true;
     };
 
+    assert.equal(settings_muting.loaded, false);
+
     settings_muting.set_up();
+    assert.equal(settings_muting.loaded, true);
 
     const click_handler = $('body').get_on_handler('click', '.settings-unmute-topic');
     assert.equal(typeof click_handler, 'function');
@@ -70,4 +73,9 @@ run_test('settings', () => {
     assert(unmute_called);
     assert(set_up_ui_called);
     assert.equal(data_called, 2);
+});
+
+run_test('reset', () => {
+    settings_muting.reset();
+    assert.equal(settings_muting.loaded, false);
 });

--- a/static/js/attachments_ui.js
+++ b/static/js/attachments_ui.js
@@ -96,6 +96,7 @@ function render_attachments_ui() {
         sort_fields: {
             mentioned_in: sort_mentioned_in,
         },
+        simplebar_container: $('#attachments-settings .progressive-table-wrapper'),
     });
 
     ui.reset_scrollbar(uploaded_files_table.closest(".progressive-table-wrapper"));

--- a/static/js/dropdown_list_widget.js
+++ b/static/js/dropdown_list_widget.js
@@ -78,6 +78,7 @@ const DropdownListWidget = function (opts) {
                     return item.name.toLowerCase().includes(value);
                 },
             },
+            simplebar_container: $(`#${opts.container_id} .dropdown-list-wrapper`),
         });
         $(`#${opts.container_id} .dropdown-search`).click((e) => {
             e.stopPropagation();

--- a/static/js/list_render.js
+++ b/static/js/list_render.js
@@ -17,6 +17,10 @@ exports.validate_opts = (opts) => {
         blueslip.error('html_selector should be a function.');
         return false;
     }
+    if (!opts.simplebar_container) {
+        blueslip.error('simplebar_container is missing.');
+        return false;
+    }
     return true;
 };
 
@@ -264,7 +268,7 @@ exports.create = function ($container, list, opts) {
     };
 
     widget.set_up_event_handlers = function () {
-        meta.scroll_container = scroll_util.get_list_scrolling_container($container);
+        meta.scroll_container = ui.get_scroll_element(opts.simplebar_container);
 
         // on scroll of the nearest scrolling container, if it hits the bottom
         // of the container then fetch a new block of items and render them.

--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -20,7 +20,9 @@ exports.rerender = function () {
     if (current_msg_list !== home_msg_list) {
         home_msg_list.update_muting_and_rerender();
     }
-    exports.set_up_muted_topics_ui();
+    if (overlays.settings_open() && settings_muting.loaded) {
+        exports.set_up_muted_topics_ui();
+    }
 };
 
 exports.persist_mute = function (stream_id, topic_name) {

--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -90,6 +90,7 @@ exports.set_up_muted_topics_ui = function () {
             },
         },
         parent_container: $('#muted-topic-settings'),
+        simplebar_container: $('#muted-topic-settings .progressive-table-wrapper'),
     });
 };
 

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -410,6 +410,7 @@ exports.complete_rerender = function () {
             topic_sort: topic_sort,
         },
         html_selector: get_topic_row,
+        simplebar_container: $('#recent_topics_table .table_fix_head'),
     });
     revive_current_focus();
 };

--- a/static/js/scroll_util.js
+++ b/static/js/scroll_util.js
@@ -1,30 +1,3 @@
-exports.get_list_scrolling_container = function (container) {
-    /*
-        This is used for list widgets that don't
-        have SimpleBar (in contrast to, say,
-        ui.get_scroll_element().
-    */
-
-    let nearestScrollingContainer = container;
-
-    while (nearestScrollingContainer.length) {
-        if (nearestScrollingContainer.is("body, html")) {
-            blueslip.error(
-                "Please wrap lists in an element with " +
-                "'max-height' attribute.");
-            break;
-        }
-
-        if (nearestScrollingContainer.css("max-height") !== "none") {
-            break;
-        }
-
-        nearestScrollingContainer = nearestScrollingContainer.parent();
-    }
-
-    return nearestScrollingContainer;
-};
-
 exports.scroll_delta = function (opts) {
     const elem_top = opts.elem_top;
     const container_height = opts.container_height;

--- a/static/js/settings_emoji.js
+++ b/static/js/settings_emoji.js
@@ -106,6 +106,7 @@ exports.populate_emoji = function (emoji_data) {
             author_full_name: sort_author_full_name,
         },
         init_sort: ['alphabetic', 'name'],
+        simplebar_container: $('#emoji-settings .progressive-table-wrapper'),
     });
 
     loading.destroy_indicator($('#admin_page_emoji_loading_indicator'));

--- a/static/js/settings_exports.js
+++ b/static/js/settings_exports.js
@@ -72,6 +72,7 @@ exports.populate_exports_table = function (exports) {
         sort_fields: {
             user: sort_user,
         },
+        simplebar_container: $('#data-exports .progressive-table-wrapper'),
     });
 
     const spinner = $('.export_row .export_url_spinner');

--- a/static/js/settings_invites.js
+++ b/static/js/settings_invites.js
@@ -68,6 +68,7 @@ function populate_invites(invites_data) {
         sort_fields: {
             invitee: sort_invitee,
         },
+        simplebar_container: $('#admin-invites-list .progressive-table-wrapper'),
     });
 
     loading.destroy_indicator($('#admin_page_invites_loading_indicator'));

--- a/static/js/settings_linkifiers.js
+++ b/static/js/settings_linkifiers.js
@@ -65,6 +65,7 @@ exports.populate_filters = function (filters_data) {
             pattern: sort_pattern,
             url: sort_url,
         },
+        simplebar_container: $('#filter-settings .progressive-table-wrapper'),
     });
 
     loading.destroy_indicator($('#admin_page_filters_loading_indicator'));

--- a/static/js/settings_muting.js
+++ b/static/js/settings_muting.js
@@ -1,4 +1,7 @@
+exports.loaded = false;
+
 exports.set_up = function () {
+    exports.loaded = true;
     $('body').on('click', '.settings-unmute-topic', function (e) {
         const $row = $(this).closest("tr");
         const stream_id = parseInt($row.attr("data-stream-id"), 10);
@@ -11,6 +14,10 @@ exports.set_up = function () {
     });
 
     muting_ui.set_up_muted_topics_ui();
+};
+
+exports.reset = function () {
+    exports.loaded = false;
 };
 
 window.settings_muting = exports;

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -47,17 +47,18 @@ function rerender_ui() {
 
     const unmatched_streams = stream_data.get_unmatched_streams_for_notification_settings();
 
-    list_render.create(unmatched_streams_table, unmatched_streams, {
-        name: "unmatched-streams-list",
-        modifier: function (unmatched_streams) {
-            return render_stream_specific_notification_row({
-                stream: unmatched_streams,
+    unmatched_streams_table.find('.stream-row').remove();
+
+    for (const stream of unmatched_streams) {
+        unmatched_streams_table.append(
+            render_stream_specific_notification_row({
+                stream: stream,
                 stream_specific_notification_settings:
                 settings_config.stream_specific_notification_settings,
                 is_disabled: settings_config.all_notifications().show_push_notifications_tooltip,
-            });
-        },
-    });
+            }),
+        );
+    }
 
     if (unmatched_streams.length === 0) {
         unmatched_streams_table.css("display", "none");

--- a/static/js/settings_sections.js
+++ b/static/js/settings_sections.js
@@ -77,6 +77,7 @@ exports.reset_sections = function () {
     settings_profile_fields.reset();
     settings_streams.reset();
     settings_user_groups.reset();
+    settings_muting.reset();
     // settings_users doesn't need a reset()
 };
 

--- a/static/js/settings_streams.js
+++ b/static/js/settings_streams.js
@@ -42,6 +42,7 @@ exports.build_default_stream_table = function () {
         },
         parent_container: $("#admin-default-streams-list").expectOne(),
         init_sort: ['alphabetic', 'name'],
+        simplebar_container: $('#admin-default-streams-list .progressive-table-wrapper'),
     });
 
     loading.destroy_indicator($('#admin_page_default_streams_loading_indicator'));

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -271,6 +271,7 @@ section.bots.create_table = () => {
             email: sort_bot_email,
             bot_owner: sort_bot_owner,
         },
+        simplebar_container: $('#admin-bot-list .progressive-table-wrapper'),
     });
 
     loading.destroy_indicator($('#admin_page_bots_loading_indicator'));
@@ -298,6 +299,7 @@ section.active.create_table = (active_users) => {
             last_active: sort_last_active,
             role: sort_role,
         },
+        simplebar_container: $('#admin-user-list .progressive-table-wrapper'),
     });
 
     loading.destroy_indicator($('#admin_page_users_loading_indicator'));
@@ -324,6 +326,7 @@ section.deactivated.create_table = (deactivated_users) => {
             email: sort_email,
             role: sort_role,
         },
+        simplebar_container: $('#admin-deactivated-users-list .progressive-table-wrapper'),
     });
 
     loading.destroy_indicator($('#admin_page_deactivated_users_loading_indicator'));

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -320,6 +320,7 @@ function show_subscription_settings(sub_row) {
                 }
             },
         },
+        simplebar_container: $('.subscriber_list_container'),
     });
 
     user_pill.set_up_typeahead_on_pills(sub_settings.find('.input'),

--- a/static/styles/recent_topics.scss
+++ b/static/styles/recent_topics.scss
@@ -105,7 +105,7 @@
             padding: 10px;
             padding-top: 0px !important;
             overflow-y: auto;
-            max-height: 100%;
+            max-height: 89%;
         }
 
         .table_fix_head table {

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -544,7 +544,7 @@ input[type=checkbox] {
     }
 }
 
-.organization-settings-parent div:first-of-type {
+.organization-settings-parent > div:first-of-type {
     margin-top: 10px;
 }
 
@@ -1592,11 +1592,17 @@ body:not(.night-mode) #settings_page .custom_user_field .datepicker {
         bottom: auto;
     }
 
-    .dropdown-list-body {
+    .dropdown-list-wrapper {
         position: relative;
         height: auto;
         max-height: 200px;
         overflow-y: auto;
+        margin-top: 0;
+        display: block;
+    }
+
+    .dropdown-list-body {
+        position: relative;
         margin-top: 0;
         display: block;
     }

--- a/static/templates/recent_topics_table.hbs
+++ b/static/templates/recent_topics_table.hbs
@@ -7,7 +7,7 @@
         <i class="fa fa-remove" aria-hidden="true"></i>
     </button>
 </div>
-<div class="table_fix_head">
+<div class="table_fix_head" data-simplebar>
     <table class="table table-responsive table-hover">
         <thead>
             <tr>

--- a/static/templates/settings/dropdown_list_widget.hbs
+++ b/static/templates/settings/dropdown_list_widget.hbs
@@ -11,7 +11,9 @@
                 <li class="dropdown-search" role="presentation">
                     <input class="no-input-change-detection" type="text" role="menuitem" placeholder="{{list_placeholder}}" autofocus/>
                 </li>
-                <span class="dropdown-list-body" data-simplebar></span>
+                <div class="dropdown-list-wrapper" data-simplebar>
+                    <span class="dropdown-list-body"></span>
+                </div>
             </ul>
         </span>
     </label>


### PR DESCRIPTION
We do not need to use list_render for displaying list of streams specific
notification settings, as this is not scrollable and we do not provide
option to sort or filter this list as well.

After this change, all our list_render instances will be using simplebar
and we can change the code accordingly to fix the behaviour of scrolling.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
