### PR TITLE
subs: Fix set_muted parameter order

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -413,7 +413,7 @@ function stream_is_muted_changed(e) {
     const sub_settings = exports.settings_for_sub(sub);
     const notification_checkboxes = sub_settings.find(".sub_notification_setting");
 
-    subs.set_muted(sub, `#stream_change_property_status${sub.stream_id}`, e.target.checked);
+    subs.set_muted(sub, e.target.checked, `#stream_change_property_status${sub.stream_id}`);
     sub_settings.find(".mute-note").toggleClass("hide-mute-note", !sub.is_muted);
     notification_checkboxes.toggleClass("muted-sub", sub.is_muted);
     notification_checkboxes.find("input[type='checkbox']").prop("disabled", sub.is_muted);

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -95,7 +95,7 @@ exports.active_stream = function () {
     }
 };
 
-exports.set_muted = function (sub, status_element, is_muted) {
+exports.set_muted = function (sub, is_muted, status_element) {
     stream_muting.update_is_muted(sub, is_muted);
     stream_edit.set_stream_property(sub, "is_muted", sub.is_muted, status_element);
 };


### PR DESCRIPTION
The `status_element` parameter is optional, and the other caller in `stream_popover.js` does not provide it. This fixes a regression in commit e6a66063a9d89bab84f754d27b3e8683c364b29f (#15868).

**Testing Plan:** Dev server.