### PR TITLE
event schema: Handle tricky update schemas

### DIFF
--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -349,6 +349,13 @@ def check_realm_bot_update(var_name: str, event: Dict[str, Any], field: str,) ->
     assert {"user_id", field} == set(event["bot"].keys())
 
 
+_check_plan_type_extra_data = check_dict_only(
+    required_keys=[
+        # force vertical
+        ("upload_quota", check_int),
+    ]
+)
+
 """
 realm/update events are flexible for values;
 we will use a more strict checker to check
@@ -360,7 +367,11 @@ _check_realm_update = check_events_dict(
         ("op", equals("update")),
         ("property", check_string),
         ("value", check_value),
-    ]
+    ],
+    optional_keys=[
+        # force vertical
+        ("extra_data", _check_plan_type_extra_data),
+    ],
 )
 
 
@@ -380,6 +391,13 @@ def check_realm_update(var_name: str, event: Dict[str, Any], prop: str,) -> None
 
     assert prop == event["property"]
     value = event["value"]
+
+    if prop == "plan_type":
+        assert isinstance(value, int)
+        assert "extra_data" in event.keys()
+        return
+
+    assert "extra_data" not in event.keys()
 
     if prop in ["notifications_stream_id", "signup_notifications_stream_id"]:
         assert isinstance(value, int)

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -364,7 +364,7 @@ _check_realm_update = check_events_dict(
 )
 
 
-def check_realm_update(var_name: str, event: Dict[str, Any],) -> None:
+def check_realm_update(var_name: str, event: Dict[str, Any], prop: str,) -> None:
     """
     Realm updates have these two fields:
 
@@ -377,10 +377,16 @@ def check_realm_update(var_name: str, event: Dict[str, Any],) -> None:
     for the property.
     """
     _check_realm_update(var_name, event)
-    prop = event["property"]
+
+    assert prop == event["property"]
     value = event["value"]
 
+    if prop in ["notifications_stream_id", "signup_notifications_stream_id"]:
+        assert isinstance(value, int)
+        return
+
     property_type = Realm.property_types[prop]
+
     if property_type in (bool, int, str):
         assert isinstance(value, property_type)
     elif property_type == (int, type(None)):

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1326,18 +1326,9 @@ class NormalActionsTest(BaseAction):
         self.assertEqual(state_data['realm_plan_type'], Realm.SELF_HOSTED)
         self.assertEqual(state_data['zulip_plan_is_not_limited'], True)
 
-        schema_checker = check_events_dict([
-            ('type', equals('realm')),
-            ('op', equals('update')),
-            ('property', equals('plan_type')),
-            ('value', equals(Realm.LIMITED)),
-            ('extra_data', check_dict_only([
-                ('upload_quota', check_int),
-            ])),
-        ])
         events = self.verify_action(
             lambda: do_change_plan_type(realm, Realm.LIMITED))
-        schema_checker('events[0]', events[0])
+        check_realm_update('events[0]', events[0], 'plan_type')
 
         state_data = fetch_initial_state_data(self.user_profile, None, "", False, False)
         self.assertEqual(state_data['realm_plan_type'], Realm.LIMITED)

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1199,12 +1199,6 @@ class NormalActionsTest(BaseAction):
             schema_checker('events[0]', events[0])
 
     def test_change_realm_notifications_stream(self) -> None:
-        schema_checker = check_events_dict([
-            ('type', equals('realm')),
-            ('op', equals('update')),
-            ('property', equals('notifications_stream_id')),
-            ('value', check_int),
-        ])
 
         stream = get_stream("Rome", self.user_profile.realm)
 
@@ -1213,16 +1207,9 @@ class NormalActionsTest(BaseAction):
                 lambda: do_set_realm_notifications_stream(self.user_profile.realm,
                                                           notifications_stream,
                                                           notifications_stream_id))
-            schema_checker('events[0]', events[0])
+            check_realm_update('events[0]', events[0], 'notifications_stream_id')
 
     def test_change_realm_signup_notifications_stream(self) -> None:
-        schema_checker = check_events_dict([
-            ('type', equals('realm')),
-            ('op', equals('update')),
-            ('property', equals('signup_notifications_stream_id')),
-            ('value', check_int),
-        ])
-
         stream = get_stream("Rome", self.user_profile.realm)
 
         for signup_notifications_stream, signup_notifications_stream_id in ((stream, stream.id), (None, -1)):
@@ -1230,7 +1217,7 @@ class NormalActionsTest(BaseAction):
                 lambda: do_set_realm_signup_notifications_stream(self.user_profile.realm,
                                                                  signup_notifications_stream,
                                                                  signup_notifications_stream_id))
-            schema_checker('events[0]', events[0])
+            check_realm_update('events[0]', events[0], 'signup_notifications_stream_id')
 
     def test_change_is_admin(self) -> None:
         reset_emails_in_zulip_realm()
@@ -2048,7 +2035,7 @@ class RealmPropertyActionTest(BaseAction):
                     RealmAuditLog.OLD_VALUE: {'property': name, 'value': old_value},
                     RealmAuditLog.NEW_VALUE: {'property': name, 'value': val}
                 })).count(), 1)
-            check_realm_update('events[0]', events[0])
+            check_realm_update('events[0]', events[0], name)
 
     def test_change_realm_property(self) -> None:
         for prop in Realm.property_types:


### PR DESCRIPTION
Our update schemas don't really follow simple rules, so the first couple commits here are gonna be kinda painful to review, but I was pretty careful with them to ensure we didn't lose any checks in `test_events`. 