### PR TITLE
puppetter: Replace 'visible: false' with 'hidden: true'.

### DIFF
--- a/frontend_tests/puppeteer_tests/03-compose.js
+++ b/frontend_tests/puppeteer_tests/03-compose.js
@@ -160,17 +160,17 @@ const markdown_preview_hide_button = "#undo_markdown_preview";
 
 async function test_markdown_preview_buttons_visibility(page) {
     await page.waitForSelector(markdown_preview_button, {visible: true});
-    await page.waitForSelector(markdown_preview_hide_button, {visible: false});
+    await page.waitForSelector(markdown_preview_hide_button, {hidden: true});
 
     // verify if markdowm preview button works.
     await page.click(markdown_preview_button);
-    await page.waitForSelector(markdown_preview_button, {visible: false});
+    await page.waitForSelector(markdown_preview_button, {hidden: true});
     await page.waitForSelector(markdown_preview_hide_button, {visible: true});
 
     // verify if write button works.
     await page.click(markdown_preview_hide_button);
     await page.waitForSelector(markdown_preview_button, {visible: true});
-    await page.waitForSelector(markdown_preview_hide_button, {visible: false});
+    await page.waitForSelector(markdown_preview_hide_button, {hidden: true});
 }
 
 async function test_markdown_preview_without_any_content(page) {

--- a/frontend_tests/puppeteer_tests/16-settings.js
+++ b/frontend_tests/puppeteer_tests/16-settings.js
@@ -153,7 +153,7 @@ async function test_edit_bot_form(page) {
     await page.click(save_btn_selector);
 
     // The form gets closed on saving. So, assert it's closed by waiting for it to be hidden.
-    await page.waitForSelector("#edit_bot_modal", {visible: false});
+    await page.waitForSelector("#edit_bot_modal", {hidden: true});
 
     const bot1_name_selector = `.details:has(${bot1_edit_btn}) .name`;
     await page.waitForFunction(
@@ -193,7 +193,7 @@ async function get_alert_words_status_text(page) {
 async function close_alert_words_status(page) {
     const status_close_btn = ".close-alert-word-status";
     await page.click(status_close_btn);
-    await page.waitForSelector(alert_word_status_selector, {visible: false});
+    await page.waitForSelector(alert_word_status_selector, {hidden: true});
 }
 
 async function test_and_close_alert_word_added_successfully_status(page, word) {


### PR DESCRIPTION
We need to replace 'visible: false' with 'hidden: true' to wait
for elements to get hidden. Using 'visible: false' just checks
whether the selector exists or not and does not check whether
the element is hidden or not.

This change was done after discussion with @chdinesh1089.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? --> Triggered 100 runs with latest master.


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
