### PR TITLE
nagios: Remove check_memcached.

### DIFF
--- a/puppet/zulip_ops/files/nagios3/commands.cfg
+++ b/puppet/zulip_ops/files/nagios3/commands.cfg
@@ -111,11 +111,6 @@ define command{
 }
 
 define command{
-        command_name    check_memcached_ssh
-        command_line    /usr/lib/nagios/plugins/check_by_ssh -p $ARG1$ -l nagios -t 30 -i /var/lib/nagios/.ssh/id_rsa -H $HOSTADDRESS$ -C '/usr/lib/nagios/plugins/check_memcached -H 127.0.0.1 -E 0'
-}
-
-define command{
         command_name    check_rabbitmq_queues
         command_line    /usr/lib/nagios/plugins/check_by_ssh -p $ARG1$ -l nagios -t 30 -i /var/lib/nagios/.ssh/id_rsa -H $HOSTADDRESS$ -C '/usr/lib/nagios/plugins/zulip_app_frontend/check_rabbitmq_queues'
 }

--- a/puppet/zulip_ops/files/nagios3/conf.d/services.cfg
+++ b/puppet/zulip_ops/files/nagios3/conf.d/services.cfg
@@ -288,15 +288,6 @@ define service {
 
 define service {
         use                             generic-service
-        service_description             Check memcached service
-        check_command                   check_memcached_ssh!22
-        max_check_attempts              3
-        hostgroups                      frontends
-        contact_groups                  page_admins
-}
-
-define service {
-        use                             generic-service
         service_description             Check rabbitmq queue sizes
         check_command                   check_rabbitmq_queues!22
         # Workaround weird checks 40s after first error causing alerts


### PR DESCRIPTION
chech_memcached does not support memcached authentication even in its
latest release (it’s in a TODO item comment, and that’s it), and was
never particularly useful.