### PR TITLE
settings_dropdown : Added collapse for settings dropdown

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -533,6 +533,10 @@ exports.initialize = function () {
         ".user-presence-link, .user_sidebar_entry .user_circle, .user_sidebar_entry .selectable_sidebar_block",
         (e) => {
             e.stopPropagation();
+            if ($("#gear-menu").hasClass("open")) {
+                $("#gear-menu").removeClass("open");
+                $("#gear-menu").addClass("active");
+            }
             const elem = $(e.currentTarget)
                 .closest(".user_sidebar_entry")
                 .find(".user-presence-link");

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -488,6 +488,10 @@ exports.set_event_handlers = function () {
         const sub = stream_data.get_sub_by_id(stream_id);
         popovers.hide_all();
         narrow.by("stream", sub.name, {trigger: "sidebar"});
+        if ($("#gear-menu").hasClass("open")) {
+            $("#gear-menu").removeClass("open");
+            $("#gear-menu").addClass("active");
+        }
 
         exports.clear_and_hide_search();
 


### PR DESCRIPTION
Earlier , Settings Dropdown used to persist its state even when clicked away form it ( not collapsing )

<strong>GIFs</strong>

Earlier             |  After
:-------------------------:|:-------------------------:
  ![Peek 2020-09-12 22-22](https://user-images.githubusercontent.com/53977614/93000510-8d93a200-f546-11ea-8d6f-dd1f3f2dc18e.gif) |  ![Peek 2020-09-12 22-07](https://user-images.githubusercontent.com/53977614/93000526-abf99d80-f546-11ea-87ce-55d4b9050046.gif)


Hey , I just noticed that the settings dropdown follows the same behaviour even if someone composes a message by clicking <code>New topic</code> or such buttons within the <code>ComposeBox</code> .

Should it be worked upon as well ? 

Fixes : #14079
