### PR TITLE
release-checklist: Restore and clarify -dev version/tag for master

### DIFF
--- a/docs/subsystems/release-checklist.md
+++ b/docs/subsystems/release-checklist.md
@@ -62,9 +62,15 @@ preparing a new release.
 
 ### Post-release
 
-* Update `ZULIP_VERSION` in `version.py` to e.g. `3.2+git` following
-  a 3.2 release.  Push this commit.
-* _Except minor releases:_ Create and push a release branch for the
-  minor releases.
+* Following a major release (e.g. 4.0):
+  * Create a release branch (e.g. `4.x`).
+  * On the release branch, update `ZULIP_VERSION` in `version.py` to
+    the present release with a `+git` suffix, e.g. `4.0+git`.
+  * On master, update `ZULIP_VERSION` to the future major release with
+    a `-dev+git` suffix, e.g. `5.0-dev+git`.  Make a Git tag for this
+    update commit with a `-dev` suffix, e.g. `5.0-dev`.
+* Following a minor release (e.g. 3.2):
+  * On the release branch, update `ZULIP_VERSION` to the present
+    release with a `+git` suffix, e.g. `3.2+git`.
 * Consider removing a few old releases from ReadTheDocs; we keep about
   two years of back-versions.


### PR DESCRIPTION
Followup to #16360. Cc @alexmv.

Also, we should create the missing `4.0-dev` tag at 23e0ea5e327ae88b58c14e34e75fab44ed63a36e, and perhaps `3.0-dev` at e46bbf18ebb1aef49319a69dcabf319e2a2c939a—better late than never. These tags are for the benefit of `git describe`.