### PR TITLE
migrations: Add case-insensitive unique indexes on realm and email.

### DIFF
--- a/zerver/migrations/0295_case_insensitive_email_indexes.py
+++ b/zerver/migrations/0295_case_insensitive_email_indexes.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('zerver', '0294_remove_userprofile_pointer'),
+    ]
+
+    operations = [
+        # First we change the django-created index on (realm_id, email) to be case-insensitive on the email,
+        # and then we create the analogical index for (realm_id, delivery_email). The purpose of these indexes
+        # is to enforce the constraint that each email address should be unique in its realm.
+        # Being case-insensitive is important as the lack of this constraint has actually lead to bugs
+        # where we ended up with user accounts in the same realm whose email addresses differed only
+        # in character capitalization.
+        migrations.RunSQL("""
+            ALTER TABLE zerver_userprofile DROP CONSTRAINT zerver_userprofile_realm_id_email_13360e45_uniq;
+            CREATE UNIQUE INDEX zerver_userprofile_realm_id_email_13360e45_uniq ON zerver_userprofile (realm_id, upper(email::text));
+            CREATE UNIQUE INDEX zerver_userprofile_realm_id_delivery_email_uniq ON zerver_userprofile (realm_id, upper(delivery_email::text));
+        """),
+    ]


### PR DESCRIPTION
Fixes #15772.

This will prevent future occurences of this issue with creating multiple accounts for the same email in one realm, but this won't fix the deployments where this has already happened and are getting exceptions due to this. That should be extremely rare though, sufficiently rare for it to be reasonable to just help out those folks debug and fix the situation on a case-by-case basis rather than trying to come up with some fancy general migration that will handle all possible variants safely without losing meaningful data from the duplicated UserProfiles. So probably it'll be sufficient to, as Tim suggested in a chat, to just put a relevant mention of this in the upgrade notes. Something like:

> Previous versions had a bug which could lead to multiple user accounts being created with the same email address in one realm, corrupting the state of the database. We believe this to be an extremely rare scenario and few, if any, of self-hosted installations will have been affected. This upgrade contains a database migration that will prevent future occurrences of this bug, but the migration will fail if the server has already been affected. If you want to ensure to avoid unexpected downtime due to that, you can run the following code in the Django shell (`/home/zulip/deployments/current/manage.py shell` ):
````
from django.db.models.functions import Lower
UserProfile.objects.all().annotate(email_lower=Lower("delivery_email")).values('realm_id', 'email_lower').annotate(Count('id')).filter(id__count__gte=2)
````
> and if it outputs any emails, contact us on chat.zulip.org and we'll help you fix the situation before proceeding with the upgrade.