### PR TITLE
emoji: Make :stuck_out_tongue: have open eyes.

### DIFF
--- a/tools/setup/emoji/emoji_names.py
+++ b/tools/setup/emoji/emoji_names.py
@@ -34,11 +34,9 @@ EMOJI_NAME_MAPS: Dict[str, Dict[str, Any]] = {
     '1f60b': {'canonical_name': 'yum', 'aliases': []},
     # crazy from https://beebom.com/emoji-meanings/, seems like best emoji for
     # joking
+    '1f61b': {'canonical_name': 'stuck_out_tongue', 'aliases': ['mischievous']},
     '1f61c': {'canonical_name': 'stuck_out_tongue_wink', 'aliases': ['joking', 'crazy']},
-    '1f61d': {'canonical_name': 'stuck_out_tongue', 'aliases': []},
-    # don't really need two stuck_out_tongues (see People/23), so chose
-    # something else that could fit
-    '1f61b': {'canonical_name': 'mischievous', 'aliases': []},
+    '1f61d': {'canonical_name': 'stuck_out_tongue_closed_eyes', 'aliases': []},
     # kaching suggested by user
     '1f911': {'canonical_name': 'money_face', 'aliases': ['kaching']},
     # arms_open seems like a natural addition

--- a/version.py
+++ b/version.py
@@ -44,4 +44,4 @@ API_FEATURE_LEVEL = 27
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '93.0'
+PROVISION_VERSION = '94.0'


### PR DESCRIPTION
:stuck_out_tongue: should be the most general version, which is the one
with open eyes. Other apps do the same and it also means that :P, which
is converted to :stuck_out_tongue: is rendered like the emoticon.

Fixes #15970.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
