### PR TITLE
move_topic_to_stream: Allow moving to/between/from private streams.

### DIFF
--- a/templates/zerver/help/rename-a-topic.md
+++ b/templates/zerver/help/rename-a-topic.md
@@ -36,7 +36,7 @@ for the details on when topic editing is allowed.
 
 {!admin-only.md!}
 
-Organization administrators can move a topic from one public stream to
+Organization administrators can move a topic from one stream to
 another.
 
 {start_tabs}
@@ -53,6 +53,12 @@ another.
    to the old location for the topic, new location for the topic, or both.
 
 1. Click **Move topic**.
+
+
+!!! warn ""
+    **Note**: When a topic is moved to a private stream with protected history,
+              messages in the topic will be visible to all the subscribers.
+
 
 {end_tabs}
 

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -187,7 +187,6 @@ def update_message_backend(request: HttpRequest, user_profile: UserMessage,
         mention_user_ids = message.mentions_user_ids
 
     new_stream = None
-    old_stream = None
     number_changed = 0
 
     if stream_id is not None:
@@ -196,14 +195,7 @@ def update_message_backend(request: HttpRequest, user_profile: UserMessage,
         if content is not None:
             raise JsonableError(_("Cannot change message content while changing stream"))
 
-        old_stream = get_stream_by_id(message.recipient.type_id)
         new_stream = get_stream_by_id(stream_id)
-
-        if not (old_stream.is_public() and new_stream.is_public()):
-            # We'll likely decide to relax this condition in the
-            # future; it just requires more care with details like the
-            # breadcrumb messages.
-            raise JsonableError(_("Streams must be public"))
 
     number_changed = do_update_message(user_profile, message, new_stream,
                                        topic_name, propagate_mode,


### PR DESCRIPTION
The work for most of it was done
when we fixed moving msgs for guest users.

The general method involves moving the messages
to the new stream with special care of UserMessage.

We delete UserMessage for subs who are losing access
to the message. For private streams with protected history,
we also create UserMessage for users who are not present
in the old stream.
