### PR TITLE
bitbucket: Use display_name/nickname when username is not available

### DIFF
--- a/zerver/webhooks/bitbucket2/tests.py
+++ b/zerver/webhooks/bitbucket2/tests.py
@@ -15,17 +15,17 @@ class Bitbucket2HookTests(WebhookTestCase):
 
     def test_bitbucket2_on_push_event(self) -> None:
         commit_info = '* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))'
-        expected_message = f"kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n{commit_info}"
+        expected_message = f"Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n{commit_info}"
         self.check_webhook("push", TOPIC_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_commits_multiple_committers(self) -> None:
         commit_info = '* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))\n'
-        expected_message = f"""kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 3 commits to branch master. Commits by zbenjamin (2) and kolaszek (1).\n\n{commit_info*2}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"""
+        expected_message = f"""Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 3 commits to branch master. Commits by Ben (2) and Tomasz (1).\n\n{commit_info*2}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"""
         self.check_webhook("push_multiple_committers", TOPIC_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_commits_multiple_committers_with_others(self) -> None:
         commit_info = '* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))\n'
-        expected_message = f"""kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 10 commits to branch master. Commits by james (3), Brendon (2), Tomasz (2) and others (3).\n\n{commit_info*9}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"""
+        expected_message = f"""Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 10 commits to branch master. Commits by Tomasz (4), James (3), Brendon (2) and others (1).\n\n{commit_info*9}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"""
         self.check_webhook(
             "push_multiple_committers_with_others", TOPIC_BRANCH_EVENTS, expected_message
         )
@@ -33,13 +33,13 @@ class Bitbucket2HookTests(WebhookTestCase):
     def test_bitbucket2_on_push_commits_multiple_committers_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url(branches='master,development')
         commit_info = '* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))\n'
-        expected_message = f"""kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 3 commits to branch master. Commits by zbenjamin (2) and kolaszek (1).\n\n{commit_info*2}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"""
+        expected_message = f"""Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 3 commits to branch master. Commits by Ben (2) and Tomasz (1).\n\n{commit_info*2}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"""
         self.check_webhook("push_multiple_committers", TOPIC_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_commits_multiple_committers_with_others_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url(branches='master,development')
         commit_info = '* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))\n'
-        expected_message = f"""kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 10 commits to branch master. Commits by james (3), Brendon (2), Tomasz (2) and others (3).\n\n{commit_info*9}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"""
+        expected_message = f"""Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 10 commits to branch master. Commits by Tomasz (4), James (3), Brendon (2) and others (1).\n\n{commit_info*9}* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"""
         self.check_webhook(
             "push_multiple_committers_with_others", TOPIC_BRANCH_EVENTS, expected_message
         )
@@ -47,32 +47,32 @@ class Bitbucket2HookTests(WebhookTestCase):
     def test_bitbucket2_on_push_event_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url(branches='master,development')
         commit_info = '* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))'
-        expected_message = f"kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n{commit_info}"
+        expected_message = f"Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n{commit_info}"
         self.check_webhook("push", TOPIC_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_commits_above_limit_event(self) -> None:
         commit_info = '* a ([6f161a7](https://bitbucket.org/kolaszek/repository-name/commits/6f161a7bced94430ac8947d87dbf45c6deee3fb0))\n'
-        expected_message = f"kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branches/compare/6f161a7bced94430ac8947d87dbf45c6deee3fb0..1221f2fda6f1e3654b09f1f3a08390e4cb25bb48) 5 commits to branch master. Commits by Tomasz (5).\n\n{(commit_info * 5)}[and more commit(s)]"
+        expected_message = f"Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branches/compare/6f161a7bced94430ac8947d87dbf45c6deee3fb0..1221f2fda6f1e3654b09f1f3a08390e4cb25bb48) 5 commits to branch master.\n\n{(commit_info * 5)}[and more commit(s)]"
         self.check_webhook("push_commits_above_limit", TOPIC_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_push_commits_above_limit_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url(branches='master,development')
         commit_info = '* a ([6f161a7](https://bitbucket.org/kolaszek/repository-name/commits/6f161a7bced94430ac8947d87dbf45c6deee3fb0))\n'
-        expected_message = f"kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branches/compare/6f161a7bced94430ac8947d87dbf45c6deee3fb0..1221f2fda6f1e3654b09f1f3a08390e4cb25bb48) 5 commits to branch master. Commits by Tomasz (5).\n\n{(commit_info * 5)}[and more commit(s)]"
+        expected_message = f"Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branches/compare/6f161a7bced94430ac8947d87dbf45c6deee3fb0..1221f2fda6f1e3654b09f1f3a08390e4cb25bb48) 5 commits to branch master.\n\n{(commit_info * 5)}[and more commit(s)]"
 
         self.check_webhook("push_commits_above_limit", TOPIC_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_force_push_event(self) -> None:
-        expected_message = "kolaszek [force pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) to branch master. Head is now 25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12."
+        expected_message = "Tomasz [force pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) to branch master. Head is now 25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12."
         self.check_webhook("force_push", TOPIC_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_force_push_event_filtered_by_branches(self) -> None:
         self.url = self.build_webhook_url(branches='master,development')
-        expected_message = "kolaszek [force pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) to branch master. Head is now 25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12."
+        expected_message = "Tomasz [force pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) to branch master. Head is now 25f93d22b719e2d678a7ad5ee0ef0d1fcdf39c12."
         self.check_webhook("force_push", TOPIC_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_remove_branch_event(self) -> None:
-        expected_message = "kolaszek deleted branch master."
+        expected_message = "Tomasz deleted branch master."
         self.check_webhook("remove_branch", TOPIC_BRANCH_EVENTS, expected_message)
 
     def test_bitbucket2_on_fork_event(self) -> None:
@@ -80,7 +80,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         self.check_webhook("fork", TOPIC, expected_message)
 
     def test_bitbucket2_on_commit_comment_created_event(self) -> None:
-        expected_message = "kolaszek [commented](https://bitbucket.org/kolaszek/repository-name/commits/32c4ea19aa3af10acd08e419e2c354941a365d74#comment-3354963) on [32c4ea1](https://bitbucket.org/kolaszek/repository-name/commits/32c4ea19aa3af10acd08e419e2c354941a365d74):\n~~~ quote\nNice fix!\n~~~"
+        expected_message = "Tomasz [commented](https://bitbucket.org/kolaszek/repository-name/commits/32c4ea19aa3af10acd08e419e2c354941a365d74#comment-3354963) on [32c4ea1](https://bitbucket.org/kolaszek/repository-name/commits/32c4ea19aa3af10acd08e419e2c354941a365d74):\n~~~ quote\nNice fix!\n~~~"
         self.check_webhook("commit_comment_created", TOPIC, expected_message)
 
     def test_bitbucket2_on_commit_status_changed_event(self) -> None:
@@ -88,31 +88,31 @@ class Bitbucket2HookTests(WebhookTestCase):
         self.check_webhook("commit_status_changed", TOPIC, expected_message)
 
     def test_bitbucket2_on_issue_created_event(self) -> None:
-        expected_message = "kolaszek created [Issue #1](https://bitbucket.org/kolaszek/repository-name/issues/2/bug) (assigned to kolaszek):\n\n~~~ quote\nSuch a bug\n~~~"
+        expected_message = "Tomasz created [Issue #1](https://bitbucket.org/kolaszek/repository-name/issues/2/bug) (assigned to Tomasz):\n\n~~~ quote\nSuch a bug\n~~~"
         self.check_webhook("issue_created", TOPIC_ISSUE_EVENTS, expected_message)
 
     def test_bitbucket2_on_issue_created_with_custom_topic_in_url(self) -> None:
         self.url = self.build_webhook_url(topic="notifications")
         expected_topic = "notifications"
-        expected_message = "kolaszek created [Issue #1 Bug](https://bitbucket.org/kolaszek/repository-name/issues/2/bug) (assigned to kolaszek):\n\n~~~ quote\nSuch a bug\n~~~"
+        expected_message = "Tomasz created [Issue #1 Bug](https://bitbucket.org/kolaszek/repository-name/issues/2/bug) (assigned to Tomasz):\n\n~~~ quote\nSuch a bug\n~~~"
         self.check_webhook("issue_created", expected_topic, expected_message)
 
     def test_bitbucket2_on_issue_updated_event(self) -> None:
-        expected_message = "kolaszek updated [Issue #1](https://bitbucket.org/kolaszek/repository-name/issues/2/bug)."
+        expected_message = "Tomasz updated [Issue #1](https://bitbucket.org/kolaszek/repository-name/issues/2/bug)."
         self.check_webhook("issue_updated", TOPIC_ISSUE_EVENTS, expected_message)
 
     def test_bitbucket2_on_issue_commented_event(self) -> None:
-        expected_message = "kolaszek [commented](https://bitbucket.org/kolaszek/repository-name/issues/2#comment-28973596) on [Issue #1](https://bitbucket.org/kolaszek/repository-name/issues/2/bug)."
+        expected_message = "Tomasz [commented](https://bitbucket.org/kolaszek/repository-name/issues/2#comment-28973596) on [Issue #1](https://bitbucket.org/kolaszek/repository-name/issues/2/bug)."
         self.check_webhook("issue_commented", TOPIC_ISSUE_EVENTS, expected_message)
 
     def test_bitbucket2_on_issue_commented_with_custom_topic_in_url(self) -> None:
         self.url = self.build_webhook_url(topic="notifications")
         expected_topic = "notifications"
-        expected_message = "kolaszek [commented](https://bitbucket.org/kolaszek/repository-name/issues/2#comment-28973596) on [Issue #1 Bug](https://bitbucket.org/kolaszek/repository-name/issues/2/bug)."
+        expected_message = "Tomasz [commented](https://bitbucket.org/kolaszek/repository-name/issues/2#comment-28973596) on [Issue #1 Bug](https://bitbucket.org/kolaszek/repository-name/issues/2/bug)."
         self.check_webhook("issue_commented", expected_topic, expected_message)
 
     def test_bitbucket2_on_pull_request_created_event(self) -> None:
-        expected_message = "kolaszek created [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1) (assigned to tkolek) from `new-branch` to `master`:\n\n~~~ quote\ndescription\n~~~"
+        expected_message = "Tomasz created [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1) (assigned to Tomasz Kolek) from `new-branch` to `master`:\n\n~~~ quote\ndescription\n~~~"
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:created',
         }
@@ -121,7 +121,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         )
 
     def test_bitbucket2_on_pull_request_created_without_reviewer_username_event(self) -> None:
-        expected_message = "kolaszek created [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1) (assigned to Tomasz Kolek) from `new-branch` to `master`:\n\n~~~ quote\ndescription\n~~~"
+        expected_message = "Tomasz created [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1) (assigned to Tomasz Kolek) from `new-branch` to `master`:\n\n~~~ quote\ndescription\n~~~"
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:created',
         }
@@ -135,7 +135,7 @@ class Bitbucket2HookTests(WebhookTestCase):
     def test_bitbucket2_on_pull_request_created_with_custom_topic_in_url(self) -> None:
         self.url = self.build_webhook_url(topic="notifications")
         expected_topic = "notifications"
-        expected_message = "kolaszek created [PR #1 new commit](https://bitbucket.org/kolaszek/repository-name/pull-requests/1) (assigned to tkolek) from `new-branch` to `master`:\n\n~~~ quote\ndescription\n~~~"
+        expected_message = "Tomasz created [PR #1 new commit](https://bitbucket.org/kolaszek/repository-name/pull-requests/1) (assigned to Tomasz Kolek) from `new-branch` to `master`:\n\n~~~ quote\ndescription\n~~~"
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:created',
         }
@@ -144,7 +144,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         )
 
     def test_bitbucket2_on_pull_request_updated_event(self) -> None:
-        expected_message = "kolaszek updated [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1) (assigned to tkolek) from `new-branch` to `master`:\n\n~~~ quote\ndescription\n~~~"
+        expected_message = "Tomasz updated [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1) (assigned to Tomasz Kolek) from `new-branch` to `master`:\n\n~~~ quote\ndescription\n~~~"
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:updated',
         }
@@ -153,7 +153,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         )
 
     def test_bitbucket2_on_pull_request_approved_event(self) -> None:
-        expected_message = "kolaszek approved [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1)."
+        expected_message = "Tomasz approved [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1)."
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:approved',
         }
