### PR TITLE
Support nginx_listen_port with http_only

### DIFF
--- a/puppet/zulip/manifests/app_frontend.pp
+++ b/puppet/zulip/manifests/app_frontend.pp
@@ -5,7 +5,11 @@ class zulip::app_frontend {
   include zulip::app_frontend_once
 
   $nginx_http_only = zulipconf('application_server', 'http_only', undef)
-  $nginx_listen_port = zulipconf('application_server', 'nginx_listen_port', 443)
+  if $nginx_http_only != '' {
+    $nginx_listen_port = zulipconf('application_server', 'nginx_listen_port', 80)
+  } else {
+    $nginx_listen_port = zulipconf('application_server', 'nginx_listen_port', 443)
+  }
   $no_serve_uploads = zulipconf('application_server', 'no_serve_uploads', undef)
   $ssl_dir = $::osfamily ? {
     'debian' => '/etc/ssl',

--- a/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
+++ b/puppet/zulip/templates/nginx/zulip-enterprise.template.erb
@@ -16,8 +16,8 @@ include /etc/nginx/zulip-include/upstreams;
 
 server {
 <% if @nginx_http_only != '' -%>
-    listen 80;
-    listen [::]:80;
+    listen <%= @nginx_listen_port %>;
+    listen [::]:<%= @nginx_listen_port %>;
 <% else -%>
     listen <%= @nginx_listen_port %> http2;
     listen [::]:<%= @nginx_listen_port %> http2;


### PR DESCRIPTION
Support using both `http_only` and `nginx_listen_port` in `zulip.conf`

**Testing Plan:**
Verified `/etc/nginx/sites-available/zulip-enterprise` port numbers for no config (443), http_only (80) and nginx_listen_port set with either.

