### PR TITLE
WIP subscriptions: Migrate to HTML5 color picker from spectrum.

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "sortablejs": "^1.9.0",
     "sorttable": "^1.0.2",
     "source-sans-pro": "^3.6.0",
-    "spectrum-colorpicker": "^1.8.1",
     "stacktrace-gps": "^3.0.4",
     "style-loader": "^1.0.0",
     "terser-webpack-plugin": "^3.0.3",

--- a/static/js/bundles/app.js
+++ b/static/js/bundles/app.js
@@ -5,7 +5,6 @@ import "../../third/bootstrap-notify/js/bootstrap-notify.js";
 import "../../third/bootstrap-typeahead/typeahead.js";
 import "jquery-caret-plugin/src/jquery.caret.js";
 import "../../third/jquery-idle/jquery.idle.js";
-import "spectrum-colorpicker";
 import "../../third/marked/lib/marked.js";
 import "xdate/src/xdate.js";
 import "jquery-validation/dist/jquery.validate.js";
@@ -202,7 +201,6 @@ import "../spoilers.js";
 // Import Styles
 
 import "../../third/bootstrap-notify/css/bootstrap-notify.css";
-import "spectrum-colorpicker/spectrum.css";
 import "katex/dist/katex.css";
 import "flatpickr/dist/flatpickr.css";
 import "flatpickr/dist/plugins/confirmDate/confirmDate.css";

--- a/static/js/stream_color.js
+++ b/static/js/stream_color.js
@@ -1,5 +1,12 @@
 exports.default_color = "#c2c2c2";
 
+exports.presets = {
+    color: ["a47462", "c2726a", "e4523d", "e7664d", "ee7e4a", "f4ae55",
+            "76ce90", "53a063", "94c849", "bfd56f", "fae589", "f5ce6e",
+            "a6dcbf", "addfe5", "a6c7e5", "4f8de4", "95a5fd", "b0a5fd",
+            "c2c2c2", "c8bebf", "c6a8ad", "e79ab5", "bd86e5", "9987e1"],
+};
+
 // Classes which could be returned by get_color_class.
 exports.color_classes = "dark_background";
 
@@ -46,48 +53,25 @@ function update_historical_message_color(stream_name, color) {
     }
 }
 
-const stream_color_palette = [
-    ["a47462", "c2726a", "e4523d", "e7664d", "ee7e4a", "f4ae55"],
-    ["76ce90", "53a063", "94c849", "bfd56f", "fae589", "f5ce6e"],
-    ["a6dcbf", "addfe5", "a6c7e5", "4f8de4", "95a5fd", "b0a5fd"],
-    ["c2c2c2", "c8bebf", "c6a8ad", "e79ab5", "bd86e5", "9987e1"],
-];
+const hexDigits = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"];
 
-const subscriptions_table_colorpicker_options = {
-    clickoutFiresChange: true,
-    showPalette: true,
-    showInput: true,
-    palette: stream_color_palette,
-};
+function hex(x) {
+    return isNaN(x) ? "00" : hexDigits[(x - x % 16) / 16] + hexDigits[x % 16];
+}
 