@@ -164,7 +164,7 @@ class Bitbucket2HookTests(WebhookTestCase):
     def test_bitbucket2_on_pull_request_approved_with_custom_topic_in_url(self) -> None:
         self.url = self.build_webhook_url(topic="notifications")
         expected_topic = "notifications"
-        expected_message = "kolaszek approved [PR #1 new commit](https://bitbucket.org/kolaszek/repository-name/pull-requests/1)."
+        expected_message = "Tomasz approved [PR #1 new commit](https://bitbucket.org/kolaszek/repository-name/pull-requests/1)."
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:approved',
         }
@@ -173,7 +173,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         )
 
     def test_bitbucket2_on_pull_request_unapproved_event(self) -> None:
-        expected_message = "kolaszek unapproved [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1)."
+        expected_message = "Tomasz unapproved [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1)."
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:unapproved',
         }
@@ -182,7 +182,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         )
 
     def test_bitbucket2_on_pull_request_declined_event(self) -> None:
-        expected_message = "kolaszek rejected [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1)."
+        expected_message = "Tomasz rejected [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1)."
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:rejected',
         }
@@ -191,7 +191,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         )
 
     def test_bitbucket2_on_pull_request_fulfilled_event(self) -> None:
-        expected_message = "kolaszek merged [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1)."
+        expected_message = "Tomasz merged [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/1)."
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:fulfilled',
         }
