### PR TITLE
github-actions: Cancel previous runs on pushes to forks and PRs.

### DIFF
--- a/.github/workflows/cancel-previous-runs.yml
+++ b/.github/workflows/cancel-previous-runs.yml
@@ -1,0 +1,41 @@
+name: Cancel Previous Runs
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  cancel:
+    name: Cancel Previous Runs
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    # Don't run this job for zulip/zulip pushes since we
+    # want to run those jobs.
+    if: ${{ github.event_name != 'push' || github.event.repository.full_name != 'zulip/zulip' }}
+
+    steps:
+      # We get workflow IDs from GitHub API so we don't have to maintain
+      # a hard-coded list of IDs which need to be updated when a workflow
+      # is added or removed. And, workflow IDs are diffrent for other forks
+      # so this is required.
+      - name: Get workflow IDs.
+        id: workflow_ids
+        env:
+          # This is in <owner>/<repo> format e.g. zulip/zulip
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          workflow_api_url=https://api.github.com/repos/$REPOSITORY/actions/workflows
+          curl $workflow_api_url -o workflows.json
+
+          script="const {workflows} = require('./workflows'); \
+                  const ids = workflows.map(workflow => workflow.id); \
+                  console.log(ids.join(','));"
+          ids=$(node -e "$script")
+          echo "::set-output name=ids::$ids"
+
+      - uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          workflow_id: ${{ steps.workflow_ids.outputs.ids }}
+          access_token: ${{ github.token }}


### PR DESCRIPTION
It only cancel previous runs on forks or for pull request builds
and does not run for zulip/zulip repo pushes. It finishes prettry
quickly (under 1 mintue) so it fine to have it as a workflow than
to add a new step under every single job to cancel it's previous
runs.

The only downside to this is that GitHub creates a notification for
the cancelled job just like it does for failed jobs!!!

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
