### PR TITLE
UI option to subscribe existing accounts during bulk invites.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2193,6 +2193,16 @@ div.topic_edit_spinner .loading_indicator_spinner {
     }
 }
 
+#subscribe_existing_accounts {
+    position: relative;
+    left: 270px;
+    background-color: hsl(50, 81%, 94%);
+
+    &:hover {
+        background-color: hsl(50, 36%, 80%);
+    }
+}
+
 #invite_status {
     display: none;
 }

--- a/static/templates/invitation_failed_error.hbs
+++ b/static/templates/invitation_failed_error.hbs
@@ -11,3 +11,14 @@
     <p id="invitation_non_admin_message">{{t "Organization administrators can reactivate deactivated users." }}</p>
     {{/if}}
 {{/if}}
+{{#if show_subscription}}
+<p id="subscribe_anyway_message">{{t "To subscribe the existing user(s) to the following stream(s), click on
+the button below." }}</p>
+<ul>
+    {{#each subscriber_stream_names}}
+    <li>#{{this.name}}</li>
+    {{/each}}
+</ul>
+<button id="subscribe_existing_accounts" class="button small round" type="button">
+{{t "Subscribe existing accounts" }}</button>
+{{/if}}

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -10,6 +10,12 @@ below features are supported.
 
 ## Changes in Zulip 4.0
 
+**Feature level 33**
+
+* `POST /invites`: Now returns `show_subscription` as well as the
+  anonymous email (4th parameter of the `errors` tuple) when raising
+  an InvitationError.
+
 **Feature level 32**
 
 * [`GET /events`](/api/get-events): Added `op` field to

--- a/version.py
+++ b/version.py
@@ -29,7 +29,7 @@ DESKTOP_WARNING_VERSION = "5.2.0"
 #
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md.
-API_FEATURE_LEVEL = 32
+API_FEATURE_LEVEL = 33
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5149,10 +5149,10 @@ class InvitationError(JsonableError):
     code = ErrorCode.INVITATION_FAILED
     data_fields = ['errors', 'sent_invitations']
 
-    def __init__(self, msg: str, errors: List[Tuple[str, str, bool]],
+    def __init__(self, msg: str, errors: List[Tuple[str, str, bool, str]],
                  sent_invitations: bool) -> None:
         self._msg: str = msg
-        self.errors: List[Tuple[str, str, bool]] = errors
+        self.errors: List[Tuple[str, str, bool, str]] = errors
         self.sent_invitations: bool = sent_invitations
 
 def estimate_recent_invites(realms: Iterable[Realm], *, days: int) -> int:
@@ -5220,7 +5220,7 @@ def do_invite_users(user_profile: UserProfile,
                 [], sent_invitations=False)
 
     good_emails: Set[str] = set()
-    errors: List[Tuple[str, str, bool]] = []
+    errors: List[Tuple[str, str, bool, str]] = []
     validate_email_allowed_in_realm = get_realm_email_validator(user_profile.realm)
     for email in invitee_emails:
         if email == '':
@@ -5231,7 +5231,7 @@ def do_invite_users(user_profile: UserProfile,
         )
 
         if email_error:
-            errors.append((email, email_error, False))
+            errors.append((email, email_error, False, ''))
         else:
             good_emails.add(email)
 
@@ -5242,10 +5242,10 @@ def do_invite_users(user_profile: UserProfile,
     '''
     error_dict = get_existing_user_errors(user_profile.realm, good_emails)
 
-    skipped: List[Tuple[str, str, bool]] = []
+    skipped: List[Tuple[str, str, bool, str]] = []
     for email in error_dict:
-        msg, deactivated = error_dict[email]
-        skipped.append((email, msg, deactivated))
+        msg, deactivated, maybe_anonymous_email = error_dict[email]
+        skipped.append((email, msg, deactivated, maybe_anonymous_email))
         good_emails.remove(email)
 
     validated_emails = list(good_emails)

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -5147,13 +5147,14 @@ def email_not_system_bot(email: str) -> None:
 
 class InvitationError(JsonableError):
     code = ErrorCode.INVITATION_FAILED
-    data_fields = ['errors', 'sent_invitations']
+    data_fields = ['errors', 'sent_invitations', 'show_subscription']
 
     def __init__(self, msg: str, errors: List[Tuple[str, str, bool, str]],
-                 sent_invitations: bool) -> None:
+                 sent_invitations: bool, show_subscription: bool=False) -> None:
         self._msg: str = msg
         self.errors: List[Tuple[str, str, bool, str]] = errors
         self.sent_invitations: bool = sent_invitations
+        self.show_subscription: bool = show_subscription
 
 def estimate_recent_invites(realms: Iterable[Realm], *, days: int) -> int:
     '''An upper bound on the number of invites sent in the last `days` days'''
@@ -5258,7 +5259,7 @@ def do_invite_users(user_profile: UserProfile,
     if skipped and len(skipped) == len(invitee_emails):
         # All e-mails were skipped, so we didn't actually invite anyone.
         raise InvitationError(_("We weren't able to invite anyone."),
-                              skipped, sent_invitations=False)
+                              skipped, sent_invitations=False, show_subscription=True)
 
     # We do this here rather than in the invite queue processor since this
     # is used for rate limiting invitations, rather than keeping track of
@@ -5284,7 +5285,7 @@ def do_invite_users(user_profile: UserProfile,
         raise InvitationError(_("Some of those addresses are already using Zulip, "
                                 "so we didn't send them an invitation. We did send "
                                 "invitations to everyone else!"),
-                              skipped, sent_invitations=True)
+                              skipped, sent_invitations=True, show_subscription=True)
     notify_invites_changed(user_profile)
 
 def do_get_user_invites(user_profile: UserProfile) -> List[Dict[str, Any]]:

--- a/zerver/lib/email_validation.py
+++ b/zerver/lib/email_validation.py
@@ -119,7 +119,7 @@ def get_existing_user_errors(
     target_realm: Realm,
     emails: Set[str],
     verbose: bool=False,
-) -> Dict[str, Tuple[str, bool]]:
+) -> Dict[str, Tuple[str, bool, str]]:
     '''
     We use this function even for a list of one emails.
 
@@ -128,7 +128,7 @@ def get_existing_user_errors(
     to cross-realm bots and mirror dummies too.
     '''
 
-    errors: Dict[str, Tuple[str, bool]] = {}
+    errors: Dict[str, Tuple[str, bool, str]] = {}
 
     users = get_users_by_delivery_email(emails, target_realm).only(
         'delivery_email',
@@ -153,7 +153,7 @@ def get_existing_user_errors(
             else:
                 msg = _('Reserved for system bots.')
             deactivated = False
-            errors[email] = (msg, deactivated)
+            errors[email] = (msg, deactivated, email)
             return
 
         existing_user_profile = user_dict.get(email.lower())
@@ -180,7 +180,12 @@ def get_existing_user_errors(
         else:
             msg = _("Account has been deactivated.")
 
-        errors[email] = (msg, deactivated)
+        '''
+        The existing_user_profile.email sends back the anonymous emails (different from
+        delivery_email depending on EMAIL_ADDRESS_VISIBILITY_EVERYONE) so that the clients
+        can continue to subscribe these existing users if they wish to.
+        '''
+        errors[email] = (msg, deactivated, existing_user_profile.email)
 
     for email in emails:
         process_email(email)
@@ -204,5 +209,5 @@ def validate_email_not_already_in_realm(target_realm: Realm,
     # Loop through errors, the only key should be our email.
     for key, error_info in error_dict.items():
         assert key == email
-        msg, deactivated = error_info
+        msg, deactivated, _ = error_info
         raise ValidationError(msg)

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -5005,6 +5005,15 @@ class EmailValidatorTestCase(ZulipTestCase):
         self.assertEqual(error, 'Already has an account.')
         self.assertEqual(maybe_anonymous_email, cordelia_anonymous_email)
 
+        do_set_realm_property(realm, 'email_address_visibility', Realm.EMAIL_ADDRESS_VISIBILITY_EVERYONE)
+        cordelia.refresh_from_db()
+
+        errors = get_existing_user_errors(realm, {cordelia_email})
+        error, is_deactivated, maybe_anonymous_email = errors[cordelia_email]
+        self.assertEqual(False, is_deactivated)
+        self.assertEqual(error, 'Already has an account.')
+        self.assertEqual(maybe_anonymous_email, cordelia_email)
+
         cordelia.is_active = False
         cordelia.save()
 
@@ -5012,7 +5021,7 @@ class EmailValidatorTestCase(ZulipTestCase):
         error, is_deactivated, maybe_anonymous_email = errors[cordelia_email]
         self.assertEqual(True, is_deactivated)
         self.assertEqual(error, 'Account has been deactivated.')
-        self.assertEqual(maybe_anonymous_email, cordelia_anonymous_email)
+        self.assertEqual(maybe_anonymous_email, cordelia_email)
 
         errors = get_existing_user_errors(realm, {'fred-is-fine@zulip.com'})
         self.assertEqual(errors, {})

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -4998,18 +4998,21 @@ class EmailValidatorTestCase(ZulipTestCase):
         self.assertIn('containing + are not allowed', error)
 
         cordelia_email = cordelia.delivery_email
+        cordelia_anonymous_email = cordelia.email
         errors = get_existing_user_errors(realm, {cordelia_email})
-        error, is_deactivated = errors[cordelia_email]
+        error, is_deactivated, maybe_anonymous_email = errors[cordelia_email]
         self.assertEqual(False, is_deactivated)
         self.assertEqual(error, 'Already has an account.')
+        self.assertEqual(maybe_anonymous_email, cordelia_anonymous_email)
 
         cordelia.is_active = False
         cordelia.save()
 
         errors = get_existing_user_errors(realm, {cordelia_email})
-        error, is_deactivated = errors[cordelia_email]
+        error, is_deactivated, maybe_anonymous_email = errors[cordelia_email]
         self.assertEqual(True, is_deactivated)
         self.assertEqual(error, 'Account has been deactivated.')
+        self.assertEqual(maybe_anonymous_email, cordelia_anonymous_email)
 
         errors = get_existing_user_errors(realm, {'fred-is-fine@zulip.com'})
         self.assertEqual(errors, {})


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Commit structure

* The first 3 commits are related to backend changes. This buildup to provide the data needed for the actual subscription UI. 
* The next commit bumps up the feature level and adds to the changelog. 
* The last two add and style the UI.

Fixes #15784 



**Testing Plan:** <!-- How have you tested? -->

I tested it manually for the most part. Of course, the backend tests pass as well.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

![subscribe_to_stream](https://user-images.githubusercontent.com/30312566/89426319-a777e300-d757-11ea-9f86-9615821ea68e.gif)


Feedback/review is much appreciated.
<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
