### PR TITLE
Some steps toward reducing urls.py noise

### DIFF
--- a/analytics/urls.py
+++ b/analytics/urls.py
@@ -35,16 +35,16 @@ i18n_urlpatterns = [
 v1_api_and_json_patterns = [
     # get data for the graphs at /stats
     path('analytics/chart_data', rest_dispatch,
-         {'GET': 'analytics.views.get_chart_data'}),
+         {'GET': analytics.views.get_chart_data}),
     path('analytics/chart_data/realm/<realm_str>', rest_dispatch,
-         {'GET': 'analytics.views.get_chart_data_for_realm'}),
+         {'GET': analytics.views.get_chart_data_for_realm}),
     path('analytics/chart_data/installation', rest_dispatch,
-         {'GET': 'analytics.views.get_chart_data_for_installation'}),
+         {'GET': analytics.views.get_chart_data_for_installation}),
     path('analytics/chart_data/remote/<int:remote_server_id>/installation', rest_dispatch,
-         {'GET': 'analytics.views.get_chart_data_for_remote_installation'}),
+         {'GET': analytics.views.get_chart_data_for_remote_installation}),
     path('analytics/chart_data/remote/<int:remote_server_id>/realm/<int:remote_realm_id>',
          rest_dispatch,
-         {'GET': 'analytics.views.get_chart_data_for_remote_realm'}),
+         {'GET': analytics.views.get_chart_data_for_remote_realm}),
 ]
 
 i18n_urlpatterns += [

--- a/analytics/urls.py
+++ b/analytics/urls.py
@@ -6,25 +6,18 @@ from zerver.lib.rest import rest_dispatch
 
 i18n_urlpatterns = [
     # Server admin (user_profile.is_staff) visible stats pages
-    path('activity', analytics.views.get_activity,
-         name='analytics.views.get_activity'),
+    path('activity', analytics.views.get_activity),
     path('activity/support', analytics.views.support,
-         name='analytics.views.support'),
-    path('realm_activity/<realm_str>/', analytics.views.get_realm_activity,
-         name='analytics.views.get_realm_activity'),
-    path('user_activity/<email>/', analytics.views.get_user_activity,
-         name='analytics.views.get_user_activity'),
+         name='support'),
+    path('realm_activity/<realm_str>/', analytics.views.get_realm_activity),
+    path('user_activity/<email>/', analytics.views.get_user_activity),
 
-    path('stats/realm/<realm_str>/', analytics.views.stats_for_realm,
-         name='analytics.views.stats_for_realm'),
-    path('stats/installation', analytics.views.stats_for_installation,
-         name='analytics.views.stats_for_installation'),
+    path('stats/realm/<realm_str>/', analytics.views.stats_for_realm),
+    path('stats/installation', analytics.views.stats_for_installation),
     path('stats/remote/<int:remote_server_id>/installation',
-         analytics.views.stats_for_remote_installation,
-         name='analytics.views.stats_for_remote_installation'),
+         analytics.views.stats_for_remote_installation),
     path('stats/remote/<int:remote_server_id>/realm/<int:remote_realm_id>/',
-         analytics.views.stats_for_remote_realm,
-         name='analytics.views.stats_for_remote_realm'),
+         analytics.views.stats_for_remote_realm),
 
     # User-visible stats page
     path('stats', analytics.views.stats,

--- a/analytics/urls.py
+++ b/analytics/urls.py
@@ -1,27 +1,42 @@
 from django.conf.urls import include
 from django.urls import path
 
-import analytics.views
+from analytics.views import (
+    get_activity,
+    get_chart_data,
+    get_chart_data_for_installation,
+    get_chart_data_for_realm,
+    get_chart_data_for_remote_installation,
+    get_chart_data_for_remote_realm,
+    get_realm_activity,
+    get_user_activity,
+    stats,
+    stats_for_installation,
+    stats_for_realm,
+    stats_for_remote_installation,
+    stats_for_remote_realm,
+    support,
+)
 from zerver.lib.rest import rest_dispatch
 
 i18n_urlpatterns = [
     # Server admin (user_profile.is_staff) visible stats pages
-    path('activity', analytics.views.get_activity),
-    path('activity/support', analytics.views.support,
+    path('activity', get_activity),
+    path('activity/support', support,
          name='support'),
-    path('realm_activity/<realm_str>/', analytics.views.get_realm_activity),
-    path('user_activity/<email>/', analytics.views.get_user_activity),
+    path('realm_activity/<realm_str>/', get_realm_activity),
+    path('user_activity/<email>/', get_user_activity),
 
-    path('stats/realm/<realm_str>/', analytics.views.stats_for_realm),
-    path('stats/installation', analytics.views.stats_for_installation),
+    path('stats/realm/<realm_str>/', stats_for_realm),
+    path('stats/installation', stats_for_installation),
     path('stats/remote/<int:remote_server_id>/installation',
-         analytics.views.stats_for_remote_installation),
+         stats_for_remote_installation),
     path('stats/remote/<int:remote_server_id>/realm/<int:remote_realm_id>/',
-         analytics.views.stats_for_remote_realm),
+         stats_for_remote_realm),
 
     # User-visible stats page
-    path('stats', analytics.views.stats,
-         name='analytics.views.stats'),
+    path('stats', stats,
+         name='stats'),
 ]
 
 # These endpoints are a part of the API (V1), which uses:
@@ -35,16 +50,16 @@ i18n_urlpatterns = [
 v1_api_and_json_patterns = [
     # get data for the graphs at /stats
     path('analytics/chart_data', rest_dispatch,
-         {'GET': analytics.views.get_chart_data}),
+         {'GET': get_chart_data}),
     path('analytics/chart_data/realm/<realm_str>', rest_dispatch,
-         {'GET': analytics.views.get_chart_data_for_realm}),
+         {'GET': get_chart_data_for_realm}),
     path('analytics/chart_data/installation', rest_dispatch,
-         {'GET': analytics.views.get_chart_data_for_installation}),
+         {'GET': get_chart_data_for_installation}),
     path('analytics/chart_data/remote/<int:remote_server_id>/installation', rest_dispatch,
-         {'GET': analytics.views.get_chart_data_for_remote_installation}),
+         {'GET': get_chart_data_for_remote_installation}),
     path('analytics/chart_data/remote/<int:remote_server_id>/realm/<int:remote_realm_id>',
          rest_dispatch,
-         {'GET': analytics.views.get_chart_data_for_remote_realm}),
+         {'GET': get_chart_data_for_remote_realm}),
 ]
 
 i18n_urlpatterns += [

--- a/analytics/urls.py
+++ b/analytics/urls.py
@@ -17,7 +17,7 @@ from analytics.views import (
     stats_for_remote_realm,
     support,
 )
-from zerver.lib.rest import rest_dispatch
+from zerver.lib.rest import rest_path
 
 i18n_urlpatterns = [
     # Server admin (user_profile.is_staff) visible stats pages
@@ -49,17 +49,16 @@ i18n_urlpatterns = [
 # All of these paths are accessed by either a /json or /api prefix
 v1_api_and_json_patterns = [
     # get data for the graphs at /stats
-    path('analytics/chart_data', rest_dispatch,
-         {'GET': get_chart_data}),
-    path('analytics/chart_data/realm/<realm_str>', rest_dispatch,
-         {'GET': get_chart_data_for_realm}),
-    path('analytics/chart_data/installation', rest_dispatch,
-         {'GET': get_chart_data_for_installation}),
-    path('analytics/chart_data/remote/<int:remote_server_id>/installation', rest_dispatch,
-         {'GET': get_chart_data_for_remote_installation}),
-    path('analytics/chart_data/remote/<int:remote_server_id>/realm/<int:remote_realm_id>',
-         rest_dispatch,
-         {'GET': get_chart_data_for_remote_realm}),
+    rest_path('analytics/chart_data',
+              GET=get_chart_data),
+    rest_path('analytics/chart_data/realm/<realm_str>',
+              GET=get_chart_data_for_realm),
+    rest_path('analytics/chart_data/installation',
+              GET=get_chart_data_for_installation),
+    rest_path('analytics/chart_data/remote/<int:remote_server_id>/installation',
+              GET=get_chart_data_for_remote_installation),
+    rest_path('analytics/chart_data/remote/<int:remote_server_id>/realm/<int:remote_realm_id>',
+              GET=get_chart_data_for_remote_realm),
 ]
 
 i18n_urlpatterns += [

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -1352,26 +1352,22 @@ def format_date_for_activity_reports(date: Optional[datetime]) -> str:
         return ''
 
 def user_activity_link(email: str) -> mark_safe:
-    url_name = 'analytics.views.get_user_activity'
-    url = reverse(url_name, kwargs=dict(email=email))
+    url = reverse(get_user_activity, kwargs=dict(email=email))
     email_link = f'<a href="{url}">{email}</a>'
     return mark_safe(email_link)
 
 def realm_activity_link(realm_str: str) -> mark_safe:
-    url_name = 'analytics.views.get_realm_activity'
-    url = reverse(url_name, kwargs=dict(realm_str=realm_str))
+    url = reverse(get_realm_activity, kwargs=dict(realm_str=realm_str))
     realm_link = f'<a href="{url}">{realm_str}</a>'
     return mark_safe(realm_link)
 
 def realm_stats_link(realm_str: str) -> mark_safe:
-    url_name = 'analytics.views.stats_for_realm'
-    url = reverse(url_name, kwargs=dict(realm_str=realm_str))
+    url = reverse(stats_for_realm, kwargs=dict(realm_str=realm_str))
     stats_link = f'<a href="{url}"><i class="fa fa-pie-chart"></i>{realm_str}</a>'
     return mark_safe(stats_link)
 
 def remote_installation_stats_link(server_id: int, hostname: str) -> mark_safe:
-    url_name = 'analytics.views.stats_for_remote_installation'
-    url = reverse(url_name, kwargs=dict(remote_server_id=server_id))
+    url = reverse(stats_for_remote_installation, kwargs=dict(remote_server_id=server_id))
     stats_link = f'<a href="{url}"><i class="fa fa-pie-chart"></i>{hostname}</a>'
     return mark_safe(stats_link)
 

--- a/confirmation/models.py
+++ b/confirmation/models.py
@@ -122,16 +122,16 @@ _properties = {
     Confirmation.USER_REGISTRATION: ConfirmationType('check_prereg_key_and_redirect'),
     Confirmation.INVITATION: ConfirmationType('check_prereg_key_and_redirect',
                                               validity_in_days=settings.INVITATION_LINK_VALIDITY_DAYS),
-    Confirmation.EMAIL_CHANGE: ConfirmationType('zerver.views.user_settings.confirm_email_change'),
+    Confirmation.EMAIL_CHANGE: ConfirmationType('confirm_email_change'),
     Confirmation.UNSUBSCRIBE: ConfirmationType(
-        'zerver.views.unsubscribe.email_unsubscribe',
+        'unsubscribe',
         validity_in_days=1000000,  # should never expire
     ),
     Confirmation.MULTIUSE_INVITE: ConfirmationType(
-        'zerver.views.registration.accounts_home_from_multiuse_invite',
+        'join',
         validity_in_days=settings.INVITATION_LINK_VALIDITY_DAYS),
     Confirmation.REALM_CREATION: ConfirmationType('check_prereg_key_and_redirect'),
-    Confirmation.REALM_REACTIVATION: ConfirmationType('zerver.views.realm.realm_reactivation'),
+    Confirmation.REALM_REACTIVATION: ConfirmationType('realm_reactivation'),
 }
 
 def one_click_unsubscribe_link(user_profile: UserProfile, email_type: str) -> str:
@@ -171,7 +171,7 @@ def generate_realm_creation_url(by_admin: bool=False) -> str:
                                     presume_email_valid=by_admin)
     return urljoin(
         settings.ROOT_DOMAIN_URI,
-        reverse('zerver.views.create_realm', kwargs={'creation_key': key}),
+        reverse('create_realm', kwargs={'creation_key': key}),
     )
 
 class RealmCreationKey(models.Model):

--- a/corporate/urls.py
+++ b/corporate/urls.py
@@ -15,8 +15,8 @@ i18n_urlpatterns: Any = [
     path('jobs/', TemplateView.as_view(template_name='corporate/jobs.html')),
 
     # Billing
-    path('billing/', corporate.views.billing_home, name='corporate.views.billing_home'),
-    path('upgrade/', corporate.views.initial_upgrade, name='corporate.views.initial_upgrade'),
+    path('billing/', corporate.views.billing_home),
+    path('upgrade/', corporate.views.initial_upgrade, name='initial_upgrade'),
 ]
 
 v1_api_and_json_patterns = [

--- a/corporate/urls.py
+++ b/corporate/urls.py
@@ -12,7 +12,7 @@ from corporate.views import (
     sponsorship,
     upgrade,
 )
-from zerver.lib.rest import rest_dispatch
+from zerver.lib.rest import rest_path
 
 i18n_urlpatterns: Any = [
     # Zephyr/MIT
@@ -27,14 +27,14 @@ i18n_urlpatterns: Any = [
 ]
 
 v1_api_and_json_patterns = [
-    path('billing/upgrade', rest_dispatch,
-         {'POST': upgrade}),
-    path('billing/sponsorship', rest_dispatch,
-         {'POST': sponsorship}),
-    path('billing/plan/change', rest_dispatch,
-         {'POST': change_plan_status}),
-    path('billing/sources/change', rest_dispatch,
-         {'POST': replace_payment_source}),
+    rest_path('billing/upgrade',
+              POST=upgrade),
+    rest_path('billing/sponsorship',
+              POST=sponsorship),
+    rest_path('billing/plan/change',
+              POST=change_plan_status),
+    rest_path('billing/sources/change',
+              POST=replace_payment_source),
 ]
 
 # Make a copy of i18n_urlpatterns so that they appear without prefix for English

--- a/corporate/urls.py
+++ b/corporate/urls.py
@@ -21,13 +21,13 @@ i18n_urlpatterns: Any = [
 
 v1_api_and_json_patterns = [
     path('billing/upgrade', rest_dispatch,
-         {'POST': 'corporate.views.upgrade'}),
+         {'POST': corporate.views.upgrade}),
     path('billing/sponsorship', rest_dispatch,
-         {'POST': 'corporate.views.sponsorship'}),
+         {'POST': corporate.views.sponsorship}),
     path('billing/plan/change', rest_dispatch,
-         {'POST': 'corporate.views.change_plan_status'}),
+         {'POST': corporate.views.change_plan_status}),
     path('billing/sources/change', rest_dispatch,
-         {'POST': 'corporate.views.replace_payment_source'}),
+         {'POST': corporate.views.replace_payment_source}),
 ]
 
 # Make a copy of i18n_urlpatterns so that they appear without prefix for English

--- a/corporate/urls.py
+++ b/corporate/urls.py
@@ -4,7 +4,14 @@ from django.conf.urls import include
 from django.urls import path
 from django.views.generic import TemplateView
 
-import corporate.views
+from corporate.views import (
+    billing_home,
+    change_plan_status,
+    initial_upgrade,
+    replace_payment_source,
+    sponsorship,
+    upgrade,
+)
 from zerver.lib.rest import rest_dispatch
 
 i18n_urlpatterns: Any = [
@@ -15,19 +22,19 @@ i18n_urlpatterns: Any = [
     path('jobs/', TemplateView.as_view(template_name='corporate/jobs.html')),
 
     # Billing
-    path('billing/', corporate.views.billing_home),
-    path('upgrade/', corporate.views.initial_upgrade, name='initial_upgrade'),
+    path('billing/', billing_home),
+    path('upgrade/', initial_upgrade, name='initial_upgrade'),
 ]
 
 v1_api_and_json_patterns = [
     path('billing/upgrade', rest_dispatch,
-         {'POST': corporate.views.upgrade}),
+         {'POST': upgrade}),
     path('billing/sponsorship', rest_dispatch,
-         {'POST': corporate.views.sponsorship}),
+         {'POST': sponsorship}),
     path('billing/plan/change', rest_dispatch,
-         {'POST': corporate.views.change_plan_status}),
+         {'POST': change_plan_status}),
     path('billing/sources/change', rest_dispatch,
-         {'POST': corporate.views.replace_payment_source}),
+         {'POST': replace_payment_source}),
 ]
 
 # Make a copy of i18n_urlpatterns so that they appear without prefix for English

--- a/corporate/views.py
+++ b/corporate/views.py
@@ -154,7 +154,7 @@ def initial_upgrade(request: HttpRequest) -> HttpResponse:
     if not settings.BILLING_ENABLED or user.is_guest:
         return render(request, "404.html", status=404)
 
-    billing_page_url = reverse('corporate.views.billing_home')
+    billing_page_url = reverse(billing_home)
 
     customer = get_customer_by_realm(user.realm)
     if customer is not None and (get_current_plan_by_customer(customer) is not None or customer.sponsorship_pending):
