### PR TITLE
puppet: Increase backlogged socket count based on uwsgi backlog.

### DIFF
--- a/puppet/zulip/templates/sysctl.d/40-uwsgi.conf.erb
+++ b/puppet/zulip/templates/sysctl.d/40-uwsgi.conf.erb
@@ -1,0 +1,2 @@
+# Allow larger listen backlog
+net.core.somaxconn=<%= [128, @somaxconn].max %>


### PR DESCRIPTION
Increasing the uwsgi listen backlog is intended to allow it to handle
higher connection rates during server restart, when many clients may
be trying to connect.  The kernel, in turn, needs to have a
proportionally increased somaxconn soas to not refuse the connection.

Set somaxconn to 2x the uwsgi backlog, but no lower than the
default (128).

**Testing Plan:** Applied on a test instance.
