### PR TITLE
people: Allow retrieving the person using their real email.

### DIFF
--- a/static/js/people.js
+++ b/static/js/people.js
@@ -1085,8 +1085,19 @@ exports._add_user = function add(person) {
     }
 
     exports.track_duplicate_full_name(person.full_name, person.user_id);
-    people_dict.set(person.email, person);
     people_by_name_dict.set(person.full_name, person);
+
+    // Delivery email is the real email address of the user
+    // which is only present if the user is an administrator
+    // or a owner. Without adding this to email dict, the code paths
+    // that take user email input such as PM Recipient email in the
+    // compose box and use people.get_by_email won't be able to retrive
+    // that person via their real email so add the delivery email along
+    // with the user<id>@<domain> email.
+    people_dict.set(person.email, person);
+    if (person.delivery_email !== undefined) {
+        people_dict.set(person.delivery_email, person);
+    }
 };
 
 exports.add_active_user = function (person) {


### PR DESCRIPTION
This change allows us to retrive people using real emails when using
people.get_by_email. I also moved a line that adds person.email to
person mapping next to the newly added code to organize it.

This also fixes an puppeteer flake where the failure screenshot
shows correct email typed in the input but there was a banner asking
us to provide a valid input. The issue occurs because we were not
using the typehead, rather just pressing Enter and allowing the
input pill validation to validate the input. It fails because it
uses people.get_by_email using the real email but can't find one.

Another reason this is a flake and didn't occur frequently is almost
all of the times we press Enter on the typehead and thus this issue
doesn't occur but since almost all the flakes with puppeteer so far
have been due to it being so fast I suspect it pressing Enter before
the typehead renders leading to the flake.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
