### PR TITLE
subscriptions: Migrate to HTML5 color picker from spectrum.

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "sortablejs": "^1.9.0",
     "sorttable": "^1.0.2",
     "source-sans-pro": "^3.6.0",
-    "spectrum-colorpicker": "^1.8.1",
     "stacktrace-gps": "^3.0.4",
     "style-loader": "^1.0.0",
     "terser-webpack-plugin": "^3.0.3",

--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -5,7 +5,6 @@ import "../../third/bootstrap-notify/js/bootstrap-notify.js";
 import "../../third/bootstrap-typeahead/typeahead.js";
 import "jquery-caret-plugin/src/jquery.caret.js";
 import "../../third/jquery-idle/jquery.idle.js";
-import "spectrum-colorpicker";
 import "../../third/marked/lib/marked.js";
 import "xdate/src/xdate.js";
 import "jquery-validation/dist/jquery.validate.js";
@@ -203,7 +202,6 @@ import "../spoilers.js";
 // Import Styles
 
 import "../../third/bootstrap-notify/css/bootstrap-notify.css";
-import "spectrum-colorpicker/spectrum.css";
 import "katex/dist/katex.css";
 import "flatpickr/dist/flatpickr.css";
 import "flatpickr/dist/plugins/confirmDate/confirmDate.css";

--- a/static/js/stream_color.js
+++ b/static/js/stream_color.js
@@ -37,36 +37,12 @@ function update_historical_message_color(stream_name, color) {
     }
 }
 
