### PR TITLE
WIP: markdown: View code in playground option for codeblocks

### DIFF
--- a/frontend_tests/node_tests/markdown.js
+++ b/frontend_tests/node_tests/markdown.js
@@ -4,6 +4,7 @@ zrequire("hash_util");
 
 const emoji = zrequire("emoji", "shared/js/emoji");
 const emoji_codes = zrequire("emoji_codes", "generated/emoji/emoji_codes.json");
+const pygments_data = zrequire("pygments_data", "generated/pygments_data.json");
 const fenced_code = zrequire("fenced_code", "shared/js/fenced_code");
 const markdown_config = zrequire("markdown_config");
 const marked = zrequire("marked", "third/marked/lib/marked");
@@ -48,6 +49,7 @@ function Image() {
 }
 set_global("Image", Image);
 emoji.initialize(emoji_params);
+fenced_code.initialize(pygments_data);
 
 const doc = "";
 set_global("document", doc);

--- a/static/js/rendered_markdown.js
+++ b/static/js/rendered_markdown.js
@@ -4,8 +4,10 @@ const ClipboardJS = require("clipboard");
 const moment = require("moment");
 
 const copy_code_button = require("../templates/copy_code_button.hbs");
+const view_code_in_playground = require("../templates/view_code_in_playground.hbs");
 
 const people = require("./people");
