### PR TITLE
markdown: Treat more twitter codes as also permanent failures.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -413,9 +413,10 @@ def fetch_tweet_data(tweet_id: str) -> Optional[Dict[str, Any]]:
             t = e.args[0]
             if len(t) == 1 and ('code' in t[0]):
                 code = t[0]['code']
-                if code == 34:
-                    # Code 34 means that the message doesn't exist; return
-                    # None so that we will cache the error
+                if code in [34, 144, 421, 422]:
+                    # All these "correspond with HTTP 404," and mean
+                    # that the message doesn't exist; return None so
+                    # that we will cache the error.
                     return None
                 elif code in [88, 130]:
                     # Code 88 means that we were rate-limited and 130

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -411,24 +411,24 @@ def fetch_tweet_data(tweet_id: str) -> Optional[Dict[str, Any]]:
             raise
         except twitter.TwitterError as e:
             t = e.args[0]
-            if len(t) == 1 and ('code' in t[0]) and (t[0]['code'] == 34):
-                # Code 34 means that the message doesn't exist; return
-                # None so that we will cache the error
-                return None
-            elif len(t) == 1 and ('code' in t[0]) and (t[0]['code'] == 88 or
-                                                       t[0]['code'] == 130):
-                # Code 88 means that we were rate-limited and 130
-                # means Twitter is having capacity issues; either way
-                # just raise the error so we don't cache None and will
-                # try again later.
-                raise
-            else:
-                # It's not clear what to do in cases of other errors,
-                # but for now it seems reasonable to log at error
-                # level (so that we get notified), but then cache the
-                # failure to proceed with our usual work
-                markdown_logger.exception("Unknown error fetching tweet data")
-                return None
+            if len(t) == 1 and ('code' in t[0]):
+                code = t[0]['code']
+                if code == 34:
+                    # Code 34 means that the message doesn't exist; return
+                    # None so that we will cache the error
+                    return None
+                elif code in [88, 130]:
+                    # Code 88 means that we were rate-limited and 130
+                    # means Twitter is having capacity issues; either way
+                    # just raise the error so we don't cache None and will
+                    # try again later.
+                    raise
+            # It's not clear what to do in cases of other errors,
+            # but for now it seems reasonable to log at error
+            # level (so that we get notified), but then cache the
+            # failure to proceed with our usual work
+            markdown_logger.exception("Unknown error fetching tweet data")
+            return None
     return res
 
 HEAD_START_RE = re.compile('^head[ >]')

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -412,6 +412,7 @@ def fetch_tweet_data(tweet_id: str) -> Optional[Dict[str, Any]]:
         except twitter.TwitterError as e:
             t = e.args[0]
             if len(t) == 1 and ('code' in t[0]):
+                # https://developer.twitter.com/en/docs/basics/response-codes
                 code = t[0]['code']
                 if code in [34, 144, 421, 422]:
                     # All these "correspond with HTTP 404," and mean


### PR DESCRIPTION
Per the API documentation[1], the following codes all correspond to
HTTP 404:

 - `34`: **Sorry, that page does not exist.**  The specified resource
   was not found.
 - `144`: **No status found with that ID.**  The requested Tweet ID is
   not found (if it existed, it was probably deleted)
 - `421`: **This Tweet is no longer available.**  The Tweet cannot be
   retrieved. This may be for a number of reasons.
 - `422`: **This Tweet is no longer available because it violated the
   Twitter Rules.**  The Tweet is not available in the API.

Treat all of these identically.

[1] https://developer.twitter.com/en/docs/basics/response-codes