### PR TITLE
Make message control buttons accessible.

### DIFF
--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -349,6 +349,23 @@ input.recipient_box {
     width: 100%;
 }
 
+#compose-send-button {
+    border-radius: 4px;
+    padding-top: 3px;
+    padding-bottom: 3px;
+    margin-bottom: 0;
+    font-weight: 600;
+    border: 1px solid hsl(170, 68%, 41%);
+    background-color: hsl(170, 48%, 54%);
+    color: hsl(0, 0%, 100%);
+    float: right;
+    font-size: 0.9em;
+
+    &:focus {
+        box-shadow: 0 0 10px hsl(170, 48%, 54%), 0 0 5px hsl(170, 48%, 54%);
+    }
+}
+
 #send_controls {
     float: right;
     position: relative;
@@ -358,20 +375,6 @@ input.recipient_box {
     .compose_checkbox_label {
         color: hsl(0, 0%, 67%);
         margin: 4px;
-    }
-
-    #compose-send-button {
-        border-radius: 4px;
-        padding-top: 3px;
-        padding-bottom: 3px;
-        font-weight: 600;
-        border: 1px solid hsl(170, 68%, 41%);
-        background-color: hsl(170, 48%, 54%);
-        color: hsl(0, 0%, 100%);
-
-        &:focus {
-            box-shadow: 0 0 10px hsl(170, 48%, 54%), 0 0 5px hsl(170, 48%, 54%);
-        }
     }
 }
 

--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -110,7 +110,7 @@
                                             <input type="checkbox" id="enter_sends" />
                                             <span></span>{{ _('Press Enter to send') }}
                                         </label>
-                                        <button type="submit" id="compose-send-button" class="button small send_message" tabindex="150" title="{{ _('Send') }} (Ctrl + Enter)">{{ _('Send') }}</button>
+                                        <button type="submit" id="compose-send-button" class="button small send_message" title="{{ _('Send') }} (Ctrl + Enter)">{{ _('Send') }}</button>
                                     </div>
                                 </div>
                             </div>

--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -94,6 +94,7 @@
                                 </div>
                                 <div class="drag"></div>
                                 <div id="below-compose-content">
+                                    <button type="submit" id="compose-send-button" class="button small send_message" title="{{ _('Send') }} (Ctrl + Enter)">{{ _('Send') }}</button>
                                     <input type="file" id="file_input" class="notvisible pull-left" multiple />
                                     <a class="message-control-button fa fa-smile-o" aria-label="{{_('Add emoji')}}" id="emoji_map" tabindex=0 title="{{ _('Add emoji') }}"></a>
                                     <a class="message-control-button fa fa-font" aria-label="{{ _('Formatting') }}" tabindex=0 title="{{ _('Formatting') }}" data-overlay-trigger="message-formatting"></a>
@@ -110,7 +111,6 @@
                                             <input type="checkbox" id="enter_sends" />
                                             <span></span>{{ _('Press Enter to send') }}
                                         </label>
-                                        <button type="submit" id="compose-send-button" class="button small send_message" title="{{ _('Send') }} (Ctrl + Enter)">{{ _('Send') }}</button>
                                     </div>
                                 </div>
                             </div>

--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -96,14 +96,14 @@
                                 <div id="below-compose-content">
                                     <button type="submit" id="compose-send-button" class="button small send_message" title="{{ _('Send') }} (Ctrl + Enter)">{{ _('Send') }}</button>
                                     <input type="file" id="file_input" class="notvisible pull-left" multiple />
-                                    <a class="message-control-button fa fa-smile-o" aria-label="{{_('Add emoji')}}" id="emoji_map" tabindex=0 title="{{ _('Add emoji') }}"></a>
-                                    <a class="message-control-button fa fa-font" aria-label="{{ _('Formatting') }}" tabindex=0 title="{{ _('Formatting') }}" data-overlay-trigger="message-formatting"></a>
+                                    <a role="button" class="message-control-button fa fa-smile-o" aria-label="{{_('Add emoji')}}" id="emoji_map" tabindex=0 title="{{ _('Add emoji') }}"></a>
+                                    <a role="button" class="message-control-button fa fa-font" aria-label="{{ _('Formatting') }}" tabindex=0 title="{{ _('Formatting') }}" data-overlay-trigger="message-formatting"></a>
                                     {% if max_file_upload_size_mib > 0 %}
-                                    <a class="message-control-button fa fa-paperclip notdisplayed" aria-label="{{ _('Attach files') }}" id="attach_files" tabindex=0 title="{{ _('Attach files') }}"></a>
+                                    <a role="button" class="message-control-button fa fa-paperclip notdisplayed" aria-label="{{ _('Attach files') }}" id="attach_files" tabindex=0 title="{{ _('Attach files') }}"></a>
                                     {% endif %}
-                                    <a class="message-control-button fa fa-video-camera video_link" aria-label="{{ _('Add video call') }}" tabindex=0 title="{{ _('Add video call') }}"></a>
-                                    <a id="undo_markdown_preview" class="message-control-button fa fa-edit" aria-label="{{ _('Write') }}" tabindex=0 style="display:none;" title="{{ _('Write') }}"></a>
-                                    <a id="markdown_preview" class="message-control-button fa fa-eye" aria-label="{{ _('Preview') }}" tabindex=0 title="{{ _('Preview') }}"></a>
+                                    <a role="button" class="message-control-button fa fa-video-camera video_link" aria-label="{{ _('Add video call') }}" tabindex=0 title="{{ _('Add video call') }}"></a>
+                                    <a role="button" id="undo_markdown_preview" class="message-control-button fa fa-edit" aria-label="{{ _('Write') }}" tabindex=0 style="display:none;" title="{{ _('Write') }}"></a>
+                                    <a role="button" id="markdown_preview" class="message-control-button fa fa-eye" aria-label="{{ _('Preview') }}" tabindex=0 title="{{ _('Preview') }}"></a>
                                     <a class="drafts-link" href="#drafts" title="{{ _('Drafts') }} (d)">{{ _('Drafts') }}</a>
                                     <span id="sending-indicator"></span>
                                     <div id="send_controls" class="new-style">


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #15910.

This should be test deployed on CZO and if no problems are found backported to 3.x.

**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
compose:
![compose_a11y](https://user-images.githubusercontent.com/47354597/89879547-69e5e080-dbc3-11ea-9b7c-516d3ff03453.gif)

edit:
![edit-a11y](https://user-images.githubusercontent.com/47354597/89879541-694d4a00-dbc3-11ea-88e6-0696858a3cd3.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
