### PR TITLE
compose: Restore Tab+Enter sending in Safari.

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -185,16 +185,28 @@ function handle_keydown(e) {
         const on_pm = target_sel === "#private_message_recipient";
         const on_compose = target_sel === "#compose-textarea";
 
-        if (on_compose && code === 13) {
-            if (exports.should_enter_send(e)) {
-                e.preventDefault();
-                if (!$("#compose-send-button").prop("disabled")) {
-                    $("#compose-send-button").prop("disabled", true);
-                    compose.finish();
+        if (on_compose) {
+            if (code === 9) {
+                // This if branch is only here to make Tab+Enter work on Safari,
+                // which does not make <button>s tab-accessible by default
+                // (even if we were to set tabindex=0).
+                if (!exports.should_enter_send(e)) {
+                    $("#compose-send-button").trigger("focus");
+                    e.preventDefault();
                 }
-                return;
+            } else {
+                // Enter
+                if (exports.should_enter_send(e)) {
+                    e.preventDefault();
+                    if (!$("#compose-send-button").prop("disabled")) {
+                        $("#compose-send-button").prop("disabled", true);
+                        compose.finish();
+                    }
+                    return;
+                }
+
+                exports.handle_enter($("#compose-textarea"), e);
             }
-            exports.handle_enter($("#compose-textarea"), e);
         } else if (on_stream || on_topic || on_pm) {
             // Prevent the form from submitting
             e.preventDefault();


### PR DESCRIPTION
Safari doesn't make <button>s tab-accessible by default,
so this commit adds back the manual focus removed in
3b0694693b15ea862d41ff0959e28e71c4ecb3dc.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->

I have not tested this because I do not have Safari. Somebody should test this on Safari before we merge it.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
