### PR TITLE
Fixed confusing terminology In Users Tab

### DIFF
--- a/frontend_tests/node_tests/buddy_data.js
+++ b/frontend_tests/node_tests/buddy_data.js
@@ -232,13 +232,13 @@ run_test("title_data", () => {
     let expected_data = {
         first_line: "Human Myself",
         second_line: "out to lunch",
-        third_line: "translated: Active now",
+        third_line: "translated: Online now",
     };
     assert.deepEqual(buddy_data.get_title_data(me.user_id, is_group), expected_data);
 
     expected_data = {
         first_line: "Old User",
-        second_line: "translated: Last active: translated: More than 2 weeks ago",
+        second_line: "translated: Last online: translated: More than 2 weeks ago",
         third_line: "",
     };
     assert.deepEqual(buddy_data.get_title_data(old_user.user_id, is_group), expected_data);
@@ -319,7 +319,7 @@ run_test("level", () => {
 });
 
 run_test("user_last_seen_time_status", () => {
-    assert.equal(buddy_data.user_last_seen_time_status(selma.user_id), "translated: Active now");
+    assert.equal(buddy_data.user_last_seen_time_status(selma.user_id), "translated: Online now");
 
     page_params.realm_is_zephyr_mirror_realm = true;
     assert.equal(buddy_data.user_last_seen_time_status(old_user.user_id), "translated: Unknown");

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -154,7 +154,7 @@ exports.my_user_status = function (user_id) {
 exports.user_last_seen_time_status = function (user_id) {
     const status = presence.get_status(user_id);
     if (status === "active") {
-        return i18n.t("Active now");
+        return i18n.t("Online now");
     }
 
     if (page_params.realm_is_zephyr_mirror_realm) {
@@ -198,7 +198,7 @@ function get_last_seen(active_status, last_seen) {
         return last_seen;
     }
 
-    const last_seen_text = i18n.t("Last active: __last_seen__", {last_seen});
+    const last_seen_text = i18n.t("Last online: __last_seen__", {last_seen});
     return last_seen_text;
 }
 


### PR DESCRIPTION
Fixes #16178 

<strong>Screenshots :</strong>

![Screenshot from 2020-08-29 14-15-20](https://user-images.githubusercontent.com/53977614/91633048-defa4800-ea02-11ea-9235-63a660a3e19c.png)         ![Screenshot from 2020-08-29 14-15-25](https://user-images.githubusercontent.com/53977614/91633050-e15ca200-ea02-11ea-88c6-fa08782975f9.png)

Edit  : Also as discussed within the topic <a href = 'https://chat.zulip.org/#narrow/stream/101-design/topic/confusing.20status.20terminology.20.2316178'>here</a> , Would love to know the exact replacement of term <code>"(unavailable)"</code> so as to make according changes <a href = 'https://github.com/zulip/zulip/blob/master/static/js/buddy_data.js#L148'>here</a> .
