### PR TITLE
[3.x] provision: Fix missing <sasl/sasl.h> headers during provision

### DIFF
--- a/scripts/lib/setup_venv.py
+++ b/scripts/lib/setup_venv.py
@@ -34,6 +34,8 @@ VENV_DEPENDENCIES = [
     # on upgrade of a production server, and it's not worth adding
     # another call to `apt install` for.
     "jq",                   # Used by scripts/lib/install-node to check yarn version
+
+    "libsasl2-dev",         # For building python-ldap from source
 ]
 
 COMMON_YUM_VENV_DEPENDENCIES = [


### PR DESCRIPTION
Backport of 7b9fe77bf17c314ab3d1794daacb4b4852a7bc37.