### PR TITLE
streams: Add date_created to Stream.API_FIELDS

### DIFF
--- a/templates/zerver/api/update-message.md
+++ b/templates/zerver/api/update-message.md
@@ -27,7 +27,8 @@ You only have permission to edit a message if:
 
 1. You sent it, **OR**:
 2. This is a topic-only edit for a (no topic) message, **OR**:
-3. This is a topic-only edit and you are an admin.
+3. This is a topic-only edit and you are an admin, **OR**:
+4. This is a topic-only edit and your realm allows users to edit topics.
 
 ## Parameters
 

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4879,8 +4879,6 @@ def gather_subscriptions_helper(user_profile: UserProfile,
     all_streams = get_active_streams(user_profile.realm).select_related(
         "realm").values(
             *Stream.API_FIELDS,
-            # date_created is used as an input for the stream_weekly_traffic computed field.
-            "date_created",
             # The realm_id and recipient_id are generally not needed in the API.
             "realm_id",
             "recipient_id",
@@ -4933,6 +4931,9 @@ def gather_subscriptions_helper(user_profile: UserProfile,
         for field_name in Stream.API_FIELDS:
             if field_name == "id":
                 stream_dict['stream_id'] = stream["id"]
+                continue
+            elif field_name == "date_created":
+                stream_dict['date_created'] = datetime_to_timestamp(stream[field_name])
                 continue
             stream_dict[field_name] = stream[field_name]
 
@@ -4990,6 +4991,9 @@ def gather_subscriptions_helper(user_profile: UserProfile,
             for field_name in Stream.API_FIELDS:
                 if field_name == "id":
                     stream_dict['stream_id'] = stream["id"]
+                    continue
+                elif field_name == "date_created":
+                    stream_dict['date_created'] = datetime_to_timestamp(stream[field_name])
                     continue
                 stream_dict[field_name] = stream[field_name]
 

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -38,6 +38,7 @@ basic_stream_fields = [
     ("rendered_description", check_string),
     ("stream_id", check_int),
     ("stream_post_policy", check_int),
+    ("date_created", check_int),
 ]
 
 subscription_fields: Sequence[Tuple[str, Validator[object]]] = [

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1554,8 +1554,6 @@ class Stream(models.Model):
     # * is_in_zephyr_realm is a backend-only optimization.
     # * "deactivated" streams are filtered from the API entirely.
     # * "realm" and "recipient" are not exposed to clients via the API.
-    # * "date_created" should probably be added here, as it's useful information
-    #   to subscribers.
     API_FIELDS = [
         "name",
         "id",
@@ -1566,7 +1564,8 @@ class Stream(models.Model):
         "stream_post_policy",
         "history_public_to_subscribers",
         "first_message_id",
-        "message_retention_days"
+        "message_retention_days",
+        "date_created",
     ]
 
     @staticmethod
@@ -1579,6 +1578,9 @@ class Stream(models.Model):
         for field_name in self.API_FIELDS:
             if field_name == "id":
                 result['stream_id'] = self.id
+                continue
+            elif field_name == "date_created":
+                result['date_created'] = datetime_to_timestamp(self.date_created)
                 continue
             result[field_name] = getattr(self, field_name)
         result['is_announcement_only'] = self.stream_post_policy == Stream.STREAM_POST_POLICY_ADMINS

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4122,6 +4122,10 @@ components:
             The short description of the stream in text/markdown format,
             intended to be used to prepopulate UI for editing a stream's
             description.
+        date_created:
+          type: integer
+          description: |
+            The UNIX timestamp for when the stream was created, in UTC seconds.
         invite_only:
           type: boolean
           description: |
@@ -4223,6 +4227,10 @@ components:
             work correctly.  And any client-side security logic for
             user-generated message content should be applied when displaying
             this HTML as though it were the body of a Zulip message.
+        date_created:
+          type: integer
+          description: |
+            The UNIX timestamp for when the stream was created, in UTC seconds.
         invite_only:
           type: boolean
           description: |


### PR DESCRIPTION
The first commit here fixes #15410 

I also noticed a mismatch b/w comment and the docs and thought of spinning up another commit for it. This is added as the second commit here.

As @timabbott mentioned in the issue, we can display this probably in the front-end. I haven't done those changes yet, thought of discussing it here/czo first.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->

I tested it manually and found the date_created parameter for both streams and subscriptions present in the data being sent to the client.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->