### PR TITLE
markdown: Use thumbor for inline URL preview images.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -646,6 +646,11 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
             parsed_url = urllib.parse.urlparse(link)
             domain = '{url.scheme}://{url.netloc}/'.format(url=parsed_url)
             img_link = urllib.parse.urljoin(domain, img_link)
+
+        if settings.THUMBNAIL_IMAGES:
+            img_link = urllib.parse.urlunsplit(
+                ("", "", "/thumbnail", urllib.parse.urlencode({"url": img_link, "size": "thumbnail"}), ""))
+
         img = SubElement(container, "a")
         img.set("style", "background-image: url(" + img_link + ")")
         img.set("href", link)


### PR DESCRIPTION
This serves the following two purposes:

* Serving all image content over HTTPS, even if the original image
was hosted on HTTP. This is important to avoid mixed-content warnings
from browsers, and does have some real security benefit in protecting
our users from malicious content.

* Minimizing potentially unnecessary bandwidth that might be used in
communication between the Zulip server and clients. Uploading large
photos could result in a bad experience for users with a slow network
connection.

Fixes #14754.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
