### PR TITLE
timestamp: Observe user's 24-hour clock setting.

### DIFF
--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -179,6 +179,27 @@ run_test('timestamp', () => {
     assert.equal($timestamp_invalid.text(), 'never-been-set');
 });
 
+run_test('timestamp-twenty-four-hour-time', () => {
+    const $content = get_content_element();
+    const $timestamp = $.create('timestamp');
+    $timestamp.attr('datetime', '2020-07-15T20:40:00Z');
+    $content.set_find_results('time', $array([$timestamp]));
+
+    // We will temporarily change the 24h setting for this test.
+    const old_page_params = global.page_params;
+
+    set_global('page_params', { ...old_page_params, twenty_four_hour_time: true });
+    rm.update_elements($content);
+    assert.equal($timestamp.text(), 'Wed, Jul 15 2020, 20:40');
+
+    set_global('page_params', { ...old_page_params, twenty_four_hour_time: false });
+    rm.update_elements($content);
+    assert.equal($timestamp.text(), 'Wed, Jul 15 2020, 8:40 PM');
+
+    // Set page_params back to its original value.
+    set_global('page_params', old_page_params);
+});
+
 run_test('timestamp-error', () => {
     // Setup
     const $content = get_content_element();

--- a/static/js/rendered_markdown.js
+++ b/static/js/rendered_markdown.js
@@ -153,8 +153,7 @@ exports.update_elements = (content) => {
         const timestamp = moment(time_str);
         if (timestamp.isValid()) {
             const text = $(this).text();
-            const rendered_time = timerender.render_markdown_timestamp(timestamp,
-                                                                       null, text);
+            const rendered_time = timerender.render_markdown_timestamp(timestamp, text);
             $(this).text(rendered_time.text);
             $(this).attr('title', rendered_time.title);
         } else {

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -171,7 +171,8 @@ exports.render_markdown_timestamp = function (time, now, text) {
         now = now.tz(page_params.timezone);
         time = time.tz(page_params.timezone);
     }
-    const timestring = time.format('ddd, MMM D YYYY, h:mm A');
+    const hourformat = page_params.twenty_four_hour_time ? 'HH:mm' : 'h:mm A';
+    const timestring = time.format('ddd, MMM D YYYY, ' + hourformat);
     const titlestring = "This time is in your timezone. Original text was '" + text + "'.";
     return {
         text: timestring,

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -165,12 +165,7 @@ exports.render_date = function (time, time_above, today) {
 };
 
 // Renders the timestamp returned by the <time:> markdown syntax.
-exports.render_markdown_timestamp = function (time, now, text) {
-    now = now || moment();
-    if (page_params.timezone) {
-        now = now.tz(page_params.timezone);
-        time = time.tz(page_params.timezone);
-    }
+exports.render_markdown_timestamp = function (time, text) {
     const hourformat = page_params.twenty_four_hour_time ? 'HH:mm' : 'h:mm A';
     const timestring = time.format('ddd, MMM D YYYY, ' + hourformat);
     const titlestring = "This time is in your timezone. Original text was '" + text + "'.";


### PR DESCRIPTION
Fixes #15791.

The `render_markdown_timestamp` function always used 12-hour format before.