### PR TITLE
webhooks/freshdesk: Remove key checking step.

### DIFF
--- a/zerver/webhooks/freshdesk/tests.py
+++ b/zerver/webhooks/freshdesk/tests.py
@@ -43,19 +43,6 @@ Requester Bob <requester-bob@example.com> updated [ticket #11](http://test1234zz
         self.api_stream_message(self.test_user, 'status_changed', expected_topic, expected_message,
                                 content_type="application/x-www-form-urlencoded")
 
-    def test_status_change_fixture_without_required_key(self) -> None:
-        """
-        A fixture without the requisite keys should raise JsonableError.
-        """
-        self.url = self.build_webhook_url()
-        payload = self.get_body('status_changed_fixture_with_missing_key')
-        kwargs = {
-            'HTTP_AUTHORIZATION': self.encode_email(self.test_user.email),
-            'content_type': 'application/x-www-form-urlencoded',
-        }
-        result = self.client_post(self.url, payload, **kwargs)
-        self.assert_json_error(result, 'Missing key triggered_event in JSON')
-
     def test_priority_change(self) -> None:
         """
         Messages are generated when a ticket's priority changes through

--- a/zerver/webhooks/freshdesk/view.py
+++ b/zerver/webhooks/freshdesk/view.py
@@ -1,14 +1,12 @@
 """Webhooks for external integrations."""
-import logging
 from typing import Any, Dict, List
 
 from django.http import HttpRequest, HttpResponse
-from django.utils.translation import ugettext as _
 
 from zerver.decorator import authenticated_rest_api_view
 from zerver.lib.email_notifications import convert_html_to_markdown
 from zerver.lib.request import REQ, has_request_variables
-from zerver.lib.response import json_error, json_success
+from zerver.lib.response import json_success
 from zerver.lib.webhooks.common import check_send_webhook_message
 from zerver.models import UserProfile
 
@@ -135,18 +133,6 @@ def format_freshdesk_ticket_creation_message(ticket: TicketDict) -> str:
 def api_freshdesk_webhook(request: HttpRequest, user_profile: UserProfile,
                           payload: Dict[str, Any]=REQ(argument_type='body')) -> HttpResponse:
     ticket_data = payload["freshdesk_webhook"]
-
-    required_keys = [
-        "triggered_event", "ticket_id", "ticket_url", "ticket_type",
-        "ticket_subject", "ticket_description", "ticket_status",
-        "ticket_priority", "requester_name", "requester_email",
-    ]
-
-    for key in required_keys:
-        if ticket_data.get(key) is None:
-            logging.warning("Freshdesk webhook error. Payload was:")
-            logging.warning(request.body)
-            return json_error(_("Missing key {} in JSON").format(key))
 
     ticket = TicketDict(ticket_data)
 


### PR DESCRIPTION
The idea behind doing this is that we would rather let the code error
out rather than add to the logs. It's webhook code usually never uses
the logging module so this section of legacy code needed to be changed
or removed.

Assists PR #15942.

Signed-off-by: Hemanth V. Alluri <hdrive1999@gmail.com>