### PR TITLE
markdown: Allow use `*` in topic markdown links.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -139,7 +139,7 @@ STREAM_TOPIC_LINK_REGEX = r"""
                      \#\*\*                        # and after hash sign followed by double asterisks
                          (?P<stream_name>[^\*>]+)  # stream name can contain anything except >
                          >                         # > acts as separator
-                         (?P<topic_name>[^\*]+)     # topic name can contain anything
+                         (?P<topic_name>.+?)       # topic name can contain anything
                      \*\*                          # ends by double asterisks
                    """
 

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -1825,6 +1825,28 @@ class MarkdownTest(ZulipTestCase):
             render_markdown(msg, content),
             '<p>#<strong>casesens</strong></p>')
 
+    def test_topic_with_asterisk(self) -> None:
+        denmark = get_stream('Denmark', get_realm('zulip'))
+        sender_user_profile = self.example_user('othello')
+        msg = Message(sender=sender_user_profile, sending_client=get_client("test"))
+        content = "#**Denmark>some *topic**"
+        self.assertEqual(
+            render_markdown(msg, content),
+            '<p><a class="stream-topic" data-stream-id="{d.id}" href="/#narrow/stream/{d.id}-Denmark/topic/some.20.2Atopic">#{d.name} &gt; some *topic</a></p>'.format(
+                d=denmark,
+            ))
+
+    def test_topic_with_asterisk_twice(self) -> None:
+        denmark = get_stream('Denmark', get_realm('zulip'))
+        sender_user_profile = self.example_user('othello')
+        msg = Message(sender=sender_user_profile, sending_client=get_client("test"))
+        content = "#**Denmark>some *topic** HI #**Denmark>some *topic**"
+        self.assertEqual(
+            render_markdown(msg, content),
+            '<p><a class="stream-topic" data-stream-id="{d.id}" href="/#narrow/stream/{d.id}-Denmark/topic/some.20.2Atopic">#{d.name} &gt; some *topic</a> HI <a class="stream-topic" data-stream-id="{d.id}" href="/#narrow/stream/{d.id}-Denmark/topic/some.20.2Atopic">#{d.name} &gt; some *topic</a></p>'.format(
+                d=denmark,
+            ))
+
     def test_topic_single(self) -> None:
         denmark = get_stream('Denmark', get_realm('zulip'))
         sender_user_profile = self.example_user('othello')


### PR DESCRIPTION
Allow use of `*` in topic when creating topic link via
`#**stream>topic**` syntax.



@timabbott I am not sure I understand you in https://chat.zulip.org/#narrow/stream/6-frontend/topic/Local.20echo.20markdown, so let me know if this solution seems bad to you.