### PR TITLE
tooltip: Fix arrow position.

### DIFF
--- a/static/third/bootstrap-tooltip/tooltip.css
+++ b/static/third/bootstrap-tooltip/tooltip.css
@@ -173,6 +173,7 @@
 .popover.bottom .arrow:after {
   top: -1px;
   left: -11px;
+  margin-left: 0;
   border-bottom-color: rgba(0, 0, 0, 0.25);
   border-width: 0 11px 11px;
 }


### PR DESCRIPTION
This was one of the regressions from our upgrade to bootstrap 2.3.2.
<img width="421" alt="Screenshot 2020-09-04 at 3 54 28 PM" src="https://user-images.githubusercontent.com/25124304/92229520-4282ea80-eec7-11ea-9ba1-8777eb9ecfd3.png">

after:
<img width="421" alt="Screenshot 2020-09-04 at 4 07 22 PM" src="https://user-images.githubusercontent.com/25124304/92230445-c1c4ee00-eec8-11ea-9140-99a82bbb63a2.png">
