### PR TITLE
Update the mailmap of major Zulip contributors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,7 @@
 Alex Vandiver <alexmv@zulip.com> <alex@chmrr.net>
 Alex Vandiver <alexmv@zulip.com> <github@chmrr.net>
+Allen Rabinovich <allenrabinovich@yahoo.com> <allenr@humbughq.com>
+Allen Rabinovich <allenrabinovich@yahoo.com> <allenr@zulip.com>
 Aman Agrawal <amanagr@zulip.com> <f2016561@pilani.bits-pilani.ac.in>
 Anders Kaseorg <anders@zulip.com> <anders@zulipchat.com>
 Anders Kaseorg <anders@zulip.com> <andersk@mit.edu>
@@ -37,5 +39,4 @@ Vishnu KS <yo@vishnuks.com> <yo@vishnuks.com>
 # Some major contributors of Zulip whose email in commit messages are not associated
 # to any GitHub account. mailmap entry added to group the commits togather so that there
 # are no multiple entries in /team page.
-Allen Rabinovich <allenr@zulip.com> <allenr@humbughq.com>
 Jeff Arnold <jbarnold@zulip.com> <jbarnold@humbughq.com>

--- a/.mailmap
+++ b/.mailmap
@@ -13,6 +13,8 @@ Greg Price <greg@zulip.com> <greg@zulipchat.com>
 Greg Price <greg@zulip.com> <price@mit.edu>
 Jessica McKellar <jesstess@mit.edu> <jesstess@humbughq.com>
 Jessica McKellar <jesstess@mit.edu> <jesstess@zulip.com>
+Kevin Mehall <km@kevinmehall.net> <kevin@humbughq.com>
+Kevin Mehall <km@kevinmehall.net> <kevin@zulip.com>
 Ray Kraesig <rkraesig@zulip.com> <rkraesig@zulipchat.com>
 Rishi Gupta <rishig@zulipchat.com> <rishig+git@mit.edu>
 Rishi Gupta <rishig@zulipchat.com> <rishig@kandralabs.com>
@@ -35,5 +37,4 @@ Vishnu KS <yo@vishnuks.com> <yo@vishnuks.com>
 # are no multiple entries in /team page.
 Allen Rabinovich <allenr@zulip.com> <allenr@humbughq.com>
 Jeff Arnold <jbarnold@zulip.com> <jbarnold@humbughq.com>
-Kevin Mehall <kevin@zulip.com> <kevin@humbughq.com>
 Scott Feeney <scott@zulip.com> <scott@humbughq.com>

--- a/.mailmap
+++ b/.mailmap
@@ -13,6 +13,8 @@ Chris Bobbe <cbobbe@zulip.com> <csbobbe@gmail.com>
 Greg Price <greg@zulip.com> <gnprice@gmail.com>
 Greg Price <greg@zulip.com> <greg@zulipchat.com>
 Greg Price <greg@zulip.com> <price@mit.edu>
+Jeff Arnold <jbarnold@gmail.com> <jbarnold@humbughq.com>
+Jeff Arnold <jbarnold@gmail.com> <jbarnold@zulip.com>
 Jessica McKellar <jesstess@mit.edu> <jesstess@humbughq.com>
 Jessica McKellar <jesstess@mit.edu> <jesstess@zulip.com>
 Kevin Mehall <km@kevinmehall.net> <kevin@humbughq.com>
@@ -35,8 +37,3 @@ Tim Abbott <tabbott@zulip.com> <tabbott@mit.edu>
 Tim Abbott <tabbott@zulip.com> <tabbott@zulipchat.com>
 Vishnu KS <yo@vishnuks.com> <hackerkid@vishnuks.com>
 Vishnu KS <yo@vishnuks.com> <yo@vishnuks.com>
-
-# Some major contributors of Zulip whose email in commit messages are not associated
-# to any GitHub account. mailmap entry added to group the commits togather so that there
-# are no multiple entries in /team page.
-Jeff Arnold <jbarnold@zulip.com> <jbarnold@humbughq.com>

--- a/.mailmap
+++ b/.mailmap
@@ -35,5 +35,5 @@ Tim Abbott <tabbott@zulip.com> <tabbott@dropbox.com>
 Tim Abbott <tabbott@zulip.com> <tabbott@humbughq.com>
 Tim Abbott <tabbott@zulip.com> <tabbott@mit.edu>
 Tim Abbott <tabbott@zulip.com> <tabbott@zulipchat.com>
-Vishnu KS <yo@vishnuks.com> <hackerkid@vishnuks.com>
-Vishnu KS <yo@vishnuks.com> <yo@vishnuks.com>
+Vishnu KS <vishnu@zulip.com> <hackerkid@vishnuks.com>
+Vishnu KS <vishnu@zulip.com> <yo@vishnuks.com>

--- a/.mailmap
+++ b/.mailmap
@@ -20,6 +20,8 @@ Rishi Gupta <rishig@zulipchat.com> <rishig+git@mit.edu>
 Rishi Gupta <rishig@zulipchat.com> <rishig@kandralabs.com>
 Rishi Gupta <rishig@zulipchat.com> <rishig@users.noreply.github.com>
 Reid Barton <rwbarton@gmail.com> <rwbarton@humbughq.com>
+Scott Feeney <scott@oceanbase.org> <scott@humbughq.com>
+Scott Feeney <scott@oceanbase.org> <scott@zulip.com>
 Steve Howell <showell@zulip.com> <showell30@yahoo.com>
 Steve Howell <showell@zulip.com> <showell@yahoo.com>
 Steve Howell <showell@zulip.com> <showell@zulipchat.com>
@@ -37,4 +39,3 @@ Vishnu KS <yo@vishnuks.com> <yo@vishnuks.com>
 # are no multiple entries in /team page.
 Allen Rabinovich <allenr@zulip.com> <allenr@humbughq.com>
 Jeff Arnold <jbarnold@zulip.com> <jbarnold@humbughq.com>
-Scott Feeney <scott@zulip.com> <scott@humbughq.com>


### PR DESCRIPTION
I have updated the .mailmap entries of @kevinmehall @graue @allenrabinovich and @jbarnold with the email linked to their GitHub account. The emails are obtained from the patch of public commits made by them in public repos (details in commit description). 

Giving priority to the email linked to GitHub account in mailmap is necessary. Else, the contributors API will return the contributor as anonymous without any associated GitHub profile data. We use the data returned by the API in  https://zulip.com/team/ for displaying the profile picture and linking to GitHub profile.

If you folks don't want your email to be included/there is a mistake in the email let us know.

Followup of https://github.com/zulip/zulip/pull/15896 