### PR TITLE
js: Fix incorrectly converted blur and click method calls

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -757,24 +757,24 @@ exports.initialize = function () {
 
     // disable the draggability for left-sidebar components
     $("#stream_filters, #global_filters").on("dragstart", (e) => {
-        e.target.trigger("blur");
+        e.target.blur();
         return false;
     });
 
     // Chrome focuses an element when dragging it which can be confusing when
     // users involuntarily drag something and we show them the focus outline.
-    $("body").on("dragstart", "a", (e) => e.target.trigger("blur"));
+    $("body").on("dragstart", "a", (e) => e.target.blur());
 
     // Don't focus links on middle click.
     $("body").on("mouseup", "a", (e) => {
         if (e.which === 2) {
             // middle click
-            e.target.trigger("blur");
+            e.target.blur();
         }
     });
 
     // Don't focus links on context menu.
-    $("body").on("contextmenu", "a", (e) => e.target.trigger("blur"));
+    $("body").on("contextmenu", "a", (e) => e.target.blur());
 
     (function () {
         const map = {

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -378,7 +378,7 @@ exports.launch = function () {
 function activate_element(elem) {
     $(".draft-info-box").removeClass("active");
     $(elem).expectOne().addClass("active");
-    elem.trigger("focus");
+    elem.focus();
 }
 
 function drafts_initialize_focus(event_name) {

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -407,7 +407,7 @@ exports.navigate = function (event_name, e) {
 
     if (event_name === "enter") {
         if (is_composition(e.target)) {
-            e.target.trigger("click");
+            e.target.click();
         } else {
             toggle_selected_emoji(e);
         }

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -272,7 +272,7 @@ exports.process_enter_key = function (e) {
         // on #gear-menu li a[tabindex] elements, force a click and prevent default.
         // this is because these links do not have an href and so don't force a
         // default action.
-        e.target.trigger("click");
+        e.target.click();
         return true;
     }
 


### PR DESCRIPTION
Commit a9ca5f603b7fbb054f57338e260cbf771a94b2ee (#15863) incorrectly converted these; `e.target` is a DOM element, not a jQuery element.