### PR TITLE
IP-based rate limiting

### DIFF
--- a/docs/production/mobile-push-notifications.md
+++ b/docs/production/mobile-push-notifications.md
@@ -173,6 +173,20 @@ itself. If your organization does not want to submit these statistics,
 you can disable this feature at any time by setting
 `SUBMIT_USAGE_STATISTICS=False` in `/etc/zulip/settings.py`.
 
+## Rate limits
+
+The Mobile Push Notifications Service API has a very high default rate
+limit of 1000 requests per minute. A Zulip server makes requests to
+this API every time it sends a push notification, which is fairly
+frequent, but we believe it to be unlikely that a self-hosted
+installation will hit this limit.
+
+This limit is primarily intended to protect the service against DoS
+attacks (intentional or otherwise). If you hit this limit or you
+anticipate that your server will require sending more push
+notifications than the limit permits, please [contact
+support](https://zulip.com/help/contact-support).
+
 ## Sending push notifications directly from your server
 
 This section documents an alternative way to send push notifications

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -674,7 +674,7 @@ class RateLimitTestCase(ZulipTestCase):
         self.assertTrue(rate_limit_mock.called)
 
     @skipUnless(settings.ZILENCER_ENABLED, "requires zilencer")
-    def test_rate_limiting_happens_by_ip_if_remote_server(self) -> None:
+    def test_rate_limiting_happens_if_remote_server(self) -> None:
         server_uuid = "1234-abcd"
         server = RemoteZulipServer(
             uuid=server_uuid,
@@ -698,7 +698,7 @@ class RateLimitTestCase(ZulipTestCase):
 
         f = rate_limit()(f)
         with self.settings(RATE_LIMITING=True):
-            with mock.patch("zerver.decorator.rate_limit_ip") as rate_limit_mock:
+            with mock.patch("zerver.decorator.rate_limit_remote_server") as rate_limit_mock:
                 with self.errors_disallowed():
                     self.assertEqual(f(req), "some value")
 

--- a/zerver/tests/test_rate_limiter.py
+++ b/zerver/tests/test_rate_limiter.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Tuple, Type
 from unittest import mock
 
 from zerver.lib.rate_limiter import (
+    RateLimitedIPAddr,
     RateLimitedObject,
     RateLimitedUser,
     RateLimiterBackend,
@@ -193,13 +194,18 @@ class TornadoInMemoryRateLimiterBackendTest(RateLimiterBackendBase):
 
     def test_used_in_tornado(self) -> None:
         user_profile = self.example_user("hamlet")
+        ip_addr = "192.168.0.123"
         with self.settings(RUNNING_INSIDE_TORNADO=True):
-            obj = RateLimitedUser(user_profile, domain="api_by_user")
-        self.assertEqual(obj.backend, TornadoInMemoryRateLimiterBackend)
+            user_obj = RateLimitedUser(user_profile, domain="api_by_user")
+            ip_obj = RateLimitedIPAddr(ip_addr, domain="api_by_ip")
+        self.assertEqual(user_obj.backend, TornadoInMemoryRateLimiterBackend)
+        self.assertEqual(ip_obj.backend, TornadoInMemoryRateLimiterBackend)
 
         with self.settings(RUNNING_INSIDE_TORNADO=True):
-            obj = RateLimitedUser(user_profile, domain="some_domain")
-        self.assertEqual(obj.backend, RedisRateLimiterBackend)
+            user_obj = RateLimitedUser(user_profile, domain="some_domain")
+            ip_obj = RateLimitedIPAddr(ip_addr, domain="some_domain")
+        self.assertEqual(user_obj.backend, RedisRateLimiterBackend)
+        self.assertEqual(ip_obj.backend, RedisRateLimiterBackend)
 
     def test_block_access(self) -> None:
         obj = self.create_object("test", [(2, 5)])

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -375,6 +375,9 @@ RATE_LIMITING_RULES = {
     "api_by_user": [
         (60, 200),  # 200 requests max every minute
     ],
+    "api_by_ip": [
+        (60, 100),
+    ],
     "authenticate_by_username": [
         (1800, 5),  # 5 login attempts within 30 minutes
     ],
@@ -389,7 +392,7 @@ RATE_LIMITING_RULES = {
 # which has its own buckets separate from the default backend.
 # In principle, it should be impossible to make requests to tornado that fall into
 # other domains, but we use this list as an extra precaution.
-RATE_LIMITING_DOMAINS_FOR_TORNADO = ["api_by_user"]
+RATE_LIMITING_DOMAINS_FOR_TORNADO = ["api_by_user", "api_by_ip"]
 
 # These ratelimits are also documented publicly at
 # https://zulip.readthedocs.io/en/latest/production/email-gateway.html

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -378,6 +378,9 @@ RATE_LIMITING_RULES = {
     "api_by_ip": [
         (60, 100),
     ],
+    "api_by_remote_server": [
+        (60, 1000),
+    ],
     "authenticate_by_username": [
         (1800, 5),  # 5 login attempts within 30 minutes
     ],

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -262,6 +262,7 @@ SOCIAL_AUTH_SAML_ENABLED_IDPS: Dict[str, SAMLIdPConfigDict] = {
 RATE_LIMITING_RULES: Dict[str, List[Tuple[int, int]]] = {
     "api_by_user": [],
     "api_by_ip": [],
+    "api_by_remote_server": [],
     "authenticate_by_username": [],
     "password_reset_form_by_email": [],
 }

--- a/zproject/test_extra_settings.py
+++ b/zproject/test_extra_settings.py
@@ -261,6 +261,7 @@ SOCIAL_AUTH_SAML_ENABLED_IDPS: Dict[str, SAMLIdPConfigDict] = {
 
 RATE_LIMITING_RULES: Dict[str, List[Tuple[int, int]]] = {
     "api_by_user": [],
+    "api_by_ip": [],
     "authenticate_by_username": [],
     "password_reset_form_by_email": [],
 }


### PR DESCRIPTION
This was way overdue, and it'll be particularly useful now that we're working on Web public views #16131, where we need to rate-limit requests from the entities in some way and we won't have UserProfiles to identify them by.

This applies IP-based rate-limiting for aunauthed requests in the `rate_limit` view decorator, in which we're already applying our UserProfile-based rate-limitng of API requests. Next step would be to remember the various other non-API places in which it might be useful to rate limit actions by IP.