### PR TITLE
streams: Show warning when unsubscribing a private stream.

### DIFF
--- a/frontend_tests/puppeteer_tests/16-settings.ts
+++ b/frontend_tests/puppeteer_tests/16-settings.ts
@@ -45,6 +45,8 @@ async function test_change_full_name(page: Page): Promise<void> {
     await page.type(full_name_input_selector, "New name");
     await page.click(change_full_name_button_selector);
     await page.waitForFunction(() => $("#change_full_name").text().trim() === "New name");
+    // Ensure that the mouse events are enabled for the background for further tests.
+    await page.waitForFunction(() => $(".overlay.show").attr("style") === undefined);
 }
 
 async function test_change_password(page: Page): Promise<void> {
@@ -64,6 +66,8 @@ async function test_change_password(page: Page): Promise<void> {
 
     // On success the change password modal gets closed.
     await page.waitForFunction(() => $("#change_password_modal").attr("aria-hidden") === "true");
+    // Ensure that the mouse events are enabled for the background for further tests.
+    await page.waitForFunction(() => $(".overlay.show").attr("style") === undefined);
 }
 
 async function test_get_api_key(page: Page): Promise<void> {
@@ -93,6 +97,8 @@ async function test_get_api_key(page: Page): Promise<void> {
     const zuliprc_decoded_url = await get_decoded_url_in_selector(page, download_zuliprc_selector);
     assert(zuliprc_regex.test(zuliprc_decoded_url), "Incorrect zuliprc file");
     await page.click("#api_key_modal .close");
+    // Ensure that the mouse events are enabled for the background for further tests.
+    await page.waitForFunction(() => $(".overlay.show").attr("style") === undefined);
 }
 
 async function test_webhook_bot_creation(page: Page): Promise<void> {
@@ -175,6 +181,9 @@ async function test_edit_bot_form(page: Page): Promise<void> {
     await page.waitForXPath(
         `//*[@class="btn open_edit_bot_form" and @data-email="${bot1_email}"]/ancestor::*[@class="details"]/*[@class="name" and text()="Bot one"]`,
     );
+
+    // Ensure that the mouse events are enabled for the background for further tests.
+    await page.waitForFunction(() => $(".overlay.show").attr("style") === undefined);
 }
 
 async function test_your_bots_section(page: Page): Promise<void> {

--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -947,6 +947,11 @@ export function initialize() {
         e.stopPropagation();
     });
 
+    $("body").on("hidden.bs.modal", () => {
+        // Enable mouse events for the background as the modal closes.
+        overlays.enable_background_mouse_events();
+    });
+
     // MAIN CLICK HANDLER
 
     $(document).on("click", (e) => {
@@ -964,12 +969,6 @@ export function initialize() {
             ).has(e.target).length === 0
         ) {
             popovers.hide_all();
-        }
-
-        // If user clicks outside an active modal
-        if ($(".modal.in").has(e.target).length === 0) {
-            // Enable mouse events for the background as the modal closes
-            $(".overlay.show").attr("style", null);
         }
 
         if (compose_state.composing()) {

--- a/static/js/confirm_dialog.js
+++ b/static/js/confirm_dialog.js
@@ -78,4 +78,8 @@ export function launch(conf) {
 
     // Open the modal
     overlays.open_modal("#confirm_dialog_modal");
+
+    conf.parent.on("shown.bs.modal", () => {
+        yes_button.trigger("focus");
+    });
 }

--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -199,8 +199,6 @@ export function close_modal(selector) {
 
     const elem = $(selector).expectOne();
     elem.modal("hide").attr("aria-hidden", true);
-    // Enable mouse events for the background as the modal closes.
-    enable_background_mouse_events();
 }
 
 export function close_active_modal() {

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -403,14 +403,6 @@ export function set_up() {
             clear_password_change();
         });
 
-    // If the modal is closed using the 'close' button or the 'Cancel' button
-    $(".modal")
-        .find("[data-dismiss=modal]")
-        .on("click", () => {
-            // Enable mouse events for the background on closing modal
-            $(".overlay.show").attr("style", null);
-        });
-
     $("#change_password_button").on("click", (e) => {
         e.preventDefault();
         e.stopPropagation();

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -745,7 +745,7 @@ export function initialize() {
 
     $("#subscriptions_table").on("click", "#change-stream-privacy-button", change_stream_privacy);
 
-    $("#subscriptions_table").on("click", ".close-privacy-modal", (e) => {
+    $("#subscriptions_table").on("click", ".close-modal-btn", (e) => {
         // Re-enable background mouse events when we close the modal
         // via the "x" in the corner.  (The other modal-close code
         // paths call `overlays.close_modal`, rather than using

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -587,7 +587,6 @@ function change_stream_privacy(e) {
 
     if (Object.keys(data).length === 0) {
         overlays.close_modal("#stream_privacy_modal");
-        $("#stream_privacy_modal").remove();
         return;
     }
 
@@ -596,7 +595,6 @@ function change_stream_privacy(e) {
         data,
         success() {
             overlays.close_modal("#stream_privacy_modal");
-            $("#stream_privacy_modal").remove();
             // The rest will be done by update stream event we will get.
         },
         error(xhr) {
@@ -882,17 +880,12 @@ export function initialize() {
     $("#subscriptions_table").on("click", "#do_deactivate_stream_button", (e) => {
         const stream_id = $(e.target).data("stream-id");
         overlays.close_modal("#deactivation_stream_modal");
-        $("#deactivation_stream_modal").remove();
         if (!stream_id) {
             ui_report.client_error(i18n.t("Invalid stream id"), $(".stream_change_property_info"));
             return;
         }
         const row = $(".stream-row.active");
         delete_stream(stream_id, $(".stream_change_property_info"), row);
-    });
-
-    $("#subscriptions_table").on("hide.bs.modal", "#deactivation_stream_modal", () => {
-        $("#deactivation_stream_modal").remove();
     });
 
     $("#subscriptions_table").on("click", ".stream-row", function (e) {

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -746,17 +746,6 @@ export function initialize() {
     $("#subscriptions_table").on("click", "#change-stream-privacy-button", change_stream_privacy);
 
     $("#subscriptions_table").on("click", ".close-modal-btn", (e) => {
-        // Re-enable background mouse events when we close the modal
-        // via the "x" in the corner.  (The other modal-close code
-        // paths call `overlays.close_modal`, rather than using
-        // bootstrap's data-dismiss=modal feature, and this is done
-        // there).
-        //
-        // TODO: It would probably be better to just do this
-        // unconditionally inside the handler for the event sent by
-        // bootstrap on closing a modal.
-        overlays.enable_background_mouse_events();
-
         // This fixes a weird bug in which, subscription_settings hides
         // unexpectedly by clicking the cancel button in a modal on top of it.
         e.stopPropagation();

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -477,7 +477,7 @@ export function register_stream_handlers() {
         $(this).closest(".popover").fadeOut(500).delay(500).remove();
 
         const sub = stream_popover_sub(e);
-        subs.sub_or_unsub(sub);
+        subs.sub_or_unsub(sub, true);
         e.preventDefault();
         e.stopPropagation();
     });

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -785,14 +785,9 @@ export function switch_rows(event) {
 
 export function keyboard_sub() {
     const active_data = get_active_data();
-    const stream_filter_tab = $(active_data.tabs[0]).text();
     const row_data = get_row_data(active_data.row);
     if (row_data) {
         sub_or_unsub(row_data.object);
-        if (row_data.object.subscribed && stream_filter_tab === "Subscribed") {
-            active_data.row.addClass("notdisplayed");
-            active_data.row.removeClass("active");
-        }
     }
 }
 

--- a/static/templates/confirm_dialog.hbs
+++ b/static/templates/confirm_dialog.hbs
@@ -1,12 +1,12 @@
 <div class="modal modal-bg new-style hide fade" id="confirm_dialog_modal" tabindex="-1" role="dialog" aria-labelledby="confirm_dialog_modal" aria-hidden="true">
     <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+        <button type="button" class="close close-modal-btn" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
         <h3 class="confirm_dialog_heading"></h3>
     </div>
     <div class="modal-body confirm_dialog_body">
     </div>
     <div class="modal-footer">
-        <button class="button rounded" data-dismiss="modal">{{t "Cancel" }}</button>
+        <button class="button rounded close-modal-btn" data-dismiss="modal">{{t "Cancel" }}</button>
         <button class="button rounded btn-danger confirm_dialog_yes_button"></button>
     </div>
 </div>

--- a/static/templates/settings/deactivation_stream_modal.hbs
+++ b/static/templates/settings/deactivation_stream_modal.hbs
@@ -1,13 +1,13 @@
 <div id="deactivation_stream_modal" class="modal modal-bg hide fade new-style" tabindex="-1" role="dialog" aria-labelledby="deactivation_stream_modal_label" aria-hidden="true">
     <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+        <button type="button" class="close close-modal-btn" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
         <h3 id="deactivation_stream_modal_label">{{t "Delete stream" }} <span class="stream_name">{{stream_name}}</span></h3>
     </div>
     <div class="modal-body">
         <p>{{t "Deleting this stream will immediately unsubscribe everyone, and the stream's content will not be recoverable." }} <strong>{{t "Are you sure you want to do this?" }}</strong></p>
     </div>
     <div class="modal-footer">
-        <button class="button rounded" data-dismiss="modal">{{t "Cancel" }}</button>
+        <button class="button rounded close-modal-btn" data-dismiss="modal">{{t "Cancel" }}</button>
         <button class="button rounded btn-danger" id="do_deactivate_stream_button" data-stream-id="{{stream_id}}">{{t "Yes, delete this stream" }}</button>
     </div>
 </div>

--- a/static/templates/subscription_stream_privacy_modal.hbs
+++ b/static/templates/subscription_stream_privacy_modal.hbs
@@ -1,11 +1,11 @@
 <div id="stream_privacy_modal" class="modal modal-bg hide fade new-style" tabindex="-1" role="dialog" aria-labelledby="stream_privacy_modal_label" aria-hidden="true">
     <div class="modal-header">
-        <button type="button" class="close close-privacy-modal" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
+        <button type="button" class="close close-modal-btn" data-dismiss="modal" aria-label="{{t 'Close' }}"><span aria-hidden="true">&times;</span></button>
         <h3 id="stream_privacy_modal_label">{{t "Change stream permissions for #" }}{{ stream_name }}<span class="email"></span></h3>
     </div>
     {{> stream_types }}
     <div class="modal-footer">
-        <button class="button rounded close-privacy-modal" data-dismiss="modal">{{t "Cancel" }}</button>
+        <button class="button rounded close-modal-btn" data-dismiss="modal">{{t "Cancel" }}</button>
         <button class="button rounded btn-danger" id="change-stream-privacy-button"
           tabindex="-1" data-stream-id="{{stream_id}}">
             {{t "Save changes"}}

--- a/static/templates/unsubscribe_private_stream_modal.hbs
+++ b/static/templates/unsubscribe_private_stream_modal.hbs
@@ -1,0 +1,1 @@
+<p>{{t "Once you leave a private stream, you will not be able to rejoin." }}</p>


### PR DESCRIPTION
We show a modal as a warning when unsubscribing a private stream
because it is a reversible action and one cannot re-subscribe to
it until added by other members of the stream.

I have used two different classes for the button in modal because we show
success message below the add subscribers input only when we unsubscribe 
from subscriber list.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


<!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![unsubscribe](https://user-images.githubusercontent.com/35494118/89590389-6c63d580-d865-11ea-979a-ac2e8832ba30.gif)

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
