### PR TITLE
Replace more jQuery deprecations

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -590,7 +590,7 @@ run_test("send_message_success", () => {
     $("#compose-textarea").val("foobarfoobar");
     $("#compose-textarea").trigger("blur");
     $("#compose-send-status").show();
-    $("#compose-send-button").attr("disabled", "disabled");
+    $("#compose-send-button").prop("disabled", true);
     $("#sending-indicator").show();
 
     let reify_message_id_checked;
@@ -688,7 +688,7 @@ run_test("send_message", () => {
         $("#compose-textarea").val("[foobar]" + "(https://foo.com/user_uploads/123456)");
         $("#compose-textarea").trigger("blur");
         $("#compose-send-status").show();
-        $("#compose-send-button").attr("disabled", "disabled");
+        $("#compose-send-button").prop("disabled", true);
         $("#sending-indicator").show();
 
         compose.send_message();
@@ -740,7 +740,7 @@ run_test("send_message", () => {
         $("#compose-textarea").val("foobarfoobar");
         $("#compose-textarea").trigger("blur");
         $("#compose-send-status").show();
-        $("#compose-send-button").attr("disabled", "disabled");
+        $("#compose-send-button").prop("disabled", true);
         $("#sending-indicator").show();
         $("#compose-textarea").off("select");
         echo_error_msg_checked = false;
@@ -1027,7 +1027,7 @@ run_test("initialize", () => {
     })();
 
     (function test_abort_xhr() {
-        $("#compose-send-button").attr("disabled", "disabled");
+        $("#compose-send-button").prop("disabled", true);
 
         reset_jquery();
         stub_out_video_calls();

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1689,10 +1689,6 @@ run_test("create_message_object", () => {
         return "stream";
     };
 
-    global.$.trim = function (s) {
-        return s;
-    };
-
     let message = compose.create_message_object();
     assert.equal(message.to, sub.stream_id);
     assert.equal(message.topic, "lunch");

--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -317,13 +317,12 @@ run_test("initiate_search", () => {
     $("#search_query").typeahead = (lookup) => {
         if (lookup === "lookup") {
             typeahead_forced_open = true;
-            return {
-                select: () => {
-                    is_searchbox_text_selected = true;
-                },
-            };
         }
+        return $("#search_query");
     };
+    $("#search_query").on("select", () => {
+        is_searchbox_text_selected = true;
+    });
 
     search.initiate_search();
     assert(typeahead_forced_open);

--- a/frontend_tests/node_tests/search_legacy.js
+++ b/frontend_tests/node_tests/search_legacy.js
@@ -263,13 +263,13 @@ run_test("initiate_search", () => {
     $("#search_query").typeahead = (lookup) => {
         if (lookup === "lookup") {
             typeahead_forced_open = true;
-            return {
-                select: () => {
-                    is_searchbox_text_selected = true;
-                },
-            };
         }
+        return $("#search_query");
     };
+    $("#search_query").on("select", () => {
+        is_searchbox_text_selected = true;
+    });
+
     search.initiate_search();
     assert(typeahead_forced_open);
     assert(is_searchbox_text_selected);

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -927,76 +927,64 @@ run_test("misc", () => {
     page_params.realm_name_changes_disabled = false;
     page_params.server_name_changes_disabled = false;
     settings_account.update_name_change_display();
-    assert.equal($("#full_name").attr("disabled"), false);
+    assert(!$("#full_name").prop("disabled"));
     assert.equal($(".change_name_tooltip").is(":visible"), false);
 
     page_params.realm_name_changes_disabled = true;
     page_params.server_name_changes_disabled = false;
     settings_account.update_name_change_display();
-    assert.equal($("#full_name").attr("disabled"), "disabled");
+    assert($("#full_name").prop("disabled"));
     assert($(".change_name_tooltip").is(":visible"));
 
     page_params.realm_name_changes_disabled = true;
     page_params.server_name_changes_disabled = true;
     settings_account.update_name_change_display();
-    assert.equal($("#full_name").attr("disabled"), "disabled");
+    assert($("#full_name").prop("disabled"));
     assert($(".change_name_tooltip").is(":visible"));
 
     page_params.realm_name_changes_disabled = false;
     page_params.server_name_changes_disabled = true;
     settings_account.update_name_change_display();
-    assert.equal($("#full_name").attr("disabled"), "disabled");
+    assert($("#full_name").prop("disabled"));
     assert($(".change_name_tooltip").is(":visible"));
 
     page_params.realm_email_changes_disabled = false;
     settings_account.update_email_change_display();
-    assert.equal($("#change_email .button").attr("disabled"), false);
+    assert(!$("#change_email .button").prop("disabled"));
 
     page_params.realm_email_changes_disabled = true;
     settings_account.update_email_change_display();
-    assert.equal($("#change_email .button").attr("disabled"), "disabled");
+    assert($("#change_email .button").prop("disabled"));
 
     page_params.realm_avatar_changes_disabled = false;
     page_params.server_avatar_changes_disabled = false;
     settings_account.update_avatar_change_display();
-    assert.equal($("#user-avatar-upload-widget .image_upload_button").attr("disabled"), false);
-    assert.equal(
-        $("#user-avatar-upload-widget .image-delete-button .button").attr("disabled"),
-        false,
-    );
+    assert(!$("#user-avatar-upload-widget .image_upload_button").prop("disabled"));
+    assert(!$("#user-avatar-upload-widget .image-delete-button .button").prop("disabled"));
     page_params.realm_avatar_changes_disabled = true;
     page_params.server_avatar_changes_disabled = false;
     settings_account.update_avatar_change_display();
-    assert.equal($("#user-avatar-upload-widget .image_upload_button").attr("disabled"), "disabled");
-    assert.equal(
-        $("#user-avatar-upload-widget .image-delete-button .button").attr("disabled"),
-        "disabled",
-    );
+    assert($("#user-avatar-upload-widget .image_upload_button").prop("disabled"));
+    assert($("#user-avatar-upload-widget .image-delete-button .button").prop("disabled"));
     page_params.realm_avatar_changes_disabled = false;
     page_params.server_avatar_changes_disabled = true;
     settings_account.update_avatar_change_display();
-    assert.equal($("#user-avatar-upload-widget .image_upload_button").attr("disabled"), "disabled");
-    assert.equal(
-        $("#user-avatar-upload-widget .image-delete-button .button").attr("disabled"),
-        "disabled",
-    );
+    assert($("#user-avatar-upload-widget .image_upload_button").prop("disabled"));
+    assert($("#user-avatar-upload-widget .image-delete-button .button").prop("disabled"));
     page_params.realm_avatar_changes_disabled = true;
     page_params.server_avatar_changes_disabled = true;
     settings_account.update_avatar_change_display();
-    assert.equal($("#user-avatar-upload-widget .image_upload_button").attr("disabled"), "disabled");
-    assert.equal(
-        $("#user-avatar-upload-widget .image-delete-button .button").attr("disabled"),
-        "disabled",
-    );
+    assert($("#user-avatar-upload-widget .image_upload_button").prop("disabled"));
+    assert($("#user-avatar-upload-widget .image-delete-button .button").prop("disabled"));
 
     // If organization admin, these UI elements are never disabled.
     page_params.is_admin = true;
     settings_account.update_name_change_display();
-    assert.equal($("#full_name").attr("disabled"), false);
+    assert(!$("#full_name").prop("disabled"));
     assert.equal($(".change_name_tooltip").is(":visible"), false);
 
     settings_account.update_email_change_display();
-    assert.equal($("#change_email .button").attr("disabled"), false);
+    assert(!$("#change_email .button").prop("disabled"));
 
     stream_data.get_streams_for_settings_page = () => {
         const arr = [];

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -137,7 +137,7 @@ run_test("get_item", () => {
 });
 
 run_test("hide_upload_status", () => {
-    $("#compose-send-button").prop("disabled", "");
+    $("#compose-send-button").prop("disabled", true);
     $("#compose-send-status").addClass("alert-info").show();
 
     upload.hide_upload_status({mode: "compose"});
@@ -148,7 +148,7 @@ run_test("hide_upload_status", () => {
 });
 
 run_test("show_error_message", () => {
-    $("#compose-send-button").prop("disabled", "");
+    $("#compose-send-button").prop("disabled", true);
     $("#compose-send-status").addClass("alert-info").removeClass("alert-error").hide();
     $("#compose-error-msg").text("");
     $("#compose-error-msg").hide();
@@ -192,9 +192,9 @@ run_test("upload_files", () => {
         assert(config.mode, "compose");
     };
     const config = {mode: "compose"};
-    $("#compose-send-button").attr("disabled", false);
+    $("#compose-send-button").prop("disabled", false);
     upload.upload_files(uppy, config, []);
-    assert.equal($("#compose-send-button").attr("disabled"), false);
+    assert(!$("#compose-send-button").prop("disabled"));
 
     page_params.max_file_upload_size_mib = 0;
     let show_error_message_called = false;
@@ -225,10 +225,10 @@ run_test("upload_files", () => {
     compose_ui.autosize_textarea = () => {
         compose_ui_autosize_textarea_called = true;
     };
-    $("#compose-send-button").attr("disabled", false);
+    $("#compose-send-button").prop("disabled", false);
     $("#compose-send-status").removeClass("alert-info").hide();
     upload.upload_files(uppy, config, files);
-    assert.equal($("#compose-send-button").attr("disabled"), "");
+    assert($("#compose-send-button").prop("disabled"));
     assert($("#compose-send-status").hasClass("alert-info"));
     assert($("#compose-send-status").visible());
     assert.equal($("<p>").text(), "translated: Uploading…");

--- a/static/js/alert_words_ui.js
+++ b/static/js/alert_words_ui.js
@@ -30,7 +30,7 @@ function update_alert_word_status(status_text, is_error) {
 }
 
 function add_alert_word(alert_word) {
-    alert_word = $.trim(alert_word);
+    alert_word = alert_word.trim();
     if (alert_word === "") {
         update_alert_word_status(i18n.t("Alert word can't be empty!"), true);
         return;

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -696,7 +696,7 @@ function validate_private_message() {
 }
 
 exports.validate = function () {
-    $("#compose-send-button").attr("disabled", "disabled").trigger("blur");
+    $("#compose-send-button").prop("disabled", true).trigger("blur");
     const message_content = compose_state.message_content();
     if (reminder.is_deferred_delivery(message_content)) {
         show_sending_indicator(i18n.t("Scheduling..."));
@@ -1062,7 +1062,7 @@ exports.initialize = function () {
         function failure(error_msg) {
             exports.clear_invites();
             compose_error(error_msg, $("#compose-textarea"));
-            $(event.target).attr("disabled", true);
+            $(event.target).prop("disabled", true);
         }
 
         function xhr_failure(xhr) {

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -237,8 +237,8 @@ function handle_keydown(e) {
             if (on_compose && code === 13) {
                 if (exports.should_enter_send(e)) {
                     e.preventDefault();
-                    if ($("#compose-send-button").attr("disabled") !== "disabled") {
-                        $("#compose-send-button").attr("disabled", "disabled");
+                    if (!$("#compose-send-button").prop("disabled")) {
+                        $("#compose-send-button").prop("disabled", true);
                         compose.finish();
                     }
                     return;

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -186,7 +186,7 @@ function handle_message_row_edit_keydown(e) {
                 if (composebox_typeahead.should_enter_send(e)) {
                     const row = $(".message_edit_content").filter(":focus").closest(".message_row");
                     const message_edit_save_button = row.find(".message_edit_save");
-                    if (message_edit_save_button.attr("disabled") === "disabled") {
+                    if (message_edit_save_button.prop("disabled")) {
                         // In cases when the save button is disabled
                         // we need to disable save on pressing enter
                         // Prevent default to avoid new-line on pressing
@@ -818,7 +818,7 @@ exports.edit_last_sent_message = function () {
 
 function hide_delete_btn_show_spinner(deleting) {
     if (deleting) {
-        $("do_delete_message_button").attr("disabled", "disabled");
+        $("do_delete_message_button").prop("disabled", true);
         $("#delete_message_modal > div.modal-footer > button").hide();
         const delete_spinner = $("#do_delete_message_spinner");
         loading.make_indicator(delete_spinner, {abs_positioned: true});

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -154,7 +154,7 @@ exports.update_message_topic_editing_pencil = function () {
 exports.show_topic_edit_spinner = function (row) {
     const spinner = row.find(".topic_edit_spinner");
     loading.make_indicator(spinner);
-    $(spinner).removeAttr("style");
+    spinner.css({height: ""});
     $(".topic_edit_save").hide();
     $(".topic_edit_cancel").hide();
 };

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -1036,13 +1036,13 @@ exports.show_empty_narrow_message = function () {
         "title",
         i18n.t("There are no messages to reply to."),
     );
-    $("#left_bar_compose_reply_button_big").attr("disabled", "disabled");
+    $("#left_bar_compose_reply_button_big").prop("disabled", true);
 };
 
 exports.hide_empty_narrow_message = function () {
     $(".empty_feed_notice").hide();
     $("#left_bar_compose_reply_button_big").attr("title", i18n.t("Reply (r)"));
-    $("#left_bar_compose_reply_button_big").removeAttr("disabled");
+    $("#left_bar_compose_reply_button_big").prop("disabled", false);
 };
 
 window.narrow = exports;

--- a/static/js/portico/landing-page.js
+++ b/static/js/portico/landing-page.js
@@ -256,6 +256,4 @@ $(() => {
 // According to https://developer.mozilla.org/en-US/docs/DOM/window.onunload
 // Using this event handler in your page prevents Firefox from caching the
 // page in the in-memory bfcache (backward/forward cache).
-$(window).on("unload", () => {
-    $(window).unbind("unload");
-});
+$(window).on("unload", () => {});

--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -125,7 +125,7 @@ $(() => {
         // check if it is the "focusout" or if it is a keydown, then check if
         // the keycode was the one for "enter" (13).
         if (e.type === "focusout" || e.which === 13) {
-            $(this).val($.trim($(this).val()));
+            $(this).val($(this).val().trim());
         }
     });
 

--- a/static/js/reminder.js
+++ b/static/js/reminder.js
@@ -56,7 +56,7 @@ exports.schedule_message = function (request) {
         deliver_at.trim() === "" ||
         command_line.slice(command.length, command.length + 1) !== " "
     ) {
-        $("#compose-textarea").attr("disabled", false);
+        $("#compose-textarea").prop("disabled", false);
         if (command_line.slice(command.length, command.length + 1) !== " ") {
             compose.compose_error(
                 i18n.t(
@@ -85,16 +85,16 @@ exports.schedule_message = function (request) {
                 "Scheduled your Message to be delivered at: " + data.deliver_at,
             );
         }
-        $("#compose-textarea").attr("disabled", false);
+        $("#compose-textarea").prop("disabled", false);
         compose.clear_compose_box();
     };
     const error = function (response) {
-        $("#compose-textarea").attr("disabled", false);
+        $("#compose-textarea").prop("disabled", false);
         compose.compose_error(response, $("#compose-textarea"));
     };
     /* We are adding a disable on compose under this block because we
     want slash commands to be blocking in nature. */
-    $("#compose-textarea").attr("disabled", true);
+    $("#compose-textarea").prop("disabled", true);
 
     transmit.send_message(request, success, error);
 };

--- a/static/js/rendered_markdown.js
+++ b/static/js/rendered_markdown.js
@@ -171,7 +171,7 @@ exports.update_elements = (content) => {
     content.find("div.spoiler-header").each(function () {
         // If a spoiler block has no header content, it should have a default header.
         // We do this client side to allow for i18n by the client.
-        if ($.trim($(this).html()).length === 0) {
+        if ($(this).html().trim().length === 0) {
             $(this).append(`<p>${i18n.t("Spoiler")}</p>`);
         }
 

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -209,7 +209,7 @@ exports.focus_search = function () {
 exports.initiate_search = function () {
     tab_bar.open_search_bar_and_close_narrow_description();
     $("#searchbox").css({"box-shadow": "inset 0px 0px 0px 2px hsl(204, 20%, 74%)"});
-    $("#search_query").typeahead("lookup").select();
+    $("#search_query").typeahead("lookup").trigger("select");
     if (page_params.search_pills_enabled) {
         $("#search_query").trigger("focus");
         ui_util.place_caret_at_end($("#search_query")[0]);

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -47,31 +47,31 @@ exports.user_can_change_avatar = function () {
 
 exports.update_name_change_display = function () {
     if (!exports.user_can_change_name()) {
-        $("#full_name").attr("disabled", "disabled");
+        $("#full_name").prop("disabled", true);
         $(".change_name_tooltip").show();
     } else {
-        $("#full_name").attr("disabled", false);
+        $("#full_name").prop("disabled", false);
         $(".change_name_tooltip").hide();
     }
 };
 
 exports.update_email_change_display = function () {
     if (page_params.realm_email_changes_disabled && !page_params.is_admin) {
-        $("#change_email .button").attr("disabled", "disabled");
+        $("#change_email .button").prop("disabled", true);
         $(".change_email_tooltip").show();
     } else {
-        $("#change_email .button").attr("disabled", false);
+        $("#change_email .button").prop("disabled", false);
         $(".change_email_tooltip").hide();
     }
 };
 
 exports.update_avatar_change_display = function () {
     if (!exports.user_can_change_avatar()) {
-        $("#user-avatar-upload-widget .image_upload_button").attr("disabled", "disabled");
-        $("#user-avatar-upload-widget .image-delete-button .button").attr("disabled", "disabled");
+        $("#user-avatar-upload-widget .image_upload_button").prop("disabled", true);
+        $("#user-avatar-upload-widget .image-delete-button .button").prop("disabled", true);
     } else {
-        $("#user-avatar-upload-widget .image_upload_button").attr("disabled", false);
-        $("#user-avatar-upload-widget .image-delete-button .button").attr("disabled", false);
+        $("#user-avatar-upload-widget .image_upload_button").prop("disabled", false);
+        $("#user-avatar-upload-widget .image-delete-button .button").prop("disabled", false);
     }
 };
 

--- a/static/js/settings_emoji.js
+++ b/static/js/settings_emoji.js
@@ -168,7 +168,7 @@ exports.set_up = function () {
             e.preventDefault();
             e.stopPropagation();
             const emoji_status = $("#admin-emoji-status");
-            $("#admin_emoji_submit").attr("disabled", true);
+            $("#admin_emoji_submit").prop("disabled", true);
             const emoji = {};
             const formData = new FormData();
 
@@ -189,7 +189,7 @@ exports.set_up = function () {
                     $("#admin-emoji-status").hide();
                     ui_report.success(i18n.t("Custom emoji added!"), emoji_status);
                     $("form.admin-emoji-form input[type='text']").val("");
-                    $("#admin_emoji_submit").removeAttr("disabled");
+                    $("#admin_emoji_submit").prop("disabled", false);
                     emoji_widget.clear();
                 },
                 error(xhr) {
@@ -197,7 +197,7 @@ exports.set_up = function () {
                     const errors = JSON.parse(xhr.responseText).msg;
                     xhr.responseText = JSON.stringify({msg: errors});
                     ui_report.error(i18n.t("Failed"), xhr, emoji_status);
-                    $("#admin_emoji_submit").removeAttr("disabled");
+                    $("#admin_emoji_submit").prop("disabled", false);
                 },
             });
         });

--- a/static/js/settings_invites.js
+++ b/static/js/settings_invites.js
@@ -161,7 +161,7 @@ exports.on_load_success = function (invites_data, initialize_event_handlers) {
             meta.is_multiuse,
         );
         $("#revoke_invite_modal").modal("show");
-        $("#do_revoke_invite_button").unbind("click");
+        $("#do_revoke_invite_button").off("click");
         $("#do_revoke_invite_button").on("click", do_revoke_invite);
     });
 

--- a/static/js/settings_linkifiers.js
+++ b/static/js/settings_linkifiers.js
@@ -112,7 +112,7 @@ exports.build_page = function () {
             const pattern_status = $("#admin-filter-pattern-status");
             const format_status = $("#admin-filter-format-status");
             const add_filter_button = $(".new-filter-form button");
-            add_filter_button.attr("disabled", "disabled");
+            add_filter_button.prop("disabled", true);
             filter_status.hide();
             pattern_status.hide();
             format_status.hide();
@@ -128,13 +128,13 @@ exports.build_page = function () {
                 success(data) {
                     $("#filter_pattern").val("");
                     $("#filter_format_string").val("");
-                    add_filter_button.removeAttr("disabled");
+                    add_filter_button.prop("disabled", false);
                     filter.id = data.id;
                     ui_report.success(i18n.t("Custom filter added!"), filter_status);
                 },
                 error(xhr) {
                     const errors = JSON.parse(xhr.responseText).errors;
-                    add_filter_button.removeAttr("disabled");
+                    add_filter_button.prop("disabled", false);
                     if (errors.pattern !== undefined) {
                         xhr.responseText = JSON.stringify({msg: errors.pattern});
                         ui_report.error(i18n.t("Failed"), xhr, pattern_status);

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -18,21 +18,21 @@ exports.maybe_disable_widgets = function () {
 
     $(".organization-box [data-name='auth-methods']")
         .find("input, button, select, checked")
-        .attr("disabled", true);
+        .prop("disabled", true);
 
     if (page_params.is_admin) {
-        $("#deactivate_realm_button").attr("disabled", true);
-        $("#org-message-retention").find("input, select").attr("disabled", true);
+        $("#deactivate_realm_button").prop("disabled", true);
+        $("#org-message-retention").find("input, select").prop("disabled", true);
         return;
     }
 
     $(".organization-box [data-name='organization-profile']")
         .find("input, textarea, button, select")
-        .attr("disabled", true);
+        .prop("disabled", true);
 
     $(".organization-box [data-name='organization-settings']")
         .find("input, textarea, button, select")
-        .attr("disabled", true);
+        .prop("disabled", true);
 
     $(".organization-box [data-name='organization-settings']")
         .find(".control-label-disabled")
@@ -40,7 +40,7 @@ exports.maybe_disable_widgets = function () {
 
     $(".organization-box [data-name='organization-permissions']")
         .find("input, textarea, button, select")
-        .attr("disabled", true);
+        .prop("disabled", true);
 
     $(".organization-box [data-name='organization-permissions']")
         .find(".control-label-disabled")

--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -12,7 +12,7 @@ exports.maybe_disable_widgets = function () {
 
     $(".organization-box [data-name='profile-field-settings']")
         .find("input, button, select")
-        .attr("disabled", true);
+        .prop("disabled", true);
 };
 
 let order = [];

--- a/static/js/settings_streams.js
+++ b/static/js/settings_streams.js
@@ -15,7 +15,7 @@ exports.maybe_disable_widgets = function () {
 
     $(".organization-box [data-name='default-streams-list']")
         .find("input:not(.search), button, select")
-        .attr("disabled", true);
+        .prop("disabled", true);
 };
 
 exports.build_default_stream_table = function () {

--- a/static/js/settings_ui.js
+++ b/static/js/settings_ui.js
@@ -75,12 +75,12 @@ exports.do_settings_change = function (request_method, url, data, status_element
 //   when main setting unchecked.
 exports.disable_sub_setting_onchange = function (is_checked, sub_setting_id, disable_on_uncheck) {
     if ((is_checked && disable_on_uncheck) || (!is_checked && !disable_on_uncheck)) {
-        $("#" + sub_setting_id).attr("disabled", false);
+        $("#" + sub_setting_id).prop("disabled", false);
         $("#" + sub_setting_id + "_label")
             .parent()
             .removeClass("control-label-disabled");
     } else if ((is_checked && !disable_on_uncheck) || (!is_checked && disable_on_uncheck)) {
-        $("#" + sub_setting_id).attr("disabled", "disabled");
+        $("#" + sub_setting_id).prop("disabled", true);
         $("#" + sub_setting_id + "_label")
             .parent()
             .addClass("control-label-disabled");

--- a/static/js/stream_color.js
+++ b/static/js/stream_color.js
@@ -13,7 +13,7 @@ function update_table_stream_color(table, stream_name, color) {
 
     for (const label of stream_labels) {
         const $label = $(label);
-        if ($.trim($label.text()) === stream_name) {
+        if ($label.text().trim() === stream_name) {
             const messages = $label.closest(".recipient_row").children(".message_row");
             messages
                 .children(".messagebox")

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -139,8 +139,8 @@ function get_principals() {
 
 function create_stream() {
     const data = {};
-    const stream_name = $.trim($("#create_stream_name").val());
-    const description = $.trim($("#create_stream_description").val());
+    const stream_name = $("#create_stream_name").val().trim();
+    const description = $("#create_stream_description").val().trim();
     created_stream = stream_name;
 
     // Even though we already check to make sure that while typing the user cannot enter
@@ -406,7 +406,7 @@ exports.set_up_handlers = function () {
         e.preventDefault();
         clear_error_display();
 
-        const stream_name = $.trim($("#create_stream_name").val());
+        const stream_name = $("#create_stream_name").val().trim();
         const name_ok = stream_name_error.validate_for_submit(stream_name);
 
         if (!name_ok) {
@@ -444,7 +444,7 @@ exports.set_up_handlers = function () {
     });
 
     container.on("input", "#create_stream_name", () => {
-        const stream_name = $.trim($("#create_stream_name").val());
+        const stream_name = $("#create_stream_name").val().trim();
 
         // This is an inexpensive check.
         stream_name_error.pre_validate(stream_name);

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -533,7 +533,7 @@ exports.change_stream_name = function (e) {
     const sub_settings = $(e.target).closest(".subscription_settings");
     const stream_id = get_stream_id(e.target);
     const new_name_box = sub_settings.find(".stream-name-editable");
-    const new_name = $.trim(new_name_box.text());
+    const new_name = new_name_box.text().trim();
     $(".stream_change_property_info").hide();
 
     channel.patch({

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -70,7 +70,7 @@ exports.update_settings_button_for_sub = function (sub) {
     } else {
         settings_button.attr("title", "");
         exports.initialize_cant_subscribe_popover(sub);
-        settings_button.attr("disabled", "disabled");
+        settings_button.prop("disabled", true);
     }
 };
 
@@ -234,13 +234,13 @@ exports.update_add_subscriptions_elements = function (sub) {
     const allow_user_to_add_subs = sub.can_add_subscribers;
 
     if (allow_user_to_add_subs) {
-        input_element.removeAttr("disabled");
-        button_element.removeAttr("disabled");
+        input_element.prop("disabled", false);
+        button_element.prop("disabled", false);
         button_element.css("pointer-events", "");
         $(".add_subscribers_container input").popover("destroy");
     } else {
-        input_element.attr("disabled", "disabled");
-        button_element.attr("disabled", "disabled");
+        input_element.prop("disabled", true);
+        button_element.prop("disabled", true);
 
         exports.initialize_disable_btn_hint_popover(
             $(".add_subscribers_container"),

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -884,7 +884,7 @@ exports.do_open_create_stream = function () {
     // Only call this directly for hash changes.
     // Prefer open_create_stream().
 
-    const stream = $.trim($("#search_stream_name").val());
+    const stream = $("#search_stream_name").val().trim();
 
     if (!should_list_all_streams()) {
         // Realms that don't allow listing streams should simply be subscribed to.

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -110,7 +110,7 @@ exports.upload_files = function (uppy, config, files) {
         );
         return;
     }
-    exports.get_item("send_button", config).attr("disabled", "");
+    exports.get_item("send_button", config).prop("disabled", true);
     exports
         .get_item("send_status", config)
         .addClass("alert-info")

--- a/static/js/user_status_ui.js
+++ b/static/js/user_status_ui.js
@@ -23,7 +23,7 @@ exports.open_overlay = function () {
     exports.toggle_clear_message_button();
 
     const button = exports.submit_button();
-    button.attr("disabled", true);
+    button.prop("disabled", true);
 };
 
 exports.close_overlay = function () {
@@ -57,9 +57,9 @@ exports.update_button = function () {
     const button = exports.submit_button();
 
     if (old_status_text === new_status_text) {
-        button.attr("disabled", true);
+        button.prop("disabled", true);
     } else {
-        button.attr("disabled", false);
+        button.prop("disabled", false);
     }
 };
 

--- a/static/third/bootstrap-typeahead/typeahead.js
+++ b/static/third/bootstrap-typeahead/typeahead.js
@@ -115,12 +115,12 @@
   , select: function (e) {
       var val = this.$menu.find('.active').data('typeahead-value')
       if (this.$element.is("[contenteditable]")) {
-        this.$element.html(this.updater(val, e)).change();
+        this.$element.html(this.updater(val, e)).trigger("change");
         // Empty textContent after the change event handler
         // converts the input text to html elements.
         this.$element.html('');
       } else {
-        this.$element.val(this.updater(val, e)).change();
+        this.$element.val(this.updater(val, e)).trigger("change");
       }
 
       return this.hide()
@@ -209,7 +209,7 @@
         }
       }
 
-      items = $.isFunction(this.source) ? this.source(this.query, $.proxy(this.process, this)) : this.source
+      items = typeof this.source === "function" ? this.source(this.query, this.process.bind(this)) : this.source
 
       if (!items && this.shown) this.hide();
       return items ? this.process(items) : this
@@ -307,17 +307,17 @@
 
   , listen: function () {
       this.$element
-        .on('blur',     $.proxy(this.blur, this))
-        .on('keypress', $.proxy(this.keypress, this))
-        .on('keyup',    $.proxy(this.keyup, this))
+        .on('blur',     this.blur(this))
+        .on('keypress', this.keypress.bind(this))
+        .on('keyup',    this.keyup.bind(this))
 
       if (this.eventSupported('keydown')) {
-        this.$element.on('keydown', $.proxy(this.keydown, this))
+        this.$element.on('keydown', this.keydown.bind(this))
       }
 
       this.$menu
-        .on('click', $.proxy(this.click, this))
-        .on('mouseenter', 'li', $.proxy(this.mouseenter, this))
+        .on('click', this.click.bind(this))
+        .on('mouseenter', 'li', this.mouseenter.bind(this))
     }
 
   , eventSupported: function(eventName) {


### PR DESCRIPTION
* search: Replace deprecated jQuery event trigger shorthand.
* js: Replace deprecated $.unbind method.
* js: Replace deprecated $.trim method.
* typeahead: Replace various deprecated jQuery methods.
* message_edit: Use the jQuery css method for style, not removeAttr.
* js: Access ‘disabled’ as a property, not an attribute.

**Testing Plan:** Dev server.