### PR TITLE
help: Stop collapsing sidebar sections.

### DIFF
--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -100,17 +100,6 @@ const update_page = function (html_map, path) {
 
 new SimpleBar($(".sidebar")[0]);
 
-$(".sidebar.slide h2").on("click", (e) => {
-    const $next = $(e.target).next();
-
-    if ($next.is("ul")) {
-        // Close other article's headings first
-        $(".sidebar ul").not($next).hide();
-        // Toggle the heading
-        $next.slideToggle("fast", "swing");
-    }
-});
-
 $(".sidebar a").on("click", function (e) {
     const path = $(this).attr("href");
     const path_dir = path.split("/")[1];
@@ -173,3 +162,5 @@ window.addEventListener("popstate", () => {
 });
 
 $("body").addClass("noscroll");
+
+$(".highlighted")[0].scrollIntoView();

--- a/templates/zerver/documentation_main.html
+++ b/templates/zerver/documentation_main.html
@@ -5,7 +5,7 @@
 
 {% block portico_content %}
 <div class="app help terms-page inline-block{% if page_is_help_center %} help-center{% endif %}{% if page_is_api_center %} api-center{% endif %}">
-    <div class="{{ sidebar_class }}">
+    <div class="sidebar">
         <div class="content">
             <h1><a href="{{ doc_root }}" class="no-underline">Home</a></h1>
             {{ render_markdown_path(sidebar_index, api_uri_context) }}

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -91,14 +91,11 @@ class MarkdownDirectoryView(ApiURLView):
             context["page_is_help_center"] = True
             context["doc_root"] = "/help/"
             (sidebar_index, http_status_ignored) = self.get_path("include/sidebar_index")
-            # We want the sliding/collapsing behavior for /help pages only
-            sidebar_class = "sidebar slide"
             title_base = "Zulip Help Center"
         else:
             context["page_is_api_center"] = True
             context["doc_root"] = "/api/"
             (sidebar_index, http_status_ignored) = self.get_path("sidebar_index")
-            sidebar_class = "sidebar"
             title_base = "Zulip API Documentation"
 
         # The following is a somewhat hacky approach to extract titles from articles.
@@ -118,7 +115,6 @@ class MarkdownDirectoryView(ApiURLView):
             context["OPEN_GRAPH_DESCRIPTION"] = self.request.placeholder_open_graph_description
 
         context["sidebar_index"] = sidebar_index
-        context["sidebar_class"] = sidebar_class
         # An "article" might require the api_uri_context to be rendered
         api_uri_context: Dict[str, Any] = {}
         add_api_uri_context(api_uri_context, self.request)


### PR DESCRIPTION
Three reasons:

1. The sliding was disorienting.
2. The collapsing disallowed searching for other pages with Ctrl+F.
3. The collapsing mechanism wasn't accessible (not usable with the
   keyboard / no ARIA tags).

Part of #15948.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
