### PR TITLE
tests: Add an explicit order_by to prevent flakes.

### DIFF
--- a/zerver/tests/test_transfer.py
+++ b/zerver/tests/test_transfer.py
@@ -63,7 +63,7 @@ class TransferUploadsToS3Test(ZulipTestCase):
         with self.assertLogs(level="INFO"):
             transfer_message_files_to_s3(1)
 
-        attachments = Attachment.objects.all()
+        attachments = Attachment.objects.all().order_by("id")
 
         self.assertEqual(len(list(bucket.objects.all())), 2)
         self.assertEqual(bucket.Object(attachments[0].path_id).get()['Body'].read(), b'zulip1!')


### PR DESCRIPTION
Without an order_by, this can fail spuriously -- see https://app.circleci.com/pipelines/github/zulip/zulip/10875/workflows/f46df229-7c5e-4e94-9ef3-1d45db934958/jobs/62315/parallel-runs/0/steps/0-111