### PR TITLE
timestamp: Remove datetime_to_precise_timestamp for datetime.timestamp

### DIFF
--- a/zerver/lib/timestamp.py
+++ b/zerver/lib/timestamp.py
@@ -1,6 +1,5 @@
 import calendar
 import datetime
-import time
 
 
 class TimezoneNotUTCException(Exception):
@@ -41,7 +40,3 @@ def timestamp_to_datetime(timestamp: float) -> datetime.datetime:
 def datetime_to_timestamp(dt: datetime.datetime) -> int:
     verify_UTC(dt)
     return calendar.timegm(dt.timetuple())
-
-def datetime_to_precise_timestamp(dt: datetime.datetime) -> float:
-    verify_UTC(dt)
-    return time.mktime(dt.timetuple()) + dt.microsecond/1000000

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -66,7 +66,7 @@ from zerver.lib.cache import (
 )
 from zerver.lib.exceptions import JsonableError
 from zerver.lib.pysa import mark_sanitized
-from zerver.lib.timestamp import datetime_to_precise_timestamp, datetime_to_timestamp
+from zerver.lib.timestamp import datetime_to_timestamp
 from zerver.lib.types import (
     DisplayRecipientT,
     ExtendedFieldElement,
@@ -1934,7 +1934,7 @@ class Draft(models.Model):
             "to": to,
             "topic": self.topic,
             "content": self.content,
-            "timestamp": datetime_to_precise_timestamp(self.last_edit_time),
+            "timestamp": self.last_edit_time.timestamp(),
         }
 
 class AbstractReaction(models.Model):

--- a/zerver/tests/test_timestamp.py
+++ b/zerver/tests/test_timestamp.py
@@ -1,4 +1,3 @@
-import time
 from datetime import timedelta, timezone
 
 from dateutil import parser
@@ -8,7 +7,6 @@ from zerver.lib.timestamp import (
     TimezoneNotUTCException,
     ceiling_to_hour,
     convert_to_UTC,
-    datetime_to_precise_timestamp,
     datetime_to_timestamp,
     floor_to_day,
     floor_to_hour,
@@ -44,9 +42,3 @@ class TestTimestamp(ZulipTestCase):
         for function in [floor_to_hour, floor_to_day, ceiling_to_hour, ceiling_to_hour]:
             with self.assertRaises(TimezoneNotUTCException):
                 function(non_utc_datetime)
-
-    def test_datetime_to_precise_timestamp(self) -> None:
-        timestamp = round(time.time(), 6)
-        dt = timestamp_to_datetime(timestamp)
-        post_conversion_timestamp = datetime_to_precise_timestamp(dt)
-        self.assertEqual(timestamp, post_conversion_timestamp)


### PR DESCRIPTION
See #15880. Cc @Hypro999.