@@ -205,7 +205,7 @@ def sponsorship(request: HttpRequest, user: UserProfile,
     user_role = user.get_role_name()
 
     support_realm_uri = get_realm(settings.STAFF_SUBDOMAIN).uri
-    support_url = urljoin(support_realm_uri, urlunsplit(("", "", reverse('analytics.views.support'),
+    support_url = urljoin(support_realm_uri, urlunsplit(("", "", reverse("support"),
                           urlencode({"q": realm.string_id}), "")))
 
     context = {
@@ -246,14 +246,14 @@ def billing_home(request: HttpRequest) -> HttpResponse:
         return render(request, 'corporate/billing.html', context=context)
 
     if customer is None:
-        return HttpResponseRedirect(reverse('corporate.views.initial_upgrade'))
+        return HttpResponseRedirect(reverse(initial_upgrade))
 
     if customer.sponsorship_pending:
         context["sponsorship_pending"] = True
         return render(request, 'corporate/billing.html', context=context)
 
     if not CustomerPlan.objects.filter(customer=customer).exists():
-        return HttpResponseRedirect(reverse('corporate.views.initial_upgrade'))
+        return HttpResponseRedirect(reverse(initial_upgrade))
 
     if not user.has_billing_access:
         return render(request, 'corporate/billing.html', context=context)

--- a/docs/tutorials/life-of-a-request.md
+++ b/docs/tutorials/life-of-a-request.md
@@ -140,9 +140,9 @@ yields a response with this HTTP header:
 
 We can see this reflected in [zproject/urls.py](https://github.com/zulip/zulip/blob/master/zproject/urls.py):
 
-    path('users', 'zerver.lib.rest.rest_dispatch',
-        {'GET': 'zerver.views.users.get_members_backend',
-         'PUT': 'zerver.views.users.create_user_backend'}),
+    path('users', zerver.lib.rest.rest_dispatch,
+        {'GET': zerver.views.users.get_members_backend,
+         'PUT': zerver.views.users.create_user_backend}),
 
 In this way, the API is partially self-documenting.
 
@@ -176,8 +176,8 @@ the request, and then figure out which view to show from that.
 In our example,
 
 ```
-{'GET': 'zerver.views.users.get_members_backend',
- 'PUT': 'zerver.views.users.create_user_backend'}
+{'GET': zerver.views.users.get_members_backend,
+ 'PUT': zerver.views.users.create_user_backend}
 ```
 
 is supplied as an argument to `rest_dispatch`, along with the

--- a/docs/tutorials/life-of-a-request.md
+++ b/docs/tutorials/life-of-a-request.md
@@ -140,9 +140,9 @@ yields a response with this HTTP header:
 
 We can see this reflected in [zproject/urls.py](https://github.com/zulip/zulip/blob/master/zproject/urls.py):
 
-    path('users', zerver.lib.rest.rest_dispatch,
-        {'GET': zerver.views.users.get_members_backend,
-         'PUT': zerver.views.users.create_user_backend}),
+    path('users', rest_dispatch,
+        {'GET': get_members_backend,
+         'PUT': create_user_backend}),
 
 In this way, the API is partially self-documenting.
 
@@ -176,8 +176,8 @@ the request, and then figure out which view to show from that.
 In our example,
 
 ```
-{'GET': zerver.views.users.get_members_backend,
- 'PUT': zerver.views.users.create_user_backend}
+{'GET': get_members_backend,
+ 'PUT': create_user_backend}
 ```
 
 is supplied as an argument to `rest_dispatch`, along with the

--- a/docs/tutorials/life-of-a-request.md
+++ b/docs/tutorials/life-of-a-request.md
@@ -140,9 +140,9 @@ yields a response with this HTTP header:
 
 We can see this reflected in [zproject/urls.py](https://github.com/zulip/zulip/blob/master/zproject/urls.py):
 
-    path('users', rest_dispatch,
-        {'GET': get_members_backend,
-         'PUT': create_user_backend}),
+    rest_path('users',
+              GET=get_members_backend,
+              PUT=create_user_backend),
 
 In this way, the API is partially self-documenting.
 
@@ -176,11 +176,11 @@ the request, and then figure out which view to show from that.
 In our example,
 
 ```
-{'GET': get_members_backend,
- 'PUT': create_user_backend}
+GET=get_members_backend,
+PUT=create_user_backend
 ```
 
-is supplied as an argument to `rest_dispatch`, along with the
+are supplied as arguments to `rest_path`, along with the
 [HTTPRequest](https://docs.djangoproject.com/en/1.8/ref/request-response/).
 The request has the HTTP verb `PUT`, which `rest_dispatch` can use to
 find the correct view to show:

--- a/templates/zerver/accounts_accept_terms.html
+++ b/templates/zerver/accounts_accept_terms.html
@@ -18,7 +18,7 @@ the registration flow has its own (nearly identical) copy of the fields below in
         {% endif %}
 
         <div class="form-horizontal white-box">
-            <form method="post" class="form-horizontal" id="registration" action="{{ url('zerver.views.home.accounts_accept_terms') }}">
+            <form method="post" class="form-horizontal" id="registration" action="{{ url('accept_terms') }}">
                 {{ csrf_input }}
                 <div class="control-group">
                     <label for="id_email" class="control-label">{{ _("Email") }}</label>

--- a/templates/zerver/dev_login.html
+++ b/templates/zerver/dev_login.html
@@ -22,7 +22,7 @@ page can be easily identified in it's respective JavaScript file -->
                         <h2>{{_('Owners') }}</h2>
                         {% if direct_owners %}
                             {% for direct_owner in direct_owners %}
-                            <p><input type="submit" formaction="{{ direct_owner.realm.uri }}{{ url('zerver.views.auth.dev_direct_login') }}"
+                            <p><input type="submit" formaction="{{ direct_owner.realm.uri }}{{ url('login-local') }}"
                                       name="direct_email" class="btn-direct btn-admin" value="{{ direct_owner.delivery_email }}" /></p>
                             {% endfor %}
                         {% else %}
@@ -31,7 +31,7 @@ page can be easily identified in it's respective JavaScript file -->
                         <h2>{{ _('Administrators') }}</h2>
                         {% if direct_admins %}
                             {% for direct_admin in direct_admins %}
-                            <p><input type="submit" formaction="{{ direct_admin.realm.uri }}{{ url('zerver.views.auth.dev_direct_login') }}"
+                            <p><input type="submit" formaction="{{ direct_admin.realm.uri }}{{ url('login-local') }}"
                                       name="direct_email" class="btn-direct btn-admin" value="{{ direct_admin.delivery_email }}" /></p>
                             {% endfor %}
                         {% else %}
@@ -40,7 +40,7 @@ page can be easily identified in it's respective JavaScript file -->
                         <h2>{{ _('Guest users') }}</h2>
                         {% if guest_users %}
                             {% for guest_user in guest_users %}
-                            <p><input type="submit" formaction="{{ guest_user.realm.uri }}{{ url('zerver.views.auth.dev_direct_login') }}"
+                            <p><input type="submit" formaction="{{ guest_user.realm.uri }}{{ url('login-local') }}"
                                       name="direct_email" class="btn-direct btn-admin" value="{{ guest_user.delivery_email }}" /></p>
                             {% endfor %}
                         {% else %}
@@ -52,7 +52,7 @@ page can be easily identified in it's respective JavaScript file -->
                         <h2>{{ _('Normal users') }}</h2>
                         {% if direct_users %}
                             {% for direct_user in direct_users %}
-                            <p><input type="submit" formaction="{{ direct_user.realm.uri }}{{ url('zerver.views.auth.dev_direct_login') }}"
+                            <p><input type="submit" formaction="{{ direct_user.realm.uri }}{{ url('login-local') }}"
                                       name="direct_email" class="btn-direct btn-admin" value="{{ direct_user.delivery_email }}" /></p>
                             {% endfor %}
                         {% else %}
@@ -62,7 +62,7 @@ page can be easily identified in it's respective JavaScript file -->
                 </div>
             </div>
         </form>
-        <form name="change_realm" action="{{ url('zerver.views.auth.login_page') }}" method="post">
+        <form name="change_realm" action="{{ url('login_page') }}" method="post">
             {{ csrf_input }}
             <h2>Realm</h2>
             <select name="new_realm" onchange="this.form.submit()">
@@ -74,10 +74,10 @@ page can be easily identified in it's respective JavaScript file -->
         </form>
         <div id="devtools-wrapper">
             <div id="devtools-registration">
-                <form name="register_dev_user" action="{{ url('zerver.views.development.registration.register_development_user') }}" method="POST">
+                <form name="register_dev_user" action="{{ url('register_dev_user') }}" method="POST">
                     <input type="submit" class="btn btn-admin" value="Create New User" />
                 </form>
-                <form name="register_dev_realm" action="{{ url('zerver.views.development.registration.register_development_realm') }}" method="POST">
+                <form name="register_dev_realm" action="{{ url('register_dev_realm') }}" method="POST">
                     <input type="submit" class="btn btn-admin" value="Create New Realm" />
                 </form>
             </div>

--- a/templates/zerver/login.html
+++ b/templates/zerver/login.html
@@ -41,7 +41,7 @@ page can be easily identified in it's respective JavaScript file. -->
                 {% else %}
                     {% if password_auth_enabled %}
                         <form name="login_form" id="login_form" method="post" class="login-form"
-                          action="{{ url('django.contrib.auth.views.login') }}">
+                          action="{{ url('login') }}">
                             <input type="hidden" name="next" value="{{ next }}">
 
                             {% if two_factor_authentication_enabled %}

--- a/templates/zerver/register.html
+++ b/templates/zerver/register.html
@@ -23,7 +23,7 @@ Form is validated both client-side using jquery-validate (see signup.js) and ser
             {% endtrans %}
         </div>
 
-        <form method="post" class="form-horizontal white-box" id="registration" action="{{ url('zerver.views.registration.accounts_register') }}">
+        <form method="post" class="form-horizontal white-box" id="registration" action="{{ url('accounts_register') }}">
             {{ csrf_input }}
 
             <fieldset class="org-registration">

--- a/templates/zerver/reset.html
+++ b/templates/zerver/reset.html
@@ -11,7 +11,7 @@
 
             <p>Forgot your password? No problem, we'll send a link to reset your password to the email you signed up with.</p>
 
-            <form method="post" class="form-horizontal" action="{{ url('zerver.views.auth.password_reset') }}">
+            <form method="post" class="form-horizontal" action="{{ url('password_reset') }}">
                 {{ csrf_input }}
                 <div class="new-style">
                     <div class="input-box horizontal moving-label">

--- a/templates/zerver/reset_done.html
+++ b/templates/zerver/reset_done.html
@@ -10,7 +10,7 @@
             </div>
 
             <div class="white-box">
-                <p>{% trans login_url=url('django.contrib.auth.views.login') %}Please <a href="{{ login_url }}">log in</a> with your new password.{% endtrans %}</p>
+                <p>{% trans login_url=url('login') %}Please <a href="{{ login_url }}">log in</a> with your new password.{% endtrans %}</p>
             </div>
         </div>
     </div>

--- a/zerver/forms.py
+++ b/zerver/forms.py
@@ -228,7 +228,7 @@ def generate_password_reset_url(user_profile: UserProfile,
                                 token_generator: PasswordResetTokenGenerator) -> str:
     token = token_generator.make_token(user_profile)
     uid = urlsafe_base64_encode(force_bytes(user_profile.id))
-    endpoint = reverse('django.contrib.auth.views.password_reset_confirm',
+    endpoint = reverse('password_reset_confirm',
                        kwargs=dict(uidb64=uid, token=token))
     return f"{user_profile.realm.uri}{endpoint}"
 

--- a/zerver/lib/rest.py
+++ b/zerver/lib/rest.py
@@ -1,7 +1,9 @@
 from functools import wraps
-from typing import Any, Dict, cast
+from typing import Any, Callable, Dict, Mapping, Set, Tuple, Union, cast
 
 from django.http import HttpRequest, HttpResponse
+from django.urls import path
+from django.urls.resolvers import URLPattern
 from django.utils.cache import add_never_cache_headers
 from django.views.decorators.csrf import csrf_exempt, csrf_protect
 
@@ -158,3 +160,10 @@ def rest_dispatch(request: HttpRequest, **kwargs: Any) -> HttpResponse:
         return target_function(request, **kwargs)
 
     return json_method_not_allowed(list(supported_methods.keys()))
+
+def rest_path(
+    route: str,
+    kwargs: Mapping[str, object] = {},
+    **handlers: Union[Callable[..., HttpResponse], Tuple[Callable[..., HttpResponse], Set[str]]],
+) -> URLPattern:
+    return path(route, rest_dispatch, {**kwargs, **handlers})

--- a/zerver/lib/rest.py
+++ b/zerver/lib/rest.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, cast
 
 from django.http import HttpRequest, HttpResponse
 from django.utils.cache import add_never_cache_headers
-from django.utils.module_loading import import_string
 from django.views.decorators.csrf import csrf_exempt, csrf_protect
 
 from zerver.decorator import (
@@ -90,9 +89,8 @@ def rest_dispatch(request: HttpRequest, **kwargs: Any) -> HttpResponse:
         entry = supported_methods[method_to_use]
         if isinstance(entry, tuple):
             target_function, view_flags = entry
-            target_function = import_string(target_function)
         else:
-            target_function = import_string(supported_methods[method_to_use])
+            target_function = supported_methods[method_to_use]
             view_flags = set()
 
         # Set request._query for update_activity_user(), which is called

--- a/zerver/lib/upload.py
+++ b/zerver/lib/upload.py
@@ -651,7 +651,7 @@ def generate_unauthed_file_access_url(path_id: str) -> str:
     token = base64.b16encode(signed_data.encode('utf-8')).decode('utf-8')
 
     filename = path_id.split('/')[-1]
-    return reverse('zerver.views.upload.serve_local_file_unauthed', args=[token, filename])
+    return reverse('local_file_unauthed', args=[token, filename])
 
 def get_local_file_path_id_from_token(token: str) -> Optional[str]:
     signer = TimestampSigner(salt=LOCAL_FILE_ACCESS_TOKEN_SALT)

--- a/zerver/tests/test_auth_backends.py
+++ b/zerver/tests/test_auth_backends.py
@@ -93,7 +93,7 @@ from zerver.models import (
     get_user_by_delivery_email,
 )
 from zerver.signals import JUST_CREATED_THRESHOLD
-from zerver.views.auth import maybe_send_to_registration
+from zerver.views.auth import log_into_subdomain, maybe_send_to_registration
 from zproject.backends import (
     AUTH_BACKEND_NAME_MAP,
     AppleAuthBackend,
@@ -2940,7 +2940,7 @@ class GoogleAuthBackendTest(SocialAuthBase):
             token = ExternalAuthResult(data_dict=data).store_data()
         else:
             token = force_token
-        url_path = reverse('zerver.views.auth.log_into_subdomain', args=[token])
+        url_path = reverse(log_into_subdomain, args=[token])
         return self.client_get(url_path, subdomain=subdomain)
 
     def test_redirect_to_next_url_for_log_into_subdomain(self) -> None:

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -1643,7 +1643,7 @@ so we didn't send them an invitation. We did send invitations to everyone else!"
         url = "/accounts/register/"
         response = self.client_post(url, {"key": registration_key, "from_confirmation": 1, "full_name": "alice"})
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse('django.contrib.auth.views.login') + '?email=' +
+        self.assertEqual(response.url, reverse('login') + '?email=' +
                          urllib.parse.quote_plus(email))
 
 class InvitationsTestCase(InviteUserBase):

--- a/zerver/tests/test_urls.py
+++ b/zerver/tests/test_urls.py
@@ -108,17 +108,6 @@ class URLResolutionTest(ZulipTestCase):
         module = importlib.import_module(module_name)
         self.assertTrue(hasattr(module, view), f"View {module_name}.{view} does not exist")
 
-    # Tests that all views in urls.v1_api_and_json_patterns exist
-    def test_rest_api_url_resolution(self) -> None:
-        for pattern in urls.v1_api_and_json_patterns:
-            callback_str = self.get_callback_string(pattern)
-            if callback_str and hasattr(pattern, "default_args"):
-                for func_string in pattern.default_args.values():
-                    if isinstance(func_string, tuple):
-                        func_string = func_string[0]
-                    module_name, view = func_string.rsplit('.', 1)
-                    self.check_function_exists(module_name, view)
-
     # Tests function-based views declared in urls.urlpatterns for
     # whether the function exists.  We at present do not test the
     # class-based views.

--- a/zerver/views/home.py
+++ b/zerver/views/home.py
@@ -232,4 +232,4 @@ def home_real(request: HttpRequest) -> HttpResponse:
 
 @zulip_login_required
 def desktop_home(request: HttpRequest) -> HttpResponse:
-    return HttpResponseRedirect(reverse('zerver.views.home.home'))
+    return HttpResponseRedirect(reverse(home))

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -162,7 +162,7 @@ def accounts_register(request: HttpRequest) -> HttpResponse:
         try:
             validate_email_not_already_in_realm(realm, email)
         except ValidationError:
-            view_url = reverse('django.contrib.auth.views.login')
+            view_url = reverse('login')
             redirect_url = add_query_to_redirect_url(view_url, 'email=' + urllib.parse.quote_plus(email))
             return HttpResponseRedirect(redirect_url)
 
@@ -351,7 +351,7 @@ def accounts_register(request: HttpRequest) -> HttpResponse:
                     # user-friendly error message, but it doesn't
                     # particularly matter, because the registration form
                     # is hidden for most users.
-                    view_url = reverse('django.contrib.auth.views.login')
+                    view_url = reverse('login')
                     query = 'email=' + urllib.parse.quote_plus(email)
                     redirect_url = add_query_to_redirect_url(view_url, query)
                     return HttpResponseRedirect(redirect_url)
@@ -448,7 +448,7 @@ def login_and_go_to_home(request: HttpRequest, user_profile: UserProfile) -> Htt
     do_login(request, user_profile)
     # Using 'mark_sanitized' to work around false positive where Pysa thinks
     # that 'user_profile' is user-controlled
-    return HttpResponseRedirect(mark_sanitized(user_profile.realm.uri) + reverse('zerver.views.home.home'))
+    return HttpResponseRedirect(mark_sanitized(user_profile.realm.uri) + reverse('home'))
 
 def prepare_activation_url(email: str, request: HttpRequest,
                            realm_creation: bool=False,
@@ -484,7 +484,7 @@ def send_confirm_registration_email(email: str, activation_url: str, language: s
                realm=realm)
 
 def redirect_to_email_login_url(email: str) -> HttpResponseRedirect:
-    login_url = reverse('django.contrib.auth.views.login')
+    login_url = reverse('login')
     email = urllib.parse.quote_plus(email)
     redirect_url = add_query_to_redirect_url(login_url, 'already_registered=' + email)
     return HttpResponseRedirect(redirect_url)
@@ -537,7 +537,7 @@ def accounts_home(request: HttpRequest, multiuse_object_key: str="",
     try:
         realm = get_realm(get_subdomain(request))
     except Realm.DoesNotExist:
-        return HttpResponseRedirect(reverse('zerver.views.registration.find_account'))
+        return HttpResponseRedirect(reverse(find_account))
     if realm.deactivated:
         return redirect_to_deactivation_notice()
 
@@ -595,7 +595,7 @@ def generate_204(request: HttpRequest) -> HttpResponse:
 
 def find_account(request: HttpRequest) -> HttpResponse:
     from zerver.context_processors import common_context
-    url = reverse('zerver.views.registration.find_account')
+    url = reverse('find_account')
 
     emails: List[str] = []
     if request.method == 'POST':

--- a/zilencer/urls.py
+++ b/zilencer/urls.py
@@ -11,22 +11,22 @@ i18n_urlpatterns: Any = []
 # Zilencer views following the REST API style
 v1_api_and_json_patterns = [
     path('remotes/push/register', rest_dispatch,
-         {'POST': 'zilencer.views.register_remote_push_device'}),
+         {'POST': zilencer.views.register_remote_push_device}),
     path('remotes/push/unregister', rest_dispatch,
-         {'POST': 'zilencer.views.unregister_remote_push_device'}),
+         {'POST': zilencer.views.unregister_remote_push_device}),
     path('remotes/push/unregister/all', rest_dispatch,
-         {'POST': 'zilencer.views.unregister_all_remote_push_devices'}),
+         {'POST': zilencer.views.unregister_all_remote_push_devices}),
     path('remotes/push/notify', rest_dispatch,
-         {'POST': 'zilencer.views.remote_server_notify_push'}),
+         {'POST': zilencer.views.remote_server_notify_push}),
 
     # Push signup doesn't use the REST API, since there's no auth.
     path('remotes/server/register', zilencer.views.register_remote_server),
 
     # For receiving table data used in analytics and billing
     path('remotes/server/analytics', rest_dispatch,
-         {'POST': 'zilencer.views.remote_server_post_analytics'}),
+         {'POST': zilencer.views.remote_server_post_analytics}),
     path('remotes/server/analytics/status', rest_dispatch,
-         {'GET': 'zilencer.views.remote_server_check_analytics'}),
+         {'GET': zilencer.views.remote_server_check_analytics}),
 ]
 
 urlpatterns = [

--- a/zilencer/urls.py
+++ b/zilencer/urls.py
@@ -3,7 +3,7 @@ from typing import Any
 from django.conf.urls import include
 from django.urls import path
 
-from zerver.lib.rest import rest_dispatch
+from zerver.lib.rest import rest_path
 from zilencer.views import (
     register_remote_push_device,
     register_remote_server,
@@ -18,23 +18,23 @@ i18n_urlpatterns: Any = []
 
 # Zilencer views following the REST API style
 v1_api_and_json_patterns = [
-    path('remotes/push/register', rest_dispatch,
-         {'POST': register_remote_push_device}),
-    path('remotes/push/unregister', rest_dispatch,
-         {'POST': unregister_remote_push_device}),
-    path('remotes/push/unregister/all', rest_dispatch,
-         {'POST': unregister_all_remote_push_devices}),
-    path('remotes/push/notify', rest_dispatch,
-         {'POST': remote_server_notify_push}),
+    rest_path('remotes/push/register',
+              POST=register_remote_push_device),
+    rest_path('remotes/push/unregister',
+              POST=unregister_remote_push_device),
+    rest_path('remotes/push/unregister/all',
+              POST=unregister_all_remote_push_devices),
+    rest_path('remotes/push/notify',
+              POST=remote_server_notify_push),
 
     # Push signup doesn't use the REST API, since there's no auth.
     path('remotes/server/register', register_remote_server),
 
     # For receiving table data used in analytics and billing
-    path('remotes/server/analytics', rest_dispatch,
-         {'POST': remote_server_post_analytics}),
-    path('remotes/server/analytics/status', rest_dispatch,
-         {'GET': remote_server_check_analytics}),
+    rest_path('remotes/server/analytics',
+              POST=remote_server_post_analytics),
+    rest_path('remotes/server/analytics/status',
+              GET=remote_server_check_analytics),
 ]
 
 urlpatterns = [

--- a/zilencer/urls.py
+++ b/zilencer/urls.py
@@ -3,30 +3,38 @@ from typing import Any
 from django.conf.urls import include
 from django.urls import path
 
-import zilencer.views
 from zerver.lib.rest import rest_dispatch
+from zilencer.views import (
+    register_remote_push_device,
+    register_remote_server,
+    remote_server_check_analytics,
+    remote_server_notify_push,
+    remote_server_post_analytics,
+    unregister_all_remote_push_devices,
+    unregister_remote_push_device,
+)
 
 i18n_urlpatterns: Any = []
 
 # Zilencer views following the REST API style
 v1_api_and_json_patterns = [
     path('remotes/push/register', rest_dispatch,
-         {'POST': zilencer.views.register_remote_push_device}),
+         {'POST': register_remote_push_device}),
     path('remotes/push/unregister', rest_dispatch,
-         {'POST': zilencer.views.unregister_remote_push_device}),
+         {'POST': unregister_remote_push_device}),
     path('remotes/push/unregister/all', rest_dispatch,
-         {'POST': zilencer.views.unregister_all_remote_push_devices}),
+         {'POST': unregister_all_remote_push_devices}),
     path('remotes/push/notify', rest_dispatch,
-         {'POST': zilencer.views.remote_server_notify_push}),
+         {'POST': remote_server_notify_push}),
 
     # Push signup doesn't use the REST API, since there's no auth.
-    path('remotes/server/register', zilencer.views.register_remote_server),
+    path('remotes/server/register', register_remote_server),
 
     # For receiving table data used in analytics and billing
     path('remotes/server/analytics', rest_dispatch,
-         {'POST': zilencer.views.remote_server_post_analytics}),
+         {'POST': remote_server_post_analytics}),
     path('remotes/server/analytics/status', rest_dispatch,
-         {'GET': zilencer.views.remote_server_check_analytics}),
+         {'GET': remote_server_check_analytics}),
 ]
 
 urlpatterns = [

--- a/zproject/backends.py
+++ b/zproject/backends.py
@@ -1073,7 +1073,7 @@ class ZulipRemoteUserBackend(RemoteUserBackend, ExternalAuthMethod):
 def redirect_deactivated_user_to_login() -> HttpResponseRedirect:
     # Specifying the template name makes sure that the user is not redirected to dev_login in case of
     # a deactivated account on a test server.
-    login_url = reverse('zerver.views.auth.login_page', kwargs = {'template_name': 'zerver/login.html'})
+    login_url = reverse('login_page', kwargs = {'template_name': 'zerver/login.html'})
     redirect_url = login_url + '?is_deactivated=true'
     return HttpResponseRedirect(redirect_url)
 
@@ -1260,7 +1260,7 @@ def social_auth_finish(backend: Any,
         # unless the user manually edits the param. In any case, it's most appropriate to just take
         # them to find_account, as there isn't even an appropriate subdomain to take them to the login
         # form on.
-        return HttpResponseRedirect(reverse('zerver.views.registration.find_account'))
+        return HttpResponseRedirect(reverse('find_account'))
 
     if inactive_user:
         backend.logger.info("Failed login attempt for deactivated account: %s@%s",
@@ -1720,7 +1720,7 @@ class SAMLAuthBackend(SocialAuthMixin, SAMLAuth):
             # If the above raise KeyError, it means invalid or no idp was specified,
             # we should log that and redirect to the login page.
             self.logger.info("/login/saml/ : Bad idp param: KeyError: %s.", str(e))
-            return reverse('zerver.views.auth.login_page',
+            return reverse('login_page',
                            kwargs = {'template_name': 'zerver/login.html'})
 
         # This where we change things.  We need to pass some params
@@ -1970,8 +1970,8 @@ class SAMLAuthBackend(SocialAuthMixin, SAMLAuth):
                 name=f'saml:{idp_name}',
                 display_name=idp_dict.get('display_name', cls.auth_backend_name),
                 display_icon=idp_dict.get('display_icon', cls.display_icon),
-                login_url=reverse('login-social-extra-arg', args=('saml', idp_name)),
-                signup_url=reverse('signup-social-extra-arg', args=('saml', idp_name)),
+                login_url=reverse('login-social', args=('saml', idp_name)),
+                signup_url=reverse('signup-social', args=('saml', idp_name)),
             )
             result.append(saml_dict)
 

--- a/zproject/dev_urls.py
+++ b/zproject/dev_urls.py
@@ -9,10 +9,19 @@ from django.urls import path
 from django.views.generic import TemplateView
 from django.views.static import serve
 
-import zerver.views.auth
-import zerver.views.development.email_log
-import zerver.views.development.integrations
-import zerver.views.development.registration
+from zerver.views.auth import login_page
+from zerver.views.development.email_log import clear_emails, email_page, generate_all_emails
+from zerver.views.development.integrations import (
+    check_send_webhook_fixture_message,
+    dev_panel,
+    get_fixtures,
+    send_all_webhook_fixture_messages,
+)
+from zerver.views.development.registration import (
+    confirmation_key,
+    register_development_realm,
+    register_development_user,
+)
 
 # These URLs are available only in the development environment
 
@@ -33,22 +42,22 @@ urls = [
                  os.path.join(settings.DEPLOY_ROOT, 'docs/_build/html')}),
 
     # The special no-password login endpoint for development
-    path('devlogin/', zerver.views.auth.login_page,
+    path('devlogin/', login_page,
          {'template_name': 'zerver/dev_login.html'}, name='login_page'),
 
     # Page for testing email templates
-    path('emails/', zerver.views.development.email_log.email_page),
-    path('emails/generate/', zerver.views.development.email_log.generate_all_emails),
-    path('emails/clear/', zerver.views.development.email_log.clear_emails),
+    path('emails/', email_page),
+    path('emails/generate/', generate_all_emails),
+    path('emails/clear/', clear_emails),
 
     # Listing of useful URLs and various tools for development
     path('devtools/', TemplateView.as_view(template_name='zerver/dev_tools.html')),
     # Register New User and Realm
     path('devtools/register_user/',
-         zerver.views.development.registration.register_development_user,
+         register_development_user,
          name='register_dev_user'),
     path('devtools/register_realm/',
-         zerver.views.development.registration.register_development_realm,
+         register_development_realm,
          name='register_dev_realm'),
 
     # Have easy access for error pages
@@ -56,13 +65,13 @@ urls = [
     path('errors/5xx/', TemplateView.as_view(template_name='500.html')),
 
     # Add a convenient way to generate webhook messages from fixtures.
-    path('devtools/integrations/', zerver.views.development.integrations.dev_panel),
+    path('devtools/integrations/', dev_panel),
     path('devtools/integrations/check_send_webhook_fixture_message',
-         zerver.views.development.integrations.check_send_webhook_fixture_message),
+         check_send_webhook_fixture_message),
     path('devtools/integrations/send_all_webhook_fixture_messages',
-         zerver.views.development.integrations.send_all_webhook_fixture_messages),
+         send_all_webhook_fixture_messages),
     path('devtools/integrations/<integration_name>/fixtures',
-         zerver.views.development.integrations.get_fixtures),
+         get_fixtures),
 ]
 
 # Serve static assets via the Django server
@@ -79,7 +88,7 @@ else:
     urls += static(urlsplit(settings.STATIC_URL).path, view=serve_static)
 
 i18n_urls = [
-    path('confirmation_key/', zerver.views.development.registration.confirmation_key),
+    path('confirmation_key/', confirmation_key),
 ]
 urls += i18n_urls
 

--- a/zproject/dev_urls.py
+++ b/zproject/dev_urls.py
@@ -34,7 +34,7 @@ urls = [
 
     # The special no-password login endpoint for development
     path('devlogin/', zerver.views.auth.login_page,
-         {'template_name': 'zerver/dev_login.html'}, name='zerver.views.auth.login_page'),
+         {'template_name': 'zerver/dev_login.html'}, name='login_page'),
 
     # Page for testing email templates
     path('emails/', zerver.views.development.email_log.email_page),
@@ -46,10 +46,10 @@ urls = [
     # Register New User and Realm
     path('devtools/register_user/',
          zerver.views.development.registration.register_development_user,
-         name='zerver.views.development.registration.register_development_user'),
+         name='register_dev_user'),
     path('devtools/register_realm/',
          zerver.views.development.registration.register_development_realm,
-         name='zerver.views.development.registration.register_development_realm'),
+         name='register_dev_realm'),
 
     # Have easy access for error pages
     path('errors/404/', TemplateView.as_view(template_name='404.html')),

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -80,11 +80,9 @@ v1_api_and_json_patterns = [
          {'PATCH': 'zerver.views.realm.update_realm'}),
 
     # Returns a 204, used by desktop app to verify connectivity status
-    path('generate_204', zerver.views.registration.generate_204,
-         name='zerver.views.registration.generate_204'),
+    path('generate_204', zerver.views.registration.generate_204),
 
-    path('realm/subdomain/<subdomain>', zerver.views.realm.check_subdomain_available,
-         name='zerver.views.realm.check_subdomain_available'),
+    path('realm/subdomain/<subdomain>', zerver.views.realm.check_subdomain_available),
 
     # realm/domains -> zerver.views.realm_domains
     path('realm/domains', rest_dispatch,
@@ -433,12 +431,11 @@ integrations_view = IntegrationView.as_view()
 # If you're adding a new page to the website (as opposed to a new
 # endpoint for use by code), you should add it here.
 i18n_urls = [
-    path('', zerver.views.home.home, name='zerver.views.home.home'),
+    path('', zerver.views.home.home, name='home'),
     # We have a desktop-specific landing page in case we change our /
     # to not log in in the future. We don't want to require a new
     # desktop app build for everyone in that case
-    path('desktop_home/', zerver.views.home.desktop_home,
-         name='zerver.views.home.desktop_home'),
+    path('desktop_home/', zerver.views.home.desktop_home),
 
     # Backwards-compatibility (legacy) Google auth URL for the mobile
     # apps; see https://github.com/zulip/zulip/issues/13081 for
@@ -448,57 +445,50 @@ i18n_urls = [
 
     path('accounts/login/start/sso/', zerver.views.auth.start_remote_user_sso, name='start-login-sso'),
     path('accounts/login/sso/', zerver.views.auth.remote_user_sso, name='login-sso'),
-    path('accounts/login/jwt/', zerver.views.auth.remote_user_jwt, name='login-jwt'),
+    path('accounts/login/jwt/', zerver.views.auth.remote_user_jwt),
     path('accounts/login/social/<backend>', zerver.views.auth.start_social_login,
          name='login-social'),
     path('accounts/login/social/<backend>/<extra_arg>', zerver.views.auth.start_social_login,
-         name='login-social-extra-arg'),
+         name='login-social'),
     path('accounts/register/social/<backend>',
          zerver.views.auth.start_social_signup,
          name='signup-social'),
     path('accounts/register/social/<backend>/<extra_arg>',
          zerver.views.auth.start_social_signup,
-         name='signup-social-extra-arg'),
-    path('accounts/login/subdomain/<token>', zerver.views.auth.log_into_subdomain,
-         name='zerver.views.auth.log_into_subdomain'),
-    path('accounts/login/local/', zerver.views.auth.dev_direct_login,
-         name='zerver.views.auth.dev_direct_login'),
+         name='signup-social'),
+    path('accounts/login/subdomain/<token>', zerver.views.auth.log_into_subdomain),
+    path('accounts/login/local/', zerver.views.auth.dev_direct_login, name='login-local'),
     # We have two entries for accounts/login; only the first one is
     # used for URL resolution.  The second here is to allow
-    # reverse("django.contrib.auth.views.login") in templates to
+    # reverse("login") in templates to
     # return `/accounts/login/`.
     path('accounts/login/', zerver.views.auth.login_page,
-         {'template_name': 'zerver/login.html'}, name='zerver.views.auth.login_page'),
+         {'template_name': 'zerver/login.html'}, name='login_page'),
     path('accounts/login/', LoginView.as_view(template_name='zerver/login.html'),
-         name='django.contrib.auth.views.login'),
-    path('accounts/logout/', zerver.views.auth.logout_then_login,
-         name='zerver.views.auth.logout_then_login'),
+         name='login'),
+    path('accounts/logout/', zerver.views.auth.logout_then_login),
 
     path('accounts/webathena_kerberos_login/',
-         zerver.views.zephyr.webathena_kerberos_login,
-         name='zerver.views.zephyr.webathena_kerberos_login'),
+         zerver.views.zephyr.webathena_kerberos_login),
 
-    path('accounts/password/reset/', zerver.views.auth.password_reset,
-         name='zerver.views.auth.password_reset'),
+    path('accounts/password/reset/', zerver.views.auth.password_reset, name='password_reset'),
     path('accounts/password/reset/done/',
          PasswordResetDoneView.as_view(template_name='zerver/reset_emailed.html')),
     path('accounts/password/reset/<uidb64>/<token>/',
          PasswordResetConfirmView.as_view(success_url='/accounts/password/done/',
                                           template_name='zerver/reset_confirm.html',
                                           form_class=zerver.forms.LoggingSetPasswordForm),
-         name='django.contrib.auth.views.password_reset_confirm'),
+         name='password_reset_confirm'),
     path('accounts/password/done/',
          PasswordResetCompleteView.as_view(template_name='zerver/reset_done.html')),
     path('accounts/deactivated/',
-         zerver.views.auth.show_deactivation_notice,
-         name='zerver.views.auth.show_deactivation_notice'),
+         zerver.views.auth.show_deactivation_notice),
 
     # Displays digest email content in browser.
     path('digest/', zerver.views.digest.digest_page),
 
     # Registration views, require a confirmation ID.
