### PR TITLE
Error reporting emails: Indicate user role.

### DIFF
--- a/zerver/lib/error_notify.py
+++ b/zerver/lib/error_notify.py
@@ -24,7 +24,7 @@ def logger_repr(report: Dict[str, Any]) -> str:
 
 def user_info_str(report: Dict[str, Any]) -> str:
     if report.get('user') and report['user'].get('user_full_name'):
-        user_info = "{user[user_full_name]} <{user[user_email]}>".format(**report)
+        user_info = "{user[user_full_name]} <{user[user_email]}> ({user[user_role]})".format(**report)
     else:
         user_info = "Anonymous user (not logged in)"
 

--- a/zerver/lib/error_notify.py
+++ b/zerver/lib/error_notify.py
@@ -23,8 +23,8 @@ def logger_repr(report: Dict[str, Any]) -> str:
     return "Logger {logger_name}, from module {log_module} line {log_lineno}:".format(**report)
 
 def user_info_str(report: Dict[str, Any]) -> str:
-    if report['user_full_name'] and report['user_email']:
-        user_info = "{user_full_name} ({user_email})".format(**report)
+    if report.get('user') and report['user'].get('user_full_name'):
+        user_info = "{user[user_full_name]} <{user[user_email]}>".format(**report)
     else:
         user_info = "Anonymous user (not logged in)"
 
@@ -44,10 +44,11 @@ def notify_browser_error(report: Dict[str, Any]) -> None:
     email_browser_error(report)
 
 def email_browser_error(report: Dict[str, Any]) -> None:
-    email_subject = f"Browser error for {user_info_str(report)}"
+    user_info = user_info_str(report)
+    email_subject = f"Browser error for {user_info}"
+    body = f"User: {user_info}"
 
-    body = """\
-User: {user_full_name} <{user_email}> on {deployment}
+    body += """\
 
 Message:
 {message}

--- a/zerver/logging_handlers.py
+++ b/zerver/logging_handlers.py
@@ -49,8 +49,11 @@ def add_request_metadata(report: Dict[str, Any], request: HttpRequest) -> None:
         traceback.print_exc()
         user_full_name = None
         user_email = None
-    report['user_email'] = user_email
-    report['user_full_name'] = user_full_name
+
+    report['user'] = {
+        'user_email': user_email,
+        'user_full_name': user_full_name,
+    }
 
     exception_filter = get_exception_reporter_filter(request)
     try:

--- a/zerver/logging_handlers.py
+++ b/zerver/logging_handlers.py
@@ -41,18 +41,22 @@ def add_request_metadata(report: Dict[str, Any], request: HttpRequest) -> None:
         if isinstance(user_profile, AnonymousUser):
             user_full_name = None
             user_email = None
+            user_role = None
         else:
             user_full_name = user_profile.full_name
             user_email = user_profile.email
+            user_role = user_profile.get_role_name()
     except Exception:
         # Unexpected exceptions here should be handled gracefully
         traceback.print_exc()
         user_full_name = None
         user_email = None
+        user_role = None
 
     report['user'] = {
         'user_email': user_email,
         'user_full_name': user_full_name,
+        'user_role': user_role,
     }
 
     exception_filter = get_exception_reporter_filter(request)

--- a/zerver/tests/test_logging_handlers.py
+++ b/zerver/tests/test_logging_handlers.py
@@ -108,7 +108,8 @@ class AdminNotifyHandlerTest(ZulipTestCase):
         record.msg = 'message\nmoremesssage\nmore'
 
         report = self.run_handler(record)
-        self.assertIn("user_email", report)
+        self.assertIn("user", report)
+        self.assertIn("user_email", report["user"])
         self.assertIn("message", report)
         self.assertIn("stack_trace", report)
         self.assertEqual(report['stack_trace'], 'message\nmoremesssage\nmore')
@@ -122,7 +123,8 @@ class AdminNotifyHandlerTest(ZulipTestCase):
         assert isinstance(record, HasRequest)
 
         report = self.run_handler(record)
-        self.assertIn("user_email", report)
+        self.assertIn("user", report)
+        self.assertIn("user_email", report["user"])
         self.assertIn("message", report)
         self.assertIn("stack_trace", report)
 
@@ -131,7 +133,7 @@ class AdminNotifyHandlerTest(ZulipTestCase):
             with patch("zerver.logging_handlers.add_request_metadata",
                        side_effect=Exception("Unexpected exception!")):
                 report = self.run_handler(record)
-        self.assertNotIn("user_email", report)
+        self.assertNotIn("user", report)
         self.assertIn("message", report)
         self.assertEqual(report["stack_trace"], "See /var/log/zulip/errors.log")
 
@@ -139,7 +141,8 @@ class AdminNotifyHandlerTest(ZulipTestCase):
         record.request.user = AnonymousUser()
         report = self.run_handler(record)
         self.assertIn("host", report)
-        self.assertIn("user_email", report)
+        self.assertIn("user", report)
+        self.assertIn("user_email", report["user"])
         self.assertIn("message", report)
         self.assertIn("stack_trace", report)
 
