### PR TITLE
lint: Restore pycodestyle wrapper’s check for empty list of files

### DIFF
--- a/tools/linter_lib/pep8.py
+++ b/tools/linter_lib/pep8.py
@@ -5,4 +5,6 @@ from zulint.printer import colors
 
 
 def check_pep8(files: List[str]) -> bool:
+    if not files:
+        return False
     return run_command("pep8", next(colors), ["pycodestyle", "--", *files]) != 0


### PR DESCRIPTION
Commit ab647abad30baa39e3973caa3152581ab9f65604 (#15779) accidentally removed this.