### PR TITLE
saml: Fix incorrect settings object being passed in get_issuing_idp.

### DIFF
--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -1797,8 +1797,7 @@ class SAMLAuthBackend(SocialAuthMixin, SAMLAuth):
             resp = OneLogin_Saml2_Response(settings=saml_settings, response=SAMLResponse)
             issuers = resp.get_issuers()
         except self.SAMLRESPONSE_PARSING_EXCEPTIONS:
-            logger = logging.getLogger(f"zulip.auth.{self.name}")
-            logger.info("Error while parsing SAMLResponse:", exc_info=True)
+            self.logger.info("Error while parsing SAMLResponse:", exc_info=True)
             return None
 
         for idp_name, idp_config in settings.SOCIAL_AUTH_SAML_ENABLED_IDPS.items():


### PR DESCRIPTION
Fixes #15904.

settings is supposed to be a proper OneLogin_Saml2_Settings object,
rather than an empty dictionary. This bug wasn't easy to spot because
the codepath that causes this to demonstrate runs only if the
SAMLResponse contains encrypted assertions.

Tested manually, since this was a simple "object of completely wrong type" bug, plus we don't have any good utilities for manipulating/generating SAMLResponses so triggering the codepath would be hard, as that requires a SAMLResponse with encrypted assertions.