### PR TITLE
typeahead: Fix binding of event handler to `blur` event.

### DIFF
--- a/static/third/bootstrap-typeahead/typeahead.js
+++ b/static/third/bootstrap-typeahead/typeahead.js
@@ -307,7 +307,7 @@
 
   , listen: function () {
       this.$element
-        .on('blur',     this.blur(this))
+        .on('blur',     this.blur.bind(this))
         .on('keypress', this.keypress.bind(this))
         .on('keyup',    this.keyup.bind(this))
 


### PR DESCRIPTION
This was a bug in 0f76e98 that prevented typeahead from closing unless we select an option from it.

Fixes #15905 and #15907.
