### PR TITLE
compose: Update compose placeholder text if recipients are changed.

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -11,6 +11,9 @@ const noop = function () {};
 
 set_global("$", global.make_zjquery());
 set_global("DOMParser", new JSDOM().window.DOMParser);
+set_global("compose_actions", {
+    update_placeholder_text: noop,
+});
 
 const LazySet = zrequire("lazy_set.js").LazySet;
 

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -29,6 +29,8 @@ zrequire("stream_data");
 
 set_global("document", "document-stub");
 
+compose_actions.update_placeholder_text = noop;
+
 const start = compose_actions.start;
 const cancel = compose_actions.cancel;
 const get_focus_area = compose_actions._get_focus_area;

--- a/frontend_tests/node_tests/compose_pm_pill.js
+++ b/frontend_tests/node_tests/compose_pm_pill.js
@@ -125,6 +125,10 @@ run_test("pills", () => {
 
     input_pill.create = input_pill_stub;
 
+    // We stub the return value of input_pill.create(), manually add widget functions to it.
+    pills.onPillCreate = () => {};
+    pills.onPillRemove = () => {};
+
     compose_pm_pill.initialize();
     assert(compose_pm_pill.widget);
 

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -1225,6 +1225,10 @@ exports.initialize = function () {
         compose_actions.update_placeholder_text();
     });
 
+    $("#stream_message_recipient_topic").on("focus", () => {
+        compose_actions.update_placeholder_text();
+    });
+
     if (page_params.narrow !== undefined) {
         if (page_params.narrow_topic !== undefined) {
             compose_actions.start("stream", {topic: page_params.narrow_topic});

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -172,6 +172,11 @@ function same_recipient_as_before(msg_type, opts) {
 }
 
 exports.update_placeholder_text = function () {
+    // Change compose placeholder text only if compose box is open.
+    if (!$("#compose-textarea").is(":visible")) {
+        return;
+    }
+
     const opts = {
         message_type: compose_state.get_message_type(),
         stream: $("#stream_message_recipient_stream").val(),

--- a/static/js/compose_pm_pill.js
+++ b/static/js/compose_pm_pill.js
@@ -9,6 +9,8 @@ exports.initialize_pill = function () {
         container,
         create_item_from_text: user_pill.create_item_from_email,
         get_text_from_item: user_pill.get_email_from_item,
+        onPillCreate: input_pill.onPillCreate,
+        onPillRemove: input_pill.onPillRemove,
     });
 
     return pill;
@@ -16,6 +18,14 @@ exports.initialize_pill = function () {
 
 exports.initialize = function () {
     exports.widget = exports.initialize_pill();
+
+    exports.widget.onPillCreate(() => {
+        compose_actions.update_placeholder_text();
+    });
+
+    exports.widget.onPillRemove(() => {
+        compose_actions.update_placeholder_text();
+    });
 };
 
 exports.clear = function () {

--- a/static/js/input_pill.js
+++ b/static/js/input_pill.js
@@ -78,10 +78,6 @@ exports.create = function (opts) {
                 return;
             }
 
-            if (typeof store.onPillCreate === "function") {
-                store.onPillCreate();
-            }
-
             return item;
         },
 
@@ -112,6 +108,10 @@ exports.create = function (opts) {
 
             if (has_image) {
                 opts.img_src = item.img_src;
+            }
+
+            if (typeof store.onPillCreate === "function") {
+                store.onPillCreate();
             }
 
             const pill_html = render_input_pill(opts);


### PR DESCRIPTION
The placeholder text is now updated every time recipients of Private Messages are changed (added or removed).

Fixes #15897.

**GIFs or Screenshots:** 

For PMs:

![compose_placeholder_group_pms](https://user-images.githubusercontent.com/25329595/88553993-90444180-d043-11ea-896f-251d328ea614.gif)

EDIT:

For stream messages:

![compose_placeholder_streams_fixed](https://user-images.githubusercontent.com/25329595/88933754-71d98280-d29d-11ea-800f-574805165f6c.gif)
