### PR TITLE
integrations: Autofocus the search input.

### DIFF
--- a/static/js/portico/integrations.js
+++ b/static/js/portico/integrations.js
@@ -370,11 +370,9 @@ function integration_events() {
 
     // combine selector use for both focusing the integrations searchbar and adding
     // the input event.
-    $(".integrations .searchbar input[type='text']")
-        .trigger("focus")
-        .on("input", (e) => {
-            dispatch("UPDATE_QUERY", {query: e.target.value.toLowerCase()});
-        });
+    $(".integrations .searchbar input[type='text']").on("input", (e) => {
+        dispatch("UPDATE_QUERY", {query: e.target.value.toLowerCase()});
+    });
 
     $(window).on("scroll", () => {
         if (document.body.scrollTop > 330) {
@@ -402,4 +400,5 @@ $(() => {
     integration_events();
     load_data();
     dispatch("LOAD_PATH");
+    $(".integrations .searchbar input[type='text']").trigger("focus");
 });

--- a/static/styles/portico/integrations.scss
+++ b/static/styles/portico/integrations.scss
@@ -53,7 +53,6 @@ $category-text: hsl(219, 23%, 33%);
         padding: 50px 0;
 
         .inner-content {
-            transition: all 0.3s ease;
             min-height: 870px;
 
             .show {


### PR DESCRIPTION
There were two problems preventing the autofocus:

* The focus was triggered at the wrong time.
* transition: all; affected the visibility, making browsers
  abort the focus since the input was still hidden.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
