### PR TITLE
sentry: Ignore DisallowedHost messages.

### DIFF
--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -343,12 +343,7 @@ class OurAuthenticationForm(AuthenticationForm):
 
         if username is not None and password:
             subdomain = get_subdomain(self.request)
-            try:
-                realm = get_realm(subdomain)
-            except Realm.DoesNotExist:
-                logging.warning("User %s attempted to password login to nonexistent subdomain %s",
-                                username, subdomain)
-                raise ValidationError("Realm does not exist")
+            realm = get_realm(subdomain)
 
             return_data: Dict[str, Any] = {}
             try:

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -384,6 +384,10 @@ class FlushDisplayRecipientCache(MiddlewareMixin):
         return response
 
 class HostDomainMiddleware(MiddlewareMixin):
+    def __init__(self, get_response: Callable[[Any, WSGIRequest], Union[HttpResponse, BaseException]]) -> None:
+        super().__init__(get_response)
+        ignore_logger("django.security.DisallowedHost")
+
     def process_request(self, request: HttpRequest) -> Optional[HttpResponse]:
         # Match against ALLOWED_HOSTS, which is rather permissive;
         # failure will raise DisallowedHost, which is a 400.

--- a/zerver/middleware.py
+++ b/zerver/middleware.py
@@ -5,7 +5,6 @@ import traceback
 from typing import Any, AnyStr, Callable, Dict, Iterable, List, MutableMapping, Optional, Union
 
 from django.conf import settings
-from django.core.exceptions import DisallowedHost
 from django.core.handlers.wsgi import WSGIRequest
 from django.db import connection
 from django.http import HttpRequest, HttpResponse, StreamingHttpResponse
@@ -385,32 +384,21 @@ class FlushDisplayRecipientCache(MiddlewareMixin):
         return response
 
 class HostDomainMiddleware(MiddlewareMixin):
-    def process_response(self, request: HttpRequest, response: HttpResponse) -> HttpResponse:
-        if getattr(response, "asynchronous", False):
-            # This special Tornado "asynchronous" response is
-            # discarded after going through this code path as Tornado
-            # intends to block, so we stop here to avoid unnecessary work.
-            return response
+    def process_request(self, request: HttpRequest) -> Optional[HttpResponse]:
+        # Match against ALLOWED_HOSTS, which is rather permissive;
+        # failure will raise DisallowedHost, which is a 400.
+        request.get_host()
 
-        try:
-            request.get_host()
-        except DisallowedHost:
-            # If we get a DisallowedHost exception trying to access
-            # the host, (1) the request is failed anyway and so the
-            # below code will do nothing, and (2) the below will
-            # trigger a recursive exception, breaking things, so we
-            # just return here.
-            return response
+        if request.path.startswith(("/static/", "/api/", "/json/")):
+            return None
 
-        if (not request.path.startswith("/static/") and not request.path.startswith("/api/") and
-                not request.path.startswith("/json/")):
-            subdomain = get_subdomain(request)
-            if subdomain != Realm.SUBDOMAIN_FOR_ROOT_DOMAIN:
-                try:
-                    get_realm(subdomain)
-                except Realm.DoesNotExist:
-                    return render(request, "zerver/invalid_realm.html", status=404)
-        return response
+        subdomain = get_subdomain(request)
+        if subdomain != Realm.SUBDOMAIN_FOR_ROOT_DOMAIN:
+            try:
+                request.realm = get_realm(subdomain)
+            except Realm.DoesNotExist:
+                return render(request, "zerver/invalid_realm.html", status=404)
+        return None
 
 class SetRemoteAddrFromForwardedFor(MiddlewareMixin):
     """

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -627,12 +627,8 @@ class LoginTest(ZulipTestCase):
         self.assert_logged_in_user_id(None)
 
     def test_login_invalid_subdomain(self) -> None:
-        with self.assertLogs(level='WARNING') as warn_log:
-            result = self.login_with_return(self.example_email("hamlet"), "xxx",
-                                            subdomain="invalid")
-        self.assertEqual(warn_log.output, [
-            'WARNING:root:User hamlet@zulip.com attempted to password login to nonexistent subdomain invalid'
-        ])
+        result = self.login_with_return(self.example_email("hamlet"), "xxx",
+                                        subdomain="invalid")
         self.assertEqual(result.status_code, 404)
         self.assert_in_response("There is no Zulip organization hosted at this subdomain.", result)
         self.assert_logged_in_user_id(None)
@@ -2407,9 +2403,7 @@ class RealmCreationTest(ZulipTestCase):
 
         result = self.submit_reg_form_for_user(email, password,
                                                realm_subdomain = string_id,
-                                               realm_name=realm_name,
-                                               # Pass HTTP_HOST for the target subdomain
-                                               HTTP_HOST=string_id + ".testserver")
+                                               realm_name=realm_name)
         self.assertEqual(result.status_code, 302)
 
         result = self.client_get(result.url, subdomain=string_id)
@@ -2447,8 +2441,7 @@ class RealmCreationTest(ZulipTestCase):
 
         result = self.submit_reg_form_for_user(email, password,
                                                realm_subdomain = string_id,
-                                               realm_name=realm_name,
-                                               HTTP_HOST=string_id + ".testserver")
+                                               realm_name=realm_name)
         self.assertEqual(result.status_code, 302)
 
         result = self.client_get(result.url, subdomain=string_id)

--- a/zerver/views/auth.py
+++ b/zerver/views/auth.py
@@ -978,12 +978,6 @@ def logout_then_login(request: HttpRequest, **kwargs: Any) -> HttpResponse:
     return django_logout_then_login(request, kwargs)
 
 def password_reset(request: HttpRequest) -> HttpResponse:
-    if not Realm.objects.filter(string_id=get_subdomain(request)).exists():
-        # If trying to get to password reset on a subdomain that
-        # doesn't exist, just go to find_account.
-        redirect_url = reverse('zerver.views.registration.find_account')
-        return HttpResponseRedirect(redirect_url)
-
     view_func = DjangoPasswordResetView.as_view(template_name='zerver/reset.html',
                                                 form_class=ZulipPasswordResetForm,
                                                 success_url='/accounts/password/reset/done/')


### PR DESCRIPTION
**Testing Plan:** Set up `ALLOWED__HOSTS` locally to not be `*`, enabled Sentry, and set a `REALM_HOSTS` so that we could check the realm bits.  Bad realms got 404's, bad hosts didn't get to Sentry.