### PR TITLE
landing-page: Fix carousel indicators alignment.

### DIFF
--- a/static/styles/portico/landing-page.scss
+++ b/static/styles/portico/landing-page.scss
@@ -1580,6 +1580,9 @@ nav {
     justify-content: center;
     padding-left: 0;
     list-style: none;
+    position: relative;
+    top: auto;
+    right: auto;
 
     li {
         position: relative;


### PR DESCRIPTION
Reset to bootstrap v2.3.2 moved the indicators to top right, we
change it back to its previous location in this commit.
