### PR TITLE
[WIP] Improve slash commands

### DIFF
--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -355,23 +355,23 @@ function should_show_custom_query(query, items) {
 
 exports.slash_commands = [
     {
-        text: i18n.t("/dark (Toggle night mode)"),
+        text: i18n.t("/dark (Switch to night mode)"),
         name: "dark",
     },
     {
-        text: i18n.t("/day (Toggle day mode)"),
+        text: i18n.t("/day (Switch to day mode)"),
         name: "day",
     },
     {
-        text: i18n.t("/fixed-width (Toggle fixed width mode)"),
+        text: i18n.t("/fixed-width (Switch to fixed width mode)"),
         name: "fixed-width",
     },
     {
-        text: i18n.t("/fluid-width (Toggle fluid width mode)"),
+        text: i18n.t("/fluid-width (Switch to fluid width mode)"),
         name: "fluid-width",
     },
     {
-        text: i18n.t("/light (Toggle day mode)"),
+        text: i18n.t("/light (Switch to day mode)"),
         name: "light",
     },
     {
@@ -379,7 +379,7 @@ exports.slash_commands = [
         name: "me",
     },
     {
-        text: i18n.t("/night (Toggle night mode)"),
+        text: i18n.t("/night (Switch to night mode)"),
         name: "night",
     },
     {

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -356,10 +356,6 @@ function should_show_custom_query(query, items) {
 // Prioritize top 5 shown in typeahead, keeping each group sorted manually.
 exports.slash_commands = [
     {
-        text: i18n.t("/dark (Switch to night mode)"),
-        name: "dark",
-    },
-    {
         text: i18n.t("/me is excited (Display action text)"),
         name: "me",
     },
@@ -372,8 +368,16 @@ exports.slash_commands = [
         name: "settings",
     },
     {
+        text: i18n.t("/theme color_mode (Switch to new color mode: dark, night, light, day)"),
+        name: "theme",
+    },
+    {
         text: i18n.t("/todo (Create a todo list)"),
         name: "todo",
+    },
+    {
+        text: i18n.t("/dark (Switch to night mode)"),
+        name: "dark",
     },
     {
         text: i18n.t("/day (Switch to day mode)"),

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -353,10 +353,27 @@ function should_show_custom_query(query, items) {
     return !matched;
 }
 
+// Prioritize top 5 shown in typeahead, keeping each group sorted manually.
 exports.slash_commands = [
     {
         text: i18n.t("/dark (Switch to night mode)"),
         name: "dark",
+    },
+    {
+        text: i18n.t("/me is excited (Display action text)"),
+        name: "me",
+    },
+    {
+        text: i18n.t("/poll Where should we go to lunch today? (Create a poll)"),
+        name: "poll",
+    },
+    {
+        text: i18n.t("/settings (Load settings menu)"),
+        name: "settings",
+    },
+    {
+        text: i18n.t("/todo (Create a todo list)"),
+        name: "todo",
     },
     {
         text: i18n.t("/day (Switch to day mode)"),
@@ -375,28 +392,12 @@ exports.slash_commands = [
         name: "light",
     },
     {
-        text: i18n.t("/me is excited (Display action text)"),
-        name: "me",
-    },
-    {
         text: i18n.t("/night (Switch to night mode)"),
         name: "night",
     },
     {
         text: i18n.t("/ping (Test server round-trip time)"),
         name: "ping",
-    },
-    {
-        text: i18n.t("/poll Where should we go to lunch today? (Create a poll)"),
-        name: "poll",
-    },
-    {
-        text: i18n.t("/settings (Load settings menu)"),
-        name: "settings",
-    },
-    {
-        text: i18n.t("/todo (Create a todo list)"),
-        name: "todo",
     },
 ];
 

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -978,6 +978,9 @@ function get_header_text() {
         case "silent_mention":
             tip_text = i18n.t("User will not be notified");
             break;
+        case "slash":
+            tip_text = i18n.t("Try /commands to receive full command list from notification bot");
+            break;
         case "syntax":
             if (page_params.realm_default_code_block_language !== null) {
                 tip_text = i18n.t("Default is __language__. Use 'text' to disable highlighting.", {

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -383,12 +383,20 @@ exports.slash_commands = [
         name: "night",
     },
     {
+        text: i18n.t("/ping (Test server round-trip time)"),
+        name: "ping",
+    },
+    {
         text: i18n.t("/poll Where should we go to lunch today? (Create a poll)"),
         name: "poll",
     },
     {
         text: i18n.t("/settings (Load settings menu)"),
         name: "settings",
+    },
+    {
+        text: i18n.t("/todo (Create a todo list)"),
+        name: "todo",
     },
 ];
 

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -354,11 +354,9 @@ function slash_command_comparator(slash_command_a, slash_command_b) {
     }
 }
 exports.sort_slash_commands = function (matches, query) {
-    // We will likely want to in the future make this sort the
-    // just-`/` commands by something approximating usefulness.
     const results = typeahead.triage(query, matches, (x) => x.name);
 
-    results.matches = results.matches.sort(slash_command_comparator);
+    // Don't sort the matches here too, as these are prioritized manually
     results.rest = results.rest.sort(slash_command_comparator);
     return results.matches.concat(results.rest);
 };

--- a/static/js/zcommand.js
+++ b/static/js/zcommand.js
@@ -142,7 +142,14 @@ exports.enter_fixed_mode = function () {
 
 exports.process = function (message_content) {
     const content = message_content.trim();
-    const [command] = content.split(" ");
+    const [command, ...raw_args] = content.split(" ");
+    const args = raw_args.filter((x) => x !== "");
+
+    // This is handled in rendering logic, but can be validated here
+    if (command === "/me") {
+        // Avoid sending '/me' as content (TODO: inform user why nothing happened)
+        return args.length === 0;
+    }
 
     if (command === "/ping") {
         const start_time = new Date();

--- a/static/js/zcommand.js
+++ b/static/js/zcommand.js
@@ -142,12 +142,13 @@ exports.enter_fixed_mode = function () {
 
 exports.process = function (message_content) {
     const content = message_content.trim();
+    const [command] = content.split(" ");
 
-    if (content === "/ping") {
+    if (command === "/ping") {
         const start_time = new Date();
 
         exports.send({
-            command: content,
+            command: command,
             on_success() {
                 const end_time = new Date();
                 let diff = end_time - start_time;
@@ -160,28 +161,28 @@ exports.process = function (message_content) {
     }
 
     const day_commands = ["/day", "/light"];
-    if (day_commands.includes(content)) {
+    if (day_commands.includes(command)) {
         exports.enter_day_mode();
         return true;
     }
 
     const night_commands = ["/night", "/dark"];
-    if (night_commands.includes(content)) {
+    if (night_commands.includes(command)) {
         exports.enter_night_mode();
         return true;
     }
 
-    if (content === "/fluid-width") {
+    if (command === "/fluid-width") {
         exports.enter_fluid_mode();
         return true;
     }
 
-    if (content === "/fixed-width") {
+    if (command === "/fixed-width") {
         exports.enter_fixed_mode();
         return true;
     }
 
-    if (content === "/settings") {
+    if (command === "/settings") {
         hashchange.go_to_location("settings/your-account");
         return true;
     }

--- a/static/js/zcommand.js
+++ b/static/js/zcommand.js
@@ -179,6 +179,36 @@ exports.process = function (message_content) {
         return true;
     }
 
+    const theme_command = "/theme";
+    if (command === theme_command) {
+        const direct_theme_command = "/" + args[0];
+        if (night_commands.includes(direct_theme_command)) {
+            exports.enter_night_mode();
+            return true;
+        }
+        if (day_commands.includes(direct_theme_command)) {
+            exports.enter_day_mode();
+            return true;
+        }
+        // Not a valid use of command, so inform user why
+        const issue = (() => {
+            if (args.length === 0) {
+                return "No theme specified";
+            }
+            return "Theme '" + direct_theme_command.slice(1) + "' does not exist";
+        })();
+        const valid_theme_slash_commands = day_commands.concat(night_commands);
+        const valid_themes = valid_theme_slash_commands.map((theme) => theme.slice(1));
+        const msg = issue + " (valid themes: " + valid_themes.join(", ") + ")";
+        exports.send({
+            command: "/ping", // FIXME: Fake ping to use tell_user
+            on_success() {
+                exports.tell_user(msg);
+            },
+        });
+        return true;
+    }
+
     if (command === "/fluid-width") {
         exports.enter_fluid_mode();
         return true;


### PR DESCRIPTION
So far this PR:
* adds typeahead for the existing `/ping` and `/todo` slash commands
* adjusts the typeahead to show prioritized commands
* adds the `/theme` typeahead as a generalized version of dark/light/night/day (it replaces /dark in the prioritized commands, but the others are still present)
* adds a tip to slash commands, to an unimplemented means to list all slash commands (not easily otherwise achieved)

I'd definitely like to add more tests, so just putting this out to get feedback on these ideas and implementation first.

Except for the last commit this is all fully implemented and should work.