@@ -200,7 +200,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         )
 
     def test_bitbucket2_on_pull_request_comment_created_event(self) -> None:
-        expected_message = "kolaszek [commented](https://bitbucket.org/kolaszek/repository-name/pull-requests/3/_/diff#comment-20576503) on [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/3):\n\n~~~ quote\nComment1\n~~~"
+        expected_message = "Tomasz [commented](https://bitbucket.org/kolaszek/repository-name/pull-requests/3/_/diff#comment-20576503) on [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/3):\n\n~~~ quote\nComment1\n~~~"
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:comment_created',
         }
@@ -211,7 +211,7 @@ class Bitbucket2HookTests(WebhookTestCase):
     def test_bitbucket2_on_pull_request_comment_created_with_custom_topic_in_url(self) -> None:
         self.url = self.build_webhook_url(topic="notifications")
         expected_topic = "notifications"
-        expected_message = "kolaszek [commented](https://bitbucket.org/kolaszek/repository-name/pull-requests/3/_/diff#comment-20576503) on [PR #1 new commit](https://bitbucket.org/kolaszek/repository-name/pull-requests/3):\n\n~~~ quote\nComment1\n~~~"
+        expected_message = "Tomasz [commented](https://bitbucket.org/kolaszek/repository-name/pull-requests/3/_/diff#comment-20576503) on [PR #1 new commit](https://bitbucket.org/kolaszek/repository-name/pull-requests/3):\n\n~~~ quote\nComment1\n~~~"
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:comment_created',
         }
