### PR TITLE
dev_settings: Add EMAIL_PORT setting in zproject/dev_settings.py.

### DIFF
--- a/docs/subsystems/email.md
+++ b/docs/subsystems/email.md
@@ -65,7 +65,8 @@ account** in `/emails` page. This feature can be used for testing how
 emails gets rendered by different email clients. Before enabling this
 you have to first configure the following SMTP settings.
 
-* The hostname `EMAIL_HOST` in `zproject/dev_settings.py`
+* The hostname `EMAIL_HOST` in `zproject/dev_settings.py`.
+* The port `EMAIL_PORT` in `zproject/dev_settings.py`.
 * The username `EMAIL_HOST_USER` in `zproject/dev_settings.py`.
 * The password `email_password` in `zproject/dev-secrets.conf`.
 

--- a/zproject/dev_settings.py
+++ b/zproject/dev_settings.py
@@ -89,6 +89,7 @@ PASSWORD_MIN_GUESSES = 0
 # SMTP settings for forwarding emails sent in development
 # environment to an email account.
 EMAIL_HOST = ""
+EMAIL_PORT = 25
 EMAIL_HOST_USER = ""
 
 # Two factor authentication: Use the fake backend for development.

--- a/zproject/email_backends.py
+++ b/zproject/email_backends.py
@@ -52,7 +52,7 @@ class EmailLogBackEnd(BaseEmailBackend):
         msg.add_alternative(text, subtype="plain")
         msg.add_alternative(html, subtype="html")
 
-        smtp = smtplib.SMTP(settings.EMAIL_HOST)
+        smtp = smtplib.SMTP(settings.EMAIL_HOST, settings.EMAIL_PORT)
         smtp.starttls()
         smtp.login(settings.EMAIL_HOST_USER, settings.EMAIL_HOST_PASSWORD)
         smtp.send_message(msg)


### PR DESCRIPTION
This PR adds EMAIL_PORT setting for explicitly specifying the
port of SMTP provider in dev_settings.py.

We also change email_backends.send_email_smtp to pass EMAIL_PORT
along with EMAIL_HOST to smtplib.SMTP.

After this change, we will not need to include the port along with
host in EMAIL_HOST.

Also updated the email.md docs accordingly for this change.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? --> Tested manually in development environment by configuring the SMTP settings


 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
