### PR TITLE
Fix exports (and add alert words to test database)

### DIFF
--- a/zerver/tests/test_alert_words.py
+++ b/zerver/tests/test_alert_words.py
@@ -4,7 +4,7 @@ from zerver.lib.actions import do_add_alert_words, do_remove_alert_words
 from zerver.lib.alert_words import alert_words_in_realm, user_alert_words
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import most_recent_message, most_recent_usermessage
-from zerver.models import UserProfile
+from zerver.models import AlertWord, UserProfile
 
 
 class AlertWordTests(ZulipTestCase):
@@ -13,7 +13,9 @@ class AlertWordTests(ZulipTestCase):
     def get_user(self) -> UserProfile:
         # One nice thing about Hamlet is that he is
         # already subscribed to Denmark.
-        return self.example_user('hamlet')
+        user = self.example_user('hamlet')
+        AlertWord.objects.filter(user_profile=user).delete()
+        return user
 
     def test_internal_endpoint(self) -> None:
         user = self.get_user()
@@ -91,6 +93,8 @@ class AlertWordTests(ZulipTestCase):
         alert_words_in_realm. Alerts added for one user do not impact other
         users.
         """
+        AlertWord.objects.all().delete()
+
         user1 = self.get_user()
 
         do_add_alert_words(user1, self.interesting_alert_word_list)

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -638,9 +638,23 @@ class Command(BaseCommand):
                 ]
                 create_users(zulip_realm, internal_zulip_users_nosubs, bot_type=UserProfile.DEFAULT_BOT)
 
-            # Mark all messages as read
-            UserMessage.objects.all().update(flags=UserMessage.flags.read)
+            mark_all_messages_as_read()
             self.stdout.write("Successfully populated test database.\n")
+
+def mark_all_messages_as_read() -> None:
+    '''
+    We want to keep these two flags intact after we
+    create messages:
+
+        has_alert_word
+        is_private
+
+    But we will mark all messages as read to save a step for users.
+    '''
+    # Mark all messages as read
+    UserMessage.objects.all().update(
+        flags=F('flags').bitor(UserMessage.flags.read),
+    )
 
 recipient_hash: Dict[int, Recipient] = {}
 def get_recipient_by_id(rid: int) -> Recipient:

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -37,6 +37,7 @@ from zerver.lib.user_groups import create_user_group
 from zerver.lib.users import add_service
 from zerver.lib.utils import generate_api_key
 from zerver.models import (
+    AlertWord,
     Client,
     CustomProfileField,
     DefaultStream,
@@ -122,6 +123,39 @@ def subscribe_users_to_streams(realm: Realm, stream_dict: Dict[str, Dict[str, An
             all_subscription_logs.append(log)
     Subscription.objects.bulk_create(subscriptions_to_add)
     RealmAuditLog.objects.bulk_create(all_subscription_logs)
+
+def create_alert_words(realm_id: int) -> None:
+    user_ids = UserProfile.objects.filter(
+        realm_id=realm_id
+    ).values_list('id', flat=True)
+
+    alert_words = [
+        'algorithms',
+        'complexity',
+        'founded',
+        'galaxy',
+        'grammar',
+        'illustrious',
+        'natural',
+        'objective',
+        'people',
+        'robotics',
+        'study',
+    ]
+
+    recs: List[AlertWord] = []
+    for user_id in user_ids:
+        random.shuffle(alert_words)
+        for i in range(4):
+            recs.append(
+                AlertWord(
+                    realm_id=realm_id,
+                    user_profile_id=user_id,
+                    word = alert_words[i],
+                )
+            )
+
+    AlertWord.objects.bulk_create(recs)
 
 class Command(BaseCommand):
     help = "Populate a test database"
@@ -521,6 +555,8 @@ class Command(BaseCommand):
         # Create several initial pairs for personals
         personals_pairs = [random.sample(user_profiles_ids, 2)
                            for i in range(options["num_personals"])]
+
+        create_alert_words(zulip_realm.id)
 
         # Generate a new set of test data.
         create_test_data()


### PR DESCRIPTION
The alert word commits here aren't crucial to the export fix, but they are vaguely related in the sense that they remove some spam from the export tests (as well as giving the export test slightly more realistic data).