### PR TITLE
events: Update subscriber list on peer_remove event for unsubscribed and never-subscribed streams.

### DIFF
--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -727,7 +727,7 @@ def apply_event(state: Dict[str, Any],
         elif event['op'] == 'peer_remove':
             stream_ids = set(event["stream_ids"])
             user_ids = set(event["user_ids"])
-            for sub_dict in [state["subscriptions"], state['unsubscribed']]:
+            for sub_dict in [state["subscriptions"], state['unsubscribed'], state['never_subscribed']]:
                 for sub in sub_dict:
                     if sub["stream_id"] in stream_ids:
                         subscribers = set(sub["subscribers"]) - user_ids

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -719,7 +719,7 @@ def apply_event(state: Dict[str, Any],
         elif event['op'] == 'peer_add':
             stream_ids = set(event["stream_ids"])
             user_ids = set(event["user_ids"])
-            for sub_dict in [state["subscriptions"], state["never_subscribed"]]:
+            for sub_dict in [state["subscriptions"], state['unsubscribed'], state["never_subscribed"]]:
                 for sub in sub_dict:
                     if sub["stream_id"] in stream_ids:
                         subscribers = set(sub["subscribers"]) | user_ids

--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -727,7 +727,7 @@ def apply_event(state: Dict[str, Any],
         elif event['op'] == 'peer_remove':
             stream_ids = set(event["stream_ids"])
             user_ids = set(event["user_ids"])
-            for sub_dict in [state["subscriptions"]]:
+            for sub_dict in [state["subscriptions"], state['unsubscribed']]:
                 for sub in sub_dict:
                     if sub["stream_id"] in stream_ids:
                         subscribers = set(sub["subscribers"]) - user_ids

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1855,7 +1855,7 @@ class SubscribeActionTest(BaseAction):
             state_change_expected=include_subscribers)
         check_subscription_peer_remove('events[0]', events[0])
 
-        # Now remove the second user, to test the 'vacate' event flow
+        # Now remove the user himself, to test the 'remove' event flow
         action = lambda: bulk_remove_subscriptions(
             [self.example_user('hamlet')],
             [stream],

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1483,6 +1483,17 @@ class NormalActionsTest(BaseAction):
         events = self.verify_action(action, num_events=2)
         check_subscription_peer_add('events[1]', events[1])
 
+    def test_remove_other_user_never_subscribed(self) -> None:
+        self.subscribe(self.example_user("othello"), "test_stream")
+        stream = get_stream("test_stream", self.user_profile.realm)
+
+        action = lambda: bulk_remove_subscriptions(
+            [self.example_user('othello')],
+            [stream],
+            get_client("website"))
+        events = self.verify_action(action)
+        check_subscription_peer_remove('events[0]', events[0])
+
     def test_do_delete_message_stream(self) -> None:
         hamlet = self.example_user('hamlet')
         msg_id = self.send_stream_message(hamlet, "Verona")

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1830,7 +1830,7 @@ class SubscribeActionTest(BaseAction):
         action: Callable[[], object] = lambda: self.subscribe(self.example_user("hamlet"), "test_stream")
         events = self.verify_action(
             action,
-            event_types=["subscription", "realm_user"],
+            event_types=["subscription"],
             include_subscribers=include_subscribers)
         check_subscription_add('events[0]', events[0], include_subscribers)
 

--- a/zerver/tests/test_events.py
+++ b/zerver/tests/test_events.py
@@ -1884,7 +1884,14 @@ class SubscribeActionTest(BaseAction):
             'test_stream',
         )
 
-        self.subscribe(self.example_user("iago"), "test_stream")
+        # Subscribe other user to test 'peer_add' event flow for unsubscribed stream.
+        action = lambda: self.subscribe(self.example_user("iago"), "test_stream")
+        events = self.verify_action(
+            action,
+            event_types=["subscription"],
+            include_subscribers=include_subscribers,
+            state_change_expected=include_subscribers)
+        check_subscription_peer_add('events[0]', events[0])
 
         # Remove the user to test 'peer_remove' event flow for unsubscribed stream.
         action = lambda: bulk_remove_subscriptions(


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
- Update subscriber list on peer_remove event for unsubscribed streams.
- Update subscriber list on peer_remove event for never subscribed streams.

 <!-- How have you tested? -->


 <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
