### PR TITLE
ui_util: Fix incorrectly converted focus method call

### DIFF
--- a/static/js/ui_util.js
+++ b/static/js/ui_util.js
@@ -7,7 +7,7 @@ exports.change_tab_to = function (tabname) {
 
 // https://stackoverflow.com/questions/4233265/contenteditable-set-caret-at-the-end-of-the-text-cross-browser
 exports.place_caret_at_end = function (el) {
-    el.trigger("focus");
+    el.focus();
 
     if (typeof window.getSelection !== "undefined" && typeof document.createRange !== "undefined") {
         const range = document.createRange();


### PR DESCRIPTION
Commit a9ca5f603b7fbb054f57338e260cbf771a94b2ee (#15863) incorrectly converted this; `el` is a DOM element, not a jQuery element.