### PR TITLE
scss: Fix misaligned close icon on notification alert panel.

### DIFF
--- a/static/styles/zulip.scss
+++ b/static/styles/zulip.scss
@@ -266,6 +266,9 @@ p.n-margin {
 
         .close {
             line-height: 24px;
+            position: fixed;
+            top: 12px;
+            right: 30px;
         }
 
         .alert-link {


### PR DESCRIPTION
Right now:
<img width="1411" alt="Screenshot 2020-08-25 at 8 41 01 PM" src="https://user-images.githubusercontent.com/25124304/91192268-5bdfa600-e713-11ea-9a98-2ed81a9de1ac.png">


Corrected Version:
<img width="1442" alt="Screenshot 2020-08-25 at 8 38 55 PM" src="https://user-images.githubusercontent.com/25124304/91192129-36529c80-e713-11ea-9409-faab025d77d5.png">
