### PR TITLE
bots: Use realm.host for bot email domain if possible.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -695,7 +695,7 @@ def do_set_realm_property(realm: Realm, name: str, value: Any,
 
         user_profiles = UserProfile.objects.filter(realm=realm, is_bot=False)
         for user_profile in user_profiles:
-            user_profile.email = get_display_email_address(user_profile, realm)
+            user_profile.email = get_display_email_address(user_profile)
             # TODO: Design a bulk event for this or force-reload all clients
             send_user_email_update_event(user_profile)
         UserProfile.objects.bulk_update(user_profiles, ['email'])

--- a/zerver/lib/bulk_create.py
+++ b/zerver/lib/bulk_create.py
@@ -41,7 +41,7 @@ def bulk_create_users(realm: Realm,
         UserProfile.objects.bulk_create(profiles_to_create)
 
         for user_profile in profiles_to_create:
-            user_profile.email = get_display_email_address(user_profile, realm)
+            user_profile.email = get_display_email_address(user_profile)
         UserProfile.objects.bulk_update(profiles_to_create, ['email'])
 
     user_ids = {user.id for user in profiles_to_create}

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -45,7 +45,7 @@ def copy_user_settings(source_profile: UserProfile, target_profile: UserProfile)
 
     copy_hotpots(source_profile, target_profile)
 
-def get_display_email_address(user_profile: UserProfile, realm: Realm) -> str:
+def get_display_email_address(user_profile: UserProfile) -> str:
     if not user_profile.email_address_is_realm_public():
         return f"user{user_profile.id}@{get_fake_email_domain()}"
     return user_profile.delivery_email
@@ -98,7 +98,7 @@ def create_user_profile(realm: Realm, email: str, password: Optional[str],
         password = None
     if user_profile.email_address_is_realm_public():
         # If emails are visible to everyone, we can set this here and save a DB query
-        user_profile.email = get_display_email_address(user_profile, realm)
+        user_profile.email = get_display_email_address(user_profile)
     user_profile.set_password(password)
     user_profile.api_key = generate_api_key()
     return user_profile
@@ -159,7 +159,7 @@ def create_user(email: str,
         # With restricted access to email addresses, we can't generate
         # the fake email addresses we use for display purposes without
         # a User ID, which isn't generated until the .save() above.
-        user_profile.email = get_display_email_address(user_profile, realm)
+        user_profile.email = get_display_email_address(user_profile)
         user_profile.save(update_fields=['email'])
 
     recipient = Recipient.objects.create(type_id=user_profile.id,

--- a/zerver/lib/create_user.py
+++ b/zerver/lib/create_user.py
@@ -47,7 +47,7 @@ def copy_user_settings(source_profile: UserProfile, target_profile: UserProfile)
 
 def get_display_email_address(user_profile: UserProfile) -> str:
     if not user_profile.email_address_is_realm_public():
-        return f"user{user_profile.id}@{get_fake_email_domain()}"
+        return f"user{user_profile.id}@{get_fake_email_domain(user_profile.realm)}"
     return user_profile.delivery_email
 
 def get_role_for_new_user(invited_as: int, realm_creation: bool=False) -> int:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -546,7 +546,12 @@ class Realm(models.Model):
                                           is_active=True)
 
     def get_bot_domain(self) -> str:
-        return get_fake_email_domain()
+        try:
+            # Check that realm.host can be used to form valid email addresses.
+            validate_email(f"bot@{self.host}")
+            return self.host
+        except ValidationError:
+            return get_fake_email_domain()
 
     def get_notifications_stream(self) -> Optional['Stream']:
         if self.notifications_stream is not None and not self.notifications_stream.deactivated:

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -546,12 +546,7 @@ class Realm(models.Model):
                                           is_active=True)
 
     def get_bot_domain(self) -> str:
-        try:
-            # Check that realm.host can be used to form valid email addresses.
-            validate_email(f"bot@{self.host}")
-            return self.host
-        except ValidationError:
-            return get_fake_email_domain()
+        return get_fake_email_domain(self)
 
     def get_notifications_stream(self) -> Optional['Stream']:
         if self.notifications_stream is not None and not self.notifications_stream.deactivated:
@@ -3116,7 +3111,14 @@ class BotConfigData(models.Model):
 class InvalidFakeEmailDomain(Exception):
     pass
 
-def get_fake_email_domain() -> str:
+def get_fake_email_domain(realm: Realm) -> str:
+    try:
+        # Check that realm.host can be used to form valid email addresses.
+        validate_email(f"bot@{realm.host}")
+        return realm.host
+    except ValidationError:
+        pass
+
     try:
         # Check that the fake email domain can be used to form valid email addresses.
         validate_email("bot@" + settings.FAKE_EMAIL_DOMAIN)

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -105,7 +105,7 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         self.assert_json_error(result, 'Bad name or username')
         self.assert_num_bots_equal(0)
 
-    @override_settings(FAKE_EMAIL_DOMAIN="invaliddomain")
+    @override_settings(FAKE_EMAIL_DOMAIN="invaliddomain", REALM_HOSTS={"zulip": "127.0.0.1"})
     def test_add_bot_with_invalid_fake_email_domain(self) -> None:
         self.login('hamlet')
         self.assert_num_bots_equal(0)
@@ -203,6 +203,26 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         [bot] = [m for m in members if m['email'] == 'hambot-bot@zulip.testserver']
         self.assertEqual(bot['bot_owner_id'], self.example_user('hamlet').id)
         self.assertEqual(bot['user_id'], self.get_bot_user(email).id)
+
+    @override_settings(FAKE_EMAIL_DOMAIN="fakedomain.com", REALM_HOSTS={"zulip": "127.0.0.1"})
+    def test_add_bot_with_fake_email_domain(self) -> None:
+        self.login('hamlet')
+        self.assert_num_bots_equal(0)
+        self.create_bot()
+        self.assert_num_bots_equal(1)
+
+        email = 'hambot-bot@fakedomain.com'
+        self.get_bot_user(email)
+
+    @override_settings(FAKE_EMAIL_DOMAIN="fakedomain.com", REALM_HOSTS={"zulip": "zulip.example.com"})
+    def test_add_bot_host_used_as_domain_if_valid(self) -> None:
+        self.login('hamlet')
+        self.assert_num_bots_equal(0)
+        self.create_bot()
+        self.assert_num_bots_equal(1)
+
+        email = 'hambot-bot@zulip.example.com'
+        self.get_bot_user(email)
 
     def test_add_bot_with_username_in_use(self) -> None:
         self.login('hamlet')

--- a/zerver/tests/test_bots.py
+++ b/zerver/tests/test_bots.py
@@ -214,6 +214,16 @@ class BotTest(ZulipTestCase, UploadSerializeMixin):
         email = 'hambot-bot@fakedomain.com'
         self.get_bot_user(email)
 
+    @override_settings(EXTERNAL_HOST="example.com")
+    def test_add_bot_verify_subdomain_in_email_address(self) -> None:
+        self.login('hamlet')
+        self.assert_num_bots_equal(0)
+        self.create_bot()
+        self.assert_num_bots_equal(1)
+
+        email = 'hambot-bot@zulip.example.com'
+        self.get_bot_user(email)
+
     @override_settings(FAKE_EMAIL_DOMAIN="fakedomain.com", REALM_HOSTS={"zulip": "zulip.example.com"})
     def test_add_bot_host_used_as_domain_if_valid(self) -> None:
         self.login('hamlet')

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -1778,12 +1778,26 @@ class DeleteUserTest(ZulipTestCase):
                                                         recipient_id=recipient_id).exists())
 
 class FakeEmailDomainTest(ZulipTestCase):
-    @override_settings(FAKE_EMAIL_DOMAIN="invaliddomain")
-    def test_invalid_fake_email_domain(self) -> None:
-        with self.assertRaises(InvalidFakeEmailDomain):
-            get_fake_email_domain()
+    def test_get_fake_email_domain(self) -> None:
+        realm = get_realm("zulip")
+        self.assertEqual("zulip.testserver", get_fake_email_domain(realm))
 
-    @override_settings(FAKE_EMAIL_DOMAIN="127.0.0.1")
+        with self.settings(EXTERNAL_HOST="example.com"):
+            self.assertEqual("zulip.example.com", get_fake_email_domain(realm))
+
+    @override_settings(FAKE_EMAIL_DOMAIN="fakedomain.com", REALM_HOSTS={"zulip": "127.0.0.1"})
+    def test_get_fake_email_domain_realm_host_is_ip_addr(self) -> None:
+        realm = get_realm("zulip")
+        self.assertEqual("fakedomain.com", get_fake_email_domain(realm))
+
+    @override_settings(FAKE_EMAIL_DOMAIN="invaliddomain", REALM_HOSTS={"zulip": "127.0.0.1"})
+    def test_invalid_fake_email_domain(self) -> None:
+        realm = get_realm("zulip")
+        with self.assertRaises(InvalidFakeEmailDomain):
+            get_fake_email_domain(realm)
+
+    @override_settings(FAKE_EMAIL_DOMAIN="127.0.0.1", REALM_HOSTS={"zulip": "127.0.0.1"})
     def test_invalid_fake_email_domain_ip(self) -> None:
         with self.assertRaises(InvalidFakeEmailDomain):
-            get_fake_email_domain()
+            realm = get_realm("zulip")
+            get_fake_email_domain(realm)


### PR DESCRIPTION
With the change in d70e1bcdb77cba37ccb5a4a3e91e87e7bf3e5671,
bots get email like bot@zulip.com with EXTERNAL_HOST="zulip.com",
rather than bot@subdomain.zulip.com, which was the old format. That's
not desirable, so with this commit, realm.host will be used when
possible and only falling back to FAKE_EMAIL_DOMAIN if needed.

Discussion for reference: https://chat.zulip.org/#narrow/stream/127-integrations/topic/bot.20email.20in.20zulipchat.2Ecom/near/967018