### PR TITLE
trello: Simplify logic for ignored card actions.

### DIFF
--- a/zerver/webhooks/trello/view/__init__.py
+++ b/zerver/webhooks/trello/view/__init__.py
@@ -22,17 +22,11 @@ def api_trello_webhook(request: HttpRequest,
                        payload: Mapping[str, Any]=REQ(argument_type='body')) -> HttpResponse:
     payload = orjson.loads(request.body)
     action_type = payload['action'].get('type')
-    try:
-        message = get_subject_and_body(payload, action_type)
-        if message is None:
-            return json_success()
-        else:
-            subject, body = message
-    except UnexpectedWebhookEventType:
-        if action_type in IGNORED_CARD_ACTIONS:
-            return json_success()
-
-        raise UnexpectedWebhookEventType('Trello', action_type)
+    message = get_subject_and_body(payload, action_type)
+    if message is None:
+        return json_success()
+    else:
+        subject, body = message
 
     check_send_webhook_message(request, user_profile, subject, body)
     return json_success()
@@ -40,6 +34,8 @@ def api_trello_webhook(request: HttpRequest,
 def get_subject_and_body(payload: Mapping[str, Any], action_type: str) -> Optional[Tuple[str, str]]:
     if action_type in SUPPORTED_CARD_ACTIONS:
         return process_card_action(payload, action_type)
+    if action_type in IGNORED_CARD_ACTIONS:
+        return None
     if action_type in SUPPORTED_BOARD_ACTIONS:
         return process_board_action(payload, action_type)
 

--- a/zerver/webhooks/trello/view/__init__.py
+++ b/zerver/webhooks/trello/view/__init__.py
@@ -39,4 +39,4 @@ def get_subject_and_body(payload: Mapping[str, Any], action_type: str) -> Option
     if action_type in SUPPORTED_BOARD_ACTIONS:
         return process_board_action(payload, action_type)
 
-    raise UnexpectedWebhookEventType("Trello", f'{action_type} is not supported')
+    raise UnexpectedWebhookEventType("Trello", action_type)


### PR DESCRIPTION
Rather than catching, checking action type, and possibly re-raising,
instead return None explicitly from `get_subject_and_body`, which
already signals for a blank success result.  This collocates the logic
of the action types in one place, and removes the complexity of the
re-raise.