### PR TITLE
compose: Reorder message action buttons.

### DIFF
--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -21,7 +21,7 @@
             }
         }
 
-        .drafts-link {
+        .message-control-link {
             float: left;
         }
 
@@ -126,10 +126,9 @@
         box-shadow: none !important;
     }
 
-    .drafts-link {
+    .message-control-link {
         position: relative;
-        margin-right: 1em;
-        margin-left: 5px;
+        margin-right: 5px;
         top: 2px;
     }
 }

--- a/static/styles/compose.css
+++ b/static/styles/compose.css
@@ -456,10 +456,6 @@ a.message-control-button {
     min-height: 42px;
 }
 
-a#markdown_preview {
-    margin-left: 2px;
-}
-
 a#undo_markdown_preview {
     text-decoration: none;
     position: relative;

--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -96,14 +96,14 @@
                                 <div id="below-compose-content">
                                     <button type="submit" id="compose-send-button" class="button small send_message" title="{{ _('Send') }} (Ctrl + Enter)">{{ _('Send') }}</button>
                                     <input type="file" id="file_input" class="notvisible pull-left" multiple />
-                                    <a role="button" class="message-control-button fa fa-smile-o" aria-label="{{_('Add emoji')}}" id="emoji_map" tabindex=0 title="{{ _('Add emoji') }}"></a>
-                                    <a role="button" class="message-control-button fa fa-font" aria-label="{{ _('Formatting') }}" tabindex=0 title="{{ _('Formatting') }}" data-overlay-trigger="message-formatting"></a>
                                     {% if max_file_upload_size_mib > 0 %}
                                     <a role="button" class="message-control-button fa fa-paperclip notdisplayed" aria-label="{{ _('Attach files') }}" id="attach_files" tabindex=0 title="{{ _('Attach files') }}"></a>
                                     {% endif %}
-                                    <a role="button" class="message-control-button fa fa-video-camera video_link" aria-label="{{ _('Add video call') }}" tabindex=0 title="{{ _('Add video call') }}"></a>
-                                    <a role="button" id="undo_markdown_preview" class="message-control-button fa fa-edit" aria-label="{{ _('Write') }}" tabindex=0 style="display:none;" title="{{ _('Write') }}"></a>
                                     <a role="button" id="markdown_preview" class="message-control-button fa fa-eye" aria-label="{{ _('Preview') }}" tabindex=0 title="{{ _('Preview') }}"></a>
+                                    <a role="button" id="undo_markdown_preview" class="message-control-button fa fa-edit" aria-label="{{ _('Write') }}" tabindex=0 style="display:none;" title="{{ _('Write') }}"></a>
+                                    <a role="button" class="message-control-button fa fa-video-camera video_link" aria-label="{{ _('Add video call') }}" tabindex=0 title="{{ _('Add video call') }}"></a>
+                                    <a role="button" class="message-control-button fa fa-smile-o" aria-label="{{_('Add emoji')}}" id="emoji_map" tabindex=0 title="{{ _('Add emoji') }}"></a>
+                                    <a role="button" class="message-control-button fa fa-font" aria-label="{{ _('Formatting') }}" tabindex=0 title="{{ _('Formatting') }}" data-overlay-trigger="message-formatting"></a>
                                     <a class="drafts-link" href="#drafts" title="{{ _('Drafts') }} (d)">{{ _('Drafts') }}</a>
                                     <span id="sending-indicator"></span>
                                     <div id="send_controls" class="new-style">

--- a/templates/zerver/app/compose.html
+++ b/templates/zerver/app/compose.html
@@ -103,8 +103,8 @@
                                     <a role="button" id="undo_markdown_preview" class="message-control-button fa fa-edit" aria-label="{{ _('Write') }}" tabindex=0 style="display:none;" title="{{ _('Write') }}"></a>
                                     <a role="button" class="message-control-button fa fa-video-camera video_link" aria-label="{{ _('Add video call') }}" tabindex=0 title="{{ _('Add video call') }}"></a>
                                     <a role="button" class="message-control-button fa fa-smile-o" aria-label="{{_('Add emoji')}}" id="emoji_map" tabindex=0 title="{{ _('Add emoji') }}"></a>
-                                    <a role="button" class="message-control-button fa fa-font" aria-label="{{ _('Formatting') }}" tabindex=0 title="{{ _('Formatting') }}" data-overlay-trigger="message-formatting"></a>
-                                    <a class="drafts-link" href="#drafts" title="{{ _('Drafts') }} (d)">{{ _('Drafts') }}</a>
+                                    <a class="message-control-link drafts-link" href="#drafts" title="{{ _('Drafts') }} (d)">{{ _('Drafts') }}</a>
+                                    <a role="button" class="message-control-link" tabindex=0 data-overlay-trigger="message-formatting">{{ _('Help') }}</a>
                                     <span id="sending-indicator"></span>
                                     <div id="send_controls" class="new-style">
                                         <label id="enter-sends-label" class="compose_checkbox_label checkbox">


### PR DESCRIPTION
Now that they are tab accessible, we should order them by importance.
Previously the order was:

1. Add emoji
2. Formatting
3. Attach files
4. Add video call
5. Preview
6. Drafts

This commit changes the order to:

1. Attach files
2. Preview
3. Add video call
4. Add emoji
5. Drafts
6. Formatting

The "Add emoji" button is moved back because emojis can be more
conveniently entered using the typeahead triggered with ":" or the
emoticon conversions.

The Formatting button that opens our Markdown help popover previously
had an "A" as its icon (the Font Awesome icon for font). This commit
changes the link to spell out "Help" to make it more discoverable.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

Before:
![image](https://user-images.githubusercontent.com/47354597/93966217-661db000-fd64-11ea-829b-c2e7053e6bdc.png)

First commit:
![image](https://user-images.githubusercontent.com/47354597/94100539-363adf00-fe2e-11ea-893c-ea5646feb119.png)

Second commit:
![image](https://user-images.githubusercontent.com/47354597/94101246-d0e7ed80-fe2f-11ea-839b-822aee25f33f.png)



<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
