### PR TITLE
Remove unittest.mock.Mock uses from production code; make tests pass with zilencer disabled

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -52,14 +52,8 @@ from zerver.lib.user_agent import parse_user_agent
 from zerver.lib.utils import has_api_key_format, statsd
 from zerver.models import Realm, UserProfile, get_client, get_user_profile_by_api_key
 
-# This is a hack to ensure that RemoteZulipServer always exists even
-# if Zilencer isn't enabled.
 if settings.ZILENCER_ENABLED:
     from zilencer.models import RemoteZulipServer, get_remote_server_by_uuid
-else:  # nocoverage # Hack here basically to make impossible code paths compile
-    from unittest.mock import Mock
-    get_remote_server_by_uuid = Mock()
-    RemoteZulipServer = Mock()  # type: ignore[misc] # https://github.com/JukkaL/mypy/issues/1188
 
 webhook_logger = logging.getLogger("zulip.zerver.webhooks")
 log_to_file(webhook_logger, settings.API_KEY_ONLY_WEBHOOK_LOG_PATH)
@@ -204,7 +198,7 @@ class InvalidZulipServerKeyError(InvalidZulipServerError):
 
 def validate_api_key(request: HttpRequest, role: Optional[str],
                      api_key: str, is_webhook: bool=False,
-                     client_name: Optional[str]=None) -> Union[UserProfile, RemoteZulipServer]:
+                     client_name: Optional[str]=None) -> Union[UserProfile, "RemoteZulipServer"]:
     # Remove whitespace to protect users from trivial errors.
     api_key = api_key.strip()
     if role is not None:

--- a/zerver/lib/push_notifications.py
+++ b/zerver/lib/push_notifications.py
@@ -40,11 +40,8 @@ logger = logging.getLogger(__name__)
 
 if settings.ZILENCER_ENABLED:
     from zilencer.models import RemotePushDeviceToken
-else:  # nocoverage  -- Not convenient to add test for this.
-    from unittest.mock import Mock
-    RemotePushDeviceToken = Mock()  # type: ignore[misc] # https://github.com/JukkaL/mypy/issues/1188
 
-DeviceToken = Union[PushDeviceToken, RemotePushDeviceToken]
+DeviceToken = Union[PushDeviceToken, "RemotePushDeviceToken"]
 
 # We store the token as b64, but apns-client wants hex strings
 def b64_to_hex(data: str) -> str:
