### PR TITLE
settings: Fix saving indicator glitch.

### DIFF
--- a/static/js/loading.js
+++ b/static/js/loading.js
@@ -9,8 +9,7 @@ exports.make_indicator = function (outer_container, opts) {
     // width calculation, above, returns a result that's a few pixels
     // too small.  The container's div will be slightly too small,
     // but that's probably OK for our purposes.
-    outer_container.css({display: 'block',
-                         'white-space': 'nowrap'});
+    outer_container.css({'white-space': 'nowrap'});
 
     container.empty();
 

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -591,7 +591,7 @@ input[type=checkbox] {
 }
 
 .alert-notification {
-    display: inline-block !important;
+    display: inline-block;
     vertical-align: top;
     height: auto !important;
     width: auto !important;


### PR DESCRIPTION
jQuery's fadeOut() sets display: none using inline CSS.
This was overriden by .alert-notification since it used !important
to override the display: block set in loading.js.  Removing the latter
allows us to remove the !important, and doesn't seem to break anything.

Fixes #15759.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
