### PR TITLE
puppet: Don’t install netcat

### DIFF
--- a/puppet/zulip/manifests/base.pp
+++ b/puppet/zulip/manifests/base.pp
@@ -27,8 +27,6 @@ class zulip::base {
         'crudini',
         # Used for tools like sponge
         'moreutils',
-        # Used in scripts
-        'netcat',
         # Nagios monitoring plugins
         $zulip::common::nagios_plugins,
         # Required for using HTTPS in apt repositories.

--- a/tools/ci/Dockerfile.template
+++ b/tools/ci/Dockerfile.template
@@ -39,7 +39,7 @@ RUN apt-get update \
     locales \
     xvfb \
     parallel \
-    netcat unzip zip jq \
+    unzip zip jq \
     python3-pip \
   && ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime \
   && {{ locale-gen en_US.UTF-8 || true; }} \

--- a/tools/lib/provision.py
+++ b/tools/lib/provision.py
@@ -144,7 +144,6 @@ UBUNTU_COMMON_APT_DEPENDENCIES = [
     "redis-server",
     "hunspell-en-us",
     "puppet-lint",
-    "netcat",               # Used for flushing memcached
     "default-jre-headless",  # Required by vnu-jar
     *THUMBOR_VENV_DEPENDENCIES,
 ]

--- a/tools/test-install/prepare-base
+++ b/tools/test-install/prepare-base
@@ -46,7 +46,7 @@ run apt-get dist-upgrade -y
 # As an optimization, we install a bunch of packages the installer
 # would install for itself.
 run apt-get install -y --no-install-recommends \
-  xvfb parallel netcat unzip zip jq python3-pip wget curl eatmydata \
+  xvfb parallel unzip zip jq python3-pip wget curl eatmydata \
   git crudini openssl ssl-cert \
   build-essential python3-dev \
   memcached redis-server \


### PR DESCRIPTION
It’s been unused since commit 0af22dad183bfda0149c0774aeec29f39bfca285 (#13239).