### PR TITLE
stream_edit: Send values of changed settings only to backend.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -465,17 +465,32 @@ exports.set_stream_property = function (sub, property, value, status_element) {
     exports.bulk_set_stream_property([sub_data], status_element);
 };
 
+function get_message_retention_days_from_sub(sub) {
+    if (sub.message_retention_days === null) {
+        return "realm_default";
+    }
+    if (sub.message_retention_days === -1) {
+        return "forever";
+    }
+    return sub.message_retention_days;
+}
+
 function change_stream_privacy(e) {
     e.stopPropagation();
 
     const stream_id = $(e.target).data("stream-id");
     const sub = stream_data.get_sub_by_id(stream_id);
+    const data = {};
 
     const privacy_setting = $("#stream_privacy_modal input[name=privacy]:checked").val();
     const stream_post_policy = parseInt(
         $("#stream_privacy_modal input[name=stream-post-policy]:checked").val(),
         10,
     );
+
+    if (sub.stream_post_policy !== stream_post_policy) {
+        data.stream_post_policy = JSON.stringify(stream_post_policy);
+    }
 
     let invite_only;
     let history_public_to_subscribers;
@@ -491,26 +506,36 @@ function change_stream_privacy(e) {
         history_public_to_subscribers = true;
     }
 
-    $(".stream_change_property_info").hide();
-    const data = {
-        stream_name: sub.name,
-        // toggle the privacy setting
-        is_private: JSON.stringify(invite_only),
-        stream_post_policy: JSON.stringify(stream_post_policy),
-        history_public_to_subscribers: JSON.stringify(history_public_to_subscribers),
-    };
+    if (
+        sub.invite_only !== invite_only ||
+        sub.history_public_to_subscribers !== history_public_to_subscribers
+    ) {
+        data.is_private = JSON.stringify(invite_only);
+        data.history_public_to_subscribers = JSON.stringify(history_public_to_subscribers);
+    }
 
-    if (page_params.is_owner) {
-        let message_retention_days = $(
-            "#stream_privacy_modal select[name=stream_message_retention_setting]",
-        ).val();
-        if (message_retention_days === "retain_for_period") {
-            message_retention_days = parseInt(
-                $("#stream_privacy_modal input[name=stream-message-retention-days]").val(),
-                10,
-            );
-        }
+    let message_retention_days = $(
+        "#stream_privacy_modal select[name=stream_message_retention_setting]",
+    ).val();
+    if (message_retention_days === "retain_for_period") {
+        message_retention_days = parseInt(
+            $("#stream_privacy_modal input[name=stream-message-retention-days]").val(),
+            10,
+        );
+    }
+
+    const message_retention_days_from_sub = get_message_retention_days_from_sub(sub);
+
+    if (message_retention_days_from_sub !== message_retention_days) {
         data.message_retention_days = JSON.stringify(message_retention_days);
+    }
+
+    $(".stream_change_property_info").hide();
+
+    if (Object.keys(data).length === 0) {
+        overlays.close_modal("#stream_privacy_modal");
+        $("#stream_privacy_modal").remove();
+        return;
     }
 
     channel.patch({


### PR DESCRIPTION
This PR changes change_stream_privacy function to only
send the values of changed settings to backend.
We also avoid sending PATCH request if none of the settings
in stream privacy modal are changed.

This change also fixes the bug in changing stream permissions
for realms with limited plans.

Fixes #16024.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
