### PR TITLE
queue: Remove a no-longer-correct comment.

### DIFF
--- a/zerver/lib/queue.py
+++ b/zerver/lib/queue.py
@@ -359,7 +359,6 @@ def queue_json_publish(
     event: Dict[str, Any],
     processor: Optional[Callable[[Any], None]] = None,
 ) -> None:
-    # most events are dicts, but zerver.middleware.write_log_line uses a str
     with queue_lock:
         if settings.USING_RABBITMQ:
             get_queue_client().json_publish(queue_name, event)


### PR DESCRIPTION
This comment stopped being true in 5686821150, and very much stopped
being relevant in dd40649e04 when the middleware entirely stopped
publishing to a queue.
