### PR TITLE
settings-ui: Fix 'Saved' alert-notification re-apperance after fading out.

### DIFF
--- a/static/js/loading.js
+++ b/static/js/loading.js
@@ -9,7 +9,7 @@ exports.make_indicator = function (outer_container, opts) {
     // width calculation, above, returns a result that's a few pixels
     // too small.  The container's div will be slightly too small,
     // but that's probably OK for our purposes.
-    outer_container.css({display: 'block',
+    outer_container.css({display: 'inline-block',
                          'white-space': 'nowrap'});
 
     container.empty();

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -591,7 +591,7 @@ input[type=checkbox] {
 }
 
 .alert-notification {
-    display: inline-block !important;
+    display: inline-block;
     vertical-align: top;
     height: auto !important;
     width: auto !important;


### PR DESCRIPTION
Removed important tag from display property of .alert-notification class in settings.scss
due to which the display property appearing from loading.js as an inline-style in alert-notification
elements was not working. Also, changed the display property appearing from loading.js from
block to inline-block so as to display the notification as it was being displayed before.

Tested on my local Ubuntu development server by modifying various settings where .alert-notification
class is being used for displaying notification. Results of a few tests are attached below. The success
notification fades away after a while whereas the error notification stays.

Stream Settings:
![settings1](https://user-images.githubusercontent.com/39924567/87332500-45adca00-c559-11ea-847a-955db263d305.gif)

User Settings:
![settings2](https://user-images.githubusercontent.com/39924567/87332510-4b0b1480-c559-11ea-936c-c4f4dc79a54c.gif)

Display Settings:
![settings3](https://user-images.githubusercontent.com/39924567/87332516-4cd4d800-c559-11ea-88f0-2658f720435f.gif)

Error Notification display:
![settings4](https://user-images.githubusercontent.com/39924567/87332529-4e060500-c559-11ea-9aed-3b6acb2d27f7.gif)


Fixes: #15759.