### PR TITLE
markdown: Fix Youtube and Vimeo preview overriding markdown link titles bug. Fixes #16100

### DIFF
--- a/zerver/lib/markdown/__init__.py
+++ b/zerver/lib/markdown/__init__.py
@@ -1234,13 +1234,19 @@ class InlineInterestingLinkProcessor(markdown.treeprocessors.Treeprocessor):
                 if youtube is not None:
                     title = self.youtube_title(extracted_data)
                     if title is not None:
-                        found_url.family.child.text = title
+                        if url == text:
+                            found_url.family.child.text = title
+                        else:
+                            found_url.family.child.text = text
                     continue
                 self.add_embed(root, url, extracted_data)
                 if self.vimeo_id(url):
                     title = self.vimeo_title(extracted_data)
                     if title:
-                        found_url.family.child.text = title
+                        if url == text:
+                            found_url.family.child.text = title
+                        else:
+                            found_url.family.child.text = text
 
 class Timestamp(markdown.inlinepatterns.Pattern):
     def handleMatch(self, match: Match[str]) -> Optional[Element]:

--- a/zerver/tests/test_link_embed.py
+++ b/zerver/tests/test_link_embed.py
@@ -741,3 +741,34 @@ class PreviewTestCase(ZulipTestCase):
         msg.refresh_from_db()
         expected_content = '<p><a href="https://www.youtube.com/watch?v=eSJTXC7Ixgg">YouTube - Clearer Code at Scale - Static Types at Zulip and Dropbox</a></p>\n<div class="youtube-video message_inline_image"><a data-id="eSJTXC7Ixgg" href="https://www.youtube.com/watch?v=eSJTXC7Ixgg"><img src="https://i.ytimg.com/vi/eSJTXC7Ixgg/default.jpg"></a></div>'
         self.assertEqual(expected_content, msg.rendered_content)
+
+    @override_settings(INLINE_URL_EMBED_PREVIEW=True)
+    def test_custom_title_replaces_youtube_url_title(self) -> None:
+        url = '[Youtube link](https://www.youtube.com/watch?v=eSJTXC7Ixgg)'
+        with mock_queue_publish('zerver.lib.actions.queue_json_publish'):
+            msg_id = self.send_personal_message(
+                self.example_user('hamlet'),
+                self.example_user('cordelia'),
+                content=url,
+            )
+        msg = Message.objects.select_related("sender").get(id=msg_id)
+        event = {
+            'message_id': msg_id,
+            'urls': [url],
+            'message_realm_id': msg.sender.realm_id,
+            'message_content': url}
+
+        mocked_data = {'title': 'Clearer Code at Scale - Static Types at Zulip and Dropbox'}
+        mocked_response = mock.Mock(side_effect=self.create_mock_response(url))
+        with self.settings(TEST_SUITE=False, CACHES=TEST_CACHES):
+            with mock.patch('requests.get', mocked_response), self.assertLogs(level='INFO') as info_logs:
+                with mock.patch('zerver.lib.markdown.link_preview.link_embed_data_from_cache',
+                                lambda *args, **kwargs: mocked_data):
+                    FetchLinksEmbedData().consume(event)
+            self.assertTrue(
+                'INFO:root:Time spent on get_link_embed_data for [Youtube link](https://www.youtube.com/watch?v=eSJTXC7Ixgg):' in info_logs.output[0]
+            )
+
+        msg.refresh_from_db()
+        expected_content = '<p><a href="https://www.youtube.com/watch?v=eSJTXC7Ixgg">Youtube link</a></p>\n<div class="youtube-video message_inline_image"><a data-id="eSJTXC7Ixgg" href="https://www.youtube.com/watch?v=eSJTXC7Ixgg"><img src="https://i.ytimg.com/vi/eSJTXC7Ixgg/default.jpg"></a></div>'
+        self.assertEqual(expected_content, msg.rendered_content)


### PR DESCRIPTION
[Issue](https://github.com/zulip/zulip/issues/16100#issue-676910913)
Youtube and Vimeo preview overriding markdown link titles bug fixed.
Now if a user uses `[Random_title](url)` then `Random_title` will be used instead of `extracted_title`. While in other cases `extracted_title` will be shown for markdown title, if **Preview of linked websites is enabled.**
Fixes #16100 


**Screenshot:**
![Solved Issue](https://user-images.githubusercontent.com/67277428/92560072-63648a80-f28f-11ea-8ba7-d764193b2aab.png)
 
**Testing Plan:**

Following is the modified testing code in zerver/tests/test_link_embed.py :

```python
@override_settings(INLINE_URL_EMBED_PREVIEW=True)
  def test_youtube_url_title_replaces_url(self) -> None:
        url = '[Youtube link](https://www.youtube.com/watch?v=eSJTXC7Ixgg)'
        with mock_queue_publish('zerver.lib.actions.queue_json_publish'):
            msg_id = self.send_personal_message(
                self.example_user('hamlet'),
                self.example_user('cordelia'),
                content=url,
            )
        msg = Message.objects.select_related("sender").get(id=msg_id)
        event = {
            'message_id': msg_id,
            'urls': [url],
            'message_realm_id': msg.sender.realm_id,
            'message_content': url}

        mocked_data = {'title': 'Clearer Code at Scale - Static Types at Zulip and Dropbox'}
        mocked_response = mock.Mock(side_effect=self.create_mock_response(url))
        with self.settings(TEST_SUITE=False, CACHES=TEST_CACHES):
            with mock.patch('requests.get', mocked_response), self.assertLogs(level='INFO') as info_logs:
                with mock.patch('zerver.lib.markdown.link_preview.link_embed_data_from_cache',
                                lambda *args, **kwargs: mocked_data):
                    FetchLinksEmbedData().consume(event)
            self.assertTrue(
                'INFO:root:Time spent on get_link_embed_data for [Youtube link](https://www.youtube.com/watch?v=eSJTXC7Ixgg):' in info_logs.output[0]
            )

        msg.refresh_from_db()
        expected_content = '<p><a href="https://www.youtube.com/watch?v=eSJTXC7Ixgg">Youtube link</a></p>\n<div class="youtube-video message_inline_image"><a data-id="eSJTXC7Ixgg" href="https://www.youtube.com/watch?v=eSJTXC7Ixgg"><img src="https://i.ytimg.com/vi/eSJTXC7Ixgg/default.jpg"></a></div>'
        self.assertEqual(expected_content, msg.rendered_content)
```


**Test Result:**

![Test Result](https://user-images.githubusercontent.com/67277428/93724520-6d5a8780-fbc5-11ea-91cc-431952d64fa6.png)


