### PR TITLE
links: Flatten the set into a list before serializing into the queue.

### DIFF
--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -1618,7 +1618,7 @@ def do_send_messages(messages_maybe_none: Sequence[Optional[MutableMapping[str, 
                 'message_id': message['message'].id,
                 'message_content': message['message'].content,
                 'message_realm_id': message['realm'].id,
-                'urls': links_for_embed}
+                'urls': list(links_for_embed)}
             queue_json_publish('embed_links', event_data)
 
         if message['message'].recipient.type == Recipient.PERSONAL:

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -223,7 +223,7 @@ def update_message_backend(request: HttpRequest, user_profile: UserMessage,
             # `sender.realm_id` must match the decision made in the
             # `render_incoming_message` call earlier in this function.
             'message_realm_id': user_profile.realm_id,
-            'urls': links_for_embed}
+            'urls': list(links_for_embed)}
         queue_json_publish('embed_links', event_data)
     return json_success()
 


### PR DESCRIPTION
orjson does not transparently do this set-to-list translation, unlike
ujson.