### PR TITLE
settings: Fix handlers of zulip.ldap and zulip.auth loggers.

### DIFF
--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -905,7 +905,7 @@ LOGGING: Dict[str, Any] = {
         },
         'zulip.auth': {
             'level': 'DEBUG',
-            'handlers': DEFAULT_ZULIP_HANDLERS + ['auth_file'],
+            'handlers': ['file', 'auth_file', 'errors_file'],
             'propagate': False,
         },
         'zulip.ldap': {


### PR DESCRIPTION
Solves the mystery of https://chat.zulip.org/#narrow/stream/49-development-help/topic/Removing.20spam.20from.20test.20output.20.231587

Generally we don't include console among the handlers of our loggers (as
evidenced by look at the configs of loggers around these two). Neither
should we for these, because
1. It's not the standard approach and there's no reason for these to
   have special behavior in terms of this.
2. It makes those loggers spam the console even with INFO-level logs
   when running the full suite test-backend, which again - is not the
   standard.