### PR TITLE
user_list: Distinguish between full and new members.

### DIFF
--- a/frontend_tests/node_tests/people.js
+++ b/frontend_tests/node_tests/people.js
@@ -20,7 +20,12 @@ function set_email_visibility(code) {
     page_params.realm_email_address_visibility = code;
 }
 
+function set_realm_waiting_period_threshold(days) {
+    page_params.realm_waiting_period_threshold = days;
+}
+
 set_email_visibility(admins_only);
+set_realm_waiting_period_threshold(3);
 
 const welcome_bot = {
     email: "welcome-bot@example.com",
@@ -39,6 +44,17 @@ const me = {
     is_guest: false,
     is_bot: false,
     // no avatar, so client should construct a /avatar/{user_id} URL.
+};
+
+const full_member = {
+    email: "full_member@example.com",
+    full_name: "Full member",
+    user_id: 31,
+    is_owner: false,
+    is_admin: false,
+    is_guest: false,
+    is_bot: false,
+    date_joined: "2020-07-13T20:13:50.593265+00:00",
 };
 
 const isaac = {
@@ -409,11 +425,13 @@ run_test("user_type", () => {
     people.init();
 
     people.add_active_user(me);
+    people.add_active_user(full_member);
     people.add_active_user(realm_admin);
     people.add_active_user(guest);
     people.add_active_user(realm_owner);
     people.add_active_user(bot_botson);
-    assert.equal(people.get_user_type(me.user_id), i18n.t("Member"));
+    assert.equal(people.get_user_type(me.user_id), i18n.t("New member"));
+    assert.equal(people.get_user_type(full_member.user_id), i18n.t("Full member"));
     assert.equal(people.get_user_type(realm_admin.user_id), i18n.t("Administrator"));
     assert.equal(people.get_user_type(guest.user_id), i18n.t("Guest"));
     assert.equal(people.get_user_type(realm_owner.user_id), i18n.t("Owner"));

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -164,7 +164,7 @@ run_test("sender_hover", (override) => {
                     user_email: "alice@example.com",
                     user_id: 42,
                     user_time: undefined,
-                    user_type: i18n.t("Member"),
+                    user_type: i18n.t("New member"),
                     user_circle_class: "user_circle_empty",
                     user_last_seen_time_status: "translated: More than 2 weeks ago",
                     pm_with_uri: "#narrow/pm-with/42-alice",

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -59,6 +59,14 @@ exports.get_by_user_id = function (user_id, ignore_missing) {
     return people_by_user_id_dict.get(user_id);
 };
 
+exports.is_full_member = function (user_id) {
+    const person = exports.get_by_user_id(user_id);
+    const current_datetime = new Date(Date.now());
+    const person_date_joined = new Date(person.date_joined);
+    const days = (current_datetime - person_date_joined) / 1000 / 86400;
+    return days > page_params.realm_waiting_period_threshold;
+};
+
 exports.get_by_email = function (email) {
     const person = people_dict.get(email);
 

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -260,8 +260,10 @@ exports.get_user_type = function (user_id) {
         return i18n.t("Guest");
     } else if (user_profile.is_bot) {
         return i18n.t("Bot");
+    } else if (exports.is_full_member(user_id)) {
+        return i18n.t("Full member");
     }
-    return i18n.t("Member");
+    return i18n.t("New member");
 };
 
 exports.emails_strings_to_user_ids_string = function (emails_string) {

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -65,6 +65,7 @@ exports.build_page = function () {
 
     const rendered_settings_tab = render_settings_tab({
         full_name: people.my_full_name(),
+        is_full_member: people.is_full_member(page_params.user_id),
         page_params,
         enable_sound_select:
             page_params.enable_sounds || page_params.enable_stream_audible_notifications,

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -226,6 +226,7 @@ function human_info(person) {
     info.is_guest = person.is_guest;
     info.is_owner = person.is_owner;
     info.is_active = people.is_person_active(person.user_id);
+    info.is_full_member = people.is_full_member(person.user_id);
     info.user_id = person.user_id;
     info.full_name = person.full_name;
     info.bot_owner_id = person.bot_owner_id;

--- a/static/templates/admin_user_list.hbs
+++ b/static/templates/admin_user_list.hbs
@@ -17,8 +17,10 @@
             {{t "Administrator" }}
             {{else if is_guest}}
             {{t "Guest" }}
-            {{else}}
-            {{t "Member" }}
+            {{else if is_full_member }}
+            {{t "Full member" }}
+            {{else }}
+            {{t "New member" }}
             {{/if}}
         </span>
     </td>

--- a/static/templates/settings/account_settings.hbs
+++ b/static/templates/settings/account_settings.hbs
@@ -128,8 +128,10 @@
                         {{t "Administrator" }}
                         {{else if page_params.is_guest}}
                         {{t "Guest" }}
+                        {{else if is_full_member}}
+                        {{t "Full member" }}
                         {{else}}
-                        {{t "Member" }}
+                        {{t "New member"}}
                         {{/if}}
                     </span>
                 </div>

--- a/static/templates/settings/user_list_admin.hbs
+++ b/static/templates/settings/user_list_admin.hbs
@@ -1,5 +1,8 @@
 <div id="admin-user-list" class="settings-section" data-name="user-list-admin">
-    <h3 class="inline-block">{{t "Users" }}</h3>
+    <h3 class="inline-block">
+        {{t "Users" }}
+        {{> ../help_link_widget link="/help/roles-and-permissions" }}
+    </h3>
 
     <input type="text" class="search" placeholder="{{t 'Filter users' }}" aria-label="{{t 'Filter users' }}"/>
     <div class="alert-notification" id="user-field-status"></div>


### PR DESCRIPTION
Previously, in the admin user list,user roles were listed as just "member"
so it's difficult to distinguish between full members and new members.

Now, the user's roles were listed as  "Full Member" or "New Member"
in admin user list rather than just "Member".

Also in this commit changes were made to distinguish between
full member and new member in other places like
`user profile` , `user info popover` etc.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
fixes #16040

**Testing Plan:** <!-- How have you tested? -->
Tested using automated node testes and manually tested in the browser

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
