### PR TITLE
docs: Add information about how desktop app handles certificates

### DIFF
--- a/templates/zerver/help/custom-certificates.md
+++ b/templates/zerver/help/custom-certificates.md
@@ -1,4 +1,4 @@
-# Add a custom certificate
+# Use a custom certificate
 
 By default, Zulip generates a signed certificate during the server install
 process. In some cases, a server administrator may choose not to use that
@@ -15,18 +15,84 @@ If you are absolutely, 100% sure that the Zulip server you are connecting to
 is supposed to have a self-signed certificate, click through the warnings
 and follow the instructions on-screen.
 
-If you are less than 100% sure, contact your server administrator. Accepting
-a malicious self-signed certificate would give a stranger full access to
-your Zulip, including your username and password.
+If you are less than 100% sure, contact your server
+administrator. Accepting a malicious self-signed certificate would
+give a stranger full access to your Zulip account, including your
+username and password.
 
 ## Desktop
 
-For safety reasons, we require you to manually enter the certificate details
-before you can connect to your Zulip server. You'll need to get a
-certificate file (should end in `.crt` or `.pem`) from your server
-administrator.
+### Version 5.4.0 and above
 
-### Add a custom certificate
+Zulip Desktop version 5.4.0 and above use the operating system's
+certificate store, like your web browser.
+
+{start_tabs}
+{tab|mac}
+1. Hit Cmd+Space to bring up Spotlight Search, type **Keychain
+   Access**, and press Enter.
+
+2. From the **File** menu, choose **Import Items...**
+
+3. Navigate to the certificate file, then click **Open**.
+
+4. Right-click the newly-added certificate, and click **Get Info** from
+   the context menu.
+
+5. Expand the **Trust** section.
+
+6. Select **Always Trust** for the **Secure Sockets Layer (SSL)** option.
+
+7. Close the window.  You will be prompted for your password to verify
+   the change.
+
+8. Restart the Zulip Desktop application.
+
+{tab|windows}
+On Windows, Zulip Desktop shares the certificate store with
+Google Chrome, so you can add certificates to it from inside
+Chrome.
+
+1. Open Google Chrome.
+
+2. From the Chrome menu (⋮) in the top-right, select **Settings**.
+
+2. In the **Privacy and Security** section, click **Security**.
+
+3. Scroll down to and click **Manage Certificates**.
+
+4. Select the **Trusted Root Certification Authorities** tab.
+
+5. Select **Import...**
+
+6. Navigate to the certificate file, then click **Open**.
+
+7. Select **Done**.
+
+8. Restart the Zulip Desktop application.
+
+{tab|linux}
+The required packages and steps vary by distribution; see the Chromium
+documentation for [detailed documentation][linux].  On most systems,
+once the `nss` tools are installed, the command to trust the
+certificate is:
+
+```
+certutil -d sql:$HOME/.pki/nssdb -A -t "C,," -n zulip \
+  -i path/to/certificate.pem
+```
+
+You will need to restart the Zulip Desktop application to pick up the
+new certificate.
+{end_tabs}
+
+
+### Version 5.3.0 and below
+
+On Zulip Desktop version 5.3.0 and below, we require you to manually
+enter the certificate details before you can connect to your Zulip
+server. You'll need to get a certificate file (should end in `.crt` or
+`.pem`) from your server administrator and add it:
 
 {start_tabs}
 
@@ -35,6 +101,11 @@ administrator.
 2. Select the **Organizations** tab.
 
 3. Under **Add Custom Certificates**, enter your organization URL and add
-   the custom certificate file (should end in `.crt` or `.pem`).
+   the custom certificate file (it should end in `.crt` or `.pem`).
 
 {end_tabs}
+
+
+
+
+[linux]: https://chromium.googlesource.com/chromium/src.git/+/master/docs/linux/cert_management.md

--- a/templates/zerver/help/desktop-app-install-guide.md
+++ b/templates/zerver/help/desktop-app-install-guide.md
@@ -126,4 +126,4 @@ sudo apt install zulip
 ## Related articles
 
 * [Connect through a proxy](/help/connect-through-a-proxy)
-* [Add a custom certificate](/help/custom-certificates)
+* [Use a custom certificate](/help/custom-certificates)

--- a/templates/zerver/help/include/sidebar_index.md
+++ b/templates/zerver/help/include/sidebar_index.md
@@ -95,7 +95,7 @@
 * [View organization statistics](/help/analytics)
 * [Linking to Zulip](/help/linking-to-zulip)
 * [Connect through a proxy](/help/connect-through-a-proxy)
-* [Add a custom certificate](/help/custom-certificates)
+* [Use a custom certificate](/help/custom-certificates)
 
 ## Apps
 * [Desktop installation guides](/help/desktop-app-install-guide)


### PR DESCRIPTION
**What's this PR for?**

Earlier desktop app supported certificates from Zulip cert store but now we are migrating to system store.
Zulip-desktop will support certificates from system store and eventually, the Zulip store will be deprecated.

This commit adds the document citing the migration and how to add certificates into the system store.