### PR TITLE
streams: Remove get_sub calls and use stream id instead of stream name.

### DIFF
--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -74,6 +74,7 @@ run_test("basics", () => {
     assert.deepEqual(stream_data.home_view_stream_names(), ["social"]);
     assert.deepEqual(stream_data.subscribed_streams(), ["social", "test"]);
     assert.deepEqual(stream_data.get_colors(), ["red", "yellow"]);
+    assert.deepEqual(stream_data.subscribed_stream_ids(), [social.stream_id, test.stream_id]);
 
     assert(stream_data.is_subscribed("social"));
     assert(stream_data.is_subscribed("Social"));

--- a/frontend_tests/node_tests/stream_sort.js
+++ b/frontend_tests/node_tests/stream_sort.js
@@ -3,7 +3,7 @@ zrequire("stream_sort");
 const with_overrides = global.with_overrides;
 
 run_test("no_subscribed_streams", () => {
-    assert.equal(stream_sort.sort_groups(""), undefined);
+    assert.equal(stream_sort.sort_groups([]), undefined);
     assert.equal(stream_sort.first_stream_id(), undefined);
 });
 
@@ -45,7 +45,7 @@ stream_data.add_sub(clarinet);
 stream_data.add_sub(weaving);
 
 function sort_groups(query) {
-    const streams = stream_data.subscribed_streams();
+    const streams = stream_data.subscribed_stream_ids();
     return stream_sort.sort_groups(streams, query);
 }
 
@@ -54,9 +54,9 @@ with_overrides((override) => {
 
     // Test sorting into categories/alphabetized
     let sorted = sort_groups("");
-    assert.deepEqual(sorted.pinned_streams, ["scalene"]);
-    assert.deepEqual(sorted.normal_streams, ["clarinet", "fast tortoise"]);
-    assert.deepEqual(sorted.dormant_streams, ["pneumonia"]);
+    assert.deepEqual(sorted.pinned_streams, [scalene.stream_id]);
+    assert.deepEqual(sorted.normal_streams, [clarinet.stream_id, fast_tortoise.stream_id]);
+    assert.deepEqual(sorted.dormant_streams, [pneumonia.stream_id]);
 
     // Test cursor helpers.
     assert.equal(stream_sort.first_stream_id(), scalene.stream_id);
@@ -69,7 +69,7 @@ with_overrides((override) => {
 
     // Test filtering
     sorted = sort_groups("s");
-    assert.deepEqual(sorted.pinned_streams, ["scalene"]);
+    assert.deepEqual(sorted.pinned_streams, [scalene.stream_id]);
     assert.deepEqual(sorted.normal_streams, []);
     assert.deepEqual(sorted.dormant_streams, []);
 
@@ -81,17 +81,17 @@ with_overrides((override) => {
     sorted = sort_groups("PnEuMoNiA");
     assert.deepEqual(sorted.pinned_streams, []);
     assert.deepEqual(sorted.normal_streams, []);
-    assert.deepEqual(sorted.dormant_streams, ["pneumonia"]);
+    assert.deepEqual(sorted.dormant_streams, [pneumonia.stream_id]);
 
     // Test searching part of word
     sorted = sort_groups("tortoise");
     assert.deepEqual(sorted.pinned_streams, []);
-    assert.deepEqual(sorted.normal_streams, ["fast tortoise"]);
+    assert.deepEqual(sorted.normal_streams, [fast_tortoise.stream_id]);
     assert.deepEqual(sorted.dormant_streams, []);
 
     // Test searching stream with spaces
     sorted = sort_groups("fast t");
     assert.deepEqual(sorted.pinned_streams, []);
-    assert.deepEqual(sorted.normal_streams, ["fast tortoise"]);
+    assert.deepEqual(sorted.normal_streams, [fast_tortoise.stream_id]);
     assert.deepEqual(sorted.dormant_streams, []);
 });

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -366,6 +366,10 @@ exports.subscribed_streams = function () {
     return exports.subscribed_subs().map((sub) => sub.name);
 };
 
+exports.subscribed_stream_ids = function () {
+    return exports.subscribed_subs().map((sub) => sub.stream_id);
+};
+
 exports.get_invite_stream_data = function () {
     function get_data(sub) {
         return {

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -85,7 +85,7 @@ exports.build_stream_list = function () {
     // sidebar rows.  Our job here is to build the bigger widget,
     // which largely is a matter of arranging the individual rows in
     // the right order.
-    const streams = stream_data.subscribed_streams();
+    const streams = stream_data.subscribed_stream_ids();
     if (streams.length === 0) {
         return;
     }
@@ -101,9 +101,8 @@ exports.build_stream_list = function () {
     const parent = $("#stream_filters");
     const elems = [];
 
-    function add_sidebar_li(stream) {
-        const sub = stream_data.get_sub(stream);
-        const sidebar_row = exports.stream_sidebar.get_row(sub.stream_id);
+    function add_sidebar_li(stream_id) {
+        const sidebar_row = exports.stream_sidebar.get_row(stream_id);
         sidebar_row.update_whether_active();
         elems.push(sidebar_row.get_li());
     }

--- a/static/js/stream_sort.js
+++ b/static/js/stream_sort.js
@@ -8,8 +8,21 @@ let all_streams = [];
 exports.get_streams = function () {
     // Right now this is only used for testing, but we should
     // use it for things like hotkeys that cycle through streams.
-    return all_streams;
+    const sorted_streams = all_streams.map((stream_id) =>
+        stream_data.maybe_get_stream_name(stream_id),
+    );
+    return sorted_streams;
 };
+
+function compare_function(a, b) {
+    const stream_a = stream_data.get_sub_by_id(a);
+    const stream_b = stream_data.get_sub_by_id(b);
+
+    const stream_name_a = stream_a ? stream_a.name : "";
+    const stream_name_b = stream_b ? stream_b.name : "";
+
+    return util.strcmp(stream_name_a, stream_name_b);
+}
 
 function filter_streams_by_search(streams, search_term) {
     if (search_term === "") {
@@ -21,7 +34,7 @@ function filter_streams_by_search(streams, search_term) {
 
     const filtered_streams = streams.filter((stream) =>
         search_terms.some((search_term) => {
-            const lower_stream_name = stream.toLowerCase();
+            const lower_stream_name = stream_data.get_sub_by_id(stream).name.toLowerCase();
             const cands = lower_stream_name.split(" ");
             cands.push(lower_stream_name);
             return cands.some((name) => name.startsWith(search_term));
@@ -47,7 +60,7 @@ exports.sort_groups = function (streams, search_term) {
     const dormant_streams = [];
 
     for (const stream of streams) {
-        const sub = stream_data.get_sub(stream);
+        const sub = stream_data.get_sub_by_id(stream);
         const pinned = sub.pin_to_top;
         if (pinned) {
             pinned_streams.push(stream);
@@ -58,9 +71,9 @@ exports.sort_groups = function (streams, search_term) {
         }
     }
 
-    pinned_streams.sort(util.strcmp);
-    normal_streams.sort(util.strcmp);
-    dormant_streams.sort(util.strcmp);
+    pinned_streams.sort(compare_function);
+    normal_streams.sort(compare_function);
+    dormant_streams.sort(compare_function);
 
     const same_as_before =
         previous_pinned !== undefined &&
@@ -84,26 +97,12 @@ exports.sort_groups = function (streams, search_term) {
     };
 };
 
-function pos(stream_id) {
-    const sub = stream_data.get_sub_by_id(stream_id);
-    const name = sub.name;
-    const i = all_streams.indexOf(name);
-
-    if (i < 0) {
-        return;
-    }
-
-    return i;
-}
-
 function maybe_get_stream_id(i) {
     if (i < 0 || i >= all_streams.length) {
         return;
     }
 
-    const name = all_streams[i];
-    const stream_id = stream_data.get_stream_id(name);
-    return stream_id;
+    return all_streams[i];
 }
 
 exports.first_stream_id = function () {
@@ -111,9 +110,9 @@ exports.first_stream_id = function () {
 };
 
 exports.prev_stream_id = function (stream_id) {
-    const i = pos(stream_id);
+    const i = all_streams.indexOf(stream_id);
 
-    if (i === undefined) {
+    if (i < 0) {
         return;
     }
 
@@ -121,9 +120,9 @@ exports.prev_stream_id = function (stream_id) {
 };
 
 exports.next_stream_id = function (stream_id) {
-    const i = pos(stream_id);
+    const i = all_streams.indexOf(stream_id);
 
-    if (i === undefined) {
+    if (i < 0) {
         return;
     }
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR has 3 commits - 
1. Change is_user_subscribed to use stream id instead of stream name.
2. Use narrow_state.stream_sub instead of narrow_state.stream for subscribing to a stream from stream narrow.
3. Store list of stream ids instead of list of stream names which will then be used sorting of streams.

 <!-- How have you tested? -->


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
