### PR TITLE
Image upload widget rename css class

### DIFF
--- a/frontend_tests/casper_tests/10-admin.js
+++ b/frontend_tests/casper_tests/10-admin.js
@@ -358,10 +358,7 @@ casper.then(function () {
     var selector =
         '#realm-icon-upload-widget .image-block[src^="https://secure.gravatar.com/avatar/"]';
     casper.waitUntilVisible(selector, function () {
-        casper.test.assertEqual(
-            casper.visible("#realm-icon-upload-widget .settings-page-delete-button"),
-            false
-        );
+        casper.test.assertEqual(casper.visible('#realm-icon-upload-widget .image-delete-button'), false);
         // Hack: Rather than submitting the form, we just fill the
         // form and then trigger a click event by clicking the button.
         casper.fill(
@@ -372,37 +369,21 @@ casper.then(function () {
             false
         );
         casper.click("#realm-icon-upload-widget .image_upload_button");
-        casper.waitWhileVisible(
-            "#realm-icon-upload-widget .upload-spinner-background",
-            function () {
-                casper.test.assertExists(
-                    '#realm-icon-upload-widget .image-block[src^="/user_avatars/2/realm/icon.png?version=2"]'
-                );
-                casper.test.assertEqual(
-                    casper.visible("#realm-icon-upload-widget .settings-page-delete-button"),
-                    true
-                );
-            }
-        );
+        casper.waitWhileVisible("#realm-icon-upload-widget .upload-spinner-background", function () {
+            casper.test.assertExists('#realm-icon-upload-widget .image-block[src^="/user_avatars/2/realm/icon.png?version=2"]');
+            casper.test.assertEqual(casper.visible('#realm-icon-upload-widget .image-delete-button'), true);
+        });
     });
 });
 
 // Test deleting realm icon image
 casper.then(function () {
     casper.click("li[data-section='organization-profile']");
-    casper.click("#realm-icon-upload-widget .settings-page-delete-button");
-    casper.test.assertEqual(
-        casper.visible("#realm-icon-upload-widget .settings-page-delete-button"),
-        true
-    );
-    casper.waitWhileVisible("#realm-icon-upload-widget .settings-page-delete-button", function () {
-        casper.test.assertExists(
-            '#realm-icon-upload-widget .image-block[src^="https://secure.gravatar.com/avatar/"]'
-        );
-        casper.test.assertEqual(
-            casper.visible("#realm-icon-upload-widget .settings-page-delete-button"),
-            false
-        );
+    casper.click("#realm-icon-upload-widget .image-delete-button");
+    casper.test.assertEqual(casper.visible('#realm-icon-upload-widget .image-delete-button'), true);
+    casper.waitWhileVisible('#realm-icon-upload-widget .image-delete-button', function () {
+        casper.test.assertExists('#realm-icon-upload-widget .image-block[src^="https://secure.gravatar.com/avatar/"]');
+        casper.test.assertEqual(casper.visible('#realm-icon-upload-widget .image-delete-button'), false);
     });
 });
 

--- a/frontend_tests/casper_tests/10-admin.js
+++ b/frontend_tests/casper_tests/10-admin.js
@@ -358,7 +358,10 @@ casper.then(function () {
     var selector =
         '#realm-icon-upload-widget .image-block[src^="https://secure.gravatar.com/avatar/"]';
     casper.waitUntilVisible(selector, function () {
-        casper.test.assertEqual(casper.visible('#realm-icon-upload-widget .image-delete-button'), false);
+        casper.test.assertEqual(
+            casper.visible("#realm-icon-upload-widget .image-delete-button"),
+            false
+        );
         // Hack: Rather than submitting the form, we just fill the
         // form and then trigger a click event by clicking the button.
         casper.fill(
@@ -369,10 +372,18 @@ casper.then(function () {
             false
         );
         casper.click("#realm-icon-upload-widget .image_upload_button");
-        casper.waitWhileVisible("#realm-icon-upload-widget .upload-spinner-background", function () {
-            casper.test.assertExists('#realm-icon-upload-widget .image-block[src^="/user_avatars/2/realm/icon.png?version=2"]');
-            casper.test.assertEqual(casper.visible('#realm-icon-upload-widget .image-delete-button'), true);
-        });
+        casper.waitWhileVisible(
+            "#realm-icon-upload-widget .upload-spinner-background",
+            function () {
+                casper.test.assertExists(
+                    '#realm-icon-upload-widget .image-block[src^="/user_avatars/2/realm/icon.png?version=2"]'
+                );
+                casper.test.assertEqual(
+                    casper.visible("#realm-icon-upload-widget .image-delete-button"),
+                    true
+                );
+            }
+        );
     });
 });
 
@@ -380,10 +391,15 @@ casper.then(function () {
 casper.then(function () {
     casper.click("li[data-section='organization-profile']");
     casper.click("#realm-icon-upload-widget .image-delete-button");
-    casper.test.assertEqual(casper.visible('#realm-icon-upload-widget .image-delete-button'), true);
-    casper.waitWhileVisible('#realm-icon-upload-widget .image-delete-button', function () {
-        casper.test.assertExists('#realm-icon-upload-widget .image-block[src^="https://secure.gravatar.com/avatar/"]');
-        casper.test.assertEqual(casper.visible('#realm-icon-upload-widget .image-delete-button'), false);
+    casper.test.assertEqual(casper.visible("#realm-icon-upload-widget .image-delete-button"), true);
+    casper.waitWhileVisible("#realm-icon-upload-widget .image-delete-button", function () {
+        casper.test.assertExists(
+            '#realm-icon-upload-widget .image-block[src^="https://secure.gravatar.com/avatar/"]'
+        );
+        casper.test.assertEqual(
+            casper.visible("#realm-icon-upload-widget .image-delete-button"),
+            false
+        );
     });
 });
 

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -959,23 +959,35 @@ run_test("misc", () => {
     page_params.realm_avatar_changes_disabled = false;
     page_params.server_avatar_changes_disabled = false;
     settings_account.update_avatar_change_display();
-    assert.equal($('#user-avatar-upload-widget .image_upload_button').attr('disabled'), false);
-    assert.equal($("#user-avatar-upload-widget .image-delete-button .button").attr('disabled'), false);
+    assert.equal($("#user-avatar-upload-widget .image_upload_button").attr("disabled"), false);
+    assert.equal(
+        $("#user-avatar-upload-widget .image-delete-button .button").attr("disabled"),
+        false,
+    );
     page_params.realm_avatar_changes_disabled = true;
     page_params.server_avatar_changes_disabled = false;
     settings_account.update_avatar_change_display();
-    assert.equal($('#user-avatar-upload-widget .image_upload_button').attr('disabled'), 'disabled');
-    assert.equal($("#user-avatar-upload-widget .image-delete-button .button").attr('disabled'), 'disabled');
+    assert.equal($("#user-avatar-upload-widget .image_upload_button").attr("disabled"), "disabled");
+    assert.equal(
+        $("#user-avatar-upload-widget .image-delete-button .button").attr("disabled"),
+        "disabled",
+    );
     page_params.realm_avatar_changes_disabled = false;
     page_params.server_avatar_changes_disabled = true;
     settings_account.update_avatar_change_display();
-    assert.equal($('#user-avatar-upload-widget .image_upload_button').attr('disabled'), 'disabled');
-    assert.equal($("#user-avatar-upload-widget .image-delete-button .button").attr('disabled'), 'disabled');
+    assert.equal($("#user-avatar-upload-widget .image_upload_button").attr("disabled"), "disabled");
+    assert.equal(
+        $("#user-avatar-upload-widget .image-delete-button .button").attr("disabled"),
+        "disabled",
+    );
     page_params.realm_avatar_changes_disabled = true;
     page_params.server_avatar_changes_disabled = true;
     settings_account.update_avatar_change_display();
-    assert.equal($('#user-avatar-upload-widget .image_upload_button').attr('disabled'), 'disabled');
-    assert.equal($("#user-avatar-upload-widget .image-delete-button .button").attr('disabled'), 'disabled');
+    assert.equal($("#user-avatar-upload-widget .image_upload_button").attr("disabled"), "disabled");
+    assert.equal(
+        $("#user-avatar-upload-widget .image-delete-button .button").attr("disabled"),
+        "disabled",
+    );
 
     // If organization admin, these UI elements are never disabled.
     page_params.is_admin = true;

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -959,38 +959,23 @@ run_test("misc", () => {
     page_params.realm_avatar_changes_disabled = false;
     page_params.server_avatar_changes_disabled = false;
     settings_account.update_avatar_change_display();
-    assert.equal($("#user-avatar-upload-widget .image_upload_button").attr("disabled"), false);
-    assert.equal(
-        $("#user-avatar-upload-widget .settings-page-delete-button .button").attr("disabled"),
-        false,
-    );
-
+    assert.equal($('#user-avatar-upload-widget .image_upload_button').attr('disabled'), false);
+    assert.equal($("#user-avatar-upload-widget .image-delete-button .button").attr('disabled'), false);
     page_params.realm_avatar_changes_disabled = true;
     page_params.server_avatar_changes_disabled = false;
     settings_account.update_avatar_change_display();
-    assert.equal($("#user-avatar-upload-widget .image_upload_button").attr("disabled"), "disabled");
-    assert.equal(
-        $("#user-avatar-upload-widget .settings-page-delete-button .button").attr("disabled"),
-        "disabled",
-    );
-
+    assert.equal($('#user-avatar-upload-widget .image_upload_button').attr('disabled'), 'disabled');
+    assert.equal($("#user-avatar-upload-widget .image-delete-button .button").attr('disabled'), 'disabled');
     page_params.realm_avatar_changes_disabled = false;
     page_params.server_avatar_changes_disabled = true;
     settings_account.update_avatar_change_display();
-    assert.equal($("#user-avatar-upload-widget .image_upload_button").attr("disabled"), "disabled");
-    assert.equal(
-        $("#user-avatar-upload-widget .settings-page-delete-button .button").attr("disabled"),
-        "disabled",
-    );
-
+    assert.equal($('#user-avatar-upload-widget .image_upload_button').attr('disabled'), 'disabled');
+    assert.equal($("#user-avatar-upload-widget .image-delete-button .button").attr('disabled'), 'disabled');
     page_params.realm_avatar_changes_disabled = true;
     page_params.server_avatar_changes_disabled = true;
     settings_account.update_avatar_change_display();
-    assert.equal($("#user-avatar-upload-widget .image_upload_button").attr("disabled"), "disabled");
-    assert.equal(
-        $("#user-avatar-upload-widget .settings-page-delete-button .button").attr("disabled"),
-        "disabled",
-    );
+    assert.equal($('#user-avatar-upload-widget .image_upload_button').attr('disabled'), 'disabled');
+    assert.equal($("#user-avatar-upload-widget .image-delete-button .button").attr('disabled'), 'disabled');
 
     // If organization admin, these UI elements are never disabled.
     page_params.is_admin = true;

--- a/static/js/avatar.js
+++ b/static/js/avatar.js
@@ -44,20 +44,19 @@ exports.build_user_avatar_widget = function (upload_function) {
         return $("#user-avatar-upload-widget .image_file_input").expectOne();
     };
 
-    if (page_params.avatar_source === 'G') {
+    if (page_params.avatar_source === "G") {
         $("#user-avatar-upload-widget .image-delete-button").hide();
         $("#user-avatar-source").show();
     } else {
         $("#user-avatar-source").hide();
     }
 
-
-    $("#user-avatar-upload-widget .image-delete-button").on('click keydown', (e) => {
+    $("#user-avatar-upload-widget .image-delete-button").on("click keydown", (e) => {
         e.preventDefault();
         e.stopPropagation();
         channel.del({
             url: "/json/users/me/avatar",
-            success: function () {
+            success() {
                 $("#user-avatar-upload-widget .image-delete-button").hide();
                 $("#user-avatar-source").show();
                 // Need to clear input because of a small edge case

--- a/static/js/avatar.js
+++ b/static/js/avatar.js
@@ -44,20 +44,21 @@ exports.build_user_avatar_widget = function (upload_function) {
         return $("#user-avatar-upload-widget .image_file_input").expectOne();
     };
 
-    if (page_params.avatar_source === "G") {
-        $("#user-avatar-upload-widget .settings-page-delete-button").hide();
+    if (page_params.avatar_source === 'G') {
+        $("#user-avatar-upload-widget .image-delete-button").hide();
         $("#user-avatar-source").show();
     } else {
         $("#user-avatar-source").hide();
     }
 
-    $("#user-avatar-upload-widget .settings-page-delete-button").on("click keydown", (e) => {
+
+    $("#user-avatar-upload-widget .image-delete-button").on('click keydown', (e) => {
         e.preventDefault();
         e.stopPropagation();
         channel.del({
             url: "/json/users/me/avatar",
-            success() {
-                $("#user-avatar-upload-widget .settings-page-delete-button").hide();
+            success: function () {
+                $("#user-avatar-upload-widget .image-delete-button").hide();
                 $("#user-avatar-source").show();
                 // Need to clear input because of a small edge case
                 // where you try to upload the same image you just deleted.

--- a/static/js/realm_icon.js
+++ b/static/js/realm_icon.js
@@ -6,12 +6,12 @@ exports.build_realm_icon_widget = function (upload_function) {
     if (!page_params.is_admin) {
         return;
     }
-    if (page_params.realm_icon_source === "G") {
-        $("#realm-icon-upload-widget .settings-page-delete-button").hide();
+    if (page_params.realm_icon_source === 'G') {
+        $("#realm-icon-upload-widget .image-delete-button").hide();
     } else {
-        $("#realm-icon-upload-widget .settings-page-delete-button").show();
+        $("#realm-icon-upload-widget .image-delete-button").show();
     }
-    $("#realm-icon-upload-widget .settings-page-delete-button").on("click", (e) => {
+    $("#realm-icon-upload-widget .image-delete-button").on('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
         channel.del({
@@ -30,10 +30,10 @@ exports.build_realm_icon_widget = function (upload_function) {
 
 exports.rerender = function () {
     $("#realm-icon-upload-widget .image-block").attr("src", page_params.realm_icon_url);
-    if (page_params.realm_icon_source === "U") {
-        $("#realm-icon-upload-widget .settings-page-delete-button").show();
+    if (page_params.realm_icon_source === 'U') {
+        $("#realm-icon-upload-widget .image-delete-button").show();
     } else {
-        $("#realm-icon-upload-widget .settings-page-delete-button").hide();
+        $("#realm-icon-upload-widget .image-delete-button").hide();
         // Need to clear input because of a small edge case
         // where you try to upload the same image you just deleted.
         const file_input = $("#realm-icon-upload-widget .image_file_input");

--- a/static/js/realm_icon.js
+++ b/static/js/realm_icon.js
@@ -6,12 +6,12 @@ exports.build_realm_icon_widget = function (upload_function) {
     if (!page_params.is_admin) {
         return;
     }
-    if (page_params.realm_icon_source === 'G') {
+    if (page_params.realm_icon_source === "G") {
         $("#realm-icon-upload-widget .image-delete-button").hide();
     } else {
         $("#realm-icon-upload-widget .image-delete-button").show();
     }
-    $("#realm-icon-upload-widget .image-delete-button").on('click', (e) => {
+    $("#realm-icon-upload-widget .image-delete-button").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();
         channel.del({
@@ -30,7 +30,7 @@ exports.build_realm_icon_widget = function (upload_function) {
 
 exports.rerender = function () {
     $("#realm-icon-upload-widget .image-block").attr("src", page_params.realm_icon_url);
-    if (page_params.realm_icon_source === 'U') {
+    if (page_params.realm_icon_source === "U") {
         $("#realm-icon-upload-widget .image-delete-button").show();
     } else {
         $("#realm-icon-upload-widget .image-delete-button").hide();

--- a/static/js/realm_logo.js
+++ b/static/js/realm_logo.js
@@ -90,12 +90,16 @@ exports.rerender = function () {
         $("#realm-logo").attr("src", page_params.realm_logo_url);
     }
 
-    change_logo_delete_button(page_params.realm_logo_source,
-                              $("#realm-day-logo-upload-widget .image-delete-button"),
-                              file_input);
-    change_logo_delete_button(page_params.realm_night_logo_source,
-                              $("#realm-night-logo-upload-widget .image-delete-button"),
-                              night_file_input);
+    change_logo_delete_button(
+        page_params.realm_logo_source,
+        $("#realm-day-logo-upload-widget .image-delete-button"),
+        file_input,
+    );
+    change_logo_delete_button(
+        page_params.realm_night_logo_source,
+        $("#realm-night-logo-upload-widget .image-delete-button"),
+        night_file_input,
+    );
 };
 
 window.realm_logo = exports;

--- a/static/js/realm_logo.js
+++ b/static/js/realm_logo.js
@@ -9,7 +9,7 @@ exports.build_realm_logo_widget = function (upload_function, is_night) {
         logo_source = page_params.realm_night_logo_source;
     }
 
-    const delete_button_elem = $(logo_section_id + " .settings-page-delete-button");
+    const delete_button_elem = $(logo_section_id + " .image-delete-button");
     const file_input_elem = $(logo_section_id + " .image_file_input");
     const file_input_error_elem = $(logo_section_id + " .image_file_input_error");
     const upload_button_elem = $(logo_section_id + " .image_upload_button");
@@ -90,16 +90,12 @@ exports.rerender = function () {
         $("#realm-logo").attr("src", page_params.realm_logo_url);
     }
 
-    change_logo_delete_button(
-        page_params.realm_logo_source,
-        $("#realm-day-logo-upload-widget .settings-page-delete-button"),
-        file_input,
-    );
-    change_logo_delete_button(
-        page_params.realm_night_logo_source,
-        $("#realm-night-logo-upload-widget .settings-page-delete-button"),
-        night_file_input,
-    );
+    change_logo_delete_button(page_params.realm_logo_source,
+                              $("#realm-day-logo-upload-widget .image-delete-button"),
+                              file_input);
+    change_logo_delete_button(page_params.realm_night_logo_source,
+                              $("#realm-night-logo-upload-widget .image-delete-button"),
+                              night_file_input);
 };
 
 window.realm_logo = exports;

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -77,14 +77,14 @@ exports.update_avatar_change_display = function () {
 
 function display_avatar_upload_complete() {
     $('#user-avatar-upload-widget .upload-spinner-background').css({visibility: 'hidden'});
-    $('#user-avatar-upload-widget .settings-page-upload-text').show();
+    $('#user-avatar-upload-widget .image-upload-text').show();
     $('#user-avatar-upload-widget .image-delete-button').show();
 }
 
 function display_avatar_upload_started() {
     $("#user-avatar-source").hide();
     $('#user-avatar-upload-widget .upload-spinner-background').css({visibility: 'visible'});
-    $('#user-avatar-upload-widget .settings-page-upload-text').hide();
+    $('#user-avatar-upload-widget .image-upload-text').hide();
     $('#user-avatar-upload-widget .image-delete-button').hide();
 }
 

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -67,25 +67,25 @@ exports.update_email_change_display = function () {
 
 exports.update_avatar_change_display = function () {
     if (!exports.user_can_change_avatar()) {
-        $('#user-avatar-upload-widget .image_upload_button').attr('disabled', 'disabled');
-        $("#user-avatar-upload-widget .image-delete-button .button").attr('disabled', 'disabled');
+        $("#user-avatar-upload-widget .image_upload_button").attr("disabled", "disabled");
+        $("#user-avatar-upload-widget .image-delete-button .button").attr("disabled", "disabled");
     } else {
-        $('#user-avatar-upload-widget .image_upload_button').attr('disabled', false);
-        $('#user-avatar-upload-widget .image-delete-button .button').attr('disabled', false);
+        $("#user-avatar-upload-widget .image_upload_button").attr("disabled", false);
+        $("#user-avatar-upload-widget .image-delete-button .button").attr("disabled", false);
     }
 };
 
 function display_avatar_upload_complete() {
-    $('#user-avatar-upload-widget .upload-spinner-background').css({visibility: 'hidden'});
-    $('#user-avatar-upload-widget .image-upload-text').show();
-    $('#user-avatar-upload-widget .image-delete-button').show();
+    $("#user-avatar-upload-widget .upload-spinner-background").css({visibility: "hidden"});
+    $("#user-avatar-upload-widget .image-upload-text").show();
+    $("#user-avatar-upload-widget .image-delete-button").show();
 }
 
 function display_avatar_upload_started() {
     $("#user-avatar-source").hide();
-    $('#user-avatar-upload-widget .upload-spinner-background').css({visibility: 'visible'});
-    $('#user-avatar-upload-widget .image-upload-text').hide();
-    $('#user-avatar-upload-widget .image-delete-button').hide();
+    $("#user-avatar-upload-widget .upload-spinner-background").css({visibility: "visible"});
+    $("#user-avatar-upload-widget .image-upload-text").hide();
+    $("#user-avatar-upload-widget .image-delete-button").hide();
 }
 
 function settings_change_error(message, xhr) {

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -67,31 +67,25 @@ exports.update_email_change_display = function () {
 
 exports.update_avatar_change_display = function () {
     if (!exports.user_can_change_avatar()) {
-        $("#user-avatar-upload-widget .image_upload_button").attr("disabled", "disabled");
-        $("#user-avatar-upload-widget .settings-page-delete-button .button").attr(
-            "disabled",
-            "disabled",
-        );
+        $('#user-avatar-upload-widget .image_upload_button').attr('disabled', 'disabled');
+        $("#user-avatar-upload-widget .image-delete-button .button").attr('disabled', 'disabled');
     } else {
-        $("#user-avatar-upload-widget .image_upload_button").attr("disabled", false);
-        $("#user-avatar-upload-widget .settings-page-delete-button .button").attr(
-            "disabled",
-            false,
-        );
+        $('#user-avatar-upload-widget .image_upload_button').attr('disabled', false);
+        $('#user-avatar-upload-widget .image-delete-button .button').attr('disabled', false);
     }
 };
 
 function display_avatar_upload_complete() {
-    $("#user-avatar-upload-widget .upload-spinner-background").css({visibility: "hidden"});
-    $("#user-avatar-upload-widget .settings-page-upload-text").show();
-    $("#user-avatar-upload-widget .settings-page-delete-button").show();
+    $('#user-avatar-upload-widget .upload-spinner-background').css({visibility: 'hidden'});
+    $('#user-avatar-upload-widget .settings-page-upload-text').show();
+    $('#user-avatar-upload-widget .image-delete-button').show();
 }
 
 function display_avatar_upload_started() {
     $("#user-avatar-source").hide();
-    $("#user-avatar-upload-widget .upload-spinner-background").css({visibility: "visible"});
-    $("#user-avatar-upload-widget .settings-page-upload-text").hide();
-    $("#user-avatar-upload-widget .settings-page-delete-button").hide();
+    $('#user-avatar-upload-widget .upload-spinner-background').css({visibility: 'visible'});
+    $('#user-avatar-upload-widget .settings-page-upload-text').hide();
+    $('#user-avatar-upload-widget .image-delete-button').hide();
 }
 
 function settings_change_error(message, xhr) {

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -1046,7 +1046,7 @@ exports.build_page = function () {
             form_data.append("night", JSON.stringify(night));
         }
         const spinner = $(`${widget} .upload-spinner-background`).expectOne();
-        const upload_text =  $(`${widget}  .image-upload-text`).expectOne();
+        const upload_text = $(`${widget}  .image-upload-text`).expectOne();
         const delete_button = $(`${widget}  .image-delete-button`).expectOne();
         const error_field = $(`${widget}  .image_file_input_error`).expectOne();
         realm_icon_logo_upload_start(spinner, upload_text, delete_button);

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -1046,8 +1046,8 @@ exports.build_page = function () {
             form_data.append("night", JSON.stringify(night));
         }
         const spinner = $(`${widget} .upload-spinner-background`).expectOne();
-        const upload_text = $(`${widget}  .settings-page-upload-text`).expectOne();
-        const delete_button = $(`${widget}  .settings-page-delete-button`).expectOne();
+        const upload_text =  $(`${widget}  .settings-page-upload-text`).expectOne();
+        const delete_button = $(`${widget}  .image-delete-button`).expectOne();
         const error_field = $(`${widget}  .image_file_input_error`).expectOne();
         realm_icon_logo_upload_start(spinner, upload_text, delete_button);
         error_field.hide();

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -1046,7 +1046,7 @@ exports.build_page = function () {
             form_data.append("night", JSON.stringify(night));
         }
         const spinner = $(`${widget} .upload-spinner-background`).expectOne();
-        const upload_text =  $(`${widget}  .settings-page-upload-text`).expectOne();
+        const upload_text =  $(`${widget}  .image-upload-text`).expectOne();
         const delete_button = $(`${widget}  .image-delete-button`).expectOne();
         const error_field = $(`${widget}  .image_file_input_error`).expectOne();
         realm_icon_logo_upload_start(spinner, upload_text, delete_button);

--- a/static/js/upload_widget.js
+++ b/static/js/upload_widget.js
@@ -70,7 +70,7 @@ exports.build_widget = function (
             if (file.size > max_file_upload_size * 1024 * 1024) {
                 input_error.text(
                     i18n.t("File size must be < __max_file_size__Mb.", {
-                        max_file_size: max_file_upload_size,
+                    max_file_size: max_file_upload_size,
                     }),
                 );
                 input_error.show();
@@ -120,7 +120,7 @@ exports.build_direct_upload_widget = function (
     max_file_upload_size = max_file_upload_size || default_max_file_size;
     function accept() {
         input_error.hide();
-        const realm_logo_section = upload_button.closest(".avatar-icon-logo-settings");
+        const realm_logo_section = upload_button.closest(".image_upload_widget");
         if (realm_logo_section.attr("id") === "realm-night-logo-upload-widget") {
             upload_function(get_file_input(), true, false);
         } else if (realm_logo_section.attr("id") === "realm-day-logo-upload-widget") {
@@ -154,7 +154,7 @@ exports.build_direct_upload_widget = function (
             if (file.size > max_file_upload_size * 1024 * 1024) {
                 input_error.text(
                     i18n.t("File size must be < __max_file_size__Mb.", {
-                        max_file_size: max_file_upload_size,
+                    max_file_size: max_file_upload_size,
                     }),
                 );
                 input_error.show();

--- a/static/js/upload_widget.js
+++ b/static/js/upload_widget.js
@@ -70,7 +70,7 @@ exports.build_widget = function (
             if (file.size > max_file_upload_size * 1024 * 1024) {
                 input_error.text(
                     i18n.t("File size must be < __max_file_size__Mb.", {
-                    max_file_size: max_file_upload_size,
+                        max_file_size: max_file_upload_size,
                     }),
                 );
                 input_error.show();
@@ -154,7 +154,7 @@ exports.build_direct_upload_widget = function (
             if (file.size > max_file_upload_size * 1024 * 1024) {
                 input_error.text(
                     i18n.t("File size must be < __max_file_size__Mb.", {
-                    max_file_size: max_file_upload_size,
+                        max_file_size: max_file_upload_size,
                     }),
                 );
                 input_error.show();

--- a/static/styles/image_upload_widget.scss
+++ b/static/styles/image_upload_widget.scss
@@ -12,7 +12,7 @@
         height: 100%;
     }
 
-    .settings-page-image-background {
+    .image-upload-background {
         content: '';
         background-color: hsl(0, 0%, 0%);
         height: 100%;
@@ -95,7 +95,7 @@
             visibility: visible;
         }
 
-        .settings-page-image-background {
+        .image-upload-background {
             display: block;
         }
     }

--- a/static/styles/image_upload_widget.scss
+++ b/static/styles/image_upload_widget.scss
@@ -1,5 +1,5 @@
 /* common CSS for all image upload widget's */
-.avatar-icon-logo-settings {
+.image_upload_widget {
     position: relative;
     border-radius: 5px;
     box-shadow: 0px 0px 10px hsla(0, 0%, 0%, 0.1);

--- a/static/styles/image_upload_widget.scss
+++ b/static/styles/image_upload_widget.scss
@@ -43,11 +43,11 @@
         visibility: hidden;
     }
 
-    .image-delete-button:hover ~ .settings-page-delete-text {
+    .image-delete-button:hover ~ .image-delete-text {
         visibility: visible;
     }
 
-    .settings-page-delete-text {
+    .image-delete-text {
         color: hsl(0, 0%, 100%);
         font-size: 0.85rem;
         position: absolute;
@@ -126,7 +126,7 @@
         font-size: 3rem;
     }
 
-    .settings-page-delete-text {
+    .image-delete-text {
         top: 90px;
         right: 40px;
     }
@@ -168,7 +168,7 @@
     border-radius: 5px;
     box-shadow: 0px 0px 10px hsla(0, 0%, 0%, 0.1);
 
-    .settings-page-delete-text {
+    .image-delete-text {
         top: 40px;
         right: 18px;
     }
@@ -201,7 +201,7 @@
     margin: 0px 80px 0px 20px;
 
     .settings-page-upload-text,
-    .settings-page-delete-text {
+    .image-delete-text {
         top: 17px;
         right: 80px;
     }

--- a/static/styles/image_upload_widget.scss
+++ b/static/styles/image_upload_widget.scss
@@ -24,7 +24,7 @@
         cursor: pointer;
     }
 
-    .settings-page-delete-button {
+    .image-delete-button {
         cursor: pointer;
         color: hsl(0, 0%, 75%);
         opacity: 0;
@@ -35,15 +35,15 @@
         z-index: 99;
     }
 
-    .settings-page-delete-button:hover {
+    .image-delete-button:hover {
         color: hsl(0, 0%, 100%);
     }
 
-    .settings-page-delete-button:hover ~ .settings-page-upload-text {
+    .image-delete-button:hover ~ .settings-page-upload-text {
         visibility: hidden;
     }
 
-    .settings-page-delete-button:hover ~ .settings-page-delete-text {
+    .image-delete-button:hover ~ .settings-page-delete-text {
         visibility: visible;
     }
 
@@ -87,7 +87,7 @@
     }
 
     &:hover {
-        .settings-page-delete-button {
+        .image-delete-button {
             opacity: 1;
         }
 
@@ -122,7 +122,7 @@
         z-index: 99;
     }
 
-    .settings-page-delete-button {
+    .image-delete-button {
         font-size: 3rem;
     }
 

--- a/static/styles/image_upload_widget.scss
+++ b/static/styles/image_upload_widget.scss
@@ -39,7 +39,7 @@
         color: hsl(0, 0%, 100%);
     }
 
-    .image-delete-button:hover ~ .settings-page-upload-text {
+    .image-delete-button:hover ~ .image-upload-text {
         visibility: hidden;
     }
 
@@ -55,7 +55,7 @@
         z-index: 99;
     }
 
-    .settings-page-upload-text {
+    .image-upload-text {
         cursor: pointer;
         font-size: 0.85rem;
         color: hsl(0, 0%, 85%);
@@ -64,7 +64,7 @@
         visibility: hidden;
     }
 
-    .settings-page-upload-text:hover {
+    .image-upload-text:hover {
         color: hsl(0, 0%, 100%);
     }
 
@@ -91,7 +91,7 @@
             opacity: 1;
         }
 
-        .settings-page-upload-text {
+        .image-upload-text {
             visibility: visible;
         }
 
@@ -131,7 +131,7 @@
         right: 40px;
     }
 
-    .settings-page-upload-text {
+    .image-upload-text {
         top: 90px;
         right: 20px;
     }
@@ -173,7 +173,7 @@
         right: 18px;
     }
 
-    .settings-page-upload-text {
+    .image-upload-text {
         top: 40px;
         right: 18px;
     }
@@ -200,7 +200,7 @@
     text-align: center;
     margin: 0px 80px 0px 20px;
 
-    .settings-page-upload-text,
+    .image-upload-text,
     .image-delete-text {
         top: 17px;
         right: 80px;

--- a/static/styles/image_upload_widget.scss
+++ b/static/styles/image_upload_widget.scss
@@ -133,7 +133,7 @@
 
     .image-upload-text {
         top: 90px;
-        right: 20px;
+        right: 24px;
     }
 
     .image_upload_spinner {

--- a/static/templates/settings/image_upload_widget.hbs
+++ b/static/templates/settings/image_upload_widget.hbs
@@ -2,7 +2,7 @@
     {{#if is_editable_by_current_user}}
     <div class="image_upload_button">
         <div class="image-upload-background"></div>
-        <span class="settings-page-delete-button" aria-label="{{ delete_text }}" role="button" tabindex="0">
+        <span class="image-delete-button" aria-label="{{ delete_text }}" role="button" tabindex="0">
             &times;
         </span>
         <span class="settings-page-delete-text" aria-label="{{ delete_text }}" tabindex="0">

--- a/static/templates/settings/image_upload_widget.hbs
+++ b/static/templates/settings/image_upload_widget.hbs
@@ -5,7 +5,7 @@
         <span class="image-delete-button" aria-label="{{ delete_text }}" role="button" tabindex="0">
             &times;
         </span>
-        <span class="settings-page-delete-text" aria-label="{{ delete_text }}" tabindex="0">
+        <span class="image-delete-text" aria-label="{{ delete_text }}" tabindex="0">
             {{ delete_text }}
         </span>
         <span class="settings-page-upload-text" aria-label="{{ upload_text }}" role="button" tabindex="0">

--- a/static/templates/settings/image_upload_widget.hbs
+++ b/static/templates/settings/image_upload_widget.hbs
@@ -8,7 +8,7 @@
         <span class="image-delete-text" aria-label="{{ delete_text }}" tabindex="0">
             {{ delete_text }}
         </span>
-        <span class="settings-page-upload-text" aria-label="{{ upload_text }}" role="button" tabindex="0">
+        <span class="image-upload-text" aria-label="{{ upload_text }}" role="button" tabindex="0">
             {{ upload_text }}
         </span>
         <span class="upload-spinner-background">

--- a/static/templates/settings/image_upload_widget.hbs
+++ b/static/templates/settings/image_upload_widget.hbs
@@ -1,7 +1,7 @@
 <div id ="{{widget}}-upload-widget" class="inline-block image_upload_widget">
     {{#if is_editable_by_current_user}}
     <div class="image_upload_button">
-        <div class="settings-page-image-background"></div>
+        <div class="image-upload-background"></div>
         <span class="settings-page-delete-button" aria-label="{{ delete_text }}" role="button" tabindex="0">
             &times;
         </span>

--- a/static/templates/settings/image_upload_widget.hbs
+++ b/static/templates/settings/image_upload_widget.hbs
@@ -1,4 +1,4 @@
-<div id ="{{widget}}-upload-widget" class="inline-block avatar-icon-logo-settings">
+<div id ="{{widget}}-upload-widget" class="inline-block image_upload_widget">
     {{#if is_editable_by_current_user}}
     <div class="image_upload_button">
         <div class="settings-page-image-background"></div>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
When migrating to `image_upload_widget.hbs`  some names of CSS class
are unchanged. This PR is to rename some of the CSS class to be more generic.

**Testing Plan:** <!-- How have you tested? -->
Tested manually in the browser

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
