### PR TITLE
Fix error message for deactivating the last oraganization owner.

### DIFF
--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -583,16 +583,16 @@ exports.set_up = function () {
                     window.location.href = "/login/";
                 },
                 error(xhr) {
-                    const error_last_admin = i18n.t(
-                        "Error: Cannot deactivate the only organization administrator.",
+                    const error_last_owner = i18n.t(
+                        "Error: Cannot deactivate the only organization owner.",
                     );
                     const error_last_user = i18n.t(
                         'Error: Cannot deactivate the only user. You can deactivate the whole organization though in your <a target="_blank" href="/#organization/organization-profile">Organization profile settings</a>.',
                     );
                     let rendered_error_msg;
                     if (xhr.responseJSON.code === "CANNOT_DEACTIVATE_LAST_USER") {
-                        if (xhr.responseJSON.is_last_admin) {
-                            rendered_error_msg = error_last_admin;
+                        if (xhr.responseJSON.is_last_owner) {
+                            rendered_error_msg = error_last_owner;
                         } else {
                             rendered_error_msg = error_last_user;
                         }

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -4402,7 +4402,7 @@ paths:
                   - $ref: "#/components/schemas/JsonError"
                   - example:
                       {
-                        "msg": "Cannot deactivate the only organization administrator",
+                        "msg": "Cannot deactivate the only organization owner",
                         "result": "error",
                       }
   /users/me/{stream_id}/topics:
@@ -5288,7 +5288,7 @@ paths:
                   - $ref: "#/components/schemas/JsonError"
                   - example:
                       {
-                        "msg": "Cannot deactivate the only organization administrator",
+                        "msg": "Cannot deactivate the only organization owner",
                         "result": "error",
                       }
   /realm/filters:


### PR DESCRIPTION
This PR fixes-
- Error message shown when deactivating the last owner to show "Cannot deactivate
the last organization owner" instead of "Cannot deactivate the last organization administrator".
- Example for "400" responses of deactivate user endpoints to show msg as "Cannot deactivate
the last organization owner" instead of "Cannot deactivate the last organization administrator"

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


 <!-- How have you tested? -->


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
