### PR TITLE
streams: Send PATCH request for stream name and description only when it is actually changed.

### DIFF
--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -602,6 +602,13 @@ exports.change_stream_description = function (e) {
     const description = sub_settings.find(".stream-description-editable").text().trim();
     $(".stream_change_property_info").hide();
 
+    if (description === sub.description) {
+        sub_settings
+            .find(".stream-description-editable")
+            .html(util.clean_user_content_links(sub.rendered_description));
+        return;
+    }
+
     channel.patch({
         // Description might contain unsafe characters so we must encode it first.
         url: "/json/streams/" + stream_id,

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -552,7 +552,13 @@ exports.change_stream_name = function (e) {
     const stream_id = get_stream_id(e.target);
     const new_name_box = sub_settings.find(".stream-name-editable");
     const new_name = new_name_box.text().trim();
+    const old_name = stream_data.maybe_get_stream_name(stream_id);
+
     $(".stream_change_property_info").hide();
+
+    if (old_name === new_name) {
+        return;
+    }
 
     channel.patch({
         // Stream names might contain unsafe characters so we must encode it first.
@@ -566,7 +572,7 @@ exports.change_stream_name = function (e) {
             );
         },
         error(xhr) {
-            new_name_box.text(stream_data.maybe_get_stream_name(stream_id));
+            new_name_box.text(old_name);
             ui_report.error(i18n.t("Error"), xhr, $(".stream_change_property_info"));
         },
     });


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR changes code to send patch request for stream name and description
only if their values are actually changed.

This also solves a bug where trying to save stream name from UI without actually
changing it returns 400 error. Ideally, it should not send request to API and should just
close the edit widget.

 <!-- How have you tested? -->


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