-const stream_color_palette = [
-    ['a47462', 'c2726a', 'e4523d', 'e7664d', 'ee7e4a', 'f4ae55'],
-    ['76ce90', '53a063', '94c849', 'bfd56f', 'fae589', 'f5ce6e'],
-    ['a6dcbf', 'addfe5', 'a6c7e5', '4f8de4', '95a5fd', 'b0a5fd'],
-    ['c2c2c2', 'c8bebf', 'c6a8ad', 'e79ab5', 'bd86e5', '9987e1'],
-];
-
-const subscriptions_table_colorpicker_options = {
-    clickoutFiresChange: true,
-    showPalette: true,
-    showInput: true,
-    palette: stream_color_palette,
-};
-
-exports.set_colorpicker_color = function (colorpicker, color) {
-    colorpicker.spectrum({
-        ...subscriptions_table_colorpicker_options,
-        color: color,
-        container: "#subscription_overlay .subscription_settings.show",
-    });
-};
-
 exports.update_stream_color = function (sub, color, opts) {
     opts = { update_historical: false, ...opts };
     sub.color = color;
     const stream_id = sub.stream_id;
     // The swatch in the subscription row header.
     $(".stream-row[data-stream-id='" + stream_id + "'] .icon").css('background-color', color);
-    // The swatch in the color picker.
-    exports.set_colorpicker_color($("#subscription_overlay .subscription_settings[data-stream-id='" + stream_id + "'] .colorpicker"), color);
     $("#subscription_overlay .subscription_settings[data-stream-id='" + stream_id + "'] .large-icon").css("color", color);
 
     if (opts.update_historical) {
@@ -76,33 +52,11 @@ exports.update_stream_color = function (sub, color, opts) {
     tab_bar.colorize_tab_bar();
 };
 
-function picker_do_change_color(color) {
-    const stream_id = parseInt($(this).attr('stream_id'), 10);
-    const hex_color = color.toHexString();
-    subs.set_color(stream_id, hex_color);
-}
-subscriptions_table_colorpicker_options.change = picker_do_change_color;
-
-exports.sidebar_popover_colorpicker_options = {
-    clickoutFiresChange: true,
-    showPaletteOnly: true,
-    showPalette: true,
-    showInput: true,
-    flat: true,
-    palette: stream_color_palette,
-    change: picker_do_change_color,
-};
-
-exports.sidebar_popover_colorpicker_options_full = {
-    clickoutFiresChange: false,
-    showPalette: true,
-    showInput: true,
-    flat: true,
-    cancelText: "",
-    chooseText: i18n.t("Confirm"),
-    palette: stream_color_palette,
-    change: picker_do_change_color,
-};
+$(document).on("change", "#stream_color_picker", function (e) {
+    const color = e.target.value;
+    const stream_id = parseInt(e.target.getAttribute("stream_id"), 10);
+    subs.set_color(stream_id, color);
+});
 
 let lightness_threshold;
 exports.initialize = function () {

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -271,9 +271,6 @@ function show_subscription_settings(sub_row) {
     const sub = stream_data.get_sub_by_id(stream_id);
     const sub_settings = exports.settings_for_sub(sub);
 
-    const colorpicker = sub_settings.find('.colorpicker');
-    const color = stream_data.get_color(sub.name);
-    stream_color.set_colorpicker_color(colorpicker, color);
     stream_ui_updates.update_add_subscriptions_elements(sub);
 
     const container = $("#subscription_overlay .subscription_settings[data-stream-id='" + stream_id + "'] .pill-container");

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -95,36 +95,6 @@ function stream_popover_sub(e) {
     return sub;
 }
 
-// This little function is a workaround for the fact that
-// Bootstrap popovers don't properly handle being resized --
-// so after resizing our popover to add in the spectrum color
-// picker, we need to adjust its height accordingly.
-function update_spectrum(popover, update_func) {
-    const initial_height = popover[0].offsetHeight;
-
-    const colorpicker = popover.find('.colorpicker-container').find('.colorpicker');
-    update_func(colorpicker);
-    const after_height = popover[0].offsetHeight;
-
-    const popover_root = popover.closest(".popover");
-    const current_top_px = parseFloat(popover_root.css('top').replace('px', ''));
-    const height_delta = after_height - initial_height;
-    let top = current_top_px - height_delta / 2;
-
-    if (top < 0) {
-        top = 0;
-        popover_root.find("div.arrow").hide();
-    } else if (top + after_height > $(window).height() - 20) {
-        top = $(window).height() - after_height - 20;
-        if (top < 0) {
-            top = 0;
-        }
-        popover_root.find("div.arrow").hide();
-    }
-
-    popover_root.css('top', top + "px");
-}
-
 function build_stream_popover(opts) {
     const elt = opts.elt;
     const stream_id = opts.stream_id;
@@ -153,10 +123,6 @@ function build_stream_popover(opts) {
 
     $(elt).popover("show");
     const popover = $('.streams_popover[data-stream-id=' + stream_id + ']');
-
-    update_spectrum(popover, (colorpicker) => {
-        colorpicker.spectrum(stream_color.sidebar_popover_colorpicker_options);
-    });
 
     current_stream_sidebar_elem = elt;
 }
@@ -415,21 +381,8 @@ exports.register_stream_handlers = function () {
     });
 
     // Choose a different color.
-    $('body').on('click', '.choose_stream_color', (e) => {
-        update_spectrum($(e.target).closest('.streams_popover'), (colorpicker) => {
-            $('.colorpicker-container').show();
-            colorpicker.spectrum("destroy");
-            colorpicker.spectrum(stream_color.sidebar_popover_colorpicker_options_full);
-            // In theory this should clean up the old color picker,
-            // but this seems a bit flaky -- the new colorpicker
-            // doesn't fire until you click a button, but the buttons
-            // have been hidden.  We work around this by just manually
-            // fixing it up here.
-            colorpicker.parent().find('.sp-container').removeClass('sp-buttons-disabled');
-            $(e.target).hide();
-        });
-
-        $('.streams_popover').on('click', 'a.sp-cancel', () => {
+    $('body').on('click', '.choose_stream_color', function (e) {
+        $('.streams_popover').on('click', 'a.sp-cancel', function () {
             exports.hide_stream_popover();
         });
     });

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -107,6 +107,10 @@
     border-radius: 4px;
 }
 
+label[for="streamcolor"] {
+    padding-top: 9px;
+}
+
 .subscription-control-label {
     display: inline-block;
     vertical-align: middle;

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -400,6 +400,25 @@ input {
     }
 }
 
+input[type="color"] {
+    height: 25px;
+    width: 25px;
+    margin-top: 5px;
+    margin-bottom: 0;
+    border: none;
+    border-radius: 5px;
+    padding: 0;
+
+    &::-webkit-color-swatch-wrapper {
+        padding: 0;
+    }
+
+    &::-webkit-color-swatch {
+        border: solid 1px hsl(0, 0%, 75%); /* change color of the swatch border here */
+        border-radius: 5px;
+    }
+}
+
 li,
 .table th,
 .table td {

--- a/static/templates/subscription_settings.hbs
+++ b/static/templates/subscription_settings.hbs
@@ -67,7 +67,7 @@
                     <li>
                         <label for="streamcolor" class="subscription-control-label">{{t "Stream color" }}</label>
                         <span class="sub_setting_control">
-                            <input stream_id="{{sub.stream_id}}" class="colorpicker" id="streamcolor" type="text" value="{{sub.color}}" tabindex="-1" />
+                            <input stream_id="{{sub.stream_id}}" id="stream_color_picker" type="color" value="{{sub.color}}"/>
                         </span>
                     </li>
                 </ul>

--- a/version.py
+++ b/version.py
@@ -44,4 +44,4 @@ API_FEATURE_LEVEL = 24
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '89.1'
+PROVISION_VERSION = '90'


### PR DESCRIPTION
Earlier Zulip was using `spectrum-colorpicker` which seemed to be an
abandoned project (last commit 3 years ago) and since we have dropped
support for IE11, switching to HTML5 native color picker was right choice.

The following commit removes absolute code referring to
`spectrum-colorpicker` and introduces the support for HTML5 color picker
for changing stream colors.

Fixes #14961.

**GIFs or Screenshots:** 
![Color Changer](https://user-images.githubusercontent.com/23737560/87217497-63b3d880-c367-11ea-93b2-04c4c475b422.gif)
