### PR TITLE
tests: Fix apple native flow test with unsuccessful authentication.

### DIFF
--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -2263,10 +2263,9 @@ class AppleAuthBackendNativeFlowTest(AppleAuthMixin, SocialAuthBase):
         mobile_flow_otp = '1234abcd' * 8
 
         def initiate_auth(mobile_flow_otp: Optional[str]=None) -> None:
-            url, headers = self.prepare_login_url_and_headers(subdomain='zulip',
-                                                              id_token='invalid',
-                                                              mobile_flow_otp=mobile_flow_otp)
-            result = self.client_get(url, **headers)
+            result = self.social_auth_test(self.get_account_data_dict(email=self.email, name=self.name),
+                                           subdomain='zulip',
+                                           mobile_flow_otp=mobile_flow_otp)
             self.assertEqual(result.status_code, 302)
 
         # Start Apple auth with mobile_flow_otp param. It should get saved into the session


### PR DESCRIPTION
test_social_auth_session_fields_cleared_preperly was sending an invalid
id_token which inturn is causing the authentication to fail.
But as we only check if session fields are saved properly we didn't
notice that the auth was failing.
It is found that the auth fails from the unwanted log it generates
for this test. So, this commit also helps clear spam output
when tests are run.

Since social_auth_test for native flow is just same as what
we want to do here to initiate_auth, social_auth_test is
used instead of copying the same.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
https://circleci.com/gh/chdinesh1089/zulip/tree/invalid_token
