### PR TITLE
url_preview: Only extract img tags with an `src`.

### DIFF
--- a/zerver/lib/url_preview/parsers/generic.py
+++ b/zerver/lib/url_preview/parsers/generic.py
@@ -41,7 +41,7 @@ class GenericParser(BaseParser):
         soup = self._soup
         first_h1 = soup.find('h1')
         if first_h1:
-            first_image = first_h1.find_next_sibling('img')
+            first_image = first_h1.find_next_sibling('img', src=True)
             if first_image and first_image['src'] != '':
                 return first_image['src']
         return None

--- a/zerver/tests/test_link_embed.py
+++ b/zerver/tests/test_link_embed.py
@@ -194,6 +194,7 @@ class GenericParserTestCase(ZulipTestCase):
           <html>
             <body>
                 <h1>Main header</h1>
+                <img data-src="Not an image">
                 <img src="http://test.com/test.jpg">
                 <div>
                     <p>Description text</p>


### PR DESCRIPTION
Some `<img>` tags do not have an SRC, if they are rewritten using JS
to have one later.  Attempting to access `first_image['src']` on these
will raise an exception, as they have no such attribute.

Only look for images which have a defined `src` attribute on them.  We
could instead check if `first_image.has_attr('src')`, but this seems
only likely to produce fewer valid images.
