### PR TITLE
compose_area: Highlight excessive message length instead of cutting it off

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -300,6 +300,25 @@ run_test("validate", () => {
     compose_state.topic("");
     assert(!compose.validate());
     assert.equal($("#compose-error-msg").html(), i18n.t("Please specify a topic"));
+
+    // test validating message length
+    const sub = {
+        stream_id: 101,
+        name: "social",
+        subscribed: true,
+    };
+    stream_data.add_sub(sub);
+    page_params.user_id = 30;
+    const message = "a".repeat(10000 + 1);
+
+    $("#compose-textarea").val(message);
+    compose_state.stream_name("social");
+    compose_state.topic("topic nam e");
+    assert(!compose.validate());
+    assert.equal($("#compose-error-msg").html(), i18n.t("Your message is too long!"));
+
+    $("#compose-textarea").val("a");
+    assert(compose.validate());
 });
 
 run_test("get_invalid_recipient_emails", () => {
@@ -1772,4 +1791,12 @@ run_test("test_video_chat_button_toggle", () => {
     page_params.jitsi_server_url = "https://meet.jit.si";
     compose.initialize();
     assert.equal($("#below-compose-content .video_link").visible(), true);
+});
+
+run_test("test_overflow_text", () => {
+    const overflowdiv = $("#overflow");
+    const textarea = $("#compose-textarea");
+    textarea.value = "a".repeat(10000 + 1);
+    compose.check_and_set_overflow_text("", [textarea]);
+    assert(overflowdiv.html().includes("highligth"));
 });

--- a/static/styles/compose.scss
+++ b/static/styles/compose.scss
@@ -295,18 +295,37 @@ div[id^="message-edit-send-status"],
     position: relative;
 }
 
-textarea.new_message_textarea {
+.wrapper > * {
     display: table-cell;
     width: calc(100% - 12px);
     padding: 5px;
     height: 1.5em;
     max-height: 22em;
     margin-bottom: 0;
-    resize: vertical !important;
     margin-top: 5px;
+    overflow: hidden;
 }
 
-textarea.new_message_textarea,
+.overflow_text {
+    position: absolute;
+    z-index: -1;
+}
+
+.highligth {
+    background-color: hsl(352, 100%, 86%);
+    color: transparent;
+}
+
+.transparent {
+    color: transparent;
+}
+
+.new_message_textarea {
+    background-color: transparent;
+    resize: vertical !important;
+}
+
+.wrapper > textarea,
 .compose_table .recipient_box {
     border: 1px solid hsla(0, 0%, 0%, 0.2);
     box-shadow: none;

--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -87,7 +87,10 @@
                         </div>
                         <div>
                             <div class="messagebox">
-                                <textarea class="new_message_textarea" name="content" id='compose-textarea' placeholder="{{ _('Compose your message here') }}" tabindex="0" maxlength="10000" aria-label="{{ _('Compose your message here...') }}"></textarea>
+                                <div class="wrapper">
+                                    <div class="overflow_text" id="overflow"></div>
+                                    <textarea class="new_message_textarea" name="content" id='compose-textarea' placeholder="{{ _('Compose your message here') }}" tabindex="0" maxlength="10000" aria-label="{{ _('Compose your message here...') }}"></textarea>
+                                </div>
                                 <div class="scrolling_list preview_message_area" id="preview_message_area" style="display:none;">
                                     <div id="markdown_preview_spinner"></div>
                                     <div id="preview_content" class="preview_content rendered_markdown"></div>


### PR DESCRIPTION
Fix a bug where the compose box cut the message without warning the user 
the message pasted was longer than the allowed. It was fixed by stopping cutting 
the message off and highlighting the excessive text,  not allowing it to send until 
the message length is fixed.

Fixes #15909

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![textarea](https://user-images.githubusercontent.com/16260725/89582190-9807a100-d80e-11ea-9f0f-6c6f84ba52b0.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
