### PR TITLE
Remove deprecated jQuery event shorthand methods

### DIFF
--- a/frontend_tests/casper_lib/common.js
+++ b/frontend_tests/casper_lib/common.js
@@ -157,7 +157,7 @@ exports.select_item_via_typeahead = function (field_selector, str, item) {
                 // Set the value and then send a bogus keyup event to trigger
                 // the typeahead.
                 $(field_selector)
-                    .focus()
+                    .trigger("focus")
                     .val(str)
                     .trigger($.Event("keyup", {which: 0}));
 

--- a/frontend_tests/casper_tests/03-narrow.js
+++ b/frontend_tests/casper_tests/03-narrow.js
@@ -345,7 +345,7 @@ casper.waitWhileSelector("#streams_list .input-append.notdisplayed", function ()
 // Enter the search box and test highlighted suggestion navigation
 casper.then(function () {
     casper.evaluate(function () {
-        $(".stream-list-filter").expectOne().focus().trigger($.Event("click"));
+        $(".stream-list-filter").expectOne().trigger("focus").trigger($.Event("click"));
     });
 });
 
@@ -399,7 +399,7 @@ casper.then(function () {
     casper.evaluate(function () {
         $(".stream-list-filter")
             .expectOne()
-            .focus()
+            .trigger("focus")
             .val("sCoT")
             .trigger($.Event("input"))
             .trigger($.Event("click"));
@@ -436,7 +436,7 @@ casper.then(function () {
 // Clearing the list should give us back all the streams in the list
 casper.then(function () {
     casper.evaluate(function () {
-        $(".stream-list-filter").expectOne().focus().val("").trigger($.Event("input"));
+        $(".stream-list-filter").expectOne().trigger("focus").val("").trigger($.Event("input"));
     });
 });
 
@@ -467,7 +467,7 @@ casper.waitForSelector(".input-append.notdisplayed", function () {
 // We search for the beginning of "Verona", not case sensitive
 casper.then(function () {
     casper.evaluate(function () {
-        $(".stream-list-filter").expectOne().focus().val("ver").trigger($.Event("input"));
+        $(".stream-list-filter").expectOne().trigger("focus").val("ver").trigger($.Event("input"));
     });
 });
 
@@ -519,7 +519,7 @@ casper.then(function () {
 // Click on search icon
 casper.then(function () {
     casper.evaluate(function () {
-        $("#user_filter_icon").expectOne().focus().trigger($.Event("click"));
+        $("#user_filter_icon").expectOne().trigger("focus").trigger($.Event("click"));
     });
 });
 

--- a/frontend_tests/casper_tests/07-stars.js
+++ b/frontend_tests/casper_tests/07-stars.js
@@ -20,7 +20,7 @@ function toggle_test_star_message() {
             return "cannot find star icon";
         }
 
-        star_icon.click();
+        star_icon.trigger("click");
     });
 
     if (error) {

--- a/frontend_tests/casper_tests/08-edit.js
+++ b/frontend_tests/casper_tests/08-edit.js
@@ -9,8 +9,8 @@ function then_edit_last_message() {
     casper.then(function () {
         casper.evaluate(function () {
             var msg = $("#zhome .message_row").last();
-            msg.find(".info").click();
-            $(".popover_edit_message").click();
+            msg.find(".info").trigger("click");
+            $(".popover_edit_message").trigger("click");
         });
     });
     casper.then(function () {
@@ -33,7 +33,7 @@ casper.then(function () {
         var msg = $("#zhome .message_row").last();
         msg.find(".message_edit_topic").val("edited");
         msg.find(".message_edit_content").val("test edited");
-        msg.find(".message_edit_save").click();
+        msg.find(".message_edit_save").trigger("click");
     });
 });
 
@@ -54,7 +54,7 @@ casper.then(function () {
         var msg = $("#zhome .message_row").last();
         msg.find(".message_edit_topic").val("edited");
         msg.find(".message_edit_content").val("/me test edited one line with me");
-        msg.find(".message_edit_save").click();
+        msg.find(".message_edit_save").trigger("click");
     });
 });
 
@@ -76,7 +76,7 @@ casper.then(function () {
     casper.evaluate(function () {
         var msg = $("#zhome .message_row").last();
         msg.find(".message_edit_content").val("test edited pm");
-        msg.find(".message_edit_save").click();
+        msg.find(".message_edit_save").trigger("click");
     });
 });
 

--- a/frontend_tests/casper_tests/10-admin.js
+++ b/frontend_tests/casper_tests/10-admin.js
@@ -302,7 +302,7 @@ function get_suggestions(str) {
     casper.then(function () {
         casper.evaluate(function (str) {
             $(".create_default_stream")
-                .focus()
+                .trigger("focus")
                 .val(str)
                 .trigger($.Event("keyup", {which: 0}));
         }, str);

--- a/frontend_tests/casper_tests/15-delete-message.js
+++ b/frontend_tests/casper_tests/15-delete-message.js
@@ -15,8 +15,8 @@ casper.then(function () {
     });
     last_message_id = this.evaluate(function () {
         var msg = $("#zhome .message_row").last();
-        msg.find(".info").click();
-        $(".delete_message").click();
+        msg.find(".info").trigger("click");
+        $(".delete_message").trigger("click");
         return msg.attr("id");
     });
 });

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -1,4 +1,7 @@
 set_global("$", global.make_zjquery());
+const window_stub = $.create("window-stub");
+set_global("to_$", () => window_stub);
+$(window).idle = () => {};
 
 let filter_key_handlers;
 
@@ -682,8 +685,6 @@ run_test("initialize", () => {
             func();
         },
     });
-    $(window).focus = (func) => func();
-    $(window).idle = () => {};
 
     channel.post = function (payload) {
         payload.success({});
@@ -700,6 +701,7 @@ run_test("initialize", () => {
     activity.client_is_active = false;
 
     activity.initialize();
+    $(window).trigger("focus");
     clear();
 
     assert(scroll_handler_started);

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -700,6 +700,7 @@ run_test("initialize", () => {
 
     activity.client_is_active = false;
 
+    $(window).off("focus");
     activity.initialize();
     $(window).trigger("focus");
     clear();
@@ -719,6 +720,7 @@ run_test("initialize", () => {
     };
     global.setInterval = (func) => func();
 
+    $(window).off("focus");
     activity.initialize();
 
     assert($("#zephyr-mirror-error").hasClass("show"));

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -243,7 +243,7 @@ function reset_setup() {
 reset_setup();
 
 run_test("presence_list_full_update", () => {
-    $(".user-list-filter").focus();
+    $(".user-list-filter").trigger("focus");
     compose_state.private_message_recipient = () => fred.email;
     compose_fade.set_focused_recipient("private");
 
@@ -603,7 +603,7 @@ run_test("escape_search", () => {
 reset_setup();
 
 run_test("initiate_search", () => {
-    $(".user-list-filter").blur();
+    $(".user-list-filter").trigger("blur");
     simulate_right_column_buddy_list();
     activity.initiate_search();
     assert.equal($(".column-right").hasClass("expanded"), true);
@@ -627,9 +627,9 @@ run_test("toggle_filter_display", () => {
 });
 
 run_test("searching", () => {
-    $(".user-list-filter").focus();
+    $(".user-list-filter").trigger("focus");
     assert.equal(activity.searching(), true);
-    $(".user-list-filter").blur();
+    $(".user-list-filter").trigger("blur");
     assert.equal(activity.searching(), false);
 });
 

--- a/frontend_tests/node_tests/buddy_list.js
+++ b/frontend_tests/node_tests/buddy_list.js
@@ -193,12 +193,6 @@ run_test("find_li w/force_render", () => {
 });
 
 run_test("scrolling", () => {
-    let scroll_f;
-
-    $(buddy_list.scroll_container_sel).scroll = (f) => {
-        scroll_f = f;
-    };
-
     buddy_list.populate({
         keys: [],
     });
@@ -212,7 +206,7 @@ run_test("scrolling", () => {
     assert(!tried_to_fill);
 
     buddy_list.start_scroll_handler();
-    scroll_f();
+    $(buddy_list.scroll_container_sel).trigger("scroll");
 
     assert(tried_to_fill);
 });

--- a/frontend_tests/node_tests/common.js
+++ b/frontend_tests/node_tests/common.js
@@ -11,7 +11,7 @@ $("body").append = noop;
 $(input).val = (arg) => {
     assert.equal(arg, "iago@zulip.com");
     return {
-        select: noop,
+        trigger: noop,
     };
 };
 

--- a/frontend_tests/node_tests/components.js
+++ b/frontend_tests/node_tests/components.js
@@ -42,8 +42,10 @@ run_test("basics", () => {
             return i;
         };
 
-        self.focus = function () {
-            focused_tab = i;
+        self.trigger = function (type) {
+            if (type === "focus") {
+                focused_tab = i;
+            }
         };
 
         tabs.push(self);

--- a/frontend_tests/node_tests/components.js
+++ b/frontend_tests/node_tests/components.js
@@ -56,12 +56,12 @@ run_test("basics", () => {
 
         self.stub = true;
 
-        self.click = function (f) {
-            click_f = f;
-        };
-
-        self.keydown = function (f) {
-            keydown_f = f;
+        self.on = function (name, f) {
+            if (name === "click") {
+                click_f = f;
+            } else if (name === "keydown") {
+                keydown_f = f;
+            }
         };
 
         self.removeClass = function (c) {

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -748,6 +748,7 @@ run_test("send_message", () => {
         $("#compose-send-status").show();
         $("#compose-send-button").attr("disabled", "disabled");
         $("#sending-indicator").show();
+        $("#compose-textarea").off("select");
         $("#compose-textarea").select(noop);
         echo_error_msg_checked = false;
         echo.try_deliver_locally = function () {
@@ -822,6 +823,7 @@ run_test("finish", () => {
         $("#compose-send-button").prop("disabled", false);
         $("#compose-send-button").focus();
         $("#sending-indicator").hide();
+        $("#compose-textarea").off("select");
         $("#compose-textarea").select(noop);
         $("#compose-textarea").val("");
         const res = compose.finish();

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -196,7 +196,7 @@ run_test("validate", () => {
         set_global("$", global.make_zjquery());
 
         $("#compose-send-button").prop("disabled", false);
-        $("#compose-send-button").focus();
+        $("#compose-send-button").trigger("focus");
         $("#sending-indicator").hide();
 
         const pm_pill_container = $.create("fake-pm-pill-container");
@@ -588,7 +588,7 @@ run_test("markdown_shortcuts", () => {
 
 run_test("send_message_success", () => {
     $("#compose-textarea").val("foobarfoobar");
-    $("#compose-textarea").blur();
+    $("#compose-textarea").trigger("blur");
     $("#compose-send-status").show();
     $("#compose-send-button").attr("disabled", "disabled");
     $("#sending-indicator").show();
@@ -686,7 +686,7 @@ run_test("send_message", () => {
         // Setting message content with a host server link and we will assert
         // later that this has been converted to a relative link.
         $("#compose-textarea").val("[foobar]" + "(https://foo.com/user_uploads/123456)");
-        $("#compose-textarea").blur();
+        $("#compose-textarea").trigger("blur");
         $("#compose-send-status").show();
         $("#compose-send-button").attr("disabled", "disabled");
         $("#sending-indicator").show();
@@ -738,7 +738,7 @@ run_test("send_message", () => {
     (function test_error_codepath_local_id_undefined() {
         stub_state = initialize_state_stub_dict();
         $("#compose-textarea").val("foobarfoobar");
-        $("#compose-textarea").blur();
+        $("#compose-textarea").trigger("blur");
         $("#compose-send-status").show();
         $("#compose-send-button").attr("disabled", "disabled");
         $("#sending-indicator").show();
@@ -794,7 +794,7 @@ run_test("enter_with_preview_open", () => {
     assert(send_message_called);
 
     page_params.enter_sends = false;
-    $("#compose-textarea").blur();
+    $("#compose-textarea").trigger("blur");
     compose.enter_with_preview_open();
     assert($("#compose-textarea").is_focused());
 
@@ -814,7 +814,7 @@ run_test("finish", () => {
     (function test_when_compose_validation_fails() {
         $("#compose_invite_users").show();
         $("#compose-send-button").prop("disabled", false);
-        $("#compose-send-button").focus();
+        $("#compose-send-button").trigger("focus");
         $("#sending-indicator").hide();
         $("#compose-textarea").off("select");
         $("#compose-textarea").val("");

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -145,8 +145,6 @@ run_test("validate_stream_message_address_info", () => {
     stream_data.add_sub(sub);
     assert(compose.validate_stream_message_address_info("social"));
 
-    $("#stream_message_recipient_stream").select(noop);
-
     sub.subscribed = false;
     stream_data.add_sub(sub);
     global.stub_templates((template_name) => {
@@ -200,7 +198,6 @@ run_test("validate", () => {
         $("#compose-send-button").prop("disabled", false);
         $("#compose-send-button").focus();
         $("#sending-indicator").hide();
-        $("#compose-textarea").select(noop);
 
         const pm_pill_container = $.create("fake-pm-pill-container");
         $("#private_message_recipient").set_parent(pm_pill_container);
@@ -212,7 +209,6 @@ run_test("validate", () => {
         ui_util.place_caret_at_end = noop;
 
         $("#zephyr-mirror-error").is = noop;
-        $("#private_message_recipient").select(noop);
 
         global.stub_templates((fn) => {
             assert.equal(fn, "input_pill");
@@ -294,14 +290,12 @@ run_test("validate", () => {
 
     compose_state.set_message_type("stream");
     compose_state.stream_name("");
-    $("#stream_message_recipient_stream").select(noop);
     assert(!compose.validate());
     assert.equal($("#compose-error-msg").html(), i18n.t("Please specify a stream"));
 
     compose_state.stream_name("Denmark");
     page_params.realm_mandatory_topics = true;
     compose_state.topic("");
-    $("#stream_message_recipient_topic").select(noop);
     assert(!compose.validate());
     assert.equal($("#compose-error-msg").html(), i18n.t("Please specify a topic"));
 });
@@ -749,7 +743,6 @@ run_test("send_message", () => {
         $("#compose-send-button").attr("disabled", "disabled");
         $("#sending-indicator").show();
         $("#compose-textarea").off("select");
-        $("#compose-textarea").select(noop);
         echo_error_msg_checked = false;
         echo.try_deliver_locally = function () {
             return;
@@ -824,7 +817,6 @@ run_test("finish", () => {
         $("#compose-send-button").focus();
         $("#sending-indicator").hide();
         $("#compose-textarea").off("select");
-        $("#compose-textarea").select(noop);
         $("#compose-textarea").val("");
         const res = compose.finish();
         assert.equal(res, false);
@@ -1346,7 +1338,6 @@ run_test("on_events", () => {
                 return "102";
             }
         };
-        $("#compose-textarea").select(noop);
         helper.target.prop("disabled", false);
 
         // !sub will result in true here and we check the success code path.

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -845,10 +845,9 @@ run_test("finish", () => {
         };
 
         let compose_finished_event_checked = false;
-        $(document).trigger = function (e) {
-            assert.equal(e.type, "compose_finished.zulip");
+        $(document).on("compose_finished.zulip", () => {
             compose_finished_event_checked = true;
-        };
+        });
         let send_message_called = false;
         compose.send_message = function () {
             send_message_called = true;
@@ -1445,10 +1444,9 @@ run_test("on_events", () => {
             assert(param);
         };
         let compose_file_input_clicked = false;
-        $("#compose #file_input").trigger = function (ev_name) {
-            assert.equal(ev_name, "click");
+        $("#compose #file_input").on("click", () => {
             compose_file_input_clicked = true;
-        };
+        });
 
         const event = {
             preventDefault: noop,

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -846,7 +846,7 @@ run_test("finish", () => {
 
         let compose_finished_event_checked = false;
         $(document).trigger = function (e) {
-            assert.equal(e.name, "compose_finished.zulip");
+            assert.equal(e.type, "compose_finished.zulip");
             compose_finished_event_checked = true;
         };
         let send_message_called = false;

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -194,7 +194,6 @@ run_test("start", () => {
         content: "hello",
     };
 
-    $("#compose-textarea").trigger = noop;
     start("private", opts);
 
     assert_hidden("#stream-message");

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -409,7 +409,7 @@ run_test("focus_in_empty_compose", () => {
 
     compose_state.composing = return_true;
     $("#compose-textarea").val("");
-    $("#compose-textarea").focus();
+    $("#compose-textarea").trigger("focus");
     assert(compose_state.focus_in_empty_compose());
 
     compose_state.composing = return_false;
@@ -418,7 +418,7 @@ run_test("focus_in_empty_compose", () => {
     $("#compose-textarea").val("foo");
     assert(!compose_state.focus_in_empty_compose());
 
-    $("#compose-textarea").blur();
+    $("#compose-textarea").trigger("blur");
     assert(!compose_state.focus_in_empty_compose());
 });
 

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -50,14 +50,6 @@ function make_textbox(s) {
         return widget.pos;
     };
 
-    widget.focus = function () {
-        widget.focused = true;
-    };
-
-    widget.blur = function () {
-        widget.focused = false;
-    };
-
     widget.val = function (new_val) {
         if (new_val) {
             widget.s = new_val;
@@ -66,8 +58,12 @@ function make_textbox(s) {
         }
     };
 
-    widget.trigger = function () {
-        return;
+    widget.trigger = function (type) {
+        if (type === "focus") {
+            widget.focused = true;
+        } else if (type === "blur") {
+            widget.focused = false;
+        }
     };
 
     return widget;
@@ -98,21 +94,21 @@ run_test("smart_insert", () => {
     assert.equal(textbox.val(), "abc :smile: ");
     assert(textbox.focused);
 
-    textbox.blur();
+    textbox.trigger("blur");
     compose_ui.smart_insert(textbox, ":airplane:");
     assert.equal(textbox.insert_text, ":airplane: ");
     assert.equal(textbox.val(), "abc :smile: :airplane: ");
     assert(textbox.focused);
 
     textbox.caret(0);
-    textbox.blur();
+    textbox.trigger("blur");
     compose_ui.smart_insert(textbox, ":octopus:");
     assert.equal(textbox.insert_text, ":octopus: ");
     assert.equal(textbox.val(), ":octopus: abc :smile: :airplane: ");
     assert(textbox.focused);
 
     textbox.caret(textbox.val().length);
-    textbox.blur();
+    textbox.trigger("blur");
     compose_ui.smart_insert(textbox, ":heart:");
     assert.equal(textbox.insert_text, ":heart: ");
     assert.equal(textbox.val(), ":octopus: abc :smile: :airplane: :heart: ");
@@ -121,7 +117,7 @@ run_test("smart_insert", () => {
     // Test handling of spaces for ```quote
     textbox = make_textbox("");
     textbox.caret(0);
-    textbox.blur();
+    textbox.trigger("blur");
     compose_ui.smart_insert(textbox, "```quote\nquoted message\n```\n");
     assert.equal(textbox.insert_text, "```quote\nquoted message\n```\n");
     assert.equal(textbox.val(), "```quote\nquoted message\n```\n");
@@ -129,7 +125,7 @@ run_test("smart_insert", () => {
 
     textbox = make_textbox("");
     textbox.caret(0);
-    textbox.blur();
+    textbox.trigger("blur");
     compose_ui.smart_insert(textbox, "[Quoting…]\n");
     assert.equal(textbox.insert_text, "[Quoting…]\n");
     assert.equal(textbox.val(), "[Quoting…]\n");
@@ -137,7 +133,7 @@ run_test("smart_insert", () => {
 
     textbox = make_textbox("abc");
     textbox.caret(3);
-    textbox.blur();
+    textbox.trigger("blur");
     compose_ui.smart_insert(textbox, " test with space");
     assert.equal(textbox.insert_text, " test with space ");
     assert.equal(textbox.val(), "abc test with space ");

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -960,11 +960,6 @@ run_test("initialize", () => {
     };
 
     page_params.enter_sends = false;
-    // We manually specify it the first time because the click_func
-    // doesn't exist yet.
-    $("#stream_message_recipient_stream").select(noop);
-    $("#stream_message_recipient_topic").select(noop);
-    $("#private_message_recipient").select(noop);
 
     ct.initialize();
 

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -777,7 +777,7 @@ run_test("initialize", () => {
         const click_event = {type: "click", target: "#doesnotmatter"};
         options.query = "othello";
         // Focus lost (caused by the click event in the typeahead list)
-        $("#private_message_recipient").blur();
+        $("#private_message_recipient").trigger("blur");
         actual_value = options.updater(othello, click_event);
         assert.equal(appended_name, "Othello, the Moor of Venice");
 
@@ -969,6 +969,7 @@ run_test("initialize", () => {
 
     // handle_keydown()
     let event = {
+        type: "keydown",
         keyCode: 13,
         target: {
             id: "stream_message_recipient_stream",
@@ -979,7 +980,7 @@ run_test("initialize", () => {
     $("#stream_message_recipient_topic").data = function () {
         return {typeahead: {shown: true}};
     };
-    $("form#send_message_form").keydown(event);
+    $("form#send_message_form").trigger(event);
 
     const stub_typeahead_hidden = function () {
         return {typeahead: {shown: false}};
@@ -988,17 +989,17 @@ run_test("initialize", () => {
     $("#stream_message_recipient_stream").data = stub_typeahead_hidden;
     $("#private_message_recipient").data = stub_typeahead_hidden;
     $("#compose-textarea").data = stub_typeahead_hidden;
-    $("form#send_message_form").keydown(event);
+    $("form#send_message_form").trigger(event);
 
     event.keyCode = undefined;
     event.which = 9;
     event.shiftKey = false;
     event.target.id = "subject";
-    $("form#send_message_form").keydown(event);
+    $("form#send_message_form").trigger(event);
     event.target.id = "compose-textarea";
-    $("form#send_message_form").keydown(event);
+    $("form#send_message_form").trigger(event);
     event.target.id = "some_non_existing_id";
-    $("form#send_message_form").keydown(event);
+    $("form#send_message_form").trigger(event);
 
     // Setup jquery functions used in compose_textarea enter
     // handler.
@@ -1015,7 +1016,7 @@ run_test("initialize", () => {
 
     event.keyCode = 13;
     event.target.id = "stream_message_recipient_topic";
-    $("form#send_message_form").keydown(event);
+    $("form#send_message_form").trigger(event);
     event.target.id = "compose-textarea";
     page_params.enter_sends = false;
     event.metaKey = true;
@@ -1024,50 +1025,52 @@ run_test("initialize", () => {
         compose_finish_called = true;
     };
 
-    $("form#send_message_form").keydown(event);
+    $("form#send_message_form").trigger(event);
     assert(compose_finish_called);
     event.metaKey = false;
     event.ctrlKey = true;
-    $("form#send_message_form").keydown(event);
+    $("form#send_message_form").trigger(event);
     page_params.enter_sends = true;
     event.ctrlKey = false;
     event.altKey = true;
-    $("form#send_message_form").keydown(event);
+    $("form#send_message_form").trigger(event);
 
     // Cover case where there's a least one character there.
     range_length = 2;
-    $("form#send_message_form").keydown(event);
+    $("form#send_message_form").trigger(event);
 
     event.altKey = false;
     event.metaKey = true;
-    $("form#send_message_form").keydown(event);
+    $("form#send_message_form").trigger(event);
     event.target.id = "private_message_recipient";
-    $("form#send_message_form").keydown(event);
+    $("form#send_message_form").trigger(event);
 
     event.keyCode = 42;
-    $("form#send_message_form").keydown(event);
+    $("form#send_message_form").trigger(event);
 
     // handle_keyup()
     event = {
+        type: "keydown",
         keyCode: 13,
         target: {
             id: "stream_message_recipient_stream",
         },
         preventDefault: noop,
     };
-    // We execute .keydown() in order to make nextFocus !== false
+    // We trigger keydown in order to make nextFocus !== false
     $("#stream_message_recipient_topic").data = function () {
         return {typeahead: {shown: true}};
     };
-    $("form#send_message_form").keydown(event);
+    $("form#send_message_form").trigger(event);
     $("#stream_message_recipient_topic").off("mouseup");
-    $("form#send_message_form").keyup(event);
+    event.type = "keyup";
+    $("form#send_message_form").trigger(event);
     event.keyCode = undefined;
     event.which = 9;
     event.shiftKey = false;
-    $("form#send_message_form").keyup(event);
+    $("form#send_message_form").trigger(event);
     event.keyCode = 42;
-    $("form#send_message_form").keyup(event);
+    $("form#send_message_form").trigger(event);
 
     // select_on_focus()
 
@@ -1084,14 +1087,14 @@ run_test("initialize", () => {
     $("#enter_sends").is = function () {
         return false;
     };
-    $("#enter_sends").click();
+    $("#enter_sends").trigger("click");
 
     // Now we re-run both .initialize() and the click handler, this time
     // with enter_sends: page_params.enter_sends being true
     $("#enter_sends").is = function () {
         return true;
     };
-    $("#enter_sends").click();
+    $("#enter_sends").trigger("click");
 
     $("#stream_message_recipient_stream").off("focus");
     $("#stream_message_recipient_topic").off("focus");

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -1097,6 +1097,14 @@ run_test("initialize", () => {
         return true;
     };
     $("#enter_sends").click();
+
+    $("#stream_message_recipient_stream").off("focus");
+    $("#stream_message_recipient_topic").off("focus");
+    $("#private_message_recipient").off("focus");
+    $("form#send_message_form").off("keydown");
+    $("form#send_message_form").off("keyup");
+    $("#enter_sends").off("click");
+    $("#private_message_recipient").off("blur");
     ct.initialize();
 
     // Now let's make sure that all the stub functions have been called

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -1078,6 +1078,7 @@ run_test("initialize", () => {
         return {typeahead: {shown: true}};
     };
     $("form#send_message_form").keydown(event);
+    $("#stream_message_recipient_topic").off("mouseup");
     $("form#send_message_form").keyup(event);
     event.keyCode = undefined;
     event.which = 9;

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -184,12 +184,6 @@ run_test("snapshot_message", () => {
 });
 
 run_test("initialize", () => {
-    const message_content = $("#compose-textarea");
-    message_content.focusout = function (f) {
-        assert.equal(f, drafts.update_draft);
-        f();
-    };
-
     global.window.addEventListener = function (event_name, f) {
         assert.equal(event_name, "beforeunload");
         let called = false;
@@ -201,6 +195,10 @@ run_test("initialize", () => {
     };
 
     drafts.initialize();
+
+    const message_content = $("#compose-textarea");
+    assert.equal(message_content.get_on_handler("focusout"), drafts.update_draft);
+    message_content.trigger("focusout");
 });
 
 run_test("remove_old_drafts", () => {

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -21,13 +21,9 @@ set_global("page_params", {});
 
 set_global("overlays", {});
 
-const noop = () => {};
-
 // jQuery stuff should go away if we make an initialize() method.
 set_global("document", "document-stub");
 set_global("$", global.make_zjquery());
-$.fn.keydown = noop;
-$.fn.keypress = noop;
 
 zrequire("emoji");
 const hotkey = zrequire("hotkey");

--- a/frontend_tests/node_tests/input_pill.js
+++ b/frontend_tests/node_tests/input_pill.js
@@ -236,13 +236,17 @@ run_test("arrows on pills", () => {
 
     const pill_stub = {
         prev: () => ({
-            focus: () => {
-                prev_focused = true;
+            trigger: (type) => {
+                if (type === "focus") {
+                    prev_focused = true;
+                }
             },
         }),
         next: () => ({
-            focus: () => {
-                next_focused = true;
+            trigger: (type) => {
+                if (type === "focus") {
+                    next_focused = true;
+                }
             },
         }),
     };
@@ -274,8 +278,10 @@ run_test("left arrow on input", () => {
 
     container.set_find_results(".pill", {
         last: () => ({
-            focus: () => {
-                last_pill_focused = true;
+            trigger: (type) => {
+                if (type === "focus") {
+                    last_pill_focused = true;
+                }
             },
         }),
     });
@@ -411,8 +417,10 @@ run_test("insert_remove", () => {
     let next_pill_focused = false;
 
     const next_pill_stub = {
-        focus: () => {
-            next_pill_focused = true;
+        trigger: (type) => {
+            if (type === "focus") {
+                next_pill_focused = true;
+            }
         },
     };
 
@@ -449,8 +457,10 @@ run_test("exit button on pill", () => {
     let next_pill_focused = false;
 
     const next_pill_stub = {
-        focus: () => {
-            next_pill_focused = true;
+        trigger: (type) => {
+            if (type === "focus") {
+                next_pill_focused = true;
+            }
         },
     };
 

--- a/frontend_tests/node_tests/keydown_util.js
+++ b/frontend_tests/node_tests/keydown_util.js
@@ -14,24 +14,26 @@ run_test("test_early_returns", () => {
     };
 
     keydown_util.handle(opts);
-    const keydown_f = stub.keydown;
 
     const e1 = {
+        type: "keydown",
         which: 17, // not in keys
     };
 
-    keydown_f(e1);
+    stub.trigger(e1);
 
     const e2 = {
+        type: "keydown",
         which: 13, // no handler
     };
 
-    keydown_f(e2);
+    stub.trigger(e2);
 
     const e3 = {
+        type: "keydown",
         which: 37,
         altKey: true, // let browser handle
     };
 
-    keydown_f(e3);
+    stub.trigger(e3);
 });

--- a/frontend_tests/node_tests/poll_widget.js
+++ b/frontend_tests/node_tests/poll_widget.js
@@ -4,7 +4,6 @@ set_global("$", global.make_zjquery());
 
 set_global("people", {});
 
-const noop = () => {};
 const return_false = () => false;
 const return_true = () => true;
 
@@ -185,19 +184,6 @@ run_test("activate another person poll", () => {
     set_widget_find_result("button.poll-question-remove");
     set_widget_find_result("input.poll-question");
 
-    let option_button_callback;
-    let vote_button_callback;
-
-    poll_option.on = (event, func) => {
-        assert.equal(event, "click");
-        option_button_callback = func;
-    };
-
-    poll_vote_button.on = (event, func) => {
-        assert.equal(event, "click");
-        vote_button_callback = func;
-    };
-
     poll_question_header.toggle = (show) => {
         assert(show);
     };
@@ -233,20 +219,16 @@ run_test("activate another person poll", () => {
     assert.equal(widget_option_container.html(), "widgets/poll_widget_results");
     assert.equal(poll_question_header.text(), "What do you want?");
 
-    const e = {
-        stopPropagation: noop,
-    };
-
     {
         /* Testing data sent to server on adding option */
         poll_option_input.val("cool choice");
         out_data = undefined;
-        option_button_callback(e);
+        poll_option.trigger("click");
         assert.deepEqual(out_data, {type: "new_option", idx: 1, option: "cool choice"});
 
         poll_option_input.val("");
         out_data = undefined;
-        option_button_callback(e);
+        poll_option.trigger("click");
         assert.deepEqual(out_data, undefined);
     }
 
@@ -274,12 +256,12 @@ run_test("activate another person poll", () => {
     {
         /* Testing data sent to server on voting */
         poll_vote_button.attr("data-key", "100,1");
-        const e = {
-            stopPropagation: noop,
-            target: poll_vote_button,
-        };
         out_data = undefined;
-        vote_button_callback(e);
+        poll_vote_button.trigger(
+            $.Event("click", {
+                target: poll_vote_button,
+            }),
+        );
         assert.deepEqual(out_data, {type: "vote", key: "100,1", vote: 1});
     }
 
@@ -331,7 +313,7 @@ run_test("activate own poll", () => {
         return elem;
     };
 
-    const poll_option = set_widget_find_result("button.poll-option");
+    set_widget_find_result("button.poll-option");
     const poll_option_input = set_widget_find_result("input.poll-option");
     const widget_option_container = set_widget_find_result("ul.poll-widget");
 
@@ -342,23 +324,11 @@ run_test("activate own poll", () => {
     const poll_question_container = set_widget_find_result(".poll-question-bar");
     const poll_option_container = set_widget_find_result(".poll-option-bar");
 
-    const poll_vote_button = set_widget_find_result("button.poll-vote");
+    set_widget_find_result("button.poll-vote");
     const poll_please_wait = set_widget_find_result(".poll-please-wait");
     const poll_author_help = set_widget_find_result(".poll-author-help");
 
     set_widget_find_result("button.poll-question-remove");
-
-    let question_button_callback;
-
-    poll_question_submit.on = (event, func) => {
-        assert.equal(event, "click");
-        question_button_callback = func;
-    };
-
-    // Following event handler are already tested and doesn't make sense
-    // to test them again
-    poll_option.on = noop;
-    poll_vote_button.on = noop;
 
     poll_question_header.toggle = (show) => {
         assert(show);
@@ -397,19 +367,15 @@ run_test("activate own poll", () => {
 
     {
         /* Testing data sent to server on editing question */
-        const e = {
-            stopPropagation: noop,
-        };
-
         poll_question_input.val("Is it new?");
         out_data = undefined;
         show_submit = true;
-        question_button_callback(e);
+        poll_question_submit.trigger("click");
         assert.deepEqual(out_data, {type: "question", question: "Is it new?"});
 
         poll_option_input.val("");
         out_data = undefined;
-        question_button_callback(e);
+        poll_question_submit.trigger("click");
         assert.deepEqual(out_data, undefined);
     }
 });

--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -31,7 +31,7 @@ global.patch_builtin("setTimeout", (func) => func());
 
 run_test("clear_search_form", () => {
     $("#search_query").val("noise");
-    $("#search_query").focus();
+    $("#search_query").trigger("focus");
     $(".search_button").prop("disabled", false);
 
     search.clear_search_form();

--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -302,13 +302,7 @@ run_test("initialize", () => {
     };
 
     searchbox.on = (event, callback) => {
-        if (event === "focusin") {
-            searchbox.css({"box-shadow": "unset"});
-            callback();
-            assert.deepEqual(searchbox.css(), {
-                "box-shadow": "inset 0px 0px 0px 2px hsl(204, 20%, 74%)",
-            });
-        } else if (event === "focusout") {
+        if (event === "focusout") {
             searchbox.css({"box-shadow": "inset 0px 0px 0px 2px hsl(204, 20%, 74%)"});
             callback();
             assert.deepEqual(searchbox.css(), {"box-shadow": "unset"});

--- a/frontend_tests/node_tests/search_legacy.js
+++ b/frontend_tests/node_tests/search_legacy.js
@@ -57,13 +57,6 @@ run_test("initialize", () => {
     const searchbox_form = $("#searchbox_form");
     const search_button = $(".search_button");
 
-    searchbox_form.on = (event, func) => {
-        assert.equal(event, "compositionend");
-        search.is_using_input_method = false;
-        func();
-        assert(search.is_using_input_method);
-    };
-
     search_suggestion.max_num_of_search_results = 999;
     search_query_box.typeahead = (opts) => {
         assert.equal(opts.fixed, true);
@@ -113,9 +106,9 @@ run_test("initialize", () => {
         {
             let operators;
             let is_blurred;
-            search_query_box.blur = () => {
+            search_query_box.on("blur", () => {
                 is_blurred = true;
-            };
+            });
             /* Test updater */
             const _setup = (search_box_val) => {
                 is_blurred = false;
@@ -156,106 +149,107 @@ run_test("initialize", () => {
             _setup("stream:Verona");
             assert.equal(opts.updater("stream:Verona"), "stream:Verona");
             assert(!is_blurred);
-        }
-    };
 
-    searchbox_form.keydown = (func) => {
-        const ev = {
-            which: 15,
-        };
-        search_query_box.is = return_false;
-        assert.equal(func(ev), undefined);
-
-        ev.which = 13;
-        assert.equal(func(ev), undefined);
-
-        ev.which = 13;
-        search_query_box.is = return_true;
-        assert.equal(func(ev), false);
-
-        return search_query_box;
-    };
-
-    search_query_box.keyup = (func) => {
-        const ev = {};
-        let operators;
-        let is_blurred;
-        narrow_state.active = return_false;
-        search_query_box.blur = () => {
-            is_blurred = true;
-        };
-
-        const _setup = (search_box_val) => {
-            is_blurred = false;
-            search_button.prop("disabled", false);
-            search_query_box.val(search_box_val);
-            Filter.parse = (search_string) => {
-                assert.equal(search_string, search_box_val);
-                return operators;
-            };
-            narrow.activate = (raw_operators, options) => {
-                assert.deepEqual(raw_operators, operators);
-                assert.deepEqual(options, {trigger: "search"});
-            };
-        };
-
-        operators = [
-            {
-                negated: false,
-                operator: "search",
-                operand: "",
-            },
-        ];
-        _setup("");
-
-        ev.which = 15;
-        search_query_box.is = return_false;
-        func(ev);
-
-        assert(!is_blurred);
-        assert(!search_button.prop("disabled"));
-
-        ev.which = 13;
-        search_query_box.is = return_false;
-        func(ev);
-
-        assert(!is_blurred);
-        assert(!search_button.prop("disabled"));
-
-        ev.which = 13;
-        search_query_box.is = return_true;
-        func(ev);
-        assert(is_blurred);
-
-        _setup("ver");
-        search.is_using_input_method = true;
-        func(ev);
-        // No change on enter keyup event when using input tool
-        assert(!is_blurred);
-        assert(!search_button.prop("disabled"));
-
-        _setup("ver");
-        ev.which = 13;
-        search_query_box.is = return_true;
-        func(ev);
-        assert(is_blurred);
-        assert(!search_button.prop("disabled"));
-    };
-
-    search_query_box.on = (event, callback) => {
-        if (event === "focus") {
-            search_button.prop("disabled", true);
-            callback();
-            assert(!search_button.prop("disabled"));
-        } else if (event === "blur") {
-            search_query_box.val("test string");
-            narrow_state.search_string = () => "ver";
-            callback();
-            assert.equal(search_query_box.val(), "test string");
+            search_query_box.off("blur");
         }
     };
 
     search.initialize();
+
+    search_button.prop("disabled", true);
+    search_query_box.trigger("focus");
+    assert(!search_button.prop("disabled"));
+
+    search_query_box.val("test string");
+    narrow_state.search_string = () => "ver";
+    search_query_box.trigger("blur");
+    assert.equal(search_query_box.val(), "test string");
+
+    search.is_using_input_method = false;
+    searchbox_form.trigger("compositionend");
+    assert(search.is_using_input_method);
+
+    const keydown = searchbox_form.get_on_handler("keydown");
+    let ev = {
+        type: "keydown",
+        which: 15,
+    };
+    search_query_box.is = return_false;
+    assert.equal(keydown(ev), undefined);
+
+    ev.which = 13;
+    assert.equal(keydown(ev), undefined);
+
+    ev.which = 13;
+    search_query_box.is = return_true;
+    assert.equal(keydown(ev), false);
+
+    ev = {
+        type: "keyup",
+    };
+    let operators;
+    let is_blurred;
+    narrow_state.active = return_false;
+    search_query_box.off("blur");
+    search_query_box.on("blur", () => {
+        is_blurred = true;
+    });
+
+    const _setup = (search_box_val) => {
+        is_blurred = false;
+        search_button.prop("disabled", false);
+        search_query_box.val(search_box_val);
+        Filter.parse = (search_string) => {
+            assert.equal(search_string, search_box_val);
+            return operators;
+        };
+        narrow.activate = (raw_operators, options) => {
+            assert.deepEqual(raw_operators, operators);
+            assert.deepEqual(options, {trigger: "search"});
+        };
+    };
+
+    operators = [
+        {
+            negated: false,
+            operator: "search",
+            operand: "",
+        },
+    ];
+    _setup("");
+
+    ev.which = 15;
+    search_query_box.is = return_false;
+    searchbox_form.trigger(ev);
+
+    assert(!is_blurred);
+    assert(!search_button.prop("disabled"));
+
+    ev.which = 13;
+    search_query_box.is = return_false;
+    searchbox_form.trigger(ev);
+
+    assert(!is_blurred);
+    assert(!search_button.prop("disabled"));
+
+    ev.which = 13;
+    search_query_box.is = return_true;
+    searchbox_form.trigger(ev);
+    assert(is_blurred);
+
+    _setup("ver");
+    search.is_using_input_method = true;
+    searchbox_form.trigger(ev);
+    // No change on enter keyup event when using input tool
+    assert(!is_blurred);
+    assert(!search_button.prop("disabled"));
+
+    _setup("ver");
+    ev.which = 13;
+    search_query_box.is = return_true;
+    searchbox_form.trigger(ev);
+    assert(is_blurred);
+    assert(!search_button.prop("disabled"));
 });
 
 run_test("initiate_search", () => {
@@ -266,7 +260,6 @@ run_test("initiate_search", () => {
     narrow_state.filter = () => ({is_search: return_true});
     let typeahead_forced_open = false;
     let is_searchbox_text_selected = false;
-    $("#search_query").select = noop;
     $("#search_query").typeahead = (lookup) => {
         if (lookup === "lookup") {
             typeahead_forced_open = true;

--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -140,11 +140,7 @@ run_test("test tab clicks", () => {
     set_up();
 
     function click_on_tab(tab_elem) {
-        const e = {
-            preventDefault: () => {},
-            stopPropagation: () => {},
-        };
-        tab_elem.click(e);
+        tab_elem.trigger("click");
     }
 
     const tabs = {

--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -118,12 +118,6 @@ function set_up() {
 
     $("#create_bot_form").validate = () => {};
 
-    $("#create_bot_type").on = (action, f) => {
-        if (action === "change") {
-            test_create_bot_type_input_box_toggle(f);
-        }
-    };
-
     $("#config_inputbox").children = () => {
         const mock_children = {
             hide: () => {},
@@ -134,6 +128,8 @@ function set_up() {
     avatar.build_bot_edit_widget = () => {};
 
     settings_bots.set_up();
+
+    test_create_bot_type_input_box_toggle(() => $("#create_bot_type").trigger("change"));
 }
 
 run_test("set_up", () => {

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -734,12 +734,6 @@ function test_discard_changes_button(discard_changes) {
 }
 
 run_test("set_up", () => {
-    const callbacks = {};
-
-    const set_callback = (name) => (f) => {
-        callbacks[name] = f;
-    };
-
     const verify_realm_domains = simulate_realm_domains_table();
     page_params.realm_available_video_chat_providers = {
         jitsi_meet: {
@@ -754,30 +748,6 @@ run_test("set_up", () => {
             id: 4,
             name: "Big Blue Button",
         },
-    };
-
-    $("#id_realm_video_chat_provider").change = set_callback("realm_video_chat_provider");
-    $("#id_realm_org_join_restrictions").change = set_callback("change_org_join_restrictions");
-    $("#submit-add-realm-domain").click = set_callback("add_realm_domain");
-
-    let submit_settings_form;
-    let discard_changes;
-    $(".organization").on = function (action, selector, f) {
-        if (selector === ".subsection-header .subsection-changes-save .button") {
-            assert.equal(action, "click");
-            submit_settings_form = f;
-        } else if (selector === ".subsection-header .subsection-changes-discard .button") {
-            assert.equal(action, "click");
-            discard_changes = f;
-        }
-    };
-
-    let change_allow_subdomains;
-    $("#realm_domains_table").on = function (action, selector, f) {
-        if (action === "change") {
-            assert.equal(selector, ".allow-subdomains");
-            change_allow_subdomains = f;
-        }
     };
 
     let upload_realm_logo_or_icon;
@@ -797,18 +767,14 @@ run_test("set_up", () => {
         $.create("<stub delete limit parent>"),
     );
     $("#id_realm_message_retention_days").set_parent($.create("<stub retention period parent>"));
-    $("#id_realm_message_retention_setting").change = noop;
     $("#message_content_in_email_notifications_label").set_parent(
         $.create("<stub in-content setting checkbox>"),
     );
     $("#enable_digest_emails_label").set_parent($.create("<stub digest setting checkbox>"));
     $("#id_realm_digest_weekday").set_parent($.create("<stub digest weekday setting dropdown>"));
-    $("#id_realm_msg_edit_limit_setting").change = noop;
-    $("#id_realm_msg_delete_limit_setting").change = noop;
     $("#allowed_domains_label").set_parent($.create("<stub-allowed-domain-label-parent>"));
     const waiting_period_parent_elem = $.create("waiting-period-parent-stub");
     $("#id_realm_waiting_period_threshold").set_parent(waiting_period_parent_elem);
-    $("#id_realm_waiting_period_setting").change = noop;
 
     const allow_topic_edit_label_parent = $.create("allow-topic-edit-label-parent");
     $("#id_realm_allow_community_topic_editing_label").set_parent(allow_topic_edit_label_parent);
@@ -824,15 +790,27 @@ run_test("set_up", () => {
 
     verify_realm_domains();
 
-    test_realms_domain_modal(callbacks.add_realm_domain);
-    test_submit_settings_form(submit_settings_form);
+    test_realms_domain_modal(() => $("#submit-add-realm-domain").trigger("click"));
+    test_submit_settings_form(
+        $(".organization").get_on_handler(
+            "click",
+            ".subsection-header .subsection-changes-save .button",
+        ),
+    );
     test_upload_realm_icon(upload_realm_logo_or_icon);
-    test_change_allow_subdomains(change_allow_subdomains);
+    test_change_allow_subdomains(
+        $("#realm_domains_table").get_on_handler("change", ".allow-subdomains"),
+    );
     test_extract_property_name();
     test_change_save_button_state();
     test_sync_realm_settings();
     test_parse_time_limit();
-    test_discard_changes_button(discard_changes);
+    test_discard_changes_button(
+        $(".organization").get_on_handler(
+            "click",
+            ".subsection-header .subsection-changes-discard .button",
+        ),
+    );
 
     window.dropdown_list_widget = dropdown_list_widget_backup;
 });

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -430,17 +430,6 @@ run_test("with_external_user", () => {
         turned_off[event_name + "/" + sel] = true;
     };
 
-    let pill_hover_called = false;
-    let callback;
-    let empty_fn;
-    pill_stub.hover = function (one, two) {
-        callback = one;
-        empty_fn = two;
-        pill_hover_called = true;
-        assert.equal(typeof one, "function");
-        assert.equal(typeof two, "function");
-    };
-
     const exit_button = $.create("fake-pill-exit");
     pill_stub.set_find_results(".exit", exit_button);
     let exit_button_called = false;
@@ -487,14 +476,9 @@ run_test("with_external_user", () => {
     const event = {
         stopPropagation: noop,
     };
-    let pill_click_called = false;
+    const pill_mouseenter_handler = pill_stub.get_on_handler("mouseenter");
     const pill_click_handler = pill_container_stub.get_on_handler("click");
-    pill_click_called = true;
-
-    assert(callback);
-    assert(empty_fn);
-    callback();
-    empty_fn();
+    pill_mouseenter_handler(event);
     pill_click_handler(event);
     assert.equal(delete_handler.call(fake_delete), undefined);
     assert.equal(name_update_handler(), undefined);
@@ -506,8 +490,6 @@ run_test("with_external_user", () => {
     assert.equal(set_attributes_called, 1);
     assert.equal(can_edit_called, 9);
     assert(exit_button_called);
-    assert(pill_click_called);
-    assert(pill_hover_called);
     assert.equal(user_group_find_called, 2);
     assert.equal(pill_container_find_called, 4);
     assert.equal(turned_off["keydown/.pill"], true);

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -132,7 +132,6 @@ set_global("$", global.make_zjquery());
 
 const document_stub = $.create("document-stub");
 document.to_$ = () => document_stub;
-document_stub.on = () => {};
 document_stub.idle = () => {};
 
 const window_stub = $.create("window-stub");

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -190,8 +190,6 @@ $tab_bar.find = () => false;
 compose.compute_show_video_chat_button = () => {};
 $("#below-compose-content .video_link").toggle = () => {};
 
-$("#tab_bar .narrow_description > a").hover = () => {};
-
 run_test("initialize_everything", () => {
     ui_init.initialize_everything();
 });

--- a/frontend_tests/node_tests/widgetize.js
+++ b/frontend_tests/node_tests/widgetize.js
@@ -5,11 +5,8 @@ set_global("todo_widget", {});
 set_global("zform", {});
 set_global("document", "document-stub");
 
-const noop = () => {};
 const return_true = () => true;
 const return_false = () => false;
-
-$(document).on = noop;
 
 zrequire("widgetize");
 

--- a/frontend_tests/node_tests/zjquery.js
+++ b/frontend_tests/node_tests/zjquery.js
@@ -116,11 +116,11 @@ run_test("clicks", () => {
     const state = {};
 
     function set_up_click_handlers() {
-        $("#widget1").click(() => {
+        $("#widget1").on("click", () => {
             state.clicked = true;
         });
 
-        $(".some-class").keydown(() => {
+        $(".some-class").on("keydown", () => {
             state.keydown = true;
         });
     }

--- a/frontend_tests/node_tests/zjquery.js
+++ b/frontend_tests/node_tests/zjquery.js
@@ -131,11 +131,11 @@ run_test("clicks", () => {
     assert(!state.keydown);
 
     // But we can simulate clicks.
-    $("#widget1").click();
+    $("#widget1").trigger("click");
     assert.equal(state.clicked, true);
 
     // and keydown
-    $(".some-class").keydown();
+    $(".some-class").trigger("keydown");
     assert.equal(state.keydown, true);
 });
 

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -15,7 +15,7 @@ exports.make_event_store = (selector) => {
     const on_functions = new Map();
     const child_on_functions = new Map();
 
-    function generic_event(event_name, arg) {
+    function generic_event($element, event_name, arg) {
         if (typeof arg === "function") {
             on_functions.set(event_name, arg);
         } else {
@@ -24,7 +24,7 @@ exports.make_event_store = (selector) => {
                 const error = "Cannot find " + event_name + " handler for " + selector;
                 throw Error(error);
             }
-            handler(arg);
+            handler.call($element, arg);
         }
     }
 
@@ -104,7 +104,7 @@ exports.make_event_store = (selector) => {
             child_on.set(event_name, handler);
         },
 
-        trigger: function (ev) {
+        trigger: function ($element, ev) {
             const ev_name = typeof ev === "string" ? ev : ev.name;
             const func = on_functions.get(ev_name);
 
@@ -117,7 +117,7 @@ exports.make_event_store = (selector) => {
                 return;
             }
 
-            func(ev.data);
+            func.call($element, ev.data);
         },
     };
 
@@ -160,7 +160,7 @@ exports.make_new_elem = function (selector, opts) {
             return self;
         },
         click: function (arg) {
-            event_store.generic_event("click", arg);
+            event_store.generic_event(self, "click", arg);
             return self;
         },
         data: function (name, val) {
@@ -264,11 +264,11 @@ exports.make_new_elem = function (selector, opts) {
             return focused;
         },
         keydown: function (arg) {
-            event_store.generic_event("keydown", arg);
+            event_store.generic_event(self, "keydown", arg);
             return self;
         },
         keyup: function (arg) {
-            event_store.generic_event("keyup", arg);
+            event_store.generic_event(self, "keyup", arg);
             return self;
         },
         off: function (...args) {
@@ -323,7 +323,7 @@ exports.make_new_elem = function (selector, opts) {
             return self;
         },
         select: function (arg) {
-            event_store.generic_event("select", arg);
+            event_store.generic_event(self, "select", arg);
             return self;
         },
         set_find_results: function (find_selector, jquery_object) {
@@ -355,7 +355,7 @@ exports.make_new_elem = function (selector, opts) {
             return text;
         },
         trigger: function (ev) {
-            event_store.trigger(ev);
+            event_store.trigger(self, ev);
             return self;
         },
         val: function (...args) {

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -1,5 +1,14 @@
 const noop = function () {};
 
+class Event {
+    constructor(type, props) {
+        this.type = type;
+        Object.assign(this, props);
+    }
+    preventDefault() {}
+    stopPropagation() {}
+}
+
 exports.make_event_store = (selector) => {
     /*
 
@@ -104,9 +113,11 @@ exports.make_event_store = (selector) => {
             child_on.set(event_name, handler);
         },
 
-        trigger: function ($element, ev) {
-            const ev_name = typeof ev === "string" ? ev : ev.name;
-            const func = on_functions.get(ev_name);
+        trigger: function ($element, ev, data) {
+            if (typeof ev === "string") {
+                ev = new Event(ev, data);
+            }
+            const func = on_functions.get(ev.type);
 
             if (!func) {
                 // It's possible that test code will trigger events
@@ -117,7 +128,7 @@ exports.make_event_store = (selector) => {
                 return;
             }
 
-            func.call($element, ev.data);
+            func.call($element, ev, data);
         },
     };
 
@@ -533,12 +544,7 @@ exports.make_zjquery = function (opts) {
         return res;
     };
 
-    zjquery.Event = function (name, data) {
-        return {
-            name: name,
-            data: data,
-        };
-    };
+    zjquery.Event = (type, props) => new Event(type, props);
 
     fn.after = function (s) {
         return s;

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -128,14 +128,6 @@ exports.make_event_store = (selector) => {
             }
         },
 
-        generic_event($element, event_name, arg) {
-            if (typeof arg === "function") {
-                self.on(event_name, arg);
-            } else {
-                self.trigger($element, event_name, arg);
-            }
-        },
-
         is_focused() {
             return focused;
         },
@@ -172,18 +164,6 @@ exports.make_new_elem = function (selector, opts) {
                 return attrs.get(name);
             }
             attrs.set(name, val);
-            return self;
-        },
-        blur: function (arg) {
-            event_store.generic_event(self, "blur", arg);
-            return self;
-        },
-        change: function (arg) {
-            event_store.generic_event(self, "change", arg);
-            return self;
-        },
-        click: function (arg) {
-            event_store.generic_event(self, "click", arg);
             return self;
         },
         data: function (name, val) {
@@ -237,18 +217,6 @@ exports.make_new_elem = function (selector, opts) {
             }
             throw Error("Cannot find " + child_selector + " in " + selector);
         },
-        focus: function (arg) {
-            event_store.generic_event(self, "focus", arg);
-            return self;
-        },
-        focusin: function (arg) {
-            event_store.generic_event(self, "focusin", arg);
-            return self;
-        },
-        focusout: function (arg) {
-            event_store.generic_event(self, "focusout", arg);
-            return self;
-        },
         get: function (idx) {
             // We have some legacy code that does $('foo').get(0).
             assert.equal(idx, 0);
@@ -285,18 +253,6 @@ exports.make_new_elem = function (selector, opts) {
             // is_focused is not a jQuery thing; this is
             // for our testing
             return event_store.is_focused();
-        },
-        keydown: function (arg) {
-            event_store.generic_event(self, "keydown", arg);
-            return self;
-        },
-        keypress: function (arg) {
-            event_store.generic_event(self, "keypress", arg);
-            return self;
-        },
-        keyup: function (arg) {
-            event_store.generic_event(self, "keyup", arg);
-            return self;
         },
         off: function (...args) {
             event_store.off(...args);
@@ -350,15 +306,7 @@ exports.make_new_elem = function (selector, opts) {
         replaceWith: function () {
             return self;
         },
-        scroll: function (arg) {
-            event_store.generic_event(self, "scroll", arg);
-            return self;
-        },
         scrollTop: function () {
-            return self;
-        },
-        select: function (arg) {
-            event_store.generic_event(self, "select", arg);
             return self;
         },
         set_find_results: function (find_selector, jquery_object) {

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -178,6 +178,10 @@ exports.make_new_elem = function (selector, opts) {
             event_store.generic_event(self, "blur", arg);
             return self;
         },
+        change: function (arg) {
+            event_store.generic_event(self, "change", arg);
+            return self;
+        },
         click: function (arg) {
             event_store.generic_event(self, "click", arg);
             return self;
@@ -286,6 +290,10 @@ exports.make_new_elem = function (selector, opts) {
             event_store.generic_event(self, "keydown", arg);
             return self;
         },
+        keypress: function (arg) {
+            event_store.generic_event(self, "keypress", arg);
+            return self;
+        },
         keyup: function (arg) {
             event_store.generic_event(self, "keyup", arg);
             return self;
@@ -340,6 +348,10 @@ exports.make_new_elem = function (selector, opts) {
         },
         removeData: noop,
         replaceWith: function () {
+            return self;
+        },
+        scroll: function (arg) {
+            event_store.generic_event(self, "scroll", arg);
             return self;
         },
         scrollTop: function () {

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -24,22 +24,7 @@ exports.make_event_store = (selector) => {
     const on_functions = new Map();
     const child_on_functions = new Map();
 
-    function generic_event($element, event_name, arg) {
-        if (typeof arg === "function") {
-            on_functions.set(event_name, arg);
-        } else {
-            const handler = on_functions.get(event_name);
-            if (!handler) {
-                const error = "Cannot find " + event_name + " handler for " + selector;
-                throw Error(error);
-            }
-            handler.call($element, arg);
-        }
-    }
-
     const self = {
-        generic_event: generic_event,
-
         get_on_handler: function (name, child_selector) {
             let handler;
 
@@ -129,6 +114,14 @@ exports.make_event_store = (selector) => {
             }
 
             func.call($element, ev, data);
+        },
+
+        generic_event($element, event_name, arg) {
+            if (typeof arg === "function") {
+                on_functions.set(event_name, arg);
+            } else {
+                self.trigger($element, event_name, arg);
+            }
         },
     };
 

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -130,7 +130,7 @@ exports.make_event_store = (selector) => {
 
         generic_event($element, event_name, arg) {
             if (typeof arg === "function") {
-                on_functions.set(event_name, arg);
+                self.on(event_name, arg);
             } else {
                 self.trigger($element, event_name, arg);
             }

--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -208,7 +208,7 @@ exports.initialize = function () {
         exports.new_user_input = true;
     });
 
-    $(window).focus(mark_client_active);
+    $(window).on("focus", mark_client_active);
     $(window).idle({
         idle: DEFAULT_IDLE_TIMEOUT_MS,
         onIdle: mark_client_idle,

--- a/static/js/alert_words_ui.js
+++ b/static/js/alert_words_ui.js
@@ -15,7 +15,7 @@ exports.render_alert_words_ui = function () {
     }
 
     // Focus new alert word name text box.
-    $("#create_alert_word_name").focus();
+    $("#create_alert_word_name").trigger("focus");
 };
 
 function update_alert_word_status(status_text, is_error) {

--- a/static/js/analytics/activity.js
+++ b/static/js/analytics/activity.js
@@ -1,5 +1,5 @@
 $(() => {
-    $("a.envelope-link").click(function () {
+    $("a.envelope-link").on("click", function () {
         common.copy_data_attribute_value($(this), "admin-emails");
     });
 });

--- a/static/js/analytics/support.js
+++ b/static/js/analytics/support.js
@@ -12,7 +12,7 @@ $(() => {
         }
     });
 
-    $("a.copy-button").click(function () {
+    $("a.copy-button").on("click", function () {
         common.copy_data_attribute_value($(this), "copytext");
     });
 });

--- a/static/js/archive.js
+++ b/static/js/archive.js
@@ -129,7 +129,8 @@ $(() => {
     $.fn.safeOuterWidth = function (...args) {
         return this.outerWidth(...args) || 0;
     };
-    $(".app").scroll(
+    $(".app").on(
+        "scroll",
         _.throttle(() => {
             scroll_finish();
         }, 50),

--- a/static/js/buddy_list.js
+++ b/static/js/buddy_list.js
@@ -315,7 +315,7 @@ function buddy_list_create() {
         // sure everything's in place.
         const scroll_container = ui.get_scroll_element($(self.scroll_container_sel));
 
-        scroll_container.scroll(() => {
+        scroll_container.on("scroll", () => {
             self.fill_screen_with_content();
         });
     };

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -9,7 +9,7 @@ function convert_enter_to_click(e) {
     const key = e.which;
     if (key === 13) {
         // enter
-        $(e.currentTarget).click();
+        $(e.currentTarget).trigger("click");
     }
 }
 
@@ -200,7 +200,7 @@ exports.initialize = function () {
 
         if (page_params.realm_allow_edit_history) {
             message_edit_history.show_history(message);
-            message_history_cancel_btn.focus();
+            message_history_cancel_btn.trigger("focus");
         }
         e.stopPropagation();
         e.preventDefault();
@@ -601,7 +601,7 @@ exports.initialize = function () {
     notifications.register_click_handlers();
 
     $("body").on("click", ".logout_button", () => {
-        $("#logout_form").submit();
+        $("#logout_form").trigger("submit");
     });
 
     $(".restart_get_events_button").on("click", () => {
@@ -757,24 +757,24 @@ exports.initialize = function () {
 
     // disable the draggability for left-sidebar components
     $("#stream_filters, #global_filters").on("dragstart", (e) => {
-        e.target.blur();
+        e.target.trigger("blur");
         return false;
     });
 
     // Chrome focuses an element when dragging it which can be confusing when
     // users involuntarily drag something and we show them the focus outline.
-    $("body").on("dragstart", "a", (e) => e.target.blur());
+    $("body").on("dragstart", "a", (e) => e.target.trigger("blur"));
 
     // Don't focus links on middle click.
     $("body").on("mouseup", "a", (e) => {
         if (e.which === 2) {
             // middle click
-            e.target.blur();
+            e.target.trigger("blur");
         }
     });
 
     // Don't focus links on context menu.
-    $("body").on("contextmenu", "a", (e) => e.target.blur());
+    $("body").on("contextmenu", "a", (e) => e.target.trigger("blur"));
 
     (function () {
         const map = {
@@ -797,7 +797,7 @@ exports.initialize = function () {
                 $(this).text($(this).attr("data-prev-text"));
                 $("[data-make-editable]").html("");
             } else if (e.which === 13) {
-                $(this).siblings(".checkmark").click();
+                $(this).siblings(".checkmark").trigger("click");
             }
         });
 
@@ -945,7 +945,7 @@ exports.initialize = function () {
         if (compose_state.composing()) {
             if ($(e.target).closest("a").length > 0) {
                 // Refocus compose message text box if link is clicked
-                $("#compose-textarea").focus();
+                $("#compose-textarea").trigger("focus");
                 return;
             } else if (
                 !window.getSelection().toString() &&

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -328,7 +328,7 @@ exports.initialize = function () {
             ui_util.blur_active_element();
         }
     });
-    $("#message_edit_form .send-status-close").click(function () {
+    $("#message_edit_form .send-status-close").on("click", function () {
         const row_id = rows.id($(this).closest(".message_row"));
         const send_status = $("#message-edit-send-status-" + row_id);
         $(send_status).stop(true).fadeOut(200);
@@ -604,7 +604,7 @@ exports.initialize = function () {
         $("#logout_form").submit();
     });
 
-    $(".restart_get_events_button").click(() => {
+    $(".restart_get_events_button").on("click", () => {
         server_events.restart_get_events({dont_block: true});
     });
 
@@ -629,18 +629,18 @@ exports.initialize = function () {
 
     // NB: This just binds to current elements, and won't bind to elements
     // created after ready() is called.
-    $("#compose-send-status .compose-send-status-close").click(() => {
+    $("#compose-send-status .compose-send-status-close").on("click", () => {
         $("#compose-send-status").stop(true).fadeOut(500);
     });
-    $("#nonexistent_stream_reply_error .compose-send-status-close").click(() => {
+    $("#nonexistent_stream_reply_error .compose-send-status-close").on("click", () => {
         $("#nonexistent_stream_reply_error").stop(true).fadeOut(500);
     });
 
-    $(".compose_stream_button").click(() => {
+    $(".compose_stream_button").on("click", () => {
         popovers.hide_mobile_message_buttons_popover();
         compose_actions.start("stream", {trigger: "new topic button"});
     });
-    $(".compose_private_button").click(() => {
+    $(".compose_private_button").on("click", () => {
         popovers.hide_mobile_message_buttons_popover();
         compose_actions.start("private");
     });
@@ -654,15 +654,15 @@ exports.initialize = function () {
         compose_actions.start("private");
     });
 
-    $(".compose_reply_button").click(() => {
+    $(".compose_reply_button").on("click", () => {
         compose_actions.respond_to_message({trigger: "reply button"});
     });
 
-    $(".empty_feed_compose_stream").click((e) => {
+    $(".empty_feed_compose_stream").on("click", (e) => {
         compose_actions.start("stream", {trigger: "empty feed message"});
         e.preventDefault();
     });
-    $(".empty_feed_compose_private").click((e) => {
+    $(".empty_feed_compose_private").on("click", (e) => {
         compose_actions.start("private", {trigger: "empty feed message"});
         e.preventDefault();
     });
@@ -696,19 +696,19 @@ exports.initialize = function () {
         popovers.hide_all();
     }
 
-    $("#compose_buttons").click(handle_compose_click);
-    $(".compose-content").click(handle_compose_click);
+    $("#compose_buttons").on("click", handle_compose_click);
+    $(".compose-content").on("click", handle_compose_click);
 
-    $("#compose_close").click(() => {
+    $("#compose_close").on("click", () => {
         compose_actions.cancel();
     });
 
-    $("#streams_inline_cog").click((e) => {
+    $("#streams_inline_cog").on("click", (e) => {
         e.stopPropagation();
         hashchange.go_to_location("streams/subscribed");
     });
 
-    $("#streams_filter_icon").click((e) => {
+    $("#streams_filter_icon").on("click", (e) => {
         e.stopPropagation();
         stream_list.toggle_filter_displayed(e);
     });

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -7,7 +7,7 @@ exports.status_classes = "alert-error alert-success alert-info alert-warning";
 
 exports.autofocus = function (selector) {
     $(() => {
-        $(selector).focus();
+        $(selector).trigger("focus");
     });
 };
 
@@ -90,7 +90,7 @@ exports.copy_data_attribute_value = function (elem, key) {
     // attribute of the element to clipboard
     const temp = $(document.createElement("input"));
     $("body").append(temp);
-    temp.val(elem.data(key)).select();
+    temp.val(elem.data(key)).trigger("select");
     document.execCommand("copy");
     temp.remove();
     elem.fadeOut(250);

--- a/static/js/components.js
+++ b/static/js/components.js
@@ -84,7 +84,7 @@ exports.toggle = function (opts) {
     }
 
     (function () {
-        meta.$ind_tab.click(function () {
+        meta.$ind_tab.on("click", function () {
             const idx = $(this).data("tab-id");
             select_tab(idx);
         });

--- a/static/js/components.js
+++ b/static/js/components.js
@@ -65,7 +65,7 @@ exports.toggle = function (opts) {
         }
 
         if (!opts.child_wants_focus) {
-            elem.focus();
+            elem.trigger("focus");
         }
     }
 

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -259,7 +259,7 @@ function compose_error(error_text, bad_input) {
     $("#compose-send-button").prop("disabled", false);
     $("#sending-indicator").hide();
     if (bad_input !== undefined) {
-        bad_input.focus().select();
+        bad_input.trigger("focus").trigger("select");
     }
 }
 
@@ -284,14 +284,14 @@ function compose_not_subscribed_error(error_text, bad_input) {
     $("#sending-indicator").hide();
     $(".compose-send-status-close").hide();
     if (bad_input !== undefined) {
-        bad_input.focus().select();
+        bad_input.trigger("focus").trigger("select");
     }
 }
 
 exports.nonexistent_stream_reply_error = nonexistent_stream_reply_error;
 
 function clear_compose_box() {
-    $("#compose-textarea").val("").focus();
+    $("#compose-textarea").val("").trigger("focus");
     drafts.delete_draft_after_send();
     compose_ui.autosize_textarea();
     $("#compose-send-status").hide(0);
@@ -379,7 +379,7 @@ exports.enter_with_preview_open = function () {
         exports.finish();
     } else {
         // Otherwise, we return to the compose box and focus it
-        $("#compose-textarea").focus();
+        $("#compose-textarea").trigger("focus");
     }
 };
 
@@ -696,7 +696,7 @@ function validate_private_message() {
 }
 
 exports.validate = function () {
-    $("#compose-send-button").attr("disabled", "disabled").blur();
+    $("#compose-send-button").attr("disabled", "disabled").trigger("blur");
     const message_content = compose_state.message_content();
     if (reminder.is_deferred_delivery(message_content)) {
         show_sending_indicator(i18n.t("Scheduling..."));

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -1216,7 +1216,7 @@ exports.initialize = function () {
         mode: "compose",
     });
 
-    $("#compose-textarea").focus(() => {
+    $("#compose-textarea").on("focus", () => {
         const opts = {
             message_type: compose_state.get_message_type(),
             stream: $("#stream_message_recipient_stream").val(),

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -1,7 +1,7 @@
 const autosize = require("autosize");
 
 exports.blur_textarea = function () {
-    $(".message_comp").find("input, textarea, button").blur();
+    $(".message_comp").find("input, textarea, button").trigger("blur");
 };
 
 function hide_box() {
@@ -45,7 +45,7 @@ exports.set_focus = function (msg_type, opts) {
 
     if (window.getSelection().toString() === "" || opts.trigger !== "message click") {
         const elt = $(focus_area);
-        elt.focus().select();
+        elt.trigger("focus").trigger("select");
     }
 };
 
@@ -384,7 +384,7 @@ exports.on_topic_narrow = function () {
     compose_state.topic(narrow_state.topic());
     compose_fade.set_focused_recipient("stream");
     compose_fade.update_message_list();
-    $("#compose-textarea").focus().select();
+    $("#compose-textarea").trigger("focus").trigger("select");
 };
 
 exports.quote_and_reply = function (opts) {

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -33,7 +33,7 @@ exports.smart_insert = function (textarea, syntax) {
         syntax += " ";
     }
 
-    textarea.focus();
+    textarea.trigger("focus");
 
     // We prefer to use insertText, which supports things like undo better
     // for rich-text editing features like inserting links.  But we fall

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -266,7 +266,7 @@ function select_on_focus(field_id) {
     // conditions in Chrome so we need to protect against infinite
     // recursion.
     let in_handler = false;
-    $("#" + field_id).focus(() => {
+    $("#" + field_id).on("focus", () => {
         if (in_handler) {
             return;
         }
@@ -1063,10 +1063,10 @@ exports.initialize = function () {
     select_on_focus("private_message_recipient");
 
     // These handlers are at the "form" level so that they are called after typeahead
-    $("form#send_message_form").keydown(handle_keydown);
-    $("form#send_message_form").keyup(handle_keyup);
+    $("form#send_message_form").on("keydown", handle_keydown);
+    $("form#send_message_form").on("keyup", handle_keyup);
 
-    $("#enter_sends").click(() => {
+    $("#enter_sends").on("click", () => {
         const send_button = $("#compose-send-button");
         page_params.enter_sends = $("#enter_sends").is(":checked");
         if (page_params.enter_sends) {
@@ -1166,7 +1166,7 @@ exports.initialize = function () {
 
     exports.initialize_compose_typeahead("#compose-textarea");
 
-    $("#private_message_recipient").blur(function () {
+    $("#private_message_recipient").on("blur", function () {
         const val = $(this).val();
         const recipients = typeahead_helper.get_cleaned_pm_recipients(val);
         $(this).val(recipients.join(", "));

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -230,7 +230,7 @@ function handle_keydown(e) {
             // takes the typeaheads a little time to open after the user finishes typing, which
             // can lead to the focus moving without the autocomplete having a chance to happen.
             if (nextFocus) {
-                $(nextFocus).focus();
+                $(nextFocus).trigger("focus");
                 nextFocus = false;
             }
 
@@ -254,7 +254,7 @@ function handle_keyup(e) {
     if (code === 13 || (code === 9 && !e.shiftKey)) {
         // Enter key or tab key
         if (nextFocus) {
-            $(nextFocus).focus();
+            $(nextFocus).trigger("focus");
             nextFocus = false;
         }
     }
@@ -272,7 +272,7 @@ function select_on_focus(field_id) {
         }
         in_handler = true;
         $("#" + field_id)
-            .select()
+            .trigger("select")
             .one("mouseup", (e) => {
                 e.preventDefault();
             });
@@ -802,7 +802,7 @@ const show_flatpickr = (element, callback, default_timestamp) => {
         instance.destroy();
     });
     instance.open();
-    container.find(".flatpickr-monthDropdown-months").focus();
+    container.find(".flatpickr-monthDropdown-months").trigger("focus");
 };
 
 exports.content_typeahead_selected = function (item, event) {
@@ -1077,7 +1077,7 @@ exports.initialize = function () {
 
         // Refocus in the content box so you can continue typing or
         // press Enter to send.
-        $("#compose-textarea").focus();
+        $("#compose-textarea").trigger("focus");
 
         return channel.post({
             url: "/json/users/me/enter-sends",

--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -329,7 +329,7 @@ exports.paste_handler = function (event) {
 };
 
 exports.initialize = function () {
-    $("#compose-textarea").bind("paste", exports.paste_handler);
+    $("#compose-textarea").on("paste", exports.paste_handler);
     $("body").on("paste", "#message_edit_form", exports.paste_handler);
 };
 

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -378,7 +378,7 @@ exports.launch = function () {
 function activate_element(elem) {
     $(".draft-info-box").removeClass("active");
     $(elem).expectOne().addClass("active");
-    elem.focus();
+    elem.trigger("focus");
 }
 
 function drafts_initialize_focus(event_name) {

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -532,7 +532,7 @@ exports.initialize = function () {
 
     set_count(Object.keys(draft_model.get()).length);
 
-    $("#compose-textarea").focusout(exports.update_draft);
+    $("#compose-textarea").on("focusout", exports.update_draft);
 
     $("body").on("focus", ".draft-info-box", (e) => {
         activate_element(e.target);

--- a/static/js/dropdown_list_widget.js
+++ b/static/js/dropdown_list_widget.js
@@ -60,7 +60,7 @@ const DropdownListWidget = function (opts) {
             const value = $(this).attr("data-value");
             update(value);
         });
-        $(`#${opts.container_id} .dropdown_list_reset_button`).click((e) => {
+        $(`#${opts.container_id} .dropdown_list_reset_button`).on("click", (e) => {
             update(opts.null_value);
             e.preventDefault();
         });
@@ -85,22 +85,22 @@ const DropdownListWidget = function (opts) {
             },
             simplebar_container: $(`#${opts.container_id} .dropdown-list-wrapper`),
         });
-        $(`#${opts.container_id} .dropdown-search`).click((e) => {
+        $(`#${opts.container_id} .dropdown-search`).on("click", (e) => {
             e.stopPropagation();
         });
 
-        dropdown_toggle.click(() => {
+        dropdown_toggle.on("click", () => {
             search_input.val("").trigger("input");
         });
 
-        dropdown_toggle.focus((e) => {
+        dropdown_toggle.on("focus", (e) => {
             // On opening a Bootstrap Dropdown, the parent element recieves focus.
             // Here, we want our search input to have focus instead.
             e.preventDefault();
             search_input.focus();
         });
 
-        search_input.keydown((e) => {
+        search_input.on("keydown", (e) => {
             if (!/(38|40|27)/.test(e.keyCode)) {
                 return;
             }

--- a/static/js/dropdown_list_widget.js
+++ b/static/js/dropdown_list_widget.js
@@ -97,7 +97,7 @@ const DropdownListWidget = function (opts) {
             // On opening a Bootstrap Dropdown, the parent element recieves focus.
             // Here, we want our search input to have focus instead.
             e.preventDefault();
-            search_input.focus();
+            search_input.trigger("focus");
         });
 
         search_input.on("keydown", (e) => {

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -265,7 +265,7 @@ function process_enter_while_filtering(e) {
         const first_emoji = get_rendered_emoji(0, 0);
         if (first_emoji) {
             if (is_composition(first_emoji)) {
-                first_emoji.click();
+                first_emoji.trigger("click");
             } else {
                 toggle_reaction(first_emoji.attr("data-emoji-name"), e);
             }
@@ -318,10 +318,10 @@ function maybe_change_focused_emoji($emoji_map, next_section, next_index, preser
         current_section = next_section;
         current_index = next_index;
         if (!preserve_scroll) {
-            next_emoji.focus();
+            next_emoji.trigger("focus");
         } else {
             const start = ui.get_scroll_element($emoji_map).scrollTop();
-            next_emoji.focus();
+            next_emoji.trigger("focus");
             if (ui.get_scroll_element($emoji_map).scrollTop() !== start) {
                 ui.get_scroll_element($emoji_map).scrollTop(start);
             }
@@ -380,7 +380,7 @@ function get_next_emoji_coordinates(move_by) {
 }
 
 function change_focus_to_filter() {
-    $(".emoji-popover-filter").focus();
+    $(".emoji-popover-filter").trigger("focus");
     // If search is active reset current selected emoji to first emoji.
     if (search_is_active) {
         current_section = 0;
@@ -407,7 +407,7 @@ exports.navigate = function (event_name, e) {
 
     if (event_name === "enter") {
         if (is_composition(e.target)) {
-            e.target.click();
+            e.target.trigger("click");
         } else {
             toggle_selected_emoji(e);
         }
@@ -426,7 +426,7 @@ exports.navigate = function (event_name, e) {
         const filter_text = $(".emoji-popover-filter").val();
         const is_cursor_at_end = $(".emoji-popover-filter").caret() === filter_text.length;
         if (event_name === "down_arrow" || (is_cursor_at_end && event_name === "right_arrow")) {
-            selected_emoji.focus();
+            selected_emoji.trigger("focus");
             if (current_section === 0 && current_index < 6) {
                 ui.get_scroll_element($emoji_map).scrollTop(0);
             }
@@ -434,7 +434,7 @@ exports.navigate = function (event_name, e) {
             return true;
         }
         if (event_name === "tab") {
-            selected_emoji.focus();
+            selected_emoji.trigger("focus");
             update_emoji_showcase(selected_emoji);
             return true;
         }
@@ -451,7 +451,7 @@ exports.navigate = function (event_name, e) {
             // goes to beginning) with something reasonable and
             // consistent (cursor goes to the end of the filter
             // string).
-            $(".emoji-popover-filter").focus().caret(Infinity);
+            $(".emoji-popover-filter").trigger("focus").caret(Infinity);
             ui.get_scroll_element($emoji_map).scrollTop(0);
             ui.get_scroll_element($(".emoji-search-results-container")).scrollTop(0);
             current_section = 0;
@@ -608,7 +608,7 @@ exports.render_emoji_popover = function (elt, id) {
     elt.prop("title", i18n.t("Add emoji reaction (:)"));
 
     const popover = elt.data("popover").$tip;
-    popover.find(".emoji-popover-filter").focus();
+    popover.find(".emoji-popover-filter").trigger("focus");
     current_message_emoji_popover_elem = elt;
 
     emoji_catalog_last_coordinates = {

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -560,9 +560,9 @@ function register_popover_events(popover) {
     });
 
     $(".emoji-popover-filter").on("input", filter_emojis);
-    $(".emoji-popover-filter").keydown(process_enter_while_filtering);
-    $(".emoji-popover").keypress(process_keypress);
-    $(".emoji-popover").keydown((e) => {
+    $(".emoji-popover-filter").on("keydown", process_enter_while_filtering);
+    $(".emoji-popover").on("keypress", process_keypress);
+    $(".emoji-popover").on("keydown", (e) => {
         // Because of cross-browser issues we need to handle backspace
         // key separately. Firefox fires `keypress` event for backspace
         // key but chrome doesn't so we need to trigger the logic for

--- a/static/js/feedback_widget.js
+++ b/static/js/feedback_widget.js
@@ -70,7 +70,7 @@ function set_up_handlers() {
     meta.handlers_set = true;
 
     // if the user mouses over the notification, don't hide it.
-    meta.$container.mouseenter(() => {
+    meta.$container.on("mouseenter", () => {
         if (!meta.opened) {
             return;
         }
@@ -79,7 +79,7 @@ function set_up_handlers() {
     });
 
     // once the user's mouse leaves the notification, restart the countdown.
-    meta.$container.mouseleave(() => {
+    meta.$container.on("mouseleave", () => {
         if (!meta.opened) {
             return;
         }

--- a/static/js/gear_menu.js
+++ b/static/js/gear_menu.js
@@ -120,9 +120,9 @@ exports.initialize = function () {
 };
 
 exports.open = function () {
-    $("#settings-dropdown").click();
+    $("#settings-dropdown").trigger("click");
     // there are invisible li tabs, which should not be clicked.
-    $("#gear-menu").find("li:not(.invisible) a").eq(0).focus();
+    $("#gear-menu").find("li:not(.invisible) a").eq(0).trigger("focus");
 };
 
 exports.is_open = function () {

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -793,7 +793,7 @@ exports.process_keydown = function (e) {
     return exports.process_hotkey(e, hotkey);
 };
 
-$(document).keydown((e) => {
+$(document).on("keydown", (e) => {
     if (exports.process_keydown(e)) {
         e.preventDefault();
     }
@@ -807,7 +807,7 @@ exports.process_keypress = function (e) {
     return exports.process_hotkey(e, hotkey);
 };
 
-$(document).keypress((e) => {
+$(document).on("keypress", (e) => {
     if (exports.process_keypress(e)) {
         e.preventDefault();
     }

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -231,10 +231,10 @@ exports.process_escape_key = function (e) {
         }
 
         if ($("#searchbox").has(":focus")) {
-            $("input:focus,textarea:focus").blur();
+            $("input:focus,textarea:focus").trigger("blur");
             if (page_params.search_pills_enabled) {
-                $("#searchbox .pill").blur();
-                $("#searchbox #search_query").blur();
+                $("#searchbox .pill").trigger("blur");
+                $("#searchbox #search_query").trigger("blur");
             } else {
                 tab_bar.exit_search();
             }
@@ -243,7 +243,7 @@ exports.process_escape_key = function (e) {
 
         // We pressed Esc and something was focused, and the composebox
         // wasn't open. In that case, we should blur the input.
-        $("input:focus,textarea:focus").blur();
+        $("input:focus,textarea:focus").trigger("blur");
         return true;
     }
 
@@ -272,12 +272,12 @@ exports.process_enter_key = function (e) {
         // on #gear-menu li a[tabindex] elements, force a click and prevent default.
         // this is because these links do not have an href and so don't force a
         // default action.
-        e.target.click();
+        e.target.trigger("click");
         return true;
     }
 
     if (hotspots.is_open()) {
-        $(e.target).find(".hotspot.overlay.show .hotspot-confirm").click();
+        $(e.target).find(".hotspot.overlay.show .hotspot-confirm").trigger("click");
         return false;
     }
 
@@ -286,7 +286,7 @@ exports.process_enter_key = function (e) {
     }
 
     if (exports.in_content_editable_widget(e)) {
-        $(e.target).parent().find(".checkmark").click();
+        $(e.target).parent().find(".checkmark").trigger("click");
         return false;
     }
 
@@ -359,14 +359,14 @@ exports.process_tab_key = function () {
     if (focused_message_edit_content.length > 0) {
         message_edit_form = focused_message_edit_content.closest(".message_edit_form");
         // Open message edit forms either have a save button or a close button, but not both.
-        message_edit_form.find(".message_edit_save,.message_edit_close").focus();
+        message_edit_form.find(".message_edit_save,.message_edit_close").trigger("focus");
         return true;
     }
 
     const focused_message_edit_save = $(".message_edit_save").filter(":focus");
     if (focused_message_edit_save.length > 0) {
         message_edit_form = focused_message_edit_save.closest(".message_edit_form");
-        message_edit_form.find(".message_edit_cancel").focus();
+        message_edit_form.find(".message_edit_cancel").trigger("focus");
         return true;
     }
 
@@ -391,7 +391,7 @@ exports.process_shift_tab_key = function () {
 
     // Shift-tabbing from the edit message cancel button takes you to save.
     if ($(".message_edit_cancel").filter(":focus").length > 0) {
-        $(".message_edit_save").focus();
+        $(".message_edit_save").trigger("focus");
         return true;
     }
 
@@ -401,7 +401,7 @@ exports.process_shift_tab_key = function () {
         focused_message_edit_save
             .closest(".message_edit_form")
             .find(".message_edit_content")
-            .focus();
+            .trigger("focus");
         return true;
     }
 

--- a/static/js/info_overlay.js
+++ b/static/js/info_overlay.js
@@ -14,7 +14,7 @@ exports.set_up_toggler = function () {
         callback: function (name, key) {
             $(".overlay-modal").hide();
             $("#" + key).show();
-            ui.get_scroll_element($("#" + key).find(".modal-body")).focus();
+            ui.get_scroll_element($("#" + key).find(".modal-body")).trigger("focus");
         },
     };
 

--- a/static/js/input_pill.js
+++ b/static/js/input_pill.js
@@ -280,7 +280,7 @@ exports.create = function (opts) {
             // below that handles events on the ".pill" class.
             if (char === KEY.LEFT_ARROW) {
                 if (window.getSelection().anchorOffset === 0) {
-                    store.$parent.find(".pill").last().focus();
+                    store.$parent.find(".pill").last().trigger("focus");
                 }
             }
 
@@ -306,14 +306,14 @@ exports.create = function (opts) {
             const $pill = store.$parent.find(".pill:focus");
 
             if (char === KEY.LEFT_ARROW) {
-                $pill.prev().focus();
+                $pill.prev().trigger("focus");
             } else if (char === KEY.RIGHT_ARROW) {
-                $pill.next().focus();
+                $pill.next().trigger("focus");
             } else if (char === KEY.BACKSPACE) {
                 const $next = $pill.next();
                 const id = $pill.data("id");
                 funcs.removePill(id);
-                $next.focus();
+                $next.trigger("focus");
                 // the "backspace" key in FireFox will go back a page if you do
                 // not prevent it.
                 e.preventDefault();
@@ -351,12 +351,12 @@ exports.create = function (opts) {
             const id = $pill.data("id");
 
             funcs.removePill(id);
-            $next.focus();
+            $next.trigger("focus");
         });
 
         store.$parent.on("click", function (e) {
             if ($(e.target).is(".pill-container")) {
-                $(this).find(".input").focus();
+                $(this).find(".input").trigger("focus");
             }
         });
 

--- a/static/js/invite.js
+++ b/static/js/invite.js
@@ -152,7 +152,7 @@ function prepare_form_to_be_shown() {
 exports.launch = function () {
     $("#submit-invitation").button();
     prepare_form_to_be_shown();
-    autosize($("#invitee_emails").focus());
+    autosize($("#invitee_emails").trigger("focus"));
 
     overlays.open_overlay({
         name: "invite",

--- a/static/js/keydown_util.js
+++ b/static/js/keydown_util.js
@@ -11,7 +11,7 @@ const keys = {
 };
 
 exports.handle = function (opts) {
-    opts.elem.keydown((e) => {
+    opts.elem.on("keydown", (e) => {
         const key = e.which || e.keyCode;
 
         if (e.altKey || e.ctrlKey || e.shiftKey) {

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -253,11 +253,11 @@ exports.parse_image_data = function (image) {
 };
 
 exports.prev = function () {
-    $(".image-list .image.selected").prev().click();
+    $(".image-list .image.selected").prev().trigger("click");
 };
 
 exports.next = function () {
-    $(".image-list .image.selected").next().click();
+    $(".image-list .image.selected").next().trigger("click");
 };
 
 // this is a block of events that are required for the lightbox to work.
@@ -332,7 +332,7 @@ exports.initialize = function () {
     });
 
     $("#lightbox_overlay .image-preview").on("dblclick", "img, canvas", (e) => {
-        $("#lightbox_overlay .lightbox-canvas-trigger").click();
+        $("#lightbox_overlay .lightbox-canvas-trigger").trigger("click");
         e.preventDefault();
     });
 

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -271,7 +271,7 @@ exports.initialize = function () {
         exports.open($img);
     });
 
-    $("#lightbox_overlay .download").click(function () {
+    $("#lightbox_overlay .download").on("click", function () {
         this.blur();
     });
 

--- a/static/js/list_cursor.js
+++ b/static/js/list_cursor.js
@@ -33,7 +33,7 @@ const list_cursor = function (opts) {
         // TODO: The list class should probably do more of the work
         //       here, so we're not so coupled to jQuery, and
         //       so we instead just get back a widget we can say
-        //       something like widget.select() on.  This will
+        //       something like widget.trigger("select") on.  This will
         //       be especially important if we do lazy rendering.
         //       It would also give the caller more flexibility on
         //       the actual styling.

--- a/static/js/list_util.js
+++ b/static/js/list_util.js
@@ -8,12 +8,12 @@ exports.inside_list = function (e) {
 
 exports.go_down = function (e) {
     const $target = $(e.target);
-    $target.closest("li").next().find("a").focus();
+    $target.closest("li").next().find("a").trigger("focus");
 };
 
 exports.go_up = function (e) {
     const $target = $(e.target);
-    $target.closest("li").prev().find("a").focus();
+    $target.closest("li").prev().find("a").trigger("focus");
 };
 
 window.list_util = exports;

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -162,7 +162,7 @@ exports.show_topic_edit_spinner = function (row) {
 exports.end_if_focused_on_inline_topic_edit = function () {
     const focused_elem = $(".topic_edit_form").find(":focus");
     if (focused_elem.length === 1) {
-        focused_elem.blur();
+        focused_elem.trigger("blur");
         const recipient_row = focused_elem.closest(".recipient_row");
         exports.end_inline_topic_edit(recipient_row);
     }
@@ -171,7 +171,7 @@ exports.end_if_focused_on_inline_topic_edit = function () {
 exports.end_if_focused_on_message_row_edit = function () {
     const focused_elem = $(".message_edit").find(":focus");
     if (focused_elem.length === 1) {
-        focused_elem.blur();
+        focused_elem.trigger("blur");
         const row = focused_elem.closest(".message_row");
         exports.end_message_row_edit(row);
     }
@@ -425,14 +425,14 @@ function edit_message(row, raw_content) {
     }
 
     if (!is_editable) {
-        row.find(".message_edit_close").focus();
+        row.find(".message_edit_close").trigger("focus");
     } else if (message.type === "stream" && message.topic === compose.empty_topic_placeholder()) {
         message_edit_topic.val("");
-        message_edit_topic.focus();
+        message_edit_topic.trigger("focus");
     } else if (editability === editability_types.TOPIC_ONLY) {
-        row.find(".message_edit_topic").focus();
+        row.find(".message_edit_topic").trigger("focus");
     } else {
-        message_edit_content.focus();
+        message_edit_content.trigger("focus");
         // Put cursor at end of input.
         const contents = message_edit_content.val();
         message_edit_content.val("");
@@ -525,7 +525,7 @@ exports.start_topic_edit = function (recipient_row) {
     if (topic === compose.empty_topic_placeholder()) {
         topic = "";
     }
-    form.find(".inline_topic_edit").val(topic).select().focus();
+    form.find(".inline_topic_edit").val(topic).trigger("select").trigger("focus");
 };
 
 exports.is_editing = function (id) {
@@ -561,7 +561,7 @@ exports.end_message_row_edit = function (row) {
 
     // We have to blur out text fields, or else hotkeys.js
     // thinks we are still editing.
-    row.find(".message_edit").blur();
+    row.find(".message_edit").trigger("blur");
 };
 
 exports.save_inline_topic_edit = function (row) {
@@ -812,7 +812,7 @@ exports.edit_last_sent_message = function () {
     // Finally do the real work!
     compose_actions.cancel();
     exports.start(msg_row, () => {
-        $("#message_edit_content").focus();
+        $("#message_edit_content").trigger("focus");
     });
 };
 

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -312,7 +312,7 @@ function edit_message(row, raw_content) {
     currently_editing_messages.set(message.id, edit_obj);
     current_msg_list.show_edit_message(row, edit_obj);
 
-    form.keydown(handle_message_row_edit_keydown);
+    form.on("keydown", handle_message_row_edit_keydown);
 
     upload.feature_check($("#attach_files_" + rows.id(row)));
 
@@ -326,7 +326,7 @@ function edit_message(row, raw_content) {
     const copy_message = row.find(".copy_message");
 
     ui_util.decorate_stream_bar(message.stream, stream_header_colorblock, false);
-    message_edit_stream.change(function () {
+    message_edit_stream.on("change", function () {
         const stream_name = stream_data.maybe_get_stream_name(parseInt(this.value, 10));
         ui_util.decorate_stream_bar(stream_name, stream_header_colorblock, false);
     });
@@ -459,7 +459,7 @@ function edit_message(row, raw_content) {
     }
 
     if (!message.locally_echoed) {
-        message_edit_topic.keyup(() => {
+        message_edit_topic.on("keyup", () => {
             set_propagate_selector_display();
         });
 
@@ -518,7 +518,7 @@ exports.start = function (row, edit_box_open_callback) {
 exports.start_topic_edit = function (recipient_row) {
     const form = $(render_topic_edit_form());
     current_msg_list.show_edit_topic_on_recipient_row(recipient_row, form);
-    form.keydown(handle_inline_topic_edit_keydown);
+    form.on("keydown", handle_inline_topic_edit_keydown);
     const msg_id = rows.id_for_recipient_row(recipient_row);
     const message = current_msg_list.get(msg_id);
     let topic = message.topic;

--- a/static/js/message_scroll.js
+++ b/static/js/message_scroll.js
@@ -152,7 +152,8 @@ function scroll_finish() {
 }
 
 exports.initialize = function () {
-    message_viewport.message_pane.scroll(
+    message_viewport.message_pane.on(
+        "scroll",
         _.throttle(() => {
             unread_ops.process_visible();
             scroll_finish();

--- a/static/js/message_viewport.js
+++ b/static/js/message_viewport.js
@@ -444,7 +444,7 @@ exports.initialize = function () {
     jwindow = $(window);
     exports.message_pane = $(".app");
     // This handler must be placed before all resize handlers in our application
-    jwindow.resize(() => {
+    jwindow.on("resize", () => {
         dimensions.height.reset();
         dimensions.width.reset();
         top_of_feed.reset();

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -411,7 +411,7 @@ function process_notification(notification) {
                 if (message.type !== "test-notification") {
                     narrow.by_topic(message.id, {trigger: "notification"});
                 }
-                window.focus();
+                window.trigger("focus");
             });
             notification_object.addEventListener("close", () => {
                 notice_memory.delete(key);

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -64,7 +64,7 @@ function get_audio_file_path(audio_element, audio_file_without_extension) {
 
 exports.initialize = function () {
     $(window)
-        .focus(() => {
+        .on("focus", () => {
             window_has_focus = true;
 
             for (const notice_mem_entry of notice_memory.values()) {
@@ -76,7 +76,7 @@ exports.initialize = function () {
             // counts.
             unread_ops.process_visible();
         })
-        .blur(() => {
+        .on("blur", () => {
             window_has_focus = false;
         });
 

--- a/static/js/poll_widget.js
+++ b/static/js/poll_widget.js
@@ -222,7 +222,7 @@ exports.activate = function (opts) {
         const question = poll_data.get_question();
         elem.find("input.poll-question").val(question);
         render_question();
-        elem.find("input.poll-question").focus();
+        elem.find("input.poll-question").trigger("focus");
     }
 
     function abort_edit() {
@@ -268,7 +268,7 @@ exports.activate = function (opts) {
             return;
         }
 
-        poll_option_input.val("").focus();
+        poll_option_input.val("").trigger("focus");
 
         const data = poll_data.handle.new_option.outbound(option);
         callback(data);

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -562,7 +562,7 @@ function focus_first_popover_item(items) {
         return;
     }
 
-    items.eq(0).expectOne().focus();
+    items.eq(0).expectOne().trigger("focus");
 }
 
 function popover_items_handle_keyboard(key, items) {
@@ -573,7 +573,7 @@ function popover_items_handle_keyboard(key, items) {
     let index = items.index(items.filter(":focus"));
 
     if (key === "enter" && index >= 0 && index < items.length) {
-        return items[index].click();
+        return items[index].trigger("click");
     }
     if (index === -1) {
         index = 0;
@@ -582,7 +582,7 @@ function popover_items_handle_keyboard(key, items) {
     } else if ((key === "up_arrow" || key === "vim_up") && index > 0) {
         index -= 1;
     }
-    items.eq(index).focus();
+    items.eq(index).trigger("focus");
 }
 
 function focus_first_action_popover_item() {
@@ -1035,7 +1035,7 @@ exports.register_click_handlers = function () {
 
         exports.hide_actions_popover();
         message_edit_history.show_history(message);
-        message_history_cancel_btn.focus();
+        message_history_cancel_btn.trigger("focus");
         e.stopPropagation();
         e.preventDefault();
     });
@@ -1083,7 +1083,7 @@ exports.register_click_handlers = function () {
         setTimeout(() => {
             // The Cliboard library works by focusing to a hidden textarea.
             // We unfocus this so keyboard shortcuts, etc., will work again.
-            $(":focus").blur();
+            $(":focus").trigger("blur");
         }, 0);
 
         e.stopPropagation();

--- a/static/js/portico/confirm-preregistrationuser.js
+++ b/static/js/portico/confirm-preregistrationuser.js
@@ -1,3 +1,3 @@
 $(() => {
-    $("#register").submit();
+    $("#register").trigger("submit");
 });

--- a/static/js/portico/email_log.js
+++ b/static/js/portico/email_log.js
@@ -1,7 +1,7 @@
 $(() => {
     // This code will be executed when the user visits /emails in
     // development mode and email_log.html is rendered.
-    $("#toggle").change(() => {
+    $("#toggle").on("change", () => {
         if ($(".email-text").css("display") === "none") {
             $(".email-text").each(function () {
                 $(this).css("display", "block");

--- a/static/js/portico/header.js
+++ b/static/js/portico/header.js
@@ -4,7 +4,7 @@ $(() => {
         return false;
     });
 
-    $("body").click((e) => {
+    $("body").on("click", (e) => {
         const $this = $(e.target);
 
         if (

--- a/static/js/portico/header.js
+++ b/static/js/portico/header.js
@@ -1,6 +1,6 @@
 $(() => {
     $(".portico-header li.logout").on("click", () => {
-        $("#logout_form").submit();
+        $("#logout_form").trigger("submit");
         return false;
     });
 

--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -6,7 +6,7 @@ function registerCodeSection($codeSection) {
     const $li = $codeSection.find("ul.nav li");
     const $blocks = $codeSection.find(".blocks div");
 
-    $li.click(function () {
+    $li.on("click", function () {
         const language = this.dataset.language;
 
         $li.removeClass("active");
@@ -99,7 +99,7 @@ const update_page = function (html_map, path) {
 
 new SimpleBar($(".sidebar")[0]);
 
-$(".sidebar.slide h2").click((e) => {
+$(".sidebar.slide h2").on("click", (e) => {
     const $next = $(e.target).next();
 
     if ($next.is("ul")) {
@@ -110,7 +110,7 @@ $(".sidebar.slide h2").click((e) => {
     }
 });
 
-$(".sidebar a").click(function (e) {
+$(".sidebar a").on("click", function (e) {
     const path = $(this).attr("href");
     const path_dir = path.split("/")[1];
     const current_dir = window.location.pathname.split("/")[1];
@@ -150,11 +150,11 @@ $(document).on(
     },
 );
 
-$(".hamburger").click(() => {
+$(".hamburger").on("click", () => {
     $(".sidebar").toggleClass("show");
 });
 
-$(".markdown").click(() => {
+$(".markdown").on("click", () => {
     if ($(".sidebar.show").length) {
         $(".sidebar.show").toggleClass("show");
     }

--- a/static/js/portico/integrations.js
+++ b/static/js/portico/integrations.js
@@ -323,7 +323,7 @@ function toggle_categories_dropdown() {
 }
 
 function integration_events() {
-    $('#integration-search input[type="text"]').keypress((e) => {
+    $('#integration-search input[type="text"]').on("keypress", (e) => {
         const integrations = $(".integration-lozenges").children().toArray();
         if (e.which === 13 && e.target.value !== "") {
             for (let i = 0; i < integrations.length; i += 1) {
@@ -337,7 +337,7 @@ function integration_events() {
         }
     });
 
-    $(".integration-categories-dropdown .dropdown-toggle").click(() => {
+    $(".integration-categories-dropdown .dropdown-toggle").on("click", () => {
         toggle_categories_dropdown();
     });
 
@@ -375,7 +375,7 @@ function integration_events() {
             dispatch("UPDATE_QUERY", {query: e.target.value.toLowerCase()});
         });
 
-    $(window).scroll(() => {
+    $(window).on("scroll", () => {
         if (document.body.scrollTop > 330) {
             $(".integration-categories-sidebar").addClass("sticky");
         } else {

--- a/static/js/portico/integrations.js
+++ b/static/js/portico/integrations.js
@@ -330,7 +330,7 @@ function integration_events() {
                 const integration = $(integrations[i]).find(".integration-lozenge");
 
                 if ($(integration).css("display") !== "none") {
-                    $(integration).closest("a")[0].click();
+                    $(integration).closest("a")[0].trigger("click");
                     break;
                 }
             }
@@ -370,7 +370,7 @@ function integration_events() {
     // combine selector use for both focusing the integrations searchbar and adding
     // the input event.
     $(".integrations .searchbar input[type='text']")
-        .focus()
+        .trigger("focus")
         .on("input", (e) => {
             dispatch("UPDATE_QUERY", {query: e.target.value.toLowerCase()});
         });

--- a/static/js/portico/integrations_dev_panel.js
+++ b/static/js/portico/integrations_dev_panel.js
@@ -341,7 +341,7 @@ $(() => {
         potential_default_bot.selected = true;
     }
 
-    $("#integration_name").change(function () {
+    $("#integration_name").on("change", function () {
         clear_elements(["custom_http_headers", "fixture_body", "fixture_name", "results_notice"]);
         const integration_name = $(this).children("option:selected").val();
         get_fixtures(integration_name);
@@ -349,27 +349,27 @@ $(() => {
         return;
     });
 
-    $("#fixture_name").change(function () {
+    $("#fixture_name").on("change", function () {
         clear_elements(["fixture_body", "results_notice"]);
         const fixture_name = $(this).children("option:selected").val();
         load_fixture_body(fixture_name);
         return;
     });
 
-    $("#send_fixture_button").click(() => {
+    $("#send_fixture_button").on("click", () => {
         send_webhook_fixture_message();
         return;
     });
 
-    $("#send_all_fixtures_button").click(() => {
+    $("#send_all_fixtures_button").on("click", () => {
         clear_elements(["results_notice"]);
         send_all_fixture_messages();
         return;
     });
 
-    $("#bot_name").change(update_url);
+    $("#bot_name").on("change", update_url);
 
-    $("#stream_name").change(update_url);
+    $("#stream_name").on("change", update_url);
 
-    $("#topic_name").change(update_url);
+    $("#topic_name").on("change", update_url);
 });

--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -8,7 +8,7 @@ export function path_parts() {
 
 const hello_events = function () {
     let counter = 0;
-    $(window).scroll(function () {
+    $(window).on("scroll", function () {
         if (counter % 2 === 0) {
             $(".screen.hero-screen .message-feed").css(
                 "transform",
@@ -149,7 +149,7 @@ const apps_events = function () {
         google_analytics.config({page_path: window.location.pathname});
     });
 
-    $(".apps a .icon").click((e) => {
+    $(".apps a .icon").on("click", (e) => {
         const next_version = $(e.target).closest("a").attr("href").replace("/apps/", "");
         version = next_version;
 
@@ -175,7 +175,7 @@ const events = function () {
 
     $("[data-on-page='" + location + "']").addClass("active");
 
-    $("body").click((e) => {
+    $("body").on("click", (e) => {
         const $e = $(e.target);
 
         if ($e.is("nav ul .exit")) {
@@ -187,7 +187,7 @@ const events = function () {
         }
     });
 
-    $(".hamburger").click((e) => {
+    $(".hamburger").on("click", (e) => {
         $("nav ul").addClass("show");
         e.stopPropagation();
     });
@@ -209,7 +209,7 @@ const load = function () {
     });
 
     // Move to the next slide on clicking inside the carousel container
-    $(".carousel-inner .item-container").click(function (e) {
+    $(".carousel-inner .item-container").on("click", function (e) {
         const get_tag_name = e.target.tagName.toLowerCase();
         const is_button = get_tag_name === "button";
         const is_link = get_tag_name === "a";

--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -81,7 +81,7 @@ $(() => {
     // Code in this block will be executed when the /accounts/send_confirm
     // endpoint is visited i.e. accounts_send_confirm.html is rendered.
     if ($("[data-page-id='accounts-send-confirm']").length > 0) {
-        $("#resend_email_link").click(() => {
+        $("#resend_email_link").on("click", () => {
             $(".resend_confirm").submit();
         });
     }
@@ -134,7 +134,7 @@ $(() => {
         $("#subdomain_section")[action]();
     };
 
-    $("#realm_in_root_domain").change(function () {
+    $("#realm_in_root_domain").on("change", function () {
         show_subdomain_section($(this).is(":checked"));
     });
 
@@ -188,7 +188,7 @@ $(() => {
         }
     }
 
-    $("#source_realm_select").change(update_full_name_section);
+    $("#source_realm_select").on("change", update_full_name_section);
     update_full_name_section();
 
     let timer;

--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -82,7 +82,7 @@ $(() => {
     // endpoint is visited i.e. accounts_send_confirm.html is rendered.
     if ($("[data-page-id='accounts-send-confirm']").length > 0) {
         $("#resend_email_link").on("click", () => {
-            $(".resend_confirm").submit();
+            $(".resend_confirm").trigger("submit");
         });
     }
 

--- a/static/js/portico/team.js
+++ b/static/js/portico/team.js
@@ -58,7 +58,7 @@ export default function render_tabs() {
         // Set as the loading template for now, and load when clicked.
         $("#tab-" + repo).html($("#loading-template").html());
 
-        $("#" + repo).click(() => {
+        $("#" + repo).on("click", () => {
             if (!loaded_repos.includes(repo)) {
                 const html = _.chain(contributors_list)
                     .filter(repo)

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -34,7 +34,7 @@ function set_default_focus() {
     // If at any point we are confused about the currently
     // focused element, we switch focus to search.
     current_focus_elem = $("#recent_topics_search");
-    current_focus_elem.focus();
+    current_focus_elem.trigger("focus");
 }
 
 function set_table_focus(row, col) {
@@ -46,7 +46,7 @@ function set_table_focus(row, col) {
         return true;
     }
 
-    topic_rows.eq(row).find(".recent_topics_focusable").eq(col).children().focus();
+    topic_rows.eq(row).find(".recent_topics_focusable").eq(col).children().trigger("focus");
     current_focus_elem = "table";
     return true;
 }
@@ -72,7 +72,7 @@ function revive_current_focus() {
         current_focus_elem = $("#recent_topics_filter_buttons").find(
             "[data-filter='" + filter_button + "']",
         );
-        current_focus_elem.focus();
+        current_focus_elem.trigger("focus");
     }
     return true;
 }
@@ -505,7 +505,7 @@ exports.change_focused_element = function (e, input_key) {
                 return true;
             case "click":
                 // Note: current_focus_elem can be different here, so we just
-                // set current_focus_elem to the input box, we don't want .focus() on
+                // set current_focus_elem to the input box, we don't want .trigger("focus") on
                 // it since it is already focused.
                 // We only do this for search beacuse we don't want the focus to
                 // go away from the input box when `revive_current_focus` is called
@@ -560,7 +560,7 @@ exports.change_focused_element = function (e, input_key) {
         return true;
     }
     if (current_focus_elem) {
-        current_focus_elem.focus();
+        current_focus_elem.trigger("focus");
     }
 
     return true;

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -121,7 +121,7 @@ exports.initialize = function () {
     });
 
     searchbox_form
-        .keydown((e) => {
+        .on("keydown", (e) => {
             exports.update_button_visibility();
             const code = e.which;
             if (code === 13 && search_query_box.is(":focus")) {
@@ -131,7 +131,7 @@ exports.initialize = function () {
                 return false;
             }
         })
-        .keyup((e) => {
+        .on("keyup", (e) => {
             if (exports.is_using_input_method) {
                 exports.is_using_input_method = false;
                 return;

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -32,7 +32,7 @@ exports.narrow_or_search_for_term = function (search_string) {
     // Narrowing will have already put some operators in the search box,
     // so leave the current text in.
     if (!page_params.search_pills_enabled) {
-        search_query_box.blur();
+        search_query_box.trigger("blur");
     }
     return search_query_box.val();
 };
@@ -147,7 +147,7 @@ exports.initialize = function () {
 
                 // Pill is already added during keydown event of input pills.
                 exports.narrow_or_search_for_term(search_query_box.val());
-                search_query_box.blur();
+                search_query_box.trigger("blur");
                 update_buttons_with_focus(false);
             }
         });
@@ -211,14 +211,14 @@ exports.initiate_search = function () {
     $("#searchbox").css({"box-shadow": "inset 0px 0px 0px 2px hsl(204, 20%, 74%)"});
     $("#search_query").typeahead("lookup").select();
     if (page_params.search_pills_enabled) {
-        $("#search_query").focus();
+        $("#search_query").trigger("focus");
         ui_util.place_caret_at_end($("#search_query")[0]);
     }
 };
 
 exports.clear_search_form = function () {
     $("#search_query").val("");
-    $("#search_query").blur();
+    $("#search_query").trigger("blur");
     $(".search_button").prop("disabled", true);
 };
 

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -2,7 +2,7 @@ const settings_config = require("./settings_config");
 const render_settings_tab = require("../templates/settings_tab.hbs");
 
 $("body").ready(() => {
-    $("#settings_overlay_container").click((e) => {
+    $("#settings_overlay_container").on("click", (e) => {
         if (!overlays.is_modal_open()) {
             return;
         }

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -362,7 +362,7 @@ exports.set_up = function () {
         });
     });
 
-    $("#api_key_button").click((e) => {
+    $("#api_key_button").on("click", (e) => {
         setup_api_key_modal();
         overlays.open_modal("#api_key_modal");
         e.preventDefault();

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -227,7 +227,7 @@ exports.set_up = function () {
     $("#config_inputbox").children().hide();
     $("[name*='" + selected_embedded_bot + "']").show();
 
-    $("#download_botserverrc").click(function () {
+    $("#download_botserverrc").on("click", function () {
         const OUTGOING_WEBHOOK_BOT_TYPE_INT = 3;
         let content = "";
 
@@ -547,19 +547,19 @@ exports.set_up = function () {
         },
     });
 
-    $("#bots_lists_navbar .add-a-new-bot-tab").click((e) => {
+    $("#bots_lists_navbar .add-a-new-bot-tab").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();
         focus_tab.add_a_new_bot_tab();
     });
 
-    $("#bots_lists_navbar .active-bots-tab").click((e) => {
+    $("#bots_lists_navbar .active-bots-tab").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();
         focus_tab.active_bots_tab();
     });
 
-    $("#bots_lists_navbar .inactive-bots-tab").click((e) => {
+    $("#bots_lists_navbar .inactive-bots-tab").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();
         focus_tab.inactive_bots_tab();

--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -41,13 +41,13 @@ exports.set_up = function () {
 
     $(".emojiset_choice[value=" + page_params.emojiset + "]").prop("checked", true);
 
-    $("#default_language_modal [data-dismiss]").click(() => {
+    $("#default_language_modal [data-dismiss]").on("click", () => {
         overlays.close_modal("#default_language_modal");
     });
 
     const all_display_settings = settings_config.get_all_display_settings();
     for (const setting of all_display_settings.settings.user_display_settings) {
-        $("#" + setting).change(function () {
+        $("#" + setting).on("change", function () {
             const data = {};
             data[setting] = JSON.stringify($(this).prop("checked"));
 
@@ -66,7 +66,7 @@ exports.set_up = function () {
         });
     }
 
-    $("#default_language_modal .language").click((e) => {
+    $("#default_language_modal .language").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();
         overlays.close_modal("#default_language_modal");
@@ -94,12 +94,12 @@ exports.set_up = function () {
         overlays.open_modal("#default_language_modal");
     });
 
-    $("#demote_inactive_streams").change(function () {
+    $("#demote_inactive_streams").on("change", function () {
         const data = {demote_inactive_streams: this.value};
         change_display_setting(data, "#display-settings-status");
     });
 
-    $("#color_scheme").change(function () {
+    $("#color_scheme").on("change", function () {
         const data = {color_scheme: this.value};
         change_display_setting(data, "#display-settings-status");
     });
@@ -108,16 +108,16 @@ exports.set_up = function () {
         window.location.reload();
     });
 
-    $("#twenty_four_hour_time").change(function () {
+    $("#twenty_four_hour_time").on("change", function () {
         const data = {twenty_four_hour_time: this.value};
         change_display_setting(data, "#time-settings-status");
     });
 
-    $("#user_timezone").change(function () {
+    $("#user_timezone").on("change", function () {
         const data = {timezone: JSON.stringify(this.value)};
         change_display_setting(data, "#time-settings-status");
     });
-    $(".emojiset_choice").click(function () {
+    $(".emojiset_choice").on("click", function () {
         const data = {emojiset: JSON.stringify($(this).val())};
         const current_emojiset = JSON.stringify(page_params.emojiset);
         if (current_emojiset === data.emojiset) {
@@ -140,7 +140,7 @@ exports.set_up = function () {
         });
     });
 
-    $("#translate_emoticons").change(function () {
+    $("#translate_emoticons").on("change", function () {
         const data = {translate_emoticons: JSON.stringify(this.checked)};
         change_display_setting(data, "#emoji-settings-status");
     });

--- a/static/js/settings_invites.js
+++ b/static/js/settings_invites.js
@@ -162,7 +162,7 @@ exports.on_load_success = function (invites_data, initialize_event_handlers) {
         );
         $("#revoke_invite_modal").modal("show");
         $("#do_revoke_invite_button").unbind("click");
-        $("#do_revoke_invite_button").click(do_revoke_invite);
+        $("#do_revoke_invite_button").on("click", do_revoke_invite);
     });
 
     $(".admin_invites_table").on("click", ".resend", (e) => {
@@ -181,7 +181,7 @@ exports.on_load_success = function (invites_data, initialize_event_handlers) {
         $("#resend_invite_modal").modal("show");
     });
 
-    $("#do_resend_invite_button").click(() => {
+    $("#do_resend_invite_button").on("click", () => {
         const modal_invite_id = $("#resend_invite_modal #do_resend_invite_button").attr(
             "data-invite-id",
         );

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -111,20 +111,20 @@ exports.set_up = function () {
 
     update_desktop_icon_count_display();
 
-    $("#send_test_notification").click(() => {
+    $("#send_test_notification").on("click", () => {
         notifications.send_test_notification(
             i18n.t("This is what a Zulip notification looks like."),
         );
     });
 
-    $("#play_notification_sound").click(() => {
+    $("#play_notification_sound").on("click", () => {
         $("#notifications-area").find("audio")[0].play();
     });
 
     const notification_sound_dropdown = $("#notification_sound");
     notification_sound_dropdown.val(page_params.notification_sound);
 
-    $("#enable_sounds, #enable_stream_audible_notifications").change(() => {
+    $("#enable_sounds, #enable_stream_audible_notifications").on("change", () => {
         if (
             $("#enable_stream_audible_notifications").prop("checked") ||
             $("#enable_sounds").prop("checked")

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -865,7 +865,7 @@ exports.build_page = function () {
             $(e.target)
                 .closest(".org-subsection-parent")
                 .find(".subsection-changes-save button")
-                .click();
+                .trigger("click");
         }
     });
 

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -869,7 +869,7 @@ exports.build_page = function () {
         }
     });
 
-    $("#id_realm_msg_edit_limit_setting").change((e) => {
+    $("#id_realm_msg_edit_limit_setting").on("change", (e) => {
         const msg_edit_limit_dropdown_value = e.target.value;
         change_element_block_display_property(
             "id_realm_message_content_edit_limit_minutes",
@@ -877,7 +877,7 @@ exports.build_page = function () {
         );
     });
 
-    $("#id_realm_msg_delete_limit_setting").change((e) => {
+    $("#id_realm_msg_delete_limit_setting").on("change", (e) => {
         const msg_delete_limit_dropdown_value = e.target.value;
         change_element_block_display_property(
             "id_realm_message_content_delete_limit_minutes",
@@ -885,7 +885,7 @@ exports.build_page = function () {
         );
     });
 
-    $("#id_realm_message_retention_setting").change((e) => {
+    $("#id_realm_message_retention_setting").on("change", (e) => {
         const message_retention_setting_dropdown_value = e.target.value;
         change_element_block_display_property(
             "id_realm_message_retention_days",
@@ -893,7 +893,7 @@ exports.build_page = function () {
         );
     });
 
-    $("#id_realm_waiting_period_setting").change(function () {
+    $("#id_realm_waiting_period_setting").on("change", function () {
         const waiting_period_threshold = this.value;
         change_element_block_display_property(
             "id_realm_waiting_period_threshold",
@@ -901,7 +901,7 @@ exports.build_page = function () {
         );
     });
 
-    $("#id_realm_org_join_restrictions").change((e) => {
+    $("#id_realm_org_join_restrictions").on("change", (e) => {
         const org_join_restrictions = e.target.value;
         const node = $("#allowed_domains_label").parent();
         if (org_join_restrictions === "only_selected_domain") {
@@ -914,7 +914,7 @@ exports.build_page = function () {
         }
     });
 
-    $("#id_realm_org_join_restrictions").click((e) => {
+    $("#id_realm_org_join_restrictions").on("click", (e) => {
         // This prevents the disappearance of modal when there are
         // no allowed domains otherwise it gets closed due to
         // the click event handler attached to `#settings_overlay_container`
@@ -945,7 +945,7 @@ exports.build_page = function () {
         });
     });
 
-    $("#submit-add-realm-domain").click(() => {
+    $("#submit-add-realm-domain").on("click", () => {
         const realm_domains_info = $(".realm_domains_info");
         const widget = $("#add-realm-domain-widget");
         const domain = widget.find(".new-realm-domain").val();

--- a/static/js/settings_panel_menu.js
+++ b/static/js/settings_panel_menu.js
@@ -22,7 +22,7 @@ exports.make_menu = function (opts) {
             // In one colum mode want to show the settings list, not the first settings section.
             self.activate_section_or_default(section);
         }
-        curr_li.focus();
+        curr_li.trigger("focus");
     };
 
     self.hide = function () {
@@ -52,12 +52,12 @@ exports.make_menu = function (opts) {
     };
 
     self.prev = function () {
-        curr_li.prevAll(":visible:first").focus().click();
+        curr_li.prevAll(":visible:first").trigger("focus").trigger("click");
         return true;
     };
 
     self.next = function () {
-        curr_li.nextAll(":visible:first").focus().click();
+        curr_li.nextAll(":visible:first").trigger("focus").trigger("click");
         return true;
     };
 
@@ -66,7 +66,7 @@ exports.make_menu = function (opts) {
         const sel = "input:visible,button:visible,select:visible";
         const panel_elem = panel.find(sel).first();
 
-        panel_elem.focus();
+        panel_elem.trigger("focus");
         return true;
     };
 

--- a/static/js/settings_streams.js
+++ b/static/js/settings_streams.js
@@ -99,7 +99,7 @@ exports.build_page = function () {
 
     exports.update_default_streams_table();
 
-    $(".create_default_stream").keypress((e) => {
+    $(".create_default_stream").on("keypress", (e) => {
         if (e.which === 13) {
             e.preventDefault();
             e.stopPropagation();

--- a/static/js/settings_user_groups.js
+++ b/static/js/settings_user_groups.js
@@ -80,12 +80,9 @@ exports.populate_user_groups = function () {
             pill_container.on("click", (e) => {
                 e.stopPropagation();
             });
-            pill_container.find(".pill").hover(
-                () => {
-                    pill_container.find(".pill").find(".exit").css("opacity", "0.5");
-                },
-                () => {},
-            );
+            pill_container.find(".pill").on("mouseenter", () => {
+                pill_container.find(".pill").find(".exit").css("opacity", "0.5");
+            });
         }
         update_membership(data.id);
 

--- a/static/js/settings_user_groups.js
+++ b/static/js/settings_user_groups.js
@@ -272,7 +272,7 @@ exports.populate_user_groups = function () {
                 // the DOM.
                 update_cancel_button();
                 setTimeout(() => {
-                    input.focus();
+                    input.trigger("focus");
                 }, 100);
             });
         })();

--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -81,9 +81,13 @@ $(() => {
         placement: "top",
         trigger: "manual",
     });
-    $("#id_last_update_question_sign").hover(() => {
-        $("span.last_update_tooltip").tooltip("toggle");
-    });
+    $("#id_last_update_question_sign")
+        .on("mouseenter", () => {
+            $("span.last_update_tooltip").tooltip("show");
+        })
+        .on("mouseleave", () => {
+            $("span.last_update_tooltip").tooltip("hide");
+        });
     // Add configuration for any additional tooltips here.
 });
 

--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -319,19 +319,19 @@ function populate_messages_sent_over_time(data) {
     }
 
     // Click handlers for aggregation buttons
-    $("#daily_button").click(function () {
+    $("#daily_button").on("click", function () {
         draw_or_update_plot(daily_rangeselector, daily_traces, last_day_is_partial, false);
         $(this).addClass("selected");
         clicked_cumulative = false;
     });
 
-    $("#weekly_button").click(function () {
+    $("#weekly_button").on("click", function () {
         draw_or_update_plot(weekly_rangeselector, weekly_traces, last_week_is_partial, false);
         $(this).addClass("selected");
         clicked_cumulative = false;
     });
 
-    $("#cumulative_button").click(function () {
+    $("#cumulative_button").on("click", function () {
         clicked_cumulative = false;
         draw_or_update_plot(daily_rangeselector, cumulative_traces, false, false);
         $(this).addClass("selected");
@@ -537,7 +537,7 @@ function populate_messages_sent_by_client(data) {
         button.addClass("selected");
     }
 
-    $("#pie_messages_sent_by_client button").click(function () {
+    $("#pie_messages_sent_by_client button").on("click", function () {
         if ($(this).attr("data-user")) {
             set_user_button($(this));
             user_button = $(this).attr("data-user");
@@ -665,7 +665,7 @@ function populate_messages_sent_by_message_type(data) {
         button.addClass("selected");
     }
 
-    $("#pie_messages_sent_by_type button").click(function () {
+    $("#pie_messages_sent_by_type button").on("click", function () {
         if ($(this).attr("data-user")) {
             set_user_button($(this));
             user_button = $(this).attr("data-user");
@@ -757,17 +757,17 @@ function populate_number_of_users(data) {
         add_hover_handler();
     }
 
-    $("#1day_actives_button").click(function () {
+    $("#1day_actives_button").on("click", function () {
         draw_or_update_plot(_1day_trace);
         $(this).addClass("selected");
     });
 
-    $("#15day_actives_button").click(function () {
+    $("#15day_actives_button").on("click", function () {
         draw_or_update_plot(_15day_trace);
         $(this).addClass("selected");
     });
 
-    $("#all_time_actives_button").click(function () {
+    $("#all_time_actives_button").on("click", function () {
         draw_or_update_plot(all_time_trace);
         $(this).addClass("selected");
     });
@@ -983,19 +983,19 @@ function populate_messages_read_over_time(data) {
     }
 
     // Click handlers for aggregation buttons
-    $("#read_daily_button").click(function () {
+    $("#read_daily_button").on("click", function () {
         draw_or_update_plot(daily_rangeselector, daily_traces, last_day_is_partial, false);
         $(this).addClass("selected");
         clicked_cumulative = false;
     });
 
-    $("#read_weekly_button").click(function () {
+    $("#read_weekly_button").on("click", function () {
         draw_or_update_plot(weekly_rangeselector, weekly_traces, last_week_is_partial, false);
         $(this).addClass("selected");
         clicked_cumulative = false;
     });
 
-    $("#read_cumulative_button").click(function () {
+    $("#read_cumulative_button").on("click", function () {
         clicked_cumulative = false;
         draw_or_update_plot(daily_rangeselector, cumulative_traces, false, false);
         $(this).addClass("selected");

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -60,7 +60,7 @@ const stream_name_error = (function () {
     };
 
     self.select = function () {
-        $("#create_stream_name").focus().select();
+        $("#create_stream_name").trigger("focus").trigger("select");
     };
 
     self.pre_validate = function (stream_name) {
@@ -227,7 +227,7 @@ function create_stream() {
                 // error text directly rather than turning it into
                 // "Error creating stream"?
                 stream_name_error.report_already_exists(stream_name);
-                stream_name_error.select();
+                stream_name_error.trigger("select");
             }
 
             ui_report.error(i18n.t("Error creating stream"), xhr, $(".stream_create_info"));
@@ -260,7 +260,7 @@ exports.new_stream_clicked = function (stream_name) {
     // is clear is that this shouldn't be touched unless you're also changing
     // the mobile @media query at 700px.
     if (window.innerWidth > 700) {
-        $("#create_stream_name").focus();
+        $("#create_stream_name").trigger("focus");
     }
 };
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -496,7 +496,7 @@ exports.set_event_handlers = function () {
 
     $("#streams_header")
         .expectOne()
-        .click((e) => {
+        .on("click", (e) => {
             exports.toggle_filter_displayed(e);
         });
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -569,7 +569,7 @@ exports.clear_search = function (e) {
         return;
     }
     filter.val("");
-    filter.blur();
+    filter.trigger("blur");
     update_streams_for_search();
 };
 
@@ -592,7 +592,7 @@ exports.initiate_search = function () {
         popovers.hide_all();
         stream_popover.show_streamlist_sidebar();
     }
-    filter.focus();
+    filter.trigger("focus");
 
     exports.stream_cursor.reset();
 };
@@ -604,7 +604,7 @@ exports.clear_and_hide_search = function () {
         update_streams_for_search();
     }
     exports.stream_cursor.clear();
-    filter.blur();
+    filter.trigger("blur");
 
     exports.hide_search_section();
 };

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -286,7 +286,7 @@ function build_move_topic_to_stream_popover(e, current_stream_id, topic_name) {
         ".stream_header_colorblock",
     );
     ui_util.decorate_stream_bar(current_stream_name, stream_header_colorblock, false);
-    $("#select_stream_id").change(function () {
+    $("#select_stream_id").on("change", function () {
         const stream_name = stream_data.maybe_get_stream_name(parseInt(this.value, 10));
         ui_util.decorate_stream_bar(stream_name, stream_header_colorblock, false);
     });

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -241,7 +241,7 @@ exports.add_sub_to_table = function (sub) {
         // good way to associate with this request because the stream
         // ID isn't known yet.  These are appended to the top of the
         // list, so they are more visible.
-        exports.row_for_stream_id(sub.stream_id).click();
+        exports.row_for_stream_id(sub.stream_id).trigger("click");
         stream_create.reset_created_stream();
     }
 };
@@ -653,7 +653,7 @@ exports.switch_to_stream_row = function (stream_id) {
     // It's dubious that we need this timeout any more.
     setTimeout(() => {
         if (stream_id === exports.get_active_data().id) {
-            stream_row.click();
+            stream_row.trigger("click");
         }
     }, 100);
 };
@@ -709,7 +709,7 @@ exports.launch = function (section) {
         exports.change_state(section);
     });
     if (!exports.get_active_data().id) {
-        $("#search_stream_name").focus();
+        $("#search_stream_name").trigger("focus");
     }
 };
 
@@ -722,7 +722,7 @@ exports.switch_rows = function (event) {
     } else if (!active_data.id || active_data.row.hasClass("notdisplayed")) {
         switch_row = $("div.stream-row:not(.notdisplayed)").first();
         if ($("#search_stream_name").is(":focus")) {
-            $("#search_stream_name").blur();
+            $("#search_stream_name").trigger("blur");
         }
     } else {
         if (event === "up_arrow") {
@@ -733,7 +733,7 @@ exports.switch_rows = function (event) {
         if ($("#search_stream_name").is(":focus")) {
             // remove focus from Filter streams input instead of switching rows
             // if Filter streams input is focused
-            return $("#search_stream_name").blur();
+            return $("#search_stream_name").trigger("blur");
         }
     }
 
@@ -742,7 +742,7 @@ exports.switch_rows = function (event) {
         const stream_id = row_data.id;
         exports.switch_to_stream_row(stream_id);
     } else if (event === "up_arrow" && !row_data) {
-        $("#search_stream_name").focus();
+        $("#search_stream_name").trigger("focus");
     }
     return true;
 };

--- a/static/js/tab_bar.js
+++ b/static/js/tab_bar.js
@@ -97,14 +97,13 @@ function bind_title_area_handlers() {
 
     // handler that makes sure that hover plays nicely
     // with whether search is being opened or not.
-    $("#tab_bar .narrow_description > a").hover(
-        () => {
+    $("#tab_bar .narrow_description > a")
+        .on("mouseenter", () => {
             $("#tab_bar .search_closed").addClass("search_icon_hover_highlight");
-        },
-        () => {
+        })
+        .on("mouseleave", () => {
             $("#tab_bar .search_closed").removeClass("search_icon_hover_highlight");
-        },
-    );
+        });
 }
 
 function build_tab_bar(filter) {

--- a/static/js/todo_widget.js
+++ b/static/js/todo_widget.js
@@ -143,8 +143,8 @@ exports.activate = function (opts) {
                 return;
             }
 
-            elem.find(".add-task").val("").focus();
-            elem.find(".add-desc").val("").focus();
+            elem.find(".add-task").val("").trigger("focus");
+            elem.find(".add-desc").val("").trigger("focus");
 
             const task_exists = task_data.name_in_use(task);
             if (task_exists) {

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -178,7 +178,7 @@ exports.maybe_show_deprecation_notice = function (key) {
     if (!shown_deprecation_notices.includes(key)) {
         $("#deprecation-notice-modal").modal("show");
         $("#deprecation-notice-message").text(message);
-        $("#close-deprecation-notice").focus();
+        $("#close-deprecation-notice").trigger("focus");
         shown_deprecation_notices.push(key);
         if (localstorage.supported()) {
             localStorage.setItem(
@@ -206,7 +206,7 @@ exports.set_compose_textarea_handlers = function () {
 };
 
 exports.restore_compose_cursor = function () {
-    $("#compose-textarea").focus().caret(saved_compose_cursor);
+    $("#compose-textarea").trigger("focus").caret(saved_compose_cursor);
 };
 
 exports.initialize = function () {

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -194,7 +194,7 @@ exports.maybe_show_deprecation_notice = function (key) {
 let saved_compose_cursor = 0;
 
 exports.set_compose_textarea_handlers = function () {
-    $("#compose-textarea").blur(function () {
+    $("#compose-textarea").on("blur", function () {
         saved_compose_cursor = $(this).caret();
     });
 

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -92,7 +92,7 @@ exports.initialize_kitchen_sink_stuff = function () {
         // preventDefault, allowing the modal to scroll normally.
     });
 
-    $(window).resize(_.throttle(resize.handler, 50));
+    $(window).on("resize", _.throttle(resize.handler, 50));
 
     // Scrolling in overlays. input boxes, and other elements that
     // explicitly scroll should not scroll the main view.  Stop

--- a/static/js/ui_util.js
+++ b/static/js/ui_util.js
@@ -7,7 +7,7 @@ exports.change_tab_to = function (tabname) {
 
 // https://stackoverflow.com/questions/4233265/contenteditable-set-caret-at-the-end-of-the-text-cross-browser
 exports.place_caret_at_end = function (el) {
-    el.focus();
+    el.trigger("focus");
 
     if (typeof window.getSelection !== "undefined" && typeof document.createRange !== "undefined") {
         const range = document.createRange();

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -127,7 +127,7 @@ exports.upload_files = function (uppy, config, files) {
         });
         compose_ui.autosize_textarea();
         uppy.cancelAll();
-        exports.get_item("textarea", config).focus();
+        exports.get_item("textarea", config).trigger("focus");
         setTimeout(() => {
             exports.hide_upload_status(config);
         }, 500);

--- a/static/js/user_pill.js
+++ b/static/js/user_pill.js
@@ -145,7 +145,7 @@ exports.set_up_typeahead_on_pills = function (input, pills, update_func, source)
         },
         updater: function (user) {
             exports.append_user(user, pills);
-            input.focus();
+            input.trigger("focus");
             update_func();
         },
         stopAdvance: true,

--- a/static/js/user_search.js
+++ b/static/js/user_search.js
@@ -31,7 +31,7 @@ const user_search = function (opts) {
         }
 
         $input.val("");
-        $input.blur();
+        $input.trigger("blur");
         opts.reset_items();
     };
 
@@ -71,7 +71,7 @@ const user_search = function (opts) {
     };
 
     self.close_widget = function () {
-        $input.blur();
+        $input.trigger("blur");
         self.hide_widget();
         opts.reset_items();
     };
@@ -91,7 +91,7 @@ const user_search = function (opts) {
     self.initiate_search = function () {
         self.expand_column();
         self.show_widget();
-        $input.focus();
+        $input.trigger("focus");
     };
 
     self.toggle_filter_displayed = function () {

--- a/static/js/user_status_ui.js
+++ b/static/js/user_status_ui.js
@@ -18,8 +18,8 @@ exports.open_overlay = function () {
     const old_status_text = user_status.get_status_text(user_id);
     const field = exports.input_field();
     field.val(old_status_text);
-    field.select();
-    field.focus();
+    field.trigger("select");
+    field.trigger("focus");
     exports.toggle_clear_message_button();
 
     const button = exports.submit_button();


### PR DESCRIPTION
The jQuery [event shorthand methods](https://github.com/jquery/jquery/blob/3.5.1/src/deprecated/event.js), of which we use `blur`, `change`, `click`, `focus`, `focusin`, `focusout`, `keydown`, `keypress`, `keyup`, `mouseenter`, `mouseleave`, `scroll`, `select`, and `submit`, are deprecated in favor of `on` and `trigger`. Do this replacement (easy), after refactoring zjquery and the Node tests to allow this (hard).

This eliminates most of the jquery-migrate warnings (#14645), and may make it reasonable to turn that on, although this PR doesn’t do so.

As a side benefit of this refactoring, the Node tests now consistently {trigger, handle} events through the normal zjquery interface rather than monkey-patching the event {handling, triggering} functions.

**Testing Plan:** `lint -g frontend` (every commit), `test-js-with-node --coverage` (every commit), dev server

Cc @showell
