### PR TITLE
tests: Rename stream messages tests in test_message_send.py.

### DIFF
--- a/zerver/tests/test_message_send.py
+++ b/zerver/tests/test_message_send.py
@@ -77,7 +77,7 @@ class MessagePOSTTest(ZulipTestCase):
             with self.assertRaisesRegex(JsonableError, error_msg):
                 self.send_stream_message(user, stream_name)
 
-    def test_message_to_self(self) -> None:
+    def test_message_to_stream_by_name(self) -> None:
         """
         Sending a message to a stream to which you are subscribed is
         successful.
@@ -90,7 +90,7 @@ class MessagePOSTTest(ZulipTestCase):
                                                      "topic": "Test topic"})
         self.assert_json_success(result)
 
-    def test_api_message_to_self(self) -> None:
+    def test_api_message_to_stream_by_name(self) -> None:
         """
         Same as above, but for the API view
         """


### PR DESCRIPTION
This PR renames 'test_message_to_self' and 'test_api_message_to_self' tests to
test_message_to_stream_by_name' and 'test_api_message_to_stream_by_name' to
depict the actual purpose of these tests.

<!-- What's this PR for?  (Just a link to an issue is fine.) -->


 <!-- How have you tested? -->


<!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->
