### PR TITLE
api: Fix trailing '/' at end of jitsi server url.

### DIFF
--- a/zerver/lib/events.py
+++ b/zerver/lib/events.py
@@ -165,7 +165,7 @@ def fetch_initial_state_data(user_profile: UserProfile,
         state['zulip_plan_is_not_limited'] = realm.plan_type != Realm.LIMITED
         state['upgrade_text_for_wide_organization_logo'] = str(Realm.UPGRADE_TEXT_STANDARD)
         state['realm_default_external_accounts'] = DEFAULT_EXTERNAL_ACCOUNTS
-        state['jitsi_server_url']                = settings.JITSI_SERVER_URL
+        state['jitsi_server_url']                = settings.JITSI_SERVER_URL.rstrip('/')
         state['development_environment']         = settings.DEVELOPMENT
         state['server_generation']               = settings.SERVER_GENERATION
         state['password_min_length']             = settings.PASSWORD_MIN_LENGTH


### PR DESCRIPTION
Some users setup zulip with trailing / at end, like 'https://meet.jit.si/
leading to extra / on clients while generating video chat link.

This commit removes trailing '/' if it exists to make it consistent. Manual
testing was done by generating jitsi url.

Fixes #16225

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/16225


**Testing Plan:** <!-- How have you tested? -->
Manually tested locally by creating the jitsi link.

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