-    path('accounts/home/', zerver.views.registration.accounts_home,
-         name='zerver.views.registration.accounts_home'),
+    path('accounts/home/', zerver.views.registration.accounts_home),
     path('accounts/send_confirm/<email>',
          TemplateView.as_view(
              template_name='zerver/accounts_send_confirm.html'),
@@ -507,60 +497,51 @@ i18n_urls = [
          TemplateView.as_view(
              template_name='zerver/accounts_send_confirm.html'),
          {'realm_creation': True}, name='new_realm_send_confirm'),
-    path('accounts/register/', zerver.views.registration.accounts_register,
-         name='zerver.views.registration.accounts_register'),
+    path('accounts/register/', zerver.views.registration.accounts_register, name='accounts_register'),
     path('accounts/do_confirm/<confirmation_key>',
          zerver.views.registration.check_prereg_key_and_redirect,
          name='check_prereg_key_and_redirect'),
 
     path('accounts/confirm_new_email/<confirmation_key>',
          zerver.views.user_settings.confirm_email_change,
-         name='zerver.views.user_settings.confirm_email_change'),
+         name='confirm_email_change'),
 
     # Email unsubscription endpoint. Allows for unsubscribing from various types of emails,
     # including the welcome emails (day 1 & 2), missed PMs, etc.
     path('accounts/unsubscribe/<email_type>/<confirmation_key>',
-         zerver.views.unsubscribe.email_unsubscribe,
-         name='zerver.views.unsubscribe.email_unsubscribe'),
+         zerver.views.unsubscribe.email_unsubscribe, name='unsubscribe'),
 
     # Portico-styled page used to provide email confirmation of terms acceptance.
-    path('accounts/accept_terms/', zerver.views.home.accounts_accept_terms,
-         name='zerver.views.home.accounts_accept_terms'),
+    path('accounts/accept_terms/', zerver.views.home.accounts_accept_terms, name='accept_terms'),
 
     # Find your account
-    path('accounts/find/', zerver.views.registration.find_account,
-         name='zerver.views.registration.find_account'),
+    path('accounts/find/', zerver.views.registration.find_account, name='find_account'),
 
     # Go to organization subdomain
-    path('accounts/go/', zerver.views.registration.realm_redirect,
-         name='zerver.views.registration.realm_redirect'),
+    path('accounts/go/', zerver.views.registration.realm_redirect, name='realm_redirect'),
 
     # Realm Creation
-    path('new/', zerver.views.registration.create_realm,
-         name='zerver.views.create_realm'),
+    path('new/', zerver.views.registration.create_realm),
     path('new/<creation_key>',
-         zerver.views.registration.create_realm, name='zerver.views.create_realm'),
+         zerver.views.registration.create_realm, name='create_realm'),
 
     # Realm Reactivation
     path('reactivate/<confirmation_key>', zerver.views.realm.realm_reactivation,
-         name='zerver.views.realm.realm_reactivation'),
+         name='realm_reactivation'),
 
     # Global public streams (Zulip's way of doing archives)
     path('archive/streams/<int:stream_id>/topics/<topic_name>',
-         zerver.views.archive.archive,
-         name='zerver.views.archive.archive'),
+         zerver.views.archive.archive),
     path('archive/streams/<int:stream_id>/topics',
-         zerver.views.archive.get_web_public_topics_backend,
-         name='zerver.views.archive.get_web_public_topics_backend'),
+         zerver.views.archive.get_web_public_topics_backend),
 
     # Login/registration
     path('register/', zerver.views.registration.accounts_home, name='register'),
     path('login/', zerver.views.auth.login_page, {'template_name': 'zerver/login.html'},
-         name='zerver.views.auth.login_page'),
+         name='login_page'),
 
     path('join/<confirmation_key>/',
-         zerver.views.registration.accounts_home_from_multiuse_invite,
-         name='zerver.views.registration.accounts_home_from_multiuse_invite'),
+         zerver.views.registration.accounts_home_from_multiuse_invite, name='join'),
 
     # Used to generate a Zoom video call URL
     path('calls/zoom/register', zerver.views.video_calls.register_zoom_user),
@@ -572,18 +553,17 @@ i18n_urls = [
 
     # API and integrations documentation
     path('integrations/doc-html/<integration_name>',
-         zerver.views.documentation.integration_doc,
-         name="zerver.views.documentation.integration_doc"),
+         zerver.views.documentation.integration_doc),
     path('integrations/', integrations_view),
     path('integrations/<path:path>', integrations_view),
 
     # Landing page, features pages, signup form, etc.
-    path('hello/', zerver.views.portico.hello_view, name='landing-page'),
+    path('hello/', zerver.views.portico.hello_view),
     path('new-user/', RedirectView.as_view(url='/hello', permanent=True)),
     path('features/', zerver.views.portico.landing_view, {'template_name': 'zerver/features.html'}),
     path('plans/', zerver.views.portico.plans_view, name='plans'),
-    path('apps/', zerver.views.portico.apps_view, name='zerver.views.home.apps_view'),
-    path('apps/<platform>', zerver.views.portico.apps_view, name='zerver.views.home.apps_view'),
+    path('apps/', zerver.views.portico.apps_view),
+    path('apps/<platform>', zerver.views.portico.apps_view),
     path('team/', zerver.views.portico.team_view),
     path('history/', zerver.views.portico.landing_view, {'template_name': 'zerver/history.html'}),
     path('why-zulip/', zerver.views.portico.landing_view, {'template_name': 'zerver/why-zulip.html'}),
