### PR TITLE
isort: Enable black profile

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,7 +1,5 @@
 [settings]
 src_paths = ., tools, tools/setup/emoji
-multi_line_output = 3
 known_third_party = zulip
-include_trailing_comma = True
-use_parentheses = True
+profile = black
 line_length = 100

--- a/zerver/lib/email_validation.py
+++ b/zerver/lib/email_validation.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
 
 from zerver.lib.name_restrictions import is_disposable_domain
+
 # TODO: Move DisposableEmailError, etc. into here.
 from zerver.models import (
     DisposableEmailError,

--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -36,6 +36,7 @@ from zerver.models import (
     get_system_bot,
     get_user_profile_by_email,
 )
+
 # Class with helper functions useful for testing archiving of reactions:
 from zerver.tornado.django_api import send_event
 

--- a/zerver/webhooks/gitea/view.py
+++ b/zerver/webhooks/gitea/view.py
@@ -8,6 +8,7 @@ from zerver.lib.request import REQ, has_request_variables
 from zerver.lib.webhooks.common import get_http_headers_from_filename
 from zerver.lib.webhooks.git import get_pull_request_event_message
 from zerver.models import UserProfile
+
 # Gitea is a fork of Gogs, and so the webhook implementation is nearly the same.
 from zerver.webhooks.gogs.view import gogs_webhook_main
 


### PR DESCRIPTION
Our isort configuration was almost Black-compatible, but we were missing `ensure_newline_before_comments`.