### PR TITLE
Add alert words to test/dev databases

### DIFF
--- a/zerver/openapi/javascript_examples.js
+++ b/zerver/openapi/javascript_examples.js
@@ -83,6 +83,20 @@ const ExamplesHandler = function () {
 
 const {main, add_example} = ExamplesHandler();
 
+const send_test_message = async (client) => {
+    const params = {
+        to: 'Verona',
+        type: 'stream',
+        topic: 'Castle',
+        // Use some random text for easier debugging if needed. We don't
+        // depend on the content of these messages for the tests.
+        content: `Random test message ${Math.random()}`,
+    };
+    const result = await client.messages.send(params);
+    // Only return the message id.
+    return result.id;
+};
+
 // Declare all the examples below.
 
 add_example('send_message', '/messages:post', 200, async (client) => {
@@ -290,7 +304,12 @@ add_example('remove_subscriptions', '/users/me/subscriptions:delete', 200, async
 });
 
 add_example('update_message_flags', '/messages/flags:post', 200, async (client) => {
-    const message_ids = [4, 8, 15];
+    // Send 3 messages to run this example on
+    const message_ids = [...Array(3)];
+    for (let i = 0; i < message_ids.length; i = i + 1) {
+        message_ids[i] = await send_test_message(client);
+    }
+
     // {code_example|start}
     // Add the "read" flag to the messages with IDs in "message_ids"
     const addflag = {
@@ -341,13 +360,7 @@ add_example('get_events', '/events:get', 200, async (client) => {
     const queue_id = res.queue_id;
     // For setup, we send a message to ensure there are events in the
     // queue; this lets the automated tests complete quickly.
-    const params = {
-        to: 'social',
-        type: 'stream',
-        topic: 'Castle',
-        content: 'I come not, friends, to steal away your hearts.',
-    };
-    client.messages.send(params);
+    await send_test_message(client);
 
     // {code_example|start}
     // Retrieve events from a queue with given "queue_id"

--- a/zerver/tests/test_alert_words.py
+++ b/zerver/tests/test_alert_words.py
@@ -4,7 +4,7 @@ from zerver.lib.actions import do_add_alert_words, do_remove_alert_words
 from zerver.lib.alert_words import alert_words_in_realm, user_alert_words
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import most_recent_message, most_recent_usermessage
-from zerver.models import UserProfile
+from zerver.models import AlertWord, UserProfile
 
 
 class AlertWordTests(ZulipTestCase):
@@ -13,7 +13,11 @@ class AlertWordTests(ZulipTestCase):
     def get_user(self) -> UserProfile:
         # One nice thing about Hamlet is that he is
         # already subscribed to Denmark.
-        return self.example_user('hamlet')
+        user = self.example_user('hamlet')
+
+        # delete words from populate_db to simplify tests
+        AlertWord.objects.filter(user_profile=user).delete()
+        return user
 
     def test_internal_endpoint(self) -> None:
         user = self.get_user()
@@ -91,6 +95,10 @@ class AlertWordTests(ZulipTestCase):
         alert_words_in_realm. Alerts added for one user do not impact other
         users.
         """
+
+        # Clear all the words that we got from populate_db.
+        AlertWord.objects.all().delete()
+
         user1 = self.get_user()
 
         do_add_alert_words(user1, self.interesting_alert_word_list)

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -638,9 +638,23 @@ class Command(BaseCommand):
                 ]
                 create_users(zulip_realm, internal_zulip_users_nosubs, bot_type=UserProfile.DEFAULT_BOT)
 
-            # Mark all messages as read
-            UserMessage.objects.all().update(flags=UserMessage.flags.read)
+            mark_all_messages_as_read()
             self.stdout.write("Successfully populated test database.\n")
+
+def mark_all_messages_as_read() -> None:
+    '''
+    We want to keep these two flags intact after we
+    create messages:
+
+        has_alert_word
+        is_private
+
+    But we will mark all messages as read to save a step for users.
+    '''
+    # Mark all messages as read
+    UserMessage.objects.all().update(
+        flags=F('flags').bitor(UserMessage.flags.read),
+    )
 
 recipient_hash: Dict[int, Recipient] = {}
 def get_recipient_by_id(rid: int) -> Recipient:


### PR DESCRIPTION
gotta fix test-api to not hard code message ids