### PR TITLE
tools/ci: Fix KeyError when running tools/ci/generate-dockerfiles.

### DIFF
--- a/tools/ci/Dockerfile.template
+++ b/tools/ci/Dockerfile.template
@@ -93,8 +93,7 @@ RUN apt-get update \
     hunspell-en-us supervisor libssl-dev puppet \
     gettext libffi-dev libfreetype6-dev zlib1g-dev \
     libjpeg-dev libldap2-dev libmemcached-dev \
-    libxml2-dev libxslt1-dev libpq-dev moreutils \
-    {extra_packages}
+    libxml2-dev libxslt1-dev libpq-dev moreutils
 
 # Upgrade git if it is less than v2.18 because GitHub Actions'
 # checkout installs source code using Rest API as an optimization


### PR DESCRIPTION
This KeyError occurs because we remove extra_packages from
images.yml because it was no longer needed in a486872a8ed28a3a56abf5498a75a9b943a82ebd.
