### PR TITLE
navbar: Fix disappearing left border when search opens.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1645,7 +1645,6 @@ div.focused_table {
     .navbar-search.expanded {
         overflow: hidden;
         margin-top: 0px;
-        right: 2px;
         width: calc(100% - 2px);
         position: absolute;
         .search_button {


### PR DESCRIPTION
Previously, we were experiencing a bug that caused the left border of
the searchbox/tab_bar to disappear when the searchbox was opened. This
bug was a result of the following changes:
- 4cdd7aed2be34795a1cbd8db84233f70daea7784 accidentally added this line
  as right: 2; instead of right: 2px;
- 46c966576d65eaec0e9a185d62a2082060b129dc fixed this line to be
  right: 2px; but caused the regression.

This commit fixes the bug by deleting this line.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

Before:
![left-border-bug-fix-before](https://user-images.githubusercontent.com/33805964/87364836-47e04a80-c592-11ea-8972-8d8c9ed734bd.gif)
After:
![left-border-bug-fix-after](https://user-images.githubusercontent.com/33805964/87364775-22534100-c592-11ea-839c-f9558c72f5f0.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
