### PR TITLE
puppeteer: Record test runs and save them on failure.

### DIFF
--- a/docs/THIRDPARTY
+++ b/docs/THIRDPARTY
@@ -130,6 +130,11 @@ Files: zerver/decorator.py zerver/management/commands/runtornado.py scripts/setu
 Copyright: Django Software Foundation and individual contributors
 License: BSD-3-Clause
 
+Files: frontend_tests/puppeteer_lib/screen-capture/*
+Copyright: 2018 Murali K G
+License: Expat
+Comment: The software has been modified.
+
 License: Apache-2.0
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/frontend_tests/puppeteer_lib/screen-capture/LICENSE
+++ b/frontend_tests/puppeteer_lib/screen-capture/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Murali K G
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/frontend_tests/puppeteer_lib/screen-capture/background.js
+++ b/frontend_tests/puppeteer_lib/screen-capture/background.js
@@ -1,0 +1,103 @@
+"use strict";
+
+/* global chrome, navigator, Blob, MediaRecorder, FileReader */
+
+let recorder = null;
+let filename = null;
+
+function startRecording(port, oldTitle) {
+    chrome.desktopCapture.chooseDesktopMedia(["tab", "audio"], async (streamId) => {
+        const options = {
+            audio: {
+                mandatory: {
+                    chromeMediaSource: "system",
+                },
+            },
+            video: {
+                mandatory: {
+                    chromeMediaSource: "desktop",
+                    chromeMediaSourceId: streamId,
+                    minWidth: 1280,
+                    maxWidth: 1280,
+                    minHeight: 720,
+                    maxHeight: 720,
+                    minFrameRate: 60,
+                },
+            },
+        };
+
+        const stream = await navigator.mediaDevices.getUserMedia(options);
+        port.postMessage({oldTitle});
+        recorder = new MediaRecorder(stream, {
+            videoBitsPerSecond: 2500000,
+            ignoreMutedMedia: true,
+            mimeType: "video/webm",
+        });
+
+        const videoChunks = [];
+        recorder.ondataavailable = function (event) {
+            if (event.data.size > 0) {
+                videoChunks.push(event.data);
+            }
+        };
+
+        recorder.onstop = function () {
+            if (filename === null || filename === undefined) {
+                return;
+            }
+
+            const buffer = new Blob(videoChunks, {
+                type: "video/webm",
+            });
+
+            const url = URL.createObjectURL(buffer);
+            chrome.downloads.download({
+                url,
+                filename,
+            });
+        };
+
+        recorder.start();
+    });
+}
+
+chrome.runtime.onConnect.addListener((port) => {
+    port.onMessage.addListener(async (msg) => {
+        console.log(msg);
+        switch (msg.type) {
+            case "SET_EXPORT_PATH":
+                filename = msg.filename;
+                break;
+
+            case "REC_STOP":
+                recorder.stop();
+                break;
+
+            case "REC_CLIENT_PLAY":
+                if (recorder) {
+                    return;
+                }
+
+                startRecording(port, msg.data.oldTitle);
+                break;
+        }
+    });
+
+    // Wait until download completes...
+    let downloadFilename = null;
+    chrome.downloads.onChanged.addListener((delta) => {
+        if (delta.filename !== undefined) {
+            downloadFilename = delta.filename.current;
+        }
+
+        if (!delta.state || delta.state.current !== "complete") {
+            return;
+        }
+
+        try {
+            port.postMessage({downloadComplete: true, downloadFilename});
+        } catch (e) {
+            console.error(e);
+        }
+    });
+});

--- a/frontend_tests/puppeteer_lib/screen-capture/content_script.js
+++ b/frontend_tests/puppeteer_lib/screen-capture/content_script.js
@@ -1,0 +1,36 @@
+"use strict";
+
+/* global chrome */
+
+const recorderInjectedProp = "__$$PuppeteerScreenCapture_recorder_injected__";
+if (!window[recorderInjectedProp]) {
+    Object.defineProperty(window, recorderInjectedProp, {value: true, writable: false});
+
+    const port = chrome.runtime.connect(chrome.runtime.id);
+    port.onMessage.addListener((msg) => window.postMessage(msg, "*"));
+    window.addEventListener("message", (event) => {
+        // Relay client messages
+        if (event.source === window && event.data.type) {
+            port.postMessage(event.data);
+        }
+
+        if (event.data.type === "PLAYBACK_COMPLETE") {
+            port.postMessage({type: "REC_STOP"}, "*");
+        }
+
+        if (event.data.downloadComplete) {
+            const $html = document.querySelector("html");
+            $html.classList.add("__PuppeteerScreenCapture_download_complete__");
+            $html.dataset.puppeteerRecordingFilename = event.data.downloadFilename;
+        }
+
+        if (event.data.oldTitle) {
+            document
+                .querySelector("html")
+                .classList.add("__PuppeteerScreenCapture_recorder_started__");
+            if (document.title === "PuppeteerRecording") {
+                document.title = event.data.oldTitle;
+            }
+        }
+    });
+}

