### PR TITLE
Send sentry user data, fix email-on-error, queue_json_publish serialization validation

### DIFF
--- a/zerver/logging_handlers.py
+++ b/zerver/logging_handlers.py
@@ -10,6 +10,7 @@ from urllib.parse import SplitResult
 from django.conf import settings
 from django.http import HttpRequest
 from django.views.debug import get_exception_reporter_filter
+from sentry_sdk import capture_exception
 from typing_extensions import Protocol, runtime_checkable
 
 from version import ZULIP_VERSION
@@ -142,6 +143,7 @@ class AdminNotifyHandler(logging.Handler):
             report['message'] = "Exception in preparing exception report!"
             logging.warning(report['message'], exc_info=True)
             report['stack_trace'] = "See /var/log/zulip/errors.log"
+            capture_exception()
 
         if settings.DEBUG_ERROR_REPORTING:  # nocoverage
             logging.warning("Reporting an error to admins...")
@@ -166,3 +168,4 @@ class AdminNotifyHandler(logging.Handler):
             # If this breaks, complain loudly but don't pass the traceback up the stream
             # However, we *don't* want to use logging.exception since that could trigger a loop.
             logging.warning("Reporting an exception triggered an exception!", exc_info=True)
+            capture_exception()

--- a/zerver/logging_handlers.py
+++ b/zerver/logging_handlers.py
@@ -9,6 +9,7 @@ from urllib.parse import SplitResult
 
 from django.conf import settings
 from django.http import HttpRequest
+from django.utils.translation import override as override_language
 from django.views.debug import get_exception_reporter_filter
 from sentry_sdk import capture_exception
 from typing_extensions import Protocol, runtime_checkable
@@ -46,7 +47,10 @@ def add_request_metadata(report: Dict[str, Any], request: HttpRequest) -> None:
         else:
             user_full_name = user_profile.full_name
             user_email = user_profile.email
-            user_role = user_profile.get_role_name()
+            with override_language(settings.LANGUAGE_CODE):
+                # str() to force the lazy-translation to apply now,
+                # since it won't serialize into the worker queue.
+                user_role = str(user_profile.get_role_name())
     except Exception:
         # Unexpected exceptions here should be handled gracefully
         traceback.print_exc()

--- a/zerver/tests/test_logging_handlers.py
+++ b/zerver/tests/test_logging_handlers.py
@@ -11,6 +11,7 @@ from django.http import HttpRequest
 from django.utils.log import AdminEmailHandler
 
 from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.test_helpers import mock_queue_publish
 from zerver.lib.types import ViewFuncT
 from zerver.logging_handlers import AdminNotifyHandler, HasRequest
 
@@ -188,8 +189,8 @@ class AdminNotifyHandlerTest(ZulipTestCase):
                    side_effect=Exception("queue error")):
             self.handler.emit(record)
         with self.settings(STAGING_ERROR_NOTIFICATIONS=False):
-            with patch('zerver.logging_handlers.queue_json_publish',
-                       side_effect=Exception("queue error")):
+            with mock_queue_publish('zerver.logging_handlers.queue_json_publish',
+                                    side_effect=Exception("queue error")):
                 self.handler.emit(record)
 
         # Test no exc_info

--- a/zerver/tests/test_message_edit_notifications.py
+++ b/zerver/tests/test_message_edit_notifications.py
@@ -6,6 +6,7 @@ from django.utils.timezone import now as timezone_now
 from zerver.lib.actions import get_client
 from zerver.lib.push_notifications import get_apns_badge_count, get_apns_badge_count_future
 from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.test_helpers import mock_queue_publish
 from zerver.models import Subscription, UserPresence
 from zerver.tornado.event_queue import maybe_enqueue_notifications
 
@@ -124,8 +125,7 @@ class EditMessageSideEffectsTest(ZulipTestCase):
                 event=event,
             ))
 
-        with mock.patch('zerver.tornado.event_queue.queue_json_publish') as m:
-            m.side_effect = fake_publish
+        with mock_queue_publish('zerver.tornado.event_queue.queue_json_publish', side_effect=fake_publish) as m:
             maybe_enqueue_notifications(**enqueue_kwargs)
 
         self.assert_json_success(result)

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -58,6 +58,7 @@ from zerver.lib.remote_server import (
 from zerver.lib.request import JsonableError
 from zerver.lib.soft_deactivation import do_soft_deactivate_users
 from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.test_helpers import mock_queue_publish
 from zerver.models import (
     Message,
     PushDeviceToken,
@@ -1994,7 +1995,7 @@ class TestClearOnRead(ZulipTestCase):
             flags=F('flags').bitor(
                 UserMessage.flags.active_mobile_push_notification))
 
-        with mock.patch("zerver.lib.actions.queue_json_publish") as mock_publish:
+        with mock_queue_publish("zerver.lib.actions.queue_json_publish") as mock_publish:
             do_mark_stream_messages_as_read(hamlet, self.client, stream)
             queue_items = [c[0][1] for c in mock_publish.call_args_list]
             groups = [item['message_ids'] for item in queue_items]

--- a/zerver/tests/test_report.py
+++ b/zerver/tests/test_report.py
@@ -5,6 +5,7 @@ import orjson
 from django.test import override_settings
 
 from zerver.lib.test_classes import ZulipTestCase
+from zerver.lib.test_helpers import mock_queue_publish
 from zerver.lib.utils import statsd
 
 
@@ -109,12 +110,11 @@ class TestReport(ZulipTestCase):
             more_info=dict(foo='bar', draft_content="**draft**"),
         ))
 