@@ -599,8 +579,8 @@ i18n_urls = [
     path('atlassian/', zerver.views.portico.landing_view, {'template_name': 'zerver/atlassian.html'}),
 
     # Terms of Service and privacy pages.
-    path('terms/', zerver.views.portico.terms_view, name='terms'),
-    path('privacy/', zerver.views.portico.privacy_view, name='privacy'),
+    path('terms/', zerver.views.portico.terms_view),
+    path('privacy/', zerver.views.portico.privacy_view),
     path('config-error/<error_category_name>', zerver.views.auth.config_error_view,
          name='config_error'),
     path('config-error/remoteuser/<error_category_name>',
@@ -627,7 +607,7 @@ urls += [
 urls += [
     path('user_uploads/temporary/<token>/<filename>',
          zerver.views.upload.serve_local_file_unauthed,
-         name='zerver.views.upload.serve_local_file_unauthed'),
+         name='local_file_unauthed'),
     path('user_uploads/<realm_id_str>/<path:filename>',
          rest_dispatch,
          {'GET': ('zerver.views.upload.serve_file_backend',
@@ -653,8 +633,7 @@ urls += [
 # This url serves as a way to receive CSP violation reports from the users.
 # We use this endpoint to just log these reports.
 urls += [
-    path('report/csp_violations', zerver.views.report.report_csp_violations,
-         name='zerver.views.report.report_csp_violations'),
+    path('report/csp_violations', zerver.views.report.report_csp_violations),
 ]
 
 # This url serves as a way to provide backward compatibility to messages
@@ -663,8 +642,7 @@ urls += [
 # images.
 urls += [
     path('external_content/<digest>/<received_url>',
-         zerver.views.camo.handle_camo_url,
-         name='zerver.views.camo.handle_camo_url'),
+         zerver.views.camo.handle_camo_url),
 ]
 
 # Incoming webhook URLs
@@ -697,20 +675,16 @@ v1_api_mobile_patterns = [
 
     # This json format view used by the mobile apps accepts a username
     # password/pair and returns an API key.
-    path('fetch_api_key', zerver.views.auth.api_fetch_api_key,
-         name='zerver.views.auth.api_fetch_api_key'),
+    path('fetch_api_key', zerver.views.auth.api_fetch_api_key),
 
     # This is for the signing in through the devAuthBackEnd on mobile apps.
-    path('dev_fetch_api_key', zerver.views.auth.api_dev_fetch_api_key,
-         name='zerver.views.auth.api_dev_fetch_api_key'),
+    path('dev_fetch_api_key', zerver.views.auth.api_dev_fetch_api_key),
     # This is for fetching the emails of the admins and the users.
-    path('dev_list_users', zerver.views.auth.api_dev_list_users,
-         name='zerver.views.auth.api_dev_list_users'),
+    path('dev_list_users', zerver.views.auth.api_dev_list_users),
 
     # Used to present the GOOGLE_CLIENT_ID to mobile apps
     path('fetch_google_client_id',
-         zerver.views.auth.api_fetch_google_client_id,
-         name='zerver.views.auth.api_fetch_google_client_id'),
+         zerver.views.auth.api_fetch_google_client_id),
 ]
 urls += [
     path('api/v1/', include(v1_api_mobile_patterns)),
@@ -718,8 +692,7 @@ urls += [
 
 # View for uploading messages from email mirror
 urls += [
-    path('email_mirror_message', zerver.views.email_mirror.email_mirror_message,
-         name='zerver.views.email_mirror.email_mirror_message'),
+    path('email_mirror_message', zerver.views.email_mirror.email_mirror_message),
 ]
 
 # Include URL configuration files for site-specified extra installed
@@ -736,8 +709,7 @@ urls += [
     #
     # Since these views don't use rest_dispatch, they cannot have
     # asynchronous Tornado behavior.
-    path('notify_tornado', zerver.tornado.views.notify,
-         name='zerver.tornado.views.notify'),
+    path('notify_tornado', zerver.tornado.views.notify),
     path('api/v1/events/internal', zerver.tornado.views.get_events_internal),
 ]
 

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -15,25 +15,45 @@ from django.views.generic import RedirectView, TemplateView
 
 import zerver.forms
 import zerver.tornado.views
-import zerver.views
+import zerver.views.alert_words
 import zerver.views.archive
+import zerver.views.attachments
 import zerver.views.auth
 import zerver.views.camo
 import zerver.views.compatibility
+import zerver.views.custom_profile_fields
 import zerver.views.digest
 import zerver.views.documentation
+import zerver.views.drafts
 import zerver.views.email_mirror
+import zerver.views.events_register
 import zerver.views.home
+import zerver.views.hotspots
+import zerver.views.invite
 import zerver.views.message_edit
 import zerver.views.message_fetch
 import zerver.views.message_flags
 import zerver.views.message_send
 import zerver.views.muting
 import zerver.views.portico
+import zerver.views.presence
+import zerver.views.push_notifications
+import zerver.views.reactions
 import zerver.views.realm
+import zerver.views.realm_domains
+import zerver.views.realm_emoji
 import zerver.views.realm_export
+import zerver.views.realm_filters
+import zerver.views.realm_icon
+import zerver.views.realm_logo
 import zerver.views.registration
+import zerver.views.report
+import zerver.views.storage
 import zerver.views.streams
+import zerver.views.submessage
+import zerver.views.thumbnail
+import zerver.views.tutorial
+import zerver.views.typing
 import zerver.views.unsubscribe
 import zerver.views.upload
 import zerver.views.user_groups
@@ -77,7 +97,7 @@ if settings.TWO_FACTOR_AUTHENTICATION_ENABLED:
 v1_api_and_json_patterns = [
     # realm-level calls
     path('realm', rest_dispatch,
-         {'PATCH': 'zerver.views.realm.update_realm'}),
+         {'PATCH': zerver.views.realm.update_realm}),
 
     # Returns a 204, used by desktop app to verify connectivity status
     path('generate_204', zerver.views.registration.generate_204),
@@ -86,144 +106,144 @@ v1_api_and_json_patterns = [
 
     # realm/domains -> zerver.views.realm_domains
     path('realm/domains', rest_dispatch,
-         {'GET': 'zerver.views.realm_domains.list_realm_domains',
-          'POST': 'zerver.views.realm_domains.create_realm_domain'}),
+         {'GET': zerver.views.realm_domains.list_realm_domains,
+          'POST': zerver.views.realm_domains.create_realm_domain}),
     path('realm/domains/<domain>', rest_dispatch,
-         {'PATCH': 'zerver.views.realm_domains.patch_realm_domain',
-          'DELETE': 'zerver.views.realm_domains.delete_realm_domain'}),
+         {'PATCH': zerver.views.realm_domains.patch_realm_domain,
+          'DELETE': zerver.views.realm_domains.delete_realm_domain}),
 
     # realm/emoji -> zerver.views.realm_emoji
     path('realm/emoji', rest_dispatch,
-         {'GET': 'zerver.views.realm_emoji.list_emoji'}),
+         {'GET': zerver.views.realm_emoji.list_emoji}),
     path('realm/emoji/<emoji_name>', rest_dispatch,
-         {'POST': 'zerver.views.realm_emoji.upload_emoji',
-          'DELETE': ('zerver.views.realm_emoji.delete_emoji', {"intentionally_undocumented"})}),
+         {'POST': zerver.views.realm_emoji.upload_emoji,
+          'DELETE': (zerver.views.realm_emoji.delete_emoji, {"intentionally_undocumented"})}),
     # this endpoint throws a status code 400 JsonableError when it should be a 404.
 
     # realm/icon -> zerver.views.realm_icon
     path('realm/icon', rest_dispatch,
-         {'POST': 'zerver.views.realm_icon.upload_icon',
-          'DELETE': 'zerver.views.realm_icon.delete_icon_backend',
-          'GET': 'zerver.views.realm_icon.get_icon_backend'}),
+         {'POST': zerver.views.realm_icon.upload_icon,
+          'DELETE': zerver.views.realm_icon.delete_icon_backend,
+          'GET': zerver.views.realm_icon.get_icon_backend}),
 
     # realm/logo -> zerver.views.realm_logo
     path('realm/logo', rest_dispatch,
-         {'POST': 'zerver.views.realm_logo.upload_logo',
-          'DELETE': 'zerver.views.realm_logo.delete_logo_backend',
-          'GET': 'zerver.views.realm_logo.get_logo_backend'}),
+         {'POST': zerver.views.realm_logo.upload_logo,
+          'DELETE': zerver.views.realm_logo.delete_logo_backend,
+          'GET': zerver.views.realm_logo.get_logo_backend}),
 
     # realm/filters -> zerver.views.realm_filters
     path('realm/filters', rest_dispatch,
-         {'GET': 'zerver.views.realm_filters.list_filters',
-          'POST': 'zerver.views.realm_filters.create_filter'}),
+         {'GET': zerver.views.realm_filters.list_filters,
+          'POST': zerver.views.realm_filters.create_filter}),
     path('realm/filters/<int:filter_id>', rest_dispatch,
-         {'DELETE': 'zerver.views.realm_filters.delete_filter'}),
+         {'DELETE': zerver.views.realm_filters.delete_filter}),
 
     # realm/profile_fields -> zerver.views.custom_profile_fields
     path('realm/profile_fields', rest_dispatch,
-         {'GET': 'zerver.views.custom_profile_fields.list_realm_custom_profile_fields',
-          'PATCH': 'zerver.views.custom_profile_fields.reorder_realm_custom_profile_fields',
-          'POST': 'zerver.views.custom_profile_fields.create_realm_custom_profile_field'}),
+         {'GET': zerver.views.custom_profile_fields.list_realm_custom_profile_fields,
+          'PATCH': zerver.views.custom_profile_fields.reorder_realm_custom_profile_fields,
+          'POST': zerver.views.custom_profile_fields.create_realm_custom_profile_field}),
     path('realm/profile_fields/<int:field_id>', rest_dispatch,
-         {'PATCH': 'zerver.views.custom_profile_fields.update_realm_custom_profile_field',
-          'DELETE': 'zerver.views.custom_profile_fields.delete_realm_custom_profile_field'}),
+         {'PATCH': zerver.views.custom_profile_fields.update_realm_custom_profile_field,
+          'DELETE': zerver.views.custom_profile_fields.delete_realm_custom_profile_field}),
 
     # realm/deactivate -> zerver.views.deactivate_realm
     path('realm/deactivate', rest_dispatch,
-         {'POST': 'zerver.views.realm.deactivate_realm'}),
+         {'POST': zerver.views.realm.deactivate_realm}),
 
     # users -> zerver.views.users
     path('users', rest_dispatch,
-         {'GET': 'zerver.views.users.get_members_backend',
-          'POST': 'zerver.views.users.create_user_backend'}),
+         {'GET': zerver.views.users.get_members_backend,
+          'POST': zerver.views.users.create_user_backend}),
     path('users/me', rest_dispatch,
-         {'GET': 'zerver.views.users.get_profile_backend',
-          'DELETE': 'zerver.views.users.deactivate_user_own_backend'}),
+         {'GET': zerver.views.users.get_profile_backend,
+          'DELETE': zerver.views.users.deactivate_user_own_backend}),
     path('users/<int:user_id>/reactivate', rest_dispatch,
-         {'POST': 'zerver.views.users.reactivate_user_backend'}),
+         {'POST': zerver.views.users.reactivate_user_backend}),
     path('users/<int:user_id>', rest_dispatch,
-         {'GET': 'zerver.views.users.get_members_backend',
-          'PATCH': 'zerver.views.users.update_user_backend',
-          'DELETE': 'zerver.views.users.deactivate_user_backend'}),
+         {'GET': zerver.views.users.get_members_backend,
+          'PATCH': zerver.views.users.update_user_backend,
+          'DELETE': zerver.views.users.deactivate_user_backend}),
     path('users/<int:user_id>/subscriptions/<int:stream_id>', rest_dispatch,
-         {'GET': 'zerver.views.users.get_subscription_backend'}),
+         {'GET': zerver.views.users.get_subscription_backend}),
     path('bots', rest_dispatch,
-         {'GET': 'zerver.views.users.get_bots_backend',
-          'POST': 'zerver.views.users.add_bot_backend'}),
+         {'GET': zerver.views.users.get_bots_backend,
+          'POST': zerver.views.users.add_bot_backend}),
     path('bots/<int:bot_id>/api_key/regenerate', rest_dispatch,
-         {'POST': 'zerver.views.users.regenerate_bot_api_key'}),
+         {'POST': zerver.views.users.regenerate_bot_api_key}),
     path('bots/<int:bot_id>', rest_dispatch,
-         {'PATCH': 'zerver.views.users.patch_bot_backend',
-          'DELETE': 'zerver.views.users.deactivate_bot_backend'}),
+         {'PATCH': zerver.views.users.patch_bot_backend,
+          'DELETE': zerver.views.users.deactivate_bot_backend}),
 
     # invites -> zerver.views.invite
     path('invites', rest_dispatch,
-         {'GET': 'zerver.views.invite.get_user_invites',
-          'POST': 'zerver.views.invite.invite_users_backend'}),
+         {'GET': zerver.views.invite.get_user_invites,
+          'POST': zerver.views.invite.invite_users_backend}),
     path('invites/<int:prereg_id>', rest_dispatch,
-         {'DELETE': 'zerver.views.invite.revoke_user_invite'}),
+         {'DELETE': zerver.views.invite.revoke_user_invite}),
     path('invites/<int:prereg_id>/resend', rest_dispatch,
-         {'POST': 'zerver.views.invite.resend_user_invite_email'}),
+         {'POST': zerver.views.invite.resend_user_invite_email}),
 
     # invites/multiuse -> zerver.views.invite
     path('invites/multiuse', rest_dispatch,
-         {'POST': 'zerver.views.invite.generate_multiuse_invite_backend'}),
+         {'POST': zerver.views.invite.generate_multiuse_invite_backend}),
     # invites/multiuse -> zerver.views.invite
     path('invites/multiuse/<int:invite_id>', rest_dispatch,
-         {'DELETE': 'zerver.views.invite.revoke_multiuse_invite'}),
+         {'DELETE': zerver.views.invite.revoke_multiuse_invite}),
 
     # mark messages as read (in bulk)
     path('mark_all_as_read', rest_dispatch,
-         {'POST': 'zerver.views.message_flags.mark_all_as_read'}),
+         {'POST': zerver.views.message_flags.mark_all_as_read}),
     path('mark_stream_as_read', rest_dispatch,
-         {'POST': 'zerver.views.message_flags.mark_stream_as_read'}),
+         {'POST': zerver.views.message_flags.mark_stream_as_read}),
     path('mark_topic_as_read', rest_dispatch,
-         {'POST': 'zerver.views.message_flags.mark_topic_as_read'}),
+         {'POST': zerver.views.message_flags.mark_topic_as_read}),
 
     path('zcommand', rest_dispatch,
-         {'POST': 'zerver.views.message_send.zcommand_backend'}),
+         {'POST': zerver.views.message_send.zcommand_backend}),
 
     # Endpoints for syncing drafts.
     path('drafts', rest_dispatch,
-         {'GET': ('zerver.views.drafts.fetch_drafts',
+         {'GET': (zerver.views.drafts.fetch_drafts,
                   {'intentionally_undocumented'}),
-          'POST': ('zerver.views.drafts.create_drafts',
+          'POST': (zerver.views.drafts.create_drafts,
                    {'intentionally_undocumented'})}),
     path('drafts/<int:draft_id>', rest_dispatch,
-         {'PATCH': ('zerver.views.drafts.edit_draft',
+         {'PATCH': (zerver.views.drafts.edit_draft,
                     {'intentionally_undocumented'}),
-          'DELETE': ('zerver.views.drafts.delete_draft',
+          'DELETE': (zerver.views.drafts.delete_draft,
                      {'intentionally_undocumented'})}),
 
     # messages -> zerver.views.message*
     # GET returns messages, possibly filtered, POST sends a message
     path('messages', rest_dispatch,
-         {'GET': ('zerver.views.message_fetch.get_messages_backend',
+         {'GET': (zerver.views.message_fetch.get_messages_backend,
                   {'allow_anonymous_user_web'}),
-          'POST': ('zerver.views.message_send.send_message_backend',
+          'POST': (zerver.views.message_send.send_message_backend,
                    {'allow_incoming_webhooks'})}),
     path('messages/<int:message_id>', rest_dispatch,
-         {'GET': 'zerver.views.message_edit.json_fetch_raw_message',
-          'PATCH': 'zerver.views.message_edit.update_message_backend',
-          'DELETE': 'zerver.views.message_edit.delete_message_backend'}),
+         {'GET': zerver.views.message_edit.json_fetch_raw_message,
+          'PATCH': zerver.views.message_edit.update_message_backend,
+          'DELETE': zerver.views.message_edit.delete_message_backend}),
     path('messages/render', rest_dispatch,
-         {'POST': 'zerver.views.message_send.render_message_backend'}),
+         {'POST': zerver.views.message_send.render_message_backend}),
     path('messages/flags', rest_dispatch,
-         {'POST': 'zerver.views.message_flags.update_message_flags'}),
+         {'POST': zerver.views.message_flags.update_message_flags}),
     path('messages/<int:message_id>/history', rest_dispatch,
-         {'GET': 'zerver.views.message_edit.get_message_edit_history'}),
+         {'GET': zerver.views.message_edit.get_message_edit_history}),
     path('messages/matches_narrow', rest_dispatch,
-         {'GET': 'zerver.views.message_fetch.messages_in_narrow_backend'}),
+         {'GET': zerver.views.message_fetch.messages_in_narrow_backend}),
 
     path('users/me/subscriptions/properties', rest_dispatch,
-         {'POST': 'zerver.views.streams.update_subscription_properties_backend'}),
+         {'POST': zerver.views.streams.update_subscription_properties_backend}),
 
     path('users/me/subscriptions/<int:stream_id>', rest_dispatch,
-         {'PATCH': 'zerver.views.streams.update_subscriptions_property'}),
+         {'PATCH': zerver.views.streams.update_subscriptions_property}),
 
     path('submessage',
          rest_dispatch,
-         {'POST': 'zerver.views.submessage.process_submessage'}),
+         {'POST': zerver.views.submessage.process_submessage}),
 
     # New endpoint for handling reactions.
     # reactions -> zerver.view.reactions
@@ -231,164 +251,164 @@ v1_api_and_json_patterns = [
     # DELETE removes a reaction from a message
     path('messages/<int:message_id>/reactions',
          rest_dispatch,
-         {'POST': 'zerver.views.reactions.add_reaction',
-          'DELETE': 'zerver.views.reactions.remove_reaction'}),
+         {'POST': zerver.views.reactions.add_reaction,
+          'DELETE': zerver.views.reactions.remove_reaction}),
 
     # attachments -> zerver.views.attachments
     path('attachments', rest_dispatch,
-         {'GET': 'zerver.views.attachments.list_by_user'}),
+         {'GET': zerver.views.attachments.list_by_user}),
     path('attachments/<int:attachment_id>', rest_dispatch,
-         {'DELETE': 'zerver.views.attachments.remove'}),
+         {'DELETE': zerver.views.attachments.remove}),
 
     # typing -> zerver.views.typing
     # POST sends a typing notification event to recipients
     path('typing', rest_dispatch,
-         {'POST': 'zerver.views.typing.send_notification_backend'}),
+         {'POST': zerver.views.typing.send_notification_backend}),
 
     # user_uploads -> zerver.views.upload
     path('user_uploads', rest_dispatch,
-         {'POST': 'zerver.views.upload.upload_file_backend'}),
+         {'POST': zerver.views.upload.upload_file_backend}),
     path('user_uploads/<realm_id_str>/<path:filename>',
          rest_dispatch,
-         {'GET': ('zerver.views.upload.serve_file_url_backend',
+         {'GET': (zerver.views.upload.serve_file_url_backend,
                   {'override_api_url_scheme'})}),
 
     # bot_storage -> zerver.views.storage
     path('bot_storage', rest_dispatch,
-         {'PUT': 'zerver.views.storage.update_storage',
-          'GET': 'zerver.views.storage.get_storage',
-          'DELETE': 'zerver.views.storage.remove_storage'}),
+         {'PUT': zerver.views.storage.update_storage,
+          'GET': zerver.views.storage.get_storage,
+          'DELETE': zerver.views.storage.remove_storage}),
 
     # Endpoint used by mobile devices to register their push
     # notification credentials
     path('users/me/apns_device_token', rest_dispatch,
-         {'POST': 'zerver.views.push_notifications.add_apns_device_token',
-          'DELETE': 'zerver.views.push_notifications.remove_apns_device_token'}),
+         {'POST': zerver.views.push_notifications.add_apns_device_token,
+          'DELETE': zerver.views.push_notifications.remove_apns_device_token}),
     path('users/me/android_gcm_reg_id', rest_dispatch,
-         {'POST': 'zerver.views.push_notifications.add_android_reg_id',
-          'DELETE': 'zerver.views.push_notifications.remove_android_reg_id'}),
+         {'POST': zerver.views.push_notifications.add_android_reg_id,
+          'DELETE': zerver.views.push_notifications.remove_android_reg_id}),
 
     # users/*/presnece => zerver.views.presence.
     path('users/me/presence', rest_dispatch,
-         {'POST': 'zerver.views.presence.update_active_status_backend'}),
+         {'POST': zerver.views.presence.update_active_status_backend}),
     # It's important that this sit after users/me/presence so that
     # Django's URL resolution order doesn't break the
     # /users/me/presence endpoint.
     path(r'users/<email>/presence', rest_dispatch,
-         {'GET': 'zerver.views.presence.get_presence_backend'}),
+         {'GET': zerver.views.presence.get_presence_backend}),
     path('realm/presence', rest_dispatch,
-         {'GET': 'zerver.views.presence.get_statuses_for_realm'}),
+         {'GET': zerver.views.presence.get_statuses_for_realm}),
     path('users/me/status', rest_dispatch,
-         {'POST': 'zerver.views.presence.update_user_status_backend'}),
+         {'POST': zerver.views.presence.update_user_status_backend}),
 
     # user_groups -> zerver.views.user_groups
     path('user_groups', rest_dispatch,
-         {'GET': 'zerver.views.user_groups.get_user_group'}),
+         {'GET': zerver.views.user_groups.get_user_group}),
     path('user_groups/create', rest_dispatch,
-         {'POST': 'zerver.views.user_groups.add_user_group'}),
+         {'POST': zerver.views.user_groups.add_user_group}),
     path('user_groups/<int:user_group_id>', rest_dispatch,
-         {'PATCH': 'zerver.views.user_groups.edit_user_group',
-          'DELETE': 'zerver.views.user_groups.delete_user_group'}),
+         {'PATCH': zerver.views.user_groups.edit_user_group,
+          'DELETE': zerver.views.user_groups.delete_user_group}),
     path('user_groups/<int:user_group_id>/members', rest_dispatch,
-         {'POST': 'zerver.views.user_groups.update_user_group_backend'}),
+         {'POST': zerver.views.user_groups.update_user_group_backend}),
 
     # users/me -> zerver.views.user_settings
     path('users/me/api_key/regenerate', rest_dispatch,
-         {'POST': 'zerver.views.user_settings.regenerate_api_key'}),
+         {'POST': zerver.views.user_settings.regenerate_api_key}),
     path('users/me/enter-sends', rest_dispatch,
-         {'POST': ('zerver.views.user_settings.change_enter_sends',
+         {'POST': (zerver.views.user_settings.change_enter_sends,
                    # This endpoint should be folded into user settings
                    {'intentionally_undocumented'})}),
     path('users/me/avatar', rest_dispatch,
-         {'POST': 'zerver.views.user_settings.set_avatar_backend',
-          'DELETE': 'zerver.views.user_settings.delete_avatar_backend'}),
+         {'POST': zerver.views.user_settings.set_avatar_backend,
+          'DELETE': zerver.views.user_settings.delete_avatar_backend}),
 
     # users/me/hotspots -> zerver.views.hotspots
     path('users/me/hotspots', rest_dispatch,
-         {'POST': ('zerver.views.hotspots.mark_hotspot_as_read',
+         {'POST': (zerver.views.hotspots.mark_hotspot_as_read,
                    # This endpoint is low priority for documentation as
                    # it is part of the webapp-specific tutorial.
                    {'intentionally_undocumented'})}),
 
     # users/me/tutorial_status -> zerver.views.tutorial
     path('users/me/tutorial_status', rest_dispatch,
-         {'POST': ('zerver.views.tutorial.set_tutorial_status',
+         {'POST': (zerver.views.tutorial.set_tutorial_status,
                    # This is a relic of an old Zulip tutorial model and
                    # should be deleted.
                    {'intentionally_undocumented'})}),
 
     # settings -> zerver.views.user_settings
     path('settings', rest_dispatch,
-         {'PATCH': 'zerver.views.user_settings.json_change_settings'}),
+         {'PATCH': zerver.views.user_settings.json_change_settings}),
     path('settings/display', rest_dispatch,
-         {'PATCH': 'zerver.views.user_settings.update_display_settings_backend'}),
+         {'PATCH': zerver.views.user_settings.update_display_settings_backend}),
     path('settings/notifications', rest_dispatch,
-         {'PATCH': 'zerver.views.user_settings.json_change_notify_settings'}),
+         {'PATCH': zerver.views.user_settings.json_change_notify_settings}),
 
     # users/me/alert_words -> zerver.views.alert_words
     path('users/me/alert_words', rest_dispatch,
-         {'GET': 'zerver.views.alert_words.list_alert_words',
-          'POST': 'zerver.views.alert_words.add_alert_words',
-          'DELETE': 'zerver.views.alert_words.remove_alert_words'}),
+         {'GET': zerver.views.alert_words.list_alert_words,
+          'POST': zerver.views.alert_words.add_alert_words,
+          'DELETE': zerver.views.alert_words.remove_alert_words}),
 
     # users/me/custom_profile_data -> zerver.views.custom_profile_data
     path('users/me/profile_data', rest_dispatch,
-         {'PATCH': 'zerver.views.custom_profile_fields.update_user_custom_profile_data',
-          'DELETE': 'zerver.views.custom_profile_fields.remove_user_custom_profile_data'}),
+         {'PATCH': zerver.views.custom_profile_fields.update_user_custom_profile_data,
+          'DELETE': zerver.views.custom_profile_fields.remove_user_custom_profile_data}),
 
     path('users/me/<int:stream_id>/topics', rest_dispatch,
-         {'GET': ('zerver.views.streams.get_topics_backend',
+         {'GET': (zerver.views.streams.get_topics_backend,
                   {'allow_anonymous_user_web'})}),
 
 
     # streams -> zerver.views.streams
     # (this API is only used externally)
     path('streams', rest_dispatch,
-         {'GET': 'zerver.views.streams.get_streams_backend'}),
+         {'GET': zerver.views.streams.get_streams_backend}),
 
     # GET returns `stream_id`, stream name should be encoded in the url query (in `stream` param)
     path('get_stream_id', rest_dispatch,
-         {'GET': 'zerver.views.streams.json_get_stream_id'}),
+         {'GET': zerver.views.streams.json_get_stream_id}),
 
     # GET returns "stream info" (undefined currently?), HEAD returns whether stream exists (200 or 404)
     path('streams/<int:stream_id>/members', rest_dispatch,
-         {'GET': 'zerver.views.streams.get_subscribers_backend'}),
+         {'GET': zerver.views.streams.get_subscribers_backend}),
     path('streams/<int:stream_id>', rest_dispatch,
-         {'PATCH': 'zerver.views.streams.update_stream_backend',
-          'DELETE': 'zerver.views.streams.deactivate_stream_backend'}),
+         {'PATCH': zerver.views.streams.update_stream_backend,
+          'DELETE': zerver.views.streams.deactivate_stream_backend}),
 
     # Delete topic in stream
     path('streams/<int:stream_id>/delete_topic', rest_dispatch,
-         {'POST': 'zerver.views.streams.delete_in_topic'}),
+         {'POST': zerver.views.streams.delete_in_topic}),
 
     path('default_streams', rest_dispatch,
-         {'POST': 'zerver.views.streams.add_default_stream',
-          'DELETE': 'zerver.views.streams.remove_default_stream'}),
+         {'POST': zerver.views.streams.add_default_stream,
+          'DELETE': zerver.views.streams.remove_default_stream}),
     path('default_stream_groups/create', rest_dispatch,
-         {'POST': 'zerver.views.streams.create_default_stream_group'}),
+         {'POST': zerver.views.streams.create_default_stream_group}),
     path('default_stream_groups/<int:group_id>', rest_dispatch,
-         {'PATCH': 'zerver.views.streams.update_default_stream_group_info',
-          'DELETE': 'zerver.views.streams.remove_default_stream_group'}),
+         {'PATCH': zerver.views.streams.update_default_stream_group_info,
+          'DELETE': zerver.views.streams.remove_default_stream_group}),
     path('default_stream_groups/<int:group_id>/streams', rest_dispatch,
-         {'PATCH': 'zerver.views.streams.update_default_stream_group_streams'}),
+         {'PATCH': zerver.views.streams.update_default_stream_group_streams}),
     # GET lists your streams, POST bulk adds, PATCH bulk modifies/removes
     path('users/me/subscriptions', rest_dispatch,
-         {'GET': 'zerver.views.streams.list_subscriptions_backend',
-          'POST': 'zerver.views.streams.add_subscriptions_backend',
-          'PATCH': 'zerver.views.streams.update_subscriptions_backend',
-          'DELETE': 'zerver.views.streams.remove_subscriptions_backend'}),
+         {'GET': zerver.views.streams.list_subscriptions_backend,
+          'POST': zerver.views.streams.add_subscriptions_backend,
+          'PATCH': zerver.views.streams.update_subscriptions_backend,
+          'DELETE': zerver.views.streams.remove_subscriptions_backend}),
     # muting -> zerver.views.muting
     path('users/me/subscriptions/muted_topics', rest_dispatch,
-         {'PATCH': 'zerver.views.muting.update_muted_topic'}),
+         {'PATCH': zerver.views.muting.update_muted_topic}),
 
     # used to register for an event queue in tornado
     path('register', rest_dispatch,
-         {'POST': 'zerver.views.events_register.events_register_backend'}),
+         {'POST': zerver.views.events_register.events_register_backend}),
 
     # events -> zerver.tornado.views
     path('events', rest_dispatch,
-         {'GET': 'zerver.tornado.views.get_events',
-          'DELETE': 'zerver.tornado.views.cleanup_event_queue'}),
+         {'GET': zerver.tornado.views.get_events,
+          'DELETE': zerver.tornado.views.cleanup_event_queue}),
 
     # report -> zerver.views.report
     #
