### PR TITLE
stream: Fix incorrect dispaly of stream notifications settings.

### DIFF
--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -504,7 +504,7 @@ exports.update_calculated_fields = function (sub) {
 
     // Apply the defaults for our notification settings for rendering.
     for (const setting of settings_config.stream_specific_notification_settings) {
-        sub[setting + "_display"] = exports.receives_notifications(sub.name, setting);
+        sub[setting + "_display"] = exports.receives_notifications(sub.stream_id, setting);
     }
 };
 


### PR DESCRIPTION
The stream notification settings checkboxes were not checked
even when the notifications were turned on for the stream.
This was happening because we were passing stream name to
receives_notifications instead of stream id.

This commit fixes the bug by passing stream id to
receives_notifications. This change should have been done
in f3604fb while refactoring receives_notifications to use
stream id instead of name.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->




<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
