### PR TITLE
Fix json validation in queues

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -2018,7 +2018,7 @@ class Markdown(markdown.Markdown):
             self.parser.blockprocessors = get_sub_registry(self.parser.blockprocessors, ['paragraph'])
 
 md_engines: Dict[Tuple[int, bool], markdown.Markdown] = {}
-realm_filter_data: Dict[int, List[Tuple[str, str, int]]] = {}
+realm_filter_data: Dict[int, List[List[Union[str, int]]]] = {}
 
 def make_md_engine(realm_filters_key: int, email_gateway: bool) -> None:
     md_engine_key = (realm_filters_key, email_gateway)
@@ -2032,7 +2032,7 @@ def make_md_engine(realm_filters_key: int, email_gateway: bool) -> None:
         email_gateway=email_gateway,
     )
 
-def build_engine(realm_filters: List[Tuple[str, str, int]],
+def build_engine(realm_filters: List[List[Union[str, int]]],
                  realm_filters_key: int,
                  email_gateway: bool) -> markdown.Markdown:
     engine = Markdown(

--- a/zerver/lib/topic_mutes.py
+++ b/zerver/lib/topic_mutes.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from django.utils.timezone import now as timezone_now
 from sqlalchemy.sql import Selectable, and_, column, not_, or_
@@ -9,7 +9,7 @@ from zerver.lib.topic import topic_match_sa
 from zerver.models import MutedTopic, UserProfile, get_stream
 
 
-def get_topic_mutes(user_profile: UserProfile) -> List[Tuple[str, str, float]]:
+def get_topic_mutes(user_profile: UserProfile) -> List[List[Union[str, float]]]:
     rows = MutedTopic.objects.filter(
         user_profile=user_profile,
     ).values(
@@ -18,7 +18,7 @@ def get_topic_mutes(user_profile: UserProfile) -> List[Tuple[str, str, float]]:
         'date_muted',
     )
     return [
-        (row['stream__name'], row['topic_name'], datetime_to_timestamp(row['date_muted']))
+        [row['stream__name'], row['topic_name'], datetime_to_timestamp(row['date_muted'])]
         for row in rows
     ]
 

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -756,21 +756,21 @@ def get_realm_filters_cache_key(realm_id: int) -> str:
     return f'{cache.KEY_PREFIX}:all_realm_filters:{realm_id}'
 
 # We have a per-process cache to avoid doing 1000 remote cache queries during page load
-per_request_realm_filters_cache: Dict[int, List[Tuple[str, str, int]]] = {}
+per_request_realm_filters_cache: Dict[int, List[List[Union[str, int]]]] = {}
 
 def realm_in_local_realm_filters_cache(realm_id: int) -> bool:
     return realm_id in per_request_realm_filters_cache
 
-def realm_filters_for_realm(realm_id: int) -> List[Tuple[str, str, int]]:
+def realm_filters_for_realm(realm_id: int) -> List[List[Union[str, int]]]:
     if not realm_in_local_realm_filters_cache(realm_id):
         per_request_realm_filters_cache[realm_id] = realm_filters_for_realm_remote_cache(realm_id)
     return per_request_realm_filters_cache[realm_id]
 
 @cache_with_key(get_realm_filters_cache_key, timeout=3600*24*7)
-def realm_filters_for_realm_remote_cache(realm_id: int) -> List[Tuple[str, str, int]]:
+def realm_filters_for_realm_remote_cache(realm_id: int) -> List[List[Union[str, int]]]:
     filters = []
     for realm_filter in RealmFilter.objects.filter(realm_id=realm_id):
-        filters.append((realm_filter.pattern, realm_filter.url_format_string, realm_filter.id))
+        filters.append([realm_filter.pattern, realm_filter.url_format_string, realm_filter.id])
 
     return filters
 

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1754,8 +1754,8 @@ paths:
                                 muted_topics:
                                   type: array
                                   description: |
-                                    Array of tuples, where each tuple describes a muted topic.
-                                    The first element of tuple is the stream name in which the topic
+                                    Array of arrays, where each inner array describes a muted topic.
+                                    The first element of an inner array is the stream name in which the topic
                                     has to be muted, the second element is the topic name to be muted
                                     and the third element is an integer UNIX timestamp representing
                                     when the topic was muted.
@@ -2306,8 +2306,8 @@ paths:
                                         - type: integer
                                         - type: string
                                   description: |
-                                    An array of tuples, where each tuple describes a linkifier.
-                                    The first element of the tuple is a
+                                    An array of arrays, where each inner array describes a linkifier.
+                                    The first element of an inner array is a
                                     string regex pattern which represents the pattern that should
                                     be linkified on matching. The second element is the url with which the
                                     pattern matching string should be linkified with and the third element

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -142,7 +142,7 @@ from zerver.lib.validator import (
     check_list,
     check_none_or,
     check_string,
-    check_tuple,
+    check_string_or_int,
     equals,
 )
 from zerver.models import (
@@ -1007,11 +1007,8 @@ class NormalActionsTest(BaseAction):
     def test_muted_topics_events(self) -> None:
         muted_topics_checker = check_events_dict([
             ('type', equals('muted_topics')),
-            ('muted_topics', check_list(check_tuple([
-                check_string,  # stream name
-                check_string,  # topic name
-                check_int,  # timestamp
-            ]))),
+            # TODO: We should change `muted_topics` to be a dictionary structure.
+            ('muted_topics', check_list(check_list(check_string_or_int))),
         ])
         stream = get_stream('Denmark', self.user_profile.realm)
         recipient = stream.recipient
@@ -1380,11 +1377,7 @@ class NormalActionsTest(BaseAction):
 
         schema_checker = check_events_dict([
             ('type', equals('realm_filters')),
-            ('realm_filters', check_list(check_tuple([
-                check_string,
-                check_string,
-                check_int,
-            ]))),
+            ('realm_filters', check_list(check_list(check_string_or_int))),
         ])
         events = self.verify_action(
             lambda: do_add_realm_filter(self.user_profile.realm, regex, url))

--- a/zerver/tests/test_muting.py
+++ b/zerver/tests/test_muting.py
@@ -73,7 +73,7 @@ class MutedTopicsTests(ZulipTestCase):
                 result = self.api_patch(user, url, data)
                 self.assert_json_success(result)
 
-            self.assertIn((stream.name, 'Verona3', mock_date_muted), get_topic_mutes(user))
+            self.assertIn([stream.name, 'Verona3', mock_date_muted], get_topic_mutes(user))
             self.assertTrue(topic_is_muted(user, stream.id, 'Verona3'))
             self.assertTrue(topic_is_muted(user, stream.id, 'verona3'))
 
@@ -106,7 +106,7 @@ class MutedTopicsTests(ZulipTestCase):
                 topic_name='Verona3',
                 date_muted=datetime(2020, 1, 1, tzinfo=timezone.utc),
             )
-            self.assertIn((stream.name, 'Verona3', mock_date_muted), get_topic_mutes(user))
+            self.assertIn([stream.name, 'Verona3', mock_date_muted], get_topic_mutes(user))
 
             result = self.api_patch(user, url, data)
 

--- a/zerver/tests/test_report.py
+++ b/zerver/tests/test_report.py
@@ -140,7 +140,8 @@ class TestReport(ZulipTestCase):
         # js_source_map actually gets instantiated.
         with \
                 self.settings(DEVELOPMENT=False, TEST_SUITE=False), \
-                mock.patch('zerver.lib.unminify.SourceMap.annotate_stacktrace') as annotate, \
+                mock.patch('zerver.lib.unminify.SourceMap.annotate_stacktrace',
+                           return_value="Stacktrace Here") as annotate, \
                 self.assertLogs(level='INFO') as info_logs:
             result = self.client_post("/json/report/error", params)
         self.assert_json_success(result)
@@ -154,7 +155,8 @@ class TestReport(ZulipTestCase):
         self.logout()
         with \
                 self.settings(DEVELOPMENT=False, TEST_SUITE=False), \
-                mock.patch('zerver.lib.unminify.SourceMap.annotate_stacktrace') as annotate, \
+                mock.patch('zerver.lib.unminify.SourceMap.annotate_stacktrace',
+                           return_value="Stacktrace Here") as annotate, \
                 self.assertLogs(level='INFO') as info_logs:
             result = self.client_post("/json/report/error", params)
         self.assert_json_success(result)


### PR DESCRIPTION
This will fail mypy because of a bit of a rabbit hole in how we handle the `realm_filters` data structure in `markdown.py`.  What I'd like us to do is replace that part of the commit with:
* Changing the data structures for linkifiers to be a normal Zulip-style dictionary marshalling (maybe a TypedDict) of the linkifier rather than a tuple.
* Just convert it to the list format when writing into an API response.
* Do the same with `muted_topics`
* As a follow-up, plan an API change we can do with a new `client_capability` that would let us remove these legacy formats entirely.