### PR TITLE
Improve resharding process

### DIFF
--- a/puppet/zulip/files/nginx/zulip-include-frontend/upstreams
+++ b/puppet/zulip/files/nginx/zulip-include-frontend/upstreams
@@ -1,0 +1,17 @@
+include /etc/nginx/zulip-include/tornado-upstreams;
+
+upstream django {
+    server unix:/home/zulip/deployments/uwsgi-socket;
+}
+
+upstream localhost_sso {
+    server 127.0.0.1:8888;
+}
+
+upstream camo {
+    server 127.0.0.1:9292;
+}
+
+upstream thumbor {
+    server localhost:9995;
+}

--- a/puppet/zulip/manifests/app_frontend_base.pp
+++ b/puppet/zulip/manifests/app_frontend_base.pp
@@ -53,23 +53,12 @@ class zulip::app_frontend_base {
     }
   }
 
-  # The number of Tornado processes to run on the server; this
-  # defaults to 1, since Tornado sharding is currently only at the
-  # Realm level.
-  $tornado_processes = Integer(zulipconf('application_server', 'tornado_processes', 1))
-  if $tornado_processes > 1 {
-    $tornado_ports = range(9800, 9800 + $tornado_processes - 1)
-    $tornado_multiprocess = true
-  } else {
-    $tornado_multiprocess = false
-  }
-
   file { '/etc/nginx/zulip-include/upstreams':
     require => Package[$zulip::common::nginx],
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    content => template('zulip/nginx/upstreams.conf.template.erb'),
+    source  => 'puppet:///modules/zulip/nginx/zulip-include-frontend/upstreams',
     notify  => Service['nginx'],
   }
 

--- a/puppet/zulip/manifests/tornado_sharding.pp
+++ b/puppet/zulip/manifests/tornado_sharding.pp
@@ -21,7 +21,7 @@ class zulip::tornado_sharding {
     require => User['zulip'],
     owner   => 'zulip',
     group   => 'zulip',
-    mode    => '0640',
+    mode    => '0644',
     content => "{}\n",
     replace => false,
   }

