### PR TITLE
Speedup /activity page

### DIFF
--- a/analytics/lib/counts.py
+++ b/analytics/lib/counts.py
@@ -665,6 +665,10 @@ def get_count_stats(realm: Optional[Realm]=None) -> Dict[str, CountStat]:
                   sql_data_collector(
                       UserCount, check_useractivityinterval_by_user_query(realm), None),
                   CountStat.DAY, interval=timedelta(days=1)-UserActivityInterval.MIN_INTERVAL_LENGTH),
+        CountStat('7day_actives::day',
+                  sql_data_collector(
+                      UserCount, check_useractivityinterval_by_user_query(realm), None),
+                  CountStat.DAY, interval=timedelta(days=7)-UserActivityInterval.MIN_INTERVAL_LENGTH),
         CountStat('15day_actives::day',
                   sql_data_collector(
                       UserCount, check_useractivityinterval_by_user_query(realm), None),

--- a/analytics/management/commands/populate_analytics_db.py
+++ b/analytics/management/commands/populate_analytics_db.py
@@ -116,9 +116,21 @@ class Command(BaseCommand):
         FillState.objects.create(property=stat.property, end_time=last_end_time,
                                  state=FillState.DONE)
 
+        stat = COUNT_STATS['7day_actives::day']
+        realm_data = {
+            None: self.generate_fixture_data(stat, .2, .07, 3, .3, 6, partial_sum=True),
+        }
+        insert_fixture_data(stat, realm_data, RealmCount)
+        installation_data = {
+            None: self.generate_fixture_data(stat, 2, .7, 4, .3, 6, partial_sum=True),
+        }
+        insert_fixture_data(stat, installation_data, InstallationCount)
+        FillState.objects.create(property=stat.property, end_time=last_end_time,
+                                 state=FillState.DONE)
+
         stat = COUNT_STATS['realm_active_humans::day']
         realm_data = {
-            None: self.generate_fixture_data(stat, .1, .03, 3, .5, 3, partial_sum=True),
+            None: self.generate_fixture_data(stat, .8, .08, 3, .5, 3, partial_sum=True),
         }
         insert_fixture_data(stat, realm_data, RealmCount)
         installation_data = {
@@ -130,11 +142,13 @@ class Command(BaseCommand):
 
         stat = COUNT_STATS['active_users_audit:is_bot:day']
         realm_data = {
-            'false': self.generate_fixture_data(stat, .1, .03, 3.5, .8, 2, partial_sum=True),
+            'false': self.generate_fixture_data(stat, 1, .2, 3.5, .8, 2, partial_sum=True),
+            'true': self.generate_fixture_data(stat, .3, .05, 3, .3, 2, partial_sum=True),
         }
         insert_fixture_data(stat, realm_data, RealmCount)
         installation_data = {
-            'false': self.generate_fixture_data(stat, 1, .3, 6, .8, 2, partial_sum=True),
+            'false': self.generate_fixture_data(stat, 3, 1, 4, .8, 2, partial_sum=True),
+            'true': self.generate_fixture_data(stat, 1, .4, 4, .8, 2, partial_sum=True),
         }
         insert_fixture_data(stat, installation_data, InstallationCount)
         FillState.objects.create(property=stat.property, end_time=last_end_time,

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -518,107 +518,71 @@ def realm_summary_table(realm_minutes: Dict[str, float]) -> str:
             realm.string_id,
             realm.date_created,
             realm.plan_type,
-            coalesce(user_counts.dau_count, 0) dau_count,
-            coalesce(wau_counts.wau_count, 0) wau_count,
-            (
+            coalesce(wau_table.value, 0) wau_count,
+            coalesce(dau_table.value, 0) dau_count,
+            coalesce(user_count_table.value, 0) user_profile_count,
+            coalesce(bot_count_table.value, 0) bot_count
+        FROM
+            zerver_realm as realm
+            LEFT OUTER JOIN (
                 SELECT
-                    count(*)
-                FROM zerver_userprofile up
-                WHERE up.realm_id = realm.id
-                AND is_active
-                AND not is_bot
-            ) user_profile_count,
-            (
-                SELECT
-                    count(*)
-                FROM zerver_userprofile up
-                WHERE up.realm_id = realm.id
-                AND is_active
-                AND is_bot
-            ) bot_count
-        FROM zerver_realm realm
-        LEFT OUTER JOIN
-            (
-                SELECT
-                    up.realm_id realm_id,
-                    count(distinct(ua.user_profile_id)) dau_count
-                FROM zerver_useractivity ua
-                JOIN zerver_userprofile up
-                    ON up.id = ua.user_profile_id
+                    value _14day_active_humans,
+                    realm_id
+                from
+                    analytics_realmcount
                 WHERE
-                    up.is_active
-                AND (not up.is_bot)
-                AND
-                    query in (
-                        '/json/send_message',
-                        'send_message_backend',
-                        '/api/v1/send_message',
-                        '/json/update_pointer',
-                        '/json/users/me/pointer',
-                        'update_pointer_backend'
-                    )
-                AND
-                    last_visit > now() - interval '1 day'
-                GROUP BY realm_id
-            ) user_counts
-            ON user_counts.realm_id = realm.id
-        LEFT OUTER JOIN
-            (
+                    property = 'realm_active_humans::day'
+                    AND end_time > now() - interval '25 hours'
+            ) as _14day_active_humans_table ON realm.id = _14day_active_humans_table.realm_id
+            LEFT OUTER JOIN (
                 SELECT
-                    realm_id,
-                    count(*) wau_count
-                FROM (
-                    SELECT
-                        realm.id as realm_id,
-                        up.delivery_email
-                    FROM zerver_useractivity ua
-                    JOIN zerver_userprofile up
-                        ON up.id = ua.user_profile_id
-                    JOIN zerver_realm realm
-                        ON realm.id = up.realm_id
-                    WHERE up.is_active
-                    AND (not up.is_bot)
-                    AND
-                        ua.query in (
-                            '/json/send_message',
-                            'send_message_backend',
-                            '/api/v1/send_message',
-                            '/json/update_pointer',
-                            '/json/users/me/pointer',
-                            'update_pointer_backend'
-                        )
-                    GROUP by realm.id, up.delivery_email
-                    HAVING max(last_visit) > now() - interval '7 day'
-                ) as wau_users
-                GROUP BY realm_id
-            ) wau_counts
-            ON wau_counts.realm_id = realm.id
+                    value,
+                    realm_id
+                from
+                    analytics_realmcount
+                WHERE
+                    property = '7day_actives::day'
+                    AND end_time > now() - interval '25 hours'
+            ) as wau_table ON realm.id = wau_table.realm_id
+            LEFT OUTER JOIN (
+                SELECT
+                    value,
+                    realm_id
+                from
+                    analytics_realmcount
+                WHERE
+                    property = '1day_actives::day'
+                    AND end_time > now() - interval '25 hours'
+            ) as dau_table ON realm.id = dau_table.realm_id
+            LEFT OUTER JOIN (
+                SELECT
+                    value,
+                    realm_id
+                from
+                    analytics_realmcount
+                WHERE
+                    property = 'active_users_audit:is_bot:day'
+                    AND subgroup = 'false'
+                    AND end_time > now() - interval '25 hours'
+            ) as user_count_table ON realm.id = user_count_table.realm_id
+            LEFT OUTER JOIN (
+                SELECT
+                    value,
+                    realm_id
+                from
+                    analytics_realmcount
+                WHERE
+                    property = 'active_users_audit:is_bot:day'
+                    AND subgroup = 'true'
+                    AND end_time > now() - interval '25 hours'
+            ) as bot_count_table ON realm.id = bot_count_table.realm_id
         WHERE
-            realm.plan_type = 3
-            OR
-            EXISTS (
-                SELECT *
-                FROM zerver_useractivity ua
-                JOIN zerver_userprofile up
-                    ON up.id = ua.user_profile_id
-                WHERE
-                    up.realm_id = realm.id
-                AND up.is_active
-                AND (not up.is_bot)
-                AND
-                    query in (
-                        '/json/send_message',
-                        '/api/v1/send_message',
-                        'send_message_backend',
-                        '/json/update_pointer',
-                        '/json/users/me/pointer',
-                        'update_pointer_backend'
-                    )
-                AND
-                    last_visit > now() - interval '2 week'
-        )
-        ORDER BY dau_count DESC, string_id ASC
-        ''')
+            _14day_active_humans IS NOT NULL
+            or realm.plan_type = 3
+        ORDER BY
+            dau_count DESC,
+            string_id ASC
+    ''')
 
     cursor = connection.cursor()
     cursor.execute(query)


### PR DESCRIPTION
My plan is to get v1 integrated and then create another PR for v2. 

v1 is not ready to be merged but a review would be appreciated.  I need to work on adding backend tests as well as do some more testing.


### v1

* Rewrite WAU query to make use of RealmCount
	* [X] Add `7day_actives::day` 
	* [X] Populate `7day_actives::day` in populate_analytics_db.
	* [ ] Tests for `7day_actives::day`
	* [X] Rewrite the query to make use of `7day_actives::day`
	* [ ] Maybe a create a new dependent countstat  on `7day_actives::day` and `active_users_audit:is_bot:day` like `realm_active_humans::day` so that we don't show inactive users in WAU. (@timabbott thoughts?)
* Rewrite DAU query to make use of RealmCount.
	* [X] Populate `1day_actives::day` in populate_analytics_db (already present).
	* [X] Rewrite the query to make use of `1day_actives::day`
	* [ ] Maybe create a new a dependent countstat on `1day_actives::day` and `active_users_audit:is_bot:day` like `realm_active_humans::day` so that we don't show inactive users in DAU. (@timabbott thoughts?)
* Replace WHERE query that checks whether there are any active humans in last 2 weeks with RealmCount
	* [X] Populate `realm_active_humans::day` in populate_analytics_db (already present).
	* [X] Rewrite the query to make use of `realm_active_humans::day`
* Rewrite user profile count query to make use of RealmCount
	* [X] Populate `active_users_audit:is_bot:day` to make use of RealmCount (already present)
	* [X] Rewrite the query to make use of `active_users_audit:is_bot:day`
* Rewrite bot count query to make use of RealmCount
	* [X] Populate `active_users_audit:is_bot:day` to make use of RealmCount
	* [X] Rewrite the query to make use of `active_users_audit:is_bot:day`

### v2

* Migrate `get_realm_day_counts` to make use of RealmCount
* Possibly migrate `user_activity_intervals` to make use of RealmCount
