### PR TITLE
push_notifications: Return if push_notify already active.

### DIFF
--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -765,7 +765,7 @@ def handle_push_notification(user_profile_id: int, missed_message: Dict[str, Any
         # TODO: It feels like this is already handled when things are
         # put in the queue; maybe we should centralize this logic with
         # the `zerver/tornado/event_queue.py` logic?
-        if user_message.flags.read:
+        if user_message.flags.read or user_message.flags.active_mobile_push_notification:
             return
 
         # Otherwise, we mark the message as having an active mobile


### PR DESCRIPTION
If the push_notification for the UserMessage is already active,
we don't send any push notification to the user. This may
happen due to race conditions.

Added and fixed test cases affected by this.

CZO https://chat.zulip.org/#narrow/stream/141-kandra-ops/topic/push.20notifications.20exception