### PR TITLE
streams: Mark all messages as read when deactivating a stream.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -916,6 +916,9 @@ def do_deactivate_user(user_profile: UserProfile,
             do_deactivate_user(profile, acting_user=acting_user, _cascade=False)
 
 def do_deactivate_stream(stream: Stream, log: bool=True, acting_user: Optional[UserProfile]=None) -> None:
+    # We want to mark all messages in the stream as read .
+    event = {"type": "mark_all_stream_messages_as_read", "stream_recipient_id": stream.recipient_id}
+    queue_json_publish("deferred_work", event)
 
     # Get the affected user ids *before* we deactivate everybody.
     affected_user_ids = can_access_stream_user_ids(stream)

--- a/zerver/migrations/0299_fix_unread_messages_in_deactivated_streams.py
+++ b/zerver/migrations/0299_fix_unread_messages_in_deactivated_streams.py
@@ -1,0 +1,34 @@
+from django.db import connection, migrations
+from django.db.backends.postgresql.schema import DatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+
+def mark_messages_read(apps: StateApps, schema_editor: DatabaseSchemaEditor) -> None:
+    Stream = apps.get_model("zerver", "Stream")
+    deactivated_stream_ids = list(Stream.objects.filter(deactivated=True).values_list('id', flat=True))
+    with connection.cursor() as cursor:
+        for i in deactivated_stream_ids:
+            cursor.execute(f"""
+                UPDATE zerver_usermessage SET flags = flags | 1
+                FROM zerver_message
+                INNER JOIN zerver_stream ON zerver_stream.recipient_id = zerver_message.recipient_id
+                WHERE zerver_message.id = zerver_usermessage.message_id
+                AND zerver_stream.id = {i};
+            """)
+
+class Migration(migrations.Migration):
+    """
+    We're changing the stream deactivation process to make it mark all messages
+    in the stream as read. For things to be consistent with streams that have been
+    deactivated before this change, we need a migration to fix those old streams,
+    to have all messages marked as read.
+    """
+    atomic = False
+
+    dependencies = [
+        ('zerver', '0298_fix_realmauditlog_format'),
+    ]
+
+    operations = [
+        migrations.RunPython(mark_messages_read, reverse_code=migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
Fixes #15770.

I went with approach (1) from https://github.com/zulip/zulip/issues/15770#issuecomment-662176897 Stream deactivation is a pretty "strong" action akin to basically deleting it, in that it even removes all user subscriptions to it. Given that, it makes perfect sense to me that messages in such a stream should be marked as read.

I tested manually, both the change and the migration and verified that it fixes the #15770 issue for users already facing it, and prevents it from recurring on future stream deactivations.