### PR TITLE
api: Fix require_post decorator not returning 405 error body.

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -9,9 +9,15 @@
             <img src="/static/images/400art.svg" alt=""/>
             <div class="errorbox">
                 <div class="errorcontent">
+                    {% if status_code == 405 %}
+                    <h1 class="lead">Method not allowed (405)</h1>
+                    <p>We know this is stressful, but we still love you.</p>
+                    <p>If you'd like, you can <a href="mailto:{{ support_email }}?Subject=405%20error%20on%20%7Bwhich%20URL%3F%7D&Body=Hi%20there%21%0A%0AI%20was%20trying%20to%20do%20%7Bwhat%20were%20you%20trying%20to%20do%3F%7D%20at%20around%20%7Bwhen%20was%20this%3F%7D%20when%20I%20got%20a%20405%20error%20while%20accessing%20%7Bwhich%20URL%3F%7D.%0A%0AThanks!%0A%0ASincerely%2C%20%0A%0A%7BYour%20name%7D">drop us a line</a> to let us know what happened.</p>
+                    {% else %}
                     <h1 class="lead">Page not found (404)</h1>
                     <p>We know this is stressful, but we still love you.</p>
                     <p>If you'd like, you can <a href="mailto:{{ support_email }}?Subject=404%20error%20on%20%7Bwhich%20URL%3F%7D&Body=Hi%20there%21%0A%0AI%20was%20trying%20to%20do%20%7Bwhat%20were%20you%20trying%20to%20do%3F%7D%20at%20around%20%7Bwhen%20was%20this%3F%7D%20when%20I%20got%20a%20404%20error%20while%20accessing%20%7Bwhich%20URL%3F%7D.%0A%0AThanks!%0A%0ASincerely%2C%20%0A%0A%7BYour%20name%7D">drop us a line</a> to let us know what happened.</p>
+                    {% endif %}
                 </div>
 
             </div>

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1524,6 +1524,39 @@ class TestHumanUsersOnlyDecorator(ZulipTestCase):
             result = self.api_delete(default_bot, endpoint)
             self.assert_json_error(result, "This endpoint does not accept bot requests.")
 
+class TestAuthenticatedRequirePostDecorator(ZulipTestCase):
+    def test_authenticated_html_post_view_with_get_request(self) -> None:
+        self.login('hamlet')
+        with mock.patch('logging.warning') as mock_warning:
+            result = self.client_get(r'/accounts/register/', {'stream': 'Verona'})
+            self.assertEqual(result.status_code, 405)
+            mock_warning.assert_called_once()  # Check we logged the Mock Not Allowed
+            self.assertEqual(mock_warning.call_args_list[0][0],
+                             ('Method Not Allowed (%s): %s', 'GET', '/accounts/register/'))
+
+        with mock.patch('logging.warning') as mock_warning:
+            result = self.client_get(r'/accounts/logout/', {'stream': 'Verona'})
+            self.assertEqual(result.status_code, 405)
+            mock_warning.assert_called_once()  # Check we logged the Mock Not Allowed
+            self.assertEqual(mock_warning.call_args_list[0][0],
+                             ('Method Not Allowed (%s): %s', 'GET', '/accounts/logout/'))
+
+    def test_authenticated_json_post_view_with_get_request(self) -> None:
+        self.login('hamlet')
+        with mock.patch('logging.warning') as mock_warning:
+            result = self.client_get(r'/api/v1/dev_fetch_api_key', {'stream': 'Verona'})
+            self.assertEqual(result.status_code, 405)
+            mock_warning.assert_called_once()  # Check we logged the Mock Not Allowed
+            self.assertEqual(mock_warning.call_args_list[0][0],
+                             ('Method Not Allowed (%s): %s', 'GET', '/api/v1/dev_fetch_api_key'))
+
+        with mock.patch('logging.warning') as mock_warning:
+            result = self.client_get(r'/json/remotes/server/register', {'stream': 'Verona'})
+            self.assertEqual(result.status_code, 405)
+            mock_warning.assert_called_once()  # Check we logged the Mock Not Allowed
+            self.assertEqual(mock_warning.call_args_list[0][0],
+                             ('Method Not Allowed (%s): %s', 'GET', '/json/remotes/server/register'))
+
 class TestAuthenticatedJsonPostViewDecorator(ZulipTestCase):
     def test_authenticated_json_post_view_if_everything_is_correct(self) -> None:
         user = self.example_user('hamlet')


### PR DESCRIPTION
require_post decorator returns an empty body when POST-only routes
are requested with GET.

Fixes: #16164.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
