### PR TITLE
fixed horizontal scrolling of table when overflow.

### DIFF
--- a/static/styles/rendered_markdown.scss
+++ b/static/styles/rendered_markdown.scss
@@ -83,6 +83,10 @@
         padding-right: 10px;
         margin: 5px 5px 5px 5px;
         width: 99%;
+        display: block;
+        max-width: fit-content;
+        overflow-x: auto;
+        white-space: nowrap;
     }
 
     thead {


### PR DESCRIPTION
https://github.com/zulip/zulip/issues/15865
close #15865

Fixed the horizontal scroll bar for a table on overflow by adding a overflow-x property to the style of the page.

Image after fix :

![issue-fix](https://user-images.githubusercontent.com/56037184/91321594-6b76f180-e7dc-11ea-96b9-edf389b339fe.png)
