### PR TITLE
styles: Reorder rule to work around weird postcss-nested bug

### DIFF
--- a/static/styles/portico/landing-page.scss
+++ b/static/styles/portico/landing-page.scss
@@ -3454,6 +3454,8 @@ nav {
                 }
 
                 &.active {
+                    font-weight: 400;
+
                     &::after {
                         content: ">";
                         transform: scale(1, 1);
@@ -3461,8 +3463,6 @@ nav {
                         left: -25px;
                         font-weight: 400;
                     }
-
-                    font-weight: 400;
                 }
             }
         }


### PR DESCRIPTION
For mysterious reasons, this avoids the following message printed by webpack on a cold cache after upgrading postcss-nested from 4.2.1 to 4.2.2:

```
Ignoring local source map at "/srv/zulip/<no source>" as resource is missing.
```