### PR TITLE
node tests: Prevent theoretical leak from Intl.

### DIFF
--- a/frontend_tests/node_tests/util.js
+++ b/frontend_tests/node_tests/util.js
@@ -117,11 +117,12 @@ run_test("robust_uri_decode", () => {
 });
 
 run_test("dumb_strcmp", () => {
-    Intl.Collator = undefined;
-    const strcmp = util.make_strcmp();
-    assert.equal(strcmp("a", "b"), -1);
-    assert.equal(strcmp("c", "c"), 0);
-    assert.equal(strcmp("z", "y"), 1);
+    with_field(Intl, "Collator", undefined, () => {
+        const strcmp = util.make_strcmp();
+        assert.equal(strcmp("a", "b"), -1);
+        assert.equal(strcmp("c", "c"), 0);
+        assert.equal(strcmp("z", "y"), 1);
+    });
 });
 
 run_test("get_edit_event_orig_topic", () => {


### PR DESCRIPTION
Because `util` is so late in the alphabet, this
leak never surfaced in practice, but I tried running
the node tests in reverse, and this leak came
up if you ran `util` before `stream_list`.  I guess
it's nice that `stream_list` actually exercises
the difference between a dumb sort and an
Intl-aware sort.

It's possible that we should just assume that
Intl.Collator is always available at this point,
which would eliminate the need for this test.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
