### PR TITLE
stream_creation_form: Remove `optional` from stream description input.

### DIFF
--- a/static/templates/stream_creation_form.hbs
+++ b/static/templates/stream_creation_form.hbs
@@ -14,7 +14,7 @@
             </section>
             <section class="block">
                 <div class="stream-title">
-                    {{t "Stream description (optional)"}}
+                    {{t "Stream description" }}
                 </div>
                 <input type="text" name="stream_description" id="create_stream_description"
                   placeholder="{{t 'Stream description' }}" value="" autocomplete="off" maxlength="{{ max_description_length }}" />


### PR DESCRIPTION
The idea behind this change is to encourage users to enter a stream
description rather than take the easy way out and leave the 'optional'
field empty. This solution intends to solve the same issue as #15997
but in a more indirect way.

Discussion in this thread:
https://chat.zulip.org/#narrow/stream/2-general/topic/Stream.20description.20mandatory.20setting.20.2315997

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->

Tested Manually.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
