### PR TITLE
mobile sharing: Make emoji.js a shared ES6 module.

### DIFF
--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -758,13 +758,12 @@ run_test("missing unicode emojis", () => {
         // return undefined
     }
 
-    const config = {
-        ...markdown_config.get_helpers(),
-        get_emoji_name: fake_get_emoji_name,
-    };
-
-    markdown.initialize(page_params.realm_filters, config);
+    const actual_get_emoji_name = emoji.get_emoji_name;
+    emoji.get_emoji_name = fake_get_emoji_name;
 
     markdown.apply_markdown(message);
     assert.equal(message.content, "<p>\u{1f6b2}</p>");
+
+    // restore get_emoji_name for any future tests that follow
+    emoji.get_emoji_name = actual_get_emoji_name;
 });

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -1,6 +1,7 @@
 const katex = require("katex/dist/katex.min.js");
 const _ = require("lodash");
 
+const emoji = require("../shared/js/emoji");
 const fenced_code = require("../shared/js/fenced_code");
 
 // This contains zulip's frontend markdown implementation; see
@@ -61,7 +62,7 @@ exports.translate_emoticons_to_names = (text) => {
         return match;
     };
 
-    for (const translation of helpers.get_emoticon_translations()) {
+    for (const translation of emoji.get_emoticon_translations()) {
         // We can't pass replacement_text directly into
         // emoticon_replacer, because emoticon_replacer is
         // a callback for `replace()`.  Instead we just mutate
@@ -263,7 +264,7 @@ function make_emoji_span(codepoint, title, alt_text) {
 
 function handleUnicodeEmoji(unicode_emoji) {
     const codepoint = unicode_emoji.codePointAt(0).toString(16);
-    const emoji_name = helpers.get_emoji_name(codepoint);
+    const emoji_name = emoji.get_emoji_name(codepoint);
 
     if (emoji_name) {
         const alt_text = ":" + emoji_name + ":";
@@ -285,7 +286,7 @@ function handleEmoji(emoji_name) {
     // Otherwise we'll look at unicode emoji to render with an emoji
     // span using the spritesheet; and if it isn't one of those
     // either, we pass through the plain text syntax unmodified.
-    const emoji_url = helpers.get_realm_emoji_url(emoji_name);
+    const emoji_url = emoji.get_realm_emoji_url(emoji_name);
 
     if (emoji_url) {
         return (
@@ -301,7 +302,7 @@ function handleEmoji(emoji_name) {
         );
     }
 
-    const codepoint = helpers.get_emoji_codepoint(emoji_name);
+    const codepoint = emoji.get_emoji_codepoint(emoji_name);
     if (codepoint) {
         return make_emoji_span(codepoint, title, alt_text);
     }

--- a/static/js/markdown_config.js
+++ b/static/js/markdown_config.js
@@ -1,6 +1,3 @@
-// TODO: move to markdown.
-const emoji = require("../shared/js/emoji");
-
 /*
     This config is in a separate file for partly
     tactical reasons.  We want the webapp to
@@ -33,12 +30,6 @@ exports.get_helpers = () => ({
     // user groups
     get_user_group_from_name: user_groups.get_user_group_from_name,
     is_member_of_user_group: user_groups.is_member_of,
-
-    // emojis
-    get_realm_emoji_url: emoji.get_realm_emoji_url,
-    get_emoji_name: emoji.get_emoji_name,
-    get_emoji_codepoint: emoji.get_emoji_codepoint,
-    get_emoticon_translations: emoji.get_emoticon_translations,
 
     // stream hashes
     get_stream_by_name: stream_data.get_sub,


### PR DESCRIPTION
As mentioned on chat, there is one commit here that will drop out if we merge the lodash stuff from @andersk first, but I don't think we need to block on it, as the interim code is just copy/pasting essentially one line of code from util.js.