### PR TITLE
emoji_picker: Fix search input length.

### DIFF
--- a/static/styles/reactions.css
+++ b/static/styles/reactions.css
@@ -169,6 +169,7 @@
                 margin: auto;
                 padding-left: 22px;
                 width: calc(100% - 22px - 8px);
+                font-size: 90%;
             }
         }
 

--- a/static/templates/emoji_popover_content.hbs
+++ b/static/templates/emoji_popover_content.hbs
@@ -1,5 +1,5 @@
 <div class="emoji-popover">
-    <div class="emoji-popover-top input-append">
+    <div class="emoji-popover-top">
         <input class="emoji-popover-filter" type="text" autofocus placeholder="{{t 'Search' }}" />
         <i class="fa fa-search" aria-hidden="true"></i>
     </div>


### PR DESCRIPTION
This was probably a regression from our upgrade to bootstrap 2.3.2.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


**Testing Plan:** <!-- How have you tested? -->


**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
before:
![image](https://user-images.githubusercontent.com/47354597/93967996-c1ea3800-fd68-11ea-9151-d8b78bd72a26.png)

after:
![image](https://user-images.githubusercontent.com/47354597/93968029-d8908f00-fd68-11ea-8d46-32ed6918f35a.png)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