@@ -397,30 +417,30 @@ v1_api_and_json_patterns = [
     # include in our API documentation.
     path('report/error', rest_dispatch,
          # Logged-out browsers can hit this endpoint, for portico page JS exceptions.
-         {'POST': ('zerver.views.report.report_error', {'allow_anonymous_user_web',
-                                                        'intentionally_undocumented'})}),
+         {'POST': (zerver.views.report.report_error, {'allow_anonymous_user_web',
+                                                      'intentionally_undocumented'})}),
     path('report/send_times', rest_dispatch,
-         {'POST': ('zerver.views.report.report_send_times', {'intentionally_undocumented'})}),
+         {'POST': (zerver.views.report.report_send_times, {'intentionally_undocumented'})}),
     path('report/narrow_times', rest_dispatch,
-         {'POST': ('zerver.views.report.report_narrow_times', {'allow_anonymous_user_web',
-                                                               'intentionally_undocumented'})}),
+         {'POST': (zerver.views.report.report_narrow_times, {'allow_anonymous_user_web',
+                                                             'intentionally_undocumented'})}),
     path('report/unnarrow_times', rest_dispatch,
-         {'POST': ('zerver.views.report.report_unnarrow_times', {'allow_anonymous_user_web',
-                                                                 'intentionally_undocumented'})}),
+         {'POST': (zerver.views.report.report_unnarrow_times, {'allow_anonymous_user_web',
+                                                               'intentionally_undocumented'})}),
 
     # Used to generate a Zoom video call URL
     path('calls/zoom/create', rest_dispatch,
-         {'POST': 'zerver.views.video_calls.make_zoom_video_call'}),
+         {'POST': zerver.views.video_calls.make_zoom_video_call}),
     # Used to generate a Big Blue Button video call URL
     path('calls/bigbluebutton/create', rest_dispatch,
-         {'GET': 'zerver.views.video_calls.get_bigbluebutton_url'}),
+         {'GET': zerver.views.video_calls.get_bigbluebutton_url}),
 
     # export/realm -> zerver.views.realm_export
     path('export/realm', rest_dispatch,
-         {'POST': 'zerver.views.realm_export.export_realm',
-          'GET': 'zerver.views.realm_export.get_realm_exports'}),
+         {'POST': zerver.views.realm_export.export_realm,
+          'GET': zerver.views.realm_export.get_realm_exports}),
     path('export/realm/<int:export_id>', rest_dispatch,
-         {'DELETE': 'zerver.views.realm_export.delete_realm_export'}),
+         {'DELETE': zerver.views.realm_export.delete_realm_export}),
 ]
 
 integrations_view = IntegrationView.as_view()
