### PR TITLE
Add spam detection in test-backend output.

### DIFF
--- a/docs/testing/testing-with-django.md
+++ b/docs/testing/testing-with-django.md
@@ -436,6 +436,13 @@ code and edge cases.  It will generate a nice HTML report that you can
 view right from your browser (the tool prints the URL where the report
 is exposed in your development environment).
 
+- **Console output** A properly written test should print nothing to
+the console; use `with self.assertLogs` to capture and verify any
+logging output.  Note that we reconfigure various loggers in
+`zproject/test_extra_settings.py` where the output is unlikely to be
+interesting when running our test suite.  `test-backend
+--ban-console-output` checks for stray print statements.
+
 Note that `test-backend --coverage` will assert that
 various specific files in the project have 100% test coverage and
 throw an error if their coverage has fallen.  One of our project goals

--- a/tools/ci/backend
+++ b/tools/ci/backend
@@ -12,7 +12,7 @@ set -x
 # docker setup means the auto-detection logic sees the ~36 processes
 # the Docker host has, not the ~2 processes of resources we're
 # allocated.
-./tools/test-backend --coverage --include-webhooks --no-cov-cleanup --parallel=6
+./tools/test-backend --coverage --include-webhooks --no-cov-cleanup --ban-console-output --parallel=6
 
 # We run mypy after the backend tests so we get output from the
 # backend tests, which tend to uncover more serious problems, first.

--- a/tools/test-all
+++ b/tools/test-all
@@ -49,7 +49,7 @@ run ./tools/clean-repo
 # ci/backend
 run ./tools/lint --groups=backend $FORCEARG
 run ./tools/test-tools
-run ./tools/test-backend --include-webhooks $FORCEARG
+run ./tools/test-backend --include-webhooks --ban-console-output $FORCEARG
 run ./tools/test-migrations
 # Not running SVG optimizing since it's low-churn
 # run ./tools/setup/optimize-svg

