### PR TITLE
Revert "help: Stop collapsing sidebar sections."

### DIFF
--- a/static/js/portico/help.js
+++ b/static/js/portico/help.js
@@ -111,6 +111,17 @@ const update_page = function (cache, path) {
 
 new SimpleBar($(".sidebar")[0]);
 
+$(".sidebar.slide h2").on("click", (e) => {
+    const $next = $(e.target).next();
+
+    if ($next.is("ul")) {
+        // Close other article's headings first
+        $(".sidebar ul").not($next).hide();
+        // Toggle the heading
+        $next.slideToggle("fast", "swing");
+    }
+});
+
 $(".sidebar a").on("click", function (e) {
     const path = $(this).attr("href");
     const path_dir = path.split("/")[1];
@@ -173,5 +184,3 @@ window.addEventListener("popstate", () => {
 });
 
 $("body").addClass("noscroll");
-
-$(".highlighted")[0].scrollIntoView({block: "center"});

--- a/templates/zerver/documentation_main.html
+++ b/templates/zerver/documentation_main.html
@@ -8,7 +8,7 @@
 
 {% block portico_content %}
 <div class="app help terms-page inline-block{% if page_is_help_center %} help-center{% endif %}{% if page_is_api_center %} api-center{% endif %}">
-    <div class="sidebar">
+    <div class="{{ sidebar_class }}">
         <div class="content">
             <h1><a href="{{ doc_root }}" class="no-underline">Home</a></h1>
             {{ render_markdown_path(sidebar_index, api_uri_context) }}

--- a/templates/zerver/documentation_main.html
+++ b/templates/zerver/documentation_main.html
@@ -10,7 +10,7 @@
 <div class="app help terms-page inline-block{% if page_is_help_center %} help-center{% endif %}{% if page_is_api_center %} api-center{% endif %}">
     <div class="{{ sidebar_class }}">
         <div class="content">
-            <h1><a href="{{ doc_root }}" class="no-underline">Home</a></h1>
+            <h1><a href="{{ doc_root }}" class="no-underline">Contents</a></h1>
             {{ render_markdown_path(sidebar_index, api_uri_context) }}
             <h1 class="home-link"><a href="/" class="no-underline">Back to Zulip</a></h1>
         </div>

--- a/zerver/views/documentation.py
+++ b/zerver/views/documentation.py
@@ -91,11 +91,14 @@ class MarkdownDirectoryView(ApiURLView):
             context["page_is_help_center"] = True
             context["doc_root"] = "/help/"
             (sidebar_index, http_status_ignored) = self.get_path("include/sidebar_index")
+            # We want the sliding/collapsing behavior for /help pages only
+            sidebar_class = "sidebar slide"
             title_base = "Zulip Help Center"
         else:
             context["page_is_api_center"] = True
             context["doc_root"] = "/api/"
             (sidebar_index, http_status_ignored) = self.get_path("sidebar_index")
+            sidebar_class = "sidebar"
             title_base = "Zulip API Documentation"
 
         # The following is a somewhat hacky approach to extract titles from articles.
@@ -115,6 +118,7 @@ class MarkdownDirectoryView(ApiURLView):
             context["OPEN_GRAPH_DESCRIPTION"] = self.request.placeholder_open_graph_description
 
         context["sidebar_index"] = sidebar_index
+        context["sidebar_class"] = sidebar_class
         # An "article" might require the api_uri_context to be rendered
         api_uri_context: Dict[str, Any] = {}
         add_api_uri_context(api_uri_context, self.request)


### PR DESCRIPTION
This reverts commit 87d8a54b91bfe0ddbcb9acd476b2d5bf3fbabe32 (#15961).

Showing hundreds of links in the sidebar makes it hard to glance at which top-level sections exist.

**Testing Plan:** Dev server.
