### PR TITLE
middleware: Move locale-setting before domain checking.

### DIFF
--- a/analytics/tests/test_views.py
+++ b/analytics/tests/test_views.py
@@ -52,12 +52,15 @@ class TestStatsEndpoint(ZulipTestCase):
         result = self.client_get('/stats/realm/zulip/')
         self.assertEqual(result.status_code, 302)
 
+        result = self.client_get('/stats/realm/not_existing_realm/')
+        self.assertEqual(result.status_code, 302)
+
         user = self.example_user('hamlet')
         user.is_staff = True
         user.save(update_fields=['is_staff'])
 
         result = self.client_get('/stats/realm/not_existing_realm/')
-        self.assertEqual(result.status_code, 302)
+        self.assertEqual(result.status_code, 404)
 
         result = self.client_get('/stats/realm/zulip/')
         self.assertEqual(result.status_code, 200)

--- a/zerver/lib/i18n.py
+++ b/zerver/lib/i18n.py
@@ -7,20 +7,7 @@ from typing import Any, Dict, List
 
 import orjson
 from django.conf import settings
-from django.utils import translation
-from django.utils.translation import ugettext as _
 
-
-def with_language(string: str, language: str) -> str:
-    """
-    This is an expensive function. If you are using it in a loop, it will
-    make your code slow.
-    """
-    old_language = translation.get_language()
-    translation.activate(language)
-    result = _(string)
-    translation.activate(old_language)
-    return result
 
 @lru_cache()
 def get_language_list() -> List[Dict[str, Any]]:

--- a/zerver/lib/test_helpers.py
+++ b/zerver/lib/test_helpers.py
@@ -426,6 +426,7 @@ def write_instrumentation_reports(full_suite: bool, include_webhooks: bool) -> N
             # static content URLs, since the content they point to may
             # or may not exist.
             'coverage/(?P<path>.+)',
+            'confirmation_key/',
             'node-coverage/(?P<path>.+)',
             'docs/(?P<path>.+)',
             'casper/(?P<path>.+)',

--- a/zerver/management/commands/compilemessages.py
+++ b/zerver/management/commands/compilemessages.py
@@ -10,9 +10,9 @@ from django.conf import settings
 from django.conf.locale import LANG_INFO
 from django.core.management.base import CommandParser
 from django.core.management.commands import compilemessages
+from django.utils.translation import override as override_language
+from django.utils.translation import ugettext as _
 from django.utils.translation.trans_real import to_language
-
-from zerver.lib.i18n import with_language
 
 
 class Command(compilemessages.Command):
@@ -127,7 +127,8 @@ class Command(compilemessages.Command):
                 # Fallback to getting the name from PO file.
                 filename = self.get_po_filename(locale_path, locale)
                 name = self.get_name_from_po_file(filename, locale)
-                name_local = with_language(name, code)
+                with override_language(code):
+                    name_local = _(name)
 
             info['name'] = name
             info['name_local'] = name_local

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -184,9 +184,9 @@ MIDDLEWARE = (
     'zerver.middleware.RateLimitMiddleware',
     'zerver.middleware.FlushDisplayRecipientCache',
     'zerver.middleware.ZulipCommonMiddleware',
-    'zerver.middleware.HostDomainMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.locale.LocaleMiddleware',
+    'zerver.middleware.LocaleMiddleware',
+    'zerver.middleware.HostDomainMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     # Make sure 2FA middlewares come after authentication middleware.

--- a/zproject/dev_urls.py
+++ b/zproject/dev_urls.py
@@ -81,6 +81,7 @@ else:
 i18n_urls = [
     path('confirmation_key/', zerver.views.development.registration.confirmation_key),
 ]
+urls += i18n_urls
 
 # On a production instance, these files would be served by nginx.
 if settings.LOCAL_UPLOADS_DIR is not None:


### PR DESCRIPTION
Calling `render()` in a middleware before LocaleMiddleware has run
will pick up the most-recently-set locale.  This may be from the
_previous_ request, since the current language is thread-local.  This
results in the "Organization does not exist" page occasionally being
in not-English, depending on the preferences of the request which that
thread just finished serving.

Move HostDomainMiddleware below LocaleMiddleware; none of the earlier
middlewares call `render()`, so are safe.  This will also allow the
"Organization does not exist" page to be localized based on the user's
browser preferences.

Unfortunately, it also means that the LocaleMiddleware catches the 404
from the HostDomainMiddlware and helpfully tries to check if it is
because the URL lacks a language component (e.g. `/en/`) and attempts
to turn it into a 304 to that new URL.  We must temporarily override
the `urlconf` for the request to not contain anything of note, to
prevent this redirect.

This regression likely came in during f00ff1ef629fd, since prior to
that, the HostDomainMiddleware ran _after_ the rest of the request had
completed.

**Testing Plan:** Existing tests.  I couldn't replicate in dev, so we'll need to deploy this and see if it resolves prod -- but it seems highly likely.