-        publish_mock = mock.patch('zerver.views.report.queue_json_publish')
         subprocess_mock = mock.patch(
             'zerver.views.report.subprocess.check_output',
             side_effect=KeyError('foo'),
         )
-        with publish_mock as m, subprocess_mock:
+        with mock_queue_publish('zerver.views.report.queue_json_publish') as m, subprocess_mock:
             result = self.client_post("/json/report/error", params)
         self.assert_json_success(result)
 
@@ -127,7 +127,7 @@ class TestReport(ZulipTestCase):
 
         # Teset with no more_info
         del params['more_info']
-        with publish_mock as m, subprocess_mock:
+        with mock_queue_publish('zerver.views.report.queue_json_publish') as m, subprocess_mock:
             result = self.client_post("/json/report/error", params)
         self.assert_json_success(result)
 

--- a/zerver/tests/test_service_bot_system.py
+++ b/zerver/tests/test_service_bot_system.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Dict, Optional
+from functools import wraps
+from typing import Any, Callable, Dict, Optional, cast
 from unittest import mock
 
 import orjson
@@ -386,6 +387,17 @@ class TestServiceBotConfigHandler(ZulipTestCase):
             self.bot_handler.send_message(message={'type': 'private', 'to': []})
 
 
+def for_all_bot_types(test_func: Callable[..., None]) -> Callable[..., None]:
+    @wraps(test_func)
+    def _wrapped(*args: object, **kwargs: object) -> None:
+        assert len(args) > 0
+        self = cast(TestServiceBotEventTriggers, args[0])
+        for bot_type in BOT_TYPE_TO_QUEUE_NAME:
+            self.bot_profile.bot_type = bot_type
+            self.bot_profile.save()
+            test_func(*args, **kwargs)
+    return _wrapped
+
 class TestServiceBotEventTriggers(ZulipTestCase):
 
     def setUp(self) -> None:
@@ -404,36 +416,34 @@ class TestServiceBotEventTriggers(ZulipTestCase):
                                                  bot_type=UserProfile.OUTGOING_WEBHOOK_BOT,
                                                  bot_owner=self.user_profile)
 
+    @for_all_bot_types
     @patch_queue_publish('zerver.lib.actions.queue_json_publish')
     def test_trigger_on_stream_mention_from_user(self, mock_queue_json_publish: mock.Mock) -> None:
-        for bot_type, expected_queue_name in BOT_TYPE_TO_QUEUE_NAME.items():
-            self.bot_profile.bot_type = bot_type
-            self.bot_profile.save()
+        content = '@**FooBot** foo bar!!!'
+        recipient = 'Denmark'
+        trigger = 'mention'
+        message_type = Recipient._type_names[Recipient.STREAM]
 
-            content = '@**FooBot** foo bar!!!'
-            recipient = 'Denmark'
-            trigger = 'mention'
-            message_type = Recipient._type_names[Recipient.STREAM]
+        def check_values_passed(
+            queue_name: Any,
+            trigger_event: Dict[str, Any],
+            processor: Optional[Callable[[Any], None]] = None,
+        ) -> None:
+            assert self.bot_profile.bot_type
+            self.assertEqual(queue_name, BOT_TYPE_TO_QUEUE_NAME[self.bot_profile.bot_type])
+            self.assertEqual(trigger_event["message"]["content"], content)
+            self.assertEqual(trigger_event["message"]["display_recipient"], recipient)
+            self.assertEqual(trigger_event["message"]["sender_email"], self.user_profile.email)
+            self.assertEqual(trigger_event["message"]["type"], message_type)
+            self.assertEqual(trigger_event['trigger'], trigger)
+            self.assertEqual(trigger_event['user_profile_id'], self.bot_profile.id)
+        mock_queue_json_publish.side_effect = check_values_passed
 
