### PR TITLE
ComposeBox : Fixed Textarea covering latest messages .

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -639,10 +639,32 @@ exports.initialize = function () {
     $(".compose_stream_button").on("click", () => {
         popovers.hide_mobile_message_buttons_popover();
         compose_actions.start("stream", {trigger: "new topic button"});
+        $("#compose-textarea").css(
+            "max-height",
+            parseInt($("#bottom_whitespace").outerHeight(), 10) -
+                (parseInt($("#below-compose-content").outerHeight(), 10) +
+                    parseInt($(".right_part").outerHeight(), 10) +
+                    parseInt($("#compose-textarea").css("padding-top"), 10) +
+                    parseInt($("#compose-textarea").css("padding-bottom"), 10) +
+                    parseInt($("#compose-textarea").css("margin-top"), 10) +
+                    parseInt($(".message_comp.compose-content").css("padding-top"), 10) +
+                    parseInt($(".message_comp.compose-content").css("padding-bottom"), 10)),
+        );
     });
     $(".compose_private_button").on("click", () => {
         popovers.hide_mobile_message_buttons_popover();
         compose_actions.start("private");
+        $("#compose-textarea").css(
+            "max-height",
+            parseInt($("#bottom_whitespace").outerHeight(), 10) -
+                (parseInt($("#below-compose-content").outerHeight(), 10) +
+                    parseInt($(".right_part").outerHeight(), 10) +
+                    parseInt($("#compose-textarea").css("padding-top"), 10) +
+                    parseInt($("#compose-textarea").css("padding-bottom"), 10) +
+                    parseInt($("#compose-textarea").css("margin-top"), 10) +
+                    parseInt($(".message_comp.compose-content").css("padding-top"), 10) +
+                    parseInt($(".message_comp.compose-content").css("padding-bottom"), 10)),
+        );
     });
 
     $("body").on("click", ".compose_mobile_stream_button", () => {

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -157,6 +157,17 @@ exports.watch_manual_resize = function (element) {
 
 exports.resize_bottom_whitespace = function (h) {
     $("#bottom_whitespace").height(h.bottom_whitespace_height);
+    $("#compose-textarea").css(
+        "max-height",
+        parseInt($("#bottom_whitespace").outerHeight(), 10) -
+            (parseInt($("#below-compose-content").outerHeight(), 10) +
+                parseInt($(".right_part").outerHeight(), 10) +
+                parseInt($("#compose-textarea").css("padding-top"), 10) +
+                parseInt($("#compose-textarea").css("padding-bottom"), 10) +
+                parseInt($("#compose-textarea").css("margin-top"), 10) +
+                parseInt($(".message_comp.compose-content").css("padding-top"), 10) +
+                parseInt($(".message_comp.compose-content").css("padding-bottom"), 10)),
+    );
 };
 
 exports.resize_stream_filters_container = function (h) {


### PR DESCRIPTION
Fixed Textarea in ComposeBox covering up latest messages in a stream while writing long messages .
CZO topic: <a href = 'https://chat.zulip.org/#narrow/stream/9-issues/topic/Long.20reply.20covers.20previous.20messages'>here</a>
 
Fixes #16038

<strong>Screenshots</strong> :

<strong>Before</strong>

![Screenshot from 2020-09-03 11-42-36](https://user-images.githubusercontent.com/53977614/92208870-b1e9e180-eea9-11ea-85b2-76d95cee36f0.png)
<strong>After</strong>

![Screenshot from 2020-09-03 11-46-21](https://user-images.githubusercontent.com/53977614/92208901-bc0be000-eea9-11ea-9369-c332faa7cabf.png)

