### PR TITLE
Convert blueslip.fatal → throw; replace empty-returns with consistent-return

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,14 +9,13 @@
         "warnOnUnsupportedTypeScriptVersion": false,
         "sourceType": "unambiguous"
     },
-    "plugins": ["eslint-plugin-empty-returns"],
     "rules": {
         "array-callback-return": "error",
         "arrow-body-style": "error",
         "block-scoped-var": "error",
+        "consistent-return": "error",
         "curly": "error",
         "dot-notation": "error",
-        "empty-returns/main": "error",
         "eqeqeq": "error",
         "guard-for-in": "error",
         "import/extensions": "error",
@@ -306,7 +305,6 @@
             },
             "rules": {
                 // Disable base rule to avoid conflict
-                "empty-returns/main": "off",
                 "no-unused-vars": "off",
                 "no-useless-constructor": "off",
 

--- a/docs/subsystems/logging.md
+++ b/docs/subsystems/logging.md
@@ -130,10 +130,9 @@ new feature hard to miss.
   this log from the browser console using `blueslip.get_log()`.
 
 Blueslip supports several error levels:
-* `blueslip.fatal`: For fatal errors that cannot be easily recovered
-  from.  We try to avoid using it, since it kills the current JS
-  thread, rather than returning execution to the caller.  Unhandled
-  exceptions in our JS code are treated like `blueslip.fatal`.
+* `throw new Error(…)`: For fatal errors that cannot be easily
+  recovered from.  We try to avoid using it, since it kills the
+  current JS thread, rather than returning execution to the caller.
 * `blueslip.error`: For logging of events that are definitely caused
   by a bug and thus sufficiently important to be reported, but where
   we can handle the error without creating major user-facing problems

--- a/frontend_tests/node_tests/activity.js
+++ b/frontend_tests/node_tests/activity.js
@@ -766,5 +766,5 @@ run_test("test_send_or_receive_no_presence_for_web_public_guest", () => {
     set_global("page_params", {
         is_web_public_guest: true,
     });
-    assert.equal(activity.send_presence_to_server(), false);
+    activity.send_presence_to_server();
 });

--- a/frontend_tests/node_tests/compose.js
+++ b/frontend_tests/node_tests/compose.js
@@ -1239,6 +1239,7 @@ run_test("warn_if_mentioning_unsubscribed_user", () => {
         if (field === "stream-id") {
             return "111";
         }
+        throw new Error(`Unknown field ${field}`);
     };
 
     const previous_users = $("#compose_invite_users .compose_invite_user");
@@ -1344,6 +1345,7 @@ run_test("on_events", () => {
             if (field === "stream-id") {
                 return "102";
             }
+            throw new Error(`Unknown field ${field}`);
         };
         helper.target.prop("disabled", false);
 

--- a/frontend_tests/node_tests/compose_actions.js
+++ b/frontend_tests/node_tests/compose_actions.js
@@ -49,6 +49,7 @@ compose_state.private_message_recipient = (function () {
         }
 
         recipient = arg;
+        return undefined;
     };
 })();
 

--- a/frontend_tests/node_tests/compose_fade.js
+++ b/frontend_tests/node_tests/compose_fade.js
@@ -52,6 +52,8 @@ run_test("set_focused_recipient", () => {
                         return "lunch";
                     },
                 };
+            default:
+                throw new Error(`Unknown selector ${selector}`);
         }
     };
 