--- a/puppet/zulip/manifests/tornado_sharding.pp
+++ b/puppet/zulip/manifests/tornado_sharding.pp
@@ -7,13 +7,17 @@ class zulip::tornado_sharding {
   # with the correct default content for the "only one shard" setup. For this
   # reason they use "replace => false", because the files are managed by
   # the sharding script afterwards and puppet shouldn't overwrite them.
+
+  # The sha256 of the empty hash, used to fingerprint the configs as
+  # having been generated with a null sharding configuration.
+  $empty_sha256 = sha256('')
   file { '/etc/zulip/nginx_sharding.conf':
     ensure  => file,
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
     notify  => Service['nginx'],
-    content => "set \$tornado_server http://tornado;\n",
+    content => "# Configuration hash: ${empty_sha256}\nset \$tornado_server http://tornado;\n",
     replace => false,
   }
   file { '/etc/zulip/sharding.json':
@@ -24,6 +28,14 @@ class zulip::tornado_sharding {
     mode    => '0644',
     content => "{}\n",
     replace => false,
+  }
+
+  exec { 'write_updated_sharding':
+    command   => "${::zulip_scripts_path}/lib/sharding.py",
+    unless    => "${::zulip_scripts_path}/lib/sharding.py --verify",
+    require   => [File['/etc/zulip/nginx_sharding.conf']],
+    logoutput => true,
+    loglevel  => 'warning',
   }
 
   # The number of Tornado processes to run on the server; this

--- a/puppet/zulip/manifests/tornado_sharding.pp
+++ b/puppet/zulip/manifests/tornado_sharding.pp
@@ -25,4 +25,24 @@ class zulip::tornado_sharding {
     content => "{}\n",
     replace => false,
   }
+
+  # The number of Tornado processes to run on the server; this
+  # defaults to 1, since Tornado sharding is currently only at the
+  # Realm level.
+  $tornado_processes = Integer(zulipconf('application_server', 'tornado_processes', 1))
+  if $tornado_processes > 1 {
+    $tornado_ports = range(9800, 9800 + $tornado_processes - 1)
+    $tornado_multiprocess = true
+  } else {
+    $tornado_multiprocess = false
+  }
+
+  file { '/etc/nginx/zulip-include/tornado-upstreams':
+    require => Package[$zulip::common::nginx],
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('zulip/nginx/tornado-upstreams.conf.template.erb'),
+    notify  => Service['nginx'],
+  }
 }

--- a/puppet/zulip/templates/nginx/tornado-upstreams.conf.template.erb
+++ b/puppet/zulip/templates/nginx/tornado-upstreams.conf.template.erb
@@ -1,7 +1,3 @@
-upstream django {
-    server unix:/home/zulip/deployments/uwsgi-socket;
-}
-
 <% if @tornado_multiprocess -%>
 <% @tornado_ports.each do |port| -%>
 upstream tornado<%= port %> {
@@ -15,15 +11,3 @@ upstream tornado {
     keepalive 10000;
 }
 <% end -%>
-
-upstream localhost_sso {
-    server 127.0.0.1:8888;
-}
-
-upstream camo {
-    server 127.0.0.1:9292;
-}
-
-upstream thumbor {
-    server localhost:9995;
-}

--- a/scripts/lib/upgrade-zulip-stage-2
+++ b/scripts/lib/upgrade-zulip-stage-2
@@ -104,7 +104,7 @@ def shutdown_server() -> None:
         core_server_services.append("zulip-thumbor")
 
     logging.info("Stopping Zulip...")
-    subprocess.check_call(["supervisorctl", "stop", *core_server_services, *worker_services],
+    subprocess.check_call(["supervisorctl", "stop", *worker_services, *core_server_services],
                           preexec_fn=su_to_zulip)
     IS_SERVER_UP = False
 

--- a/scripts/refresh-sharding-and-restart
+++ b/scripts/refresh-sharding-and-restart
@@ -2,8 +2,16 @@
 
 set -e
 
-"$(dirname "$0")/zulip-puppet-apply" -f
-# The step above should have generated the config files, now we need to move them into place:
+# Stand up the new zulip-tornado supervisor instances, and write out
+# the newly generated config files, with .tmp suffix
+SUPPRESS_SHARDING_NOTICE=1 "$(dirname "$0")/zulip-puppet-apply" -f
+
+# Verify, before we move them into place
+if ! [ -e /etc/zulip/nginx_sharding.conf.tmp ] || ! [ -e /etc/zulip/sharding.json.tmp ]; then
+    echo "No sharding updates found to apply."
+    exit 1
+fi
+
 chown root:root /etc/zulip/nginx_sharding.conf.tmp
 chmod 644 /etc/zulip/nginx_sharding.conf.tmp
 chown zulip:zulip /etc/zulip/sharding.json.tmp

--- a/scripts/refresh-sharding-and-restart
+++ b/scripts/refresh-sharding-and-restart
@@ -7,7 +7,7 @@ set -e
 chown root:root /etc/zulip/nginx_sharding.conf.tmp
 chmod 644 /etc/zulip/nginx_sharding.conf.tmp
 chown zulip:zulip /etc/zulip/sharding.json.tmp
-chmod 640 /etc/zulip/sharding.json.tmp
+chmod 644 /etc/zulip/sharding.json.tmp
 mv /etc/zulip/nginx_sharding.conf.tmp /etc/zulip/nginx_sharding.conf
 mv /etc/zulip/sharding.json.tmp /etc/zulip/sharding.json
 

--- a/scripts/refresh-sharding-and-restart
+++ b/scripts/refresh-sharding-and-restart
@@ -5,7 +5,7 @@ set -e
 "$(dirname "$0")/zulip-puppet-apply" -f
 # The step above should have generated the config files, now we need to move them into place:
 chown root:root /etc/zulip/nginx_sharding.conf.tmp
-chmod 640 /etc/zulip/nginx_sharding.conf.tmp
+chmod 644 /etc/zulip/nginx_sharding.conf.tmp
 chown zulip:zulip /etc/zulip/sharding.json.tmp
 chmod 640 /etc/zulip/sharding.json.tmp
 mv /etc/zulip/nginx_sharding.conf.tmp /etc/zulip/nginx_sharding.conf

--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -78,7 +78,7 @@ logging.info("Stopping server core")
 subprocess.check_call(["supervisorctl", "stop", *core_server_services])
 
 logging.info("Starting server core")
-subprocess.check_call(["supervisorctl", "start", *core_server_services])
+subprocess.check_call(["supervisorctl", "start", *reversed(core_server_services)])
 logging.info("Starting workers")
 subprocess.check_call(["supervisorctl", "start", "zulip-workers:*"])
 


### PR DESCRIPTION
`zulip-puppet-apply` generates the new sharding in `.tmp` files, and also warns if `scripts/refresh-sharding-and-restart` needs to be run.  `scripts/refresh-sharding-and-restart` suffices to pick up all of the changes.

Also adjusts some minor start/stop ordering discrepancies, found due to comparing `scripts/refresh-sharding-and-restart` restart ordering to elsewhere.

**Testing Plan:** Ran `zulip-puppet-apply` with unchanged and changed config files; same with `scripts/refresh-sharding-and-restart`.