@@ -610,22 +630,22 @@ urls += [
          name='local_file_unauthed'),
     path('user_uploads/<realm_id_str>/<path:filename>',
          rest_dispatch,
-         {'GET': ('zerver.views.upload.serve_file_backend',
+         {'GET': (zerver.views.upload.serve_file_backend,
                   {'override_api_url_scheme'})}),
     # This endpoint serves thumbnailed versions of images using thumbor;
     # it requires an exception for the same reason.
     path('thumbnail', rest_dispatch,
-         {'GET': ('zerver.views.thumbnail.backend_serve_thumbnail',
+         {'GET': (zerver.views.thumbnail.backend_serve_thumbnail,
                   {'override_api_url_scheme'})}),
     # Avatars have the same constraint because their URLs are included
     # in API data structures used by both the mobile and web clients.
     path('avatar/<email_or_id>',
          rest_dispatch,
-         {'GET': ('zerver.views.users.avatar',
+         {'GET': (zerver.views.users.avatar,
                   {'override_api_url_scheme'})}),
     path('avatar/<email_or_id>/medium',
          rest_dispatch,
-         {'GET': ('zerver.views.users.avatar',
+         {'GET': (zerver.views.users.avatar,
                   {'override_api_url_scheme'}),
           'medium': True}),
 ]
@@ -655,7 +675,7 @@ for incoming_webhook in WEBHOOK_INTEGRATIONS:
 # Desktop-specific authentication URLs
 urls += [
     path('json/fetch_api_key', rest_dispatch,
-         {'POST': 'zerver.views.auth.json_fetch_api_key'}),
+         {'POST': zerver.views.auth.json_fetch_api_key}),
 ]
 
 # Mobile-specific authentication URLs

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -13,57 +13,206 @@ from django.urls import path
 from django.utils.module_loading import import_string
 from django.views.generic import RedirectView, TemplateView
 
-import zerver.forms
-import zerver.tornado.views
-import zerver.views.alert_words
-import zerver.views.archive
-import zerver.views.attachments
-import zerver.views.auth
-import zerver.views.camo
-import zerver.views.compatibility
-import zerver.views.custom_profile_fields
-import zerver.views.digest
-import zerver.views.documentation
-import zerver.views.drafts
-import zerver.views.email_mirror
-import zerver.views.events_register
-import zerver.views.home
-import zerver.views.hotspots
-import zerver.views.invite
-import zerver.views.message_edit
-import zerver.views.message_fetch
-import zerver.views.message_flags
-import zerver.views.message_send
-import zerver.views.muting
-import zerver.views.portico
-import zerver.views.presence
-import zerver.views.push_notifications
-import zerver.views.reactions
-import zerver.views.realm
-import zerver.views.realm_domains
-import zerver.views.realm_emoji
-import zerver.views.realm_export
-import zerver.views.realm_filters
-import zerver.views.realm_icon
-import zerver.views.realm_logo
-import zerver.views.registration
-import zerver.views.report
-import zerver.views.storage
-import zerver.views.streams
-import zerver.views.submessage
-import zerver.views.thumbnail
-import zerver.views.tutorial
-import zerver.views.typing
-import zerver.views.unsubscribe
-import zerver.views.upload
-import zerver.views.user_groups
-import zerver.views.user_settings
-import zerver.views.users
-import zerver.views.video_calls
-import zerver.views.zephyr
+from zerver.forms import LoggingSetPasswordForm
 from zerver.lib.integrations import WEBHOOK_INTEGRATIONS
 from zerver.lib.rest import rest_dispatch
-from zerver.views.documentation import IntegrationView, MarkdownDirectoryView
+from zerver.tornado.views import cleanup_event_queue, get_events, get_events_internal, notify
+from zerver.views.alert_words import add_alert_words, list_alert_words, remove_alert_words
+from zerver.views.archive import archive, get_web_public_topics_backend
+from zerver.views.attachments import list_by_user, remove
+from zerver.views.auth import (
+    api_dev_fetch_api_key,
+    api_dev_list_users,
+    api_fetch_api_key,
+    api_fetch_google_client_id,
+    api_get_server_settings,
+    config_error_view,
+    dev_direct_login,
+    json_fetch_api_key,
+    log_into_subdomain,
+    login_page,
+    logout_then_login,
+    password_reset,
+    remote_user_jwt,
+    remote_user_sso,
+    saml_sp_metadata,
+    show_deactivation_notice,
+    start_remote_user_sso,
+    start_social_login,
+    start_social_signup,
+)
+from zerver.views.camo import handle_camo_url
+from zerver.views.compatibility import check_global_compatibility
+from zerver.views.custom_profile_fields import (
+    create_realm_custom_profile_field,
+    delete_realm_custom_profile_field,
+    list_realm_custom_profile_fields,
+    remove_user_custom_profile_data,
+    reorder_realm_custom_profile_fields,
+    update_realm_custom_profile_field,
+    update_user_custom_profile_data,
+)
+from zerver.views.digest import digest_page
+from zerver.views.documentation import IntegrationView, MarkdownDirectoryView, integration_doc
+from zerver.views.drafts import create_drafts, delete_draft, edit_draft, fetch_drafts
+from zerver.views.email_mirror import email_mirror_message
+from zerver.views.events_register import events_register_backend
+from zerver.views.home import accounts_accept_terms, desktop_home, home
+from zerver.views.hotspots import mark_hotspot_as_read
+from zerver.views.invite import (
+    generate_multiuse_invite_backend,
+    get_user_invites,
+    invite_users_backend,
+    resend_user_invite_email,
+    revoke_multiuse_invite,
+    revoke_user_invite,
+)
+from zerver.views.message_edit import (
+    delete_message_backend,
+    get_message_edit_history,
+    json_fetch_raw_message,
+    update_message_backend,
+)
+from zerver.views.message_fetch import get_messages_backend, messages_in_narrow_backend
+from zerver.views.message_flags import (
+    mark_all_as_read,
+    mark_stream_as_read,
+    mark_topic_as_read,
+    update_message_flags,
+)
+from zerver.views.message_send import render_message_backend, send_message_backend, zcommand_backend
+from zerver.views.muting import update_muted_topic
+from zerver.views.portico import (
+    apps_view,
+    hello_view,
+    landing_view,
+    plans_view,
+    privacy_view,
+    team_view,
+    terms_view,
+)
+from zerver.views.presence import (
+    get_presence_backend,
+    get_statuses_for_realm,
+    update_active_status_backend,
+    update_user_status_backend,
+)
+from zerver.views.push_notifications import (
+    add_android_reg_id,
+    add_apns_device_token,
+    remove_android_reg_id,
+    remove_apns_device_token,
+)
+from zerver.views.reactions import add_reaction, remove_reaction
+from zerver.views.realm import (
+    check_subdomain_available,
+    deactivate_realm,
+    realm_reactivation,
+    update_realm,
+)
+from zerver.views.realm_domains import (
+    create_realm_domain,
+    delete_realm_domain,
+    list_realm_domains,
+    patch_realm_domain,
+)
+from zerver.views.realm_emoji import delete_emoji, list_emoji, upload_emoji
+from zerver.views.realm_export import delete_realm_export, export_realm, get_realm_exports
+from zerver.views.realm_filters import create_filter, delete_filter, list_filters
+from zerver.views.realm_icon import delete_icon_backend, get_icon_backend, upload_icon
+from zerver.views.realm_logo import delete_logo_backend, get_logo_backend, upload_logo
+from zerver.views.registration import (
+    accounts_home,
+    accounts_home_from_multiuse_invite,
+    accounts_register,
+    check_prereg_key_and_redirect,
+    create_realm,
+    find_account,
+    generate_204,
+    realm_redirect,
+)
+from zerver.views.report import (
+    report_csp_violations,
+    report_error,
+    report_narrow_times,
+    report_send_times,
+    report_unnarrow_times,
+)
+from zerver.views.storage import get_storage, remove_storage, update_storage
+from zerver.views.streams import (
+    add_default_stream,
+    add_subscriptions_backend,
+    create_default_stream_group,
+    deactivate_stream_backend,
+    delete_in_topic,
+    get_streams_backend,
+    get_subscribers_backend,
+    get_topics_backend,
+    json_get_stream_id,
+    list_subscriptions_backend,
+    remove_default_stream,
+    remove_default_stream_group,
+    remove_subscriptions_backend,
+    update_default_stream_group_info,
+    update_default_stream_group_streams,
+    update_stream_backend,
+    update_subscription_properties_backend,
+    update_subscriptions_backend,
+    update_subscriptions_property,
+)
+from zerver.views.submessage import process_submessage
+from zerver.views.thumbnail import backend_serve_thumbnail
+from zerver.views.tutorial import set_tutorial_status
+from zerver.views.typing import send_notification_backend
+from zerver.views.unsubscribe import email_unsubscribe
+from zerver.views.upload import (
+    serve_file_backend,
+    serve_file_url_backend,
+    serve_local_file_unauthed,
+    upload_file_backend,
+)
+from zerver.views.user_groups import (
+    add_user_group,
+    delete_user_group,
+    edit_user_group,
+    get_user_group,
+    update_user_group_backend,
+)
+from zerver.views.user_settings import (
+    change_enter_sends,
+    confirm_email_change,
+    delete_avatar_backend,
+    json_change_notify_settings,
+    json_change_settings,
+    regenerate_api_key,
+    set_avatar_backend,
+    update_display_settings_backend,
+)
+from zerver.views.users import (
+    add_bot_backend,
+    avatar,
+    create_user_backend,
+    deactivate_bot_backend,
+    deactivate_user_backend,
+    deactivate_user_own_backend,
+    get_bots_backend,
+    get_members_backend,
+    get_profile_backend,
+    get_subscription_backend,
+    patch_bot_backend,
+    reactivate_user_backend,
+    regenerate_bot_api_key,
+    update_user_backend,
+)
+from zerver.views.video_calls import (
+    complete_zoom_user,
+    deauthorize_zoom_user,
+    get_bigbluebutton_url,
+    join_bigbluebutton,
+    make_zoom_video_call,
+    register_zoom_user,
+)
+from zerver.views.zephyr import webathena_kerberos_login
 from zproject import dev_urls
 from zproject.legacy_urls import legacy_urls
 
@@ -97,153 +246,153 @@ if settings.TWO_FACTOR_AUTHENTICATION_ENABLED:
 v1_api_and_json_patterns = [
     # realm-level calls
     path('realm', rest_dispatch,
-         {'PATCH': zerver.views.realm.update_realm}),
+         {'PATCH': update_realm}),
 
     # Returns a 204, used by desktop app to verify connectivity status
-    path('generate_204', zerver.views.registration.generate_204),
+    path('generate_204', generate_204),
 
-    path('realm/subdomain/<subdomain>', zerver.views.realm.check_subdomain_available),
+    path('realm/subdomain/<subdomain>', check_subdomain_available),
 
     # realm/domains -> zerver.views.realm_domains
     path('realm/domains', rest_dispatch,
-         {'GET': zerver.views.realm_domains.list_realm_domains,
-          'POST': zerver.views.realm_domains.create_realm_domain}),
+         {'GET': list_realm_domains,
+          'POST': create_realm_domain}),
     path('realm/domains/<domain>', rest_dispatch,
-         {'PATCH': zerver.views.realm_domains.patch_realm_domain,
-          'DELETE': zerver.views.realm_domains.delete_realm_domain}),
+         {'PATCH': patch_realm_domain,
+          'DELETE': delete_realm_domain}),
 
     # realm/emoji -> zerver.views.realm_emoji
     path('realm/emoji', rest_dispatch,
-         {'GET': zerver.views.realm_emoji.list_emoji}),
+         {'GET': list_emoji}),
     path('realm/emoji/<emoji_name>', rest_dispatch,
-         {'POST': zerver.views.realm_emoji.upload_emoji,
-          'DELETE': (zerver.views.realm_emoji.delete_emoji, {"intentionally_undocumented"})}),
+         {'POST': upload_emoji,
+          'DELETE': (delete_emoji, {"intentionally_undocumented"})}),
     # this endpoint throws a status code 400 JsonableError when it should be a 404.
 
     # realm/icon -> zerver.views.realm_icon
     path('realm/icon', rest_dispatch,
-         {'POST': zerver.views.realm_icon.upload_icon,
-          'DELETE': zerver.views.realm_icon.delete_icon_backend,
-          'GET': zerver.views.realm_icon.get_icon_backend}),
+         {'POST': upload_icon,
+          'DELETE': delete_icon_backend,
+          'GET': get_icon_backend}),
 
     # realm/logo -> zerver.views.realm_logo
     path('realm/logo', rest_dispatch,
-         {'POST': zerver.views.realm_logo.upload_logo,
-          'DELETE': zerver.views.realm_logo.delete_logo_backend,
-          'GET': zerver.views.realm_logo.get_logo_backend}),
+         {'POST': upload_logo,
+          'DELETE': delete_logo_backend,
+          'GET': get_logo_backend}),
 
     # realm/filters -> zerver.views.realm_filters
     path('realm/filters', rest_dispatch,
-         {'GET': zerver.views.realm_filters.list_filters,
-          'POST': zerver.views.realm_filters.create_filter}),
+         {'GET': list_filters,
+          'POST': create_filter}),
     path('realm/filters/<int:filter_id>', rest_dispatch,
-         {'DELETE': zerver.views.realm_filters.delete_filter}),
+         {'DELETE': delete_filter}),
 
     # realm/profile_fields -> zerver.views.custom_profile_fields
     path('realm/profile_fields', rest_dispatch,
-         {'GET': zerver.views.custom_profile_fields.list_realm_custom_profile_fields,
-          'PATCH': zerver.views.custom_profile_fields.reorder_realm_custom_profile_fields,
-          'POST': zerver.views.custom_profile_fields.create_realm_custom_profile_field}),
+         {'GET': list_realm_custom_profile_fields,
+          'PATCH': reorder_realm_custom_profile_fields,
+          'POST': create_realm_custom_profile_field}),
     path('realm/profile_fields/<int:field_id>', rest_dispatch,
-         {'PATCH': zerver.views.custom_profile_fields.update_realm_custom_profile_field,
-          'DELETE': zerver.views.custom_profile_fields.delete_realm_custom_profile_field}),
+         {'PATCH': update_realm_custom_profile_field,
+          'DELETE': delete_realm_custom_profile_field}),
 
     # realm/deactivate -> zerver.views.deactivate_realm
     path('realm/deactivate', rest_dispatch,
-         {'POST': zerver.views.realm.deactivate_realm}),
+         {'POST': deactivate_realm}),
 
     # users -> zerver.views.users
     path('users', rest_dispatch,
-         {'GET': zerver.views.users.get_members_backend,
-          'POST': zerver.views.users.create_user_backend}),
+         {'GET': get_members_backend,
+          'POST': create_user_backend}),
     path('users/me', rest_dispatch,
-         {'GET': zerver.views.users.get_profile_backend,
-          'DELETE': zerver.views.users.deactivate_user_own_backend}),
+         {'GET': get_profile_backend,
+          'DELETE': deactivate_user_own_backend}),
     path('users/<int:user_id>/reactivate', rest_dispatch,
-         {'POST': zerver.views.users.reactivate_user_backend}),
+         {'POST': reactivate_user_backend}),
     path('users/<int:user_id>', rest_dispatch,
-         {'GET': zerver.views.users.get_members_backend,
-          'PATCH': zerver.views.users.update_user_backend,
-          'DELETE': zerver.views.users.deactivate_user_backend}),
+         {'GET': get_members_backend,
+          'PATCH': update_user_backend,
+          'DELETE': deactivate_user_backend}),
     path('users/<int:user_id>/subscriptions/<int:stream_id>', rest_dispatch,
-         {'GET': zerver.views.users.get_subscription_backend}),
+         {'GET': get_subscription_backend}),
     path('bots', rest_dispatch,
-         {'GET': zerver.views.users.get_bots_backend,
-          'POST': zerver.views.users.add_bot_backend}),
+         {'GET': get_bots_backend,
+          'POST': add_bot_backend}),
     path('bots/<int:bot_id>/api_key/regenerate', rest_dispatch,
-         {'POST': zerver.views.users.regenerate_bot_api_key}),
+         {'POST': regenerate_bot_api_key}),
     path('bots/<int:bot_id>', rest_dispatch,
-         {'PATCH': zerver.views.users.patch_bot_backend,
-          'DELETE': zerver.views.users.deactivate_bot_backend}),
+         {'PATCH': patch_bot_backend,
+          'DELETE': deactivate_bot_backend}),
 
     # invites -> zerver.views.invite
     path('invites', rest_dispatch,
-         {'GET': zerver.views.invite.get_user_invites,
-          'POST': zerver.views.invite.invite_users_backend}),
+         {'GET': get_user_invites,
+          'POST': invite_users_backend}),
     path('invites/<int:prereg_id>', rest_dispatch,
-         {'DELETE': zerver.views.invite.revoke_user_invite}),
+         {'DELETE': revoke_user_invite}),
     path('invites/<int:prereg_id>/resend', rest_dispatch,
-         {'POST': zerver.views.invite.resend_user_invite_email}),
+         {'POST': resend_user_invite_email}),
 
     # invites/multiuse -> zerver.views.invite
     path('invites/multiuse', rest_dispatch,
-         {'POST': zerver.views.invite.generate_multiuse_invite_backend}),
+         {'POST': generate_multiuse_invite_backend}),
     # invites/multiuse -> zerver.views.invite
     path('invites/multiuse/<int:invite_id>', rest_dispatch,
-         {'DELETE': zerver.views.invite.revoke_multiuse_invite}),
+         {'DELETE': revoke_multiuse_invite}),
 
     # mark messages as read (in bulk)
     path('mark_all_as_read', rest_dispatch,
-         {'POST': zerver.views.message_flags.mark_all_as_read}),
+         {'POST': mark_all_as_read}),
     path('mark_stream_as_read', rest_dispatch,
-         {'POST': zerver.views.message_flags.mark_stream_as_read}),
+         {'POST': mark_stream_as_read}),
     path('mark_topic_as_read', rest_dispatch,
-         {'POST': zerver.views.message_flags.mark_topic_as_read}),
+         {'POST': mark_topic_as_read}),
 
     path('zcommand', rest_dispatch,
-         {'POST': zerver.views.message_send.zcommand_backend}),
+         {'POST': zcommand_backend}),
 
     # Endpoints for syncing drafts.
     path('drafts', rest_dispatch,
-         {'GET': (zerver.views.drafts.fetch_drafts,
+         {'GET': (fetch_drafts,
                   {'intentionally_undocumented'}),
-          'POST': (zerver.views.drafts.create_drafts,
+          'POST': (create_drafts,
                    {'intentionally_undocumented'})}),
     path('drafts/<int:draft_id>', rest_dispatch,
-         {'PATCH': (zerver.views.drafts.edit_draft,
+         {'PATCH': (edit_draft,
                     {'intentionally_undocumented'}),
-          'DELETE': (zerver.views.drafts.delete_draft,
+          'DELETE': (delete_draft,
                      {'intentionally_undocumented'})}),
 
     # messages -> zerver.views.message*
     # GET returns messages, possibly filtered, POST sends a message
     path('messages', rest_dispatch,
-         {'GET': (zerver.views.message_fetch.get_messages_backend,
+         {'GET': (get_messages_backend,
                   {'allow_anonymous_user_web'}),
-          'POST': (zerver.views.message_send.send_message_backend,
+          'POST': (send_message_backend,
                    {'allow_incoming_webhooks'})}),
     path('messages/<int:message_id>', rest_dispatch,
-         {'GET': zerver.views.message_edit.json_fetch_raw_message,
-          'PATCH': zerver.views.message_edit.update_message_backend,
-          'DELETE': zerver.views.message_edit.delete_message_backend}),
+         {'GET': json_fetch_raw_message,
+          'PATCH': update_message_backend,
+          'DELETE': delete_message_backend}),
     path('messages/render', rest_dispatch,
-         {'POST': zerver.views.message_send.render_message_backend}),
+         {'POST': render_message_backend}),
     path('messages/flags', rest_dispatch,
-         {'POST': zerver.views.message_flags.update_message_flags}),
+         {'POST': update_message_flags}),
     path('messages/<int:message_id>/history', rest_dispatch,
-         {'GET': zerver.views.message_edit.get_message_edit_history}),
+         {'GET': get_message_edit_history}),
     path('messages/matches_narrow', rest_dispatch,
-         {'GET': zerver.views.message_fetch.messages_in_narrow_backend}),
+         {'GET': messages_in_narrow_backend}),
 
     path('users/me/subscriptions/properties', rest_dispatch,
-         {'POST': zerver.views.streams.update_subscription_properties_backend}),
+         {'POST': update_subscription_properties_backend}),
 
     path('users/me/subscriptions/<int:stream_id>', rest_dispatch,
-         {'PATCH': zerver.views.streams.update_subscriptions_property}),
+         {'PATCH': update_subscriptions_property}),
 
     path('submessage',
          rest_dispatch,
-         {'POST': zerver.views.submessage.process_submessage}),
+         {'POST': process_submessage}),
 
     # New endpoint for handling reactions.
     # reactions -> zerver.view.reactions
@@ -251,164 +400,164 @@ v1_api_and_json_patterns = [
     # DELETE removes a reaction from a message
     path('messages/<int:message_id>/reactions',
          rest_dispatch,
-         {'POST': zerver.views.reactions.add_reaction,
-          'DELETE': zerver.views.reactions.remove_reaction}),
+         {'POST': add_reaction,
+          'DELETE': remove_reaction}),
 
     # attachments -> zerver.views.attachments
     path('attachments', rest_dispatch,
-         {'GET': zerver.views.attachments.list_by_user}),
+         {'GET': list_by_user}),
     path('attachments/<int:attachment_id>', rest_dispatch,
-         {'DELETE': zerver.views.attachments.remove}),
+         {'DELETE': remove}),
 
     # typing -> zerver.views.typing
     # POST sends a typing notification event to recipients
     path('typing', rest_dispatch,
-         {'POST': zerver.views.typing.send_notification_backend}),
+         {'POST': send_notification_backend}),
 
     # user_uploads -> zerver.views.upload
     path('user_uploads', rest_dispatch,
-         {'POST': zerver.views.upload.upload_file_backend}),
+         {'POST': upload_file_backend}),
     path('user_uploads/<realm_id_str>/<path:filename>',
          rest_dispatch,
-         {'GET': (zerver.views.upload.serve_file_url_backend,
+         {'GET': (serve_file_url_backend,
                   {'override_api_url_scheme'})}),
 
     # bot_storage -> zerver.views.storage
     path('bot_storage', rest_dispatch,
-         {'PUT': zerver.views.storage.update_storage,
-          'GET': zerver.views.storage.get_storage,
-          'DELETE': zerver.views.storage.remove_storage}),
+         {'PUT': update_storage,
+          'GET': get_storage,
+          'DELETE': remove_storage}),
 
     # Endpoint used by mobile devices to register their push
     # notification credentials
     path('users/me/apns_device_token', rest_dispatch,
-         {'POST': zerver.views.push_notifications.add_apns_device_token,
-          'DELETE': zerver.views.push_notifications.remove_apns_device_token}),
+         {'POST': add_apns_device_token,
+          'DELETE': remove_apns_device_token}),
     path('users/me/android_gcm_reg_id', rest_dispatch,
-         {'POST': zerver.views.push_notifications.add_android_reg_id,
-          'DELETE': zerver.views.push_notifications.remove_android_reg_id}),
+         {'POST': add_android_reg_id,
+          'DELETE': remove_android_reg_id}),
 
     # users/*/presnece => zerver.views.presence.
     path('users/me/presence', rest_dispatch,
-         {'POST': zerver.views.presence.update_active_status_backend}),
+         {'POST': update_active_status_backend}),
     # It's important that this sit after users/me/presence so that
     # Django's URL resolution order doesn't break the
     # /users/me/presence endpoint.
     path(r'users/<email>/presence', rest_dispatch,
-         {'GET': zerver.views.presence.get_presence_backend}),
+         {'GET': get_presence_backend}),
     path('realm/presence', rest_dispatch,
-         {'GET': zerver.views.presence.get_statuses_for_realm}),
+         {'GET': get_statuses_for_realm}),
     path('users/me/status', rest_dispatch,
-         {'POST': zerver.views.presence.update_user_status_backend}),
+         {'POST': update_user_status_backend}),
 
     # user_groups -> zerver.views.user_groups
     path('user_groups', rest_dispatch,
-         {'GET': zerver.views.user_groups.get_user_group}),
+         {'GET': get_user_group}),
     path('user_groups/create', rest_dispatch,
-         {'POST': zerver.views.user_groups.add_user_group}),
+         {'POST': add_user_group}),
     path('user_groups/<int:user_group_id>', rest_dispatch,
-         {'PATCH': zerver.views.user_groups.edit_user_group,
-          'DELETE': zerver.views.user_groups.delete_user_group}),
+         {'PATCH': edit_user_group,
+          'DELETE': delete_user_group}),
     path('user_groups/<int:user_group_id>/members', rest_dispatch,
-         {'POST': zerver.views.user_groups.update_user_group_backend}),
+         {'POST': update_user_group_backend}),
 
     # users/me -> zerver.views.user_settings
     path('users/me/api_key/regenerate', rest_dispatch,
-         {'POST': zerver.views.user_settings.regenerate_api_key}),
+         {'POST': regenerate_api_key}),
     path('users/me/enter-sends', rest_dispatch,
-         {'POST': (zerver.views.user_settings.change_enter_sends,
+         {'POST': (change_enter_sends,
                    # This endpoint should be folded into user settings
                    {'intentionally_undocumented'})}),
     path('users/me/avatar', rest_dispatch,
-         {'POST': zerver.views.user_settings.set_avatar_backend,
-          'DELETE': zerver.views.user_settings.delete_avatar_backend}),
+         {'POST': set_avatar_backend,
+          'DELETE': delete_avatar_backend}),
 
     # users/me/hotspots -> zerver.views.hotspots
     path('users/me/hotspots', rest_dispatch,
-         {'POST': (zerver.views.hotspots.mark_hotspot_as_read,
+         {'POST': (mark_hotspot_as_read,
                    # This endpoint is low priority for documentation as
                    # it is part of the webapp-specific tutorial.
                    {'intentionally_undocumented'})}),
 
     # users/me/tutorial_status -> zerver.views.tutorial
     path('users/me/tutorial_status', rest_dispatch,
-         {'POST': (zerver.views.tutorial.set_tutorial_status,
+         {'POST': (set_tutorial_status,
                    # This is a relic of an old Zulip tutorial model and
                    # should be deleted.
                    {'intentionally_undocumented'})}),
 
     # settings -> zerver.views.user_settings
     path('settings', rest_dispatch,
-         {'PATCH': zerver.views.user_settings.json_change_settings}),
+         {'PATCH': json_change_settings}),
     path('settings/display', rest_dispatch,
-         {'PATCH': zerver.views.user_settings.update_display_settings_backend}),
+         {'PATCH': update_display_settings_backend}),
     path('settings/notifications', rest_dispatch,
-         {'PATCH': zerver.views.user_settings.json_change_notify_settings}),
+         {'PATCH': json_change_notify_settings}),
 
     # users/me/alert_words -> zerver.views.alert_words
     path('users/me/alert_words', rest_dispatch,
-         {'GET': zerver.views.alert_words.list_alert_words,
-          'POST': zerver.views.alert_words.add_alert_words,
-          'DELETE': zerver.views.alert_words.remove_alert_words}),
+         {'GET': list_alert_words,
+          'POST': add_alert_words,
+          'DELETE': remove_alert_words}),
 
     # users/me/custom_profile_data -> zerver.views.custom_profile_data
     path('users/me/profile_data', rest_dispatch,
-         {'PATCH': zerver.views.custom_profile_fields.update_user_custom_profile_data,
-          'DELETE': zerver.views.custom_profile_fields.remove_user_custom_profile_data}),
+         {'PATCH': update_user_custom_profile_data,
+          'DELETE': remove_user_custom_profile_data}),
 
     path('users/me/<int:stream_id>/topics', rest_dispatch,
-         {'GET': (zerver.views.streams.get_topics_backend,
+         {'GET': (get_topics_backend,
                   {'allow_anonymous_user_web'})}),
 
 
     # streams -> zerver.views.streams
     # (this API is only used externally)
     path('streams', rest_dispatch,
-         {'GET': zerver.views.streams.get_streams_backend}),
+         {'GET': get_streams_backend}),
 
     # GET returns `stream_id`, stream name should be encoded in the url query (in `stream` param)
     path('get_stream_id', rest_dispatch,
-         {'GET': zerver.views.streams.json_get_stream_id}),
+         {'GET': json_get_stream_id}),
 
     # GET returns "stream info" (undefined currently?), HEAD returns whether stream exists (200 or 404)
     path('streams/<int:stream_id>/members', rest_dispatch,
-         {'GET': zerver.views.streams.get_subscribers_backend}),
+         {'GET': get_subscribers_backend}),
     path('streams/<int:stream_id>', rest_dispatch,
-         {'PATCH': zerver.views.streams.update_stream_backend,
-          'DELETE': zerver.views.streams.deactivate_stream_backend}),
+         {'PATCH': update_stream_backend,
+          'DELETE': deactivate_stream_backend}),
 
     # Delete topic in stream
     path('streams/<int:stream_id>/delete_topic', rest_dispatch,
-         {'POST': zerver.views.streams.delete_in_topic}),
+         {'POST': delete_in_topic}),
 
     path('default_streams', rest_dispatch,
-         {'POST': zerver.views.streams.add_default_stream,
-          'DELETE': zerver.views.streams.remove_default_stream}),
+         {'POST': add_default_stream,
+          'DELETE': remove_default_stream}),
     path('default_stream_groups/create', rest_dispatch,
-         {'POST': zerver.views.streams.create_default_stream_group}),
+         {'POST': create_default_stream_group}),
     path('default_stream_groups/<int:group_id>', rest_dispatch,
-         {'PATCH': zerver.views.streams.update_default_stream_group_info,
-          'DELETE': zerver.views.streams.remove_default_stream_group}),
+         {'PATCH': update_default_stream_group_info,
+          'DELETE': remove_default_stream_group}),
     path('default_stream_groups/<int:group_id>/streams', rest_dispatch,
-         {'PATCH': zerver.views.streams.update_default_stream_group_streams}),
+         {'PATCH': update_default_stream_group_streams}),
     # GET lists your streams, POST bulk adds, PATCH bulk modifies/removes
     path('users/me/subscriptions', rest_dispatch,
-         {'GET': zerver.views.streams.list_subscriptions_backend,
-          'POST': zerver.views.streams.add_subscriptions_backend,
-          'PATCH': zerver.views.streams.update_subscriptions_backend,
-          'DELETE': zerver.views.streams.remove_subscriptions_backend}),
+         {'GET': list_subscriptions_backend,
+          'POST': add_subscriptions_backend,
+          'PATCH': update_subscriptions_backend,
+          'DELETE': remove_subscriptions_backend}),
     # muting -> zerver.views.muting
     path('users/me/subscriptions/muted_topics', rest_dispatch,
-         {'PATCH': zerver.views.muting.update_muted_topic}),
+         {'PATCH': update_muted_topic}),
 
     # used to register for an event queue in tornado
     path('register', rest_dispatch,
-         {'POST': zerver.views.events_register.events_register_backend}),
+         {'POST': events_register_backend}),
 
     # events -> zerver.tornado.views
     path('events', rest_dispatch,
-         {'GET': zerver.tornado.views.get_events,
-          'DELETE': zerver.tornado.views.cleanup_event_queue}),
+         {'GET': get_events,
+          'DELETE': cleanup_event_queue}),
 
     # report -> zerver.views.report
     #
@@ -417,30 +566,30 @@ v1_api_and_json_patterns = [
     # include in our API documentation.
     path('report/error', rest_dispatch,
          # Logged-out browsers can hit this endpoint, for portico page JS exceptions.
-         {'POST': (zerver.views.report.report_error, {'allow_anonymous_user_web',
-                                                      'intentionally_undocumented'})}),
+         {'POST': (report_error, {'allow_anonymous_user_web',
+                                  'intentionally_undocumented'})}),
     path('report/send_times', rest_dispatch,
-         {'POST': (zerver.views.report.report_send_times, {'intentionally_undocumented'})}),
+         {'POST': (report_send_times, {'intentionally_undocumented'})}),
     path('report/narrow_times', rest_dispatch,
-         {'POST': (zerver.views.report.report_narrow_times, {'allow_anonymous_user_web',
-                                                             'intentionally_undocumented'})}),
+         {'POST': (report_narrow_times, {'allow_anonymous_user_web',
+                                         'intentionally_undocumented'})}),
     path('report/unnarrow_times', rest_dispatch,
-         {'POST': (zerver.views.report.report_unnarrow_times, {'allow_anonymous_user_web',
-                                                               'intentionally_undocumented'})}),
+         {'POST': (report_unnarrow_times, {'allow_anonymous_user_web',
+                                           'intentionally_undocumented'})}),
 
     # Used to generate a Zoom video call URL
     path('calls/zoom/create', rest_dispatch,
-         {'POST': zerver.views.video_calls.make_zoom_video_call}),
+         {'POST': make_zoom_video_call}),
     # Used to generate a Big Blue Button video call URL
     path('calls/bigbluebutton/create', rest_dispatch,
-         {'GET': zerver.views.video_calls.get_bigbluebutton_url}),
+         {'GET': get_bigbluebutton_url}),
 
     # export/realm -> zerver.views.realm_export
     path('export/realm', rest_dispatch,
-         {'POST': zerver.views.realm_export.export_realm,
-          'GET': zerver.views.realm_export.get_realm_exports}),
+         {'POST': export_realm,
+          'GET': get_realm_exports}),
     path('export/realm/<int:export_id>', rest_dispatch,
-         {'DELETE': zerver.views.realm_export.delete_realm_export}),
+         {'DELETE': delete_realm_export}),
 ]
 
 integrations_view = IntegrationView.as_view()
