### PR TITLE
click_handlers: Don't focus elements on dragstart.

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -732,7 +732,14 @@ exports.initialize = function () {
     // End Webathena code
 
     // disable the draggability for left-sidebar components
-    $('#stream_filters, #global_filters').on('dragstart', () => false);
+    $('#stream_filters, #global_filters').on('dragstart', (e) => {
+        e.target.blur();
+        return false;
+    });
+
+    // Chrome focuses an element when dragging it which can be confusing when
+    // users involuntarily drag something and we show them the focus outline.
+    $('body').on('dragstart', (e) => e.target.blur());
 
     (function () {
         const map = {


### PR DESCRIPTION
Chrome focuses elements when you start dragging them,
which can confuse users because of our focus outline.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
