### PR TITLE
events: Add `op` field to `update_message_flags` events.

### DIFF
--- a/frontend_tests/node_tests/lib/events.js
+++ b/frontend_tests/node_tests/lib/events.js
@@ -684,6 +684,7 @@ exports.fixtures = {
 
     update_message_flags__read: {
         type: "update_message_flags",
+        op: "add",
         operation: "add",
         flag: "read",
         messages: [999],
@@ -692,6 +693,7 @@ exports.fixtures = {
 
     update_message_flags__starred_add: {
         type: "update_message_flags",
+        op: "add",
         operation: "add",
         flag: "starred",
         messages: [exports.test_message.id],
@@ -700,6 +702,7 @@ exports.fixtures = {
 
     update_message_flags__starred_remove: {
         type: "update_message_flags",
+        op: "remove",
         operation: "remove",
         flag: "starred",
         messages: [exports.test_message.id],

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -12,6 +12,14 @@ below features are supported.
 
 **Feature level 31**
 
+* [`GET /events`](/api/get-events): Added `op` field to
+  `update_message_flags` events. This was an anomaly as all other
+  events use `op` flag but `update_message_flags` used the `operation`
+  The `operation` field is now deprecated and will be removed in a later
+  feature level.
+
+**Feature level 31**
+
 * [`GET users/me/subscriptions`](/api/get-subscriptions): Added a
   `role` field to Subscription objects representing whether the user
   is a stream administrator.

--- a/version.py
+++ b/version.py
@@ -29,7 +29,7 @@ DESKTOP_WARNING_VERSION = "5.2.0"
 #
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md.
-API_FEATURE_LEVEL = 31
+API_FEATURE_LEVEL = 32
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -4120,6 +4120,7 @@ def do_mark_all_as_read(user_profile: UserProfile, client: Client) -> int:
 
     event = dict(
         type='update_message_flags',
+        op ='add',
         operation='add',
         flag='read',
         messages=[],  # we don't send messages, since the client reloads anyway
@@ -4167,6 +4168,7 @@ def do_mark_stream_messages_as_read(user_profile: UserProfile,
 
     event = dict(
         type='update_message_flags',
+        op='add',
         operation='add',
         flag='read',
         messages=message_ids,
@@ -4274,6 +4276,7 @@ def do_update_message_flags(user_profile: UserProfile,
         raise AssertionError("Invalid message flags operation")
 
     event = {'type': 'update_message_flags',
+             'op': operation,
              'operation': operation,
              'flag': flag,
              'messages': messages,

--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -811,6 +811,7 @@ check_update_message_embedded = check_events_dict(
 _check_update_message_flags = check_events_dict(
     required_keys=[
         ("type", equals("update_message_flags")),
+        ("op", check_add_or_remove),
         ("operation", check_add_or_remove),
         ("flag", check_string),
         ("messages", check_list(check_int)),
@@ -823,7 +824,7 @@ def check_update_message_flags(
     var_name: str, event: Dict[str, object], operation: str
 ) -> None:
     _check_update_message_flags(var_name, event)
-    assert event["operation"] == operation
+    assert event["operation"] == operation and event['op'] == operation
 
 
 _check_group = check_dict_only(

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -742,13 +742,13 @@ def apply_event(state: Dict[str, Any],
         # We don't return messages in `/register`, so most flags we
         # can ignore, but we do need to update the unread_msgs data if
         # unread state is changed.
-        if 'raw_unread_msgs' in state and event['flag'] == 'read' and event['operation'] == 'add':
+        if 'raw_unread_msgs' in state and event['flag'] == 'read' and event['op'] == 'add':
             for remove_id in event['messages']:
                 remove_message_id_from_unread_mgs(state['raw_unread_msgs'], remove_id)
         if event['flag'] == 'starred' and 'starred_messages' in state:
-            if event['operation'] == 'add':
+            if event['op'] == 'add':
                 state['starred_messages'] += event['messages']
-            if event['operation'] == 'remove':
+            if event['op'] == 'remove':
                 state['starred_messages'] = [message for message in state['starred_messages']
                                              if not (message in event['messages'])]
     elif event['type'] == "realm_domains":

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -2043,9 +2043,18 @@ paths:
                                   type: string
                                   enum:
                                     - update_message_flags
+                                op:
+                                  type: string
+                                  enum:
+                                    - add
                                 operation:
+                                  deprecated: true
                                   description: |
                                     Whether the flags are added or removed.
+
+                                    **Deprecated**: After the addition of `op` field
+                                    to `update_message_flags` in API feature level 32, this
+                                    field is redundant and is deprecated.
                                   type: string
                                   enum:
                                     - add
@@ -2087,10 +2096,19 @@ paths:
                                   type: string
                                   enum:
                                     - update_message_flags
+                                op:
+                                  type: string
+                                  enum:
+                                    - remove
                                 operation:
+                                  deprecated: true
                                   type: string
                                   description: |
                                     Whether the flags are added or removed.
+
+                                    **Deprecated**: After the addition of `op` field
+                                    to `update_message_flags` in API feature level 32, this
+                                    field is redundant and is deprecated.
                                   enum:
                                     - remove
                                 flag:


### PR DESCRIPTION
`update_message_flags` events used `operation` instead of `op`, the
latter being the standard field used in other events. So add `op`
field to `update_message_flags` and mark `operation` as deprecated,
so that it can be removed later.