### PR TITLE
setup_venv: Install libyaml-dev

### DIFF
--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -25,6 +25,7 @@ VENV_DEPENDENCIES = [
     "libpq-dev",            # Needed by psycopg2
     "libssl-dev",           # Needed to build pycurl and other libraries
     "libmagic1",            # Used for install python-magic
+    "libyaml-dev",          # For fast YAML parsing in PyYAML
     # Needed by python-xmlsec:
     "libxmlsec1-dev",
     "pkg-config",
@@ -42,6 +43,7 @@ COMMON_YUM_VENV_DEPENDENCIES = [
     "zlib-devel",
     "libjpeg-turbo-devel",
     "openldap-devel",
+    "libyaml-devel",
     # Needed by python-xmlsec:
     "gcc"
     "python3-devel",


### PR DESCRIPTION
This will let PyYAML link against LibYAML when PyYAML is next installed. Due to virtualenv-clone, that won’t happen until the next Python package removal anyway, so we don’t bother bumping `PROVISION_VERSION`.

Conveniently, it looks like we’re about to remove a Python package in #16063! Let’s merge this before #16063.

**Testing Plan:** Dev server.