### PR TITLE
[WIP] Handle incoming no-op edits

### DIFF
--- a/scripts/lib/check_rabbitmq_queue.py
+++ b/scripts/lib/check_rabbitmq_queue.py
@@ -110,7 +110,7 @@ CRITICAL_COUNT_THRESHOLD_DEFAULT = 50
 
 
 def check_other_queues(queue_counts_dict: Dict[str, int]) -> List[Dict[str, Any]]:
-    """ Do a simple queue size check for queues whose workers don't publish stats files."""
+    """Do a simple queue size check for queues whose workers don't publish stats files."""
 
     results = []
     for queue, count in queue_counts_dict.items():

--- a/templates/zerver/api/changelog.md
+++ b/templates/zerver/api/changelog.md
@@ -10,6 +10,13 @@ below features are supported.
 
 ## Changes in Zulip 4.0
 
+**Feature level 39**
+
+* Include `orig_subject` in update message events where the stream is
+changed, in addition to the existing inclusion when the topic is changed.
+NOTE: This change happened between feature levels 9 and 10, but due to
+an error, did not receive its own feature level at the time.
+
 **Feature level 38**
 
 * [`POST /register`](/api/register-queue): Increased

--- a/version.py
+++ b/version.py
@@ -30,7 +30,7 @@ DESKTOP_WARNING_VERSION = "5.2.0"
 #
 # Changes should be accompanied by documentation explaining what the
 # new level means in templates/zerver/api/changelog.md.
-API_FEATURE_LEVEL = 38
+API_FEATURE_LEVEL = 39
 
 # Bump the minor PROVISION_VERSION to indicate that folks should provision
 # only when going from an old version of the code to a newer version. Bump

