### PR TITLE
certbot: Explicitly apt-get update before installing certbot.

### DIFF
--- a/scripts/setup/setup-certbot
+++ b/scripts/setup/setup-certbot
@@ -91,6 +91,7 @@ set -x
 
 case " $os_id $os_id_like " in
     *' debian '*)
+        apt-get update
         apt-get install -y certbot
         ;;
     *' rhel '*)


### PR DESCRIPTION
There is no guarantee that the apt data is up-to-date, unless we
explicitly update.

Fixes: zulip/docker-zulip#275