### PR TITLE
gear_menu : Added collapse for gear menu settings

### DIFF
--- a/static/js/click_handlers.js
+++ b/static/js/click_handlers.js
@@ -536,6 +536,7 @@ exports.initialize = function () {
         ".user-presence-link, .user_sidebar_entry .user_circle, .user_sidebar_entry .selectable_sidebar_block",
         (e) => {
             e.stopPropagation();
+            gear_menu.close_if_needed();
             const elem = $(e.currentTarget)
                 .closest(".user_sidebar_entry")
                 .find(".user-presence-link");
@@ -644,10 +645,12 @@ exports.initialize = function () {
 
     $(".compose_stream_button").on("click", () => {
         popovers.hide_mobile_message_buttons_popover();
+        gear_menu.close_if_needed();
         compose_actions.start("stream", {trigger: "new topic button"});
     });
     $(".compose_private_button").on("click", () => {
         popovers.hide_mobile_message_buttons_popover();
+        gear_menu.close_if_needed();
         compose_actions.start("private");
     });
 
@@ -659,9 +662,9 @@ exports.initialize = function () {
         popovers.hide_mobile_message_buttons_popover();
         compose_actions.start("private");
     });
-
     $(".compose_reply_button").on("click", () => {
         compose_actions.respond_to_message({trigger: "reply button"});
+        gear_menu.close_if_needed();
     });
 
     $(".empty_feed_compose_stream").on("click", (e) => {

--- a/static/js/gear_menu.js
+++ b/static/js/gear_menu.js
@@ -85,6 +85,13 @@ exports.update_org_settings_menu_item = function () {
     }
 };
 
+exports.close_if_needed = function () {
+    const gear_menu = $("#gear-menu");
+    if (gear_menu.hasClass("open")) {
+        gear_menu.removeClass("open");
+    }
+};
+
 exports.initialize = function () {
     exports.update_org_settings_menu_item();
 

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -488,6 +488,7 @@ exports.set_event_handlers = function () {
         const sub = stream_data.get_sub_by_id(stream_id);
         popovers.hide_all();
         narrow.by("stream", sub.name, {trigger: "sidebar"});
+        gear_menu.close_if_needed();
 
         exports.clear_and_hide_search();
 
@@ -496,7 +497,6 @@ exports.set_event_handlers = function () {
     });
 
     $("#clear_search_stream_button").on("click", exports.clear_search);
-
     $("#streams_header")
         .expectOne()
         .on("click", (e) => {


### PR DESCRIPTION
Earlier , Settings Dropdown/Gear menu used to persist its state even when clicked away form it ( not collapsing )

<strong>GIFs</strong>

Earlier             |  After
:-------------------------:|:-------------------------:
  ![Peek 2020-09-12 22-22](https://user-images.githubusercontent.com/53977614/93000510-8d93a200-f546-11ea-8d6f-dd1f3f2dc18e.gif) |  ![Peek 2020-09-12 22-07](https://user-images.githubusercontent.com/53977614/93000526-abf99d80-f546-11ea-87ce-55d4b9050046.gif)

The similar use case is applied when the user presses on <code>ComposeBox</code> buttons or on any <code>streams</code> link

Fixes : #14079

P.S : Resumption of  #16336 , Had to close the previous Pr (changes suggested by @showell ) as I messed up my previously forked repository :(  