@@ -123,6 +120,7 @@ def send_apple_push_notification(user_id: int, devices: List[DeviceToken],
         return
 
     if remote:
+        assert settings.ZILENCER_ENABLED
         DeviceTokenClass = RemotePushDeviceToken
     else:
         DeviceTokenClass = PushDeviceToken
@@ -291,6 +289,7 @@ def send_android_push_notification(devices: List[DeviceToken], data: Dict[str, A
             logger.info("GCM: Sent %s as %s", reg_id, msg_id)
 
     if remote:
+        assert settings.ZILENCER_ENABLED
         DeviceTokenClass = RemotePushDeviceToken
     else:
         DeviceTokenClass = PushDeviceToken

--- a/zerver/lib/test_classes.py
+++ b/zerver/lib/test_classes.py
@@ -72,7 +72,9 @@ from zerver.models import (
 )
 from zerver.openapi.openapi import validate_against_openapi_schema, validate_request
 from zerver.tornado.event_queue import clear_client_event_queues_for_testing
-from zilencer.models import get_remote_server_by_uuid
+
+if settings.ZILENCER_ENABLED:
+    from zilencer.models import get_remote_server_by_uuid
 
 
 class UploadSerializeMixin(SerializeMixin):

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -3,7 +3,7 @@ import os
 import re
 from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Tuple
-from unittest import mock
+from unittest import mock, skipUnless
 
 import orjson
 from django.conf import settings
@@ -78,7 +78,9 @@ from zerver.lib.validator import (
 )
 from zerver.lib.webhooks.common import UnexpectedWebhookEventType
 from zerver.models import Realm, UserProfile, get_realm, get_user
-from zilencer.models import RemoteZulipServer
+
+if settings.ZILENCER_ENABLED:
+    from zilencer.models import RemoteZulipServer
 
 
 class DecoratorTestCase(ZulipTestCase):
@@ -708,6 +710,7 @@ class RateLimitTestCase(ZulipTestCase):
 
         self.assertTrue(rate_limit_mock.called)
 
+    @skipUnless(settings.ZILENCER_ENABLED, "requires zilencer")
     def test_rate_limiting_skipped_if_remote_server(self) -> None:
         server_uuid = "1234-abcd"
         server = RemoteZulipServer(uuid=server_uuid,

--- a/zerver/tests/test_docs.py
+++ b/zerver/tests/test_docs.py
@@ -1,6 +1,6 @@
 import os
 from typing import Any, Dict, Sequence
-from unittest import mock
+from unittest import mock, skipUnless
 from urllib.parse import urlsplit
 
 import orjson
@@ -123,11 +123,13 @@ class DocPageTest(ZulipTestCase):
         self._test('/api/subscribe', 'authorization_errors_fatal')
         self._test('/api/create-user', 'zuliprc-admin')
         self._test('/api/unsubscribe', 'not_removed')
-        self._test('/team/', 'industry veterans')
+        if settings.ZILENCER_ENABLED:
+            self._test('/team/', 'industry veterans')
         self._test('/history/', 'Cambridge, Massachusetts')
         # Test the i18n version of one of these pages.
         self._test('/en/history/', 'Cambridge, Massachusetts')
-        self._test('/apps/', 'Apps for every platform.')
+        if settings.ZILENCER_ENABLED:
+            self._test('/apps/', 'Apps for every platform.')
         self._test('/features/', 'Beautiful messaging')
         self._test('/hello/', 'Chat for distributed teams', landing_missing_strings=["Login"])
         self._test('/why-zulip/', 'Why Zulip?')
@@ -325,6 +327,7 @@ class IntegrationTest(ZulipTestCase):
             '<a target="_blank" href="/#streams">streams page</a>')
 
 class AboutPageTest(ZulipTestCase):
+    @skipUnless(settings.ZILENCER_ENABLED, "requires zilencer")
     def test_endpoint(self) -> None:
         with self.settings(CONTRIBUTOR_DATA_FILE_PATH="zerver/tests/fixtures/authors.json"):
             result = self.client_get('/team/')

--- a/zerver/tests/test_push_notifications.py
+++ b/zerver/tests/test_push_notifications.py
@@ -5,7 +5,7 @@ import os
 import uuid
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator, List, Optional
-from unittest import mock
+from unittest import mock, skipUnless
 from unittest.mock import call
 
 import orjson
@@ -74,16 +74,19 @@ from zerver.models import (
     receives_online_notifications,
     receives_stream_notifications,
 )
-from zilencer.models import (
-    RemoteInstallationCount,
-    RemotePushDeviceToken,
-    RemoteRealmAuditLog,
-    RemoteRealmCount,
-    RemoteZulipServer,
-)
+
+if settings.ZILENCER_ENABLED:
+    from zilencer.models import (
+        RemoteInstallationCount,
+        RemotePushDeviceToken,
+        RemoteRealmAuditLog,
+        RemoteRealmCount,
+        RemoteZulipServer,
+    )
 
 ZERVER_DIR = os.path.dirname(os.path.dirname(__file__))
 
+@skipUnless(settings.ZILENCER_ENABLED, "requires zilencer")
 class BouncerTestCase(ZulipTestCase):
     def setUp(self) -> None:
         self.server_uuid = "1234-abcd"
@@ -2123,6 +2126,7 @@ class TestPushNotificationsContent(ZulipTestCase):
             actual_output = get_mobile_push_content(test["rendered_content"])
             self.assertEqual(actual_output, test["expected_output"])
 
+@skipUnless(settings.ZILENCER_ENABLED, "requires zilencer")
 class PushBouncerSignupTest(ZulipTestCase):
     def test_push_signup_invalid_host(self) -> None:
         zulip_org_id = str(uuid.uuid4())


### PR DESCRIPTION
`unittest.mock.Mock` is somewhat expensive to import and confuses mypy. This reduces our `type: ignore` count from 15 to 10.

**Testing Plan:** Dev server; `test-backend` with `zilencer` manually removed from `EXTRA_INSTALLED_APPS`.