### PR TITLE
recent_topics: Update topics post message deletion.

### DIFF
--- a/frontend_tests/node_tests/recent_senders.js
+++ b/frontend_tests/node_tests/recent_senders.js
@@ -199,4 +199,19 @@ run_test('process_message_for_senders', () => {
     assert.equal(
         rs.get_topic_recent_senders(stream5, topic4).toString(), '2,3',
     );
+
+    set_global('message_store', {
+        get: () => message1,
+    });
+
+    assert.equal(
+        rs.get_topic_recent_senders(stream1, topic1).toString(), '2,1',
+    );
+    // delete message1 and message5 sent by sender1
+    messages.splice(4, 1);
+    messages.splice(0, 1);
+    rs.update_topics_of_message_ids([message1.id, message5.id]);
+    assert.equal(
+        rs.get_topic_recent_senders(stream1, topic1).toString(), '2',
+    );
 });

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -620,7 +620,58 @@ run_test('test_reify_local_echo_message', () => {
     }), false);
 });
 
+
+run_test('test_delete_messages', () => {
+    const rt = zrequire('recent_topics');
+    rt.set_filter('all');
+    rt.process_messages(messages);
+
+    set_global('message_list', {
+        all: {
+            all_messages: function () {
+                // messages[0] was removed.
+                const reduced_msgs = [...messages];
+                reduced_msgs.splice(0, 1);
+                return reduced_msgs;
+            },
+        },
+    });
+
+    let all_topics = rt.get();
+    assert.equal(Array.from(all_topics.keys()).toString(),
+                 '4:topic-10,1:topic-7,1:topic-6,1:topic-5,1:topic-4,1:topic-3,1:topic-2,1:topic-1');
+    rt.update_topics_of_message_ids([messages[0].id]);
+
+    all_topics = rt.get();
+    assert.equal(Array.from(all_topics.keys()).toString(),
+                 '4:topic-10,1:topic-7,1:topic-6,1:topic-5,1:topic-4,1:topic-3,1:topic-2');
+
+    set_global('message_list', {
+        all: {
+            all_messages: function () {
+                // messages[0], messages[1] and message[2] were removed.
+                const reduced_msgs = [...messages];
+                reduced_msgs.splice(0, 3);
+                return reduced_msgs;
+            },
+        },
+    });
+
+    rt.update_topics_of_message_ids([messages[1].id, messages[2].id]);
+
+    all_topics = rt.get();
+    assert.equal(Array.from(all_topics.keys()).toString(),
+                 '4:topic-10,1:topic-7,1:topic-6,1:topic-5,1:topic-4,1:topic-3');
+});
+
 run_test('test_topic_edit', () => {
+    set_global('message_list', {
+        all: {
+            all_messages: function () {
+                return messages;
+            },
+        },
+    });
     // NOTE: This test should always run in the end as it modified the messages data.
     const rt = zrequire('recent_topics');
     rt.set_filter('all');

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -236,6 +236,21 @@ exports.topic_in_search_results = function (keyword, stream, topic) {
     });
 };
 
+exports.update_topics_of_message_ids = function (message_ids) {
+    const topics_to_rerender = new Map();
+    for (const msg_id of message_ids) {
+        const message = message_store.get(msg_id);
+        const topic_key = get_topic_key(message.stream_id, message.topic);
+        topics_to_rerender.set(topic_key, [message.stream_id, message.topic]);
+    }
+
+    for (const [stream_id, topic] of topics_to_rerender.values()) {
+        topics.delete(get_topic_key(stream_id, topic));
+        const msgs = message_util.get_messages_in_topic(stream_id, topic);
+        exports.process_messages(msgs);
+    }
+};
+
 exports.filters_should_hide_topic = function (topic_data) {
     const msg = message_store.get(topic_data.last_msg_id);
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -131,6 +131,8 @@ exports.remove_messages = function (message_ids) {
         }
         list.remove_and_rerender(msg_ids_to_rerender);
     }
+    recent_senders.update_topics_of_message_ids(message_ids);
+    recent_topics.update_topics_of_message_ids(message_ids);
 };
 
 exports.show_failed_message_success = function (message_id) {


### PR DESCRIPTION
Delete stored topic data in `recent_senders` and `recent_topics`
about the message's topics and re-render them. The process is similar
to topic editing. See `recent_senders.process_topic_edit` for
logical details.