@@ -220,7 +220,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         )
 
     def test_bitbucket2_on_pull_request_comment_updated_event(self) -> None:
-        expected_message = "kolaszek updated a [comment](https://bitbucket.org/kolaszek/repository-name/pull-requests/3/_/diff#comment-20576503) on [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/3):\n\n~~~ quote\nComment1\n~~~"
+        expected_message = "Tomasz updated a [comment](https://bitbucket.org/kolaszek/repository-name/pull-requests/3/_/diff#comment-20576503) on [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/3):\n\n~~~ quote\nComment1\n~~~"
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:comment_updated',
         }
@@ -231,7 +231,7 @@ class Bitbucket2HookTests(WebhookTestCase):
     def test_bitbucket2_on_pull_request_comment_updated_with_custom_topic_in_url(self) -> None:
         self.url = self.build_webhook_url(topic="notifications")
         expected_topic = "notifications"
-        expected_message = "kolaszek updated a [comment](https://bitbucket.org/kolaszek/repository-name/pull-requests/3/_/diff#comment-20576503) on [PR #1 new commit](https://bitbucket.org/kolaszek/repository-name/pull-requests/3):\n\n~~~ quote\nComment1\n~~~"
+        expected_message = "Tomasz updated a [comment](https://bitbucket.org/kolaszek/repository-name/pull-requests/3/_/diff#comment-20576503) on [PR #1 new commit](https://bitbucket.org/kolaszek/repository-name/pull-requests/3):\n\n~~~ quote\nComment1\n~~~"
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:comment_updated',
         }
