### PR TITLE
Hyperlink to zulip-devel-announce added.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ user, or anything else. Make sure to read the
 before posting. The Zulip community is also governed by a
 [code of conduct](https://zulip.readthedocs.io/en/latest/code-of-conduct.html).
 
-You can subscribe to zulip-devel-announce@googlegroups.com or our
+You can subscribe to [zulip-devel-announce@googlegroups.com](https://groups.google.com/g/zulip-devel-announce) or our
 [Twitter](https://twitter.com/zulip) account for a lower traffic (~1
 email/month) way to hear about things like mentorship opportunities with Google
 Code-in, in-person sprints at conferences, and other opportunities to


### PR DESCRIPTION
This way it is a bit simpler for users to find the page to subscribe.
