### PR TITLE
upgrade: With `skip_puppet`, show what puppet changes are outstanding.

### DIFF
--- a/scripts/lib/install
+++ b/scripts/lib/install
@@ -327,7 +327,7 @@ has_class() {
 # The home directory here should match what's declared in base.pp.
 id -u zulip &>/dev/null || useradd -m zulip --home-dir /home/zulip
 if [ -n "$NO_OVERWRITE_SETTINGS" ] && [ -e "/etc/zulip/zulip.conf" ]; then
-    "$ZULIP_PATH"/scripts/zulip-puppet-apply --force --noop \
+    "$ZULIP_PATH"/scripts/zulip-puppet-apply --noop \
                  --write-catalog-summary \
                  --classfile=/var/lib/puppet/classes.txt \
                  >/dev/null
@@ -351,7 +351,7 @@ EOF
         crudini --set /etc/zulip/zulip.conf postgresql missing_dictionaries true
     fi
 
-    "$ZULIP_PATH"/scripts/zulip-puppet-apply --force --noop \
+    "$ZULIP_PATH"/scripts/zulip-puppet-apply --noop \
                  --write-catalog-summary \
                  --classfile=/var/lib/puppet/classes.txt \
                  >/dev/null

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -280,3 +280,7 @@ if not args.skip_purge_old_deployments:
     subprocess.check_call(["./scripts/purge-old-deployments"])
 else:
     logging.info("Skipping purging old deployments.")
+
+if args.skip_puppet:
+    logging.info("Showing un-applied puppet changes:")
+    subprocess.check_call(["./scripts/zulip-puppet-apply", "--noop", "--show_diff"])

--- a/scripts/zulip-puppet-apply
+++ b/scripts/zulip-puppet-apply
@@ -14,6 +14,8 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 parser = argparse.ArgumentParser(description="Run puppet")
 parser.add_argument('--force', '-f', action="store_true",
                     help="Do not prompt with proposed changes")
+parser.add_argument('--noop', action="store_true",
+                    help="Do not apply the changes")
 parser.add_argument('--config', action="store",
                     default="/etc/zulip/zulip.conf",
                     help="Alternate zulip.conf path")
@@ -34,6 +36,8 @@ for pclass in re.split(r'\s*,\s*', config.get('machine', 'puppet_classes')):
 scripts_path = os.path.join(BASE_DIR, "scripts")
 puppet_module_path = os.path.join(BASE_DIR, "puppet")
 puppet_cmd = ["puppet", "apply", "--modulepath", puppet_module_path, "-e", puppet_config]
+if args.noop:
+    puppet_cmd += ["--noop"]
 puppet_cmd += extra_args
 
 # Set the scripts path to be a factor so it can be used by puppet code
@@ -45,7 +49,7 @@ puppet_env["FACTER_zulip_scripts_path"] = scripts_path
 if (distro_info['ID'], distro_info['VERSION_ID']) in [('ubuntu', '20.04')]:
     puppet_env["RUBYOPT"] = "-W0"
 
-if not args.force:
+if not args.noop and not args.force:
     subprocess.check_call(puppet_cmd + ['--noop', '--show_diff'], env=puppet_env)
 
     do_apply = None


### PR DESCRIPTION
This prevents puppet changes from building up over time.
