### PR TITLE
sentry: Ignore SuspiciousOperation exceptions themselves.

### DIFF
--- a/zproject/sentry.py
+++ b/zproject/sentry.py
@@ -48,6 +48,7 @@ def setup_sentry(dsn: Optional[str], *integrations: Integration) -> None:
 
     # Ignore all of the loggers from django.security that are for user
     # errors; see https://docs.djangoproject.com/en/3.0/ref/exceptions/#suspiciousoperation
+    ignore_logger("django.security.SuspiciousOperation")
     ignore_logger("django.security.DisallowedHost")
     ignore_logger("django.security.DisallowedModelAdminLookup")
     ignore_logger("django.security.DisallowedModelAdminToField")


### PR DESCRIPTION
596cf2580b ignored the loggers of all SuspiciousOperation subclasses,
but not SuspiciousOperation itself.  Almost all locations raise one of
the more specific subclasses, with the exception of one location in
the session middleware[1].

Ignore the overall django.security.SuspiciousOperation logger as well.

[1] https://code.djangoproject.com/ticket/31962
