### PR TITLE
edit_content : Added hide event for clipboard tooltip .

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -329,6 +329,9 @@ exports.initialize = function () {
         row.find(".alert-msg").text(i18n.t("Copied!"));
         row.find(".alert-msg").css("display", "block");
         row.find(".alert-msg").delay(1000).fadeOut(300);
+        if ($(".tooltip").is(":visible")) {
+            $(".tooltip").hide();
+        }
         e.preventDefault();
         e.stopPropagation();
     });


### PR DESCRIPTION
Added an <code>.hide()</code> event for the clipboard tooltip so that the tooltip hides instantly once the user presses on it . 
For better understanding : 

<strong>Before</strong>

![error](https://user-images.githubusercontent.com/53977614/92993019-65874d00-f50c-11ea-87cd-fcb751af07eb.gif)


<strong>After</strong>

![resolve](https://user-images.githubusercontent.com/53977614/92993020-68823d80-f50c-11ea-8e22-c7bf8181e156.gif)


Fixes : #16328
