### PR TITLE
fixed devlogin when a # is present in the url

### DIFF
--- a/static/js/portico/dev-login.js
+++ b/static/js/portico/dev-login.js
@@ -5,12 +5,12 @@ $(() => {
     // dev_login.html is rendered.
     if ($("[data-page-id='dev-login']").length > 0) {
         if (window.location.hash.substring(0, 1) === "#") {
-            /* We append the location.hash to the formaction so that URL can be
+            /* We append the location.hash to the input field with name next so that URL can be
             preserved after user is logged in. See this:
             https://stackoverflow.com/questions/5283395/url-hash-is-persisting-between-redirects */
-            $("input[name='direct_email']").each(function () {
-                const new_formaction = $(this).attr("formaction") + "/" + window.location.hash;
-                $(this).attr("formaction", new_formaction);
+            $("input[name='next']").each(function () {
+                const new_value = $(this).attr("value") + window.location.hash;
+                $(this).attr("value", new_value);
             });
         }
     }


### PR DESCRIPTION
closes #16215

As # is the property of browser in the url so i added the next parameter in all the form action to solve this issue.

Now the redirection also works successfully.

The main cause of this issue is not with the next parameter but it's with the url('zerver.views.auth.dev_direct_login') because it adds //#scholarship in the form action which is an invalid url. Therefore after adding `?next=` the redirection works successfully. Also if a next parameter is not present in the url then i have tested this for that also and it work successfully.


