### PR TITLE
recent_topics: Patch colors.

### DIFF
--- a/static/styles/night_mode.scss
+++ b/static/styles/night_mode.scss
@@ -432,12 +432,8 @@ on a dark background, and don't change the dark labels dark either. */
         background-color: hsl(212, 28%, 18%);
 
         &:hover {
-            background-color: hsl(208, 26%, 11%);
+            background-color: hsl(208, 26%, 11%, 0.6);
         }
-    }
-
-    #recent_topics_table .unread_topic {
-        background-color: hsl(211, 28%, 16%);
     }
 
     .btn-recent-selected,

--- a/static/styles/recent_topics.scss
+++ b/static/styles/recent_topics.scss
@@ -227,15 +227,11 @@
         }
 
         tr {
-            background-color: hsl(100, 11%, 96%);
+            background-color: hsl(0, 0%, 100%);
 
             &:hover {
                 background-color: hsl(210, 100%, 97%);
             }
-        }
-
-        .unread_topic {
-            background-color: hsl(0, 0%, 100%);
         }
 
         .last_msg_time {

--- a/static/templates/recent_topics_table.hbs
+++ b/static/templates/recent_topics_table.hbs
@@ -10,7 +10,7 @@
     </div>
 </div>
 <div class="table_fix_head" data-simplebar>
-    <table class="table table-responsive table-hover">
+    <table class="table table-responsive">
         <thead>
             <tr>
                 <th data-sort="stream_sort">{{t 'Stream' }}</th>


### PR DESCRIPTION
Don't allow bootstrap to override row hover colors.
Show unread topics in same color as others.
