### PR TITLE
search: Allow searching of messages with link by typing parts of url.

### DIFF
--- a/puppet/zulip/files/postgresql/process_fts_updates
+++ b/puppet/zulip/files/postgresql/process_fts_updates
@@ -54,15 +54,23 @@ def update_fts_columns(cursor: psycopg2.extensions.cursor) -> int:
         [BATCH_SIZE],
     )
     ids = []
+
+    # extract_url_tokens(rendered_content) will extract url and it's tokens from html
+    # message content. These tokens will be indexed in postgres.
+    # Eg. If a message content have url chat.zulip.org/home, It will be extarcted from
+    # the message content and will be tokeniseed to chat, zulip, org, home.
+    # These these tokens will be indexed.
     for (id, message_id) in cursor.fetchall():
         if USING_PGROONGA:
             cursor.execute("UPDATE zerver_message SET "
                            "search_pgroonga = "
-                           "escape_html(subject) || ' ' || rendered_content "
+                           "escape_html(subject) || ' ' || rendered_content ||"
+                           "' ' || extract_url_tokens(rendered_content)"
                            "WHERE id = %s", (message_id,))
         cursor.execute("UPDATE zerver_message SET "
                        "search_tsvector = to_tsvector('zulip.english_us_search', "
-                       "subject || rendered_content) "
+                       "subject || rendered_content ||"
+                       "' ' || extract_url_tokens(rendered_content))"
                        "WHERE id = %s", (message_id,))
         ids.append(id)
     cursor.execute("DELETE FROM fts_update_log WHERE id = ANY(%s)", (ids,))

--- a/zerver/management/commands/audit_fts_indexes.py
+++ b/zerver/management/commands/audit_fts_indexes.py
@@ -11,8 +11,8 @@ class Command(ZulipBaseCommand):
             cursor.execute("""
                 UPDATE zerver_message
                 SET search_tsvector =
-                to_tsvector('zulip.english_us_search', subject || rendered_content)
-                WHERE to_tsvector('zulip.english_us_search', subject || rendered_content) != search_tsvector
+                to_tsvector('zulip.english_us_search', subject || rendered_content || ' ' || extract_url_tokens(rendered_content))
+                WHERE to_tsvector('zulip.english_us_search', subject || rendered_content || ' ' || extract_url_tokens(rendered_content)) != search_tsvector
             """)
 
             fixed_message_count = cursor.rowcount

--- a/zerver/migrations/0304_add_url_token_extract_function.py
+++ b/zerver/migrations/0304_add_url_token_extract_function.py
@@ -1,0 +1,36 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('zerver', '0303_realm_wildcard_mention_policy'),
+    ]
+
+    # This creates an SQL function that extract url from html rendered content and tokenise it.
+    # Tokenise logic is simple:
+    # 1. Regex <a\s+(?:[^>]*?\s+)?href="([^"]*)" extract url provided to href attr in anchor tag
+    #    of html of message_content.
+    # 2. Regex (_|-|\.|\/|:) matches _ - . / : characters from extracted url and then replace them
+    #    with space.
+    # Eg. <a href="https://chat.zulip.org/">CZO</a> in html content. This function will extract url
+    # https://chat.zulip.org/ and replace :, /, . with spaces to make it:
+    # "https   chat zulip org ".
+    operations = [
+        migrations.RunSQL(
+            sql=r"""
+CREATE FUNCTION extract_url_tokens(message_content text) RETURNS text IMMUTABLE LANGUAGE 'sql' AS $$
+  SELECT COALESCE(REGEXP_REPLACE(
+    STRING_AGG(
+        ARRAY_TO_STRING(links.matched_url, ' '), ' '
+    ),'(_|-|\.|\/|:)',' ','g'
+  ), '')
+  FROM (
+    SELECT REGEXP_MATCHES(
+        message_content,'<a\s+(?:[^>]*?\s+)?href="([^"]*)"','g'
+    ) as matched_url
+  ) as links;
+$$ ;
+            """,
+        ),
+    ]


### PR DESCRIPTION
This commit adds a postgres function that extract urls from
rendered_content of message using REGEXP_MATCH in sql and then replace
the .,/,_,- in url with spaces. The result is then passed to be indexed
by full text search system of postgres.
Fixes: #9165.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->
Manual testing pending.


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
