### PR TITLE
js: Add "use strict" directive to CommonJS files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,7 @@
     "parser": "babel-eslint",
     "parserOptions": {
         "warnOnUnsupportedTypeScriptVersion": false,
-        "sourceType": "module"
+        "sourceType": "unambiguous"
     },
     "plugins": ["eslint-plugin-empty-returns"],
     "rules": {
@@ -29,6 +29,7 @@
                 "newlines-between": "always"
             }
         ],
+        "import/unambiguous": "error",
         "new-cap": [
             "error",
             {
@@ -88,7 +89,7 @@
         ],
         "radix": "error",
         "spaced-comment": "off",
-        "strict": "off",
+        "strict": "error",
         "valid-typeof": ["error", {"requireStringLiterals": true}],
         "yoda": "error"
     },
@@ -329,6 +330,12 @@
                 "@typescript-eslint/prefer-string-starts-ends-with": "error",
                 "@typescript-eslint/promise-function-async": "error",
                 "@typescript-eslint/unified-signatures": "error"
+            }
+        },
+        {
+            "files": ["**/*.d.ts"],
+            "rules": {
+                "import/unambiguous": "off"
             }
         },
         {

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = {
     presets: [
         [

--- a/frontend_tests/casper_lib/common.js
+++ b/frontend_tests/casper_lib/common.js
@@ -222,7 +222,7 @@ exports.wait_for_message_fully_processed = function (content) {
                     - does it look to have been
                       re-rendered based on server info?
             */
-                const last_msg = current_msg_list.last();
+                var last_msg = current_msg_list.last();
 
                 if (last_msg.raw_content !== content) {
                     return false;

--- a/frontend_tests/casper_lib/common.js
+++ b/frontend_tests/casper_lib/common.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var util = require("util");
 
 var test_credentials = require("../../var/casper/test_credentials.js").test_credentials;

--- a/frontend_tests/casper_lib/polyfill.js
+++ b/frontend_tests/casper_lib/polyfill.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /* eslint-env browser */
 
 // PhantomJS doesn’t support new DOMParser().parseFromString(…, "text/html").

--- a/frontend_tests/casper_tests/00-realm-creation.js
+++ b/frontend_tests/casper_tests/00-realm-creation.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var common = require("../casper_lib/common.js");
 
 var email = "alice@test.example.com";

--- a/frontend_tests/casper_tests/01-login.js
+++ b/frontend_tests/casper_tests/01-login.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var common = require("../casper_lib/common.js");
 
 var realm_url = "http://zulip.zulipdev.com:9981/";

--- a/frontend_tests/casper_tests/02-site.js
+++ b/frontend_tests/casper_tests/02-site.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /* Script for testing the web client.
 
    This runs under CasperJS.  It's an end-to-end black-box sort of test.  It

--- a/frontend_tests/casper_tests/03-narrow.js
+++ b/frontend_tests/casper_tests/03-narrow.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var common = require("../casper_lib/common.js");
 
 common.start_and_log_in();

--- a/frontend_tests/casper_tests/04-compose.js
+++ b/frontend_tests/casper_tests/04-compose.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var common = require("../casper_lib/common.js");
 
 common.start_and_log_in();

--- a/frontend_tests/casper_tests/05-subscriptions.js
+++ b/frontend_tests/casper_tests/05-subscriptions.js
@@ -1,7 +1,7 @@
 var common = require("../casper_lib/common.js");
 
 function stream_checkbox(stream_name) {
-    const stream_id = common.get_stream_id(stream_name);
+    var stream_id = common.get_stream_id(stream_name);
     return '#stream-checkboxes [data-stream-id="' + stream_id + '"]';
 }
 

--- a/frontend_tests/casper_tests/05-subscriptions.js
+++ b/frontend_tests/casper_tests/05-subscriptions.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var common = require("../casper_lib/common.js");
 
 function stream_checkbox(stream_name) {

--- a/frontend_tests/casper_tests/06-settings.js
+++ b/frontend_tests/casper_tests/06-settings.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var test_credentials = require("../../var/casper/test_credentials.js").test_credentials;
 var common = require("../casper_lib/common.js");
 

--- a/frontend_tests/casper_tests/07-stars.js
+++ b/frontend_tests/casper_tests/07-stars.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var common = require("../casper_lib/common.js");
 
 function star_count() {

--- a/frontend_tests/casper_tests/08-edit.js
+++ b/frontend_tests/casper_tests/08-edit.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var common = require("../casper_lib/common.js");
 
 casper.options.verbose = true;

--- a/frontend_tests/casper_tests/09-navigation.js
+++ b/frontend_tests/casper_tests/09-navigation.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var common = require("../casper_lib/common.js");
 
 // Test basic tab navigation.

--- a/frontend_tests/casper_tests/10-admin.js
+++ b/frontend_tests/casper_tests/10-admin.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var common = require("../casper_lib/common.js");
 
 common.start_and_log_in();

--- a/frontend_tests/casper_tests/11-mention.js
+++ b/frontend_tests/casper_tests/11-mention.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var common = require("../casper_lib/common.js");
 
 common.start_and_log_in();

--- a/frontend_tests/casper_tests/12-custom-profile.js
+++ b/frontend_tests/casper_tests/12-custom-profile.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var common = require("../casper_lib/common.js");
 
 common.start_and_log_in();

--- a/frontend_tests/casper_tests/13-user-deactivation.js
+++ b/frontend_tests/casper_tests/13-user-deactivation.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var common = require("../casper_lib/common.js");
 
 function user_row(name) {

--- a/frontend_tests/casper_tests/14-drafts.js
+++ b/frontend_tests/casper_tests/14-drafts.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var common = require("../casper_lib/common.js");
 
 function waitWhileDraftsVisible(then) {

--- a/frontend_tests/casper_tests/15-delete-message.js
+++ b/frontend_tests/casper_tests/15-delete-message.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var common = require("../casper_lib/common.js");
 
 common.start_and_log_in();

--- a/frontend_tests/casper_tests/16-copy-and-paste.js
+++ b/frontend_tests/casper_tests/16-copy-and-paste.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var common = require("../casper_lib/common.js");
 
 common.start_and_log_in();

--- a/frontend_tests/casper_tests/17-realm-linkifier.js
+++ b/frontend_tests/casper_tests/17-realm-linkifier.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var common = require("../casper_lib/common.js");
 
 common.start_and_log_in();

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("$", global.make_zjquery());
 const window_stub = $.create("window-stub");
 set_global("to_$", () => window_stub);

--- a/frontend_tests/node_tests/alert_words.js
+++ b/frontend_tests/node_tests/alert_words.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const params = {
     alert_words: ["alertone", "alerttwo", "alertthree", "al*rt.*s", ".+", "emoji"],
 };

--- a/frontend_tests/node_tests/alert_words_ui.js
+++ b/frontend_tests/node_tests/alert_words_ui.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("$", global.make_zjquery());
 
 set_global("channel", {});

--- a/frontend_tests/node_tests/billing.js
+++ b/frontend_tests/node_tests/billing.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const noop = () => {};
 const fs = require("fs");
 

--- a/frontend_tests/node_tests/billing_helpers.js
+++ b/frontend_tests/node_tests/billing_helpers.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const fs = require("fs");
 
 const JQuery = require("jquery");

--- a/frontend_tests/node_tests/blueslip_stacktrace.js
+++ b/frontend_tests/node_tests/blueslip_stacktrace.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const blueslip_stacktrace = zrequire("blueslip_stacktrace");
 
 run_test("clean_path", () => {

--- a/frontend_tests/node_tests/bot_data.js
+++ b/frontend_tests/node_tests/bot_data.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _settings_bots = {
     render_bots: () => {},
 };

--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 const _page_params = {};

--- a/frontend_tests/node_tests/buddy_list.js
+++ b/frontend_tests/node_tests/buddy_list.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/channel.js
+++ b/frontend_tests/node_tests/channel.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 set_global("$", {});

--- a/frontend_tests/node_tests/color_data.js
+++ b/frontend_tests/node_tests/color_data.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("color_data");
 
 run_test("pick_color", () => {

--- a/frontend_tests/node_tests/colorspace.js
+++ b/frontend_tests/node_tests/colorspace.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("colorspace");
 
 run_test("sRGB_to_linear", () => {

--- a/frontend_tests/node_tests/common.js
+++ b/frontend_tests/node_tests/common.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const noop = () => {};
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/components.js
+++ b/frontend_tests/node_tests/components.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 zrequire("keydown_util");

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -199,6 +199,7 @@ run_test("validate", () => {
         $("#sending-indicator").hide();
 
         const pm_pill_container = $.create("fake-pm-pill-container");
+        $("#private_message_recipient")[0] = {};
         $("#private_message_recipient").set_parent(pm_pill_container);
         pm_pill_container.set_find_results(".input", $("#private_message_recipient"));
         $("#private_message_recipient").before = noop;

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const {JSDOM} = require("jsdom");
 const rewiremock = require("rewiremock/node");
 

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const noop = function () {};
 const return_false = function () {
     return false;

--- a/frontend_tests/node_tests/compose_fade.js
+++ b/frontend_tests/node_tests/compose_fade.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("stream_data");
 zrequire("people");
 zrequire("compose_fade");

--- a/frontend_tests/node_tests/compose_pm_pill.js
+++ b/frontend_tests/node_tests/compose_pm_pill.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("$", global.make_zjquery());
 
 const _people = {

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("compose_ui");
 zrequire("people");
 zrequire("user_status");

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const emoji = zrequire("emoji", "shared/js/emoji");
 const typeahead = zrequire("typeahead", "shared/js/typeahead");
 zrequire("compose_state");

--- a/frontend_tests/node_tests/copy_and_paste.js
+++ b/frontend_tests/node_tests/copy_and_paste.js
@@ -1,3 +1,5 @@
+"use strict";
+
 global.stub_out_jquery();
 
 set_global("page_params", {

--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const noop = function () {};
 
 const events = require("./lib/events.js");

--- a/frontend_tests/node_tests/dispatch_subs.js
+++ b/frontend_tests/node_tests/dispatch_subs.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const events = require("./lib/events.js");
 
 const event_fixtures = events.fixtures;

--- a/frontend_tests/node_tests/drafts.js
+++ b/frontend_tests/node_tests/drafts.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const XDate = require("xdate");
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/dropdown_list_widget.js
+++ b/frontend_tests/node_tests/dropdown_list_widget.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("dropdown_list_widget");
 zrequire("scroll_util");
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/echo.js
+++ b/frontend_tests/node_tests/echo.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("$", global.make_zjquery());
 set_global("markdown", {});
 set_global("local_message", {

--- a/frontend_tests/node_tests/emoji.js
+++ b/frontend_tests/node_tests/emoji.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const emoji_codes = zrequire("emoji_codes", "generated/emoji/emoji_codes.json");
 
 const events = require("./lib/events.js");

--- a/frontend_tests/node_tests/emoji_picker.js
+++ b/frontend_tests/node_tests/emoji_picker.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 const emoji = zrequire("emoji", "shared/js/emoji");

--- a/frontend_tests/node_tests/fenced_code.js
+++ b/frontend_tests/node_tests/fenced_code.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const fenced_code = zrequire("fenced_code", "shared/js/fenced_code");
 
 run_test("get_unused_fence", () => {

--- a/frontend_tests/node_tests/fetch_status.js
+++ b/frontend_tests/node_tests/fetch_status.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const FetchStatus = zrequire("fetch_status");
 set_global("message_scroll", {
     hide_loading_older: () => {},

--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("unread");
 zrequire("stream_data");
 zrequire("people");

--- a/frontend_tests/node_tests/fold_dict.js
+++ b/frontend_tests/node_tests/fold_dict.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const FoldDict = zrequire("fold_dict").FoldDict;
 
 run_test("basic", () => {

--- a/frontend_tests/node_tests/general.js
+++ b/frontend_tests/node_tests/general.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // This is a general tour of how to write node tests that
 // may also give you some quick insight on how the Zulip
 // browser app is constructed.  Let's start with testing

--- a/frontend_tests/node_tests/hash_util.js
+++ b/frontend_tests/node_tests/hash_util.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("hash_util");
 zrequire("stream_data");
 zrequire("people");

--- a/frontend_tests/node_tests/hashchange.js
+++ b/frontend_tests/node_tests/hashchange.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("$", global.make_zjquery());
 const window_stub = $.create("window-stub");
 set_global("location", {

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // Important note on these tests:
 //
 // The way the Zulip hotkey tests work is as follows.  First, we set

--- a/frontend_tests/node_tests/i18n.js
+++ b/frontend_tests/node_tests/i18n.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("templates");
 
 // We download our translations in `page_params` (which

--- a/frontend_tests/node_tests/input_pill.js
+++ b/frontend_tests/node_tests/input_pill.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("$", global.make_zjquery());
 zrequire("input_pill");
 

--- a/frontend_tests/node_tests/input_pill.js
+++ b/frontend_tests/node_tests/input_pill.js
@@ -106,6 +106,7 @@ function set_up() {
 
     const pill_input = $.create("pill_input");
 
+    pill_input[0] = {};
     pill_input.before = () => {};
 
     const create_item_from_text = function (text) {

--- a/frontend_tests/node_tests/keydown_util.js
+++ b/frontend_tests/node_tests/keydown_util.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("$", global.make_zjquery());
 
 zrequire("keydown_util");

--- a/frontend_tests/node_tests/lazy_set.js
+++ b/frontend_tests/node_tests/lazy_set.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const LazySet = zrequire("lazy_set").LazySet;
 
 /*

--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // TODO: These events are not guaranteed to be perfectly
 //       representative of what the server sends.  For
 //       now we just want very basic test coverage.  We

--- a/frontend_tests/node_tests/lightbox.js
+++ b/frontend_tests/node_tests/lightbox.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("rows");
 zrequire("lightbox");
 

--- a/frontend_tests/node_tests/list_cursor.js
+++ b/frontend_tests/node_tests/list_cursor.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("list_cursor");
 
 run_test("config errors", () => {

--- a/frontend_tests/node_tests/list_render.js
+++ b/frontend_tests/node_tests/list_render.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("list_render");
 
 // We need these stubs to get by instanceof checks.

--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("hash_util");
 
 const emoji = zrequire("emoji", "shared/js/emoji");

--- a/frontend_tests/node_tests/markdown_katex.js
+++ b/frontend_tests/node_tests/markdown_katex.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /*
     This whole module is dedicated to adding
     one line of coverage for markdown.js.

--- a/frontend_tests/node_tests/message_edit.js
+++ b/frontend_tests/node_tests/message_edit.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("document", null);
 set_global("page_params", {
     realm_community_topic_editing_limit_seconds: 86400,

--- a/frontend_tests/node_tests/message_events.js
+++ b/frontend_tests/node_tests/message_events.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("message_events");
 zrequire("message_store");
 zrequire("muting");

--- a/frontend_tests/node_tests/message_fetch.js
+++ b/frontend_tests/node_tests/message_fetch.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/message_flags.js
+++ b/frontend_tests/node_tests/message_flags.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("unread");
 zrequire("unread_ops");
 zrequire("message_flags");

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // These unit tests for static/js/message_list.js emphasize the model-ish
 // aspects of the MessageList class.  We have to stub out a few functions
 // related to views and events to get the tests working.

--- a/frontend_tests/node_tests/message_list_data.js
+++ b/frontend_tests/node_tests/message_list_data.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("unread");
 
 zrequire("Filter", "js/filter");

--- a/frontend_tests/node_tests/message_list_view.js
+++ b/frontend_tests/node_tests/message_list_view.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/message_store.js
+++ b/frontend_tests/node_tests/message_store.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const util = zrequire("util");
 zrequire("pm_conversations");
 zrequire("people");

--- a/frontend_tests/node_tests/muting.js
+++ b/frontend_tests/node_tests/muting.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("timerender");
 zrequire("muting");
 zrequire("stream_data");

--- a/frontend_tests/node_tests/narrow.js
+++ b/frontend_tests/node_tests/narrow.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("$", global.make_zjquery());
 zrequire("hash_util");
 zrequire("hashchange");

--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const util = zrequire("util");
 set_global("$", global.make_zjquery());
 

--- a/frontend_tests/node_tests/narrow_local.js
+++ b/frontend_tests/node_tests/narrow_local.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("Filter", "js/filter");
 zrequire("FetchStatus", "js/fetch_status");
 zrequire("MessageListData", "js/message_list_data");

--- a/frontend_tests/node_tests/narrow_state.js
+++ b/frontend_tests/node_tests/narrow_state.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("people");
 zrequire("Filter", "js/filter");
 zrequire("stream_data");

--- a/frontend_tests/node_tests/narrow_unread.js
+++ b/frontend_tests/node_tests/narrow_unread.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("Filter", "js/filter");
 zrequire("people");
 zrequire("stream_data");

--- a/frontend_tests/node_tests/notifications.js
+++ b/frontend_tests/node_tests/notifications.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // Dependencies
 set_global(
     "$",

--- a/frontend_tests/node_tests/password.js
+++ b/frontend_tests/node_tests/password.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("zxcvbn", zrequire("zxcvbn", "zxcvbn"));
 zrequire("common");
 

--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 const moment = require("moment-timezone");
 const rewiremock = require("rewiremock/node");

--- a/frontend_tests/node_tests/people_errors.js
+++ b/frontend_tests/node_tests/people_errors.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("people");
 
 const return_false = function () {

--- a/frontend_tests/node_tests/pm_conversations.js
+++ b/frontend_tests/node_tests/pm_conversations.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const pmc = zrequire("pm_conversations");
 
 run_test("partners", () => {

--- a/frontend_tests/node_tests/pm_list.js
+++ b/frontend_tests/node_tests/pm_list.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("$", global.make_zjquery());
 
 set_global("narrow_state", {});

--- a/frontend_tests/node_tests/poll_widget.js
+++ b/frontend_tests/node_tests/poll_widget.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("poll_widget");
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const rewiremock = require("rewiremock/node");
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/presence.js
+++ b/frontend_tests/node_tests/presence.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const XDate = require("xdate");
 
 zrequire("people");

--- a/frontend_tests/node_tests/reactions.js
+++ b/frontend_tests/node_tests/reactions.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("document", "document-stub");
 set_global("$", global.make_zjquery());
 

--- a/frontend_tests/node_tests/recent_senders.js
+++ b/frontend_tests/node_tests/recent_senders.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const rs = zrequire("recent_senders");
 
 let next_id = 0;

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("message_util");
 
 const noop = () => {};

--- a/frontend_tests/node_tests/rendered_markdown.js
+++ b/frontend_tests/node_tests/rendered_markdown.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const rm = zrequire("rendered_markdown");
 zrequire("people");
 zrequire("user_groups");

--- a/frontend_tests/node_tests/rtl.js
+++ b/frontend_tests/node_tests/rtl.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const rtl = zrequire("rtl");
 
 run_test("get_direction", () => {

--- a/frontend_tests/node_tests/schema.js
+++ b/frontend_tests/node_tests/schema.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("schema");
 
 run_test("basics", () => {

--- a/frontend_tests/node_tests/scroll_util.js
+++ b/frontend_tests/node_tests/scroll_util.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("scroll_util");
 set_global("ui", {
     get_scroll_element: (element) => element,

--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("page_params", {
     search_pills_enabled: true,
 });

--- a/frontend_tests/node_tests/search_legacy.js
+++ b/frontend_tests/node_tests/search_legacy.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("page_params", {
     search_pills_enabled: false,
 });

--- a/frontend_tests/node_tests/search_pill.js
+++ b/frontend_tests/node_tests/search_pill.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("search_pill");
 zrequire("input_pill");
 zrequire("Filter", "js/filter");

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("page_params", {
     search_pills_enabled: true,
 });

--- a/frontend_tests/node_tests/search_suggestion_legacy.js
+++ b/frontend_tests/node_tests/search_suggestion_legacy.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("page_params", {
     search_pills_enabled: false,
 });

--- a/frontend_tests/node_tests/server_events.js
+++ b/frontend_tests/node_tests/server_events.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const noop = function () {};
 
 set_global("document", {});

--- a/frontend_tests/node_tests/settings_bots.js
+++ b/frontend_tests/node_tests/settings_bots.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const rewiremock = require("rewiremock/node");
 
 set_global("page_params", {

--- a/frontend_tests/node_tests/settings_data.js
+++ b/frontend_tests/node_tests/settings_data.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const settings_data = zrequire("settings_data");
 const settings_config = zrequire("settings_config");
 

--- a/frontend_tests/node_tests/settings_emoji.js
+++ b/frontend_tests/node_tests/settings_emoji.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("$", global.make_zjquery());
 set_global("upload_widget", {});
 zrequire("settings_emoji");

--- a/frontend_tests/node_tests/settings_muting.js
+++ b/frontend_tests/node_tests/settings_muting.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("$", global.make_zjquery());
 set_global("XDate", zrequire("XDate", "xdate"));
 

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("$", global.make_zjquery());
 
 const noop = () => {};

--- a/frontend_tests/node_tests/settings_profile_fields.js
+++ b/frontend_tests/node_tests/settings_profile_fields.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const rewiremock = require("rewiremock/node");
 
 set_global("page_params", {});

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 zrequire("user_pill");

--- a/frontend_tests/node_tests/spoilers.js
+++ b/frontend_tests/node_tests/spoilers.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("$", global.make_zjquery());
 zrequire("spoilers");
 

--- a/frontend_tests/node_tests/stream_data.js
+++ b/frontend_tests/node_tests/stream_data.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 set_global("page_params", {

--- a/frontend_tests/node_tests/stream_events.js
+++ b/frontend_tests/node_tests/stream_events.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const noop = function () {};
 const return_true = function () {
     return true;

--- a/frontend_tests/node_tests/stream_list.js
+++ b/frontend_tests/node_tests/stream_list.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("document", "document-stub");
 set_global("$", global.make_zjquery());
 

--- a/frontend_tests/node_tests/stream_search.js
+++ b/frontend_tests/node_tests/stream_search.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // This tests the stream searching functionality which currently
 // lives in stream_list.js.
 

--- a/frontend_tests/node_tests/stream_sort.js
+++ b/frontend_tests/node_tests/stream_sort.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("stream_data");
 zrequire("stream_sort");
 

--- a/frontend_tests/node_tests/stream_topic_history.js
+++ b/frontend_tests/node_tests/stream_topic_history.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("unread");
 zrequire("stream_data");
 zrequire("stream_topic_history");

--- a/frontend_tests/node_tests/submessage.js
+++ b/frontend_tests/node_tests/submessage.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("submessage");
 
 set_global("channel", {});

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -1,3 +1,5 @@
+"use strict";
+
 global.stub_out_jquery();
 
 set_global("ui", {

--- a/frontend_tests/node_tests/support.js
+++ b/frontend_tests/node_tests/support.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const fs = require("fs");
 
 const {JSDOM} = require("jsdom");

--- a/frontend_tests/node_tests/timerender.js
+++ b/frontend_tests/node_tests/timerender.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const moment = require("moment");
 const XDate = require("xdate");
 

--- a/frontend_tests/node_tests/top_left_corner.js
+++ b/frontend_tests/node_tests/top_left_corner.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("$", global.make_zjquery());
 
 zrequire("Filter", "js/filter");

--- a/frontend_tests/node_tests/topic_generator.js
+++ b/frontend_tests/node_tests/topic_generator.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("pm_conversations", {
     recent: {},
 });

--- a/frontend_tests/node_tests/topic_list_data.js
+++ b/frontend_tests/node_tests/topic_list_data.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 set_global("narrow_state", {});

--- a/frontend_tests/node_tests/transmit.js
+++ b/frontend_tests/node_tests/transmit.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const noop = function () {};
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/typeahead.js
+++ b/frontend_tests/node_tests/typeahead.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const typeahead = zrequire("typeahead", "shared/js/typeahead");
 
 // The data structures here may be different for

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("page_params", {realm_is_zephyr_mirror_realm: false});
 set_global("md5", (s) => "md5-" + s);
 

--- a/frontend_tests/node_tests/typing_data.js
+++ b/frontend_tests/node_tests/typing_data.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("typing_data");
 
 run_test("basics", () => {

--- a/frontend_tests/node_tests/typing_status.js
+++ b/frontend_tests/node_tests/typing_status.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("typing");
 zrequire("people");
 zrequire("compose_pm_pill");

--- a/frontend_tests/node_tests/ui.js
+++ b/frontend_tests/node_tests/ui.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const ui = zrequire("ui");
 
 set_global("navigator", {

--- a/frontend_tests/node_tests/ui_init.js
+++ b/frontend_tests/node_tests/ui_init.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const rewiremock = require("rewiremock/node");
 
 /*

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 zrequire("muting");

--- a/frontend_tests/node_tests/upgrade.js
+++ b/frontend_tests/node_tests/upgrade.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const noop = () => {};
 const fs = require("fs");
 

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const rewiremock = require("rewiremock/node");
 
 set_global("$", global.make_zjquery());

--- a/frontend_tests/node_tests/user_events.js
+++ b/frontend_tests/node_tests/user_events.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("$", global.make_zjquery());
 
 zrequire("people");

--- a/frontend_tests/node_tests/user_groups.js
+++ b/frontend_tests/node_tests/user_groups.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("user_groups");
 
 run_test("user_groups", () => {

--- a/frontend_tests/node_tests/user_pill.js
+++ b/frontend_tests/node_tests/user_pill.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("people");
 set_global("md5", (s) => "md5-" + s);
 zrequire("user_pill");

--- a/frontend_tests/node_tests/user_status.js
+++ b/frontend_tests/node_tests/user_status.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("channel", {});
 zrequire("user_status");
 

--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const {JSDOM} = require("jsdom");
 const _ = require("lodash");
 

--- a/frontend_tests/node_tests/vdom.js
+++ b/frontend_tests/node_tests/vdom.js
@@ -1,3 +1,5 @@
+"use strict";
+
 zrequire("vdom");
 
 run_test("basics", () => {

--- a/frontend_tests/node_tests/widgetize.js
+++ b/frontend_tests/node_tests/widgetize.js
@@ -1,3 +1,5 @@
+"use strict";
+
 set_global("$", global.make_zjquery());
 set_global("poll_widget", {});
 set_global("tictactoe_widget", {});

--- a/frontend_tests/node_tests/zblueslip.js
+++ b/frontend_tests/node_tests/zblueslip.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /*
 
 This test module actually tests our test code, particularly zblueslip, and

--- a/frontend_tests/node_tests/zjquery.js
+++ b/frontend_tests/node_tests/zjquery.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /*
 
 This test module actually tests our test code, particularly zjquery, and

--- a/frontend_tests/puppeteer_lib/common.js
+++ b/frontend_tests/puppeteer_lib/common.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const assert = require("assert").strict;
 const path = require("path");
 

--- a/frontend_tests/puppeteer_tests/00-realm-creation.js
+++ b/frontend_tests/puppeteer_tests/00-realm-creation.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const assert = require("assert").strict;
 
 const common = require("../puppeteer_lib/common");

--- a/frontend_tests/puppeteer_tests/01-login.js
+++ b/frontend_tests/puppeteer_tests/01-login.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const test_credentials = require("../../var/casper/test_credentials.js").test_credentials;
 const common = require("../puppeteer_lib/common");
 

--- a/frontend_tests/puppeteer_tests/02-message-basics.js
+++ b/frontend_tests/puppeteer_tests/02-message-basics.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const common = require("../puppeteer_lib/common");
 
 async function message_basic_tests(page) {

--- a/frontend_tests/puppeteer_tests/03-compose.js
+++ b/frontend_tests/puppeteer_tests/03-compose.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const assert = require("assert").strict;
 
 const common = require("../puppeteer_lib/common");

--- a/frontend_tests/puppeteer_tests/04-subscriptions.js
+++ b/frontend_tests/puppeteer_tests/04-subscriptions.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const assert = require("assert").strict;
 
 const common = require("../puppeteer_lib/common");

--- a/frontend_tests/puppeteer_tests/05-settings.js
+++ b/frontend_tests/puppeteer_tests/05-settings.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const assert = require("assert").strict;
 
 const test_credentials = require("../../var/casper/test_credentials.js").test_credentials;

--- a/frontend_tests/zjsunit/finder.js
+++ b/frontend_tests/zjsunit/finder.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const fs = require("fs");
 const path = require("path");
 

--- a/frontend_tests/zjsunit/handlebars.js
+++ b/frontend_tests/zjsunit/handlebars.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const fs = require("fs");
 const path = require("path");
 

--- a/frontend_tests/zjsunit/i18n.js
+++ b/frontend_tests/zjsunit/i18n.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.t = function (str, context) {
     // HAPPY PATH: most translations are a simple string:
     if (context === undefined) {

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const fs = require("fs");
 const Module = require("module");
 const path = require("path");

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -46,7 +46,10 @@ global.stub_out_jquery = namespace.stub_out_jquery;
 global.with_overrides = namespace.with_overrides;
 
 global.window = new Proxy(global, {
-    set: (obj, prop, value) => namespace.set_global(prop, value),
+    set: (obj, prop, value) => {
+        namespace.set_global(prop, value);
+        return true;
+    },
 });
 global.to_$ = () => window;
 

--- a/frontend_tests/zjsunit/markdown_assert.js
+++ b/frontend_tests/zjsunit/markdown_assert.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /**
  * markdown_assert.js
  *

--- a/frontend_tests/zjsunit/mdiff.js
+++ b/frontend_tests/zjsunit/mdiff.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /**
  * mdiff.js
  *

--- a/frontend_tests/zjsunit/namespace.js
+++ b/frontend_tests/zjsunit/namespace.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 const requires = [];

--- a/frontend_tests/zjsunit/stub.js
+++ b/frontend_tests/zjsunit/stub.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const assert = require("assert").strict;
 
 // Stubs don't do any magical modifications to your namespace.  They

--- a/frontend_tests/zjsunit/zblueslip.js
+++ b/frontend_tests/zjsunit/zblueslip.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.make_zblueslip = function () {
     const lib = {};
 

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const noop = function () {};
 
 class Event {

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = ({file}) => ({
     parser: file.extname === ".scss" ? "postcss-scss" : false,
     plugins: {

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = {
     bracketSpacing: false,
     trailingComma: "all",

--- a/static/assets/icons/zulip-icons.font.js
+++ b/static/assets/icons/zulip-icons.font.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = {
     files: ["./*.svg"],
     fontName: "zulip-icons",

--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 /*
     Helpers for detecting user activity and managing user idle states

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_admin_tab = require("../templates/admin_tab.hbs");
 const render_settings_organization_settings_tip = require("../templates/settings/organization_settings_tip.hbs");
 

--- a/static/js/alert_words.js
+++ b/static/js/alert_words.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 // For simplicity, we use a list for our internal

--- a/static/js/alert_words_ui.js
+++ b/static/js/alert_words_ui.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_alert_word_settings_item = require("../templates/settings/alert_word_settings_item.hbs");
 
 exports.render_alert_words_ui = function () {

--- a/static/js/analytics/activity.js
+++ b/static/js/analytics/activity.js
@@ -1,3 +1,5 @@
+"use strict";
+
 $(() => {
     $("a.envelope-link").on("click", function () {
         common.copy_data_attribute_value($(this), "admin-emails");

--- a/static/js/analytics/support.js
+++ b/static/js/analytics/support.js
@@ -1,3 +1,5 @@
+"use strict";
+
 $(() => {
     $("body").on("click", ".scrub-realm-button", function (e) {
         e.preventDefault();

--- a/static/js/archive.js
+++ b/static/js/archive.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 const XDate = require("xdate");
 

--- a/static/js/attachments_ui.js
+++ b/static/js/attachments_ui.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const XDate = require("xdate");
 
 const render_settings_upload_space_stats = require("../templates/settings/upload_space_stats.hbs");

--- a/static/js/avatar.js
+++ b/static/js/avatar.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.build_bot_create_widget = function () {
     // We have to do strange gyrations with the file input to clear it,
     // where we replace it wholesale, so we generalize the file input with

--- a/static/js/billing/billing.js
+++ b/static/js/billing/billing.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.initialize = function () {
     helpers.set_tab("billing");
 

--- a/static/js/billing/helpers.js
+++ b/static/js/billing/helpers.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.create_ajax_request = function (
     url,
     form_name,

--- a/static/js/billing/upgrade.js
+++ b/static/js/billing/upgrade.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.initialize = () => {
     helpers.set_tab("upgrade");
 

--- a/static/js/blueslip.js
+++ b/static/js/blueslip.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /* eslint-disable no-console */
 
 // System documented in https://zulip.readthedocs.io/en/latest/subsystems/logging.html

--- a/static/js/bot_data.js
+++ b/static/js/bot_data.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 const bots = new Map();

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const util = require("./util");
 /*
 

--- a/static/js/buddy_list.js
+++ b/static/js/buddy_list.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_user_presence_row = require("../templates/user_presence_row.hbs");
 const render_user_presence_rows = require("../templates/user_presence_rows.hbs");
 

--- a/static/js/channel.js
+++ b/static/js/channel.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const pending_requests = [];
 
 function add_pending_request(jqXHR) {

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 const WinChan = require("winchan");
 

--- a/static/js/color_data.js
+++ b/static/js/color_data.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 // These colors are used now for streams.
 const stream_colors = [

--- a/static/js/colorspace.js
+++ b/static/js/colorspace.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // Convert an sRGB value in [0, 255] to a linear intensity
 // value in [0, 1].
 //

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // This reloads the module in development rather than refreshing the page
 if (module.hot) {
     module.hot.accept();

--- a/static/js/components.js
+++ b/static/js/components.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /* USAGE:
     Toggle x = components.toggle({
         selected: Integer selected_index,

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const Handlebars = require("handlebars/runtime");
 
 const render_compose_all_everyone = require("../templates/compose_all_everyone.hbs");

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const autosize = require("autosize");
 
 const fenced_code = require("../shared/js/fenced_code");

--- a/static/js/compose_fade.js
+++ b/static/js/compose_fade.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 const util = require("./util");

--- a/static/js/compose_pm_pill.js
+++ b/static/js/compose_pm_pill.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const util = require("./util");
 
 exports.initialize_pill = function () {

--- a/static/js/compose_state.js
+++ b/static/js/compose_state.js
@@ -1,3 +1,5 @@
+"use strict";
+
 let message_type = false; // 'stream', 'private', or false-y
 
 exports.set_message_type = function (msg_type) {

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const autosize = require("autosize");
 
 exports.autosize_textarea = function () {

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const autosize = require("autosize");
 const confirmDatePlugin = require("flatpickr/dist/plugins/confirmDate/confirmDate.js");
 const moment = require("moment");

--- a/static/js/condense.js
+++ b/static/js/condense.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /*
 This library implements two related, similar concepts:
 

--- a/static/js/confirm_dialog.js
+++ b/static/js/confirm_dialog.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_confirm_dialog = require("../templates/confirm_dialog.hbs");
 
 /*

--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const TurndownService = require("turndown/lib/turndown.cjs.js");
 
 function find_boundary_tr(initial_tr, iterate_row) {

--- a/static/js/csrf.js
+++ b/static/js/csrf.js
@@ -1,3 +1,5 @@
+"use strict";
+
 let csrf_token;
 $(() => {
     // This requires that we used Jinja2's {% csrf_input %} somewhere on the page.

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const Handlebars = require("handlebars/runtime");
 const XDate = require("xdate");
 

--- a/static/js/dropdown_list_widget.js
+++ b/static/js/dropdown_list_widget.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const DropdownListWidget = function (opts) {
     const init = () => {
         // Run basic sanity checks on opts, and set up sane defaults.

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const util = require("./util");
 // Docs: https://zulip.readthedocs.io/en/latest/subsystems/sending-messages.html
 

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const emoji_codes = require("../generated/emoji/emoji_codes.json");
 const emoji = require("../shared/js/emoji");
 const typeahead = require("../shared/js/typeahead");

--- a/static/js/favicon.js
+++ b/static/js/favicon.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.set = function (url) {
     $("#favicon").attr("href", url);
 };

--- a/static/js/feature_flags.js
+++ b/static/js/feature_flags.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // The features below have all settled into their final states and the flags
 // below can be removed when we get a chance.
 exports.reminders_in_message_action_menu = false;

--- a/static/js/feedback_widget.js
+++ b/static/js/feedback_widget.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_feedback_container = require("../templates/feedback_container.hbs");
 
 /*

--- a/static/js/fetch_status.js
+++ b/static/js/fetch_status.js
@@ -1,3 +1,5 @@
+"use strict";
+
 function max_id_for_messages(messages) {
     let max_id = 0;
     for (const msg of messages) {

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const Handlebars = require("handlebars/runtime");
 const _ = require("lodash");
 

--- a/static/js/floating_recipient_bar.js
+++ b/static/js/floating_recipient_bar.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const XDate = require("xdate");
 
 let is_floating_recipient_bar_showing = false;

--- a/static/js/gear_menu.js
+++ b/static/js/gear_menu.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /*
 For various historical reasons there isn't one
 single chunk of code that really makes our gear

--- a/static/js/hash_util.js
+++ b/static/js/hash_util.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.get_hash_category = function (hash) {
     // given "#streams/subscribed", returns "streams"
     return hash ? hash.replace(/^#/, "").split(/\//)[0] : "";

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // Read https://zulip.readthedocs.io/en/latest/subsystems/hashchange-system.html
 // or locally: docs/subsystems/hashchange-system.md
 let changing_hash = false;

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const emoji = require("../shared/js/emoji");
 
 function do_narrow_action(action) {

--- a/static/js/hotspots.js
+++ b/static/js/hotspots.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 const render_hotspot_overlay = require("../templates/hotspot_overlay.hbs");

--- a/static/js/huddle_data.js
+++ b/static/js/huddle_data.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 const huddle_timestamps = new Map();

--- a/static/js/info_overlay.js
+++ b/static/js/info_overlay.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // Make it explicit that our toggler is undefined until
 // set_up_toggler is called.
 exports.toggler = undefined;

--- a/static/js/input_pill.js
+++ b/static/js/input_pill.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_input_pill = require("../templates/input_pill.hbs");
 
 // See https://zulip.readthedocs.io/en/latest/subsystems/input-pills.html

--- a/static/js/invite.js
+++ b/static/js/invite.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const autosize = require("autosize");
 
 const render_invitation_failed_error = require("../templates/invitation_failed_error.hbs");

--- a/static/js/keydown_util.js
+++ b/static/js/keydown_util.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /*
     See hotkey.js for handlers that are more app-wide.
 */

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -1,3 +1,5 @@
+"use strict";
+
 let is_open = false;
 // the asset map is a map of all retrieved images and YouTube videos that are
 // memoized instead of being looked up multiple times.

--- a/static/js/lightbox_canvas.js
+++ b/static/js/lightbox_canvas.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const funcs = {
     setZoom(meta, zoom) {
         // condition to handle zooming event by zoom hotkeys

--- a/static/js/list_cursor.js
+++ b/static/js/list_cursor.js
@@ -1,3 +1,5 @@
+"use strict";
+
 class ListCursor {
     constructor({highlight_class, list}) {
         const config_ok =

--- a/static/js/list_render.js
+++ b/static/js/list_render.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const DEFAULTS = {
     INITIAL_RENDER_COUNT: 80,
     LOAD_COUNT: 20,

--- a/static/js/list_util.js
+++ b/static/js/list_util.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const list_selectors = ["#stream_filters", "#global_filters", "#user_presences"];
 
 exports.inside_list = function (e) {

--- a/static/js/loading.js
+++ b/static/js/loading.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_loader = require("../templates/loader.hbs");
 
 exports.make_indicator = function (outer_container, opts) {

--- a/static/js/local_message.js
+++ b/static/js/local_message.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const XDate = require("xdate");
 
 function truncate_precision(float) {

--- a/static/js/localstorage.js
+++ b/static/js/localstorage.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const ls = {
     // parse JSON without throwing an error.
     parseJSON(str) {

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const katex = require("katex/dist/katex.min.js");
 const _ = require("lodash");
 const moment = require("moment");

--- a/static/js/markdown_config.js
+++ b/static/js/markdown_config.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /*
     This config is in a separate file for partly
     tactical reasons.  We want the webapp to

--- a/static/js/message_edit.js
+++ b/static/js/message_edit.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const ClipboardJS = require("clipboard");
 const XDate = require("xdate");
 

--- a/static/js/message_edit_history.js
+++ b/static/js/message_edit_history.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const XDate = require("xdate");
 
 const render_message_edit_history = require("../templates/message_edit_history.hbs");

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const huddle_data = require("./huddle_data");
 const util = require("./util");
 

--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const huddle_data = require("./huddle_data");
 
 const consts = {

--- a/static/js/message_flags.js
+++ b/static/js/message_flags.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 function send_flag_update(message, flag, op) {

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const autosize = require("autosize");
 
 exports.narrowed = undefined;

--- a/static/js/message_list_data.js
+++ b/static/js/message_list_data.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 const util = require("./util");

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 const XDate = require("xdate");
 

--- a/static/js/message_live_update.js
+++ b/static/js/message_live_update.js
@@ -1,3 +1,5 @@
+"use strict";
+
 function rerender_messages_view() {
     for (const list of [home_msg_list, message_list.narrowed, message_list.all]) {
         if (list === undefined) {

--- a/static/js/message_scroll.js
+++ b/static/js/message_scroll.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 let actively_scrolling = false;

--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const util = require("./util");
 
 const stored_messages = new Map();

--- a/static/js/message_util.js
+++ b/static/js/message_util.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.do_unread_count_updates = function do_unread_count_updates(messages) {
     unread.process_loaded_messages(messages);
     unread_ui.update_unread_counts();

--- a/static/js/message_view_header.js
+++ b/static/js/message_view_header.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_message_view_header = require("../templates/message_view_header.hbs");
 
 const rendered_markdown = require("./rendered_markdown");

--- a/static/js/message_viewport.js
+++ b/static/js/message_viewport.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const util = require("./util");
 
 let jwindow;

--- a/static/js/muting.js
+++ b/static/js/muting.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const XDate = require("xdate");
 
 const FoldDict = require("./fold_dict").FoldDict;

--- a/static/js/muting_ui.js
+++ b/static/js/muting_ui.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_muted_topic_ui_row = require("../templates/muted_topic_ui_row.hbs");
 const render_topic_muted = require("../templates/topic_muted.hbs");
 

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const util = require("./util");
 
 let unnarrow_times;

--- a/static/js/narrow_state.js
+++ b/static/js/narrow_state.js
@@ -1,3 +1,5 @@
+"use strict";
+
 let current_filter;
 
 exports.reset_current_filter = function () {

--- a/static/js/navigate.js
+++ b/static/js/navigate.js
@@ -1,3 +1,5 @@
+"use strict";
+
 function go_to_row(msg_id) {
     current_msg_list.select_id(msg_id, {then_scroll: true, from_scroll: true});
 }

--- a/static/js/night_mode.js
+++ b/static/js/night_mode.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.enable = function () {
     $("body").removeClass("color-scheme-automatic").addClass("night-mode");
 };

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 const render_compose_notification = require("../templates/compose_notification.hbs");

--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -1,3 +1,5 @@
+"use strict";
+
 let active_overlay;
 let close_handler;
 let open_overlay_name;

--- a/static/js/padded_widget.js
+++ b/static/js/padded_widget.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.update_padding = function (opts) {
     const content = $(opts.content_sel);
     const padding = $(opts.padding_sel);

--- a/static/js/page_params.js
+++ b/static/js/page_params.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /* global __webpack_public_path__:writable */
 
 const t1 = performance.now();

--- a/static/js/panels.js
+++ b/static/js/panels.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const util = require("./util");
 
 const resize_app = function () {

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const md5 = require("blueimp-md5");
 const _ = require("lodash");
 const moment = require("moment-timezone");

--- a/static/js/pm_conversations.js
+++ b/static/js/pm_conversations.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const FoldDict = require("./fold_dict").FoldDict;
 
 const partners = new Set();

--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -1,3 +1,5 @@
+"use strict";
+
 let prior_dom;
 let private_messages_open = false;
 

--- a/static/js/pm_list_dom.js
+++ b/static/js/pm_list_dom.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 const render_pm_list_item = require("../templates/pm_list_item.hbs");

--- a/static/js/poll_widget.js
+++ b/static/js/poll_widget.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_widgets_poll_widget = require("../templates/widgets/poll_widget.hbs");
 const render_widgets_poll_widget_results = require("../templates/widgets/poll_widget_results.hbs");
 

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const ClipboardJS = require("clipboard");
 const confirmDatePlugin = require("flatpickr/dist/plugins/confirmDate/confirmDate.js");
 const moment = require("moment");

--- a/static/js/portico/confirm-preregistrationuser.js
+++ b/static/js/portico/confirm-preregistrationuser.js
@@ -1,3 +1,5 @@
+"use strict";
+
 $(() => {
     $("#register").trigger("submit");
 });

--- a/static/js/portico/desktop-login.js
+++ b/static/js/portico/desktop-login.js
@@ -1,3 +1,5 @@
+"use strict";
+
 document.querySelector("#form").addEventListener("submit", () => {
     document.querySelector("#bad-token").hidden = false;
 });

--- a/static/js/portico/desktop-redirect.js
+++ b/static/js/portico/desktop-redirect.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const ClipboardJS = require("clipboard");
 
 new ClipboardJS("#copy");

--- a/static/js/portico/dev-login.js
+++ b/static/js/portico/dev-login.js
@@ -1,3 +1,5 @@
+"use strict";
+
 $(() => {
     // This code will be executed when the user visits /login and
     // dev_login.html is rendered.

--- a/static/js/portico/email_log.js
+++ b/static/js/portico/email_log.js
@@ -1,3 +1,5 @@
+"use strict";
+
 $(() => {
     // This code will be executed when the user visits /emails in
     // development mode and email_log.html is rendered.

--- a/static/js/portico/header.js
+++ b/static/js/portico/header.js
@@ -1,3 +1,5 @@
+"use strict";
+
 $(() => {
     $(".portico-header li.logout").on("click", () => {
         $("#logout_form").trigger("submit");

--- a/static/js/portico/integrations_dev_panel.js
+++ b/static/js/portico/integrations_dev_panel.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // Main JavaScript file for the Integrations development panel at
 // /devtools/integrations.
 

--- a/static/js/portico/signup.js
+++ b/static/js/portico/signup.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const moment = require("moment-timezone");
 
 $(() => {

--- a/static/js/presence.js
+++ b/static/js/presence.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const XDate = require("xdate");
 
 // This module just manages data.  See activity.js for

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 const emoji = require("../shared/js/emoji");

--- a/static/js/ready.js
+++ b/static/js/ready.js
@@ -1,1 +1,3 @@
+"use strict";
+
 $("#app-loading").addClass("loaded");

--- a/static/js/realm_icon.js
+++ b/static/js/realm_icon.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.build_realm_icon_widget = function (upload_function) {
     const get_file_input = function () {
         return $("#realm-icon-upload-widget .image_file_input").expectOne();

--- a/static/js/realm_logo.js
+++ b/static/js/realm_logo.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const settings_config = require("./settings_config");
 
 exports.build_realm_logo_widget = function (upload_function, is_night) {

--- a/static/js/recent_senders.js
+++ b/static/js/recent_senders.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const FoldDict = require("./fold_dict").FoldDict;
 
 // topic_senders[stream_id][topic_id][sender_id] = latest_message_id

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const XDate = require("xdate");
 
 const render_recent_topic_row = require("../templates/recent_topic_row.hbs");

--- a/static/js/reload.js
+++ b/static/js/reload.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const util = require("./util");
 // Read https://zulip.readthedocs.io/en/latest/subsystems/hashchange-system.html
 function preserve_state(send_after_reload, save_pointer, save_narrow, save_compose) {

--- a/static/js/reload_state.js
+++ b/static/js/reload_state.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /*
     We want his module to load pretty early in the process
     of starting the app, so that people.js can load early.

--- a/static/js/reminder.js
+++ b/static/js/reminder.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const moment = require("moment-timezone");
 
 const util = require("./util");

--- a/static/js/rendered_markdown.js
+++ b/static/js/rendered_markdown.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const moment = require("moment");
 
 /*

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const autosize = require("autosize");
 
 const util = require("./util");

--- a/static/js/rows.js
+++ b/static/js/rows.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // We don't need an andSelf() here because we already know
 // that our next element is *not* a message_row, so this
 // isn't going to end up empty unless we're at the bottom or top.

--- a/static/js/rtl.js
+++ b/static/js/rtl.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const util = require("./util");
 // How to determine the direction of a paragraph (P1-P3): https://www.unicode.org/reports/tr9/tr9-35.html#The_Paragraph_Level
 // Embedding level: https://www.unicode.org/reports/tr9/tr9-35.html#BD2

--- a/static/js/schema.js
+++ b/static/js/schema.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /*
 
 These runtime schema validators are defensive and

--- a/static/js/scroll_bar.js
+++ b/static/js/scroll_bar.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // A few of our width properties in zulip depend on the width of the
 // browser scrollbar that is generated at the far right side of the
 // page, which unfortunately varies depending on the browser and

--- a/static/js/scroll_util.js
+++ b/static/js/scroll_util.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.scroll_delta = function (opts) {
     const elem_top = opts.elem_top;
     const container_height = opts.container_height;

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // Exported for unit testing
 exports.is_using_input_method = false;
 

--- a/static/js/search_pill.js
+++ b/static/js/search_pill.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.create_item_from_search_string = function (search_string) {
     const operator = Filter.parse(search_string);
     const description = Filter.describe(operator);

--- a/static/js/search_pill_widget.js
+++ b/static/js/search_pill_widget.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.initialize = function () {
     if (!page_params.search_pills_enabled) {
         return;

--- a/static/js/search_suggestion.js
+++ b/static/js/search_suggestion.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const Handlebars = require("handlebars/runtime");
 
 const huddle_data = require("./huddle_data");

--- a/static/js/search_util.js
+++ b/static/js/search_util.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.get_search_terms = function (input) {
     const search_terms = input
         .toLowerCase()

--- a/static/js/sent_messages.js
+++ b/static/js/sent_messages.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.messages = new Map();
 
 exports.reset_id_state = function () {

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 // Docs: https://zulip.readthedocs.io/en/latest/subsystems/events-system.html
 

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const emoji = require("../shared/js/emoji");
 
 const settings_config = require("./settings_config");

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const moment = require("moment-timezone");
 
 const render_settings_tab = require("../templates/settings_tab.hbs");

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 const render_settings_api_key_modal = require("../templates/settings/api_key_modal.hbs");

--- a/static/js/settings_bots.js
+++ b/static/js/settings_bots.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const ClipboardJS = require("clipboard");
 
 const render_bot_avatar_row = require("../templates/bot_avatar_row.hbs");

--- a/static/js/settings_config.js
+++ b/static/js/settings_config.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /*
     This file contains translations between the integer values used in
     the Zulip API to describe values in dropdowns, radio buttons, and

--- a/static/js/settings_data.js
+++ b/static/js/settings_data.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const settings_config = require("./settings_config");
 
 /*

--- a/static/js/settings_display.js
+++ b/static/js/settings_display.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const emojisets = require("./emojisets.js");
 const settings_config = require("./settings_config");
 

--- a/static/js/settings_emoji.js
+++ b/static/js/settings_emoji.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const emoji = require("../shared/js/emoji");
 const render_admin_emoji_list = require("../templates/admin_emoji_list.hbs");
 const render_settings_emoji_settings_tip = require("../templates/settings/emoji_settings_tip.hbs");

--- a/static/js/settings_exports.js
+++ b/static/js/settings_exports.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const XDate = require("xdate");
 
 const render_admin_export_list = require("../templates/admin_export_list.hbs");

--- a/static/js/settings_invites.js
+++ b/static/js/settings_invites.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_admin_invites_list = require("../templates/admin_invites_list.hbs");
 const render_settings_revoke_invite_modal = require("../templates/settings/revoke_invite_modal.hbs");
 

--- a/static/js/settings_linkifiers.js
+++ b/static/js/settings_linkifiers.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_admin_filter_list = require("../templates/admin_filter_list.hbs");
 
 const meta = {

--- a/static/js/settings_muting.js
+++ b/static/js/settings_muting.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.loaded = false;
 
 exports.set_up = function () {

--- a/static/js/settings_notifications.js
+++ b/static/js/settings_notifications.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_stream_specific_notification_row = require("../templates/settings/stream_specific_notification_row.hbs");
 
 const settings_config = require("./settings_config");

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const pygments_data = require("../generated/pygments_data.json");
 const render_settings_admin_auth_methods_list = require("../templates/settings/admin_auth_methods_list.hbs");
 const render_settings_admin_realm_domains_list = require("../templates/settings/admin_realm_domains_list.hbs");

--- a/static/js/settings_panel_menu.js
+++ b/static/js/settings_panel_menu.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.mobile_deactivate_section = function () {
     const $settings_overlay_container = $("#settings_overlay_container");
     $settings_overlay_container.find(".right").removeClass("show");

--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const Sortable = require("sortablejs").default;
 
 const render_admin_profile_field_list = require("../templates/admin_profile_field_list.hbs");

--- a/static/js/settings_sections.js
+++ b/static/js/settings_sections.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const load_func_dict = new Map(); // group -> function
 const loaded_groups = new Set();
 

--- a/static/js/settings_streams.js
+++ b/static/js/settings_streams.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_admin_default_streams_list = require("../templates/admin_default_streams_list.hbs");
 
 const meta = {

--- a/static/js/settings_toggle.js
+++ b/static/js/settings_toggle.js
@@ -1,3 +1,5 @@
+"use strict";
+
 let toggler;
 
 exports.highlight_toggle = function (tab_name) {

--- a/static/js/settings_ui.js
+++ b/static/js/settings_ui.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.display_checkmark = function ($elem) {
     const check_mark = document.createElement("img");
     check_mark.src = "/static/images/checkbox-green.svg";

--- a/static/js/settings_user_groups.js
+++ b/static/js/settings_user_groups.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 const render_admin_user_group_list = require("../templates/admin_user_group_list.hbs");

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_admin_bot_form = require("../templates/admin_bot_form.hbs");
 const render_admin_human_form = require("../templates/admin_human_form.hbs");
 const render_admin_user_list = require("../templates/admin_user_list.hbs");

--- a/static/js/setup.js
+++ b/static/js/setup.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const util = require("./util");
 // Miscellaneous early setup.
 

--- a/static/js/spoilers.js
+++ b/static/js/spoilers.js
@@ -1,3 +1,5 @@
+"use strict";
+
 function collapse_spoiler(spoiler) {
     const spoiler_height = spoiler.height();
 

--- a/static/js/starred_messages.js
+++ b/static/js/starred_messages.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.ids = new Set();
 
 exports.initialize = function () {

--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const Plotly = require("plotly.js/lib/core");
 
 Plotly.register([require("plotly.js/lib/bar"), require("plotly.js/lib/pie")]);

--- a/static/js/stream_color.js
+++ b/static/js/stream_color.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 exports.default_color = "#c2c2c2";

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_announce_stream_docs = require("../templates/announce_stream_docs.hbs");
 const render_new_stream_users = require("../templates/new_stream_users.hbs");
 const render_subscription_invites_warning_modal = require("../templates/subscription_invites_warning_modal.hbs");

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const FoldDict = require("./fold_dict").FoldDict;
 const LazySet = require("./lazy_set").LazySet;
 const settings_config = require("./settings_config");

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_settings_deactivation_stream_modal = require("../templates/settings/deactivation_stream_modal.hbs");
 const render_stream_member_list_entry = require("../templates/stream_member_list_entry.hbs");
 const render_subscription_settings = require("../templates/subscription_settings.hbs");

--- a/static/js/stream_events.js
+++ b/static/js/stream_events.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // In theory, this function should apply the account-level defaults,
 // however, they are only called after a manual override, so
 // doing so is unnecessary with the current code.  Ideally, we'd do a

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 const render_stream_privacy = require("../templates/stream_privacy.hbs");

--- a/static/js/stream_muting.js
+++ b/static/js/stream_muting.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.update_is_muted = function (sub, value) {
     sub.is_muted = value;
 

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_all_messages_sidebar_actions = require("../templates/all_messages_sidebar_actions.hbs");
 const render_delete_topic_modal = require("../templates/delete_topic_modal.hbs");
 const render_move_topic_to_stream = require("../templates/move_topic_to_stream.hbs");

--- a/static/js/stream_sort.js
+++ b/static/js/stream_sort.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const util = require("./util");
 
 let previous_pinned;

--- a/static/js/stream_topic_history.js
+++ b/static/js/stream_topic_history.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const FoldDict = require("./fold_dict").FoldDict;
 
 const stream_dict = new Map(); // stream_id -> PerStreamHistory object

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_subscription_count = require("../templates/subscription_count.hbs");
 const render_subscription_setting_icon = require("../templates/subscription_setting_icon.hbs");
 const render_subscription_type = require("../templates/subscription_type.hbs");

--- a/static/js/submessage.js
+++ b/static/js/submessage.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.get_message_events = function (message) {
     if (message.locally_echoed) {
         return;

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 const render_subscription = require("../templates/subscription.hbs");

--- a/static/js/templates.js
+++ b/static/js/templates.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const Handlebars = require("handlebars/runtime");
 
 const util = require("./util");

--- a/static/js/tictactoe_widget.js
+++ b/static/js/tictactoe_widget.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_widgets_tictactoe_widget = require("../templates/widgets/tictactoe_widget.hbs");
 
 class TicTacToeData {

--- a/static/js/timerender.js
+++ b/static/js/timerender.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const moment = require("moment");
 const XDate = require("xdate");
 

--- a/static/js/todo_widget.js
+++ b/static/js/todo_widget.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_widgets_todo_widget = require("../templates/widgets/todo_widget.hbs");
 const render_widgets_todo_widget_tasks = require("../templates/widgets/todo_widget_tasks.hbs");
 

--- a/static/js/top_left_corner.js
+++ b/static/js/top_left_corner.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.update_count_in_dom = function (unread_count_elem, count) {
     const count_span = unread_count_elem.find(".count");
     const value_span = count_span.find(".value");

--- a/static/js/topic_generator.js
+++ b/static/js/topic_generator.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.sub_list_generator = function (lst, lower, upper) {
     // lower/upper has Python range semantics so if you pass
     // in lower=5 and upper=8, you get elements 5/6/7

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 const render_more_topics = require("../templates/more_topics.hbs");

--- a/static/js/topic_list_data.js
+++ b/static/js/topic_list_data.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const max_topics = 5;
 const max_topics_with_unread = 8;
 

--- a/static/js/topic_zoom.js
+++ b/static/js/topic_zoom.js
@@ -1,3 +1,5 @@
+"use strict";
+
 let zoomed_in = false;
 
 exports.is_zoomed_in = function () {

--- a/static/js/transmit.js
+++ b/static/js/transmit.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.send_message = function (request, on_success, error) {
     channel.post({
         url: "/json/messages",

--- a/static/js/tutorial.js
+++ b/static/js/tutorial.js
@@ -1,3 +1,5 @@
+"use strict";
+
 function set_tutorial_status(status, callback) {
     return channel.post({
         url: "/json/users/me/tutorial_status",

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const Handlebars = require("handlebars/runtime");
 const _ = require("lodash");
 

--- a/static/js/typing.js
+++ b/static/js/typing.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const typing_status = require("../shared/js/typing_status");
 
 // This module handles the outbound side of typing indicators.

--- a/static/js/typing_data.js
+++ b/static/js/typing_data.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 const util = require("./util");

--- a/static/js/typing_events.js
+++ b/static/js/typing_events.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_typing_notifications = require("../templates/typing_notifications.hbs");
 
 // See docs/subsystems/typing-indicators.md for details on typing indicators.

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const SimpleBar = require("simplebar/dist/simplebar.js");
 
 // What, if anything, obscures the home tab?

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 const generated_emoji_codes = require("../generated/emoji/emoji_codes.json");

--- a/static/js/ui_report.js
+++ b/static/js/ui_report.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 /* Arguments used in the report_* functions are,
    response- response that we want to display

--- a/static/js/ui_util.js
+++ b/static/js/ui_util.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // Add functions to this that have no non-trivial
 // dependencies other than jQuery.
 

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const FoldDict = require("./fold_dict").FoldDict;
 const util = require("./util");
 

--- a/static/js/unread_ops.js
+++ b/static/js/unread_ops.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.mark_all_as_read = function () {
     unread.declare_bankruptcy();
     unread_ui.update_unread_counts();

--- a/static/js/unread_ui.js
+++ b/static/js/unread_ui.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const XDate = require("xdate");
 
 let last_mention_count = 0;

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const Uppy = require("@uppy/core");
 const ProgressBar = require("@uppy/progress-bar");
 const XHRUpload = require("@uppy/xhr-upload");

--- a/static/js/upload_widget.js
+++ b/static/js/upload_widget.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const default_max_file_size = 5;
 
 const supported_types = ["image/jpeg", "image/png", "image/gif", "image/tiff"];

--- a/static/js/user_events.js
+++ b/static/js/user_events.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // This module is kind of small, but it will help us keep
 // server_events.js simple while breaking some circular
 // dependencies that existed when this code was in people.js.

--- a/static/js/user_groups.js
+++ b/static/js/user_groups.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const FoldDict = require("./fold_dict").FoldDict;
 
 let user_group_name_dict;

--- a/static/js/user_pill.js
+++ b/static/js/user_pill.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // This will be used for pills for things like composing PMs
 // or adding users to a stream/group.
 const settings_data = require("./settings_data");

--- a/static/js/user_search.js
+++ b/static/js/user_search.js
@@ -1,3 +1,5 @@
+"use strict";
+
 class UserSearch {
     // This is mostly view code to manage the user search widget
     // above the buddy list.  We rely on other code to manage the

--- a/static/js/user_status.js
+++ b/static/js/user_status.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const away_user_ids = new Set();
 const user_info = new Map();
 

--- a/static/js/user_status_ui.js
+++ b/static/js/user_status_ui.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.input_field = function () {
     return $(".user_status_overlay input.user_status");
 };

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 // From MDN: https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Math/random
 exports.random_int = function random_int(min, max) {

--- a/static/js/vdom.js
+++ b/static/js/vdom.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const _ = require("lodash");
 
 exports.eq_array = (a, b, eq) => {

--- a/static/js/widgetize.js
+++ b/static/js/widgetize.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const widgets = new Map([
     ["poll", poll_widget],
     ["tictactoe", tictactoe_widget],

--- a/static/js/zcommand.js
+++ b/static/js/zcommand.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const marked = require("../third/marked/lib/marked");
 
 /*

--- a/static/js/zform.js
+++ b/static/js/zform.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const render_widgets_zform_choices = require("../templates/widgets/zform_choices.hbs");
 
 exports.validate_extra_data = function (data) {

--- a/static/js/zulip.js
+++ b/static/js/zulip.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // This file is being eliminated as part of the general purge of
 // global variables from Zulip (everything is being moved into
 // modules).  Please don't add things here.

--- a/tools/check-openapi
+++ b/tools/check-openapi
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+"use strict";
 
 const fs = require("fs");
 

--- a/tools/debug-require.js
+++ b/tools/debug-require.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /* global __webpack_require__ */
 
 var webpackModules;

--- a/tools/message-screenshot.js
+++ b/tools/message-screenshot.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const path = require("path");
 
 const commander = require("commander");

--- a/tools/node_lib/dump_fixtures.js
+++ b/tools/node_lib/dump_fixtures.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const events = require("../../frontend_tests/node_tests/lib/events.js");
 
 console.info(JSON.stringify(events.fixtures, null, 4));

--- a/zerver/openapi/javascript_examples.js
+++ b/zerver/openapi/javascript_examples.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /* eslint-disable arrow-body-style */
 /*
   This file makes use of functional comments in a way that makes the


### PR DESCRIPTION
ES and TypeScript modules are strict by default and don’t need this directive.  ESLint will remind us to add it to new CommonJS files and remove it from ES and TypeScript modules.

Strict mode changes runtime behavior in a handful of situations; I don’t expect us to have been relying on any of them them, at least intentionally.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode/Transitioning_to_strict_mode

**Testing Plan:** Dev server.