### PR TITLE
Don't ask for card details for free trial

### DIFF
--- a/corporate/tests/test_stripe.py
+++ b/corporate/tests/test_stripe.py
@@ -639,7 +639,7 @@ class StripeTest(StripeTestCase):
             f"{self.seat_count} of {self.seat_count} licenses",
             "Licenses are automatically managed by Zulip; when you add",
             "Your plan will renew on",
-            "January 2, 2013",
+            "Jan. 2, 2013",
             f"${80 * self.seat_count}.00",
             f"Billing email: <strong>{user.email}</strong>",
             "Visa ending in 4242",
@@ -778,7 +778,7 @@ class StripeTest(StripeTestCase):
             f"{self.seat_count} of {123} licenses",
             "Licenses are manually managed. You will not be able to add ",
             "Your plan will renew on",
-            "January 2, 2013",
+            "Jan. 2, 2013",
             "$9,840.00",  # 9840 = 80 * 123
             f"Billing email: <strong>{user.email}</strong>",
             "Billed by invoice",
@@ -1830,8 +1830,8 @@ class StripeTest(StripeTestCase):
                 self.assert_in_success_response(
                     [
                         "Your plan will be downgraded to <strong>Zulip Limited</strong> on "
-                        "<strong>January 2, 2013</strong>",
-                        "You plan is scheduled for downgrade on <strong>January 2, 2013</strong>",
+                        "<strong>Jan. 2, 2013</strong>",
+                        "You plan is scheduled for downgrade on <strong>Jan. 2, 2013</strong>",
                         "Cancel downgrade",
                     ],
                     response,
@@ -1929,7 +1929,7 @@ class StripeTest(StripeTestCase):
         with patch("corporate.views.timezone_now", return_value=self.now):
             response = self.client_get("/billing/")
         self.assert_in_success_response(
-            ["be switched from monthly to annual billing on <strong>February 2, 2012"], response
+            ["be switched from monthly to annual billing on <strong>Feb. 2, 2012"], response
         )
 
         with patch("corporate.lib.stripe.get_latest_seat_count", return_value=20):
@@ -2116,7 +2116,7 @@ class StripeTest(StripeTestCase):
         with patch("corporate.views.timezone_now", return_value=self.now):
             response = self.client_get("/billing/")
         self.assert_in_success_response(
-            ["be switched from monthly to annual billing on <strong>February 2, 2012"], response
+            ["be switched from monthly to annual billing on <strong>Feb. 2, 2012"], response
         )
 
         invoice_plans_as_needed(self.next_month)

--- a/corporate/views.py
+++ b/corporate/views.py
@@ -311,9 +311,7 @@ def billing_home(request: HttpRequest) -> HttpResponse:
             seat_count = get_latest_seat_count(user.realm)
 
             # Should do this in javascript, using the user's timezone
-            renewal_date = "{dt:%B} {dt.day}, {dt.year}".format(
-                dt=start_of_next_billing_cycle(plan, now)
-            )
+            renewal_date = start_of_next_billing_cycle(plan, now)
             renewal_cents = renewal_amount(plan, now)
             charge_automatically = plan.charge_automatically
             stripe_customer = stripe_get_customer(customer.stripe_customer_id)

--- a/templates/corporate/billing.html
+++ b/templates/corporate/billing.html
@@ -47,18 +47,18 @@
                         <p>
                             {% if renewal_amount %}
                                 {% if free_trial %}
-                                Your plan will be upgraded to <strong>{{ plan_name }}</strong> on <strong>{{ renewal_date }}</strong> for
+                                Your plan will be upgraded to <strong>{{ plan_name }}</strong> on <strong>{{ renewal_date|date }}</strong> for
                                 <strong>${{ renewal_amount }}</strong>.
                                 {% elif downgrade_at_end_of_cycle %}
-                                Your plan will be downgraded to <strong>Zulip Limited</strong> on <strong>{{ renewal_date }}</strong>.
+                                Your plan will be downgraded to <strong>Zulip Limited</strong> on <strong>{{ renewal_date|date }}</strong>.
                                 {% elif switch_to_annual_at_end_of_cycle %}
-                                Your plan will be switched from monthly to annual billing on <strong>{{ renewal_date }}</strong>.
+                                Your plan will be switched from monthly to annual billing on <strong>{{ renewal_date|date }}</strong>.
                                 {% else %}
-                                Your plan will renew on <strong>{{ renewal_date }}</strong> for
+                                Your plan will renew on <strong>{{ renewal_date|date }}</strong> for
                                 <strong>${{ renewal_amount }}</strong>.
                                 {% endif %}
                             {% else %}
-                                Your plan ends on <strong>{{ renewal_date }}</strong>, and does not renew.
+                                Your plan ends on <strong>{{ renewal_date|date }}</strong>, and does not renew.
                             {% endif %}
                         </p>
                     </div>
@@ -140,7 +140,7 @@
                                 {% else %}
                                     {% if downgrade_at_end_of_cycle %}
                                     <p>
-                                        You plan is scheduled for downgrade on <strong>{{ renewal_date }}</strong>.
+                                        You plan is scheduled for downgrade on <strong>{{ renewal_date|date }}</strong>.
                                     </p>
                                     <input name="status" type="hidden" value="{{ CustomerPlan.ACTIVE }}" />
                                     <button class="btn-info" id="change-plan-status">Cancel downgrade</button>

--- a/templates/corporate/upgrade.html
+++ b/templates/corporate/upgrade.html
@@ -220,6 +220,9 @@
                         <div id="sponsorship-error" class="alert alert-danger"></div>
                         <div id="sponsorship-input-section">
                             <form id="sponsorship-form" method="post">
+                                <p>
+                                    Zulip Cloud Standard is free for open source projects, events and academic research. We also offer steep discounts to many non-profits, educational institutions, groups of friends, and in other scenarios where most of the users are not fulltime employees of the customer. Generally, only closed organizations that also pay their members’ salaries pay full price.
+                                </p>
                                 <label>
                                     <h4>Organization type</h4>
                                 </label>

--- a/zproject/jinja2/__init__.py
+++ b/zproject/jinja2/__init__.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import orjson
 from django.contrib.staticfiles.storage import staticfiles_storage
-from django.template.defaultfilters import pluralize, slugify
+from django.template.defaultfilters import date, pluralize, slugify
 from django.urls import reverse
 from django.utils import translation
 from django.utils.timesince import timesince
@@ -37,6 +37,7 @@ def environment(**options: Any) -> Environment:
     env.filters["display_list"] = display_list
     env.filters["device_action"] = device_action
     env.filters["timesince"] = timesince
+    env.filters["date"] = date
 
     env.policies["json.dumps_function"] = json_dumps
     env.policies["json.dumps_kwargs"] = {}


### PR DESCRIPTION
- Onboarding page
	- Ask user to choose the plan they want to get started with
		- [x] Zulip Free Plan
		- Upgrade to Zulip Standard
			- [x] Free Trial with no questions asked
			- [x] Request sponsorship
- Upgrade page
	- If they user is not already on free trial
		- [x] Give them option to start free trial with no questions asked
		- [x] Request sponsorship
	- If the user is already on free trial woul be redirected to /billing page
- Billing page
	- The user is already on free trial
		- If the user is on charge_automatically but has no payment methods attached
			- [x] Show in billing page that they are already on free trial
			- Ask them to add payment method or they would be downgraded
				- [x] They would be redirected to the normal upgrade page where they can add card or upgrade by invoice
		- If they user is on charge by invoice or has card attached
			- [x] Show in billing page they are on free trial along with renewal amounts
- User can sign up for free trial without card/invoice.
	- [x] They would be marked as charge_automatically
	- [x] Fix the UI messages
- Send reminder emails asking them to enter card details
	- [x] When 30 days, 10 days, 5 days and 1 days remaining if they don't have card details on file.
- [x] If they have card details on file/billing by invoice, send an email 5 days remaining telling them to unsubscribe if they don't want to be charged.
- [x] When FREE_TRIAL is over, if charge_automatically and no card details on file, downgrade them to LIMITED plan.
- Maybe send an email telling them this happened.
- Tests
	- [x] Test upgrade to free trial
	- [x] Test upgrade from free trial using card
	- [x] Test upgrade from free trial using invoice
	- [x] Test free trial expiry
- End plans if marked as sponsored
