### PR TITLE
i18n: Fix translation bug in stream creation page.

### DIFF
--- a/static/templates/stream_types.hbs
+++ b/static/templates/stream_types.hbs
@@ -36,7 +36,7 @@
             <select name="stream_message_retention_setting"
               class="stream_message_retention_setting" class="prop-element"
               {{#if disable_message_retention_setting}}disabled{{/if}}>
-                <option value="realm_default">{{t 'Use organization level settings '}}{{realm_message_retention_setting}} </option>
+                <option value="realm_default">{{t 'Use organization level settings' }} {{realm_message_retention_setting}}</option>
                 <option value="forever">{{t 'Retain forever' }}</option>
                 <option value="retain_for_period">{{t 'Retain for N days after posting' }}</option>
             </select>


### PR DESCRIPTION
This change fixes a translation bug that prevented a string in the message retention dropdown options from getting translation.
Removing the space properly matched the string with the translated strings.

[Relevant conversation on CZO](https://chat.zulip.org/#narrow/stream/58-translation/topic/Missing.20string.3F/near/993120)

**GIFs or Screenshots:**

![Screenshot_2](https://user-images.githubusercontent.com/25329595/91453646-a5f49300-e89d-11ea-938c-1e13dcd910b6.png)
