### PR TITLE
Make /accounts/go respect #hash in the URL

### DIFF
--- a/templates/zerver/faq.html
+++ b/templates/zerver/faq.html
@@ -23,7 +23,7 @@
                 <p class="answer">
                     You can request sponsorship during
                     <a href="/new">organization creation</a>, in an organization's
-                    <a href="/accounts/go/?next=/upgrade%23sponsorship">billing page</a>, or contact us at
+                    <a href="/upgrade/#sponsorship">billing page</a>, or contact us at
                     <a href="mailto:sales@zulip.com">sales@zulip.com</a>
                 </p>
                 <p class="answer">

--- a/templates/zerver/realm_redirect.html
+++ b/templates/zerver/realm_redirect.html
@@ -10,9 +10,7 @@
 
         <div class="app-main goto-account-page-container white-box">
             <div class="realm-redirect-form">
-                <form class="form-inline" name="realm_redirect_form"
-                  action="/accounts/go/{% if request.GET %}?{{ request.GET.urlencode() }}{% endif %}" method="post">
-                    {{ csrf_input }}
+                <form class="form-inline" name="realm_redirect_form" method="get">
                     <div class="input-box moving-label horizontal">
                         <div class="inline-block relative">
                             <p id="realm_redirect_description">{{ _("Enter your organization's Zulip URL:") }}</p>
@@ -20,6 +18,7 @@
                               type="text" value="{% if form.subdomain.value() %}{{ form.subdomain.value() }}{% endif %}"
                               placeholder="{{ _('your-organization-url') }}" autofocus id="realm_redirect_subdomain" name="subdomain"
                               autocomplete="off" required/>
+                            <input type="hidden" name="next" value="{{ request.GET.get('next', '') }}" />
                             <span id="realm_redirect_external_host">.{{external_host}}</span>
                         </div>
                         <div id="errors">

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -4326,17 +4326,17 @@ class RealmRedirectTest(ZulipTestCase):
         result = self.client_get("/accounts/go/")
         self.assert_in_success_response(["Enter your organization's Zulip URL"], result)
 
-        result = self.client_post("/accounts/go/", {"subdomain": "zephyr"})
+        result = self.client_get("/accounts/go/", {"subdomain": "zephyr"})
         self.assertEqual(result.status_code, 302)
         self.assertEqual(result["Location"], "http://zephyr.testserver")
 
-        result = self.client_post("/accounts/go/", {"subdomain": "invalid"})
+        result = self.client_get("/accounts/go/", {"subdomain": "invalid"})
         self.assert_in_success_response(["We couldn&#39;t find that Zulip organization."], result)
 
     def test_realm_redirect_with_next_param(self) -> None:
         result = self.client_get("/accounts/go/?next=billing")
-        self.assert_in_success_response(["Enter your organization's Zulip URL", 'action="/accounts/go/?next=billing"'], result)
+        self.assert_in_success_response(["Enter your organization's Zulip URL", 'name="next" value="billing"'], result)
 
-        result = self.client_post("/accounts/go/?next=billing", {"subdomain": "lear"})
+        result = self.client_get("/accounts/go/", {"subdomain": "lear", "next": "billing"})
         self.assertEqual(result.status_code, 302)
         self.assertEqual(result["Location"], "http://lear.testserver/billing")

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -644,8 +644,8 @@ def find_account(request: HttpRequest) -> HttpResponse:
                            'emails': emails})
 
 def realm_redirect(request: HttpRequest) -> HttpResponse:
-    if request.method == 'POST':
-        form = RealmRedirectForm(request.POST)
+    if request.GET.get('subdomain', None):
+        form = RealmRedirectForm(request.GET)
         if form.is_valid():
             subdomain = form.cleaned_data['subdomain']
             realm = get_realm(subdomain)


### PR DESCRIPTION
Before, if a user opens https://zulipchat.com/upgrade#sponsorship, they would be redirected to https://zulipchat.com/accounts/go/?next=%2Fupgrade%2F#sponsorship.

Once the user enters the subdomain, they would be redirected to https://realm.zulipchat.com/upgrade and not https://realm.zulipchat.com/upgrade#sponsorship. The #hash used to be missing.

The reason behind this was we used to explicitly specify the value of action attribute of the form. This resulted in the browser ignoring the #hash present in the URL, when it was redirected to the realm after the POST request.

I also changed the method of this form from POST to GET since this is an idempotent request.

Followup of https://github.com/zulip/zulip/pull/16181
