### PR TITLE
Compose box resize issue while uploading file and while editing messages

### DIFF
--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const autosize = require("autosize");
+
 zrequire("compose_ui");
 const people = zrequire("people");
 zrequire("user_status");
@@ -70,6 +72,27 @@ function make_textbox(s) {
 
     return widget;
 }
+
+run_test("autosize_textarea", () => {
+    const textarea_autosized = {};
+
+    function fake_autosize_update(textarea) {
+        textarea_autosized.textarea = textarea;
+        textarea_autosized.autosized = true;
+    }
+
+    with_field(autosize, "update", fake_autosize_update, () => {
+        // Call autosize_textarea without any argument
+        compose_ui.autosize_textarea();
+        assert.equal(textarea_autosized.textarea, $("#compose-textarea"));
+        assert(textarea_autosized.autosized);
+
+        // Call autosize_textarea with an argument
+        compose_ui.autosize_textarea($("#message_edit_content_65"));
+        assert.equal(textarea_autosized.textarea, $("#message_edit_content_65"));
+        assert(textarea_autosized.autosized);
+    });
+});
 
 run_test("insert_syntax_and_focus", () => {
     $("#compose-textarea").val("xyz ");

--- a/frontend_tests/node_tests/upload.js
+++ b/frontend_tests/node_tests/upload.js
@@ -51,6 +51,10 @@ run_test("get_item", () => {
     assert.equal(upload.get_item("file_input_identifier", {mode: "compose"}), "#file_input");
     assert.equal(upload.get_item("source", {mode: "compose"}), "compose-file-input");
     assert.equal(upload.get_item("drag_drop_container", {mode: "compose"}), $("#compose"));
+    assert.equal(
+        upload.get_item("markdown_preview_hide_button", {mode: "compose"}),
+        $("#undo_markdown_preview"),
+    );
 
     assert.equal(upload.get_item("textarea", {mode: "edit", row: 1}), $("#message_edit_content_1"));
 
@@ -89,6 +93,10 @@ run_test("get_item", () => {
     assert.equal(
         upload.get_item("drag_drop_container", {mode: "edit", row: 1}),
         $("#message_edit_form"),
+    );
+    assert.equal(
+        upload.get_item("markdown_preview_hide_button", {mode: "edit", row: 65}),
+        $("#undo_markdown_preview_65"),
     );
 
     assert.throws(
@@ -227,8 +235,13 @@ run_test("upload_files", () => {
     compose_ui.autosize_textarea = () => {
         compose_ui_autosize_textarea_called = true;
     };
+    let markdown_preview_hide_button_clicked = false;
+    $("#undo_markdown_preview").on("click", () => {
+        markdown_preview_hide_button_clicked = true;
+    });
     $("#compose-send-button").prop("disabled", false);
     $("#compose-send-status").removeClass("alert-info").hide();
+    $("#undo_markdown_preview").show();
     upload.upload_files(uppy, config, files);
     assert($("#compose-send-button").prop("disabled"));
     assert($("#compose-send-status").hasClass("alert-info"));
@@ -236,6 +249,7 @@ run_test("upload_files", () => {
     assert.equal($("<p>").text(), "translated: Uploading…");
     assert(compose_ui_insert_syntax_and_focus_called);
     assert(compose_ui_autosize_textarea_called);
+    assert(markdown_preview_hide_button_clicked);
     assert(uppy_add_file_called);
 
     files = [

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -299,7 +299,7 @@ exports.nonexistent_stream_reply_error = nonexistent_stream_reply_error;
 function clear_compose_box() {
     $("#compose-textarea").val("").trigger("focus");
     drafts.delete_draft_after_send();
-    compose_ui.autosize_textarea();
+    compose_ui.autosize_textarea($("#compose-textarea"));
     $("#compose-send-status").hide(0);
     $("#compose-send-button").prop("disabled", false);
     $("#sending-indicator").hide();
@@ -781,7 +781,7 @@ exports.handle_keydown = function (event, textarea) {
             }
         }
 
-        compose_ui.autosize_textarea();
+        compose_ui.autosize_textarea(textarea);
         return;
     }
 };

--- a/static/js/compose_actions.js
+++ b/static/js/compose_actions.js
@@ -92,7 +92,7 @@ function clear_box() {
 
     exports.clear_textarea();
     $("#compose-textarea").removeData("draft-id");
-    compose_ui.autosize_textarea();
+    compose_ui.autosize_textarea($("#compose-textarea"));
     $("#compose-send-status").hide(0);
 }
 

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -4,8 +4,11 @@ const autosize = require("autosize");
 
 const people = require("./people");
 
-exports.autosize_textarea = function () {
-    autosize.update($("#compose-textarea"));
+exports.autosize_textarea = function (textarea) {
+    if (textarea === undefined) {
+        textarea = $("#compose-textarea");
+    }
+    autosize.update(textarea);
 };
 
 exports.smart_insert = function (textarea, syntax) {

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -876,7 +876,7 @@ exports.content_typeahead_selected = function (item, event) {
             }
             textbox.val(beginning + rest);
             textbox.caret(beginning.length, beginning.length);
-            compose_ui.autosize_textarea();
+            compose_ui.autosize_textarea(textbox);
         };
         show_flatpickr(this.$element[0], on_timestamp_selection, timestamp);
         return beginning + rest;
@@ -887,7 +887,7 @@ exports.content_typeahead_selected = function (item, event) {
     setTimeout(() => {
         textbox.caret(beginning.length, beginning.length);
         // Also, trigger autosize to check if compose box needs to be resized.
-        compose_ui.autosize_textarea();
+        compose_ui.autosize_textarea(textbox);
     }, 0);
     return beginning + rest;
 };

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -201,7 +201,7 @@ exports.restore_draft = function (draft_id) {
         compose_args.topic = "";
     }
     compose_actions.start(compose_args.type, compose_args);
-    compose_ui.autosize_textarea();
+    compose_ui.autosize_textarea($("#compose-textarea"));
     $("#compose-textarea").data("draft-id", draft_id);
 };
 

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -47,6 +47,8 @@ exports.get_item = function (key, config) {
                 return "compose-file-input";
             case "drag_drop_container":
                 return $("#compose");
+            case "markdown_preview_hide_button":
+                return $("#undo_markdown_preview");
             default:
                 throw Error(`Invalid key name for mode "${config.mode}"`);
         }
@@ -75,6 +77,8 @@ exports.get_item = function (key, config) {
                 return "message-edit-file-input";
             case "drag_drop_container":
                 return $("#message_edit_form");
+            case "markdown_preview_hide_button":
+                return $("#undo_markdown_preview_" + config.row);
             default:
                 throw Error(`Invalid key name for mode "${config.mode}"`);
         }
@@ -111,6 +115,9 @@ exports.upload_files = function (uppy, config, files) {
             i18n.t("File and image uploads have been disabled for this organization."),
         );
         return;
+    }
+    if (exports.get_item("markdown_preview_hide_button", config).is(":visible")) {
+        exports.get_item("markdown_preview_hide_button", config).trigger("click");
     }
     exports.get_item("send_button", config).prop("disabled", true);
     exports

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -134,7 +134,7 @@ exports.upload_files = function (uppy, config, files) {
                 exports.get_item("textarea", config),
             );
         });
-        compose_ui.autosize_textarea();
+        compose_ui.autosize_textarea(exports.get_item("textarea", config));
         uppy.cancelAll();
         exports.get_item("textarea", config).trigger("focus");
         setTimeout(() => {
@@ -148,7 +148,7 @@ exports.upload_files = function (uppy, config, files) {
                 exports.get_translated_status(file),
                 exports.get_item("textarea", config),
             );
-            compose_ui.autosize_textarea();
+            compose_ui.autosize_textarea(exports.get_item("textarea", config));
             uppy.addFile({
                 source: exports.get_item("source", config),
                 name: file.name,
@@ -247,7 +247,7 @@ exports.setup_upload = function (config) {
             filename_uri,
             exports.get_item("textarea", config),
         );
-        compose_ui.autosize_textarea();
+        compose_ui.autosize_textarea(exports.get_item("textarea", config));
     });
 
     uppy.on("complete", () => {
@@ -304,7 +304,7 @@ exports.setup_upload = function (config) {
             "",
             exports.get_item("textarea", config),
         );
-        compose_ui.autosize_textarea();
+        compose_ui.autosize_textarea(exports.get_item("textarea", config));
     });
 
     uppy.on("restriction-failed", (file) => {
@@ -313,7 +313,7 @@ exports.setup_upload = function (config) {
             "",
             exports.get_item("textarea", config),
         );
-        compose_ui.autosize_textarea();
+        compose_ui.autosize_textarea(exports.get_item("textarea", config));
     });
 
     return uppy;


### PR DESCRIPTION
**Commit 1:**

On uploading a few files from markdown_preview mode of compose box and
then switching back to edit mode, the compose box doesn't get resized.
It even doesn't allow to scroll through the content.

Fixed this by switching back to the edit mode everytime user uploads
some file in markdown_preview mode as there's no use of staying in
markdown_preview mode anyways after uploading a file as the preview
doesn't get updated.

Fixes: zulip#16296.

**Commit 2:**

Currently compose_ui.autosize_textarea doesn't seem to work while
editing messages in many cases (uploading files, typeaheads, keydown
handling, etc.).

Refactored the autosize_textarea function in compose_ui to work
while editing messages too and added appropriate argument for the
introduced function parameter at all occurences of the function
use.