### PR TITLE
check-openapi: Disallow siblings of $ref

### DIFF
--- a/tools/check-openapi
+++ b/tools/check-openapi
@@ -7,17 +7,39 @@ const jsyaml = require("js-yaml");
 const ExampleValidator = require("openapi-examples-validator");
 const SwaggerParser = require("swagger-parser");
 
+function checkRefSiblings(file, path, data) {
+    let ok = true;
+    if (typeof data === "object" && data !== null) {
+        if ("$ref" in data && Object.entries(data).length !== 1) {
+            console.error(
+                `${file}: Siblings of $ref have no effect at ${JSON.stringify(
+                    path,
+                )}: ${JSON.stringify(data, undefined, 2)}`,
+            );
+            ok = false;
+        }
+        for (const [key, child] of Array.isArray(data) ? data.entries() : Object.entries(data)) {
+            if (!checkRefSiblings(file, [...path, key], child)) {
+                ok = false;
+            }
+        }
+    }
+    return ok;
+}
+
 (async () => {
     // Iterate through the changed files, passed in the arguments.
     // The two first arguments are the call to the Node interpreter and this
     // script, hence the starting point at 2.
     for (const file of process.argv.slice(2)) {
         try {
-            if (
-                jsyaml.safeLoad(await fs.promises.readFile(file, "utf8"), {
-                    filename: file,
-                }).openapi !== undefined
-            ) {
+            const data = jsyaml.safeLoad(await fs.promises.readFile(file, "utf8"), {
+                filename: file,
+            });
+            if (data.openapi !== undefined) {
+                if (!checkRefSiblings(file, [], data)) {
+                    process.exitCode = 1;
+                }
                 await SwaggerParser.validate(file);
                 const res = await ExampleValidator.validateFile(file);
                 if (!res.valid) {

--- a/zerver/openapi/test_curl_examples.py
+++ b/zerver/openapi/test_curl_examples.py
@@ -22,11 +22,15 @@ def test_generated_curl_examples_for_success(client: Client) -> None:
     md_engine = markdown.Markdown(extensions=[markdown_extension.makeExtension(
         api_url=realm.uri + "/api")])
 
-    # We run our curl tests in alphabetical order, since we depend
+    # We run our curl tests in alphabetical order (except that we
+    # delay the deactivate-user test to the very end), since we depend
     # on "add" tests coming before "remove" tests in some cases.  We
     # should try to either avoid ordering dependencies or make them
     # very explicit.
-    for file_name in sorted(glob.glob("templates/zerver/api/*.md")):
+    for file_name in sorted(
+        glob.glob("templates/zerver/api/*.md"),
+        key=lambda file_name: (file_name == "templates/zerver/api/deactivate-user.md", file_name),
+    ):
         documentation_lines = open(file_name).readlines()
         for line in documentation_lines:
             # A typical example from the Markdown source looks like this:

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2978,7 +2978,13 @@ paths:
 
         `GET {{ api_url }}/v1/get_stream_id`
       parameters:
-        - $ref: "#/components/parameters/Stream"
+        - name: stream
+          in: query
+          description: |
+            The name of the stream to access.
+          schema:
+            type: string
+          example: Denmark
           required: true
       responses:
         "200":
@@ -3029,7 +3035,13 @@ paths:
       description: |
         Mark all the unread messages in a stream as read.
       parameters:
-        - $ref: "#/components/parameters/StreamIdInQuery"
+        - name: stream_id
+          in: query
+          description: |
+            The ID of the stream to access.
+          schema:
+            type: integer
+          example: 42
           required: true
       responses:
         "200":
@@ -3045,7 +3057,13 @@ paths:
       description: |
         Mark all the unread messages in a topic as read.
       parameters:
-        - $ref: "#/components/parameters/StreamIdInQuery"
+        - name: stream_id
+          in: query
+          description: |
+            The ID of the stream to access.
+          schema:
+            type: integer
+          example: 42
           required: true
         - name: topic_name
           in: query
@@ -3656,7 +3674,18 @@ paths:
         `POST {{ api_url }}/v1/messages/{message_id}/reactions`
       parameters:
         - $ref: "#/components/parameters/MessageId"
-        - $ref: "#/components/parameters/EmojiName"
+        - name: emoji_name
+          in: query
+          description: |
+            The target emoji's human-readable name.
+
+            To find an emoji's name, hover over a message to reveal
+            three icons on the right, then click the smiley face icon.
+            Images of available reaction emojis appear. Hover over the
+            emoji you want, and note that emoji's text name.
+          schema:
+            type: string
+          example: "octopus"
           required: true
         - $ref: "#/components/parameters/EmojiCode"
         - $ref: "#/components/parameters/ReactionType"
@@ -3687,7 +3716,18 @@ paths:
         `DELETE {{ api_url }}/v1/messages/{message_id}/reactions`
       parameters:
         - $ref: "#/components/parameters/MessageId"
-        - $ref: "#/components/parameters/EmojiName"
+        - name: emoji_name
+          in: query
+          description: |
+            The target emoji's human-readable name.
+
+            To find an emoji's name, hover over a message to reveal
+            three icons on the right, then click the smiley face icon.
+            Images of available reaction emojis appear. Hover over the
+            emoji you want, and note that emoji's text name.
+          schema:
+            type: string
+          example: "octopus"
           required: false
         - $ref: "#/components/parameters/EmojiCode"
         - $ref: "#/components/parameters/ReactionType"
@@ -3890,7 +3930,13 @@ paths:
             default: true
           example: true
         - $ref: "#/components/parameters/OptionalContent"
-        - $ref: "#/components/parameters/StreamIdInQuery"
+        - name: stream_id
+          in: query
+          description: |
+            The ID of the stream to access.
+          schema:
+            type: integer
+          example: 42
       responses:
         "200":
           description: Success.
@@ -4962,9 +5008,21 @@ paths:
         `PATCH {{ api_url }}/v1/users/me/subscriptions/muted_topics`
 
       parameters:
-        - $ref: "#/components/parameters/Stream"
+        - name: stream
+          in: query
+          description: |
+            The name of the stream to access.
+          schema:
+            type: string
+          example: Denmark
           required: false
-        - $ref: "#/components/parameters/StreamIdInQuery"
+        - name: stream_id
+          in: query
+          description: |
+            The ID of the stream to access.
+          schema:
+            type: integer
+          example: 42
           required: false
         - name: topic
           in: query
@@ -9892,22 +9950,6 @@ components:
         type: string
       example: 1375801870:2942
       required: true
-    Stream:
-      name: stream
-      in: query
-      description: |
-        The name of the stream to access.
-      schema:
-        type: string
-      example: Denmark
-    StreamIdInQuery:
-      name: stream_id
-      in: query
-      description: |
-        The ID of the stream to access.
-      schema:
-        type: integer
-      example: 42
     StreamIdInPath:
       name: stream_id
       in: path
@@ -10015,19 +10057,6 @@ components:
         type: boolean
         default: false
       example: true
-    EmojiName:
-      name: emoji_name
-      in: query
-      description: |
-        The target emoji's human-readable name.
-
-        To find an emoji's name, hover over a message to reveal
-        three icons on the right, then click the smiley face icon.
-        Images of available reaction emojis appear. Hover over the
-        emoji you want, and note that emoji's text name.
-      schema:
-        type: string
-      example: "octopus"
     IncludeCustomProfileFields:
       name: include_custom_profile_fields
       in: query

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4978,9 +4978,7 @@ paths:
         **Changes**: New in Zulip 3.0 (feature level 11).
       parameters:
         - $ref: "#/components/parameters/UserId"
-          example: 7
         - $ref: "#/components/parameters/StreamIdInPath"
-          example: 1
       responses:
         "200":
           description: Success
@@ -8272,7 +8270,6 @@ paths:
         `POST {{ api_url }}/v1/user_groups/{user_group_id}/members`
       parameters:
         - $ref: "#/components/parameters/UserGroupId"
-          example: 1
         - name: delete
           in: query
           description: |
@@ -9924,7 +9921,7 @@ components:
         The ID of the target user group.
       schema:
         type: integer
-      example: 42
+      example: 1
       required: true
     Topic:
       name: topic
@@ -9957,7 +9954,7 @@ components:
         The ID of the stream to access.
       schema:
         type: integer
-      example: 42
+      example: 1
       required: true
     ClientGravatar:
       name: client_gravatar


### PR DESCRIPTION
The specification says “any sibling elements of a `$ref` are ignored”, so their presence, although not invalid, indicates a mistake.  `yamole` incorrectly merges these siblings into the referenced object, but we should not rely on this nonstandard behavior.

https://swagger.io/docs/specification/using-ref/#sibling

**Testing Plan:** This test currently fails. We need to fix `zulip.yaml` before merging.

```
openapi   | zerver/openapi/zulip.yaml: Siblings of $ref have no effect at ["paths","/get_stream_id","get","parameters",0]: {
openapi   |   "$ref": "#/components/parameters/Stream",
openapi   |   "required": true
openapi   | }
openapi   | zerver/openapi/zulip.yaml: Siblings of $ref have no effect at ["paths","/mark_stream_as_read","post","parameters",0]: {
openapi   |   "$ref": "#/components/parameters/StreamIdInQuery",
openapi   |   "required": true
openapi   | }
openapi   | zerver/openapi/zulip.yaml: Siblings of $ref have no effect at ["paths","/mark_topic_as_read","post","parameters",0]: {
openapi   |   "$ref": "#/components/parameters/StreamIdInQuery",
openapi   |   "required": true
openapi   | }
openapi   | zerver/openapi/zulip.yaml: Siblings of $ref have no effect at ["paths","/messages/{message_id}/reactions","post","parameters",1]: {
openapi   |   "$ref": "#/components/parameters/EmojiName",
openapi   |   "required": true
openapi   | }
openapi   | zerver/openapi/zulip.yaml: Siblings of $ref have no effect at ["paths","/messages/{message_id}/reactions","delete","parameters",1]: {
openapi   |   "$ref": "#/components/parameters/EmojiName",
openapi   |   "required": false
openapi   | }
openapi   | zerver/openapi/zulip.yaml: Siblings of $ref have no effect at ["paths","/users/{user_id}/subscriptions/{stream_id}","get","parameters",0]: {
openapi   |   "$ref": "#/components/parameters/UserId",
openapi   |   "example": 7
openapi   | }
openapi   | zerver/openapi/zulip.yaml: Siblings of $ref have no effect at ["paths","/users/{user_id}/subscriptions/{stream_id}","get","parameters",1]: {
openapi   |   "$ref": "#/components/parameters/StreamIdInPath",
openapi   |   "example": 1
openapi   | }
openapi   | zerver/openapi/zulip.yaml: Siblings of $ref have no effect at ["paths","/users/me/subscriptions/muted_topics","patch","parameters",0]: {
openapi   |   "$ref": "#/components/parameters/Stream",
openapi   |   "required": false
openapi   | }
openapi   | zerver/openapi/zulip.yaml: Siblings of $ref have no effect at ["paths","/users/me/subscriptions/muted_topics","patch","parameters",1]: {
openapi   |   "$ref": "#/components/parameters/StreamIdInQuery",
openapi   |   "required": false
openapi   | }
```

Cc @orientor @YagoGG 