### PR TITLE
Revert "markdown: Remove paragraphs that only contain a tweet link."

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1070,8 +1070,6 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
 
         div.set("class", "inline-preview-twitter")
         div.insert(0, twitter_data)
-        if info['remove'] is not None:
-            info['parent'].remove(info['remove'])
 
     def find_proper_insertion_index(self, grandparent: Element, parent: Element,
                                     parent_index_in_grandparent: int) -> int:

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -789,21 +789,21 @@ class MarkdownTest(ZulipTestCase):
         converted = markdown_convert_wrapper(msg)
         self.assertEqual(converted, '<p>{}</p>'.format(make_link('http://www.twitter.com/wdaher/status/999999999999999999')))
 
-        msg = 'Tweet: http://www.twitter.com/wdaher/status/287977969287315456'
+        msg = 'http://www.twitter.com/wdaher/status/287977969287315456'
         converted = markdown_convert_wrapper(msg)
-        self.assertEqual(converted, '<p>Tweet: {}</p>\n{}'.format(
+        self.assertEqual(converted, '<p>{}</p>\n{}'.format(
             make_link('http://www.twitter.com/wdaher/status/287977969287315456'),
             make_inline_twitter_preview('http://www.twitter.com/wdaher/status/287977969287315456', normal_tweet_html)))
 
-        msg = 'Tweet: https://www.twitter.com/wdaher/status/287977969287315456'
+        msg = 'https://www.twitter.com/wdaher/status/287977969287315456'
         converted = markdown_convert_wrapper(msg)
-        self.assertEqual(converted, '<p>Tweet: {}</p>\n{}'.format(
+        self.assertEqual(converted, '<p>{}</p>\n{}'.format(
             make_link('https://www.twitter.com/wdaher/status/287977969287315456'),
             make_inline_twitter_preview('https://www.twitter.com/wdaher/status/287977969287315456', normal_tweet_html)))
 
-        msg = 'Tweet: http://twitter.com/wdaher/status/287977969287315456'
+        msg = 'http://twitter.com/wdaher/status/287977969287315456'
         converted = markdown_convert_wrapper(msg)
-        self.assertEqual(converted, '<p>Tweet: {}</p>\n{}'.format(
+        self.assertEqual(converted, '<p>{}</p>\n{}'.format(
             make_link('http://twitter.com/wdaher/status/287977969287315456'),
             make_inline_twitter_preview('http://twitter.com/wdaher/status/287977969287315456', normal_tweet_html)))
 
@@ -838,27 +838,28 @@ class MarkdownTest(ZulipTestCase):
 
         # Test smart in-place inlining behavior:
         msg = ('Paragraph 1: http://twitter.com/wdaher/status/287977969287315456\n\n'
-               'Paragraph 2. Below paragraph will be removed.\n\n'
-               'http://twitter.com/wdaher/status/287977969287315457')
+               'Paragraph 2\n\n'
+               'Paragraph 3: http://twitter.com/wdaher/status/287977969287315457')
         converted = markdown_convert_wrapper(msg)
-        self.assertEqual(converted, '<p>Paragraph 1: {}</p>\n{}<p>Paragraph 2. Below paragraph will be removed.</p>\n{}'.format(
+        self.assertEqual(converted, '<p>Paragraph 1: {}</p>\n{}<p>Paragraph 2</p>\n<p>Paragraph 3: {}</p>\n{}'.format(
             make_link('http://twitter.com/wdaher/status/287977969287315456'),
             make_inline_twitter_preview('http://twitter.com/wdaher/status/287977969287315456', normal_tweet_html),
+            make_link('http://twitter.com/wdaher/status/287977969287315457'),
             make_inline_twitter_preview('http://twitter.com/wdaher/status/287977969287315457', normal_tweet_html)))
 
         # Tweet has a mention in a URL, only the URL is linked
-        msg = 'Tweet: http://twitter.com/wdaher/status/287977969287315458'
+        msg = 'http://twitter.com/wdaher/status/287977969287315458'
 
         converted = markdown_convert_wrapper(msg)
-        self.assertEqual(converted, '<p>Tweet: {}</p>\n{}'.format(
+        self.assertEqual(converted, '<p>{}</p>\n{}'.format(
             make_link('http://twitter.com/wdaher/status/287977969287315458'),
             make_inline_twitter_preview('http://twitter.com/wdaher/status/287977969287315458', mention_in_link_tweet_html)))
 
         # Tweet with an image
-        msg = 'Tweet: http://twitter.com/wdaher/status/287977969287315459'
+        msg = 'http://twitter.com/wdaher/status/287977969287315459'
 
         converted = markdown_convert_wrapper(msg)
-        self.assertEqual(converted, '<p>Tweet: {}</p>\n{}'.format(
+        self.assertEqual(converted, '<p>{}</p>\n{}'.format(
             make_link('http://twitter.com/wdaher/status/287977969287315459'),
             make_inline_twitter_preview('http://twitter.com/wdaher/status/287977969287315459',
                                         media_tweet_html,
@@ -868,9 +869,9 @@ class MarkdownTest(ZulipTestCase):
                                          '</a>'
                                          '</div>'))))
 
-        msg = 'Tweet: http://twitter.com/wdaher/status/287977969287315460'
+        msg = 'http://twitter.com/wdaher/status/287977969287315460'
         converted = markdown_convert_wrapper(msg)
-        self.assertEqual(converted, '<p>Tweet: {}</p>\n{}'.format(
+        self.assertEqual(converted, '<p>{}</p>\n{}'.format(
             make_link('http://twitter.com/wdaher/status/287977969287315460'),
             make_inline_twitter_preview('http://twitter.com/wdaher/status/287977969287315460', emoji_in_tweet_html)))
 


### PR DESCRIPTION
This reverts commit d3770153a6aec97ffd36baa294ee747364d1d4ae.

We do not show a link to the tweet in our preview, so we should revert
to our previous behavior for now.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
