### PR TITLE
Sentry tweaks

### DIFF
--- a/zerver/webhooks/sentry/doc.md
+++ b/zerver/webhooks/sentry/doc.md
@@ -8,6 +8,9 @@ us](/help/contact-support) if a platform you care about is missing.
 
 2. {!create-bot-construct-url-indented.md!}
 
+    The default topic, if not set in the URL, will be the title of the
+    issue or event.
+
 3. Go to your organization's **settings** in Sentry. Then go to
 **Developer Settings** and click on the button to create a
 **New Internal Integration**. There, set the **Webhook URL** to

--- a/zerver/webhooks/sentry/view.py
+++ b/zerver/webhooks/sentry/view.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, Dict, List, Optional, Tuple
 
 from django.http import HttpRequest, HttpResponse
@@ -91,9 +92,9 @@ def handle_event_payload(event: Dict[str, Any]) -> Tuple[str, str]:
         raise UnexpectedWebhookEventType("Sentry", "Raven SDK")
 
     platform_name = event["platform"]
-    syntax_highlight_as = syntax_highlight_as_map.get(platform_name)
-    if syntax_highlight_as is None:  # nocoverage
-        raise UnexpectedWebhookEventType("Sentry", f"platform {platform_name}")
+    syntax_highlight_as = syntax_highlight_as_map.get(platform_name, "")
+    if syntax_highlight_as == "":  # nocoverage
+        logging.info(f"Unknown Sentry platform: {platform_name}")
 
     context = {
         "title": subject,

--- a/zerver/webhooks/sentry/view.py
+++ b/zerver/webhooks/sentry/view.py
@@ -35,7 +35,7 @@ EXCEPTION_EVENT_TEMPLATE = """
 
 EXCEPTION_EVENT_TEMPLATE_WITH_TRACEBACK = EXCEPTION_EVENT_TEMPLATE + """
 Traceback:
-```{platform}
+```{syntax_highlight_as}
 {pre_context}---> {context_line}{post_context}\
 ```
 """
@@ -63,11 +63,12 @@ ISSUE_IGNORED_MESSAGE_TEMPLATE = """
 Issue **{title}** was ignored by **{actor}**.
 """
 
-platforms_map = {
+# Maps "platform" name provided by Sentry to the Pygments lexer name
+syntax_highlight_as_map = {
     "go": "go",
     "node": "javascript",
     "python": "python3",
-}  # We can expand this as and when users use this integration with different platforms.
+}
 
 
 def convert_lines_to_traceback_string(lines: Optional[List[str]]) -> str:
@@ -90,8 +91,8 @@ def handle_event_payload(event: Dict[str, Any]) -> Tuple[str, str]:
         raise UnexpectedWebhookEventType("Sentry", "Raven SDK")
 
     platform_name = event["platform"]
-    platform = platforms_map.get(platform_name)
-    if platform is None:  # nocoverage
+    syntax_highlight_as = syntax_highlight_as_map.get(platform_name)
+    if syntax_highlight_as is None:  # nocoverage
         raise UnexpectedWebhookEventType("Sentry", f"platform {platform_name}")
 
     context = {
@@ -130,7 +131,7 @@ def handle_event_payload(event: Dict[str, Any]) -> Tuple[str, str]:
                 post_context = convert_lines_to_traceback_string(exception_frame["post_context"])
 
                 context.update({
-                    "platform": platform,
+                    "syntax_highlight_as": syntax_highlight_as,
                     "filename": filename,
                     "pre_context": pre_context,
                     "context_line": context_line,

--- a/zerver/webhooks/sentry/view.py
+++ b/zerver/webhooks/sentry/view.py
@@ -67,6 +67,8 @@ Issue **{title}** was ignored by **{actor}**.
 # Maps "platform" name provided by Sentry to the Pygments lexer name
 syntax_highlight_as_map = {
     "go": "go",
+    "java": "java",
+    "javascript": "javascript",
     "node": "javascript",
     "python": "python3",
 }


### PR DESCRIPTION
Support arbitrary languages (without syntax highlighting), add `java` and `javascript` support, and document the default topic if not hardcoded.
 
**Testing Plan:** Looked at the docs locally; existing tests.


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
