### PR TITLE
Clean up webhook exception logging

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -34,7 +34,6 @@ from zerver.lib.exceptions import (
     OrganizationOwnerRequired,
     UnsupportedWebhookEventType,
 )
-from zerver.lib.logging_util import log_to_file
 from zerver.lib.queue import queue_json_publish
 from zerver.lib.rate_limiter import RateLimitedUser
 from zerver.lib.request import REQ, has_request_variables
@@ -50,11 +49,7 @@ if settings.ZILENCER_ENABLED:
     from zilencer.models import RemoteZulipServer, get_remote_server_by_uuid
 
 webhook_logger = logging.getLogger("zulip.zerver.webhooks")
-log_to_file(webhook_logger, settings.WEBHOOK_LOG_PATH)
-
 webhook_unsupported_events_logger = logging.getLogger("zulip.zerver.webhooks.unsupported")
-log_to_file(webhook_unsupported_events_logger,
-            settings.WEBHOOK_UNSUPPORTED_EVENTS_LOG_PATH)
 
 FuncT = TypeVar('FuncT', bound=Callable[..., object])
 

--- a/zerver/webhooks/github/tests.py
+++ b/zerver/webhooks/github/tests.py
@@ -461,9 +461,8 @@ A temporary team so that I can get some webhook fixtures!
         msg = m.call_args[0][0]
         stack_info = m.call_args[1]["stack_info"]
 
-        self.assertIn("content_type: application/json", msg)
         self.assertIn(
-            "summary: The 'team/edited (changes: bogus_key1/bogus_key2)' event isn't currently supported by the GitHub webhook",
+            "The 'team/edited (changes: bogus_key1/bogus_key2)' event isn't currently supported by the GitHub webhook",
             msg,
         )
         self.assertTrue(stack_info)

--- a/zerver/webhooks/github/view.py
+++ b/zerver/webhooks/github/view.py
@@ -32,19 +32,15 @@ fixture_to_headers = get_http_headers_from_filename("HTTP_X_GITHUB_EVENT")
 class Helper:
     def __init__(
         self,
-        request: HttpRequest,
         payload: Dict[str, Any],
         include_title: bool,
     ) -> None:
         self.payload = payload
         self.include_title = include_title
-        self._request = request
 
     def log_unsupported(self, event: str) -> None:
         summary = f"The '{event}' event isn't currently supported by the GitHub webhook"
-        request = self._request
         log_exception_to_webhook_logger(
-            request=request,
             summary=summary,
             unsupported_event=True,
         )
@@ -630,7 +626,6 @@ def api_github_webhook(
     body_function = EVENT_FUNCTION_MAPPER[event]
 
     helper = Helper(
-        request=request,
         payload=payload,
         include_title=user_specified_topic is not None,
     )

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -716,6 +716,9 @@ LOGGING: Dict[str, Any] = {
         'default': {
             '()': 'zerver.lib.logging_util.ZulipFormatter',
         },
+        'webhook_request_data': {
+            '()': 'zerver.lib.logging_util.ZulipWebhookFormatter',
+        },
     },
     'filters': {
         'ZulipLimiter': {
@@ -794,13 +797,13 @@ LOGGING: Dict[str, Any] = {
         'webhook_file': {
             'level': 'DEBUG',
             'class': 'logging.handlers.WatchedFileHandler',
-            'formatter': 'default',
+            'formatter': 'webhook_request_data',
             'filename': WEBHOOK_LOG_PATH,
         },
         'webhook_unsupported_file': {
             'level': 'DEBUG',
             'class': 'logging.handlers.WatchedFileHandler',
-            'formatter': 'default',
+            'formatter': 'webhook_request_data',
             'filename': WEBHOOK_UNSUPPORTED_EVENTS_LOG_PATH,
         },
     },

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -791,6 +791,18 @@ LOGGING: Dict[str, Any] = {
             'formatter': 'default',
             'filename': SLOW_QUERIES_LOG_PATH,
         },
+        'webhook_file': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.WatchedFileHandler',
+            'formatter': 'default',
+            'filename': WEBHOOK_LOG_PATH,
+        },
+        'webhook_unsupported_file': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.WatchedFileHandler',
+            'formatter': 'default',
+            'filename': WEBHOOK_UNSUPPORTED_EVENTS_LOG_PATH,
+        },
     },
     'loggers': {
         # The Python logging module uses a hierarchy of logger names for config:
@@ -937,12 +949,12 @@ LOGGING: Dict[str, Any] = {
         },
         'zulip.zerver.webhooks': {
             'level': 'DEBUG',
-            'handlers': ['file', 'errors_file'],
+            'handlers': ['webhook_file'],
             'propagate': False,
         },
         'zulip.zerver.webhooks.unsupported': {
             'level': 'DEBUG',
-            'handlers': ['file', 'errors_file'],
+            'handlers': ['webhook_unsupported_file'],
             'propagate': False,
         },
     },

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -178,6 +178,7 @@ MIDDLEWARE = (
     # our logging middleware should be the top middleware item.
     'zerver.middleware.TagRequests',
     'zerver.middleware.SetRemoteAddrFromForwardedFor',
+    'zerver.middleware.RequestContext',
     'zerver.middleware.LogRequests',
     'zerver.middleware.JsonErrorHandler',
     'zerver.middleware.RateLimitMiddleware',


### PR DESCRIPTION
**Testing Plan:** Adjusted existing tests.  Verified that logfiles still contain the full data, and that Sentry sees just the summary line (and metadata, but placed in indexed fields).
