### PR TITLE
buddy_list: Show status messages directly.

### DIFF
--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -280,14 +280,6 @@ run_test("bulk_data_hacks", () => {
 });
 
 run_test("level", () => {
-    assert.equal(buddy_data.my_user_status(me.user_id), "translated: (you)");
-    user_status.set_away(me.user_id);
-    assert.equal(buddy_data.my_user_status(me.user_id), "translated: (unavailable)");
-    user_status.revoke_away(me.user_id);
-    assert.equal(buddy_data.my_user_status(me.user_id), "translated: (you)");
-});
-
-run_test("level", () => {
     presence.presence_info.clear();
     assert.equal(buddy_data.level(me.user_id), 0);
     assert.equal(buddy_data.level(selma.user_id), 3);

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -137,18 +137,6 @@ function get_num_unread(user_id) {
     return unread.num_unread_for_person(user_id.toString());
 }
 
-exports.my_user_status = function (user_id) {
-    if (!people.is_my_user_id(user_id)) {
-        return;
-    }
-
-    if (user_status.is_away(user_id)) {
-        return i18n.t("(unavailable)");
-    }
-
-    return i18n.t("(you)");
-};
-
 exports.user_last_seen_time_status = function (user_id) {
     const status = presence.get_status(user_id);
     if (status === "active") {
@@ -176,16 +164,15 @@ exports.user_last_seen_time_status = function (user_id) {
 exports.info_for = function (user_id) {
     const user_circle_class = exports.get_user_circle_class(user_id);
     const person = people.get_by_user_id(user_id);
-    const my_user_status = exports.my_user_status(user_id);
     const user_circle_status = exports.status_description(user_id);
 
     return {
         href: hash_util.pm_with_uri(person.email),
         name: person.full_name,
         user_id,
-        my_user_status,
         is_current_user: people.is_my_user_id(user_id),
         num_unread: get_num_unread(user_id),
+        user_status_message: user_status.get_status_text(user_id),
         user_circle_class,
         user_circle_status,
     };

--- a/static/styles/right-sidebar.scss
+++ b/static/styles/right-sidebar.scss
@@ -102,7 +102,7 @@
     width: calc(100% - 24px);
 }
 
-.my_user_status {
+.user_status {
     opacity: 0.5;
 }
 

--- a/static/templates/admin_user_list.hbs
+++ b/static/templates/admin_user_list.hbs
@@ -1,6 +1,6 @@
 <tr class="user_row{{#unless is_active}} deactivated_user{{/unless}}" data-user-id="{{user_id}}">
     <td>
-        <span class="user_name" >{{full_name}} {{#if is_current_user}}<span class="my_user_status">{{t '(you)' }}</span>{{/if}}</span>
+        <span class="user_name" >{{full_name}} {{#if is_current_user}}<span class="user_status">{{t '(you)' }}</span>{{/if}}</span>
         <i class="fa fa-ban deactivated-user-icon" title="{{t 'User is deactivated' }}" {{#if is_active}}style="display: none;"{{/if}}></i>
     </td>
     {{#if display_email}}

--- a/static/templates/user_presence_row.hbs
+++ b/static/templates/user_presence_row.hbs
@@ -6,8 +6,8 @@
           data-user-id="{{user_id}}"
           data-name="{{name}}">
             {{name}}
-            {{#if my_user_status}}
-            <span class="my_user_status">{{my_user_status}}</span>
+            {{#if user_status_message}}
+            <span class="user_status">{{user_status_message}}</span>
             {{/if}}
         </a>
         <span class="count"><span class="value">{{#if num_unread}}{{num_unread}}{{/if}}</span></span>


### PR DESCRIPTION
Previously status messages were only shown on hover.

Part of #15682.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/47354597/88218746-c444ee80-cc60-11ea-9d03-a3247f1824c6.png)
![image](https://user-images.githubusercontent.com/47354597/88218790-d58dfb00-cc60-11ea-98df-4459d1598c1c.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->

I think this should be test deployed on CZO for community feedback first.
