### PR TITLE
vagrant: Add installation support for MacOS 10.15.6.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -119,6 +119,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.memory = vm_memory
     vb.cpus = vm_num_cpus
   end
+  config.vm.provider "parallels" do |vb, override|
+    config.vm.box = "bento/ubuntu-20.04"
+    config.vm.box_version = "202005.21.0"
+    vb.memory = vm_memory
+    vb.cpus = vm_num_cpus
+  end
 
 $provision_script = <<SCRIPT
 set -x

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -142,6 +142,13 @@ COMMON_DEPENDENCIES = [
     "libappindicator1",
     "xdg-utils",
     # Puppeteer dependencies end here.
+
+    # Fixes missing sasl.h headers during
+    # python-ldap installation.
+    "libsasl2-dev",
+    "gcc",
+    "python-dev",
+
 ]
 
 UBUNTU_COMMON_APT_DEPENDENCIES = COMMON_DEPENDENCIES + [


### PR DESCRIPTION
There are file sharing issues with the mac version 10.15.6 and
vagrant. Using parallels as a provider for vagrant fixes the issue.
