### PR TITLE
openapi: Fix DELETE /users/me status 200 response description.

### DIFF
--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4386,7 +4386,7 @@ paths:
         Delete the requesting user from the realm.
       responses:
         "200":
-          description: Bad Request
+          description: Success.
           content:
             application/json:
               schema:
@@ -4394,7 +4394,7 @@ paths:
                   - $ref: "#/components/schemas/JsonSuccess"
                   - example: {"msg": "", "result": "success"}
         "400":
-          description: Bad Request
+          description: Bad Request.
           content:
             application/json:
               schema:


### PR DESCRIPTION
If you look at line number 1121 (new) of commit 14c0a387cf, I seem to have accidently set the description for a status 200 response to "Bad Request" instead of "Success" which is what it really is. It's basically an ugly typo (maybe due to hastily copy-pasting the template).

@rht, thanks for finding this!