### PR TITLE
styles: Make focus outline work reliably.

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -964,6 +964,10 @@ on a dark background, and don't change the dark labels dark either. */
             }
         }
     }
+
+    a:focus {
+        outline-color: hsl(0, 0%, 100%);
+    }
 }
 
 @supports (-moz-appearance: none) {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -379,6 +379,12 @@ label {
     line-height: inherit;
 }
 
+/* Bootstrap's focus outline uses -webkit-focus-ring-color which doesn't exist in Firefox */
+a:focus {
+    outline: 2px solid hsl(215, 47%, 50%);
+    // TODO: change solid to auto once the Chromium bug #1105822 is fixed
+}
+
 /* List of text-like input types taken from Bootstrap */
 input {
     &[type="text"],


### PR DESCRIPTION
For a:focus Bootstrap sets the following rules:

    outline: thin dotted #333;
    outline: 5px auto -webkit-focus-ring-color;

Firefox does not know -webkit-focus-ring-color and falls back to the
previous rule, making the outline invisible in darkmode.

Chromium has a bug[1] that makes outline: auto invisible when focussing
elements programmatically (which we do for the up & down arrow keys).

[1]: https://bugs.chromium.org/p/chromium/issues/detail?id=1105822

Fixes #15768.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
