### PR TITLE
Weblog errors

### DIFF
--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -550,8 +550,8 @@ def authenticated_rest_api_view(
                     target_view_func = view_func
                 return target_view_func(request, profile, *args, **kwargs)
             except Exception as err:
-                if allow_webhook_access:
-                    if isinstance(err, UnsupportedWebhookEventType) and webhook_client_name is not None:
+                if webhook_client_name is not None:
+                    if isinstance(err, UnsupportedWebhookEventType):
                         err.webhook_name = webhook_client_name
                     request_body = request.POST.get('payload')
                     if request_body is not None:

--- a/zerver/decorator.py
+++ b/zerver/decorator.py
@@ -553,12 +553,10 @@ def authenticated_rest_api_view(
                 if webhook_client_name is not None:
                     if isinstance(err, UnsupportedWebhookEventType):
                         err.webhook_name = webhook_client_name
-                    request_body = request.POST.get('payload')
-                    if request_body is not None:
-                        log_exception_to_webhook_logger(
-                            summary=str(err),
-                            unsupported_event=isinstance(err, UnsupportedWebhookEventType),
-                        )
+                    log_exception_to_webhook_logger(
+                        summary=str(err),
+                        unsupported_event=isinstance(err, UnsupportedWebhookEventType),
+                    )
 
                 raise err
         return _wrapped_func_arguments

--- a/zerver/lib/logging_util.py
+++ b/zerver/lib/logging_util.py
@@ -259,7 +259,7 @@ class ZulipWebhookFormatter(ZulipFormatter):
 
         header_message = header_text if header_text else None
 
-        setattr(record, 'user', f"{request.user.delivery_email} (request.user.realm.string_id)")
+        setattr(record, 'user', f"{request.user.delivery_email} ({request.user.realm.string_id})")
         setattr(record, 'client', request.client.name)
         setattr(record, 'url', request.META.get('PATH_INFO', None))
         setattr(record, 'content_type', request.content_type)

--- a/zerver/lib/rest.py
+++ b/zerver/lib/rest.py
@@ -138,7 +138,7 @@ def rest_dispatch(request: HttpRequest, **kwargs: Any) -> HttpResponse:
             # Wrap function with decorator to authenticate the user before
             # proceeding
             target_function = authenticated_rest_api_view(
-                is_webhook='allow_incoming_webhooks' in view_flags,
+                allow_webhook_access='allow_incoming_webhooks' in view_flags,
             )(target_function)
         elif request.path.startswith("/json") and 'allow_anonymous_user_web' in view_flags:
             # For endpoints that support anonymous web access, we do that.

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -461,7 +461,6 @@ class DecoratorLoggingTestCase(ZulipTestCase):
         request.host = "zulip.testserver"
 
         request.body = '{}'
-        request.POST['payload'] = '{}'
         request.content_type = 'text/plain'
 
         with mock.patch('zerver.decorator.webhook_logger.exception') as mock_exception:
@@ -483,7 +482,6 @@ class DecoratorLoggingTestCase(ZulipTestCase):
         request.host = "zulip.testserver"
 
         request.body = '{}'
-        request.POST['payload'] = '{}'
         request.content_type = 'text/plain'
 
         with mock.patch('zerver.decorator.webhook_unsupported_events_logger.exception') as mock_exception:

--- a/zerver/tests/test_decorators.py
+++ b/zerver/tests/test_decorators.py
@@ -1314,7 +1314,7 @@ class TestValidateApiKey(ZulipTestCase):
         api_key = get_api_key(self.webhook_bot)
         profile = validate_api_key(HostRequestMock(host="zulip.testserver"),
                                    self.webhook_bot.email, api_key,
-                                   is_webhook=True)
+                                   allow_webhook_access=True)
         self.assertEqual(profile.id, self.webhook_bot.id)
 
     def test_validate_api_key_if_email_is_case_insensitive(self) -> None:


### PR DESCRIPTION
Better error handling for the authenticated_rest_api_view side of webhooks.

**Testing Plan:** Existing tests, POST'd to `/api/v1/messages` on localhost with `&payload={}`
