### PR TITLE
[3.x] requirements: Remove django-cookies-samesite

### DIFF
--- a/requirements/common.in
+++ b/requirements/common.in
@@ -178,9 +178,6 @@ pyahocorasick
 # Used for rate limiting authentication.
 decorator
 
-# Use SameSite cookies in legacy Django (remove with Django 2.1)
-django-cookies-samesite
-
 # For server-side enforcement of password strength
 zxcvbn
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -276,9 +276,6 @@ django-bitfield==2.0.1 \
 django-bmemcached==0.3.0 \
     --hash=sha256:4e4b7d97216dbae331c1de10e699ca22804b94ec3a90d2762dd5d146e6986a8a \
     # via -r requirements/common.in
-django-cookies-samesite==0.6.6 \
-    --hash=sha256:a26dc27bfc446279c981a301b053eff845b93d9ba62798e281c90584a7ccaa4a \
-    # via -r requirements/common.in
 django-formtools==2.2 \
     --hash=sha256:304fa777b8ef9e0693ce7833f885cb89ba46b0e46fc23b01176900a93f46742f \
     --hash=sha256:c5272c03c1cd51b2375abf7397a199a3148a9fbbf2f100e186467a84025d13b2 \
@@ -1106,10 +1103,6 @@ typing-extensions==3.7.4.2 \
     --hash=sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae \
     --hash=sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392 \
     # via -r requirements/common.in, mypy, zulint
-ua-parser==0.10.0 \
-    --hash=sha256:46ab2e383c01dbd2ab284991b87d624a26a08f72da4d7d413f5bfab8b9036f8a \
-    --hash=sha256:47b1782ed130d890018d983fac37c2a80799d9e0b9c532e734c67cf70f185033 \
-    # via django-cookies-samesite
 uhashring==1.2 \
     --hash=sha256:f7304ca2ff763bbf1e2f8a78f21131721811619c5841de4f8c98063344906931 \
     # via python-binary-memcached

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -188,9 +188,6 @@ django-bitfield==2.0.1 \
 django-bmemcached==0.3.0 \
     --hash=sha256:4e4b7d97216dbae331c1de10e699ca22804b94ec3a90d2762dd5d146e6986a8a \
     # via -r requirements/common.in
-django-cookies-samesite==0.6.6 \
-    --hash=sha256:a26dc27bfc446279c981a301b053eff845b93d9ba62798e281c90584a7ccaa4a \
-    # via -r requirements/common.in
 django-formtools==2.2 \
     --hash=sha256:304fa777b8ef9e0693ce7833f885cb89ba46b0e46fc23b01176900a93f46742f \
     --hash=sha256:c5272c03c1cd51b2375abf7397a199a3148a9fbbf2f100e186467a84025d13b2 \
@@ -742,10 +739,6 @@ typing-extensions==3.7.4.2 \
     --hash=sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae \
     --hash=sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392 \
     # via -r requirements/common.in
-ua-parser==0.10.0 \
-    --hash=sha256:46ab2e383c01dbd2ab284991b87d624a26a08f72da4d7d413f5bfab8b9036f8a \
-    --hash=sha256:47b1782ed130d890018d983fac37c2a80799d9e0b9c532e734c67cf70f185033 \
-    # via django-cookies-samesite
 uhashring==1.2 \
     --hash=sha256:f7304ca2ff763bbf1e2f8a78f21131721811619c5841de4f8c98063344906931 \
     # via python-binary-memcached

--- a/version.py
+++ b/version.py
@@ -44,4 +44,4 @@ API_FEATURE_LEVEL = 27
 #   historical commits sharing the same major version, in which case a
 #   minor version bump suffices.
 
-PROVISION_VERSION = '91.20'
+PROVISION_VERSION = '92.0'

--- a/zproject/computed_settings.py
+++ b/zproject/computed_settings.py
@@ -393,8 +393,6 @@ REDIS_PASSWORD = get_secret('redis_password')
 # SECURITY SETTINGS
 ########################################################################
 
-SESSION_COOKIE_SAMESITE = 'Lax'
-
 # Tell the browser to never send our cookies without encryption, e.g.
 # when executing the initial http -> https redirect.
 #


### PR DESCRIPTION
Backport #16350 to 3.x.

Upstream apparently deleted django-cookies-samesite 0.6.6 from PyPI, breaking our installer: jotes/django-cookies-samesite#40.