### PR TITLE
events_documentation: Document some events, create parser and add validation.

### DIFF
--- a/zerver/lib/markdown/api_return_values_table_generator.py
+++ b/zerver/lib/markdown/api_return_values_table_generator.py
@@ -114,6 +114,9 @@ class APIReturnValuesTablePreprocessor(Preprocessor):
         argument_template = ('<div class="api-argument"><p class="api-argument-name"><h3 id="{h3_id}">' +
                              ' {event_type} {op}</h3></p></div> \n{description}\n\n\n')
         for events in events_dict['oneOf']:
+            # `id` is present in every event so it will be redundant to display
+            # it everytime. So remove it from the dictionary.
+            events['properties'].pop('id')
             event_type: Dict[str, Any] = events['properties'].pop('type')
             event_type_str: str = event_type['enum'][0]
             # Internal hyperlink name

--- a/zerver/openapi/openapi.py
+++ b/zerver/openapi/openapi.py
@@ -18,7 +18,7 @@ OPENAPI_SPEC_PATH = os.path.abspath(os.path.join(
 EXCLUDE_UNDOCUMENTED_ENDPOINTS = {"/realm/emoji/{emoji_name}:delete", "/users:patch"}
 # Consists of endpoints with some documentation remaining.
 # These are skipped but return true as the validator cannot exclude objects
-EXCLUDE_DOCUMENTED_ENDPOINTS = {"/events:get", "/register:post", "/settings/notifications:patch"}
+EXCLUDE_DOCUMENTED_ENDPOINTS = {"/register:post", "/settings/notifications:patch"}
 class OpenAPISpec():
     def __init__(self, path: str) -> None:
         self.path = path
@@ -26,6 +26,7 @@ class OpenAPISpec():
         self.data: Dict[str, Any] = {}
         self.regex_dict: Dict[str, str] = {}
         self.core_data: Any = None
+        self.documented_events: Set[str] = set()
 
     def reload(self) -> None:
         # Because importing yamole (and in turn, yaml) takes
@@ -46,6 +47,16 @@ class OpenAPISpec():
         self.core_data = RequestValidator(validator_spec)
         self.create_regex_dict()
         self.last_update = os.path.getmtime(self.path)
+        # Form a set of all documented events
+        self.documented_events.clear()
+        schema = (self.data['paths']['/events']['get']['responses']
+                  ['200']['content']['application/json']['schema'])
+        for events in schema['properties']['events']['items']['oneOf']:
+            op_str = ':'
+            if 'op' in events['properties']:
+                op_str = f':{events["properties"]["op"]["enum"][0]}'
+            self.documented_events.add(events['properties']['type']['enum'][0]
+                                       + op_str)
 
     def create_regex_dict(self) -> None:
         # Alogrithm description:
@@ -121,6 +132,19 @@ class OpenAPISpec():
             self.reload()
         return self.core_data
 
+    def get_documented_events(self) -> Set[str]:
+        """Reload the OpenAPI file if it has been modified after the last time
+        it was read, and then return the set of documented events. Similar
+        to preceding functions. Used for proper access to OpenAPI objects.
+        """
+        last_modified = os.path.getmtime(self.path)
+        # Using != rather than < to cover the corner case of users placing an
+        # earlier version than the current one
+        if self.last_update != last_modified:
+            self.reload()
+        return self.documented_events
+
+
 class SchemaError(Exception):
     pass
 
@@ -190,6 +214,21 @@ def match_against_openapi_regex(endpoint: str) -> Optional[str]:
             return openapi_spec.regex_keys()[key]
     return None
 
+def get_event_type(event: Dict[str, Any]) -> str:
+    return event['type'] + ':' + event.get('op', '')
+
+def fix_events(content: Dict[str, Any]) -> None:
+    """Remove undocumented events from events array. This is a makeshift
+    function so that further documentation of `/events` can happen with
+    only zulip.yaml changes and minimal other changes. It should be removed
+    as soon as `/events` documentation is complete.
+    """
+    content['events'] = [event for event in content['events']
+                         if get_event_type(event) in openapi_spec.get_documented_events()]
+    # 'user' is deprecated so remove its occurences from the events array
+    for event in content['events']:
+        event.pop('user', None)
+
 def validate_against_openapi_schema(content: Dict[str, Any], endpoint: str,
                                     method: str, response: str) -> bool:
     """Compare a "content" dict with the defined schema for a specific method
@@ -225,10 +264,14 @@ def validate_against_openapi_schema(content: Dict[str, Any], endpoint: str,
         # been added as all 400 have the same schema.  When all 400
         # response have been defined this should be removed.
         return True
-
     # The actual work of validating that the response matches the
     # schema is done via the third-party OAS30Validator.
     schema = get_schema(endpoint, method, response)
+    if endpoint == '/events' and method == 'get':
+        # This a temporary function for checking only documented events
+        # as all events haven't been documented yet.
+        # TODO: Remove this after all events have been documented.
+        fix_events(content)
     validator = OAS30Validator(schema)
     validator.validate(content)
     return True

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -228,7 +228,81 @@ paths:
                                 notification_name:
                                   type: string
                                   description: |
-                                    Notification setting to be changed.
+                                    Notification setting to be changed. It is one of the following:
+                                      * `enable_stream_desktop_notifications`: Enable visual desktop
+                                      notifications for stream messages.
+
+                                      * `enable_stream_email_notifications`: Enable email notifications
+                                      for stream messages.
+
+                                      * `enable_stream_push_notifications`: Enable mobile notifications
+                                      for stream messages.
+
+                                      * `enable_stream_audible_notifications`: Enable audible desktop
+                                      notifications for stream messages.
+
+                                      * `notification_sound`: Notification sound name.
+
+                                      * `enable_desktop_notifications`: Enable visual desktop notifications
+                                      for private messages and @-mentions.
+
+                                      * `enable_sounds`: Enable audible desktop notifications for private
+                                      messages and @-mentions.
+
+                                      * `enable_offline_email_notifications`: Enable email notifications for
+                                      private messages and @-mentions received when the user is offline.
+
+                                      * `enable_offline_push_notifications`: Enable mobile notification for
+                                      private messages and @-mentions received when the user is offline.
+
+                                      * `enable_online_push_notifications`: Enable mobile notification for
+                                      private messages and @-mentions received when the user is online.
+
+                                      * `enable_digest_emails`: Enable digest emails when the user is away.
+
+                                      * `enable_login_emails`: Enable email notifications for new logins to
+                                      account.
+
+                                      * `message_content_in_email_notifications`: Include the message's
+                                      content in missed messages email notifications.
+
+                                      * `pm_content_in_desktop_notifications`: Include content of
+                                      private messages in desktop notifications.
+
+                                      * `wildcard_mentions_notify`: Whether wildcard mentions (E.g. @**all**)
+                                      should send notifications like a personal mention.
+
+                                      * `desktop_icon_count_display`: Unread count summary
+                                      (appears in desktop sidebar and browser tab)
+
+                                          * 1 - All unreads
+                                          * 2 - Private messages and mentions
+                                          * 3 - None
+
+                                      * `realm_name_in_notifications`: Include organization name in subject of
+                                      missed message emails.
+
+                                      * `presence_enabled`: Display the presence status to other users when
+                                      online.
+                                  enum:
+                                    - enable_stream_desktop_notifications
+                                    - enable_stream_email_notifications
+                                    - enable_stream_push_notifications
+                                    - enable_stream_audible_notifications
+                                    - notification_sound
+                                    - enable_desktop_notifications
+                                    - enable_sounds
+                                    - enable_offline_email_notifications
+                                    - enable_offline_push_notifications
+                                    - enable_online_push_notifications
+                                    - enable_digest_emails
+                                    - enable_login_emails
+                                    - message_content_in_email_notifications
+                                    - pm_content_in_desktop_notifications
+                                    - wildcard_mentions_notify
+                                    - desktop_icon_count_display
+                                    - realm_name_in_notifications
+                                    - presence_enabled
                                 setting:
                                   description: |
                                     Final value of setting.

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -156,8 +156,215 @@ paths:
                           guaranteed to be increasing, but they are not guaranteed to be
                           consecutive.
                         items:
-                          type: object
-                          additionalProperties: false
+                          oneOf:
+                            - type: object
+                              description: |
+                                Event type for changing alert words for the user.
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - alert_words
+                                alert_words:
+                                  type: array
+                                  description: |
+                                    Array of words which are to be used
+                                    as alert words
+                                  items:
+                                    type: string
+                              additionalProperties: false
+                              example:
+                                {
+                                  "type": "alert_words",
+                                  "alert_words": ["alert_word"],
+                                  "id": 0,
+                                }
+                            - type: object
+                              description: |
+                                Event type for updating display settings.
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - update_display_settings
+                                setting_name:
+                                  type: string
+                                  description: |
+                                    Display setting to be changed.
+                                setting:
+                                  description: |
+                                    Final value of setting.
+                                  type: boolean
+                              additionalProperties: false
+                              example:
+                                {
+                                  "type": "update_display_settings",
+                                  "setting_name": "high_contrast_mode",
+                                  "setting": false,
+                                }
+                            - type: object
+                              description: |
+                                Event type for updating global notification settings.
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - update_global_notifications
+                                notification_name:
+                                  type: string
+                                  description: |
+                                    Notification setting to be changed.
+                                setting:
+                                  description: |
+                                    Final value of setting.
+                                  type: boolean
+                              additionalProperties: false
+                              example:
+                                {
+                                  "type": "update_global_notifications",
+                                  "notification_name": "enable_sounds",
+                                  "setting": true,
+                                }
+                            - type: object
+                              description: |
+                                Event type for various updates to the users in the
+                                Zulip organization.
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - realm_user
+                                op:
+                                  type: string
+                                  enum:
+                                    - update
+                                person:
+                                  description: |
+                                    Object containing the changed details of the user.
+                                    It has multiple forms depending on the value changed.
+                                  oneOf:
+                                    - type: object
+                                      description: |
+                                        When a user changes their full name.
+                                      properties:
+                                        user_id:
+                                          type: integer
+                                          description: |
+                                            The id of the user who is affected by this change.
+                                        full_name:
+                                          type: string
+                                          description: |
+                                            The new full name of the user.
+                                    - type: object
+                                      description: |
+                                        When a user changes their avatar.
+                                      properties:
+                                        user_id:
+                                          type: integer
+                                          description: |
+                                            The id of the user who is affected by this change.
+                                        avatar_url:
+                                          type: string
+                                          description: |
+                                            The url of the new avatar of the user.
+                                        avatar_source:
+                                          type: string
+                                          description: |
+                                            The source of the new avatar of the user.
+                                        avatar_url_medium:
+                                          type: string
+                                          description: |
+                                            The url medium of the user's new avatar.
+                                        avatar_version:
+                                          type: string
+                                          description: |
+                                            The version of the user's avatar.
+                                    - type: object
+                                      description: |
+                                        When a user changes their timezone display settings.
+                                      properties:
+                                        user_id:
+                                          type: integer
+                                          description: |
+                                            The id of the user who is affected by this change.
+                                        email:
+                                          type: string
+                                          description: |
+                                            The email of the user.
+                                        timezone:
+                                          type: string
+                                          description: |
+                                            The new timezone of the user.
+                              additionalProperties: false
+                              example:
+                                {
+                                  "type": "realm_user",
+                                  "op": "update",
+                                  "person":
+                                    {
+                                      "avatar_source": "G",
+                                      "avatar_url": "https:\/\/secure.gravatar.com\/avatar\/6d8cad0fd00256e7b40691d27ddfd466?d=identicon&version=3",
+                                      "avatar_url_medium": "https:\/\/secure.gravatar.com\/avatar\/6d8cad0fd00256e7b40691d27ddfd466?d=identicon&s=500&version=3",
+                                      "avatar_version": 3,
+                                      "user_id": 10,
+                                    },
+                                  "id": 0,
+                                }
+                            - type: object
+                              description: |
+                                Event type for notifying user that they have been subscribed
+                                to a stream.
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - subscription
+                                op:
+                                  type: string
+                                  enum:
+                                    - add
+                                subscriptions:
+                                  type: array
+                                  description: |
+                                    A list of dictionaries where each dictionary contains
+                                    information about one of the subscribed streams.
+                                  items:
+                                    $ref: "#/components/schemas/Subscriptions"
+                              additionalProperties: false
+                              example:
+                                {
+                                  "type": "subscription",
+                                  "op": "add",
+                                  "subscriptions":
+                                    [
+                                      {
+                                        "name": "test_stream",
+                                        "stream_id": 9,
+                                        "description": "",
+                                        "rendered_description": "",
+                                        "invite_only": false,
+                                        "is_web_public": false,
+                                        "stream_post_policy": 1,
+                                        "history_public_to_subscribers": true,
+                                        "first_message_id": null,
+                                        "message_retention_days": null,
+                                        "is_announcement_only": false,
+                                        "color": "#76ce90",
+                                        "is_muted": false,
+                                        "pin_to_top": false,
+                                        "audible_notifications": null,
+                                        "desktop_notifications": null,
+                                        "email_notifications": null,
+                                        "push_notifications": null,
+                                        "wildcard_mentions_notify": null,
+                                        "in_home_view": true,
+                                        "email_address": "test_stream.af64447e9e39374841063747ade8e6b0.show-sender@testserver",
+                                        "stream_weekly_traffic": null,
+                                        "subscribers": [10],
+                                      },
+                                    ],
+                                  "id": 0,
+                                }
                       queue_id:
                         type: string
                         description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -161,6 +161,8 @@ paths:
                               description: |
                                 Event type for changing alert words for the user.
                               properties:
+                                id:
+                                  type: integer
                                 type:
                                   type: string
                                   enum:
@@ -183,6 +185,8 @@ paths:
                               description: |
                                 Event type for updating display settings.
                               properties:
+                                id:
+                                  type: integer
                                 type:
                                   type: string
                                   enum:
@@ -194,7 +198,16 @@ paths:
                                 setting:
                                   description: |
                                     Final value of setting.
-                                  type: boolean
+                                  oneOf:
+                                    - type: boolean
+                                    - type: integer
+                                    - type: string
+                                language_name:
+                                  description: |
+                                    Present only if the setting to be changed is
+                                    `default_language`. Contains the name of the
+                                    new default language in English.
+                                  type: string
                               additionalProperties: false
                               example:
                                 {
@@ -206,6 +219,8 @@ paths:
                               description: |
                                 Event type for updating global notification settings.
                               properties:
+                                id:
+                                  type: integer
                                 type:
                                   type: string
                                   enum:
@@ -217,7 +232,10 @@ paths:
                                 setting:
                                   description: |
                                     Final value of setting.
-                                  type: boolean
+                                  oneOf:
+                                    - type: boolean
+                                    - type: integer
+                                    - type: string
                               additionalProperties: false
                               example:
                                 {
@@ -234,6 +252,8 @@ paths:
                                   type: string
                                   enum:
                                     - realm_user
+                                id:
+                                  type: integer
                                 op:
                                   type: string
                                   enum:
@@ -255,6 +275,7 @@ paths:
                                           type: string
                                           description: |
                                             The new full name of the user.
+                                      additionalProperties: false
                                     - type: object
                                       description: |
                                         When a user changes their avatar.
@@ -276,10 +297,12 @@ paths:
                                           description: |
                                             The url medium of the user's new avatar.
                                         avatar_version:
-                                          type: string
+                                          type: integer
                                           description: |
                                             The version of the user's avatar.
+                                      additionalProperties: false
                                     - type: object
+                                      additionalProperties: false
                                       description: |
                                         When a user changes their timezone display settings.
                                       properties:
@@ -295,6 +318,81 @@ paths:
                                           type: string
                                           description: |
                                             The new timezone of the user.
+                                    - type: object
+                                      additionalProperties: false
+                                      description: |
+                                        When the owner of a bot changes.
+                                      properties:
+                                        user_id:
+                                          type: integer
+                                          description: |
+                                            The id of the user/bot whose owner has changed.
+                                        bot_owner_id:
+                                          type: integer
+                                          description: |
+                                            The user id of the new bot owner.
+                                    - type: object
+                                      additionalProperties: false
+                                      description: |
+                                        When the role of a user changes.
+                                      properties:
+                                        user_id:
+                                          type: integer
+                                          description: |
+                                            The id of the user affected by this change.
+                                        role:
+                                          type: integer
+                                          description: |
+                                            The new role of the user in integer.
+                                    - type: object
+                                      additionalProperties: false
+                                      description: |
+                                        When the delivery email of a user changes.
+
+                                        Note: This event is only visible to admins.
+                                      properties:
+                                        user_id:
+                                          type: integer
+                                          description: |
+                                            The id of the user affected by this change.
+                                        delivery_email:
+                                          type: string
+                                          description: |
+                                            The new delivery email of the user.
+                                    - type: object
+                                      additionalProperties: false
+                                      description: |
+                                        When the user updates one of their custom profile
+                                        fields.
+                                      properties:
+                                        user_id:
+                                          type: integer
+                                          description: |
+                                            The id of the user affected by this change.
+                                        custom_profile_field:
+                                          type: object
+                                          additionalProperties: false
+                                          description: |
+                                            Object containing details about the custom
+                                            profile data change.
+                                          properties:
+                                            id:
+                                              type: integer
+                                              description: |
+                                                The id of the custom profile field which user updated.
+                                            value:
+                                              type: string
+                                              description: |
+                                                User's personal value for this custom profile field.
+                                            rendered_value:
+                                              type: string
+                                              description: |
+                                                The `value` rendered in HTML.  Will only be present for
+                                                custom profile field types that support markdown rendering.
+
+                                                This user-generated HTML content should be rendered
+                                                using the same CSS and client-side security protections
+                                                as are used for message content.
                               additionalProperties: false
                               example:
                                 {
@@ -315,6 +413,8 @@ paths:
                                 Event type for notifying user that they have been subscribed
                                 to a stream.
                               properties:
+                                id:
+                                  type: integer
                                 type:
                                   type: string
                                   enum:
@@ -369,6 +469,10 @@ paths:
                         type: string
                         description: |
                           The ID of the registered queue.
+                      handler_id:
+                        type: integer
+                        description: |
+                          The ID of the queue handler.
                   - example:
                       {
                         "queue_id": "1375801870:2942",
@@ -4578,6 +4682,7 @@ components:
             assumption, as we may change that behavior in the future.
         first_message_id:
           type: integer
+          nullable: true
           description: |
             The id of the first message in the stream.
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -539,6 +539,78 @@ paths:
                                     ],
                                   "id": 0,
                                 }
+                            - type: object
+                              description: |
+                                Event type for messages.
+                              properties:
+                                id:
+                                  type: integer
+                                type:
+                                  type: string
+                                  enum:
+                                    - message
+                                message:
+                                  $ref: "#/components/schemas/Messages"
+                                flags:
+                                  type: array
+                                  description: |
+                                    The user's [message flags][message-flags] for the message.
+                                  items:
+                                    type: string
+                                email_notified:
+                                  type: boolean
+                                  description: |
+                                    Whether the user receiving the event has already been
+                                    notified via email.
+                                push_notified:
+                                  type: boolean
+                                  description: |
+                                    Whether the user receiving the event has already been
+                                    notified via mobile notification.
+                                stream_push_notify:
+                                  type: boolean
+                                  description: |
+                                    Whether the user receiving the event has to be notified
+                                    via mobile notification for stream message.
+                                stream_email_notify:
+                                  type: boolean
+                                  description: |
+                                    Whether the user receiving the event has to be notified
+                                    via email for stream message.
+                                wildcard_mention_notify:
+                                  type: boolean
+                                  description: |
+                                    Whether the user has to be notified due to wildcard mention.
+                              additionalProperties: false
+                              example:
+                                {
+                                  "type": "message",
+                                  "message":
+                                    {
+                                      "id": 31,
+                                      "sender_id": 10,
+                                      "content": "<p>First message ...<a href=\"user_uploads\/2\/ce\/2Xpnnwgh8JWKxBXtTfD6BHKV\/zulip.txt\">zulip.txt<\/a><\/p>",
+                                      "recipient_id": 23,
+                                      "timestamp": 1594825416,
+                                      "client": "test suite",
+                                      "subject": "test",
+                                      "topic_links": [],
+                                      "is_me_message": false,
+                                      "reactions": [],
+                                      "submessages": [],
+                                      "sender_full_name": "King Hamlet",
+                                      "sender_short_name": "hamlet",
+                                      "sender_email": "user10@zulip.testserver",
+                                      "sender_realm_str": "zulip",
+                                      "display_recipient": "Denmark",
+                                      "type": "stream",
+                                      "stream_id": 1,
+                                      "avatar_url": null,
+                                      "content_type": "text\/html",
+                                    },
+                                  "flags": [],
+                                  "id": 1,
+                                }
                       queue_id:
                         type: string
                         description: |
@@ -4839,6 +4911,8 @@ components:
                 Whether the user is a mirror dummy.
     Messages:
       type: object
+      description: |
+        Object containing details of the message.
       additionalProperties: false
       properties:
         avatar_url:

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -161,6 +161,7 @@ from zerver.models import (
     get_stream,
     get_user_by_delivery_email,
 )
+from zerver.openapi.openapi import validate_against_openapi_schema
 from zerver.tornado.event_queue import (
     allocate_client_descriptor,
     clear_client_event_queues_for_testing,
@@ -219,8 +220,14 @@ class BaseAction(ZulipTestCase):
         )
         action()
         events = client.event_queue.contents()
+        content = {
+            'queue_id': '123.12',
+            'events': copy.deepcopy(events),
+            'msg': '',
+            'result': 'success'
+        }
+        validate_against_openapi_schema(content, '/events', 'get', '200')
         self.assertEqual(len(events), num_events)
-
         initial_state = copy.deepcopy(hybrid_state)
         post_process_state(self.user_profile, initial_state, notification_settings_null)
         before = ujson.dumps(initial_state)


### PR DESCRIPTION
Document some basic events and create a parser for rendering these description to the docs directly from their OpenAPI specifications. The first four commits are data movements and will help in future events documentation. The second last commit documents a bunch of events and the last commit creates the parser.

The parser uses VERY basic design and its design will require some reviews. 
