### PR TITLE
rate_limit: Handle the case of request.user being a RemoteZulipServer.

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -789,7 +789,7 @@ def rate_limit(domain: str='api_by_user') -> Callable[[ViewFuncT], ViewFuncT]:
 
             user = request.user
 
-            if isinstance(user, AnonymousUser):  # nocoverage
+            if isinstance(user, AnonymousUser) or isinstance(user, RemoteZulipServer):
                 # We can only rate-limit logged-in users for now.
                 # We also only support rate-limiting authenticated
                 # views right now.


### PR DESCRIPTION
For now we can just skip rate limiting for this case and rate limit by
the server uuid or simply by IP in a follow-up.