### PR TITLE
Inline Twitter Previews

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1070,6 +1070,8 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
 
         div.set("class", "inline-preview-twitter")
         div.insert(0, twitter_data)
+        if info['remove'] is not None:
+            info['parent'].remove(info['remove'])
 
     def find_proper_insertion_index(self, grandparent: Element, parent: Element,
                                     parent_index_in_grandparent: int) -> int:

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -790,21 +790,21 @@ class MarkdownTest(ZulipTestCase):
         converted = markdown_convert_wrapper(msg)
         self.assertEqual(converted, '<p>{}</p>'.format(make_link('http://www.twitter.com/wdaher/status/999999999999999999')))
 
-        msg = 'http://www.twitter.com/wdaher/status/287977969287315456'
+        msg = 'Tweet: http://www.twitter.com/wdaher/status/287977969287315456'
         converted = markdown_convert_wrapper(msg)
-        self.assertEqual(converted, '<p>{}</p>\n{}'.format(
+        self.assertEqual(converted, '<p>Tweet: {}</p>\n{}'.format(
             make_link('http://www.twitter.com/wdaher/status/287977969287315456'),
             make_inline_twitter_preview('http://www.twitter.com/wdaher/status/287977969287315456', normal_tweet_html)))
 
-        msg = 'https://www.twitter.com/wdaher/status/287977969287315456'
+        msg = 'Tweet: https://www.twitter.com/wdaher/status/287977969287315456'
         converted = markdown_convert_wrapper(msg)
-        self.assertEqual(converted, '<p>{}</p>\n{}'.format(
+        self.assertEqual(converted, '<p>Tweet: {}</p>\n{}'.format(
             make_link('https://www.twitter.com/wdaher/status/287977969287315456'),
             make_inline_twitter_preview('https://www.twitter.com/wdaher/status/287977969287315456', normal_tweet_html)))
 
-        msg = 'http://twitter.com/wdaher/status/287977969287315456'
+        msg = 'Tweet: http://twitter.com/wdaher/status/287977969287315456'
         converted = markdown_convert_wrapper(msg)
-        self.assertEqual(converted, '<p>{}</p>\n{}'.format(
+        self.assertEqual(converted, '<p>Tweet: {}</p>\n{}'.format(
             make_link('http://twitter.com/wdaher/status/287977969287315456'),
             make_inline_twitter_preview('http://twitter.com/wdaher/status/287977969287315456', normal_tweet_html)))
 
@@ -839,28 +839,27 @@ class MarkdownTest(ZulipTestCase):
 
         # Test smart in-place inlining behavior:
         msg = ('Paragraph 1: http://twitter.com/wdaher/status/287977969287315456\n\n'
-               'Paragraph 2\n\n'
-               'Paragraph 3: http://twitter.com/wdaher/status/287977969287315457')
+               'Paragraph 2. Below paragraph will be removed.\n\n'
+               'http://twitter.com/wdaher/status/287977969287315457')
         converted = markdown_convert_wrapper(msg)
-        self.assertEqual(converted, '<p>Paragraph 1: {}</p>\n{}<p>Paragraph 2</p>\n<p>Paragraph 3: {}</p>\n{}'.format(
+        self.assertEqual(converted, '<p>Paragraph 1: {}</p>\n{}<p>Paragraph 2. Below paragraph will be removed.</p>\n{}'.format(
             make_link('http://twitter.com/wdaher/status/287977969287315456'),
             make_inline_twitter_preview('http://twitter.com/wdaher/status/287977969287315456', normal_tweet_html),
-            make_link('http://twitter.com/wdaher/status/287977969287315457'),
             make_inline_twitter_preview('http://twitter.com/wdaher/status/287977969287315457', normal_tweet_html)))
 
         # Tweet has a mention in a URL, only the URL is linked
-        msg = 'http://twitter.com/wdaher/status/287977969287315458'
+        msg = 'Tweet: http://twitter.com/wdaher/status/287977969287315458'
 
         converted = markdown_convert_wrapper(msg)
-        self.assertEqual(converted, '<p>{}</p>\n{}'.format(
+        self.assertEqual(converted, '<p>Tweet: {}</p>\n{}'.format(
             make_link('http://twitter.com/wdaher/status/287977969287315458'),
             make_inline_twitter_preview('http://twitter.com/wdaher/status/287977969287315458', mention_in_link_tweet_html)))
 
         # Tweet with an image
-        msg = 'http://twitter.com/wdaher/status/287977969287315459'
+        msg = 'Tweet: http://twitter.com/wdaher/status/287977969287315459'
 
         converted = markdown_convert_wrapper(msg)
-        self.assertEqual(converted, '<p>{}</p>\n{}'.format(
+        self.assertEqual(converted, '<p>Tweet: {}</p>\n{}'.format(
             make_link('http://twitter.com/wdaher/status/287977969287315459'),
             make_inline_twitter_preview('http://twitter.com/wdaher/status/287977969287315459',
                                         media_tweet_html,
@@ -870,9 +869,9 @@ class MarkdownTest(ZulipTestCase):
                                          '</a>'
                                          '</div>'))))
 
-        msg = 'http://twitter.com/wdaher/status/287977969287315460'
+        msg = 'Tweet: http://twitter.com/wdaher/status/287977969287315460'
         converted = markdown_convert_wrapper(msg)
-        self.assertEqual(converted, '<p>{}</p>\n{}'.format(
+        self.assertEqual(converted, '<p>Tweet: {}</p>\n{}'.format(
             make_link('http://twitter.com/wdaher/status/287977969287315460'),
             make_inline_twitter_preview('http://twitter.com/wdaher/status/287977969287315460', emoji_in_tweet_html)))
 

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -837,6 +837,17 @@ class MarkdownTest(ZulipTestCase):
             make_inline_twitter_preview('http://twitter.com/wdaher/status/287977969287315457', normal_tweet_html),
             make_inline_twitter_preview('https://twitter.com/wdaher/status/287977969287315456', normal_tweet_html)))
 
+        # Test smart in-place inlining behavior:
+        msg = ('Paragraph 1: http://twitter.com/wdaher/status/287977969287315456\n\n'
+               'Paragraph 2\n\n'
+               'Paragraph 3: http://twitter.com/wdaher/status/287977969287315457')
+        converted = markdown_convert_wrapper(msg)
+        self.assertEqual(converted, '<p>Paragraph 1: {}</p>\n{}<p>Paragraph 2</p>\n<p>Paragraph 3: {}</p>\n{}'.format(
+            make_link('http://twitter.com/wdaher/status/287977969287315456'),
+            make_inline_twitter_preview('http://twitter.com/wdaher/status/287977969287315456', normal_tweet_html),
+            make_link('http://twitter.com/wdaher/status/287977969287315457'),
+            make_inline_twitter_preview('http://twitter.com/wdaher/status/287977969287315457', normal_tweet_html)))
+
         # Tweet has a mention in a URL, only the URL is linked
         msg = 'http://twitter.com/wdaher/status/287977969287315458'
 

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -875,6 +875,15 @@ class MarkdownTest(ZulipTestCase):
             make_link('http://twitter.com/wdaher/status/287977969287315460'),
             make_inline_twitter_preview('http://twitter.com/wdaher/status/287977969287315460', emoji_in_tweet_html)))
 
+        # Test twitter previews in spoiler tags.
+        msg = '```spoiler secret tweet\nTweet: http://twitter.com/wdaher/status/287977969287315456\n```'
+        converted = markdown_convert_wrapper(msg)
+
+        rendered_spoiler = "<div class=\"spoiler-block\"><div class=\"spoiler-header\">\n\n<p>secret tweet</p>\n</div><div class=\"spoiler-content\" aria-hidden=\"true\">\n\n<p>Tweet: {}</p>\n{}</div></div>"
+        self.assertEqual(converted, rendered_spoiler.format(
+            make_link('http://twitter.com/wdaher/status/287977969287315456'),
+            make_inline_twitter_preview('http://twitter.com/wdaher/status/287977969287315456', normal_tweet_html)))
+
     def test_fetch_tweet_data_settings_validation(self) -> None:
         with self.settings(TEST_SUITE=False, TWITTER_CONSUMER_KEY=None):
             self.assertIs(None, fetch_tweet_data('287977969287315459'))


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->

As a part of fixing #15518, this is an improved approach for the issue making the twitter previews behave like our image previews. Overall the experience feels more consistent and the spoiler-preview interaction is fixed as a consequence of the overall change here.

The main concern to not add the previews in the middle of the message seemed to be about interrupting the message flow, which could still be a concern. here is a screenshot to show examples:

![image](https://user-images.githubusercontent.com/8033238/87332138-c7512800-c558-11ea-8b1b-a8bba3656c44.png)

For most chat-like cases (where people just send a single paragraph/message), the behavior should remain the same as before and for longer messages, now the previews wouldn't appear as if they are footnotes.

(We might have similar bugs in link previews, I've yet to test for those.)