### PR TITLE
recent_topics: Handle a topic being deleted.

### DIFF
--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -1,4 +1,5 @@
 zrequire('message_util');
+zrequire('stream_topic_history');
 
 const noop = () => {};
 set_global('$', global.make_zjquery({
@@ -696,6 +697,26 @@ run_test('test_topic_edit', () => {
     rt.process_topic_edit(stream3, topic9, topic8, stream5);
     all_topics = rt.get();
     assert.equal(rt.filters_should_hide_topic(all_topics.get('5:topic-8')), true);
+
+    // Finally, test that deleting a topic will also lead to it getting removed
+    // from recent topics.
+    let key = get_topic_key(messages[6].stream_id, messages[6].topic);
+    assert.equal(rt.filters_should_hide_topic(all_topics.get(key)), false);
+    // We need to set up some appropriate initial state in stream_topic_history to be able
+    // to use its remove_messages().
+    stream_topic_history.add_message({
+        stream_id: messages[6].stream_id,
+        topic_name: messages[6].topic,
+        message_id: messages[6].id,
+    });
+    stream_topic_history.remove_messages({
+        stream_id: messages[6].stream_id,
+        topic_name: messages[6].topic,
+        num_messages: 1,
+    });
+    all_topics = rt.get();
+    key = get_topic_key(messages[6].stream_id, messages[6].topic);
+    assert.equal(rt.filters_should_hide_topic(all_topics.get(key)), true);
 });
 
 run_test('test_search', () => {

--- a/frontend_tests/node_tests/stream_topic_history.js
+++ b/frontend_tests/node_tests/stream_topic_history.js
@@ -2,6 +2,7 @@
 zrequire('unread');
 zrequire('stream_data');
 zrequire('stream_topic_history');
+zrequire('recent_topics');
 
 set_global('channel', {});
 set_global('message_list', {});

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -123,6 +123,17 @@ exports.process_message = function (msg) {
     return true;
 };
 
+exports.delete_topic = function (stream_id, topic) {
+    const key = get_topic_key(stream_id, topic);
+    if (!topics.has(key)) {
+        return;
+    }
+
+    const topic_data = topics.get(key);
+    topic_data.deleted = true;
+    exports.inplace_rerender(key);
+};
+
 exports.reify_message_id_if_available = function (opts) {
     // We don't need to reify the message_id of the topic
     // if a new message arrives in the topic from another user,
@@ -237,6 +248,9 @@ exports.topic_in_search_results = function (keyword, stream, topic) {
 };
 
 exports.filters_should_hide_topic = function (topic_data) {
+    if (topic_data.deleted) {
+        return true;
+    }
     const msg = message_store.get(topic_data.last_msg_id);
 
     if (stream_data.get_sub_by_id(msg.stream_id) === undefined) {

--- a/static/js/stream_topic_history.js
+++ b/static/js/stream_topic_history.js
@@ -132,6 +132,7 @@ exports.per_stream_history = function (stream_id) {
 
         if (existing.count <= num_messages) {
             topics.delete(topic_name);
+            recent_topics.delete_topic(stream_id, topic_name);
             return;
         }
 


### PR DESCRIPTION
Commit message:
```quote
This will handle a topic being deleted:
1. If the user doesn't have recent topics open at the moment of the
   deletion happening, the topic won't appear upon opening the view.
2. If the user does have recent topics open, the topic will disappear
   from the view upon receiving the deletion event.

We still don't handle individual message deletions - upon deletion of a
recent message, last_msg_id of the topic should get updated so that the
topic is ordered correctly in the view.
```

A reasonable way to let us handle updating the view when a single message gets deleted could be by including `last message id in the topic` in message deletion events when the messages being deleted are in a topic. Otherwise this might be tricky, as the data about the topic we keep in `recent_topics.topics` doesn't allow us to figure out that information if the current latest message is getting deleted. I'm not familiar with this system though so could be wrong.