### PR TITLE
python: Catch JSONDecodeError instead of ValueError when decoding JSON

### DIFF
--- a/tools/generate-integration-docs-screenshot
+++ b/tools/generate-integration-docs-screenshot
@@ -107,7 +107,7 @@ def custom_headers(headers_json: str) -> Dict[str, str]:
         return {}
     try:
         return orjson.loads(headers_json)
-    except ValueError as ve:
+    except orjson.JSONDecodeError as ve:
         raise argparse.ArgumentTypeError(
             'Encountered an error while attempting to parse custom headers: {}\n'
             'Note: all strings must be enclosed within "" instead of \'\''.format(ve))

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -286,7 +286,7 @@ def log_exception_to_webhook_logger(
     if request.content_type == 'application/json':
         try:
             payload = orjson.dumps(orjson.loads(payload), option=orjson.OPT_INDENT_2).decode()
-        except ValueError:
+        except orjson.JSONDecodeError:
             request_body = str(payload)
     else:
         request_body = str(payload)

--- a/zerver/lib/outgoing_webhook.py
+++ b/zerver/lib/outgoing_webhook.py
@@ -272,7 +272,7 @@ def process_success_response(event: Dict[str, Any],
                              response: Response) -> None:
     try:
         response_json = json.loads(response.text)
-    except ValueError:
+    except json.JSONDecodeError:
         fail_with_message(event, "Invalid JSON in response")
         return
 

--- a/zerver/lib/request.py
+++ b/zerver/lib/request.py
@@ -297,7 +297,7 @@ def has_request_variables(view_func: ViewFuncT) -> ViewFuncT:
             if param.argument_type == 'body':
                 try:
                     val = orjson.loads(request.body)
-                except ValueError:
+                except orjson.JSONDecodeError:
                     raise InvalidJSONError(_("Malformed JSON"))
                 kwargs[func_var_name] = val
                 continue

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -183,7 +183,7 @@ class ZulipTestCase(TestCase):
             return
         try:
             content = orjson.loads(result.content)
-        except ValueError:
+        except orjson.JSONDecodeError:
             return
         json_url = False
         if url.startswith('/json'):

--- a/zerver/management/commands/send_webhook_fixture_message.py
+++ b/zerver/management/commands/send_webhook_fixture_message.py
@@ -56,7 +56,7 @@ approach shown above.
             return {}
         try:
             custom_headers_dict = orjson.loads(custom_headers)
-        except ValueError as ve:
+        except orjson.JSONDecodeError as ve:
             raise CommandError('Encountered an error while attempting to parse custom headers: {}\n'
                                'Note: all strings must be enclosed within "" instead of \'\''.format(ve))
         return standardize_headers(custom_headers_dict)

--- a/zerver/tornado/event_queue.py
+++ b/zerver/tornado/event_queue.py
@@ -482,7 +482,7 @@ def load_event_queues(port: int) -> None:
             data = orjson.loads(stored_queues.read())
     except FileNotFoundError:
         pass
-    except ValueError:
+    except orjson.JSONDecodeError:
         logging.exception("Tornado %d could not deserialize event queues", port, stack_info=True)
     else:
         try:

--- a/zerver/views/development/integrations.py
+++ b/zerver/views/development/integrations.py
@@ -66,7 +66,7 @@ def get_fixtures(request: HttpResponse,
             body = f.read()
         try:
             body = orjson.loads(body)
-        except ValueError:
+        except orjson.JSONDecodeError:
             pass  # The file extension will be used to determine the type.
 
         headers_raw = get_fixture_http_headers(valid_integration_name,
@@ -91,7 +91,7 @@ def check_send_webhook_fixture_message(request: HttpRequest,
                                        custom_headers: str=REQ()) -> HttpResponse:
     try:
         custom_headers_dict = orjson.loads(custom_headers)
-    except ValueError as ve:
+    except orjson.JSONDecodeError as ve:
         return json_error(f"Custom HTTP headers are not in a valid JSON format. {ve}")  # nolint
 
     response = send_webhook_fixture_message(url, body, is_json,

--- a/zerver/webhooks/librato/view.py
+++ b/zerver/webhooks/librato/view.py
@@ -146,7 +146,7 @@ def api_librato_webhook(request: HttpRequest, user_profile: UserProfile,
                         payload: Dict[str, Any]=REQ(converter=orjson.loads, default={})) -> HttpResponse:
     try:
         attachments = orjson.loads(request.body).get('attachments', [])
-    except ValueError:
+    except orjson.JSONDecodeError:
         attachments = []
 
     if not attachments and not payload:

--- a/zerver/webhooks/slack_incoming/view.py
+++ b/zerver/webhooks/slack_incoming/view.py
@@ -31,7 +31,7 @@ def api_slack_incoming_webhook(request: HttpRequest, user_profile: UserProfile,
     if payload is None:
         try:
             payload = orjson.loads(request.body)
-        except ValueError:  # nocoverage
+        except orjson.JSONDecodeError:  # nocoverage
             raise InvalidJSONError(_("Malformed JSON"))
 
     if user_specified_topic is None and "channel" in payload:


### PR DESCRIPTION
These weren’t wrong since `orjson.JSONDecodeError` subclasses `json.JSONDecodeError` which subclasses `ValueError`, but the more specific ones express the intention more clearly.

(`ujson` raised `ValueError` directly, as did `json` in Python 2.)