### PR TITLE
settings: Don't use css classes starting with `icon`.

### DIFF
--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -150,14 +150,14 @@ function createSaveButtons(subsection) {
     const save_button_controls = $(".save-button-controls");
     const stub_save_button = $(`#org-submit-${subsection}`);
     const stub_discard_button = $(`#org-discard-${subsection}`);
-    const stub_save_button_text = $(".icon-button-text");
+    const stub_save_button_text = $(".save-discard-widget-button-text");
     stub_save_button_header.set_find_results(
         ".subsection-failed-status p",
         $("<failed status element>"),
     );
     stub_save_button.closest = () => stub_save_button_header;
     save_button_controls.set_find_results(".save-button", stub_save_button);
-    stub_save_button.set_find_results(".icon-button-text", stub_save_button_text);
+    stub_save_button.set_find_results(".save-discard-widget-button-text", stub_save_button_text);
     stub_save_button_header.set_find_results(".save-button-controls", save_button_controls);
     stub_save_button_header.set_find_results(
         ".subsection-changes-discard .button",

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -447,7 +447,7 @@ exports.change_save_button_state = function ($element, state) {
     }
 
     const $saveBtn = $element.find(".save-button");
-    const $textEl = $saveBtn.find(".icon-button-text");
+    const $textEl = $saveBtn.find(".save-discard-widget-button-text");
 
     if (state !== "saving") {
         $saveBtn.removeClass("saving");

--- a/static/styles/settings.scss
+++ b/static/styles/settings.scss
@@ -1090,7 +1090,7 @@ input[type="checkbox"] {
     overflow: hidden;
     border-radius: 4px;
 
-    .icon-button {
+    .save-discard-widget-button {
         border-radius: 5px;
         border: 1px solid hsl(0, 0%, 80%);
         font-size: 14px;
@@ -1105,7 +1105,7 @@ input[type="checkbox"] {
             border: 1px solid hsl(0, 0%, 61%);
             color: hsl(0, 0%, 18%);
 
-            .icon-button-icon {
+            .save-discard-widget-button-icon {
                 color: hsl(0, 0%, 47%);
             }
         }
@@ -1120,7 +1120,7 @@ input[type="checkbox"] {
                 border: 1px solid hsl(166, 35%, 57%);
             }
 
-            .icon-button-icon {
+            .save-discard-widget-button-icon {
                 font-weight: lighter;
                 color: hsl(0, 0%, 100%);
             }
@@ -1131,7 +1131,7 @@ input[type="checkbox"] {
             }
         }
 
-        .icon-button-icon {
+        .save-discard-widget-button-icon {
             vertical-align: bottom;
             margin-right: 3px;
             margin-bottom: 1px;
@@ -1152,16 +1152,16 @@ input[type="checkbox"] {
     .save-button {
         margin-right: 5px;
 
-        .icon-button-loading {
+        .save-discard-widget-button-loading {
             display: none;
         }
 
         &.saving {
-            .icon-button-icon {
+            .save-discard-widget-button-icon {
                 display: none;
             }
 
-            .icon-button-loading {
+            .save-discard-widget-button-loading {
                 display: inline-block;
                 margin-right: 2px;
             }

--- a/static/templates/settings/settings_save_discard_widget.hbs
+++ b/static/templates/settings/settings_save_discard_widget.hbs
@@ -1,17 +1,17 @@
 <div class="save-button-controls hide">
     <div class="inline-block organization-submission subsection-changes-save">
-        <div class="icon-button button primary save-button" type="button" id="org-submit-{{section_name}}" data-status="save">
-            <span class="fa fa-spinner fa-spin icon-button-loading"></span>
-            <span class="fa fa-check icon-button-icon"></span>
-            <span class="icon-button-text">
+        <div class="save-discard-widget-button button primary save-button" type="button" id="org-submit-{{section_name}}" data-status="save">
+            <span class="fa fa-spinner fa-spin save-discard-widget-button-loading"></span>
+            <span class="fa fa-check save-discard-widget-button-icon"></span>
+            <span class="save-discard-widget-button-text">
                 {{t 'Save changes' }}
             </span>
         </div>
     </div>
     <div class="inline-block subsection-changes-discard">
-        <div class="icon-button button discard-button" type="button" id="org-discard-{{section_name}}">
-            <span class="fa fa-times icon-button-icon"></span>
-            <span class="icon-button-text">
+        <div class="save-discard-widget-button button discard-button" type="button" id="org-discard-{{section_name}}">
+            <span class="fa fa-times save-discard-widget-button-icon"></span>
+            <span class="save-discard-widget-button-text">
                 {{t 'Discard' }}
             </span>
         </div>


### PR DESCRIPTION
Fixes #16252.

icon* classes are used by bootstrap for displaying glyphicons.
We removed these classes in our custom version of bootstrap 2.1.1;
but since our reset to v2.3.2, they have been added again and hence
any classes starting with icon* in zulip will have to be renamed.
