### PR TITLE
hotspots: Use ugettext_lazy for i18n.

### DIFF
--- a/zerver/lib/hotspots.py
+++ b/zerver/lib/hotspots.py
@@ -3,7 +3,7 @@
 from typing import Dict, List
 
 from django.conf import settings
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from zerver.models import UserHotspot, UserProfile
 
@@ -44,8 +44,8 @@ def get_next_hotspots(user: UserProfile) -> List[Dict[str, object]]:
     if settings.ALWAYS_SEND_ALL_HOTSPOTS:
         return [{
             'name': hotspot,
-            'title': ALL_HOTSPOTS[hotspot]['title'],
-            'description': ALL_HOTSPOTS[hotspot]['description'],
+            'title': str(ALL_HOTSPOTS[hotspot]['title']),
+            'description': str(ALL_HOTSPOTS[hotspot]['description']),
             'delay': 0,
         } for hotspot in ALL_HOTSPOTS]
 
@@ -57,8 +57,8 @@ def get_next_hotspots(user: UserProfile) -> List[Dict[str, object]]:
         if hotspot not in seen_hotspots:
             return [{
                 'name': hotspot,
-                'title': ALL_HOTSPOTS[hotspot]['title'],
-                'description': ALL_HOTSPOTS[hotspot]['description'],
+                'title': str(ALL_HOTSPOTS[hotspot]['title']),
+                'description': str(ALL_HOTSPOTS[hotspot]['description']),
                 'delay': 0.5,
             }]
 


### PR DESCRIPTION
Since ALL_HOTSPOTS is a global object, it is initialized at the time the backend server is started. Hence, the
title and description is translated only once. Using ugettext_lazy makes sure that the strings are translated in each and every request according to the language of the user.

Also did a quick search for other similar occurrences by doing `git grep -wn "_("` and going through files which have matches in with line nos less than 40. There do not seem to be any other occurrences.

Fixes #16224

