### PR TITLE
composebox: Blur PM recipient input after close.

### DIFF
--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -1,7 +1,7 @@
 const autosize = require("autosize");
 
 exports.blur_textarea = function () {
-    $(".message_comp").find("input, textarea, button").trigger("blur");
+    $(".message_comp").find("input, textarea, button, #private_message_recipient").trigger("blur");
 };
 
 function hide_box() {


### PR DESCRIPTION
Previously the private_message_recipient input remained focused after
closing the composebox with Escape. On Firefox this resulted in it
gobbling up all further keyboard shortcuts (until you clicked
somewhere). On Chromium this bug didn't occur because it automatically
blurs hidden inputs.

Fixes #15849.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
