### PR TITLE
github-actions: Add production build and install jobs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,16 +294,10 @@ jobs:
           # or relative path from working_directory.
           # This is a directory on the container which is
           # taken to be the root directory of the workspace.
-          root: /tmp
+          root: /tmp/production-build
           # Must be relative path from root
           paths:
-            - zulip-server-test.tar.gz
-            - success-http-headers.template.txt
-            - production-install
-            - production-verify
-            - production-upgrade-pg
-            - production
-            - production-extract-tarball
+            - "*"
       - *notify_failure_status
 
   "bionic-production-install":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,19 +136,19 @@ aliases:
       name: install production
       command: |
         sudo service rabbitmq-server restart
-        sudo mispipe "/tmp/production-install 2>&1" ts
+        sudo --preserve-env=CIRCLECI mispipe "/tmp/production-install 2>&1" ts
 
   - &verify_production
     run:
       name: verify install
       command: |
-        sudo mispipe "/tmp/production-verify 2>&1" ts
+        sudo --preserve-env=CIRCLECI mispipe "/tmp/production-verify 2>&1" ts
 
   - &upgrade_postgresql
     run:
       name: upgrade postgresql
       command: |
-        sudo mispipe "/tmp/production-upgrade-pg 2>&1" ts
+        sudo --preserve-env=CIRCLECI mispipe "/tmp/production-upgrade-pg 2>&1" ts
 
   - &check_xenial_provision_error
     run:

--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -77,3 +77,86 @@ jobs:
         with:
           name: production-tarball
           path: /tmp/production-build