+const settings_config = require("./settings_config");
 
 /*
     rendered_markdown
@@ -189,10 +191,30 @@ exports.update_elements = (content) => {
         $(this).prepend(toggle_button_html);
     });
 
-    // Display the copy-to-clipboard button inside the div.codehilite element.
+    // Display the view-code-in-playground and the copy-to-clipboard button inside the div.codehilite element.
     content.find("div.codehilite").each(function () {
+        const $codehilite = $(this);
+        const $pre = $codehilite.find("pre");
+        const fenced_code_lang = $codehilite.data("code-language");
+        if (fenced_code_lang !== undefined) {
+            const playground_info = settings_config.get_playground_info_for_languages(
+                fenced_code_lang,
+            );
+            // If the playground info for the language isn't available we don't display the option.
+            if (playground_info !== undefined) {
+                const view_in_playground_button = $(view_code_in_playground());
+                $pre.prepend(view_in_playground_button);
+                if (playground_info.length === 1) {
+                    const title = i18n.t(`View code in ${playground_info[0].name}`);
+                    view_in_playground_button.attr("title", title);
+                    view_in_playground_button.attr("aria-label", title);
+                } else {
+                    view_in_playground_button.attr("aria-haspopup", "true");
+                }
+            }
+        }
         const copy_button = $(copy_code_button());
-        $(this).find("pre").prepend(copy_button);
+        $pre.prepend(copy_button);
         new ClipboardJS(copy_button[0], {
             text(copy_element) {
                 return $(copy_element).siblings("code").text();

--- a/static/js/settings_config.js
+++ b/static/js/settings_config.js
@@ -320,3 +320,52 @@ exports.all_notifications = () => ({
         enable_online_push_notifications: !page_params.realm_push_notifications_enabled,
     },
 });
+
+const map_language_to_playground_info = {
+    // TODO: This is being hardcoded just for the prototype, post which we should
+    // add support for realm admins to configure their own choices. The keys here
+    // are the pygment lexer subclass names for the different language alias it
+    // supports.
+    Rust: [
+        {
+            name: "Rust playground",
+            url_prefix: "https://play.rust-lang.org/?code=",
+        },
+    ],
+    Julia: [
+        {
+            name: "Julia playground",
+            url_prefix: "https://repl.it/languages/julia/?code=",
+        },
+    ],
+    Python: [
+        {
+            name: "Python 3.x playground",
+            url_prefix: "https://repl.it/languages/python3/?code=",
+        },
+    ],
+    "Python 2.x": [
+        {
+            name: "Python 2.x playground",
+            url_prefix: "https://repl.it/languages/python/?code=",
+        },
+    ],
+    JavaScript: [
+        {
+            name: "Javascript playground",
+            url_prefix: "https://repl.it/languages/javascript/?code=",
+        },
+    ],
+    Lean: [
+        {
+            name: "Lean playground",
+            url_prefix: "https://leanprover.github.io/live/latest/#code=",
+        },
+        {
+            name: "Lean community playground",
+            url_prefix: "https://leanprover-community.github.io/lean-web-editor/#code=",
+        },
+    ],
+};
+
+exports.get_playground_info_for_languages = (lang) => map_language_to_playground_info[lang];

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -3,7 +3,9 @@
 const _ = require("lodash");
 
 const generated_emoji_codes = require("../generated/emoji/emoji_codes.json");
+const generated_pygments_data = require("../generated/pygments_data.json");
 const emoji = require("../shared/js/emoji");
+const fenced_code = require("../shared/js/fenced_code");
 const render_edit_content_button = require("../templates/edit_content_button.hbs");
 
 const emojisets = require("./emojisets");
@@ -477,6 +479,7 @@ exports.initialize_everything = function () {
     typing.initialize();
     starred_messages.initialize();
     user_status_ui.initialize();
+    fenced_code.initialize(generated_pygments_data);
 };
 
 $(() => {

--- a/static/shared/js/fenced_code.js
+++ b/static/shared/js/fenced_code.js
@@ -1,9 +1,6 @@
 import katex from "katex";
 import _ from "lodash";
 
-// eslint-disable-next-line
-const pygments_data = require("../../generated/pygments_data.json");
-
 // Parsing routine that can be dropped in to message parsing
 // and formats code blocks
 //
@@ -33,16 +30,23 @@ let stash_func = function (text) {
     return text;
 };
 
+// We fill up the actual values when initializing.
+let pygments_data = {};
+
+export function initialize(generated_pygments_data) {
+    pygments_data = generated_pygments_data.langs;
+}
+
 export function wrap_code(code, lang) {
     let header = '<div class="codehilite"><pre><span></span><code>';
     // Mimics the backend logic of adding a data-attribute (data-code-language)
     // to know what Pygments language was used to highlight this code block.
-    if (lang !== undefined && lang !== "") {
-        const pygments_language_info = pygments_data.langs[lang];
-        let code_language = _.escape(lang);
-        if (pygments_language_info !== undefined) {
-            code_language = pygments_language_info.pretty_name;
-        }
+    //
+    // NOTE: Clients like zulip-mobile wouldn't receive the pygments data since that comes from outside
+    // the `/shared` folder. To handle such a case we check if pygments data is empty and fallback to
+    // using the default header if it is.
+    if (lang !== undefined && lang !== "" && Object.keys(pygments_data).length > 0) {
+        const code_language = _.get(pygments_data, [lang, "pretty_name"], _.escape(lang));
         header = `<div class="codehilite" data-code-language="${code_language}"><pre><span></span><code>`;
     }
     // Trim trailing \n until there's just one left

--- a/static/styles/rendered_markdown.css
+++ b/static/styles/rendered_markdown.css
@@ -451,7 +451,7 @@
 
     pre {
         &:hover .copy_codeblock,
-        &:focus-within .copy_codeblock {
+        &:hover .code_external_link {
             visibility: visible;
         }
     }
@@ -479,6 +479,21 @@
     .copy_codeblock:hover svg path {
         fill: hsl(200, 100%, 40%);
     }
+
+    .code_external_link {
+        visibility: hidden;
+        position: absolute;
+        right: 23px;
+        margin-top: -2px;
+        font-size: 1.2em;
+        /* The default icon and on-hover colors are inherited from <a> tag.
+        so we set our own to match the copy-to-clipbord icon */
+        color: hsl(0, 0%, 47%);
+
+        &:hover {
+            color: hsl(200, 100%, 40%);
+        }
+    }
 }
 
 .preview_content .copy_codeblock {
@@ -487,6 +502,10 @@
        the "edit" state.  We may change this decision when we add
        menu options for viewing the code in a coding playground. */
     display: none;
+}
+
+.preview_content .code_external_link {
+    right: 12px;
 }
 
 @media (max-width: 600px) {

--- a/static/templates/playground_links_popover_content.hbs
+++ b/static/templates/playground_links_popover_content.hbs
@@ -1,0 +1,9 @@
+{{! Contents of "view code in playground" popover for code blocks}}
+<ul class="nav nav-list">
+    {{#each playground_info}}
+    <li>
+        <a href="{{this/playground_url}}" target="_blank" rel="noopener noreferrer" class="popover_playground_link">{{this/name}}</a>
+    </li>
+    {{/each}}
+</ul>
+

--- a/static/templates/view_code_in_playground.hbs
+++ b/static/templates/view_code_in_playground.hbs
@@ -1,0 +1,2 @@
+{{! Display the "view code in playground" option for code blocks}}
+<a target="_blank" rel="noopener noreferrer" class="code_external_link" data-toggle="tooltip"><i class="fa fa-external-link"></i></a>


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This is a prototype PR to solve #11618 and right now hardcodes the playground link for ~5 languages (Rust, python2, python3, Lean, Julia). Post this we can start working on supporting Realm Admins configuring their own choices for playground links.

**Testing Plan:** <!-- How have you tested? -->
Manually testing done to verify that clicking on the link opens the playground (and loads the code).

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![view-code-2](https://user-images.githubusercontent.com/30312566/94343448-efb7d100-0035-11eb-96dd-f1b7844f35a6.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
Fixes: #11618 

## TODO:

- [x] Tweak build_pygments_data tool to generate `pygments_lang.json` in a format most useful for us.
- [x] We should add a mention of the new markdown feature in `templates/zerver/api/changelog.md` and bump the feature level.
- [x] Experiment with a dropdown UI for multiple playground options.
- [ ] Start working towards adding support for realm admins to configure their own playground choices (open up an issue for this)
- [ ] Add Help Center documentation for this once we've properly documented the configuration interface.