--- a/frontend_tests/puppeteer_lib/screen-capture/index.js
+++ b/frontend_tests/puppeteer_lib/screen-capture/index.js
@@ -1,0 +1,85 @@
+"use strict";
+
+const fs = require("fs").promises;
+const path = require("path");
+
+let xvfb;
+function initXvfb({width, height}) {
+    const Xvfb = require("xvfb");
+    xvfb = new Xvfb({silent: true, xvfb_args: ["-screen", "0", `${width}x${height}x24`, "-ac"]});
+    xvfb.startSync();
+}
+
+const launchArgsOptions = [
+    "--enable-usermedia-screen-capturing",
+    "--allow-http-screen-capture",
+    "--auto-select-desktop-capture-source=PuppeteerRecording",
+    "--load-extension=" + __dirname,
+    "--disable-extensions-except=" + __dirname,
+];
+
+async function startRecording(page) {
+    await page.evaluate(() => {
+        // The document.title set there must be in sync with
+        // --auto-select-desktop-capture-source=PuppeteerRecording
+        // in launchArgOption above. If the title is not the same,
+        // chrome will not auto select this tab when the screen
+        // capture permission dialog pops up and the browser will
+        // be stuck. We revert back to the old title once we get the
+        // screen capture permission.
+        const oldTitle = document.title;
+        document.title = "PuppeteerRecording";
+        window.postMessage({type: "REC_CLIENT_PLAY", data: {oldTitle}}, "*");
+    });
+
+    await page.waitForSelector("html.__PuppeteerScreenCapture_recorder_started__");
+}
+
+async function stopRecording(page, {filename = null, directory} = {}) {
+    if (directory) {
+        // This hacky use of page._client to directly use chrome
+        // devtools API here is just to avoid creating ~/Downloads
+        // directory. If it doesn't work this can be removed and the
+        // saving recording to specified path would still work without
+        // issues but it will create ~/Downloads or equivalent directory.
+        await page._client.send("Page.setDownloadBehavior", {
+            behavior: "allow",
+            downloadPath: directory,
+        });
+    }
+
+    await page.evaluate((filename) => {
+        window.postMessage({type: "SET_EXPORT_PATH", filename}, "*");
+        window.postMessage({type: "REC_STOP"}, "*");
+    }, filename);
+
+    if (filename !== null) {
+        await page.waitForSelector("html.__PuppeteerScreenCapture_download_complete__");
+
+        const savePath = path.join(directory, filename);
+        const downloadPath = await page.evaluate(() => {
+            const $html = document.querySelector("html");
+            return $html.dataset.puppeteerRecordingFilename;
+        });
+
+        try {
+            // Remove the old recording it exist!
+            await fs.unlink(savePath);
+        } catch (e) {
+            /* Ignore the error */
+        }
+
+        await fs.rename(downloadPath, savePath);
+    }
+
+    if (xvfb) {
+        xvfb.stopSync();
+    }
+}
+
+module.exports = {
+    launchArgsOptions,
+    initXvfb,
+    startRecording,
+    stopRecording,
+};

--- a/frontend_tests/puppeteer_lib/screen-capture/manifest.json
+++ b/frontend_tests/puppeteer_lib/screen-capture/manifest.json
@@ -1,0 +1,16 @@
+{
+    "name": "Puppeteer Screen Capture",
+    "version": "0.1.0",
+    "manifest_version": 2,
+    "background": {
+        "scripts": ["background.js"]
+    },
+    "content_scripts": [
+        {
+            "matches": ["<all_urls>"],
+            "js": ["content_script.js"],
+            "run_at": "document_start"
+        }
+    ],
+    "permissions": ["desktopCapture", "<all_urls>", "downloads"]
+}

--- a/tools/test-js-with-puppeteer
+++ b/tools/test-js-with-puppeteer
@@ -96,6 +96,9 @@ also ask for help in chat.zulip.org""", file=sys.stderr)
             print("", file=sys.stderr)
             print("In CircleCI, the Artifacts tab contains screenshots and recording of the failure.", file=sys.stderr)
             print("", file=sys.stderr)
+        if os.environ.get("GITHUB_ACTIONS"):
+            print("", file=sys.stderr)
+            print("The Artifacts dropdown in top-right corner contains screenshots and test recording of the failure.", file=sys.stderr)
         sys.exit(ret)
 
 external_host = "zulipdev.com:9981"

--- a/tools/test-js-with-puppeteer
+++ b/tools/test-js-with-puppeteer
@@ -89,10 +89,12 @@ def run_tests(files: Iterable[str], external_host: str) -> None:
             ret = run_tests()[0]
     if ret != 0:
         print("""
-The Puppeteer frontend tests failed! Please report and ask for help in chat.zulip.org""", file=sys.stderr)
+The Puppeteer frontend tests failed! The failure screenshot and
+test recording is stored in var/puppeteer. Alternatively, you can
+also ask for help in chat.zulip.org""", file=sys.stderr)
         if os.environ.get("CIRCLECI"):
             print("", file=sys.stderr)
-            print("In CircleCI, the Artifacts tab contains screenshots of the failure.", file=sys.stderr)
+            print("In CircleCI, the Artifacts tab contains screenshots and recording of the failure.", file=sys.stderr)
             print("", file=sys.stderr)
         sys.exit(ret)
 


### PR DESCRIPTION
**Testing Plan:** Check that tests run recording is saved on failure by adding `throw Error()` right after `await test_function()` in common.js `run_test` function. Here is [failure.webm](https://chat.zulip.org/user_uploads/2/3d/3gJq_w7yN9X25zNZcJgdnb4J/failure.webm) I got by doing so.

We likely want to experiment with `slowMo` option in future is the recording does things way too quickly with careful testing about it's impact on the time it takes to run the tests.

Finally, do we have a better name other than `screen-capture` for this?