--- a/tools/test-backend
+++ b/tools/test-backend
@@ -108,6 +108,7 @@ not_yet_fully_covered = {path for target in [
     'zerver/lib/server_initialization.py',
     'zerver/lib/test_fixtures.py',
     'zerver/lib/test_runner.py',
+    'zerver/lib/test_console_output.py',
     'zerver/openapi/python_examples.py',
     # Tornado should ideally have full coverage, but we're not there.
     'zerver/tornado/autoreload.py',
@@ -260,8 +261,14 @@ def main() -> None:
                         default=False,
                         help=("Generate Stripe test fixtures by making requests to Stripe test network"))
     parser.add_argument('args', nargs='*')
+    parser.add_argument('--ban-console-output', dest='ban_console_output',
+                        action="store_true",
+                        default=False, help='Require stdout and stderr to be clean of unexpected output.')
 
     options = parser.parse_args()
+    if options.ban_console_output:
+        os.environ["BAN_CONSOLE_OUTPUT"] = "1"
+
     args = options.args
     parallel = options.processes
     include_webhooks = options.coverage or options.include_webhooks

--- a/zerver/lib/test_console_output.py
+++ b/zerver/lib/test_console_output.py
@@ -1,0 +1,114 @@
+import logging
+import re
+import sys
+from types import TracebackType
+from typing import Iterable, Optional, Type, cast
+
+
+class ExtraConsoleOutputInTestException(Exception):
+    pass
+
+class ExtraConsoleOutputFinder:
+    def __init__(self) -> None:
+        self.latest_test_name = ""
+        valid_line_patterns = [
+            # Example: Running zerver.tests.test_attachments.AttachmentsTests.test_delete_unauthenticated
+            "^Running ",
+
+            # Example: ** Test is TOO slow: analytics.tests.test_counts.TestRealmActiveHumans.test_end_to_end (0.581 s)
+            "^\\*\\* Test is TOO slow: ",
+            "^----------------------------------------------------------------------",
+
+            # Example: INFO: URL coverage report is in var/url_coverage.txt
+            "^INFO: URL coverage report is in",
+
+            # Example: INFO: Try running: ./tools/create-test-api-docs
+            "^INFO: Try running:",
+
+            # Example: -- Running tests in parallel mode with 4 processes
+            "^-- Running tests in",
+            "^OK",
+
+            # Example: Ran 2139 tests in 115.659s
+            "^Ran [0-9]+ tests in",
+
+            # Destroying test database for alias 'default'...
+            "^Destroying test database for alias ",
+            "^Using existing clone",
+            "^\\*\\* Skipping ",
+        ]
+        self.compiled_line_patterns = []
+        for pattern in valid_line_patterns:
+            self.compiled_line_patterns.append(re.compile(pattern))
+        self.full_extra_output = ""
+
+    def find_extra_output(self, data: str) -> None:
+        lines = data.split('\n')
+        for line in lines:
+            if not line:
+                continue
+            found_extra_output = True
+            for compiled_pattern in self.compiled_line_patterns:
+                if compiled_pattern.match(line):
+                    found_extra_output = False
+                    break
+            if found_extra_output:
+                self.full_extra_output += f'{line}\n'
+
+class TeeStderrAndFindExtraConsoleOutput():
+    def __init__(self, extra_output_finder: ExtraConsoleOutputFinder) -> None:
+        self.stderr_stream = sys.stderr
+
+        # get shared console handler instance from any logger that have it
+        self.console_log_handler = cast(logging.StreamHandler, logging.getLogger('django.server').handlers[0])
+
+        assert isinstance(self.console_log_handler, logging.StreamHandler)
+        assert self.console_log_handler.stream == sys.stderr
+        self.extra_output_finder = extra_output_finder
+
+    def __enter__(self) -> None:
+        sys.stderr = self  # type: ignore[assignment] # Doing tee by swapping stderr stream with custom file like class
+        self.console_log_handler.stream = self  # type: ignore[assignment] # Doing tee by swapping stderr stream with custom file like class
+
+    def __exit__(self, exc_type: Optional[Type[BaseException]],
+                 exc_value: Optional[BaseException],
+                 traceback: Optional[TracebackType]) -> None:
+        sys.stderr = self.stderr_stream
+        self.console_log_handler.stream = sys.stderr
+
+    def write(self, data: str) -> None:
+        self.stderr_stream.write(data)
+        self.extra_output_finder.find_extra_output(data)
+
+    def writelines(self, data: Iterable[str]) -> None:
+        self.stderr_stream.writelines(data)
+        lines = "".join(data)
+        self.extra_output_finder.find_extra_output(lines)
+
+    def flush(self) -> None:
+        self.stderr_stream.flush()
+
+class TeeStdoutAndFindExtraConsoleOutput():
+    def __init__(self, extra_output_finder: ExtraConsoleOutputFinder) -> None:
+        self.stdout_stream = sys.stdout
+        self.extra_output_finder = extra_output_finder
+
+    def __enter__(self) -> None:
+        sys.stdout = self  # type: ignore[assignment] # Doing tee by swapping stderr stream with custom file like class
+
+    def __exit__(self, exc_type: Optional[Type[BaseException]],
+                 exc_value: Optional[BaseException],
+                 traceback: Optional[TracebackType]) -> None:
+        sys.stdout = self.stdout_stream
+
+    def write(self, data: str) -> None:
+        self.stdout_stream.write(data)
+        self.extra_output_finder.find_extra_output(data)
+
+    def writelines(self, data: Iterable[str]) -> None:
+        self.stdout_stream.writelines(data)
+        lines = "".join(data)
+        self.extra_output_finder.find_extra_output(lines)
+
+    def flush(self) -> None:
+        self.stdout_stream.flush()

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -104,6 +104,8 @@ CASPER_TESTS = False
 RUNNING_OPENAPI_CURL_TEST = False
 # This is overridden in test_settings.py for the test suites
 GENERATE_STRIPE_FIXTURES = False
+# This is overridden in test_settings.py for the test suites
+BAN_CONSOLE_OUTPUT = False
 
 # Google Compute Engine has an /etc/boto.cfg that is "nicely
 # configured" to work with GCE's storage service.  However, their

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -56,6 +56,9 @@ if "RUNNING_OPENAPI_CURL_TEST" in os.environ:
 if "GENERATE_STRIPE_FIXTURES" in os.environ:
     GENERATE_STRIPE_FIXTURES = True
 
+if "BAN_CONSOLE_OUTPUT" in os.environ:
+    BAN_CONSOLE_OUTPUT = True
+
 # Decrease the get_updates timeout to 1 second.
 # This allows CasperJS to proceed quickly to the next test step.
 POLL_TIMEOUT = 1000


### PR DESCRIPTION
This commit adds automatic spam detection in output printed to
stderr and stdout by test-backend while running instances of
ZulipTestCase in parallel mode.
It also prints the test file and method that produced the
spam.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
#1587

- [x] Add flag to disable the spam detection.

**Testing Plan:** <!-- How have you tested? -->
1. Added print statements in test cases randomly and confirmed if the it's being caught.
2. Removed few commits that suppressed logs using assertLogs and ensured that spam was caught by the script and right test that printed the spam.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![image](https://user-images.githubusercontent.com/23462580/90652945-3d356700-e25c-11ea-8836-e661924f62f0.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