+
+  production_install:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - docker_image: mepriyank/actions:bionic
+            name: Bionic Production Install
+            is_bionic: true
+            os: bionic
+
+          - docker_image: mepriyank/actions:focal
+            name: Focal Production Install
+            is_focal: true
+            os: focal
+
+    name: ${{ matrix.name  }}
+    container: ${{ matrix.docker_image }}
+    runs-on: ubuntu-latest
+    needs: production_build
+
+    steps:
+      - name: Download built production tarball
+        uses: actions/download-artifact@v2
+        with:
+          name: production-tarball
+          path: /tmp
+
+      - name: Add required permissions and setup
+        run: |
+          # This is the GitHub Actions specific cache directory the
+          # the current github user must be able to access for the
+          # cache action to work. It is owned by root currently.
+          sudo chmod -R 0777 /__w/_temp/
+
+          # Create the zulip directory that the tools/ci/ scripts needs
+          mkdir -p /home/github/zulip
+
+          # Since actions/download-artifact@v2 loses all the permissions
+          # of the tarball uploaded by the upload artifact fix those.
+          chmod +x /tmp/production-extract-tarball
+          chmod +x /tmp/production-upgrade-pg
+          chmod +x /tmp/production-install
+          chmod +x /tmp/production-verify
+
+      - name: Create cache directories
+        run: |
+          dirs=(/srv/zulip-{npm,venv,emoji}-cache)
+          sudo mkdir -p "${dirs[@]}"
+          sudo chown -R github "${dirs[@]}"
+
+      - name: Restore node_modules cache
+        uses: actions/cache@v2
+        with:
+          path: /srv/zulip-npm-cache
+          key: v1-yarn-deps-${{ matrix.os }}-${{ hashFiles('package.json') }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: v1-yarn-deps-${{ matrix.os }}
+
+      - name: Do Bionic hack
+        if: ${{ matrix.is_bionic }}
+        run: |
+          # Temporary hack till `sudo service redis-server start` gets fixes in Bionic. See
+          # https://chat.zulip.org/#narrow/stream/3-backend/topic/Ubuntu.20bionic.20CircleCI
+          sudo sed -i '/^bind/s/bind.*/bind 0.0.0.0/' /etc/redis/redis.conf
+
+      - name: Production extract tarball
+        run: mispipe "/tmp/production-extract-tarball 2>&1" ts
+
+      - name: Install production
+        run: |
+          sudo service rabbitmq-server restart
+          sudo mispipe "/tmp/production-install 2>&1" ts
+
+      - name: Verify install
+        run: sudo mispipe "/tmp/production-verify 2>&1" ts
+
+      - name: Upgrade postgresql
+        if: ${{ matrix.is_bionic }}
+        run: sudo mispipe "/tmp/production-upgrade-pg 2>&1" ts
+
+      - name: Verify install after upgrading postgresql
+        if: ${{ matrix.is_bionic }}
+        run: sudo mispipe "/tmp/production-verify 2>&1" ts

--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -1,0 +1,79 @@
+name: Zulip Production Suite
+
+on:
+  push:
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  production_build:
+    name: Bionic Production Build
+    runs-on: ubuntu-latest
+
+    # This docker image was created by a generated Dockerfile at:
+    #   tools/ci/images/bionic/Dockerfile
+    # Bionic ships with Python 3.6.
+    container: mepriyank/actions:bionic
+    steps:
+      - name: Add required permissions
+        run: |
+          # The checkout actions doesn't clone to ~/zulip or allow
+          # us to use the path option to clone outside the current
+          # /__w/zulip/zulip directory. Since this directory is owned
+          # by root we need to change it's ownership to allow the
+          # github user to clone the code here.
+          # Note: /__w/ is a docker volume mounted to $GITHUB_WORKSPACE
+          # which is /home/runner/work/.
+          sudo chown -R github .
+
+          # This is the GitHub Actions specific cache directory the
+          # the current github user must be able to access for the
+          # cache action to work. It is owned by root currently.
+          sudo chmod -R 0777 /__w/_temp/
+
+      - uses: actions/checkout@v2
+
+      - name: Create cache directories
+        run: |
+          dirs=(/srv/zulip-{npm,venv,emoji}-cache)
+          sudo mkdir -p "${dirs[@]}"
+          sudo chown -R github "${dirs[@]}"
+
+      - name: Restore node_modules cache
+        uses: actions/cache@v2
+        with:
+          path: /srv/zulip-npm-cache
+          key: v1-yarn-deps-${{ github.job }}-${{ hashFiles('package.json') }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: v1-yarn-deps-${{ github.job }}
+
+      - name: Restore python cache
+        uses: actions/cache@v2
+        with:
+          path: /srv/zulip-venv-cache
+          key: v1-venv-${{ github.job }}-${{ hashFiles('requirements/thumbor-dev.txt') }}-${{ hashFiles('requirements/dev.txt') }}
+          restore-keys: v1-venv-${{ github.job }}
+
+      - name: Restore emoji cache
+        uses: actions/cache@v2
+        with:
+          path: /srv/zulip-emoji-cache
+          key: v1-emoji-${{ github.job }}-${{ hashFiles('tools/setup/emoji/emoji_map.json') }}-${{ hashFiles('tools/setup/emoji/build_emoji') }}-${{ hashFiles('tools/setup/emoji/emoji_setup_utils.py') }}-${{ hashFiles('tools/setup/emoji/emoji_names.py') }}-${{ hashFiles('package.json') }}
+          restore-keys: v1-emoji-${{ github.job }}
+
+      - name: Do Bionic hack
+        run: |
+          # Temporary hack till `sudo service redis-server start` gets fixes in Bionic. See
+          # https://chat.zulip.org/#narrow/stream/3-backend/topic/Ubuntu.20bionic.20CircleCI
+          sudo sed -i '/^bind/s/bind.*/bind 0.0.0.0/' /etc/redis/redis.conf
+
+      - name: Build production tarball
+        run: mispipe "./tools/ci/production-build 2>&1" ts
+
+      - name: Upload production build artifacts for install jobs
+        uses: actions/upload-artifact@v2
+        with:
+          name: production-tarball
+          path: /tmp/production-build

--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -2,7 +2,27 @@ name: Zulip Production Suite
 
 on:
   push:
+    paths:
+      - "**/migrations/**"
+      - puppet/**
+      - requirements/**
+      - scripts/**
+      - static/**
+      - tools/**
+      - zproject/**
+      - yarn.lock
+      - .github/workflows/production-suite.yml
   pull_request:
+    paths:
+      - "**/migrations/**"
+      - puppet/**
+      - requirements/**
+      - scripts/**
+      - static/**
+      - tools/**
+      - zproject/**
+      - yarn.lock
+      - .github/workflows/production-suite.yml
 
 defaults:
   run:

--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -9,6 +9,7 @@ defaults:
 jobs:
   focal_bionic:
     strategy:
+      fail-fast: false
       matrix:
         include:
           # This docker image was created by a generated Dockerfile at:

--- a/.github/workflows/zulip-ci.yml
+++ b/.github/workflows/zulip-ci.yml
@@ -7,7 +7,7 @@ defaults:
     shell: bash
 
 jobs:
-  focal_bionic:
+  unit_tests:
     strategy:
       fail-fast: false
       matrix:

--- a/tools/ci/production-build
+++ b/tools/ci/production-build
@@ -28,9 +28,10 @@ if ! ./tools/build-release-tarball test; then
     exit 1
 fi
 
-# This list matches up against the persist_to_workspace step in
-# .circleci/config.yml
-mv /tmp/tmp.*/zulip-server-test.tar.gz /tmp/
+# Move all the required artifacts to /tmp/production-build
+# that will be later sent down to downstream install jobs.
+mkdir /tmp/production-build
+mv /tmp/tmp.*/zulip-server-test.tar.gz /tmp/production-build
 cp -a \
    tools/ci/success-http-headers.template.txt \
    tools/ci/production-install \
@@ -38,4 +39,4 @@ cp -a \
    tools/ci/production-upgrade-pg \
    tools/ci/production-extract-tarball \
    \
-   /tmp/
+   /tmp/production-build

--- a/tools/ci/production-extract-tarball
+++ b/tools/ci/production-extract-tarball
@@ -3,5 +3,9 @@
 set -e
 set -x
 
-ZULIP_PATH=/home/circleci/zulip
+ZULIP_PATH=/home/github/zulip
+if [ "$CIRCLECI" = true ]; then
+    ZULIP_PATH=/home/circleci/zulip
+fi
+
 tar -xf /tmp/zulip-server-test.tar.gz -C "$ZULIP_PATH" --strip-components=1

--- a/tools/ci/production-install
+++ b/tools/ci/production-install
@@ -4,7 +4,10 @@
 set -e
 set -x
 
-ZULIP_PATH=/home/circleci/zulip
+ZULIP_PATH=/home/github/zulip
+if [ "$CIRCLECI" = true ]; then
+    ZULIP_PATH=/home/circleci/zulip
+fi
 
 # Do an apt upgrade to start with an up-to-date machine
 APT_OPTIONS=(-o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold')

--- a/tools/ci/production-upgrade-pg
+++ b/tools/ci/production-upgrade-pg
@@ -3,7 +3,10 @@
 set -e
 set -x
 
-ZULIP_PATH=/home/circleci/zulip
+ZULIP_PATH=/home/github/zulip
+if [ "$CIRCLECI" = true ]; then
+    ZULIP_PATH=/home/circleci/zulip
+fi
 
 supervisorctl stop all
 "$ZULIP_PATH"/scripts/setup/upgrade-postgres


### PR DESCRIPTION
With this all the jobs from Circle CI expect `xenial-legacy` will be migrated. The last commit may need adjustments because I am not sure I got all directories list correct for which we should run the production suite. For example, do we need `requirements`? 