### PR TITLE
Add emoji reactions to messages in develop environment.

### DIFF
--- a/zerver/lib/bulk_create.py
+++ b/zerver/lib/bulk_create.py
@@ -1,3 +1,5 @@
+import random
+from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 from django.db.models import Model
@@ -5,7 +7,16 @@ from django.db.models import Model
 from zerver.lib.create_user import create_user_profile, get_display_email_address
 from zerver.lib.initial_password import initial_password
 from zerver.lib.streams import render_stream_description
-from zerver.models import Realm, RealmAuditLog, Recipient, Stream, Subscription, UserProfile
+from zerver.models import (
+    Message,
+    Reaction,
+    Realm,
+    RealmAuditLog,
+    Recipient,
+    Stream,
+    Subscription,
+    UserProfile,
+)
 
 
 def bulk_create_users(realm: Realm,
@@ -145,3 +156,112 @@ def bulk_create_streams(realm: Realm,
     Recipient.objects.bulk_create(recipients_to_create)
 
     bulk_set_users_or_streams_recipient_fields(Stream, streams_to_create, recipients_to_create)
+
+_DEFAULT_EMOJIS = [
+    ('+1', '1f44d'),
+    ('smiley', '1f603'),
+    ('eyes', '1f440'),
+    ('crying_cat_face', '1f63f'),
+    ('arrow_up', '2b06'),
+    ('confetti_ball', '1f38a'),
+    ('hundred_points', '1f4af'),
+]
+
+def bulk_create_reactions(
+        messages: Iterable[Message],
+        users: Optional[List[UserProfile]] = None,
+        emojis: Optional[List[Tuple[str, str]]] = None
+) -> None:
+    messages = list(messages)
+    if not emojis:
+        emojis = _DEFAULT_EMOJIS
+    emojis = list(emojis)
+
+    reactions: List[Reaction] = []
+    for message in messages:
+        reactions.extend(_add_random_reactions_to_message(
+            message, emojis, users))
+    Reaction.objects.bulk_create(reactions)
+
+def _add_random_reactions_to_message(
+        message: Message,
+        emojis: List[Tuple[str, str]],
+        users: Optional[List[UserProfile]] = None,
+        prob_reaction: float = 0.075,
+        prob_upvote: float = 0.5,
+        prob_repeat: float = 0.5) -> List[Reaction]:
+    '''Randomly add emoji reactions to each message from a list.
+
+    Algorithm:
+
+    Give the message at least one reaction with probability `prob_reaction`.
+    Once the first reaction is added, have another user upvote it with probability
+    `prob_upvote`, provided there is another recipient of the message left to upvote.
+    Repeat the process for a different emoji with probability `prob_repeat`.
+
+    If the number of emojis or users is small, there is a chance the above process
+    will produce multiple reactions with the same user and emoji, so group the
+    reactions by emoji code and user profile and then return one reaction from
+    each group.
+    '''
+    for p in (prob_reaction, prob_repeat, prob_upvote):
+        # Prevent p=1 since for prob_repeat and prob_upvote, this will
+        # lead to an infinite loop.
+        if p >= 1 or p < 0:
+            raise ValueError('Probability argument must be between 0 and 1.')
+
+    if not users:
+        if message.recipient.type == Recipient.PERSONAL:
+            users = [
+                UserProfile.objects.get(recipient__id=message.recipient.id),
+                message.sender]
+        else:
+            # Streams and huddles
+            users = [
+                subscription.user_profile
+                for subscription in Subscription.objects.filter(
+                    recipient=message.recipient)]
+        if not users:
+            return []
+
+    emojis = list(emojis)
+
+    reactions = []
+    while random.random() < prob_reaction:
+        # We do this O(users) operation only if we've decided to do a
+        # reaction, to avoid performance issues with large numbers of
+        # users.
+        users_available = set([user.id for user in users])
+
+        (emoji_name, emoji_code) = random.choice(emojis)
+        while True:
+            # Handle corner case where all the users have reacted.
+            if len(users_available) == 0:
+                break
+
+            user_id = random.choice(list(users_available))
+            reactions.append(Reaction(
+                user_profile_id=user_id,
+                message=message,
+                emoji_name=emoji_name,
+                emoji_code=emoji_code,
+                reaction_type=Reaction.UNICODE_EMOJI
+            ))
+            users_available.remove(user_id)
+
+            # Add an upvote with the defined probability.
+            if not random.random() < prob_upvote:
+                break
+
+        # Repeat with a possibly different random emoji with the
+        # defined probability.
+        if not random.random() < prob_repeat:
+            break
+
+    # Avoid returning duplicate reactions by deduplicating on
+    # (user_profile_id, emoji_code).
+    grouped_reactions = defaultdict(list)
+    for reaction in reactions:
+        k = (str(reaction.user_profile_id), str(reaction.emoji_code))
+        grouped_reactions[k].append(reaction)
+    return [reactions[0] for reactions in grouped_reactions.values()]

--- a/zerver/tests/test_bulk_create.py
+++ b/zerver/tests/test_bulk_create.py
@@ -1,0 +1,230 @@
+import itertools
+import random
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from django.utils.timezone import now as timezone_now
+
+from zerver.lib.bulk_create import _add_random_reactions_to_message, bulk_create_reactions
+from zerver.models import (
+    Client,
+    Huddle,
+    Message,
+    Reaction,
+    Realm,
+    Recipient,
+    Stream,
+    Subscription,
+    UserProfile,
+)
+
+
+class TestBulkCreateReactions(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.realm = Realm.objects.create(
+            name="test_realm",
+            string_id="test_realm"
+        )
+        self.message_client = Client.objects.create(
+            name='test_client'
+        )
+        self.alice = UserProfile.objects.create(
+            delivery_email='alice@gmail.com',
+            email='alice@gmail.com',
+            realm=self.realm,
+            full_name='Alice'
+        )
+        self.bob = UserProfile.objects.create(
+            delivery_email='bob@gmail.com',
+            email='bob@gmail.com',
+            realm=self.realm,
+            full_name='Bob'
+        )
+        self.charlie = UserProfile.objects.create(
+            delivery_email='charlie@gmail.com',
+            email='charlie@gmail.com',
+            realm=self.realm,
+            full_name='Charlie'
+        )
+        self.users = [self.alice, self.bob, self.charlie]
+        type_ids = Recipient \
+            .objects.filter(type=Recipient.PERSONAL).values_list('type_id')
+        max_type_id = max(x[0] for x in type_ids)
+        self.recipients = []
+        for i, user in enumerate(self.users):
+            recipient = Recipient.objects.create(
+                type=Recipient.PERSONAL,
+                type_id=max_type_id + i + 1
+            )
+            user.recipient = recipient
+            user.save()
+            self.recipients.append(recipient)
+        self.personal_message = Message.objects.create(
+            sender=self.alice,
+            recipient=self.bob.recipient,
+            content='It is I, Alice.',
+            sending_client=self.message_client,
+            date_sent=timezone_now()
+        )
+
+        self.stream = Stream.objects.create(
+            name="test_stream",
+            realm=self.realm,
+        )
+        self.stream.recipient = Recipient.objects.create(
+            type=Recipient.STREAM,
+            type_id=1 + max(
+                x[0] for x in Recipient.objects.filter(type=Recipient.STREAM).values_list('type_id'))
+        )
+        self.stream.save()
+        for user in self.users:
+            Subscription.objects.create(
+                user_profile=user,
+                recipient=self.stream.recipient
+            )
+        self.stream_message = Message.objects.create(
+            sender=self.alice,
+            recipient=self.stream.recipient,
+            content='This is Alice.',
+            sending_client=self.message_client,
+            date_sent=timezone_now()
+        )
+
+        self.huddle = Huddle.objects.create(
+            huddle_hash="bad-hash",
+        )
+        self.huddle.recipient = Recipient.objects.create(
+            type=Recipient.HUDDLE,
+            type_id=1 + max(
+                itertools.chain(
+                    (x[0] for x in Recipient.objects.filter(type=Recipient.HUDDLE).values_list('type_id')),
+                    [0])))
+        self.huddle.save()
+        for user in self.users:
+            Subscription.objects.create(
+                user_profile=user,
+                recipient=self.huddle.recipient
+            )
+        self.huddle_message = Message.objects.create(
+            sender=self.alice,
+            recipient=self.huddle.recipient,
+            content='Alice my name is.',
+            sending_client=self.message_client,
+            date_sent=timezone_now()
+        )
+
+    def tearDown(self) -> None:
+        for reaction in Reaction.objects.filter(message=self.personal_message):
+            reaction.delete()
+        self.personal_message.delete()
+        self.realm.delete()
+        self.message_client.delete()
+        for recipient in self.recipients:
+            recipient.delete()
+        super().tearDown()
+
+    @patch('zerver.lib.bulk_create.random')
+    def test_reactions_to_personal_messages(self, mock_random: MagicMock) -> None:
+        assert Reaction.objects.filter(message=self.personal_message).count() == 0
+        mock_random.random.side_effect = [0, 1, 1]  # first reaction, no upvote, no second reaction
+        bulk_create_reactions(messages=[self.personal_message], users=[self.bob], emojis=[('+1', '1f44d')])
+        assert Reaction.objects.filter(message=self.personal_message).count() == 1
+
+    @patch('zerver.lib.bulk_create.random')
+    def test_reactions_default_users(self, mock_random: MagicMock) -> None:
+        assert Reaction.objects.filter(message=self.personal_message).count() == 0
+        mock_random.random.side_effect = [0, 1, 1]  # first reaction, no upvote, no second reaction
+        bulk_create_reactions(messages=[self.personal_message], emojis=[('+1', '1f44d')])
+        assert Reaction.objects.filter(message=self.personal_message).count() == 1
+
+    @patch('zerver.lib.bulk_create.random')
+    def test_upvoted_reaction_to_personal_message(self, mock_random: MagicMock) -> None:
+        assert Reaction.objects.filter(message=self.personal_message).count() == 0
+        mock_random.random.side_effect = [0, 0, 1, 1]  # first reaction, one upvote, no second reaction
+        bulk_create_reactions(messages=[self.personal_message], users=[self.bob, self.alice], emojis=[('+1', '1f44d'), ('smiley', '1f603')])
+        reactions = Reaction.objects.filter(message=self.personal_message)
+        assert reactions.count() == 2
+        r1, r2 = reactions
+        assert r1.emoji_name == r2.emoji_name
+        assert r1.emoji_code == r2.emoji_code
+        assert r1.user_profile != r2.user_profile
+
+    @patch('zerver.lib.bulk_create.random')
+    def test_reactions_to_stream_messages(self, mock_random: MagicMock) -> None:
+        assert Reaction.objects.filter(message=self.stream_message).count() == 0
+        mock_random.random.side_effect = [0, 0, 0, 1, 0, 0, 1, 1]  # first reaction, two upvotes, second reaction, one upvote
+        bulk_create_reactions(messages=[self.stream_message], emojis=[('+1', '1f44d'), ('smiley', '1f603')])
+        reactions = Reaction.objects.filter(message=self.stream_message)
+        assert reactions.count() == 5
+        plus_one_reactions = reactions.filter(emoji_name='+1')
+        assert plus_one_reactions.count() == 3
+        smiley_reactions = reactions.filter(emoji_name='smiley')
+        assert smiley_reactions.count() == 2
+
+    @patch('zerver.lib.bulk_create.random')
+    def test_reactions_to_huddle_messages(self, mock_random: MagicMock) -> None:
+        assert Reaction.objects.filter(message=self.huddle_message).count() == 0
+        mock_random.random.side_effect = [0, 0, 1, 0, 0, 0, 1, 1]  # first reaction, one upvote, second reaction, two upvotes
+        bulk_create_reactions(messages=[self.huddle_message], emojis=[('+1', '1f44d'), ('smiley', '1f603')])
+        reactions = Reaction.objects.filter(message=self.huddle_message)
+        assert reactions.count() == 5
+        plus_one_reactions = reactions.filter(emoji_name='+1')
+        assert plus_one_reactions.count() == 2
+        smiley_reactions = reactions.filter(emoji_name='smiley')
+        assert smiley_reactions.count() == 3
+
+    @patch('zerver.lib.bulk_create.random')
+    def test_duplicate_reactions_removed(self, mock_random: MagicMock) -> None:
+        assert Reaction.objects.filter(message=self.stream_message).count() == 0
+        # a bunch of duplicated reactions from the second set of loops
+        mock_random.random.side_effect = [0] * 20 + [1] + [0] * 20 + [1, 1]
+        bulk_create_reactions(messages=[self.stream_message], emojis=[('+1', '1f44d')])
+        reactions = Reaction.objects.filter(message=self.stream_message)
+        assert reactions.count() == 3
+
+    @patch('zerver.lib.bulk_create.random')
+    def test_reactions_default_emojis(self, mock_random: MagicMock) -> None:
+        assert Reaction.objects.filter(message=self.stream_message).count() == 0
+        mock_random.random.side_effect = itertools.chain([0], (random.random() for _ in itertools.count(1)))
+        bulk_create_reactions(messages=[self.stream_message])
+        assert Reaction.objects.filter(message=self.stream_message).count() > 0
+
+    @patch('zerver.lib.bulk_create.Subscription')
+    def test_no_subscription_users(self, MockSubscription: MagicMock) -> None:
+        assert Reaction.objects.filter(message=self.stream_message).count() == 0
+        MockSubscription.objects.filter.return_value = []
+        bulk_create_reactions(messages=[self.stream_message])
+        assert Reaction.objects.filter(message = self.stream_message).count() == 0
+
+    def test_probabilities_between_zero_and_one(self) -> None:
+        with self.assertRaises(ValueError):
+            _add_random_reactions_to_message(
+                self.personal_message, [('+1', '1f44d')], self.users,
+                prob_reaction=-1
+            )
+        with self.assertRaises(ValueError):
+            _add_random_reactions_to_message(
+                self.personal_message, [('+1', '1f44d')], self.users,
+                prob_reaction=2
+            )
+        with self.assertRaises(ValueError):
+            _add_random_reactions_to_message(
+                self.personal_message, [('+1', '1f44d')], self.users,
+                prob_upvote=-1
+            )
+        with self.assertRaises(ValueError):
+            _add_random_reactions_to_message(
+                self.personal_message, [('+1', '1f44d')], self.users,
+                prob_upvote=2
+            )
+        with self.assertRaises(ValueError):
+            _add_random_reactions_to_message(
+                self.personal_message, [('+1', '1f44d')], self.users,
+                prob_repeat=-1
+            )
+        with self.assertRaises(ValueError):
+            _add_random_reactions_to_message(
+                self.personal_message, [('+1', '1f44d')], self.users,
+                prob_repeat=2
+            )

--- a/zerver/tests/test_bulk_create.py
+++ b/zerver/tests/test_bulk_create.py
@@ -18,6 +18,7 @@ from zerver.models import (
     Recipient,
     Stream,
     Subscription,
+    UserMessage,
     UserProfile,
 )
 
@@ -154,7 +155,7 @@ class TestBulkCreateReactions(TestCase):
         self.assertFalse(MockSubscription.objects.filter.called)
 
     @patch('zerver.lib.bulk_create.random')
-    @patch('zerver.lib.bulk_create.UserProfile')
+    @patch('zerver.lib.bulk_create.UserMessage')
     def test_query_for_personal_message_users(
             self,
             MockUserProfile: MagicMock,
@@ -165,13 +166,13 @@ class TestBulkCreateReactions(TestCase):
         mock_random.choice = random.choice
         mock_random.random.side_effect = [0, 1, 1, 1, 1, 1]
         _add_random_reactions_to_message(message, emojis, users)
-        self.assertTrue(MockUserProfile.objects.get.called)
+        self.assertTrue(MockUserProfile.objects.filter.called)
 
     @patch('zerver.lib.bulk_create.random')
-    @patch('zerver.lib.bulk_create.Subscription')
+    @patch('zerver.lib.bulk_create.UserMessage')
     def test_query_for_stream_message_users(
             self,
-            MockSubscription: MagicMock,
+            MockUserMessage: MagicMock,
             mock_random: MagicMock) -> None:
         message = self.stream_message
         emojis = DEFAULT_EMOJIS
@@ -179,13 +180,13 @@ class TestBulkCreateReactions(TestCase):
         mock_random.choice = random.choice
         mock_random.random.side_effect = [0, 1, 1, 1, 1, 1]
         _add_random_reactions_to_message(message, emojis, users)
-        self.assertTrue(MockSubscription.objects.filter.called)
+        self.assertTrue(MockUserMessage.objects.filter.called)
 
     @patch('zerver.lib.bulk_create.random')
-    @patch('zerver.lib.bulk_create.Subscription')
+    @patch('zerver.lib.bulk_create.UserMessage')
     def test_query_for_huddle_message_users(
             self,
-            MockSubscription: MagicMock,
+            MockUserMessage: MagicMock,
             mock_random: MagicMock) -> None:
         message = self.huddle_message
         emojis = DEFAULT_EMOJIS
@@ -193,22 +194,22 @@ class TestBulkCreateReactions(TestCase):
         mock_random.choice = random.choice
         mock_random.random.side_effect = [0, 1, 1, 1, 1, 1]
         _add_random_reactions_to_message(message, emojis, users)
-        self.assertTrue(MockSubscription.objects.filter.called)
+        self.assertTrue(MockUserMessage.objects.filter.called)
 
     @patch('zerver.lib.bulk_create.random')
-    @patch('zerver.lib.bulk_create.Subscription')
+    @patch('zerver.lib.bulk_create.UserMessage')
     def test_early_exit_if_no_users(
             self,
-            MockSubscription: MagicMock,
+            MockUserMessage: MagicMock,
             mock_random: MagicMock) -> None:
         message = self.stream_message
         emojis = DEFAULT_EMOJIS
         users = None
         mock_random.choice = random.choice
         mock_random.random.side_effect = [0, 1, 1, 1, 1, 1]
-        MockSubscription.objects.filter.return_value = []
+        MockUserMessage.objects.filter.return_value = UserMessage.objects.none()
         reactions = _add_random_reactions_to_message(message, emojis, users)
-        self.assertTrue(MockSubscription.objects.filter.called)
+        self.assertTrue(MockUserMessage.objects.filter.called)
         self.assertEqual(reactions, [])
 
     @patch('zerver.lib.bulk_create.random')

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -24,7 +24,7 @@ from zerver.lib.actions import (
     try_add_realm_custom_profile_field,
     try_add_realm_default_custom_profile_field,
 )
-from zerver.lib.bulk_create import bulk_create_streams
+from zerver.lib.bulk_create import bulk_create_reactions, bulk_create_streams
 from zerver.lib.cache import cache_set
 from zerver.lib.generate_test_data import create_test_data, generate_topics
 from zerver.lib.onboarding import create_if_missing_realm_internal_bots
@@ -720,7 +720,7 @@ def generate_and_send_messages(data: Tuple[int, Sequence[Sequence[int]], Mapping
     num_messages = 0
     random_max = 1000000
     recipients: Dict[int, Tuple[int, int, Dict[str, Any]]] = {}
-    messages = []
+    messages: List[Message] = []
     while num_messages < tot_messages:
         saved_data: Dict[str, Any] = {}
         message = Message()
@@ -793,6 +793,7 @@ def send_messages(messages: List[Message]) -> None:
     # life of the database, which naturally throws exceptions.
     settings.USING_RABBITMQ = False
     do_send_messages([{'message': message} for message in messages])
+    bulk_create_reactions(messages)
     settings.USING_RABBITMQ = True
 
 def choose_date_sent(num_messages: int, tot_messages: int, threads: int) -> datetime:


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
Addresses part of issue [14991](https://github.com/zulip/zulip/issues/14991).

**Testing Plan:** <!-- How have you tested? -->
- Added a unit test to `test_bulk_create.py`. Made sure 100% of the code I added is covered.

- Checked manually emoji reactions are present in develop environment:
  - start dev environment `./tools/run-dev.py`
  - in a separate terminal, run `python manage.py populate_db`
  - go to `localhost:9991` in browser and select Aaron user
  - scroll up in messages until you see the first emoji reactions

**GIFs or Screenshots:** <!-- If a UI change.  See:   https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->

![image](https://user-images.githubusercontent.com/20004072/91667350-34952a00-eac1-11ea-8ced-178798fd07f2.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