-            def check_values_passed(
-                queue_name: Any,
-                trigger_event: Dict[str, Any],
-                processor: Optional[Callable[[Any], None]] = None,
-            ) -> None:
-                self.assertEqual(queue_name, expected_queue_name)
-                self.assertEqual(trigger_event["message"]["content"], content)
-                self.assertEqual(trigger_event["message"]["display_recipient"], recipient)
-                self.assertEqual(trigger_event["message"]["sender_email"], self.user_profile.email)
-                self.assertEqual(trigger_event["message"]["type"], message_type)
-                self.assertEqual(trigger_event['trigger'], trigger)
-                self.assertEqual(trigger_event['user_profile_id'], self.bot_profile.id)
-            mock_queue_json_publish.side_effect = check_values_passed
-
-            self.send_stream_message(
-                self.user_profile,
-                'Denmark',
-                content)
-            self.assertTrue(mock_queue_json_publish.called)
+        self.send_stream_message(
+            self.user_profile,
+            'Denmark',
+            content)
+        self.assertTrue(mock_queue_json_publish.called)
 
     @patch_queue_publish('zerver.lib.actions.queue_json_publish')
     def test_no_trigger_on_stream_message_without_mention(self, mock_queue_json_publish: mock.Mock) -> None:
@@ -441,95 +451,81 @@ class TestServiceBotEventTriggers(ZulipTestCase):
         self.send_stream_message(sender, "Denmark")
         self.assertFalse(mock_queue_json_publish.called)
 
+    @for_all_bot_types
     @patch_queue_publish('zerver.lib.actions.queue_json_publish')
     def test_no_trigger_on_stream_mention_from_bot(self, mock_queue_json_publish: mock.Mock) -> None:
-        for bot_type in BOT_TYPE_TO_QUEUE_NAME:
-            self.bot_profile.bot_type = bot_type
-            self.bot_profile.save()
+        self.send_stream_message(
+            self.second_bot_profile,
+            'Denmark',
+            '@**FooBot** foo bar!!!')
+        self.assertFalse(mock_queue_json_publish.called)
 
-            self.send_stream_message(
-                self.second_bot_profile,
-                'Denmark',
-                '@**FooBot** foo bar!!!')
-            self.assertFalse(mock_queue_json_publish.called)
-
+    @for_all_bot_types
     @patch_queue_publish('zerver.lib.actions.queue_json_publish')
     def test_trigger_on_personal_message_from_user(self, mock_queue_json_publish: mock.Mock) -> None:
-        for bot_type, expected_queue_name in BOT_TYPE_TO_QUEUE_NAME.items():
-            self.bot_profile.bot_type = bot_type
-            self.bot_profile.save()
+        sender = self.user_profile
+        recipient = self.bot_profile
 
-            sender = self.user_profile
-            recipient = self.bot_profile
+        def check_values_passed(
+            queue_name: Any,
+            trigger_event: Dict[str, Any],
+            processor: Optional[Callable[[Any], None]] = None,
+        ) -> None:
+            assert self.bot_profile.bot_type
+            self.assertEqual(queue_name, BOT_TYPE_TO_QUEUE_NAME[self.bot_profile.bot_type])
+            self.assertEqual(trigger_event["user_profile_id"], self.bot_profile.id)
+            self.assertEqual(trigger_event["trigger"], "private_message")
+            self.assertEqual(trigger_event["message"]["sender_email"], sender.email)
+            display_recipients = [
+                trigger_event["message"]["display_recipient"][0]["email"],
+                trigger_event["message"]["display_recipient"][1]["email"],
+            ]
+            self.assertTrue(sender.email in display_recipients)
+            self.assertTrue(recipient.email in display_recipients)
+        mock_queue_json_publish.side_effect = check_values_passed
 
-            def check_values_passed(
-                queue_name: Any,
-                trigger_event: Dict[str, Any],
-                processor: Optional[Callable[[Any], None]] = None,
-            ) -> None:
-                self.assertEqual(queue_name, expected_queue_name)
-                self.assertEqual(trigger_event["user_profile_id"], self.bot_profile.id)
-                self.assertEqual(trigger_event["trigger"], "private_message")
-                self.assertEqual(trigger_event["message"]["sender_email"], sender.email)
-                display_recipients = [
-                    trigger_event["message"]["display_recipient"][0]["email"],
-                    trigger_event["message"]["display_recipient"][1]["email"],
-                ]
-                self.assertTrue(sender.email in display_recipients)
-                self.assertTrue(recipient.email in display_recipients)
-            mock_queue_json_publish.side_effect = check_values_passed
+        self.send_personal_message(sender, recipient, 'test')
+        self.assertTrue(mock_queue_json_publish.called)
 
