### PR TITLE
Reactions_tooltip : Improved responsiveness of reaction tooltip .

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -228,7 +228,10 @@ exports.initialize = function () {
             animation: false,
         });
         elem.tooltip("show");
-        $(".tooltip, .tooltip-inner").css("max-width", "600px");
+        $(".tooltip, .tooltip-inner").css({
+            "margin-left": "15px",
+            "max-width": $(window).width() * 0.6,
+        });
         // Remove the arrow from the tooltip.
         $(".tooltip-arrow").remove();
     });


### PR DESCRIPTION
Improved responsiveness of tooltip to get all emoji reactions by the members  .
Earlier , In screen sizes of width less than 775px , the tooltip would overflow ( or exceed ) towards the left side of screen .

<strong>Screenshots</strong>

<strong>Before :</strong>

![Screenshot from 2020-09-06 20-05-58](https://user-images.githubusercontent.com/53977614/92330066-b8cf4a80-f089-11ea-9d43-a965592fa4e5.png)

<strong>After :</strong>

![Screenshot from 2020-09-06 20-05-38](https://user-images.githubusercontent.com/53977614/92330085-d7354600-f089-11ea-8fae-2ae26cde48a1.png)
