### PR TITLE
tests: Use real path when getting commands in TestCommandsCanStart.

### DIFF
--- a/zerver/tests/test_management_commands.py
+++ b/zerver/tests/test_management_commands.py
@@ -183,7 +183,7 @@ class TestCommandsCanStart(ZulipTestCase):
         self.commands = [
             command
             for app_config in apps.get_app_configs()
-            if os.path.dirname(app_config.path) == settings.DEPLOY_ROOT
+            if os.path.dirname(os.path.realpath(app_config.path)) == settings.DEPLOY_ROOT
             for command in find_commands(os.path.join(app_config.path, "management"))
         ]
         assert self.commands


### PR DESCRIPTION
In 468c5b9a58b613d88dcb100ab2e5e32de90e579f we changed the method of
getting the list of management commands. Using app_config.path has a
caveat in that the value depends on the path from which we're executing.
An example of things breaking can be reproduced by calling
/home/vagrant/zulip/tools/test-backend TestCommandsCanStart

This makes the app_config.path values to start with /home/vagrant/zulip,
but DEPLOY_ROOT in the dev environment is set to /srv/zulip.
/home/vagrant/zulip is a soft link to /srv/zulip, so it's a valid path
to call test-backend through, but it causes self.commands to end up
being an empty list. We fix this by converting app_config.path to the
real path.