-            self.send_personal_message(sender, recipient, 'test')
-            self.assertTrue(mock_queue_json_publish.called)
-
+    @for_all_bot_types
     @patch_queue_publish('zerver.lib.actions.queue_json_publish')
     def test_no_trigger_on_personal_message_from_bot(self, mock_queue_json_publish: mock.Mock) -> None:
-        for bot_type in BOT_TYPE_TO_QUEUE_NAME:
-            self.bot_profile.bot_type = bot_type
-            self.bot_profile.save()
+        sender = self.second_bot_profile
+        recipient = self.bot_profile
+        self.send_personal_message(sender, recipient)
+        self.assertFalse(mock_queue_json_publish.called)
 
-            sender = self.second_bot_profile
-            recipient = self.bot_profile
-            self.send_personal_message(sender, recipient)
-            self.assertFalse(mock_queue_json_publish.called)
-
+    @for_all_bot_types
     @patch_queue_publish('zerver.lib.actions.queue_json_publish')
     def test_trigger_on_huddle_message_from_user(self, mock_queue_json_publish: mock.Mock) -> None:
-        for bot_type, expected_queue_name in BOT_TYPE_TO_QUEUE_NAME.items():
-            self.bot_profile.bot_type = bot_type
-            self.bot_profile.save()
+        self.second_bot_profile.bot_type = self.bot_profile.bot_type
+        self.second_bot_profile.save()
 
-            self.second_bot_profile.bot_type = bot_type
-            self.second_bot_profile.save()
+        sender = self.user_profile
+        recipients = [self.bot_profile, self.second_bot_profile]
+        profile_ids = [self.bot_profile.id, self.second_bot_profile.id]
 
-            sender = self.user_profile
-            recipients = [self.bot_profile, self.second_bot_profile]
-            profile_ids = [self.bot_profile.id, self.second_bot_profile.id]
+        def check_values_passed(
+            queue_name: Any,
+            trigger_event: Dict[str, Any],
+            processor: Optional[Callable[[Any], None]] = None,
+        ) -> None:
+            assert self.bot_profile.bot_type
+            self.assertEqual(queue_name, BOT_TYPE_TO_QUEUE_NAME[self.bot_profile.bot_type])
+            self.assertIn(trigger_event["user_profile_id"], profile_ids)
+            profile_ids.remove(trigger_event["user_profile_id"])
+            self.assertEqual(trigger_event["trigger"], "private_message")
+            self.assertEqual(trigger_event["message"]["sender_email"], sender.email)
+            self.assertEqual(trigger_event["message"]["type"], 'private')
+        mock_queue_json_publish.side_effect = check_values_passed
 
-            def check_values_passed(
-                queue_name: Any,
-                trigger_event: Dict[str, Any],
-                processor: Optional[Callable[[Any], None]] = None,
-            ) -> None:
-                self.assertEqual(queue_name, expected_queue_name)
-                self.assertIn(trigger_event["user_profile_id"], profile_ids)
-                profile_ids.remove(trigger_event["user_profile_id"])
-                self.assertEqual(trigger_event["trigger"], "private_message")
-                self.assertEqual(trigger_event["message"]["sender_email"], sender.email)
-                self.assertEqual(trigger_event["message"]["type"], 'private')
-            mock_queue_json_publish.side_effect = check_values_passed
+        self.send_huddle_message(sender, recipients, 'test')
+        self.assertEqual(mock_queue_json_publish.call_count, 2)
 
-            self.send_huddle_message(sender, recipients, 'test')
-            self.assertEqual(mock_queue_json_publish.call_count, 2)
-            mock_queue_json_publish.reset_mock()
-
+    @for_all_bot_types
     @patch_queue_publish('zerver.lib.actions.queue_json_publish')
     def test_no_trigger_on_huddle_message_from_bot(self, mock_queue_json_publish: mock.Mock) -> None:
-        for bot_type in BOT_TYPE_TO_QUEUE_NAME:
-            self.bot_profile.bot_type = bot_type
-            self.bot_profile.save()
-
-            sender = self.second_bot_profile
-            recipients = [self.user_profile, self.bot_profile]
-            self.send_huddle_message(sender, recipients)
-            self.assertFalse(mock_queue_json_publish.called)
+        sender = self.second_bot_profile
+        recipients = [self.user_profile, self.bot_profile]
+        self.send_huddle_message(sender, recipients)
+        self.assertFalse(mock_queue_json_publish.called)


### PR DESCRIPTION
Fixes three related things:
 - Failure to send an error email to the admins did not signal Sentry.
 - Sending error emails to admins currently fails due to failure to serialize a lazily-translated string to JSON.  Adjust testing around this to catch future errors like this.  This is a non-overlapping but related test to #16121.
 - Begin sending user information to Sentry, which would have failed for the same reason as above.

**Testing Plan:** Existing and new tests.