-exports.set_colorpicker_color = function (colorpicker, color) {
-    colorpicker.spectrum({
-        ...subscriptions_table_colorpicker_options,
-        color,
-        container: "#subscription_overlay .subscription_settings.show",
-    });
-};
+// Function to convert rgb color to hex format
+function rgb2hex(rgb) {
+    rgb = rgb.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/);
+    return "#" + hex(rgb[1]) + hex(rgb[2]) + hex(rgb[3]);
+}
 
 exports.update_stream_color = function (sub, color, opts) {
     opts = {update_historical: false, ...opts};
     sub.color = color;
     const stream_id = sub.stream_id;
     // The swatch in the subscription row header.
-    $(".stream-row[data-stream-id='" + stream_id + "'] .icon").css("background-color", color);
-    // The swatch in the color picker.
-    exports.set_colorpicker_color(
-        $(
-            "#subscription_overlay .subscription_settings[data-stream-id='" +
-                stream_id +
-                "'] .colorpicker",
-        ),
-        color,
-    );
-    $(
-        "#subscription_overlay .subscription_settings[data-stream-id='" +
-            stream_id +
-            "'] .large-icon",
-    ).css("color", color);
+    $(".stream-row[data-stream-id='" + stream_id + "'] .icon").css('background-color', color);
+    $("#subscription_overlay .subscription_settings[data-stream-id='" + stream_id + "'] .large-icon").css("color", color);
 
     if (opts.update_historical) {
         update_historical_message_color(sub.name, color);
@@ -96,33 +80,32 @@ exports.update_stream_color = function (sub, color, opts) {
     tab_bar.colorize_tab_bar();
 };
 
-function picker_do_change_color(color) {
-    const stream_id = parseInt($(this).attr("stream_id"), 10);
-    const hex_color = color.toHexString();
-    subs.set_color(stream_id, hex_color);
-}
-subscriptions_table_colorpicker_options.change = picker_do_change_color;
+$("body").on("change", "#stream_color_picker", (e) => {
+    const color = e.target.value;
+    const stream_id = parseInt(e.target.getAttribute("stream_id"), 10);
+    subs.set_color(stream_id, color);
+});
 
-exports.sidebar_popover_colorpicker_options = {
-    clickoutFiresChange: true,
-    showPaletteOnly: true,
-    showPalette: true,
-    showInput: true,
-    flat: true,
-    palette: stream_color_palette,
-    change: picker_do_change_color,
-};
+$("body").on("click", (e) => {
+    if (e.target.matches("#custom_color")) {
+        const color_picker = $("body").find("#stream_color_picker");
+        $(color_picker).click();
+    }
 
-exports.sidebar_popover_colorpicker_options_full = {
-    clickoutFiresChange: false,
-    showPalette: true,
-    showInput: true,
-    flat: true,
-    cancelText: "",
-    chooseText: i18n.t("Confirm"),
-    palette: stream_color_palette,
-    change: picker_do_change_color,
-};
+    if (e.target.matches("#color_picker") || e.target.matches("#color_swatch") || e.target.matches("#color_dropdown")) {
+        $("body").find(".color_picker_body").toggleClass("visible");
+    } else if (!(e.target.class === "color_picker_body" || $(e.target).parents(".color_picker_body").length)) {
+        if ($("body").find(".color_picker_body").hasClass("visible")) {
+            $("body").find(".color_picker_body").removeClass("visible");
+        }
+    }
+
+    if (e.target.matches(".presets")) {
+        const color = $(e.target).css("background-color");
+        const stream_id = parseInt($(e.target).parent().attr("stream_id"), 10);
+        subs.set_color(stream_id, rgb2hex(color));
+    }
+});
 
 let lightness_threshold;
 exports.initialize = function () {

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -288,9 +288,6 @@ function show_subscription_settings(sub_row) {
     const sub = stream_data.get_sub_by_id(stream_id);
     const sub_settings = exports.settings_for_sub(sub);
 
-    const colorpicker = sub_settings.find(".colorpicker");
-    const color = stream_data.get_color(sub.name);
-    stream_color.set_colorpicker_color(colorpicker, color);
     stream_ui_updates.update_add_subscriptions_elements(sub);
 
     const container = $(
@@ -392,6 +389,7 @@ exports.show_settings_for = function (node) {
         settings: exports.stream_settings(sub),
         stream_post_policy_values: stream_data.stream_post_policy_values,
         message_retention_text: exports.get_retention_policy_text_for_subscription_type(sub),
+        stream_color_presets: stream_color.presets,
     });
     ui.get_content_element($(".subscriptions .right .settings")).html(html);
 

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -94,36 +94,6 @@ function stream_popover_sub(e) {
     return sub;
 }
 
-// This little function is a workaround for the fact that
-// Bootstrap popovers don't properly handle being resized --
-// so after resizing our popover to add in the spectrum color
-// picker, we need to adjust its height accordingly.
-function update_spectrum(popover, update_func) {
-    const initial_height = popover[0].offsetHeight;
-
-    const colorpicker = popover.find(".colorpicker-container").find(".colorpicker");
-    update_func(colorpicker);
-    const after_height = popover[0].offsetHeight;
-
-    const popover_root = popover.closest(".popover");
-    const current_top_px = parseFloat(popover_root.css("top").replace("px", ""));
-    const height_delta = after_height - initial_height;
-    let top = current_top_px - height_delta / 2;
-
-    if (top < 0) {
-        top = 0;
-        popover_root.find("div.arrow").hide();
-    } else if (top + after_height > $(window).height() - 20) {
-        top = $(window).height() - after_height - 20;
-        if (top < 0) {
-            top = 0;
-        }
-        popover_root.find("div.arrow").hide();
-    }
-
-    popover_root.css("top", top + "px");
-}
-
 function build_stream_popover(opts) {
     const elt = opts.elt;
     const stream_id = opts.stream_id;
@@ -139,6 +109,7 @@ function build_stream_popover(opts) {
 
     const content = render_stream_sidebar_actions({
         stream: stream_data.get_sub_by_id(stream_id),
+        stream_color_presets: stream_color.presets,
     });
 
     $(elt).popover({
@@ -150,11 +121,6 @@ function build_stream_popover(opts) {
     });
 
     $(elt).popover("show");
-    const popover = $(".streams_popover[data-stream-id=" + stream_id + "]");
-
-    update_spectrum(popover, (colorpicker) => {
-        colorpicker.spectrum(stream_color.sidebar_popover_colorpicker_options);
-    });
 
     current_stream_sidebar_elem = elt;
 }
@@ -418,23 +384,8 @@ exports.register_stream_handlers = function () {
     });
 
     // Choose a different color.
-    $("body").on("click", ".choose_stream_color", (e) => {
-        update_spectrum($(e.target).closest(".streams_popover"), (colorpicker) => {
-            $(".colorpicker-container").show();
-            colorpicker.spectrum("destroy");
-            colorpicker.spectrum(stream_color.sidebar_popover_colorpicker_options_full);
-            // In theory this should clean up the old color picker,
-            // but this seems a bit flaky -- the new colorpicker
-            // doesn't fire until you click a button, but the buttons
-            // have been hidden.  We work around this by just manually
-            // fixing it up here.
-            colorpicker.parent().find(".sp-container").removeClass("sp-buttons-disabled");
-            $(e.target).hide();
-        });
-
-        $(".streams_popover").on("click", "a.sp-cancel", () => {
-            exports.hide_stream_popover();
-        });
+    $('body').click('.choose_stream_color', () => {
+        $("body").find(".sidebar_color_picker").toggleClass("visible");
     });
 };
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -190,6 +190,9 @@ exports.update_message_retention_setting = function (sub, new_value) {
 };
 
 exports.set_color = function (stream_id, color) {
+    const swatch_color = $(document).find('#color_swatch');
+    $(swatch_color).css("background-color", color);
+
     const sub = stream_data.get_sub_by_id(stream_id);
     stream_edit.set_stream_property(sub, "color", color);
 };

--- a/static/styles/popovers.scss
+++ b/static/styles/popovers.scss
@@ -61,42 +61,15 @@
         margin-bottom: 5px;
     }
 
-    .colorpicker-container {
+    .sidebar_color_picker {
         display: none;
-        margin-right: 10px;
 
-        .sp-container {
-            background-color: hsl(0, 0%, 100%);
-            cursor: pointer;
-            border: none;
+        > * {
+            user-select: none;
+        }
 
-            .sp-palette-container {
-                border-right: none;
-            }
-
-            input {
-                box-sizing: inherit;  /* IE */
-                box-sizing: initial;
-
-                width: calc(100% - 13px);
-            }
-
-            button {
-                background-color: hsl(0, 0%, 100%);
-                background-image: none;
-                border: 1px solid hsl(0, 0%, 80%);
-                border-radius: 4px;
-                color: hsl(0, 0%, 25%);
-                font-size: 12px;
-                padding: 6px;
-                text-transform: capitalize;
-                text-align: center;
-                text-shadow: none;
-            }
-
-            .sp-picker-container {
-                border-left: solid 1px hsl(0, 0%, 88%);
-            }
+        input[type="color"] {
+            left: 0px;
         }
     }
 

--- a/static/styles/subscriptions.scss
+++ b/static/styles/subscriptions.scss
@@ -107,6 +107,10 @@
     border-radius: 4px;
 }
 
+label[for="streamcolor"] {
+    padding-top: 9px;
+}
+
 .subscription-control-label {
     display: inline-block;
     vertical-align: middle;
@@ -1005,6 +1009,11 @@ form#add_new_subscription {
 
         &.show {
             display: block;
+        }
+
+        // Fix for color picker body to display the overflown content.
+        .collapse {
+            position: static;
         }
     }
 

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -406,6 +406,125 @@ input {
     }
 }
 
+input[type="color"] {
+    height: 25px;
+    width: 25px;
+    margin-top: 5px;
+    margin-bottom: 0;
+    border: none;
+    border-radius: 5px;
+    padding: 0;
+
+    &::-webkit-color-swatch-wrapper {
+        padding: 0;
+    }
+
+    &::-webkit-color-swatch {
+        border: solid 1px hsl(0, 0%, 75%); /* change color of the swatch border here */
+        border-radius: 5px;
+    }
+}
+
+#color_picker_parent {
+    vertical-align: middle;
+
+    #color_picker {
+        height: 29px;
+        margin-top: 5px;
+        margin-bottom: 0;
+        border: 1px solid hsl(0, 0%, 43%);
+        border-radius: 5px;
+        padding: 0;
+        user-select: none;
+        cursor: pointer;
+
+        div {
+            display: inline-block;
+        }
+
+        #color_swatch {
+            user-select: none;
+            float: left;
+            margin: 2px;
+            height: 25px;
+            width: 25px;
+            border-radius: 3px;
+        }
+
+        #color_dropdown {
+            user-select: none;
+            margin-top: 5px;
+            margin-right: 1px;
+        }
+    }
+}
+
+.color_picker_body {
+    display: none;
+    position: absolute;
+    overflow: auto;
+    z-index: 10;
+    background-color: hsl(0, 0%, 98%);
+    border: 1px solid hsl(0, 0%, 43%);
+    border-radius: 5px;
+
+    > * {
+        user-select: none;
+    }
+}
+
+#stream_color_picker {
+    opacity: 0;
+    visibility: hidden;
+    position: absolute;
+    height: 23px;
+}
+
+#custom_color {
+    border-radius: 4px;
+    margin: 0 2px 2px 2px;
+    padding: 3px;
+    padding-left: 5px;
+    cursor: pointer;
+
+    &:hover {
+        background-color: hsl(0, 0%, 75%);
+    }
+}
+.preset_container {
+    padding: 5px;
+    width: 160px;
+    height: 98px;
+
+    .presets {
+        display: inline-block;
+        height: 20px;
+        width: 20px;
+        border-radius: 5px;
+        margin-right: 5px;
+        cursor: pointer;
+        line-height: 20px;
+        transition: box-shadow 0.5s;
+
+        &:hover {
+            box-shadow: 0px 0px 5px hsl(215, 47%, 50%);
+        }
+
+        &:nth-child(6n) {
+            margin-right: 0px;
+        }
+    }
+}
+
+hr {
+    border: 1px solid hsl(0, 0%, 43%);
+    margin: 2px;
+}
+
+.visible {
+    display: block !important;
+}
+
 li,
 .table th,
 .table td {
@@ -864,7 +983,7 @@ td.pointer {
         border-width: 11px 0 11px 5px;
         border-color: inherit;
         z-index: 2;
-        transform: scale(.9999);
+        transform: scale(0.9999);
     }
 
     &::before {
@@ -878,9 +997,9 @@ td.pointer {
         margin-top: -14px;
         border-style: solid;
         border-width: 14px 0 14px 6px;
-        border-color: hsla(0, 0%, 0%, 0.0) hsla(0, 0%, 0%, 0.0) hsla(0, 0%, 0%, 0.0) transparent;
+        border-color: hsla(0, 0%, 0%, 0) hsla(0, 0%, 0%, 0) hsla(0, 0%, 0%, 0) transparent;
         z-index: 1;
-        transform: scale(.9999);
+        transform: scale(0.9999);
     }
 }
 
@@ -1025,9 +1144,7 @@ td.pointer {
     .messagebox,
     .date_row {
         background-color: hsla(192, 19%, 75%, 0.2);
-        box-shadow:
-            inset 2px 0px 0px 0px hsl(0, 0%, 27%),
-            -1px 0px 0px 0px hsl(0, 0%, 27%);
+        box-shadow: inset 2px 0px 0px 0px hsl(0, 0%, 27%), -1px 0px 0px 0px hsl(0, 0%, 27%);
     }
 }
 
@@ -2056,7 +2173,7 @@ div.floating_recipient {
     .checkbox {
         display: block;
 
-        input[type=checkbox] {
+        input[type="checkbox"] {
             margin: 5px 0px;
             float: none;
         }
@@ -2427,6 +2544,10 @@ div.topic_edit_spinner .loading_indicator_spinner {
     color: inherit;
     margin-left: 2px;
     font-size: .9em;
+}
+
+.popover.right .arrow {
+    top: 100px;
 }
 
 .no-drag {

--- a/static/templates/stream_sidebar_actions.hbs
+++ b/static/templates/stream_sidebar_actions.hbs
@@ -53,11 +53,13 @@
         </a>
     </li>
     <li>
-        <span class="colorpicker-container"><input stream_id="{{stream.stream_id}}" class="colorpicker" type="text" value="{{stream.color}}" /></span>
         <a class="choose_stream_color">
             <i class="fa fa-eyedropper" aria-hidden="true"></i>
             {{t "Change color" }}
         </a>
+        <div class="sidebar_color_picker">
+            {{> stream_sidebar_color_picker }}
+        </div>
     </li>
 
 </ul>

--- a/static/templates/stream_sidebar_color_picker.hbs
+++ b/static/templates/stream_sidebar_color_picker.hbs
@@ -1,0 +1,8 @@
+<div stream_id="{{stream.stream_id}}" class="preset_container">
+    {{#each stream_color_presets.color }}
+    <div class="presets" style="background-color: #{{this}};"></div>
+    {{/each}}
+</div>
+<hr>
+<input stream_id="{{stream.stream_id}}" id="stream_color_picker" type="color" value="{{stream.color}}"/>
+<div id="custom_color">{{t "Custom input" }}</div>

--- a/static/templates/subscription_color_picker.hbs
+++ b/static/templates/subscription_color_picker.hbs
@@ -1,0 +1,8 @@
+<div stream_id="{{sub.stream_id}}" class="preset_container">
+    {{#each stream_color_presets.color }}
+    <div class="presets" style="background-color: #{{this}};"></div>
+    {{/each}}
+</div>
+<hr>
+<input stream_id="{{sub.stream_id}}" id="stream_color_picker" type="color" value="{{sub.color}}"/>
+<div id="custom_color">{{t "Custom input" }}</div>

--- a/static/templates/subscription_settings.hbs
+++ b/static/templates/subscription_settings.hbs
@@ -66,8 +66,15 @@
                     {{/each}}
                     <li>
                         <label for="streamcolor" class="subscription-control-label">{{t "Stream color" }}</label>
-                        <span class="sub_setting_control">
-                            <input stream_id="{{sub.stream_id}}" class="colorpicker" id="streamcolor" type="text" value="{{sub.color}}" tabindex="-1" />
+                        <span class="sub_setting_control" id="color_picker_parent">
+                            {{!-- <input stream_id="{{sub.stream_id}}" id="stream_color_picker" type="color" value="{{sub.color}}"/> --}}
+                            <div id="color_picker" stream_id="{{sub.stream_id}}">
+                                <div id="color_swatch" style="background-color: {{sub.color}};"></div>
+                                <div id="color_dropdown">▼</div>
+                            </div>
+                            <div class="color_picker_body">
+                                {{> subscription_color_picker }}
+                            </div>
                         </span>
                     </li>
                 </ul>

--- a/tools/linter_lib/custom_check.py
+++ b/tools/linter_lib/custom_check.py
@@ -603,6 +603,10 @@ html_rules: List["Rule"] = whitespace_rules + prose_style_rules + [
          'templates/analytics/realm_summary_table.html',
          'templates/corporate/zephyr.html',
          'templates/corporate/zephyr-mirror.html',
+
+         # Color picker preset swatches are generated using HBS each loop
+         'static/templates/stream_sidebar_color_picker.hbs',
+         'static/templates/subscription_color_picker.hbs'
      },
      'good_lines': ['#my-style {color: blue;}', 'style="display: none"', "style='display: none"],
      'bad_lines': ['<p style="color: blue;">Foo</p>', 'style = "color: blue;"']},

--- a/version.py
+++ b/version.py
@@ -44,4 +44,4 @@ API_FEATURE_LEVEL = 27
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '91.3'
+PROVISION_VERSION = '92.0'


### PR DESCRIPTION
Earlier Zulip was using `spectrum-colorpicker` which seemed to be an
abandoned project (last commit 3 years ago) and since we have dropped
support for IE11, switching to HTML5 native color picker was right choice.

The following commit removes absolute code referring to
`spectrum-colorpicker` and introduces the support for HTML5 color picker
for changing stream colors. Now user can change stream colors from the
sidebar itself or using streams settings menu using HTML5 native color
picker with an option of using presets that works in all current browsers.

Fixes #14961.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Changing Color From Sidebar:
![Sidebar](https://user-images.githubusercontent.com/23737560/87484400-a8838c00-c653-11ea-8f4d-7130fd886072.gif)

Changing Color From Stream Setting Menu:
![Stream Settings](https://user-images.githubusercontent.com/23737560/87484414-b0dbc700-c653-11ea-91eb-b640ecf07f7c.gif)
