### PR TITLE
api: Return 'user_id' in 'POST /users' response.

### DIFF
--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -10,6 +10,11 @@ below features are supported.
 
 ## Changes in Zulip 4.0
 
+**Feature level 31**
+
+* [`POST /users`](/api/create-user): The `user_id` of the user
+  created is now returned in the response.
+
 **Feature Level 30**
 
 * [`GET users/me/subscriptions`](/api/get-subscriptions), [`GET

--- a/templates/zerver/api/create-user.md
+++ b/templates/zerver/api/create-user.md
@@ -27,6 +27,10 @@ More examples and documentation can be found [here](https://github.com/zulip/zul
 
 ## Response
 
+#### Return values
+
+{generate_return_values_table|zulip.yaml|/users:post}
+
 #### Example response
 
 A typical successful JSON response may look like:

--- a/version.py
+++ b/version.py
@@ -29,7 +29,7 @@ DESKTOP_WARNING_VERSION = "5.2.0"
 #
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md.
-API_FEATURE_LEVEL = 27
+API_FEATURE_LEVEL = 31
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4081,7 +4081,14 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/JsonSuccess"
+                allOf:
+                  - $ref: "#/components/schemas/JsonSuccess"
+                  - properties:
+                      user_id:
+                        type: integer
+                        description: |
+                          The User ID of the user created.
+                  - example: {"msg": "", "result": "success", "user_id": 25}
         "400":
           description: Bad request.
           content:

--- a/zerver/tests/test_users.py
+++ b/zerver/tests/test_users.py
@@ -823,7 +823,9 @@ class AdminCreateUserTest(ZulipTestCase):
 
         # Romeo is a newly registered user
         new_user = get_user_by_delivery_email('romeo@zulip.net', get_realm('zulip'))
+        result = orjson.loads(result.content)
         self.assertEqual(new_user.full_name, 'Romeo Montague')
+        self.assertEqual(new_user.id, result['user_id'])
 
         # Make sure the recipient field is set correctly.
         self.assertEqual(new_user.recipient, Recipient.objects.get(type=Recipient.PERSONAL,

--- a/zerver/views/users.py
+++ b/zerver/views/users.py
@@ -521,8 +521,8 @@ def create_user_backend(
     if not check_password_strength(password):
         return json_error(PASSWORD_TOO_WEAK_ERROR)
 
-    do_create_user(email, password, realm, full_name, acting_user=user_profile)
-    return json_success()
+    target_user = do_create_user(email, password, realm, full_name, acting_user=user_profile)
+    return json_success({'user_id': target_user.id})
 
 def get_profile_backend(request: HttpRequest, user_profile: UserProfile) -> HttpResponse:
     raw_user_data = get_raw_user_data(user_profile.realm, user_profile,


### PR DESCRIPTION
This adds 'user_id' to the simple success response for 'POST /users'
api endpoint. Appropriate changes have been made in the docs and
test_users.py.

Fixes  #16072.