### PR TITLE
Removed private Python 2 compatibility APIs depreciated from Django 3.0.

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -23,7 +23,6 @@ from django.http import (
 from django.http.multipartparser import MultiPartParser
 from django.shortcuts import resolve_url
 from django.template.response import SimpleTemplateResponse
-from django.utils.decorators import available_attrs
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import csrf_exempt
@@ -388,7 +387,7 @@ def redirect_to_login(next: str, login_url: Optional[str]=None,
 
     return HttpResponseRedirect(urllib.parse.urlunparse(login_url_parts))
 
-# From Django 1.8
+# From Django 2.2
 def user_passes_test(test_func: Callable[[HttpResponse], bool], login_url: Optional[str]=None,
                      redirect_field_name: str=REDIRECT_FIELD_NAME) -> Callable[[ViewFuncT], ViewFuncT]:
     """
@@ -397,7 +396,7 @@ def user_passes_test(test_func: Callable[[HttpResponse], bool], login_url: Optio
     that takes the user object and returns True if the user passes.
     """
     def decorator(view_func: ViewFuncT) -> ViewFuncT:
-        @wraps(view_func, assigned=available_attrs(view_func))
+        @wraps(view_func)
         def _wrapped_view(request: HttpRequest, *args: object, **kwargs: object) -> HttpResponse:
             if test_func(request):
                 return view_func(request, *args, **kwargs)

--- a/zerver/lib/cache.py
+++ b/zerver/lib/cache.py
@@ -8,7 +8,7 @@ import re
 import sys
 import time
 import traceback
-from functools import wraps
+from functools import lru_cache, wraps
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -29,7 +29,6 @@ from django.core.cache import caches
 from django.core.cache.backends.base import BaseCache
 from django.db.models import Q
 from django.http import HttpRequest
-from django.utils.lru_cache import lru_cache
 
 from zerver.lib.utils import make_safe_digest, statsd, statsd_key
 
@@ -662,7 +661,7 @@ def ignore_unhashable_lru_cache(maxsize: int=128, typed: bool=False) -> DECORATO
         * It will not cache result of functions with unhashable arguments.
         * It will clear cache whenever zerver.lib.cache.KEY_PREFIX changes.
     """
-    internal_decorator = lru_cache(maxsize=maxsize, typed=typed)
+    internal_decorator = cast(Any, lru_cache(maxsize=maxsize, typed=typed))
 
     def decorator(user_function: Callable[..., Any]) -> Callable[..., Any]:
         if settings.DEVELOPMENT and not settings.TEST_SUITE:  # nocoverage

--- a/zerver/lib/i18n.py
+++ b/zerver/lib/i18n.py
@@ -1,13 +1,13 @@
 import logging
 import operator
 import os
+from functools import lru_cache
 from itertools import zip_longest
 from typing import Any, Dict, List
 
 import orjson
 from django.conf import settings
 from django.utils import translation
-from django.utils.lru_cache import lru_cache
 from django.utils.translation import ugettext as _
 
 


### PR DESCRIPTION
Address second checkbox of [https://github.com/zulip/zulip/issues/16030](https://github.com/zulip/zulip/issues/16030).
 `Removed Python 2 compatibility APIs: https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis. We need to audit if we're using any and change them (3.0)`
@timabbott  Can you check this.

