### PR TITLE
filters: Fix has:image and avoid future issues for other has filters.

### DIFF
--- a/frontend_tests/node_tests/filter.js
+++ b/frontend_tests/node_tests/filter.js
@@ -721,34 +721,40 @@ run_test("predicate_basics", () => {
     // HTML content of message is used to determine if image have link, image or attachment.
     // We are using jquery to parse the html and find existence of relevant tags/elements.
     // In tests we need to stub the calls to jquery so using zjquery's .set_find_results method.
+    function set_find_results_for_msg_content(msg, jquery_selector, results) {
+        $(`<div>${msg.content}</div>`).set_find_results(jquery_selector, results);
+    }
+
     const has_link = get_predicate([["has", "link"]]);
-    $(img_msg.content).set_find_results("a", [$("<a>")]);
+    set_find_results_for_msg_content(img_msg, "a", [$("<a>")]);
     assert(has_link(img_msg));
-    $(non_img_attachment_msg.content).set_find_results("a", [$("<a>")]);
+    set_find_results_for_msg_content(non_img_attachment_msg, "a", [$("<a>")]);
     assert(has_link(non_img_attachment_msg));
-    $(link_msg.content).set_find_results("a", [$("<a>")]);
+    set_find_results_for_msg_content(link_msg, "a", [$("<a>")]);
     assert(has_link(link_msg));
-    $(no_has_filter_matching_msg.content).set_find_results("a", false);
+    set_find_results_for_msg_content(no_has_filter_matching_msg, "a", false);
     assert(!has_link(no_has_filter_matching_msg));
 
     const has_attachment = get_predicate([["has", "attachment"]]);
-    $(img_msg.content).set_find_results("a[href^='/user_uploads']", [$("<a>")]);
+    set_find_results_for_msg_content(img_msg, "a[href^='/user_uploads']", [$("<a>")]);
     assert(has_attachment(img_msg));
-    $(non_img_attachment_msg.content).set_find_results("a[href^='/user_uploads']", [$("<a>")]);
+    set_find_results_for_msg_content(non_img_attachment_msg, "a[href^='/user_uploads']", [
+        $("<a>"),
+    ]);
     assert(has_attachment(non_img_attachment_msg));
-    $(link_msg.content).set_find_results("a[href^='/user_uploads']", false);
+    set_find_results_for_msg_content(link_msg, "a[href^='/user_uploads']", false);
     assert(!has_attachment(link_msg));
-    $(no_has_filter_matching_msg.content).set_find_results("a[href^='/user_uploads']", false);
+    set_find_results_for_msg_content(no_has_filter_matching_msg, "a[href^='/user_uploads']", false);
     assert(!has_attachment(no_has_filter_matching_msg));
 
     const has_image = get_predicate([["has", "image"]]);
-    $(img_msg.content).set_find_results(".message_inline_image", [$("<img>")]);
+    set_find_results_for_msg_content(img_msg, ".message_inline_image", [$("<img>")]);
     assert(has_image(img_msg));
-    $(non_img_attachment_msg.content).set_find_results(".message_inline_image", false);
+    set_find_results_for_msg_content(non_img_attachment_msg, ".message_inline_image", false);
     assert(!has_image(non_img_attachment_msg));
-    $(link_msg.content).set_find_results(".message_inline_image", false);
+    set_find_results_for_msg_content(link_msg, ".message_inline_image", false);
     assert(!has_image(link_msg));
-    $(no_has_filter_matching_msg.content).set_find_results(".message_inline_image", false);
+    set_find_results_for_msg_content(no_has_filter_matching_msg, ".message_inline_image", false);
     assert(!has_image(no_has_filter_matching_msg));
 });
 

--- a/static/js/message_util.js
+++ b/static/js/message_util.js
@@ -18,8 +18,8 @@ function add_messages(messages, msg_list, opts) {
     return render_info;
 }
 
-// For the three message_has_* functions below message.content is html which is
-// wrapped inside a <div> and passed to jquery so that jquery can parse html
+// is_element_in_message_content finds element inside the message content html by
+// wrapping it inside a <div> and passed to jquery so that jquery can parse html
 // and create jQuery object which can be used to find certain html elements using
 // built-in .find() which finds the descendants which match the selector passed to
 // it.
@@ -32,16 +32,20 @@ function add_messages(messages, msg_list, opts) {
 // In above case without wrapper <div> around message.content won't find the
 // .message_inline_image. Wrapping the above eg. html in <div> will make the
 // .message_inline_image a descendant hence will be esaily found using find().
+function is_element_in_message_content(message, element_selector) {
+    return $(`<div>${message.content}</div>`).find(element_selector).length > 0;
+}
+
 exports.message_has_link = function (message) {
-    return $(`<div>${message.content}</div>`).find("a").length > 0;
+    return is_element_in_message_content(message, "a");
 };
 
 exports.message_has_image = function (message) {
-    return $(`<div>${message.content}</div>`).find(".message_inline_image").length > 0;
+    return is_element_in_message_content(message, ".message_inline_image");
 };
 
 exports.message_has_attachment = function (message) {
-    return $(`<div>${message.content}</div>`).find("a[href^='/user_uploads']").length > 0;
+    return is_element_in_message_content(message, "a[href^='/user_uploads']");
 };
 
 exports.add_old_messages = function (messages, msg_list) {

--- a/static/js/message_util.js
+++ b/static/js/message_util.js
@@ -18,16 +18,30 @@ function add_messages(messages, msg_list, opts) {
     return render_info;
 }
 
+// For the three message_has_* functions below message.content is html which is
+// wrapped inside a <div> and passed to jquery so that jquery can parse html
+// and create jQuery object which can be used to find certain html elements using
+// built-in .find() which finds the descendants which match the selector passed to
+// it.
+//
+// The reason for extra <div> wrapping is to make sure all the elements of
+// message.content are descendants of the extra div and we can find any element in html
+// without issue.
+// Eg. message.content can be:
+// <p>Some message</p><div class='message_inline_image'></div><p>some more</p>
+// In above case without wrapper <div> around message.content won't find the
+// .message_inline_image. Wrapping the above eg. html in <div> will make the
+// .message_inline_image a descendant hence will be esaily found using find().
 exports.message_has_link = function (message) {
-    return $(message.content).find("a").length > 0;
+    return $(`<div>${message.content}</div>`).find("a").length > 0;
 };
 
 exports.message_has_image = function (message) {
-    return $(message.content).find(".message_inline_image").length > 0;
+    return $(`<div>${message.content}</div>`).find(".message_inline_image").length > 0;
 };
 
 exports.message_has_attachment = function (message) {
-    return $(message.content).find("a[href^='/user_uploads']").length > 0;
+    return $(`<div>${message.content}</div>`).find("a[href^='/user_uploads']").length > 0;
 };
 
 exports.add_old_messages = function (messages, msg_list) {


### PR DESCRIPTION
This commit solves a bug due non working find() for a html element
which was not a descendant and fixes it by wrapping a virtual div
around the message content so that find works as intended in any
case whatsoever. This solution even protects from future cases of
html content or hierarchy changes.

Fixes #16118.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
