### PR TITLE
migrations: Add case-insensitive unique index on realm and stream name.

### DIFF
--- a/zerver/migrations/0302_case_insensitive_stream_name_index.py
+++ b/zerver/migrations/0302_case_insensitive_stream_name_index.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('zerver', '0301_fix_unread_messages_in_deactivated_streams'),
+    ]
+
+    operations = [
+        # We do Stream lookups case-insensitively with respect to the name, but we were missing
+        # the appropriate (realm_id, upper(name::text)) unique index to enforce uniqueness
+        # on database level.
+        migrations.RunSQL("""
+            CREATE UNIQUE INDEX zerver_stream_realm_id_name_uniq ON zerver_stream (realm_id, upper(name::text));
+        """),
+        migrations.AlterUniqueTogether(
+            name='stream',
+            unique_together=set(),
+        ),
+    ]

--- a/zerver/models.py
+++ b/zerver/models.py
@@ -1546,9 +1546,6 @@ class Stream(models.Model):
     def is_history_public_to_subscribers(self) -> bool:
         return self.history_public_to_subscribers
 
-    class Meta:
-        unique_together = ("name", "realm")
-
     # Stream fields included whenever a Stream object is provided to
     # Zulip clients via the API.  A few details worth noting:
     # * "id" is represented as "stream_id" in most API interfaces.


### PR DESCRIPTION
We were missing the index.