### PR TITLE
markdown: Inline Youtube previews instead of appending it to the end.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1071,6 +1071,18 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
         div.set("class", "inline-preview-twitter")
         div.insert(0, twitter_data)
 
+    def handle_youtube_url_inlining(
+        self,
+        root: Element,
+        found_url: ResultWithFamily[Tuple[str, Optional[str]]],
+        yt_image: str,
+    ) -> None:
+        info = self.get_inlining_information(root, found_url)
+        (url, text) = found_url.result
+        yt_id = self.youtube_id(url)
+        self.add_a(info['parent'], yt_image, url, None, None, "youtube-video message_inline_image",
+                   yt_id, insertion_index=info['index'], already_thumbnailed=True)
+
     def find_proper_insertion_index(self, grandparent: Element, parent: Element,
                                     parent_index_in_grandparent: int) -> int:
         # If there are several inline images from same paragraph, ensure that
@@ -1194,10 +1206,7 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
                 continue
             youtube = self.youtube_image(url)
             if youtube is not None:
-                yt_id = self.youtube_id(url)
-                self.add_a(root, youtube, url, None, None,
-                           "youtube-video message_inline_image",
-                           yt_id, already_thumbnailed=True)
+                self.handle_youtube_url_inlining(root, found_url, youtube)
                 # NOTE: We don't `continue` here, to allow replacing the URL with
                 # the title, if INLINE_URL_EMBED_PREVIEW feature is enabled.
                 # The entire preview would ideally be shown only if the feature

--- a/zerver/tests/test_markdown.py
+++ b/zerver/tests/test_markdown.py
@@ -721,6 +721,24 @@ class MarkdownTest(ZulipTestCase):
 
         self.assertEqual(converted, '<p>Test: <a href="https://developer.github.com/assets/images/hero-circuit-bg.png">https://developer.github.com/assets/images/hero-circuit-bg.png</a></p>\n<div class="message_inline_image"><a href="https://developer.github.com/assets/images/hero-circuit-bg.png"><img data-src-fullsize="/thumbnail?url=https%3A%2F%2Fdeveloper.github.com%2Fassets%2Fimages%2Fhero-circuit-bg.png&amp;size=full" src="/thumbnail?url=https%3A%2F%2Fdeveloper.github.com%2Fassets%2Fimages%2Fhero-circuit-bg.png&amp;size=thumbnail"></a></div>')
 
+    def test_inline_youtube_preview(self) -> None:
+        # Test youtube urls in spoilers
+        msg = """\n```spoiler Check out this Pycon Video\nhttps://www.youtube.com/watch?v=0c46YHS3RY8\n```"""
+        converted = markdown_convert_wrapper(msg)
+
+        self.assertEqual(converted, '<div class="spoiler-block"><div class="spoiler-header">\n\n<p>Check out this Pycon Video</p>\n</div><div class="spoiler-content" aria-hidden="true">\n\n<p><a href="https://www.youtube.com/watch?v=0c46YHS3RY8">https://www.youtube.com/watch?v=0c46YHS3RY8</a></p>\n<div class="youtube-video message_inline_image"><a data-id="0c46YHS3RY8" href="https://www.youtube.com/watch?v=0c46YHS3RY8"><img src="https://i.ytimg.com/vi/0c46YHS3RY8/default.jpg"></a></div></div></div>')
+
+        # Test youtube urls in normal messages.
+        msg = '[Youtube link](https://www.youtube.com/watch?v=0c46YHS3RY8)'
+        converted = markdown_convert_wrapper(msg)
+
+        self.assertEqual(converted, '<p><a href="https://www.youtube.com/watch?v=0c46YHS3RY8">Youtube link</a></p>\n<div class="youtube-video message_inline_image"><a data-id="0c46YHS3RY8" href="https://www.youtube.com/watch?v=0c46YHS3RY8"><img src="https://i.ytimg.com/vi/0c46YHS3RY8/default.jpg"></a></div>')
+
+        msg = 'https://www.youtube.com/watch?v=0c46YHS3RY8\n\nSample text\n\nhttps://www.youtube.com/watch?v=lXFO2ULktEI'
+        converted = markdown_convert_wrapper(msg)
+
+        self.assertEqual(converted, '<p><a href="https://www.youtube.com/watch?v=0c46YHS3RY8">https://www.youtube.com/watch?v=0c46YHS3RY8</a></p>\n<div class="youtube-video message_inline_image"><a data-id="0c46YHS3RY8" href="https://www.youtube.com/watch?v=0c46YHS3RY8"><img src="https://i.ytimg.com/vi/0c46YHS3RY8/default.jpg"></a></div><p>Sample text</p>\n<p><a href="https://www.youtube.com/watch?v=lXFO2ULktEI">https://www.youtube.com/watch?v=lXFO2ULktEI</a></p>\n<div class="youtube-video message_inline_image"><a data-id="lXFO2ULktEI" href="https://www.youtube.com/watch?v=lXFO2ULktEI"><img src="https://i.ytimg.com/vi/lXFO2ULktEI/default.jpg"></a></div>')
+
     def test_twitter_id_extraction(self) -> None:
         self.assertEqual(get_tweet_id('http://twitter.com/#!/VizzQuotes/status/409030735191097344'), '409030735191097344')
         self.assertEqual(get_tweet_id('http://twitter.com/VizzQuotes/status/409030735191097344'), '409030735191097344')


### PR DESCRIPTION
This change makes our handling of youtube-url previews consistent with how we handle our inline images. This allows the reviews to render next to the paragraph that links to the youtube video.

Follow-up to PR #15773 & #15828


**GIFs or Screenshots:** 

![yt_in_spoiler](https://user-images.githubusercontent.com/25329595/87695609-4f2f7000-c7ad-11ea-9872-0ea695e17b65.gif)
