### PR TITLE
stream_edit: Restore keyboard accessibility to checkboxes

### DIFF
--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -98,7 +98,7 @@ exports.set_up = function () {
         e.stopPropagation();
         const input_elem = $(e.currentTarget);
         if (input_elem.parents("#stream-specific-notify-table").length) {
-            stream_edit.stream_setting_clicked(e);
+            stream_edit.stream_setting_changed(e, true);
             return;
         }
         const setting_name = input_elem.attr("name");

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -399,7 +399,7 @@ exports.register_stream_handlers = function () {
         });
     });
     // Mute/unmute
-    $("body").on("click", ".toggle_home", (e) => {
+    $("body").on("click", ".toggle_stream_muted", (e) => {
         const sub = stream_popover_sub(e);
         exports.hide_stream_popover();
         subs.set_muted(sub, !sub.is_muted);

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -402,7 +402,7 @@ exports.register_stream_handlers = function () {
     $("body").on("click", ".toggle_home", (e) => {
         const sub = stream_popover_sub(e);
         exports.hide_stream_popover();
-        subs.toggle_home(sub);
+        subs.set_muted(sub, !sub.is_muted);
         e.stopPropagation();
     });
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -95,8 +95,8 @@ exports.active_stream = function () {
     }
 };
 
-exports.toggle_home = function (sub, status_element) {
-    stream_muting.update_is_muted(sub, !sub.is_muted);
+exports.set_muted = function (sub, status_element, is_muted) {
+    stream_muting.update_is_muted(sub, is_muted);
     stream_edit.set_stream_property(sub, "is_muted", sub.is_muted, status_element);
 };
 

--- a/static/templates/stream_settings_checkbox.hbs
+++ b/static/templates/stream_settings_checkbox.hbs
@@ -5,11 +5,11 @@
   {{#if notification_setting}}sub_notification_setting {{#if is_muted}}muted-sub{{/if}}{{/if}}{{/if}} new-style">
     <label class="checkbox">
         <input id="{{setting_name}}_{{stream_id}}" name="{{setting_name}}"
-          class="sub_setting_control" type="checkbox" tabindex="-1"
+          class="sub_setting_control" type="checkbox"
           {{#if is_checked}}checked{{/if}}{{#if is_disabled}}disabled="disabled"{{/if}} />
         <span></span>
     </label>
-    <label class="subscription-control-label">{{label}}</label>
+    <label class="subscription-control-label" for="{{setting_name}}_{{stream_id}}">{{label}}</label>
 
     {{!-- Tooltips for settings --}}
     {{#if (eq setting_name "is_muted")}}

--- a/static/templates/stream_sidebar_actions.hbs
+++ b/static/templates/stream_sidebar_actions.hbs
@@ -36,7 +36,7 @@
         </a>
     </li>
     <li>
-        <a class="toggle_home">
+        <a class="toggle_stream_muted">
             {{#if stream.is_muted}}
             <i class="fa fa-bell" aria-hidden="true"></i>
             {{t "Unmute stream"}}


### PR DESCRIPTION
Listen to `change` events from the checkbox and pay attention to its actual value, rather than simulating it by toggling booleans on `click` events.

**Testing Plan:** Dev server (stream settings, notification settings)

Cc @SiddharthVarshney 