--- a/zerver/lib/actions.py
+++ b/zerver/lib/actions.py
@@ -6502,7 +6502,7 @@ def do_remove_realm_domain(
 
 def get_occupied_streams(realm: Realm) -> QuerySet:
     # TODO: Make a generic stub for QuerySet
-    """ Get streams with subscribers """
+    """Get streams with subscribers"""
     exists_expression = Exists(
         Subscription.objects.filter(
             active=True,

--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -560,7 +560,7 @@ class InlineHttpsProcessor(markdown.treeprocessors.Treeprocessor):
 
 
 class BacktickInlineProcessor(markdown.inlinepatterns.BacktickInlineProcessor):
-    """ Return a `<code>` element containing the matching text. """
+    """Return a `<code>` element containing the matching text."""
 
     def handleMatch(self, m: Match[str], data: str) -> Tuple[Union[None, Element], int, int]:
         # Let upstream's implementation do its job as it is, we'll
@@ -1438,7 +1438,7 @@ def unicode_emoji_to_codepoint(unicode_emoji: str) -> str:
 
 
 class EmoticonTranslation(markdown.inlinepatterns.Pattern):
-    """ Translates emoticons like `:)` into emoji like `:smile:`. """
+    """Translates emoticons like `:)` into emoji like `:smile:`."""
 
     def handleMatch(self, match: Match[str]) -> Optional[Element]:
         db_data = self.md.zulip_db_data
@@ -1609,7 +1609,7 @@ class OListProcessor(sane_lists.SaneOListProcessor):
 
 
 class UListProcessor(sane_lists.SaneUListProcessor):
-    """ Unordered lists, but with 2-space indent """
+    """Unordered lists, but with 2-space indent"""
 
     def __init__(self, parser: Any) -> None:
         parser.md.tab_length = 2
@@ -1705,7 +1705,7 @@ class MarkdownListPreprocessor(markdown.preprocessors.Preprocessor):
     LI_RE = re.compile(r"^[ ]*([*+-]|\d\.)[ ]+(.*)", re.MULTILINE)
 
     def run(self, lines: List[str]) -> List[str]:
-        """ Insert a newline between a paragraph and ulist if missing """
+        """Insert a newline between a paragraph and ulist if missing"""
         inserts = 0
         in_code_fence: bool = False
         open_fences: List[Fence] = []
@@ -1761,7 +1761,7 @@ def prepare_realm_pattern(source: str) -> str:
 # Given a regular expression pattern, linkifies groups that match it
 # using the provided format string to construct the URL.
 class RealmFilterPattern(markdown.inlinepatterns.Pattern):
-    """ Applied a given realm filter to the input """
+    """Applied a given realm filter to the input"""
 
     def __init__(
         self,

--- a/zerver/lib/markdown/fenced_code.py
+++ b/zerver/lib/markdown/fenced_code.py
@@ -157,7 +157,7 @@ class FencedCodeExtension(Extension):
             self.setConfig(key, value)
 
     def extendMarkdown(self, md: Markdown) -> None:
-        """ Add FencedBlockPreprocessor to the Markdown instance. """
+        """Add FencedBlockPreprocessor to the Markdown instance."""
         md.registerExtension(self)
         processor = FencedBlockPreprocessor(
             md, run_content_validators=self.config["run_content_validators"][0]
@@ -379,7 +379,7 @@ class FencedBlockPreprocessor(Preprocessor):
         self.handlers.pop()
 
     def run(self, lines: Iterable[str]) -> List[str]:
-        """ Match and store Fenced Code Blocks in the HtmlStash. """
+        """Match and store Fenced Code Blocks in the HtmlStash."""
 
         output: List[str] = []
 
@@ -502,7 +502,7 @@ class FencedBlockPreprocessor(Preprocessor):
         return self.md.htmlStash.store(code)
 
     def _escape(self, txt: str) -> str:
-        """ basic html escaping """
+        """basic html escaping"""
         txt = txt.replace("&", "&amp;")
         txt = txt.replace("<", "&lt;")
         txt = txt.replace(">", "&gt;")

--- a/zerver/lib/markdown/help_emoticon_translations_table.py
+++ b/zerver/lib/markdown/help_emoticon_translations_table.py
@@ -39,7 +39,7 @@ ROW_HTML = """\
 
 class EmoticonTranslationsHelpExtension(Extension):
     def extendMarkdown(self, md: Markdown) -> None:
-        """ Add SettingHelpExtension to the Markdown instance. """
+        """Add SettingHelpExtension to the Markdown instance."""
         md.registerExtension(self)
         md.preprocessors.register(EmoticonTranslation(), "emoticon_translations", -505)
 

--- a/zerver/lib/markdown/help_relative_links.py
+++ b/zerver/lib/markdown/help_relative_links.py
@@ -72,7 +72,7 @@ LINK_TYPE_HANDLERS = {
 
 class RelativeLinksHelpExtension(Extension):
     def extendMarkdown(self, md: Markdown) -> None:
-        """ Add RelativeLinksHelpExtension to the Markdown instance. """
+        """Add RelativeLinksHelpExtension to the Markdown instance."""
         md.registerExtension(self)
         md.preprocessors.register(RelativeLinks(), "help_relative_links", 520)
 

--- a/zerver/lib/markdown/help_settings_links.py
+++ b/zerver/lib/markdown/help_settings_links.py
@@ -88,7 +88,7 @@ settings_markdown = """
 
 class SettingHelpExtension(Extension):
     def extendMarkdown(self, md: Markdown) -> None:
-        """ Add SettingHelpExtension to the Markdown instance. """
+        """Add SettingHelpExtension to the Markdown instance."""
         md.registerExtension(self)
         md.preprocessors.register(Setting(), "setting", 515)
 

--- a/zerver/lib/storage.py
+++ b/zerver/lib/storage.py
@@ -13,7 +13,6 @@ if settings.DEBUG:
     def static_path(path: str) -> str:
         return find(path) or "/nonexistent"
 
-
 else:
 
     def static_path(path: str) -> str:

--- a/zerver/lib/test_runner.py
+++ b/zerver/lib/test_runner.py
@@ -181,7 +181,7 @@ def destroy_test_databases(worker_id: Optional[int] = None) -> None:
             # delete that database, we need to not pass a number
             # argument to destroy_test_db.
             if worker_id is not None:
-                """Modified from the Django original to """
+                """Modified from the Django original to"""
                 database_id = get_database_id(worker_id)
                 connection.creation.destroy_test_db(suffix=database_id)
             else:

--- a/zerver/openapi/markdown_extension.py
+++ b/zerver/openapi/markdown_extension.py
@@ -334,7 +334,7 @@ def render_curl_example(
     exclude: Optional[List[str]] = None,
     include: Optional[List[str]] = None,
 ) -> List[str]:
-    """ A simple wrapper around generate_curl_example. """
+    """A simple wrapper around generate_curl_example."""
     parts = function.split(":")
     endpoint = parts[0]
     method = parts[1]

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3862,7 +3862,7 @@ paths:
         `PATCH {{ api_url }}/v1/messages/{msg_id}`
 
         `{msg_id}` in the above URL should be replaced with the ID of the
-        message you wish you update.
+        message you wish to update.
       parameters:
         - $ref: "#/components/parameters/MessageId"
         - $ref: "#/components/parameters/Topic"

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -1843,8 +1843,15 @@ paths:
                                 orig_subject:
                                   type: string
                                   description: |
-                                    The original topic of the message. Only present if the topic of the message
-                                    was changed.
+                                    The original topic of the message. Present if either the topic or the
+                                    stream of the message has changed, or both.
+
+                                    **Changes**: Before Zulip 3.0, this was only present if a topic edit had
+                                    been specified. As of 3.0, it's also present if a stream edit has been
+                                    specified. The change happened between feature levels 9 and 10, but due to
+                                    an error, did not receive its own feature level at the time. It now has
+                                    feature level 39.
+
                                 subject:
                                   type: string
                                   description: |

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -3362,7 +3362,19 @@ paths:
               example: [9, 10]
           required: true
         - $ref: "#/components/parameters/RequiredContent"
-        - $ref: "#/components/parameters/Topic"
+        - name: topic
+          in: query
+          description: |
+            The topic of the message. Only required for stream messages
+            (`type="stream"`), ignored otherwise.
+
+            Maximum length of 60 characters.
+
+            **Changes**: New in Zulip 2.0.  Previous Zulip releases encoded
+            this as `subject`, which is currently a deprecated alias.
+          schema:
+            type: string
+          example: Castle
         - name: queue_id
           in: query
           schema:
@@ -3865,7 +3877,19 @@ paths:
         message you wish to update.
       parameters:
         - $ref: "#/components/parameters/MessageId"
-        - $ref: "#/components/parameters/Topic"
+        - name: topic
+          in: query
+          description: |
+            The topic of the message. Only has an effect for stream messages,
+            ignored otherwise.
+
+            Maximum length of 60 characters.
+
+            **Changes**: New in Zulip 2.0.  Previous Zulip releases encoded
+            this as `subject`, which is currently a deprecated alias.
+          schema:
+            type: string
+          example: Castle
         - name: propagate_mode
           in: query
           description: |
@@ -10219,20 +10243,6 @@ components:
         type: integer
       example: 1
       required: true
-    Topic:
-      name: topic
-      in: query
-      description: |
-        The topic of the message. Only required for stream messages
-        (`type="stream"`), ignored otherwise.
-
-        Maximum length of 60 characters.
-
-        **Changes**: New in Zulip 2.0.  Previous Zulip releases encoded
-        this as `subject`, which is currently a deprecated alias.
-      schema:
-        type: string
-      example: Castle
     QueueId:
       name: queue_id
       in: query

--- a/zerver/tests/test_drafts.py
+++ b/zerver/tests/test_drafts.py
@@ -189,7 +189,7 @@ class DraftCreationTests(ZulipTestCase):
         self.create_and_check_drafts_for_error(draft_dicts, "Timestamp must not be negative.")
 
     def test_create_non_stream_draft_with_no_recipient(self) -> None:
-        """ When "to" is an empty list, the type should become "" as well. """
+        """When "to" is an empty list, the type should become "" as well."""
         draft_dicts = [
             {
                 "type": "private",

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -6,6 +6,7 @@ from unittest import mock
 import orjson
 from django.db import IntegrityError
 from django.http import HttpResponse
+from typing_extensions import Literal, TypedDict
 
 from zerver.lib.actions import (
     do_set_realm_property,
@@ -17,7 +18,7 @@ from zerver.lib.message import MessageDict, has_message_access, messages_for_ids
 from zerver.lib.test_classes import ZulipTestCase
 from zerver.lib.test_helpers import cache_tries_captured, queries_captured
 from zerver.lib.topic import LEGACY_PREV_TOPIC, TOPIC_NAME
-from zerver.models import Message, Stream, UserMessage, UserProfile
+from zerver.models import Message, Stream, UserMessage, UserProfile, get_realm, get_stream
 
 
 class EditMessageTest(ZulipTestCase):
@@ -213,6 +214,130 @@ class EditMessageTest(ZulipTestCase):
             },
         )
         self.assert_json_error(result, "Nothing to change")
+
+    def test_edit_message_noop_changes(self) -> None:
+        class MsgDict(TypedDict, total=False):
+            stream_id: int
+            topic: str
+            content: str
+
+        msg_dict_attr_type = Literal["stream_id", "topic", "content"]
+        msg_dict_attrs: List[msg_dict_attr_type] = ["stream_id", "topic", "content"]
+
+        HISTORY_KEY_TO_ATTR_NAME = {
+            "prev_stream": "stream_id",
+            LEGACY_PREV_TOPIC: "topic",
+            "prev_content": "content",
+        }
+
+        realm = get_realm("zulip")
+        old_stream = get_stream("Scotland", realm)
+        new_stream = get_stream("Verona", realm)
+
+        original_msg_dict: MsgDict = {
+            "stream_id": old_stream.id,
+            "topic": "old topic",
+            "content": "old content",
+        }
+
+        # These subtests do not include edits where all the changes
+        # are actual changes; those edits are commented out. It does
+        # include edits that are currently disallowed – those that edit
+        # the stream and content at the same time – but marks them as
+        # expected to fail. When they become allowed in the future,
+        # those subtests will fail, which will alert whoever is making
+        # the changes to update this test to start really testing those
+        # edits.
+        subtests: List[Tuple[MsgDict, bool]] = [
+            # (edit_dict, should_succeed)
+            ({"stream_id": old_stream.id}, True),
+            # ({'stream_id': new_stream.id}, True),
+            ({"topic": "old topic"}, True),
+            # ({'topic': 'new topic'}, True),
+            ({"content": "old content"}, True),
+            # ({'content': 'new content'}, True),
+            ({"stream_id": old_stream.id, "topic": "old topic"}, True),
+            ({"stream_id": old_stream.id, "topic": "new topic"}, True),
+            ({"stream_id": new_stream.id, "topic": "old topic"}, True),
+            # ({'stream_id': new_stream.id, 'topic': 'new topic'}, True),
+            ({"stream_id": old_stream.id, "content": "old content"}, True),
+            ({"stream_id": old_stream.id, "content": "new content"}, True),
+            ({"stream_id": new_stream.id, "content": "old content"}, True),
+            # ({'stream_id': new_stream.id, 'content': 'new content'}, False),
+            ({"topic": "old topic", "content": "old content"}, True),
+            ({"topic": "old topic", "content": "new content"}, True),
+            ({"topic": "new topic", "content": "old content"}, True),
+            # ({'topic': 'new topic', 'content': 'new content'}, True),
+            ({"stream_id": old_stream.id, "topic": "old topic", "content": "old content"}, True),
+            ({"stream_id": old_stream.id, "topic": "old topic", "content": "new content"}, True),
+            ({"stream_id": old_stream.id, "topic": "new topic", "content": "old content"}, True),
+            ({"stream_id": old_stream.id, "topic": "new topic", "content": "new content"}, True),
+            ({"stream_id": new_stream.id, "topic": "old topic", "content": "old content"}, True),
+            ({"stream_id": new_stream.id, "topic": "old topic", "content": "new content"}, False),
+            ({"stream_id": new_stream.id, "topic": "new topic", "content": "old content"}, True),
+            # ({'stream_id': new_stream.id, 'topic': 'new topic', 'content': 'new content'}, False),
+        ]
+
+        # Must be an admin in order to edit the stream of a message
+        self.login("iago")
+
+        for (edit_dict, should_succeed) in subtests:
+            with self.subTest(edit_dict=edit_dict):
+                msg_id = self.send_stream_message(
+                    self.example_user("iago"),
+                    old_stream.name,
+                    topic_name=original_msg_dict["topic"],
+                    content=original_msg_dict["content"],
+                )
+                result = self.client_patch(
+                    f"/json/messages/{msg_id}",
+                    {
+                        "message_id": msg_id,
+                        **edit_dict,
+                    },
+                )
+
+                if not should_succeed:
+                    self.assert_json_error(
+                        result, "Cannot change message content while changing stream"
+                    )
+                    continue
+
+                self.assert_json_success(result)
+
+                msg = Message.objects.get(id=msg_id)
+
+                new_msg_dict: MsgDict = {
+                    "stream_id": msg.recipient.type_id,
+                    "topic": msg.topic_name(),
+                    "content": msg.content,
+                }
+
+                # Build the set of attributes that were saved in the latest edit.
+                latest_edit = set()
+                if msg.edit_history:
+                    history = orjson.loads(msg.edit_history)
+                    latest_edit = {
+                        HISTORY_KEY_TO_ATTR_NAME[key]
+                        for key in history[0].keys()
+                        if key in HISTORY_KEY_TO_ATTR_NAME
+                    }
+
+                # Build the set of attributes that were really changed, as
+                # opposed to being no-op edits.
+                real_changes = set()
+                for attr in msg_dict_attrs:
+                    if attr in edit_dict:
+                        # No matter what, these should be equal at this point.
+                        # It was either a no-op change, meaning they were already
+                        # the same, or it was a real change, and they should now
+                        # be the same.
+                        self.assertEqual(new_msg_dict[attr], edit_dict[attr])
+
+                        if new_msg_dict[attr] != original_msg_dict[attr]:
+                            real_changes.add(attr)
+
+                self.assertEqual(latest_edit, real_changes)
 
     def test_edit_message_no_topic(self) -> None:
         self.login("hamlet")

--- a/zerver/tests/test_message_edit.py
+++ b/zerver/tests/test_message_edit.py
@@ -115,7 +115,7 @@ class EditMessageTest(ZulipTestCase):
             self.example_user("hamlet"), "Scotland", topic_name="editing", content="before edit"
         )
         result = self.client_patch(
-            "/json/messages/" + str(msg_id),
+            f"/json/messages/{msg_id}",
             {
                 "message_id": msg_id,
                 "content": "after edit",
@@ -125,7 +125,7 @@ class EditMessageTest(ZulipTestCase):
         self.check_message(msg_id, topic_name="editing", content="after edit")
 
         result = self.client_patch(
-            "/json/messages/" + str(msg_id),
+            f"/json/messages/{msg_id}",
             {
                 "message_id": msg_id,
                 "topic": "edited",
@@ -141,7 +141,7 @@ class EditMessageTest(ZulipTestCase):
             to_user=self.example_user("cordelia"),
             content="**before** edit",
         )
-        result = self.client_get("/json/messages/" + str(msg_id))
+        result = self.client_get(f"/json/messages/{msg_id}")
         self.assert_json_success(result)
         self.assertEqual(result.json()["raw_content"], "**before** edit")
 
@@ -150,11 +150,11 @@ class EditMessageTest(ZulipTestCase):
         self.assert_json_error(result, "Invalid message(s)")
 
         self.login("cordelia")
-        result = self.client_get("/json/messages/" + str(msg_id))
+        result = self.client_get(f"/json/messages/{msg_id}")
         self.assert_json_success(result)
 
         self.login("othello")
-        result = self.client_get("/json/messages/" + str(msg_id))
+        result = self.client_get(f"/json/messages/{msg_id}")
         self.assert_json_error(result, "Invalid message(s)")
 
     def test_fetch_raw_message_stream_wrong_realm(self) -> None:
@@ -165,12 +165,12 @@ class EditMessageTest(ZulipTestCase):
         msg_id = self.send_stream_message(
             user_profile, stream.name, topic_name="test", content="test"
         )
-        result = self.client_get("/json/messages/" + str(msg_id))
+        result = self.client_get(f"/json/messages/{msg_id}")
         self.assert_json_success(result)
 
         mit_user = self.mit_user("sipbtest")
         self.login_user(mit_user)
-        result = self.client_get("/json/messages/" + str(msg_id), subdomain="zephyr")
+        result = self.client_get(f"/json/messages/{msg_id}", subdomain="zephyr")
         self.assert_json_error(result, "Invalid message(s)")
 
     def test_fetch_raw_message_private_stream(self) -> None:
@@ -181,10 +181,10 @@ class EditMessageTest(ZulipTestCase):
         msg_id = self.send_stream_message(
             user_profile, stream.name, topic_name="test", content="test"
         )
-        result = self.client_get("/json/messages/" + str(msg_id))
+        result = self.client_get(f"/json/messages/{msg_id}")
         self.assert_json_success(result)
         self.login("othello")
-        result = self.client_get("/json/messages/" + str(msg_id))
+        result = self.client_get(f"/json/messages/{msg_id}")
         self.assert_json_error(result, "Invalid message(s)")
 
     def test_edit_message_no_permission(self) -> None:
@@ -193,7 +193,7 @@ class EditMessageTest(ZulipTestCase):
             self.example_user("iago"), "Scotland", topic_name="editing", content="before edit"
         )
         result = self.client_patch(
-            "/json/messages/" + str(msg_id),
+            f"/json/messages/{msg_id}",
             {
                 "message_id": msg_id,
                 "content": "content after edit",
@@ -207,7 +207,7 @@ class EditMessageTest(ZulipTestCase):
             self.example_user("hamlet"), "Scotland", topic_name="editing", content="before edit"
         )
         result = self.client_patch(
-            "/json/messages/" + str(msg_id),
+            f"/json/messages/{msg_id}",
             {
                 "message_id": msg_id,
             },
@@ -220,7 +220,7 @@ class EditMessageTest(ZulipTestCase):
             self.example_user("hamlet"), "Scotland", topic_name="editing", content="before edit"
         )
         result = self.client_patch(
-            "/json/messages/" + str(msg_id),
+            f"/json/messages/{msg_id}",
             {
                 "message_id": msg_id,
                 "topic": " ",
@@ -234,7 +234,7 @@ class EditMessageTest(ZulipTestCase):
             self.example_user("hamlet"), "Scotland", topic_name="editing", content="before edit"
         )
         result = self.client_patch(
-            "/json/messages/" + str(msg_id),
+            f"/json/messages/{msg_id}",
             {
                 "message_id": msg_id,
                 "content": " ",
@@ -259,7 +259,7 @@ class EditMessageTest(ZulipTestCase):
 
         new_content_1 = "content after edit"
         result_1 = self.client_patch(
-            "/json/messages/" + str(msg_id_1),
+            f"/json/messages/{msg_id_1}",
             {
                 "message_id": msg_id_1,
                 "content": new_content_1,
@@ -267,7 +267,7 @@ class EditMessageTest(ZulipTestCase):
         )
         self.assert_json_success(result_1)
 
-        result = self.client_get("/json/messages/" + str(msg_id_1) + "/history")
+        result = self.client_get(f"/json/messages/{msg_id_1}/history")
         self.assert_json_error(result, "Message edit history is disabled in this organization")
 
         # Now verify that if we fetch the message directly, there's no
@@ -292,7 +292,7 @@ class EditMessageTest(ZulipTestCase):
         )
         new_content_1 = "content after edit"
         result_1 = self.client_patch(
-            "/json/messages/" + str(msg_id_1),
+            f"/json/messages/{msg_id_1}",
             {
                 "message_id": msg_id_1,
                 "content": new_content_1,
@@ -300,7 +300,7 @@ class EditMessageTest(ZulipTestCase):
         )
         self.assert_json_success(result_1)
 
-        message_edit_history_1 = self.client_get("/json/messages/" + str(msg_id_1) + "/history")
+        message_edit_history_1 = self.client_get(f"/json/messages/{msg_id_1}/history")
         json_response_1 = orjson.loads(message_edit_history_1.content)
         message_history_1 = json_response_1["message_history"]
 
@@ -334,7 +334,7 @@ class EditMessageTest(ZulipTestCase):
             "content before edit, line 3"
         )
         result_2 = self.client_patch(
-            "/json/messages/" + str(msg_id_2),
+            f"/json/messages/{msg_id_2}",
             {
                 "message_id": msg_id_2,
                 "content": new_content_2,
@@ -342,7 +342,7 @@ class EditMessageTest(ZulipTestCase):
         )
         self.assert_json_success(result_2)
 
-        message_edit_history_2 = self.client_get("/json/messages/" + str(msg_id_2) + "/history")
+        message_edit_history_2 = self.client_get(f"/json/messages/{msg_id_2}/history")
         json_response_2 = orjson.loads(message_edit_history_2.content)
         message_history_2 = json_response_2["message_history"]
 
@@ -382,7 +382,7 @@ class EditMessageTest(ZulipTestCase):
         )
         new_content_1 = "Here is a link to [zulip](www.zulipchat.com)."
         result_1 = self.client_patch(
-            "/json/messages/" + str(msg_id_1),
+            f"/json/messages/{msg_id_1}",
             {
                 "message_id": msg_id_1,
                 "content": new_content_1,
@@ -390,7 +390,7 @@ class EditMessageTest(ZulipTestCase):
         )
         self.assert_json_success(result_1)
 
-        message_edit_history_1 = self.client_get("/json/messages/" + str(msg_id_1) + "/history")
+        message_edit_history_1 = self.client_get(f"/json/messages/{msg_id_1}/history")
         json_response_1 = orjson.loads(message_edit_history_1.content)
         message_history_1 = json_response_1["message_history"]
 
@@ -458,7 +458,7 @@ class EditMessageTest(ZulipTestCase):
             self.example_user("hamlet"), "Scotland", topic_name="topic 1", content="content 1"
         )
         result = self.client_patch(
-            "/json/messages/" + str(msg_id),
+            f"/json/messages/{msg_id}",
             {
                 "message_id": msg_id,
                 "content": "content 2",
@@ -480,7 +480,7 @@ class EditMessageTest(ZulipTestCase):
         )
 
         result = self.client_patch(
-            "/json/messages/" + str(msg_id),
+            f"/json/messages/{msg_id}",
             {
                 "message_id": msg_id,
                 "topic": "topic 2",
@@ -493,7 +493,7 @@ class EditMessageTest(ZulipTestCase):
         self.assertEqual(set(history[0].keys()), {"timestamp", LEGACY_PREV_TOPIC, "user_id"})
 
         result = self.client_patch(
-            "/json/messages/" + str(msg_id),
+            f"/json/messages/{msg_id}",
             {
                 "message_id": msg_id,
                 "content": "content 3",
@@ -518,7 +518,7 @@ class EditMessageTest(ZulipTestCase):
         )
 
         result = self.client_patch(
-            "/json/messages/" + str(msg_id),
+            f"/json/messages/{msg_id}",
             {
                 "message_id": msg_id,
                 "content": "content 4",
@@ -531,7 +531,7 @@ class EditMessageTest(ZulipTestCase):
 
         self.login("iago")
         result = self.client_patch(
-            "/json/messages/" + str(msg_id),
+            f"/json/messages/{msg_id}",
             {
                 "message_id": msg_id,
                 "topic": "topic 4",
@@ -552,7 +552,7 @@ class EditMessageTest(ZulipTestCase):
 
         # Now, we verify that the edit history data sent back has the
         # correct filled-out fields
-        message_edit_history = self.client_get("/json/messages/" + str(msg_id) + "/history")
+        message_edit_history = self.client_get(f"/json/messages/{msg_id}/history")
 
         json_response = orjson.loads(message_edit_history.content)
 
@@ -617,7 +617,7 @@ class EditMessageTest(ZulipTestCase):
             params_dict = {"message_id": id_, "topic": new_topic}
             if not topic_only:
                 params_dict["content"] = new_content
-            result = self.client_patch("/json/messages/" + str(id_), params_dict)
+            result = self.client_patch(f"/json/messages/{id_}", params_dict)
             self.assert_json_success(result)
             if topic_only:
                 self.check_topic(id_, topic_name=new_topic)
@@ -635,7 +635,7 @@ class EditMessageTest(ZulipTestCase):
             params_dict = {"message_id": id_, "topic": new_topic}
             if not topic_only:
                 params_dict["content"] = new_content
-            result = self.client_patch("/json/messages/" + str(id_), params_dict)
+            result = self.client_patch(f"/json/messages/{id_}", params_dict)
             message = Message.objects.get(id=id_)
             self.assert_json_error(result, error)
 
@@ -701,7 +701,7 @@ class EditMessageTest(ZulipTestCase):
         def do_edit_message_assert_success(id_: int, unique_str: str) -> None:
             new_topic = "topic" + unique_str
             params_dict = {"message_id": id_, "topic": new_topic}
-            result = self.client_patch("/json/messages/" + str(id_), params_dict)
+            result = self.client_patch(f"/json/messages/{id_}", params_dict)
             self.assert_json_success(result)
             self.check_topic(id_, topic_name=new_topic)
 
@@ -711,7 +711,7 @@ class EditMessageTest(ZulipTestCase):
             old_content = message.content
             new_topic = "topic" + unique_str
             params_dict = {"message_id": id_, "topic": new_topic}
-            result = self.client_patch("/json/messages/" + str(id_), params_dict)
+            result = self.client_patch(f"/json/messages/{id_}", params_dict)
             message = Message.objects.get(id=id_)
             self.assert_json_error(result, error)
             msg = Message.objects.get(id=id_)
@@ -863,7 +863,7 @@ class EditMessageTest(ZulipTestCase):
 
         users_to_be_notified = sorted(map(notify, [cordelia.id, hamlet.id]), key=itemgetter("id"))
         result = self.client_patch(
-            "/json/messages/" + str(message_id),
+            f"/json/messages/{message_id}",
             {
                 "message_id": message_id,
                 "content": "Hello @**everyone**",
@@ -912,7 +912,7 @@ class EditMessageTest(ZulipTestCase):
 
         new_topic = "edited"
         result = self.client_patch(
-            "/json/messages/" + str(id1),
+            f"/json/messages/{id1}",
             {
                 "message_id": id1,
                 "topic": new_topic,
@@ -925,7 +925,7 @@ class EditMessageTest(ZulipTestCase):
 
         new_topic = "edited2"
         result = self.client_patch(
-            "/json/messages/" + str(id1),
+            f"/json/messages/{id1}",
             {
                 "message_id": id1,
                 "topic": new_topic,
@@ -945,7 +945,7 @@ class EditMessageTest(ZulipTestCase):
         id5 = self.send_stream_message(self.example_user("iago"), "Scotland", topic_name="topic1")
 
         result = self.client_patch(
-            "/json/messages/" + str(id1),
+            f"/json/messages/{id1}",
             {
                 "message_id": id1,
                 "topic": "edited",
@@ -970,7 +970,7 @@ class EditMessageTest(ZulipTestCase):
         id6 = self.send_stream_message(self.example_user("iago"), "Scotland", topic_name="topic3")
 
         result = self.client_patch(
-            "/json/messages/" + str(id2),
+            f"/json/messages/{id2}",
             {
                 "message_id": id2,
                 "topic": "edited",
@@ -994,7 +994,7 @@ class EditMessageTest(ZulipTestCase):
         id4 = self.send_stream_message(self.example_user("iago"), "Scotland", topic_name="toPic1")
 
         result = self.client_patch(
-            "/json/messages/" + str(id2),
+            f"/json/messages/{id2}",
             {
                 "message_id": id2,
                 "topic": "edited",
@@ -1013,7 +1013,7 @@ class EditMessageTest(ZulipTestCase):
         id1 = self.send_stream_message(self.example_user("hamlet"), "Scotland", topic_name="topic1")
 
         result = self.client_patch(
-            "/json/messages/" + str(id1),
+            f"/json/messages/{id1}",
             {
                 "topic": "edited",
                 "propagate_mode": "invalid",
@@ -1023,7 +1023,7 @@ class EditMessageTest(ZulipTestCase):
         self.check_topic(id1, topic_name="topic1")
 
         result = self.client_patch(
-            "/json/messages/" + str(id1),
+            f"/json/messages/{id1}",
             {
                 "content": "edited",
                 "propagate_mode": "change_all",
@@ -1058,7 +1058,7 @@ class EditMessageTest(ZulipTestCase):
         )
 
         result = self.client_patch(
-            "/json/messages/" + str(msg_id),
+            f"/json/messages/{msg_id}",
             {
                 "message_id": msg_id,
                 "stream_id": new_stream.id,
@@ -1088,7 +1088,7 @@ class EditMessageTest(ZulipTestCase):
         )
 
         result = self.client_patch(
-            "/json/messages/" + str(msg_id_later),
+            f"/json/messages/{msg_id_later}",
             {
                 "message_id": msg_id_later,
                 "stream_id": new_stream.id,
@@ -1119,7 +1119,7 @@ class EditMessageTest(ZulipTestCase):
         )
 
         result = self.client_patch(
-            "/json/messages/" + str(msg_id),
+            f"/json/messages/{msg_id}",
             {
                 "message_id": msg_id,
                 "stream_id": new_stream.id,
@@ -1140,7 +1140,7 @@ class EditMessageTest(ZulipTestCase):
         )
 
         result = self.client_patch(
-            "/json/messages/" + str(msg_id),
+            f"/json/messages/{msg_id}",
             {
                 "message_id": msg_id,
                 "stream_id": new_stream.id,
@@ -1163,7 +1163,7 @@ class EditMessageTest(ZulipTestCase):
 
         with queries_captured() as queries, cache_tries_captured() as cache_tries:
             result = self.client_patch(
-                "/json/messages/" + str(msg_id),
+                f"/json/messages/{msg_id}",
                 {
                     "message_id": msg_id,
                     "stream_id": new_stream.id,
@@ -1214,7 +1214,7 @@ class EditMessageTest(ZulipTestCase):
         )
 
         result = self.client_patch(
-            "/json/messages/" + str(msg_id),
+            f"/json/messages/{msg_id}",
             {
                 "message_id": msg_id,
                 "stream_id": new_stream.id,
@@ -1252,7 +1252,7 @@ class EditMessageTest(ZulipTestCase):
         )
 
         result = self.client_patch(
-            "/json/messages/" + str(msg_id),
+            f"/json/messages/{msg_id}",
             {
                 "message_id": msg_id,
                 "stream_id": new_stream.id,
@@ -1276,7 +1276,7 @@ class EditMessageTest(ZulipTestCase):
         )
 
         result = self.client_patch(
-            "/json/messages/" + str(msg_id),
+            f"/json/messages/{msg_id}",
             {
                 "message_id": msg_id,
                 "stream_id": new_stream.id,
@@ -1304,7 +1304,7 @@ class EditMessageTest(ZulipTestCase):
         )
 
         result = self.client_patch(
-            "/json/messages/" + str(msg_id),
+            f"/json/messages/{msg_id}",
             {
                 "message_id": msg_id,
                 "stream_id": new_stream.id,
@@ -1372,7 +1372,7 @@ class EditMessageTest(ZulipTestCase):
         )
 
         result = self.client_patch(
-            "/json/messages/" + str(msg_id),
+            f"/json/messages/{msg_id}",
             {
                 "message_id": msg_id,
                 "stream_id": new_stream.id,

--- a/zerver/tests/test_retention.py
+++ b/zerver/tests/test_retention.py
@@ -295,7 +295,7 @@ class TestArchiveMessagesGeneral(ArchiveMessagesTestingBase):
         self._verify_archive_data([msg_id], usermsg_ids)
 
     def test_cross_realm_personal_message_archiving(self) -> None:
-        """Check that cross-realm personal messages get correctly archived. """
+        """Check that cross-realm personal messages get correctly archived."""
         msg_ids = [self._send_cross_realm_personal_message() for i in range(1, 7)]
         usermsg_ids = self._get_usermessage_ids(msg_ids)
         # Make the message expired on the recipient's realm:

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -130,6 +130,21 @@ def update_message_backend(
             content = "(deleted)"
         content = normalize_body(content)
 
+    # Check for no-op changes; if we find any, ignore them and set a flag.
+    # The purpose of the flag is to allow us to return json_success() in the
+    # case that changes were provided but no changes ended up being made, due
+    # to all of them being no-op changes.
+    noop_changes = False
+    if stream_id == message.recipient.type_id:
+        stream_id = None
+        noop_changes = True
+    if content == message.content:
+        content = None
+        noop_changes = True
+    if topic_name == message.topic_name():
+        topic_name = None
+        noop_changes = True
+
     # You only have permission to edit a message if:
     # 1. You sent it, OR:
     # 2. This is a topic-only edit for a (no topic) message, OR:
@@ -172,8 +187,10 @@ def update_message_backend(
             raise JsonableError(_("The time limit for editing this message has passed"))
 
     if topic_name is None and content is None and stream_id is None:
-        return json_error(_("Nothing to change"))
-
+        if noop_changes:
+            return json_success()
+        else:
+            return json_error(_("Nothing to change"))
     if topic_name is not None and topic_name == "":
         raise JsonableError(_("Topic can't be empty"))
 

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -122,6 +122,14 @@ def update_message_backend(
     message, ignored_user_message = access_message(user_profile, message_id)
     is_no_topic_msg = message.topic_name() == "(no topic)"
 
+    # Normalize topic and content.
+    if topic_name is not None:
+        topic_name = topic_name.strip()
+    if content is not None:
+        if content.rstrip() == "":
+            content = "(deleted)"
+        content = normalize_body(content)
+
     # You only have permission to edit a message if:
     # 1. You sent it, OR:
     # 2. This is a topic-only edit for a (no topic) message, OR:
@@ -165,20 +173,16 @@ def update_message_backend(
 
     if topic_name is None and content is None and stream_id is None:
         return json_error(_("Nothing to change"))
-    if topic_name is not None:
-        topic_name = topic_name.strip()
-        if topic_name == "":
-            raise JsonableError(_("Topic can't be empty"))
+
+    if topic_name is not None and topic_name == "":
+        raise JsonableError(_("Topic can't be empty"))
+
     rendered_content = None
     links_for_embed: Set[str] = set()
     prior_mention_user_ids: Set[int] = set()
     mention_user_ids: Set[int] = set()
     mention_data: Optional[MentionData] = None
     if content is not None:
-        if content.rstrip() == "":
-            content = "(deleted)"
-        content = normalize_body(content)
-
         mention_data = MentionData(
             realm_id=user_profile.realm.id,
             content=content,

--- a/zerver/views/message_edit.py
+++ b/zerver/views/message_edit.py
@@ -123,7 +123,6 @@ def update_message_backend(
     is_no_topic_msg = message.topic_name() == "(no topic)"
 
     # You only have permission to edit a message if:
-    # you change this value also change those two parameters in message_edit.js.
     # 1. You sent it, OR:
     # 2. This is a topic-only edit for a (no topic) message, OR:
     # 3. This is a topic-only edit and you are an admin, OR:

--- a/zerver/webhooks/sentry/view.py
+++ b/zerver/webhooks/sentry/view.py
@@ -92,7 +92,7 @@ def convert_lines_to_traceback_string(lines: Optional[List[str]]) -> str:
 
 
 def handle_event_payload(event: Dict[str, Any]) -> Tuple[str, str]:
-    """ Handle either an exception type event or a message type event payload."""
+    """Handle either an exception type event or a message type event payload."""
     # We shouldn't support the officially deprecated Raven series of SDKs.
     if int(event["version"]) < 7:
         raise UnsupportedWebhookEventType("Raven SDK")
@@ -167,7 +167,7 @@ def handle_event_payload(event: Dict[str, Any]) -> Tuple[str, str]:
 def handle_issue_payload(
     action: str, issue: Dict[str, Any], actor: Dict[str, Any]
 ) -> Tuple[str, str]:
-    """ Handle either an issue type event. """
+    """Handle either an issue type event."""
     subject = issue["title"]
     datetime = issue["lastSeen"].split(".")[0].replace("T", " ")
 

--- a/zerver/webhooks/taiga/view.py
+++ b/zerver/webhooks/taiga/view.py
@@ -157,14 +157,14 @@ return_type = Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]
 
 
 def get_old_and_new_values(change_type: str, message: Mapping[str, Any]) -> return_type:
-    """ Parses the payload and finds previous and current value of change_type."""
+    """Parses the payload and finds previous and current value of change_type."""
     old = message["change"]["diff"][change_type].get("from")
     new = message["change"]["diff"][change_type].get("to")
     return old, new
 
 
 def parse_comment(message: Mapping[str, Any]) -> Dict[str, Any]:
-    """ Parses the comment to issue, task or US. """
+    """Parses the comment to issue, task or US."""
     return {
         "event": "commented",
         "type": message["type"],
@@ -177,7 +177,7 @@ def parse_comment(message: Mapping[str, Any]) -> Dict[str, Any]:
 
 
 def parse_create_or_delete(message: Mapping[str, Any]) -> Dict[str, Any]:
-    """ Parses create or delete event. """
+    """Parses create or delete event."""
     if message["type"] == "relateduserstory":
         return {
             "type": message["type"],
@@ -202,7 +202,7 @@ def parse_create_or_delete(message: Mapping[str, Any]) -> Dict[str, Any]:
 
 
 def parse_change_event(change_type: str, message: Mapping[str, Any]) -> Optional[Dict[str, Any]]:
-    """ Parses change event. """
+    """Parses change event."""
     evt: Dict[str, Any] = {}
     values: Dict[str, Any] = {
         "user": get_owner_name(message),
@@ -285,7 +285,7 @@ def parse_webhook_test(message: Mapping[str, Any]) -> Dict[str, Any]:
 
 
 def parse_message(message: Mapping[str, Any]) -> List[Dict[str, Any]]:
-    """ Parses the payload by delegating to specialized functions. """
+    """Parses the payload by delegating to specialized functions."""
     events = []
     if message["action"] in ["create", "delete"]:
         events.append(parse_create_or_delete(message))
@@ -304,7 +304,7 @@ def parse_message(message: Mapping[str, Any]) -> List[Dict[str, Any]]:
 
 
 def generate_content(data: Mapping[str, Any]) -> str:
-    """ Gets the template string and formats it with parsed data. """
+    """Gets the template string and formats it with parsed data."""
     template = templates[data["type"]][data["event"]]
     content = template.format(**data["values"])
     return content

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -385,7 +385,7 @@ class EmailAuthBackend(ZulipAuthMixin):
         realm: Realm,
         return_data: Optional[Dict[str, Any]] = None,
     ) -> Optional[UserProfile]:
-        """ Authenticate a user based on email address as the user name. """
+        """Authenticate a user based on email address as the user name."""
         if not password_auth_enabled(realm):
             if return_data is not None:
                 return_data["password_auth_disabled"] = True


### PR DESCRIPTION
<!-- What's this PR for?  (Just a link to an issue is fine.) -->
This adds code to handle no-op edits – edits that specify a value for one or more attributes, e.g. 'content', that are the same as the current value.

It also makes some related OpenAPI changes; and it starts with an f-string conversion commit.

Question: does the new handling of no-op edits warrant a feature level bump? It is a change in (undocumented) API behavior. If so, should that be separate from the bump I already have for the `orig_subject` change, or should they use one bump since they're so close together?

**Testing Plan:** <!-- How have you tested? -->
I've written a test that tries all possible variations of no-op edits.

**WIP:**

There's still some polish that needs to be applied, but it's a good time to get some review and make sure I'm not going off the rails.