### PR TITLE
navbar_alerts: Fix close button position.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -243,6 +243,7 @@ p.n-margin {
 
 #panels {
     font-size: 1rem;
+    position: relative;
 
     .alert {
         margin: 0;
@@ -266,6 +267,10 @@ p.n-margin {
 
         .close {
             line-height: 24px;
+            position: absolute;
+            right: 18px;
+            top: 50%;
+            transform: translateY(-50%);
         }
 
         .alert-link {


### PR DESCRIPTION
Fixes the position of close button in navbar alerts which seemed to
be shifted towards the bottom and wasn't visible completely.

Issue introduced in #16089.

**GIFs or Screenshots:**
 
Before changes
![Screenshot_2020-08-23 (4258) frontend - Zulip Community - Zulip](https://user-images.githubusercontent.com/39924567/91151522-641bef00-e6db-11ea-8526-c666d6ddca37.png)

After Changes
![Screenshot_2020-08-25 home - Zulip Dev - Zulip](https://user-images.githubusercontent.com/39924567/91151545-6bdb9380-e6db-11ea-843a-674b465496ba.png)
