### PR TITLE
filter: Fix bug of not showing results on using "has:image".

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -742,13 +742,10 @@ run_test("predicate_basics", () => {
     assert(!has_attachment(no_has_filter_matching_msg));
 
     const has_image = get_predicate([["has", "image"]]);
-    $(img_msg.content).set_find_results(".message_inline_image", [$("<img>")]);
+    $(img_msg.content).addClass("message_inline_image");
     assert(has_image(img_msg));
-    $(non_img_attachment_msg.content).set_find_results(".message_inline_image", false);
     assert(!has_image(non_img_attachment_msg));
-    $(link_msg.content).set_find_results(".message_inline_image", false);
     assert(!has_image(link_msg));
-    $(no_has_filter_matching_msg.content).set_find_results(".message_inline_image", false);
     assert(!has_image(no_has_filter_matching_msg));
 });
 

--- a/static/js/message_util.js
+++ b/static/js/message_util.js
@@ -23,7 +23,7 @@ exports.message_has_link = function (message) {
 };
 
 exports.message_has_image = function (message) {
-    return $(message.content).find(".message_inline_image").length > 0;
+    return $(message.content).hasClass("message_inline_image");
 };
 
 exports.message_has_attachment = function (message) {


### PR DESCRIPTION
There was a bug where filtering using "has:image" does not show
any messages, while filtering using "has:attachments" includes
messages with images.

This commit fixes the bug by changing message_util.message_has_image
to use 'hasClass' for checking if element with 'message_inline_image'
class exists or not instead of using find.

This change is done because '.find' searches for descendants of the
element, whereas in this case the '.message_inline_image' element is
not a descendant of a element in 'message.content', but it is one of
the elements of 'message.content'.

Fixes #16118.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
