### PR TITLE
navbar: Add user status alongside name in PM screen.

### DIFF
--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -31,6 +31,15 @@ function make_tab_data(filter) {
         tab_data.rendered_narrow_description = i18n.t("This stream does not exist or is private.");
         return tab_data;
     }
+    if (filter.has_operator('pm-with')) {
+        const user_email = filter.operands('pm-with')[0];
+        // We dont fetch user status if the following is a group pm.
+        if (user_email.split(',').length < 2) {
+            const user_id = people.get_user_id(user_email);
+            tab_data.user_status = user_status.get_status_text(user_id);
+        }
+        return tab_data;
+    }
     if (filter._sub) {
         // We can now be certain that the narrow
         // involves a stream which exists and

--- a/static/templates/tab_bar.hbs
+++ b/static/templates/tab_bar.hbs
@@ -12,6 +12,13 @@
     {{t "(no description)"}}
     {{/if}}
 </span>
+{{else if user_status}}
+<span>
+    {{> navbar_icon_and_title }}
+</span>
+<span class="narrow_description rendered_markdown">
+    {{user_status}}
+</span>
 {{else}}
 <span>
     {{> navbar_icon_and_title }}


### PR DESCRIPTION
The following commit adds user status to be displayed alongside the
user name while in PM with them. The user status is only displayed
only when it's a private message not a group private message.

Fixes #15686.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/23737560/87580422-221f8680-c6f5-11ea-93b7-289881ffa53c.png)
