### PR TITLE
reactions: Add back missing e.stopPropagation().

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -170,7 +170,9 @@ exports.initialize = function () {
         message_flags.toggle_starred_and_update_server(message);
     });
 
-    $("#main_div").on("click", ".message_reaction", function () {
+    $("#main_div").on("click", ".message_reaction", function (e) {
+        e.stopPropagation();
+        emoji_picker.hide_emoji_popover();
         const local_id = $(this).attr('data-reaction-id');
         const message_id = rows.get_message_id(this);
         reactions.process_reaction_click(message_id, local_id);


### PR DESCRIPTION
In 42f20e81bedbafbd2cb19b677660a5d86662d4c4 I fixed an edge case but
also accidentally made clicking on reactions open the compose box.

This commit adds back the e.stopPropagation(); and explicitly hides the
emoji picker popover, to address the inconsistency fixed in the previous
commit.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
