### PR TITLE
styles: Hide focus outline for active elements.

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -978,7 +978,7 @@ on a dark background, and don't change the dark labels dark either. */
         }
     }
 
-    div.popover-content a:focus {
+    a:not(:active):focus {
         outline-color: hsl(0, 0%, 100%);
     }
 }

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -380,7 +380,7 @@ label {
 }
 
 /* Bootstrap's focus outline uses -webkit-focus-ring-color which doesn't exist in Firefox */
-div.popover-content a:focus {
+a:not(:active):focus {
     outline: 2px solid hsl(215, 47%, 50%);
     // TODO: change solid to auto once the Chromium bug #1105822 is fixed
 }


### PR DESCRIPTION
We still want it everywhere for accessibility.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
