### PR TITLE
message_list: Live update trailing bookend on stream deactivation.

### DIFF
--- a/frontend_tests/node_tests/dispatch.js
+++ b/frontend_tests/node_tests/dispatch.js
@@ -29,6 +29,7 @@ set_global("markdown", {});
 set_global("message_edit", {});
 set_global("message_list", {});
 set_global("muting_ui", {});
+set_global("narrow_state", {});
 set_global("night_mode", {});
 set_global("notifications", {});
 set_global("overlays", {});
@@ -574,10 +575,19 @@ run_test("stream", (override) => {
         override("stream_data.get_sub_by_id", (id) =>
             id === devel_id ? {subscribed: true} : {subscribed: false},
         );
+
+        narrow_state.is_for_stream_id = () => true;
+
+        let updated = false;
+        override("current_msg_list.update_trailing_bookend", () => {
+            updated = true;
+        });
+
         override("stream_list.remove_sidebar_row", stub.f);
         dispatch(event);
         const args = stub.get_args("stream_id");
         assert_same(args.stream_id, devel_id);
+        assert_same(updated, true);
 
         override("settings_org.sync_realm_settings", noop);
         override("stream_list.remove_sidebar_row", noop);

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -307,6 +307,7 @@ run_test("bookend", (override) => {
     override("narrow_state.stream", () => "IceCream");
 
     override("stream_data.is_subscribed", () => true);
+    override("stream_data.get_sub", () => ({invite_only: false}));
 
     global.with_stub((stub) => {
         list.view.render_trailing_bookend = stub.f;
@@ -320,8 +321,6 @@ run_test("bookend", (override) => {
     expected = "translated: You unsubscribed from stream IceCream";
     list.last_message_historical = false;
     override("stream_data.is_subscribed", () => false);
-
-    override("stream_data.get_sub", () => ({invite_only: false}));
 
     global.with_stub((stub) => {
         list.view.render_trailing_bookend = stub.f;

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -236,6 +236,10 @@ class MessageList {
         return i18n.t("You are not subscribed to stream __stream__", {stream: stream_name});
     }
 
+    deactivated_bookend_content() {
+        return i18n.t("This stream has been deactivated");
+    }
+
     // Maintains a trailing bookend element explaining any changes in
     // your subscribed/unsubscribed status at the bottom of the
     // message list.
@@ -251,21 +255,20 @@ class MessageList {
         let trailing_bookend_content;
         let show_button = true;
         const subscribed = stream_data.is_subscribed(stream_name);
-        if (subscribed) {
+        const sub = stream_data.get_sub(stream_name);
+        if (sub === undefined) {
+            trailing_bookend_content = this.deactivated_bookend_content();
+            // Hide the resubscribe button for streams that no longer exist.
+            show_button = false;
+        } else if (subscribed) {
             trailing_bookend_content = this.subscribed_bookend_content(stream_name);
         } else {
             if (!this.last_message_historical) {
                 trailing_bookend_content = this.unsubscribed_bookend_content(stream_name);
 
-                // For invite only streams or streams that no longer
-                // exist, hide the resubscribe button
+                // For invite only streams hide the resubscribe button
                 // Hide button for guest users
-                const sub = stream_data.get_sub(stream_name);
-                if (sub !== undefined) {
-                    show_button = !page_params.is_guest && !sub.invite_only;
-                } else {
-                    show_button = false;
-                }
+                show_button = !page_params.is_guest && !sub.invite_only;
             } else {
                 trailing_bookend_content = this.not_subscribed_bookend_content(stream_name);
             }

--- a/static/js/server_events_dispatch.js
+++ b/static/js/server_events_dispatch.js
@@ -292,6 +292,7 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
             } else if (event.op === "delete") {
                 for (const stream of event.streams) {
                     const was_subscribed = stream_data.get_sub_by_id(stream.stream_id).subscribed;
+                    const is_narrowed_to_stream = narrow_state.is_for_stream_id(stream.stream_id);
                     subs.remove_stream(stream.stream_id);
                     stream_data.delete_sub(stream.stream_id);
                     if (was_subscribed) {
@@ -299,6 +300,9 @@ exports.dispatch_normal_event = function dispatch_normal_event(event) {
                     }
                     settings_streams.update_default_streams_table();
                     stream_data.remove_default_stream(stream.stream_id);
+                    if (is_narrowed_to_stream) {
+                        current_msg_list.update_trailing_bookend();
+                    }
                     if (page_params.realm_notifications_stream_id === stream.stream_id) {
                         page_params.realm_notifications_stream_id = -1;
                         settings_org.sync_realm_settings("notifications_stream_id");


### PR DESCRIPTION
We were not updating the trailing bookend on deactivation of stream
if the user was narrowed to deactivated stream and this commit fixes
this.

For subscribed streams, we just show the trailing bookend with
content as 'This stream has been deactivated' and hide the
Unsubscribe button.

For unsubscribed streams, we change the content of trailing bookend
to 'This stream has been deactivated' and hide the Subscribe button.

Fixes #15999.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? --> Tested manually in the development environment.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![trailing-bookend](https://user-images.githubusercontent.com/35494118/90967339-8f47e800-e4fb-11ea-983a-b43b6c751a76.gif)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
