### PR TITLE
ui: Fix loading spinner glitch.

### DIFF
--- a/static/js/loading.js
+++ b/static/js/loading.js
@@ -59,7 +59,7 @@ exports.destroy_indicator = function (container) {
     }
     container.removeData("spinner_obj");
     container.empty();
-    container.css({width: 0, height: 0, display: "none"});
+    container.css({width: 0, height: 0});
 };
 
 window.loading = exports;


### PR DESCRIPTION
On calling `loading.make_indicator` for the second
time or more no spinner is being displayed.

This bug can be viewed on visiting a `near: 1` narrow
and the spinner for the newer messages is displayed
only once (i.e. the first time it is rendered), while
the logo is displayed every time.

This happens because `loading.destroy_indicator` sets
the css of that container to display: "none". This can
be removed as we are emptying the container just above.

Introduced in 953d475274368ceed0c9584e71498a3cd2c93d41.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
