### PR TITLE
github-actions: Fix incorrect hash key in production install job.

### DIFF
--- a/.github/workflows/production-suite.yml
+++ b/.github/workflows/production-suite.yml
@@ -152,7 +152,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /srv/zulip-npm-cache
-          key: v1-yarn-deps-${{ matrix.os }}-${{ hashFiles('package.json') }}-${{ hashFiles('yarn.lock') }}
+          key: v1-yarn-deps-${{ matrix.os }}-${{ hashFiles('/tmp/package.json') }}-${{ hashFiles('/tmp/yarn.lock') }}
           restore-keys: v1-yarn-deps-${{ matrix.os }}
 
       - name: Do Bionic hack

--- a/tools/ci/production-build
+++ b/tools/ci/production-build
@@ -38,5 +38,6 @@ cp -a \
    tools/ci/production-verify \
    tools/ci/production-upgrade-pg \
    tools/ci/production-extract-tarball \
+   package.json yarn.lock \
    \
    /tmp/production-build


### PR DESCRIPTION
The hash keys were missing hash for package.json and yarn.lock
because they were not present since we don't do a full checkout
in this job. We fix this by sending over those files and generating
hashes from them.

I usally verify these cache keys by clicking the Restore <cache>
step dropdown menu and then clicking the Run ... dropdown menu again
to see the generated hash.

**Testing Plan:** Check the the completed run has correct cache key.