@@ -451,64 +600,64 @@ integrations_view = IntegrationView.as_view()
 # If you're adding a new page to the website (as opposed to a new
 # endpoint for use by code), you should add it here.
 i18n_urls = [
-    path('', zerver.views.home.home, name='home'),
+    path('', home, name='home'),
     # We have a desktop-specific landing page in case we change our /
     # to not log in in the future. We don't want to require a new
     # desktop app build for everyone in that case
-    path('desktop_home/', zerver.views.home.desktop_home),
+    path('desktop_home/', desktop_home),
 
     # Backwards-compatibility (legacy) Google auth URL for the mobile
     # apps; see https://github.com/zulip/zulip/issues/13081 for
     # background.  We can remove this once older versions of the
     # mobile app are no longer present in the wild.
-    path('accounts/login/google/', zerver.views.auth.start_social_login, {"backend": "google"}),
+    path('accounts/login/google/', start_social_login, {"backend": "google"}),
 
-    path('accounts/login/start/sso/', zerver.views.auth.start_remote_user_sso, name='start-login-sso'),
-    path('accounts/login/sso/', zerver.views.auth.remote_user_sso, name='login-sso'),
-    path('accounts/login/jwt/', zerver.views.auth.remote_user_jwt),
-    path('accounts/login/social/<backend>', zerver.views.auth.start_social_login,
+    path('accounts/login/start/sso/', start_remote_user_sso, name='start-login-sso'),
+    path('accounts/login/sso/', remote_user_sso, name='login-sso'),
+    path('accounts/login/jwt/', remote_user_jwt),
+    path('accounts/login/social/<backend>', start_social_login,
          name='login-social'),
-    path('accounts/login/social/<backend>/<extra_arg>', zerver.views.auth.start_social_login,
+    path('accounts/login/social/<backend>/<extra_arg>', start_social_login,
          name='login-social'),
     path('accounts/register/social/<backend>',
-         zerver.views.auth.start_social_signup,
+         start_social_signup,
          name='signup-social'),
     path('accounts/register/social/<backend>/<extra_arg>',
-         zerver.views.auth.start_social_signup,
+         start_social_signup,
          name='signup-social'),
-    path('accounts/login/subdomain/<token>', zerver.views.auth.log_into_subdomain),
-    path('accounts/login/local/', zerver.views.auth.dev_direct_login, name='login-local'),
+    path('accounts/login/subdomain/<token>', log_into_subdomain),
+    path('accounts/login/local/', dev_direct_login, name='login-local'),
     # We have two entries for accounts/login; only the first one is
     # used for URL resolution.  The second here is to allow
     # reverse("login") in templates to
     # return `/accounts/login/`.
-    path('accounts/login/', zerver.views.auth.login_page,
+    path('accounts/login/', login_page,
          {'template_name': 'zerver/login.html'}, name='login_page'),
     path('accounts/login/', LoginView.as_view(template_name='zerver/login.html'),
          name='login'),
-    path('accounts/logout/', zerver.views.auth.logout_then_login),
+    path('accounts/logout/', logout_then_login),
 
     path('accounts/webathena_kerberos_login/',
-         zerver.views.zephyr.webathena_kerberos_login),
+         webathena_kerberos_login),
 
-    path('accounts/password/reset/', zerver.views.auth.password_reset, name='password_reset'),
+    path('accounts/password/reset/', password_reset, name='password_reset'),
     path('accounts/password/reset/done/',
          PasswordResetDoneView.as_view(template_name='zerver/reset_emailed.html')),
     path('accounts/password/reset/<uidb64>/<token>/',
          PasswordResetConfirmView.as_view(success_url='/accounts/password/done/',
                                           template_name='zerver/reset_confirm.html',
-                                          form_class=zerver.forms.LoggingSetPasswordForm),
+                                          form_class=LoggingSetPasswordForm),
          name='password_reset_confirm'),
     path('accounts/password/done/',
          PasswordResetCompleteView.as_view(template_name='zerver/reset_done.html')),
     path('accounts/deactivated/',
-         zerver.views.auth.show_deactivation_notice),
+         show_deactivation_notice),
 
     # Displays digest email content in browser.
-    path('digest/', zerver.views.digest.digest_page),
+    path('digest/', digest_page),
 
     # Registration views, require a confirmation ID.
-    path('accounts/home/', zerver.views.registration.accounts_home),
+    path('accounts/home/', accounts_home),
     path('accounts/send_confirm/<email>',
          TemplateView.as_view(
              template_name='zerver/accounts_send_confirm.html'),
@@ -517,94 +666,94 @@ i18n_urls = [
          TemplateView.as_view(
              template_name='zerver/accounts_send_confirm.html'),
          {'realm_creation': True}, name='new_realm_send_confirm'),
-    path('accounts/register/', zerver.views.registration.accounts_register, name='accounts_register'),
+    path('accounts/register/', accounts_register, name='accounts_register'),
     path('accounts/do_confirm/<confirmation_key>',
-         zerver.views.registration.check_prereg_key_and_redirect,
+         check_prereg_key_and_redirect,
          name='check_prereg_key_and_redirect'),
 
     path('accounts/confirm_new_email/<confirmation_key>',
-         zerver.views.user_settings.confirm_email_change,
+         confirm_email_change,
          name='confirm_email_change'),
 
     # Email unsubscription endpoint. Allows for unsubscribing from various types of emails,
     # including the welcome emails (day 1 & 2), missed PMs, etc.
     path('accounts/unsubscribe/<email_type>/<confirmation_key>',
-         zerver.views.unsubscribe.email_unsubscribe, name='unsubscribe'),
+         email_unsubscribe, name='unsubscribe'),
 
     # Portico-styled page used to provide email confirmation of terms acceptance.
-    path('accounts/accept_terms/', zerver.views.home.accounts_accept_terms, name='accept_terms'),
+    path('accounts/accept_terms/', accounts_accept_terms, name='accept_terms'),
 
     # Find your account
-    path('accounts/find/', zerver.views.registration.find_account, name='find_account'),
+    path('accounts/find/', find_account, name='find_account'),
 
     # Go to organization subdomain
-    path('accounts/go/', zerver.views.registration.realm_redirect, name='realm_redirect'),
+    path('accounts/go/', realm_redirect, name='realm_redirect'),
 
     # Realm Creation
-    path('new/', zerver.views.registration.create_realm),
+    path('new/', create_realm),
     path('new/<creation_key>',
-         zerver.views.registration.create_realm, name='create_realm'),
+         create_realm, name='create_realm'),
 
     # Realm Reactivation
-    path('reactivate/<confirmation_key>', zerver.views.realm.realm_reactivation,
+    path('reactivate/<confirmation_key>', realm_reactivation,
          name='realm_reactivation'),
 
     # Global public streams (Zulip's way of doing archives)
     path('archive/streams/<int:stream_id>/topics/<topic_name>',
-         zerver.views.archive.archive),
+         archive),
     path('archive/streams/<int:stream_id>/topics',
-         zerver.views.archive.get_web_public_topics_backend),
+         get_web_public_topics_backend),
 
     # Login/registration
-    path('register/', zerver.views.registration.accounts_home, name='register'),
-    path('login/', zerver.views.auth.login_page, {'template_name': 'zerver/login.html'},
+    path('register/', accounts_home, name='register'),
+    path('login/', login_page, {'template_name': 'zerver/login.html'},
          name='login_page'),
 
     path('join/<confirmation_key>/',
-         zerver.views.registration.accounts_home_from_multiuse_invite, name='join'),
+         accounts_home_from_multiuse_invite, name='join'),
 
     # Used to generate a Zoom video call URL
-    path('calls/zoom/register', zerver.views.video_calls.register_zoom_user),
-    path('calls/zoom/complete', zerver.views.video_calls.complete_zoom_user),
-    path('calls/zoom/deauthorize', zerver.views.video_calls.deauthorize_zoom_user),
+    path('calls/zoom/register', register_zoom_user),
+    path('calls/zoom/complete', complete_zoom_user),
+    path('calls/zoom/deauthorize', deauthorize_zoom_user),
 
     # Used to join a Big Blue Button video call
-    path('calls/bigbluebutton/join', zerver.views.video_calls.join_bigbluebutton),
+    path('calls/bigbluebutton/join', join_bigbluebutton),
 
     # API and integrations documentation
     path('integrations/doc-html/<integration_name>',
-         zerver.views.documentation.integration_doc),
+         integration_doc),
     path('integrations/', integrations_view),
     path('integrations/<path:path>', integrations_view),
 
     # Landing page, features pages, signup form, etc.
-    path('hello/', zerver.views.portico.hello_view),
+    path('hello/', hello_view),
     path('new-user/', RedirectView.as_view(url='/hello', permanent=True)),
