### PR TITLE
puppet: Don't run thumbor services in production.

### DIFF
--- a/puppet/zulip/manifests/dockervoyager.pp
+++ b/puppet/zulip/manifests/dockervoyager.pp
@@ -9,7 +9,6 @@ class zulip::dockervoyager {
   include zulip::app_frontend
   include zulip::supervisor
   include zulip::process_fts_updates
-  include zulip::thumbor
 
   file { "${zulip::common::supervisor_conf_dir}/cron.conf":
     ensure  => file,

--- a/puppet/zulip/manifests/voyager.pp
+++ b/puppet/zulip/manifests/voyager.pp
@@ -33,5 +33,4 @@ class zulip::voyager {
     include zulip::localhost_camo
   }
   include zulip::static_asset_compiler
-  include zulip::thumbor
 }


### PR DESCRIPTION
My approach to fixing the problem that https://github.com/zulip/zulip/pull/15687 had, with not really stopping thumbor on existing deployments. This uses the `purge` attribute on the supervisord config directory - https://puppet.com/docs/puppet/5.5/types/file.html#file-attribute-purge

Fixes zulip#15649.
Currently, no production services use thumbor; so, it makes sense
to not run them in production systems.

We make the supervisord config directory managed by puppet on all
system, and through the purge attribute we make puppet delete any files
in the directory that are not managed by it. That means that removing
zulip::thumbor from the production classes will cause its config file to
be deleted, which otherwise wouldn't happen. Some caution is needed when
applying this, because any custom supervisord configs added by the admin
will be deleted, if they weren't properly added in puppet.
