### PR TITLE
events: Add documentation and tests for `typing: stop` event.

### DIFF
--- a/zerver/lib/event_schema.py
+++ b/zerver/lib/event_schema.py
@@ -669,6 +669,15 @@ check_typing_start = check_events_dict(
     ]
 )
 
+check_typing_stop = check_events_dict(
+    required_keys=[
+        ("type", equals("typing")),
+        ("op", equals("stop")),
+        ("sender", _check_typing_person),
+        ("recipients", check_list(_check_typing_person)),
+    ]
+)
+
 _check_update_display_settings = check_events_dict(
     required_keys=[
         ("type", equals("update_display_settings")),

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1962,7 +1962,9 @@ paths:
                               additionalProperties: false
                               description: |
                                 Event sent when a user starts typing a private or group private message. Sent
-                                to all clients for users who would receive the message being typed.
+                                to all clients for users who would receive the message being typed. It should
+                                be noted that clients should set their own timeouts to stop the typing status
+                                incase `typing: stop` event is not received.
                               properties:
                                 id:
                                   type: integer
@@ -2013,6 +2015,79 @@ paths:
                                 {
                                   "type": "typing",
                                   "op": "start",
+                                  "sender":
+                                    {
+                                      "user_id": 10,
+                                      "email": "user10@zulip.testserver",
+                                    },
+                                  "recipients":
+                                    [
+                                      {
+                                        "user_id": 8,
+                                        "email": "user8@zulip.testserver",
+                                      },
+                                      {
+                                        "user_id": 10,
+                                        "email": "user10@zulip.testserver",
+                                      },
+                                    ],
+                                  "id": 0,
+                                }
+                            - type: object
+                              additionalProperties: false
+                              description: |
+                                Event sent when a user stops typing a private or group private message. Sent
+                                to all clients for users who would receive the message being typed.
+                              properties:
+                                id:
+                                  type: integer
+                                type:
+                                  type: string
+                                  enum:
+                                    - typing
+                                op:
+                                  type: string
+                                  enum:
+                                    - stop
+                                sender:
+                                  additionalProperties: false
+                                  type: object
+                                  description: |
+                                    Object containing user id and email of the sender i.e
+                                    the user who has stopped typing.
+                                  properties:
+                                    user_id:
+                                      type: integer
+                                      description: |
+                                        The ID of the user.
+                                    email:
+                                      type: string
+                                      description: |
+                                        The Zulip display email address for the user.
+                                recipients:
+                                  type: array
+                                  description: |
+                                    Array of dictionaries, where each dictionary contains the
+                                    email and user_id of a single user who will receive the
+                                    typed message.
+                                  items:
+                                    type: object
+                                    additionalProperties: false
+                                    description: |
+                                      Object containing the user id and email of a recipient.
+                                    properties:
+                                      user_id:
+                                        type: integer
+                                        description: |
+                                          The ID of the user.
+                                      email:
+                                        type: string
+                                        description: |
+                                          The Zulip display email address for the user.
+                              example:
+                                {
+                                  "type": "typing",
+                                  "op": "stop",
                                   "sender":
                                     {
                                       "user_id": 10,

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -114,6 +114,7 @@ from zerver.lib.event_schema import (
     check_subscription_peer_remove,
     check_subscription_remove,
     check_typing_start,
+    check_typing_stop,
     check_update_display_settings,
     check_update_global_notifications,
     check_update_message,
@@ -632,6 +633,12 @@ class NormalActionsTest(BaseAction):
             state_change_expected=False,
         )
         check_typing_start('events[0]', events[0])
+        events = self.verify_action(
+            lambda: check_send_typing_notification(
+                self.user_profile, [self.example_user("cordelia").id], "stop"),
+            state_change_expected=False,
+        )
+        check_typing_stop('events[0]', events[0])
 
     def test_custom_profile_fields_events(self) -> None:
         events = self.verify_action(


### PR DESCRIPTION
The `typing: stop` event did not have any tests in test_events
hence its documentation wasn't added. So add tests and relevant
documentation for the typing stop event. Also edit the documentation
of `typing: start` to include the fact that servers should use
their own timeout incase `stop` event event isn't received.

Fixes #16122 .