### PR TITLE
js: Fix more incorrectly converted trigger calls

### DIFF
--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -577,7 +577,7 @@ function popover_items_handle_keyboard(key, items) {
     let index = items.index(items.filter(":focus"));
 
     if (key === "enter" && index >= 0 && index < items.length) {
-        return items[index].trigger("click");
+        return items[index].click();
     }
     if (index === -1) {
         index = 0;

--- a/static/js/portico/integrations.js
+++ b/static/js/portico/integrations.js
@@ -331,7 +331,7 @@ function integration_events() {
                 const integration = $(integrations[i]).find(".integration-lozenge");
 
                 if ($(integration).css("display") !== "none") {
-                    $(integration).closest("a")[0].trigger("click");
+                    $(integration).closest("a")[0].click();
                     break;
                 }
             }


### PR DESCRIPTION
Commit a9ca5f603b7fbb054f57338e260cbf771a94b2ee (#15863) incorrectly converted these too; indexing a jQuery object gives you a DOM element.