### PR TITLE
queue: Use locking to avoid race conditions in missedmessage_emails.

### DIFF
--- a/zerver/tests/test_queue_worker.py
+++ b/zerver/tests/test_queue_worker.py
@@ -188,9 +188,6 @@ class WorkerTest(ZulipTestCase):
             def start(self) -> None:
                 self.is_running = True
 
-            def cancel(self) -> None:
-                self.is_running = False
-
         timer = MockTimer()
         loopworker_sleep_mock = patch(
             'zerver.worker.queue_processors.Timer',
@@ -223,7 +220,7 @@ class WorkerTest(ZulipTestCase):
                     'INFO:root:Batch-processing 1 missedmessage_emails events for user 12'
                 ])
 
-                self.assertFalse(timer.is_alive())
+                self.assertEqual(mmw.timer_event, None)
 
         self.assertEqual(tm.call_args[0][0], 5)  # should sleep 5 seconds
 

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -466,45 +466,42 @@ class MissedMessageWorker(QueueProcessingWorker):
     TIMER_FREQUENCY = 5
     BATCH_DURATION = 120
     timer_event: Optional[Timer] = None
-    lock = Lock()
     events_by_recipient: Dict[int, List[Dict[str, Any]]] = defaultdict(list)
     batch_start_by_recipient: Dict[int, float] = {}
 
+    # This lock protects access to all of the data structures declared
+    # above.  A lock is required because maybe_send_batched_emails, as
+    # the argument to Timer, runs in a separate thread from the rest
+    # of the consumer.
+    lock = Lock()
+
     def consume(self, event: Dict[str, Any]) -> None:
-        logging.debug("Received missedmessage_emails event: %s", event)
+        with self.lock:
+            logging.debug("Received missedmessage_emails event: %s", event)
 
-        # When we process an event, just put it into the queue and ensure we have a timer going.
-        user_profile_id = event['user_profile_id']
-        if user_profile_id not in self.batch_start_by_recipient:
-            self.batch_start_by_recipient[user_profile_id] = time.time()
-        self.events_by_recipient[user_profile_id].append(event)
+            # When we process an event, just put it into the queue and ensure we have a timer going.
+            user_profile_id = event['user_profile_id']
+            if user_profile_id not in self.batch_start_by_recipient:
+                self.batch_start_by_recipient[user_profile_id] = time.time()
+            self.events_by_recipient[user_profile_id].append(event)
 
-        self.ensure_timer()
+            self.ensure_timer()
 
     def ensure_timer(self) -> None:
-        # We don't want to block the consume() function if the lock is being held
-        # by the maybe_send_batched_emails thread, as that would stop consumption
-        # of new events until all the batches are sent out - which would be exactly
-        # the opposite of the intended purpose of the design of this queue worker.
-        if not self.lock.acquire(blocking=False):
+        # The caller is responsible for ensuring self.lock is held when it calls this.
+        if self.timer_event is not None:
             return
 
-        try:
-            if self.timer_event is not None:
-                return
-
-            self.timer_event = Timer(self.TIMER_FREQUENCY, MissedMessageWorker.maybe_send_batched_emails,
-                                     [self])
-            self.timer_event.start()
-        finally:
-            self.lock.release()
+        self.timer_event = Timer(self.TIMER_FREQUENCY, MissedMessageWorker.maybe_send_batched_emails,
+                                 [self])
+        self.timer_event.start()
 
     def maybe_send_batched_emails(self) -> None:
         with self.lock:
-            # self.timer_event just triggered execution of this function in a thread, so now
-            # that we hold the lock we clear the attribute to signal
-            # that no Timer is active, so a new one can be set (once the setter acquires the lock)
-            # if there are more events to process.
+            # self.timer_event just triggered execution of this
+            # function in a thread, so now that we hold the lock, we
+            # clear the timer_event attribute to record that no Timer
+            # is active.
             self.timer_event = None
 
             current_time = time.time()
@@ -518,11 +515,12 @@ class MissedMessageWorker(QueueProcessingWorker):
                 del self.events_by_recipient[user_profile_id]
                 del self.batch_start_by_recipient[user_profile_id]
 
-        # By only restarting the timer if there are actually events in
-        # the queue, we ensure this queue processor is idle when there
-        # are no missed-message emails to process.
-        if len(self.batch_start_by_recipient) > 0:
-            self.ensure_timer()
+            # By only restarting the timer if there are actually events in
+            # the queue, we ensure this queue processor is idle when there
+            # are no missed-message emails to process.  This avoids
+            # constant CPU usage when there is no work to do.
+            if len(self.batch_start_by_recipient) > 0:
+                self.ensure_timer()
 
 @assign_queue('email_senders')
 class EmailSendingWorker(QueueProcessingWorker):


### PR DESCRIPTION
This queue had a race condition with creation of another Timer while
maybe_send_batched_emails is still doing its work, which may cause
two or more threads to be running maybe_send_batched_emails
at the same time, mutating the shared data simultaneously.

Another less likely potential race condition was that
maybe_send_batched_emails after sending out its email, can call
ensure_timer(). If the consume function is run simultaneously
in the main thread, it will call ensure_timer() too, which,
given unfortunate timings, might lead to both calls setting a new Timer.

We add locking to the queue to avoid such race conditions.

Tested manually, by print debugging with the following setup:
1. Making handle_missedmessage_emails sleep 2 seconds for each email,
   and changed BATCH_DURATION to 1s to make the queue start working
   right after launching.
2. Putting a bunch of events in the queue.
3. ./manage.py process_queue --queue_name missedmessage_emails
4. Once maybe_send_batched_emails is called and while it's processing
the events, I pushed more events to the queue. That triggers the
consume() function and ensure_timer().

Before implementing the locking mechanism, this causes two threads
to run maybe_send_batched_emails at the same time, mutating each other's
shared data, causing a traceback such as

Exception in thread Thread-3:
Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.6/threading.py", line 1182, in run
    self.function(*self.args, **self.kwargs)
  File "/srv/zulip/zerver/worker/queue_processors.py", line 507, in maybe_send_batched_emails
    del self.events_by_recipient[user_profile_id]
KeyError: '5'

With the locking mechanism, things get handled as expected, and
ensure_timer() exits if it can't obtain the lock due to
maybe_send_batched_emails still working.
