### PR TITLE
puppeteer: Fix flakes related to settings tests.

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const rewiremock = require("rewiremock/node");
+
 set_global("$", global.make_zjquery());
 
 const noop = () => {};
@@ -77,7 +79,11 @@ set_global("list_render", _list_render);
 const settings_config = zrequire("settings_config");
 const settings_bots = zrequire("settings_bots");
 zrequire("stream_data");
-zrequire("settings_account");
+rewiremock.proxy(() => zrequire("settings_account"), {
+    // Setup is only imported to set the
+    // setup.password_change_in_progress flag.
+    "../../static/js/setup": {},
+});
 zrequire("settings_org");
 zrequire("settings_ui");
 zrequire("dropdown_list_widget");

--- a/frontend_tests/puppeteer_tests/16-settings.js
+++ b/frontend_tests/puppeteer_tests/16-settings.js
@@ -286,6 +286,7 @@ async function test_default_language_setting(page) {
     await page.waitForSelector("#default_language", {visible: true});
     await assert_language_changed_to_chinese(page);
     await test_i18n_language_precedence(page);
+    await page.waitForSelector(display_settings_section, {visible: true});
     await page.click(display_settings_section);
 
     // Change the language back to English so that subsequent tests pass.

--- a/frontend_tests/puppeteer_tests/16-settings.js
+++ b/frontend_tests/puppeteer_tests/16-settings.js
@@ -270,7 +270,7 @@ async function assert_language_changed_to_chinese(page) {
 async function test_i18n_language_precedence(page) {
     const settings_url_for_german = "http://zulip.zulipdev.com:9981/de/#settings";
     await page.goto(settings_url_for_german);
-    await page.waitForSelector("#settings-change-box");
+    await page.waitForSelector("#settings-change-box", {visible: true});
     const page_language_code = await page.evaluate(() => document.documentElement.lang);
     assert.strictEqual(page_language_code, "de");
 }
@@ -295,7 +295,7 @@ async function test_default_language_setting(page) {
     // As we've opened settings page in German the language status will be german.
     await check_language_setting_status(page, "de");
     await page.goto("http://zulip.zulipdev.com:9981/#settings"); // get back to normal language.
-    await page.waitForSelector(display_settings_section);
+    await page.waitForSelector(display_settings_section, {visible: true});
     await page.click(display_settings_section);
     await page.waitForSelector("#language-settings-status", {visible: true});
     await page.waitForSelector("#default_language", {visible: true});

--- a/static/js/settings_account.js
+++ b/static/js/settings_account.js
@@ -6,6 +6,8 @@ const render_settings_api_key_modal = require("../templates/settings/api_key_mod
 const render_settings_custom_user_profile_field = require("../templates/settings/custom_user_profile_field.hbs");
 const render_settings_dev_env_email_access = require("../templates/settings/dev_env_email_access.hbs");
 
+const setup = require("./setup");
+
 exports.update_email = function (new_email) {
     const email_input = $("#email_value");
 
@@ -445,9 +447,14 @@ exports.set_up = function () {
             }
         }
 
+        setup.password_change_in_progress = true;
         const opts = {
             success_continuation() {
+                setup.password_change_in_progress = false;
                 overlays.close_modal("#change_password_modal");
+            },
+            error_continuation() {
+                setup.password_change_in_progress = false;
             },
             error_msg_element: change_password_error,
         };

--- a/static/js/setup.js
+++ b/static/js/setup.js
@@ -1,8 +1,9 @@
 "use strict";
 
 const util = require("./util");
-// Miscellaneous early setup.
 
+// Miscellaneous early setup.
+exports.password_change_in_progress = false;
 $(() => {
     if (util.is_mobile()) {
         // Disable the tutorial; it's ugly on mobile.
@@ -35,7 +36,11 @@ $(() => {
 
     // For some reason, jQuery wants this to be attached to an element.
     $(document).ajaxError((event, xhr) => {
-        if (xhr.status === 401) {
+        // Don't redirect to the login page when a password change
+        // is in progress. Since 401 in that process means this is
+        // a race condition caused by a request that was made just
+        // before the session hash was updated in the backend.
+        if (xhr.status === 401 && !exports.password_change_in_progress) {
             // We got logged out somehow, perhaps from another window or a session timeout.
             // We could display an error message, but jumping right to the login page seems
             // smoother and conveys the same information.


### PR DESCRIPTION
This handles a rare race condition that occurs when the session hash
is not updated by the backend during the password change process.
This mostly occurs in puppeteer tests, but could occur to a user.

And other two minor fixes related to `visible: true`.
All of these passed 400 runs in CI.