### PR TITLE
Actually focus selected messages, make message controls more accessible

### DIFF
--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -215,7 +215,16 @@ exports.initialize_kitchen_sink_stuff = function () {
         }
         const row = event.msg_list.get_row(event.id);
         $(".selected_message").removeClass("selected_message");
-        row.addClass("selected_message");
+        const messagebox = $(row).children(".messagebox");
+        messagebox.addClass("selected_message");
+
+        if (event.id !== event.previously_selected) {
+            // If we just selected a new messages, we should focus it
+            // so that tabbing between elements works.  But we don't
+            // want to change focus after local echo completes or any
+            // other form of background rerendering.
+            messagebox[0].focus({preventScroll: true});
+        }
 
         if (event.then_scroll) {
             if (row.length === 0) {

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -1086,6 +1086,9 @@ td.pointer {
 }
 
 .selected_message {
+    // Disable Chrome's native focus outline.
+    outline: 0;
+
     .messagebox {
         z-index: 1;
     }

--- a/static/templates/single_message.hbs
+++ b/static/templates/single_message.hbs
@@ -5,7 +5,7 @@
     {{#if want_date_divider}}
     <div class="date_row no-select" {{#if msg/is_stream}}style="box-shadow: inset 2px 0px 0px 0px {{background_color}}, -1px 0px 0px 0px {{background_color}};"{{/if}}>{{{date_divider_html}}}</div>
     {{/if}}
-    <div class="messagebox {{#if next_is_same_sender}}next_is_same_sender{{/if}}"
+    <div class="messagebox {{#if next_is_same_sender}}next_is_same_sender{{/if}}" tabindex="0"
       {{#if msg/is_stream}}style="box-shadow: inset 2px 0px 0px 0px {{background_color}}, -1px 0px 0px 0px {{background_color}};"{{/if}}>
         <div class="messagebox-content">
             {{> message_body}}


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![message-focus](https://user-images.githubusercontent.com/47354597/88617540-2d7c9580-d097-11ea-97d1-bc7f2a95907b.gif)

The focused elements can be activated with enter.

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
