### PR TITLE
markdown: Cache Twitter 403 responses that are semi-permanent.

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -419,6 +419,10 @@ def fetch_tweet_data(tweet_id: str) -> Optional[Dict[str, Any]]:
                     # that the message doesn't exist; return None so
                     # that we will cache the error.
                     return None
+                elif code in [63, 179]:
+                    # 63 is that the account is suspended, 179 is that
+                    # it is now locked; cache the None.
+                    return None
                 elif code in [88, 130]:
                     # Code 88 means that we were rate-limited and 130
                     # means Twitter is having capacity issues; either way

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -423,11 +423,12 @@ def fetch_tweet_data(tweet_id: str) -> Optional[Dict[str, Any]]:
                     # 63 is that the account is suspended, 179 is that
                     # it is now locked; cache the None.
                     return None
-                elif code in [88, 130]:
-                    # Code 88 means that we were rate-limited and 130
-                    # means Twitter is having capacity issues; either way
-                    # just raise the error so we don't cache None and will
-                    # try again later.
+                elif code in [88, 130, 131]:
+                    # Code 88 means that we were rate-limited, 130
+                    # means Twitter is having capacity issues, and 131
+                    # is other 400-equivalent; in these cases, raise
+                    # the error so we don't cache None and will try
+                    # again later.
                     raise
             # It's not clear what to do in cases of other errors,
             # but for now it seems reasonable to log at error


### PR DESCRIPTION
03ca3afbc2 added more codes that are equivalent to 404's; this adds to
the list of cache-as-None codes a couple which are equivalent to
403's.  It does not comprise _all_ possible 403-like codes -- many of
them are "the client is not OK," which is relevant to log as an error
still.