### PR TITLE
stream: Do not hide stream email on live update after unsubscribing.

### DIFF
--- a/static/js/stream_settings_ui.js
+++ b/static/js/stream_settings_ui.js
@@ -339,7 +339,6 @@ export function update_settings_for_unsubscribed(slim_sub) {
     stream_ui_updates.update_regular_sub_settings(sub);
     stream_ui_updates.update_change_stream_privacy_settings(sub);
 
-    stream_data.update_stream_email_address(sub, "");
     // If user unsubscribed from private stream then user cannot subscribe to
     // stream without invitation and cannot add subscribers to stream.
     if (!stream_data.can_toggle_subscription(sub)) {

--- a/static/js/stream_ui_updates.js
+++ b/static/js/stream_ui_updates.js
@@ -107,8 +107,6 @@ export function update_regular_sub_settings(sub) {
         $settings.find(".personal_settings").addClass("in");
     } else {
         $settings.find(".personal_settings").removeClass("in");
-        // Clear email address widget
-        $settings.find(".email-address").html("");
     }
 }
 


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This PR fixes the bug where we hide the stream email and show empty container on live-update 
after unsubscribing and then we hide the complete email element after coming to unsubscribed
stream after changing streams in the settings page.

We now do not hide emails on live update after unsubscribing as we actually show stream emails for
unsubscribed streams.

Fixes #22308.

**Testing Plan:** <!-- How have you tested? --> Tested manually in dev environment.


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
Present behaviour - 
![before](https://user-images.githubusercontent.com/35494118/90079568-e7c1fd00-dd25-11ea-9da5-fa46b591125c.gif)

After this change-
![unsub-email](https://user-images.githubusercontent.com/35494118/90079603-fc05fa00-dd25-11ea-8121-8bcb7cffe33e.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
