### PR TITLE
wip- recent_topics: Add persistence for filters via localstorage.

### DIFF
--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -101,6 +101,7 @@ alert_words.process_message = noop;
 zrequire("recent_senders");
 zrequire("unread");
 zrequire("stream_topic_history");
+zrequire("localstorage");
 zrequire("recent_topics");
 zrequire("overlays");
 

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -1,6 +1,7 @@
 "use strict";
 
 zrequire("message_util");
+zrequire("localstorage");
 
 const noop = () => {};
 set_global(
@@ -71,6 +72,22 @@ set_global("list_render", {
     },
     hard_redraw: noop,
     render_item: (item) => list_render.modifier(item),
+});
+
+const ls_container = new Map();
+set_global("localStorage", {
+    getItem(key) {
+        return ls_container.get(key);
+    },
+    setItem(key, val) {
+        ls_container.set(key, val);
+    },
+    removeItem(key) {
+        ls_container.delete(key);
+    },
+    clear() {
+        ls_container.clear();
+    },
 });
 
 // Custom Data

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -13,7 +13,6 @@ let topics_widget;
 // Sets the number of avatars to display.
 // Rest of the avatars, if present, are displayed as {+x}
 const MAX_AVATAR = 4;
-let filters = new Set();
 
 // Use this to set the focused element.
 //
@@ -36,6 +35,19 @@ let col_focus = 1;
 // increased when we add new actions, or rethought if we add optional
 // actions that only appear in some rows.
 const MAX_SELECTABLE_COLS = 4;
+
+// we use localstorage to persist the recent topic filters
+const ls_key = "recent_topic_filters";
+const ls = localstorage();
+
+let filters = new Set();
+exports.save_filters = function () {
+    ls.set(ls_key, Array.from(filters));
+};
+
+exports.load_filters = function () {
+    filters = new Set(ls.get(ls_key));
+};
 
 function set_default_focus() {
     // If at any point we are confused about the currently
@@ -338,6 +350,8 @@ exports.set_filter = function (filter) {
     } else {
         filters.add(filter);
     }
+
+    exports.save_filters();
 };
 
 function show_selected_filters() {
@@ -434,6 +448,8 @@ exports.complete_rerender = function () {
 };
 
 exports.launch = function () {
+    exports.load_filters();
+
     overlays.open_overlay({
         name: "recent_topics",
         overlay: $("#recent_topics_overlay"),


### PR DESCRIPTION
Previously the filter would be reset every time the page was
refreshed.

Given that the above was annoying and also that most users would
prefer to have their choice of default here, we add persistence to the
filter via localstorage.


Fixes: #15676.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
