### PR TITLE
Fix bug 'Commits by None (1)' in Bitbucket Bot

### DIFF
--- a/zerver/webhooks/bitbucket2/view.py
+++ b/zerver/webhooks/bitbucket2/view.py
@@ -198,7 +198,7 @@ def get_force_push_body(payload: Dict[str, Any], change: Dict[str, Any]) -> str:
 
 def get_commit_author_name(commit: Dict[str, Any]) -> str:
     if commit['author'].get('user'):
-        return commit['author']['user'].get('username')
+        return commit['author']['user'].get('display_name')
     return commit['author']['raw'].split()[0]
 
 def get_normal_push_body(payload: Dict[str, Any], change: Dict[str, Any]) -> str:


### PR DESCRIPTION
Issue:
Bitbucket Bot messages was including "Commits by None (1)" into Push Messages.

Cause: 
There is not 'username'  element in the JSON request. 

Solution:
Using 'display_name' will get the expected results.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