@@ -240,7 +240,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         )
 
     def test_bitbucket2_on_pull_request_comment_deleted_event(self) -> None:
-        expected_message = "kolaszek deleted a [comment](https://bitbucket.org/kolaszek/repository-name/pull-requests/3/_/diff#comment-20576503) on [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/3):\n\n~~~ quote\nComment1\n~~~"
+        expected_message = "Tomasz deleted a [comment](https://bitbucket.org/kolaszek/repository-name/pull-requests/3/_/diff#comment-20576503) on [PR #1](https://bitbucket.org/kolaszek/repository-name/pull-requests/3):\n\n~~~ quote\nComment1\n~~~"
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:comment_deleted',
         }
@@ -255,21 +255,21 @@ class Bitbucket2HookTests(WebhookTestCase):
         self.check_webhook("repo_updated", expected_topic, expected_message, **kwargs)
 
     def test_bitbucket2_on_push_one_tag_event(self) -> None:
-        expected_message = "kolaszek pushed tag [a](https://bitbucket.org/kolaszek/repository-name/commits/tag/a)."
+        expected_message = "Tomasz pushed tag [a](https://bitbucket.org/kolaszek/repository-name/commits/tag/a)."
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:push',
         }
         self.check_webhook("push_one_tag", TOPIC, expected_message, **kwargs)
 
     def test_bitbucket2_on_push_remove_tag_event(self) -> None:
-        expected_message = "kolaszek removed tag [a](https://bitbucket.org/kolaszek/repository-name/commits/tag/a)."
+        expected_message = "Tomasz removed tag [a](https://bitbucket.org/kolaszek/repository-name/commits/tag/a)."
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:push',
         }
         self.check_webhook("push_remove_tag", TOPIC, expected_message, **kwargs)
 
     def test_bitbucket2_on_push_more_than_one_tag_event(self) -> None:
-        expected_message = "kolaszek pushed tag [{name}](https://bitbucket.org/kolaszek/repository-name/commits/tag/{name})."
+        expected_message = "Tomasz pushed tag [{name}](https://bitbucket.org/kolaszek/repository-name/commits/tag/{name})."
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:push',
         }
@@ -322,7 +322,7 @@ class Bitbucket2HookTests(WebhookTestCase):
             message=msg,
             stream_name=self.STREAM_NAME,
             topic_name=TOPIC_BRANCH_EVENTS,
