### PR TITLE
tornado: Retry POST requests from Django to Tornado.

### DIFF
--- a/zerver/tornado/django_api.py
+++ b/zerver/tornado/django_api.py
@@ -17,7 +17,10 @@ from zerver.tornado.sharding import get_tornado_port, get_tornado_uri, notify_to
 
 class TornadoAdapter(HTTPAdapter):
     def __init__(self) -> None:
-        retry = Retry(total=3, backoff_factor=1)
+        # All of the POST requests we make to Tornado are safe to
+        # retry; allow retries of them, which is not the default.
+        retry_methods = Retry.DEFAULT_METHOD_WHITELIST | set(['POST'])
+        retry = Retry(total=3, backoff_factor=1, method_whitelist=retry_methods)
         super().__init__(max_retries=retry)
 
     def send(


### PR DESCRIPTION
While urllib3 retries all connection errors, it only retries a subset
of read errors, since not all requests are safe to retry if they are
not idempotent, and the far side may have already processed them once.
By default, the only methods that are urllib3 retries read errors on
are GET, TRACE, DELETE, OPTIONS, HEAD, and PUT.  However, all of the
requests into Tornado from Django are POST requests, which limits the
effectiveness of bb754e09028a.

POST requests to `/api/v1/events/internal` are safe to retry; at worst,
they will result in another event queue, which is low cost and will be
GC'd in short order.

POST requests to `/notify_tornado` are _not_ safe to retry, but this
codepath is only used if USING_RABBITMQ is False, which only occurs
during testing.

Enable retries for read errors during all POSTs to Tornado, to better
handle Tornado restarts without 500's.