--- a/frontend_tests/node_tests/compose_pm_pill.js
+++ b/frontend_tests/node_tests/compose_pm_pill.js
@@ -81,6 +81,7 @@ run_test("pills", () => {
         if (user_email === othello.email) {
             return othello;
         }
+        throw new Error(`Unknown user email ${user_email}`);
     };
 
     let get_by_user_id_called = false;
@@ -89,8 +90,10 @@ run_test("pills", () => {
         if (id === othello.user_id) {
             return othello;
         }
-        assert.equal(id, 3);
-        return hamlet;
+        if (id === hamlet.user_id) {
+            return hamlet;
+        }
+        throw new Error(`Unknown user ID ${id}`);
     };
 
     function test_create_item(handler) {

--- a/frontend_tests/node_tests/compose_ui.js
+++ b/frontend_tests/node_tests/compose_ui.js
@@ -38,7 +38,7 @@ function make_textbox(s) {
     widget.caret = function (arg) {
         if (typeof arg === "number") {
             widget.pos = arg;
-            return;
+            return this;
         }
 
         if (arg) {
@@ -48,7 +48,7 @@ function make_textbox(s) {
             const after = widget.s.slice(widget.pos);
             widget.s = before + arg + after;
             widget.pos += arg.length;
-            return;
+            return this;
         }
 
         return widget.pos;
@@ -57,9 +57,9 @@ function make_textbox(s) {
     widget.val = function (new_val) {
         if (new_val) {
             widget.s = new_val;
-        } else {
-            return widget.s;
+            return this;
         }
+        return widget.s;
     };
 
     widget.trigger = function (type) {
@@ -68,6 +68,7 @@ function make_textbox(s) {
         } else if (type === "blur") {
             widget.focused = false;
         }
+        return this;
     };
 
     return widget;
@@ -99,9 +100,9 @@ run_test("insert_syntax_and_focus", () => {
     $("#compose-textarea").caret = function (syntax) {
         if (syntax !== undefined) {
             $("#compose-textarea").val($("#compose-textarea").val() + syntax);
-        } else {
-            return 4;
+            return this;
         }
+        return 4;
     };
     compose_ui.insert_syntax_and_focus(":octopus:");
     assert.equal($("#compose-textarea").caret(), 4);

--- a/frontend_tests/node_tests/composebox_typeahead.js
+++ b/frontend_tests/node_tests/composebox_typeahead.js
@@ -320,6 +320,7 @@ run_test("content_typeahead_selected", () => {
         // .caret() used in setTimeout
         assert.equal(arg1, arg2);
         caret_called2 = true;
+        return this;
     };
     let autosize_called = false;
     set_global("compose_ui", {

--- a/frontend_tests/node_tests/hotkey.js
+++ b/frontend_tests/node_tests/hotkey.js
@@ -181,6 +181,7 @@ run_test("basic_chars", () => {
             // provide a useful error message.
             // add a newline to separate from other console output.
             console.log('\nERROR: Mapping for character "' + e.which + '" does not match tests.');
+            throw err;
         }
     }
 
@@ -390,6 +391,7 @@ run_test("motion_keys", () => {
             // provide a useful error message.
             // add a newline to separate from other console output.
             console.log('\nERROR: Mapping for character "' + e.which + '" does not match tests.');
+            throw err;
         }
     }
 

--- a/frontend_tests/node_tests/list_render.js
+++ b/frontend_tests/node_tests/list_render.js
@@ -671,7 +671,7 @@ run_test("render item", () => {
         const regex = new RegExp(`\\<tr data-item=${item}\\>.*?<\\/tr\\>`);
         assert(expected_queries.includes(query));
         if (query.includes(`data-item='${INITIAL_RENDER_COUNT}'`)) {
-            return; // This item is not rendered, so we find nothing
+            return undefined; // This item is not rendered, so we find nothing
         }
         return {
             // Return a JQuery stub for the original HTML.

--- a/frontend_tests/node_tests/password.js
+++ b/frontend_tests/node_tests/password.js
@@ -38,6 +38,7 @@ run_test("basics", () => {
             } else if (field === "minGuesses") {
                 return min_guesses;
             }
+            throw new Error(`Unknown field ${field}`);
         };
 
         return self;

--- a/frontend_tests/node_tests/poll_widget.js
+++ b/frontend_tests/node_tests/poll_widget.js
@@ -143,6 +143,7 @@ run_test("activate another person poll", () => {
         if (template_name === "widgets/poll_widget_results") {
             return "widgets/poll_widget_results";
         }
+        throw new Error(`Unknown template ${template_name}`);
     });
 
     const widget_elem = $("<div>").addClass("widget-content");
@@ -291,6 +292,7 @@ run_test("activate own poll", () => {
         if (template_name === "widgets/poll_widget_results") {
             return "widgets/poll_widget_results";
         }
+        throw new Error(`Unknown template ${template_name}`);
     });
 
     const widget_elem = $("<div>").addClass("widget-content");

--- a/frontend_tests/node_tests/recent_topics.js
+++ b/frontend_tests/node_tests/recent_topics.js
@@ -124,7 +124,7 @@ set_global("stream_data", {
     get_sub_by_id: (stream) => {
         if (stream === stream5) {
             // No data is available for deactivated streams
-            return;
+            return undefined;
         }
 
         return {

--- a/frontend_tests/node_tests/scroll_util.js
+++ b/frontend_tests/node_tests/scroll_util.js
@@ -92,6 +92,7 @@ run_test("scroll_element_into_container", () => {
                     return top;
                 }
                 top = arg;
+                return this;
             },
         };
     })();

--- a/frontend_tests/node_tests/search.js
+++ b/frontend_tests/node_tests/search.js
@@ -90,7 +90,7 @@ run_test("initialize", () => {
         assert.equal(opts.naturalSearch, true);
         assert.equal(opts.helpOnEmptyStrings, true);
         assert.equal(opts.matcher(), true);
-        assert.equal(opts.on_move(), true);
+        opts.on_move();
 
         {
             const search_suggestions = {
@@ -214,19 +214,26 @@ run_test("initialize", () => {
     assert(search.is_using_input_method);
 
     const keydown = searchbox_form.get_on_handler("keydown");
+    let default_prevented = false;
     let ev = {
         type: "keydown",
         which: 15,
+        preventDefault() {
+            default_prevented = true;
+        },
     };
     search_query_box.is = return_false;
     assert.equal(keydown(ev), undefined);
+    assert(!default_prevented);
 
     ev.which = 13;
     assert.equal(keydown(ev), undefined);
+    assert(!default_prevented);
 
     ev.which = 13;
     search_query_box.is = return_true;
-    assert.equal(keydown(ev), false);
+    assert.equal(keydown(ev), undefined);
+    assert(default_prevented);
 
     let operators;
     let is_blurred;

--- a/frontend_tests/node_tests/search_legacy.js
+++ b/frontend_tests/node_tests/search_legacy.js
@@ -172,19 +172,26 @@ run_test("initialize", () => {
     assert(search.is_using_input_method);
 
     const keydown = searchbox_form.get_on_handler("keydown");
+    let default_prevented = false;
     let ev = {
         type: "keydown",
         which: 15,
+        preventDefault() {
+            default_prevented = true;
+        },
     };
     search_query_box.is = return_false;
     assert.equal(keydown(ev), undefined);
+    assert(!default_prevented);
 
     ev.which = 13;
     assert.equal(keydown(ev), undefined);
+    assert(!default_prevented);
 
     ev.which = 13;
     search_query_box.is = return_true;
-    assert.equal(keydown(ev), false);
+    assert.equal(keydown(ev), undefined);
+    assert(default_prevented);
 
     ev = {
         type: "keyup",

--- a/frontend_tests/node_tests/search_suggestion.js
+++ b/frontend_tests/node_tests/search_suggestion.js
@@ -693,6 +693,8 @@ run_test("topic_suggestions", () => {
                 return office_id;
             case "devel":
                 return devel_id;
+            default:
+                return undefined;
         }
     };
 

--- a/frontend_tests/node_tests/search_suggestion_legacy.js
+++ b/frontend_tests/node_tests/search_suggestion_legacy.js
@@ -660,6 +660,8 @@ run_test("topic_suggestions", () => {
                 return office_id;
             case "devel":
                 return devel_id;
+            default:
+                return undefined;
         }
     };
 

--- a/frontend_tests/node_tests/settings_muting.js
+++ b/frontend_tests/node_tests/settings_muting.js
@@ -63,6 +63,7 @@ run_test("settings", () => {
             data_called += 1;
             return "js";
         }
+        throw new Error(`Unknown attribute ${opts}`);
     };
 
     let unmute_called = false;

--- a/frontend_tests/node_tests/settings_org.js
+++ b/frontend_tests/node_tests/settings_org.js
@@ -42,6 +42,7 @@ global.stub_templates((name, data) => {
         assert(data.realm_domain.domain);
         return "stub-domains-list";
     }
+    throw new Error(`Unknown template ${name}`);
 });
 
 const _overlays = {};

--- a/frontend_tests/node_tests/settings_user_groups.js
+++ b/frontend_tests/node_tests/settings_user_groups.js
@@ -153,6 +153,7 @@ run_test("populate_user_groups", () => {
         assert.equal(user_id, 4);
         blueslip.expect("warn", "Undefined user in function append_user");
         get_by_user_id_called = true;
+        return undefined;
     };
 
     settings_user_groups.can_edit = function () {
@@ -301,7 +302,7 @@ run_test("populate_user_groups", () => {
         if (user_email === bob.email) {
             return bob;
         }
-        assert.equal(user_email, "Expected user email to be of Alice or Iago here.");
+        throw new Error("Expected user email to be of Alice or Iago here.");
     };
     pills.onPillCreate = function (handler) {
         assert.equal(typeof handler, "function");
@@ -402,6 +403,7 @@ run_test("with_external_user", () => {
             user_group_find_called += 1;
             return description_field_stub;
         }
+        throw new Error(`Unknown element ${elem}`);
     };
 
     const pill_container_stub = $('.pill-container[data-group-pills="1"]');
@@ -416,6 +418,7 @@ run_test("with_external_user", () => {
             pill_container_find_called += 1;
             return pill_stub;
         }
+        throw new Error(`Unknown element ${elem}`);
     };
 
     input_stub.css = function (property, val) {

--- a/frontend_tests/node_tests/subs.js
+++ b/frontend_tests/node_tests/subs.js
@@ -31,6 +31,7 @@ run_test("filter_table", () => {
             return 10;
         }
         assert.equal(set, 10);
+        return this;
     };
 
     // set-up sub rows stubs

--- a/frontend_tests/node_tests/topic_generator.js
+++ b/frontend_tests/node_tests/topic_generator.js
@@ -305,7 +305,7 @@ run_test("get_next_unread_pm_string", () => {
 
     unread.num_unread_for_person = function (user_ids_string) {
         if (user_ids_string === "unk") {
-            return;
+            return undefined;
         }
 
         if (user_ids_string === "read") {

--- a/frontend_tests/node_tests/unread.js
+++ b/frontend_tests/node_tests/unread.js
@@ -259,6 +259,7 @@ run_test("num_unread_for_topic", () => {
         if (arg === stream_id) {
             return {name: "Some Stream"};
         }
+        throw new Error(`Unknown stream ${arg}`);
     };
 
     let count = unread.num_unread_for_topic(stream_id, "lunch");

--- a/frontend_tests/puppeteer_tests/05-stars.js
+++ b/frontend_tests/puppeteer_tests/05-stars.js
@@ -11,21 +11,19 @@ async function stars_count(page) {
 }
 
 async function toggle_test_star_message(page) {
-    const error = await page.evaluate((message) => {
+    await page.evaluate((message) => {
         const msg = $(`.message_content:contains(${message}):visible`).last();
         if (msg.length !== 1) {
-            return "cannot find test star message";
+            throw new Error("cannot find test star message");
         }
 
         const star_icon = msg.closest(".messagebox").find(".star");
         if (star_icon.length !== 1) {
-            return "cannot find star icon";
+            throw new Error("cannot find star icon");
         }
 
         star_icon.trigger("click");
     }, message);
-
-    assert(!error, "\n\nERROR:" + error);
 }
 
 async function test_narrow_to_starred_messages(page) {

--- a/frontend_tests/zjsunit/zjquery.js
+++ b/frontend_tests/zjsunit/zjquery.js
@@ -170,11 +170,7 @@ exports.make_new_elem = function (selector, opts) {
         },
         data(name, val) {
             if (val === undefined) {
-                const data_val = attrs.get("data-" + name);
-                if (data_val === undefined) {
-                    return;
-                }
-                return data_val;
+                return attrs.get("data-" + name);
             }
             attrs.set("data-" + name, val);
             return self;
@@ -417,17 +413,10 @@ exports.make_zjquery = function (opts) {
 
                 const val = target[key];
 
-                if (val === undefined) {
+                if (val === undefined && typeof key !== "symbol" && key !== "inspect") {
                     // For undefined values, we'll throw errors to devs saying
                     // they need to create stubs.  We ignore certain keys that
                     // are used for simply printing out the object.
-                    if (typeof key === "symbol") {
-                        return;
-                    }
-                    if (key === "inspect") {
-                        return;
-                    }
-
                     throw Error('You must create a stub for $("' + selector + '").' + key);
                 }
 
@@ -447,7 +436,7 @@ exports.make_zjquery = function (opts) {
             // page load time.  But there are no pages to load,
             // so we just call it right away.
             arg();
-            return;
+            return undefined;
         }
 
         // If somebody is passing us an element, we return

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "eslint": "^7.2.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-import-resolver-webpack": "^0.12.2",
-    "eslint-plugin-empty-returns": "^1.0.2",
     "eslint-plugin-import": "^2.22.0",
     "js-yaml": "^3.13.1",
     "jsdom": "^16.1.0",

--- a/static/js/activity.js
+++ b/static/js/activity.js
@@ -102,7 +102,7 @@ exports.searching = function () {
 
 exports.build_user_sidebar = function () {
     if (page_params.realm_presence_disabled) {
-        return;
+        return undefined;
     }
 
     const filter_text = exports.get_filter_text();
@@ -174,7 +174,7 @@ exports.send_presence_to_server = function (want_redraw) {
     // reload if the device was offline for more than
     // DEFAULT_EVENT_QUEUE_TIMEOUT_SECS).
     if (page_params.is_web_public_guest) {
-        return false;
+        return;
     }
 
     server_events.check_for_unsuspend();

--- a/static/js/avatar.js
+++ b/static/js/avatar.js
@@ -78,6 +78,8 @@ exports.build_user_avatar_widget = function (upload_function) {
             page_params.max_avatar_file_size_mib,
         );
     }
+
+    return undefined;
 };
 
 window.avatar = exports;

--- a/static/js/blueslip.js
+++ b/static/js/blueslip.js
@@ -246,11 +246,9 @@ exports.error = function blueslip_error(msg, more_info, stack) {
     if (page_params.debug_mode) {
         throw new BlueslipError(msg, more_info);
     }
-};
 
-exports.fatal = function blueslip_fatal(msg, more_info) {
-    report_error(msg, Error().stack, {more_info});
-    throw new BlueslipError(msg, more_info);
+    // This function returns to its caller in production!  To raise a
+    // fatal error even in production, use throw new Error(…) instead.
 };
 
 exports.timings = new Map();

--- a/static/js/buddy_data.js
+++ b/static/js/buddy_data.js
@@ -142,7 +142,7 @@ function get_num_unread(user_id) {
 
 exports.my_user_status = function (user_id) {
     if (!people.is_my_user_id(user_id)) {
-        return;
+        return undefined;
     }
 
     if (user_status.is_away(user_id)) {
@@ -348,7 +348,7 @@ exports.huddle_fraction_present = function (huddle) {
     } else if (num_present !== 0) {
         return 0.5;
     }
-    return;
+    return undefined;
 };
 
 window.buddy_data = exports;

--- a/static/js/buddy_list.js
+++ b/static/js/buddy_list.js
@@ -109,7 +109,7 @@ class BuddyList extends BuddyListConf {
         const i = this.keys.indexOf(key);
 
         if (i <= 0) {
-            return;
+            return undefined;
         }
 
         return this.keys[i - 1];
@@ -119,7 +119,7 @@ class BuddyList extends BuddyListConf {
         const i = this.keys.indexOf(key);
 
         if (i < 0) {
-            return;
+            return undefined;
         }
 
         return this.keys[i + 1];

--- a/static/js/channel.js
+++ b/static/js/channel.js
@@ -24,7 +24,7 @@ function call(args, idempotent) {
         // If we're in the process of reloading, most HTTP requests
         // are useless, with exceptions like cleaning up our event
         // queue and blueslip (Which doesn't use channel.js).
-        return;
+        return undefined;
     }
 
     // Wrap the error handlers to reload the page if we get a CSRF error
@@ -63,7 +63,7 @@ function call(args, idempotent) {
                 );
             }
         }
-        return orig_error(xhr, error_type, xhn);
+        orig_error(xhr, error_type, xhn);
     };
     let orig_success = args.success;
     if (orig_success === undefined) {
@@ -90,7 +90,7 @@ function call(args, idempotent) {
             }, 0);
             return;
         }
-        return orig_success(data, textStatus, jqXHR);
+        orig_success(data, textStatus, jqXHR);
     };
 
     const jqXHR = $.ajax(args);

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -24,7 +24,7 @@ exports.autofocus = function (selector) {
 exports.password_quality = function (password, bar, password_field) {
     // We load zxcvbn.js asynchronously, so the variable might not be set.
     if (typeof zxcvbn === "undefined") {
-        return;
+        return undefined;
     }
 
     const min_length = password_field.data("minLength");
@@ -55,7 +55,7 @@ exports.password_quality = function (password, bar, password_field) {
 
 exports.password_warning = function (password, password_field) {
     if (typeof zxcvbn === "undefined") {
-        return;
+        return undefined;
     }
 
     const min_length = password_field.data("minLength");

--- a/static/js/components.js
+++ b/static/js/components.js
@@ -82,6 +82,7 @@ exports.toggle = function (opts) {
             }
             i += 1;
         }
+        return false;
     }
 
     function maybe_go_right() {
@@ -93,6 +94,7 @@ exports.toggle = function (opts) {
             }
             i += 1;
         }
+        return false;
     }
 
     (function () {
@@ -138,6 +140,8 @@ exports.toggle = function (opts) {
             if (meta.idx >= 0) {
                 return opts.values[meta.idx].label;
             }
+            /* istanbul ignore next */
+            return undefined;
         },
 
         get() {

--- a/static/js/compose.js
+++ b/static/js/compose.js
@@ -403,7 +403,7 @@ exports.finish = function () {
     if (zcommand.process(message_content)) {
         exports.do_post_send_tasks();
         clear_compose_box();
-        return;
+        return undefined;
     }
 
     if (!exports.validate()) {

--- a/static/js/compose_state.js
+++ b/static/js/compose_state.js
@@ -47,9 +47,9 @@ exports.message_content = get_or_set("compose-textarea", true);
 exports.private_message_recipient = function (value) {
     if (typeof value === "string") {
         compose_pm_pill.set_from_emails(value);
-    } else {
-        return compose_pm_pill.get_emails();
+        return undefined;
     }
+    return compose_pm_pill.get_emails();
 };
 
 exports.has_message_content = function () {

--- a/static/js/composebox_typeahead.js
+++ b/static/js/composebox_typeahead.js
@@ -732,6 +732,7 @@ exports.content_highlighter = function (item) {
     } else if (this.completing === "time_jump") {
         return typeahead_helper.render_typeahead_item({primary: item});
     }
+    return undefined;
 };
 
 const show_flatpickr = (element, callback, default_timestamp) => {
@@ -916,6 +917,8 @@ exports.compose_content_matcher = function (completing, token) {
             case "time_jump":
                 // these don't actually have a typeahead popover, so we return quickly here.
                 return true;
+            default:
+                return undefined;
         }
     };
 };
@@ -936,6 +939,8 @@ exports.sort_results = function (completing, matches, token) {
             return matches;
         case "topic_list":
             return typeahead_helper.sorter(token, matches, (x) => x);
+        default:
+            return undefined;
     }
 };
 

--- a/static/js/copy_and_paste.js
+++ b/static/js/copy_and_paste.js
@@ -11,7 +11,7 @@ function find_boundary_tr(initial_tr, iterate_row) {
     // parent tr, we should let the browser handle the copy-paste
     // entirely on its own
     if (tr.length === 0) {
-        return;
+        return undefined;
     }
 
     // If the selection boundary is on a table row that does not have an
@@ -24,7 +24,7 @@ function find_boundary_tr(initial_tr, iterate_row) {
         tr = iterate_row(tr);
     }
     if (j === 10) {
-        return;
+        return undefined;
     } else if (j !== 0) {
         // If we updated tr, then we are not dealing with a selection
         // that is entirely within one td, and we can skip the same td

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -80,7 +80,7 @@ exports.snapshot_message = function () {
     if (!compose_state.composing() || compose_state.message_content().length <= 2) {
         // If you aren't in the middle of composing the body of a
         // message or the message is shorter than 2 characters long, don't try to snapshot.
-        return;
+        return undefined;
     }
 
     // Save what we can.
@@ -286,7 +286,7 @@ exports.format_draft = function (draft) {
             },
             error.stack,
         );
-        return;
+        return undefined;
     }
 
     return formatted;

--- a/static/js/echo.js
+++ b/static/js/echo.js
@@ -149,15 +149,15 @@ exports.is_slash_command = function (content) {
 
 exports.try_deliver_locally = function (message_request) {
     if (markdown.contains_backend_only_syntax(message_request.content)) {
-        return;
+        return undefined;
     }
 
     if (narrow_state.active() && !narrow_state.filter().can_apply_locally(true)) {
-        return;
+        return undefined;
     }
 
     if (exports.is_slash_command(message_request.content)) {
-        return;
+        return undefined;
     }
 
     if (!current_msg_list.data.fetch_status.has_found_newest()) {
@@ -170,14 +170,14 @@ exports.try_deliver_locally = function (message_request) {
         // message we just sent placed appropriately when we get it
         // from either server_events or message_fetch.
         blueslip.info("Skipping local echo until newest messages get loaded.");
-        return;
+        return undefined;
     }
 
     const local_id_float = local_message.get_next_id_float();
 
     if (!local_id_float) {
         // This can happen for legit reasons.
-        return;
+        return undefined;
     }
 
     const message = exports.insert_local_message(message_request, local_id_float);

--- a/static/js/emoji_picker.js
+++ b/static/js/emoji_picker.js
@@ -57,6 +57,7 @@ function get_max_index(section) {
     } else if (section >= 0 && section < get_total_sections()) {
         return exports.complete_emoji_catalog[section].emojis.length;
     }
+    return undefined;
 }
 
 function get_emoji_id(section, index) {
@@ -197,6 +198,7 @@ function get_rendered_emoji(section, index) {
     if (emoji.length > 0) {
         return emoji;
     }
+    return undefined;
 }
 
 function filter_emojis() {

--- a/static/js/filter.js
+++ b/static/js/filter.js
@@ -584,6 +584,8 @@ class Filter {
                 return "at";
             case "pm-with":
                 return "envelope";
+            default:
+                return undefined;
         }
     }
 
@@ -634,6 +636,8 @@ class Filter {
                 }
             }
         }
+        /* istanbul ignore next */
+        return undefined;
     }
 
     allow_use_first_unread_when_narrowing() {

--- a/static/js/floating_recipient_bar.js
+++ b/static/js/floating_recipient_bar.js
@@ -81,19 +81,19 @@ exports.get_date = function (elem) {
     const message_row = exports.first_visible_message(elem);
 
     if (!message_row || !message_row.length) {
-        return;
+        return undefined;
     }
 
     const msg_id = rows.id(message_row);
 
     if (msg_id === undefined) {
-        return;
+        return undefined;
     }
 
     const message = message_store.get(msg_id);
 
     if (!message) {
-        return;
+        return undefined;
     }
 
     const time = new XDate(message.timestamp * 1000);
@@ -236,12 +236,12 @@ exports.candidate_recipient_bar = function () {
     const selected_row = current_msg_list.selected_row();
 
     if (selected_row === undefined || selected_row.length === 0) {
-        return;
+        return undefined;
     }
 
     let candidate = rows.get_message_recipient_row(selected_row);
     if (candidate === undefined) {
-        return;
+        return undefined;
     }
 
     while (candidate.length) {
@@ -253,6 +253,8 @@ exports.candidate_recipient_bar = function () {
         // row, rather than finding the first recipient_row.
         candidate = candidate.prev();
     }
+
+    return undefined;
 };
 
 function show_floating_recipient_bar() {

--- a/static/js/hash_util.js
+++ b/static/js/hash_util.js
@@ -192,7 +192,7 @@ exports.parse_narrow = function (hash) {
         const raw_operand = hash[i + 1];
 
         if (!raw_operand) {
-            return;
+            return undefined;
         }
 
         let negated = false;

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -248,12 +248,12 @@ function hashchanged(from_reload, e) {
 
     if (state.is_internal_change) {
         state.is_internal_change = false;
-        return;
+        return undefined;
     }
 
     if (is_overlay_hash(window.location.hash)) {
         do_hashchange_overlay(old_hash);
-        return;
+        return undefined;
     }
 
     // We are changing to a "main screen" view.

--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -117,7 +117,7 @@ const keypress_mappings = {
 
 exports.get_keydown_hotkey = function (e) {
     if (e.altKey) {
-        return;
+        return undefined;
     }
 
     let hotkey;
@@ -135,9 +135,9 @@ exports.get_keydown_hotkey = function (e) {
         if (hotkey) {
             return hotkey;
         }
-        return;
+        return undefined;
     } else if (e.metaKey || e.ctrlKey) {
-        return;
+        return undefined;
     }
 
     if (e.shiftKey) {
@@ -159,7 +159,7 @@ exports.get_keydown_hotkey = function (e) {
 
 exports.get_keypress_hotkey = function (e) {
     if (e.metaKey || e.ctrlKey || e.altKey) {
-        return;
+        return undefined;
     }
 
     return keypress_mappings[e.which];

--- a/static/js/input_pill.js
+++ b/static/js/input_pill.js
@@ -20,17 +20,17 @@ exports.create = function (opts) {
 
     if (!opts.container) {
         blueslip.error("Pill needs container.");
-        return;
+        return undefined;
     }
 
     if (!opts.create_item_from_text) {
         blueslip.error("Pill needs create_item_from_text");
-        return;
+        return undefined;
     }
 
     if (!opts.get_text_from_item) {
         blueslip.error("Pill needs get_text_from_item");
-        return;
+        return undefined;
     }
 
     // a stateful object of this `pill_container` instance.
@@ -75,7 +75,7 @@ exports.create = function (opts) {
 
             if (!item || !item.display_value) {
                 store.$input.addClass("shake");
-                return;
+                return undefined;
             }
 
             return item;
@@ -123,7 +123,7 @@ exports.create = function (opts) {
         // input block.
         appendPill(value) {
             if (value.length === 0) {
-                return;
+                return true;
             }
             if (value.match(",")) {
                 funcs.insertManyPills(value);
@@ -138,6 +138,7 @@ exports.create = function (opts) {
             }
 
             this.appendValidatedData(payload);
+            return true;
         },
 
         // this searches given a particlar pill ID for it, removes the node
@@ -161,6 +162,9 @@ exports.create = function (opts) {
 
                 return pill;
             }
+
+            /* istanbul ignore next */
+            return undefined;
         },
 
         // this will remove the last pill in the container -- by default tied
@@ -210,12 +214,10 @@ exports.create = function (opts) {
             // the end.
             ui_util.place_caret_at_end(store.$input[0]);
 
-            // this sends a flag that the operation wasn't completely successful,
+            // this sends a flag if the operation wasn't completely successful,
             // which in this case is defined as some of the pills not autofilling
             // correctly.
-            if (drafts.length > 0) {
-                return false;
-            }
+            return drafts.length === 0;
         },
 
         getByID(id) {

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -196,7 +196,7 @@ exports.parse_image_data = function (image) {
 
     if (asset_map.has($preview_src)) {
         // check if image's data is already present in asset_map.
-        return;
+        return asset_map.get($preview_src);
     }
 
     // if wrapped in the .youtube-video class, it will be length = 1, and therefore

--- a/static/js/list_cursor.js
+++ b/static/js/list_cursor.js
@@ -43,7 +43,7 @@ class ListCursor {
         //       It would also give the caller more flexibility on
         //       the actual styling.
         if (key === undefined) {
-            return;
+            return undefined;
         }
 
         const li = this.list.find_li({
@@ -52,7 +52,7 @@ class ListCursor {
         });
 
         if (!li || li.length === 0) {
-            return;
+            return undefined;
         }
 
         return {

--- a/static/js/list_render.js
+++ b/static/js/list_render.js
@@ -121,11 +121,11 @@ exports.valid_filter_opts = (opts) => {
 exports.create = function ($container, list, opts) {
     if (!opts) {
         blueslip.error("Need opts to create widget.");
-        return;
+        return undefined;
     }
 
     if (!exports.validate_opts(opts)) {
-        return;
+        return undefined;
     }
 
     if (opts.name && DEFAULTS.instances.get(opts.name)) {
@@ -149,12 +149,12 @@ exports.create = function ($container, list, opts) {
     };
 
     if (!exports.valid_filter_opts(opts)) {
-        return;
+        return undefined;
     }
 
     if (opts.get_item && typeof opts.get_item !== "function") {
         blueslip.error("get_item should be a function");
-        return;
+        return undefined;
     }
 
     const widget = {};

--- a/static/js/local_message.js
+++ b/static/js/local_message.js
@@ -35,19 +35,19 @@ exports.get_next_id_float = (function () {
             // If our id is already used, it is probably an edge case like we had
             // to abort a very recent message.
             blueslip.warn("We don't reuse ids for local echo.");
-            return;
+            return undefined;
         }
 
         if (local_id_float % 1 > local_id_increment * 5) {
             blueslip.warn("Turning off local echo for this message to let host catch up");
-            return;
+            return undefined;
         }
 
         if (local_id_float % 1 === 0) {
             // The logic to stop at 0.05 should prevent us from ever wrapping around
             // to the next integer.
             blueslip.error("Programming error");
-            return;
+            return undefined;
         }
 
         already_used.add(local_id_float);

--- a/static/js/localstorage.js
+++ b/static/js/localstorage.js
@@ -6,7 +6,7 @@ const ls = {
         try {
             return JSON.parse(str);
         } catch (err) {
-            return;
+            return undefined;
         }
     },
 
@@ -44,6 +44,8 @@ const ls = {
                 }
             }
         }
+
+        return undefined;
     },
 
     // set the wrapped version of the data into localStorage.
@@ -83,6 +85,8 @@ const ls = {
 
             return data;
         }
+
+        return undefined;
     },
 };
 
@@ -111,6 +115,8 @@ const localstorage = function () {
             if (data) {
                 return data.data;
             }
+
+            return undefined;
         },
 
         set(name, data) {

--- a/static/js/markdown.js
+++ b/static/js/markdown.js
@@ -146,7 +146,7 @@ exports.apply_markdown = function (message) {
                 // This is nothing to be concerned about--the users
                 // are allowed to hand-type mentions and they may
                 // have had a typo in the name.
-                return;
+                return undefined;
             }
 
             // HAPPY PATH! Note that we not only need to return the
@@ -185,7 +185,7 @@ exports.apply_markdown = function (message) {
                     "</span>"
                 );
             }
-            return;
+            return undefined;
         },
         silencedMentionHandler(quote) {
             // Silence quoted mentions.
@@ -347,7 +347,7 @@ function handleTimestamp(time) {
 function handleStream(stream_name) {
     const stream = helpers.get_stream_by_name(stream_name);
     if (stream === undefined) {
-        return;
+        return undefined;
     }
     const href = helpers.stream_hash(stream.stream_id);
     return (
@@ -367,7 +367,7 @@ function handleStream(stream_name) {
 function handleStreamTopic(stream_name, topic) {
     const stream = helpers.get_stream_by_name(stream_name);
     if (stream === undefined || !topic) {
-        return;
+        return undefined;
     }
     const href = helpers.stream_topic_hash(stream.stream_id, topic);
     const text = "#" + _.escape(stream.name) + " > " + _.escape(topic);
@@ -407,6 +407,7 @@ function handleTex(tex, fullmatch) {
             return '<span class="tex-error">' + _.escape(fullmatch) + "</span>";
         }
         blueslip.error(ex);
+        return undefined;
     }
 }
 

--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -275,8 +275,7 @@ exports.get_backfill_anchor = function (msg_list) {
 
     // msg_list is empty, which is an impossible
     // case, raise a fatal error.
-    blueslip.fatal("There are no message available to backfill.");
-    return;
+    throw new Error("There are no message available to backfill.");
 };
 
 exports.get_frontfill_anchor = function (msg_list) {
@@ -295,8 +294,7 @@ exports.get_frontfill_anchor = function (msg_list) {
     // and user cannot be scrolling down on an empty message_list to
     // fetch more data, and if user is, then the available data is wrong
     // and we raise a fatal error.
-    blueslip.fatal("There are no message available to frontfill.");
-    return;
+    throw new Error("There are no message available to frontfill.");
 };
 
 exports.maybe_load_older_messages = function (opts) {

--- a/static/js/message_list.js
+++ b/static/js/message_list.js
@@ -152,7 +152,7 @@ class MessageList {
         const convert_id = (str_id) => {
             const id = parseFloat(str_id);
             if (isNaN(id)) {
-                blueslip.fatal("Bad message id " + str_id);
+                throw new Error("Bad message id " + str_id);
             }
             return id;
         };
@@ -184,7 +184,7 @@ class MessageList {
                 id,
                 items_length: this.data.num_items(),
             };
-            blueslip.fatal("Cannot select id -1", error_data);
+            throw new Error("Cannot select id -1", error_data);
         }
 
         id = closest_id;

--- a/static/js/message_list_data.js
+++ b/static/js/message_list_data.js
@@ -442,7 +442,7 @@ class MessageListData {
         messages.forEach((elem) => {
             const id = parseFloat(elem.id);
             if (isNaN(id)) {
-                blueslip.fatal("Bad message id");
+                throw new Error("Bad message id");
             }
             if (this._is_localonly_id(id)) {
                 this._local_only.add(id);

--- a/static/js/message_list_data.js
+++ b/static/js/message_list_data.js
@@ -46,13 +46,13 @@ class MessageListData {
 
     select_idx() {
         if (this._selected_id === -1) {
-            return;
+            return undefined;
         }
         const ids = this._items.map((message) => message.id);
 
         const i = ids.indexOf(this._selected_id);
         if (i === -1) {
-            return;
+            return undefined;
         }
         return i;
     }
@@ -61,11 +61,11 @@ class MessageListData {
         const i = this.select_idx();
 
         if (i === undefined) {
-            return;
+            return undefined;
         }
 
         if (i === 0) {
-            return;
+            return undefined;
         }
 
         return this._items[i - 1].id;
@@ -75,11 +75,11 @@ class MessageListData {
         const i = this.select_idx();
 
         if (i === undefined) {
-            return;
+            return undefined;
         }
 
         if (i + 1 >= this._items.length) {
-            return;
+            return undefined;
         }
 
         return this._items[i + 1].id;
@@ -121,7 +121,7 @@ class MessageListData {
     get(id) {
         id = parseFloat(id);
         if (isNaN(id)) {
-            return;
+            return undefined;
         }
         return this._hash.get(id);
     }
@@ -531,7 +531,7 @@ class MessageListData {
     get_last_message_sent_by_me() {
         const msg_index = _.findLastIndex(this._items, {sender_id: page_params.user_id});
         if (msg_index === -1) {
-            return;
+            return undefined;
         }
         const msg = this._items[msg_index];
         return msg;

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -190,6 +190,7 @@ class MessageListView {
                 timerender.stringify_time(last_edit_time)
             );
         }
+        return undefined;
     }
 
     _add_msg_edited_vars(message_container) {
@@ -571,7 +572,7 @@ class MessageListView {
         // and templates them to be inserted as table rows into the DOM.
 
         if (messages.length === 0 || this.table_name === undefined) {
-            return;
+            return undefined;
         }
 
         const list = this.list; // for convenience
@@ -616,7 +617,7 @@ class MessageListView {
         // and templates them to be inserted as table rows into the DOM.
 
         if (message_containers.length === 0 || this.table_name === undefined) {
-            return;
+            return undefined;
         }
 
         const new_message_groups = this.build_message_groups(message_containers, this.table_name);
@@ -821,6 +822,8 @@ class MessageListView {
                 };
             }
         }
+
+        return undefined;
     }
 
     _new_messages_height(rendered_elems) {

--- a/static/js/message_store.js
+++ b/static/js/message_store.js
@@ -28,7 +28,7 @@ exports.user_ids = function () {
 exports.get = function get(message_id) {
     if (message_id === undefined || message_id === null) {
         blueslip.error("message_store.get got bad value: " + message_id);
-        return;
+        return undefined;
     }
 
     if (typeof message_id !== "number") {

--- a/static/js/message_util.js
+++ b/static/js/message_util.js
@@ -8,7 +8,7 @@ exports.do_unread_count_updates = function do_unread_count_updates(messages) {
 
 function add_messages(messages, msg_list, opts) {
     if (!messages) {
-        return;
+        return undefined;
     }
 
     loading.destroy_indicator($("#page_loading_indicator"));
@@ -50,7 +50,7 @@ exports.add_new_messages = function (messages, msg_list) {
         // narrow. Otherwise the new message would be rendered just after
         // the previously fetched messages when that's inaccurate.
         msg_list.data.fetch_status.update_expected_max_message_id(messages);
-        return;
+        return undefined;
     }
     return add_messages(messages, msg_list, {messages_are_new: true});
 };

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -157,7 +157,8 @@ exports.activate = function (raw_operators, opts) {
     $(".tooltip").hide();
 
     if (raw_operators.length === 0) {
-        return exports.deactivate();
+        exports.deactivate();
+        return;
     }
     const filter = new Filter(raw_operators);
     const operators = filter.operators();

--- a/static/js/narrow_state.js
+++ b/static/js/narrow_state.js
@@ -36,7 +36,7 @@ exports.update_email = function (user_id, new_email) {
 /* Operators we should send to the server. */
 exports.public_operators = function () {
     if (current_filter === undefined) {
-        return;
+        return undefined;
     }
     return current_filter.public_operators();
 };
@@ -96,7 +96,7 @@ exports.set_compose_defaults = function () {
 
 exports.stream = function () {
     if (current_filter === undefined) {
-        return;
+        return undefined;
     }
     const stream_operands = current_filter.operands("stream");
     if (stream_operands.length === 1) {
@@ -106,16 +106,16 @@ exports.stream = function () {
         // name (considering renames and capitalization).
         return stream_data.get_name(name);
     }
-    return;
+    return undefined;
 };
 
 exports.stream_sub = function () {
     if (current_filter === undefined) {
-        return;
+        return undefined;
     }
     const stream_operands = current_filter.operands("stream");
     if (stream_operands.length !== 1) {
-        return;
+        return undefined;
     }
 
     const name = stream_operands[0];
@@ -128,7 +128,7 @@ exports.stream_id = function () {
     const sub = exports.stream_sub();
 
     if (!sub) {
-        return;
+        return undefined;
     }
 
     return sub.stream_id;
@@ -136,13 +136,13 @@ exports.stream_id = function () {
 
 exports.topic = function () {
     if (current_filter === undefined) {
-        return;
+        return undefined;
     }
     const operands = current_filter.operands("topic");
     if (operands.length === 1) {
         return operands[0];
     }
-    return;
+    return undefined;
 };
 
 exports.pm_string = function () {
@@ -150,18 +150,18 @@ exports.pm_string = function () {
     // with users 4, 5, and 99, this will return "4,5,99"
 
     if (current_filter === undefined) {
-        return;
+        return undefined;
     }
 
     const operands = current_filter.operands("pm-with");
     if (operands.length !== 1) {
-        return;
+        return undefined;
     }
 
     const emails_string = operands[0];
 
     if (!emails_string) {
-        return;
+        return undefined;
     }
 
     const user_ids_string = people.reply_to_to_user_ids_string(emails_string);
@@ -220,7 +220,7 @@ exports._possible_unread_message_ids = function () {
     // message ids but possibly a superset of unread message ids
     // that match our filter.
     if (current_filter === undefined) {
-        return;
+        return undefined;
     }
 
     let stream_id;
@@ -273,7 +273,7 @@ exports._possible_unread_message_ids = function () {
         return unread.get_all_msg_ids();
     }
 
-    return;
+    return undefined;
 };
 
 // Are we narrowed to PMs: all PMs or PMs with particular people.

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -567,7 +567,7 @@ exports.granted_desktop_notifications_permission = function () {
 
 exports.request_desktop_notifications_permission = function () {
     if (NotificationAPI) {
-        return NotificationAPI.requestPermission();
+        NotificationAPI.requestPermission();
     }
 };
 
@@ -629,7 +629,7 @@ exports.get_local_notify_mix_reason = function (message) {
     if (row.length > 0) {
         // If our message is in the current message list, we do
         // not have a mix, so we are happy.
-        return;
+        return undefined;
     }
 
     if (message.type === "stream" && muting.is_topic_muted(message.stream_id, message.topic)) {
@@ -651,6 +651,8 @@ exports.get_local_notify_mix_reason = function (message) {
     ) {
         return i18n.t("Sent! Your message is outside your current narrow.");
     }
+
+    return undefined;
 };
 
 exports.notify_local_mixes = function (messages, need_user_to_scroll) {

--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -63,7 +63,7 @@ exports.enable_background_mouse_events = function () {
 exports.active_modal = function () {
     if (!exports.is_modal_open()) {
         blueslip.error("Programming error — Called active_modal when there is no modal open");
-        return;
+        return undefined;
     }
     return "#" + $(".modal.in").attr("id");
 };

--- a/static/js/people.js
+++ b/static/js/people.js
@@ -52,7 +52,7 @@ function split_to_ints(lst) {
 export function get_by_user_id(user_id, ignore_missing) {
     if (!people_by_user_id_dict.has(user_id) && !ignore_missing) {
         blueslip.error("Unknown user_id in get_by_user_id: " + user_id);
-        return;
+        return undefined;
     }
     return people_by_user_id_dict.get(user_id);
 }
@@ -61,7 +61,7 @@ export function get_by_email(email) {
     const person = people_dict.get(email);
 
     if (!person) {
-        return;
+        return undefined;
     }
 
     if (person.email.toLowerCase() !== email.toLowerCase()) {
@@ -78,7 +78,7 @@ export function get_bot_owner_user(user) {
 
     if (owner_id === undefined || owner_id === null) {
         // This is probably a cross-realm bot.
-        return;
+        return undefined;
     }
 
     return get_by_user_id(owner_id);
@@ -119,12 +119,12 @@ export function get_user_id(email) {
     if (person === undefined) {
         const error_msg = "Unknown email for get_user_id: " + email;
         blueslip.error(error_msg);
-        return;
+        return undefined;
     }
     const user_id = person.user_id;
     if (!user_id) {
         blueslip.error("No user_id found for " + email);
-        return;
+        return undefined;
     }
 
     return user_id;
@@ -149,7 +149,7 @@ function sort_numerically(user_ids) {
 
 export function huddle_string(message) {
     if (message.type !== "private") {
-        return;
+        return undefined;
     }
 
     let user_ids = message.display_recipient.map((recip) => recip.id);
@@ -161,7 +161,7 @@ export function huddle_string(message) {
     user_ids = user_ids.filter(is_huddle_recip);
 
     if (user_ids.length <= 1) {
-        return;
+        return undefined;
     }
 
     user_ids = sort_numerically(user_ids);
@@ -179,7 +179,7 @@ export function user_ids_string_to_emails_string(user_ids_string) {
 
     if (!emails.every(Boolean)) {
         blueslip.warn("Unknown user ids: " + user_ids_string);
-        return;
+        return undefined;
     }
 
     emails = emails.map((email) => email.toLowerCase());
@@ -198,7 +198,7 @@ export function user_ids_string_to_ids_array(user_ids_string) {
 export function emails_strings_to_user_ids_array(emails_string) {
     const user_ids_string = emails_strings_to_user_ids_string(emails_string);
     if (user_ids_string === undefined) {
-        return;
+        return undefined;
     }
 
     const user_ids_array = user_ids_string_to_ids_array(user_ids_string);
@@ -217,7 +217,7 @@ export function reply_to_to_user_ids_string(emails_string) {
     });
 
     if (!user_ids.every(Boolean)) {
-        return;
+        return undefined;
     }
 
     user_ids = sort_numerically(user_ids);
@@ -230,6 +230,7 @@ export function get_user_time_preferences(user_id) {
     if (user_timezone) {
         return settings_data.get_time_preferences(user_timezone);
     }
+    return undefined;
 }
 
 export function get_user_time(user_id) {
@@ -237,6 +238,7 @@ export function get_user_time(user_id) {
     if (user_pref) {
         return moment().tz(user_pref.timezone).format(user_pref.format);
     }
+    return undefined;
 }
 
 export function get_user_type(user_id) {
@@ -267,7 +269,7 @@ export function email_list_to_user_ids_string(emails) {
 
     if (!user_ids.every(Boolean)) {
         blueslip.warn("Unknown emails: " + emails);
-        return;
+        return undefined;
     }
 
     user_ids = sort_numerically(user_ids);
@@ -309,7 +311,7 @@ export function pm_reply_user_string(message) {
     const user_ids = pm_with_user_ids(message);
 
     if (!user_ids) {
-        return;
+        return undefined;
     }
 
     return user_ids.join(",");
@@ -319,7 +321,7 @@ export function pm_reply_to(message) {
     const user_ids = pm_with_user_ids(message);
 
     if (!user_ids) {
-        return;
+        return undefined;
     }
 
     const emails = user_ids.map((user_id) => {
@@ -380,12 +382,12 @@ export function pm_lookup_key(user_ids_string) {
 
 export function all_user_ids_in_pm(message) {
     if (message.type !== "private") {
-        return;
+        return undefined;
     }
 
     if (message.display_recipient.length === 0) {
         blueslip.error("Empty recipient list in message");
-        return;
+        return undefined;
     }
 
     let user_ids = message.display_recipient.map((recip) => recip.id);
@@ -396,12 +398,12 @@ export function all_user_ids_in_pm(message) {
 
 export function pm_with_user_ids(message) {
     if (message.type !== "private") {
-        return;
+        return undefined;
     }
 
     if (message.display_recipient.length === 0) {
         blueslip.error("Empty recipient list in message");
-        return;
+        return undefined;
     }
 
     const user_ids = message.display_recipient.map((recip) => recip.id);
@@ -411,12 +413,12 @@ export function pm_with_user_ids(message) {
 
 export function group_pm_with_user_ids(message) {
     if (message.type !== "private") {
-        return;
+        return undefined;
     }
 
     if (message.display_recipient.length === 0) {
         blueslip.error("Empty recipient list in message");
-        return;
+        return undefined;
     }
 
     const user_ids = message.display_recipient.map((recip) => recip.id);
@@ -434,7 +436,7 @@ export function pm_perma_link(message) {
     const user_ids = all_user_ids_in_pm(message);
 
     if (!user_ids) {
-        return;
+        return undefined;
     }
 
     let suffix;
@@ -454,7 +456,7 @@ export function pm_with_url(message) {
     const user_ids = pm_with_user_ids(message);
 
     if (!user_ids) {
-        return;
+        return undefined;
     }
 
     let suffix;
@@ -515,7 +517,7 @@ export function pm_with_operand_ids(operand) {
     }
 
     if (!persons.every(Boolean)) {
-        return;
+        return undefined;
     }
 
     let user_ids = persons.map((person) => person.user_id);
@@ -529,7 +531,7 @@ export function emails_to_slug(emails_string) {
     let slug = reply_to_to_user_ids_string(emails_string);
 
     if (!slug) {
-        return;
+        return undefined;
     }
 
     slug += "-";
@@ -564,6 +566,8 @@ export function slug_to_emails(slug) {
         user_ids_string = exclude_me_from_string(user_ids_string);
         return user_ids_string_to_emails_string(user_ids_string);
     }
+    /* istanbul ignore next */
+    return undefined;
 }
 
 export function exclude_me_from_string(user_ids_string) {
@@ -798,7 +802,7 @@ export function get_non_active_realm_users() {
 export function is_cross_realm_email(email) {
     const person = get_by_email(email);
     if (!person) {
-        return;
+        return undefined;
     }
     return cross_realm_dict.has(person.user_id);
 }
@@ -960,7 +964,7 @@ export const get_actual_name_from_user_id = (user_id) => {
 
     if (!person) {
         blueslip.error("Unknown user_id: " + user_id);
-        return;
+        return undefined;
     }
 
     return person.full_name;
@@ -985,11 +989,11 @@ export function get_user_id_from_name(full_name) {
     const person = people_by_name_dict.get(full_name);
 
     if (!person) {
-        return;
+        return undefined;
     }
 
     if (is_duplicate_full_name(full_name)) {
-        return;
+        return undefined;
     }
 
     return person.user_id;
@@ -1275,7 +1279,7 @@ export function my_current_user_id() {
 export function my_custom_profile_data(field_id) {
     if (field_id === undefined) {
         blueslip.error("Undefined field id");
-        return;
+        return undefined;
     }
     return get_custom_profile_data(my_user_id, field_id);
 }

--- a/static/js/pm_list.js
+++ b/static/js/pm_list.js
@@ -44,13 +44,13 @@ exports.get_active_user_ids_string = function () {
     const filter = narrow_state.filter();
 
     if (!filter) {
-        return;
+        return undefined;
     }
 
     const emails = filter.operands("pm-with")[0];
 
     if (!emails) {
-        return;
+        return undefined;
     }
 
     return people.emails_strings_to_user_ids_string(emails);

--- a/static/js/poll_widget.js
+++ b/static/js/poll_widget.js
@@ -118,7 +118,7 @@ class PollData {
                 if (this.is_my_poll) {
                     return event;
                 }
-                return;
+                return undefined;
             },
 
             inbound: (sender_id, data) => {

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -117,6 +117,8 @@ function calculate_info_popover_placement(size, elt) {
             return "top";
         }
     }
+
+    return undefined;
 }
 
 function get_custom_profile_field_data(user, field, field_types, dateFormat) {
@@ -376,13 +378,13 @@ exports.show_user_info_popover = function (element, user) {
 function get_user_info_popover_for_message_items() {
     if (!current_message_info_popover_elem) {
         blueslip.error("Trying to get menu items when action popover is closed.");
-        return;
+        return undefined;
     }
 
     const popover_data = current_message_info_popover_elem.data("popover");
     if (!popover_data) {
         blueslip.error("Cannot find popover data for actions menu.");
-        return;
+        return undefined;
     }
 
     return $("li:not(.divider):visible a", popover_data.$tip);
@@ -392,12 +394,12 @@ function get_user_info_popover_items() {
     const popover_elt = $("div.user-info-popover");
     if (!current_user_info_popover_elem || !popover_elt.length) {
         blueslip.error("Trying to get menu items when action popover is closed.");
-        return;
+        return undefined;
     }
 
     if (popover_elt.length >= 2) {
         blueslip.error("More than one user info popovers cannot be opened at same time.");
-        return;
+        return undefined;
     }
 
     return $("li:not(.divider):visible a", popover_elt);
@@ -591,13 +593,13 @@ exports.render_actions_remind_popover = function (element, id) {
 function get_action_menu_menu_items() {
     if (!current_actions_popover_elem) {
         blueslip.error("Trying to get menu items when action popover is closed.");
-        return;
+        return undefined;
     }
 
     const popover_data = current_actions_popover_elem.data("popover");
     if (!popover_data) {
         blueslip.error("Cannot find popover data for actions menu.");
-        return;
+        return undefined;
     }
 
     return $("li:not(.divider):visible a", popover_data.$tip);
@@ -619,7 +621,8 @@ exports.popover_items_handle_keyboard = (key, items) => {
     let index = items.index(items.filter(":focus"));
 
     if (key === "enter" && index >= 0 && index < items.length) {
-        return items[index].click();
+        items[index].click();
+        return;
     }
     if (index === -1) {
         index = 0;
@@ -744,7 +747,7 @@ function focus_user_info_popover_item() {
 function get_user_sidebar_popover_items() {
     if (!current_user_sidebar_popover) {
         blueslip.error("Trying to get menu items when user sidebar popover is closed.");
-        return;
+        return undefined;
     }
 
     return $("li:not(.divider):visible > a", current_user_sidebar_popover.$tip);

--- a/static/js/portico/integrations.js
+++ b/static/js/portico/integrations.js
@@ -344,29 +344,29 @@ function integration_events() {
     });
 
     $(".integration-instruction-block").on("click", "a .integration-category", (e) => {
+        e.preventDefault();
         const category = $(e.target).data("category");
         dispatch("SHOW_CATEGORY", {category});
-        return false;
     });
 
     $(".integrations a .integration-category").on("click", (e) => {
+        e.preventDefault();
         const category = $(e.target).data("category");
         dispatch("CHANGE_CATEGORY", {category});
         toggle_categories_dropdown();
-        return false;
     });
 
     $(".integrations a .integration-lozenge").on("click", (e) => {
         if (!$(e.target).closest(".integration-lozenge").hasClass("integration-create-your-own")) {
+            e.preventDefault();
             const integration = $(e.target).closest(".integration-lozenge").data("name");
             dispatch("SHOW_INTEGRATION", {integration});
-            return false;
         }
     });
 
-    $("a#integration-list-link span, a#integration-list-link i").on("click", () => {
+    $("a#integration-list-link span, a#integration-list-link i").on("click", (e) => {
+        e.preventDefault();
         dispatch("HIDE_INTEGRATION");
-        return false;
     });
 
     // combine selector use for both focusing the integrations searchbar and adding

--- a/static/js/portico/integrations_dev_panel.js
+++ b/static/js/portico/integrations_dev_panel.js
@@ -86,7 +86,7 @@ function get_custom_http_headers() {
             custom_headers = JSON.stringify(JSON.parse(custom_headers));
         } catch (err) {
             set_results_notice("Custom HTTP headers are not in a valid JSON format.", "warning");
-            return;
+            return undefined;
         }
     }
     return custom_headers;

--- a/static/js/portico/team.js
+++ b/static/js/portico/team.js
@@ -44,6 +44,8 @@ function get_profile_url(contributor, tab_name) {
             return `https://github.com/zulip/${repo_name}/commits?author=${email}`;
         }
     }
+
+    return undefined;
 }
 
 function get_display_name(contributor) {

--- a/static/js/presence.js
+++ b/static/js/presence.js
@@ -246,7 +246,7 @@ exports.last_active_date = function (user_id) {
     const info = exports.presence_info.get(user_id);
 
     if (!info || !info.last_active) {
-        return;
+        return undefined;
     }
 
     const date = new XDate(info.last_active * 1000);

--- a/static/js/reactions.js
+++ b/static/js/reactions.js
@@ -34,7 +34,7 @@ function get_message(message_id) {
     const message = message_store.get(message_id);
     if (!message) {
         blueslip.error("reactions: Bad message id: " + message_id);
-        return;
+        return undefined;
     }
 
     exports.set_clean_reactions(message);

--- a/static/js/realm_icon.js
+++ b/static/js/realm_icon.js
@@ -6,7 +6,7 @@ exports.build_realm_icon_widget = function (upload_function) {
     };
 
     if (!page_params.is_admin) {
-        return;
+        return undefined;
     }
     if (page_params.realm_icon_source === "G") {
         $("#realm-icon-upload-widget .image-delete-button").hide();

--- a/static/js/realm_logo.js
+++ b/static/js/realm_logo.js
@@ -21,7 +21,7 @@ exports.build_realm_logo_widget = function (upload_function, is_night) {
     };
 
     if (!page_params.is_admin) {
-        return;
+        return undefined;
     }
 
     if (logo_source === "D") {

--- a/static/js/recent_topics.js
+++ b/static/js/recent_topics.js
@@ -393,7 +393,7 @@ function topic_sort(a, b) {
 
 exports.complete_rerender = function () {
     if (!overlays.recent_topics_open()) {
-        return false;
+        return;
     }
     // Prepare header
     const rendered_body = render_recent_topics_body({

--- a/static/js/rendered_markdown.js
+++ b/static/js/rendered_markdown.js
@@ -38,9 +38,8 @@ function get_user_id_for_mention_button(elem) {
         if (user) {
             return user.user_id;
         }
-        return;
     }
-    return;
+    return undefined;
 }
 
 function get_user_group_id_for_mention_button(elem) {
@@ -50,7 +49,7 @@ function get_user_group_id_for_mention_button(elem) {
         return parseInt(user_group_id, 10);
     }
 
-    return;
+    return undefined;
 }
 
 // Helper function to update a mentioned user's name.

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -119,7 +119,7 @@ exports.watch_manual_resize = function (element) {
 
         if (!box) {
             blueslip.error("Bad selector in watch_manual_resize: " + element);
-            return;
+            return undefined;
         }
 
         const meta = {

--- a/static/js/rows.js
+++ b/static/js/rows.js
@@ -74,7 +74,7 @@ exports.is_draft_row = function (row) {
 exports.id = function (message_row) {
     if (exports.is_draft_row(message_row)) {
         blueslip.error("Drafts have no zid");
-        return;
+        return undefined;
     }
 
     /*
@@ -103,7 +103,7 @@ exports.local_echo_id = function (message_row) {
 
     if (zid === undefined) {
         blueslip.error("Calling code passed rows.local_id a row with no zid attr.");
-        return;
+        return undefined;
     }
 
     if (!zid.includes(".0")) {

--- a/static/js/schema.js
+++ b/static/js/schema.js
@@ -13,6 +13,7 @@ exports.check_string = function (var_name, val) {
     if (typeof val !== "string") {
         return var_name + " is not a string";
     }
+    return undefined;
 };
 
 exports.check_record = function (var_name, val, fields) {
@@ -32,6 +33,8 @@ exports.check_record = function (var_name, val, fields) {
     if (msg) {
         return "in " + var_name + " " + msg;
     }
+
+    return undefined;
 };
 
 exports.check_array = function (var_name, val, checker) {
@@ -46,6 +49,8 @@ exports.check_array = function (var_name, val, checker) {
             return "in " + var_name + " we found an item where " + msg;
         }
     }
+
+    return undefined;
 };
 
 window.schema = exports;

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -105,7 +105,6 @@ exports.initialize = function () {
         on_move() {
             if (page_params.search_pills_enabled) {
                 ui_util.place_caret_at_end(search_query_box[0]);
-                return true;
             }
         },
         // Use our custom typeahead `on_escape` hook to exit
@@ -130,7 +129,7 @@ exports.initialize = function () {
                 // Don't submit the form so that the typeahead can instead
                 // handle our Enter keypress. Any searching that needs
                 // to be done will be handled in the keyup.
-                return false;
+                e.preventDefault();
             }
         })
         .on("keyup", (e) => {

--- a/static/js/server_events.js
+++ b/static/js/server_events.js
@@ -74,7 +74,7 @@ function get_events_success(events) {
                 break;
 
             default:
-                return server_events_dispatch.dispatch_normal_event(event);
+                server_events_dispatch.dispatch_normal_event(event);
         }
     };
 

--- a/static/js/settings_data.js
+++ b/static/js/settings_data.js
@@ -25,11 +25,12 @@ exports.show_email = function () {
     ) {
         return page_params.is_admin;
     }
+    return undefined;
 };
 
 exports.email_for_user_settings = function (person) {
     if (!exports.show_email()) {
-        return;
+        return undefined;
     }
 
     if (

--- a/static/js/settings_org.js
+++ b/static/js/settings_org.js
@@ -514,7 +514,7 @@ exports.get_input_element_value = function (input_elem, input_type) {
             return parseInt(input_elem.val().trim(), 10);
         }
     }
-    return;
+    return undefined;
 };
 
 exports.set_input_element_value = function (input_elem, value) {
@@ -528,6 +528,7 @@ exports.set_input_element_value = function (input_elem, value) {
         }
     }
     blueslip.error(`Failed to set value of property ${exports.extract_property_name(input_elem)}`);
+    return undefined;
 };
 
 exports.set_up = function () {
@@ -681,6 +682,7 @@ exports.build_page = function () {
 
         const subsection = $(e.target).closest(".org-subsection-parent");
         exports.save_discard_widget_status_handler(subsection);
+        return undefined;
     });
 
     $(".organization").on(

--- a/static/js/settings_profile_fields.js
+++ b/static/js/settings_profile_fields.js
@@ -35,6 +35,7 @@ exports.field_type_id_to_string = function (type_id) {
             return field_type.name;
         }
     }
+    return undefined;
 };
 
 function update_profile_fields_table_element() {
@@ -156,6 +157,7 @@ function read_field_data_from_form(field_type_id, field_elem) {
     } else if (field_type_id === field_types.EXTERNAL_ACCOUNT.id) {
         return read_external_account_field_data(field_elem);
     }
+    return undefined;
 }
 
 function create_profile_field(e) {

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -161,12 +161,12 @@ function reset_scrollbar($sel) {
 
 function bot_owner_full_name(owner_id) {
     if (!owner_id) {
-        return;
+        return undefined;
     }
 
     const bot_owner = people.get_by_user_id(owner_id);
     if (!bot_owner) {
-        return;
+        return undefined;
     }
 
     return bot_owner.full_name;
@@ -176,7 +176,7 @@ function bot_info(bot_user_id) {
     const bot_user = bot_data.get(bot_user_id);
 
     if (!bot_user) {
-        return;
+        return undefined;
     }
 
     const owner_id = bot_user.owner_id;

--- a/static/js/settings_users.js
+++ b/static/js/settings_users.js
@@ -130,7 +130,7 @@ function get_status_field() {
         case "bot-list-admin":
             return $("#bot-field-status").expectOne();
         default:
-            blueslip.fatal("Invalid admin settings page");
+            throw new Error("Invalid admin settings page");
     }
 }
 

--- a/static/js/stream_create.js
+++ b/static/js/stream_create.js
@@ -150,7 +150,7 @@ function create_stream() {
             $(".stream_create_info"),
             "alert-error",
         );
-        return;
+        return undefined;
     }
     data.subscriptions = JSON.stringify([{name: stream_name, description}]);
 

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -761,8 +761,8 @@ exports.create_streams = function (streams) {
 
 exports.create_sub_from_server_data = function (attrs) {
     if (!attrs.stream_id) {
-        // fail fast (blueslip.fatal will throw an error on our behalf)
-        blueslip.fatal("We cannot create a sub without a stream_id");
+        // fail fast
+        throw new Error("We cannot create a sub without a stream_id");
     }
 
     let sub = exports.get_sub_by_id(attrs.stream_id);

--- a/static/js/stream_data.js
+++ b/static/js/stream_data.js
@@ -256,7 +256,7 @@ exports.get_sub_by_name = function (name) {
     const stream_id = stream_ids_by_name.get(name);
 
     if (!stream_id) {
-        return;
+        return undefined;
     }
 
     return subs_by_stream_id.get(stream_id);
@@ -474,7 +474,7 @@ exports.get_subscriber_count = function (stream_id) {
     const sub = exports.get_sub_by_id(stream_id);
     if (sub === undefined) {
         blueslip.warn("We got a get_subscriber_count count call for a non-existent stream.");
-        return;
+        return undefined;
     }
     if (!sub.subscribers) {
         return 0;
@@ -681,12 +681,12 @@ exports.get_name = function (stream_name) {
 
 exports.maybe_get_stream_name = function (stream_id) {
     if (!stream_id) {
-        return;
+        return undefined;
     }
     const stream = exports.get_sub_by_id(stream_id);
 
     if (!stream) {
-        return;
+        return undefined;
     }
 
     return stream.name;
@@ -736,11 +736,11 @@ exports.is_user_subscribed = function (stream_id, user_id) {
         blueslip.warn(
             "We got a is_user_subscribed call for a non-existent or inaccessible stream.",
         );
-        return;
+        return undefined;
     }
     if (typeof user_id === "undefined") {
         blueslip.warn("Undefined user_id passed to function is_user_subscribed");
-        return;
+        return undefined;
     }
 
     return sub.subscribers.has(user_id);

--- a/static/js/stream_edit.js
+++ b/static/js/stream_edit.js
@@ -68,7 +68,7 @@ exports.get_retention_policy_text_for_subscription_type = function (sub) {
         (sub.message_retention_days === null ||
             sub.message_retention_days === settings_config.retain_message_forever)
     ) {
-        return;
+        return undefined;
     }
 
     // Forever for this stream, overriding the organization default
@@ -127,13 +127,13 @@ function get_sub_for_target(target) {
     const stream_id = get_stream_id(target);
     if (!stream_id) {
         blueslip.error("Cannot find stream id for target");
-        return;
+        return undefined;
     }
 
     const sub = stream_data.get_sub_by_id(stream_id);
     if (!sub) {
         blueslip.error("get_sub_for_target() failed id lookup: " + stream_id);
-        return;
+        return undefined;
     }
     return sub;
 }
@@ -354,6 +354,8 @@ function show_subscription_settings(sub) {
                     }
                     return person.full_name.toLowerCase().includes(value);
                 }
+
+                return false;
             },
         },
         simplebar_container: $(".subscriber_list_container"),
@@ -469,6 +471,7 @@ exports.bulk_set_stream_property = function (sub_data, status_element) {
     }
 
     settings_ui.do_settings_change(channel.post, url, data, status_element);
+    return undefined;
 };
 
 exports.set_stream_property = function (sub, property, value, status_element) {

--- a/static/js/stream_list.js
+++ b/static/js/stream_list.js
@@ -141,18 +141,18 @@ exports.get_stream_li = function (stream_id) {
         // Not all streams are in the sidebar, so we don't report
         // an error here, and it's up for the caller to error if
         // they expected otherwise.
-        return;
+        return undefined;
     }
 
     const li = row.get_li();
     if (!li) {
         blueslip.error("Cannot find li for id " + stream_id);
-        return;
+        return undefined;
     }
 
     if (li.length > 1) {
         blueslip.error("stream_li has too many elements for " + stream_id);
-        return;
+        return undefined;
     }
 
     return li;
@@ -397,7 +397,7 @@ exports.update_stream_sidebar_for_narrow = function (filter) {
 
     if (!stream_id) {
         topic_zoom.clear_topics();
-        return;
+        return undefined;
     }
 
     const stream_li = exports.get_stream_li(stream_id);
@@ -410,7 +410,7 @@ exports.update_stream_sidebar_for_narrow = function (filter) {
         // April 2020, so if it appears again, something regressed.
         blueslip.error("No stream_li for subscribed stream " + stream_id);
         topic_zoom.clear_topics();
-        return;
+        return undefined;
     }
 
     if (!info.topic_selected) {
@@ -649,7 +649,7 @@ exports.get_current_stream_li = function () {
 
     if (!stream_id) {
         // stream_id is undefined in non-stream narrows
-        return;
+        return undefined;
     }
 
     const stream_li = exports.get_stream_li(stream_id);
@@ -657,7 +657,7 @@ exports.get_current_stream_li = function () {
     if (!stream_li) {
         // This code path shouldn't ever be reached.
         blueslip.warn("No active stream_li found for defined id " + stream_id);
-        return;
+        return undefined;
     }
 
     return stream_li;

--- a/static/js/stream_pill.js
+++ b/static/js/stream_pill.js
@@ -7,18 +7,18 @@ function display_pill(sub) {
 exports.create_item_from_stream_name = function (stream_name, current_items) {
     stream_name = stream_name.trim();
     if (!stream_name.startsWith("#")) {
-        return;
+        return undefined;
     }
     stream_name = stream_name.substring(1);
 
     const sub = stream_data.get_sub(stream_name);
     if (!sub) {
-        return;
+        return undefined;
     }
 
     const existing_ids = current_items.map((item) => item.stream_id);
     if (existing_ids.includes(sub.stream_id)) {
-        return;
+        return undefined;
     }
 
     const item = {

--- a/static/js/stream_popover.js
+++ b/static/js/stream_popover.js
@@ -18,13 +18,13 @@ let starred_messages_sidebar_elem;
 function get_popover_menu_items(sidebar_elem) {
     if (!sidebar_elem) {
         blueslip.error("Trying to get menu items when action popover is closed.");
-        return;
+        return undefined;
     }
 
     const popover_data = $(sidebar_elem).data("popover");
     if (!popover_data) {
         blueslip.error("Cannot find popover data for stream sidebar menu.");
-        return;
+        return undefined;
     }
     return $("li:not(.divider):visible > a", popover_data.$tip);
 }
@@ -125,7 +125,7 @@ function stream_popover_sub(e) {
     const sub = stream_data.get_sub_by_id(stream_id);
     if (!sub) {
         blueslip.error("Unknown stream: " + stream_id);
-        return;
+        return undefined;
     }
     return sub;
 }
@@ -477,13 +477,13 @@ function topic_popover_sub(e) {
     const stream_id = topic_popover_stream_id(e);
     if (!stream_id) {
         blueslip.error("cannot find stream id");
-        return;
+        return undefined;
     }
 
     const sub = stream_data.get_sub_by_id(stream_id);
     if (!sub) {
         blueslip.error("Unknown stream: " + stream_id);
-        return;
+        return undefined;
     }
     return sub;
 }
@@ -587,6 +587,8 @@ exports.register_topic_handlers = function () {
     });
 
     $("body").on("click", "#do_move_topic_button", (e) => {
+        e.preventDefault();
+
         function show_error_msg(msg) {
             $("#topic_stream_edit_form_error .error-msg").text(msg);
             $("#topic_stream_edit_form_error").show();
@@ -616,7 +618,7 @@ exports.register_topic_handlers = function () {
             new_topic_name.toLowerCase() === old_topic_name.toLowerCase()
         ) {
             show_error_msg("Please select a different stream or change topic name.");
-            return false;
+            return;
         }
 
         // The API endpoint for editing messages to change their
@@ -672,7 +674,6 @@ exports.register_topic_handlers = function () {
                 show_error_msg(xhr.responseJSON.msg);
             },
         });
-        e.preventDefault();
     });
 };
 

--- a/static/js/stream_sort.js
+++ b/static/js/stream_sort.js
@@ -48,7 +48,7 @@ function filter_streams_by_search(streams, search_term) {
 
 exports.sort_groups = function (streams, search_term) {
     if (streams.length === 0) {
-        return;
+        return undefined;
     }
 
     streams = filter_streams_by_search(streams, search_term);
@@ -101,7 +101,7 @@ exports.sort_groups = function (streams, search_term) {
 
 function maybe_get_stream_id(i) {
     if (i < 0 || i >= all_streams.length) {
-        return;
+        return undefined;
     }
 
     return all_streams[i];
@@ -115,7 +115,7 @@ exports.prev_stream_id = function (stream_id) {
     const i = all_streams.indexOf(stream_id);
 
     if (i < 0) {
-        return;
+        return undefined;
     }
 
     return maybe_get_stream_id(i - 1);
@@ -125,7 +125,7 @@ exports.next_stream_id = function (stream_id) {
     const i = all_streams.indexOf(stream_id);
 
     if (i < 0) {
-        return;
+        return undefined;
     }
 
     return maybe_get_stream_id(i + 1);

--- a/static/js/submessage.js
+++ b/static/js/submessage.js
@@ -2,15 +2,15 @@
 
 exports.get_message_events = function (message) {
     if (message.locally_echoed) {
-        return;
+        return undefined;
     }
 
     if (!message.submessages) {
-        return;
+        return undefined;
     }
 
     if (message.submessages.length === 0) {
-        return;
+        return undefined;
     }
 
     message.submessages.sort((m1, m2) => parseInt(m1.id, 10) - parseInt(m2.id, 10));
@@ -30,6 +30,7 @@ exports.process_submessages = function (in_opts) {
         return exports.do_process_submessages(in_opts);
     } catch (err) {
         blueslip.error("in process_submessages: " + err.message);
+        return undefined;
     }
 };
 

--- a/static/js/subs.js
+++ b/static/js/subs.js
@@ -48,6 +48,7 @@ function get_row_data(row) {
             object: row_object,
         };
     }
+    return undefined;
 }
 
 exports.get_active_data = function () {
@@ -103,6 +104,8 @@ exports.active_stream = function () {
             name: hash_components[2],
         };
     }
+
+    return undefined;
 };
 
 exports.set_muted = function (sub, is_muted, status_element) {

--- a/static/js/todo_widget.js
+++ b/static/js/todo_widget.js
@@ -63,7 +63,7 @@ class TaskData {
                 if (!this.name_in_use(task)) {
                     return event;
                 }
-                return;
+                return undefined;
             },
 
             inbound: (sender_id, data) => {

--- a/static/js/topic_generator.js
+++ b/static/js/topic_generator.js
@@ -10,7 +10,7 @@ exports.sub_list_generator = function (lst, lower, upper) {
     return {
         next() {
             if (i >= upper) {
-                return;
+                return undefined;
             }
             const res = lst[i];
             i += 1;
@@ -27,7 +27,7 @@ exports.reverse_sub_list_generator = function (lst, lower, upper) {
     return {
         next() {
             if (i < lower) {
-                return;
+                return undefined;
             }
             const res = lst[i];
             i -= 1;
@@ -55,7 +55,7 @@ exports.fchain = function (outer_gen, get_inner_gen) {
                     inner_gen = get_inner_gen(outer_val);
                     if (!inner_gen || !inner_gen.next) {
                         blueslip.error("Invalid generator returned.");
-                        return;
+                        return undefined;
                     }
                 }
                 const inner = inner_gen.next();
@@ -65,6 +65,7 @@ exports.fchain = function (outer_gen, get_inner_gen) {
                 outer_val = outer_gen.next();
                 inner_gen = undefined;
             }
+            return undefined;
         },
     };
 };
@@ -139,7 +140,7 @@ exports.filter = function (gen, filter_func) {
             while (true) {
                 const val = gen.next();
                 if (val === undefined) {
-                    return;
+                    return undefined;
                 }
                 if (filter_func(val)) {
                     return val;
@@ -154,7 +155,7 @@ exports.map = function (gen, map_func) {
         next() {
             const val = gen.next();
             if (val === undefined) {
-                return;
+                return undefined;
             }
             return map_func(val);
         },

--- a/static/js/topic_list.js
+++ b/static/js/topic_list.js
@@ -178,7 +178,7 @@ exports.active_stream_id = function () {
     const stream_ids = Array.from(active_widgets.keys());
 
     if (stream_ids.length !== 1) {
-        return;
+        return undefined;
     }
 
     return stream_ids[0];
@@ -188,7 +188,7 @@ exports.get_stream_li = function () {
     const widgets = Array.from(active_widgets.values());
 
     if (widgets.length !== 1) {
-        return;
+        return undefined;
     }
 
     const stream_li = widgets[0].get_parent();

--- a/static/js/typeahead_helper.js
+++ b/static/js/typeahead_helper.js
@@ -352,6 +352,8 @@ function slash_command_comparator(slash_command_a, slash_command_b) {
     } else if (slash_command_a.name > slash_command_b.name) {
         return 1;
     }
+    /* istanbul ignore next */
+    return 0;
 }
 exports.sort_slash_commands = function (matches, query) {
     // We will likely want to in the future make this sort the

--- a/static/js/ui_util.js
+++ b/static/js/ui_util.js
@@ -49,7 +49,7 @@ function update_lock_icon_for_stream(stream_name) {
 //  have that color be reflected here too.)
 exports.decorate_stream_bar = function (stream_name, element, is_compose) {
     if (stream_name === undefined) {
-        return false;
+        return;
     }
     const color = stream_data.get_color(stream_name);
     if (is_compose) {

--- a/static/js/user_groups.js
+++ b/static/js/user_groups.js
@@ -32,7 +32,7 @@ exports.get_user_group_from_id = function (group_id, suppress_errors) {
         if (suppress_errors === undefined) {
             blueslip.error("Unknown group_id in get_user_group_from_id: " + group_id);
         }
-        return;
+        return undefined;
     }
     return user_group_by_id_dict.get(group_id);
 };

--- a/static/js/user_pill.js
+++ b/static/js/user_pill.js
@@ -14,7 +14,7 @@ exports.create_item_from_email = function (email, current_items) {
             const existing_emails = current_items.map((item) => item.email);
 
             if (existing_emails.includes(email)) {
-                return;
+                return undefined;
             }
 
             // For Zephyr we can't assume any emails are invalid,
@@ -27,13 +27,13 @@ exports.create_item_from_email = function (email, current_items) {
         }
 
         // The email is not allowed, so return.
-        return;
+        return undefined;
     }
 
     const existing_ids = current_items.map((item) => item.user_id);
 
     if (existing_ids.includes(user.user_id)) {
-        return;
+        return undefined;
     }
 
     const avatar_url = people.small_avatar_url_for_person(user);

--- a/static/js/vdom.js
+++ b/static/js/vdom.js
@@ -48,7 +48,7 @@ exports.render_tag = (tag) => {
 
     if (opts.keyed_nodes === undefined) {
         blueslip.error("We need keyed_nodes to render innards.");
-        return;
+        return undefined;
     }
 
     const innards = opts.keyed_nodes.map((node) => node.render()).join("\n");

--- a/static/js/zform.js
+++ b/static/js/zform.js
@@ -48,7 +48,7 @@ exports.activate = function (opts) {
 
     if (!exports.validate_extra_data(data)) {
         // callee will log reason we fail
-        return;
+        return undefined;
     }
 
     function make_choices(data) {

--- a/static/shared/js/emoji.js
+++ b/static/shared/js/emoji.js
@@ -77,6 +77,7 @@ export function get_emoji_name(codepoint) {
     if (Object.prototype.hasOwnProperty.call(emoji_codes.codepoint_to_name, codepoint)) {
         return emoji_codes.codepoint_to_name[codepoint];
     }
+    return undefined;
 }
 
 export function get_emoji_codepoint(emoji_name) {
@@ -84,6 +85,7 @@ export function get_emoji_codepoint(emoji_name) {
     if (Object.prototype.hasOwnProperty.call(emoji_codes.name_to_codepoint, emoji_name)) {
         return emoji_codes.name_to_codepoint[emoji_name];
     }
+    return undefined;
 }
 
 export function get_realm_emoji_url(emoji_name) {
@@ -100,7 +102,7 @@ export function get_realm_emoji_url(emoji_name) {
         // and then try alternate ways of parsing the
         // emoji (in the case of Markdown) or just do
         // whatever makes sense for the caller.
-        return;
+        return undefined;
     }
 
     return data.emoji_url;
@@ -196,7 +198,7 @@ export function get_canonical_name(emoji_name) {
     const codepoint = get_emoji_codepoint(emoji_name);
     if (codepoint === undefined) {
         // Our caller needs to handle this possibility.
-        return;
+        return undefined;
     }
 
     return get_emoji_name(codepoint);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4431,11 +4431,6 @@ eslint-module-utils@^2.6.0:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
-eslint-plugin-empty-returns@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-empty-returns/-/eslint-plugin-empty-returns-1.0.2.tgz#9f9d4b10215a25c719f32675f44ffe5c80963147"
-  integrity sha1-n51LECFaJccZ8yZ19E/+XICWMUc=
-
 eslint-plugin-import@^2.22.0:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz#92f7736fe1fde3e2de77623c838dd992ff5ffb7e"


### PR DESCRIPTION
Converting `blueslip.fatal` to `throw new Error(…)` makes it clear to humans and ESLint that execution will not continue.

Then, instead of prohibiting `return undefined` (#8669), we require that a function must `return` an explicit value always or never. This prevents you from forgetting to `return` a value in some cases. It will also be important for TypeScript, which distinguishes between `undefined` and `void`.

**Testing Plan:** Dev server.