### PR TITLE
css: Don't use `Monaco` font for <code>.

### DIFF
--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -66,6 +66,11 @@ a {
     }
 }
 
+code,
+pre {
+    font-family: Menlo, Consolas, "Courier New", monospace;
+}
+
 .no-select {
     user-select: none;
 }


### PR DESCRIPTION
bootstrap sets <code> to use `Monaco` font by default. We don't
want to use this font since some characters are not clearly
readable like `()` appearing as `0`.

Hence, we use Menlo font by default if available.

Since `Monaco` font is only installed in macOS by default, this
mostly affected mac users.
