### PR TITLE
test: Add order_by in query for RealmAuditLog.

### DIFF
--- a/zerver/tests/test_audit_log.py
+++ b/zerver/tests/test_audit_log.py
@@ -293,7 +293,7 @@ class TestRealmAuditLog(ZulipTestCase):
 
         do_set_realm_message_editing(realm, True, 1000, False, acting_user=user)
         realm_audit_logs = RealmAuditLog.objects.filter(realm=realm, event_type=RealmAuditLog.REALM_PROPERTY_CHANGED,
-                                                        event_time__gte=now, acting_user=user)
+                                                        event_time__gte=now, acting_user=user).order_by("id")
         self.assertEqual(realm_audit_logs.count(), 2)
 
         # allow_message_editing was already True.


### PR DESCRIPTION
Added ```order_by("id")``` clause in query for ```RealmAuditLog```
for consistent output.
It was causing zerver.tests.test_audit_log.TestRealmAuditLog
to fail due to order mismatch.
```
FAIL: test_set_realm_message_editing (zerver.tests.test_audit_log.TestRealmAuditLog)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/zulip/zerver/tests/test_audit_log.py", line 309, in test_set_realm_message_editing
    self.assertEqual(new_values_seen, new_values_expected)
AssertionError: Lists differ: [{'property': 'allow_community_topic_editing', 'value': [69 chars]000}] != [{'property': 'message_content_edit_limit_seconds', 'val[69 chars]lse}]

First differing element 0:
{'property': 'allow_community_topic_editing', 'value': False}
{'property': 'message_content_edit_limit_seconds', 'value': 1000}

- [{'property': 'allow_community_topic_editing', 'value': False},
-  {'property': 'message_content_edit_limit_seconds', 'value': 1000}]
? ^                                                                 ^

+ [{'property': 'message_content_edit_limit_seconds', 'value': 1000},
? ^                                                                 ^

+  {'property': 'allow_community_topic_editing', 'value': False}]
```

**Testing Plan:** tested locally using ```./tools/test-backend --reverse --parallel=1 --nonfatal-errors```
