### PR TITLE
ui: Add loading indicator for message edits.

### DIFF
--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -294,7 +294,6 @@ function build_move_topic_to_stream_popover(e, current_stream_id, topic_name) {
     });
 
     $("#move_topic_modal").modal("show");
-    e.stopPropagation();
 }
 
 exports.register_click_handlers = function () {
@@ -610,6 +609,7 @@ exports.register_topic_handlers = function () {
             ]),
         };
 
+        message_edit.show_topic_move_spinner();
         channel.get({
             url: "/json/messages",
             data,
@@ -631,10 +631,10 @@ exports.register_topic_handlers = function () {
                         send_notification_to_new_thread,
                         send_notification_to_old_thread,
                     );
-                    $("#move_topic_modal").modal("hide");
                 }
             },
             error(xhr) {
+                message_edit.hide_topic_move_spinner();
                 show_error_msg(xhr.responseJSON.msg);
             },
         });

--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -2141,6 +2141,7 @@ div.topic_edit_spinner .loading_indicator_spinner {
     height: 20px;
 }
 
+.topic_move_spinner,
 #do_delete_message_spinner {
     margin: 0 auto;
 }

--- a/static/templates/move_topic_to_stream.hbs
+++ b/static/templates/move_topic_to_stream.hbs
@@ -37,7 +37,7 @@
                 </div>
             </div>
         </form>
-        <div class="topic_edit_spinner"></div>
+        <div class="topic_move_spinner"></div>
     </div>
     <div class="modal-footer">
         <button class="button" data-dismiss="modal">{{t "Cancel" }}</button>


### PR DESCRIPTION
Fixes #16143.
![message_edit_indicator](https://user-images.githubusercontent.com/40122794/90857877-afb05f00-e3a2-11ea-83b0-ca8d57f992dd.gif)
