### PR TITLE
settings: Adjust documentation and comment references to settings.py.

### DIFF
--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -218,8 +218,8 @@ messages).
 ### Paths to state or log files
 
 When writing out state or log files, always pass an absolute path
-through `zulip_path` (found in `zproject/settings.py`), which will do
-the right thing in both development and production.
+through `zulip_path` (found in `zproject/computed_settings.py`), which
+will do the right thing in both development and production.
 
 ## JS array/object manipulation
 

--- a/docs/production/authentication-methods.md
+++ b/docs/production/authentication-methods.md
@@ -548,11 +548,12 @@ This summary should help with understanding what's going on as you try
 to debug.
 
 * Since you've configured `/etc/zulip/settings.py` to only define the
-  `zproject.backends.ZulipRemoteUserBackend`, `zproject/settings.py`
-  configures `/accounts/login/sso/` as `HOME_NOT_LOGGED_IN`.  This
-  makes `https://zulip.example.com/` (a.k.a. the homepage for the main
-  Zulip Django app running behind nginx) redirect to
-  `/accounts/login/sso/` for a user that isn't logged in.
+  `zproject.backends.ZulipRemoteUserBackend`,
+  `zproject/computed_settings.py` configures `/accounts/login/sso/` as
+  `HOME_NOT_LOGGED_IN`.  This makes `https://zulip.example.com/`
+  (a.k.a. the homepage for the main Zulip Django app running behind
+  nginx) redirect to `/accounts/login/sso/` for a user that isn't
+  logged in.
 
 * nginx proxies requests to `/accounts/login/sso/` to an Apache
   instance listening on `localhost:8888`, via the config in

--- a/docs/production/postgres.md
+++ b/docs/production/postgres.md
@@ -22,8 +22,8 @@ certificate authentication (see
 http://www.postgresql.org/docs/9.1/static/ssl-tcp.html and
 http://www.postgresql.org/docs/9.1/static/libpq-ssl.html for
 documentation on how to set this up and deploy the certificates) to
-make the DATABASES configuration in `zproject/settings.py` work (or
-override that configuration).
+make the DATABASES configuration in `zproject/computed_settings.py`
+work (or override that configuration).
 
 If you want to use a remote Postgresql database, you should configure
 the information about the connection with the server. You need a user

--- a/docs/subsystems/html-css.md
+++ b/docs/subsystems/html-css.md
@@ -212,7 +212,7 @@ needs to be accessible from one of the entry points defined in
   relevant Jinja2 template to inject the compiled JS and CSS.
 
 If you want to test minified files in development, look for the
-`DEBUG =` line in `zproject/settings.py` and set it to `False`.
+`DEBUG =` line in `zproject/default_settings.py` and set it to `False`.
 
 ### How it works in production
 

--- a/docs/subsystems/settings.md
+++ b/docs/subsystems/settings.md
@@ -63,10 +63,10 @@ In a production environment, we have:
   `scripts/setup/generate_secrets.py` as part of installation)
   contains secrets used by the Zulip installation.  These are read
   using the standard Python `ConfigParser`, and accessed in
-  `zproject/settings.py` by the `get_secret` function.  All
+  `zproject/computed_settings.py` by the `get_secret` function.  All
   secrets/API keys/etc. used by the Zulip Django application should be
   stored here, and read using the `get_secret` function in
-  `zproject/settings.py`.
+  `zproject/config.py`.
 
 * `zproject/settings.py` is the main Django settings file for Zulip.
   It imports everything from `zproject/configured_settings.py` and
@@ -106,7 +106,7 @@ in two or three places:
   for production environments.
 
 * If the settings has a secret key,
-  you'll add a `get_secret` call in `zproject/settings.py` (and the
+  you'll add a `get_secret` call in `zproject/computed_settings.py` (and the
   user will add the value when they configure the feature).
 
 * In an appropriate section of `zproject/prod_settings_template.py`,

--- a/zerver/lib/logging_util.py
+++ b/zerver/lib/logging_util.py
@@ -214,7 +214,7 @@ def log_to_file(logger: Logger,
                 filename: str,
                 log_format: str="%(asctime)s %(levelname)-8s %(message)s",
                 ) -> None:
-    """Note: `filename` should be declared in zproject/settings.py with zulip_path."""
+    """Note: `filename` should be declared in zproject/computed_settings.py with zulip_path."""
     formatter = logging.Formatter(log_format)
     handler = logging.FileHandler(filename)
     handler.setFormatter(formatter)

--- a/zerver/management/commands/deliver_scheduled_messages.py
+++ b/zerver/management/commands/deliver_scheduled_messages.py
@@ -53,7 +53,8 @@ Usage: ./manage.py deliver_scheduled_messages
             # Here doing a check and sleeping indefinitely on this setting might
             # not sound right. Actually we do this check to avoid running this
             # process on every server that might be in service to a realm. See
-            # the comment in zproject/settings.py file about renaming this setting.
+            # the comment in zproject/default_settings.py file about renaming this
+            # setting.
             sleep_forever()
 
         while True:


### PR DESCRIPTION
`zproject/settings.py` itself is mostly-empty now.  Adjust the
references which should now point to `zproject/computed_settings.py`
or `zproject/default_settings.py`.