### PR TITLE
zulip-icons: Set writeFiles to false

### DIFF
--- a/static/assets/icons/zulip-icons.font.js
+++ b/static/assets/icons/zulip-icons.font.js
@@ -7,4 +7,5 @@ module.exports = {
     baseSelector: ".zulip-icon",
     cssTemplate: "./template.hbs",
     ligature: false,
+    writeFiles: false,
 };


### PR DESCRIPTION
`webfonts-loader` now defaults `writeFiles` to `true`, which makes spurious copies of `zulip-icons.{css,eot,svg,ttf,woff,woff2}` for no reason.

**Testing Plan:** Dev server.