### PR TITLE
settings-ui: Fix 'Saved' alert-notification re-apperance after fading out.

### DIFF
--- a/static/js/ui_report.js
+++ b/static/js/ui_report.js
@@ -15,7 +15,9 @@ exports.message = function (response, status_box, cls, remove_after) {
         .html(response).stop(true).fadeTo(0, 1);
     if (remove_after) {
         setTimeout(() => {
-            status_box.fadeOut(400);
+            status_box.fadeOut(400, () => {
+                status_box.attr('style', (index, prev_attr) => (prev_attr || '') + 'display: none !important;');
+            });
         }, remove_after);
     }
     status_box.addClass("show");


### PR DESCRIPTION
The modified jQuery code adds 'display: none;' style with 'important' tag
to the message element just after fadeOut is completed which overrides the
'display: inline-block !important' property of .alert-notification class
specified in settings.scss and thus completely hides the message element
after fadeOut.

Tested on my local Ubuntu development server in Chrome and Firefox browsers
by modifying various settings.

Stream Settings:
![settings1](https://user-images.githubusercontent.com/39924567/87332500-45adca00-c559-11ea-847a-955db263d305.gif)

User Settings:
![settings2](https://user-images.githubusercontent.com/39924567/87332510-4b0b1480-c559-11ea-936c-c4f4dc79a54c.gif)

Display Settings:
![settings3](https://user-images.githubusercontent.com/39924567/87332516-4cd4d800-c559-11ea-88f0-2658f720435f.gif)

Error Notification display:
![settings4](https://user-images.githubusercontent.com/39924567/87332529-4e060500-c559-11ea-9aed-3b6acb2d27f7.gif)


Fixes: #15759.