-            content="kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"
+            content="Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))"
         )
 
         msg = self.get_last_message()
@@ -330,7 +330,7 @@ class Bitbucket2HookTests(WebhookTestCase):
             message=msg,
             stream_name=self.STREAM_NAME,
             topic_name=TOPIC,
-            content="kolaszek pushed tag [a](https://bitbucket.org/kolaszek/repository-name/commits/tag/a).",
+            content="Tomasz pushed tag [a](https://bitbucket.org/kolaszek/repository-name/commits/tag/a).",
         )
 
     def test_bitbucket2_on_more_than_one_push_event_filtered_by_branches(self) -> None:
@@ -355,7 +355,7 @@ class Bitbucket2HookTests(WebhookTestCase):
             message=msg,
             stream_name=self.STREAM_NAME,
             topic_name=TOPIC_BRANCH_EVENTS,
-            content="kolaszek [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))",
+            content="Tomasz [pushed](https://bitbucket.org/kolaszek/repository-name/branch/master) 1 commit to branch master.\n\n* first commit ([84b96ad](https://bitbucket.org/kolaszek/repository-name/commits/84b96adc644a30fd6465b3d196369d880762afed))",
         )
 
         msg = self.get_last_message()
@@ -363,7 +363,7 @@ class Bitbucket2HookTests(WebhookTestCase):
             message=msg,
             stream_name=self.STREAM_NAME,
             topic_name=TOPIC,
-            content="kolaszek pushed tag [a](https://bitbucket.org/kolaszek/repository-name/commits/tag/a).",
+            content="Tomasz pushed tag [a](https://bitbucket.org/kolaszek/repository-name/commits/tag/a).",
         )
 
     def test_bitbucket2_on_more_than_one_push_event_filtered_by_branches_ignore(self) -> None:
@@ -371,7 +371,7 @@ class Bitbucket2HookTests(WebhookTestCase):
         kwargs = {
             "HTTP_X_EVENT_KEY": 'pullrequest:push',
         }
-        expected_message = "kolaszek pushed tag [a](https://bitbucket.org/kolaszek/repository-name/commits/tag/a)."
+        expected_message = "Tomasz pushed tag [a](https://bitbucket.org/kolaszek/repository-name/commits/tag/a)."
         self.check_webhook("more_than_one_push_event", TOPIC, expected_message, **kwargs)
 
     @patch('zerver.webhooks.bitbucket2.view.check_send_webhook_message')

--- a/zerver/webhooks/bitbucket3/view.py
+++ b/zerver/webhooks/bitbucket3/view.py
@@ -21,12 +21,9 @@ from zerver.lib.webhooks.git import (
     get_remove_branch_event_message,
 )
 from zerver.models import UserProfile
-from zerver.webhooks.bitbucket2.view import (
-    BITBUCKET_FORK_BODY,
-    BITBUCKET_REPO_UPDATED_CHANGED,
-    BITBUCKET_TOPIC_TEMPLATE,
-)
+from zerver.webhooks.bitbucket2.view import BITBUCKET_REPO_UPDATED_CHANGED, BITBUCKET_TOPIC_TEMPLATE
 
+BITBUCKET_FORK_BODY = "User {display_name}(login: {username}) forked the repository into [{fork_name}]({fork_url})."
 BRANCH_UPDATED_MESSAGE_TEMPLATE = "{user_name} pushed to branch {branch_name}. Head is now {head}."
 PULL_REQUEST_MARKED_AS_NEEDS_WORK_TEMPLATE = "{user_name} marked [PR #{number}]({url}) as \"needs work\"."
 PULL_REQUEST_MARKED_AS_NEEDS_WORK_TEMPLATE_WITH_TITLE = """


### PR DESCRIPTION
I trusted our unit tests on this, which are pretty extensive, and the changes here are pretty straightforward.