### PR TITLE
Add `/settings` slash command to typeahead.

### DIFF
--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -138,6 +138,11 @@ const my_slash = {
     text: "translated: /my (Test)",
 };
 
+const settings_slash = {
+    name: "settings",
+    text: "translated: /settings (Load settings menu)",
+};
+
 const sweden_stream = {
     name: "Sweden",
     description: "Cold, mountains and home decor.",
@@ -1490,6 +1495,7 @@ run_test("typeahead_results", () => {
 
     // Autocomplete by slash commands.
     assert_slash_matches("me", [me_slash]);
+    assert_slash_matches("settings", [settings_slash]);
 
     // Autocomplete stream by stream name or stream description.
     assert_stream_matches("den", [denmark_stream, sweden_stream]);

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -386,6 +386,10 @@ exports.slash_commands = [
         text: i18n.t("/poll Where should we go to lunch today? (Create a poll)"),
         name: "poll",
     },
+    {
+        text: i18n.t("/settings (Load settings menu)"),
+        name: "settings",
+    },
 ];
 
 exports.filter_and_sort_mentions = function (is_silent, query, opts) {


### PR DESCRIPTION
The `/settings` slash command is not present in the typeahead; this adds it, as well as a small test.

I'm unsure if this needs to be adjusted for internationalization?
Also, perhaps this would be better as `(Show settings menu)`?