### PR TITLE
Fix some failing Casper tests

### DIFF
--- a/frontend_tests/casper_tests/03-narrow.js
+++ b/frontend_tests/casper_tests/03-narrow.js
@@ -338,7 +338,7 @@ casper.then(function () {
 
 casper.waitWhileSelector("#streams_list .input-append.notdisplayed", function () {
     casper.test.assertExists(get_stream_li("Denmark"), "Original stream list contains Denmark");
-    casper.test.assertExists(get_stream_li("Scotland"), "Original stream list contains Scotland");
+    casper.test.assertExists(get_stream_li("Venice"), "Original stream list contains Venice");
     casper.test.assertExists(get_stream_li("Verona"), "Original stream list contains Verona");
 });
 
@@ -356,8 +356,8 @@ casper.waitForSelector("#stream_filters .highlighted_stream", function () {
         "Stream Denmark is highlighted"
     );
     casper.test.assertDoesntExist(
-        get_stream_li("Scotland") + ".highlighted_stream",
-        "Stream Scotland is not highlighted"
+        get_stream_li("Venice") + ".highlighted_stream",
+        "Stream Venice is not highlighted"
     );
     casper.test.assertDoesntExist(
         get_stream_li("Verona") + ".highlighted_stream",
@@ -370,22 +370,22 @@ casper.then(function () {
     function arrow(key) {
         casper.sendKeys(".stream-list-filter", casper.page.event.key[key], {keepFocus: true});
     }
-    arrow("Down"); // Denmark -> Scotland
-    arrow("Up"); // Scotland -> Denmark
+    arrow("Down"); // Denmark -> Venice
+    arrow("Up"); // Venice -> Denmark
     arrow("Up"); // Denmark -> Denmark
-    arrow("Down"); // Denmark -> Scotland
+    arrow("Down"); // Denmark -> Venice
 });
 
 casper.then(function () {
-    casper.waitForSelector(get_stream_li("Scotland") + ".highlighted_stream", function () {
+    casper.waitForSelector(get_stream_li("Venice") + ".highlighted_stream", function () {
         casper.test.info("Suggestion highlighting - after arrow key navigation");
         casper.test.assertDoesntExist(
             get_stream_li("Denmark") + ".highlighted_stream",
             "Stream Denmark is not highlighted"
         );
         casper.test.assertExist(
-            get_stream_li("Scotland") + ".highlighted_stream",
-            "Stream Scotland is  highlighted"
+            get_stream_li("Venice") + ".highlighted_stream",
+            "Stream Venice is highlighted"
         );
         casper.test.assertDoesntExist(
             get_stream_li("Verona") + ".highlighted_stream",
@@ -394,13 +394,13 @@ casper.then(function () {
     });
 });
 
-// We search for the beginning of "Scotland", not case sensitive
+// We search for the beginning of "Venice", not case sensitive
 casper.then(function () {
     casper.evaluate(function () {
         $(".stream-list-filter")
             .expectOne()
             .trigger("focus")
-            .val("sCoT")
+            .val("vEnI")
             .trigger($.Event("input"))
             .trigger($.Event("click"));
     });
@@ -423,13 +423,10 @@ casper.waitWhileVisible(get_stream_li("Verona"), function () {
 });
 
 casper.then(function () {
+    casper.test.assertExists(get_stream_li("Venice"), "Filtered stream list does contain Venice");
     casper.test.assertExists(
-        get_stream_li("Scotland"),
-        "Filtered stream list does contain Scotland"
-    );
-    casper.test.assertExists(
-        get_stream_li("Scotland") + ".highlighted_stream",
-        "Stream Scotland is highlighted"
+        get_stream_li("Venice") + ".highlighted_stream",
+        "Stream Venice is highlighted"
     );
 });
 
@@ -444,11 +441,8 @@ casper.then(function () {
     casper.waitUntilVisible(get_stream_li("Denmark"), function () {
         casper.test.assertExists(get_stream_li("Denmark"), "Restored stream list contains Denmark");
     });
-    casper.waitUntilVisible(get_stream_li("Scotland"), function () {
-        casper.test.assertExists(
-            get_stream_li("Denmark"),
-            "Restored stream list contains Scotland"
-        );
+    casper.waitUntilVisible(get_stream_li("Venice"), function () {
+        casper.test.assertExists(get_stream_li("Denmark"), "Restored stream list contains Venice");
     });
     casper.waitUntilVisible(get_stream_li("Verona"), function () {
         casper.test.assertExists(get_stream_li("Denmark"), "Restored stream list contains Verona");
@@ -509,7 +503,7 @@ function assert_not_selected(name) {
 // User search at the right sidebar
 casper.then(function () {
     casper.test.info("Search users using right sidebar");
-    assert_in_list("Iago");
+    assert_in_list("Desdemona");
     assert_in_list("Cordelia Lear");
     assert_in_list("King Hamlet");
     assert_in_list("aaron");
@@ -525,7 +519,7 @@ casper.then(function () {
 
 casper.waitForSelector("#user_presences .highlighted_user", function () {
     casper.test.info("Suggestion highlighting - initial situation");
-    assert_selected("Iago");
+    assert_selected("Desdemona");
     assert_not_selected("Cordelia Lear");
     assert_not_selected("King Hamlet");
     assert_not_selected("aaron");

--- a/frontend_tests/casper_tests/06-settings.js
+++ b/frontend_tests/casper_tests/06-settings.js
@@ -48,10 +48,10 @@ casper.then(function () {
             casper.test.assertVisible("#old_password");
             casper.test.assertVisible("#new_password");
 
-            casper.test.assertEqual(casper.getFormValues(form_sel).full_name, "Iago");
+            casper.test.assertEqual(casper.getFormValues(form_sel).full_name, "Desdemona");
 
             casper.fill(form_sel, {
-                full_name: "IagoNew",
+                full_name: "DesdemonaNew",
                 old_password: test_credentials.default_user.password,
                 new_password: "qwertyuiop",
             });
@@ -87,7 +87,7 @@ casper.then(function () {
         /*
         // Change it all back so the next test can still log in
         casper.fill(form_sel, {
-            full_name: "Iago",
+            full_name: "Desdemona",
             old_password: "qwertyuiop",
             new_password: test_credentials.default_user.password,
         });

--- a/frontend_tests/casper_tests/06-settings.js
+++ b/frontend_tests/casper_tests/06-settings.js
@@ -294,7 +294,7 @@ casper.then(function () {
 
 casper.then(function () {
     casper.test.info("Deleting alert word");
-    casper.click("button.remove-alert-word");
+    casper.click("button.remove-alert-word[data-word='some phrase']");
     casper.test.info("Checking that a success message is displayed");
     casper.waitUntilVisible("#alert_word_status", function () {
         casper.test.assertSelectorHasText(
@@ -308,7 +308,6 @@ casper.then(function () {
     });
     casper.test.info("Checking that the element was deleted");
     casper.waitWhileVisible(".alert-word-item[data-word='some phrase']", function () {
-        casper.test.assertDoesntExist("div.alert-word-information-box");
         casper.test.info("Element deleted successfully");
     });
 });

--- a/frontend_tests/casper_tests/16-copy-and-paste.js
+++ b/frontend_tests/casper_tests/16-copy-and-paste.js
@@ -111,7 +111,7 @@ casper.then(function () {
 // test copying two first messages from topic
 casper.then(function () {
     var actual_copied_lines = copy_messages("copy paste test C", "copy paste test D");
-    var expected_copied_lines = ["Iago: copy paste test C", "Iago: copy paste test D"];
+    var expected_copied_lines = ["Desdemona: copy paste test C", "Desdemona: copy paste test D"];
     casper.test.assertEquals(
         actual_copied_lines,
         expected_copied_lines,
@@ -123,9 +123,9 @@ casper.then(function () {
 casper.then(function () {
     var actual_copied_lines = copy_messages("copy paste test C", "copy paste test E");
     var expected_copied_lines = [
-        "Iago: copy paste test C",
-        "Iago: copy paste test D",
-        "Iago: copy paste test E",
+        "Desdemona: copy paste test C",
+        "Desdemona: copy paste test D",
+        "Desdemona: copy paste test E",
     ];
     casper.test.assertEquals(
         actual_copied_lines,
@@ -139,9 +139,9 @@ casper.then(function () {
     var actual_copied_lines = copy_messages("copy paste test B", "copy paste test C");
     var expected_copied_lines = [
         "Verona > copy-paste-subject #1 Today",
-        "Iago: copy paste test B",
+        "Desdemona: copy paste test B",
         "Verona > copy-paste-subject #2 Today",
-        "Iago: copy paste test C",
+        "Desdemona: copy paste test C",
     ];
     casper.test.assertEquals(
         actual_copied_lines,
@@ -155,11 +155,11 @@ casper.then(function () {
     var actual_copied_lines = copy_messages("copy paste test B", "copy paste test E");
     var expected_copied_lines = [
         "Verona > copy-paste-subject #1 Today",
-        "Iago: copy paste test B",
+        "Desdemona: copy paste test B",
         "Verona > copy-paste-subject #2 Today",
-        "Iago: copy paste test C",
-        "Iago: copy paste test D",
-        "Iago: copy paste test E",
+        "Desdemona: copy paste test C",
+        "Desdemona: copy paste test D",
+        "Desdemona: copy paste test E",
     ];
     casper.test.assertEquals(
         actual_copied_lines,
@@ -173,10 +173,10 @@ casper.then(function () {
     var actual_copied_lines = copy_messages("copy paste test A", "copy paste test C");
     var expected_copied_lines = [
         "Verona > copy-paste-subject #1 Today",
-        "Iago: copy paste test A",
-        "Iago: copy paste test B",
+        "Desdemona: copy paste test A",
+        "Desdemona: copy paste test B",
         "Verona > copy-paste-subject #2 Today",
-        "Iago: copy paste test C",
+        "Desdemona: copy paste test C",
     ];
     casper.test.assertEquals(
         actual_copied_lines,
@@ -190,13 +190,13 @@ casper.then(function () {
     var actual_copied_lines = copy_messages("copy paste test B", "copy paste test F");
     var expected_copied_lines = [
         "Verona > copy-paste-subject #1 Today",
-        "Iago: copy paste test B",
+        "Desdemona: copy paste test B",
         "Verona > copy-paste-subject #2 Today",
-        "Iago: copy paste test C",
-        "Iago: copy paste test D",
-        "Iago: copy paste test E",
+        "Desdemona: copy paste test C",
+        "Desdemona: copy paste test D",
+        "Desdemona: copy paste test E",
         "Verona > copy-paste-subject #3 Today",
-        "Iago: copy paste test F",
+        "Desdemona: copy paste test F",
     ];
     casper.test.assertEquals(
         actual_copied_lines,

--- a/tools/setup/generate-test-credentials
+++ b/tools/setup/generate-test-credentials
@@ -3,7 +3,7 @@ set -e
 
 cd "$(dirname "$0")"/../..
 
-email=iago@zulip.com
+email=desdemona@zulip.com
 
 mkdir -p var/casper
 


### PR DESCRIPTION
This fixes some but not all of the current Casper test failures. 15-delete-messages.js still has issues introduced by #15792 and #15803.

**Testing Plan:** `test-js-with-casper`, `test-js-with-puppeteer`