### PR TITLE
puppet: Revert PostgreSQL setting of recovery_target_timeline

### DIFF
--- a/puppet/zulip/templates/postgresql/10/postgresql.conf.centos.template.erb
+++ b/puppet/zulip/templates/postgresql/10/postgresql.conf.centos.template.erb
@@ -701,7 +701,6 @@ archive_mode = on
 archive_command = '/usr/local/bin/env-wal-g wal-push %p'
 
 # Replica settings (ignored on primary)
-recovery_target_timeline = 'latest'
 hot_standby = on
 <% end -%>
 

--- a/puppet/zulip/templates/postgresql/10/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/10/postgresql.conf.template.erb
@@ -701,7 +701,6 @@ archive_mode = on
 archive_command = '/usr/local/bin/env-wal-g wal-push %p'
 
 # Replica settings (ignored on primary)
-recovery_target_timeline = 'latest'
 hot_standby = on
 <% end -%>
 

--- a/puppet/zulip/templates/postgresql/11/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/11/postgresql.conf.template.erb
@@ -701,7 +701,6 @@ archive_mode = on
 archive_command = '/usr/local/bin/env-wal-g wal-push %p'
 
 # Replica settings (ignored on primary)
-recovery_target_timeline = 'latest'
 hot_standby = on
 <% end -%>
 

--- a/puppet/zulip/templates/postgresql/12/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/12/postgresql.conf.template.erb
@@ -795,7 +795,6 @@ archive_mode = on
 archive_command = '/usr/local/bin/env-wal-g wal-push %p'
 
 # Replica settings (ignored on primary)
-recovery_target_timeline = 'latest'
 hot_standby = on
 <% end -%>
 

--- a/puppet/zulip/templates/postgresql/9.5/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/9.5/postgresql.conf.template.erb
@@ -673,7 +673,6 @@ archive_mode = on
 archive_command = '/usr/local/bin/env-wal-g wal-push %p'
 
 # Replica settings (ignored on primary)
-recovery_target_timeline = 'latest'
 hot_standby = on
 <% end -%>
 

--- a/puppet/zulip/templates/postgresql/9.6/postgresql.conf.template.erb
+++ b/puppet/zulip/templates/postgresql/9.6/postgresql.conf.template.erb
@@ -686,7 +686,6 @@ archive_mode = on
 archive_command = '/usr/local/bin/env-wal-g wal-push %p'
 
 # Replica settings (ignored on primary)
-recovery_target_timeline = 'latest'
 hot_standby = on
 <% end -%>
 


### PR DESCRIPTION
Prior to PostgreSQL 12, the `recovery_target_timeline` setting is only
valid in a `recovery.conf` file, as that file has its own
configuration parser.  As such, including it in `postgresql.conf`
results in an error, and PostgreSQL will fail to start.

Remove the setting, reverting bff3b540b1.  This fixes PostgreSQL 9.5,
9.6, 10, and 11; while the setting is not an error in a PostgreSQL 12
configuration file, it is unnecessary since `latest` is the default.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
