### PR TITLE
Don't call prettify_date on Trello card descriptions

### DIFF
--- a/zerver/webhooks/trello/view/card_actions.py
+++ b/zerver/webhooks/trello/view/card_actions.py
@@ -189,14 +189,14 @@ def get_changed_due_date_body(payload: Mapping[str, Any], action_type: str) -> s
 
 def get_managed_desc_body(payload: Mapping[str, Any], action_type: str) -> str:
     data = {
-        'desc': prettify_date(get_action_data(payload)['card']['desc']),
+        'desc': get_action_data(payload)['card']['desc'],
     }
     return fill_appropriate_message_content(payload, action_type, data)
 
 def get_changed_desc_body(payload: Mapping[str, Any], action_type: str) -> str:
     data = {
-        'desc': prettify_date(get_action_data(payload)['card']['desc']),
-        'old_desc': prettify_date(get_action_data(payload)['old']['desc']),
+        'desc': get_action_data(payload)['card']['desc'],
+        'old_desc': get_action_data(payload)['old']['desc'],
     }
     return fill_appropriate_message_content(payload, action_type, data)
 


### PR DESCRIPTION
Card descriptions aren't dates, and calling prettify_date on them results in removing upper case T characters, replacing uppercase Z characters with " UTC", etc. in descriptions when they appear in Zulip.

This was pretty clearly just a copy/paste mistake (these functions are very closely parallel to the *_due_date_* functions above, which do work on dates and call prettify_date).

I am using zulipchat.com and can't easily test this.