### PR TITLE
lint: Use prettier --loglevel=warn for quiet output

### DIFF
--- a/tools/lint
+++ b/tools/lint
@@ -91,12 +91,10 @@ def run() -> None:
     linter_config.external_linter('isort', ['isort'], ['py'],
                                   description="Sorts Python import statements",
                                   check_arg=['--check-only', '--diff'])
-    linter_config.external_linter('prettier', ['node_modules/.bin/prettier', '--check'],
+    linter_config.external_linter('prettier', ['node_modules/.bin/prettier', '--check', '--loglevel=warn'],
                                   ['css', 'js', 'json', 'scss', 'ts', 'yaml', 'yml'],
                                   fix_arg=['--write'],
-                                  description="Formats CSS, JavaScript, YAML",
-                                  # https://github.com/prettier/prettier/pull/8703
-                                  suppress_line=lambda line: line in ["Checking formatting...\n", "All matched files use Prettier code style!\n"])
+                                  description="Formats CSS, JavaScript, YAML")
 
     semgrep_command = ["semgrep", "--config=./tools/semgrep.yml", "--error",
                        "--disable-version-check", "--quiet",


### PR DESCRIPTION
I fixed this upstream in prettier/prettier#8703.

**Testing Plan:**


```console
$ tools/lint --only=prettier
$ tools/lint --only=prettier --fix
$ echo >> stylelint.config.js
$ tools/lint --only=prettier
prettier  | [warn] stylelint.config.js
prettier  | [warn] Code style issues found in the above file(s). Forgot to run Prettier?
$ tools/lint --only=prettier --fix
prettier  | [warn] stylelint.config.js
prettier  | [warn] Code style issues fixed in the above file(s).
```