### PR TITLE
Revert "digest: Support digest of web public streams for guest users."

### DIFF
--- a/zerver/lib/digest.py
+++ b/zerver/lib/digest.py
@@ -148,14 +148,9 @@ def gather_hot_conversations(user_profile: UserProfile, messages: List[Message])
 
 def gather_new_streams(user_profile: UserProfile,
                        threshold: datetime.datetime) -> Tuple[int, Dict[str, List[str]]]:
-    if user_profile.is_guest:
-        new_streams = list(get_active_streams(user_profile.realm).filter(
-            is_web_public=True, date_created__gt=threshold))
-
-    elif user_profile.can_access_public_streams():
+    if user_profile.can_access_public_streams():
         new_streams = list(get_active_streams(user_profile.realm).filter(
             invite_only=False, date_created__gt=threshold))
-
     else:
         new_streams = []
 


### PR DESCRIPTION
This reverts commit c3779338c6fde0c6f3c3307a21d9b6eef23ffd9d (part of #14638), which incorrectly depended on commits from the future, with the effect of either halting the flow of entropic time in an irresolvable temporal paradox, summoning extradimensional beings to rain destruction on the galaxy, or failing CI.