### PR TITLE
stream_topic_history: Update topic last msg_id after msg deletion.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -811,6 +811,7 @@ run_test("delete_message", (override) => {
         assert_same(args.opts.stream_id, 99);
         assert_same(args.opts.topic_name, "topic1");
         assert_same(args.opts.num_messages, 1);
+        assert_same(args.opts.max_removed_msg_id, 1337);
     });
 });
 

--- a/frontend_tests/node_tests/stream_topic_history.js
+++ b/frontend_tests/node_tests/stream_topic_history.js
@@ -51,6 +51,7 @@ run_test("basics", () => {
 
     set_global("message_util", {
         get_messages_in_topic: () => [{id: 101}, {id: 102}],
+        get_max_message_id_in_stream: () => 103,
     });
     // Removing the last msg in topic1 changes the order
     stream_topic_history.remove_messages({
@@ -61,11 +62,13 @@ run_test("basics", () => {
     });
     history = stream_topic_history.get_recent_topic_names(stream_id);
     assert.deepEqual(history, ["topic2", "Topic1"]);
+    // check if stream's max_message_id is updated.
     max_message_id = stream_topic_history.get_max_message_id(stream_id);
-    assert.deepEqual(max_message_id, 104);
+    assert.deepEqual(max_message_id, 103);
 
     set_global("message_util", {
         get_messages_in_topic: () => [{id: 102}],
+        get_max_message_id_in_stream: () => 103,
     });
     // Removing first topic1 message has no effect.
     stream_topic_history.remove_messages({
@@ -76,7 +79,6 @@ run_test("basics", () => {
     });
     history = stream_topic_history.get_recent_topic_names(stream_id);
     assert.deepEqual(history, ["topic2", "Topic1"]);
-    // Removing a topic message shouldn't effect the max_message_id.
     max_message_id = stream_topic_history.get_max_message_id(stream_id);
     assert.deepEqual(max_message_id, 103);
 

--- a/frontend_tests/node_tests/stream_topic_history.js
+++ b/frontend_tests/node_tests/stream_topic_history.js
@@ -39,11 +39,40 @@ run_test("basics", () => {
     assert.deepEqual(history, ["topic2", "Topic1"]);
     assert.deepEqual(max_message_id, 103);
 
+    stream_topic_history.add_message({
+        stream_id,
+        message_id: 104,
+        topic_name: "Topic1",
+    });
+    history = stream_topic_history.get_recent_topic_names(stream_id);
+    max_message_id = stream_topic_history.get_max_message_id(stream_id);
+    assert.deepEqual(history, ["Topic1", "topic2"]);
+    assert.deepEqual(max_message_id, 104);
+
+    set_global("message_util", {
+        get_messages_in_topic: () => [{id: 101}, {id: 102}],
+    });
+    // Removing the last msg in topic1 changes the order
+    stream_topic_history.remove_messages({
+        stream_id,
+        topic_name: "Topic1",
+        num_messages: 1,
+        max_removed_msg_id: 104,
+    });
+    history = stream_topic_history.get_recent_topic_names(stream_id);
+    assert.deepEqual(history, ["topic2", "Topic1"]);
+    max_message_id = stream_topic_history.get_max_message_id(stream_id);
+    assert.deepEqual(max_message_id, 104);
+
+    set_global("message_util", {
+        get_messages_in_topic: () => [{id: 102}],
+    });
     // Removing first topic1 message has no effect.
     stream_topic_history.remove_messages({
         stream_id,
         topic_name: "toPic1",
         num_messages: 1,
+        max_removed_msg_id: 101,
     });
     history = stream_topic_history.get_recent_topic_names(stream_id);
     assert.deepEqual(history, ["topic2", "Topic1"]);
@@ -56,6 +85,7 @@ run_test("basics", () => {
         stream_id,
         topic_name: "Topic1",
         num_messages: 1,
+        max_removed_msg_id: 102,
     });
     history = stream_topic_history.get_recent_topic_names(stream_id);
     assert.deepEqual(history, ["topic2"]);
@@ -65,6 +95,7 @@ run_test("basics", () => {
         stream_id,
         topic_name: "Topic1",
         num_messages: 1,
+        max_removed_msg_id: 0,
     });
     history = stream_topic_history.get_recent_topic_names(stream_id);
     assert.deepEqual(history, ["topic2"]);

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -200,6 +200,7 @@ exports.edit_locally = function (message, request) {
             stream_id: message.stream_id,
             topic_name: message.topic,
             num_messages: 1,
+            max_removed_msg_id: message.id,
         });
 
         if (new_stream_id !== undefined) {

--- a/static/js/message_events.js
+++ b/static/js/message_events.js
@@ -194,6 +194,7 @@ exports.update_messages = function update_messages(events) {
                     stream_id: msg.stream_id,
                     topic_name: msg.topic,
                     num_messages: 1,
+                    max_removed_msg_id: msg.id,
                 });
 
                 // Update the unread counts; again, this must be called

--- a/static/js/message_util.js
+++ b/static/js/message_util.js
@@ -45,10 +45,6 @@ exports.add_new_messages = function (messages, msg_list) {
 };
 
 exports.get_messages_in_topic = function (stream_id, topic) {
-    // This function is very expensive since it searches
-    // all the messages. Please only use it in case of
-    // very rare events like topic edits. Its primary
-    // use case is the new experimental Recent Topics UI.
     return message_list.all
         .all_messages()
         .filter(
@@ -57,6 +53,18 @@ exports.get_messages_in_topic = function (stream_id, topic) {
                 x.stream_id === stream_id &&
                 x.topic.toLowerCase() === topic.toLowerCase(),
         );
+};
+
+exports.get_max_message_id_in_stream = function (stream_id) {
+    let max_message_id = 0;
+    for (const msg of message_list.all.all_messages()) {
+        if (msg.type === "stream" && msg.stream_id === stream_id) {
+            if (msg.id > max_message_id) {
+                max_message_id = msg.id;
+            }
+        }
+    }
+    return max_message_id;
 };
 
 window.message_util = exports;

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -31,17 +31,20 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             // which returns all the unread messages out of a given list.
             // So double marking something as read would not occur
             unread_ops.process_read_messages_event(msg_ids);
+            // This methods updates message_list too and since stream_topic_history relies on it
+            // this method should be called first.
+            ui.remove_messages(msg_ids);
 
             if (event.message_type === "stream") {
                 stream_topic_history.remove_messages({
                     stream_id: event.stream_id,
                     topic_name: event.topic,
                     num_messages: msg_ids.length,
+                    max_removed_msg_id: Math.max(...msg_ids),
                 });
                 stream_list.update_streams_sidebar();
             }
 
-            ui.remove_messages(msg_ids);
             break;
         }
 

--- a/static/js/stream_topic_history.js
+++ b/static/js/stream_topic_history.js
@@ -229,6 +229,11 @@ exports.remove_messages = function (opts) {
         }
         existing_topic.message_id = max_message_id;
     }
+
+    // Update max_message_id in stream
+    if (history.max_message_id <= max_removed_msg_id) {
+        history.max_message_id = message_util.get_max_message_id_in_stream(stream_id);
+    }
 };
 
 exports.find_or_create = function (stream_id) {


### PR DESCRIPTION
Fixes #15992.
If the last message of the topic was deleted, we update the stored
message_id in the topic history so that the topic order in topic_list
is updated correctly.
