### PR TITLE
js: Use destructuring for require statements

### DIFF
--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -15,7 +15,7 @@ set_global("compose_actions", {
     update_placeholder_text: noop,
 });
 
-const LazySet = zrequire("lazy_set").LazySet;
+const {LazySet} = zrequire("lazy_set");
 
 const _navigator = {
     platform: "",

--- a/frontend_tests/node_tests/fold_dict.js
+++ b/frontend_tests/node_tests/fold_dict.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const FoldDict = zrequire("fold_dict").FoldDict;
+const {FoldDict} = zrequire("fold_dict");
 
 run_test("basic", () => {
     const d = new FoldDict();

--- a/frontend_tests/node_tests/lazy_set.js
+++ b/frontend_tests/node_tests/lazy_set.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const LazySet = zrequire("lazy_set").LazySet;
+const {LazySet} = zrequire("lazy_set");
 
 /*
     We mostly test LazySet indirectly.  This code

--- a/frontend_tests/node_tests/message_list.js
+++ b/frontend_tests/node_tests/message_list.js
@@ -17,7 +17,7 @@ zrequire("FetchStatus", "js/fetch_status");
 zrequire("muting");
 zrequire("MessageListData", "js/message_list_data");
 zrequire("MessageListView", "js/message_list_view");
-const MessageList = zrequire("message_list").MessageList;
+const {MessageList} = zrequire("message_list");
 
 function accept_all_filter() {
     const filter = {

--- a/frontend_tests/node_tests/stream_edit.js
+++ b/frontend_tests/node_tests/stream_edit.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const LazySet = zrequire("lazy_set").LazySet;
+const {LazySet} = zrequire("lazy_set");
 
 const noop = () => {};
 global.stub_templates(() => noop);

--- a/frontend_tests/node_tests/typeahead_helper.js
+++ b/frontend_tests/node_tests/typeahead_helper.js
@@ -20,7 +20,7 @@ const pygments_data = zrequire("pygments_data", "generated/pygments_data.json");
 const actual_pygments_data = Object.assign({}, pygments_data);
 const ct = zrequire("composebox_typeahead");
 const th = zrequire("typeahead_helper");
-const LazySet = zrequire("lazy_set").LazySet;
+const {LazySet} = zrequire("lazy_set");
 
 let next_id = 0;
 

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -12,7 +12,7 @@ set_global("page_params", {
 });
 zrequire("settings_notifications");
 
-const FoldDict = zrequire("fold_dict").FoldDict;
+const {FoldDict} = zrequire("fold_dict");
 
 set_global("narrow_state", {});
 set_global("current_msg_list", {});

--- a/frontend_tests/puppeteer_lib/common.js
+++ b/frontend_tests/puppeteer_lib/common.js
@@ -1,11 +1,11 @@
 "use strict";
 
-const assert = require("assert").strict;
+const {strict: assert} = require("assert");
 const path = require("path");
 
 const puppeteer = require("puppeteer");
 
-const test_credentials = require("../../var/puppeteer/test_credentials").test_credentials;
+const {test_credentials} = require("../../var/puppeteer/test_credentials");
 
 const root_dir = path.resolve(__dirname, "../../");
 const puppeteer_dir = path.join(root_dir, "var/puppeteer");

--- a/frontend_tests/puppeteer_tests/00-realm-creation.js
+++ b/frontend_tests/puppeteer_tests/00-realm-creation.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const assert = require("assert").strict;
+const {strict: assert} = require("assert");
 
 const common = require("../puppeteer_lib/common");
 

--- a/frontend_tests/puppeteer_tests/01-login.js
+++ b/frontend_tests/puppeteer_tests/01-login.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const test_credentials = require("../../var/puppeteer/test_credentials").test_credentials;
+const {test_credentials} = require("../../var/puppeteer/test_credentials");
 const common = require("../puppeteer_lib/common");
 
 async function login_tests(page) {

--- a/frontend_tests/puppeteer_tests/02-message-basics.js
+++ b/frontend_tests/puppeteer_tests/02-message-basics.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const assert = require("assert").strict;
+const {strict: assert} = require("assert");
 
 const common = require("../puppeteer_lib/common");
 

--- a/frontend_tests/puppeteer_tests/03-compose.js
+++ b/frontend_tests/puppeteer_tests/03-compose.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const assert = require("assert").strict;
+const {strict: assert} = require("assert");
 
 const common = require("../puppeteer_lib/common");
 

--- a/frontend_tests/puppeteer_tests/04-subscriptions.js
+++ b/frontend_tests/puppeteer_tests/04-subscriptions.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const assert = require("assert").strict;
+const {strict: assert} = require("assert");
 
 const common = require("../puppeteer_lib/common");
 

--- a/frontend_tests/puppeteer_tests/05-stars.js
+++ b/frontend_tests/puppeteer_tests/05-stars.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const assert = require("assert").strict;
+const {strict: assert} = require("assert");
 
 const common = require("../puppeteer_lib/common");
 

--- a/frontend_tests/puppeteer_tests/07-navigation.js
+++ b/frontend_tests/puppeteer_tests/07-navigation.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const assert = require("assert").strict;
+const {strict: assert} = require("assert");
 
 const common = require("../puppeteer_lib/common");
 

--- a/frontend_tests/puppeteer_tests/08-admin.js
+++ b/frontend_tests/puppeteer_tests/08-admin.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const assert = require("assert").strict;
+const {strict: assert} = require("assert");
 
 const common = require("../puppeteer_lib/common");
 

--- a/frontend_tests/puppeteer_tests/09-mention.js
+++ b/frontend_tests/puppeteer_tests/09-mention.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const assert = require("assert").strict;
+const {strict: assert} = require("assert");
 
 const common = require("../puppeteer_lib/common");
 

--- a/frontend_tests/puppeteer_tests/10-custom-profile.js
+++ b/frontend_tests/puppeteer_tests/10-custom-profile.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const assert = require("assert").strict;
+const {strict: assert} = require("assert");
 
 const common = require("../puppeteer_lib/common");
 

--- a/frontend_tests/puppeteer_tests/11-user-deactivation.js
+++ b/frontend_tests/puppeteer_tests/11-user-deactivation.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const assert = require("assert").strict;
+const {strict: assert} = require("assert");
 
 const common = require("../puppeteer_lib/common");
 

--- a/frontend_tests/puppeteer_tests/12-drafts.js
+++ b/frontend_tests/puppeteer_tests/12-drafts.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const assert = require("assert").strict;
+const {strict: assert} = require("assert");
 
 const common = require("../puppeteer_lib/common");
 

--- a/frontend_tests/puppeteer_tests/14-copy-and-paste.js
+++ b/frontend_tests/puppeteer_tests/14-copy-and-paste.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const assert = require("assert").strict;
+const {strict: assert} = require("assert");
 
 const common = require("../puppeteer_lib/common");
 

--- a/frontend_tests/puppeteer_tests/15-realm-linkifier.js
+++ b/frontend_tests/puppeteer_tests/15-realm-linkifier.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const assert = require("assert").strict;
+const {strict: assert} = require("assert");
 
 const common = require("../puppeteer_lib/common");
 

--- a/frontend_tests/puppeteer_tests/16-settings.js
+++ b/frontend_tests/puppeteer_tests/16-settings.js
@@ -1,8 +1,8 @@
 "use strict";
 
-const assert = require("assert").strict;
+const {strict: assert} = require("assert");
 
-const test_credentials = require("../../var/puppeteer/test_credentials").test_credentials;
+const {test_credentials} = require("../../var/puppeteer/test_credentials");
 const common = require("../puppeteer_lib/common");
 
 const OUTGOING_WEBHOOK_BOT_TYPE = "3";

--- a/frontend_tests/zjsunit/index.js
+++ b/frontend_tests/zjsunit/index.js
@@ -11,7 +11,7 @@ const handlebars = require("./handlebars");
 const stub_i18n = require("./i18n");
 const namespace = require("./namespace");
 const stub = require("./stub");
-const make_blueslip = require("./zblueslip").make_zblueslip;
+const {make_zblueslip} = require("./zblueslip");
 const zjquery = require("./zjquery");
 
 require("@babel/register")({
@@ -130,7 +130,7 @@ try {
         _.throttle = immediate;
         _.debounce = immediate;
 
-        set_global("blueslip", make_blueslip());
+        set_global("blueslip", make_zblueslip());
         set_global("i18n", stub_i18n);
         namespace.clear_zulip_refs();
 

--- a/frontend_tests/zjsunit/stub.js
+++ b/frontend_tests/zjsunit/stub.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const assert = require("assert").strict;
+const {strict: assert} = require("assert");
 
 // Stubs don't do any magical modifications to your namespace.  They
 // just provide you a function that records what arguments get passed

--- a/static/js/muting.js
+++ b/static/js/muting.js
@@ -2,7 +2,7 @@
 
 const XDate = require("xdate");
 
-const FoldDict = require("./fold_dict").FoldDict;
+const {FoldDict} = require("./fold_dict");
 
 const muted_topics = new Map();
 

--- a/static/js/recent_senders.js
+++ b/static/js/recent_senders.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const FoldDict = require("./fold_dict").FoldDict;
+const {FoldDict} = require("./fold_dict");
 
 // topic_senders[stream_id][topic_id][sender_id] = latest_message_id
 const topic_senders = new Map();

--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const Sortable = require("sortablejs").default;
+const {default: Sortable} = require("sortablejs");
 
 const render_admin_profile_field_list = require("../templates/admin_profile_field_list.hbs");
 const render_settings_profile_field_choice = require("../templates/settings/profile_field_choice.hbs");

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -1,7 +1,7 @@
 "use strict";
 
-const FoldDict = require("./fold_dict").FoldDict;
-const LazySet = require("./lazy_set").LazySet;
+const {FoldDict} = require("./fold_dict");
+const {LazySet} = require("./lazy_set");
 const people = require("./people");
 const settings_config = require("./settings_config");
 const util = require("./util");

--- a/static/js/stream_topic_history.js
+++ b/static/js/stream_topic_history.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const FoldDict = require("./fold_dict").FoldDict;
+const {FoldDict} = require("./fold_dict");
 
 const stream_dict = new Map(); // stream_id -> PerStreamHistory object
 const fetched_stream_ids = new Set();

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const SimpleBar = require("simplebar").default;
+const {default: SimpleBar} = require("simplebar");
 
 // What, if anything, obscures the home tab?
 

--- a/static/js/unread.js
+++ b/static/js/unread.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const FoldDict = require("./fold_dict").FoldDict;
+const {FoldDict} = require("./fold_dict");
 const people = require("./people");
 const util = require("./util");
 

--- a/static/js/user_groups.js
+++ b/static/js/user_groups.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const FoldDict = require("./fold_dict").FoldDict;
+const {FoldDict} = require("./fold_dict");
 
 let user_group_name_dict;
 let user_group_by_id_dict;


### PR DESCRIPTION
This allows `import/order` to auto-fix blocks including these statements.