### PR TITLE
search icon code clean up + night_mode regression fix

### DIFF
--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -194,7 +194,7 @@ $tab_bar.find = () => false;
 compose.compute_show_video_chat_button = () => {};
 $("#below-compose-content .video_link").toggle = () => {};
 
-$(".narrow_description > a").hover = () => {};
+$("#tab_bar .narrow_description > a").hover = () => {};
 
 run_test('initialize_everything', () => {
     ui_init.initialize_everything();

--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -90,19 +90,12 @@ function bind_title_area_handlers() {
         }
     });
 
-    const color = $(".search_closed").css("color");
-    const night_mode_color = $(".nightmode .closed_icon").css("color");
-
-    // make sure that hover plays nicely with whether search is being
-    // opened or not.
-    $(".narrow_description > a").hover(() => {
-        if (night_mode_color) {
-            $(".search_closed").css("color", night_mode_color);
-        } else {
-            $(".search_closed").css("color", color);
-        }
+    // handler that makes sure that hover plays nicely
+    // with whether search is being opened or not.
+    $("#tab_bar .narrow_description > a").hover(() => {
+        $("#tab_bar .search_closed").addClass("search_icon_hover_highlight");
     }, () => {
-        $(".search_closed").css("color", "");
+        $("#tab_bar .search_closed").removeClass("search_icon_hover_highlight");
     });
 }
 

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -343,6 +343,7 @@ on a dark background, and don't change the dark labels dark either. */
     #message_edit_tooltip:hover,
     .clear_search_button:hover,
     #tab_bar .search_icon:hover,
+    .search_icon_hover_highlight,
     #searchbox_legacy .search_icon:hover,
     #searchbox_legacy .search_button:hover,
     #searchbox .search_icon:hover,

--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -326,6 +326,7 @@ on a dark background, and don't change the dark labels dark either. */
     .clear_search_button:active,
     .clear_search_button[disabled]:hover,
     #user-groups .save-instructions,
+    #tab_bar .search_icon,
     #searchbox_legacy .search_icon,
     #searchbox_legacy .search_button,
     #searchbox .search_icon,
@@ -341,6 +342,7 @@ on a dark background, and don't change the dark labels dark either. */
 
     #message_edit_tooltip:hover,
     .clear_search_button:hover,
+    #tab_bar .search_icon:hover,
     #searchbox_legacy .search_icon:hover,
     #searchbox_legacy .search_button:hover,
     #searchbox .search_icon:hover,

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1734,6 +1734,7 @@ div.focused_table {
         left: 0px;
     }
 
+    .search_icon_hover_highlight,
     .search_icon:hover {
         color: hsl(0, 0%, 0%);
         text-decoration: none;


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![highlighting correctly](https://user-images.githubusercontent.com/33805964/87488773-d3bfa880-c65e-11ea-9a96-7bf9b545ceed.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