@@ -151,7 +154,8 @@ class AdminNotifyHandlerTest(ZulipTestCase):
         report = self.run_handler(record)
         record.request.get_host = orig_get_host
         self.assertIn("host", report)
-        self.assertIn("user_email", report)
+        self.assertIn("user", report)
+        self.assertIn("user_email", report["user"])
         self.assertIn("message", report)
         self.assertIn("stack_trace", report)
 
@@ -162,7 +166,8 @@ class AdminNotifyHandlerTest(ZulipTestCase):
             report = self.run_handler(record)
             record.request.method = "GET"
         self.assertIn("host", report)
-        self.assertIn("user_email", report)
+        self.assertIn("user", report)
+        self.assertIn("user_email", report["user"])
         self.assertIn("message", report)
         self.assertIn("stack_trace", report)
 
@@ -179,7 +184,8 @@ class AdminNotifyHandlerTest(ZulipTestCase):
         record.exc_info = None
         report = self.run_handler(record)
         self.assertIn("host", report)
-        self.assertIn("user_email", report)
+        self.assertIn("user", report)
+        self.assertIn("user_email", report["user"])
         self.assertIn("message", report)
         self.assertEqual(report["stack_trace"], 'No stack trace available')
 
@@ -188,7 +194,8 @@ class AdminNotifyHandlerTest(ZulipTestCase):
         with patch("zerver.logging_handlers.traceback.print_exc"):
             report = self.run_handler(record)
         self.assertIn("host", report)
-        self.assertIn("user_email", report)
+        self.assertIn("user", report)
+        self.assertIn("user_email", report["user"])
         self.assertIn("message", report)
         self.assertIn("stack_trace", report)
 

--- a/zerver/tests/test_logging_handlers.py
+++ b/zerver/tests/test_logging_handlers.py
@@ -110,6 +110,7 @@ class AdminNotifyHandlerTest(ZulipTestCase):
         report = self.run_handler(record)
         self.assertIn("user", report)
         self.assertIn("user_email", report["user"])
+        self.assertIn("user_role", report["user"])
         self.assertIn("message", report)
         self.assertIn("stack_trace", report)
         self.assertEqual(report['stack_trace'], 'message\nmoremesssage\nmore')
@@ -125,6 +126,7 @@ class AdminNotifyHandlerTest(ZulipTestCase):
         report = self.run_handler(record)
         self.assertIn("user", report)
         self.assertIn("user_email", report["user"])
+        self.assertIn("user_role", report["user"])
         self.assertIn("message", report)
         self.assertIn("stack_trace", report)
 
@@ -143,6 +145,7 @@ class AdminNotifyHandlerTest(ZulipTestCase):
         self.assertIn("host", report)
         self.assertIn("user", report)
         self.assertIn("user_email", report["user"])
+        self.assertIn("user_role", report["user"])
         self.assertIn("message", report)
         self.assertIn("stack_trace", report)
 
@@ -156,6 +159,7 @@ class AdminNotifyHandlerTest(ZulipTestCase):
         self.assertIn("host", report)
         self.assertIn("user", report)
         self.assertIn("user_email", report["user"])
+        self.assertIn("user_role", report["user"])
         self.assertIn("message", report)
         self.assertIn("stack_trace", report)
 
@@ -168,6 +172,7 @@ class AdminNotifyHandlerTest(ZulipTestCase):
         self.assertIn("host", report)
         self.assertIn("user", report)
         self.assertIn("user_email", report["user"])
+        self.assertIn("user_role", report["user"])
         self.assertIn("message", report)
         self.assertIn("stack_trace", report)
 
@@ -186,6 +191,7 @@ class AdminNotifyHandlerTest(ZulipTestCase):
         self.assertIn("host", report)
         self.assertIn("user", report)
         self.assertIn("user_email", report["user"])
+        self.assertIn("user_role", report["user"])
         self.assertIn("message", report)
         self.assertEqual(report["stack_trace"], 'No stack trace available')
 
@@ -196,6 +202,7 @@ class AdminNotifyHandlerTest(ZulipTestCase):
         self.assertIn("host", report)
         self.assertIn("user", report)
         self.assertIn("user_email", report["user"])
+        self.assertIn("user_role", report["user"])
         self.assertIn("message", report)
         self.assertIn("stack_trace", report)
 

--- a/zproject/sentry.py
+++ b/zproject/sentry.py
@@ -19,6 +19,7 @@ def add_context(event: 'Event', hint: 'Hint') -> 'Event':
         if user_info.get("id"):
             user_profile = get_user_profile_by_id(user_info["id"])
             user_info["realm"] = user_profile.realm.string_id or 'root'
+            user_info["role"] = user_profile.get_role_name()
     return event
 
 def setup_sentry(dsn: Optional[str], *integrations: Integration) -> None:


### PR DESCRIPTION
Adds user role to the user's information in the error reporting
emails, as some bugs are role-dependent.

Fixes: #15344


**Testing Plan:** <!-- How have you tested? -->
Automated tests.
