### PR TITLE
zulip.org redirects to zulip.com.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,8 +21,8 @@ Welcome! Zulip's documentation is split into four parts:
 Zulip has well over 150,000 words of documentation. If you can't find
 what you're looking for, please `let us know
 <contributing/chat-zulip-org.html>`__!  Further information on the
-Zulip project and its features can be found at `https://www.zulip.org
-<https://www.zulip.org>`__.
+Zulip project and its features can be found at `https://www.zulip.com
+<https://www.zulip.com>`__.
 
 This site contains our installation and contributor documentation. If
 this is your first time here, you may want to start with `Production


### PR DESCRIPTION
I guess it make sense to use zulip.com in the first place.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
