### PR TITLE
puppet: Restrict postfix incoming addresses to postmaster and zulip.

### DIFF
--- a/puppet/zulip/files/postfix/access
+++ b/puppet/zulip/files/postfix/access
@@ -1,0 +1,9 @@
+# This is the list of email addresses that are accepted via SMTP;
+# these consist of only the addresses in `virtual`, as well as the
+# RFC822-specified postmaster.
+
+/\+.*@/         OK
+/\..*@/         OK
+/^mm/           OK
+
+/^postmaster@/  OK

--- a/puppet/zulip/files/postfix/virtual
+++ b/puppet/zulip/files/postfix/virtual
@@ -1,3 +1,6 @@
-/\+.*@/ zulip@localhost
-/\..*@/ zulip@localhost
-/^mm/ zulip@localhost
+# Changes to this list require a corresponding change to `access` as
+# well.
+
+/\+.*@/  zulip@localhost
+/\..*@/  zulip@localhost
+/^mm/    zulip@localhost

--- a/puppet/zulip/manifests/postfix_localmail.pp
+++ b/puppet/zulip/manifests/postfix_localmail.pp
@@ -67,4 +67,12 @@ class zulip::postfix_localmail {
     ],
   }
 
+  file {'/etc/postfix/access':
+    ensure  => file,
+    mode    => '0644',
+    owner   => root,
+    group   => root,
+    source  => 'puppet:///modules/zulip/postfix/access',
+    require => Package[postfix],
+  }
 }

--- a/puppet/zulip/templates/postfix/main.cf.erb
+++ b/puppet/zulip/templates/postfix/main.cf.erb
@@ -16,6 +16,7 @@ smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 
 smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated reject_unauth_destination
+smtpd_recipient_restrictions = check_recipient_access regexp:/etc/postfix/access, reject
 myhostname = <%= @fqdn %>
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases


### PR DESCRIPTION
This removes the possibility of local user enumeration via RCPT TO.

**Testing Plan:** Applied on a test `voyager` instance.  Before:
```
220 alexmv-prod.zulipdev.org ESMTP Postfix (Zulip)
HELO localhost
250 alexmv-prod.zulipdev.org
MAIL FROM: alex@chmrr.net
250 2.1.0 Ok
RCPT TO: root@alexmv-prod.zulipdev.org
250 2.1.5 Ok
RCPT TO: zulip@alexmv-prod.zulipdev.org
250 2.1.5 Ok
RCPT TO: postmaster@alexmv-prod.zulipdev.org
250 2.1.5 Ok
RCPT TO: foo@alexmv-prod.zulipdev.org
550 5.1.1 <foo@alexmv-prod.zulipdev.org>: Recipient address rejected: User unknown in local recipient table
RCPT TO: mmfoo@alexmv-prod.zulipdev.org
250 2.1.5 Ok
RCPT TO: fo+o@alexmv-prod.zulipdev.org
250 2.1.5 Ok
RCPT TO: fo.o@alexmv-prod.zulipdev.org
250 2.1.5 Ok
```

After:
```
220 alexmv-prod.zulipdev.org ESMTP Postfix (Zulip)
HELO localhost
250 alexmv-prod.zulipdev.org
MAIL FROM: alex@chmrr.net
250 2.1.0 Ok
RCPT TO: root@alexmv-prod.zulipdev.org
554 5.7.1 <root@alexmv-prod.zulipdev.org>: Recipient address rejected: Access denied
RCPT TO: zulip@alexmv-prod.zulipdev.org
554 5.7.1 <zulip@alexmv-prod.zulipdev.org>: Recipient address rejected: Access denied
RCPT TO: postmaster@alexmv-prod.zulipdev.org
250 2.1.5 Ok
RCPT TO: foo@alexmv-prod.zulipdev.org
554 5.7.1 <foo@alexmv-prod.zulipdev.org>: Recipient address rejected: Access denied
RCPT TO: mmfoo@alexmv-prod.zulipdev.org
250 2.1.5 Ok
RCPT TO: fo+o@alexmv-prod.zulipdev.org
250 2.1.5 Ok
RCPT TO: fo.o@alexmv-prod.zulipdev.org
250 2.1.5 Ok
```