### PR TITLE
Queue monitoring fixes

### DIFF
--- a/scripts/lib/check_rabbitmq_queue.py
+++ b/scripts/lib/check_rabbitmq_queue.py
@@ -38,23 +38,15 @@ states = {
     3: "UNKNOWN",
 }
 
-MAX_SECONDS_TO_CLEAR_FOR_BURSTS: DefaultDict[str, int] = defaultdict(
-    lambda: 120,
-    digest_emails=600,
-)
-MAX_SECONDS_TO_CLEAR_NORMAL: DefaultDict[str, int] = defaultdict(
+MAX_SECONDS_TO_CLEAR: DefaultDict[str, int] = defaultdict(
     lambda: 30,
     digest_emails=1200,
     missedmessage_mobile_notifications=120,
 )
-CRITICAL_SECONDS_TO_CLEAR_FOR_BURSTS: DefaultDict[str, int] = defaultdict(
-    lambda: 240,
-    digest_emails=1200,
-)
-CRITICAL_SECONDS_TO_CLEAR_NORMAL: DefaultDict[str, int] = defaultdict(
+CRITICAL_SECONDS_TO_CLEAR: DefaultDict[str, int] = defaultdict(
     lambda: 60,
     missedmessage_mobile_notifications=180,
-    digest_emails=600,
+    digest_emails=1800,
 )
 
 def analyze_queue_stats(queue_name: str, stats: Dict[str, Any],
@@ -93,34 +85,15 @@ def analyze_queue_stats(queue_name: str, stats: Dict[str, Any],
                     message='')
 
     expected_time_to_clear_backlog = current_size * average_consume_time
-    time_since_emptied = now - stats['queue_last_emptied_timestamp']
-    if time_since_emptied > max(300, CRITICAL_SECONDS_TO_CLEAR_FOR_BURSTS[queue_name]):
-        # We need the max() expression in case the rules for the queue
-        # permit longer processing times than 300s - to prevent
-        # incorrectly throwing an error by changing the classification
-        # of the the backlog from "burst" to "not burst" after 300s,
-        # while the worker is still processing it and staying below
-        # the CRITICAL threshold.
-        if expected_time_to_clear_backlog > MAX_SECONDS_TO_CLEAR_NORMAL[queue_name]:
-            if expected_time_to_clear_backlog > CRITICAL_SECONDS_TO_CLEAR_NORMAL[queue_name]:
-                status = CRITICAL
-            else:
-                status = WARNING
+    if expected_time_to_clear_backlog > MAX_SECONDS_TO_CLEAR[queue_name]:
+        if expected_time_to_clear_backlog > CRITICAL_SECONDS_TO_CLEAR[queue_name]:
+            status = CRITICAL
+        else:
+            status = WARNING
 
-            return dict(status=status,
-                        name=queue_name,
-                        message=f'clearing the backlog will take too long: {expected_time_to_clear_backlog}s, size: {current_size}')
-    else:
-        # We slept recently, so treat this as a burst.
-        if expected_time_to_clear_backlog > MAX_SECONDS_TO_CLEAR_FOR_BURSTS[queue_name]:
-            if expected_time_to_clear_backlog > CRITICAL_SECONDS_TO_CLEAR_FOR_BURSTS[queue_name]:
-                status = CRITICAL
-            else:
-                status = WARNING
-
-            return dict(status=status,
-                        name=queue_name,
-                        message=f'clearing the burst will take too long: {expected_time_to_clear_backlog}s, size: {current_size}')
+        return dict(status=status,
+                    name=queue_name,
+                    message=f'clearing the backlog will take too long: {expected_time_to_clear_backlog}s, size: {current_size}')
 
     return dict(status=OK,
                 name=queue_name,

--- a/scripts/lib/check_rabbitmq_queue.py
+++ b/scripts/lib/check_rabbitmq_queue.py
@@ -42,11 +42,13 @@ MAX_SECONDS_TO_CLEAR: DefaultDict[str, int] = defaultdict(
     lambda: 30,
     digest_emails=1200,
     missedmessage_mobile_notifications=120,
+    embed_links=60,
 )
 CRITICAL_SECONDS_TO_CLEAR: DefaultDict[str, int] = defaultdict(
     lambda: 60,
     missedmessage_mobile_notifications=180,
     digest_emails=1800,
+    embed_links=90,
 )
 
 def analyze_queue_stats(queue_name: str, stats: Dict[str, Any],

--- a/tools/tests/test_check_rabbitmq_queue.py
+++ b/tools/tests/test_check_rabbitmq_queue.py
@@ -10,12 +10,8 @@ class AnalyzeQueueStatsTests(TestCase):
         self.assertEqual(result['status'], UNKNOWN)
 
     def test_queue_stuck(self) -> None:
-        """Last update > 5 minutes ago and there's events in the queue.
+        """Last update > 5 minutes ago and there's events in the queue."""
 
-        In theory, we could be having bad luck with a race where in
-        the last (event_handing_time * 50) a burst was added, but it's
-        unlikely and shouldn't fail 2 in a row for Nagios anyway.
-        """
         result = analyze_queue_stats('name', {'update_time': time.time() - 301}, 100)
         self.assertEqual(result['status'], CRITICAL)
         self.assertIn('queue appears to be stuck', result['message'])

--- a/tools/tests/test_check_rabbitmq_queue.py
+++ b/tools/tests/test_check_rabbitmq_queue.py
@@ -42,8 +42,8 @@ class AnalyzeQueueStatsTests(TestCase):
                                               'recent_average_consume_time': 0.0001}, 10000)
         self.assertEqual(result['status'], OK)
 
-        # Verify logic around whether it'll take MAX_SECONDS_TO_CLEAR_NORMAL to clear queue.
-        with mock.patch.dict('scripts.lib.check_rabbitmq_queue.MAX_SECONDS_TO_CLEAR_NORMAL',
+        # Verify logic around whether it'll take MAX_SECONDS_TO_CLEAR to clear queue.
+        with mock.patch.dict('scripts.lib.check_rabbitmq_queue.MAX_SECONDS_TO_CLEAR',
                              {'name': 10}):
             result = analyze_queue_stats('name', {'update_time': time.time(),
                                                   'current_queue_size': 11,
@@ -57,54 +57,3 @@ class AnalyzeQueueStatsTests(TestCase):
                                                   'queue_last_emptied_timestamp': time.time() - 10000,
                                                   'recent_average_consume_time': 1}, 9)
             self.assertEqual(result['status'], OK)
-
-    def test_queue_burst(self) -> None:
-        """Test logic for just after a large number of events were added
-        to an empty queue.  Happens routinely for digest emails, for example."""
-        result = analyze_queue_stats('name', {'update_time': time.time(),
-                                              'current_queue_size': 10000,
-                                              'queue_last_emptied_timestamp': time.time() - 1,
-                                              'recent_average_consume_time': 1}, 10000)
-        self.assertEqual(result['status'], CRITICAL)
-        self.assertIn('clearing the burst', result['message'])
-
-        # verify logic around MAX_SECONDS_TO_CLEAR_FOR_BURSTS.
-        with mock.patch.dict('scripts.lib.check_rabbitmq_queue.MAX_SECONDS_TO_CLEAR_FOR_BURSTS',
-                             {'name': 10}):
-            result = analyze_queue_stats('name', {'update_time': time.time(),
-                                                  'current_queue_size': 11,
-                                                  'queue_last_emptied_timestamp': time.time() - 1,
-                                                  'recent_average_consume_time': 1}, 11)
-            self.assertEqual(result['status'], WARNING)
-            self.assertIn('clearing the burst', result['message'])
-
-            result = analyze_queue_stats('name', {'update_time': time.time(),
-                                                  'current_queue_size': 9,
-                                                  'queue_last_emptied_timestamp': time.time() - 1,
-                                                  'recent_average_consume_time': 1}, 9)
-            self.assertEqual(result['status'], OK)
-
-    def test_queue_burst_long_time_to_clear_allowed(self) -> None:
-        """
-        For a queue that is allowed > 300s to clear a burst of events,
-        we need to verify that the checker will not stop categorizing this as a burst
-        while the worker is still processing the events, within the allowed time limit.
-        """
-        start_time = time.time()
-        with mock.patch.dict('scripts.lib.check_rabbitmq_queue.CRITICAL_SECONDS_TO_CLEAR_FOR_BURSTS',
-                             {'name': 600}), \
-                mock.patch.dict('scripts.lib.check_rabbitmq_queue.MAX_SECONDS_TO_CLEAR_FOR_BURSTS',
-                                {'name': 600}):
-            with mock.patch('time.time', return_value=start_time + 599):
-                result = analyze_queue_stats('name', {'update_time': time.time(),
-                                                      'current_queue_size': 599,
-                                                      'queue_last_emptied_timestamp': start_time,
-                                                      'recent_average_consume_time': 1}, 599)
-                self.assertEqual(result['status'], OK)
-
-            with mock.patch('time.time', return_value=start_time + 601):
-                result = analyze_queue_stats('name', {'update_time': time.time(),
-                                                      'current_queue_size': 599,
-                                                      'queue_last_emptied_timestamp': start_time,
-                                                      'recent_average_consume_time': 1}, 599)
-                self.assertEqual(result['status'], CRITICAL)

--- a/zerver/worker/queue_processors.py
+++ b/zerver/worker/queue_processors.py
@@ -176,7 +176,7 @@ class QueueProcessingWorker(ABC):
         self.queue_last_emptied_timestamp = time.time()
         self.consumed_since_last_emptied = 0
         self.recent_consume_times: MutableSequence[Tuple[int, float]] = deque(maxlen=50)
-        self.consume_interation_counter = 0
+        self.consume_iteration_counter = 0
         self.idle = True
 
         self.update_statistics(0)
@@ -258,10 +258,10 @@ class QueueProcessingWorker(ABC):
                 self.idle = True
                 return
 
-            self.consume_interation_counter += 1
-            if self.consume_interation_counter >= self.CONSUME_ITERATIONS_BEFORE_UPDATE_STATS_NUM:
+            self.consume_iteration_counter += 1
+            if self.consume_iteration_counter >= self.CONSUME_ITERATIONS_BEFORE_UPDATE_STATS_NUM:
 
-                self.consume_interation_counter = 0
+                self.consume_iteration_counter = 0
                 self.update_statistics(remaining_queue_size)
 
     def consume_wrapper(self, data: Dict[str, Any]) -> None:


### PR DESCRIPTION
First 2 commits fix two reasons for a recent CRITICAL page from `embed_links` queue, and then we fix a race condition described in a `TODO` that would have been annoying if it happened as well.