### PR TITLE
ComposeBox : Fixed composebox overlapping latest messages

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -645,10 +645,12 @@ exports.initialize = function () {
     $(".compose_stream_button").on("click", () => {
         popovers.hide_mobile_message_buttons_popover();
         compose_actions.start("stream", {trigger: "new topic button"});
+        compose_ui.autosize_textarea();
     });
     $(".compose_private_button").on("click", () => {
         popovers.hide_mobile_message_buttons_popover();
         compose_actions.start("private");
+        compose_ui.autosize_textarea();
     });
 
     $("body").on("click", ".compose_mobile_stream_button", () => {

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -8,7 +8,18 @@ exports.autosize_textarea = function (textarea) {
     // Since this supports both compose and file upload, one must pass
     // in the text area to autosize.
     autosize.update(textarea);
-};
+    $("#compose-textarea").css(
+        "max-height",
+        parseInt($("#bottom_whitespace").outerHeight(), 10) -
+            (parseInt($("#below-compose-content").outerHeight(), 10) +
+                parseInt($("#right_part").outerHeight(), 10) +
+                parseInt($("#compose-textarea").css("padding-top"), 10) +
+                parseInt($("#compose-textarea").css("padding-bottom"), 10) +
+                parseInt($("#compose-textarea").css("margin-top"), 10) +
+                parseInt($(".message_comp.compose-content").css("padding-top"), 10) +
+                parseInt($(".message_comp.compose-content").css("padding-bottom"), 10)),
+    );
+}
 
 exports.smart_insert = function (textarea, syntax) {
     function is_space(c) {

--- a/static/js/compose_ui.js
+++ b/static/js/compose_ui.js
@@ -12,14 +12,14 @@ exports.autosize_textarea = function (textarea) {
         "max-height",
         parseInt($("#bottom_whitespace").outerHeight(), 10) -
             (parseInt($("#below-compose-content").outerHeight(), 10) +
-                parseInt($("#right_part").outerHeight(), 10) +
+                parseInt($(".right_part").outerHeight(), 10) +
                 parseInt($("#compose-textarea").css("padding-top"), 10) +
                 parseInt($("#compose-textarea").css("padding-bottom"), 10) +
                 parseInt($("#compose-textarea").css("margin-top"), 10) +
                 parseInt($(".message_comp.compose-content").css("padding-top"), 10) +
                 parseInt($(".message_comp.compose-content").css("padding-bottom"), 10)),
     );
-}
+};
 
 exports.smart_insert = function (textarea, syntax) {
     function is_space(c) {

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -157,6 +157,7 @@ exports.watch_manual_resize = function (element) {
 
 exports.resize_bottom_whitespace = function (h) {
     $("#bottom_whitespace").height(h.bottom_whitespace_height);
+    compose_ui.autosize_textarea();
 };
 
 exports.resize_stream_filters_container = function (h) {

--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -64,7 +64,7 @@
                     <div class="compose_table">
                         <div id="stream-message">
                             <div class="stream-selection-header-colorblock message_header_stream left_part"></div>
-                            <div class="right_part">
+                            <div class="right_part" id = 'right_part'>
                                 <span id="compose-lock-icon">
                                     <i class="fa fa-lock" title="{{ _('This is a private stream') }}" aria-hidden="true"></i>
                                 </span>


### PR DESCRIPTION
Fixed Textarea in ComposeBox covering up latest messages in a stream while writing long messages .
CZO topic: <a href = 'https://chat.zulip.org/#narrow/stream/9-issues/topic/Long.20reply.20covers.20previous.20messages'>here</a>
 
This is in the continuation of #16295 , I messed up my previous forked repository and hence had to create a new pr closing #16295 

Fixes #16038
