### PR TITLE
message_header: Fix date alignment in PMs.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1019,6 +1019,7 @@ td.pointer {
 .message-header-contents {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     border-right: 1px solid hsl(0, 0%, 88%);
     background-color: hsl(0, 0%, 88%);
 }


### PR DESCRIPTION
My previous message_header fix
0b4568d249ec668379856bc101723b62728ca43a
accidentally changed the alignment of dates in private messages (so that
it was inconsistent to the alignment in other narrows).

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

before:

![image](https://user-images.githubusercontent.com/47354597/87349931-683ee380-c557-11ea-9150-9ffafa6c55b5.png)

after:
![image](https://user-images.githubusercontent.com/47354597/87349974-7856c300-c557-11ea-90a6-e3d8daa4cd77.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
