### PR TITLE
sentry: When there are multiple stacktraces, take the most recent.

### DIFF
--- a/zerver/webhooks/sentry/view.py
+++ b/zerver/webhooks/sentry/view.py
@@ -112,7 +112,7 @@ def handle_event_payload(event: Dict[str, Any]) -> Tuple[str, str]:
         filename = event["metadata"].get("filename", None)
 
         stacktrace = None
-        for value in event["exception"]["values"]:
+        for value in reversed(event["exception"]["values"]):
             if "stacktrace" in value:
                 stacktrace = value["stacktrace"]
                 break


### PR DESCRIPTION
Sentry may get reported multiple exceptions stacks, in the case where
a `raise ...` was caught, and a new exception was `raise`d.  In this
case, the `filename` is the most recent exception -- but the
exceptions are stored in the `exception` key in the order in which
they occurred.  As such, taking the first value with a `stacktrace`
will result in showing the wrong line, or in no stack trace being
resolved at all.

Look from the last `exception` backwards, for matching stacks.