### PR TITLE
sentry: Ignore SystemExit exceptions.

### DIFF
--- a/zproject/sentry.py
+++ b/zproject/sentry.py
@@ -12,7 +12,12 @@ from .config import PRODUCTION
 if TYPE_CHECKING:
     from sentry_sdk._types import Event, Hint
 
-def add_context(event: 'Event', hint: 'Hint') -> 'Event':
+def add_context(event: 'Event', hint: 'Hint') -> Optional['Event']:
+    if "exc_info" in hint:
+        _, exc_value, _ = hint["exc_info"]
+        # Ignore GeneratorExit, KeyboardInterrupt, and SystemExit exceptions
+        if not isinstance(exc_value, Exception):
+            return None
     from zerver.models import get_user_profile_by_id
     with capture_internal_exceptions():
         user_info = event.get("user", {})


### PR DESCRIPTION
SystemExit is raised by `sys.exit`; in that sense, it is never
"uncaught" because we chose to cause it explicitly.  For instance,
Tornado responds to SIGTERM by calling `sys.exit(1)`, which does not
merit being logged to Sentry.

Use the suggested form[1] for ignoring classes of error.

[1] https://github.com/getsentry/sentry-python/issues/149#issuecomment-434448781