-    path('features/', zerver.views.portico.landing_view, {'template_name': 'zerver/features.html'}),
-    path('plans/', zerver.views.portico.plans_view, name='plans'),
-    path('apps/', zerver.views.portico.apps_view),
-    path('apps/<platform>', zerver.views.portico.apps_view),
-    path('team/', zerver.views.portico.team_view),
-    path('history/', zerver.views.portico.landing_view, {'template_name': 'zerver/history.html'}),
-    path('why-zulip/', zerver.views.portico.landing_view, {'template_name': 'zerver/why-zulip.html'}),
-    path('for/open-source/', zerver.views.portico.landing_view,
+    path('features/', landing_view, {'template_name': 'zerver/features.html'}),
+    path('plans/', plans_view, name='plans'),
+    path('apps/', apps_view),
+    path('apps/<platform>', apps_view),
+    path('team/', team_view),
+    path('history/', landing_view, {'template_name': 'zerver/history.html'}),
+    path('why-zulip/', landing_view, {'template_name': 'zerver/why-zulip.html'}),
+    path('for/open-source/', landing_view,
          {'template_name': 'zerver/for-open-source.html'}),
-    path('for/research/', zerver.views.portico.landing_view,
+    path('for/research/', landing_view,
          {'template_name': 'zerver/for-research.html'}),
-    path('for/companies/', zerver.views.portico.landing_view,
+    path('for/companies/', landing_view,
          {'template_name': 'zerver/for-companies.html'}),
-    path('for/working-groups-and-communities/', zerver.views.portico.landing_view,
+    path('for/working-groups-and-communities/', landing_view,
          {'template_name': 'zerver/for-working-groups-and-communities.html'}),
-    path('security/', zerver.views.portico.landing_view, {'template_name': 'zerver/security.html'}),
-    path('atlassian/', zerver.views.portico.landing_view, {'template_name': 'zerver/atlassian.html'}),
+    path('security/', landing_view, {'template_name': 'zerver/security.html'}),
+    path('atlassian/', landing_view, {'template_name': 'zerver/atlassian.html'}),
 
     # Terms of Service and privacy pages.
-    path('terms/', zerver.views.portico.terms_view),
-    path('privacy/', zerver.views.portico.privacy_view),
-    path('config-error/<error_category_name>', zerver.views.auth.config_error_view,
+    path('terms/', terms_view),
+    path('privacy/', privacy_view),
+    path('config-error/<error_category_name>', config_error_view,
          name='config_error'),
     path('config-error/remoteuser/<error_category_name>',
-         zerver.views.auth.config_error_view),
+         config_error_view),
 ]
 
 # Make a copy of i18n_urls so that they appear without prefix for english
@@ -626,26 +775,26 @@ urls += [
 # 'override_api_url_scheme' flag passed to rest_dispatch
 urls += [
     path('user_uploads/temporary/<token>/<filename>',
-         zerver.views.upload.serve_local_file_unauthed,
+         serve_local_file_unauthed,
          name='local_file_unauthed'),
     path('user_uploads/<realm_id_str>/<path:filename>',
          rest_dispatch,
-         {'GET': (zerver.views.upload.serve_file_backend,
+         {'GET': (serve_file_backend,
                   {'override_api_url_scheme'})}),
     # This endpoint serves thumbnailed versions of images using thumbor;
     # it requires an exception for the same reason.
     path('thumbnail', rest_dispatch,
-         {'GET': (zerver.views.thumbnail.backend_serve_thumbnail,
+         {'GET': (backend_serve_thumbnail,
                   {'override_api_url_scheme'})}),
     # Avatars have the same constraint because their URLs are included
     # in API data structures used by both the mobile and web clients.
     path('avatar/<email_or_id>',
          rest_dispatch,
-         {'GET': (zerver.views.users.avatar,
+         {'GET': (avatar,
                   {'override_api_url_scheme'})}),
     path('avatar/<email_or_id>/medium',
          rest_dispatch,
-         {'GET': (zerver.views.users.avatar,
+         {'GET': (avatar,
                   {'override_api_url_scheme'}),
           'medium': True}),
 ]
@@ -653,7 +802,7 @@ urls += [
 # This url serves as a way to receive CSP violation reports from the users.
 # We use this endpoint to just log these reports.
 urls += [
-    path('report/csp_violations', zerver.views.report.report_csp_violations),
+    path('report/csp_violations', report_csp_violations),
 ]
 
 # This url serves as a way to provide backward compatibility to messages
@@ -662,7 +811,7 @@ urls += [
 # images.
 urls += [
     path('external_content/<digest>/<received_url>',
-         zerver.views.camo.handle_camo_url),
+         handle_camo_url),
 ]
 
 # Incoming webhook URLs
@@ -675,7 +824,7 @@ for incoming_webhook in WEBHOOK_INTEGRATIONS:
 # Desktop-specific authentication URLs
 urls += [
     path('json/fetch_api_key', rest_dispatch,
-         {'POST': zerver.views.auth.json_fetch_api_key}),
+         {'POST': json_fetch_api_key}),
 ]
 
 # Mobile-specific authentication URLs
@@ -683,7 +832,7 @@ urls += [
     # Used as a global check by all mobile clients, which currently send
     # requests to https://zulip.com/compatibility almost immediately after
     # starting up.
-    path('compatibility', zerver.views.compatibility.check_global_compatibility),
+    path('compatibility', check_global_compatibility),
 ]
 
 v1_api_mobile_patterns = [
@@ -691,20 +840,20 @@ v1_api_mobile_patterns = [
     # authentication backends the server allows as well as details
     # like the requested subdomains'd realm icon (if known) and
     # server-specific compatibility.
-    path('server_settings', zerver.views.auth.api_get_server_settings),
+    path('server_settings', api_get_server_settings),
 
     # This json format view used by the mobile apps accepts a username
     # password/pair and returns an API key.
-    path('fetch_api_key', zerver.views.auth.api_fetch_api_key),
+    path('fetch_api_key', api_fetch_api_key),
 
     # This is for the signing in through the devAuthBackEnd on mobile apps.
-    path('dev_fetch_api_key', zerver.views.auth.api_dev_fetch_api_key),
+    path('dev_fetch_api_key', api_dev_fetch_api_key),
     # This is for fetching the emails of the admins and the users.
-    path('dev_list_users', zerver.views.auth.api_dev_list_users),
+    path('dev_list_users', api_dev_list_users),
 
     # Used to present the GOOGLE_CLIENT_ID to mobile apps
     path('fetch_google_client_id',
-         zerver.views.auth.api_fetch_google_client_id),
+         api_fetch_google_client_id),
 ]
 urls += [
     path('api/v1/', include(v1_api_mobile_patterns)),
@@ -712,7 +861,7 @@ urls += [
 
 # View for uploading messages from email mirror
 urls += [
-    path('email_mirror_message', zerver.views.email_mirror.email_mirror_message),
+    path('email_mirror_message', email_mirror_message),
 ]
 
 # Include URL configuration files for site-specified extra installed
@@ -729,14 +878,14 @@ urls += [
     #
     # Since these views don't use rest_dispatch, they cannot have
     # asynchronous Tornado behavior.
-    path('notify_tornado', zerver.tornado.views.notify),
-    path('api/v1/events/internal', zerver.tornado.views.get_events_internal),
+    path('notify_tornado', notify),
+    path('api/v1/events/internal', get_events_internal),
 ]
 
 # Python Social Auth
 
 urls += [path('', include('social_django.urls', namespace='social'))]
-urls += [path('saml/metadata.xml', zerver.views.auth.saml_sp_metadata)]
+urls += [path('saml/metadata.xml', saml_sp_metadata)]
 
 # User documentation site
 help_documentation_view = MarkdownDirectoryView.as_view(

--- a/zproject/urls.py
+++ b/zproject/urls.py
@@ -15,7 +15,7 @@ from django.views.generic import RedirectView, TemplateView
 
 from zerver.forms import LoggingSetPasswordForm
 from zerver.lib.integrations import WEBHOOK_INTEGRATIONS
-from zerver.lib.rest import rest_dispatch
+from zerver.lib.rest import rest_path
 from zerver.tornado.views import cleanup_event_queue, get_events, get_events_internal, notify
 from zerver.views.alert_words import add_alert_words, list_alert_words, remove_alert_words
 from zerver.views.archive import archive, get_web_public_topics_backend
@@ -245,8 +245,8 @@ if settings.TWO_FACTOR_AUTHENTICATION_ENABLED:
 # e.g. `PATCH /json/realm` or `PATCH /api/v1/realm`.
 v1_api_and_json_patterns = [
     # realm-level calls
-    path('realm', rest_dispatch,
-         {'PATCH': update_realm}),
+    rest_path('realm',
+              PATCH=update_realm),
 
     # Returns a 204, used by desktop app to verify connectivity status
     path('generate_204', generate_204),
@@ -254,342 +254,339 @@ v1_api_and_json_patterns = [
     path('realm/subdomain/<subdomain>', check_subdomain_available),
 
     # realm/domains -> zerver.views.realm_domains
-    path('realm/domains', rest_dispatch,
-         {'GET': list_realm_domains,
-          'POST': create_realm_domain}),
-    path('realm/domains/<domain>', rest_dispatch,
-         {'PATCH': patch_realm_domain,
-          'DELETE': delete_realm_domain}),
+    rest_path('realm/domains',
+              GET=list_realm_domains,
+              POST=create_realm_domain),
+    rest_path('realm/domains/<domain>',
+              PATCH=patch_realm_domain,
+              DELETE=delete_realm_domain),
 
     # realm/emoji -> zerver.views.realm_emoji
-    path('realm/emoji', rest_dispatch,
-         {'GET': list_emoji}),
-    path('realm/emoji/<emoji_name>', rest_dispatch,
-         {'POST': upload_emoji,
-          'DELETE': (delete_emoji, {"intentionally_undocumented"})}),
+    rest_path('realm/emoji',
+              GET=list_emoji),
+    rest_path('realm/emoji/<emoji_name>',
+              POST=upload_emoji,
+              DELETE=(delete_emoji, {"intentionally_undocumented"})),
     # this endpoint throws a status code 400 JsonableError when it should be a 404.
 
     # realm/icon -> zerver.views.realm_icon
-    path('realm/icon', rest_dispatch,
-         {'POST': upload_icon,
-          'DELETE': delete_icon_backend,
-          'GET': get_icon_backend}),
+    rest_path('realm/icon',
+              POST=upload_icon,
+              DELETE=delete_icon_backend,
+              GET=get_icon_backend),
 
     # realm/logo -> zerver.views.realm_logo
-    path('realm/logo', rest_dispatch,
-         {'POST': upload_logo,
-          'DELETE': delete_logo_backend,
-          'GET': get_logo_backend}),
+    rest_path('realm/logo',
+              POST=upload_logo,
+              DELETE=delete_logo_backend,
+              GET=get_logo_backend),
 
     # realm/filters -> zerver.views.realm_filters
-    path('realm/filters', rest_dispatch,
-         {'GET': list_filters,
-          'POST': create_filter}),
-    path('realm/filters/<int:filter_id>', rest_dispatch,
-         {'DELETE': delete_filter}),
+    rest_path('realm/filters',
+              GET=list_filters,
+              POST=create_filter),
+    rest_path('realm/filters/<int:filter_id>',
+              DELETE=delete_filter),
 
     # realm/profile_fields -> zerver.views.custom_profile_fields
-    path('realm/profile_fields', rest_dispatch,
-         {'GET': list_realm_custom_profile_fields,
-          'PATCH': reorder_realm_custom_profile_fields,
-          'POST': create_realm_custom_profile_field}),
-    path('realm/profile_fields/<int:field_id>', rest_dispatch,
-         {'PATCH': update_realm_custom_profile_field,
-          'DELETE': delete_realm_custom_profile_field}),
+    rest_path('realm/profile_fields',
+              GET=list_realm_custom_profile_fields,
+              PATCH=reorder_realm_custom_profile_fields,
+              POST=create_realm_custom_profile_field),
+    rest_path('realm/profile_fields/<int:field_id>',
+              PATCH=update_realm_custom_profile_field,
+              DELETE=delete_realm_custom_profile_field),
 
     # realm/deactivate -> zerver.views.deactivate_realm
-    path('realm/deactivate', rest_dispatch,
-         {'POST': deactivate_realm}),
+    rest_path('realm/deactivate',
+              POST=deactivate_realm),
 
     # users -> zerver.views.users
-    path('users', rest_dispatch,
-         {'GET': get_members_backend,
-          'POST': create_user_backend}),
-    path('users/me', rest_dispatch,
-         {'GET': get_profile_backend,
-          'DELETE': deactivate_user_own_backend}),
-    path('users/<int:user_id>/reactivate', rest_dispatch,
-         {'POST': reactivate_user_backend}),
-    path('users/<int:user_id>', rest_dispatch,
-         {'GET': get_members_backend,
-          'PATCH': update_user_backend,
-          'DELETE': deactivate_user_backend}),
-    path('users/<int:user_id>/subscriptions/<int:stream_id>', rest_dispatch,
-         {'GET': get_subscription_backend}),
-    path('bots', rest_dispatch,
-         {'GET': get_bots_backend,
-          'POST': add_bot_backend}),
-    path('bots/<int:bot_id>/api_key/regenerate', rest_dispatch,
-         {'POST': regenerate_bot_api_key}),
-    path('bots/<int:bot_id>', rest_dispatch,
-         {'PATCH': patch_bot_backend,
-          'DELETE': deactivate_bot_backend}),
+    rest_path('users',
+              GET=get_members_backend,
+              POST=create_user_backend),
+    rest_path('users/me',
+              GET=get_profile_backend,
+              DELETE=deactivate_user_own_backend),
+    rest_path('users/<int:user_id>/reactivate',
+              POST=reactivate_user_backend),
+    rest_path('users/<int:user_id>',
+              GET=get_members_backend,
+              PATCH=update_user_backend,
+              DELETE=deactivate_user_backend),
+    rest_path('users/<int:user_id>/subscriptions/<int:stream_id>',
+              GET=get_subscription_backend),
+    rest_path('bots',
+              GET=get_bots_backend,
+              POST=add_bot_backend),
+    rest_path('bots/<int:bot_id>/api_key/regenerate',
+              POST=regenerate_bot_api_key),
+    rest_path('bots/<int:bot_id>',
+              PATCH=patch_bot_backend,
+              DELETE=deactivate_bot_backend),
 
     # invites -> zerver.views.invite
-    path('invites', rest_dispatch,
-         {'GET': get_user_invites,
-          'POST': invite_users_backend}),
-    path('invites/<int:prereg_id>', rest_dispatch,
-         {'DELETE': revoke_user_invite}),
-    path('invites/<int:prereg_id>/resend', rest_dispatch,
-         {'POST': resend_user_invite_email}),
+    rest_path('invites',
+              GET=get_user_invites,
+              POST=invite_users_backend),
+    rest_path('invites/<int:prereg_id>',
+              DELETE=revoke_user_invite),
+    rest_path('invites/<int:prereg_id>/resend',
+              POST=resend_user_invite_email),
 
     # invites/multiuse -> zerver.views.invite
-    path('invites/multiuse', rest_dispatch,
-         {'POST': generate_multiuse_invite_backend}),
+    rest_path('invites/multiuse',
+              POST=generate_multiuse_invite_backend),
     # invites/multiuse -> zerver.views.invite
-    path('invites/multiuse/<int:invite_id>', rest_dispatch,
-         {'DELETE': revoke_multiuse_invite}),
+    rest_path('invites/multiuse/<int:invite_id>',
+              DELETE=revoke_multiuse_invite),
 
     # mark messages as read (in bulk)
-    path('mark_all_as_read', rest_dispatch,
-         {'POST': mark_all_as_read}),
-    path('mark_stream_as_read', rest_dispatch,
-         {'POST': mark_stream_as_read}),
-    path('mark_topic_as_read', rest_dispatch,
-         {'POST': mark_topic_as_read}),
+    rest_path('mark_all_as_read',
+              POST=mark_all_as_read),
+    rest_path('mark_stream_as_read',
+              POST=mark_stream_as_read),
+    rest_path('mark_topic_as_read',
+              POST=mark_topic_as_read),
 
-    path('zcommand', rest_dispatch,
-         {'POST': zcommand_backend}),
+    rest_path('zcommand',
+              POST=zcommand_backend),
 
     # Endpoints for syncing drafts.
-    path('drafts', rest_dispatch,
-         {'GET': (fetch_drafts,
-                  {'intentionally_undocumented'}),
-          'POST': (create_drafts,
-                   {'intentionally_undocumented'})}),
-    path('drafts/<int:draft_id>', rest_dispatch,
-         {'PATCH': (edit_draft,
-                    {'intentionally_undocumented'}),
-          'DELETE': (delete_draft,
-                     {'intentionally_undocumented'})}),
+    rest_path('drafts',
+              GET=(fetch_drafts,
+                   {'intentionally_undocumented'}),
+              POST=(create_drafts,
+                    {'intentionally_undocumented'})),
+    rest_path('drafts/<int:draft_id>',
+              PATCH=(edit_draft,
+                     {'intentionally_undocumented'}),
+              DELETE=(delete_draft,
+                      {'intentionally_undocumented'})),
 
     # messages -> zerver.views.message*
     # GET returns messages, possibly filtered, POST sends a message
-    path('messages', rest_dispatch,
-         {'GET': (get_messages_backend,
-                  {'allow_anonymous_user_web'}),
-          'POST': (send_message_backend,
-                   {'allow_incoming_webhooks'})}),
-    path('messages/<int:message_id>', rest_dispatch,
-         {'GET': json_fetch_raw_message,
-          'PATCH': update_message_backend,
-          'DELETE': delete_message_backend}),
-    path('messages/render', rest_dispatch,
-         {'POST': render_message_backend}),
-    path('messages/flags', rest_dispatch,
-         {'POST': update_message_flags}),
-    path('messages/<int:message_id>/history', rest_dispatch,
-         {'GET': get_message_edit_history}),
-    path('messages/matches_narrow', rest_dispatch,
-         {'GET': messages_in_narrow_backend}),
+    rest_path('messages',
+              GET=(get_messages_backend,
+                   {'allow_anonymous_user_web'}),
+              POST=(send_message_backend,
+                    {'allow_incoming_webhooks'})),
+    rest_path('messages/<int:message_id>',
+              GET=json_fetch_raw_message,
+              PATCH=update_message_backend,
+              DELETE=delete_message_backend),
+    rest_path('messages/render',
+              POST=render_message_backend),
+    rest_path('messages/flags',
+              POST=update_message_flags),
+    rest_path('messages/<int:message_id>/history',
+              GET=get_message_edit_history),
+    rest_path('messages/matches_narrow',
+              GET=messages_in_narrow_backend),
 
-    path('users/me/subscriptions/properties', rest_dispatch,
-         {'POST': update_subscription_properties_backend}),
+    rest_path('users/me/subscriptions/properties',
+              POST=update_subscription_properties_backend),
 
-    path('users/me/subscriptions/<int:stream_id>', rest_dispatch,
-         {'PATCH': update_subscriptions_property}),
+    rest_path('users/me/subscriptions/<int:stream_id>',
+              PATCH=update_subscriptions_property),
 
-    path('submessage',
-         rest_dispatch,
-         {'POST': process_submessage}),
+    rest_path('submessage',
+              POST=process_submessage),
 
     # New endpoint for handling reactions.
     # reactions -> zerver.view.reactions
     # POST adds a reaction to a message
     # DELETE removes a reaction from a message
-    path('messages/<int:message_id>/reactions',
-         rest_dispatch,
-         {'POST': add_reaction,
-          'DELETE': remove_reaction}),
+    rest_path('messages/<int:message_id>/reactions',
+              POST=add_reaction,
+              DELETE=remove_reaction),
 
     # attachments -> zerver.views.attachments
-    path('attachments', rest_dispatch,
-         {'GET': list_by_user}),
-    path('attachments/<int:attachment_id>', rest_dispatch,
-         {'DELETE': remove}),
+    rest_path('attachments',
+              GET=list_by_user),
+    rest_path('attachments/<int:attachment_id>',
+              DELETE=remove),
 
     # typing -> zerver.views.typing
     # POST sends a typing notification event to recipients
-    path('typing', rest_dispatch,
-         {'POST': send_notification_backend}),
+    rest_path('typing',
+              POST=send_notification_backend),
 
     # user_uploads -> zerver.views.upload
-    path('user_uploads', rest_dispatch,
-         {'POST': upload_file_backend}),
-    path('user_uploads/<realm_id_str>/<path:filename>',
-         rest_dispatch,
-         {'GET': (serve_file_url_backend,
-                  {'override_api_url_scheme'})}),
+    rest_path('user_uploads',
+              POST=upload_file_backend),
+    rest_path('user_uploads/<realm_id_str>/<path:filename>',
+              GET=(serve_file_url_backend,
+                   {'override_api_url_scheme'})),
 
     # bot_storage -> zerver.views.storage
-    path('bot_storage', rest_dispatch,
-         {'PUT': update_storage,
-          'GET': get_storage,
-          'DELETE': remove_storage}),
+    rest_path('bot_storage',
+              PUT=update_storage,
+              GET=get_storage,
+              DELETE=remove_storage),
 
     # Endpoint used by mobile devices to register their push
     # notification credentials
-    path('users/me/apns_device_token', rest_dispatch,
-         {'POST': add_apns_device_token,
-          'DELETE': remove_apns_device_token}),
-    path('users/me/android_gcm_reg_id', rest_dispatch,
-         {'POST': add_android_reg_id,
-          'DELETE': remove_android_reg_id}),
+    rest_path('users/me/apns_device_token',
+              POST=add_apns_device_token,
+              DELETE=remove_apns_device_token),
+    rest_path('users/me/android_gcm_reg_id',
+              POST=add_android_reg_id,
+              DELETE=remove_android_reg_id),
 
     # users/*/presnece => zerver.views.presence.
-    path('users/me/presence', rest_dispatch,
-         {'POST': update_active_status_backend}),
+    rest_path('users/me/presence',
+              POST=update_active_status_backend),
     # It's important that this sit after users/me/presence so that
     # Django's URL resolution order doesn't break the
     # /users/me/presence endpoint.
-    path(r'users/<email>/presence', rest_dispatch,
-         {'GET': get_presence_backend}),
-    path('realm/presence', rest_dispatch,
-         {'GET': get_statuses_for_realm}),
-    path('users/me/status', rest_dispatch,
-         {'POST': update_user_status_backend}),
+    rest_path(r'users/<email>/presence',
+              GET=get_presence_backend),
+    rest_path('realm/presence',
+              GET=get_statuses_for_realm),
+    rest_path('users/me/status',
+              POST=update_user_status_backend),
 
     # user_groups -> zerver.views.user_groups
-    path('user_groups', rest_dispatch,
-         {'GET': get_user_group}),
-    path('user_groups/create', rest_dispatch,
-         {'POST': add_user_group}),
-    path('user_groups/<int:user_group_id>', rest_dispatch,
-         {'PATCH': edit_user_group,
-          'DELETE': delete_user_group}),
-    path('user_groups/<int:user_group_id>/members', rest_dispatch,
-         {'POST': update_user_group_backend}),
+    rest_path('user_groups',
+              GET=get_user_group),
+    rest_path('user_groups/create',
+              POST=add_user_group),
+    rest_path('user_groups/<int:user_group_id>',
+              PATCH=edit_user_group,
+              DELETE=delete_user_group),
+    rest_path('user_groups/<int:user_group_id>/members',
+              POST=update_user_group_backend),
 
     # users/me -> zerver.views.user_settings
-    path('users/me/api_key/regenerate', rest_dispatch,
-         {'POST': regenerate_api_key}),
-    path('users/me/enter-sends', rest_dispatch,
-         {'POST': (change_enter_sends,
-                   # This endpoint should be folded into user settings
-                   {'intentionally_undocumented'})}),
-    path('users/me/avatar', rest_dispatch,
-         {'POST': set_avatar_backend,
-          'DELETE': delete_avatar_backend}),
+    rest_path('users/me/api_key/regenerate',
+              POST=regenerate_api_key),
+    rest_path('users/me/enter-sends',
+              POST=(change_enter_sends,
+                    # This endpoint should be folded into user settings
+                    {'intentionally_undocumented'})),
+    rest_path('users/me/avatar',
+              POST=set_avatar_backend,
+              DELETE=delete_avatar_backend),
 
     # users/me/hotspots -> zerver.views.hotspots
-    path('users/me/hotspots', rest_dispatch,
-         {'POST': (mark_hotspot_as_read,
-                   # This endpoint is low priority for documentation as
-                   # it is part of the webapp-specific tutorial.
-                   {'intentionally_undocumented'})}),
+    rest_path('users/me/hotspots',
+              POST=(mark_hotspot_as_read,
+                    # This endpoint is low priority for documentation as
+                    # it is part of the webapp-specific tutorial.
+                    {'intentionally_undocumented'})),
 
     # users/me/tutorial_status -> zerver.views.tutorial
-    path('users/me/tutorial_status', rest_dispatch,
-         {'POST': (set_tutorial_status,
-                   # This is a relic of an old Zulip tutorial model and
-                   # should be deleted.
-                   {'intentionally_undocumented'})}),
+    rest_path('users/me/tutorial_status',
+              POST=(set_tutorial_status,
+                    # This is a relic of an old Zulip tutorial model and
+                    # should be deleted.
+                    {'intentionally_undocumented'})),
 
     # settings -> zerver.views.user_settings
-    path('settings', rest_dispatch,
-         {'PATCH': json_change_settings}),
-    path('settings/display', rest_dispatch,
-         {'PATCH': update_display_settings_backend}),
-    path('settings/notifications', rest_dispatch,
-         {'PATCH': json_change_notify_settings}),
+    rest_path('settings',
+              PATCH=json_change_settings),
+    rest_path('settings/display',
+              PATCH=update_display_settings_backend),
+    rest_path('settings/notifications',
+              PATCH=json_change_notify_settings),
 
     # users/me/alert_words -> zerver.views.alert_words
-    path('users/me/alert_words', rest_dispatch,
-         {'GET': list_alert_words,
-          'POST': add_alert_words,
-          'DELETE': remove_alert_words}),
+    rest_path('users/me/alert_words',
+              GET=list_alert_words,
+              POST=add_alert_words,
+              DELETE=remove_alert_words),
 
     # users/me/custom_profile_data -> zerver.views.custom_profile_data
-    path('users/me/profile_data', rest_dispatch,
-         {'PATCH': update_user_custom_profile_data,
-          'DELETE': remove_user_custom_profile_data}),
+    rest_path('users/me/profile_data',
+              PATCH=update_user_custom_profile_data,
+              DELETE=remove_user_custom_profile_data),
 
-    path('users/me/<int:stream_id>/topics', rest_dispatch,
-         {'GET': (get_topics_backend,
-                  {'allow_anonymous_user_web'})}),
+    rest_path('users/me/<int:stream_id>/topics',
+              GET=(get_topics_backend,
+                   {'allow_anonymous_user_web'})),
 
 
     # streams -> zerver.views.streams
     # (this API is only used externally)
-    path('streams', rest_dispatch,
-         {'GET': get_streams_backend}),
+    rest_path('streams',
+              GET=get_streams_backend),
 
     # GET returns `stream_id`, stream name should be encoded in the url query (in `stream` param)
-    path('get_stream_id', rest_dispatch,
-         {'GET': json_get_stream_id}),
+    rest_path('get_stream_id',
+              GET=json_get_stream_id),
 
     # GET returns "stream info" (undefined currently?), HEAD returns whether stream exists (200 or 404)
-    path('streams/<int:stream_id>/members', rest_dispatch,
-         {'GET': get_subscribers_backend}),
-    path('streams/<int:stream_id>', rest_dispatch,
-         {'PATCH': update_stream_backend,
-          'DELETE': deactivate_stream_backend}),
+    rest_path('streams/<int:stream_id>/members',
+              GET=get_subscribers_backend),
+    rest_path('streams/<int:stream_id>',
+              PATCH=update_stream_backend,
+              DELETE=deactivate_stream_backend),
 
     # Delete topic in stream
-    path('streams/<int:stream_id>/delete_topic', rest_dispatch,
-         {'POST': delete_in_topic}),
+    rest_path('streams/<int:stream_id>/delete_topic',
+              POST=delete_in_topic),
 
-    path('default_streams', rest_dispatch,
-         {'POST': add_default_stream,
-          'DELETE': remove_default_stream}),
-    path('default_stream_groups/create', rest_dispatch,
-         {'POST': create_default_stream_group}),
-    path('default_stream_groups/<int:group_id>', rest_dispatch,
-         {'PATCH': update_default_stream_group_info,
-          'DELETE': remove_default_stream_group}),
-    path('default_stream_groups/<int:group_id>/streams', rest_dispatch,
-         {'PATCH': update_default_stream_group_streams}),
+    rest_path('default_streams',
+              POST=add_default_stream,
+              DELETE=remove_default_stream),
+    rest_path('default_stream_groups/create',
+              POST=create_default_stream_group),
+    rest_path('default_stream_groups/<int:group_id>',
+              PATCH=update_default_stream_group_info,
+              DELETE=remove_default_stream_group),
+    rest_path('default_stream_groups/<int:group_id>/streams',
+              PATCH=update_default_stream_group_streams),
     # GET lists your streams, POST bulk adds, PATCH bulk modifies/removes
-    path('users/me/subscriptions', rest_dispatch,
-         {'GET': list_subscriptions_backend,
-          'POST': add_subscriptions_backend,
-          'PATCH': update_subscriptions_backend,
-          'DELETE': remove_subscriptions_backend}),
+    rest_path('users/me/subscriptions',
+              GET=list_subscriptions_backend,
+              POST=add_subscriptions_backend,
+              PATCH=update_subscriptions_backend,
+              DELETE=remove_subscriptions_backend),
     # muting -> zerver.views.muting
-    path('users/me/subscriptions/muted_topics', rest_dispatch,
-         {'PATCH': update_muted_topic}),
+    rest_path('users/me/subscriptions/muted_topics',
+              PATCH=update_muted_topic),
 
     # used to register for an event queue in tornado
-    path('register', rest_dispatch,
-         {'POST': events_register_backend}),
+    rest_path('register',
+              POST=events_register_backend),
 
     # events -> zerver.tornado.views
-    path('events', rest_dispatch,
-         {'GET': get_events,
-          'DELETE': cleanup_event_queue}),
+    rest_path('events',
+              GET=get_events,
+              DELETE=cleanup_event_queue),
 
     # report -> zerver.views.report
     #
     # These endpoints are for internal error/performance reporting
     # from the browser to the webapp, and we don't expect to ever
     # include in our API documentation.
-    path('report/error', rest_dispatch,
-         # Logged-out browsers can hit this endpoint, for portico page JS exceptions.
-         {'POST': (report_error, {'allow_anonymous_user_web',
-                                  'intentionally_undocumented'})}),
-    path('report/send_times', rest_dispatch,
-         {'POST': (report_send_times, {'intentionally_undocumented'})}),
-    path('report/narrow_times', rest_dispatch,
-         {'POST': (report_narrow_times, {'allow_anonymous_user_web',
-                                         'intentionally_undocumented'})}),
-    path('report/unnarrow_times', rest_dispatch,
-         {'POST': (report_unnarrow_times, {'allow_anonymous_user_web',
-                                           'intentionally_undocumented'})}),
+    rest_path('report/error',
+              # Logged-out browsers can hit this endpoint, for portico page JS exceptions.
+              POST=(report_error, {'allow_anonymous_user_web',
+                                   'intentionally_undocumented'})),
+    rest_path('report/send_times',
+              POST=(report_send_times, {'intentionally_undocumented'})),
+    rest_path('report/narrow_times',
+              POST=(report_narrow_times, {'allow_anonymous_user_web',
+                                          'intentionally_undocumented'})),
+    rest_path('report/unnarrow_times',
+              POST=(report_unnarrow_times, {'allow_anonymous_user_web',
+                                            'intentionally_undocumented'})),
 
     # Used to generate a Zoom video call URL
-    path('calls/zoom/create', rest_dispatch,
-         {'POST': make_zoom_video_call}),
+    rest_path('calls/zoom/create',
+              POST=make_zoom_video_call),
     # Used to generate a Big Blue Button video call URL
-    path('calls/bigbluebutton/create', rest_dispatch,
-         {'GET': get_bigbluebutton_url}),
+    rest_path('calls/bigbluebutton/create',
+              GET=get_bigbluebutton_url),
 
     # export/realm -> zerver.views.realm_export
-    path('export/realm', rest_dispatch,
-         {'POST': export_realm,
-          'GET': get_realm_exports}),
-    path('export/realm/<int:export_id>', rest_dispatch,
-         {'DELETE': delete_realm_export}),
+    rest_path('export/realm',
+              POST=export_realm,
+              GET=get_realm_exports),
+    rest_path('export/realm/<int:export_id>',
+              DELETE=delete_realm_export),
 ]
 
 integrations_view = IntegrationView.as_view()
@@ -777,26 +774,23 @@ urls += [
     path('user_uploads/temporary/<token>/<filename>',
          serve_local_file_unauthed,
          name='local_file_unauthed'),
-    path('user_uploads/<realm_id_str>/<path:filename>',
-         rest_dispatch,
-         {'GET': (serve_file_backend,
-                  {'override_api_url_scheme'})}),
+    rest_path('user_uploads/<realm_id_str>/<path:filename>',
+              GET=(serve_file_backend,
+                   {'override_api_url_scheme'})),
     # This endpoint serves thumbnailed versions of images using thumbor;
     # it requires an exception for the same reason.
-    path('thumbnail', rest_dispatch,
-         {'GET': (backend_serve_thumbnail,
-                  {'override_api_url_scheme'})}),
+    rest_path('thumbnail',
+              GET=(backend_serve_thumbnail,
+                   {'override_api_url_scheme'})),
     # Avatars have the same constraint because their URLs are included
     # in API data structures used by both the mobile and web clients.
-    path('avatar/<email_or_id>',
-         rest_dispatch,
-         {'GET': (avatar,
-                  {'override_api_url_scheme'})}),
-    path('avatar/<email_or_id>/medium',
-         rest_dispatch,
-         {'GET': (avatar,
-                  {'override_api_url_scheme'}),
-          'medium': True}),
+    rest_path('avatar/<email_or_id>',
+              GET=(avatar,
+                   {'override_api_url_scheme'})),
+    rest_path('avatar/<email_or_id>/medium',
+              {'medium': True},
+              GET=(avatar,
+                   {'override_api_url_scheme'})),
 ]
 
 # This url serves as a way to receive CSP violation reports from the users.
@@ -823,8 +817,8 @@ for incoming_webhook in WEBHOOK_INTEGRATIONS:
 
 # Desktop-specific authentication URLs
 urls += [
-    path('json/fetch_api_key', rest_dispatch,
-         {'POST': json_fetch_api_key}),
+    rest_path('json/fetch_api_key',
+              POST=json_fetch_api_key),
 ]
 
 # Mobile-specific authentication URLs


### PR DESCRIPTION
Inspired by [Tim’s complaint](https://github.com/zulip/zulip/pull/15662#discussion_r492391038) about Black formatting of `urls.py`, which I claim is really a complaint about the low signal-to-noise ratio in `urls.py` to begin with.

* urls: Remove unused URL `name`s and shorten others.
* rest: Specify `rest_dispatch` handlers by function, not by string.
* urls: Use unqualified imports.
* rest: Add `rest_path` shortcut for `path` with `rest_dispatch`.

Here are some further improvements we could make in the future:

* Replace `view_flags` with function decorators.
* Replace the entire `rest_dispatch` method-dispatching mechanism with Django’s [class-based views](https://docs.djangoproject.com/en/3.1/topics/class-based-views/intro/), which have dedicated methods `get`, `post`, `put`, etc.

**Testing Plan:** Dev server.