### PR TITLE
sanity_check: Test for the virtualenv by its path

### DIFF
--- a/tools/lib/sanity_check.py
+++ b/tools/lib/sanity_check.py
@@ -4,17 +4,7 @@ import sys
 
 
 def check_venv(filename: str) -> None:
-    try:
-        # Here we import 3 modules that we expect to be in any valid
-        # Zulip virtualenv but are unlikely to all be present on a
-        # host system to help check whether we're in Vagrant.
-        import bitfield
-        import django
-        import zulip
-        bitfield
-        django
-        zulip
-    except ImportError:
+    if os.path.basename(sys.prefix) != "zulip-py3-venv":
         print(f"You need to run {filename} inside a Zulip dev environment.")
         user_id = os.getuid()
         user_name = pwd.getpwuid(user_id).pw_name


### PR DESCRIPTION
This is faster and probably more foolproof than importing arbitrary modules.

**Testing Plan:** Dev environment with the virtualenv activated and deactivated, and also `vagrant provision` after deleting /srv/zulip-venv-cache completely.