### PR TITLE
docs: Change Zoom app type to user-managed

### DIFF
--- a/docs/production/zoom-configuration.md
+++ b/docs/production/zoom-configuration.md
@@ -1,28 +1,31 @@
-# Zoom Video Calling OAuth Configuration
+# Zoom video calling OAuth configuration
 
 To use the [Zoom](https://zoom.us) integration on a self-hosted
-installation, you'll need to register a custom Zoom Application as
+installation, you'll need to register a custom Zoom app as follows:
+
+1. Select [**Build App**](https://marketplace.zoom.us/develop/create)
+   at the Zoom Marketplace.
+
+1. Create an app with the **OAuth** type.
+
+   * Choose an app name such as "ExampleCorp Zulip".
+   * Select **User-managed app**.
+   * Disable the option to publish the app on the Marketplace.
+   * Click **Create**.
+
+1. Inside of the Zoom app management page:
+
+   * On the **App Credentials** tab, set both the **Redirect URL for
+     OAuth** and the **Whitelist URL** to
+     `https://zulip.example.com/calls/zoom/complete` (replacing
+     `zulip.example.com` by your main Zulip hostname).
+   * On the **Scopes** tab, add the `meeting:write` scope.
+
+You can then configure your Zulip server to use that Zoom app as
 follows:
 
-1. Visit the [Zoom Marketplace](https://marketplace.zoom.us/develop/create).
-
-1. Create a new application, choosing **OAuth** as the app type.
-We recommend using a name like "ExampleCorp Zulip".
-
-1. Select *account-level app* for the authentication type, disable
-the option to publish the app in the Marketplace, and click **Create**.
-
-1. Inside of the Zoom app management page, set the Redirect URL to
-`https://zulip.example.com/calls/zoom/complete` (replacing
-`zulip.example.com` by your main Zulip hostname).
-
-1. Set the "Scopes" to `meeting:write:admin`.
-
-You can then configure your Zulip server to use that Zoom application
-as follows:
-
 1. In `/etc/zulip/zulip-secrets.conf`, set `video_zoom_client_secret`
-to be your app's "Client Secret".
+   to be your app's "Client Secret".
 
 1. In `/etc/zulip/settings.py`, set `VIDEO_ZOOM_CLIENT_ID` to your
    app's "Client ID".


### PR DESCRIPTION
Based on the Zoom documentation, a user-managed app seems more appropriate for our use.

https://marketplace.zoom.us/docs/guides/build#account-level-user-managed-apps

**Testing Plan:** Tested these instructions with https://andersk.zulipdev.org.