### PR TITLE
js: Use unminified KaTeX (and minifiy it with everything else).

### DIFF
--- a/frontend_tests/node_tests/markdown_katex.js
+++ b/frontend_tests/node_tests/markdown_katex.js
@@ -20,7 +20,7 @@ zrequire("stream_data");
 zrequire("user_groups");
 
 const markdown = rewiremock.proxy(() => zrequire("markdown"), {
-    "katex/dist/katex.min.js": {
+    katex: {
         renderToString: () => {
             throw new Error("some-exception");
         },

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const katex = require("katex/dist/katex.min.js");
+const katex = require("katex");
 const _ = require("lodash");
 const moment = require("moment");
 

--- a/static/shared/js/fenced_code.js
+++ b/static/shared/js/fenced_code.js
@@ -1,4 +1,4 @@
-import katex from "katex/dist/katex.min.js";
+import katex from "katex";
 import _ from "lodash";
 
 // Parsing routine that can be dropped in to message parsing

--- a/tools/webpack.assets.json
+++ b/tools/webpack.assets.json
@@ -7,7 +7,6 @@
     ],
     "archive": [
         "./static/js/bundles/portico.js",
-        "katex/dist/katex.min.js",
         "./static/js/archive.js",
         "./static/js/colorspace.js",
         "./static/js/floating_recipient_bar.js",
@@ -113,6 +112,6 @@
         "./static/styles/portico/stats.scss",
         "./static/js/stats/stats.js"
     ],
-    "app": ["./static/js/bundles/app.js", "katex/dist/katex.min.js"],
+    "app": ["./static/js/bundles/app.js"],
     "digest": ["./static/js/bundles/portico.js"]
 }


### PR DESCRIPTION
Since our Webpack config passes pre-minified JS files to script-loader, they can’t be used as modules. Use the normal unminified version, letting Webpack minify it and give us source maps.

**Testing Plan:** Dev server.