### PR TITLE
Fix trailing slashes when creating Jitsi video meeting

### DIFF
--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -121,7 +121,7 @@ LOCAL_UPLOADS_DIR: Optional[str] = None
 MAX_FILE_UPLOAD_SIZE = 25
 
 # Jitsi Meet video call integration; set to None to disable integration.
-JITSI_SERVER_URL = 'https://meet.jit.si/'
+JITSI_SERVER_URL = 'https://meet.jit.si'
 
 # Allow setting BigBlueButton settings in zulip-secrets.conf in
 # development; this is useful since there are no public BigBlueButton servers.


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Fixes #16176 

**Testing Plan:** <!-- How have you tested? -->
Tested by creating a Jisti video meeting URL.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
