### PR TITLE
message view: Scroll on document instead of ".app".

### DIFF
--- a/frontend_tests/node_tests/narrow_activate.js
+++ b/frontend_tests/node_tests/narrow_activate.js
@@ -27,6 +27,9 @@ const message_lists = mock_esm("../../static/js/message_lists", {
         message_lists.current = msg_list;
     },
 });
+mock_esm("../../static/js/message_viewport", {
+    scrollTop: () => 0,
+});
 const message_scroll = mock_esm("../../static/js/message_scroll");
 const message_view_header = mock_esm("../../static/js/message_view_header");
 const notifications = mock_esm("../../static/js/notifications");

--- a/frontend_tests/node_tests/popovers.js
+++ b/frontend_tests/node_tests/popovers.js
@@ -9,6 +9,7 @@ const $ = require("../zjsunit/zjquery");
 const {page_params} = require("../zjsunit/zpage_params");
 
 const noop = function () {};
+$(window).on = () => {};
 
 const rows = mock_esm("../../static/js/rows");
 mock_esm("../../static/js/emoji_picker", {

--- a/static/js/floating_recipient_bar.js
+++ b/static/js/floating_recipient_bar.js
@@ -11,8 +11,8 @@ let is_floating_recipient_bar_showing = false;
 function top_offset($elem) {
     return (
         $elem.offset().top -
-        $("#message_view_header").safeOuterHeight() -
-        $("#navbar_alerts_wrapper").height()
+        $("#navbar-middle").offset().top -
+        $("#navbar-middle").safeOuterHeight()
     );
 }
 

--- a/static/js/hashchange.js
+++ b/static/js/hashchange.js
@@ -76,6 +76,11 @@ export function changehash(newhash) {
         return;
     }
     maybe_hide_recent_topics();
+    // Some browsers reset scrollTop when changing the hash to "",
+    // so we save and restore it.
+    //
+    // TODO: Remove comment from bf57839e8584ccb224595b5a55c90e4551a7b51e
+    // commit as Recent Topics will have hash "" with scrollTop set to 0.
     message_viewport.stop_auto_scrolling();
     set_hash(newhash);
 }

--- a/static/js/message_fetch.js
+++ b/static/js/message_fetch.js
@@ -10,6 +10,7 @@ import * as message_lists from "./message_lists";
 import * as message_scroll from "./message_scroll";
 import * as message_util from "./message_util";
 import * as narrow_banner from "./narrow_banner";
+import * as overlays from "./overlays";
 import {page_params} from "./page_params";
 import * as people from "./people";
 import * as pm_list from "./pm_list";
@@ -176,6 +177,10 @@ function handle_operators_supporting_id_based_api(data) {
 }
 
 export function load_messages(opts) {
+    if (overlays.is_overlay_or_modal_open()) {
+        return;
+    }
+
     if (typeof opts.anchor === "number") {
         // Messages that have been locally echoed messages have
         // floating point temporary IDs, which is intended to be a.

--- a/static/js/message_list_view.js
+++ b/static/js/message_list_view.js
@@ -730,7 +730,8 @@ export class MessageListView {
 
         const save_scroll_position = () => {
             if (orig_scrolltop_offset === undefined && this.selected_row().length > 0) {
-                orig_scrolltop_offset = this.selected_row().offset().top;
+                orig_scrolltop_offset =
+                    this.selected_row().offset().top - $message_viewport.scrollTop();
             }
         };
 
@@ -1120,7 +1121,7 @@ export class MessageListView {
         const $selected_row = this.selected_row();
         const selected_in_view = $selected_row.length > 0;
         if (selected_in_view) {
-            old_offset = $selected_row.offset().top;
+            old_offset = $selected_row.offset().top - $message_viewport.scrollTop();
         }
         if (discard_rendering_state) {
             // If we know that the existing render is invalid way
@@ -1134,7 +1135,7 @@ export class MessageListView {
 
     set_message_offset(offset) {
         const $msg = this.selected_row();
-        $message_viewport.scrollTop($message_viewport.scrollTop() + $msg.offset().top - offset);
+        $message_viewport.scrollTop($msg.offset().top - offset);
     }
 
     rerender_with_target_scrolltop(selected_row, target_offset) {

--- a/static/js/message_scroll.js
+++ b/static/js/message_scroll.js
@@ -9,6 +9,7 @@ import * as message_lists from "./message_lists";
 import * as message_viewport from "./message_viewport";
 import * as narrow_banner from "./narrow_banner";
 import * as narrow_state from "./narrow_state";
+import * as overlays from "./overlays";
 import * as recent_topics_util from "./recent_topics_util";
 import * as unread from "./unread";
 import * as unread_ops from "./unread_ops";
@@ -183,6 +184,10 @@ export function scroll_finished() {
     actively_scrolling = false;
     hide_scroll_to_bottom();
 
+    if (overlays.is_overlay_or_modal_open()) {
+        return;
+    }
+
     if (!$("#message_feed_container").hasClass("active")) {
         return;
     }
@@ -223,7 +228,7 @@ function scroll_finish() {
 }
 
 export function initialize() {
-    message_viewport.$message_pane.on(
+    $(window).on(
         "scroll",
         _.throttle(() => {
             unread_ops.process_visible();

--- a/static/js/narrow.js
+++ b/static/js/narrow.js
@@ -20,6 +20,7 @@ import * as message_lists from "./message_lists";
 import * as message_scroll from "./message_scroll";
 import * as message_store from "./message_store";
 import * as message_view_header from "./message_view_header";
+import * as message_viewport from "./message_viewport";
 import * as narrow_banner from "./narrow_banner";
 import * as narrow_state from "./narrow_state";
 import * as notifications from "./notifications";
@@ -110,7 +111,8 @@ export function save_pre_narrow_offset_for_reload() {
                 render_end: message_lists.current.view._render_win_end,
             });
         }
-        message_lists.current.pre_narrow_offset = message_lists.current.selected_row().offset().top;
+        message_lists.current.pre_narrow_offset =
+            message_lists.current.selected_row().offset().top - message_viewport.scrollTop();
     }
 }
 
@@ -421,7 +423,7 @@ export function activate(raw_operators, opts) {
         if (opts.then_select_offset === undefined) {
             const $row = message_lists.current.get_row(opts.then_select_id);
             if ($row.length > 0) {
-                opts.then_select_offset = $row.offset().top;
+                opts.then_select_offset = $row.offset().top - message_viewport.scrollTop();
             }
         }
     }

--- a/static/js/overlays.js
+++ b/static/js/overlays.js
@@ -4,6 +4,7 @@ import Micromodal from "micromodal";
 import * as blueslip from "./blueslip";
 import * as browser_history from "./browser_history";
 import * as popovers from "./popovers";
+import * as scroll_bar from "./scroll_bar";
 
 let $active_overlay;
 let close_handler;
@@ -81,6 +82,7 @@ export function active_modal() {
 }
 
 export function open_overlay(opts) {
+    scroll_bar.disable_scrolling();
     popovers.hide_all();
 
     if (!opts.name || !opts.$overlay || !opts.on_close) {
@@ -155,6 +157,7 @@ export function open_modal(selector, conf) {
     }
 
     blueslip.debug("open modal: " + selector);
+    scroll_bar.disable_scrolling();
 
     // Show a modal using micromodal.
     if (conf && conf.micromodal) {
@@ -249,6 +252,7 @@ export function close_overlay(name) {
     }
 
     close_handler();
+    scroll_bar.enable_scrolling();
 }
 
 export function close_active() {
@@ -285,6 +289,7 @@ export function close_modal(selector, conf) {
     }
 
     blueslip.debug("close modal: " + selector);
+    scroll_bar.disable_scrolling();
 
     if (conf && conf.micromodal) {
         const id_selector = `#${selector}`;

--- a/static/js/popovers.js
+++ b/static/js/popovers.js
@@ -1295,7 +1295,7 @@ export function register_click_handlers() {
     {
         let last_scroll = 0;
 
-        $(".app").on("scroll", () => {
+        $(window).on("scroll", () => {
             if (suppress_scroll_hide) {
                 suppress_scroll_hide = false;
                 return;

--- a/static/js/reload.js
+++ b/static/js/reload.js
@@ -12,6 +12,7 @@ import * as hashchange from "./hashchange";
 import {localstorage} from "./localstorage";
 import * as message_list from "./message_list";
 import * as message_lists from "./message_lists";
+import * as message_viewport from "./message_viewport";
 import * as narrow_state from "./narrow_state";
 import {page_params} from "./page_params";
 import * as reload_state from "./reload_state";
@@ -68,7 +69,7 @@ function preserve_state(send_after_reload, save_pointer, save_narrow, save_compo
         const $row = message_lists.home.selected_row();
         if (!narrow_state.active()) {
             if ($row.length > 0) {
-                url += "+offset=" + $row.offset().top;
+                url += "+offset=" + $row.offset().top - message_viewport.scrollTop();
             }
         } else {
             url += "+offset=" + message_lists.home.pre_narrow_offset;
@@ -79,7 +80,7 @@ function preserve_state(send_after_reload, save_pointer, save_narrow, save_compo
             }
             const $narrow_row = message_list.narrowed.selected_row();
             if ($narrow_row.length > 0) {
-                url += "+narrow_offset=" + $narrow_row.offset().top;
+                url += "+narrow_offset=" + $narrow_row.offset().top - message_viewport.scrollTop();
             }
         }
     }

--- a/static/js/resize.js
+++ b/static/js/resize.js
@@ -41,68 +41,42 @@ function size_blocks(blocks, usable_height) {
 
 function get_new_heights() {
     const res = {};
-    const viewport_height = message_viewport.height();
-    const top_navbar_height = $("#top_navbar").safeOuterHeight(true);
-    const right_sidebar_shorcuts_height = $(".right-sidebar-shortcuts").safeOuterHeight(true) || 0;
-
+    const viewport_height = $(window).height();
     res.bottom_whitespace_height = viewport_height * 0.4;
 
-    res.main_div_min_height = viewport_height - top_navbar_height;
-
-    res.stream_filters_max_height =
-        viewport_height -
-        Number.parseInt($("#left-sidebar").css("marginTop"), 10) -
-        Number.parseInt($(".narrows_panel").css("marginTop"), 10) -
-        Number.parseInt($(".narrows_panel").css("marginBottom"), 10) -
-        $("#global_filters").safeOuterHeight(true) -
-        $("#streams_header").safeOuterHeight(true);
-
-    // Don't let us crush the stream sidebar completely out of view
-    res.stream_filters_max_height = Math.max(80, res.stream_filters_max_height);
+    // LEFT SIDEBAR
+    const $stream_filters_container = $("#stream-filters-container").expectOne();
+    const stream_filters_top = $stream_filters_container.offset().top - $(window).scrollTop();
+    const left_sidebar_shortcuts = $("#add-stream-link").outerHeight();
+    const stream_filters_max_height = viewport_height - stream_filters_top - left_sidebar_shortcuts;
+    res.stream_filters_max_height = Math.max(80, stream_filters_max_height);
 
     // RIGHT SIDEBAR
-
-    const usable_height =
-        viewport_height -
-        Number.parseInt($("#right-sidebar").css("marginTop"), 10) -
-        $("#userlist-header").safeOuterHeight(true) -
-        $("#user_search_section").safeOuterHeight(true) -
-        right_sidebar_shorcuts_height;
-
-    res.buddy_list_wrapper_max_height = Math.max(80, usable_height);
+    const $buddy_list_wrapper = $("#buddy_list_wrapper").expectOne();
+    const buddy_list_wrapper_top = $buddy_list_wrapper.offset().top - $(window).scrollTop();
+    const right_sidebar_shortcuts = $(".right-sidebar-shortcuts").outerHeight();
+    const buddy_list_wrapper_max_height =
+        viewport_height - buddy_list_wrapper_top - right_sidebar_shortcuts;
+    res.buddy_list_wrapper_max_height = Math.max(80, buddy_list_wrapper_max_height);
 
     return res;
 }
 
 function left_userlist_get_new_heights() {
     const res = {};
-    const viewport_height = message_viewport.height();
-    const viewport_width = message_viewport.width();
-    res.viewport_height = viewport_height;
-    res.viewport_width = viewport_width;
-
-    // main div
-    const top_navbar_height = $(".header").safeOuterHeight(true);
-    res.bottom_whitespace_height = viewport_height * 0.4;
-    res.main_div_min_height = viewport_height - top_navbar_height;
-
-    // left sidebar
-    const $stream_filters = $("#stream_filters").expectOne();
+    const viewport_height = $(window).height();
+    const $stream_filters_container = $("#stream-filters-container").expectOne();
     const $buddy_list_wrapper = $("#buddy_list_wrapper").expectOne();
 
-    const stream_filters_real_height = $stream_filters.prop("scrollHeight");
+    res.bottom_whitespace_height = viewport_height * 0.4;
+
+    const stream_filters_real_height = ui
+        .get_scroll_element($stream_filters_container)
+        .prop("scrollHeight");
     const user_list_real_height = ui.get_scroll_element($buddy_list_wrapper).prop("scrollHeight");
 
-    res.total_leftlist_height =
-        viewport_height -
-        Number.parseInt($("#left-sidebar").css("marginTop"), 10) -
-        Number.parseInt($(".narrows_panel").css("marginTop"), 10) -
-        Number.parseInt($(".narrows_panel").css("marginBottom"), 10) -
-        $("#global_filters").safeOuterHeight(true) -
-        $("#streams_header").safeOuterHeight(true) -
-        $("#userlist-header").safeOuterHeight(true) -
-        $("#user_search_section").safeOuterHeight(true) -
-        Number.parseInt($stream_filters.css("marginBottom"), 10);
+    const stream_filters_top = $stream_filters_container.offset().top - $(window).scrollTop();
+    res.total_leftlist_height = viewport_height - stream_filters_top;
 
     const blocks = [
         {

--- a/static/js/scroll_bar.js
+++ b/static/js/scroll_bar.js
@@ -1,55 +1,24 @@
 import $ from "jquery";
 
+import * as message_viewport from "./message_viewport";
 import {user_settings} from "./user_settings";
 
-// A few of our width properties in Zulip depend on the width of the
-// browser scrollbar that is generated at the far right side of the
-// page, which unfortunately varies depending on the browser and
-// cannot be detected directly using CSS.  As a result, we adjust a
-// number of element widths based on the value detected here.
-//
-// From https://stackoverflow.com/questions/13382516/getting-scroll-bar-width-using-javascript
-function getScrollbarWidth() {
-    const outer = document.createElement("div");
-    outer.style.visibility = "hidden";
-    outer.style.width = "100px";
-    outer.style.msOverflowStyle = "scrollbar"; // needed for WinJS apps
-
-    document.body.append(outer);
-
-    const widthNoScroll = outer.offsetWidth;
-    // force scrollbars
-    outer.style.overflow = "scroll";
-
-    // add inner div
-    const inner = document.createElement("div");
-    inner.style.width = "100%";
-    outer.append(inner);
-
-    const widthWithScroll = inner.offsetWidth;
-
-    // remove divs
-    outer.remove();
-
-    return widthNoScroll - widthWithScroll;
-}
-
-let sbWidth;
+let last_scroll_position = 0;
 
 export function initialize() {
-    // Workaround for browsers with fixed scrollbars
-    sbWidth = getScrollbarWidth();
-    if (sbWidth > 0) {
-        // Reduce width of screen-wide parent containers, whose width doesn't vary with scrollbar width, by scrollbar width.
-        $("#navbar-container .header, .fixed-app .app-main, #compose").css(
-            "width",
-            `calc(100% - ${sbWidth}px)`,
-        );
-
-        // Align floating recipient bar with the middle column.
-        $(".fixed-app").css("left", "-" + sbWidth / 2 + "px");
-    }
     set_layout_width();
+}
+
+export function disable_scrolling() {
+    last_scroll_position = message_viewport.scrollTop();
+    $("body").addClass("modal-open");
+    $("#middle-container").css("top", `-${last_scroll_position}px`);
+}
+
+export function enable_scrolling() {
+    $("body").removeClass("modal-open");
+    $("#middle-container").css("top", `0px`);
+    message_viewport.scrollTop(last_scroll_position);
 }
 
 export function set_layout_width() {

--- a/static/js/stream_muting.js
+++ b/static/js/stream_muting.js
@@ -22,7 +22,8 @@ export function update_is_muted(sub, value) {
             message_lists.home === message_lists.current &&
             message_lists.current.selected_row().offset() !== null
         ) {
-            msg_offset = message_lists.current.selected_row().offset().top;
+            msg_offset =
+                message_lists.current.selected_row().offset().top - message_viewport.scrollTop();
         }
 
         message_lists.home.clear({clear_selected_id: false});

--- a/static/js/ui_init.js
+++ b/static/js/ui_init.js
@@ -237,7 +237,7 @@ export function initialize_kitchen_sink_stuff() {
         message_viewport.set_last_movement_direction(delta);
     }, 50);
 
-    message_viewport.$message_pane.on("wheel", (e) => {
+    $(window).on("wheel", (e) => {
         const delta = e.originalEvent.deltaY;
         if (!overlays.is_overlay_or_modal_open() && !recent_topics_util.is_visible()) {
             // In the message view, we use a throttled mousewheel handler.

--- a/static/styles/alerts.css
+++ b/static/styles/alerts.css
@@ -29,7 +29,7 @@ $alert-error-red: hsl(0, 80%, 40%);
 
 /* alert box component changes */
 .alert-box {
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
     width: 900px;

--- a/static/styles/left_sidebar.css
+++ b/static/styles/left_sidebar.css
@@ -207,6 +207,7 @@ li.show-more-topics {
     text-decoration: none;
     margin: 5px auto 5.5px 10px;
     margin-bottom: 25px;
+    margin-left: 10px;
 
     i {
         min-width: 19px;

--- a/static/styles/right_sidebar.css
+++ b/static/styles/right_sidebar.css
@@ -213,7 +213,6 @@
     display: flex;
     flex-direction: row;
     justify-content: space-between;
-    margin-top: 5px;
 }
 
 /* This max-width must be synced with message_viewport.is_narrow */

--- a/static/styles/zulip.css
+++ b/static/styles/zulip.css
@@ -25,10 +25,6 @@ $right_sidebar_width: 250px;
 body,
 html {
     width: 100%;
-    height: 100%;
-    overflow-x: hidden;
-    overflow-y: hidden;
-
     touch-action: manipulation;
 }
 
@@ -36,10 +32,20 @@ html {
     display: none !important; /* We are now loaded, by definition. */
 }
 
+html {
+    overflow-x: hidden;
+    overflow-y: scroll;
+    overscroll-behavior-y: none;
+}
+
 body {
     font-size: 14px;
     line-height: calc(20 / 14);
     font-family: "Source Sans 3", sans-serif;
+}
+
+body.modal-open {
+    position: fixed;
 }
 
 /* Common background color */
@@ -316,8 +322,11 @@ p.n-margin {
 }
 
 #navbar_alerts_wrapper {
+    width: 100%;
+    top: 0;
     font-size: 1rem;
-    position: relative;
+    position: sticky;
+    z-index: 102;
 
     .alert {
         /* Since alerts are only rendered into the DOM when they are first
@@ -367,18 +376,13 @@ p.n-margin {
 
 .app {
     width: 100%;
-    height: 100%;
-    overflow-y: scroll;
     z-index: 99;
-    -webkit-overflow-scrolling: touch;
 }
 
 .app-main,
 .header-main {
     width: 100%;
-    /* `max-width` is changed based on `fluid_layout_width` setting in
-       `scroll_bar.js`. User may or may not see a flash of mispositioned content
-       based on how quickly the JS code is executed. */
+    /* This should match the value in scroll_bar.set_layout_width */
     max-width: 1400px;
     min-width: 950px;
     margin: 0 auto;

--- a/static/third/bootstrap-tooltip/tooltip.js
+++ b/static/third/bootstrap-tooltip/tooltip.js
@@ -154,7 +154,7 @@
           }
 
           if (this.options.fix_positions) {
-              var win_height = $(window).height();
+              var win_height = $(window).scrollTop() + $(window).height();
               var win_width = $(window).width();
 
               /* Ensure that the popover stays fully onscreen,
@@ -167,8 +167,8 @@
                  If you use this fix_positions option, you want
                  to also use the "no_arrow_popover" template.
               */
-              if (top < 0) {
-                  top = 0;
+              if (top < $(window).scrollTop()) {
+                  top = $(window).scrollTop();
                   $tip.find("div.arrow").hide();
               } else if (top + actualHeight > win_height - 20) {
                   top = win_height - actualHeight - 20;

--- a/static/third/bootstrap-typeahead/typeahead.js
+++ b/static/third/bootstrap-typeahead/typeahead.js
@@ -179,6 +179,7 @@
       if (this.dropup) {
         top_pos = pos.top - this.$container.outerHeight()
       }
+      top_pos = top_pos - $(window).scrollTop()
 
       // Zulip patch: Avoid typeahead going off top of screen.
       if (top_pos < 0) {

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -124,7 +124,7 @@
     <div class="app-main">
         <div class="column-left" id="left-sidebar-container">
         </div>
-        <div class="column-middle">
+        <div class="column-middle" id="middle-container">
             <div class="column-middle-inner tab-content">
                 <div id="recent_topics_view">
                     <div class="recent_topics_container">


### PR DESCRIPTION
Fixes #9911.
The compose box also had a partial overlap with the scrollbar. This fixes it.
![header](https://user-images.githubusercontent.com/40122794/94192125-240f7e00-fecc-11ea-865a-c04de8a0440e.png)

- [ ] It looks like we used to use the browser scrollbar ([`dedd3c`](dedd3cf03cdc7291817da9ba370e806d2e069267)) but then `#panels` wasn't implemented,
used `sticky` as I couldn't find simpler way without including javascript changes and
we could polyfill it as we are doing so for the `frb`.

WIP as I'm looking into this and haven't tested on IE11+.

**Testing Plan:** <!-- How have you tested? -->
For scroll changes, grepped for `.offset().top` and `$(".app")` then manually tested the events which called those functions.
For UI changes, added extra users, streams and messages using `populate_db`.