### PR TITLE
landing-page: Don't transition all li elements.

### DIFF
--- a/static/styles/portico/landing-page.css
+++ b/static/styles/portico/landing-page.css
@@ -295,7 +295,6 @@ nav {
             color: hsl(0, 0%, 100%);
 
             opacity: 0.7;
-            transition: all 0.2s ease;
 
             &.active,
             &:hover {


### PR DESCRIPTION
This looks weird and shouldn't be present in the first place.

@timabbott since I cannot reproduce the flaky bug after removing this transition, I am 90% sure the bug you described in https://chat.zulip.org/#narrow/stream/6-frontend/topic/zulip.2Ecom.20website.20bug is fixed.

Also, it makes sense something like this would cause the bug.